### PR TITLE
[PR #931] chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ release-plz updates this file in the Release PR.
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-tr-plugin-v0.1.4...cf-static-tr-plugin-v0.1.5) - 2026-03-06
+
+### Other
+
+- updated the following local packages: cf-modkit-security, cf-modkit-odata, cf-modkit-macros, cf-modkit, cf-tenant-resolver-sdk
+
+## [0.1.3](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-authz-plugin-v0.1.2...cf-static-authz-plugin-v0.1.3) - 2026-03-06
+
+### Other
+
+- updated the following local packages: cf-modkit-security, cf-modkit-macros, cf-modkit, cf-authz-resolver-sdk
+
+## [0.1.3](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-authn-plugin-v0.1.2...cf-static-authn-plugin-v0.1.3) - 2026-03-06
+
+### Other
+
+- updated the following local packages: cf-modkit-security, cf-modkit-macros, cf-modkit, cf-authn-resolver-sdk
+
+## [0.1.5](https://github.com/cyberfabric/cyberfabric-core/compare/cf-single-tenant-tr-plugin-v0.1.4...cf-single-tenant-tr-plugin-v0.1.5) - 2026-03-06
+
+### Other
+
+- updated the following local packages: cf-modkit-security, cf-modkit-odata, cf-modkit-macros, cf-modkit, cf-tenant-resolver-sdk
+
 ## [0.1.4](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-tr-plugin-v0.1.3...cf-static-tr-plugin-v0.1.4) - 2026-03-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "cf-api-gateway"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "cf-authn-resolver"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "cf-authn-resolver-sdk"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "cf-authz-resolver"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "cf-authz-resolver-sdk"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "cf-credstore"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "cf-credstore-sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "cf-file-parser"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1208,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "cf-grpc-hub"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "cf-mini-chat"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "cf-mini-chat-sdk"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-auth"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aliri_clock",
  "aliri_tokens",
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db-macros"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-error2",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "axum",
  "http",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors-macro"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-http"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bytes",
  "flate2",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-macros"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-macros-tests"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-node-info"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-odata"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "base64 0.22.1",
  "bigdecimal",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-odata-macros"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "cf-modkit-odata",
  "heck 0.5.0",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-sdk"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "cf-modkit-odata",
  "cf-modkit-odata-macros",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-security"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "postcard",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-transport-grpc"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "cf-modkit-security",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-utils"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "humantime",
  "serde",
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "cf-module-orchestrator"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "cf-nodes-registry"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1655,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "cf-nodes-registry-sdk"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "cf-modkit-node-info",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "cf-oagw"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "cf-oagw-sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "cf-single-tenant-tr-plugin"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-authn-plugin"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-authz-plugin"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-credstore-plugin"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1885,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-mini-chat-model-policy-plugin"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-tr-plugin"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "cf-system-sdk-directory"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "cf-system-sdks"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "cf-system-sdk-directory",
 ]
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "cf-tenant-resolver-sdk"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -3384,7 +3384,7 @@ dependencies = [
 
 [[package]]
 name = "gts-docs-validator"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap",
  "gts-validator",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "hyperspot-server"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "calculator",
@@ -8238,7 +8238,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "types"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8254,7 +8254,7 @@ dependencies = [
 
 [[package]]
 name = "types-sdk"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "cf-modkit-odata",
@@ -8410,7 +8410,7 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "users-info"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8456,7 +8456,7 @@ dependencies = [
 
 [[package]]
 name = "users-info-sdk"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "cf-modkit-odata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["Cyber Fabric"]
@@ -212,39 +212,39 @@ verbose_file_reads = "deny"
 
 [workspace.dependencies]
 # libs
-modkit = { package = "cf-modkit", version = "0.3.1", path = "libs/modkit" }
-modkit-http = { package = "cf-modkit-http", version = "0.3.1", path = "libs/modkit-http" }
-modkit-auth = { package = "cf-modkit-auth", version = "0.3.1", path = "libs/modkit-auth" }
-modkit-db = { package = "cf-modkit-db", version = "0.3.1", path = "libs/modkit-db" }
-modkit-db-macros = { package = "cf-modkit-db-macros", version = "0.3.1", path = "libs/modkit-db-macros" }
-modkit-errors = { package = "cf-modkit-errors", version = "0.3.1", path = "libs/modkit-errors" }
-modkit-errors-macro = { package = "cf-modkit-errors-macro", version = "0.3.1", path = "libs/modkit-errors-macro" }
-modkit-macros = { package = "cf-modkit-macros", version = "0.3.1", path = "libs/modkit-macros" }
-modkit-node-info = { package = "cf-modkit-node-info", version = "0.3.1", path = "libs/modkit-node-info" }
-modkit-odata = { package = "cf-modkit-odata", version = "0.3.1", path = "libs/modkit-odata" }
-modkit-odata-macros = { package = "cf-modkit-odata-macros", version = "0.3.1", path = "libs/modkit-odata-macros" }
-modkit-sdk = { package = "cf-modkit-sdk", version = "0.3.1", path = "libs/modkit-sdk" }
-modkit-security = { package = "cf-modkit-security", version = "0.3.1", path = "libs/modkit-security" }
-modkit-transport-grpc = { package = "cf-modkit-transport-grpc", version = "0.3.1", path = "libs/modkit-transport-grpc" }
-modkit-utils = { package = "cf-modkit-utils", version = "0.3.1", path = "libs/modkit-utils" }
+modkit = { package = "cf-modkit", version = "0.3.2", path = "libs/modkit" }
+modkit-http = { package = "cf-modkit-http", version = "0.3.2", path = "libs/modkit-http" }
+modkit-auth = { package = "cf-modkit-auth", version = "0.3.2", path = "libs/modkit-auth" }
+modkit-db = { package = "cf-modkit-db", version = "0.3.2", path = "libs/modkit-db" }
+modkit-db-macros = { package = "cf-modkit-db-macros", version = "0.3.2", path = "libs/modkit-db-macros" }
+modkit-errors = { package = "cf-modkit-errors", version = "0.3.2", path = "libs/modkit-errors" }
+modkit-errors-macro = { package = "cf-modkit-errors-macro", version = "0.3.2", path = "libs/modkit-errors-macro" }
+modkit-macros = { package = "cf-modkit-macros", version = "0.3.2", path = "libs/modkit-macros" }
+modkit-node-info = { package = "cf-modkit-node-info", version = "0.3.2", path = "libs/modkit-node-info" }
+modkit-odata = { package = "cf-modkit-odata", version = "0.3.2", path = "libs/modkit-odata" }
+modkit-odata-macros = { package = "cf-modkit-odata-macros", version = "0.3.2", path = "libs/modkit-odata-macros" }
+modkit-sdk = { package = "cf-modkit-sdk", version = "0.3.2", path = "libs/modkit-sdk" }
+modkit-security = { package = "cf-modkit-security", version = "0.3.2", path = "libs/modkit-security" }
+modkit-transport-grpc = { package = "cf-modkit-transport-grpc", version = "0.3.2", path = "libs/modkit-transport-grpc" }
+modkit-utils = { package = "cf-modkit-utils", version = "0.3.2", path = "libs/modkit-utils" }
 
-cf-system-sdks = { version = "0.1.17", path = "libs/system-sdks" }
-cf-system-sdk-directory = { version = "0.1.17", path = "libs/system-sdks/sdks/directory" }
+cf-system-sdks = { version = "0.1.18", path = "libs/system-sdks" }
+cf-system-sdk-directory = { version = "0.1.18", path = "libs/system-sdks/sdks/directory" }
 
 # system modules SDKs
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.4", path = "modules/system/types-registry/types-registry-sdk" }
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.2.1", path = "modules/system/tenant-resolver/tenant-resolver-sdk" }
-authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.2.2", path = "modules/system/authz-resolver/authz-resolver-sdk" }
-oagw-sdk = { package = "cf-oagw-sdk", version = "0.1.1", path = "modules/system/oagw/oagw-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.2.2", path = "modules/system/tenant-resolver/tenant-resolver-sdk" }
+authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.2.3", path = "modules/system/authz-resolver/authz-resolver-sdk" }
+oagw-sdk = { package = "cf-oagw-sdk", version = "0.1.2", path = "modules/system/oagw/oagw-sdk" }
 
 # credstore
-credstore-sdk = { package = "cf-credstore-sdk", version = "0.1.1", path = "modules/credstore/credstore-sdk" }
+credstore-sdk = { package = "cf-credstore-sdk", version = "0.1.2", path = "modules/credstore/credstore-sdk" }
 
 # mini-chat
-mini-chat-sdk = { package = "cf-mini-chat-sdk", version = "0.1.0", path = "modules/mini-chat/mini-chat-sdk" }
+mini-chat-sdk = { package = "cf-mini-chat-sdk", version = "0.2.0", path = "modules/mini-chat/mini-chat-sdk" }
 
 # system modules
-grpc_hub = { package = "cf-grpc-hub", version = "0.1.5", path = "modules/system/grpc-hub" }
+grpc_hub = { package = "cf-grpc-hub", version = "0.1.6", path = "modules/system/grpc-hub" }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/libs/system-sdks/Cargo.toml
+++ b/libs/system-sdks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-system-sdks"
-version = "0.1.17"
+version = "0.1.18"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/system-sdks/sdks/directory/Cargo.toml
+++ b/libs/system-sdks/sdks/directory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-system-sdk-directory"
-version = "0.1.17"
+version = "0.1.18"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/credstore/credstore-sdk/Cargo.toml
+++ b/modules/credstore/credstore-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-credstore-sdk"
 description = "SDK for credstore module: API traits, models, and error definitions"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/credstore/credstore/Cargo.toml
+++ b/modules/credstore/credstore/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-credstore"
 description = "credstore gateway module"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/credstore/plugins/static-credstore-plugin/Cargo.toml
+++ b/modules/credstore/plugins/static-credstore-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-static-credstore-plugin"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -16,7 +16,7 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-credstore-sdk = { package = "cf-credstore-sdk", version = "0.1.1", path = "../../credstore-sdk" }
+credstore-sdk = { package = "cf-credstore-sdk", version = "0.1.2", path = "../../credstore-sdk" }
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.3", path = "../../../system/types-registry/types-registry-sdk" }
 
 # ModKit dependencies

--- a/modules/file-parser/Cargo.toml
+++ b/modules/file-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-file-parser"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/mini-chat/mini-chat-sdk/Cargo.toml
+++ b/modules/mini-chat/mini-chat-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-mini-chat-sdk"
 description = "SDK for mini-chat: policy plugin traits, models, and errors"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/mini-chat/mini-chat/Cargo.toml
+++ b/modules/mini-chat/mini-chat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-mini-chat"
 description = "Mini-chat module: multi-tenant AI chat"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/api-gateway/Cargo.toml
+++ b/modules/system/api-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-api-gateway"
-version = "0.1.6"
+version = "0.1.7"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ workspace = true
 modkit = { workspace = true }
 modkit-http = { workspace = true }
 modkit-security = { workspace = true }
-authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.2.1", path = "../authn-resolver/authn-resolver-sdk" }
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.2.2", path = "../authn-resolver/authn-resolver-sdk" }
 modkit-macros = { workspace = true }
 inventory = { workspace = true }
 anyhow = { workspace = true }

--- a/modules/system/authn-resolver/authn-resolver-sdk/Cargo.toml
+++ b/modules/system/authn-resolver/authn-resolver-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-authn-resolver-sdk"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/authn-resolver/authn-resolver/Cargo.toml
+++ b/modules/system/authn-resolver/authn-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-authn-resolver"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.2.1", path = "../authn-resolver-sdk" }
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.2.2", path = "../authn-resolver-sdk" }
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.4", path = "../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies

--- a/modules/system/authn-resolver/plugins/static-authn-plugin/Cargo.toml
+++ b/modules/system/authn-resolver/plugins/static-authn-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-static-authn-plugin"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.2.1", path = "../../authn-resolver-sdk" }
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.2.2", path = "../../authn-resolver-sdk" }
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.4", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies

--- a/modules/system/authz-resolver/authz-resolver-sdk/Cargo.toml
+++ b/modules/system/authz-resolver/authz-resolver-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-authz-resolver-sdk"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/authz-resolver/authz-resolver/Cargo.toml
+++ b/modules/system/authz-resolver/authz-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-authz-resolver"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.2.2", path = "../authz-resolver-sdk" }
+authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.2.3", path = "../authz-resolver-sdk" }
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.4", path = "../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies

