### PR TITLE
[PR #1513] chore(deps): Bump ureq from 2.12.1 to 3.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,7 +778,7 @@ dependencies = [
  "prost-types",
  "tonic",
  "tonic-prost",
- "ureq 3.3.0",
+ "ureq",
 ]
 
 [[package]]
@@ -1122,7 +1122,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
- "ureq 2.12.1",
+ "ureq",
  "utoipa",
  "uuid",
 ]
@@ -7055,7 +7055,7 @@ checksum = "546b4da4f679832602a8f8ab8ddc10b6b1d2e1a13b4f9dddcaee499436fa06ad"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "nohash-hasher",
@@ -8619,33 +8619,19 @@ dependencies = [
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64 0.22.1",
- "flate2",
- "log",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "url",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "ureq"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
+ "flate2",
  "log",
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -424,7 +424,7 @@ prost-build = "0.14"
 tonic-prost-build = "0.14"
 
 # Blocking HTTP client (for build scripts)
-ureq = "2.12"
+ureq = "3.3"
 
 # Time handling
 time = { version = "0.3.47", features = ["serde", "formatting", "parsing"] }


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#1513](https://github.com/cyberfabric/cyberware-rust/pull/1513) | **Author:** dependabot[bot] | **Opened:** 2026-04-15T09:09:17Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

Bumps [ureq](https://github.com/algesten/ureq) from 2.12.1 to 3.3.0.
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/algesten/ureq/blob/main/CHANGELOG.md">ureq's changelog</a>.</em></p>
<blockquote>
<h1>3.3.0</h1>
<ul>
<li>Bump MSRV 1.71 -&gt; 1.85, edition 2024 <a href="https://redirect.github.com/algesten/ureq/issues/1167">#1691</a></li>
</ul>
<h1>3.2.1</h1>
<ul>
<li>Switch archived utf-8 crate for utf8-zero <a href="https://redirect.github.com/algesten/ureq/issues/1163">#1692</a></li>
</ul>
<h1>3.2.0</h1>
<ul>
<li>Strip Content-Encoding/Content-Length headers after decompression <a href="https://redirect.github.com/algesten/ureq/issues/1156">#1696</a></li>
<li>Timeout per resolved ip for try_connect <a href="https://redirect.github.com/algesten/ureq/issues/1152">#3690</a></li>
<li>Fix body header bug on redirect <a href="https://redirect.github.com/algesten/ureq/issues/1140">#3693</a></li>
<li>ureq-proto 0.5.3 to fix unsolicited 100-continue <a href="https://redirect.github.com/algesten/ureq/issues/1139">#2938</a></li>
<li>Make socks5:// locally resolve before calling proxy <a href="https://redirect.github.com/algesten/ureq/issues/1138">#3694</a></li>
<li>Add socks5h:// which DOESN'T locally resolve before calling proxy <a href="https://redirect.github.com/algesten/ureq/issues/1138">#3694</a></li>
</ul>
<h1>3.1.4</h1>
<ul>
<li>Set content-type with new Multipart form <a href="https://redirect.github.com/algesten/ureq/issues/1133">#1720</a></li>
</ul>
<h1>3.1.3</h1>
<ul>
<li>Fix short read with multi-byte charset <a href="https://redirect.github.com/algesten/ureq/issues/1131">#2935</a></li>
<li>Replace rustls-pemfile usage with rustls-pki-types <a href="https://redirect.github.com/algesten/ureq/issues/1122">#1726</a></li>
<li>Support for env NO_PROXY and proxy config <a href="https://redirect.github.com/algesten/ureq/issues/1118">#2929</a></li>
<li>Experimental multi-part form support <a href="https://redirect.github.com/algesten/ureq/issues/1102">#2913</a></li>
</ul>
<h1>3.1.2</h1>
<ul>
<li>Fix bug when query is after host &quot;example.com?query&quot; <a href="https://redirect.github.com/algesten/ureq/issues/1115">#2926</a></li>
</ul>
<h1>3.1.1</h1>
<ul>
<li>Fix regression in MSRV (hold back native-tls) <a href="https://redirect.github.com/algesten/ureq/issues/1113">#2924</a></li>
<li>Fix edge case regression when setting request header Content-Length: 0 <a href="https://redirect.github.com/algesten/ureq/issues/1109">#2920</a></li>
</ul>
<h1>3.1.0</h1>
<p>DECISION: webpki-roots and webpki-root-certs goes from pre-release (0.26)
to stable release (1.0.0). This is potentially a big change
for ureq users. We release this as semver minor.</p>
<ul>
<li>Bump all deps to latest <a href="https://redirect.github.com/algesten/ureq/issues/1104">#2915</a></li>
<li>Fixes to CONNECT to follow spec <a href="https://redirect.github.com/algesten/ureq/issues/1103">#2914</a></li>
<li>Send Content-Length for File <a href="https://redirect.github.com/algesten/ureq/issues/1100">#2911</a></li>
<li>native-tls transport capture and surface underlying errors <a href="https://redirect.github.com/algesten/ureq/issues/1093">#2906</a></li>
<li>Bump webpki-roots/webpki-root-certs to 1.0.0 <a href="https://redirect.github.com/algesten/ureq/issues/1089">#2902</a></li>
<li>Bump rustls-platform-verifier to 0.6.0 <a href="https://redirect.github.com/algesten/ureq/issues/1089">#2902</a></li>
<li>Allow the license CDLA-Permissive-2.0 <a href="https://redirect.github.com/algesten/ureq/issues/1089">#2902</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/algesten/ureq/commit/b2adbf00f9a7ac0e2fbcb39d23c1b4f3da723e5c"><code>b2adbf0</code></a> 3.3.0</li>
<li><a href="https://github.com/algesten/ureq/commit/76622199969c0e71da2bb426e136ded487b1ccc9"><code>7662219</code></a> Bump MSRV 1.71 -&gt; 1.85, edition 2024</li>
<li><a href="https://github.com/algesten/ureq/commit/eb51f2c57da93137b9260b8a50e99e709870c41b"><code>eb51f2c</code></a> 3.2.1</li>
<li><a href="https://github.com/algesten/ureq/commit/ad49981a91c32c36ed9bce3e9670d0daeeb448a9"><code>ad49981</code></a> Bump deps to fix cargo-deny RUSTSEC</li>
<li><a href="https://github.com/algesten/ureq/commit/08785cb67f3f140d112f00b0e1bf66c46d0cd9f3"><code>08785cb</code></a> Switch out utf-8 crate with utf8-zero</li>
<li><a href="https://github.com/algesten/ureq/commit/9ef2153b2242e65a4eb51fc442b4be0e442840ee"><code>9ef2153</code></a> Clarify that json feature is disabled by default</li>
<li><a href="https://github.com/algesten/ureq/commit/eb2539d0c9246162ca25fe284e3b399ad69fcc00"><code>eb2539d</code></a> Fix misleading unsafe wording in crate docs</li>
<li><a href="https://github.com/algesten/ureq/commit/b45d3d20f81f81a3e24e1b8d77495694f3f5bf4e"><code>b45d3d2</code></a> Fix cargo-deny advisory failures</li>
<li><a href="https://github.com/algesten/ureq/commit/852b8043553f8ae47a78c639c0f60c257ae46adf"><code>852b804</code></a> 3.2.0</li>
<li><a href="https://github.com/algesten/ureq/commit/378f768300cd312d824e44bc17185620cd96adff"><code>378f768</code></a> Update deny.toml given current dependencies</li>
<li>Additional commits viewable in <a href="https://github.com/algesten/ureq/compare/2.12.1...3.3.0">compare view</a></li>
</ul>
</details>
<br />

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#1513 -->