### PR TITLE
[PR #1035] fix(mini-chat): fail-fast on tenant upstream registration and avoid secret declassification

### DIFF
--- a/modules/mini-chat/mini-chat/src/infra/oagw_provisioning.rs
+++ b/modules/mini-chat/mini-chat/src/infra/oagw_provisioning.rs
@@ -57,10 +57,14 @@ pub async fn register_oagw_upstreams(
             }
 
             let label = format!("{provider_id}[tenant={tenant_id}]");
-            if let Some(alias) =
-                create_tenant_upstream(gateway, ctx, &label, entry, tenant_id).await
-                && let Some(tenant_override) = entry.tenant_overrides.get_mut(tenant_id)
-            {
+            let alias = create_tenant_upstream(gateway, ctx, &label, entry, tenant_id)
+                .await
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "OAGW tenant upstream registration failed for provider '{provider_id}', tenant '{tenant_id}'"
+                    )
+                })?;
+            if let Some(tenant_override) = entry.tenant_overrides.get_mut(tenant_id) {
                 tenant_override.upstream_alias = Some(alias);
             }
         }

--- a/modules/mini-chat/mini-chat/src/module.rs
+++ b/modules/mini-chat/mini-chat/src/module.rs
@@ -10,7 +10,6 @@ use modkit::{DatabaseCapability, Module, ModuleCtx, RestApiCapability};
 use modkit_db::outbox::{Outbox, OutboxHandle, Partitions};
 use oagw_sdk::ServiceGatewayClientV1;
 use sea_orm_migration::MigrationTrait;
-use secrecy::ExposeSecret;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 use types_registry_sdk::{RegisterResult, TypesRegistryClient};
@@ -358,7 +357,7 @@ async fn exchange_client_credentials(
     info!("Exchanging client credentials for OAGW provisioning context");
     let request = ClientCredentialsRequest {
         client_id: creds.client_id.clone(),
-        client_secret: secrecy::SecretString::from(creds.client_secret.expose_secret().to_owned()),
+        client_secret: creds.client_secret.clone(),
         scopes: Vec::new(),
     };
     let result = authn


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#1035](https://github.com/cyberfabric/cyberware-rust/pull/1035) | **Author:** aviator5 | **Opened:** 2026-03-12T12:30:05Z | **Status:** merged on 2026-03-12T13:41:05Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for tenant upstream provisioning, now explicitly reporting creation failures instead of silently skipping configurations.

* **Refactor**
  * Optimized credential secret handling in client authentication processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#1035 -->