--- a/modules/system/authz-resolver/plugins/static-authz-plugin/Cargo.toml
+++ b/modules/system/authz-resolver/plugins/static-authz-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-static-authz-plugin"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.2.2", path = "../../authz-resolver-sdk" }
+authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.2.3", path = "../../authz-resolver-sdk" }
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.4", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies

--- a/modules/system/grpc-hub/Cargo.toml
+++ b/modules/system/grpc-hub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-grpc-hub"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/module-orchestrator/Cargo.toml
+++ b/modules/system/module-orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-module-orchestrator"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/nodes-registry/nodes-registry-sdk/Cargo.toml
+++ b/modules/system/nodes-registry/nodes-registry-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-nodes-registry-sdk"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/nodes-registry/nodes-registry/Cargo.toml
+++ b/modules/system/nodes-registry/nodes-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-nodes-registry"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -31,4 +31,4 @@ thiserror = { workspace = true }
 modkit = { workspace = true }
 modkit-node-info = { workspace = true }
 modkit-macros = { workspace = true }
-nodes_registry-sdk = { package = "cf-nodes-registry-sdk", version = "0.1.5", path = "../nodes-registry-sdk" }
+nodes_registry-sdk = { package = "cf-nodes-registry-sdk", version = "0.1.6", path = "../nodes-registry-sdk" }

