### PR TITLE
[PR #1512] chore(deps): bump rand from 0.9.4 to 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,7 +1817,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "pin-project-lite",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
@@ -1949,7 +1949,7 @@ version = "0.6.3"
 dependencies = [
  "anyhow",
  "cf-modkit-security",
- "rand 0.9.4",
+ "rand 0.10.1",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -6518,7 +6518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91bb5030596a3d442c0866ac68afe29c14ba558e77c726dcdf7016b0dbb359d9"
 dependencies = [
  "arrayvec",
- "hashbrown 0.17.0",
+ "hashbrown 0.12.3",
  "parking_lot",
  "rand 0.8.5",
 ]
@@ -6854,7 +6854,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -8365,7 +8365,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -353,7 +353,7 @@ http-body = "1"
 
 # HTTP client (default-tls = rustls + aws-lc-rs in 0.13)
 reqwest = { version = "0.13", features = ["stream"] }
-rand = "0.9"
+rand = "0.10"
 
 # Synchronous locks for better performance
 parking_lot = "0.12"


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#1512](https://github.com/cyberfabric/cyberware-rust/pull/1512) | **Author:** dependabot[bot] | **Opened:** 2026-04-15T09:08:24Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

Bumps [rand](https://github.com/rust-random/rand) from 0.9.4 to 0.10.1.
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/rust-random/rand/blob/master/CHANGELOG.md">rand's changelog</a>.</em></p>
<blockquote>
<h2>[0.10.1] — 2026-02-11</h2>
<p>This release includes a fix for a soundness bug; see <a href="https://redirect.github.com/rust-random/rand/issues/1763">#3333</a>.</p>
<h3>Changes</h3>
<ul>
<li>Document panic behavior of <code>make_rng</code> and add <code>#[track_caller]</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1761">#3331</a>)</li>
<li>Deprecate feature <code>log</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1763">#3333</a>)</li>
</ul>
<p><a href="https://redirect.github.com/rust-random/rand/issues/1761">#3331</a>: <a href="https://redirect.github.com/rust-random/rand/pull/1761">rust-random/rand#1761</a>
<a href="https://redirect.github.com/rust-random/rand/issues/1763">#3333</a>: <a href="https://redirect.github.com/rust-random/rand/pull/1763">rust-random/rand#1763</a></p>
<h2>[0.10.0] - 2026-02-08</h2>
<h3>Changes</h3>
<ul>
<li>The dependency on <code>rand_chacha</code> has been replaced with a dependency on <code>chacha20</code>. This changes the implementation behind <code>StdRng</code>, but the output remains the same. There may be some API breakage when using the ChaCha-types directly as these are now the ones in <code>chacha20</code> instead of <code>rand_chacha</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1642">#3227</a>).</li>
<li>Rename fns <code>IndexedRandom::choose_multiple</code> -&gt; <code>sample</code>, <code>choose_multiple_array</code> -&gt; <code>sample_array</code>, <code>choose_multiple_weighted</code> -&gt; <code>sample_weighted</code>, struct <code>SliceChooseIter</code> -&gt; <code>IndexedSamples</code> and fns <code>IteratorRandom::choose_multiple</code> -&gt; <code>sample</code>, <code>choose_multiple_fill</code> -&gt; <code>sample_fill</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1632">#3217</a>)</li>
<li>Use Edition 2024 and MSRV 1.85 (<a href="https://redirect.github.com/rust-random/rand/issues/1653">#3238</a>)</li>
<li>Let <code>Fill</code> be implemented for element types, not sliceable types (<a href="https://redirect.github.com/rust-random/rand/issues/1652">#3237</a>)</li>
<li>Fix <code>OsError::raw_os_error</code> on UEFI targets by returning <code>Option&lt;usize&gt;</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1665">#3250</a>)</li>
<li>Replace fn <code>TryRngCore::read_adapter(..) -&gt; RngReadAdapter</code> with simpler struct <code>RngReader</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1669">#3254</a>)</li>
<li>Remove fns <code>SeedableRng::from_os_rng</code>, <code>try_from_os_rng</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1674">#3259</a>)</li>
<li>Remove <code>Clone</code> support for <code>StdRng</code>, <code>ReseedingRng</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1677">#3262</a>)</li>
<li>Use <code>postcard</code> instead of <code>bincode</code> to test the serde feature (<a href="https://redirect.github.com/rust-random/rand/issues/1693">#3278</a>)</li>
<li>Avoid excessive allocation in <code>IteratorRandom::sample</code> when <code>amount</code> is much larger than iterator size (<a href="https://redirect.github.com/rust-random/rand/issues/1695">#3280</a>)</li>
<li>Rename <code>os_rng</code> -&gt; <code>sys_rng</code>, <code>OsRng</code> -&gt; <code>SysRng</code>, <code>OsError</code> -&gt; <code>SysError</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1697">#3282</a>)</li>
<li>Rename <code>Rng</code> -&gt; <code>RngExt</code> as upstream <code>rand_core</code> has renamed <code>RngCore</code> -&gt; <code>Rng</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1717">#3302</a>)</li>
</ul>
<h3>Additions</h3>
<ul>
<li>Add fns <code>IndexedRandom::choose_iter</code>, <code>choose_weighted_iter</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1632">#3217</a>)</li>
<li>Pub export <code>Xoshiro128PlusPlus</code>, <code>Xoshiro256PlusPlus</code> prngs (<a href="https://redirect.github.com/rust-random/rand/issues/1649">#3234</a>)</li>
<li>Pub export <code>ChaCha8Rng</code>, <code>ChaCha12Rng</code>, <code>ChaCha20Rng</code> behind <code>chacha</code> feature (<a href="https://redirect.github.com/rust-random/rand/issues/1659">#3244</a>)</li>
<li>Fn <code>rand::make_rng() -&gt; R where R: SeedableRng</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1734">#3588</a>)</li>
</ul>
<h3>Removals</h3>
<ul>
<li>Removed <code>ReseedingRng</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1722">#3592</a>)</li>
<li>Removed unused feature &quot;nightly&quot; (<a href="https://redirect.github.com/rust-random/rand/issues/1732">#3590</a>)</li>
<li>Removed feature <code>small_rng</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1732">#3590</a>)</li>
</ul>
<p><a href="https://redirect.github.com/rust-random/rand/issues/1632">#3217</a>: <a href="https://redirect.github.com/rust-random/rand/pull/1632">rust-random/rand#1632</a>
<a href="https://redirect.github.com/rust-random/rand/issues/1642">#3227</a>: <a href="https://redirect.github.com/rust-random/rand/pull/1642">rust-random/rand#1642</a>
<a href="https://redirect.github.com/rust-random/rand/issues/1649">#3234</a>: <a href="https://redirect.github.com/rust-random/rand/pull/1649">rust-random/rand#1649</a>
<a href="https://redirect.github.com/rust-random/rand/issues/1652">#3237</a>: <a href="https://redirect.github.com/rust-random/rand/pull/1652">rust-random/rand#1652</a>
<a href="https://redirect.github.com/rust-random/rand/issues/1653">#3238</a>: <a href="https://redirect.github.com/rust-random/rand/pull/1653">rust-random/rand#1653</a>
<a href="https://redirect.github.com/rust-random/rand/issues/1659">#3244</a>: <a href="https://redirect.github.com/rust-random/rand/pull/1659">rust-random/rand#1659</a>
<a href="https://redirect.github.com/rust-random/rand/issues/1665">#3250</a>: <a href="https://redirect.github.com/rust-random/rand/pull/1665">rust-random/rand#1665</a>
<a href="https://redirect.github.com/rust-random/rand/issues/1669">#3254</a>: <a href="https://redirect.github.com/rust-random/rand/pull/1669">rust-random/rand#1669</a>
<a href="https://redirect.github.com/rust-random/rand/issues/1674">#3259</a>: <a href="https://redirect.github.com/rust-random/rand/pull/1674">rust-random/rand#1674</a>
<a href="https://redirect.github.com/rust-random/rand/issues/1677">#3262</a>: <a href="https://redirect.github.com/rust-random/rand/pull/1677">rust-random/rand#1677</a>
<a href="https://redirect.github.com/rust-random/rand/issues/1693">#3278</a>: <a href="https://redirect.github.com/rust-random/rand/pull/1693">rust-random/rand#1693</a>
<a href="https://redirect.github.com/rust-random/rand/issues/1695">#3280</a>: <a href="https://redirect.github.com/rust-random/rand/pull/1695">rust-random/rand#1695</a>
<a href="https://redirect.github.com/rust-random/rand/issues/1697">#3282</a>: <a href="https://redirect.github.com/rust-random/rand/pull/1697">rust-random/rand#1697</a></p>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/rust-random/rand/commit/27ff4cb7ced3122a1f677fc248c1a07e59ddc8cd"><code>27ff4cb</code></a> Prepare v0.10.1: deprecate feature <code>log</code> (<a href="https://redirect.github.com/rust-random/rand/issues/1763">#3333</a>)</li>
<li><a href="https://github.com/rust-random/rand/commit/98d06386dc4e1d1c89a91f4e483d571921c29ecf"><code>98d0638</code></a> make_rng: document panic and add #[track_caller] (<a href="https://redirect.github.com/rust-random/rand/issues/1761">#3331</a>)</li>
<li><a href="https://github.com/rust-random/rand/commit/54e5eaaa7ac11af3aa60b5ccc486182189e6f9ef"><code>54e5eaa</code></a> Fix doc error (<a href="https://redirect.github.com/rust-random/rand/issues/1758">#3328</a>)</li>
<li><a href="https://github.com/rust-random/rand/commit/1ce4c080186730595a8d464591d17aac22a42252"><code>1ce4c08</code></a> Bump itoa from 1.0.17 to 1.0.18 in the all-deps group (<a href="https://redirect.github.com/rust-random/rand/issues/1756">#3579</a>)</li>
<li><a href="https://github.com/rust-random/rand/commit/ccb734b9c22891a19f11be125c2f09a43809b08e"><code>ccb734b</code></a> docs: fix typo in doc comment (<a href="https://redirect.github.com/rust-random/rand/issues/1754">#3326</a>)</li>
<li><a href="https://github.com/rust-random/rand/commit/357eb7de9c9c80184449e8b515c821e48cf4df74"><code>357eb7d</code></a> Bump libc from 0.2.182 to 0.2.183 in the all-deps group (<a href="https://redirect.github.com/rust-random/rand/issues/1753">#3580</a>)</li>
<li><a href="https://github.com/rust-random/rand/commit/5e77fe5d61b886988cae67b6d8fb09e405845c63"><code>5e77fe5</code></a> Fix trait references in documentation (<a href="https://redirect.github.com/rust-random/rand/issues/1752">#3325</a>)</li>
<li><a href="https://github.com/rust-random/rand/commit/da891850ab2b38f4322ec140ae29d305dfb162c3"><code>da89185</code></a> Bump the all-deps group with 3 updates (<a href="https://redirect.github.com/rust-random/rand/issues/1751">#3324</a>)</li>
<li><a href="https://github.com/rust-random/rand/commit/50516ff45c3675d9c2d247e70bc8db691ed8366d"><code>50516ff</code></a> Bump the all-deps group with 2 updates (<a href="https://redirect.github.com/rust-random/rand/issues/1749">#3581</a>)</li>
<li><a href="https://github.com/rust-random/rand/commit/fd71de97fdc7050b9a2d8384f5f8afce7d991ca3"><code>fd71de9</code></a> Bump the all-deps group with 2 updates (<a href="https://redirect.github.com/rust-random/rand/issues/1747">#3321</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/rust-random/rand/compare/0.9.4...0.10.1">compare view</a></li>
</ul>
</details>
<br />

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#1512 -->