### PR TITLE
[PR #1572] feat(oagw): support deploy with static config and read-only management API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2169,6 +2169,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cf-static-types-registry-plugin"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cf-modkit",
+ "cf-modkit-security",
+ "cf-types-registry-sdk",
+ "inventory",
+ "serde",
+ "serde-saphyr 0.0.22",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "cf-system-sdk-directory"
 version = "0.1.34"
 dependencies = [
@@ -4055,6 +4073,7 @@ dependencies = [
  "cf-static-authz-plugin",
  "cf-static-credstore-plugin",
  "cf-static-tr-plugin",
+ "cf-static-types-registry-plugin",
  "cf-tenant-resolver",
  "cf-types-registry",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ members = [
     "examples/oop-modules/calculator/calculator",
     "modules/system/types-registry/types-registry-sdk",
     "modules/system/types-registry/types-registry",
+    "modules/system/types-registry/plugins/static-types-registry-plugin",
     "modules/system/types-sdk",
     "modules/system/types",
     "modules/simple-user-settings/simple-user-settings-sdk",

--- a/modules/system/oagw/oagw/src/api/rest/routes/mod.rs
+++ b/modules/system/oagw/oagw/src/api/rest/routes/mod.rs
@@ -19,13 +19,18 @@ impl AsRef<str> for License {
 impl LicenseFeature for License {}
 
 /// Register all OAGW REST routes with OpenAPI metadata.
+///
+/// When `state.config.management_api_enabled` is `false`, only read-only
+/// endpoints (list / get) and the proxy catch-all are registered. Write
+/// operations (create / update / delete) are omitted.
 pub fn register_routes(
     mut router: Router,
     openapi: &dyn OpenApiRegistry,
     state: AppState,
 ) -> Router {
-    router = upstream::register(router, openapi);
-    router = route::register(router, openapi);
+    let writable = state.config.management_api_enabled;
+    router = upstream::register(router, openapi, writable);
+    router = route::register(router, openapi, writable);
     router = proxy::register(router);
     router.layer(axum::Extension(state))
 }

--- a/modules/system/oagw/oagw/src/api/rest/routes/route.rs
+++ b/modules/system/oagw/oagw/src/api/rest/routes/route.rs
@@ -8,24 +8,30 @@ use super::License;
 
 const API_TAG: &str = "OAGW Routes";
 
-pub(super) fn register(mut router: Router, openapi: &dyn OpenApiRegistry) -> Router {
+pub(super) fn register(
+    mut router: Router,
+    openapi: &dyn OpenApiRegistry,
+    writable: bool,
+) -> Router {
     // POST /oagw/v1/routes — Create route
-    router = OperationBuilder::post("/oagw/v1/routes")
-        .operation_id("oagw.create_route")
-        .summary("Create route")
-        .description("Create a new route mapping for an upstream service")
-        .tag(API_TAG)
-        .authenticated()
-        .require_license_features::<License>([])
-        .json_request::<dto::CreateRouteRequest>(openapi, "Route configuration")
-        .handler(handlers::route::create_route)
-        .json_response_with_schema::<dto::RouteResponse>(
-            openapi,
-            http::StatusCode::CREATED,
-            "Created route",
-        )
-        .standard_errors(openapi)
-        .register(router, openapi);
+    if writable {
+        router = OperationBuilder::post("/oagw/v1/routes")
+            .operation_id("oagw.create_route")
+            .summary("Create route")
+            .description("Create a new route mapping for an upstream service")
+            .tag(API_TAG)
+            .authenticated()
+            .require_license_features::<License>([])
+            .json_request::<dto::CreateRouteRequest>(openapi, "Route configuration")
+            .handler(handlers::route::create_route)
+            .json_response_with_schema::<dto::RouteResponse>(
+                openapi,
+                http::StatusCode::CREATED,
+                "Created route",
+            )
+            .standard_errors(openapi)
+            .register(router, openapi);
+    }
 
     // GET /oagw/v1/routes/{id} — Get route
     router = OperationBuilder::get("/oagw/v1/routes/{id}")
@@ -45,38 +51,40 @@ pub(super) fn register(mut router: Router, openapi: &dyn OpenApiRegistry) -> Rou
         .standard_errors(openapi)
         .register(router, openapi);
 
-    // PUT /oagw/v1/routes/{id} — Update route
-    router = OperationBuilder::put("/oagw/v1/routes/{id}")
-        .operation_id("oagw.update_route")
-        .summary("Update route")
-        .description("Replace an existing route configuration")
-        .tag(API_TAG)
-        .path_param("id", "Route GTS identifier")
-        .authenticated()
-        .require_license_features::<License>([])
-        .json_request::<dto::UpdateRouteRequest>(openapi, "Route update data")
-        .handler(handlers::route::update_route)
-        .json_response_with_schema::<dto::RouteResponse>(
-            openapi,
-            http::StatusCode::OK,
-            "Updated route",
-        )
-        .standard_errors(openapi)
-        .register(router, openapi);
+    if writable {
+        // PUT /oagw/v1/routes/{id} — Update route
+        router = OperationBuilder::put("/oagw/v1/routes/{id}")
+            .operation_id("oagw.update_route")
+            .summary("Update route")
+            .description("Replace an existing route configuration")
+            .tag(API_TAG)
+            .path_param("id", "Route GTS identifier")
+            .authenticated()
+            .require_license_features::<License>([])
+            .json_request::<dto::UpdateRouteRequest>(openapi, "Route update data")
+            .handler(handlers::route::update_route)
+            .json_response_with_schema::<dto::RouteResponse>(
+                openapi,
+                http::StatusCode::OK,
+                "Updated route",
+            )
+            .standard_errors(openapi)
+            .register(router, openapi);
 
-    // DELETE /oagw/v1/routes/{id} — Delete route
-    router = OperationBuilder::delete("/oagw/v1/routes/{id}")
-        .operation_id("oagw.delete_route")
-        .summary("Delete route")
-        .description("Delete a route by its GTS identifier")
-        .tag(API_TAG)
-        .path_param("id", "Route GTS identifier")
-        .authenticated()
-        .require_license_features::<License>([])
-        .handler(handlers::route::delete_route)
-        .json_response(http::StatusCode::NO_CONTENT, "Route deleted")
-        .standard_errors(openapi)
-        .register(router, openapi);
+        // DELETE /oagw/v1/routes/{id} — Delete route
+        router = OperationBuilder::delete("/oagw/v1/routes/{id}")
+            .operation_id("oagw.delete_route")
+            .summary("Delete route")
+            .description("Delete a route by its GTS identifier")
+            .tag(API_TAG)
+            .path_param("id", "Route GTS identifier")
+            .authenticated()
+            .require_license_features::<License>([])
+            .handler(handlers::route::delete_route)
+            .json_response(http::StatusCode::NO_CONTENT, "Route deleted")
+            .standard_errors(openapi)
+            .register(router, openapi);
+    }
 
     // GET /oagw/v1/routes — List routes (optional upstream_id filter)
     router = OperationBuilder::get("/oagw/v1/routes")

--- a/modules/system/oagw/oagw/src/api/rest/routes/upstream.rs
+++ b/modules/system/oagw/oagw/src/api/rest/routes/upstream.rs
@@ -8,24 +8,30 @@ use super::License;
 
 const API_TAG: &str = "OAGW Upstreams";
 
-pub(super) fn register(mut router: Router, openapi: &dyn OpenApiRegistry) -> Router {
+pub(super) fn register(
+    mut router: Router,
+    openapi: &dyn OpenApiRegistry,
+    writable: bool,
+) -> Router {
     // POST /oagw/v1/upstreams — Create upstream
-    router = OperationBuilder::post("/oagw/v1/upstreams")
-        .operation_id("oagw.create_upstream")
-        .summary("Create upstream")
-        .description("Create a new upstream service configuration")
-        .tag(API_TAG)
-        .authenticated()
-        .require_license_features::<License>([])
-        .json_request::<dto::CreateUpstreamRequest>(openapi, "Upstream configuration")
-        .handler(handlers::upstream::create_upstream)
-        .json_response_with_schema::<dto::UpstreamResponse>(
-            openapi,
-            http::StatusCode::CREATED,
-            "Created upstream",
-        )
-        .standard_errors(openapi)
-        .register(router, openapi);
+    if writable {
+        router = OperationBuilder::post("/oagw/v1/upstreams")
+            .operation_id("oagw.create_upstream")
+            .summary("Create upstream")
+            .description("Create a new upstream service configuration")
+            .tag(API_TAG)
+            .authenticated()
+            .require_license_features::<License>([])
+            .json_request::<dto::CreateUpstreamRequest>(openapi, "Upstream configuration")
+            .handler(handlers::upstream::create_upstream)
+            .json_response_with_schema::<dto::UpstreamResponse>(
+                openapi,
+                http::StatusCode::CREATED,
+                "Created upstream",
+            )
+            .standard_errors(openapi)
+            .register(router, openapi);
+    }
 
     // GET /oagw/v1/upstreams — List upstreams
     router = OperationBuilder::get("/oagw/v1/upstreams")
@@ -69,38 +75,40 @@ pub(super) fn register(mut router: Router, openapi: &dyn OpenApiRegistry) -> Rou
         .standard_errors(openapi)
         .register(router, openapi);
 
-    // PUT /oagw/v1/upstreams/{id} — Update upstream
-    router = OperationBuilder::put("/oagw/v1/upstreams/{id}")
-        .operation_id("oagw.update_upstream")
-        .summary("Update upstream")
-        .description("Replace an existing upstream service configuration")
-        .tag(API_TAG)
-        .path_param("id", "Upstream GTS identifier")
-        .authenticated()
-        .require_license_features::<License>([])
-        .json_request::<dto::UpdateUpstreamRequest>(openapi, "Upstream update data")
-        .handler(handlers::upstream::update_upstream)
-        .json_response_with_schema::<dto::UpstreamResponse>(
-            openapi,
-            http::StatusCode::OK,
-            "Updated upstream",
-        )
-        .standard_errors(openapi)
-        .register(router, openapi);
+    if writable {
+        // PUT /oagw/v1/upstreams/{id} — Update upstream
+        router = OperationBuilder::put("/oagw/v1/upstreams/{id}")
+            .operation_id("oagw.update_upstream")
+            .summary("Update upstream")
+            .description("Replace an existing upstream service configuration")
+            .tag(API_TAG)
+            .path_param("id", "Upstream GTS identifier")
+            .authenticated()
+            .require_license_features::<License>([])
+            .json_request::<dto::UpdateUpstreamRequest>(openapi, "Upstream update data")
+            .handler(handlers::upstream::update_upstream)
+            .json_response_with_schema::<dto::UpstreamResponse>(
+                openapi,
+                http::StatusCode::OK,
+                "Updated upstream",
+            )
+            .standard_errors(openapi)
+            .register(router, openapi);
 
-    // DELETE /oagw/v1/upstreams/{id} — Delete upstream
-    router = OperationBuilder::delete("/oagw/v1/upstreams/{id}")
-        .operation_id("oagw.delete_upstream")
-        .summary("Delete upstream")
-        .description("Delete an upstream and cascade-delete its routes")
-        .tag(API_TAG)
-        .path_param("id", "Upstream GTS identifier")
-        .authenticated()
-        .require_license_features::<License>([])
-        .handler(handlers::upstream::delete_upstream)
-        .json_response(http::StatusCode::NO_CONTENT, "Upstream deleted")
-        .standard_errors(openapi)
-        .register(router, openapi);
+        // DELETE /oagw/v1/upstreams/{id} — Delete upstream
+        router = OperationBuilder::delete("/oagw/v1/upstreams/{id}")
+            .operation_id("oagw.delete_upstream")
+            .summary("Delete upstream")
+            .description("Delete an upstream and cascade-delete its routes")
+            .tag(API_TAG)
+            .path_param("id", "Upstream GTS identifier")
+            .authenticated()
+            .require_license_features::<License>([])
+            .handler(handlers::upstream::delete_upstream)
+            .json_response(http::StatusCode::NO_CONTENT, "Upstream deleted")
+            .standard_errors(openapi)
+            .register(router, openapi);
+    }
 
     router
 }

--- a/modules/system/oagw/oagw/src/config.rs
+++ b/modules/system/oagw/oagw/src/config.rs
@@ -48,6 +48,12 @@ pub struct OagwConfig {
     /// will use ALPN H2H1 negotiation). Default: 3600 (1 hour).
     #[serde(default = "default_protocol_cache_ttl_secs")]
     pub protocol_cache_ttl_secs: u64,
+    /// Whether the upstream/route management REST APIs are enabled.
+    /// When `true`, all CRUD endpoints are registered. When `false`, only
+    /// read-only endpoints (list / get) are available — write operations
+    /// (create / update / delete) are omitted. Default: `true`.
+    #[serde(default = "default_true")]
+    pub management_api_enabled: bool,
 }
 
 impl Default for OagwConfig {
@@ -63,8 +69,13 @@ impl Default for OagwConfig {
             websocket_max_frame_size_bytes: None,
             streaming_idle_timeout_secs: default_streaming_idle_timeout_secs(),
             protocol_cache_ttl_secs: default_protocol_cache_ttl_secs(),
+            management_api_enabled: true,
         }
     }
+}
+
+fn default_true() -> bool {
+    true
 }
 
 fn default_proxy_timeout_secs() -> u64 {
@@ -126,6 +137,7 @@ pub struct RuntimeConfig {
     pub websocket_close_timeout_secs: u64,
     pub websocket_max_frame_size_bytes: Option<usize>,
     pub streaming_idle_timeout_secs: u64,
+    pub management_api_enabled: bool,
 }
 
 impl From<&OagwConfig> for RuntimeConfig {
@@ -136,6 +148,7 @@ impl From<&OagwConfig> for RuntimeConfig {
             websocket_close_timeout_secs: cfg.websocket_close_timeout_secs,
             websocket_max_frame_size_bytes: cfg.websocket_max_frame_size_bytes,
             streaming_idle_timeout_secs: cfg.streaming_idle_timeout_secs,
+            management_api_enabled: cfg.management_api_enabled,
         }
     }
 }
@@ -190,6 +203,7 @@ impl fmt::Debug for OagwConfig {
                 &self.streaming_idle_timeout_secs,
             )
             .field("protocol_cache_ttl_secs", &self.protocol_cache_ttl_secs)
+            .field("management_api_enabled", &self.management_api_enabled)
             .finish()
     }
 }

--- a/modules/system/oagw/oagw/src/domain/test_support.rs
+++ b/modules/system/oagw/oagw/src/domain/test_support.rs
@@ -673,6 +673,7 @@ pub fn build_test_app_state(
                 websocket_close_timeout_secs: 5,
                 websocket_max_frame_size_bytes: None,
                 streaming_idle_timeout_secs: 300,
+                management_api_enabled: true,
             },
         },
         facade,

--- a/modules/system/oagw/oagw/src/module.rs
+++ b/modules/system/oagw/oagw/src/module.rs
@@ -179,6 +179,7 @@ impl Module for OutboundApiGatewayModule {
         };
 
         self.state.store(Some(Arc::new(app_state)));
+
         Ok(())
     }
 }
@@ -276,8 +277,6 @@ impl RestApiCapability for OutboundApiGatewayModule {
         router: axum::Router,
         openapi: &dyn OpenApiRegistry,
     ) -> anyhow::Result<axum::Router> {
-        info!("Registering OAGW REST routes");
-
         let state = self
             .state
             .load()
@@ -285,6 +284,12 @@ impl RestApiCapability for OutboundApiGatewayModule {
             .ok_or_else(|| anyhow::anyhow!("OAGW module not initialized — call init() first"))?
             .as_ref()
             .clone();
+
+        let mgmt_enabled = state.config.management_api_enabled;
+        info!(
+            management_api_enabled = mgmt_enabled,
+            "Registering OAGW REST routes"
+        );
 
         let router = routes::register_routes(router, openapi, state);
         Ok(router)

--- a/modules/system/types-registry/plugins/static-types-registry-plugin/Cargo.toml
+++ b/modules/system/types-registry/plugins/static-types-registry-plugin/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "cf-static-types-registry-plugin"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Types Registry plugin that seeds static GTS entities from YAML configuration"
+repository.workspace = true
+keywords = ["cyberfabric", "cyberfabric-module"]
+
+[lib]
+name = "static_types_registry_plugin"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Local dependencies
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.5", path = "../../types-registry-sdk" }
+
+# ModKit dependencies
+modkit = { workspace = true }
+modkit-security = { workspace = true }
+
+# Async runtime
+async-trait = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# UUID
+uuid = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+# Required by modkit::module macro
+inventory = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }
+serde-saphyr = { workspace = true }

--- a/modules/system/types-registry/plugins/static-types-registry-plugin/src/config.rs
+++ b/modules/system/types-registry/plugins/static-types-registry-plugin/src/config.rs
@@ -1,0 +1,110 @@
+use serde::Deserialize;
+use uuid::Uuid;
+
+/// Plugin configuration for seeding static GTS entities into the Types Registry.
+///
+/// Entities are registered during `init()` in the configuration phase (before
+/// ready-mode validation), following the same lifecycle as programmatic
+/// registrations from other modules.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct StaticTypesRegistryPluginConfig {
+    /// Default tenant ID injected into entities that don't specify one.
+    ///
+    /// When an entity in `entities` has no `tenant_id` field, this value is
+    /// automatically inserted before registration. Defaults to
+    /// `modkit_security::constants::DEFAULT_TENANT_ID`.
+    #[serde(default = "default_tenant_id")]
+    pub default_tenant_id: Uuid,
+
+    /// Raw GTS entity JSON values to register at startup.
+    ///
+    /// Each entry must be a valid GTS entity with at least an `$id` (or
+    /// `gtsId`/`id`) field. Entities are registered in order.
+    pub entities: Vec<serde_json::Value>,
+}
+
+fn default_tenant_id() -> Uuid {
+    modkit_security::constants::DEFAULT_TENANT_ID
+}
+
+impl Default for StaticTypesRegistryPluginConfig {
+    fn default() -> Self {
+        Self {
+            default_tenant_id: default_tenant_id(),
+            entities: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_defaults_to_empty_entities() {
+        let cfg = StaticTypesRegistryPluginConfig::default();
+        assert!(cfg.entities.is_empty());
+        assert_eq!(
+            cfg.default_tenant_id,
+            modkit_security::constants::DEFAULT_TENANT_ID
+        );
+    }
+
+    #[test]
+    fn config_deserializes_empty_object() {
+        let cfg: StaticTypesRegistryPluginConfig = serde_json::from_str("{}").unwrap();
+        assert!(cfg.entities.is_empty());
+        assert_eq!(
+            cfg.default_tenant_id,
+            modkit_security::constants::DEFAULT_TENANT_ID
+        );
+    }
+
+    #[test]
+    fn config_deserializes_entities() {
+        let json = r#"{"entities": [{"$id": "gts.x.test.v1~abc123", "tenant_id": "00000000-0000-0000-0000-000000000000"}]}"#;
+        let cfg: StaticTypesRegistryPluginConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.entities.len(), 1);
+        assert_eq!(
+            cfg.entities[0]["$id"].as_str().unwrap(),
+            "gts.x.test.v1~abc123"
+        );
+    }
+
+    #[test]
+    fn config_custom_default_tenant_id() {
+        let json = r#"{"default_tenant_id": "11111111-1111-1111-1111-111111111111", "entities": []}"#;
+        let cfg: StaticTypesRegistryPluginConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            cfg.default_tenant_id,
+            uuid::uuid!("11111111-1111-1111-1111-111111111111")
+        );
+    }
+
+    #[test]
+    fn config_rejects_unknown_fields() {
+        let json = r#"{"entities": [], "unexpected": true}"#;
+        let result = serde_json::from_str::<StaticTypesRegistryPluginConfig>(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn config_yaml_round_trip() {
+        let yaml = r#"
+entities:
+  - $id: "gts.x.core.oagw.upstream.v1~abc123"
+    server:
+      endpoints:
+        - scheme: https
+          host: api.openai.com
+          port: 443
+    protocol: "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1"
+    enabled: true
+    tags: []
+"#;
+        let cfg: StaticTypesRegistryPluginConfig = serde_saphyr::from_str(yaml).unwrap();
+        assert_eq!(cfg.entities.len(), 1);
+    }
+}

--- a/modules/system/types-registry/plugins/static-types-registry-plugin/src/lib.rs
+++ b/modules/system/types-registry/plugins/static-types-registry-plugin/src/lib.rs
@@ -1,0 +1,6 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+pub mod config;
+pub mod module;
+
+pub use module::StaticTypesRegistryPlugin;

--- a/modules/system/types-registry/plugins/static-types-registry-plugin/src/module.rs
+++ b/modules/system/types-registry/plugins/static-types-registry-plugin/src/module.rs
@@ -1,0 +1,77 @@
+use async_trait::async_trait;
+use modkit::Module;
+use modkit::context::ModuleCtx;
+use tracing::info;
+use types_registry_sdk::{RegisterResult, RegisterSummary, TypesRegistryClient};
+
+use crate::config::StaticTypesRegistryPluginConfig;
+
+/// Static types-registry plugin module.
+///
+/// Seeds pre-configured GTS entities into the Types Registry from YAML configuration.
+#[modkit::module(
+    name = "static-types-registry-plugin",
+    deps = ["types-registry"]
+)]
+pub struct StaticTypesRegistryPlugin;
+
+impl Default for StaticTypesRegistryPlugin {
+    fn default() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Module for StaticTypesRegistryPlugin {
+    async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        let cfg: StaticTypesRegistryPluginConfig = ctx.config_or_default()?;
+
+        if cfg.entities.is_empty() {
+            info!("No static entities configured — nothing to register");
+            return Ok(());
+        }
+
+        let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
+
+        let tenant_id_str = cfg.default_tenant_id.to_string();
+        let entities: Vec<serde_json::Value> = cfg
+            .entities
+            .into_iter()
+            .map(|mut v| {
+                if let Some(obj) = v.as_object_mut() {
+                    obj.entry("tenant_id")
+                        .or_insert_with(|| serde_json::Value::String(tenant_id_str.clone()));
+                }
+                v
+            })
+            .collect();
+
+        let entity_count = entities.len();
+        let results = registry.register(entities).await?;
+        let summary = RegisterSummary::from_results(&results);
+
+        if !summary.all_succeeded() {
+            for result in &results {
+                if let RegisterResult::Err { gts_id, error } = result {
+                    tracing::error!(
+                        gts_id = gts_id.as_deref().unwrap_or("<unknown>"),
+                        error = %error,
+                        "Failed to register static GTS entity"
+                    );
+                }
+            }
+            anyhow::bail!(
+                "Static types-registry plugin: {}/{} entities failed to register",
+                summary.failed,
+                summary.total()
+            );
+        }
+
+        info!(
+            count = entity_count,
+            "Registered static GTS entities in types-registry"
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#1572](https://github.com/cyberfabric/cyberware-rust/pull/1572) | **Author:** mattgarmon | **Opened:** 2026-04-20T22:14:08Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `management_api_enabled` configuration flag to conditionally gate write operations; read-only endpoints remain available when disabled.
  * Introduced a new static types registry plugin for registering entity types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#1572 -->