--- a/modules/system/oagw/oagw-sdk/Cargo.toml
+++ b/modules/system/oagw/oagw-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-oagw-sdk"
 description = "SDK for the OpenAPI Gateway: API traits, models, and error definitions"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/oagw/oagw/Cargo.toml
+++ b/modules/system/oagw/oagw/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-oagw"
 description = "OAGW module - discovers and routes to plugins"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 test-utils = ["axum/ws", "dep:async-stream", "dep:futures", "dep:tower", "dep:rustls", "tokio/net", "tokio/sync", "tokio/rt"]
 
 [dependencies]
-oagw-sdk = { path = "../oagw-sdk", package="cf-oagw-sdk", version = "0.1.1", features = ["axum"] }
+oagw-sdk = { path = "../oagw-sdk", package="cf-oagw-sdk", version = "0.1.2", features = ["axum"] }
 modkit = { workspace = true }
 modkit-auth = { workspace = true }
 modkit-http = { workspace = true }

--- a/modules/system/tenant-resolver/plugins/single-tenant-tr-plugin/Cargo.toml
+++ b/modules/system/tenant-resolver/plugins/single-tenant-tr-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-single-tenant-tr-plugin"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.2.1", path = "../../tenant-resolver-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.2.2", path = "../../tenant-resolver-sdk" }
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.4", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies

