### PR TITLE
[PR #1593] chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,164 @@ release-plz updates this file in the Release PR.
 
 ### Other
 
+- release (by @github-actions[bot]) - #1592
+- Some real code split (by @ffedoroff) - #1462
+- release (by @github-actions[bot]) - #1381
+- *(modkit)* split required and defaulted module config loading (by @fluiderson)
+
+### Contributors
+
+* @github-actions[bot]
+* @aviator5
+* @ffedoroff
+* @fluiderson
+
+## [0.1.14](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-credstore-plugin-v0.1.13...cf-static-credstore-plugin-v0.1.14) - 2026-04-22
+
+### Other
+
+- release (by @github-actions[bot]) - #1592
+- Some real code split (by @ffedoroff) - #1462
+- release (by @github-actions[bot]) - #1381
+- *(modkit)* split required and defaulted module config loading (by @fluiderson)
+
+### Contributors
+
+* @github-actions[bot]
+* @ffedoroff
+* @fluiderson
+
+## [0.1.16](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-authz-plugin-v0.1.15...cf-static-authz-plugin-v0.1.16) - 2026-04-22
+
+### Added
+
+- *(de1101)* add max_inline_test_lines threshold and companion file guard (by @ffedoroff)
+- *(authz)* InGroup/InGroupSubtree predicates + PDP tenant resolution (by @ffedoroff)
+
+### Other
+
+- release (by @github-actions[bot]) - #1592
+- Some real code split (by @ffedoroff) - #1462
+- release (by @github-actions[bot]) - #1381
+- *(modkit)* split required and defaulted module config loading (by @fluiderson)
+
+### Contributors
+
+* @github-actions[bot]
+* @ffedoroff
+* @fluiderson
+
+## [0.2.7](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-authn-plugin-v0.2.6...cf-static-authn-plugin-v0.2.7) - 2026-04-22
+
+### Other
+
+- release (by @github-actions[bot]) - #1592
+- Some real code split (by @ffedoroff) - #1462
+- release (by @github-actions[bot]) - #1381
+- *(modkit)* split required and defaulted module config loading (by @fluiderson)
+
+### Contributors
+
+* @github-actions[bot]
+* @ffedoroff
+* @fluiderson
+
+## [0.1.18](https://github.com/cyberfabric/cyberfabric-core/compare/cf-single-tenant-tr-plugin-v0.1.17...cf-single-tenant-tr-plugin-v0.1.18) - 2026-04-22
+
+### Added
+
+- *(tenant-resolver)* adopt single-root tree topology (by @aviator5)
+
+### Other
+
+- release (by @github-actions[bot]) - #1592
+- Some real code split (by @ffedoroff) - #1462
+- release (by @github-actions[bot]) - #1381
+
+### Contributors
+
+* @github-actions[bot]
+* @aviator5
+* @ffedoroff
+
+## [0.6.3](https://github.com/cyberfabric/cyberfabric-core/compare/cf-modkit-http-v0.6.2...cf-modkit-http-v0.6.3) - 2026-04-22
+
+### Other
+
+- release (by @github-actions[bot]) - #1592
+- fix new warnings from Clippy (by @fluiderson) - #1534
+
+### Contributors
+
+* @github-actions[bot]
+* @fluiderson
+
+## [0.6.4](https://github.com/cyberfabric/cyberfabric-core/compare/cf-modkit-v0.6.3...cf-modkit-v0.6.4) - 2026-04-22
+
+### Fixed
+
+- *(bootstrap)* unify crypto provider init in main() for both FIPS and non-FIPS modes (by @MikeFalcon77)
+- *(modkit)* pass fresh deadline token to stop() for graceful shutdown
+
+### Other
+
+- release (by @github-actions[bot]) - #1592
+- fix new warnings from Clippy (by @fluiderson) - #1534
+- restore spawned-task approach for two-phase shutdown
+- per-module deadline tokens, RunOptions.shutdown_deadline, test guards
+
+### Removed
+
+- removed additional task spawn in run_stop_phase, removed arc wrapper for AromicBool
+
+### Contributors
+
+* @github-actions[bot]
+* @MikeFalcon77
+* @fluiderson
+
+## [0.7.0](https://github.com/cyberfabric/cyberfabric-core/compare/cf-modkit-canonical-errors-v0.6.1...cf-modkit-canonical-errors-v0.7.0) - 2026-04-22
+
+### Other
+
+- release (by @github-actions[bot]) - #1381
+- *(errors)* convert resource_error macro to attribute macro (by @lansfy)
+
+### Contributors
+
+* @github-actions[bot]
+* @lansfy
+
+## [0.6.1](https://github.com/cyberfabric/cyberfabric-core/releases/tag/cf-modkit-canonical-errors-macro-v0.6.1) - 2026-04-22
+
+### Other
+
+- fix new warnings from Clippy (by @fluiderson) - #1534
+- *(errors)* convert resource_error macro to attribute macro (by @lansfy)
+
+### Contributors
+
+* @fluiderson
+* @lansfy
+
+## [0.6.2](https://github.com/cyberfabric/cyberfabric-core/compare/types-sdk-v0.6.1...types-sdk-v0.6.2) - 2026-04-22
+
+### Other
+
+- release (by @github-actions[bot]) - #1381
+
+### Contributors
+
+* @github-actions[bot]
+
+## [0.1.17](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-tr-plugin-v0.1.16...cf-static-tr-plugin-v0.1.17) - 2026-04-22
+
+### Added
+
+- *(tenant-resolver)* adopt single-root tree topology (by @aviator5)
+
+### Other
+
 - Some real code split (by @ffedoroff) - #1462
 - release (by @github-actions[bot]) - #1381
 - *(modkit)* split required and defaulted module config loading (by @fluiderson)


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#1593](https://github.com/cyberfabric/cyberware-rust/pull/1593) | **Author:** github-actions[bot] | **Opened:** 2026-04-22T20:41:25Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---




## 🤖 New release

* `cf-modkit-odata`: 0.7.0 -> 0.7.1
* `cf-modkit-utils`: 0.6.2 -> 0.6.3
* `cf-modkit-db`: 0.7.1 -> 0.7.2
* `cf-modkit-odata-macros`: 0.6.3 -> 0.6.4
* `cf-modkit-sdk`: 0.6.3 -> 0.6.4
* `cf-modkit`: 0.6.3 -> 0.6.4
* `cf-authz-resolver-sdk`: 0.2.18 -> 0.3.0
* `cf-tenant-resolver-sdk`: 0.2.17 -> 0.3.0
* `cf-credstore-sdk`: 0.1.17 -> 0.1.18
* `cf-modkit-http`: 0.6.2 -> 0.6.3
* `cf-modkit-auth`: 0.6.2 -> 0.6.3
* `cf-oagw-sdk`: 0.4.0 -> 0.4.1
* `cf-oagw`: 0.2.18 -> 0.2.19
* `cf-authn-resolver-sdk`: 0.3.9 -> 0.3.10
* `cf-api-gateway`: 0.2.0 -> 0.2.1
* `cf-authn-resolver`: 0.2.9 -> 0.2.10
* `cf-authz-resolver`: 0.1.16 -> 0.1.17
* `cf-grpc-hub`: 0.1.19 -> 0.2.0
* `cf-credstore`: 0.1.15 -> 0.1.16
* `cf-file-parser`: 0.1.19 -> 0.1.20
* `cf-mini-chat-sdk`: 0.9.0 -> 0.10.0
* `cf-mini-chat`: 0.1.24 -> 0.1.25
* `cf-module-orchestrator`: 0.1.18 -> 0.1.19
* `cf-modkit-node-info`: 0.6.1 -> 0.6.2
* `cf-nodes-registry-sdk`: 0.1.18 -> 0.1.19
* `cf-nodes-registry`: 0.1.18 -> 0.1.19
* `cf-single-tenant-tr-plugin`: 0.1.17 -> 0.1.18
* `cf-static-authn-plugin`: 0.2.6 -> 0.2.7
* `cf-static-authz-plugin`: 0.1.15 -> 0.1.16
* `cf-static-credstore-plugin`: 0.1.13 -> 0.1.14
* `cf-static-tr-plugin`: 0.1.16 -> 0.1.17
* `cf-tenant-resolver`: 0.1.16 -> 0.1.17
* `types-sdk`: 0.6.1 -> 0.6.2
* `cf-types-registry`: 0.1.17 -> 0.1.18
* `cf-modkit-canonical-errors-macro`: 0.6.1
* `cf-modkit-canonical-errors`: 0.6.1 -> 0.7.0

<details><summary><i><b>Changelog</b></i></summary><p>






## `cf-modkit`

<blockquote>


## [0.6.4](https://github.com/constructorfabric/cyberfabric-core/compare/cf-modkit-v0.6.3...cf-modkit-v0.6.4) - 2026-04-22

### Fixed

- *(bootstrap)* unify crypto provider init in main() for both FIPS and non-FIPS modes (by &#2369;MikeFalcon77)
- *(modkit)* pass fresh deadline token to stop() for graceful shutdown

### Other

- release (by &#2369;github-actions[bot]) - #1535
- fix new warnings from Clippy (by &#2369;fluiderson) - #3623
- restore spawned-task approach for two-phase shutdown
- per-module deadline tokens, RunOptions.shutdown_deadline, test guards

### Removed

- removed additional task spawn in run_stop_phase, removed arc wrapper for AromicBool

### Contributors

* &#2369;github-actions[bot]
* &#2369;MikeFalcon77
* &#2369;fluiderson
</blockquote>




## `cf-modkit-http`

<blockquote>


## [0.6.3](https://github.com/constructorfabric/cyberfabric-core/compare/cf-modkit-http-v0.6.2...cf-modkit-http-v0.6.3) - 2026-04-22

### Other

- release (by &#2369;github-actions[bot]) - #1535
- fix new warnings from Clippy (by &#2369;fluiderson) - #3623

### Contributors

* &#2369;github-actions[bot]
* &#2369;fluiderson
</blockquote>

















## `cf-single-tenant-tr-plugin`

<blockquote>


## [0.1.18](https://github.com/constructorfabric/cyberfabric-core/compare/cf-single-tenant-tr-plugin-v0.1.17...cf-single-tenant-tr-plugin-v0.1.18) - 2026-04-22

### Added

- *(tenant-resolver)* adopt single-root tree topology (by &#2369;aviator5)

### Other

- release (by &#2369;github-actions[bot]) - #1535
- Some real code split (by &#2369;ffedoroff) - #1566
- release (by &#2369;github-actions[bot]) - #3638

### Contributors

* &#2369;github-actions[bot]
* &#2369;aviator5
* &#2369;ffedoroff
</blockquote>

## `cf-static-authn-plugin`

<blockquote>


## [0.2.7](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-authn-plugin-v0.2.6...cf-static-authn-plugin-v0.2.7) - 2026-04-22

### Other

- release (by &#2369;github-actions[bot]) - #1535
- Some real code split (by &#2369;ffedoroff) - #1566
- release (by &#2369;github-actions[bot]) - #3638
- *(modkit)* split required and defaulted module config loading (by &#2369;fluiderson)

### Contributors

* &#2369;github-actions[bot]
* &#2369;ffedoroff
* &#2369;fluiderson
</blockquote>

## `cf-static-authz-plugin`

<blockquote>


## [0.1.16](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-authz-plugin-v0.1.15...cf-static-authz-plugin-v0.1.16) - 2026-04-22

### Added

- *(de1101)* add max_inline_test_lines threshold and companion file guard (by &#2369;ffedoroff)
- *(authz)* InGroup/InGroupSubtree predicates + PDP tenant resolution (by &#2369;ffedoroff)

### Other

- release (by &#2369;github-actions[bot]) - #1535
- Some real code split (by &#2369;ffedoroff) - #1566
- release (by &#2369;github-actions[bot]) - #3638
- *(modkit)* split required and defaulted module config loading (by &#2369;fluiderson)

### Contributors

* &#2369;github-actions[bot]
* &#2369;ffedoroff
* &#2369;fluiderson
</blockquote>

## `cf-static-credstore-plugin`

<blockquote>


## [0.1.14](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-credstore-plugin-v0.1.13...cf-static-credstore-plugin-v0.1.14) - 2026-04-22

### Other

- release (by &#2369;github-actions[bot]) - #1535
- Some real code split (by &#2369;ffedoroff) - #1566
- release (by &#2369;github-actions[bot]) - #3638
- *(modkit)* split required and defaulted module config loading (by &#2369;fluiderson)

### Contributors

* &#2369;github-actions[bot]
* &#2369;ffedoroff
* &#2369;fluiderson
</blockquote>

## `cf-static-tr-plugin`

<blockquote>


## [0.1.17](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-tr-plugin-v0.1.16...cf-static-tr-plugin-v0.1.17) - 2026-04-22

### Added

- *(tenant-resolver)* adopt single-root tree topology (by &#2369;aviator5)

### Other

- release (by &#2369;github-actions[bot]) - #1535
- Some real code split (by &#2369;ffedoroff) - #1566
- release (by &#2369;github-actions[bot]) - #3638
- *(modkit)* split required and defaulted module config loading (by &#2369;fluiderson)

### Contributors

* &#2369;github-actions[bot]
* &#2369;aviator5
* &#2369;ffedoroff
* &#2369;fluiderson
</blockquote>


## `types-sdk`

<blockquote>


## [0.6.2](https://github.com/constructorfabric/cyberfabric-core/compare/types-sdk-v0.6.1...types-sdk-v0.6.2) - 2026-04-22

### Other

- release (by &#2369;github-actions[bot]) - #3638

### Contributors

* &#2369;github-actions[bot]
</blockquote>


## `cf-modkit-canonical-errors-macro`

<blockquote>


## [0.6.1](https://github.com/constructorfabric/cyberfabric-core/releases/tag/cf-modkit-canonical-errors-macro-v0.6.1) - 2026-04-22

### Other

- fix new warnings from Clippy (by &#2369;fluiderson) - #3623
- *(errors)* convert resource_error macro to attribute macro (by &#2369;lansfy)

### Contributors

* &#2369;fluiderson
* &#2369;lansfy
</blockquote>

## `cf-modkit-canonical-errors`

<blockquote>


## [0.7.0](https://github.com/constructorfabric/cyberfabric-core/compare/cf-modkit-canonical-errors-v0.6.1...cf-modkit-canonical-errors-v0.7.0) - 2026-04-22

### Other

- release (by &#2369;github-actions[bot]) - #3638
- *(errors)* convert resource_error macro to attribute macro (by &#2369;lansfy)

### Contributors

* &#2369;github-actions[bot]
* &#2369;lansfy
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#1593 -->