### PR TITLE
[PR #1186] fix(modkit): deserialize vendor config without cloning raw value

### DIFF
--- a/libs/modkit/src/bootstrap/config/mod.rs
+++ b/libs/modkit/src/bootstrap/config/mod.rs
@@ -370,7 +370,7 @@ impl AppConfig {
             .ok_or_else(|| VendorConfigError::NotFound {
                 vendor: vendor_name.to_owned(),
             })?;
-        serde_json::from_value(raw.clone()).map_err(|e| VendorConfigError::InvalidConfig {
+        T::deserialize(raw).map_err(|e| VendorConfigError::InvalidConfig {
             vendor: vendor_name.to_owned(),
             source: e,
         })
@@ -388,7 +388,7 @@ impl AppConfig {
         let Some(raw) = self.vendor.get(vendor_name) else {
             return Ok(T::default());
         };
-        serde_json::from_value(raw.clone()).map_err(|e| VendorConfigError::InvalidConfig {
+        T::deserialize(raw).map_err(|e| VendorConfigError::InvalidConfig {
             vendor: vendor_name.to_owned(),
             source: e,
         })


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#1186](https://github.com/cyberfabric/cyberware-rust/pull/1186) | **Author:** aviator5 | **Opened:** 2026-03-17T07:57:29Z | **Status:** merged on 2026-03-17T08:17:15Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved vendor configuration deserialization to use generic type handling for better flexibility and robustness. No public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#1186 -->