--- a/modules/system/tenant-resolver/plugins/static-tr-plugin/Cargo.toml
+++ b/modules/system/tenant-resolver/plugins/static-tr-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-static-tr-plugin"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.2.1", path = "../../tenant-resolver-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.2.2", path = "../../tenant-resolver-sdk" }
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.4", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies

--- a/modules/system/tenant-resolver/tenant-resolver-sdk/Cargo.toml
+++ b/modules/system/tenant-resolver/tenant-resolver-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-tenant-resolver-sdk"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/tenant-resolver/tenant-resolver/Cargo.toml
+++ b/modules/system/tenant-resolver/tenant-resolver/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.2.1", path = "../tenant-resolver-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.2.2", path = "../tenant-resolver-sdk" }
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.4", path = "../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#931](https://github.com/cyberfabric/cyberware-rust/pull/931) | **Author:** github-actions[bot] | **Opened:** 2026-03-06T20:32:59Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---




## 🤖 New release

* `cf-modkit-security`: 0.3.1 -> 0.3.2
* `cf-modkit-transport-grpc`: 0.3.1 -> 0.3.2
* `cf-modkit-db-macros`: 0.3.1 -> 0.3.2
* `cf-modkit-errors`: 0.3.1 -> 0.3.2
* `cf-modkit-errors-macro`: 0.3.1 -> 0.3.2
* `cf-modkit-odata`: 0.3.1 -> 0.3.2
* `cf-modkit-utils`: 0.3.1 -> 0.3.2
* `cf-modkit-db`: 0.3.1 -> 0.3.2
* `cf-modkit-macros`: 0.3.1 -> 0.3.2
* `cf-modkit-odata-macros`: 0.3.1 -> 0.3.2
* `cf-modkit-sdk`: 0.3.1 -> 0.3.2
* `cf-modkit`: 0.3.1 -> 0.3.2 (✓ API compatible changes)
* `cf-modkit-http`: 0.3.1 -> 0.3.2
* `cf-modkit-auth`: 0.2.14 -> 0.3.2
* `cf-oagw-sdk`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `cf-oagw`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `cf-mini-chat-sdk`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `cf-mini-chat`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `cf-modkit-node-info`: 0.3.1 -> 0.3.2
* `cf-static-credstore-plugin`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `cf-tenant-resolver`: 0.1.4 -> 0.1.5
* `types-sdk`: 0.3.1 -> 0.3.2
* `cf-types-registry`: 0.1.4 -> 0.1.5
* `cf-system-sdk-directory`: 0.1.17 -> 0.1.18
* `cf-system-sdks`: 0.1.17 -> 0.1.18
* `cf-authz-resolver-sdk`: 0.2.2 -> 0.2.3
* `cf-credstore-sdk`: 0.1.1 -> 0.1.2
* `cf-authn-resolver-sdk`: 0.2.1 -> 0.2.2
* `cf-api-gateway`: 0.1.6 -> 0.1.7
* `cf-authn-resolver`: 0.1.3 -> 0.1.4
* `cf-authz-resolver`: 0.1.2 -> 0.1.3
* `cf-grpc-hub`: 0.1.5 -> 0.1.6
* `cf-credstore`: 0.1.1 -> 0.1.2
* `cf-file-parser`: 0.1.5 -> 0.1.6
* `cf-module-orchestrator`: 0.1.5 -> 0.1.6
* `cf-nodes-registry-sdk`: 0.1.5 -> 0.1.6
* `cf-nodes-registry`: 0.1.5 -> 0.1.6
* `cf-tenant-resolver-sdk`: 0.2.1 -> 0.2.2
* `cf-single-tenant-tr-plugin`: 0.1.4 -> 0.1.5
* `cf-static-authn-plugin`: 0.1.2 -> 0.1.3
* `cf-static-authz-plugin`: 0.1.2 -> 0.1.3
* `cf-static-tr-plugin`: 0.1.4 -> 0.1.5

