### PR TITLE
[PR #1395] fix(oagw): handle missing SecurityContext for CORS preflight requests

### DIFF
--- a/config/e2e-local.yaml
+++ b/config/e2e-local.yaml
@@ -111,7 +111,7 @@ modules:
           in_flight: 64
 
       # Authentication Configuration
-      auth_disabled: true
+      auth_disabled: false
       require_auth_by_default: true
 
   # --- Tenant Resolver example (gateway + plugins) ---
@@ -126,6 +126,11 @@ modules:
         # Root tenant used by oagw + credstore e2e tests
         - id: "00000000-df51-5b42-9538-d2b56b7ee953"
           name: "e2e-root"
+          parent_id: null
+          status: active
+        # Tenant B for cross-tenant E2E tests
+        - id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+          name: "e2e-tenant-b"
           parent_id: null
           status: active
         # Hierarchy tenants
@@ -221,7 +226,18 @@ modules:
     config:
       vendor: "hyperspot"
       priority: 100
-      mode: accept_all
+      mode: static_tokens
+      tokens:
+        - token: "e2e-token-tenant-a"
+          identity:
+            subject_id: "11111111-6a88-4768-9dfc-6bcd5187d9ed"
+            subject_tenant_id: "00000000-df51-5b42-9538-d2b56b7ee953"
+            token_scopes: ["*"]
+        - token: "e2e-token-tenant-b"
+          identity:
+            subject_id: "22222222-6a88-4768-9dfc-6bcd5187d9ed"
+            subject_tenant_id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+            token_scopes: ["*"]
       s2s_credentials:
         - client_id: "mini-chat"
           client_secret: "mini-chat-dev-secret"
@@ -243,6 +259,12 @@ modules:
         client_id: "mini-chat"
         client_secret: "mini-chat-dev-secret"
 
+
+  resource-group:
+    database:
+      server: "sqlite_users"
+      file: "resource_group.db"
+    config: {}
 
   simple-user-settings:
     # Module-specific database configuration


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#1395](https://github.com/cyberfabric/cyberware-rust/pull/1395) | **Author:** ffedoroff | **Opened:** 2026-04-01T20:56:19Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

Body:

  ## Summary

  - CORS preflight (OPTIONS) requests to `/oagw/v1/proxy/{alias}/*` return 500 instead of the expected CORS response
  - Root cause: `authn_middleware` correctly skips authentication for CORS preflights (no SecurityContext injected), but `proxy_handler` unconditionally
  requires `Extension<SecurityContext>` — axum fails to extract it and returns 500
  - Fix: detect CORS preflight in `proxy_handler` before requiring SecurityContext and handle it directly, bypassing the authenticated proxy pipeline

  ## Test plan

  - [ ] Run `E2E_AUTH_TOKEN=e2e-token-tenant-a make e2e-local`
  - [ ] All 5 previously failing tests in `testing/e2e/modules/oagw/test_cors.py` now pass:
    - `test_cors_preflight_allowed_origin`
    - `test_cors_preflight_rejected_origin`
    - `test_cors_preflight_rejected_method`
    - `test_cors_preflight_rejected_header`
    - `test_cors_preflight_with_credentials`
  - [ ] No regression in other oagw tests (198 → 203 passed)

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#1395 -->