### ⚠ `cf-mini-chat-sdk` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ModelCatalogEntry.provider_id in /tmp/.tmpqGcY1j/cyberfabric-core/modules/mini-chat/mini-chat-sdk/src/models.rs:58
  field ModelCatalogEntry.provider_id in /tmp/.tmpqGcY1j/cyberfabric-core/modules/mini-chat/mini-chat-sdk/src/models.rs:58
```

<details><summary><i><b>Changelog</b></i></summary><p>












## `cf-modkit`

<blockquote>


## [0.3.2](https://github.com/constructorfabric/cyberfabric-core/compare/cf-modkit-v0.3.1...cf-modkit-v0.3.2) - 2026-03-06

### Other

- Merge pull request #3773 from lizreu/fix/odata-query-param-error (by &#2369;Artifizer) - #3773
- Merge pull request #3770 from lizreu/fix/select-serialization-warn (by &#2369;Artifizer) - #3770

### Contributors

* &#2369;Artifizer
</blockquote>








## `cf-static-credstore-plugin`

<blockquote>


## [0.1.1](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-credstore-plugin-v0.1.0...cf-static-credstore-plugin-v0.1.1) - 2026-03-06

### Added

- *(credstore)* distinguish shared vs global secrets in static plugin (by &#2369;aviator5)

### Contributors

* &#2369;aviator5
</blockquote>



















## `cf-single-tenant-tr-plugin`

<blockquote>


## [0.1.5](https://github.com/constructorfabric/cyberfabric-core/compare/cf-single-tenant-tr-plugin-v0.1.4...cf-single-tenant-tr-plugin-v0.1.5) - 2026-03-06

### Other

- updated the following local packages: cf-modkit-security, cf-modkit-odata, cf-modkit-macros, cf-modkit, cf-tenant-resolver-sdk
</blockquote>

## `cf-static-authn-plugin`

<blockquote>


## [0.1.3](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-authn-plugin-v0.1.2...cf-static-authn-plugin-v0.1.3) - 2026-03-06

### Other

- updated the following local packages: cf-modkit-security, cf-modkit-macros, cf-modkit, cf-authn-resolver-sdk
</blockquote>

## `cf-static-authz-plugin`

<blockquote>


## [0.1.3](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-authz-plugin-v0.1.2...cf-static-authz-plugin-v0.1.3) - 2026-03-06

### Other

- updated the following local packages: cf-modkit-security, cf-modkit-macros, cf-modkit, cf-authz-resolver-sdk
</blockquote>

## `cf-static-tr-plugin`

<blockquote>


## [0.1.5](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-tr-plugin-v0.1.4...cf-static-tr-plugin-v0.1.5) - 2026-03-06

### Other

- updated the following local packages: cf-modkit-security, cf-modkit-odata, cf-modkit-macros, cf-modkit, cf-tenant-resolver-sdk
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#931 -->