### PR TITLE
[PR #220] feat(oagw): WiP - add outbound API gateway module and SDK PoC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1865,7 +1865,7 @@ dependencies = [
 [[package]]
 name = "gts"
 version = "0.1.0"
-source = "git+https://github.com/globaltypesystem/gts-rust.git?tag=v0.7.6#836bcff115751fb062e0d5e9832a6cf13ed69ead"
+source = "git+https://github.com/globaltypesystem/gts-rust.git?tag=v0.7.7#eb53551654ce97426ee891ba99ced0fd56b72d59"
 dependencies = [
  "anyhow",
  "jsonschema",
@@ -1883,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "gts-macros"
 version = "0.1.0"
-source = "git+https://github.com/globaltypesystem/gts-rust.git?tag=v0.7.6#836bcff115751fb062e0d5e9832a6cf13ed69ead"
+source = "git+https://github.com/globaltypesystem/gts-rust.git?tag=v0.7.7#eb53551654ce97426ee891ba99ced0fd56b72d59"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2271,6 +2271,8 @@ dependencies = [
  "modkit-db",
  "module_orchestrator",
  "nodes_registry",
+ "oagw-gw",
+ "oagw_default_plugin",
  "serde_json",
  "sqlx",
  "tempfile",
@@ -3406,6 +3408,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "oagw-gw"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "api_ingress",
+ "arc-swap",
+ "async-trait",
+ "axum",
+ "bytes",
+ "chrono",
+ "futures",
+ "gts",
+ "http",
+ "inventory",
+ "modkit",
+ "modkit-auth",
+ "modkit-db",
+ "modkit-db-macros",
+ "modkit-odata",
+ "modkit-security",
+ "oagw-sdk",
+ "sea-orm",
+ "sea-orm-migration",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-test",
+ "tower",
+ "tower-http",
+ "tracing",
+ "types-registry-sdk",
+ "utoipa",
+ "uuid",
+]
+
+[[package]]
+name = "oagw-sdk"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "gts",
+ "gts-macros",
+ "modkit",
+ "modkit-odata",
+ "modkit-security",
+ "pin-project-lite",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "oagw_default_plugin"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "gts",
+ "inventory",
+ "modkit",
+ "modkit-security",
+ "oagw-sdk",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-test",
+ "tracing",
+ "types-registry-sdk",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4369,12 +4458,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.4",
 ]
@@ -6630,6 +6721,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,10 @@ members = [
     "examples/plugin-modules/tenant_resolver/tenant_resolver-sdk",
     "examples/plugin-modules/tenant_resolver/tenant_resolver-gw",
     "examples/plugin-modules/tenant_resolver/plugins/contoso_tr_plugin",
-    "examples/plugin-modules/tenant_resolver/plugins/fabrikam_tr_plugin"
+    "examples/plugin-modules/tenant_resolver/plugins/fabrikam_tr_plugin",
+    "modules/oagw/oagw-sdk",
+    "modules/oagw/oagw-gw",
+    "modules/oagw/plugins/oagw_default_plugin"
 ]
 resolver = "2"
 
@@ -254,7 +257,9 @@ prost-build = "0.14"
 tonic-prost-build = "0.14"
 
 # HTTP client
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
+reqwest-eventsource = "0.6"
+pin-project-lite = "0.2"
 
 # Time handling
 time = { version = "0.3", features = ["serde", "formatting", "parsing"] }
@@ -338,5 +343,5 @@ serde_yaml = "0.9"
 shellexpand = "3.1"
 
 # GTS library
-gts = { git = "https://github.com/globaltypesystem/gts-rust.git", tag = "v0.7.6" }
-gts-macros = { git = "https://github.com/globaltypesystem/gts-rust.git", tag = "v0.7.6" }
+gts = { git = "https://github.com/globaltypesystem/gts-rust.git", tag = "v0.7.7" }
+gts-macros = { git = "https://github.com/globaltypesystem/gts-rust.git", tag = "v0.7.7" }

--- a/apps/hyperspot-server/Cargo.toml
+++ b/apps/hyperspot-server/Cargo.toml
@@ -35,6 +35,10 @@ types-registry = { path = "../../modules/types-registry/types-registry" }
 file_parser = { path = "../../modules/file_parser" }
 nodes_registry = { path = "../../modules/nodes_registry" }
 
+# OAGW (Outbound API Gateway)
+oagw_gw = { package = "oagw-gw", path = "../../modules/oagw/oagw-gw" }
+oagw_default_plugin = { path = "../../modules/oagw/plugins/oagw_default_plugin" }
+
 anyhow = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true, features = ["rt"] }

--- a/apps/hyperspot-server/src/registered_modules.rs
+++ b/apps/hyperspot-server/src/registered_modules.rs
@@ -10,6 +10,10 @@ use module_orchestrator as _;
 use nodes_registry as _;
 use types_registry as _;
 
+// OAGW (Outbound API Gateway)
+use oagw_default_plugin as _;
+use oagw_gw as _;
+
 #[cfg(feature = "users-info-example")]
 use users_info as _;
 

--- a/config/quickstart.yaml
+++ b/config/quickstart.yaml
@@ -2,7 +2,7 @@
 #
 # Database Architecture Overview:
 # ===============================
-# 
+#
 # HyperSpot uses a centralized DbManager that:
 # 1. Loads global database server templates from `database.servers`
 # 2. For each module, merges server template with module-specific overrides
@@ -16,19 +16,19 @@
 # - Environment variables are expanded (${VAR_NAME})
 # - All paths are resolved relative to server.home_dir
 
-# Core server configuration (global section)  
+# Core server configuration (global section)
 server:
   home_dir: "~/.hyperspot"
 
 # Database configuration (DbManager architecture)
-# 
+#
 # The database config has two levels:
 # 1. Global "servers" - shared connection templates that modules can reference
 # 2. Per-module configs - specific database settings for each module
 #
 # Configuration precedence (highest to lowest):
 # - Module `params` map (highest priority)
-# - Module DSN query params 
+# - Module DSN query params
 # - Module fields (host, port, user, etc.)
 # - Module DSN base
 # - Server `params` map
@@ -53,7 +53,7 @@ database:
       pool:
         max_conns: 5             # Maximum 5 concurrent connections
         acquire_timeout: "30s"   # Timeout when acquiring connection from pool
-  
+
   # Global database options
   # auto_provision: true       # (default) Create directories automatically for SQLite files
   # auto_provision: false      # Fail if directories don't exist
@@ -89,7 +89,7 @@ modules:
       bind_addr: "127.0.0.1:8087"
       enable_docs: true
       cors_enabled: false
-      
+
       # OpenAPI Documentation Configuration
       openapi:
         title: "HyperSpot API"
@@ -105,7 +105,7 @@ modules:
       # Authentication Configuration
       auth_disabled: true
       require_auth_by_default: true
-      
+
       # JWKS Configuration (replace with your OIDC provider)
       jwks_uri: "http://localhost:8080/realms/dev/protocol/openid-connect/certs"
       issuer: "http://localhost:8080/realms/dev"
@@ -125,28 +125,28 @@ modules:
     database:
       # Reference to global server template defined above
       server: "sqlite_users"               # Inherits params and pool settings from sqlite_users
-      
+
       # Module-specific database file (required for SQLite modules)
       file: "users_info.db"                # Creates: ~/.hyperspot/users_info/users_info.db
-      
+
       # Module can override server settings:
       # params:
       #   synchronous: "FULL"              # Would override server's "NORMAL" setting
       #   custom_pragma: "value"           # Would add new PRAGMA setting
       # pool:
       #   max_conns: 10                    # Would override server's max_conns: 5
-      
+
       # Alternative ways to specify database location:
       # path: "/absolute/path/to/db.sqlite" # Use absolute path instead of file
       # dsn: "sqlite://custom.db?WAL=false" # Complete DSN override (ignores server)
-      
+
       # For other database types (PostgreSQL, MySQL):
       # host: "localhost"                  # Override server host
-      # port: 5432                         # Override server port  
+      # port: 5432                         # Override server port
       # user: "app_user"                   # Override server user
       # password: "${DB_PASSWORD}"         # Environment variable expansion
       # dbname: "users_db"                 # Override server database name
-    
+
     # Module-specific application configuration
     config:
       default_page_size: 5
@@ -197,6 +197,15 @@ modules:
           parent_id: "00000000000000000000000000000011"
           status: ACTIVE
           is_accessible_by_parent: true
+
+  oagw_gw:
+    database:
+      server: "sqlite_users"
+      file: "oagw.db"
+    config: {}
+
+  oagw_default_plugin:
+    config: {}
 
 # OpenTelemetry tracing configuration
 tracing:
@@ -299,4 +308,3 @@ tracing:
 #     # No database section - module won't get database access
 #     config:
 #       static_dir: "/var/www/static"
-

--- a/modules/oagw/docs/1_INTENT_DESIGN.md
+++ b/modules/oagw/docs/1_INTENT_DESIGN.md
@@ -1,0 +1,662 @@
+> This is module intent - planned design and implementation notes.
+
+### Requirement: oagw module responsibility
+The system SHALL provide an `oagw` gateway module with **pluggable co-loaded protocol/auth/streaming implementations** responsible for invoking outbound remote API calls in a reusable way.
+
+The `oagw` module SHALL:
+- Manage tenant-scoped outbound route/link configuration.
+- Delegate actual invocation to a selected plugin implementation.
+- Provide error normalization for known protocols.
+
+#### Scenario: Reusable outbound invocation
+- **WHEN** a module needs to call an external HTTP API
+- **THEN** it can delegate to `oagw` instead of implementing its own transport/auth logic
+
+### Requirement: oagw GTS schemas and instances registration
+The system SHALL register the following GTS schemas in `types_registry` during gateway startup:
+- `gts.x.core.oagw.proto.v1~`
+- `gts.x.core.oagw.stream_proto.v1~`
+- `gts.x.core.oagw.auth_type.v1~`
+- `gts.x.core.oagw.strategy.v1~`
+
+Each schema SHALL define:
+- `id: GtsInstanceId`
+- `display_name: string`
+- `description?: string`
+- `priority?: int` (lower wins)`
+
+Well-known instances SHALL be loaded from `oagw/.../gts/*.instances.json` and registered during gateway `init()`.
+
+priority is used to select the best protocol for a given route, e.g. HTTP/3 if supported by downstream would have lower priority than HTTP/2.
+
+Well-known route protocol instances SHOULD include:
+- `gts.x.core.oagw.proto.v1~x.core.http.http11.v1`
+- `gts.x.core.oagw.proto.v1~x.core.http.http2.v1`
+- `gts.x.core.oagw.proto.v1~x.core.http.http3.v1`
+- `gts.x.core.oagw.proto.v1~x.core.http.sse.v1`
+
+Well-known strategy instances SHOULD include:
+- `gts.x.core.oagw.strategy.v1~x.core._.sticky_session.v1`
+- `gts.x.core.oagw.strategy.v1~x.core._.round_robin.v1`
+
+Auth type schemas and instances SHOULD be treated analogously to protocol/strategy schemas:
+- The `gts.x.core.oagw.auth_type.v1~` schema defines the shape of an auth mechanism.
+- Well-known auth type instances define a stable set of supported auth behaviors.
+- An `outbound_api_route` references exactly one `auth_type_gts_id`, allowing tenants to select behavior without hardcoding.
+
+#### Scenario: Startup registration
+- **WHEN** `oagw` gateway `init()` runs
+- **THEN** it registers the listed schemas and shipped instances in `types_registry`
+
+#### Scenario: Sticky session strategy
+- **GIVEN** a link is configured with `strategy_gts_id` = `gts.x.core.oagw.strategy.v1~x.core._.sticky_session.v1`
+- **WHEN** `oagw` selects a link for a given tenant
+- **THEN** it SHOULD try to stick to the previously selected link for that tenant
+
+#### Scenario: Round robin strategy
+- **GIVEN** a link is configured with `strategy_gts_id` = `gts.x.core.oagw.strategy.v1~x.core._.round_robin.v1`
+- **WHEN** `oagw` selects a link for a given tenant
+- **THEN** it SHOULD distribute invocations across links for the same route
+
+### Requirement: oagw persistence model
+The system SHALL persist anonymous objects (UUID IDs) in the `oagw` database.
+
+#### Database tables (logical), managed by OAGW gateway module
+- `outbound_api_route`
+  - `id uuid pk`
+  - `tenant_id uuid not null`
+  - `base_url text not null`
+  - `rate_limit_req_per_min int not null default 1000`
+  - `auth_type_gts_id text not null` (schema: `gts.x.core.oagw.auth_type.v1~`)
+
+- `outbound_api_route_supported_protocol`
+  - `id uuid pk`
+  - `route_id uuid not null fk outbound_api_route(id)`
+  - `protocol_gts_id text not null` (list of supported protocols, schema: `gts.x.core.oagw.proto.v1~`)
+
+- `outbound_api_link`
+  - `id uuid pk`
+  - `tenant_id uuid not null`
+  - `secret_ref uuid not null` (logical/not-physical FK to `cred_store.secret_store.id`)
+  - `route_id uuid not null fk outbound_api_route(id)`
+  - `secret_type_gts_id text not null` (schema: `gts.x.core.cred_store.secret_type.v1~`)
+  - `enabled bool not null`
+  - `priority int not null`
+  - `strategy_gts_id text not null` (schema: `gts.x.core.oagw.strategy.v1~`)
+
+- `outbound_api_route_limits`
+  - `id uuid pk`
+  - `tenant_id uuid not null`
+  - `link_id uuid null unique (logical FK to outbound_api_link.id)` (can be per link)
+  - `route_id uuid null unique (logical FK to outbound_api_route.id)` (... or per route)
+  - `connection_timeout_ms int not null default 5000` (5s to establish connection)
+  - `request_timeout_ms int not null default 30000` (30s total request duration)
+  - `idle_timeout_ms int not null default 60000` (60s idle connection reuse)
+  - `circuit_breaker_threshold int not null default 5`
+  - `circuit_breaker_timeout_sec int not null default 30`
+  - `circuit_breaker_success_threshold int not null default 2`
+  - `max_concurrent_requests int not null default 100`
+  - `max_request_size_bytes int not null default 10485760` (10 MB)
+  - `max_response_size_bytes int not null default 104857600` (100 MB)
+  - `rate_limit_per_min int not null default 1000`
+
+#### Scenario: Configure link for a tenant
+- **WHEN** a tenant configures an outbound link
+- **THEN** the link references a `cred_store` secret by UUID
+
+### Requirement: oagw gateway API (Rust-native)
+The system SHALL expose a Rust-native API (ClientHub) named `OagwApi`.
+
+The API SHALL:
+- Accept `&SecurityCtx` for every method.
+- Allow selecting an outbound link and invoking requests through it.
+- Support non-streaming and streaming responses.
+
+The Rust-native API SHOULD expose two shapes:
+- Unary (synchronous) invocation: request/response completes with a single response value.
+- Streaming (asynchronous) invocation: response is a stream of items.
+
+The Rust-native API SHOULD support streaming over:
+- HTTP SSE (`gts.x.core.oagw.proto.v1~x.core.http.sse.v1`) as a server-to-client stream.
+
+#### Scenario: Rust-native unary invocation
+- **WHEN** a consumer calls `OagwApi::invoke_unary(ctx, request)`
+- **THEN** the gateway resolves an eligible plugin and executes a single request/response exchange
+
+#### Scenario: Rust-native streaming invocation
+- **WHEN** a consumer calls `OagwApi::invoke_stream(ctx, request)`
+- **THEN** the gateway resolves an eligible plugin and returns a stream of response items
+
+#### Scenario: Rust-native invocation
+- **WHEN** a consumer calls `OagwApi::invoke(ctx, request)`
+- **THEN** the gateway resolves an eligible plugin and executes the request
+
+### Requirement: oagw unary vs streaming Rust API shape
+The system SHALL define a contract model for outbound invocations that supports both unary and streaming responses.
+
+The Rust-native API SHOULD define method shapes similar to:
+- `invoke_unary(&self, ctx: &SecurityCtx, req: OagwInvokeRequest) -> Result<OagwInvokeResponse, OagwError>`
+- `invoke_stream(&self, ctx: &SecurityCtx, req: OagwInvokeRequest) -> Result<OagwResponseStream, OagwError>`
+
+The streaming response type SHOULD be compatible with `futures::Stream`, enabling transport-independent composition.
+
+#### Scenario: Streaming response as futures::Stream
+- **WHEN** a consumer uses `invoke_stream`
+- **THEN** it can process response items incrementally using backpressure-aware `Stream` combinators
+
+### Requirement: oagw REST API
+The system SHALL expose REST endpoints:
+- `GET/POST /oagw/v1/routes`
+- `GET/PATCH/DELETE /oagw/v1/routes/{routeId}`
+- `GET/POST /oagw/v1/links`
+- `GET/PATCH/DELETE /oagw/v1/links/{linkId}`
+- `POST /oagw/v1/invoke`
+
+#### Scenario: REST invoke
+- **WHEN** a client POSTs to `/oagw/v1/invoke` with a link id and request payload
+- **THEN** `oagw` executes the request via the selected plugin
+- **AND** returns normalized errors using RFC-9457 Problem Details
+
+### Requirement: oagw plugin interface and selection
+The system SHALL define an `oagw` plugin interface.
+
+Each plugin SHALL report:
+- Supported route protocols (instances of `gts.x.core.oagw.proto.v1~`).
+- Supported stream protocols (instances of `gts.x.core.oagw.stream_proto.v1~`).
+- Supported auth types (instances of `gts.x.core.oagw.auth_type.v1~`).
+- Supported strategies (instances of `gts.x.core.oagw.strategy.v1~`).
+- Plugin priority (lower wins).
+
+The gateway SHALL choose the eligible plugin with the lowest priority.
+
+The gateway SHOULD implement sticky session selection keyed by:
+- `(tenant_id, user_id)` when available.
+
+#### Scenario: Eligible plugin selection
+- **GIVEN** an outbound link requiring protocol P and auth type A
+- **WHEN** `oagw` resolves its plugin
+- **THEN** it filters to plugins supporting (P, A)
+- **AND** selects the lowest-priority plugin
+
+### Requirement: oagw protocol and transport implementation libraries
+The system SHALL define the Rust libraries used for outbound transport per selected protocol.
+
+For outbound HTTP (`http11`, `http2`) the gateway SHOULD use:
+- `reqwest` for request construction and execution.
+- `modkit::http::TracedClient` to inject OpenTelemetry trace context into outbound calls.
+
+For outbound HTTP/3 (`http3`) the gateway SHOULD use an HTTP/3-capable Rust client library.
+
+For outbound SSE (`sse`) the gateway SHOULD:
+- Use `reqwest` for initiating the HTTP request.
+- Use an SSE-compatible client implementation to parse `text/event-stream` frames into stream items.
+
+### Requirement: oagw auth mechanisms, token exchange, and caching
+The system SHALL define how outbound authentication is produced for each outbound call.
+
+The gateway SHALL treat outbound auth configuration as data:
+- A route references an auth type instance via `auth_type_gts_id`.
+- A link references secret material via `secret_ref` and `secret_type_gts_id`.
+
+Outbound auth material SHOULD be resolved using `cred_store` and SHOULD NOT be embedded directly into `oagw` tables.
+
+#### Token exchange model
+When the inbound request is authenticated with an end-user token, the gateway MAY need to exchange it for an outbound token.
+
+If token exchange is required, the gateway SHOULD implement RFC 8693 OAuth 2.0 Token Exchange against a configured identity provider.
+
+The gateway SHOULD cache exchanged tokens.
+
+Caching behavior SHOULD:
+- Use an in-memory cache keyed by `(tenant_id, user_id, route_id, auth_type_gts_id, requested_scopes)`.
+- Store tokens with TTL derived from the token `exp` claim minus a safety skew.
+- Deduplicate concurrent exchanges for the same cache key.
+
+#### Scenario: Exchanged token cache hit
+- **GIVEN** an exchanged outbound token exists in cache for `(tenant_id, user_id, route_id, auth_type, scopes)`
+- **WHEN** the tenant invokes the same route again
+- **THEN** `oagw` reuses the cached token
+- **AND** does not call the identity provider
+
+#### Scenario: Exchanged token cache miss
+- **GIVEN** no cached outbound token exists
+- **WHEN** the tenant invokes the route
+- **THEN** `oagw` exchanges the inbound identity token for an outbound token
+- **AND** caches the result until its effective expiry
+
+#### Auth library mapping (non-exhaustive)
+The system SHOULD implement outbound auth using common, audited Rust libraries:
+- OAuth2 client credentials / token exchange: `oauth2` (for token acquisition flows)
+- JWT validation/parsing (when needed for caching/expiry decisions): `jsonwebtoken`
+- Static headers / API keys: `http` header types and `reqwest` request builders
+
+#### Scenario: Outbound auth derived from link secret
+- **GIVEN** a link references `secret_ref` and `secret_type_gts_id`
+- **WHEN** the gateway prepares the outbound request
+- **THEN** it loads secret material from `cred_store` using the reference
+- **AND** applies it to the request according to `auth_type_gts_id`
+
+### Requirement: Caller-controlled retry semantics
+The system SHALL treat retries as an explicit caller-provided policy.
+
+The gateway MUST NOT perform implicit retries.
+
+The gateway MAY perform retries **within a single invocation** only when explicitly requested by the caller via a declarative `RetryIntent`.
+
+The retry state MUST be ephemeral and live only within the invocation context.
+
+#### Scenario: No implicit retry
+- **WHEN** the caller provides no `RetryIntent` (or `max_attempts = 1`)
+- **THEN** the gateway executes exactly one outbound attempt
+
+#### Scenario: Retry intent enables bounded retries
+- **GIVEN** a caller provides `RetryIntent.max_attempts > 1`
+- **WHEN** the first attempt fails with a condition matching `RetryIntent.retry_on`
+- **THEN** the gateway MAY retry within the same invocation until attempts are exhausted
+- **AND** the response MUST include the attempt number that produced the returned result
+
+### Requirement: oagw audit logging
+The system SHALL maintain an audit log for all outbound invocations.
+
+#### Database table: outbound_api_audit_log
+- `id uuid pk`
+- `tenant_id uuid not null`
+- `user_id uuid null`
+- `route_id uuid not null`
+- `link_id uuid not null`
+- `operation text not null` (HTTP method)
+- `target_url text not null`
+- `status_code int null` (HTTP status)
+- `duration_ms int not null`
+- `error_message text null`
+- `trace_id text not null`
+- `timestamp timestamptz not null`
+
+**Indexes:**
+- `(tenant_id, timestamp desc)` for tenant audit queries
+- `(route_id, timestamp desc)` for route-specific audit trail
+- `(link_id, timestamp desc)` for link performance analysis
+
+NOTE: table parititioning and archiving and retention policies are not specified in this document. It's a subject for future improvements.
+
+The system SHALL define audit logging guarantees.
+
+Guarantee options are:
+- best-effort
+- guaranteed
+- fail-closed
+
+If audit logging is synchronous, the system SHALL enforce an upper bound on audit log latency.
+
+#### Scenario: Audit latency budget
+- **WHEN** the audit subsystem exceeds the maximum configured latency budget
+- **THEN** the gateway applies the configured guarantee mode (best-effort drop, guaranteed wait, or fail-closed)
+
+#### Scenario: Audit successful invocation
+- **WHEN** oagw invokes external API successfully
+- **THEN** logs (tenant_id, route_id, link_id, status_code, duration_ms, timestamp)
+- **AND** includes OpenTelemetry trace_id from current span
+
+#### Scenario: Audit failed invocation
+- **WHEN** oagw invocation fails (timeout, 500 error)
+- **THEN** logs error details for troubleshooting
+- **AND** records error_message and status_code
+
+### Requirement: oagw observability
+The system SHALL expose Prometheus-compatible metrics.
+
+Required metrics (using `metrics` crate):
+- `oagw.invocations_total` (counter, labels: tenant_id, route_id, status)
+- `oagw.request.duration_msec` (histogram, labels: route_id, protocol)
+- `oagw.errors_total` (counter, labels: error_type, route_id)
+- `oagw.active_connections` (gauge, labels: route_id)
+- `oagw.circuit_breaker.opened` (counter, labels: link_id)
+- `oagw.circuit_breaker.state` (gauge, labels: link_id)
+- `oagw.bytes_sent_total` (counter, labels: tenant_id, route_id, link_id)
+- `oagw.bytes_received_total` (counter, labels: tenant_id, route_id, link_id)
+- `oagw.token_cache.hit_total` (counter)
+- `oagw.token_cache.miss_total` (counter)
+- `oagw.token_cache.size` (gauge)
+
+Implementation SHALL use `metrics` and `metrics-exporter-prometheus` crates.
+
+#### Scenario: Metrics collection
+- **WHEN** outbound invocation completes
+- **THEN** system increments appropriate counters
+- **AND** records latency histogram
+- **AND** metrics are exposed at GET /metrics endpoint
+
+### Requirement: oagw health checks
+The system SHALL expose health check endpoints.
+
+REST endpoints:
+- `GET /oagw/v1/health` - Liveness probe
+- `GET /oagw/v1/ready` - Readiness probe (checks core dependencies like DB)
+- `GET /oagw/v1/routes/{routeId}/health` - Route-specific health check
+
+The `/oagw/v1/health` and `/oagw/v1/ready` endpoints access is not protected by any role.
+
+#### Scenario: Health check
+- **WHEN** `GET /oagw/v1/health` is called
+- **AND** no role is required
+- **THEN** returns 200 OK if system is health
+
+#### Scenario: Readiness check
+- **WHEN** `GET /oagw/v1/ready` is called
+- **AND** no role is required
+- **THEN** returns 200 OK if system can serve traffic
+- **AND** includes results of core dependency checks
+
+#### Scenario: Check downstream health
+- **WHEN** `GET /oagw/v1/routes/{routeId}/health` is called
+- **THEN** access is protected by role `gts.x.core.idp.role.v1~x.oagw.route.health.v1` assigned
+- **AND** system tests connectivity to all links for that route
+- **AND** returns aggregated health status
+
+### Requirement: oagw tracing integration
+The system SHALL integrate with OpenTelemetry for distributed tracing.
+
+All operations SHALL create spans with attributes:
+- `tenant_id`
+- `user_id` (if available)
+- `route_id`
+- `link_id`
+- `protocol`
+- `auth_type`
+- `target_url`
+- `http.method` (for HTTP)
+- `http.status_code` (for HTTP)
+
+Implementation SHALL use `tracing` and `tracing-opentelemetry` crates.
+
+#### Scenario: Trace outbound invocation
+- **WHEN** outbound invocation is performed
+- **THEN** system creates OpenTelemetry span with all relevant attributes
+- **AND** span is linked to parent trace context
+- **AND** errors are recorded as span events
+
+### Requirement: oagw circuit breaker
+The system SHALL implement circuit breaker state globally or per tenant-scoped link to prevent cascade failures.
+
+Circuit breaker state MUST be hierarchically scoped per `(provider_id, route_id, tenant_id, link_id)`.
+
+The system MAY maintain an aggregate breaker signal per `(tenant_id, route_id)` only for reporting and health aggregation.
+
+#### Extended table: outbound_api_link
+- Add: `circuit_breaker_threshold int not null default 5`
+- Add: `circuit_breaker_timeout_sec int not null default 30`
+- Add: `circuit_breaker_success_threshold int not null default 2`
+
+Circuit breaker configuration:
+- **Failure threshold:** 5 consecutive failures (configurable per link)
+- **Timeout:** 30 seconds (half-open state)
+- **Success threshold:** 2 successes to close
+- **Configurable:** module config file parameters can override these defaults
+
+Implementation SHOULD use `failsafe` or `tower` crate.
+
+#### Scenario: Circuit breaker opens
+- **GIVEN** link L fails 5 consecutive times
+- **WHEN** circuit breaker opens
+- **THEN** subsequent requests to L fail-fast (503)
+- **AND** system tries next eligible link (if available)
+- **AND** after 30s, circuit enters half-open state
+
+#### Scenario: Fallback to alternate link
+- **GIVEN** primary link has open circuit breaker
+- **WHEN** oagw selects link for invocation
+- **THEN** gateway skips primary and selects next highest-priority link
+
+#### Scenario: Circuit breaker recovery
+- **GIVEN** circuit breaker is half-open
+- **WHEN** 2 consecutive calls succeed
+- **THEN** circuit breaker closes
+- **AND** normal operation resumes
+
+### Requirement: oagw resource limits
+The system SHALL enforce resource limits per route.
+
+The system SHALL define explicit backpressure and buffering limits for unary and streaming requests.
+
+#### Scenario: Enforce per-invocation inflight bytes
+- **WHEN** the response body stream exceeds the configured per-invocation inflight byte budget
+- **THEN** the gateway aborts the stream and returns a stream abort error
+
+#### Scenario: Enforce concurrent request limit
+- **GIVEN** route R has 100 active requests
+- **WHEN** 101st request arrives
+- **THEN** gateway returns 429 Too Many Requests
+- **AND** includes Retry-After header
+
+#### Scenario: Enforce request size limit
+- **WHEN** client attempts to send 20 MB request payload
+- **AND** route limit is 10 MB
+- **THEN** gateway returns 413 Payload Too Large before sending to downstream
+
+NOTE: limits above are per route, configurable globally in module config or per tenant in database (`outbound_api_route_limits`).
+
+#### Scenario: Enforce response size limit
+- **WHEN** downstream returns response exceeding max_response_size_bytes
+- **THEN** gateway aborts response stream
+- **AND** returns 502 Bad Gateway to client
+
+### Requirement: oagw timeout configuration
+The system SHALL support granular timeout settings per link.
+
+#### Scenario: Connection timeout
+- **WHEN** TCP connection to link takes > 5s (configured in `outbound_api_link.connection_timeout_ms`)
+- **THEN** gateway aborts connection attempt
+- **AND** tries next link or returns 504 Gateway Timeout
+
+#### Scenario: Request timeout
+- **WHEN** request takes > 30s (including all retries, configured in `outbound_api_link`)
+- **THEN** gateway cancels request
+- **AND** returns 504 Gateway Timeout to client
+
+#### Scenario: Idle connection reuse
+- **WHEN** HTTP connection is idle for > 60s (configured in `outbound_api_link`)
+- **THEN** gateway closes connection
+- **AND** establishes new connection for next request
+
+### Requirement: oagw streaming error handling
+The system SHALL handle mid-stream errors gracefully.
+
+#### Scenario: SSE stream interruption
+- **WHEN** SSE stream from downstream breaks mid-stream
+- **THEN** gateway closes client stream with error event
+- **AND** logs partial stream duration and bytes received
+
+The streaming contract SHALL be treated as a stream of results.
+
+Stream items MUST be shaped as `Result<Chunk, StreamAbort>`.
+
+`StreamAbort` MUST include:
+- abort_reason (network | protocol | auth | timeout)
+- resumable: bool
+- resume_hint (e.g., Last-Event-ID)
+
+#### Scenario: Stream timeout
+- **WHEN** streaming response stalls (no data for > configured in `outbound_api_link.idle_timeout_ms`)
+- **THEN** gateway terminates stream
+- **AND** returns timeout error to client
+
+### Requirement: oagw token cache implementation
+The system SHALL implement token caching using in-memory LRU cache.
+
+Implementation SHOULD use `moka` crate for high-performance caching.
+
+Cache configuration:
+- **Max capacity:** 10,000 entries
+- **TTL:** Derived from token `exp` claim minus 60s safety margin
+- **Max TTL:** 3600s (1 hour)
+
+Cache key SHALL include:
+- `(tenant_id, user_id, route_id, auth_type_gts_id, scopes)`
+
+#### Scenario: Token TTL respects JWT exp claim
+- **WHEN** token exchange returns JWT with exp = 1 hour
+- **THEN** cache TTL = exp - 60s (safety margin)
+- **AND** token is evicted before actual expiry
+
+#### Scenario: Token cache eviction
+- **WHEN** cache reaches max capacity
+- **THEN** least recently used tokens are evicted
+- **AND** next access triggers fresh token exchange
+
+### Requirement: oagw token cache invalidation
+The system SHALL support manual token cache invalidation.
+
+REST endpoint:
+- `DELETE /oagw/v1/routes/{routeId}/cache/tokens` - Clear cached tokens for route
+
+#### Scenario: Clear cached tokens after credential rotation
+- **WHEN** admin rotates credentials for route R
+- **THEN** admin calls `DELETE /oagw/v1/routes/{R}/cache/tokens`
+- **AND** all cached tokens for R are evicted
+- **AND** next invocation triggers fresh token exchange
+
+#### Scenario: Clear all tokens for tenant
+- **WHEN** tenant credentials are compromised
+- **THEN** admin can clear all tenant tokens via cache flush
+- **AND** all active tokens are invalidated immediately
+
+### Requirement: oagw protocol version selection
+The system SHALL automatically select optimal protocol version.
+
+#### Scenario: Automatic HTTP/2 vs HTTP/3 selection
+- **GIVEN** route supports both `http2` and `http3` protocols
+- **WHEN** oagw initiates connection based on protocol GTS id with lower priority
+- **THEN** attempts HTTP/3 (QUIC) first if supported by downstream
+- **AND** falls back to HTTP/2 if HTTP/3 negotiation fails
+
+#### Scenario: Force protocol version
+- **WHEN** link explicitly specifies `protocol_gts_id = ... http11`
+- **THEN** gateway MUST use HTTP/1.1 only (no automatic upgrade)
+
+#### Scenario: Protocol negotiation failure
+- **WHEN** client requires protocol P but downstream doesn't support it
+- **THEN** gateway returns 502 Bad Gateway
+- **AND** error detail specifies protocol mismatch
+
+### Requirement: oagw response caching (optional)
+The system MAY support response caching for idempotent GET requests.
+
+#### Extended table: outbound_api_route
+- Add: `cache_ttl_sec int null` (NULL = no caching)
+
+Cache key SHALL include:
+- `(route_id, request_path, query_params, relevant_headers)`
+
+Implementation SHOULD use `moka` crate.
+
+#### Scenario: Cache GET response
+- **GIVEN** route has `cache_ttl_sec = 300` (5 min)
+- **WHEN** client performs GET request
+- **THEN** gateway caches response for 5 minutes
+- **AND** subsequent identical GET requests return cached response
+
+#### Scenario: Cache invalidation on mutation
+- **WHEN** client performs POST/PUT/DELETE on cached route
+- **THEN** gateway invalidates cached GET responses for that route
+
+#### Scenario: Respect Cache-Control headers
+- **WHEN** downstream response includes `Cache-Control: no-store`
+- **THEN** gateway bypasses cache regardless of route configuration
+
+### Requirement: oagw error taxonomy
+The system SHALL define comprehensive error types using RFC 9457 Problem Details defined in the modkit unified system.
+
+Error types SHALL include errors with appropriate GTS identifier:
+- `LinkUnavailable`: All links for route are down
+- `CircuitBreakerOpen`: Circuit breaker prevents invocation
+- `ConnectionTimeout`: Cannot establish connection
+- `RequestTimeout`: Request exceeded timeout
+- `RateLimitExceeded`: Route rate limit hit
+- `PayloadTooLarge`: Request or response size exceeded
+- `ProtocolError`: Protocol negotiation or parsing failed
+- `AuthenticationFailed`: Cannot obtain or refresh token
+- `DownstreamError`: Downstream returned error status
+
+#### Scenario: Link unavailable error
+- **WHEN** all eligible links are unavailable (circuit breakers open)
+- **THEN** gateway returns 503 Service Unavailable
+- **AND** includes Problem Detail with type `urn:oagw:error:link-unavailable`
+- **AND** lists affected link IDs
+
+#### Scenario: Rate limit error
+- **WHEN** route rate limit is exceeded
+- **THEN** gateway returns 429 Too Many Requests
+- **AND** includes `Retry-After` header with seconds until reset
+
+### Requirement: oagw rate limiting
+The system SHALL enforce rate limits per route using token bucket algorithm.
+
+Implementation SHOULD use `governor` crate.
+
+Rate limits SHALL be configurable per route (default: 1000 req/min).
+There must be global limit and per-tenant limit provided in `outbound_api_route`.
+
+The system SHALL support distributed rate limiting for multi-instance deployments.
+
+#### Scenario: Distributed rate limiting with Redis
+- **GIVEN** the deployment runs multiple gateway instances
+- **WHEN** rate limiting is enforced for `(tenant_id, route_id)`
+- **THEN** the system uses a Redis-backed shared limiter to ensure consistent quotas across instances
+
+### Requirement: outbound TLS and credential lifecycle
+The system SHALL define outbound TLS and credential refresh behavior.
+
+#### Scenario: TLS certificate validation
+- **WHEN** the gateway makes an outbound HTTPS request
+- **THEN** it validates the remote certificate chain by default
+
+#### Scenario: Credential rotation for long-lived streams
+- **WHEN** credentials referenced from `cred_store` rotate
+- **THEN** new invocations use the latest secret material
+- **AND** long-lived SSE streams require an explicit caller-initiated restart to pick up the new credentials
+
+#### Scenario: Rate limit enforcement
+- **GIVEN** route R has rate limit 1000 req/min
+- **WHEN** client exceeds limit
+- **THEN** gateway returns 429 Too Many Requests
+- **AND** includes Retry-After header
+
+#### Scenario: Per-tenant rate limiting
+- **GIVEN** route R has per-tenant limit configured
+- **WHEN** tenant T exceeds its quota
+- **THEN** only tenant T is rate limited
+- **AND** other tenants continue normally
+
+### Requirement: oagw OData support
+The system SHALL implement OData query capabilities per ModKit conventions.
+
+REST endpoints SHALL support:
+- `$skip` and `$top` for pagination
+- `$filter` for filtering
+- `$orderby` for sorting
+- `$select` for field projection
+
+Implementation SHALL use `modkit::api::OperationBuilder` OData support.
+
+#### Scenario: Paginated route list
+- **WHEN** GET /oagw/v1/routes?$skip=20&$top=10
+- **THEN** returns routes 21-30
+- **AND** includes `@odata.nextLink` for pagination
+
+#### Scenario: Filter links by route
+- **WHEN** GET /oagw/v1/links?$filter=route_id eq '550e8400-e29b-41d4-a716-446655440000'
+- **THEN** returns only links for that route
+
+### Requirement: oagw SLOs (Service Level Objectives)
+The system SHOULD target:
+- **Availability:** 99.9% (excluding planned maintenance and downstream failures)
+- **Latency:**
+  - p50: < 100ms overhead (excluding downstream latency)
+  - p95: < 200ms overhead
+  - p99: < 500ms overhead
+- **Error rate:** < 0.1% (excluding downstream errors)
+
+#### Scenario: SLO monitoring
+- **WHEN** operations team reviews SLO dashboard
+- **THEN** metrics show p95 latency overhead, error rate, and uptime
+- **AND** alerts trigger if SLO thresholds are breached

--- a/modules/oagw/docs/2_INTENT_FACTS.md
+++ b/modules/oagw/docs/2_INTENT_FACTS.md
@@ -1,0 +1,920 @@
+> This is module facts - generated from 1_INTENT.md and guidelines/NEW_MODULE.md, docs/MODKIT_PLUGINS.md, docs/MODKIT_UNIFIED_SYSTEM.md, examples/
+
+# OAGW Module Facts
+
+This document captures all facts required to implement the OAGW (Outbound API Gateway) module for managing outbound traffic to external APIs.
+
+---
+
+## F0 — Context & System Definition
+
+### F00 — Overview
+
+**[F00.001]** – Service Mission Statement
+> OAGW is a reusable **outbound API gateway** responsible for invoking external **HTTP APIs** (including **HTTP SSE** streaming) with pluggable protocol, authentication, and streaming implementations. It manages tenant-scoped route/link configuration, delegates actual invocation to selected plugins, and provides integrated circuit breaking, error normalization, and `Retry-After` propagation.
+> **OAGW performs no implicit retries** — retries occur only when explicitly requested by the caller via `RetryIntent`.
+
+**[F00.002]** – Bounded Context Definition
+> OAGW owns **outbound transport orchestration only**. It does NOT:
+> - Parse or interpret protocol-specific payloads (that's the consumer's responsibility)
+> - Implement vendor-specific logic (delegated to plugins)
+> - Store credentials directly (references `cred_store` by UUID)
+
+**[F00.003]** – Non-Goals / Explicitly Unsupported Behavior
+> - Inbound request handling (reverse proxy)
+> - Protocol payload parsing (e.g., LLM response parsing)
+> - Direct credential storage (uses `cred_store` references)
+> - WebSocket bidirectional streaming (v1 scope)
+> - **Automatic retry** (caller controls via `RetryIntent`)
+> - **Job scheduling or background processing** (OAGW is a synchronous gateway)
+> - **Streaming retry** (caller must restart stream if protocol supports resume)
+
+**[F00.004]** – Service Dependencies Map
+> | Dependency | Purpose |
+> |------------|---------|
+> | `types_registry` | GTS schema/instance registration |
+> | `cred_store` | Secret material retrieval by UUID reference |
+> | `api_ingress` | REST API hosting |
+> | `modkit-db` | Database persistence |
+> | `modkit-auth` | SecurityCtx authorization |
+
+**[F00.005]** – Data Ownership Boundaries
+> - **Owns**: `outbound_api_route`, `outbound_api_link`, `outbound_api_route_limits`, `outbound_api_audit_log`
+> - **References**: `cred_store.secret_store.id` (logical FK)
+> - **Reads**: `types_registry` for GTS instances
+
+---
+
+### F01 — Project Facts
+
+**[F01.001]** – Programming Language & Runtime
+> Rust 2021 edition, async runtime: Tokio
+
+**[F01.002]** – Project Layout Conventions
+> SDK pattern: `oagw-sdk/` (public API) + `oagw-gw/` (gateway implementation)
+> Plugin: `plugins/oagw-generic` (all in-one implementation)
+> See [NEW_MODULE.md](../../guidelines/NEW_MODULE.md)
+
+**[F01.003]** – Coding Standards
+> - `#![forbid(unsafe_code)]` in SDK crate
+> - All API methods accept `&SecurityCtx`
+> - SDK types have NO `serde` derives
+> - RFC-9457 Problem Details for errors
+
+**[F01.004]** – Versioning Strategy
+> REST API versioned: `/oagw/v1/...`
+> GTS schemas versioned: `gts.x.core.oagw.*.v1~`
+
+---
+
+### F01 — Main Rust Entrypoints
+
+**[F01.010]** – SDK Crate (`oagw-sdk`)
+> - `OagwApi` trait: `oagw_sdk::api::OagwApi`
+> - `OagwError` enum: `oagw_sdk::error::OagwError`
+> - `OagwInvokeRequest`: `oagw_sdk::types::OagwInvokeRequest`
+> - `OagwInvokeResponse`: `oagw_sdk::types::OagwInvokeResponse`
+> - `RetryIntent`: `oagw_sdk::retry::RetryIntent`
+> - `RetryBudget`: `oagw_sdk::retry::RetryBudget`
+
+**[F01.011]** – Gateway Crate (`oagw-gw`)
+> - Module struct: `oagw_gw::OagwModule`
+> - Service impl: `oagw_gw::service::OagwService`
+> - REST handlers: `oagw_gw::api::rest::handlers`
+> - Domain entities: `oagw_gw::domain::entities`
+
+**[F01.012]** – Plugin Crate (`oagw-generic`)
+> - Plugin impl: `oagw_generic::HttpPlugin`
+> - Plugin trait: `oagw_sdk::plugin::OagwPluginApi`
+
+---
+
+### F02 — External Dependencies
+
+**[F02.001]** – HTTP Client Library
+> `reqwest` for HTTP/1.1 and HTTP/2 requests
+> `modkit::http::TracedClient` for OpenTelemetry trace context injection
+
+**[F02.002]** – HTTP/3 Client Library
+> `reqwest` with `http3` feature or `h3` crate (future)
+
+**[F02.003]** – SSE Client Library
+> `reqwest` + `eventsource-client` or `reqwest-eventsource` for Server-Sent Events parsing
+
+**[F02.004]** – gRPC Client Library (Not in v1)
+> Not implemented in the current scope. OAGW supports **HTTP + SSE only** for now.
+
+**[F02.005]** – Circuit Breaker Library
+> `failsafe` or `tower` crate for circuit breaker implementation
+
+**[F02.006]** – Rate Limiting Library
+> `governor` crate for token bucket rate limiting
+
+**[F02.007]** – Caching Library
+> `moka` crate for in-memory LRU caching (token cache, response cache)
+
+**[F02.008]** – OAuth2 Library
+> `oauth2` crate for token exchange flows
+> `jsonwebtoken` for JWT parsing/validation
+
+---
+
+### F03 — Deployment
+
+**[F03.001]** – Health Check Endpoints
+> - `GET /oagw/v1/health` — Liveness probe (no auth)
+> - `GET /oagw/v1/ready` — Readiness probe (no auth; checks critical dependencies like DB)
+> - `GET /oagw/v1/routes/{routeId}/health` — Route health (requires role)
+
+---
+
+### F05 — Secrets Handling
+
+**[F05.001]** – Secret Reference Model
+> OAGW stores `secret_ref: uuid` pointing to `cred_store.secret_store.id`
+> Never stores actual secrets in OAGW tables
+
+**[F05.002]** – Secret Resolution
+> At invocation time: load secret from `cred_store` via `CredStoreApi`
+> Apply to request based on `auth_type_gts_id`
+
+---
+
+### F07 — Configuration Management
+
+**[F07.001]** – Module Config Structure
+```rust
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct OagwConfig {
+    pub token_cache_max_capacity: usize,      // default: 10_000
+    pub token_cache_max_ttl_sec: u64,         // default: 3600
+    pub token_cache_safety_margin_sec: u64,   // default: 60
+    pub response_cache_max_capacity: usize,   // default: 1_000
+    pub max_inflight_bytes_per_invocation: usize, // default: 8_388_608 (8 MiB)
+    pub max_stream_chunk_size_bytes: usize,       // default: 65_536 (64 KiB)
+    pub default_connection_timeout_ms: u64,   // default: 5_000
+    pub default_request_timeout_ms: u64,      // default: 30_000
+    pub default_idle_timeout_ms: u64,         // default: 60_000
+    pub default_rate_limit_per_min: u32,      // default: 1_000
+    pub circuit_breaker_threshold: u32,       // default: 5
+    pub circuit_breaker_timeout_sec: u32,     // default: 30
+    pub circuit_breaker_success_threshold: u32, // default: 2
+    pub audit_guarantee: AuditGuarantee,          // default: BestEffort
+    pub max_audit_latency_ms: u64,                // default: 50
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub enum AuditGuarantee {
+    BestEffort,
+    Guaranteed,
+    FailClosed,
+}
+```
+
+---
+
+### F08 — Logging & Tracing
+
+**[F08.001]** – Span Attributes
+> All operations create spans with:
+> - `tenant_id`, `user_id` (if available)
+> - `route_id`, `link_id`
+> - `protocol`, `auth_type`
+> - `target_url`
+> - `http.method`, `http.status_code` (for HTTP)
+
+**[F08.002]** – Tracing Crates
+> `tracing`, `tracing-opentelemetry` for distributed tracing
+
+---
+
+## F1 — GTS Types & Instances
+
+### F10 — GTS Schemas (Types)
+
+**[F10.001]** – Protocol Schema
+> `gts.x.core.oagw.proto.v1~`
+> Fields: `id`, `display_name`, `description?`, `priority?`
+
+**[F10.002]** – Auth Type Schema
+> `gts.x.core.oagw.auth_type.v1~`
+> Fields: `id`, `display_name`, `description?`
+
+**[F10.003]** – Strategy Schema
+> `gts.x.core.oagw.strategy.v1~`
+> Fields: `id`, `display_name`, `description?`
+
+---
+
+### F11 — Well-Known Protocol Instances
+
+**[F11.001]** – HTTP/1.1 Protocol
+> `gts.x.core.oagw.proto.v1~x.core.http.http11.v1`
+
+**[F11.002]** – HTTP/2 Protocol
+> `gts.x.core.oagw.proto.v1~x.core.http.http2.v1`
+
+**[F11.003]** – HTTP/3 Protocol
+> `gts.x.core.oagw.proto.v1~x.core.http.http3.v1`
+
+**[F11.004]** – SSE Protocol
+> `gts.x.core.oagw.proto.v1~x.core.http.sse.v1`
+
+**[F11.005]** – gRPC Protocol (Not supported)
+> Not supported in the current scope.
+
+---
+
+### F12 — Well-Known Strategy Instances
+
+**[F12.001]** – Sticky Session Strategy
+> `gts.x.core.oagw.strategy.v1~x.core._.sticky_session.v1`
+> Sticks to previously selected link for `(tenant_id, user_id)`
+
+**[F12.002]** – Round Robin Strategy
+> `gts.x.core.oagw.strategy.v1~x.core._.round_robin.v1`
+> Distributes invocations across links for same route
+
+---
+
+### F13 — Well-Known Auth Type Instances
+
+**[F13.001]** – Bearer Token Auth
+> `gts.x.core.oagw.auth_type.v1~x.core.auth.bearer_token.v1`
+> Header: `Authorization: Bearer <token>`
+
+**[F13.002]** – API Key Header Auth
+> `gts.x.core.oagw.auth_type.v1~x.core.auth.api_key_header.v1`
+> Custom header with API key (e.g., `X-API-Key: <key>`)
+
+**[F13.003]** – API Key Query Auth
+> `gts.x.core.oagw.auth_type.v1~x.core.auth.api_key_query.v1`
+> Query parameter with API key (e.g., `?key=<key>`)
+
+**[F13.004]** – OAuth2 Client Credentials Auth
+> `gts.x.core.oagw.auth_type.v1~x.core.auth.oauth2_client_creds.v1`
+> OAuth2 client credentials flow
+
+**[F13.005]** – OAuth2 Token Exchange Auth
+> `gts.x.core.oagw.auth_type.v1~x.core.auth.oauth2_token_exchange.v1`
+> RFC 8693 token exchange
+
+---
+
+## F2 — Domain Model
+
+### F20 — Domain Entities
+
+**[F20.001]** – OutboundApiRoute Entity
+> Represents a downstream API endpoint configuration
+> Fields: `id`, `tenant_id`, `base_url`, `rate_limit_req_per_min`, `auth_type_gts_id`, `cache_ttl_sec?`
+
+**[F20.002]** – OutboundApiRouteSupportedProtocol Entity
+> M:N relation between route and supported protocols
+> Fields: `id`, `route_id`, `protocol_gts_id`
+
+**[F20.003]** – OutboundApiLink Entity
+> Represents a tenant's configured connection to a route with credentials
+> Fields: `id`, `tenant_id`, `secret_ref`, `route_id`, `secret_type_gts_id`, `enabled`, `priority`, `strategy_gts_id`
+
+**[F20.004]** – OutboundApiRouteLimits Entity
+> Configurable limits per route or per link
+> Fields: `id`, `tenant_id`, `link_id?`, `route_id?`, timeouts, circuit breaker settings, size limits, rate limits
+
+**[F20.005]** – OutboundApiAuditLog Entity
+> Audit trail for all outbound invocations
+> Fields: `id`, `tenant_id`, `user_id?`, `route_id`, `link_id`, `operation`, `target_url`, `status_code?`, `duration_ms`, `error_message?`, `trace_id`, `timestamp`
+
+---
+
+### F21 — Value Objects
+
+**[F21.001]** – OagwInvokeRequest
+```rust
+pub struct OagwInvokeRequest {
+    pub link_id: Option<Uuid>,
+    pub route_id: Uuid,
+    pub method: HttpMethod,
+    pub path: String,
+    pub query: Option<HashMap<String, String>>,
+    pub headers: Option<HashMap<String, String>>,
+    pub body: Option<Bytes>,
+    pub timeout_ms: Option<u64>,
+    pub retry_intent: RetryIntent,      // Default: max_attempts=1 (no retry)
+}
+```
+
+**[F21.002]** – OagwInvokeResponse
+```rust
+pub struct OagwInvokeResponse {
+    pub status_code: u16,
+    pub headers: HashMap<String, String>,
+    pub body: Bytes,
+    pub duration_ms: u64,
+    pub link_id: Uuid,
+    pub retry_after_sec: Option<u64>,   // Propagated from downstream
+    pub attempt_number: u32,            // Which attempt succeeded (1-based)
+}
+```
+
+**[F21.003]** – OagwResponseStream
+```rust
+pub type OagwResponseStream = Pin<Box<dyn Stream<Item = Result<OagwStreamChunk, OagwStreamAbort>> + Send>>;
+
+pub struct OagwStreamChunk {
+    pub data: Bytes,
+    pub event_type: Option<String>,
+    pub event_id: Option<String>,       // SSE Last-Event-ID for resume
+}
+```
+
+**[F21.004]** – OagwStreamAbort (for stream failures)
+```rust
+pub struct OagwStreamAbort {
+    pub gts_id: GtsInstanceId,            // gts.x.core.errors.err.v1~x.oagw.stream.aborted.v1
+    pub bytes_received: u64,              // How much was received before failure
+    pub abort_reason: StreamAbortReason,  // network | protocol | auth | timeout
+    pub resumable: bool,
+    pub resume_hint: Option<String>,      // e.g., SSE Last-Event-ID
+    pub detail: Option<String>,
+}
+
+pub enum StreamAbortReason {
+    Network,
+    Protocol,
+    Auth,
+    Timeout,
+}
+```
+
+---
+
+## F2 — REST API
+
+### F20 — REST Handlers
+
+**[F20.001]** – POST /oagw/v1/routes
+> Create a new outbound route
+
+**[F20.002]** – GET /oagw/v1/routes
+> List routes with OData pagination
+
+**[F20.003]** – GET /oagw/v1/routes/{routeId}
+> Get route by ID
+
+**[F20.004]** – PATCH /oagw/v1/routes/{routeId}
+> Update route
+
+**[F20.005]** – DELETE /oagw/v1/routes/{routeId}
+> Delete route
+
+**[F20.006]** – POST /oagw/v1/links
+> Create a new outbound link
+
+**[F20.007]** – GET /oagw/v1/links
+> List links with OData pagination
+
+**[F20.008]** – GET /oagw/v1/links/{linkId}
+> Get link by ID
+
+**[F20.009]** – PATCH /oagw/v1/links/{linkId}
+> Update link
+
+**[F20.010]** – DELETE /oagw/v1/links/{linkId}
+> Delete link
+
+**[F20.011]** – POST /oagw/v1/invoke
+> Execute outbound invocation via REST
+
+**[F20.012]** – DELETE /oagw/v1/routes/{routeId}/cache/tokens
+> Clear cached tokens for route
+
+**[F20.013]** – GET /oagw/v1/health
+> Liveness probe (no auth)
+
+**[F20.014]** – GET /oagw/v1/ready
+> Readiness probe (no auth)
+
+**[F20.015]** – GET /oagw/v1/routes/{routeId}/health
+> Route health check (requires role)
+
+---
+
+### F27 — REST Status Codes
+
+**[F27.001]** – 200 OK
+> Successful GET/PATCH operations
+
+**[F27.002]** – 201 Created
+> Successful POST (create) operations
+
+**[F27.003]** – 204 No Content
+> Successful DELETE operations
+
+**[F27.004]** – 400 Bad Request
+> Invalid request payload
+
+**[F27.005]** – 401 Unauthorized
+> Missing or invalid authentication
+
+**[F27.006]** – 403 Forbidden
+> Insufficient permissions
+
+**[F27.007]** – 404 Not Found
+> Route/Link not found
+
+**[F27.008]** – 409 Conflict
+> Duplicate resource
+
+**[F27.009]** – 413 Payload Too Large
+> Request size exceeds limit
+
+**[F27.010]** – 429 Too Many Requests
+> Rate limit exceeded
+
+**[F27.011]** – 502 Bad Gateway
+> Downstream error
+
+**[F27.012]** – 503 Service Unavailable
+> Circuit breaker open / all links down
+
+**[F27.013]** – 504 Gateway Timeout
+> Request/connection timeout
+
+---
+
+## F4 — Security Model
+
+### F41 — Authentication
+
+**[F41.001]** – SecurityCtx Propagation
+> All API methods receive `&SecurityCtx` for tenant isolation and audit
+
+### F42 — Authorization (Roles)
+
+**[F42.001]** – Route Health Role
+> `gts.x.core.idp.role.v1~x.oagw.route.health.v1` — Required for `/routes/{routeId}/health`
+
+**[F42.002]** – Route Admin Role
+> `gts.x.core.idp.role.v1~x.oagw.route.admin.v1` — Full CRUD on routes
+
+**[F42.003]** – Link Admin Role
+> `gts.x.core.idp.role.v1~x.oagw.link.admin.v1` — Full CRUD on links
+
+**[F42.004]** – Invoke Role
+> `gts.x.core.idp.role.v1~x.oagw.invoke.v1` — Can invoke via REST API
+
+### F43 — Transport Security (Outbound)
+
+**[F43.001]** – TLS / mTLS Requirements
+> - Outbound HTTP connections MUST validate TLS certificates by default.
+> - The system MUST support configuring trust roots and certificate pinning policies per route/link.
+> - The system SHOULD support mTLS (client certificates) per link.
+
+**[F43.002]** – Secret Rotation & Long-Lived Connections
+> - Secrets referenced via `cred_store` MAY rotate.
+> - OAGW MUST bound connection reuse (idle timeout) and SHOULD avoid holding credentials indefinitely in memory.
+> - For long-lived SSE streams, credential refresh semantics MUST be explicit (caller-initiated stream restart).
+
+---
+
+## F5 — Service Layer
+
+### F50 — Service Methods (OagwApi Trait)
+
+**[F50.001]** – invoke_unary
+```rust
+async fn invoke_unary(&self, ctx: &SecurityCtx, req: OagwInvokeRequest) -> Result<OagwInvokeResponse, OagwError>;
+```
+
+**[F50.002]** – invoke_stream
+```rust
+async fn invoke_stream(&self, ctx: &SecurityCtx, req: OagwInvokeRequest) -> Result<OagwResponseStream, OagwError>;
+```
+
+**[F50.003]** – Route CRUD
+```rust
+async fn create_route(&self, ctx: &SecurityCtx, req: NewRoute) -> Result<Route, OagwError>;
+async fn get_route(&self, ctx: &SecurityCtx, id: Uuid) -> Result<Route, OagwError>;
+async fn list_routes(&self, ctx: &SecurityCtx, query: ODataQuery) -> Result<Page<Route>, OagwError>;
+async fn update_route(&self, ctx: &SecurityCtx, id: Uuid, patch: RoutePatch) -> Result<Route, OagwError>;
+async fn delete_route(&self, ctx: &SecurityCtx, id: Uuid) -> Result<(), OagwError>;
+```
+
+**[F50.004]** – Link CRUD
+```rust
+async fn create_link(&self, ctx: &SecurityCtx, req: NewLink) -> Result<Link, OagwError>;
+async fn get_link(&self, ctx: &SecurityCtx, id: Uuid) -> Result<Link, OagwError>;
+async fn list_links(&self, ctx: &SecurityCtx, query: ODataQuery) -> Result<Page<Link>, OagwError>;
+async fn update_link(&self, ctx: &SecurityCtx, id: Uuid, patch: LinkPatch) -> Result<Link, OagwError>;
+async fn delete_link(&self, ctx: &SecurityCtx, id: Uuid) -> Result<(), OagwError>;
+```
+
+---
+
+### F51 — Concurrency Model
+
+**[F51.001]** – Token Cache Deduplication
+> Deduplicate concurrent token exchanges for same cache key using `tokio::sync::OnceCell` or similar
+
+**[F51.002]** – Circuit Breaker State
+> Thread-safe circuit breaker state scoped per **(provider_id, route_id, tenant_id, link_id)**.
+> Optional aggregate state may be maintained per **(tenant_id, route_id)** strictly for reporting/health aggregation.
+> Circuit breakers MUST NOT be shared across tenants.
+
+---
+
+### F52 — Caching
+
+**[F52.001]** – Token Cache
+> Key: `(tenant_id, user_id, route_id, auth_type_gts_id, scopes)`
+> TTL: `token.exp - safety_margin`
+> Max TTL: 3600s
+> Max capacity: 10,000 entries
+
+**[F52.002]** – Response Cache (Optional)
+> Key: `(route_id, request_path, query_params, relevant_headers)`
+> TTL: from `route.cache_ttl_sec`
+> Bypass on `Cache-Control: no-store`
+
+---
+
+### F56 — Rate Limiting Governance
+
+**[F56.001]** – Scope
+> Rate limiting MUST be tenant-isolated and at minimum support per **(tenant_id, route_id)**.
+> Optional tighter scopes may be added (e.g., per link, per user) but MUST NOT cross tenant boundaries.
+
+**[F56.002]** – Distributed Rate Limiting (v4+)
+> For multi-instance deployments, rate limiting MUST support a Redis-backed distributed implementation.
+
+---
+
+### F53 — Observability (Metrics)
+
+**[F53.001]** – Invocation Counter
+> `oagw.invocations_total` (counter, labels: tenant_id, route_id, status)
+
+**[F53.002]** – Request Duration Histogram
+> `oagw.request.duration_msec` (histogram, labels: route_id, protocol)
+
+**[F53.003]** – Error Counter
+> `oagw.errors_total` (counter, labels: error_type, route_id)
+
+**[F53.004]** – Active Connections Gauge
+> `oagw.active_connections` (gauge, labels: route_id)
+
+**[F53.005]** – Circuit Breaker Metrics
+> `oagw.circuit_breaker.opened` (counter, labels: link_id)
+> `oagw.circuit_breaker.state` (gauge, labels: link_id)
+
+**[F53.006]** – Bytes Transferred
+> `oagw.bytes_sent_total` (counter, labels: tenant_id, route_id, link_id)
+> `oagw.bytes_received_total` (counter, labels: tenant_id, route_id, link_id)
+
+**[F53.007]** – Token Cache Metrics
+> `oagw.token_cache.hit_total` (counter)
+> `oagw.token_cache.miss_total` (counter)
+> `oagw.token_cache.size` (gauge)
+
+---
+
+### F54 — Error Handling
+
+**[F54.001]** – Error GTS Schema
+> `gts.x.core.errors.err.v1~` — Base error schema
+> All OAGW errors are registered as GTS instances under this schema
+
+**[F54.002]** – Error GTS Instances (Error Taxonomy)
+> | Error Type | HTTP | GTS Instance ID | Retriable |
+> |------------|------|-----------------|--------|
+> | RouteNotFound | 404 | `gts.x.core.errors.err.v1~x.oagw.route.not_found.v1` | No |
+> | LinkNotFound | 404 | `gts.x.core.errors.err.v1~x.oagw.link.not_found.v1` | No |
+> | LinkUnavailable | 503 | `gts.x.core.errors.err.v1~x.oagw.link.unavailable.v1` | Yes |
+> | CircuitBreakerOpen | 503 | `gts.x.core.errors.err.v1~x.oagw.circuit_breaker.open.v1` | Yes |
+> | ConnectionTimeout | 504 | `gts.x.core.errors.err.v1~x.oagw.timeout.connection.v1` | Yes |
+> | RequestTimeout | 504 | `gts.x.core.errors.err.v1~x.oagw.timeout.request.v1` | Yes |
+> | IdleTimeout | 504 | `gts.x.core.errors.err.v1~x.oagw.timeout.idle.v1` | Yes |
+> | RateLimitExceeded | 429 | `gts.x.core.errors.err.v1~x.oagw.rate_limit.exceeded.v1` | Yes* |
+> | PayloadTooLarge | 413 | `gts.x.core.errors.err.v1~x.oagw.payload.too_large.v1` | No |
+> | ProtocolError | 502 | `gts.x.core.errors.err.v1~x.oagw.protocol.error.v1` | No |
+> | AuthenticationFailed | 401 | `gts.x.core.errors.err.v1~x.oagw.auth.failed.v1` | No |
+> | SecretNotFound | 500 | `gts.x.core.errors.err.v1~x.oagw.secret.not_found.v1` | No |
+> | PluginNotFound | 503 | `gts.x.core.errors.err.v1~x.oagw.plugin.not_found.v1` | No |
+> | DownstreamError | 502 | `gts.x.core.errors.err.v1~x.oagw.downstream.error.v1` | Depends |
+> | StreamAborted | 502 | `gts.x.core.errors.err.v1~x.oagw.stream.aborted.v1` | No** |
+> | ValidationError | 400 | `gts.x.core.errors.err.v1~x.oagw.validation.error.v1` | No |
+>
+> \* Retriable after `Retry-After` delay
+> \** Streaming errors are never auto-retried; caller may restart stream
+
+**[F54.003]** – Error Response Structure (RFC-9457)
+```rust
+pub struct OagwError {
+    pub gts_id: GtsInstanceId,      // e.g., gts.x.core.errors.err.v1~x.oagw.timeout.connection.v1
+    pub status: u16,
+    pub title: String,
+    pub detail: Option<String>,
+    pub retry_after_sec: Option<u64>,  // Propagated from downstream or circuit breaker
+    pub retriable: bool,               // Hint for caller's RetryIntent
+    pub link_id: Option<Uuid>,         // Which link failed (if applicable)
+    pub downstream_status: Option<u16>, // Original status from downstream
+}
+```
+
+**[F54.004]** – Circuit Breaker Configuration
+> - Failure threshold: 5 consecutive failures
+> - Half-open timeout: 30 seconds
+> - Success threshold to close: 2 successes
+
+---
+
+### F55 — Retry Policy (Client-Controlled)
+
+**[F55.001]** – Retry Intent Structure
+> Retry is **fully controlled by the caller**, never automatic in OAGW.
+```rust
+pub struct RetryIntent {
+    pub max_attempts: u32,              // 1 = no retry (default)
+    pub retry_on: Vec<RetryOn>,         // Declarative retry conditions
+    pub scope: RetryScope,              // same_link | different_link | reroute
+    pub allow_strategy_reselect: bool,  // Can re-run strategy when switching links
+    pub backoff: BackoffStrategy,       // Exponential, linear, constant
+    pub budget: Option<Arc<RetryBudget>>, // Optional shared budget
+}
+
+pub enum RetryOn {
+    Timeout,
+    ConnectError,
+    StatusClass(StatusClass),
+    ErrorGtsId(GtsInstanceId),
+}
+
+pub enum StatusClass {
+    C5xx,
+    C429,
+}
+
+pub enum RetryScope {
+    SameLink,
+    DifferentLink,
+    Reroute,
+}
+
+pub enum BackoffStrategy {
+    None,
+    Constant { delay_ms: u64 },
+    Linear { initial_ms: u64, increment_ms: u64, max_ms: u64 },
+    Exponential { initial_ms: u64, multiplier: f64, max_ms: u64 },
+}
+```
+
+**[F55.002]** – Default Retry Intent
+> Default is **no retry**: `RetryIntent { max_attempts: 1, .. }`
+> Caller must explicitly opt-in to retries.
+
+**[F55.003]** – Retry Budget
+> Shared budget to limit total retries across multiple calls.
+```rust
+pub struct RetryBudget {
+    pub max_retries: AtomicU32,         // Total retries allowed in window
+    pub time_window_sec: u64,           // Budget replenishes after window
+    pub min_retries_per_sec: f64,       // Minimum retry rate guarantee
+}
+```
+
+**[F55.004]** – Retry Decision Flow (Caller-Side)
+> OAGW may perform retries **within the same invocation** when requested by the caller via `RetryIntent`.
+> - Retry state is **ephemeral** and lives only in the invocation context.
+> - `attempt_number` is **semantic** (1-based) and MUST reflect the attempt that produced the returned result.
+
+**[F55.005]** – Retry-After Propagation
+> OAGW **always propagates** `Retry-After` from:
+> - Downstream `429` responses
+> - Downstream `503` responses with `Retry-After` header
+> - Circuit breaker half-open timeout
+> - Rate limiter quota reset time
+
+**[F55.006]** – Streaming Retry Policy
+> **OAGW never retries streaming requests.**
+> - If stream fails mid-way, the stream yields a terminal `OagwStreamAbort`
+> - Abort includes `bytes_received` and `resume_hint` (if SSE)
+> - Caller may restart stream using protocol-specific resume (e.g., SSE `Last-Event-ID`)
+> - Resume capability is protocol-dependent, not OAGW's responsibility
+
+**[F55.007]** – Route-Level Retry Policy
+> Routes can define **allowed** retry behavior (limits, not defaults):
+```rust
+pub struct RouteRetryPolicy {
+    pub allow_retry: bool,              // false = reject any RetryIntent with max_attempts > 1
+    pub max_attempts_limit: u32,        // Cap on caller's max_attempts
+    pub allowed_error_classes: Vec<GtsInstanceId>,  // Errors that may be retried
+}
+```
+
+## F6 — Outbound Gateways (Plugin Interface)
+
+### F60 — Plugin API Trait
+
+**[F60.001]** – OagwPluginApi Trait
+```rust
+#[async_trait]
+pub trait OagwPluginApi: Send + Sync {
+    fn supported_protocols(&self) -> &[GtsInstanceId];
+    fn supported_stream_protocols(&self) -> &[GtsInstanceId];
+    fn supported_auth_types(&self) -> &[GtsInstanceId];
+    fn supported_strategies(&self) -> &[GtsInstanceId];
+    fn priority(&self) -> i16;
+
+    async fn invoke_unary(
+        &self,
+        ctx: &SecurityCtx,
+        link: &Link,
+        route: &Route,
+        secret: &Secret,
+        req: OagwInvokeRequest,
+    ) -> Result<OagwInvokeResponse, OagwError>;
+
+    async fn invoke_stream(
+        &self,
+        ctx: &SecurityCtx,
+        link: &Link,
+        route: &Route,
+        secret: &Secret,
+        req: OagwInvokeRequest,
+    ) -> Result<OagwResponseStream, OagwError>;
+}
+```
+
+**[F60.002]** – Plugin Selection
+> Filter plugins by: protocol + auth_type
+> Select lowest priority plugin
+
+---
+
+## F7 — Persistence
+
+### F70 — DB Connectivity
+
+**[F70.001]** – Database Backend
+> PostgreSQL/MariaDB/SQLite via SeaORM
+
+### F73 — Schemas
+
+**[F73.001]** – outbound_api_route Table
+```sql
+CREATE TABLE outbound_api_route (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL,
+    base_url TEXT NOT NULL,
+    rate_limit_req_per_min INT NOT NULL DEFAULT 1000,
+    auth_type_gts_id TEXT NOT NULL,
+    cache_ttl_sec INT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+**[F73.002]** – outbound_api_route_supported_protocol Table
+```sql
+CREATE TABLE outbound_api_route_supported_protocol (
+    id UUID PRIMARY KEY,
+    route_id UUID NOT NULL REFERENCES outbound_api_route(id) ON DELETE CASCADE,
+    protocol_gts_id TEXT NOT NULL
+);
+```
+
+**[F73.003]** – outbound_api_link Table
+```sql
+CREATE TABLE outbound_api_link (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL,
+    secret_ref UUID NOT NULL,
+    route_id UUID NOT NULL REFERENCES outbound_api_route(id),
+    secret_type_gts_id TEXT NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    priority INT NOT NULL DEFAULT 0,
+    strategy_gts_id TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+**[F73.004]** – outbound_api_route_limits Table
+```sql
+CREATE TABLE outbound_api_route_limits (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL,
+    link_id UUID NULL UNIQUE,
+    route_id UUID NULL UNIQUE,
+    connection_timeout_ms INT NOT NULL DEFAULT 5000,
+    request_timeout_ms INT NOT NULL DEFAULT 30000,
+    idle_timeout_ms INT NOT NULL DEFAULT 60000,
+    circuit_breaker_threshold INT NOT NULL DEFAULT 5,
+    circuit_breaker_timeout_sec INT NOT NULL DEFAULT 30,
+    circuit_breaker_success_threshold INT NOT NULL DEFAULT 2,
+    max_concurrent_requests INT NOT NULL DEFAULT 100,
+    max_request_size_bytes INT NOT NULL DEFAULT 10485760,
+    max_response_size_bytes INT NOT NULL DEFAULT 104857600,
+    rate_limit_per_min INT NOT NULL DEFAULT 1000,
+    CHECK (link_id IS NOT NULL OR route_id IS NOT NULL)
+);
+```
+
+**[F73.005]** – outbound_api_audit_log Table
+```sql
+CREATE TABLE outbound_api_audit_log (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL,
+    user_id UUID NULL,
+    route_id UUID NOT NULL,
+    link_id UUID NOT NULL,
+    operation TEXT NOT NULL,
+    target_url TEXT NOT NULL,
+    status_code INT NULL,
+    duration_ms INT NOT NULL,
+    error_message TEXT NULL,
+    trace_id TEXT NOT NULL,
+    timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_audit_tenant_ts ON outbound_api_audit_log(tenant_id, timestamp DESC);
+CREATE INDEX idx_audit_route_ts ON outbound_api_audit_log(route_id, timestamp DESC);
+CREATE INDEX idx_audit_link_ts ON outbound_api_audit_log(link_id, timestamp DESC);
+```
+
+---
+
+## F8 — Provider-Specific Facts (Reference)
+
+### F80 — OpenAI API Facts
+
+**[F80.001]** – Base URL
+> `https://api.openai.com/v1`
+
+**[F80.002]** – Authentication
+> Bearer token: `Authorization: Bearer <api_key>`
+
+**[F80.003]** – Completion Endpoint
+> `POST /chat/completions`
+
+**[F80.004]** – Embedding Endpoint
+> `POST /embeddings`
+
+**[F80.005]** – Streaming
+> SSE via `stream: true` parameter
+
+---
+
+### F81 — Anthropic API Facts
+
+**[F81.001]** – Base URL
+> `https://api.anthropic.com`
+
+**[F81.002]** – Authentication
+> API key header: `x-api-key: <api_key>`
+> Version header: `anthropic-version: 2023-06-01`
+
+**[F81.003]** – Completion Endpoint
+> `POST /v1/messages`
+
+**[F81.004]** – Streaming
+> SSE via `stream: true` parameter
+
+**[F81.005]** – No Embedding Support
+> Anthropic does not provide embedding API
+
+---
+
+### F82 — Gemini API Facts
+
+**[F82.001]** – Base URL
+> `https://generativelanguage.googleapis.com`
+
+**[F82.002]** – Authentication
+> Query parameter: `?key=<api_key>`
+
+**[F82.003]** – Completion Endpoint
+> `POST /v1beta/models/{model}:generateContent`
+
+**[F82.004]** – Embedding Endpoint
+> `POST /v1beta/models/{model}:batchEmbedContents`
+
+**[F82.005]** – Streaming
+> SSE via `?alt=sse` query parameter
+
+---
+
+## F9 — SLOs
+
+**[F90.001]** – Availability Target
+> 99.9% (excluding planned maintenance and downstream failures)
+
+**[F90.002]** – Latency Targets
+> - p50: < 100ms overhead
+> - p95: < 200ms overhead
+> - p99: < 500ms overhead
+
+**[F90.003]** – Error Rate Target
+> < 0.1% (excluding downstream errors)

--- a/modules/oagw/docs/3_INTENT_SCENARIOS.md
+++ b/modules/oagw/docs/3_INTENT_SCENARIOS.md
@@ -1,0 +1,589 @@
+> This is module scenarios - generated from 1_INTENT.md and guidelines/NEW_MODULE.md, docs/MODKIT_PLUGINS.md, docs/MODKIT_UNIFIED_SYSTEM.md, examples/
+
+# OAGW Module Scenarios
+
+This document provides detailed step-by-step scenarios for the OAGW (Outbound API Gateway) module. Each scenario is versioned v1-v5, where v1 is MVP and v5 is full-featured.
+
+**Version Definitions:**
+
+| Version | Focus | Key Features |
+|---------|-------|--------------|
+| **v1** | MVP | Basic invocation, route/link CRUD, plugin selection, bearer/API key auth, GTS error taxonomy, no-retry default |
+| **v2** | Production | Streaming (no retry), audit logging, metrics, rate limiting, OData pagination, `Retry-After` propagation |
+| **v3** | Reliability | Circuit breaker, token caching, OAuth2, health checks, `RetryIntent` support, `RetryBudget` |
+| **v4** | Performance | Sticky sessions, round robin, response caching |
+| **v5** | Enterprise | Token exchange, advanced caching, per-tenant rate limits |
+
+---
+
+## Design Principles
+
+1. **OAGW is a synchronous gateway** — no background job processing, no in-memory queues
+2. **Retry is caller-controlled** — OAGW performs no implicit retries; caller provides a declarative `RetryIntent` per request [F55.001]
+3. **Streaming never retries** — caller must restart stream if protocol supports resume [F55.006]
+4. **`Retry-After` always propagates** — from downstream, circuit breaker, or rate limiter [F55.005]
+5. **All errors have GTS IDs** — enables programmatic error handling [F54.002]
+6. **No constants except GTS IDs** — all identifiers are GTS instance IDs
+
+
+**Notation:** Steps reference `[FXXX]` fact IDs from [FACTS.md](./FACTS.md).
+
+---
+
+## Scenario 1: REST API Invocation
+
+External client invokes downstream API via OAGW REST endpoint.
+
+### 1.1 Request Reception
+
+- [ ] v1 - HTTP request arrives at `POST /oagw/v1/invoke` [F20.011]
+- [ ] v1 - `api_ingress` routes request to OAGW handler
+- [ ] v1 - Extract `Authorization` header, validate JWT via `modkit-auth`
+- [ ] v1 - Construct `SecurityCtx` with `tenant_id`, `user_id` [F41.001]
+- [ ] v2 - Validate request against OpenAPI schema (utoipa)
+- [ ] v2 - Check caller has `gts.x.core.idp.role.v1~x.oagw.invoke.v1` role [F42.004]
+- [ ] v3 - Extract `X-Request-Id` header for correlation
+- [ ] v1 - Apply request size limit check before parsing body [F27.009]
+
+### 1.2 Request Parsing & Validation
+
+- [ ] v1 - Deserialize JSON body into `InvokeRequestDto`
+- [ ] v1 - Validate required fields: `route_id`, `method`, `path`
+- [ ] v1 - **IF** `link_id` provided:
+  - [ ] v1 - Use specified link directly
+- [ ] v1 - **ELSE**:
+  - [ ] v1 - OAGW will select link in step 1.4
+- [ ] v2 - Validate `method` is one of: GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+- [ ] v3 - Validate `headers` map doesn't contain forbidden headers (Host, Authorization)
+- [ ] v4 - Validate `body` size against `max_request_size_bytes` from route limits [F20.004]
+
+### 1.3 Route Resolution
+
+- [ ] v1 - Query `outbound_api_route` by `route_id` and `tenant_id` [F73.001]
+- [ ] v1 - **IF** route not found:
+  - [ ] v1 - Return `404 Not Found` with Problem Detail [F27.007]
+- [ ] v1 - Load route configuration: `base_url`, `auth_type_gts_id`
+- [ ] v2 - Load supported protocols from `outbound_api_route_supported_protocol` [F73.002]
+- [ ] v3 - Load route limits from `outbound_api_route_limits` (if exists) [F73.004]
+- [ ] v3 - **IF** no route-specific limits:
+  - [ ] v3 - Use module config defaults [F07.001]
+
+### 1.4 Link Selection
+
+- [ ] v1 - **IF** `link_id` was provided in request:
+  - [ ] v1 - Query `outbound_api_link` by `link_id`, `tenant_id` [F73.003]
+  - [ ] v1 - **IF** link not found OR `enabled = false`:
+    - [ ] v1 - Return `404 Not Found` [F27.007]
+  - [ ] v1 - Verify `link.route_id == route_id`
+- [ ] v1 - **ELSE** (auto-select link):
+  - [ ] v1 - Query all enabled links for `(route_id, tenant_id)` [F73.003]
+  - [ ] v1 - **IF** no enabled links:
+    - [ ] v1 - Return `503 Service Unavailable` [F27.012]
+    - [ ] v1 - Error: `gts.x.core.errors.err.v1~x.oagw.link.unavailable.v1` [F54.002]
+  - [ ] v2 - Sort links by `priority` ASC (lower = higher priority)
+  - [ ] v3 - Filter out links with open circuit breakers [F54.004]
+  - [ ] v3 - **IF** all links filtered out:
+    - [ ] v3 - Return `503 Service Unavailable`
+    - [ ] v3 - Error: `gts.x.core.errors.err.v1~x.oagw.circuit_breaker.open.v1`
+    - [ ] v3 - Set `retry_after_sec` from circuit breaker half-open timeout [F55.005]
+  - [ ] v4 - **SWITCH** on `link.strategy_gts_id`:
+    - [ ] v4 - **CASE** `sticky_session` [F12.001]:
+      - [ ] v4 - Lookup sticky mapping for `(tenant_id, user_id)`
+      - [ ] v4 - **IF** mapping exists AND link is available:
+        - [ ] v4 - Use mapped link
+      - [ ] v4 - **ELSE**:
+        - [ ] v4 - Select first available link, store mapping
+    - [ ] v4 - **CASE** `round_robin` [F12.002]:
+      - [ ] v4 - Get atomic counter for route
+      - [ ] v4 - Select `links[counter % links.len()]`
+      - [ ] v4 - Increment counter
+    - [ ] v4 - **DEFAULT**:
+      - [ ] v4 - Select first available link (by priority)
+
+### 1.5 Rate Limit Check
+
+- [ ] v2 - Get rate limiter for `(tenant_id, route_id)` [F56.001]
+- [ ] v4 - In multi-instance deployments, use Redis-backed distributed rate limiter for `(tenant_id, route_id)` [F56.002]
+- [ ] v2 - **IF** rate limit exceeded:
+  - [ ] v2 - Calculate `retry_after_sec` from quota reset time [F55.005]
+  - [ ] v2 - Return `429 Too Many Requests` [F27.010]
+  - [ ] v2 - Error: `gts.x.core.errors.err.v1~x.oagw.rate_limit.exceeded.v1` [F54.002]
+  - [ ] v2 - Set `Retry-After` header (MUST propagate) [F55.005]
+  - [ ] v2 - Increment `oagw.errors_total{error_type="rate_limit"}` [F53.003]
+- [ ] v3 - Check concurrent request limit for route [F20.004]
+- [ ] v3 - **IF** `active_requests >= max_concurrent_requests`:
+  - [ ] v3 - Return `429 Too Many Requests`
+- [ ] v3 - Increment active request counter
+- [ ] v5 - Check per-tenant rate limit (if configured separately)
+
+### 1.6 Plugin Selection
+
+- [ ] v1 - Get route's required protocol from `outbound_api_route_supported_protocol`
+- [ ] v1 - Get route's required auth type from `route.auth_type_gts_id`
+- [ ] v1 - Query `types_registry` for plugins matching schema `gts.x.core.modkit.plugin.v1~x.core.oagw.plugin.v1~*`
+- [ ] v1 - **FOR EACH** plugin instance:
+  - [ ] v1 - Parse `properties` as `OagwPluginSpecV1`
+  - [ ] v1 - Check `supported_protocols` contains required protocol
+  - [ ] v1 - Check `supported_auth_types` contains required auth type
+  - [ ] v1 - **IF** both match:
+    - [ ] v1 - Add to eligible plugins list
+- [ ] v1 - **IF** no eligible plugins:
+  - [ ] v1 - Return `503 Service Unavailable`, log error
+- [ ] v1 - Sort eligible plugins by `priority` ASC [F60.002]
+- [ ] v1 - Select first plugin (lowest priority)
+- [ ] v1 - Get plugin client from `ClientHub` via scoped lookup [F60.001]
+
+### 1.7 Secret Resolution
+
+- [ ] v1 - Get `link.secret_ref` UUID
+- [ ] v1 - Get `link.secret_type_gts_id`
+- [ ] v1 - Call `CredStoreApi::get_secret(ctx, secret_ref)` [F05.002]
+- [ ] v1 - **IF** secret not found:
+  - [ ] v1 - Return `500 Internal Server Error`
+  - [ ] v1 - Error: `gts.x.core.errors.err.v1~x.oagw.secret.not_found.v1` [F54.002]
+  - [ ] v1 - Log error (do NOT expose secret details)
+- [ ] v2 - Validate secret type matches `secret_type_gts_id`
+
+### 1.8 Authentication Preparation
+
+- [ ] v1 - **SWITCH** on `route.auth_type_gts_id`:
+  - [ ] v1 - **CASE** `bearer_token` [F13.001]:
+    - [ ] v1 - Set header: `Authorization: Bearer {secret.value}`
+  - [ ] v1 - **CASE** `api_key_header` [F13.002]:
+    - [ ] v1 - Get header name from secret metadata
+    - [ ] v1 - Set header: `{header_name}: {secret.value}`
+  - [ ] v2 - **CASE** `api_key_query` [F13.003]:
+    - [ ] v2 - Get query param name from secret metadata
+    - [ ] v2 - Append to URL: `?{param_name}={secret.value}`
+  - [ ] v3 - **CASE** `oauth2_client_creds` [F13.004]:
+    - [ ] v3 - Build cache key: `(tenant_id, route_id, auth_type, scopes)` [F52.001]
+    - [ ] v3 - Check token cache
+    - [ ] v3 - **IF** cache hit:
+      - [ ] v3 - Use cached token
+      - [ ] v3 - Increment `oagw.token_cache.hit_total` [F53.007]
+    - [ ] v3 - **ELSE**:
+      - [ ] v3 - Increment `oagw.token_cache.miss_total`
+      - [ ] v3 - Call OAuth2 token endpoint with client credentials
+      - [ ] v3 - Parse JWT, extract `exp` claim
+      - [ ] v3 - Calculate TTL: `min(exp - safety_margin, max_ttl)` [F52.001]
+      - [ ] v3 - Store in cache with TTL
+    - [ ] v3 - Set header: `Authorization: Bearer {token}`
+  - [ ] v4 - **CASE** `oauth2_token_exchange` [F13.005]:
+    - [ ] v4 - Build cache key: `(tenant_id, user_id, route_id, auth_type, scopes)`
+    - [ ] v4 - Check token cache
+    - [ ] v4 - **IF** cache miss:
+      - [ ] v4 - Get inbound user token from `SecurityCtx`
+      - [ ] v4 - Call RFC 8693 token exchange endpoint
+      - [ ] v4 - Cache exchanged token
+    - [ ] v4 - Set header: `Authorization: Bearer {exchanged_token}`
+
+### 1.9 Request Construction
+
+- [ ] v1 - Build target URL: `{route.base_url}{request.path}`
+- [ ] v1 - **IF** `request.query` provided:
+  - [ ] v1 - Append query string to URL
+- [ ] v1 - Create HTTP request with:
+  - [ ] v1 - Method from `request.method`
+  - [ ] v1 - URL from above
+  - [ ] v1 - Body from `request.body` (if provided)
+- [ ] v1 - Add authentication headers (from step 1.8)
+- [ ] v2 - Add custom headers from `request.headers`
+- [ ] v3 - Inject OpenTelemetry trace context via `TracedClient` [F02.001]
+- [ ] v3 - Set `User-Agent` header with OAGW identifier
+
+### 1.10 Timeout Configuration
+
+- [ ] v1 - Get `connection_timeout_ms` from route limits (or default 5000ms)
+- [ ] v1 - Get `request_timeout_ms` from route limits (or default 30000ms)
+- [ ] v1 - **IF** `request.timeout_ms` provided AND < `request_timeout_ms`:
+  - [ ] v1 - Use `request.timeout_ms`
+- [ ] v2 - Configure idle timeout for connection reuse
+
+### 1.11 Plugin Invocation
+
+- [ ] v1 - Start timer for duration tracking
+- [ ] v2 - Create tracing span with attributes [F08.001]:
+  - [ ] v2 - `tenant_id`, `route_id`, `link_id`
+  - [ ] v2 - `target_url`, `http.method`
+- [ ] v1 - Call `plugin.invoke_unary(ctx, link, route, secret, request)` [F60.001]
+- [ ] v1 - **TRY**:
+  - [ ] v1 - Await response
+- [ ] v1 - **CATCH** connection timeout:
+  - [ ] v1 - Increment circuit breaker failure count
+  - [ ] v1 - Return `504 Gateway Timeout` [F27.013]
+  - [ ] v1 - Error: `gts.x.core.errors.err.v1~x.oagw.timeout.connection.v1` (retriable=true) [F54.002]
+- [ ] v1 - **CATCH** request timeout:
+  - [ ] v1 - Increment circuit breaker failure count
+  - [ ] v1 - Return `504 Gateway Timeout`
+  - [ ] v1 - Error: `gts.x.core.errors.err.v1~x.oagw.timeout.request.v1` (retriable=true) [F54.002]
+- [ ] v2 - **CATCH** protocol error:
+  - [ ] v2 - Return `502 Bad Gateway` [F27.011]
+  - [ ] v2 - Error: `gts.x.core.errors.err.v1~x.oagw.protocol.error.v1` (retriable=false) [F54.002]
+- [ ] v1 - Stop timer, record duration
+
+### 1.12 Circuit Breaker Update
+
+- [ ] v3 - **IF** invocation succeeded (2xx status):
+  - [ ] v3 - Reset consecutive failure count for link
+  - [ ] v3 - **IF** circuit was half-open:
+    - [ ] v3 - Increment success count
+    - [ ] v3 - **IF** success_count >= `circuit_breaker_success_threshold`:
+      - [ ] v3 - Close circuit breaker
+      - [ ] v3 - Update `oagw.circuit_breaker.state` gauge [F53.005]
+- [ ] v3 - **ELSE IF** invocation failed (5xx status or error):
+  - [ ] v3 - Increment consecutive failure count
+  - [ ] v3 - **IF** failure_count >= `circuit_breaker_threshold`:
+    - [ ] v3 - Open circuit breaker
+    - [ ] v3 - Set half-open timer for `circuit_breaker_timeout_sec`
+    - [ ] v3 - Increment `oagw.circuit_breaker.opened` counter [F53.005]
+    - [ ] v3 - Update state gauge
+
+### 1.13 Audit Logging
+
+- [ ] v2 - Insert row into `outbound_api_audit_log` [F73.005]:
+  - [ ] v2 - `tenant_id` from `SecurityCtx`
+  - [ ] v2 - `user_id` from `SecurityCtx` (if available)
+  - [ ] v2 - `route_id`, `link_id`
+  - [ ] v2 - `operation` = HTTP method
+  - [ ] v2 - `target_url`
+  - [ ] v2 - `status_code` from response
+  - [ ] v2 - `duration_ms` from timer
+  - [ ] v2 - `error_message` (if error occurred)
+  - [ ] v2 - `trace_id` from current span [F08.001]
+  - [ ] v2 - `timestamp` = now
+
+### 1.14 Metrics Recording
+
+- [ ] v2 - Increment `oagw.invocations_total{tenant_id, route_id, status}` [F53.001]
+- [ ] v2 - Record `oagw.request.duration_msec{route_id, protocol}` histogram [F53.002]
+- [ ] v2 - **IF** error occurred:
+  - [ ] v2 - Increment `oagw.errors_total{error_type, route_id}` [F53.003]
+- [ ] v3 - Record `oagw.bytes_sent_total` (request body size) [F53.006]
+- [ ] v3 - Record `oagw.bytes_received_total` (response body size)
+- [ ] v3 - Decrement active request counter
+
+### 1.15 Response Construction
+
+- [ ] v1 - **IF** success (plugin returned response):
+  - [ ] v1 - Map `OagwInvokeResponse` to `InvokeResponseDto`
+  - [ ] v1 - Return `200 OK` with JSON body [F27.001]
+- [ ] v1 - **ELSE IF** downstream error (4xx/5xx from downstream):
+  - [ ] v1 - Propagate status code
+  - [ ] v1 - Include downstream body in response
+  - [ ] v1 - **IF** downstream returned `Retry-After` header:
+    - [ ] v1 - Propagate `retry_after_sec` in response [F55.005]
+- [ ] v2 - Add response headers:
+  - [ ] v2 - `X-Request-Id` (correlation)
+  - [ ] v2 - `X-OAGW-Duration-Ms` (processing time)
+  - [ ] v2 - `X-OAGW-Link-Id` (which link was used)
+  - [ ] v2 - `Retry-After` (if applicable, MUST propagate) [F55.005]
+
+### 1.16 Response Caching (Optional)
+
+- [ ] v5 - **IF** request method was GET AND `route.cache_ttl_sec` is set:
+  - [ ] v5 - **IF** response does NOT have `Cache-Control: no-store`:
+    - [ ] v5 - Build cache key: `(route_id, path, query, relevant_headers)` [F52.002]
+    - [ ] v5 - Store response in cache with TTL
+- [ ] v5 - **BEFORE** step 1.11, check response cache:
+  - [ ] v5 - **IF** cache hit for GET request:
+    - [ ] v5 - Return cached response immediately
+    - [ ] v5 - Skip plugin invocation
+
+---
+
+## Scenario 2: Direct Rust API Invocation
+
+Internal module invokes downstream API via `OagwApi` trait (ClientHub).
+
+### 2.1 Client Acquisition
+
+- [ ] v1 - Caller module gets `OagwApi` client from `ClientHub`:
+  ```rust
+  let oagw = ctx.client_hub().get::<dyn OagwApi>()?;
+  ```
+- [ ] v1 - `OagwApi` is registered by OAGW gateway during `init()` [F50.001]
+
+### 2.2 Request Construction
+
+- [ ] v1 - Caller constructs `OagwInvokeRequest` [F21.001]:
+  ```rust
+  let req = OagwInvokeRequest {
+      route_id,
+      link_id: None, // or Some(specific_link)
+      method: HttpMethod::Post,
+      path: "/v1/chat/completions".to_string(),
+      query: None,
+      headers: Some(custom_headers),
+      body: Some(request_body),
+      timeout_ms: Some(30000),
+      retry_intent: RetryIntent::default(), // No retry by default [F55.002]
+  };
+  ```
+- [ ] v3 - **IF** caller wants retry, configure `RetryIntent` [F55.001]:
+  ```rust
+  let req = OagwInvokeRequest {
+      // ...
+      retry_intent: RetryIntent {
+          max_attempts: 3,
+          retry_on: vec![
+              GtsInstanceId::from("gts.x.core.errors.err.v1~x.oagw.timeout.connection.v1"),
+              GtsInstanceId::from("gts.x.core.errors.err.v1~x.oagw.timeout.request.v1"),
+          ],
+          backoff: BackoffStrategy::Exponential {
+              initial_ms: 100,
+              multiplier: 2.0,
+              max_ms: 5000,
+          },
+          budget: Some(shared_budget.clone()), // Optional shared budget [F55.003]
+      },
+  };
+  ```
+
+### 2.3 Unary Invocation
+
+- [ ] v1 - Call `invoke_unary`:
+  ```rust
+  let response = oagw.invoke_unary(&ctx, req).await?;
+  ```
+- [ ] v1 - Service validates `SecurityCtx` has valid `tenant_id`
+- [ ] v1 - **EXECUTE** steps 1.3 through 1.15 (same as REST scenario)
+- [ ] v1 - Return `OagwInvokeResponse` [F21.002]:
+  ```rust
+  OagwInvokeResponse {
+      status_code: 200,
+      headers: response_headers,
+      body: response_body,
+      duration_ms: 150,
+      link_id: selected_link_id,
+  }
+  ```
+
+### 2.4 Streaming Invocation
+
+- [ ] v2 - Call `invoke_stream` for SSE/streaming responses [F50.002]:
+  ```rust
+  let stream = oagw.invoke_stream(&ctx, req).await?;
+  ```
+- [ ] v2 - Service selects plugin supporting stream protocol [F11.004]
+- [ ] v2 - Plugin returns `OagwResponseStream` [F21.003]
+- [ ] v2 - Caller consumes stream:
+  ```rust
+  while let Some(chunk) = stream.next().await {
+      match chunk {
+          Ok(data) => process_chunk(data),
+          Err(e) => handle_stream_error(e),
+      }
+  }
+  ```
+
+### 2.5 Stream Protocol Selection
+
+- [ ] v2 - **IF** route supports SSE protocol [F11.004]:
+  - [ ] v2 - Select plugin with `supported_stream_protocols` containing SSE
+  - [ ] v2 - Plugin initiates HTTP request with SSE headers
+  - [ ] v2 - Plugin parses `text/event-stream` frames
+  - [ ] v2 - Each SSE event becomes `OagwStreamChunk`
+
+### 2.6 Stream Error Handling (No Retry)
+
+- [ ] v2 - **OAGW never retries streaming requests** [F55.006]
+- [ ] v2 - **IF** stream connection drops mid-stream:
+  - [ ] v2 - Stream yields terminal `OagwStreamAbort` [F21.004]
+  - [ ] v2 - Error: `gts.x.core.errors.err.v1~x.oagw.stream.aborted.v1` (retriable=false)
+  - [ ] v2 - Include `bytes_received` in error
+  - [ ] v2 - Include `resume_hint` (if SSE) for caller to resume
+  - [ ] v2 - Record error in audit log
+- [ ] v3 - **IF** stream idle timeout exceeded [F20.004]:
+  - [ ] v3 - Terminate stream
+  - [ ] v3 - Error: `gts.x.core.errors.err.v1~x.oagw.timeout.idle.v1`
+- [ ] v3 - **IF** response size limit exceeded:
+  - [ ] v3 - Abort stream
+  - [ ] v3 - Error: `gts.x.core.errors.err.v1~x.oagw.payload.too_large.v1`
+- [ ] v3 - **Caller is responsible for stream restart**:
+  - [ ] v3 - Use `resume_hint` (e.g., `Last-Event-ID`) for SSE resume (if protocol supports)
+  - [ ] v3 - Resume capability is protocol-dependent, NOT OAGW's responsibility
+
+### 2.7 Error Propagation
+
+- [ ] v1 - **IF** OAGW returns error:
+  - [ ] v1 - Error is typed `OagwError` with GTS ID [F54.002]
+  - [ ] v1 - Error includes `retriable` hint and `retry_after_sec` [F54.003]
+  - [ ] v1 - Caller can match on GTS error ID:
+    ```rust
+    match &result {
+        Err(e) if e.gts_id == GTS_OAGW_LINK_UNAVAILABLE => fallback_logic(),
+        Err(e) if e.gts_id == GTS_OAGW_CIRCUIT_BREAKER_OPEN => {
+            // Use retry_after_sec if available
+            if let Some(delay) = e.retry_after_sec {
+                sleep(Duration::from_secs(delay)).await;
+            }
+            retry_with_different_link()
+        },
+        Err(e) if e.gts_id == GTS_OAGW_RATE_LIMIT_EXCEEDED => {
+            // MUST respect retry_after_sec [F55.005]
+            let delay = e.retry_after_sec.unwrap_or(60);
+            sleep(Duration::from_secs(delay)).await;
+        },
+        Err(e) => return Err(e.into()),
+    }
+    ```
+
+### 2.8 Retry Decision (Caller-Side) [F55.004]
+
+- [ ] v1 - **Default: No retry** — `RetryIntent::default()` has `max_attempts: 1`
+- [ ] v3 - **IF** `RetryIntent.max_attempts > 1`, OAGW MAY perform retries within the same invocation [F55.004]
+- [ ] v3 - `attempt_number` in `OagwInvokeResponse` is semantic and shows which attempt produced the returned response
+- [ ] v1 - **Streaming requests are NEVER retried by OAGW** [F55.006]
+
+---
+
+## Scenario 3: Route & Link Management (REST API)
+
+Admin configures routes and links via REST API.
+
+### 3.1 Create Route
+
+- [ ] v1 - `POST /oagw/v1/routes` [F20.001]
+- [ ] v1 - Validate caller has `gts.x.core.idp.role.v1~x.oagw.route.admin.v1` role [F42.002]
+- [ ] v1 - Validate request body:
+  - [ ] v1 - `base_url` is valid URL
+  - [ ] v1 - `auth_type_gts_id` exists in `types_registry`
+  - [ ] v2 - `protocol_gts_ids[]` all exist in `types_registry`
+- [ ] v1 - Generate UUID for route
+- [ ] v1 - Insert into `outbound_api_route` [F73.001]
+- [ ] v2 - Insert supported protocols [F73.002]
+- [ ] v1 - Return `201 Created` with route [F27.002]
+
+### 3.2 Create Link
+
+- [ ] v1 - `POST /oagw/v1/links` [F20.006]
+- [ ] v1 - Validate caller has `gts.x.core.idp.role.v1~x.oagw.link.admin.v1` role [F42.003]
+- [ ] v1 - Validate `route_id` exists and belongs to tenant
+- [ ] v1 - Validate `secret_ref` exists in `cred_store`
+- [ ] v1 - Validate `strategy_gts_id` exists
+- [ ] v1 - Generate UUID for link
+- [ ] v1 - Insert into `outbound_api_link` [F73.003]
+- [ ] v1 - Return `201 Created` with link
+
+### 3.3 List Routes (with OData)
+
+- [ ] v2 - `GET /oagw/v1/routes?$skip=0&$top=20&$filter=...` [F20.002]
+- [ ] v2 - Apply tenant isolation filter
+- [ ] v2 - Apply OData `$filter` to query
+- [ ] v2 - Apply `$orderby` sorting
+- [ ] v2 - Apply pagination (`$skip`, `$top`)
+- [ ] v3 - Apply `$select` field projection
+- [ ] v2 - Return `Page<RouteDto>` with `@odata.nextLink`
+
+### 3.4 Update Route Limits
+
+- [ ] v3 - `PUT /oagw/v1/routes/{routeId}/limits`
+- [ ] v3 - Validate caller has `gts.x.core.idp.role.v1~x.oagw.route.admin.v1` role
+- [ ] v3 - Upsert into `outbound_api_route_limits` [F73.004]
+- [ ] v3 - Invalidate any cached configuration
+- [ ] v3 - Return updated limits
+
+### 3.5 Clear Token Cache
+
+- [ ] v3 - `DELETE /oagw/v1/routes/{routeId}/cache/tokens` [F20.012]
+- [ ] v3 - Validate caller has `gts.x.core.idp.role.v1~x.oagw.route.admin.v1` role
+- [ ] v3 - Evict all cache entries matching `route_id` [F52.001]
+- [ ] v3 - Log cache clear operation
+- [ ] v3 - Return `204 No Content` [F27.003]
+
+---
+
+## Scenario 4: Health Checks
+
+### 4.1 Liveness Probe
+
+- [ ] v1 - `GET /oagw/v1/health` [F20.013]
+- [ ] v1 - No authentication required [F03.001]
+- [ ] v1 - Return `200 OK` if service is running
+- [ ] v1 - Response body: `{ "status": "healthy" }`
+
+### 4.2 Readiness Probe
+
+- [ ] v2 - `GET /oagw/v1/ready` [F20.014]
+- [ ] v2 - No authentication required
+- [ ] v2 - Check database connectivity
+- [ ] v2 - **IF** all checks pass:
+  - [ ] v2 - Return `200 OK`
+
+### 4.3 Route Health Check
+
+- [ ] v3 - `GET /oagw/v1/routes/{routeId}/health` [F20.015]
+- [ ] v3 - Require `gts.x.core.idp.role.v1~x.oagw.route.health.v1` role [F42.001]
+- [ ] v3 - Get all links for route
+- [ ] v3 - **FOR EACH** link:
+  - [ ] v3 - Check circuit breaker state
+  - [ ] v3 - **IF** route has `healthcheck_url`:
+    - [ ] v4 - Perform lightweight health check request
+- [ ] v3 - Return aggregated health status:
+  ```json
+  {
+    "route_id": "...",
+    "status": "degraded",
+    "links": [
+      { "link_id": "...", "status": "healthy" },
+      { "link_id": "...", "status": "circuit_open" }
+    ]
+  }
+  ```
+
+---
+
+## Scenario 5: Plugin Lifecycle
+
+### 5.1 Gateway Module Initialization
+
+- [ ] v1 - OAGW gateway `init()` runs
+- [ ] v1 - Register GTS schemas in `types_registry` [F10.001-F10.003]:
+  - [ ] v1 - `gts.x.core.oagw.proto.v1~`
+  - [ ] v1 - `gts.x.core.oagw.stream_proto.v1~`
+  - [ ] v1 - `gts.x.core.oagw.auth_type.v1~`
+  - [ ] v1 - `gts.x.core.oagw.strategy.v1~`
+- [ ] v1 - Load well-known instances from `gts/*.instances.json`
+- [ ] v1 - Register instances in `types_registry` [F11.001-F13.005]
+- [ ] v1 - Create `OagwService` with dependencies
+- [ ] v1 - Register `OagwApi` client in `ClientHub` (unscoped)
+
+### 5.2 Plugin Module Initialization
+
+- [ ] v1 - Plugin module `init()` runs (after OAGW gateway)
+- [ ] v1 - Generate stable GTS instance ID:
+  ```rust
+  let instance_id = OagwPluginSpecV1::gts_make_instance_id(
+      "x.core.oagw.http_plugin.v1"
+  );
+  ```
+- [ ] v1 - Register plugin instance in `types_registry`:
+  ```rust
+  let instance = BaseModkitPluginV1::<OagwPluginSpecV1> {
+      id: instance_id.clone(),
+      vendor: "x".into(),
+      priority: 10,
+      properties: OagwPluginSpecV1 {
+          supported_protocols: vec![HTTP11, HTTP2, SSE],
+          supported_auth_types: vec![BEARER, API_KEY_HEADER],
+          // ...
+      },
+  };
+  registry.register(&ctx, vec![instance_json]).await?;
+  ```
+- [ ] v1 - Create plugin service
+- [ ] v1 - Register scoped client in `ClientHub`:
+  ```rust
+  ctx.client_hub().register_scoped::<dyn OagwPluginApi>(
+      ClientScope::gts_id(&instance_id),
+      plugin_service,
+  );
+  ```
+
+### 5.3 Plugin Discovery at Runtime
+
+- [ ] v1 - When OAGW needs to select plugin (step 1.6):
+- [ ] v1 - Query `types_registry` for plugin instances
+- [ ] v1 - Filter by capability requirements
+- [ ] v1 - Select by priority
+- [ ] v1 - Resolve from `ClientHub` via scoped lookup

--- a/modules/oagw/docs/4_ACTUAL_DESIGN.md
+++ b/modules/oagw/docs/4_ACTUAL_DESIGN.md
@@ -1,0 +1,1 @@
+> This is design reconstructed from code

--- a/modules/oagw/oagw-gw/Cargo.toml
+++ b/modules/oagw/oagw-gw/Cargo.toml
@@ -1,0 +1,55 @@
+[package]
+name = "oagw-gw"
+version.workspace = true
+publish = false
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "OAGW (Outbound API Gateway) module implementation"
+
+[lints]
+workspace = true
+
+[dependencies]
+# SDK - public API, models, and errors
+oagw-sdk = { path = "../oagw-sdk" }
+
+# Core dependencies
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+inventory = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+utoipa = { workspace = true }
+axum = { workspace = true, features = ["macros"] }
+tower-http = { workspace = true, features = ["timeout"] }
+futures = { workspace = true }
+chrono = { workspace = true, features = ["serde"] }
+uuid = { workspace = true }
+arc-swap = { workspace = true }
+sea-orm = { workspace = true, features = ["sqlx-sqlite", "runtime-tokio-rustls", "macros", "with-chrono", "with-uuid"] }
+sea-orm-migration = { workspace = true }
+thiserror = { workspace = true }
+bytes = { workspace = true }
+http = { workspace = true }
+
+# Local dependencies
+modkit = { path = "../../../libs/modkit" }
+modkit-db = { path = "../../../libs/modkit-db" }
+modkit-db-macros = { path = "../../../libs/modkit-db-macros" }
+modkit-auth = { path = "../../../libs/modkit-auth" }
+modkit-security = { path = "../../../libs/modkit-security" }
+modkit-odata = { path = "../../../libs/modkit-odata" }
+
+# GTS support
+gts = { workspace = true }
+
+# Types registry for plugin discovery
+types-registry-sdk = { path = "../../types-registry/types-registry-sdk" }
+
+[dev-dependencies]
+tower = { workspace = true, features = ["util"] }
+api_ingress = { path = "../../api_ingress" }
+tokio-test = { workspace = true }

--- a/modules/oagw/oagw-gw/src/api/mod.rs
+++ b/modules/oagw/oagw-gw/src/api/mod.rs
@@ -1,0 +1,3 @@
+//! API layer for OAGW.
+
+pub mod rest;

--- a/modules/oagw/oagw-gw/src/api/rest/dto.rs
+++ b/modules/oagw/oagw-gw/src/api/rest/dto.rs
@@ -1,0 +1,356 @@
+//! REST DTOs for OAGW.
+//!
+//! These DTOs have serde and utoipa derives for REST serialization.
+
+use chrono::{DateTime, Utc};
+use modkit_db_macros::ODataFilterable;
+use oagw_sdk::{
+    HttpMethod, Link, LinkPatch, NewLink, NewRoute, OagwInvokeRequest, OagwInvokeResponse,
+    RetryIntent, Route, RoutePatch,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+// === Route DTOs ===
+
+/// Response DTO for a route.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, ODataFilterable)]
+#[serde(rename_all = "camelCase")]
+pub struct RouteDto {
+    #[odata(filter(kind = "Uuid"))]
+    pub id: Uuid,
+    #[odata(filter(kind = "Uuid"))]
+    pub tenant_id: Uuid,
+    #[odata(filter(kind = "String"))]
+    pub base_url: String,
+    #[odata(filter(kind = "I64"))]
+    pub rate_limit_req_per_min: i32,
+    #[odata(filter(kind = "String"))]
+    pub auth_type_gts_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_ttl_sec: Option<i32>,
+    pub supported_protocols: Vec<String>,
+    #[odata(filter(kind = "DateTimeUtc"))]
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<Route> for RouteDto {
+    fn from(route: Route) -> Self {
+        Self {
+            id: route.id,
+            tenant_id: route.tenant_id,
+            base_url: route.base_url,
+            rate_limit_req_per_min: route.rate_limit_req_per_min,
+            auth_type_gts_id: route.auth_type_gts_id,
+            cache_ttl_sec: route.cache_ttl_sec,
+            supported_protocols: route.supported_protocols,
+            created_at: route.created_at,
+            updated_at: route.updated_at,
+        }
+    }
+}
+
+/// Request DTO for creating a route.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateRouteRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<Uuid>,
+    pub base_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate_limit_req_per_min: Option<i32>,
+    pub auth_type_gts_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_ttl_sec: Option<i32>,
+    #[serde(default)]
+    pub supported_protocols: Vec<String>,
+}
+
+impl CreateRouteRequest {
+    /// Convert to domain model with tenant ID from security context.
+    pub fn into_new_route(self, tenant_id: Uuid) -> NewRoute {
+        NewRoute {
+            id: self.id,
+            tenant_id,
+            base_url: self.base_url,
+            rate_limit_req_per_min: self.rate_limit_req_per_min,
+            auth_type_gts_id: self.auth_type_gts_id,
+            cache_ttl_sec: self.cache_ttl_sec,
+            supported_protocols: self.supported_protocols,
+        }
+    }
+}
+
+/// Request DTO for updating a route.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateRouteRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate_limit_req_per_min: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth_type_gts_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[allow(clippy::option_option)] // Intentional: distinguish set-to-null from not-set
+    pub cache_ttl_sec: Option<Option<i32>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supported_protocols: Option<Vec<String>>,
+}
+
+impl From<UpdateRouteRequest> for RoutePatch {
+    fn from(req: UpdateRouteRequest) -> Self {
+        Self {
+            base_url: req.base_url,
+            rate_limit_req_per_min: req.rate_limit_req_per_min,
+            auth_type_gts_id: req.auth_type_gts_id,
+            cache_ttl_sec: req.cache_ttl_sec,
+            supported_protocols: req.supported_protocols,
+        }
+    }
+}
+
+// === Link DTOs ===
+
+/// Response DTO for a link.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, ODataFilterable)]
+#[serde(rename_all = "camelCase")]
+pub struct LinkDto {
+    #[odata(filter(kind = "Uuid"))]
+    pub id: Uuid,
+    #[odata(filter(kind = "Uuid"))]
+    pub tenant_id: Uuid,
+    #[odata(filter(kind = "Uuid"))]
+    pub secret_ref: Uuid,
+    #[odata(filter(kind = "Uuid"))]
+    pub route_id: Uuid,
+    #[odata(filter(kind = "String"))]
+    pub secret_type_gts_id: String,
+    #[odata(filter(kind = "Bool"))]
+    pub enabled: bool,
+    #[odata(filter(kind = "I64"))]
+    pub priority: i32,
+    #[odata(filter(kind = "String"))]
+    pub strategy_gts_id: String,
+    #[odata(filter(kind = "DateTimeUtc"))]
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<Link> for LinkDto {
+    fn from(link: Link) -> Self {
+        Self {
+            id: link.id,
+            tenant_id: link.tenant_id,
+            secret_ref: link.secret_ref,
+            route_id: link.route_id,
+            secret_type_gts_id: link.secret_type_gts_id,
+            enabled: link.enabled,
+            priority: link.priority,
+            strategy_gts_id: link.strategy_gts_id,
+            created_at: link.created_at,
+            updated_at: link.updated_at,
+        }
+    }
+}
+
+/// Request DTO for creating a link.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateLinkRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<Uuid>,
+    pub secret_ref: Uuid,
+    pub route_id: Uuid,
+    pub secret_type_gts_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<i32>,
+    pub strategy_gts_id: String,
+}
+
+impl CreateLinkRequest {
+    /// Convert to domain model with tenant ID from security context.
+    pub fn into_new_link(self, tenant_id: Uuid) -> NewLink {
+        NewLink {
+            id: self.id,
+            tenant_id,
+            secret_ref: self.secret_ref,
+            route_id: self.route_id,
+            secret_type_gts_id: self.secret_type_gts_id,
+            enabled: self.enabled,
+            priority: self.priority,
+            strategy_gts_id: self.strategy_gts_id,
+        }
+    }
+}
+
+/// Request DTO for updating a link.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateLinkRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secret_ref: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secret_type_gts_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strategy_gts_id: Option<String>,
+}
+
+impl From<UpdateLinkRequest> for LinkPatch {
+    fn from(req: UpdateLinkRequest) -> Self {
+        Self {
+            secret_ref: req.secret_ref,
+            secret_type_gts_id: req.secret_type_gts_id,
+            enabled: req.enabled,
+            priority: req.priority,
+            strategy_gts_id: req.strategy_gts_id,
+        }
+    }
+}
+
+// === Invocation DTOs ===
+
+/// HTTP method for invocation requests.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum HttpMethodDto {
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+    Head,
+    Options,
+}
+
+impl From<HttpMethodDto> for HttpMethod {
+    fn from(dto: HttpMethodDto) -> Self {
+        match dto {
+            HttpMethodDto::Get => Self::Get,
+            HttpMethodDto::Post => Self::Post,
+            HttpMethodDto::Put => Self::Put,
+            HttpMethodDto::Patch => Self::Patch,
+            HttpMethodDto::Delete => Self::Delete,
+            HttpMethodDto::Head => Self::Head,
+            HttpMethodDto::Options => Self::Options,
+        }
+    }
+}
+
+impl From<HttpMethod> for HttpMethodDto {
+    fn from(method: HttpMethod) -> Self {
+        match method {
+            HttpMethod::Get => Self::Get,
+            HttpMethod::Post => Self::Post,
+            HttpMethod::Put => Self::Put,
+            HttpMethod::Patch => Self::Patch,
+            HttpMethod::Delete => Self::Delete,
+            HttpMethod::Head => Self::Head,
+            HttpMethod::Options => Self::Options,
+        }
+    }
+}
+
+/// Request DTO for invoking an outbound API.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InvokeRequest {
+    /// Optional link ID to use (if not provided, OAGW selects based on route).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub link_id: Option<Uuid>,
+    /// Route ID identifying the downstream API configuration.
+    pub route_id: Uuid,
+    /// HTTP method for the request.
+    pub method: HttpMethodDto,
+    /// Path to append to the route's base URL.
+    pub path: String,
+    /// Optional query parameters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query: Option<HashMap<String, String>>,
+    /// Optional custom headers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headers: Option<HashMap<String, String>>,
+    /// Optional request body (base64 encoded for binary).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+    /// Optional timeout override in milliseconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+}
+
+impl From<InvokeRequest> for OagwInvokeRequest {
+    fn from(req: InvokeRequest) -> Self {
+        Self {
+            link_id: req.link_id,
+            route_id: req.route_id,
+            method: req.method.into(),
+            path: req.path,
+            query: req.query,
+            headers: req.headers,
+            body: req.body.map(bytes::Bytes::from),
+            timeout_ms: req.timeout_ms,
+            retry_intent: RetryIntent::default(), // No retry by default for REST
+        }
+    }
+}
+
+/// Response DTO for an invocation.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InvokeResponse {
+    /// HTTP status code from downstream.
+    pub status_code: u16,
+    /// Response headers.
+    pub headers: HashMap<String, String>,
+    /// Response body (base64 encoded for binary).
+    pub body: String,
+    /// Total duration in milliseconds.
+    pub duration_ms: u64,
+    /// Link ID that was used for the invocation.
+    pub link_id: Uuid,
+    /// Retry-After hint propagated from downstream (if any).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_after_sec: Option<u64>,
+    /// Which attempt succeeded (1-based).
+    pub attempt_number: u32,
+}
+
+impl From<OagwInvokeResponse> for InvokeResponse {
+    fn from(resp: OagwInvokeResponse) -> Self {
+        Self {
+            status_code: resp.status_code,
+            headers: resp.headers,
+            body: String::from_utf8_lossy(&resp.body).to_string(),
+            duration_ms: resp.duration_ms,
+            link_id: resp.link_id,
+            retry_after_sec: resp.retry_after_sec,
+            attempt_number: resp.attempt_number,
+        }
+    }
+}
+
+// === Health DTOs ===
+
+/// Health status response.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct HealthResponse {
+    pub status: String,
+}
+
+impl Default for HealthResponse {
+    fn default() -> Self {
+        Self {
+            status: "healthy".to_string(),
+        }
+    }
+}

--- a/modules/oagw/oagw-gw/src/api/rest/error.rs
+++ b/modules/oagw/oagw-gw/src/api/rest/error.rs
@@ -1,0 +1,145 @@
+//! REST error mapping for OAGW.
+
+use http::StatusCode;
+use modkit::api::problem::Problem;
+
+use crate::domain::error::DomainError;
+
+/// Convert DomainError to Problem for REST responses.
+impl From<DomainError> for Problem {
+    fn from(e: DomainError) -> Self {
+        let trace_id = tracing::Span::current()
+            .id()
+            .map(|id| id.into_u64().to_string());
+
+        let (status, code, title, detail) = match &e {
+            DomainError::RouteNotFound { id } => (
+                StatusCode::NOT_FOUND,
+                "OAGW_ROUTE_NOT_FOUND",
+                "Route not found",
+                format!("No route with id {id}"),
+            ),
+            DomainError::LinkNotFound { id } => (
+                StatusCode::NOT_FOUND,
+                "OAGW_LINK_NOT_FOUND",
+                "Link not found",
+                format!("No link with id {id}"),
+            ),
+            DomainError::LinkUnavailable { route_id } => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "OAGW_LINK_UNAVAILABLE",
+                "No available link",
+                format!("No available link for route {route_id}"),
+            ),
+            DomainError::RouteAlreadyExists { id } => (
+                StatusCode::CONFLICT,
+                "OAGW_ROUTE_EXISTS",
+                "Route already exists",
+                format!("Route with id {id} already exists"),
+            ),
+            DomainError::LinkAlreadyExists { id } => (
+                StatusCode::CONFLICT,
+                "OAGW_LINK_EXISTS",
+                "Link already exists",
+                format!("Link with id {id} already exists"),
+            ),
+            DomainError::InvalidRoute { message } => (
+                StatusCode::BAD_REQUEST,
+                "OAGW_INVALID_ROUTE",
+                "Invalid route",
+                message.clone(),
+            ),
+            DomainError::InvalidLink { message } => (
+                StatusCode::BAD_REQUEST,
+                "OAGW_INVALID_LINK",
+                "Invalid link",
+                message.clone(),
+            ),
+            DomainError::PluginNotFound {
+                protocol,
+                auth_type,
+            } => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "OAGW_PLUGIN_NOT_FOUND",
+                "No plugin available",
+                format!("No plugin found for protocol '{protocol}' and auth type '{auth_type}'"),
+            ),
+            DomainError::PluginClientNotFound { gts_id } => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "OAGW_PLUGIN_CLIENT_NOT_FOUND",
+                "Plugin client not found",
+                format!("Plugin client not registered: {gts_id}"),
+            ),
+            DomainError::SecretNotFound { secret_ref } => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "OAGW_SECRET_NOT_FOUND",
+                "Secret not found",
+                format!("Secret {secret_ref} not found in credential store"),
+            ),
+            DomainError::TypesRegistryUnavailable(msg) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "OAGW_REGISTRY_UNAVAILABLE",
+                "Types registry unavailable",
+                msg.clone(),
+            ),
+            DomainError::Validation { field, message } => (
+                StatusCode::BAD_REQUEST,
+                "OAGW_VALIDATION",
+                "Validation error",
+                format!("{field}: {message}"),
+            ),
+            DomainError::Forbidden { message } => (
+                StatusCode::FORBIDDEN,
+                "OAGW_FORBIDDEN",
+                "Forbidden",
+                message.clone(),
+            ),
+            DomainError::Authorization(msg) => (
+                StatusCode::FORBIDDEN,
+                "OAGW_AUTHORIZATION",
+                "Authorization error",
+                msg.clone(),
+            ),
+            DomainError::ConnectionTimeout => (
+                StatusCode::GATEWAY_TIMEOUT,
+                "OAGW_CONNECTION_TIMEOUT",
+                "Connection timeout",
+                "Connection to downstream API timed out".to_string(),
+            ),
+            DomainError::RequestTimeout => (
+                StatusCode::GATEWAY_TIMEOUT,
+                "OAGW_REQUEST_TIMEOUT",
+                "Request timeout",
+                "Request to downstream API timed out".to_string(),
+            ),
+            DomainError::DownstreamError {
+                status_code,
+                retry_after_sec: _,
+            } => (
+                StatusCode::BAD_GATEWAY,
+                "OAGW_DOWNSTREAM_ERROR",
+                "Downstream error",
+                format!("Downstream API returned status {status_code}"),
+            ),
+            DomainError::Database(_) => {
+                tracing::error!(error = ?e, "Database error occurred");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "OAGW_INTERNAL",
+                    "Internal Server Error",
+                    "An internal error occurred".to_string(),
+                )
+            }
+        };
+
+        let mut problem = Problem::new(status, title, detail)
+            .with_type(format!("https://errors.hyperspot.com/{code}"))
+            .with_code(code);
+
+        if let Some(id) = trace_id {
+            problem = problem.with_trace_id(id);
+        }
+
+        problem
+    }
+}

--- a/modules/oagw/oagw-gw/src/api/rest/handlers.rs
+++ b/modules/oagw/oagw-gw/src/api/rest/handlers.rs
@@ -1,0 +1,223 @@
+//! REST handlers for OAGW.
+//!
+//! Handlers are thin: parse/validate input, call domain service, map errors to Problem.
+
+use std::sync::Arc;
+
+use axum::extract::{Extension, Path};
+use axum::http::Uri;
+use axum::Json;
+use modkit::api::odata::OData;
+use modkit::api::prelude::*;
+use modkit_security::SecurityContext;
+use uuid::Uuid;
+
+use super::dto::{
+    CreateLinkRequest, CreateRouteRequest, HealthResponse, InvokeRequest, InvokeResponse, LinkDto,
+    RouteDto, UpdateLinkRequest, UpdateRouteRequest,
+};
+use crate::domain::service::Service;
+
+// === Health Endpoints ===
+
+/// GET /oagw/v1/health - Liveness probe (no auth required).
+pub async fn health() -> ApiResult<JsonBody<HealthResponse>> {
+    Ok(Json(HealthResponse::default()))
+}
+
+/// GET /oagw/v1/ready - Readiness probe (no auth required).
+///
+/// TODO(v2): Check database connectivity and other critical dependencies.
+pub async fn ready() -> ApiResult<JsonBody<HealthResponse>> {
+    // TODO(v2): Implement actual readiness checks
+    Ok(Json(HealthResponse::default()))
+}
+
+// === Route Endpoints ===
+
+/// POST /oagw/v1/routes - Create a new route.
+#[tracing::instrument(skip(ctx, svc, req), fields(base_url = %req.base_url))]
+pub async fn create_route(
+    uri: Uri,
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<Service>>,
+    Json(req): Json<CreateRouteRequest>,
+) -> ApiResult<impl axum::response::IntoResponse> {
+    let tenant_id = ctx.tenant_id();
+    let new_route = req.into_new_route(tenant_id);
+
+    let route = svc.create_route(&ctx, new_route).await?;
+    let id_str = route.id.to_string();
+
+    Ok(created_json(RouteDto::from(route), &uri, &id_str))
+}
+
+/// GET /oagw/v1/routes - List routes with OData pagination.
+#[tracing::instrument(skip(ctx, svc))]
+pub async fn list_routes(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<Service>>,
+    OData(query): OData,
+) -> ApiResult<JsonPage<RouteDto>> {
+    let page = svc.list_routes(&ctx, query).await?;
+    let dto_page = page.map_items(RouteDto::from);
+    Ok(Json(dto_page))
+}
+
+/// GET /oagw/v1/routes/{routeId} - Get a route by ID.
+#[tracing::instrument(skip(ctx, svc), fields(route_id = %route_id))]
+pub async fn get_route(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<Service>>,
+    Path(route_id): Path<Uuid>,
+) -> ApiResult<JsonBody<RouteDto>> {
+    let route = svc.get_route(&ctx, route_id).await?;
+    Ok(Json(RouteDto::from(route)))
+}
+
+/// PATCH /oagw/v1/routes/{routeId} - Update a route.
+#[tracing::instrument(skip(ctx, svc, req), fields(route_id = %route_id))]
+pub async fn update_route(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<Service>>,
+    Path(route_id): Path<Uuid>,
+    Json(req): Json<UpdateRouteRequest>,
+) -> ApiResult<JsonBody<RouteDto>> {
+    let patch = req.into();
+    let route = svc.update_route(&ctx, route_id, patch).await?;
+    Ok(Json(RouteDto::from(route)))
+}
+
+/// DELETE /oagw/v1/routes/{routeId} - Delete a route.
+#[tracing::instrument(skip(ctx, svc), fields(route_id = %route_id))]
+pub async fn delete_route(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<Service>>,
+    Path(route_id): Path<Uuid>,
+) -> ApiResult<impl axum::response::IntoResponse> {
+    svc.delete_route(&ctx, route_id).await?;
+    Ok(no_content())
+}
+
+// === Link Endpoints ===
+
+/// POST /oagw/v1/links - Create a new link.
+#[tracing::instrument(skip(ctx, svc, req), fields(route_id = %req.route_id))]
+pub async fn create_link(
+    uri: Uri,
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<Service>>,
+    Json(req): Json<CreateLinkRequest>,
+) -> ApiResult<impl axum::response::IntoResponse> {
+    let tenant_id = ctx.tenant_id();
+    let new_link = req.into_new_link(tenant_id);
+
+    let link = svc.create_link(&ctx, new_link).await?;
+    let id_str = link.id.to_string();
+
+    Ok(created_json(LinkDto::from(link), &uri, &id_str))
+}
+
+/// GET /oagw/v1/links - List links with OData pagination.
+#[tracing::instrument(skip(ctx, svc))]
+pub async fn list_links(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<Service>>,
+    OData(query): OData,
+) -> ApiResult<JsonPage<LinkDto>> {
+    let page = svc.list_links(&ctx, query).await?;
+    let dto_page = page.map_items(LinkDto::from);
+    Ok(Json(dto_page))
+}
+
+/// GET /oagw/v1/links/{linkId} - Get a link by ID.
+#[tracing::instrument(skip(ctx, svc), fields(link_id = %link_id))]
+pub async fn get_link(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<Service>>,
+    Path(link_id): Path<Uuid>,
+) -> ApiResult<JsonBody<LinkDto>> {
+    let link = svc.get_link(&ctx, link_id).await?;
+    Ok(Json(LinkDto::from(link)))
+}
+
+/// PATCH /oagw/v1/links/{linkId} - Update a link.
+#[tracing::instrument(skip(ctx, svc, req), fields(link_id = %link_id))]
+pub async fn update_link(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<Service>>,
+    Path(link_id): Path<Uuid>,
+    Json(req): Json<UpdateLinkRequest>,
+) -> ApiResult<JsonBody<LinkDto>> {
+    let patch = req.into();
+    let link = svc.update_link(&ctx, link_id, patch).await?;
+    Ok(Json(LinkDto::from(link)))
+}
+
+/// DELETE /oagw/v1/links/{linkId} - Delete a link.
+#[tracing::instrument(skip(ctx, svc), fields(link_id = %link_id))]
+pub async fn delete_link(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<Service>>,
+    Path(link_id): Path<Uuid>,
+) -> ApiResult<impl axum::response::IntoResponse> {
+    svc.delete_link(&ctx, link_id).await?;
+    Ok(no_content())
+}
+
+// === Invocation Endpoints ===
+
+/// POST /oagw/v1/invoke - Invoke an outbound API.
+#[tracing::instrument(skip(ctx, svc, req), fields(route_id = %req.route_id, method = ?req.method))]
+pub async fn invoke(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<Service>>,
+    Json(req): Json<InvokeRequest>,
+) -> ApiResult<JsonBody<InvokeResponse>> {
+    // TODO(v2): Validate caller has invoke role
+    // TODO(v2): Validate request against OpenAPI schema
+
+    let invoke_req = req.into();
+    let response = svc.invoke_unary(&ctx, invoke_req).await?;
+
+    Ok(Json(InvokeResponse::from(response)))
+}
+
+// === Route Health Endpoint (v3) ===
+
+/// GET /oagw/v1/routes/{routeId}/health - Route health check.
+///
+/// TODO(v3): Implement route health check with circuit breaker status.
+#[tracing::instrument(skip(ctx, svc), fields(route_id = %route_id))]
+pub async fn route_health(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<Service>>,
+    Path(route_id): Path<Uuid>,
+) -> ApiResult<JsonBody<HealthResponse>> {
+    // TODO(v3): Check circuit breaker state for all links
+    // TODO(v3): Require route health role
+
+    // For v1, just verify route exists
+    let _route = svc.get_route(&ctx, route_id).await?;
+
+    Ok(Json(HealthResponse {
+        status: "healthy".to_string(),
+    }))
+}
+
+// === Token Cache Management (v3) ===
+
+/// DELETE /oagw/v1/routes/{routeId}/cache/tokens - Clear cached tokens for route.
+///
+/// TODO(v3): Implement token cache clearing.
+#[tracing::instrument(skip(_ctx, _svc), fields(route_id = %route_id))]
+pub async fn clear_token_cache(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(_svc): Extension<Arc<Service>>,
+    Path(route_id): Path<Uuid>,
+) -> ApiResult<impl axum::response::IntoResponse> {
+    // TODO(v3): Clear token cache entries for route_id
+    tracing::info!(route_id = %route_id, "Token cache clear requested (not yet implemented)");
+
+    Ok(no_content())
+}

--- a/modules/oagw/oagw-gw/src/api/rest/mod.rs
+++ b/modules/oagw/oagw-gw/src/api/rest/mod.rs
@@ -1,0 +1,6 @@
+//! REST API layer for OAGW.
+
+pub mod dto;
+pub mod error;
+pub mod handlers;
+pub mod routes;

--- a/modules/oagw/oagw-gw/src/api/rest/routes.rs
+++ b/modules/oagw/oagw-gw/src/api/rest/routes.rs
@@ -1,0 +1,365 @@
+//! REST route registration for OAGW.
+
+use std::sync::Arc;
+
+use axum::{Extension, Router};
+use http::StatusCode;
+use modkit::api::operation_builder::{
+    AuthReqAction, AuthReqResource, LicenseFeature, OperationBuilderODataExt,
+};
+use modkit::api::{OpenApiRegistry, OperationBuilder};
+use modkit_odata::Page;
+
+use super::dto::{
+    CreateLinkRequest, CreateRouteRequest, HealthResponse, InvokeRequest, InvokeResponse, LinkDto,
+    LinkDtoFilterField, RouteDto, RouteDtoFilterField, UpdateLinkRequest, UpdateRouteRequest,
+};
+use super::handlers;
+use crate::domain::service::Service;
+
+/// License feature for OAGW.
+struct OagwLicense;
+
+impl AsRef<str> for OagwLicense {
+    fn as_ref(&self) -> &'static str {
+        "gts.x.core.lic.feat.v1~x.core.global.base.v1"
+    }
+}
+
+impl LicenseFeature for OagwLicense {}
+
+/// Resource enum for authorization.
+#[derive(Debug, Clone, Copy)]
+pub enum Resource {
+    Routes,
+    Links,
+    Invoke,
+    Health,
+}
+
+impl AsRef<str> for Resource {
+    fn as_ref(&self) -> &'static str {
+        match self {
+            Self::Routes => "oagw.routes",
+            Self::Links => "oagw.links",
+            Self::Invoke => "oagw.invoke",
+            Self::Health => "oagw.health",
+        }
+    }
+}
+
+impl AuthReqResource for Resource {}
+
+/// Action enum for authorization.
+#[derive(Debug, Clone, Copy)]
+pub enum Action {
+    Create,
+    Read,
+    Update,
+    Delete,
+    Execute,
+}
+
+impl AsRef<str> for Action {
+    fn as_ref(&self) -> &'static str {
+        match self {
+            Self::Create => "create",
+            Self::Read => "read",
+            Self::Update => "update",
+            Self::Delete => "delete",
+            Self::Execute => "execute",
+        }
+    }
+}
+
+impl AuthReqAction for Action {}
+
+/// Register all OAGW REST routes.
+#[allow(clippy::too_many_lines)] // Route registration is naturally verbose
+#[allow(clippy::unnecessary_wraps)] // Result needed for error propagation in future
+pub fn register_routes(
+    mut router: Router,
+    openapi: &dyn OpenApiRegistry,
+    service: Arc<Service>,
+) -> anyhow::Result<Router> {
+    // === Health Endpoints (public, no auth) ===
+
+    // GET /oagw/v1/health - Liveness probe
+    router = OperationBuilder::get("/oagw/v1/health")
+        .operation_id("oagw.health")
+        .summary("Liveness probe")
+        .description("Returns healthy if the service is running")
+        .tag("oagw-health")
+        .public()
+        .handler(handlers::health)
+        .json_response_with_schema::<HealthResponse>(openapi, StatusCode::OK, "Service is healthy")
+        .register(router, openapi);
+
+    // GET /oagw/v1/ready - Readiness probe
+    router = OperationBuilder::get("/oagw/v1/ready")
+        .operation_id("oagw.ready")
+        .summary("Readiness probe")
+        .description("Returns healthy if the service is ready to accept requests")
+        .tag("oagw-health")
+        .public()
+        .handler(handlers::ready)
+        .json_response_with_schema::<HealthResponse>(openapi, StatusCode::OK, "Service is ready")
+        .problem_response(
+            openapi,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Service not ready",
+        )
+        .register(router, openapi);
+
+    // === Route Endpoints ===
+
+    // POST /oagw/v1/routes - Create route
+    router = OperationBuilder::post("/oagw/v1/routes")
+        .operation_id("oagw.create_route")
+        .summary("Create a new outbound API route")
+        .tag("oagw-routes")
+        .require_auth(&Resource::Routes, &Action::Create)
+        .require_license_features::<OagwLicense>([])
+        .json_request::<CreateRouteRequest>(openapi, "Route configuration")
+        .handler(handlers::create_route)
+        .json_response_with_schema::<RouteDto>(openapi, StatusCode::CREATED, "Route created")
+        .error_400(openapi)
+        .error_401(openapi)
+        .error_403(openapi)
+        .error_409(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // GET /oagw/v1/routes - List routes
+    router = OperationBuilder::get("/oagw/v1/routes")
+        .operation_id("oagw.list_routes")
+        .summary("List outbound API routes")
+        .description("Returns a paginated list of routes with OData query support")
+        .tag("oagw-routes")
+        .require_auth(&Resource::Routes, &Action::Read)
+        .require_license_features::<OagwLicense>([])
+        .with_odata_filter::<RouteDtoFilterField>()
+        .with_odata_select()
+        .with_odata_orderby::<RouteDtoFilterField>()
+        .handler(handlers::list_routes)
+        .json_response_with_schema::<Page<RouteDto>>(
+            openapi,
+            StatusCode::OK,
+            "Paginated list of routes",
+        )
+        .error_400(openapi)
+        .error_401(openapi)
+        .error_403(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // GET /oagw/v1/routes/{routeId} - Get route
+    router = OperationBuilder::get("/oagw/v1/routes/{routeId}")
+        .operation_id("oagw.get_route")
+        .summary("Get a route by ID")
+        .tag("oagw-routes")
+        .require_auth(&Resource::Routes, &Action::Read)
+        .require_license_features::<OagwLicense>([])
+        .path_param("routeId", "Route UUID")
+        .handler(handlers::get_route)
+        .json_response_with_schema::<RouteDto>(openapi, StatusCode::OK, "Route found")
+        .error_401(openapi)
+        .error_403(openapi)
+        .error_404(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // PATCH /oagw/v1/routes/{routeId} - Update route
+    router = OperationBuilder::patch("/oagw/v1/routes/{routeId}")
+        .operation_id("oagw.update_route")
+        .summary("Update a route")
+        .tag("oagw-routes")
+        .require_auth(&Resource::Routes, &Action::Update)
+        .require_license_features::<OagwLicense>([])
+        .path_param("routeId", "Route UUID")
+        .json_request::<UpdateRouteRequest>(openapi, "Route update data")
+        .handler(handlers::update_route)
+        .json_response_with_schema::<RouteDto>(openapi, StatusCode::OK, "Route updated")
+        .error_400(openapi)
+        .error_401(openapi)
+        .error_403(openapi)
+        .error_404(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // DELETE /oagw/v1/routes/{routeId} - Delete route
+    router = OperationBuilder::delete("/oagw/v1/routes/{routeId}")
+        .operation_id("oagw.delete_route")
+        .summary("Delete a route")
+        .tag("oagw-routes")
+        .require_auth(&Resource::Routes, &Action::Delete)
+        .require_license_features::<OagwLicense>([])
+        .path_param("routeId", "Route UUID")
+        .handler(handlers::delete_route)
+        .json_response(StatusCode::NO_CONTENT, "Route deleted")
+        .error_401(openapi)
+        .error_403(openapi)
+        .error_404(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // GET /oagw/v1/routes/{routeId}/health - Route health (v3)
+    router = OperationBuilder::get("/oagw/v1/routes/{routeId}/health")
+        .operation_id("oagw.route_health")
+        .summary("Check route health")
+        .description("Returns health status of a route including circuit breaker states")
+        .tag("oagw-health")
+        .require_auth(&Resource::Health, &Action::Read)
+        .require_license_features::<OagwLicense>([])
+        .path_param("routeId", "Route UUID")
+        .handler(handlers::route_health)
+        .json_response_with_schema::<HealthResponse>(openapi, StatusCode::OK, "Route health status")
+        .error_401(openapi)
+        .error_403(openapi)
+        .error_404(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // DELETE /oagw/v1/routes/{routeId}/cache/tokens - Clear token cache (v3)
+    router = OperationBuilder::delete("/oagw/v1/routes/{routeId}/cache/tokens")
+        .operation_id("oagw.clear_token_cache")
+        .summary("Clear cached tokens for a route")
+        .description("Evicts all cached OAuth tokens associated with this route")
+        .tag("oagw-routes")
+        .require_auth(&Resource::Routes, &Action::Update)
+        .require_license_features::<OagwLicense>([])
+        .path_param("routeId", "Route UUID")
+        .handler(handlers::clear_token_cache)
+        .json_response(StatusCode::NO_CONTENT, "Token cache cleared")
+        .error_401(openapi)
+        .error_403(openapi)
+        .error_404(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // === Link Endpoints ===
+
+    // POST /oagw/v1/links - Create link
+    router = OperationBuilder::post("/oagw/v1/links")
+        .operation_id("oagw.create_link")
+        .summary("Create a new outbound API link")
+        .tag("oagw-links")
+        .require_auth(&Resource::Links, &Action::Create)
+        .require_license_features::<OagwLicense>([])
+        .json_request::<CreateLinkRequest>(openapi, "Link configuration")
+        .handler(handlers::create_link)
+        .json_response_with_schema::<LinkDto>(openapi, StatusCode::CREATED, "Link created")
+        .error_400(openapi)
+        .error_401(openapi)
+        .error_403(openapi)
+        .error_404(openapi) // Route not found
+        .error_409(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // GET /oagw/v1/links - List links
+    router = OperationBuilder::get("/oagw/v1/links")
+        .operation_id("oagw.list_links")
+        .summary("List outbound API links")
+        .description("Returns a paginated list of links with OData query support")
+        .tag("oagw-links")
+        .require_auth(&Resource::Links, &Action::Read)
+        .require_license_features::<OagwLicense>([])
+        .with_odata_filter::<LinkDtoFilterField>()
+        .with_odata_select()
+        .with_odata_orderby::<LinkDtoFilterField>()
+        .handler(handlers::list_links)
+        .json_response_with_schema::<Page<LinkDto>>(
+            openapi,
+            StatusCode::OK,
+            "Paginated list of links",
+        )
+        .error_400(openapi)
+        .error_401(openapi)
+        .error_403(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // GET /oagw/v1/links/{linkId} - Get link
+    router = OperationBuilder::get("/oagw/v1/links/{linkId}")
+        .operation_id("oagw.get_link")
+        .summary("Get a link by ID")
+        .tag("oagw-links")
+        .require_auth(&Resource::Links, &Action::Read)
+        .require_license_features::<OagwLicense>([])
+        .path_param("linkId", "Link UUID")
+        .handler(handlers::get_link)
+        .json_response_with_schema::<LinkDto>(openapi, StatusCode::OK, "Link found")
+        .error_401(openapi)
+        .error_403(openapi)
+        .error_404(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // PATCH /oagw/v1/links/{linkId} - Update link
+    router = OperationBuilder::patch("/oagw/v1/links/{linkId}")
+        .operation_id("oagw.update_link")
+        .summary("Update a link")
+        .tag("oagw-links")
+        .require_auth(&Resource::Links, &Action::Update)
+        .require_license_features::<OagwLicense>([])
+        .path_param("linkId", "Link UUID")
+        .json_request::<UpdateLinkRequest>(openapi, "Link update data")
+        .handler(handlers::update_link)
+        .json_response_with_schema::<LinkDto>(openapi, StatusCode::OK, "Link updated")
+        .error_400(openapi)
+        .error_401(openapi)
+        .error_403(openapi)
+        .error_404(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // DELETE /oagw/v1/links/{linkId} - Delete link
+    router = OperationBuilder::delete("/oagw/v1/links/{linkId}")
+        .operation_id("oagw.delete_link")
+        .summary("Delete a link")
+        .tag("oagw-links")
+        .require_auth(&Resource::Links, &Action::Delete)
+        .require_license_features::<OagwLicense>([])
+        .path_param("linkId", "Link UUID")
+        .handler(handlers::delete_link)
+        .json_response(StatusCode::NO_CONTENT, "Link deleted")
+        .error_401(openapi)
+        .error_403(openapi)
+        .error_404(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // === Invocation Endpoint ===
+
+    // POST /oagw/v1/invoke - Invoke outbound API
+    router = OperationBuilder::post("/oagw/v1/invoke")
+        .operation_id("oagw.invoke")
+        .summary("Invoke an outbound API")
+        .description("Execute an HTTP request to a configured downstream API")
+        .tag("oagw-invoke")
+        .require_auth(&Resource::Invoke, &Action::Execute)
+        .require_license_features::<OagwLicense>([])
+        .json_request::<InvokeRequest>(openapi, "Invocation request")
+        .handler(handlers::invoke)
+        .json_response_with_schema::<InvokeResponse>(openapi, StatusCode::OK, "Invocation response")
+        .error_400(openapi)
+        .error_401(openapi)
+        .error_403(openapi)
+        .error_404(openapi)
+        .error_429(openapi) // Rate limit
+        .error_500(openapi)
+        .problem_response(openapi, StatusCode::BAD_GATEWAY, "Downstream error")
+        .problem_response(
+            openapi,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Service unavailable",
+        )
+        .problem_response(openapi, StatusCode::GATEWAY_TIMEOUT, "Gateway timeout")
+        .register(router, openapi);
+
+    // Attach service extension to all routes
+    router = router.layer(Extension(service));
+
+    Ok(router)
+}

--- a/modules/oagw/oagw-gw/src/config.rs
+++ b/modules/oagw/oagw-gw/src/config.rs
@@ -1,0 +1,100 @@
+//! OAGW module configuration.
+
+use serde::Deserialize;
+
+/// OAGW module configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct OagwConfig {
+    // === Token Cache Settings (v3+) ===
+    /// Maximum capacity of the token cache.
+    pub token_cache_max_capacity: usize,
+    /// Maximum TTL for cached tokens in seconds.
+    pub token_cache_max_ttl_sec: u64,
+    /// Safety margin to subtract from token expiry in seconds.
+    pub token_cache_safety_margin_sec: u64,
+
+    // === Response Cache Settings (v5+) ===
+    /// Maximum capacity of the response cache.
+    pub response_cache_max_capacity: usize,
+
+    // === Request Limits ===
+    /// Maximum in-flight bytes per invocation.
+    pub max_inflight_bytes_per_invocation: usize,
+    /// Maximum size of a streaming chunk in bytes.
+    pub max_stream_chunk_size_bytes: usize,
+
+    // === Timeout Defaults ===
+    /// Default connection timeout in milliseconds.
+    pub default_connection_timeout_ms: u64,
+    /// Default request timeout in milliseconds.
+    pub default_request_timeout_ms: u64,
+    /// Default idle timeout in milliseconds.
+    pub default_idle_timeout_ms: u64,
+
+    // === Rate Limiting (v2+) ===
+    /// Default rate limit per minute.
+    pub default_rate_limit_per_min: u32,
+
+    // === Circuit Breaker (v3+) ===
+    /// Number of consecutive failures to open circuit.
+    pub circuit_breaker_threshold: u32,
+    /// Timeout in seconds before half-open state.
+    pub circuit_breaker_timeout_sec: u32,
+    /// Number of successes in half-open to close circuit.
+    pub circuit_breaker_success_threshold: u32,
+
+    // === Audit Logging (v2+) ===
+    /// Audit guarantee level.
+    pub audit_guarantee: AuditGuarantee,
+    /// Maximum latency for audit logging in milliseconds.
+    pub max_audit_latency_ms: u64,
+}
+
+impl Default for OagwConfig {
+    fn default() -> Self {
+        Self {
+            // Token cache defaults
+            token_cache_max_capacity: 10_000,
+            token_cache_max_ttl_sec: 3600,
+            token_cache_safety_margin_sec: 60,
+
+            // Response cache defaults
+            response_cache_max_capacity: 1_000,
+
+            // Request limits
+            max_inflight_bytes_per_invocation: 8_388_608, // 8 MiB
+            max_stream_chunk_size_bytes: 65_536,          // 64 KiB
+
+            // Timeout defaults
+            default_connection_timeout_ms: 5_000,
+            default_request_timeout_ms: 30_000,
+            default_idle_timeout_ms: 60_000,
+
+            // Rate limiting
+            default_rate_limit_per_min: 1_000,
+
+            // Circuit breaker
+            circuit_breaker_threshold: 5,
+            circuit_breaker_timeout_sec: 30,
+            circuit_breaker_success_threshold: 2,
+
+            // Audit logging
+            audit_guarantee: AuditGuarantee::BestEffort,
+            max_audit_latency_ms: 50,
+        }
+    }
+}
+
+/// Audit guarantee level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditGuarantee {
+    /// Best-effort audit logging (non-blocking).
+    #[default]
+    BestEffort,
+    /// Guaranteed audit logging (blocks until written).
+    Guaranteed,
+    /// Fail-closed audit logging (fail request if audit fails).
+    FailClosed,
+}

--- a/modules/oagw/oagw-gw/src/domain/error.rs
+++ b/modules/oagw/oagw-gw/src/domain/error.rs
@@ -1,0 +1,144 @@
+//! Domain errors for OAGW.
+
+use oagw_sdk::OagwError;
+use thiserror::Error;
+use uuid::Uuid;
+
+/// Domain-level errors for OAGW operations.
+#[derive(Error, Debug)]
+pub enum DomainError {
+    /// Route not found.
+    #[error("route not found: {id}")]
+    RouteNotFound { id: Uuid },
+
+    /// Link not found.
+    #[error("link not found: {id}")]
+    LinkNotFound { id: Uuid },
+
+    /// Link is unavailable (disabled or filtered out).
+    #[error("no available link for route {route_id}")]
+    LinkUnavailable { route_id: Uuid },
+
+    /// Route already exists.
+    #[error("route already exists: {id}")]
+    RouteAlreadyExists { id: Uuid },
+
+    /// Link already exists.
+    #[error("link already exists: {id}")]
+    LinkAlreadyExists { id: Uuid },
+
+    /// Invalid route configuration.
+    #[error("invalid route: {message}")]
+    InvalidRoute { message: String },
+
+    /// Invalid link configuration.
+    #[error("invalid link: {message}")]
+    InvalidLink { message: String },
+
+    /// Plugin not found for requirements.
+    #[error("no plugin found for protocol '{protocol}' and auth type '{auth_type}'")]
+    PluginNotFound { protocol: String, auth_type: String },
+
+    /// Plugin client not registered in ClientHub.
+    #[error("plugin client not registered: {gts_id}")]
+    PluginClientNotFound { gts_id: String },
+
+    /// Secret not found in cred_store.
+    #[error("secret not found: {secret_ref}")]
+    SecretNotFound { secret_ref: Uuid },
+
+    /// Types registry unavailable.
+    #[error("types registry unavailable: {0}")]
+    TypesRegistryUnavailable(String),
+
+    /// Validation error.
+    #[error("validation error: {field}: {message}")]
+    Validation { field: String, message: String },
+
+    /// Authorization error.
+    #[error("forbidden: {message}")]
+    Forbidden { message: String },
+
+    /// Authorization scope preparation error.
+    #[error("authorization error: {0}")]
+    Authorization(String),
+
+    /// Connection timeout.
+    #[error("connection timeout")]
+    ConnectionTimeout,
+
+    /// Request timeout.
+    #[error("request timeout")]
+    RequestTimeout,
+
+    /// Downstream error.
+    #[error("downstream error: status {status_code}")]
+    DownstreamError {
+        status_code: u16,
+        retry_after_sec: Option<u64>,
+    },
+
+    /// Database error.
+    #[error("database error: {0}")]
+    Database(#[from] anyhow::Error),
+}
+
+impl DomainError {
+    /// Create a validation error.
+    #[must_use]
+    pub fn validation(field: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::Validation {
+            field: field.into(),
+            message: message.into(),
+        }
+    }
+
+    /// Create a forbidden error.
+    #[must_use]
+    pub fn forbidden(message: impl Into<String>) -> Self {
+        Self::Forbidden {
+            message: message.into(),
+        }
+    }
+}
+
+/// Convert DomainError to SDK OagwError.
+impl From<DomainError> for OagwError {
+    fn from(e: DomainError) -> Self {
+        match e {
+            DomainError::RouteNotFound { id } => Self::route_not_found(id),
+            DomainError::LinkNotFound { id } => Self::link_not_found(id),
+            DomainError::LinkUnavailable { route_id } => Self::link_unavailable(route_id),
+            DomainError::RouteAlreadyExists { id } => {
+                Self::validation(format!("route already exists: {id}"))
+            }
+            DomainError::LinkAlreadyExists { id } => {
+                Self::validation(format!("link already exists: {id}"))
+            }
+            DomainError::InvalidRoute { message } | DomainError::InvalidLink { message } => {
+                Self::validation(message)
+            }
+            DomainError::PluginNotFound {
+                protocol,
+                auth_type,
+            } => Self::plugin_not_found(protocol, auth_type),
+            DomainError::PluginClientNotFound { gts_id } => {
+                Self::internal(format!("plugin client not registered: {gts_id}"))
+            }
+            DomainError::SecretNotFound { secret_ref } => Self::secret_not_found(secret_ref),
+            DomainError::TypesRegistryUnavailable(msg) => Self::internal(msg),
+            DomainError::Validation { field, message } => {
+                Self::validation(format!("{field}: {message}"))
+            }
+            DomainError::Forbidden { message } => Self::forbidden(message),
+            DomainError::Authorization(msg) => Self::forbidden(msg),
+            DomainError::ConnectionTimeout => Self::ConnectionTimeout,
+            DomainError::RequestTimeout => Self::RequestTimeout,
+            DomainError::DownstreamError {
+                status_code,
+                retry_after_sec,
+            } => Self::downstream_error(status_code, retry_after_sec),
+            DomainError::Database(_) => Self::Database,
+        }
+    }
+}

--- a/modules/oagw/oagw-gw/src/domain/mod.rs
+++ b/modules/oagw/oagw-gw/src/domain/mod.rs
@@ -1,0 +1,6 @@
+//! Domain layer for OAGW.
+
+pub mod error;
+pub mod ports;
+pub mod repo;
+pub mod service;

--- a/modules/oagw/oagw-gw/src/domain/ports.rs
+++ b/modules/oagw/oagw-gw/src/domain/ports.rs
@@ -1,0 +1,49 @@
+//! Output ports (interfaces) for domain services.
+
+use async_trait::async_trait;
+use modkit_security::SecurityContext;
+use oagw_sdk::Secret;
+use uuid::Uuid;
+
+use super::error::DomainError;
+
+/// Port for resolving secrets from cred_store.
+#[async_trait]
+pub trait SecretResolver: Send + Sync {
+    /// Get a secret by its reference UUID.
+    async fn get_secret(
+        &self,
+        ctx: &SecurityContext,
+        secret_ref: Uuid,
+    ) -> Result<Secret, DomainError>;
+}
+
+/// Stub implementation of SecretResolver for v1.
+///
+/// TODO(v2): Replace with actual cred_store integration.
+#[derive(Debug, Default)]
+pub struct StubSecretResolver;
+
+#[async_trait]
+impl SecretResolver for StubSecretResolver {
+    async fn get_secret(
+        &self,
+        _ctx: &SecurityContext,
+        secret_ref: Uuid,
+    ) -> Result<Secret, DomainError> {
+        // TODO(v2): Implement actual cred_store lookup via CredStoreApi
+        // For v1, return a stub secret for testing
+        tracing::warn!(
+            secret_ref = %secret_ref,
+            "Using stub secret resolver - replace with cred_store integration"
+        );
+
+        Ok(Secret {
+            id: secret_ref,
+            secret_type_gts_id: "gts.x.core.oagw.auth_type.v1~x.core.auth.bearer_token.v1"
+                .to_string(),
+            value: "stub-secret-value".to_string(),
+            metadata: None,
+        })
+    }
+}

--- a/modules/oagw/oagw-gw/src/domain/repo.rs
+++ b/modules/oagw/oagw-gw/src/domain/repo.rs
@@ -1,0 +1,69 @@
+//! Repository traits for OAGW domain.
+
+use async_trait::async_trait;
+use modkit_odata::{ODataQuery, Page};
+use modkit_security::AccessScope;
+use oagw_sdk::{Link, LinkPatch, NewLink, NewRoute, Route, RoutePatch};
+use uuid::Uuid;
+
+/// Repository trait for Route entities.
+#[async_trait]
+pub trait RouteRepository: Send + Sync {
+    /// Find a route by ID within the security scope.
+    async fn find_by_id(&self, scope: &AccessScope, id: Uuid) -> anyhow::Result<Option<Route>>;
+
+    /// List routes with OData pagination.
+    async fn list_page(
+        &self,
+        scope: &AccessScope,
+        query: ODataQuery,
+    ) -> anyhow::Result<Page<Route>>;
+
+    /// Insert a new route.
+    async fn insert(&self, scope: &AccessScope, new_route: NewRoute) -> anyhow::Result<Route>;
+
+    /// Update a route with patch data.
+    async fn update(
+        &self,
+        scope: &AccessScope,
+        id: Uuid,
+        patch: RoutePatch,
+    ) -> anyhow::Result<Route>;
+
+    /// Delete a route by ID.
+    async fn delete(&self, scope: &AccessScope, id: Uuid) -> anyhow::Result<bool>;
+
+    /// Check if a route exists.
+    async fn exists(&self, scope: &AccessScope, id: Uuid) -> anyhow::Result<bool>;
+}
+
+/// Repository trait for Link entities.
+#[async_trait]
+pub trait LinkRepository: Send + Sync {
+    /// Find a link by ID within the security scope.
+    async fn find_by_id(&self, scope: &AccessScope, id: Uuid) -> anyhow::Result<Option<Link>>;
+
+    /// Find all enabled links for a route.
+    async fn find_enabled_by_route(
+        &self,
+        scope: &AccessScope,
+        route_id: Uuid,
+    ) -> anyhow::Result<Vec<Link>>;
+
+    /// List links with OData pagination.
+    async fn list_page(&self, scope: &AccessScope, query: ODataQuery)
+        -> anyhow::Result<Page<Link>>;
+
+    /// Insert a new link.
+    async fn insert(&self, scope: &AccessScope, new_link: NewLink) -> anyhow::Result<Link>;
+
+    /// Update a link with patch data.
+    async fn update(&self, scope: &AccessScope, id: Uuid, patch: LinkPatch)
+        -> anyhow::Result<Link>;
+
+    /// Delete a link by ID.
+    async fn delete(&self, scope: &AccessScope, id: Uuid) -> anyhow::Result<bool>;
+
+    /// Check if a link exists.
+    async fn exists(&self, scope: &AccessScope, id: Uuid) -> anyhow::Result<bool>;
+}

--- a/modules/oagw/oagw-gw/src/domain/service.rs
+++ b/modules/oagw/oagw-gw/src/domain/service.rs
@@ -1,0 +1,470 @@
+//! Domain service for OAGW.
+//!
+//! This service orchestrates all business logic for outbound API invocations,
+//! route/link management, and plugin selection.
+
+use std::sync::Arc;
+
+use modkit::client_hub::ClientHub;
+use modkit_odata::{ODataQuery, Page};
+use modkit_security::{AccessScope, PolicyEngineRef, SecurityContext};
+use oagw_sdk::{
+    Link, LinkPatch, NewLink, NewRoute, OagwInvokeRequest, OagwInvokeResponse, OagwPluginApi,
+    OagwResponseStream, Route, RoutePatch,
+};
+use tracing::{info_span, instrument, Instrument};
+use uuid::Uuid;
+
+use super::error::DomainError;
+use super::ports::SecretResolver;
+use super::repo::{LinkRepository, RouteRepository};
+use crate::config::OagwConfig;
+
+/// Service configuration extracted from module config.
+#[derive(Debug, Clone)]
+pub struct ServiceConfig {
+    /// Default connection timeout in milliseconds.
+    pub default_connection_timeout_ms: u64,
+    /// Default request timeout in milliseconds.
+    pub default_request_timeout_ms: u64,
+}
+
+impl From<&OagwConfig> for ServiceConfig {
+    fn from(cfg: &OagwConfig) -> Self {
+        Self {
+            default_connection_timeout_ms: cfg.default_connection_timeout_ms,
+            default_request_timeout_ms: cfg.default_request_timeout_ms,
+        }
+    }
+}
+
+/// Domain service for OAGW operations.
+pub struct Service {
+    policy_engine: PolicyEngineRef,
+    route_repo: Arc<dyn RouteRepository>,
+    link_repo: Arc<dyn LinkRepository>,
+    secret_resolver: Arc<dyn SecretResolver>,
+    client_hub: Arc<ClientHub>,
+    config: ServiceConfig,
+}
+
+impl Service {
+    /// Create a new service instance.
+    pub fn new(
+        route_repo: Arc<dyn RouteRepository>,
+        link_repo: Arc<dyn LinkRepository>,
+        secret_resolver: Arc<dyn SecretResolver>,
+        client_hub: Arc<ClientHub>,
+        config: ServiceConfig,
+    ) -> Self {
+        Self {
+            policy_engine: Arc::new(modkit_security::DummyPolicyEngine),
+            route_repo,
+            link_repo,
+            secret_resolver,
+            client_hub,
+            config,
+        }
+    }
+
+    /// Convert SecurityContext to AccessScope for repository operations.
+    async fn prepare_scope(&self, ctx: &SecurityContext) -> Result<AccessScope, DomainError> {
+        ctx.scope(self.policy_engine.clone())
+            .include_tenant_children()
+            .prepare()
+            .await
+            .map_err(|e| DomainError::Authorization(e.to_string()))
+    }
+
+    // === Invocation Methods ===
+
+    /// Invoke an outbound API with unary semantics.
+    #[instrument(skip(self, ctx, req), fields(route_id = %req.route_id, method = %req.method))]
+    pub async fn invoke_unary(
+        &self,
+        ctx: &SecurityContext,
+        req: OagwInvokeRequest,
+    ) -> Result<OagwInvokeResponse, DomainError> {
+        let start = std::time::Instant::now();
+        let scope = self.prepare_scope(ctx).await?;
+
+        // Step 1.3: Route Resolution
+        let route = self.resolve_route(&scope, req.route_id).await?;
+
+        // Step 1.4: Link Selection
+        let link = self.select_link(&scope, &route, req.link_id).await?;
+
+        // TODO(v2): Step 1.5 - Rate Limit Check
+        // TODO(v3): Check circuit breaker state
+
+        // Step 1.6: Plugin Selection
+        let plugin = self.select_plugin()?;
+
+        // Step 1.7: Secret Resolution
+        let secret = self
+            .secret_resolver
+            .get_secret(ctx, link.secret_ref)
+            .await?;
+
+        // Step 1.8: Authentication Preparation is handled by plugin
+
+        // Step 1.9-1.11: Request Construction and Plugin Invocation
+        let timeout_ms = req
+            .timeout_ms
+            .unwrap_or(self.config.default_request_timeout_ms);
+
+        let invoke_req = OagwInvokeRequest {
+            timeout_ms: Some(timeout_ms),
+            ..req
+        };
+
+        let response = plugin
+            .invoke_unary(ctx, &link, &route, &secret, invoke_req)
+            .instrument(info_span!("plugin_invoke"))
+            .await
+            .map_err(|e| match e {
+                oagw_sdk::OagwError::ConnectionTimeout => DomainError::ConnectionTimeout,
+                oagw_sdk::OagwError::RequestTimeout => DomainError::RequestTimeout,
+                oagw_sdk::OagwError::DownstreamError {
+                    status_code,
+                    retry_after_sec,
+                } => DomainError::DownstreamError {
+                    status_code,
+                    retry_after_sec,
+                },
+                other => DomainError::Database(anyhow::anyhow!("{other}")),
+            })?;
+
+        // TODO(v3): Step 1.12 - Circuit Breaker Update
+        // TODO(v2): Step 1.13 - Audit Logging
+        // TODO(v2): Step 1.14 - Metrics Recording
+
+        // Duration in ms is always small enough for u64 in practice
+        #[allow(clippy::cast_possible_truncation)]
+        let duration_ms = start.elapsed().as_millis() as u64;
+        tracing::info!(
+            duration_ms,
+            status_code = response.status_code,
+            link_id = %link.id,
+            "Invocation completed"
+        );
+
+        Ok(response)
+    }
+
+    /// Invoke an outbound API with streaming response.
+    #[instrument(skip(self, ctx, req), fields(route_id = %req.route_id, method = %req.method))]
+    pub async fn invoke_stream(
+        &self,
+        ctx: &SecurityContext,
+        req: OagwInvokeRequest,
+    ) -> Result<OagwResponseStream, DomainError> {
+        // TODO(v2): Implement streaming invocation
+        // For v1, streaming is not supported
+        tracing::warn!("Streaming invocation not yet implemented (v2)");
+
+        let scope = self.prepare_scope(ctx).await?;
+
+        // Resolve route and link for validation
+        let route = self.resolve_route(&scope, req.route_id).await?;
+        let link = self.select_link(&scope, &route, req.link_id).await?;
+        let plugin = self.select_plugin()?;
+        let secret = self
+            .secret_resolver
+            .get_secret(ctx, link.secret_ref)
+            .await?;
+
+        let timeout_ms = req
+            .timeout_ms
+            .unwrap_or(self.config.default_request_timeout_ms);
+
+        let invoke_req = OagwInvokeRequest {
+            timeout_ms: Some(timeout_ms),
+            ..req
+        };
+
+        plugin
+            .invoke_stream(ctx, &link, &route, &secret, invoke_req)
+            .await
+            .map_err(|e| DomainError::Database(anyhow::anyhow!("{e}")))
+    }
+
+    // === Route Resolution ===
+
+    /// Resolve a route by ID with tenant scoping.
+    async fn resolve_route(
+        &self,
+        scope: &AccessScope,
+        route_id: Uuid,
+    ) -> Result<Route, DomainError> {
+        self.route_repo
+            .find_by_id(scope, route_id)
+            .await?
+            .ok_or(DomainError::RouteNotFound { id: route_id })
+    }
+
+    // === Link Selection ===
+
+    /// Select a link for invocation.
+    ///
+    /// If `link_id` is provided, use that specific link.
+    /// Otherwise, select the best available link based on priority.
+    async fn select_link(
+        &self,
+        scope: &AccessScope,
+        route: &Route,
+        link_id: Option<Uuid>,
+    ) -> Result<Link, DomainError> {
+        if let Some(id) = link_id {
+            // Step 1.4a: Use specified link directly
+            let link = self
+                .link_repo
+                .find_by_id(scope, id)
+                .await?
+                .ok_or(DomainError::LinkNotFound { id })?;
+
+            // Verify link is enabled and belongs to the route
+            if !link.enabled {
+                return Err(DomainError::LinkNotFound { id });
+            }
+            if link.route_id != route.id {
+                return Err(DomainError::Validation {
+                    field: "link_id".to_string(),
+                    message: format!("Link {id} does not belong to route {}", route.id),
+                });
+            }
+            return Ok(link);
+        }
+
+        // Step 1.4b: Auto-select link
+        let links = self
+            .link_repo
+            .find_enabled_by_route(scope, route.id)
+            .await?;
+
+        if links.is_empty() {
+            return Err(DomainError::LinkUnavailable { route_id: route.id });
+        }
+
+        // TODO(v3): Filter out links with open circuit breakers
+        // TODO(v4): Apply strategy-based selection (sticky session, round robin)
+
+        // v1: Select first available link by priority (already sorted)
+        let mut sorted_links = links;
+        sorted_links.sort_by_key(|l| l.priority);
+
+        sorted_links
+            .into_iter()
+            .next()
+            .ok_or(DomainError::LinkUnavailable { route_id: route.id })
+    }
+
+    // === Plugin Selection ===
+
+    /// Select a plugin that supports the route's protocol and auth type.
+    ///
+    /// TODO(v1): Implement full plugin discovery via types-registry.
+    /// For now, returns the first registered plugin from ClientHub.
+    fn select_plugin(&self) -> Result<Arc<dyn OagwPluginApi>, DomainError> {
+        // TODO(v1): Query types-registry for plugin instances matching OagwPluginSpecV1 schema
+        // TODO(v1): Filter plugins by supported_protocols and supported_auth_types
+        // TODO(v1): Sort by priority and select best match
+        //
+        // For v1 skeleton, we attempt to get any registered OagwPluginApi from ClientHub.
+        // This works when there's exactly one plugin registered (the default plugin).
+
+        self.client_hub
+            .get::<dyn OagwPluginApi>()
+            .map_err(|e| DomainError::PluginNotFound {
+                protocol: "any".to_string(),
+                auth_type: format!("no plugin registered: {e}"),
+            })
+    }
+
+    // === Route CRUD ===
+
+    /// Create a new route.
+    #[instrument(skip(self, ctx, new_route), fields(base_url = %new_route.base_url))]
+    pub async fn create_route(
+        &self,
+        ctx: &SecurityContext,
+        new_route: NewRoute,
+    ) -> Result<Route, DomainError> {
+        let scope = self.prepare_scope(ctx).await?;
+
+        // Validate base URL
+        if new_route.base_url.is_empty() {
+            return Err(DomainError::validation("base_url", "cannot be empty"));
+        }
+
+        // Validate auth type GTS ID
+        if new_route.auth_type_gts_id.is_empty() {
+            return Err(DomainError::validation(
+                "auth_type_gts_id",
+                "cannot be empty",
+            ));
+        }
+
+        // TODO(v1): Validate auth_type_gts_id exists in types_registry
+        // TODO(v2): Validate protocol_gts_ids exist in types_registry
+
+        let route = self.route_repo.insert(&scope, new_route).await?;
+
+        tracing::info!(route_id = %route.id, "Route created");
+        Ok(route)
+    }
+
+    /// Get a route by ID.
+    pub async fn get_route(&self, ctx: &SecurityContext, id: Uuid) -> Result<Route, DomainError> {
+        let scope = self.prepare_scope(ctx).await?;
+        self.route_repo
+            .find_by_id(&scope, id)
+            .await?
+            .ok_or(DomainError::RouteNotFound { id })
+    }
+
+    /// List routes with OData pagination.
+    pub async fn list_routes(
+        &self,
+        ctx: &SecurityContext,
+        query: ODataQuery,
+    ) -> Result<Page<Route>, DomainError> {
+        let scope = self.prepare_scope(ctx).await?;
+        self.route_repo
+            .list_page(&scope, query)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Update a route with partial data.
+    #[instrument(skip(self, ctx, patch), fields(route_id = %id))]
+    pub async fn update_route(
+        &self,
+        ctx: &SecurityContext,
+        id: Uuid,
+        patch: RoutePatch,
+    ) -> Result<Route, DomainError> {
+        let scope = self.prepare_scope(ctx).await?;
+
+        // Verify route exists
+        if !self.route_repo.exists(&scope, id).await? {
+            return Err(DomainError::RouteNotFound { id });
+        }
+
+        // Validate patch
+        if let Some(ref base_url) = patch.base_url {
+            if base_url.is_empty() {
+                return Err(DomainError::validation("base_url", "cannot be empty"));
+            }
+        }
+
+        let route = self.route_repo.update(&scope, id, patch).await?;
+
+        tracing::info!(route_id = %route.id, "Route updated");
+        Ok(route)
+    }
+
+    /// Delete a route by ID.
+    #[instrument(skip(self, ctx), fields(route_id = %id))]
+    pub async fn delete_route(&self, ctx: &SecurityContext, id: Uuid) -> Result<(), DomainError> {
+        let scope = self.prepare_scope(ctx).await?;
+        let deleted = self.route_repo.delete(&scope, id).await?;
+        if !deleted {
+            return Err(DomainError::RouteNotFound { id });
+        }
+
+        tracing::info!(route_id = %id, "Route deleted");
+        Ok(())
+    }
+
+    // === Link CRUD ===
+
+    /// Create a new link.
+    #[instrument(skip(self, ctx, new_link), fields(route_id = %new_link.route_id))]
+    pub async fn create_link(
+        &self,
+        ctx: &SecurityContext,
+        new_link: NewLink,
+    ) -> Result<Link, DomainError> {
+        let scope = self.prepare_scope(ctx).await?;
+
+        // Validate route exists
+        if !self.route_repo.exists(&scope, new_link.route_id).await? {
+            return Err(DomainError::RouteNotFound {
+                id: new_link.route_id,
+            });
+        }
+
+        // Validate secret_ref
+        // TODO(v2): Validate secret exists in cred_store
+
+        // Validate strategy GTS ID
+        if new_link.strategy_gts_id.is_empty() {
+            return Err(DomainError::validation(
+                "strategy_gts_id",
+                "cannot be empty",
+            ));
+        }
+
+        let link = self.link_repo.insert(&scope, new_link).await?;
+
+        tracing::info!(link_id = %link.id, "Link created");
+        Ok(link)
+    }
+
+    /// Get a link by ID.
+    pub async fn get_link(&self, ctx: &SecurityContext, id: Uuid) -> Result<Link, DomainError> {
+        let scope = self.prepare_scope(ctx).await?;
+        self.link_repo
+            .find_by_id(&scope, id)
+            .await?
+            .ok_or(DomainError::LinkNotFound { id })
+    }
+
+    /// List links with OData pagination.
+    pub async fn list_links(
+        &self,
+        ctx: &SecurityContext,
+        query: ODataQuery,
+    ) -> Result<Page<Link>, DomainError> {
+        let scope = self.prepare_scope(ctx).await?;
+        self.link_repo
+            .list_page(&scope, query)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Update a link with partial data.
+    #[instrument(skip(self, ctx, patch), fields(link_id = %id))]
+    pub async fn update_link(
+        &self,
+        ctx: &SecurityContext,
+        id: Uuid,
+        patch: LinkPatch,
+    ) -> Result<Link, DomainError> {
+        let scope = self.prepare_scope(ctx).await?;
+
+        // Verify link exists
+        if !self.link_repo.exists(&scope, id).await? {
+            return Err(DomainError::LinkNotFound { id });
+        }
+
+        let link = self.link_repo.update(&scope, id, patch).await?;
+
+        tracing::info!(link_id = %link.id, "Link updated");
+        Ok(link)
+    }
+
+    /// Delete a link by ID.
+    #[instrument(skip(self, ctx), fields(link_id = %id))]
+    pub async fn delete_link(&self, ctx: &SecurityContext, id: Uuid) -> Result<(), DomainError> {
+        let scope = self.prepare_scope(ctx).await?;
+        let deleted = self.link_repo.delete(&scope, id).await?;
+        if !deleted {
+            return Err(DomainError::LinkNotFound { id });
+        }
+
+        tracing::info!(link_id = %id, "Link deleted");
+        Ok(())
+    }
+}

--- a/modules/oagw/oagw-gw/src/infra/mod.rs
+++ b/modules/oagw/oagw-gw/src/infra/mod.rs
@@ -1,0 +1,3 @@
+//! Infrastructure layer for OAGW.
+
+pub mod storage;

--- a/modules/oagw/oagw-gw/src/infra/storage/entity.rs
+++ b/modules/oagw/oagw-gw/src/infra/storage/entity.rs
@@ -1,0 +1,130 @@
+//! SeaORM entities for OAGW.
+
+pub use link::Entity as LinkEntity;
+pub use route::Entity as RouteEntity;
+
+/// Route entity module.
+pub mod route {
+    use chrono::{DateTime, Utc};
+    use modkit_db_macros::Scopable;
+    use sea_orm::entity::prelude::*;
+    use uuid::Uuid;
+
+    /// Route entity for `outbound_api_route` table.
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Scopable)]
+    #[sea_orm(table_name = "outbound_api_route")]
+    #[secure(tenant_col = "tenant_id", resource_col = "id", no_owner, no_type)]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub tenant_id: Uuid,
+        pub base_url: String,
+        pub rate_limit_req_per_min: i32,
+        pub auth_type_gts_id: String,
+        pub cache_ttl_sec: Option<i32>,
+        pub created_at: DateTime<Utc>,
+        pub updated_at: DateTime<Utc>,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {
+        #[sea_orm(has_many = "super::link::Entity")]
+        Links,
+        #[sea_orm(has_many = "super::route_protocol::Entity")]
+        Protocols,
+    }
+
+    impl Related<super::link::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::Links.def()
+        }
+    }
+
+    impl Related<super::route_protocol::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::Protocols.def()
+        }
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+/// Route supported protocol entity module.
+pub mod route_protocol {
+    use modkit_db_macros::Scopable;
+    use sea_orm::entity::prelude::*;
+    use uuid::Uuid;
+
+    /// Route protocol entity for `outbound_api_route_supported_protocol` table.
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Scopable)]
+    #[sea_orm(table_name = "outbound_api_route_supported_protocol")]
+    #[secure(no_tenant, resource_col = "id", no_owner, no_type)]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub route_id: Uuid,
+        pub protocol_gts_id: String,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {
+        #[sea_orm(
+            belongs_to = "super::route::Entity",
+            from = "Column::RouteId",
+            to = "super::route::Column::Id"
+        )]
+        Route,
+    }
+
+    impl Related<super::route::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::Route.def()
+        }
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+/// Link entity module.
+pub mod link {
+    use chrono::{DateTime, Utc};
+    use modkit_db_macros::Scopable;
+    use sea_orm::entity::prelude::*;
+    use uuid::Uuid;
+
+    /// Link entity for `outbound_api_link` table.
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Scopable)]
+    #[sea_orm(table_name = "outbound_api_link")]
+    #[secure(tenant_col = "tenant_id", resource_col = "id", no_owner, no_type)]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub tenant_id: Uuid,
+        pub secret_ref: Uuid,
+        pub route_id: Uuid,
+        pub secret_type_gts_id: String,
+        pub enabled: bool,
+        pub priority: i32,
+        pub strategy_gts_id: String,
+        pub created_at: DateTime<Utc>,
+        pub updated_at: DateTime<Utc>,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {
+        #[sea_orm(
+            belongs_to = "super::route::Entity",
+            from = "Column::RouteId",
+            to = "super::route::Column::Id"
+        )]
+        Route,
+    }
+
+    impl Related<super::route::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::Route.def()
+        }
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}

--- a/modules/oagw/oagw-gw/src/infra/storage/link_repo.rs
+++ b/modules/oagw/oagw-gw/src/infra/storage/link_repo.rs
@@ -1,0 +1,162 @@
+//! SeaORM repository implementation for links.
+
+use async_trait::async_trait;
+use modkit_db::secure::SecureConn;
+use modkit_odata::{ODataQuery, Page, PageInfo};
+use modkit_security::AccessScope;
+use oagw_sdk::{Link, LinkPatch, NewLink};
+use sea_orm::{ActiveValue, ColumnTrait, Condition, Order};
+use uuid::Uuid;
+
+use super::entity::link;
+use super::mapper::new_link_to_active_model;
+use crate::domain::repo::LinkRepository;
+
+/// SeaORM implementation of LinkRepository.
+pub struct SeaOrmLinkRepository {
+    conn: SecureConn,
+}
+
+impl SeaOrmLinkRepository {
+    /// Create a new repository instance.
+    pub fn new(conn: SecureConn) -> Self {
+        Self { conn }
+    }
+}
+
+#[async_trait]
+impl LinkRepository for SeaOrmLinkRepository {
+    async fn find_by_id(&self, scope: &AccessScope, id: Uuid) -> anyhow::Result<Option<Link>> {
+        let link_opt = self
+            .conn
+            .find_by_id::<link::Entity>(scope, id)?
+            .one(self.conn.conn())
+            .await?;
+
+        Ok(link_opt.map(Link::from))
+    }
+
+    async fn find_enabled_by_route(
+        &self,
+        scope: &AccessScope,
+        route_id: Uuid,
+    ) -> anyhow::Result<Vec<Link>> {
+        let base_query = self.conn.find::<link::Entity>(scope);
+
+        let filter_cond = Condition::all()
+            .add(link::Column::RouteId.eq(route_id))
+            .add(link::Column::Enabled.eq(true));
+
+        let links: Vec<link::Model> = base_query
+            .filter(filter_cond)
+            .order_by(link::Column::Priority, Order::Asc)
+            .all(self.conn.conn())
+            .await?;
+
+        Ok(links.into_iter().map(Link::from).collect())
+    }
+
+    async fn list_page(
+        &self,
+        scope: &AccessScope,
+        query: ODataQuery,
+    ) -> anyhow::Result<Page<Link>> {
+        // TODO(v2): Implement proper OData filtering with paginate_odata
+        // For v1, simple pagination without filters
+
+        let limit = query.limit.unwrap_or(25).min(1000);
+
+        let base_query = self.conn.find::<link::Entity>(scope);
+
+        let links: Vec<link::Model> = base_query
+            .order_by(link::Column::CreatedAt, Order::Desc)
+            .limit(limit + 1)
+            .all(self.conn.conn())
+            .await?;
+
+        let has_more = links.len() > limit as usize;
+        let items: Vec<_> = links
+            .into_iter()
+            .take(limit as usize)
+            .map(Link::from)
+            .collect();
+
+        Ok(Page {
+            items,
+            page_info: PageInfo {
+                next_cursor: if has_more {
+                    Some("next".to_string())
+                } else {
+                    None
+                }, // TODO(v2): Implement proper cursor
+                prev_cursor: None,
+                limit,
+            },
+        })
+    }
+
+    async fn insert(&self, scope: &AccessScope, new_link: NewLink) -> anyhow::Result<Link> {
+        let id = new_link.id.unwrap_or_else(Uuid::now_v7);
+        let now = chrono::Utc::now();
+
+        let active_model = new_link_to_active_model(&new_link, id, now);
+        let model = self
+            .conn
+            .insert::<link::Entity>(scope, active_model)
+            .await?;
+
+        Ok(Link::from(model))
+    }
+
+    async fn update(
+        &self,
+        scope: &AccessScope,
+        id: Uuid,
+        patch: LinkPatch,
+    ) -> anyhow::Result<Link> {
+        let now = chrono::Utc::now();
+
+        // Build active model with only changed fields
+        let mut active_model = link::ActiveModel {
+            id: ActiveValue::Unchanged(id),
+            updated_at: ActiveValue::Set(now),
+            ..Default::default()
+        };
+
+        if let Some(secret_ref) = patch.secret_ref {
+            active_model.secret_ref = ActiveValue::Set(secret_ref);
+        }
+        if let Some(secret_type) = patch.secret_type_gts_id {
+            active_model.secret_type_gts_id = ActiveValue::Set(secret_type);
+        }
+        if let Some(enabled) = patch.enabled {
+            active_model.enabled = ActiveValue::Set(enabled);
+        }
+        if let Some(priority) = patch.priority {
+            active_model.priority = ActiveValue::Set(priority);
+        }
+        if let Some(strategy) = patch.strategy_gts_id {
+            active_model.strategy_gts_id = ActiveValue::Set(strategy);
+        }
+
+        let model = self
+            .conn
+            .update_with_ctx::<link::Entity>(scope, id, active_model)
+            .await?;
+
+        Ok(Link::from(model))
+    }
+
+    async fn delete(&self, scope: &AccessScope, id: Uuid) -> anyhow::Result<bool> {
+        Ok(self.conn.delete_by_id::<link::Entity>(scope, id).await?)
+    }
+
+    async fn exists(&self, scope: &AccessScope, id: Uuid) -> anyhow::Result<bool> {
+        let link = self
+            .conn
+            .find_by_id::<link::Entity>(scope, id)?
+            .one(self.conn.conn())
+            .await?;
+        Ok(link.is_some())
+    }
+}

--- a/modules/oagw/oagw-gw/src/infra/storage/mapper.rs
+++ b/modules/oagw/oagw-gw/src/infra/storage/mapper.rs
@@ -1,0 +1,100 @@
+//! Entity to domain model mappers.
+
+use oagw_sdk::{Link, NewLink, NewRoute, Route};
+
+use super::entity::{link, route};
+
+/// Convert route entity to domain model.
+impl From<route::Model> for Route {
+    fn from(model: route::Model) -> Self {
+        Self {
+            id: model.id,
+            tenant_id: model.tenant_id,
+            base_url: model.base_url,
+            rate_limit_req_per_min: model.rate_limit_req_per_min,
+            auth_type_gts_id: model.auth_type_gts_id,
+            cache_ttl_sec: model.cache_ttl_sec,
+            supported_protocols: Vec::new(), // Loaded separately
+            created_at: model.created_at,
+            updated_at: model.updated_at,
+        }
+    }
+}
+
+/// Convert route with protocols to domain model.
+pub fn route_with_protocols(
+    model: route::Model,
+    protocols: Vec<super::entity::route_protocol::Model>,
+) -> Route {
+    Route {
+        id: model.id,
+        tenant_id: model.tenant_id,
+        base_url: model.base_url,
+        rate_limit_req_per_min: model.rate_limit_req_per_min,
+        auth_type_gts_id: model.auth_type_gts_id,
+        cache_ttl_sec: model.cache_ttl_sec,
+        supported_protocols: protocols.into_iter().map(|p| p.protocol_gts_id).collect(),
+        created_at: model.created_at,
+        updated_at: model.updated_at,
+    }
+}
+
+/// Convert new route to active model.
+pub fn new_route_to_active_model(
+    new_route: &NewRoute,
+    id: uuid::Uuid,
+    now: chrono::DateTime<chrono::Utc>,
+) -> route::ActiveModel {
+    use sea_orm::ActiveValue::Set;
+
+    route::ActiveModel {
+        id: Set(id),
+        tenant_id: Set(new_route.tenant_id),
+        base_url: Set(new_route.base_url.clone()),
+        rate_limit_req_per_min: Set(new_route.rate_limit_req_per_min.unwrap_or(1000)),
+        auth_type_gts_id: Set(new_route.auth_type_gts_id.clone()),
+        cache_ttl_sec: Set(new_route.cache_ttl_sec),
+        created_at: Set(now),
+        updated_at: Set(now),
+    }
+}
+
+/// Convert link entity to domain model.
+impl From<link::Model> for Link {
+    fn from(model: link::Model) -> Self {
+        Self {
+            id: model.id,
+            tenant_id: model.tenant_id,
+            secret_ref: model.secret_ref,
+            route_id: model.route_id,
+            secret_type_gts_id: model.secret_type_gts_id,
+            enabled: model.enabled,
+            priority: model.priority,
+            strategy_gts_id: model.strategy_gts_id,
+            created_at: model.created_at,
+            updated_at: model.updated_at,
+        }
+    }
+}
+
+/// Convert new link to active model.
+pub fn new_link_to_active_model(
+    new_link: &NewLink,
+    id: uuid::Uuid,
+    now: chrono::DateTime<chrono::Utc>,
+) -> link::ActiveModel {
+    use sea_orm::ActiveValue::Set;
+
+    link::ActiveModel {
+        id: Set(id),
+        tenant_id: Set(new_link.tenant_id),
+        secret_ref: Set(new_link.secret_ref),
+        route_id: Set(new_link.route_id),
+        secret_type_gts_id: Set(new_link.secret_type_gts_id.clone()),
+        enabled: Set(new_link.enabled.unwrap_or(true)),
+        priority: Set(new_link.priority.unwrap_or(0)),
+        strategy_gts_id: Set(new_link.strategy_gts_id.clone()),
+        created_at: Set(now),
+        updated_at: Set(now),
+    }
+}

--- a/modules/oagw/oagw-gw/src/infra/storage/migrations/m20241228_000001_create_oagw_tables.rs
+++ b/modules/oagw/oagw-gw/src/infra/storage/migrations/m20241228_000001_create_oagw_tables.rs
@@ -1,0 +1,235 @@
+//! Initial migration for OAGW tables.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Create outbound_api_route table
+        manager
+            .create_table(
+                Table::create()
+                    .table(OutboundApiRoute::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(OutboundApiRoute::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(OutboundApiRoute::TenantId).uuid().not_null())
+                    .col(ColumnDef::new(OutboundApiRoute::BaseUrl).text().not_null())
+                    .col(
+                        ColumnDef::new(OutboundApiRoute::RateLimitReqPerMin)
+                            .integer()
+                            .not_null()
+                            .default(1000),
+                    )
+                    .col(
+                        ColumnDef::new(OutboundApiRoute::AuthTypeGtsId)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(OutboundApiRoute::CacheTtlSec).integer())
+                    .col(
+                        ColumnDef::new(OutboundApiRoute::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OutboundApiRoute::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // Create index on tenant_id
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_outbound_api_route_tenant")
+                    .table(OutboundApiRoute::Table)
+                    .col(OutboundApiRoute::TenantId)
+                    .to_owned(),
+            )
+            .await?;
+
+        // Create outbound_api_route_supported_protocol table
+        manager
+            .create_table(
+                Table::create()
+                    .table(OutboundApiRouteSupportedProtocol::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(OutboundApiRouteSupportedProtocol::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(OutboundApiRouteSupportedProtocol::RouteId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OutboundApiRouteSupportedProtocol::ProtocolGtsId)
+                            .text()
+                            .not_null(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(
+                                OutboundApiRouteSupportedProtocol::Table,
+                                OutboundApiRouteSupportedProtocol::RouteId,
+                            )
+                            .to(OutboundApiRoute::Table, OutboundApiRoute::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // Create outbound_api_link table
+        manager
+            .create_table(
+                Table::create()
+                    .table(OutboundApiLink::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(OutboundApiLink::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(OutboundApiLink::TenantId).uuid().not_null())
+                    .col(ColumnDef::new(OutboundApiLink::SecretRef).uuid().not_null())
+                    .col(ColumnDef::new(OutboundApiLink::RouteId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(OutboundApiLink::SecretTypeGtsId)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OutboundApiLink::Enabled)
+                            .boolean()
+                            .not_null()
+                            .default(true),
+                    )
+                    .col(
+                        ColumnDef::new(OutboundApiLink::Priority)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(
+                        ColumnDef::new(OutboundApiLink::StrategyGtsId)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OutboundApiLink::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OutboundApiLink::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(OutboundApiLink::Table, OutboundApiLink::RouteId)
+                            .to(OutboundApiRoute::Table, OutboundApiRoute::Id),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // Create indexes on link table
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_outbound_api_link_tenant")
+                    .table(OutboundApiLink::Table)
+                    .col(OutboundApiLink::TenantId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_outbound_api_link_route")
+                    .table(OutboundApiLink::Table)
+                    .col(OutboundApiLink::RouteId)
+                    .to_owned(),
+            )
+            .await?;
+
+        // TODO(v2): Create outbound_api_route_limits table
+        // TODO(v2): Create outbound_api_audit_log table
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(OutboundApiLink::Table).to_owned())
+            .await?;
+
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(OutboundApiRouteSupportedProtocol::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_table(Table::drop().table(OutboundApiRoute::Table).to_owned())
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Iden)]
+enum OutboundApiRoute {
+    Table,
+    Id,
+    TenantId,
+    BaseUrl,
+    RateLimitReqPerMin,
+    AuthTypeGtsId,
+    CacheTtlSec,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[derive(Iden)]
+enum OutboundApiRouteSupportedProtocol {
+    Table,
+    Id,
+    RouteId,
+    ProtocolGtsId,
+}
+
+#[derive(Iden)]
+enum OutboundApiLink {
+    Table,
+    Id,
+    TenantId,
+    SecretRef,
+    RouteId,
+    SecretTypeGtsId,
+    Enabled,
+    Priority,
+    StrategyGtsId,
+    CreatedAt,
+    UpdatedAt,
+}

--- a/modules/oagw/oagw-gw/src/infra/storage/migrations/mod.rs
+++ b/modules/oagw/oagw-gw/src/infra/storage/migrations/mod.rs
@@ -1,0 +1,14 @@
+//! Database migrations for OAGW.
+
+use sea_orm_migration::prelude::*;
+
+mod m20241228_000001_create_oagw_tables;
+
+pub struct Migrator;
+
+#[async_trait::async_trait]
+impl MigratorTrait for Migrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        vec![Box::new(m20241228_000001_create_oagw_tables::Migration)]
+    }
+}

--- a/modules/oagw/oagw-gw/src/infra/storage/mod.rs
+++ b/modules/oagw/oagw-gw/src/infra/storage/mod.rs
@@ -1,0 +1,7 @@
+//! Storage infrastructure for OAGW.
+
+pub mod entity;
+pub mod link_repo;
+pub mod mapper;
+pub mod migrations;
+pub mod route_repo;

--- a/modules/oagw/oagw-gw/src/infra/storage/route_repo.rs
+++ b/modules/oagw/oagw-gw/src/infra/storage/route_repo.rs
@@ -1,0 +1,225 @@
+//! `SeaORM` repository implementation for routes.
+
+use async_trait::async_trait;
+use modkit_db::secure::SecureConn;
+use modkit_odata::{ODataQuery, Page, PageInfo};
+use modkit_security::AccessScope;
+use oagw_sdk::{NewRoute, Route, RoutePatch};
+use sea_orm::{ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, Order, QueryFilter};
+use uuid::Uuid;
+
+use super::entity::{route, route_protocol};
+use super::mapper::{new_route_to_active_model, route_with_protocols};
+use crate::domain::repo::RouteRepository;
+
+/// `SeaORM` implementation of `RouteRepository`.
+pub struct SeaOrmRouteRepository {
+    conn: SecureConn,
+}
+
+impl SeaOrmRouteRepository {
+    /// Create a new repository instance.
+    #[must_use]
+    pub fn new(conn: SecureConn) -> Self {
+        Self { conn }
+    }
+}
+
+#[async_trait]
+impl RouteRepository for SeaOrmRouteRepository {
+    async fn find_by_id(&self, scope: &AccessScope, id: Uuid) -> anyhow::Result<Option<Route>> {
+        let route_opt = self
+            .conn
+            .find_by_id::<route::Entity>(scope, id)?
+            .one(self.conn.conn())
+            .await?;
+
+        let Some(route_model) = route_opt else {
+            return Ok(None);
+        };
+
+        // Load associated protocols
+        // Note: route_protocol is a join table without tenant_id - access is controlled via route
+        #[allow(clippy::disallowed_methods)]
+        let protocols = route_protocol::Entity::find()
+            .filter(route_protocol::Column::RouteId.eq(id))
+            .all(self.conn.conn())
+            .await?;
+
+        Ok(Some(route_with_protocols(route_model, protocols)))
+    }
+
+    async fn list_page(
+        &self,
+        scope: &AccessScope,
+        query: ODataQuery,
+    ) -> anyhow::Result<Page<Route>> {
+        // TODO(v2): Implement proper OData filtering with paginate_odata
+        // For v1, simple pagination without filters
+
+        let limit = query.limit.unwrap_or(25).min(1000);
+
+        let base_query = self.conn.find::<route::Entity>(scope);
+
+        let routes: Vec<route::Model> = base_query
+            .order_by(route::Column::CreatedAt, Order::Desc)
+            .limit(limit + 1) // Fetch one extra to check for more
+            .all(self.conn.conn())
+            .await?;
+
+        let has_more = routes.len() > limit as usize;
+        let items: Vec<_> = routes
+            .into_iter()
+            .take(limit as usize)
+            .map(Route::from)
+            .collect();
+
+        // TODO(v2): Load protocols for each route in batch
+        // For v1, protocols are loaded separately when needed
+
+        Ok(Page {
+            items,
+            page_info: PageInfo {
+                next_cursor: if has_more {
+                    Some("next".to_owned())
+                } else {
+                    None
+                }, // TODO(v2): Implement proper cursor
+                prev_cursor: None,
+                limit,
+            },
+        })
+    }
+
+    async fn insert(&self, scope: &AccessScope, new_route: NewRoute) -> anyhow::Result<Route> {
+        let id = new_route.id.unwrap_or_else(Uuid::now_v7);
+        let now = chrono::Utc::now();
+
+        let active_model = new_route_to_active_model(&new_route, id, now);
+        let model = self
+            .conn
+            .insert::<route::Entity>(scope, active_model)
+            .await?;
+
+        // Insert supported protocols
+        for protocol_gts_id in &new_route.supported_protocols {
+            let protocol_model = route_protocol::ActiveModel {
+                id: ActiveValue::Set(Uuid::now_v7()),
+                route_id: ActiveValue::Set(id),
+                protocol_gts_id: ActiveValue::Set(protocol_gts_id.clone()),
+            };
+            protocol_model.insert(self.conn.conn()).await?;
+        }
+
+        Ok(route_with_protocols(
+            model,
+            new_route
+                .supported_protocols
+                .into_iter()
+                .map(|protocol_gts_id| route_protocol::Model {
+                    id: Uuid::nil(), // Not needed for conversion
+                    route_id: id,
+                    protocol_gts_id,
+                })
+                .collect(),
+        ))
+    }
+
+    async fn update(
+        &self,
+        scope: &AccessScope,
+        id: Uuid,
+        patch: RoutePatch,
+    ) -> anyhow::Result<Route> {
+        let now = chrono::Utc::now();
+
+        // Build active model with only changed fields
+        let mut active_model = route::ActiveModel {
+            id: ActiveValue::Unchanged(id),
+            updated_at: ActiveValue::Set(now),
+            ..Default::default()
+        };
+
+        if let Some(base_url) = patch.base_url {
+            active_model.base_url = ActiveValue::Set(base_url);
+        }
+        if let Some(rate_limit) = patch.rate_limit_req_per_min {
+            active_model.rate_limit_req_per_min = ActiveValue::Set(rate_limit);
+        }
+        if let Some(auth_type) = patch.auth_type_gts_id {
+            active_model.auth_type_gts_id = ActiveValue::Set(auth_type);
+        }
+        if let Some(cache_ttl) = patch.cache_ttl_sec {
+            active_model.cache_ttl_sec = ActiveValue::Set(cache_ttl);
+        }
+
+        let model = self
+            .conn
+            .update_with_ctx::<route::Entity>(scope, id, active_model)
+            .await?;
+
+        // Update protocols if provided
+        if let Some(protocols) = patch.supported_protocols {
+            // Delete existing protocols
+            // Note: route_protocol is a join table without tenant_id - access is controlled via route
+            #[allow(clippy::disallowed_methods)]
+            route_protocol::Entity::delete_many()
+                .filter(route_protocol::Column::RouteId.eq(id))
+                .exec(self.conn.conn())
+                .await?;
+
+            // Insert new protocols
+            for protocol_gts_id in &protocols {
+                let protocol_model = route_protocol::ActiveModel {
+                    id: ActiveValue::Set(Uuid::now_v7()),
+                    route_id: ActiveValue::Set(id),
+                    protocol_gts_id: ActiveValue::Set(protocol_gts_id.clone()),
+                };
+                protocol_model.insert(self.conn.conn()).await?;
+            }
+
+            return Ok(route_with_protocols(
+                model,
+                protocols
+                    .into_iter()
+                    .map(|protocol_gts_id| route_protocol::Model {
+                        id: Uuid::nil(),
+                        route_id: id,
+                        protocol_gts_id,
+                    })
+                    .collect(),
+            ));
+        }
+
+        // Load current protocols
+        // Note: route_protocol is a join table without tenant_id - access is controlled via route
+        #[allow(clippy::disallowed_methods)]
+        let protocols = route_protocol::Entity::find()
+            .filter(route_protocol::Column::RouteId.eq(id))
+            .all(self.conn.conn())
+            .await?;
+
+        Ok(route_with_protocols(model, protocols))
+    }
+
+    async fn delete(&self, scope: &AccessScope, id: Uuid) -> anyhow::Result<bool> {
+        // Delete associated protocols first (cascade)
+        // Note: route_protocol is a join table without tenant_id - access is controlled via route
+        #[allow(clippy::disallowed_methods)]
+        route_protocol::Entity::delete_many()
+            .filter(route_protocol::Column::RouteId.eq(id))
+            .exec(self.conn.conn())
+            .await?;
+
+        Ok(self.conn.delete_by_id::<route::Entity>(scope, id).await?)
+    }
+
+    async fn exists(&self, scope: &AccessScope, id: Uuid) -> anyhow::Result<bool> {
+        let route = self
+            .conn
+            .find_by_id::<route::Entity>(scope, id)?
+            .one(self.conn.conn())
+            .await?;
+        Ok(route.is_some())
+    }
+}

--- a/modules/oagw/oagw-gw/src/lib.rs
+++ b/modules/oagw/oagw-gw/src/lib.rs
@@ -1,0 +1,108 @@
+// Clippy allows for v1 implementation - to be tightened in v2
+#![allow(clippy::doc_markdown)] // Many technical terms without backticks
+#![allow(clippy::must_use_candidate)] // Will add systematically in v2
+#![allow(clippy::str_to_string)] // Prefer consistency over micro-optimization
+
+//! OAGW Gateway Module Implementation
+//!
+//! The OAGW (Outbound API Gateway) module manages outbound traffic to external APIs.
+//! It provides:
+//!
+//! - Route and link configuration management
+//! - Plugin-based protocol and authentication handling
+//! - Circuit breaking, rate limiting, and error normalization
+//! - Streaming support (SSE)
+//!
+//! ## Architecture
+//!
+//! ```text
+//!           Consumer Module
+//!                 │
+//!                 ▼ hub.get::<dyn OagwApi>()
+//! ┌────────────────────────────────────┐
+//! │          OAGW Gateway              │
+//! │  ┌──────────────────────────────┐  │
+//! │  │     REST API (/oagw/v1/...)  │  │
+//! │  └──────────────────────────────┘  │
+//! │               │                    │
+//! │               ▼                    │
+//! │  ┌──────────────────────────────┐  │
+//! │  │     Domain Service           │  │
+//! │  │  - Route/Link resolution     │  │
+//! │  │  - Plugin selection          │  │
+//! │  │  - Circuit breaker           │  │
+//! │  └──────────────────────────────┘  │
+//! │               │                    │
+//! │               ▼ hub.get_scoped()   │
+//! └────────────────────────────────────┘
+//!                │
+//!     ┌──────────┴──────────┐
+//!     ▼                     ▼
+//! ┌────────┐           ┌────────┐
+//! │Plugin A│           │Plugin B│
+//! │(HTTP)  │           │(Custom)│
+//! └────────┘           └────────┘
+//! ```
+//!
+//! ## Usage
+//!
+//! The public API is defined in `oagw-sdk` and re-exported here.
+
+// === PUBLIC API (from SDK) ===
+pub use oagw_sdk::{
+    // GTS types
+    get_oagw_base_schemas,
+    get_oagw_well_known_instances,
+    // Retry types
+    BackoffStrategy,
+    // Models
+    HttpMethod,
+    Link,
+    LinkPatch,
+    NewLink,
+    NewRoute,
+    // Pagination
+    ODataQuery,
+    // API traits
+    OagwApi,
+    OagwAuthTypeV1,
+    // Error types
+    OagwError,
+    OagwInvokeRequest,
+    OagwInvokeResponse,
+    OagwPluginApi,
+    OagwPluginSpecV1,
+    OagwProtoV1,
+    OagwResponseStream,
+    OagwStrategyV1,
+    OagwStreamAbort,
+    OagwStreamChunk,
+    OagwStreamProtoV1,
+    Page,
+    RetryBudget,
+    RetryIntent,
+    RetryOn,
+    RetryScope,
+    Route,
+    RoutePatch,
+    Secret,
+    StatusClass,
+    StreamAbortReason,
+};
+
+// === MODULE DEFINITION ===
+pub mod module;
+pub use module::OagwGateway;
+
+// === LOCAL CLIENT ===
+pub mod local_client;
+
+// === INTERNAL MODULES ===
+#[doc(hidden)]
+pub mod api;
+#[doc(hidden)]
+pub mod config;
+#[doc(hidden)]
+pub mod domain;
+#[doc(hidden)]
+pub mod infra;

--- a/modules/oagw/oagw-gw/src/local_client.rs
+++ b/modules/oagw/oagw-gw/src/local_client.rs
@@ -1,0 +1,146 @@
+//! Local client adapter implementing the SDK API trait.
+//!
+//! This adapter bridges the domain service to the public OagwApi trait,
+//! allowing other modules to consume OAGW via ClientHub.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use modkit_odata::{ODataQuery, Page};
+use modkit_security::SecurityContext;
+use oagw_sdk::{
+    Link, LinkPatch, NewLink, NewRoute, OagwApi, OagwError, OagwInvokeRequest, OagwInvokeResponse,
+    OagwResponseStream, Route, RoutePatch,
+};
+use uuid::Uuid;
+
+use crate::domain::service::Service;
+
+/// Local client adapter implementing the SDK API trait.
+///
+/// Registered in ClientHub during module init().
+pub struct OagwLocalClient {
+    service: Arc<Service>,
+}
+
+impl OagwLocalClient {
+    /// Create a new local client adapter.
+    pub fn new(service: Arc<Service>) -> Self {
+        Self { service }
+    }
+}
+
+#[async_trait]
+impl OagwApi for OagwLocalClient {
+    // === Invocation Methods ===
+
+    async fn invoke_unary(
+        &self,
+        ctx: &SecurityContext,
+        req: OagwInvokeRequest,
+    ) -> Result<OagwInvokeResponse, OagwError> {
+        self.service
+            .invoke_unary(ctx, req)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn invoke_stream(
+        &self,
+        ctx: &SecurityContext,
+        req: OagwInvokeRequest,
+    ) -> Result<OagwResponseStream, OagwError> {
+        self.service
+            .invoke_stream(ctx, req)
+            .await
+            .map_err(Into::into)
+    }
+
+    // === Route CRUD ===
+
+    async fn create_route(
+        &self,
+        ctx: &SecurityContext,
+        new_route: NewRoute,
+    ) -> Result<Route, OagwError> {
+        self.service
+            .create_route(ctx, new_route)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn get_route(&self, ctx: &SecurityContext, id: Uuid) -> Result<Route, OagwError> {
+        self.service.get_route(ctx, id).await.map_err(Into::into)
+    }
+
+    async fn list_routes(
+        &self,
+        ctx: &SecurityContext,
+        query: ODataQuery,
+    ) -> Result<Page<Route>, OagwError> {
+        self.service
+            .list_routes(ctx, query)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn update_route(
+        &self,
+        ctx: &SecurityContext,
+        id: Uuid,
+        patch: RoutePatch,
+    ) -> Result<Route, OagwError> {
+        self.service
+            .update_route(ctx, id, patch)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn delete_route(&self, ctx: &SecurityContext, id: Uuid) -> Result<(), OagwError> {
+        self.service.delete_route(ctx, id).await.map_err(Into::into)
+    }
+
+    // === Link CRUD ===
+
+    async fn create_link(
+        &self,
+        ctx: &SecurityContext,
+        new_link: NewLink,
+    ) -> Result<Link, OagwError> {
+        self.service
+            .create_link(ctx, new_link)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn get_link(&self, ctx: &SecurityContext, id: Uuid) -> Result<Link, OagwError> {
+        self.service.get_link(ctx, id).await.map_err(Into::into)
+    }
+
+    async fn list_links(
+        &self,
+        ctx: &SecurityContext,
+        query: ODataQuery,
+    ) -> Result<Page<Link>, OagwError> {
+        self.service
+            .list_links(ctx, query)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn update_link(
+        &self,
+        ctx: &SecurityContext,
+        id: Uuid,
+        patch: LinkPatch,
+    ) -> Result<Link, OagwError> {
+        self.service
+            .update_link(ctx, id, patch)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn delete_link(&self, ctx: &SecurityContext, id: Uuid) -> Result<(), OagwError> {
+        self.service.delete_link(ctx, id).await.map_err(Into::into)
+    }
+}

--- a/modules/oagw/oagw-gw/src/module.rs
+++ b/modules/oagw/oagw-gw/src/module.rs
@@ -1,0 +1,154 @@
+//! OAGW Gateway module definition.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use modkit::api::OpenApiRegistry;
+use modkit::{DbModule, Module, ModuleCtx, RestfulModule};
+use modkit_security::SecurityCtx;
+use oagw_sdk::{get_oagw_base_schemas, get_oagw_well_known_instances, OagwApi, OagwPluginSpecV1};
+use sea_orm_migration::MigratorTrait;
+use tracing::info;
+use types_registry_sdk::TypesRegistryApi;
+
+use crate::api::rest::routes;
+use crate::config::OagwConfig;
+use crate::domain::ports::StubSecretResolver;
+use crate::domain::repo::{LinkRepository, RouteRepository};
+use crate::domain::service::{Service, ServiceConfig};
+use crate::infra::storage::link_repo::SeaOrmLinkRepository;
+use crate::infra::storage::route_repo::SeaOrmRouteRepository;
+use crate::local_client::OagwLocalClient;
+
+/// OAGW Gateway module.
+///
+/// This module provides:
+/// - Route and link configuration management
+/// - Plugin-based protocol and authentication handling
+/// - REST API for outbound API invocation
+#[modkit::module(
+    name = "oagw_gw",
+    deps = ["types_registry", "oagw_default_plugin"],
+    capabilities = [db, rest]
+)]
+pub struct OagwGateway {
+    service: arc_swap::ArcSwapOption<Service>,
+}
+
+impl Default for OagwGateway {
+    fn default() -> Self {
+        Self {
+            service: arc_swap::ArcSwapOption::from(None),
+        }
+    }
+}
+
+#[async_trait]
+impl Module for OagwGateway {
+    async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        info!("Initializing OAGW gateway module");
+
+        // Load module configuration
+        let cfg: OagwConfig = ctx.config()?;
+
+        // Acquire DB with SecureConn for security-aware queries
+        let db = ctx.db_required()?;
+        let sec_conn = db.sea_secure();
+
+        // === SCHEMA REGISTRATION ===
+        // Gateway registers the plugin SCHEMA; plugins register their INSTANCES
+        let registry = ctx.client_hub().get::<dyn TypesRegistryApi>()?;
+
+        // Register OAGW base schemas (proto, stream_proto, auth_type, strategy)
+        let base_schemas = get_oagw_base_schemas()?;
+        let _ = registry
+            .register(&SecurityCtx::root_ctx(), base_schemas)
+            .await?;
+        info!("Registered OAGW base schemas: proto, stream_proto, auth_type, strategy");
+
+        // Register OAGW plugin schema
+        let schema_str = OagwPluginSpecV1::gts_schema_with_refs_as_string();
+        let schema_json: serde_json::Value = serde_json::from_str(&schema_str)?;
+        let _ = registry
+            .register(&SecurityCtx::root_ctx(), vec![schema_json])
+            .await?;
+        info!(
+            schema_id = %OagwPluginSpecV1::gts_schema_id(),
+            "Registered OAGW plugin schema in types-registry"
+        );
+
+        // Register well-known instances for protocols, auth types, and strategies
+        let well_known_instances = get_oagw_well_known_instances();
+        let _ = registry
+            .register(&SecurityCtx::root_ctx(), well_known_instances)
+            .await?;
+        info!(
+            "Registered OAGW well-known instances (protocols, stream_protocols, auth_types, strategies)"
+        );
+
+        // Wire repositories with SecureConn
+        let route_repo: Arc<dyn RouteRepository> =
+            Arc::new(SeaOrmRouteRepository::new(sec_conn.clone()));
+        let link_repo: Arc<dyn LinkRepository> = Arc::new(SeaOrmLinkRepository::new(sec_conn));
+
+        // Wire secret resolver
+        // TODO(v2): Replace with actual cred_store integration
+        let secret_resolver = Arc::new(StubSecretResolver);
+
+        // Create service with dependencies
+        let service_config = ServiceConfig::from(&cfg);
+        let domain_service = Arc::new(Service::new(
+            route_repo,
+            link_repo,
+            secret_resolver,
+            ctx.client_hub(),
+            service_config,
+        ));
+
+        // Store service for REST handlers
+        self.service.store(Some(domain_service.clone()));
+
+        // === EXPLICIT CLIENT REGISTRATION ===
+        // Create local client adapter that implements the SDK API trait
+        let local_client = OagwLocalClient::new(domain_service);
+        let api: Arc<dyn OagwApi> = Arc::new(local_client);
+
+        // Register directly in ClientHub
+        ctx.client_hub().register::<dyn OagwApi>(api);
+        info!("OAGW API registered in ClientHub via local adapter");
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl DbModule for OagwGateway {
+    async fn migrate(&self, db: &modkit_db::DbHandle) -> anyhow::Result<()> {
+        info!("Running OAGW database migrations");
+        let conn = db.sea();
+        crate::infra::storage::migrations::Migrator::up(&conn, None).await?;
+        Ok(())
+    }
+}
+
+impl RestfulModule for OagwGateway {
+    fn register_rest(
+        &self,
+        _ctx: &ModuleCtx,
+        router: axum::Router,
+        openapi: &dyn OpenApiRegistry,
+    ) -> anyhow::Result<axum::Router> {
+        info!("Registering OAGW REST routes");
+
+        let service = self
+            .service
+            .load()
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("OAGW service not initialized"))?
+            .clone();
+
+        let router = routes::register_routes(router, openapi, service)?;
+
+        Ok(router)
+    }
+}

--- a/modules/oagw/oagw-sdk/Cargo.toml
+++ b/modules/oagw/oagw-sdk/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "oagw-sdk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "SDK for OAGW (Outbound API Gateway): API traits, types, and error definitions"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Core dependencies for API trait
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true }
+chrono = { workspace = true }
+bytes = { workspace = true }
+
+# Security context for API methods
+modkit-security = { path = "../../../libs/modkit-security" }
+
+# ModKit for GTS types
+modkit = { path = "../../../libs/modkit" }
+
+# OData support for pagination
+modkit-odata = { path = "../../../libs/modkit-odata" }
+
+# GTS support
+gts = { workspace = true }
+gts-macros = { workspace = true }
+
+# Serialization for GTS schemas
+serde = { workspace = true }
+serde_json = { workspace = true }
+schemars = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+
+# Streaming support
+futures = { workspace = true }
+pin-project-lite = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/modules/oagw/oagw-sdk/src/api.rs
+++ b/modules/oagw/oagw-sdk/src/api.rs
@@ -1,0 +1,189 @@
+//! OAGW API traits.
+//!
+//! This module defines both the public gateway API and the internal plugin API.
+
+use async_trait::async_trait;
+use modkit_odata::{ODataQuery, Page};
+use modkit_security::SecurityContext;
+use uuid::Uuid;
+
+use crate::error::OagwError;
+use crate::models::{
+    Link, LinkPatch, NewLink, NewRoute, OagwInvokeRequest, OagwInvokeResponse, OagwResponseStream,
+    Route, RoutePatch, Secret,
+};
+
+/// Public API trait for the OAGW gateway.
+///
+/// This trait is exposed by the gateway to other modules via `ClientHub`:
+/// ```ignore
+/// let client = hub.get::<dyn OagwApi>()?;
+/// let response = client.invoke_unary(&ctx, request).await?;
+/// ```
+///
+/// All methods require a `SecurityContext` for proper authorization and tenant isolation.
+#[async_trait]
+pub trait OagwApi: Send + Sync {
+    // === Invocation Methods ===
+
+    /// Invoke an outbound API with unary (request-response) semantics.
+    ///
+    /// # Arguments
+    /// * `ctx` - Security context for authorization
+    /// * `req` - Invocation request with route, method, path, etc.
+    ///
+    /// # Returns
+    /// * `Ok(OagwInvokeResponse)` - Response from downstream API
+    /// * `Err(OagwError)` - Error if invocation fails
+    async fn invoke_unary(
+        &self,
+        ctx: &SecurityContext,
+        req: OagwInvokeRequest,
+    ) -> Result<OagwInvokeResponse, OagwError>;
+
+    /// Invoke an outbound API with streaming response (e.g., SSE).
+    ///
+    /// # Arguments
+    /// * `ctx` - Security context for authorization
+    /// * `req` - Invocation request with route, method, path, etc.
+    ///
+    /// # Returns
+    /// * `Ok(OagwResponseStream)` - Stream of response chunks
+    /// * `Err(OagwError)` - Error if stream cannot be established
+    ///
+    /// # Note
+    /// Streaming requests are never retried by OAGW. If the stream fails mid-way,
+    /// it yields a terminal `OagwStreamAbort` with resume hints if applicable.
+    async fn invoke_stream(
+        &self,
+        ctx: &SecurityContext,
+        req: OagwInvokeRequest,
+    ) -> Result<OagwResponseStream, OagwError>;
+
+    // === Route CRUD ===
+
+    /// Create a new outbound API route.
+    async fn create_route(
+        &self,
+        ctx: &SecurityContext,
+        new_route: NewRoute,
+    ) -> Result<Route, OagwError>;
+
+    /// Get a route by ID.
+    async fn get_route(&self, ctx: &SecurityContext, id: Uuid) -> Result<Route, OagwError>;
+
+    /// List routes with `OData` pagination.
+    async fn list_routes(
+        &self,
+        ctx: &SecurityContext,
+        query: ODataQuery,
+    ) -> Result<Page<Route>, OagwError>;
+
+    /// Update a route with partial data.
+    async fn update_route(
+        &self,
+        ctx: &SecurityContext,
+        id: Uuid,
+        patch: RoutePatch,
+    ) -> Result<Route, OagwError>;
+
+    /// Delete a route by ID.
+    async fn delete_route(&self, ctx: &SecurityContext, id: Uuid) -> Result<(), OagwError>;
+
+    // === Link CRUD ===
+
+    /// Create a new outbound API link.
+    async fn create_link(
+        &self,
+        ctx: &SecurityContext,
+        new_link: NewLink,
+    ) -> Result<Link, OagwError>;
+
+    /// Get a link by ID.
+    async fn get_link(&self, ctx: &SecurityContext, id: Uuid) -> Result<Link, OagwError>;
+
+    /// List links with `OData` pagination.
+    async fn list_links(
+        &self,
+        ctx: &SecurityContext,
+        query: ODataQuery,
+    ) -> Result<Page<Link>, OagwError>;
+
+    /// Update a link with partial data.
+    async fn update_link(
+        &self,
+        ctx: &SecurityContext,
+        id: Uuid,
+        patch: LinkPatch,
+    ) -> Result<Link, OagwError>;
+
+    /// Delete a link by ID.
+    async fn delete_link(&self, ctx: &SecurityContext, id: Uuid) -> Result<(), OagwError>;
+}
+
+/// Plugin API trait implemented by OAGW plugins.
+///
+/// Plugins register themselves with a scoped client in `ClientHub`:
+/// ```ignore
+/// let scope = ClientScope::gts_id(&instance_id);
+/// hub.register_scoped::<dyn OagwPluginApi>(scope, plugin_impl);
+/// ```
+///
+/// The gateway resolves plugins at runtime based on protocol and auth type requirements.
+#[async_trait]
+pub trait OagwPluginApi: Send + Sync {
+    /// Get the list of supported protocol GTS IDs.
+    fn supported_protocols(&self) -> &[String];
+
+    /// Get the list of supported streaming protocol GTS IDs.
+    fn supported_stream_protocols(&self) -> &[String];
+
+    /// Get the list of supported auth type GTS IDs.
+    fn supported_auth_types(&self) -> &[String];
+
+    /// Get the list of supported strategy GTS IDs.
+    fn supported_strategies(&self) -> &[String];
+
+    /// Get the plugin priority (lower = higher priority).
+    fn priority(&self) -> i16;
+
+    /// Invoke an outbound API with unary semantics.
+    ///
+    /// # Arguments
+    /// * `ctx` - Security context
+    /// * `link` - Link configuration
+    /// * `route` - Route configuration
+    /// * `secret` - Secret material for authentication
+    /// * `req` - Invocation request
+    ///
+    /// # Returns
+    /// Response from downstream API or error
+    async fn invoke_unary(
+        &self,
+        ctx: &SecurityContext,
+        link: &Link,
+        route: &Route,
+        secret: &Secret,
+        req: OagwInvokeRequest,
+    ) -> Result<OagwInvokeResponse, OagwError>;
+
+    /// Invoke an outbound API with streaming response.
+    ///
+    /// # Arguments
+    /// * `ctx` - Security context
+    /// * `link` - Link configuration
+    /// * `route` - Route configuration
+    /// * `secret` - Secret material for authentication
+    /// * `req` - Invocation request
+    ///
+    /// # Returns
+    /// Stream of response chunks or error
+    async fn invoke_stream(
+        &self,
+        ctx: &SecurityContext,
+        link: &Link,
+        route: &Route,
+        secret: &Secret,
+        req: OagwInvokeRequest,
+    ) -> Result<OagwResponseStream, OagwError>;
+}

--- a/modules/oagw/oagw-sdk/src/error.rs
+++ b/modules/oagw/oagw-sdk/src/error.rs
@@ -1,0 +1,282 @@
+//! OAGW error types.
+//!
+//! Transport-agnostic error definitions for the OAGW module.
+
+use thiserror::Error;
+use uuid::Uuid;
+
+/// Error type for OAGW operations.
+#[derive(Error, Debug, Clone)]
+pub enum OagwError {
+    /// Route not found.
+    #[error("route not found: {id}")]
+    RouteNotFound { id: Uuid },
+
+    /// Link not found.
+    #[error("link not found: {id}")]
+    LinkNotFound { id: Uuid },
+
+    /// Link is unavailable (disabled or all filtered out).
+    #[error("link unavailable for route {route_id}")]
+    LinkUnavailable { route_id: Uuid },
+
+    /// Circuit breaker is open.
+    #[error("circuit breaker open for link {link_id}")]
+    CircuitBreakerOpen {
+        link_id: Uuid,
+        retry_after_sec: Option<u64>,
+    },
+
+    /// Connection timeout.
+    #[error("connection timeout")]
+    ConnectionTimeout,
+
+    /// Request timeout.
+    #[error("request timeout")]
+    RequestTimeout,
+
+    /// Idle timeout.
+    #[error("idle timeout")]
+    IdleTimeout,
+
+    /// Rate limit exceeded.
+    #[error("rate limit exceeded")]
+    RateLimitExceeded { retry_after_sec: Option<u64> },
+
+    /// Payload too large.
+    #[error("payload too large: {size} bytes exceeds limit of {limit} bytes")]
+    PayloadTooLarge { size: u64, limit: u64 },
+
+    /// Protocol error.
+    #[error("protocol error: {message}")]
+    ProtocolError { message: String },
+
+    /// Authentication failed.
+    #[error("authentication failed: {message}")]
+    AuthenticationFailed { message: String },
+
+    /// Secret not found in `cred_store`.
+    #[error("secret not found: {secret_ref}")]
+    SecretNotFound { secret_ref: Uuid },
+
+    /// Plugin not found for required capabilities.
+    #[error("no plugin found for protocol {protocol} and auth type {auth_type}")]
+    PluginNotFound { protocol: String, auth_type: String },
+
+    /// Downstream API error.
+    #[error("downstream error: status {status_code}")]
+    DownstreamError {
+        status_code: u16,
+        retry_after_sec: Option<u64>,
+    },
+
+    /// Stream was aborted.
+    #[error("stream aborted: {reason}")]
+    StreamAborted {
+        reason: String,
+        bytes_received: u64,
+        resumable: bool,
+    },
+
+    /// Validation error.
+    #[error("validation error: {message}")]
+    ValidationError { message: String },
+
+    /// Internal error.
+    #[error("internal error: {message}")]
+    Internal { message: String },
+
+    /// Authorization error.
+    #[error("forbidden: {message}")]
+    Forbidden { message: String },
+
+    /// Database error.
+    #[error("database error")]
+    Database,
+}
+
+impl OagwError {
+    /// Create a route not found error.
+    #[must_use]
+    pub fn route_not_found(id: Uuid) -> Self {
+        Self::RouteNotFound { id }
+    }
+
+    /// Create a link not found error.
+    #[must_use]
+    pub fn link_not_found(id: Uuid) -> Self {
+        Self::LinkNotFound { id }
+    }
+
+    /// Create a link unavailable error.
+    #[must_use]
+    pub fn link_unavailable(route_id: Uuid) -> Self {
+        Self::LinkUnavailable { route_id }
+    }
+
+    /// Create a circuit breaker open error.
+    #[must_use]
+    pub fn circuit_breaker_open(link_id: Uuid, retry_after_sec: Option<u64>) -> Self {
+        Self::CircuitBreakerOpen {
+            link_id,
+            retry_after_sec,
+        }
+    }
+
+    /// Create a rate limit exceeded error.
+    #[must_use]
+    pub fn rate_limit_exceeded(retry_after_sec: Option<u64>) -> Self {
+        Self::RateLimitExceeded { retry_after_sec }
+    }
+
+    /// Create a payload too large error.
+    #[must_use]
+    pub fn payload_too_large(size: u64, limit: u64) -> Self {
+        Self::PayloadTooLarge { size, limit }
+    }
+
+    /// Create a protocol error.
+    #[must_use]
+    pub fn protocol_error(message: impl Into<String>) -> Self {
+        Self::ProtocolError {
+            message: message.into(),
+        }
+    }
+
+    /// Create an authentication failed error.
+    #[must_use]
+    pub fn authentication_failed(message: impl Into<String>) -> Self {
+        Self::AuthenticationFailed {
+            message: message.into(),
+        }
+    }
+
+    /// Create a secret not found error.
+    #[must_use]
+    pub fn secret_not_found(secret_ref: Uuid) -> Self {
+        Self::SecretNotFound { secret_ref }
+    }
+
+    /// Create a plugin not found error.
+    #[must_use]
+    pub fn plugin_not_found(protocol: impl Into<String>, auth_type: impl Into<String>) -> Self {
+        Self::PluginNotFound {
+            protocol: protocol.into(),
+            auth_type: auth_type.into(),
+        }
+    }
+
+    /// Create a downstream error.
+    #[must_use]
+    pub fn downstream_error(status_code: u16, retry_after_sec: Option<u64>) -> Self {
+        Self::DownstreamError {
+            status_code,
+            retry_after_sec,
+        }
+    }
+
+    /// Create a validation error.
+    #[must_use]
+    pub fn validation(message: impl Into<String>) -> Self {
+        Self::ValidationError {
+            message: message.into(),
+        }
+    }
+
+    /// Create an internal error.
+    #[must_use]
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal {
+            message: message.into(),
+        }
+    }
+
+    /// Create a forbidden error.
+    #[must_use]
+    pub fn forbidden(message: impl Into<String>) -> Self {
+        Self::Forbidden {
+            message: message.into(),
+        }
+    }
+
+    /// Check if this error is retriable.
+    #[must_use]
+    pub fn is_retriable(&self) -> bool {
+        matches!(
+            self,
+            Self::ConnectionTimeout
+                | Self::RequestTimeout
+                | Self::IdleTimeout
+                | Self::RateLimitExceeded { .. }
+                | Self::CircuitBreakerOpen { .. }
+                | Self::LinkUnavailable { .. }
+        )
+    }
+
+    /// Get the retry-after hint if available.
+    #[must_use]
+    pub fn retry_after_sec(&self) -> Option<u64> {
+        match self {
+            Self::RateLimitExceeded { retry_after_sec }
+            | Self::CircuitBreakerOpen {
+                retry_after_sec, ..
+            }
+            | Self::DownstreamError {
+                retry_after_sec, ..
+            } => *retry_after_sec,
+            _ => None,
+        }
+    }
+
+    /// Get the GTS error instance ID for this error.
+    #[must_use]
+    pub fn gts_id(&self) -> &'static str {
+        match self {
+            Self::RouteNotFound { .. } => "gts.x.core.errors.err.v1~x.oagw.route.not_found.v1",
+            Self::LinkNotFound { .. } => "gts.x.core.errors.err.v1~x.oagw.link.not_found.v1",
+            Self::LinkUnavailable { .. } => "gts.x.core.errors.err.v1~x.oagw.link.unavailable.v1",
+            Self::CircuitBreakerOpen { .. } => {
+                "gts.x.core.errors.err.v1~x.oagw.circuit_breaker.open.v1"
+            }
+            Self::ConnectionTimeout => "gts.x.core.errors.err.v1~x.oagw.timeout.connection.v1",
+            Self::RequestTimeout => "gts.x.core.errors.err.v1~x.oagw.timeout.request.v1",
+            Self::IdleTimeout => "gts.x.core.errors.err.v1~x.oagw.timeout.idle.v1",
+            Self::RateLimitExceeded { .. } => {
+                "gts.x.core.errors.err.v1~x.oagw.rate_limit.exceeded.v1"
+            }
+            Self::PayloadTooLarge { .. } => "gts.x.core.errors.err.v1~x.oagw.payload.too_large.v1",
+            Self::ProtocolError { .. } => "gts.x.core.errors.err.v1~x.oagw.protocol.error.v1",
+            Self::AuthenticationFailed { .. } => "gts.x.core.errors.err.v1~x.oagw.auth.failed.v1",
+            Self::SecretNotFound { .. } => "gts.x.core.errors.err.v1~x.oagw.secret.not_found.v1",
+            Self::PluginNotFound { .. } => "gts.x.core.errors.err.v1~x.oagw.plugin.not_found.v1",
+            Self::DownstreamError { .. } => "gts.x.core.errors.err.v1~x.oagw.downstream.error.v1",
+            Self::StreamAborted { .. } => "gts.x.core.errors.err.v1~x.oagw.stream.aborted.v1",
+            Self::ValidationError { .. } => "gts.x.core.errors.err.v1~x.oagw.validation.error.v1",
+            Self::Internal { .. } | Self::Database => {
+                "gts.x.core.errors.err.v1~x.oagw.internal.error.v1"
+            }
+            Self::Forbidden { .. } => "gts.x.core.errors.err.v1~x.oagw.access.forbidden.v1",
+        }
+    }
+
+    /// Get the HTTP status code for this error.
+    #[must_use]
+    pub fn status_code(&self) -> u16 {
+        match self {
+            Self::RouteNotFound { .. } | Self::LinkNotFound { .. } => 404,
+            Self::LinkUnavailable { .. }
+            | Self::CircuitBreakerOpen { .. }
+            | Self::PluginNotFound { .. } => 503,
+            Self::ConnectionTimeout | Self::RequestTimeout | Self::IdleTimeout => 504,
+            Self::RateLimitExceeded { .. } => 429,
+            Self::PayloadTooLarge { .. } => 413,
+            Self::ProtocolError { .. }
+            | Self::DownstreamError { .. }
+            | Self::StreamAborted { .. } => 502,
+            Self::AuthenticationFailed { .. } => 401,
+            Self::SecretNotFound { .. } | Self::Internal { .. } | Self::Database => 500,
+            Self::ValidationError { .. } => 400,
+            Self::Forbidden { .. } => 403,
+        }
+    }
+}

--- a/modules/oagw/oagw-sdk/src/gts.rs
+++ b/modules/oagw/oagw-sdk/src/gts.rs
@@ -1,0 +1,361 @@
+//! GTS schema types for OAGW.
+//!
+//! This module defines the GTS schemas for:
+//! - Plugin instances (`OagwPluginSpecV1`)
+//! - Protocol types (`OagwProtoV1`)
+//! - Stream protocol types (`OagwStreamProtoV1`)
+//! - Auth types (`OagwAuthTypeV1`)
+//! - Strategy types (`OagwStrategyV1`)
+//!
+//! Well-known instances are defined in submodules:
+//! - `protocols` - HTTP/1.1, HTTP/2, HTTP/3, SSE
+//! - `stream_protocols` - SSE stream
+//! - `auth_types` - Bearer token, API key, OAuth2
+//! - `strategies` - Sticky session, round robin, priority
+
+use gts::GtsInstanceId;
+pub use gts::GtsSchemaId;
+use gts_macros::struct_to_gts_schema;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+// For helper functions
+use anyhow::Result;
+
+// Re-export BaseModkitPluginV1 from modkit for convenience
+pub use modkit::gts::BaseModkitPluginV1;
+
+// Well-known GTS IDs for protocols
+pub mod protocols {
+    /// HTTP/1.1 protocol.
+    pub const HTTP11: &str = "gts.x.core.oagw.proto.v1~x.core.http.http11.v1";
+    /// HTTP/2 protocol.
+    pub const HTTP2: &str = "gts.x.core.oagw.proto.v1~x.core.http.http2.v1";
+    /// HTTP/3 protocol (future).
+    pub const HTTP3: &str = "gts.x.core.oagw.proto.v1~x.core.http.http3.v1";
+    /// Server-Sent Events protocol.
+    pub const SSE: &str = "gts.x.core.oagw.proto.v1~x.core.http.sse.v1";
+}
+
+// Well-known GTS IDs for auth types
+pub mod auth_types {
+    /// Bearer token authentication.
+    pub const BEARER_TOKEN: &str = "gts.x.core.oagw.auth_type.v1~x.core.auth.bearer_token.v1";
+    /// API key in header.
+    pub const API_KEY_HEADER: &str = "gts.x.core.oagw.auth_type.v1~x.core.auth.api_key_header.v1";
+    /// API key in query parameter.
+    pub const API_KEY_QUERY: &str = "gts.x.core.oagw.auth_type.v1~x.core.auth.api_key_query.v1";
+    /// `OAuth2` client credentials flow.
+    pub const OAUTH2_CLIENT_CREDS: &str =
+        "gts.x.core.oagw.auth_type.v1~x.core.auth.oauth2_client_creds.v1";
+    /// `OAuth2` token exchange (RFC 8693).
+    pub const OAUTH2_TOKEN_EXCHANGE: &str =
+        "gts.x.core.oagw.auth_type.v1~x.core.auth.oauth2_token_exchange.v1";
+}
+
+// Well-known GTS IDs for strategies
+pub mod strategies {
+    /// Sticky session strategy.
+    pub const STICKY_SESSION: &str = "gts.x.core.oagw.strategy.v1~x.core._.sticky_session.v1";
+    /// Round-robin strategy.
+    pub const ROUND_ROBIN: &str = "gts.x.core.oagw.strategy.v1~x.core._.round_robin.v1";
+    /// Priority-based selection (default).
+    pub const PRIORITY: &str = "gts.x.core.oagw.strategy.v1~x.core._.priority.v1";
+}
+
+// Well-known GTS IDs for stream protocols
+pub mod stream_protocols {
+    /// Server-Sent Events streaming protocol.
+    pub const SSE: &str = "gts.x.core.oagw.stream_proto.v1~x.core.http.sse.v1";
+}
+
+// Well-known GTS IDs for roles
+pub mod roles {
+    /// Role for route health checks.
+    pub const ROUTE_HEALTH: &str = "gts.x.core.idp.role.v1~x.oagw.route.health.v1";
+    /// Role for route administration.
+    pub const ROUTE_ADMIN: &str = "gts.x.core.idp.role.v1~x.oagw.route.admin.v1";
+    /// Role for link administration.
+    pub const LINK_ADMIN: &str = "gts.x.core.idp.role.v1~x.oagw.link.admin.v1";
+    /// Role for invocation.
+    pub const INVOKE: &str = "gts.x.core.idp.role.v1~x.oagw.api.invoke.v1";
+}
+
+// ============================================================================
+// BASE GTS SCHEMAS
+// ============================================================================
+
+/// GTS schema for OAGW protocol types.
+///
+/// Schema ID: `gts.x.core.oagw.proto.v1~`
+///
+/// Defines the shape of protocol instances (HTTP/1.1, HTTP/2, HTTP/3, etc.)
+/// that routes can support.
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.x.core.oagw.proto.v1~",
+    description = "OAGW protocol type specification",
+    properties = "id, display_name, description, priority"
+)]
+#[derive(Debug, Clone)]
+pub struct OagwProtoV1 {
+    /// Full GTS instance ID (e.g., `gts.x.core.oagw.proto.v1~x.core.http.http2.v1`).
+    pub id: GtsInstanceId,
+    /// Human-readable display name.
+    pub display_name: String,
+    /// Optional description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Priority for protocol selection (lower wins).
+    #[serde(default)]
+    pub priority: i16,
+}
+
+/// GTS schema for OAGW stream protocol types.
+///
+/// Schema ID: `gts.x.core.oagw.stream_proto.v1~`
+///
+/// Defines the shape of streaming protocol instances (SSE, WebSocket, etc.)
+/// that routes can support for streaming responses.
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.x.core.oagw.stream_proto.v1~",
+    description = "OAGW stream protocol type specification",
+    properties = "id, display_name, description, priority"
+)]
+#[derive(Debug, Clone)]
+pub struct OagwStreamProtoV1 {
+    /// Full GTS instance ID.
+    pub id: GtsInstanceId,
+    /// Human-readable display name.
+    pub display_name: String,
+    /// Optional description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Priority for protocol selection (lower wins).
+    #[serde(default)]
+    pub priority: i16,
+}
+
+/// GTS schema for OAGW auth type definitions.
+///
+/// Schema ID: `gts.x.core.oagw.auth_type.v1~`
+///
+/// Defines the shape of authentication type instances (bearer token, API key, OAuth2, etc.)
+/// that routes can use for outbound authentication.
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.x.core.oagw.auth_type.v1~",
+    description = "OAGW auth type specification",
+    properties = "id, display_name, description, priority"
+)]
+#[derive(Debug, Clone)]
+pub struct OagwAuthTypeV1 {
+    /// Full GTS instance ID.
+    pub id: GtsInstanceId,
+    /// Human-readable display name.
+    pub display_name: String,
+    /// Optional description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Priority for auth type selection (lower wins).
+    #[serde(default)]
+    pub priority: i16,
+}
+
+/// GTS schema for OAGW link selection strategy types.
+///
+/// Schema ID: `gts.x.core.oagw.strategy.v1~`
+///
+/// Defines the shape of strategy instances (sticky session, round robin, priority, etc.)
+/// that links can use for load balancing.
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.x.core.oagw.strategy.v1~",
+    description = "OAGW link selection strategy specification",
+    properties = "id, display_name, description, priority"
+)]
+#[derive(Debug, Clone)]
+pub struct OagwStrategyV1 {
+    /// Full GTS instance ID.
+    pub id: GtsInstanceId,
+    /// Human-readable display name.
+    pub display_name: String,
+    /// Optional description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Priority for strategy selection (lower wins).
+    #[serde(default)]
+    pub priority: i16,
+}
+
+// ============================================================================
+// PLUGIN SCHEMA
+// ============================================================================
+
+/// GTS schema for OAGW plugin instances.
+///
+/// Schema ID: `gts.x.core.modkit.plugin.v1~x.core.oagw.plugin.v1~`
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = BaseModkitPluginV1,
+    schema_id = "gts.x.core.modkit.plugin.v1~x.core.oagw.plugin.v1~",
+    description = "OAGW plugin specification",
+    properties = "supported_protocols, supported_stream_protocols, supported_auth_types, supported_strategies"
+)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[allow(clippy::struct_field_names)] // Fields prefixed for clarity in GTS schema
+pub struct OagwPluginSpecV1 {
+    /// Supported unary protocol GTS IDs.
+    pub supported_protocols: Vec<String>,
+    /// Supported streaming protocol GTS IDs.
+    pub supported_stream_protocols: Vec<String>,
+    /// Supported auth type GTS IDs.
+    pub supported_auth_types: Vec<String>,
+    /// Supported strategy GTS IDs.
+    pub supported_strategies: Vec<String>,
+}
+
+// ============================================================================
+// WELL-KNOWN INSTANCES HELPERS
+// ============================================================================
+
+/// Returns all well-known OAGW GTS schemas as JSON values for registration.
+///
+/// This includes:
+/// - `gts.x.core.oagw.proto.v1~`
+/// - `gts.x.core.oagw.stream_proto.v1~`
+/// - `gts.x.core.oagw.auth_type.v1~`
+/// - `gts.x.core.oagw.strategy.v1~`
+///
+/// # Errors
+///
+/// Returns an error if schema JSON cannot be parsed.
+pub fn get_oagw_base_schemas() -> Result<Vec<serde_json::Value>> {
+    let mut schemas = Vec::new();
+
+    // Protocol schema
+    let proto_schema: serde_json::Value =
+        serde_json::from_str(&OagwProtoV1::gts_schema_with_refs_as_string())?;
+    schemas.push(proto_schema);
+
+    // Stream protocol schema
+    let stream_proto_schema: serde_json::Value =
+        serde_json::from_str(&OagwStreamProtoV1::gts_schema_with_refs_as_string())?;
+    schemas.push(stream_proto_schema);
+
+    // Auth type schema
+    let auth_type_schema: serde_json::Value =
+        serde_json::from_str(&OagwAuthTypeV1::gts_schema_with_refs_as_string())?;
+    schemas.push(auth_type_schema);
+
+    // Strategy schema
+    let strategy_schema: serde_json::Value =
+        serde_json::from_str(&OagwStrategyV1::gts_schema_with_refs_as_string())?;
+    schemas.push(strategy_schema);
+
+    Ok(schemas)
+}
+
+/// Returns all well-known OAGW instances as JSON values for registration.
+///
+/// This includes well-known instances for:
+/// - Protocols (HTTP/1.1, HTTP/2, HTTP/3, SSE)
+/// - Stream protocols (SSE)
+/// - Auth types (bearer token, API key header/query, OAuth2)
+/// - Strategies (sticky session, round robin, priority)
+pub fn get_oagw_well_known_instances() -> Vec<serde_json::Value> {
+    let mut instances = Vec::new();
+
+    // Protocol instances
+    instances.push(serde_json::json!({
+        "id": protocols::HTTP11,
+        "display_name": "HTTP/1.1",
+        "description": "HTTP/1.1 protocol for outbound requests",
+        "priority": 30
+    }));
+    instances.push(serde_json::json!({
+        "id": protocols::HTTP2,
+        "display_name": "HTTP/2",
+        "description": "HTTP/2 protocol for outbound requests with multiplexing",
+        "priority": 20
+    }));
+    instances.push(serde_json::json!({
+        "id": protocols::HTTP3,
+        "display_name": "HTTP/3",
+        "description": "HTTP/3 (QUIC) protocol for outbound requests",
+        "priority": 10
+    }));
+    instances.push(serde_json::json!({
+        "id": protocols::SSE,
+        "display_name": "Server-Sent Events",
+        "description": "HTTP-based Server-Sent Events for streaming responses",
+        "priority": 25
+    }));
+
+    // Stream protocol instances
+    instances.push(serde_json::json!({
+        "id": stream_protocols::SSE,
+        "display_name": "SSE Stream",
+        "description": "Server-Sent Events streaming protocol",
+        "priority": 10
+    }));
+
+    // Auth type instances
+    instances.push(serde_json::json!({
+        "id": auth_types::BEARER_TOKEN,
+        "display_name": "Bearer Token",
+        "description": "Bearer token authentication via Authorization header",
+        "priority": 10
+    }));
+    instances.push(serde_json::json!({
+        "id": auth_types::API_KEY_HEADER,
+        "display_name": "API Key (Header)",
+        "description": "API key authentication via custom header",
+        "priority": 20
+    }));
+    instances.push(serde_json::json!({
+        "id": auth_types::API_KEY_QUERY,
+        "display_name": "API Key (Query)",
+        "description": "API key authentication via query parameter",
+        "priority": 30
+    }));
+    instances.push(serde_json::json!({
+        "id": auth_types::OAUTH2_CLIENT_CREDS,
+        "display_name": "OAuth2 Client Credentials",
+        "description": "OAuth2 client credentials flow for machine-to-machine auth",
+        "priority": 40
+    }));
+    instances.push(serde_json::json!({
+        "id": auth_types::OAUTH2_TOKEN_EXCHANGE,
+        "display_name": "OAuth2 Token Exchange",
+        "description": "RFC 8693 OAuth2 token exchange for user delegation",
+        "priority": 50
+    }));
+
+    // Strategy instances
+    instances.push(serde_json::json!({
+        "id": strategies::PRIORITY,
+        "display_name": "Priority",
+        "description": "Select link with lowest priority value (default strategy)",
+        "priority": 10
+    }));
+    instances.push(serde_json::json!({
+        "id": strategies::ROUND_ROBIN,
+        "display_name": "Round Robin",
+        "description": "Distribute requests across links in round-robin fashion",
+        "priority": 20
+    }));
+    instances.push(serde_json::json!({
+        "id": strategies::STICKY_SESSION,
+        "display_name": "Sticky Session",
+        "description": "Route requests from same tenant/user to same link",
+        "priority": 30
+    }));
+
+    instances
+}

--- a/modules/oagw/oagw-sdk/src/lib.rs
+++ b/modules/oagw/oagw-sdk/src/lib.rs
@@ -1,0 +1,63 @@
+//! OAGW SDK (Outbound API Gateway)
+//!
+//! This crate provides the public API contract for the OAGW gateway
+//! and its plugin implementations.
+//!
+//! ## API Traits
+//!
+//! - `OagwApi` - Public API exposed by the gateway to other modules
+//! - `OagwPluginApi` - Internal API implemented by plugins
+//!
+//! ## GTS Types
+//!
+//! - `OagwPluginSpecV1` - Plugin instance schema
+//! - Protocol, auth type, and strategy schemas
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use oagw_sdk::OagwApi;
+//!
+//! // Get the client from ClientHub
+//! let client = hub.get::<dyn OagwApi>()?;
+//!
+//! // Invoke an outbound API
+//! let response = client.invoke_unary(&ctx, request).await?;
+//! ```
+
+#![forbid(unsafe_code)]
+#![deny(rust_2018_idioms)]
+
+pub mod api;
+pub mod error;
+pub mod gts;
+pub mod models;
+pub mod retry;
+
+// API traits
+pub use api::{OagwApi, OagwPluginApi};
+
+// Error types
+pub use error::OagwError;
+
+// GTS schema types
+pub use gts::{
+    get_oagw_base_schemas, get_oagw_well_known_instances, OagwAuthTypeV1, OagwPluginSpecV1,
+    OagwProtoV1, OagwStrategyV1, OagwStreamProtoV1,
+};
+
+// Models
+pub use models::{
+    HttpMethod, Link, LinkPatch, NewLink, NewRoute, OagwInvokeRequest, OagwInvokeResponse,
+    OagwResponseStream, OagwStreamAbort, OagwStreamChunk, Route, RoutePatch, Secret,
+    StreamAbortReason,
+};
+
+// Retry types
+pub use retry::{BackoffStrategy, RetryBudget, RetryIntent, RetryOn, RetryScope, StatusClass};
+
+// GTS types (re-exported for convenience)
+pub use gts::GtsSchemaId;
+
+// Pagination primitives (re-exported for convenience)
+pub use modkit_odata::{ODataQuery, Page, PageInfo};

--- a/modules/oagw/oagw-sdk/src/models.rs
+++ b/modules/oagw/oagw-sdk/src/models.rs
@@ -1,0 +1,338 @@
+//! OAGW domain models.
+//!
+//! These are transport-agnostic models used across the SDK.
+//! Note: NO serde derives here - these are pure domain models.
+
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+use std::pin::Pin;
+use uuid::Uuid;
+
+use crate::retry::RetryIntent;
+
+/// HTTP method for outbound requests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HttpMethod {
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+    Head,
+    Options,
+}
+
+impl HttpMethod {
+    /// Convert to uppercase string representation.
+    #[must_use]
+    #[allow(clippy::trivially_copy_pass_by_ref)] // Consistent API with other enums
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Get => "GET",
+            Self::Post => "POST",
+            Self::Put => "PUT",
+            Self::Patch => "PATCH",
+            Self::Delete => "DELETE",
+            Self::Head => "HEAD",
+            Self::Options => "OPTIONS",
+        }
+    }
+}
+
+impl std::fmt::Display for HttpMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// Request to invoke an outbound API.
+#[derive(Debug, Clone)]
+pub struct OagwInvokeRequest {
+    /// Optional link ID to use (if not provided, OAGW selects based on route).
+    pub link_id: Option<Uuid>,
+    /// Route ID identifying the downstream API configuration.
+    pub route_id: Uuid,
+    /// HTTP method for the request.
+    pub method: HttpMethod,
+    /// Path to append to the route's base URL.
+    pub path: String,
+    /// Optional query parameters.
+    pub query: Option<HashMap<String, String>>,
+    /// Optional custom headers.
+    pub headers: Option<HashMap<String, String>>,
+    /// Optional request body.
+    pub body: Option<Bytes>,
+    /// Optional timeout override in milliseconds.
+    pub timeout_ms: Option<u64>,
+    /// Retry intent (default: no retry).
+    pub retry_intent: RetryIntent,
+}
+
+impl Default for OagwInvokeRequest {
+    fn default() -> Self {
+        Self {
+            link_id: None,
+            route_id: Uuid::nil(),
+            method: HttpMethod::Get,
+            path: String::new(),
+            query: None,
+            headers: None,
+            body: None,
+            timeout_ms: None,
+            retry_intent: RetryIntent::default(),
+        }
+    }
+}
+
+/// Response from an outbound API invocation.
+#[derive(Debug, Clone)]
+pub struct OagwInvokeResponse {
+    /// HTTP status code from downstream.
+    pub status_code: u16,
+    /// Response headers.
+    pub headers: HashMap<String, String>,
+    /// Response body.
+    pub body: Bytes,
+    /// Total duration in milliseconds.
+    pub duration_ms: u64,
+    /// Link ID that was used for the invocation.
+    pub link_id: Uuid,
+    /// Retry-After hint propagated from downstream (if any).
+    pub retry_after_sec: Option<u64>,
+    /// Which attempt succeeded (1-based).
+    pub attempt_number: u32,
+}
+
+/// A chunk from a streaming response.
+#[derive(Debug, Clone)]
+pub struct OagwStreamChunk {
+    /// Raw data bytes.
+    pub data: Bytes,
+    /// SSE event type (if applicable).
+    pub event_type: Option<String>,
+    /// SSE event ID for resume (if applicable).
+    pub event_id: Option<String>,
+}
+
+/// Reason for stream abort.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamAbortReason {
+    /// Network-level failure.
+    Network,
+    /// Protocol-level error.
+    Protocol,
+    /// Authentication failure.
+    Auth,
+    /// Timeout exceeded.
+    Timeout,
+}
+
+impl std::fmt::Display for StreamAbortReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Network => write!(f, "network"),
+            Self::Protocol => write!(f, "protocol"),
+            Self::Auth => write!(f, "auth"),
+            Self::Timeout => write!(f, "timeout"),
+        }
+    }
+}
+
+/// Stream abort error with metadata for potential resume.
+#[derive(Debug, Clone)]
+pub struct OagwStreamAbort {
+    /// GTS error ID.
+    pub gts_id: String,
+    /// Bytes received before failure.
+    pub bytes_received: u64,
+    /// Reason for abort.
+    pub abort_reason: StreamAbortReason,
+    /// Whether stream can potentially be resumed.
+    pub resumable: bool,
+    /// Resume hint (e.g., SSE Last-Event-ID).
+    pub resume_hint: Option<String>,
+    /// Additional detail message.
+    pub detail: Option<String>,
+}
+
+/// Streaming response type.
+pub type OagwResponseStream =
+    Pin<Box<dyn futures::Stream<Item = Result<OagwStreamChunk, OagwStreamAbort>> + Send + 'static>>;
+
+/// Outbound API route configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Route {
+    /// Unique route identifier.
+    pub id: Uuid,
+    /// Tenant owning this route.
+    pub tenant_id: Uuid,
+    /// Base URL for the downstream API.
+    pub base_url: String,
+    /// Rate limit in requests per minute.
+    pub rate_limit_req_per_min: i32,
+    /// GTS ID of the auth type required.
+    pub auth_type_gts_id: String,
+    /// Optional cache TTL in seconds.
+    pub cache_ttl_sec: Option<i32>,
+    /// Supported protocol GTS IDs.
+    pub supported_protocols: Vec<String>,
+    /// Creation timestamp.
+    pub created_at: DateTime<Utc>,
+    /// Last update timestamp.
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Data for creating a new route.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewRoute {
+    /// Optional ID (generated if not provided).
+    pub id: Option<Uuid>,
+    /// Tenant owning this route.
+    pub tenant_id: Uuid,
+    /// Base URL for the downstream API.
+    pub base_url: String,
+    /// Rate limit in requests per minute.
+    pub rate_limit_req_per_min: Option<i32>,
+    /// GTS ID of the auth type required.
+    pub auth_type_gts_id: String,
+    /// Optional cache TTL in seconds.
+    pub cache_ttl_sec: Option<i32>,
+    /// Supported protocol GTS IDs.
+    pub supported_protocols: Vec<String>,
+}
+
+/// Partial update for a route.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RoutePatch {
+    /// Updated base URL.
+    pub base_url: Option<String>,
+    /// Updated rate limit.
+    pub rate_limit_req_per_min: Option<i32>,
+    /// Updated auth type GTS ID.
+    pub auth_type_gts_id: Option<String>,
+    /// Updated cache TTL. Use `Some(None)` to clear, `Some(Some(v))` to set.
+    #[allow(clippy::option_option)] // Intentional: distinguish set-to-null from not-set
+    pub cache_ttl_sec: Option<Option<i32>>,
+    /// Updated supported protocols.
+    pub supported_protocols: Option<Vec<String>>,
+}
+
+/// Outbound API link (tenant's connection to a route).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Link {
+    /// Unique link identifier.
+    pub id: Uuid,
+    /// Tenant owning this link.
+    pub tenant_id: Uuid,
+    /// Reference to secret in `cred_store`.
+    pub secret_ref: Uuid,
+    /// Route this link connects to.
+    pub route_id: Uuid,
+    /// GTS ID of the secret type.
+    pub secret_type_gts_id: String,
+    /// Whether this link is enabled.
+    pub enabled: bool,
+    /// Priority for link selection (lower = higher priority).
+    pub priority: i32,
+    /// GTS ID of the selection strategy.
+    pub strategy_gts_id: String,
+    /// Creation timestamp.
+    pub created_at: DateTime<Utc>,
+    /// Last update timestamp.
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Data for creating a new link.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewLink {
+    /// Optional ID (generated if not provided).
+    pub id: Option<Uuid>,
+    /// Tenant owning this link.
+    pub tenant_id: Uuid,
+    /// Reference to secret in `cred_store`.
+    pub secret_ref: Uuid,
+    /// Route this link connects to.
+    pub route_id: Uuid,
+    /// GTS ID of the secret type.
+    pub secret_type_gts_id: String,
+    /// Whether this link is enabled.
+    pub enabled: Option<bool>,
+    /// Priority for link selection.
+    pub priority: Option<i32>,
+    /// GTS ID of the selection strategy.
+    pub strategy_gts_id: String,
+}
+
+/// Partial update for a link.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LinkPatch {
+    /// Updated secret reference.
+    pub secret_ref: Option<Uuid>,
+    /// Updated secret type.
+    pub secret_type_gts_id: Option<String>,
+    /// Updated enabled state.
+    pub enabled: Option<bool>,
+    /// Updated priority.
+    pub priority: Option<i32>,
+    /// Updated strategy.
+    pub strategy_gts_id: Option<String>,
+}
+
+/// Secret material retrieved from `cred_store`.
+#[derive(Debug, Clone)]
+#[allow(clippy::struct_field_names)] // Prefix needed for clarity in domain model
+pub struct Secret {
+    /// Secret ID.
+    pub id: Uuid,
+    /// GTS ID of the secret type.
+    pub secret_type_gts_id: String,
+    /// The actual secret value.
+    pub value: String,
+    /// Optional metadata (e.g., header name for API key).
+    pub metadata: Option<HashMap<String, String>>,
+}
+
+/// Health status for a route or link.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HealthStatus {
+    /// Fully operational.
+    Healthy,
+    /// Some links are down.
+    Degraded,
+    /// All links are down.
+    Unhealthy,
+    /// Circuit breaker is open.
+    CircuitOpen,
+}
+
+impl std::fmt::Display for HealthStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Healthy => write!(f, "healthy"),
+            Self::Degraded => write!(f, "degraded"),
+            Self::Unhealthy => write!(f, "unhealthy"),
+            Self::CircuitOpen => write!(f, "circuit_open"),
+        }
+    }
+}
+
+/// Health check response for a route.
+#[derive(Debug, Clone)]
+pub struct RouteHealth {
+    /// Route ID.
+    pub route_id: Uuid,
+    /// Overall status.
+    pub status: HealthStatus,
+    /// Per-link health status.
+    pub links: Vec<LinkHealth>,
+}
+
+/// Health check response for a link.
+#[derive(Debug, Clone)]
+pub struct LinkHealth {
+    /// Link ID.
+    pub link_id: Uuid,
+    /// Link status.
+    pub status: HealthStatus,
+}

--- a/modules/oagw/oagw-sdk/src/retry.rs
+++ b/modules/oagw/oagw-sdk/src/retry.rs
@@ -1,0 +1,238 @@
+//! Retry intent and related types.
+//!
+//! OAGW performs no implicit retries — retries occur only when explicitly
+//! requested by the caller via `RetryIntent`.
+
+use std::sync::atomic::AtomicU32;
+use std::sync::Arc;
+
+/// Retry intent specifying how OAGW should handle retries.
+///
+/// Default is no retry (`max_attempts: 1`).
+#[derive(Debug, Clone)]
+pub struct RetryIntent {
+    /// Maximum number of attempts (1 = no retry).
+    pub max_attempts: u32,
+    /// Conditions under which to retry.
+    pub retry_on: Vec<RetryOn>,
+    /// Scope for retry (same link, different link, or reroute).
+    pub scope: RetryScope,
+    /// Whether to allow strategy re-selection when switching links.
+    pub allow_strategy_reselect: bool,
+    /// Backoff strategy between retries.
+    pub backoff: BackoffStrategy,
+    /// Optional shared budget limiting total retries.
+    pub budget: Option<Arc<RetryBudget>>,
+}
+
+impl Default for RetryIntent {
+    fn default() -> Self {
+        Self {
+            max_attempts: 1, // No retry by default
+            retry_on: Vec::new(),
+            scope: RetryScope::SameLink,
+            allow_strategy_reselect: false,
+            backoff: BackoffStrategy::None,
+            budget: None,
+        }
+    }
+}
+
+impl RetryIntent {
+    /// Create a retry intent with the specified max attempts.
+    #[must_use]
+    pub fn with_max_attempts(mut self, max_attempts: u32) -> Self {
+        self.max_attempts = max_attempts;
+        self
+    }
+
+    /// Add a retry condition.
+    #[must_use]
+    pub fn retry_on(mut self, condition: RetryOn) -> Self {
+        self.retry_on.push(condition);
+        self
+    }
+
+    /// Set the retry scope.
+    #[must_use]
+    pub fn with_scope(mut self, scope: RetryScope) -> Self {
+        self.scope = scope;
+        self
+    }
+
+    /// Set the backoff strategy.
+    #[must_use]
+    pub fn with_backoff(mut self, backoff: BackoffStrategy) -> Self {
+        self.backoff = backoff;
+        self
+    }
+
+    /// Set a shared retry budget.
+    #[must_use]
+    pub fn with_budget(mut self, budget: Arc<RetryBudget>) -> Self {
+        self.budget = Some(budget);
+        self
+    }
+}
+
+/// Condition for triggering a retry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RetryOn {
+    /// Retry on timeout errors.
+    Timeout,
+    /// Retry on connection errors.
+    ConnectError,
+    /// Retry on specific HTTP status class.
+    StatusClass(StatusClass),
+    /// Retry on specific GTS error ID.
+    ErrorGtsId(String),
+}
+
+/// HTTP status class for retry conditions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusClass {
+    /// 5xx server errors.
+    C5xx,
+    /// 429 Too Many Requests.
+    C429,
+}
+
+/// Scope for retry attempts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RetryScope {
+    /// Retry using the same link.
+    #[default]
+    SameLink,
+    /// Retry using a different link if available.
+    DifferentLink,
+    /// Re-run the full route selection strategy.
+    Reroute,
+}
+
+/// Backoff strategy between retry attempts.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum BackoffStrategy {
+    /// No delay between retries.
+    #[default]
+    None,
+    /// Constant delay.
+    Constant {
+        /// Delay in milliseconds.
+        delay_ms: u64,
+    },
+    /// Linear backoff.
+    Linear {
+        /// Initial delay in milliseconds.
+        initial_ms: u64,
+        /// Increment per attempt in milliseconds.
+        increment_ms: u64,
+        /// Maximum delay in milliseconds.
+        max_ms: u64,
+    },
+    /// Exponential backoff.
+    Exponential {
+        /// Initial delay in milliseconds.
+        initial_ms: u64,
+        /// Multiplier per attempt.
+        multiplier: f64,
+        /// Maximum delay in milliseconds.
+        max_ms: u64,
+    },
+}
+
+impl BackoffStrategy {
+    /// Calculate delay for a given attempt (0-indexed).
+    #[must_use]
+    pub fn delay_for_attempt(&self, attempt: u32) -> u64 {
+        match self {
+            Self::None => 0,
+            Self::Constant { delay_ms } => *delay_ms,
+            Self::Linear {
+                initial_ms,
+                increment_ms,
+                max_ms,
+            } => {
+                let delay = initial_ms + (u64::from(attempt) * increment_ms);
+                delay.min(*max_ms)
+            }
+            Self::Exponential {
+                initial_ms,
+                multiplier,
+                max_ms,
+            } => {
+                // Allow precision loss for backoff calculation - acceptable for timing
+                #[allow(clippy::cast_precision_loss, clippy::cast_possible_wrap)]
+                let delay = (*initial_ms as f64) * multiplier.powi(attempt as i32);
+                // Truncation is intentional - we want milliseconds as integer
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                let delay_ms = delay as u64;
+                delay_ms.min(*max_ms)
+            }
+        }
+    }
+}
+
+/// Shared budget to limit total retries across multiple calls.
+#[derive(Debug)]
+pub struct RetryBudget {
+    /// Maximum retries allowed in the time window.
+    pub max_retries: AtomicU32,
+    /// Time window in seconds.
+    pub time_window_sec: u64,
+    /// Minimum retry rate guarantee.
+    pub min_retries_per_sec: f64,
+}
+
+impl RetryBudget {
+    /// Create a new retry budget.
+    #[must_use]
+    pub fn new(max_retries: u32, time_window_sec: u64, min_retries_per_sec: f64) -> Self {
+        Self {
+            max_retries: AtomicU32::new(max_retries),
+            time_window_sec,
+            min_retries_per_sec,
+        }
+    }
+
+    /// Try to acquire a retry from the budget.
+    ///
+    /// Returns `true` if a retry is allowed, `false` otherwise.
+    pub fn try_acquire(&self) -> bool {
+        // TODO(v3): Implement proper budget tracking with time window
+        // For now, simple atomic decrement
+        let current = self.max_retries.load(std::sync::atomic::Ordering::Relaxed);
+        if current > 0 {
+            self.max_retries
+                .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_retry_intent() {
+        let intent = RetryIntent::default();
+        assert_eq!(intent.max_attempts, 1);
+        assert!(intent.retry_on.is_empty());
+    }
+
+    #[test]
+    fn test_exponential_backoff() {
+        let backoff = BackoffStrategy::Exponential {
+            initial_ms: 100,
+            multiplier: 2.0,
+            max_ms: 5000,
+        };
+
+        assert_eq!(backoff.delay_for_attempt(0), 100);
+        assert_eq!(backoff.delay_for_attempt(1), 200);
+        assert_eq!(backoff.delay_for_attempt(2), 400);
+        assert_eq!(backoff.delay_for_attempt(6), 5000); // Capped at max
+    }
+}

--- a/modules/oagw/plugins/oagw_default_plugin/Cargo.toml
+++ b/modules/oagw/plugins/oagw_default_plugin/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "oagw_default_plugin"
+version.workspace = true
+publish = false
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Default HTTP plugin for OAGW (Outbound API Gateway)"
+
+[lints]
+workspace = true
+
+[dependencies]
+# SDK - plugin API trait and types
+oagw-sdk = { path = "../../oagw-sdk" }
+
+# Core dependencies
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+inventory = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+arc-swap = { workspace = true }
+thiserror = { workspace = true }
+bytes = { workspace = true }
+futures = { workspace = true }
+
+# HTTP client
+reqwest = { workspace = true }
+
+# Additional dependencies
+uuid = { workspace = true }
+chrono = { workspace = true }
+url = { workspace = true }
+
+# Local dependencies
+modkit = { path = "../../../../libs/modkit" }
+modkit-security = { path = "../../../../libs/modkit-security" }
+
+# GTS support
+gts = { workspace = true }
+
+# Types registry for plugin registration
+types-registry-sdk = { path = "../../../types-registry/types-registry-sdk" }
+
+[dev-dependencies]
+tokio-test = { workspace = true }

--- a/modules/oagw/plugins/oagw_default_plugin/src/config.rs
+++ b/modules/oagw/plugins/oagw_default_plugin/src/config.rs
@@ -1,0 +1,28 @@
+//! Plugin configuration.
+
+use serde::Deserialize;
+
+/// Configuration for the default OAGW plugin.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct PluginConfig {
+    /// Vendor name for the plugin.
+    pub vendor: String,
+    /// Priority for plugin selection (lower = higher priority).
+    pub priority: i16,
+    /// Default timeout for HTTP requests in milliseconds.
+    pub default_timeout_ms: u64,
+    /// Maximum response body size in bytes.
+    pub max_response_size_bytes: usize,
+}
+
+impl Default for PluginConfig {
+    fn default() -> Self {
+        Self {
+            vendor: "x".to_string(),
+            priority: 10,
+            default_timeout_ms: 30_000,
+            max_response_size_bytes: 104_857_600, // 100 MiB
+        }
+    }
+}

--- a/modules/oagw/plugins/oagw_default_plugin/src/lib.rs
+++ b/modules/oagw/plugins/oagw_default_plugin/src/lib.rs
@@ -1,0 +1,40 @@
+// Clippy allows for v1 implementation - to be tightened in v2
+#![allow(clippy::doc_markdown)] // Many technical terms without backticks
+#![allow(clippy::must_use_candidate)] // Will add systematically in v2
+#![allow(clippy::str_to_string)] // Prefer consistency over micro-optimization
+#![allow(clippy::unused_self)] // Stub implementations have unused self
+#![allow(clippy::redundant_clone)] // Some clones needed for future async use
+
+//! OAGW Default HTTP Plugin
+//!
+//! This plugin provides HTTP/1.1, HTTP/2, and SSE support for the OAGW gateway.
+//! It implements the `OagwPluginApi` trait and registers itself with the types-registry.
+//!
+//! ## Supported Features
+//!
+//! - **Protocols**: HTTP/1.1, HTTP/2, SSE
+//! - **Auth Types**: Bearer token, API key (header)
+//! - **Strategies**: Priority-based selection
+//!
+//! ## v1 Scope
+//!
+//! - Basic HTTP invocation with bearer token and API key auth
+//! - Request/response handling
+//! - Timeout support
+//!
+//! ## Future Versions (TODOs)
+//!
+//! - v2: SSE streaming support
+//! - v3: OAuth2 client credentials, token caching
+//! - v4: Sticky sessions, round-robin strategies
+//! - v5: OAuth2 token exchange
+
+// === MODULE DEFINITION ===
+pub mod module;
+pub use module::OagwDefaultPlugin;
+
+// === INTERNAL MODULES ===
+#[doc(hidden)]
+pub mod config;
+#[doc(hidden)]
+pub mod service;

--- a/modules/oagw/plugins/oagw_default_plugin/src/module.rs
+++ b/modules/oagw/plugins/oagw_default_plugin/src/module.rs
@@ -1,0 +1,121 @@
+//! OAGW Default Plugin module definition.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use modkit::client_hub::ClientScope;
+use modkit::{Module, ModuleCtx};
+use modkit_security::SecurityCtx;
+use oagw_sdk::{OagwPluginApi, OagwPluginSpecV1};
+use tracing::info;
+use types_registry_sdk::TypesRegistryApi;
+
+use crate::config::PluginConfig;
+use crate::service::HttpPluginService;
+
+/// OAGW Default HTTP Plugin module.
+///
+/// This plugin provides HTTP/1.1, HTTP/2, and SSE support for the OAGW gateway.
+#[modkit::module(
+    name = "oagw_default_plugin",
+    deps = ["types_registry"]
+)]
+pub struct OagwDefaultPlugin {
+    service: arc_swap::ArcSwapOption<HttpPluginService>,
+}
+
+impl Default for OagwDefaultPlugin {
+    fn default() -> Self {
+        Self {
+            service: arc_swap::ArcSwapOption::from(None),
+        }
+    }
+}
+
+#[async_trait]
+impl Module for OagwDefaultPlugin {
+    async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        info!("Initializing OAGW default HTTP plugin");
+
+        // Load plugin configuration
+        let cfg: PluginConfig = ctx.config()?;
+
+        // Create plugin service
+        let service = Arc::new(HttpPluginService::new(cfg.clone()));
+        self.service.store(Some(service.clone()));
+
+        // Generate stable GTS instance ID
+        let instance_id = OagwPluginSpecV1::gts_make_instance_id("x.core.oagw.http_plugin.v1");
+
+        // Register plugin INSTANCE in types-registry
+        // Note: The plugin SCHEMA is registered by the gateway module
+        let registry = ctx.client_hub().get::<dyn TypesRegistryApi>()?;
+
+        // Ensure schema exists before registering instance (plugin may start before gateway).
+        let schema_str = OagwPluginSpecV1::gts_schema_with_refs_as_string();
+        let schema_json: serde_json::Value = serde_json::from_str(&schema_str)?;
+        let _ = registry
+            .register(&SecurityCtx::root_ctx(), vec![schema_json])
+            .await?;
+        info!(
+            schema_id = %OagwPluginSpecV1::gts_schema_id(),
+            "Ensured OAGW plugin schema registered in types-registry"
+        );
+
+        let supported_protocols = service.supported_protocols().to_vec();
+        let supported_stream_protocols = service.supported_stream_protocols().to_vec();
+        let supported_auth_types = service.supported_auth_types().to_vec();
+        let supported_strategies = service.supported_strategies().to_vec();
+
+        info!(
+            protocols = ?supported_protocols,
+            stream_protocols = ?supported_stream_protocols,
+            auth_types = ?supported_auth_types,
+            strategies = ?supported_strategies,
+            "Registering plugin instance with capabilities"
+        );
+
+        // Construct instance JSON with properties nested under "properties" field.
+        // The base schema requires "properties" as a field, and the child schema
+        // should validate the contents of that field.
+        let instance_json = serde_json::json!({
+            "id": instance_id.to_string(),
+            "vendor": cfg.vendor.clone(),
+            "priority": cfg.priority,
+            "properties": {
+                "supported_protocols": supported_protocols,
+                "supported_stream_protocols": supported_stream_protocols,
+                "supported_auth_types": supported_auth_types,
+                "supported_strategies": supported_strategies,
+            }
+        });
+        info!(
+            instance_json = ?instance_json,
+            "Registering plugin instance JSON"
+        );
+
+        // Register the instance - the registry expects the full BaseModkitPluginV1 wrapper
+        let _ = registry
+            .register(&SecurityCtx::root_ctx(), vec![instance_json])
+            .await?;
+
+        info!(
+            instance_id = %instance_id,
+            vendor = %cfg.vendor,
+            priority = cfg.priority,
+            "Registered OAGW plugin instance in types-registry"
+        );
+
+        // Register scoped client in ClientHub
+        let api: Arc<dyn OagwPluginApi> = service;
+        ctx.client_hub()
+            .register_scoped::<dyn OagwPluginApi>(ClientScope::gts_id(&instance_id), api);
+
+        info!(
+            instance_id = %instance_id,
+            "OAGW plugin API registered in ClientHub (scoped)"
+        );
+
+        Ok(())
+    }
+}

--- a/modules/oagw/plugins/oagw_default_plugin/src/service.rs
+++ b/modules/oagw/plugins/oagw_default_plugin/src/service.rs
@@ -1,0 +1,372 @@
+//! Plugin service implementing OagwPluginApi.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use modkit_security::SecurityContext;
+use oagw_sdk::{
+    gts::{auth_types, protocols, strategies},
+    Link, OagwError, OagwInvokeRequest, OagwInvokeResponse, OagwPluginApi, OagwResponseStream,
+    Route, Secret,
+};
+use tracing::{info_span, instrument, Instrument};
+
+use crate::config::PluginConfig;
+
+/// Default HTTP plugin service.
+pub struct HttpPluginService {
+    client: reqwest::Client,
+    config: PluginConfig,
+    supported_protocols: Vec<String>,
+    supported_stream_protocols: Vec<String>,
+    supported_auth_types: Vec<String>,
+    supported_strategies: Vec<String>,
+}
+
+impl HttpPluginService {
+    /// Create a new HTTP plugin service.
+    ///
+    /// # Panics
+    /// Panics if the HTTP client cannot be created (should never happen with valid config).
+    pub fn new(config: PluginConfig) -> Self {
+        #[allow(clippy::expect_used)]
+        // Safe: reqwest client creation only fails with invalid TLS config
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(config.default_timeout_ms))
+            .pool_max_idle_per_host(10)
+            .build()
+            .expect("Failed to create HTTP client");
+
+        Self {
+            client,
+            config,
+            supported_protocols: vec![protocols::HTTP11.to_string(), protocols::HTTP2.to_string()],
+            supported_stream_protocols: vec![protocols::SSE.to_string()],
+            supported_auth_types: vec![
+                auth_types::BEARER_TOKEN.to_string(),
+                auth_types::API_KEY_HEADER.to_string(),
+                // TODO(v2): Add API_KEY_QUERY support
+                // TODO(v3): Add OAUTH2_CLIENT_CREDS support
+                // TODO(v5): Add OAUTH2_TOKEN_EXCHANGE support
+            ],
+            supported_strategies: vec![
+                strategies::PRIORITY.to_string(),
+                // TODO(v4): Add STICKY_SESSION support
+                // TODO(v4): Add ROUND_ROBIN support
+            ],
+        }
+    }
+
+    /// Build the target URL from route base URL and request path.
+    fn build_url(&self, route: &Route, req: &OagwInvokeRequest) -> String {
+        let base = route.base_url.trim_end_matches('/');
+        let path = if req.path.starts_with('/') {
+            req.path.clone()
+        } else {
+            format!("/{}", req.path)
+        };
+
+        let mut url = format!("{base}{path}");
+
+        // Add query parameters
+        if let Some(ref query) = req.query {
+            if !query.is_empty() {
+                let query_str: String = query
+                    .iter()
+                    .map(|(k, v)| format!("{}={}", urlencoding::encode(k), urlencoding::encode(v)))
+                    .collect::<Vec<_>>()
+                    .join("&");
+                url = format!("{url}?{query_str}");
+            }
+        }
+
+        url
+    }
+
+    /// Apply authentication to the request builder.
+    fn apply_auth(
+        &self,
+        builder: reqwest::RequestBuilder,
+        route: &Route,
+        secret: &Secret,
+    ) -> Result<reqwest::RequestBuilder, OagwError> {
+        let auth_type = &route.auth_type_gts_id;
+
+        if auth_type == auth_types::BEARER_TOKEN {
+            // Bearer token: Authorization: Bearer <token>
+            Ok(builder.header("Authorization", format!("Bearer {}", secret.value)))
+        } else if auth_type == auth_types::API_KEY_HEADER {
+            // API key header: custom header with key
+            let header_name = secret
+                .metadata
+                .as_ref()
+                .and_then(|m| m.get("header_name"))
+                .map_or("X-API-Key", String::as_str);
+
+            Ok(builder.header(header_name, &secret.value))
+        } else if auth_type == auth_types::API_KEY_QUERY {
+            // TODO(v2): API key query parameter support
+            // For now, return error
+            Err(OagwError::authentication_failed(
+                "API key query auth not yet supported",
+            ))
+        } else if auth_type == auth_types::OAUTH2_CLIENT_CREDS {
+            // TODO(v3): OAuth2 client credentials support with token caching
+            Err(OagwError::authentication_failed(
+                "OAuth2 client credentials auth not yet supported (v3)",
+            ))
+        } else if auth_type == auth_types::OAUTH2_TOKEN_EXCHANGE {
+            // TODO(v5): OAuth2 token exchange support
+            Err(OagwError::authentication_failed(
+                "OAuth2 token exchange auth not yet supported (v5)",
+            ))
+        } else {
+            Err(OagwError::authentication_failed(format!(
+                "Unknown auth type: {auth_type}"
+            )))
+        }
+    }
+
+    /// Convert reqwest method to HTTP method.
+    fn to_reqwest_method(&self, method: oagw_sdk::HttpMethod) -> reqwest::Method {
+        match method {
+            oagw_sdk::HttpMethod::Get => reqwest::Method::GET,
+            oagw_sdk::HttpMethod::Post => reqwest::Method::POST,
+            oagw_sdk::HttpMethod::Put => reqwest::Method::PUT,
+            oagw_sdk::HttpMethod::Patch => reqwest::Method::PATCH,
+            oagw_sdk::HttpMethod::Delete => reqwest::Method::DELETE,
+            oagw_sdk::HttpMethod::Head => reqwest::Method::HEAD,
+            oagw_sdk::HttpMethod::Options => reqwest::Method::OPTIONS,
+        }
+    }
+
+    /// Extract Retry-After header from response.
+    fn extract_retry_after(headers: &reqwest::header::HeaderMap) -> Option<u64> {
+        headers
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok())
+    }
+}
+
+#[async_trait]
+impl OagwPluginApi for HttpPluginService {
+    fn supported_protocols(&self) -> &[String] {
+        &self.supported_protocols
+    }
+
+    fn supported_stream_protocols(&self) -> &[String] {
+        &self.supported_stream_protocols
+    }
+
+    fn supported_auth_types(&self) -> &[String] {
+        &self.supported_auth_types
+    }
+
+    fn supported_strategies(&self) -> &[String] {
+        &self.supported_strategies
+    }
+
+    fn priority(&self) -> i16 {
+        self.config.priority
+    }
+
+    #[instrument(skip(self, _ctx, link, route, secret, req), fields(
+        target_url,
+        method = %req.method,
+        link_id = %link.id
+    ))]
+    async fn invoke_unary(
+        &self,
+        _ctx: &SecurityContext,
+        link: &Link,
+        route: &Route,
+        secret: &Secret,
+        req: OagwInvokeRequest,
+    ) -> Result<OagwInvokeResponse, OagwError> {
+        let start = std::time::Instant::now();
+
+        // Build URL
+        let url = self.build_url(route, &req);
+        tracing::Span::current().record("target_url", &url);
+
+        // Create request builder
+        let method = self.to_reqwest_method(req.method);
+        let mut builder = self.client.request(method.clone(), &url);
+
+        // Apply timeout
+        if let Some(timeout_ms) = req.timeout_ms {
+            builder = builder.timeout(Duration::from_millis(timeout_ms));
+        }
+
+        // Apply authentication
+        builder = self.apply_auth(builder, route, secret)?;
+
+        // Add custom headers
+        if let Some(headers) = req.headers {
+            for (key, value) in headers {
+                builder = builder.header(&key, &value);
+            }
+        }
+
+        // Add body
+        if let Some(body) = req.body {
+            builder = builder.body(body);
+        }
+
+        // Execute request
+        let response = builder
+            .send()
+            .instrument(info_span!("http_request"))
+            .await
+            .map_err(|e| {
+                if e.is_timeout() {
+                    if e.is_connect() {
+                        OagwError::ConnectionTimeout
+                    } else {
+                        OagwError::RequestTimeout
+                    }
+                } else if e.is_connect() {
+                    OagwError::protocol_error(format!("Connection error: {e}"))
+                } else {
+                    OagwError::protocol_error(format!("Request error: {e}"))
+                }
+            })?;
+
+        let status_code = response.status().as_u16();
+        let retry_after_sec = Self::extract_retry_after(response.headers());
+
+        // Convert headers
+        let mut headers = HashMap::new();
+        for (name, value) in response.headers() {
+            if let Ok(v) = value.to_str() {
+                headers.insert(name.to_string(), v.to_string());
+            }
+        }
+
+        // Read body
+        let body = response
+            .bytes()
+            .await
+            .map_err(|e| OagwError::protocol_error(format!("Failed to read response body: {e}")))?;
+
+        // Duration in ms is always small enough for u64 in practice
+        #[allow(clippy::cast_possible_truncation)]
+        let duration_ms = start.elapsed().as_millis() as u64;
+
+        tracing::info!(
+            status_code,
+            duration_ms,
+            body_size = body.len(),
+            "HTTP request completed"
+        );
+
+        Ok(OagwInvokeResponse {
+            status_code,
+            headers,
+            body,
+            duration_ms,
+            link_id: link.id,
+            retry_after_sec,
+            attempt_number: 1, // No retry in plugin - handled by gateway
+        })
+    }
+
+    #[instrument(skip_all, fields(link_id = %link.id))]
+    async fn invoke_stream(
+        &self,
+        _ctx: &SecurityContext,
+        link: &Link,
+        route: &Route,
+        _secret: &Secret,
+        _req: OagwInvokeRequest,
+    ) -> Result<OagwResponseStream, OagwError> {
+        // TODO(v2): Implement SSE streaming support
+        // For v1, streaming is not supported - return error
+        tracing::warn!(
+            link_id = %link.id,
+            route_id = %route.id,
+            "Streaming invocation not yet implemented (v2)"
+        );
+
+        Err(OagwError::protocol_error(
+            "Streaming not yet supported. Use invoke_unary for HTTP requests. Streaming support planned for v2.",
+        ))
+    }
+}
+
+// URL encoding helper
+mod urlencoding {
+    pub fn encode(s: &str) -> String {
+        url::form_urlencoded::byte_serialize(s.as_bytes()).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_url_with_path() {
+        let config = PluginConfig::default();
+        let service = HttpPluginService::new(config);
+
+        let route = Route {
+            id: uuid::Uuid::nil(),
+            tenant_id: uuid::Uuid::nil(),
+            base_url: "https://api.example.com/v1".to_string(),
+            rate_limit_req_per_min: 1000,
+            auth_type_gts_id: auth_types::BEARER_TOKEN.to_string(),
+            cache_ttl_sec: None,
+            supported_protocols: vec![],
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+
+        let req = OagwInvokeRequest {
+            route_id: uuid::Uuid::nil(),
+            method: oagw_sdk::HttpMethod::Get,
+            path: "/users".to_string(),
+            ..Default::default()
+        };
+
+        let url = service.build_url(&route, &req);
+        assert_eq!(url, "https://api.example.com/v1/users");
+    }
+
+    #[test]
+    fn test_build_url_with_query() {
+        let config = PluginConfig::default();
+        let service = HttpPluginService::new(config);
+
+        let route = Route {
+            id: uuid::Uuid::nil(),
+            tenant_id: uuid::Uuid::nil(),
+            base_url: "https://api.example.com".to_string(),
+            rate_limit_req_per_min: 1000,
+            auth_type_gts_id: auth_types::BEARER_TOKEN.to_string(),
+            cache_ttl_sec: None,
+            supported_protocols: vec![],
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+
+        let mut query = HashMap::new();
+        query.insert("limit".to_string(), "10".to_string());
+        query.insert("offset".to_string(), "0".to_string());
+
+        let req = OagwInvokeRequest {
+            route_id: uuid::Uuid::nil(),
+            method: oagw_sdk::HttpMethod::Get,
+            path: "/items".to_string(),
+            query: Some(query),
+            ..Default::default()
+        };
+
+        let url = service.build_url(&route, &req);
+        assert!(url.starts_with("https://api.example.com/items?"));
+        assert!(url.contains("limit=10"));
+        assert!(url.contains("offset=0"));
+    }
+}

--- a/openspec/changes/add-model-provider-cred-store-oagw/design.md
+++ b/openspec/changes/add-model-provider-cred-store-oagw/design.md
@@ -1,0 +1,69 @@
+## Context
+This change proposes specifications for three new modules:
+
+- `model_provider`: manages GenAI model providers and their endpoints, plus tenant provisioning.
+- `cred_store`: a generic secret storage gateway with a single active plugin (highest priority).
+- `oagw`: outbound API gateway for invoking remote calls with pluggable protocol/auth/streaming implementations.
+
+The system MUST use existing ModKit patterns:
+
+- `types_registry` as authoritative registry for GTS schemas and well-known instances.
+- Gateway+plugin architecture with scoped `ClientHub` registration.
+- `types_registry` two-phase lifecycle: module `init()` registration in configuration mode, then `types_registry` `post_init()` switches to ready mode.
+
+## Goals / Non-Goals
+- Goals:
+  - Provide complete domain model definitions and storage responsibilities.
+  - Provide both Rust-native and REST gateway contracts.
+  - Provide plugin contracts and selection algorithms.
+  - Provide module startup procedure for schema + instance registration.
+  - Provide OpenAPI 3.1 specifications (module-local) for code generation.
+
+- Non-Goals:
+  - Implement the modules.
+  - Decide concrete authentication/authorization policy and RBAC model.
+  - Standardize global tag taxonomy beyond what is required for the described relationships.
+
+## Decisions
+- Decision: Use TypesRegistry as the only storage for GTS schemas and well-known instances.
+  - Gateway modules register schemas and well-known instances during `init()`.
+  - Plugin modules register their plugin instance objects during `init()`.
+
+- Decision: Keep plugin discovery lazy.
+  - Rationale: matches `tenant_resolver` example and avoids race with `types_registry` ready switch.
+
+- Decision: Persist only anonymous objects (UUID IDs) and tenant-scoped configuration in module DB tables.
+  - Rationale: aligns with the request and keeps global taxonomies as GTS instances.
+
+## Recommended building blocks (Rust crates)
+- `modkit`, `modkit-security`, `modkit-db` (Secure ORM), `modkit-odata` (pagination), `modkit::TracedClient`.
+- `types_registry_sdk::TypesRegistryApi` for GTS registration and discovery.
+- `gts` / `gts_macros` for schema definitions (`struct_to_gts_schema`).
+- `secrecy` for secret material handling in memory.
+- `age` (or KMS/Vault SDKs) for envelope encryption in plugins.
+- `reqwest` via `modkit::TracedClient` for outbound HTTP.
+- `tonic` for gRPC client generation and streaming.
+- `oauth2` for OAuth2 client credentials and token exchange.
+- `jsonwebtoken` for JWT validation and parsing.
+- `metrics` + `metrics-exporter-prometheus` for Prometheus metrics.
+- `tracing` + `tracing-opentelemetry` for distributed tracing.
+- `governor` for rate limiting.
+- `tower` for retry middleware and service composition.
+- `failsafe` for circuit breaker pattern.
+- `moka` for high-performance in-memory caching (token cache, response cache).
+- `ring` or `aws-lc-rs` for FIPS 140-2 validated cryptography (HIPAA compliance).
+- Optional (if adopted): `rig` for provider integrations and tool calling abstractions. No `rig` dependency exists in the repo yet; adding it is a follow-up implementation decision.
+
+## OpenAPI
+HyperSpot generates a single OpenAPI document at runtime (owned by `api_ingress`), but each module contributes operations. For code generation, the following module-local OpenAPI 3.1 documents are specified.
+
+## Module Startup Procedure (shared pattern)
+All three modules MUST follow `types_registry` lifecycle constraints:
+
+1. `types_registry` module `init()` runs first, registers core GTS base types.
+2. Plugin modules `init()` run and register their plugin instances and scoped clients (no `list()` calls).
+3. Gateway modules `init()` run and register:
+   - their module-owned GTS schemas via `XxxV1::gts_schema_with_refs_as_string()`.
+   - module-owned well-known instances loaded from `gts/<schema-id>.instances.json`.
+4. After *all* modules finish `init()`, `types_registry` `post_init()` runs and switches to ready mode, validating all registered entities.
+5. Gateways MUST perform plugin discovery lazily on first request (after ready mode), mirroring `tenant_resolver`.

--- a/openspec/changes/add-model-provider-cred-store-oagw/proposal.md
+++ b/openspec/changes/add-model-provider-cred-store-oagw/proposal.md
@@ -1,0 +1,55 @@
+# Change: Add model_provider, cred_store, and oagw module specifications
+
+## Why
+HyperSpot needs standardized, reusable building blocks for (1) managing GenAI model providers and their endpoints, (2) secure tenant-scoped secret storage, and (3) outbound remote-call invocation with pluggable protocol/auth/streaming implementations.
+
+These three modules are foundational for inference, embeddings, and future integrations, and must follow HyperSpot/ModKit conventions (DDD-light, TypesRegistry-backed GTS registration, gateway+plugin patterns).
+
+## What Changes
+- Define three new gateway modules and their plugin interfaces:
+  - `model_provider` (gateway + plugins)
+  - `cred_store` (gateway + single highest-priority plugin)
+  - `oagw` (gateway + single highest-priority eligible plugin)
+- Define complete domain model (GTS schemas/instances + DB entities) and the module startup procedure for registering:
+  - All GTS schemas (`XxxV1::gts_schema_with_refs_as_string()`)
+  - All well-known GTS instances from `gts/*.instances.json` payloads
+- Define complete REST APIs (OpenAPI 3.1) and Rust-native (ClientHub) APIs, including DTOs, errors, and step-by-step processing scenarios.
+- Define detailed database schema for anonymous (UUID-identified) objects.
+
+## Impact
+- Affected specs:
+  - New: `model-provider` (gateway + plugin contracts)
+  - New: `cred-store` (gateway + plugin contracts)
+  - New: `oagw` (gateway + plugin contracts)
+- Affected code:
+  - New modules will be introduced under `modules/` (implementation is **out of scope** for this proposal stage)
+  - Integrates with existing `types_registry` module lifecycle (`init()` registration + `post_init()` ready switch)
+
+## Success Criteria
+
+### Specification Completeness
+- ✅ Complete domain models (GTS schemas, DB tables, anonymous UUID-based persistence)
+- ✅ Complete API contracts (Rust-native ClientHub APIs + REST OpenAPI 3.1 endpoints)
+- ✅ Complete plugin interfaces (trait definitions, priority-based selection, scoped client registration)
+- ✅ Complete operational requirements (audit logging, observability, error handling, resilience)
+- ✅ Complete compliance requirements (SOC2, HIPAA, PCI-DSS guidelines for `cred_store`)
+- ✅ Complete security requirements (RBAC, ACL, secret versioning, KEK rotation, encryption)
+
+### Industry Standards Alignment
+- ✅ Audit logging comparable to HashiCorp Vault, AWS Secrets Manager
+- ✅ Access control (RBAC + ACL) following least-privilege principle
+- ✅ Circuit breaker and retry patterns per industry best practices
+- ✅ Observability (Prometheus metrics, OpenTelemetry tracing, health checks)
+- ✅ Rate limiting and resource quotas to prevent abuse
+- ✅ Comprehensive error taxonomy using RFC 9457 Problem Details
+
+### Production Readiness
+- ✅ SLOs defined (99.9% availability, p95 latency targets)
+- ✅ Disaster recovery (backup, KEK rotation, secret versioning)
+- ✅ Compliance posture (GDPR right-to-erasure, data residency, retention policies)
+- ✅ Operational excellence (health checks, readiness probes, graceful degradation)
+
+### OpenSpec Validation
+- Specifications MUST pass `openspec validate --strict` without errors
+- All requirements MUST have at least one scenario
+- All scenarios MUST use correct `#### Scenario:` formatting

--- a/openspec/changes/add-model-provider-cred-store-oagw/specs/cred-store/spec.md
+++ b/openspec/changes/add-model-provider-cred-store-oagw/specs/cred-store/spec.md
@@ -1,0 +1,843 @@
+## ADDED Requirements
+
+### Requirement: cred_store module responsibility
+The system SHALL provide a `cred_store` gateway module with a **single active plugin chosen by minimal priority value** responsible for tenant-scoped secret storage and retrieval.
+
+The `cred_store` module SHALL be generic (not GenAI-specific) and reusable by other modules.
+
+#### Scenario: Generic usage
+- **WHEN** `oagw` needs a secret for outbound auth
+- **THEN** it references `cred_store` secrets by UUID and `credential_type` (GTS instance id)
+- **AND** `cred_store` does not assume inference-specific semantics
+
+### Requirement: cred_store GTS schemas and instances registration
+The system SHALL register the following GTS schema in `types_registry` during gateway startup:
+- `gts.x.core.cred_store.secret_type.v1~`
+
+The base schema SHALL define:
+- `id: GtsInstanceId`
+- `secret_schema: string` (JSON schema for secret material for the nested secret type, defined as GTS nested schema)
+
+Plus additional traits:
+- `display_name: string`
+- `description?: string`
+- `versioning_enabled: boolean` (global default)
+- `last_versions: int` (global default 5)
+- `retention_days: int` (global default)
+- `encryption_required: boolean` (global default)
+- `audit_retention_days: int` (global default)
+
+There must be also predefined secret types for the following use cases:
+- `gts.x.core.cred_store.secret_type.v1~x.core.db.password.v1~`
+- `gts.x.core.cred_store.secret_type.v1~x.core.db.api_key.v1~`
+- `gts.x.core.cred_store.secret_type.v1~x.core.ssh.private_key.v1~`
+- `gts.x.core.cred_store.secret_type.v1~x.core.ssh.public_key.v1~`
+- `gts.x.core.cred_store.secret_type.v1~x.core.ssh.passphrase.v1~`
+- `gts.x.core.cred_store.secret_type.v1~x.core.pci.cardholder_data.v1~`
+- `gts.x.core.cred_store.secret_type.v1~x.core.phi.secret.v1~`
+- `gts.x.core.cred_store.secret_type.v1~x.core.api.secret.v1~`
+- `gts.x.core.cred_store.secret_type.v1~x.core.user.password.v1~`
+
+Well-known secret types SHALL be stored under `cred_store/.../gts/*.instances.json` and registered during gateway module `init()`. THe well-known secret types should define proper defaults for all the fields and define schema of the secret material.
+
+#### Scenario: Startup registration
+- **WHEN** `cred_store` gateway module `init()` runs
+- **THEN** it registers the secret type schema and all shipped instances from its `gts/` folder
+
+### Requirement: cred_store persistence model
+The system SHALL persist actual per-tenant and per-user secret records as anonymous objects in the `cred_store` database.
+
+The persistent model SHALL include:
+- `secret_config` (per tenant settings for secret types)
+  - `id uuid pk`
+  - `type GtsInstanceId`
+  - `versioning_enabled bool`
+  - `last_versions int` (default 5)
+  - `retention_days int`
+  - `encryption_required bool`
+  - `audit_retention_days int`
+
+- `secret_store`
+  - `id uuid pk`
+  - `tenant_id uuid not null`
+  - `client_id uuid null`
+  - `secret_type text not null` (GTS instance id from `gts.x.core.cred_store.secret_type.v1~`)
+  - `secret_ciphertext bytes not null` (recommended; plugin-dependent)
+  - `parameters jsonb null` (client-dependent, tenants/users/integrations can store it's own attributes here, the schema need to be defined separately for each secret type `gts.x.core.cred_store.secret_type.v1~vendor.pkg._.secrets_extension.v1~`)
+  - `created_at timestamptz not null`
+  - `updated_at timestamptz not null`
+
+The system SHOULD avoid storing plaintext secrets in the database.
+
+#### Scenario: Store a new secret
+- **WHEN** a client creates a secret
+- **THEN** the stored record contains encrypted secret material
+- **AND** the gateway does not log the secret value
+
+### Requirement: cred_store gateway API (Rust-native)
+The system SHALL expose a Rust-native API (ClientHub) named `CredStoreApi`.
+
+The API SHALL:
+- Accept `&SecurityCtx` for every method.
+- Support create/get/list/delete operations for secrets with proper Access control (role check, DB-level tenant/user scope)
+
+#### Scenario: Rust-native read
+- **WHEN** a consumer calls `CredStoreApi::get_secret(ctx, secret_id, secret_type_id)`
+- **THEN** the gateway enforces tenant and user (optional) scope via `SecurityCtx`
+- **AND** the gateway enforces secret type scope via `secret_type_id`
+- **AND** the gateway returns the secret material
+
+### Requirement: cred_store REST API
+The system SHALL expose a REST API:
+- `GET/POST /cred-store/v1/secrets`
+- `GET/DELETE /cred-store/v1/secrets/{secretId}`
+The system must distinguish global per-tenant secret and per-user secret types.
+
+REST responses SHOULD avoid returning secret plaintext except in explicitly authorized retrieval modes.
+
+#### Scenario: REST list secrets
+- **WHEN** a client calls `GET /cred-store/v1/secrets`
+- **THEN** the response omits plaintext secret values
+
+### Requirement: cred_store plugin interface and selection
+The system SHALL define a plugin interface for secret storage backends.
+
+The plugin interface SHALL be expressed as a Rust-native async trait in the `cred_store` plugin SDK.
+
+The plugin SDK SHALL define a `CredStorePluginApi` trait where all methods accept `&SecurityCtx`.
+
+The plugin trait SHALL support at least:
+- `upsert_secret(ctx, secret_id, secret_type_id, secret_ciphertext, parameters) -> ()`
+- `get_secret_material(ctx, secret_id, secret_type_id) -> SecretMaterial`
+- `delete_secret(ctx, secret_id, secret_type_id) -> ()`
+
+The plugin trait SHALL treat `secret_id` as an opaque UUID and SHALL require `secret_type_id` to prevent accidental cross-type retrieval.
+
+The plugin SDK SHALL define a plugin spec schema type (for plugin instance registration) as a derived GTS schema:
+- `CredStorePluginSpecV1` with schema id `gts.x.core.modkit.plugin.v1~x.core.cred_store.plugin.v1~`
+
+Each plugin module SHALL register exactly one or more plugin instances in `types_registry` using:
+- `BaseModkitPluginV1<CredStorePluginSpecV1>`
+
+Each registered plugin instance SHALL include:
+- `id: GtsInstanceId` (full instance id)
+- `vendor: string`
+- `priority: int` (lower wins)
+- `properties: CredStorePluginSpecV1` can be empty
+
+Each plugin module SHALL also register a scoped client in `ClientHub` under `ClientScope::gts_id(&instance_id)`.
+
+Only one plugin SHALL be active at runtime: the eligible plugin with the lowest `priority` value among registered instances.
+
+Eligibility MUST be determined by priority (lower priority wins).
+
+#### Scenario: Single active plugin
+- **GIVEN** multiple cred_store plugins are registered
+- **WHEN** the gateway resolves its plugin
+- **THEN** it chooses the plugin with the lowest priority
+
+#### Scenario: Scoped client resolution
+- **GIVEN** the gateway selected plugin instance id `gts.x.core.modkit.plugin.v1~x.core.cred_store.plugin.v1~vendor.pkg.plugin.v1`
+- **WHEN** the gateway requests a client via `ClientHub.get_scoped::<dyn CredStorePluginApi>(ClientScope::gts_id(&plugin_instance_id))`
+- **THEN** the plugin client is resolved and used to serve the request
+
+### Requirement: cred_store plugin persistence, access control, and cryptography
+The system SHALL define how `cred_store` plugins persist secrets, enforce access control, and apply cryptography.
+
+The gateway SHALL be responsible for:
+- Performing request authentication and high-level authorization (role/permission checks) before calling the plugin.
+- Passing request-scoped `SecurityCtx` into the plugin.
+
+Each plugin SHALL be responsible for:
+- Enforcing tenant/user scoping when it interacts with any persistent store.
+- Ensuring that secret material is never logged.
+
+#### Access control (DB-backed plugins)
+For DB-backed plugins, access control SHALL be enforced using the `modkit-db` secure ORM layer.
+
+DB-backed plugins SHALL:
+- Use a secure DB access wrapper (e.g., `SecureConn`) for all queries.
+- Derive an `AccessScope` from the request `SecurityCtx` and apply it to all queries.
+- Use scoped CRUD operations that automatically produce deny-by-default behavior for empty scopes.
+
+#### Scenario: DB-backed plugin denies cross-tenant reads
+- **GIVEN** a secret record exists for tenant A with secret id `S`
+- **WHEN** a caller from tenant B calls `CredStorePluginApi::get_secret_material(ctx, S, secret_type_id)`
+- **THEN** the plugin query is scoped to tenant B
+- **AND** the plugin returns a not-found or permission-denied error
+
+#### Cryptography (DB-backed plugins)
+DB-backed plugins SHALL encrypt secret material before persisting it.
+
+DB-backed plugins SHOULD implement envelope encryption:
+- A per-record Data Encryption Key (DEK) encrypts the secret plaintext
+- A Key Encryption Key (KEK) encrypts (wraps) the DEK
+
+The system SHOULD support the following AEAD algorithms for DEK encryption:
+- `AES-256-GCM`
+- `XChaCha20-Poly1305`
+
+The plugin SHOULD bind context into Additional Authenticated Data (AAD), including:
+- `tenant_id`
+- `client_id` (if present)
+- `secret_id`
+- `secret_type_id`
+
+#### Scenario: Envelope encryption
+- **WHEN** the plugin persists secret material
+- **THEN** the plugin encrypts the plaintext with a per-record DEK using an AEAD cipher
+- **AND** the plugin stores only ciphertext and encryption metadata
+- **AND** the plugin stores the DEK only in wrapped form (encrypted by KEK)
+
+### Requirement: cred_store SQLite-backed plugin
+The system SHALL support a `cred_store` plugin implementation that persists secrets in a local database (SQLite/SeaORM).
+
+The SQLite-backed plugin SHALL store only encrypted secret material in the database.
+
+#### SQLite-backed plugin tables (logical)
+The plugin SHALL persist at least the following tables.
+
+- `cred_store_secret_blob`
+  - `id uuid pk` (same identifier as `cred_store.secret_store.id`)
+  - `tenant_id uuid not null`
+  - `client_id uuid null`
+  - `secret_type_id uuid not null` (GTS instance UUID5 obtained by gts-rust lib)
+  - `ciphertext bytes not null`
+  - `cipher_alg text not null` (e.g., `AES-256-GCM`)
+  - `nonce bytes not null`
+  - `aad bytes not null`
+  - `wrapped_dek bytes not null`
+  - `kek_id text not null` (key identifier; plugin-defined)
+  - `created_at timestamptz not null`
+  - `updated_at timestamptz not null`
+
+- `cred_store_secret_kek_state`
+  - `kek_id text pk`
+  - `kek_provider text not null` (e.g., `env`, `os_keychain`, `vault_transit`)
+  - `kek_version int not null`
+  - `created_at timestamptz not null`
+
+The SQLite-backed plugin SHOULD add indexes for hot paths:
+- `(tenant_id, id)`
+- `(tenant_id, id, client_id)`
+- `(tenant_id, client_id, secret_type_id)`
+
+#### Scenario: SQLite-backed plugin write
+- **WHEN** the gateway calls `CredStorePluginApi::upsert_secret(ctx, secret_id, secret_type_id, secret_ciphertext, parameters)`
+- **THEN** the plugin scopes the operation to the tenant/user in `SecurityCtx`
+- **AND** the plugin writes encryption metadata and ciphertext to `cred_store_secret_blob`
+
+#### Scenario: SQLite-backed plugin read
+- **WHEN** the gateway calls `CredStorePluginApi::get_secret_material(ctx, secret_id, secret_type_id)`
+- **THEN** the plugin loads the row from `cred_store_secret_blob` under secure ORM scope
+- **AND** the plugin unwraps the DEK using the configured KEK
+- **AND** the plugin decrypts ciphertext using the configured AEAD algorithm
+
+### Requirement: cred_store Hashicorp Vault-backed plugin
+The system SHALL support a `cred_store` plugin implementation that uses Hashicorp Vault as the backend.
+
+The Vault-backed plugin SHALL avoid persisting secret plaintext in the HyperSpot database.
+
+The Vault-backed plugin SHOULD use one of the following Vault mechanisms:
+- Vault KV v2 for storing secret values (Vault handles encryption-at-rest)
+- Vault Transit for encryption/decryption (HyperSpot DB stores only ciphertext)
+
+#### Vault-backed plugin tables (logical)
+The plugin SHALL persist references required to locate the secret in Vault.
+
+- `cred_store_vault_secret_ref`
+  - `id uuid pk` (same identifier as `cred_store.secret_store.id`)
+  - `tenant_id uuid not null`
+  - `client_id uuid null`
+  - `secret_type_id text not null` (GTS instance id)
+  - `vault_mount text not null` (e.g., `kv`, `secret`, `transit`)
+  - `vault_path text not null` (logical secret path)
+  - `vault_key_name text null` (required for transit)
+  - `vault_version int null` (required for kv v2 reads)
+  - `created_at timestamptz not null`
+  - `updated_at timestamptz not null`
+
+The Vault-backed plugin SHALL enforce access control by scoping the reference table queries (tenant/user) using secure ORM.
+
+#### Scenario: Vault-backed plugin write
+- **WHEN** the gateway calls `CredStorePluginApi::upsert_secret(ctx, secret_id, secret_type_id, secret_ciphertext, parameters)`
+- **THEN** the plugin scopes the operation to the tenant/user in `SecurityCtx`
+- **AND** the plugin writes the secret to Vault under a tenant/user scoped path
+- **AND** the plugin stores only a Vault reference in `cred_store_vault_secret_ref`
+
+#### Scenario: Vault-backed plugin read
+- **WHEN** the gateway calls `CredStorePluginApi::get_secret_material(ctx, secret_id, secret_type_id)`
+- **THEN** the plugin resolves the Vault reference under secure ORM scope
+- **AND** the plugin reads/decrypts the secret material from Vault
+
+### Requirement: global and per-tenant configuration
+
+All the parameters, such as timeouts, retries, etc must be configurable globally (as serviec config) and on per-tenant basis.
+
+### Requirement: cred_store audit logging
+The system SHALL maintain an immutable audit log for all secret operations.
+
+The system SHALL persist audit records in a separate append-only table.
+
+#### Database table: cred_store_audit_log
+- `id uuid pk`
+- `tenant_id uuid not null`
+- `client_id uuid null`
+- `is_user_operation bool not null` (true for user-initiated operations, false for system-initiated operations)
+- `operation text not null` (enum: 'create', 'read', 'update', 'delete', 'rotate')
+- `secret_id uuid not null`
+- `secret_type_id uuid not null`
+- `status text not null` (enum: 'success', 'failure')
+- `error_code text null`
+- `source_ip inet null`
+- `user_agent text null`
+- `trace_id text null`
+- `context_metadata jsonb null`
+- `timestamp timestamptz not null default now()`
+
+**Indexes:**
+- `(tenant_id, timestamp desc)` for tenant audit queries
+- `(secret_id, timestamp desc)` for secret-specific audit trail
+- `(client_id, timestamp desc)` for user activity queries
+
+NOTE: table parititioning and archiving and retention policies are not specified in this document. It's a subject for future improvements.
+
+#### Scenario: Audit log write on secret read
+- **WHEN** user/client U reads secret S via `get_secret()`
+- **THEN** the gateway inserts a row into `cred_store_audit_log`
+- **AND** captures (tenant_id, client_id, 'read', secret_id, secret_type_id, 'success', timestamp)
+- **AND** includes OpenTelemetry trace_id from current span
+
+#### Scenario: Audit log for failed access
+- **WHEN** user U attempts to read secret S but is denied (403)
+- **THEN** the gateway logs (client_id, 'read', secret_id, 'failure', 'access_denied')
+
+### Requirement: cred_store audit retention
+The system SHOULD support configurable audit log retention policies.
+
+Retention SHALL be configurable per tenant with defaults:
+- Default retention: 90 days
+- Compliance mode: 7 years (for financial/healthcare tenants)
+
+Audit log cleanup SHOULD run as a background job.
+
+#### Scenario: Audit log cleanup
+- **GIVEN** tenant T has retention policy = 90 days (configurable, global, per-tenant)
+- **WHEN** cleanup job runs
+- **THEN** audit records older than 90 days are archived or purged
+
+### Requirement: cred_store audit export
+The system SHALL expose audit log export via REST API.
+
+REST endpoints:
+- `GET /cred-store/v1/audit` - List audit logs with OData support
+- apply tenant/user/client scope
+- require admin role (`gts.x.core.idp.role.v1~x.cred_store.secret.admin.v1`)
+- apply OData filters (paging, sorting, filtering)
+
+Export format SHOULD support JSON and CSV.
+
+#### Scenario: Export audit logs for compliance
+- **GIVEN** admin U has `gts.x.core.idp.role.v1~x.cred_store.secret.admin.v1` role
+- **AND** admin U is scoped to tenant T
+- **WHEN** admin U requests `GET /cred-store/v1/audit` with date range filter
+- **THEN** system returns paginated audit records with OData support (`$filter`, `$orderby`, `$skip`, `$top`)
+
+### Requirement: cred_store RBAC model
+The system SHALL enforce role-based access control for secret operations.
+
+#### Database table: cred_store_role_assignment
+- `id uuid pk`
+- `tenant_id uuid not null`
+- `principal_id uuid not null`
+- `principal_type text not null` (enum: 'user', 'service_account')
+- `role text not null` (enum: 'secret.admin', 'secret.writer', 'secret.reader', 'secret.none')
+- `scope text null`
+- `created_at timestamptz not null`
+
+**Indexes:**
+- `(tenant_id, principal_id)` for fast role lookup
+
+NOTE: `cred_store_role_assignment` is currently out of implementation scope, it's assumed to be implemented by external access policy engine.
+
+#### Role definitions:
+- `gts.x.core.idp.role.v1~x.cred_store.secret.admin.v1`: full CRUD + key management + audit access
+- `gts.x.core.idp.role.v1~x.cred_store.secret.writer.v1`: create, update, read (no delete, no key rotation)
+- `gts.x.core.idp.role.v1~x.cred_store.secret.reader.v1`: read-only
+- `gts.x.core.idp.role.v1~x.cred_store.secret.none.v1`: explicit deny (overrides other grants)
+
+#### Scenario: Role enforcement at gateway
+- **GIVEN** user U has role `gts.x.core.idp.role.v1~x.cred_store.secret.reader.v1`
+- **WHEN** U attempts `DELETE /cred-store/v1/secrets/{id}`
+- **THEN** gateway checks SecurityCtx roles
+- **AND** returns 403 Forbidden with RFC 9457 Problem Detail
+
+#### Scenario: Scoped role assignment
+- **GIVEN** user U has role `gts.x.core.idp.role.v1~x.cred_store.secret.writer.v1` scoped to `secret_type_id = API_KEY`
+- **WHEN** U attempts to create a DATABASE_PASSWORD secret
+- **THEN** gateway denies with 403 Forbidden
+
+### Requirement: cred_store secret-level ACL
+The system SHALL support per-secret access control lists.
+
+#### Database table: cred_store_secret_acl
+- `id uuid pk`
+- `tenant_id uuid not null`
+- `secret_id uuid not null fk cred_store.secret_store(id)`
+- `principal_id uuid not null`
+- `principal_type text not null` (enum: 'user', 'service_account')
+- `permissions text[] not null` (array of: 'read', 'update', 'delete', 'share')
+- `created_at timestamptz not null`
+
+**Indexes:**
+- `(secret_id, principal_id)` for ACL lookup
+
+NOTE: `cred_store_secret_acl` is currently out of implementation scope, it's assumed to be implemented by external access policy engine.
+
+#### Scenario: ACL-based access grant
+- **GIVEN** secret S has ACL: {user_A: ['read'], user_B: ['read', 'update']}
+- **WHEN** user_C (not in ACL) attempts GET /cred-store/v1/secrets/{S}
+- **THEN** gateway checks ACL after RBAC check
+- **AND** returns 403 Forbidden
+
+#### Scenario: ACL precedence over RBAC
+- **GIVEN** user U has tenant-wide role `gts.x.core.idp.role.v1~x.cred_store.secret.reader.v1`
+- **AND** secret S has ACL excluding U
+- **WHEN** U attempts to read S
+- **THEN** ACL denial takes precedence, returns 403
+
+### Requirement: cred_store authorization enforcement
+The gateway SHALL enforce authorization at two layers:
+1. **API layer**: Check SecurityCtx roles/permissions before domain service calls
+2. **DB layer**: Use `modkit-db` SecureConn with tenant/user scoping
+
+#### Scenario: Double-layer authorization
+- **WHEN** gateway invokes domain service `get_secret(ctx, secret_id)`
+- **THEN** API layer checks RBAC roles first
+- **AND** domain service uses `SecureConn::scoped_to_tenant(tenant_id)` for DB query
+- **AND** DB layer ensures tenant isolation via secure ORM
+
+### Requirement: cred_store data residency
+The system SHALL support per-tenant data residency constraints.
+
+#### Database table: cred_store_compliance_policy
+- `id uuid pk`
+- `tenant_id uuid not null unique`
+- `secret_type_id uuid not null fk cred_store.secret_type(id)` (GTS secret type UUID)
+- `data_residency text[] null` (e.g., ['EU', 'US'])
+- `retention_days int not null default 90`
+- `encryption_required bool not null default true`
+- `audit_retention_days int not null default 365`
+
+NOTE: `cred_store_compliance_policy` support is out of scope of the first version.
+
+#### Scenario: EU-only data residency
+- **GIVEN** tenant T has data_residency = ['EU']
+- **WHEN** secret is created
+- **THEN** system ensures storage in EU-region database shard
+- **AND** prevents replication to non-EU regions
+
+### Requirement: cred_store GDPR right-to-erasure
+The system SHALL support complete user data deletion.
+
+REST endpoint:
+- `DELETE /cred-store/v1/users/{userId}/secrets?gdpr_erasure=true`
+
+#### Scenario: GDPR erasure request
+- **WHEN** user/client U requests GDPR erasure
+- **THEN** system permanently deletes all secrets where `cliend_id = U`
+- **AND** retains audit logs per legal retention requirements (anonymized)
+- **AND** logs erasure operation with justification
+
+### Requirement: cred_store SOC2 compliance
+To achieve SOC2 Type II compliance, the system SHALL:
+- Maintain comprehensive audit logs (all CRUD operations)
+- Enforce least-privilege access control (RBAC + ACL)
+- Encrypt secrets at rest and in transit
+- Implement key rotation procedures
+- Provide security monitoring and alerting
+- Support access reviews and attestation exports
+
+Additional requirements:
+- Audit logs MUST be immutable (append-only)
+- Access to encryption keys MUST be logged
+- Failed access attempts MUST trigger alerts after threshold
+- Security incidents MUST be trackable via audit trail
+
+#### Scenario: SOC2 audit trail verification
+- **WHEN** auditor reviews secret access for period P
+- **THEN** system provides complete audit log export
+- **AND** verifies log integrity via checksums or signatures
+
+### Requirement: cred_store HIPAA compliance
+To achieve HIPAA compliance, the system SHALL:
+- Explicitly tag secrets as `gts.x.core.cred_store.secret_type.v1~x.core.phi.secret.v1`
+- Encrypt all PHI (Protected Health Information) at rest using FIPS 140-2 validated crypto modules
+- Implement automatic logoff after 15 minutes of inactivity (enforced by session management)
+- Maintain audit trails for minimum 6 years
+- Provide data breach notification capabilities
+- Support Business Associate Agreement (BAA) requirements via tenant compliance policies
+
+Additional requirements:
+- Audit logs MUST capture all access to secrets containing PHI
+- System MUST support emergency access procedures with justification
+- Encryption keys MUST be rotatable without service interruption
+
+#### Scenario: HIPAA emergency access
+- **WHEN** admin requires emergency access to PHI secret
+- **THEN** system logs access with justification field required
+- **AND** triggers security alert for review
+
+### Requirement: cred_store PCI-DSS compliance
+To achieve PCI-DSS compliance, the system SHALL:
+- Explicitly tag secrets as `gts.x.core.cred_store.secret_type.v1~x.core.pci.cardholder_data.v1`
+- Never store full magnetic stripe data, card verification codes (CVV2/CVC2), or PINs
+- Mask PAN (Primary Account Number) when displaying (show first 6 and last 4 digits only)
+- Implement quarterly key rotation for cardholder data encryption keys
+- Maintain audit trails for minimum 1 year (immediately accessible) + 3 years (archival)
+- Restrict access to cardholder data on need-to-know basis
+
+Additional requirements:
+- Secrets tagged as `gts.x.core.cred_store.secret_type.v1~x.core.pci.cardholder_data.v1` MUST have additional access restrictions
+- All access to PCI-scoped secrets MUST be logged and monitored
+- Failed access attempts exceeding threshold MUST trigger security alerts
+- Quarterly access reviews MUST be facilitated via export API
+
+#### Scenario: PCI secret masking
+- **WHEN** admin views secret metadata for PAN (tagged as `gts.x.core.cred_store.secret_type.v1~x.core.pci.cardholder_data.v1`)
+- **THEN** system displays masked value: `411111******1111`
+- **AND** full value only accessible via explicit `get_secret()` call (audited)
+
+### Requirement: cred_store secret versioning
+The system SHALL support optional secret versioning, configurable per secret type.
+
+#### Extended database table: cred_store.secret_store
+- Add: `versioning_enabled bool not null default false`
+- Add: `current_version int not null default 1`
+
+#### New table: cred_store_secret_version
+- `id uuid pk`
+- `tenant_id uuid not null`
+- `secret_id uuid not null fk cred_store.secret_store(id)`
+- `version int not null`
+- `secret_type_id uuid not null`
+- `parameters jsonb null`
+- `created_at timestamptz not null`
+- `created_by uuid null`
+- **Unique constraint:** `(secret_id, version)`
+
+#### New table: cred_store_secret_blob_version
+- `id uuid pk`
+- `secret_id uuid not null`
+- `version int not null`
+- `ciphertext bytes not null`
+- `cipher_alg text not null`
+- `nonce bytes not null`
+- `aad bytes not null`
+- **Unique constraint:** `(secret_id, version)`
+
+**Indexes:**
+- `(secret_id, version desc)` for version retrieval
+
+#### Scenario: Enable versioning per secret type
+- **GIVEN** secret_type `cred_store.secret_type.v1~x.core.db.password.v1` has versioning enabled
+- **WHEN** admin creates a secret of this type
+- **THEN** `versioning_enabled = true` is set
+- **AND** initial version = 1 is created
+
+#### Scenario: Update secret with versioning
+- **WHEN** user updates a secret with `versioning_enabled = true`
+- **THEN** system creates new version (e.g., v2)
+- **AND** preserves previous version (v1) in `cred_store_secret_version`
+- **AND** updates `current_version = 2`
+
+#### Scenario: Retrieve specific version
+- **WHEN** client requests `GET /cred-store/v1/secrets/{id}/versions/2`
+- **THEN** system retrieves version 2 from `cred_store_secret_blob_version`
+- **AND** decrypts using stored KEK metadata
+
+#### Scenario: List secret versions
+- **WHEN** client requests `GET /cred-store/v1/secrets/{id}/versions`
+- **THEN** system returns versions ordered by version desc
+- **AND** each version includes (version, created_at, created_by)
+
+### Requirement: cred_store version retention
+The system SHALL support configurable version retention policies.
+
+Default policy:
+- Keep last 5 versions (configurable) for the secrets of the same type
+- Auto-prune older versions after retention period
+
+#### Scenario: Version pruning
+- **GIVEN** secret S has 10 versions and retention policy = 5
+- **WHEN** version cleanup job runs
+- **THEN** versions 1-5 are pruned
+- **AND** versions 6-10 are retained
+
+### Requirement: cred_store version REST API
+The system SHALL expose version management endpoints.
+
+REST endpoints:
+- `GET /cred-store/v1/secrets/{secretId}/versions` - List versions
+- `GET /cred-store/v1/secrets/{secretId}/versions/{version}` - Get specific version
+- `POST /cred-store/v1/secrets/{secretId}/rollback` - Rollback to previous version
+
+#### Scenario: Rollback to previous version
+- **WHEN** admin posts to `/cred-store/v1/secrets/{id}/rollback` with target_version=3
+- **THEN** system creates new version (e.g., v6) with content from v3
+- **AND** marks v6 as current version
+
+### Requirement: cred_store error taxonomy
+The system SHALL define comprehensive error types using RFC 9457 Problem Details.
+
+Error types SHALL include:
+- `PluginUnavailable`: Plugin is unreachable
+- `DecryptionFailure`: Cannot decrypt ciphertext
+- `KekUnavailable`: KEK not accessible
+- `QuotaExceeded`: Tenant secret limit reached
+- `SecretTooLarge`: Secret exceeds size limit
+- `InvalidSecretType`: Unknown secret type
+- `ConcurrentModification`: Optimistic locking conflict
+- `Forbidden`: Access denied
+- `NotFound`: Secret does not exist
+
+#### Scenario: Plugin unavailable error
+- **WHEN** active plugin is unreachable (connection timeout)
+- **THEN** gateway returns 503 Service Unavailable
+- **AND** includes Problem Detail with type `urn:cred-store:error:plugin-unavailable`
+- **AND** logs error with OpenTelemetry span
+
+#### Scenario: Decryption failure error
+- **WHEN** plugin cannot decrypt ciphertext (corrupted data or missing KEK)
+- **THEN** gateway returns 500 Internal Server Error
+- **AND** triggers alert to operations team
+- **AND** logs error with secret_id and kek_id context
+
+### Requirement: cred_store retry logic
+The system SHALL implement exponential backoff retry for transient failures.
+
+Retry policy:
+- **Transient errors:** Network timeout, 502/503/504 from plugin
+- **Max retries:** 3
+- **Backoff:** 100ms, 200ms, 400ms (max timeout must be configurable)
+- **Non-retryable:** 400 Bad Request, 403 Forbidden, 404 Not Found, 409 Conflict
+
+Implementation SHOULD use `tower` crate retry middleware.
+
+#### Scenario: Retry transient plugin error
+- **WHEN** plugin returns 503 Service Unavailable
+- **THEN** gateway retries after 100ms
+- **AND** if still failing, retries after 200ms, then 400ms
+- **AND** if all retries exhausted, returns 503 to client
+
+### Requirement: cred_store circuit breaker
+The system SHALL implement circuit breaker pattern to prevent cascade failures.
+
+Circuit breaker configuration:
+- **Failure threshold:** 5 consecutive failures (configurable)
+- **Timeout:** 30 seconds (half-open after this duration, configurable)
+- **Success threshold:** 2 consecutive successes to close circuit (configurable)
+
+Implementation SHOULD use `failsafe` or `tower` crate.
+
+#### Scenario: Circuit breaker opens
+- **GIVEN** plugin fails 5 consecutive operations (configurable)
+- **WHEN** circuit breaker opens
+- **THEN** subsequent requests fail-fast with 503 (no plugin call)
+- **AND** after 30 seconds, circuit enters half-open state
+- **AND** next request tests plugin availability
+
+#### Scenario: Circuit breaker recovery
+- **GIVEN** circuit breaker is half-open
+- **WHEN** 2 consecutive plugin calls succeed (configurable)
+- **THEN** circuit breaker closes
+- **AND** normal operation resumes
+
+### Requirement: cred_store KEK rotation without downtime
+The system SHALL support KEK (Key Encryption Key) rotation with zero downtime.
+
+#### Extended table: cred_store_secret_kek_state
+- Add: `kek_version int not null default 1`
+- Add: `rotation_status text null` (enum: 'active', 'rotating', 'deprecated')
+
+#### New table: cred_store_kek_metadata
+- `id uuid pk`
+- `tenant_id uuid null`
+- `kek_version int not null`
+- `kek_algorithm text not null` (e.g., 'age', 'aes-256-gcm')
+- `status text not null` (enum: 'active', 'deprecated', 'revoked')
+- `created_at timestamptz not null`
+- `rotated_at timestamptz null`
+- **Unique constraint:** `(tenant_id, kek_version)`
+
+#### Scenario: Initiate KEK rotation
+- **WHEN** admin triggers KEK rotation for tenant T
+- **THEN** system generates new KEK v2
+- **AND** marks KEK v1 as `status = 'deprecated'`
+- **AND** marks KEK v2 as `status = 'active'`
+- **AND** new secrets use KEK v2 immediately
+
+#### Scenario: Gradual re-encryption
+- **WHEN** KEK rotation is initiated
+- **THEN** background job lists all secrets encrypted with old KEK v1
+- **AND** decrypts each secret with KEK v1
+- **AND** re-encrypts with new KEK v2
+- **AND** updates `kek_version = 2` in `cred_store_secret_kek_state`
+- **AND** both KEK v1 and v2 remain available during transition
+
+#### Scenario: Dual-KEK read during rotation
+- **GIVEN** secret S is still encrypted with KEK v1
+- **AND** KEK rotation is in progress (v2 is active)
+- **WHEN** user reads secret S
+- **THEN** system checks `kek_version = 1` in metadata
+- **AND** uses KEK v1 to decrypt
+
+#### Scenario: Complete KEK rotation
+- **WHEN** all secrets have been re-encrypted with KEK v2
+- **THEN** admin marks KEK v1 as `status = 'revoked'`
+- **AND** KEK v1 is deleted from key storage
+
+### Requirement: cred_store tenant quotas
+The system SHALL enforce per-tenant resource limits.
+
+#### Database table: cred_store_tenant_quota
+- `id uuid pk`
+- `tenant_id uuid not null unique`
+- `max_secrets_per_client int not null default 1000`
+- `max_secret_size_bytes int not null default 65536` (64 KB)
+- `max_versions_per_secret int not null default 5`
+- `max_write_requests_per_minute int not null default 100`
+- `max_read_requests_per_minute int not null default 1000`
+- `max_admin_requests_per_minute int not null default 10`
+
+#### Scenario: Enforce secret count quota
+- **GIVEN** tenant T has max_secrets = 1000 and current count = 1000
+- **WHEN** T attempts to create secret 1001
+- **THEN** gateway returns 429 Too Many Requests
+- **AND** includes Problem Detail with retry guidance
+
+#### Scenario: Enforce secret size limit
+- **WHEN** client attempts to store 128 KB secret
+- **AND** tenant quota max_secret_size_bytes = 65536
+- **THEN** gateway returns 400 Bad Request
+- **AND** error detail specifies: "Secret size 131072 bytes exceeds limit of 65536 bytes"
+
+### Requirement: cred_store rate limiting
+The system SHALL enforce rate limits per tenant.
+
+Rate limits:
+- **Write operations:** 100 req/min per tenant
+- **Read operations:** 1000 req/min per tenant
+- **Admin operations:** 10 req/min per tenant
+
+Implementation SHOULD use `governor` crate.
+
+#### Scenario: Rate limit exceeded
+- **GIVEN** tenant T has made 100 write requests in current minute
+- **WHEN** T attempts write request 101
+- **THEN** gateway returns 429 Too Many Requests
+- **AND** includes `Retry-After: 15` header (seconds until reset)
+
+### Requirement: cred_store quota management REST API
+The system SHALL expose quota management endpoints.
+
+REST endpoints:
+- `GET /cred-store/v1/quotas` - View current quota and usage
+- `PATCH /cred-store/v1/quotas` - Update quota (admin only)
+
+#### Scenario: View quota usage
+- **WHEN** tenant requests GET /cred-store/v1/quotas
+- **THEN** response includes current quota configuration and usage metrics
+
+### Requirement: cred_store metrics instrumentation
+The system SHALL expose Prometheus-compatible metrics.
+
+Required metrics (using `metrics` crate):
+- `cred_store.secrets.created_total` (counter, labels: tenant_id, secret_type)
+- `cred_store.secrets.read_total` (counter, labels: tenant_id)
+- `cred_store.secrets.updated_total` (counter, labels: tenant_id)
+- `cred_store.secrets.deleted_total` (counter, labels: tenant_id)
+- `cred_store.errors_total` (counter, labels: error_type, plugin_id)
+- `cred_store.operation.duration_msec` (histogram, labels: operation, tenant_id)
+- `cred_store.plugin.call.duration_msec` (histogram, labels: plugin_id, method)
+- `cred_store.secrets.total` (gauge, labels: tenant_id)
+- `cred_store.kek.active_version` (gauge, labels: tenant_id)
+- `cred_store.circuit_breaker.state` (gauge, labels: plugin_id)
+
+#### Scenario: Metrics collection
+- **WHEN** secret operation completes
+- **THEN** system increments appropriate counters
+- **AND** records latency histogram
+- **AND** metrics are exposed at GET /metrics endpoint
+
+### Requirement: cred_store health checks
+The system SHALL expose health check endpoints.
+
+REST endpoints:
+- `GET /cred-store/v1/health` - Liveness probe
+- `GET /cred-store/v1/ready` - Readiness probe (checks plugin connectivity)
+
+#### Scenario: Readiness check
+- **WHEN** GET /cred-store/v1/ready is called
+- **THEN** gateway tests active plugin connectivity (lightweight ping operation)
+- **AND** returns 200 OK if plugin is reachable
+- **AND** returns 503 Service Unavailable if plugin is down
+
+### Requirement: cred_store tracing integration
+The system SHALL integrate with OpenTelemetry for distributed tracing.
+
+All operations SHALL create spans with attributes:
+- `tenant_id`
+- `client_id` (if available)
+- `secret_id`
+- `secret_type`
+- `plugin_id`
+- `kek_version`
+- `operation` (create/read/update/delete)
+
+Implementation SHALL use `tracing` and `tracing-opentelemetry` crates.
+
+#### Scenario: Trace secret operation
+- **WHEN** secret operation is performed
+- **THEN** system creates OpenTelemetry span with all relevant attributes
+- **AND** span is linked to parent trace context
+- **AND** errors are recorded as span events
+
+### Requirement: cred_store SLOs (Service Level Objectives)
+The system SHOULD target:
+- **Availability:** 99.9% (excluding planned maintenance)
+- **Latency:**
+  - p50: < 50ms for `get_secret`
+  - p95: < 100ms for `get_secret`
+  - p99: < 500ms for `upsert_secret`
+- **Error rate:** < 0.1% (excluding client errors 4xx)
+
+#### Scenario: SLO monitoring
+- **WHEN** operations team reviews SLO dashboard
+- **THEN** metrics show p95 latency, error rate, and uptime
+- **AND** alerts trigger if SLO thresholds are breached
+
+### Requirement: cred_store OData support
+The system SHALL implement OData query capabilities per ModKit conventions.
+
+REST endpoints SHALL support:
+- `$skip` and `$top` for pagination
+- `$filter` for filtering
+- `$orderby` for sorting
+- `$select` for field projection
+
+Implementation SHALL use `modkit::api::OperationBuilder` OData support.
+
+#### Scenario: Paginated secret list
+- **WHEN** `GET /cred-store/v1/secrets?$skip=20&$top=10`
+- **THEN** returns secrets 21-30
+- **AND** includes `@odata.nextLink` for pagination
+
+#### Scenario: Filter by secret type
+- **WHEN** `GET /cred-store/v1/secrets?$filter=secret_type_id eq '550e8400-e29b-41d4-a716-446655440000'`
+- **THEN** returns only secrets matching that type
+
+#### Scenario: Sort and project fields
+- **WHEN** `GET /cred-store/v1/secrets?$orderby=created_at desc&$select=id,created_at,secret_type_id`
+- **THEN** returns secrets sorted by creation date
+- **AND** response includes only selected fields

--- a/openspec/changes/add-model-provider-cred-store-oagw/specs/model-provider/spec.md
+++ b/openspec/changes/add-model-provider-cred-store-oagw/specs/model-provider/spec.md
@@ -1,0 +1,633 @@
+## ADDED Requirements
+
+### Requirement: model_provider module responsibility
+The system SHALL provide a `model_provider` gateway module with **pluggable co-loaded model provider plugins** responsible for managing GenAI model providers, their endpoints, and tenant provisioning state.
+
+The `model_provider` module SHALL:
+- Own persistence of anonymous objects identified by UUID (provider instances, endpoints, join tables).
+- Treat global taxonomies (vendor/kind/capability/feature/endpoint_type) as well-known GTS instances stored in `types_registry`.
+- Expose:
+  - A Rust-native gateway API (ClientHub) for other modules.
+  - A REST API for external clients.
+  - A plugin interface for provider connectivity and capabilities.
+
+#### Scenario: Module boundaries
+- **WHEN** a caller needs to list known provider vendors
+- **THEN** the caller retrieves vendor instances from `types_registry`
+- **AND** the `model_provider` database is not used to store vendor taxonomy
+
+### Requirement: model_provider GTS schemas and instances registration
+The system SHALL register all `model_provider`-owned GTS schemas and well-known instances during module startup.
+
+The gateway module SHALL register the following schema IDs (types) in `types_registry`:
+- `gts.x.genai.provider.vendor.v1~`
+- `gts.x.genai.provider.kind.v1~`
+- `gts.x.genai.provider.api_style.v1~`
+- `gts.x.genai.provider.cap.v1~`
+- `gts.x.genai.provider.feature.v1~`
+
+Each schema SHALL define an object with:
+- `id: GtsInstanceId`
+- `display_name: string`
+- `description?: string`
+
+Well-known instances SHALL be stored as JSON arrays under `modules/model_provider/.../gts/` and registered during gateway `init()` (configuration phase), for example:
+- `gts/gts.x.genai.provider.kind.v1~.instances.json`
+
+#### Scenario: Startup registration
+- **GIVEN** `types_registry` is in configuration mode
+- **WHEN** `model_provider` gateway `init()` runs
+- **THEN** it registers all schemas listed above
+- **AND** it loads and registers all well-known instance lists from its `gts/` folder
+
+### Requirement: model_provider persistence model
+The system SHALL persist the following anonymous objects (UUID IDs) in the `model_provider` database.
+
+#### Database tables (logical)
+- `genai_model_provider`
+  - `id uuid pk`
+  - `tenant_id uuid not null` (always tenant-owned)
+  - `available_to_children bool not null` (default: false, given provider is available to tenant children)
+  - `vendor_gts_id text not null` (schema: `gts.x.genai.provider.vendor.v1~` instance id)
+  - `kind_gts_id text not null` (schema: `gts.x.genai.provider.kind.v1~` instance id)
+  - `base_url text not null`
+  - `config_params jsonb not null` (gateway config overrides)
+  - `parameters jsonb null` (provider-specific parameters)
+  - `description text null`
+  - `created_at timestamptz not null`
+  - `updated_at timestamptz not null`
+
+- `genai_model_provider_tag`
+  - `id uuid pk`
+  - `tenant_id uuid not null`
+  - `provider_id uuid not null fk genai_model_provider(id)`
+  - `tag text not null`
+
+- `genai_model_provider_endpoint`
+  - `id uuid pk`
+  - `provider_id uuid not null fk genai_model_provider(id)`
+  - `endpoint_type_gts_id text not null` (schema: `gts.x.genai.provider.api_style.v1~` instance id)
+  - `base_url text not null`
+  - `healthcheck_url text null`
+
+- `genai_model_provider_endpoint_capability`
+  - `id uuid pk`
+  - `endpoint_id uuid not null fk genai_model_provider_endpoint(id)`
+  - `capability_gts_id text not null` (schema: `gts.x.genai.provider.cap.v1~` instance id)
+
+- `genai_model_provider_endpoint_feature`
+  - `id uuid pk`
+  - `endpoint_id uuid not null fk genai_model_provider_endpoint(id)`
+  - `feature_gts_id text not null` (schema: `gts.x.genai.provider.feature.v1~` instance id)
+
+- `genai_model_provider_provisioned_endpoint`
+  - `id uuid pk`
+  - `tenant_id uuid not null`
+  - `available_to_children bool not null` (default: false, given endpoint is available to tenant children)
+  - `endpoint_id uuid not null fk genai_model_provider_endpoint(id)`
+  - `enabled bool not null`
+  - `created_at timestamptz not null`
+  - `updated_at timestamptz not null`
+
+- `genai_model_provider_provisioned_endpoint_tag`
+  - `id uuid pk`
+  - `tenant_id uuid not null`
+  - `available_to_children bool not null` (default: false, given endpoint is available to tenant children)
+  - `provisioned_endpoint_id uuid not null fk genai_model_provider_provisioned_endpoint(id)`
+  - `tag text not null`
+
+#### Scenario: Persist provider and endpoint
+- **WHEN** a tenant creates a provider instance and endpoint
+- **THEN** the gateway stores rows in `genai_model_provider` and `genai_model_provider_endpoint`
+- **AND** capabilities/features are stored in join tables
+
+### Requirement: model_provider gateway API (Rust-native)
+The system SHALL expose a Rust-native API (ClientHub) for managing providers and endpoints.
+
+The gateway SDK SHALL define a `ModelProviderApi` trait where all methods accept `&SecurityCtx`.
+
+The API SHALL support at least:
+- Create/get/list/delete provider instances.
+- Create/get/list/delete endpoints bound to provider instances.
+- Upsert tenant provisioning (enable/disable endpoint for tenant).
+
+Also, some of the providers to be created and registered using static JSON files with GTS identifiers and provider charatecteristics. THe following known providers must be defined
+statically: openai, anthropic, gemini, deepseek, qwen, ollama, local lm studio, vllm, huggingface, openrouter.
+
+The following GTS schemas and instances must be defined, and the JSON files must be placed in the `gts/` folder:
+- `gts.x.genai.provider.vendor.v1~`
+- `gts.x.genai.provider.kind.v1~`
+- `gts.x.genai.provider.api_style.v1~`
+- `gts.x.genai.provider.cap.v1~`
+- `gts.x.genai.provider.feature.v1~`
+
+#### Scenario: Rust-native call path
+- **WHEN** another module calls `ModelProviderApi::list_endpoints(ctx, ...)`
+- **THEN** the gateway enforces tenant isolation using `SecurityCtx`
+- **AND** returns transport-agnostic SDK models
+
+### Requirement: model_provider REST API
+The system SHALL expose a REST API for managing providers and endpoints.
+
+The REST API SHALL include:
+- `GET/POST /model-provider/v1/providers`
+- `GET/PATCH/DELETE /model-provider/v1/providers/{providerId}`
+- `GET/POST /model-provider/v1/endpoints`
+- `GET/PATCH/DELETE /model-provider/v1/endpoints/{endpointId}`
+- `GET/PUT /model-provider/v1/provisioned-endpoints`
+
+All endpoints SHALL use RFC-9457 Problem Details for errors.
+
+#### Scenario: REST create provider
+- **WHEN** a client POSTs to `/model-provider/v1/providers`
+- **THEN** the gateway validates referenced GTS IDs exist in `types_registry`
+- **AND** responds `201` with the created provider
+
+### Requirement: model_provider plugin interface
+The system SHALL define a plugin interface for provider connectivity.
+
+Each plugin instance SHALL be represented in `types_registry` as a `BaseModkitPluginV1<...>` instance with:
+- `id` (GTS instance id)
+- `vendor` string
+- `priority` integer (lower wins)
+- `properties` describing supported `vendor_gts_id`, `endpoint_type_gts_id`, and supported capabilities/features.
+
+The gateway SHALL select an eligible plugin on demand based on:
+- Provider vendor/kind
+- Endpoint type
+- Capability/feature requirements
+- Priority
+
+#### Scenario: Plugin selection
+- **GIVEN** multiple eligible plugins are registered
+- **WHEN** the gateway resolves a plugin for an endpoint
+- **THEN** it selects the eligible plugin with the lowest priority
+
+### Requirement: model_provider client resolution API
+The system SHALL provide a client resolution API for retrieving provider client instances by GTS ID.
+
+The gateway SDK SHALL define methods:
+- `resolve_provider_client(ctx: &SecurityCtx, provider_gts_id: &str) -> Result<Box<dyn ProviderClient>, Error>`
+- `resolve_provider_client_by_id(ctx: &SecurityCtx, provider_id: Uuid) -> Result<Box<dyn ProviderClient>, Error>`
+
+The API SHALL:
+- Resolve the appropriate plugin based on provider vendor/kind/endpoint type
+- Return a typed client instance for invoking provider APIs
+- Enforce tenant isolation via SecurityCtx
+- Support caching of client instances for performance
+
+#### Scenario: Resolve client by GTS ID
+- **WHEN** caller invokes `resolve_provider_client(ctx, "gts.x.genai.provider.vendor.v1~x.openai._.vendor.v1")`
+- **THEN** gateway looks up provider configuration for tenant
+- **AND** selects appropriate plugin (OpenAI plugin)
+- **AND** returns typed client instance implementing `ProviderClient` trait
+
+#### Scenario: Resolve client by provider UUID
+- **WHEN** caller invokes `resolve_provider_client_by_id(ctx, provider_uuid)`
+- **THEN** gateway loads provider from database
+- **AND** resolves plugin based on vendor_gts_id and kind_gts_id
+- **AND** returns configured client instance
+
+#### Scenario: Client resolution failure
+- **WHEN** no eligible plugin found for requested provider
+- **THEN** returns error with type `urn:<module GTS type>:error:<error GTS type>`
+- **AND** includes available plugins in error detail
+
+### Requirement: model_provider hierarchical tenant access
+The system SHALL support hierarchical tenant access using `available_to_children` flag.
+
+When `available_to_children = true`:
+- Provider is accessible to tenant and all descendant tenants
+- Provisioned endpoints are accessible to descendant tenants
+- Tags are inherited by descendant tenants
+
+#### Scenario: Parent tenant creates provider available to children
+- **GIVEN** parent tenant P creates provider with `available_to_children = true`
+- **WHEN** child tenant C lists available providers
+- **THEN** provider created by P appears in C's list
+- **AND** C can provision endpoints from that provider
+
+#### Scenario: Child tenant cannot modify parent's provider
+- **GIVEN** parent tenant P created provider with `available_to_children = true`
+- **WHEN** child tenant C attempts to update that provider
+- **THEN** gateway returns 403 Forbidden
+- **AND** only P can modify the provider
+
+#### Scenario: Provisioned endpoint inheritance
+- **GIVEN** parent tenant P provisions endpoint E with `available_to_children = true`
+- **WHEN** child tenant C queries provisioned endpoints
+- **THEN** endpoint E is available to C
+- **AND** C can use the endpoint without re-provisioning
+
+#### Scenario: Tag inheritance
+- **GIVEN** parent tenant P tags provisioned endpoint with `available_to_children = true`
+- **WHEN** child tenant C searches by tag
+- **THEN** C discovers endpoints tagged by P
+- **AND** tags are read-only for C
+
+#### Scenario: Revoke child access
+- **WHEN** parent tenant P sets `available_to_children = false` on provider
+- **THEN** child tenants lose access immediately
+- **AND** existing child usage is terminated gracefully
+
+### Requirement: model_provider audit logging
+The system SHALL maintain an audit log for all provider operations.
+
+#### Database table: model_provider_audit_log
+- `id uuid pk`
+- `tenant_id uuid not null`
+- `user_id uuid null`
+- `operation text not null` (enum: 'create_provider', 'update_provider', 'delete_provider', 'provision_endpoint', 'invoke_model', 'resolve_client')
+- `provider_id uuid null`
+- `endpoint_id uuid null`
+- `status text not null` (enum: 'success', 'failure')
+- `error_code text null`
+- `trace_id text null`
+- `context_metadata jsonb null`
+- `timestamp timestamptz not null`
+
+**Indexes:**
+- `(tenant_id, timestamp desc)` for tenant audit queries
+- `(provider_id, timestamp desc)` for provider-specific audit trail
+- `(operation, timestamp desc)` for operation-specific queries
+
+NOTE: table parititioning and archiving and retention policies are not specified in this document. It's a subject for future improvements.
+
+#### Scenario: Audit provider creation
+- **WHEN** tenant creates a new provider
+- **THEN** logs (tenant_id, user_id, 'create_provider', provider_id, 'success', timestamp)
+- **AND** includes OpenTelemetry trace_id
+
+#### Scenario: Audit model invocation
+- **WHEN** client invokes model via resolved provider client
+- **THEN** logs invocation with (operation='invoke_model', provider_id, status, duration)
+- **AND** captures error details on failure
+
+### Requirement: model_provider RBAC model
+The system SHALL enforce role-based access control for provider operations.
+
+#### Database table: model_provider_role_assignment
+- `id uuid pk`
+- `tenant_id uuid not null`
+- `principal_id uuid not null`
+- `principal_type text not null` (enum: 'user', 'service_account')
+- `role text not null` (enum: 'provider.admin', 'provider.writer', 'provider.reader', 'provider.invoker')
+- `scope text null` (optional scope to specific provider or vendor)
+- `created_at timestamptz not null`
+
+**Indexes:**
+- `(tenant_id, principal_id)` for fast role lookup
+
+NOTE: `model_provider_role_assignment` is out of scope for this document. It's a subject for external access control module.
+
+#### Role definitions:
+- `gts.x.core.idp.role.v1~x.model_provider.provider.admin.v1`: Full CRUD on providers, endpoints, provisioning
+- `gts.x.core.idp.role.v1~x.model_provider.provider.writer.v1`: Create/update providers and endpoints (no delete)
+- `gts.x.core.idp.role.v1~x.model_provider.provider.reader.v1`: Read-only access to providers and endpoints
+- `gts.x.core.idp.role.v1~x.model_provider.provider.invoker.v1`: Can invoke models but not manage providers
+
+#### Scenario: Enforce role at gateway
+- **GIVEN** user U has role `gts.x.core.idp.role.v1~x.model_provider.provider.reader.v1`
+- **WHEN** U attempts `DELETE /model-provider/v1/providers/{id}`
+- **THEN** gateway checks SecurityCtx roles
+- **AND** returns 403 Forbidden with RFC 9457 Problem Detail
+
+#### Scenario: Scoped role to vendor
+- **GIVEN** user U has role `gts.x.core.idp.role.v1~x.model_provider.provider.writer.v1` scoped to vendor='gts.x.genai.provider.vendor.v1~x.openai._.vendor.v1'
+- **WHEN** U attempts to create an Anthropic provider
+- **THEN** gateway denies with 403 Forbidden
+
+### Requirement: model_provider observability
+The system SHALL expose Prometheus-compatible metrics.
+
+Required metrics (using `metrics` crate):
+- `model_provider.providers.created` (counter, labels: tenant_id, vendor)
+- `model_provider.providers.total` (gauge, labels: tenant_id, vendor)
+- `model_provider.endpoints.provisioned` (counter, labels: tenant_id, endpoint_type)
+- `model_provider.invocations_total` (counter, labels: tenant_id, provider_id, status)
+- `model_provider.invocation.duration_msec` (histogram, labels: provider_id, capability)
+- `model_provider.errors_total` (counter, labels: error_type, provider_id)
+- `model_provider.client_cache.hit_total` (counter)
+- `model_provider.client_cache.miss_total` (counter)
+- `model_provider.plugin.resolution.duration_msec` (histogram, labels: plugin_id)
+
+Implementation SHALL use `metrics` and `metrics-exporter-prometheus` crates.
+
+#### Scenario: Metrics collection
+- **WHEN** provider operation completes
+- **THEN** system increments appropriate counters
+- **AND** records latency histogram
+- **AND** metrics are exposed at GET /metrics endpoint
+
+### Requirement: model_provider health checks
+The system SHALL expose health check endpoints.
+
+REST endpoints:
+- `GET /model-provider/v1/health` - Liveness probe
+- `GET /model-provider/v1/ready` - Readiness probe (checks plugin availability)
+- `GET /model-provider/v1/providers/{providerId}/health` - Provider-specific health check
+
+#### Scenario: Health check
+- **WHEN** `GET /model-provider/v1/health` is called
+- **AND** access is not protected by any role
+- **AND** returns 200 OK if system is health
+
+#### Scenario: Readiness check
+- **WHEN** `GET /model-provider/v1/ready` is called
+- **AND** access is not protected by any role
+- **THEN** checks that at least one plugin is available
+- **AND** returns 200 OK if system is ready
+
+#### Scenario: Provider health check
+- **WHEN** `GET /model-provider/v1/providers/{providerId}/health` is called
+- **AND** access is not protected by any role
+- **THEN** system invokes provider's healthcheck_url endpoint
+- **AND** returns aggregated health status
+
+### Requirement: model_provider tracing integration
+The system SHALL integrate with OpenTelemetry for distributed tracing.
+
+All operations SHALL create spans with attributes:
+- `tenant_id`
+- `user_id` (if available)
+- `provider_id`
+- `endpoint_id`
+- `vendor`
+- `operation`
+- `plugin_id`
+
+Implementation SHALL use `tracing` and `tracing-opentelemetry` crates.
+
+#### Scenario: Trace model invocation
+- **WHEN** model invocation is performed
+- **THEN** system creates OpenTelemetry span with all relevant attributes
+- **AND** span is linked to parent trace context
+- **AND** errors are recorded as span events
+
+### Requirement: model_provider error taxonomy
+The system SHALL define comprehensive error types using RFC 9457 Problem Details.
+
+Error types SHALL include:
+- `PluginUnavailable`: No plugin available for provider
+- `ProviderNotFound`: Provider UUID does not exist
+- `EndpointNotProvisioned`: Endpoint not enabled for tenant
+- `QuotaExceeded`: Tenant provider limit reached
+- `InvalidVendor`: Unknown vendor GTS ID
+- `InvocationFailed`: Model invocation failed
+- `RateLimitExceeded`: Invocation rate limit hit
+- `Forbidden`: Access denied
+
+#### Scenario: Plugin unavailable error
+- **WHEN** no plugin available for requested provider vendor
+- **THEN** gateway returns 503 Service Unavailable
+- **AND** includes Problem Detail with type `urn:<model provider GTS id>:error:<error GTS id>`
+- **AND** lists required plugin characteristics
+
+#### Scenario: Quota exceeded error
+- **WHEN** tenant attempts to create provider beyond quota
+- **THEN** gateway returns 429 Too Many Requests
+- **AND** includes current quota and usage in error detail
+
+### Requirement: configurable per-tenant defaults
+
+There must be per-module defaults configurable via global config file and also per-tenant defaults
+stored in database. If per-tenant defaults are not set, then global per-module defaults are used.
+
+### Requirement: model_provider resource limits
+The system SHALL enforce resource limits per tenant.
+
+#### Database table: model_provider_tenant_quota
+- `id uuid pk`
+- `tenant_id uuid not null unique`
+- `max_providers int not null default 50`
+- `max_endpoints_per_provider int not null default 10`
+- `max_provisioned_endpoints int not null default 100`
+- `max_invocations_per_min int not null default 1000`
+
+#### Scenario: Enforce provider count quota
+- **GIVEN** tenant T has max_providers = 50 and current count = 50
+- **WHEN** T attempts to create provider 51
+- **THEN** gateway returns 429 Too Many Requests
+- **AND** includes Problem Detail with quota information
+
+#### Scenario: Enforce invocation rate limit
+- **GIVEN** tenant T has max_invocations_per_min = 1000
+- **WHEN** T exceeds 1000 invocations in current minute
+- **THEN** gateway returns 429 Too Many Requests
+- **AND** includes Retry-After header
+
+### Requirement: model_provider rate limiting
+The system SHALL enforce rate limits per tenant using token bucket algorithm.
+
+Implementation SHOULD use `governor` crate.
+
+Rate limits SHALL be configurable per tenant (default: 1000 invocations/min).
+
+#### Scenario: Rate limit enforcement
+- **GIVEN** tenant T has rate limit 1000 invocations/min
+- **WHEN** T exceeds limit
+- **THEN** gateway returns 429 Too Many Requests
+- **AND** includes Retry-After header with seconds until reset
+
+#### Scenario: Per-provider rate limiting
+- **GIVEN** specific provider has per-provider limit configured
+- **WHEN** tenant exceeds provider-specific limit
+- **THEN** only that provider is rate limited
+- **AND** other providers continue normally
+
+### Requirement: model_provider circuit breaker
+The system SHALL implement circuit breaker per provider to prevent cascade failures.
+
+#### Extended table: genai_model_provider
+- Add: `circuit_breaker_threshold int not null default 5`
+- Add: `circuit_breaker_timeout_sec int not null default 30`
+- Add: `circuit_breaker_success_threshold int not null default 2`
+
+Circuit breaker configuration:
+- **Failure threshold:** 5 consecutive failures (configurable per provider)
+- **Timeout:** 30 seconds (half-open state)
+- **Success threshold:** 2 successes to close
+- **Configurable:** module config file parameters can override defaults
+
+Implementation SHOULD use `failsafe` or `tower` crate.
+
+#### Scenario: Circuit breaker opens
+- **GIVEN** provider P fails 5 consecutive invocations
+- **WHEN** circuit breaker opens
+- **THEN** subsequent invocations to P fail-fast (503)
+- **AND** after 30s, circuit enters half-open state
+
+#### Scenario: Circuit breaker recovery
+- **GIVEN** circuit breaker is half-open
+- **WHEN** 2 consecutive invocations succeed
+- **THEN** circuit breaker closes
+- **AND** normal operation resumes
+
+### Requirement: model_provider retry logic
+The system SHALL implement exponential backoff retry for transient failures.
+
+Retry policy:
+- **Transient errors:** Network timeout, 502/503/504 from provider
+- **Max retries:** 3
+- **Backoff:** 100ms, 200ms, 400ms
+- **Non-retryable:** 400 Bad Request, 401 Unauthorized, 403 Forbidden, 404 Not Found
+
+Implementation SHOULD use `tower` crate retry middleware.
+
+#### Scenario: Retry transient provider error
+- **WHEN** provider returns 503 Service Unavailable
+- **THEN** gateway retries after 100ms
+- **AND** if still failing, retries after 200ms, then 400ms
+- **AND** if all retries exhausted, returns 503 to client
+
+### Requirement: model_provider client caching
+The system SHALL cache resolved provider client instances for performance.
+
+Implementation SHOULD use in-memory cache with:
+- **Max capacity:** 1,000 client instances
+- **TTL:** 300 seconds (5 minutes)
+- **Cache key:** `(tenant_id, provider_id, plugin_id)`
+
+#### Scenario: Client cache hit
+- **WHEN** client resolution requested for cached provider
+- **THEN** returns cached client instance (no plugin resolution)
+- **AND** records cache hit metric
+
+#### Scenario: Client cache eviction
+- **WHEN** provider configuration is updated
+- **THEN** invalidate cached client for that provider
+- **AND** next resolution creates fresh client
+
+### Requirement: model_provider OData support
+The system SHALL implement OData query capabilities per ModKit conventions.
+
+REST endpoints SHALL support:
+- `$skip` and `$top` for pagination
+- `$filter` for filtering
+- `$orderby` for sorting
+- `$select` for field projection
+
+Implementation SHALL use `modkit::api::OperationBuilder` OData support.
+
+#### Scenario: Paginated provider list
+- **WHEN** `GET /model-provider/v1/providers?$skip=20&$top=10`
+- **THEN** returns providers 21-30
+- **AND** includes `@odata.nextLink` for pagination
+
+#### Scenario: Filter by vendor
+- **WHEN** `GET /model-provider/v1/providers?$filter=vendor_gts_id eq 'gts.x.genai.provider.vendor.v1~openai'`
+- **THEN** returns only OpenAI providers
+
+#### Scenario: Filter inherited providers
+- **WHEN** `GET /model-provider/v1/providers?$filter=available_to_children eq true`
+- **THEN** returns providers shared by parent tenants
+
+### Requirement: model_provider timeout configuration
+The system SHALL support configurable timeouts for provider invocations.
+
+#### Extended table: genai_model_provider_endpoint
+- Add: `connection_timeout_ms int not null default 5000` (5s to establish connection)
+- Add: `request_timeout_ms int not null default 30000` (30s total request duration)
+- Add: `idle_timeout_ms int not null default 60000` (60s idle connection reuse)
+
+These settings are overriable by OAGW per-tenant, per-endpoint and per-link defaults.
+
+#### Scenario: Connection timeout
+- **WHEN** connection to provider takes > 5s (configured in endpoint)
+- **THEN** gateway aborts connection attempt
+- **AND** returns 504 Gateway Timeout to client
+
+#### Scenario: Request timeout
+- **WHEN** model invocation takes > 30s (configured in endpoint)
+- **THEN** gateway cancels request
+- **AND** returns 504 Gateway Timeout to client
+
+### Requirement: model_provider plugin trait definition
+The system SHALL define a Rust trait for provider plugins.
+
+```rust
+#[async_trait]
+pub trait ModelProviderPlugin: Send + Sync {
+    /// Plugin metadata
+    fn metadata(&self) -> &PluginMetadata;
+
+    /// Check if plugin can handle this provider configuration
+    fn can_handle(&self, vendor_gts_id: &str, kind_gts_id: &str, endpoint_type_gts_id: &str) -> bool;
+
+    /// Create a provider client instance
+    async fn create_client(
+        &self,
+        ctx: &SecurityCtx,
+        provider: &ProviderConfig,
+    ) -> Result<Box<dyn ProviderClient>, Error>;
+
+    /// Health check
+    async fn health_check(&self, ctx: &SecurityCtx) -> Result<HealthStatus, Error>;
+}
+
+#[async_trait]
+pub trait ProviderClient: Send + Sync {
+    /// Invoke model with given parameters
+    async fn invoke(
+        &self,
+        ctx: &SecurityCtx,
+        capability: &str,
+        request: InvocationRequest,
+    ) -> Result<InvocationResponse, Error>;
+
+    /// Stream model response
+    async fn invoke_stream(
+        &self,
+        ctx: &SecurityCtx,
+        capability: &str,
+        request: InvocationRequest,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk, Error>>>>, Error>;
+}
+```
+
+#### Scenario: Plugin registration
+- **WHEN** plugin module `init()` runs
+- **THEN** plugin registers instance in `types_registry` with metadata
+- **AND** registers scoped client in `ClientHub` for `ModelProviderPlugin` trait
+
+#### Scenario: Client invocation
+- **WHEN** caller invokes `client.invoke(ctx, "chat_completion", request)`
+- **THEN** plugin-specific client executes provider API call
+- **AND** normalizes response to common format
+- **AND** records metrics and tracing spans
+
+### Requirement: model_provider request/response normalization
+The system SHALL normalize provider-specific requests and responses to common formats.
+
+Common request format:
+```rust
+pub struct InvocationRequest {
+    pub messages: Vec<Message>,
+    pub model: String,
+    pub temperature: Option<f32>,
+    pub max_tokens: Option<u32>,
+    pub stream: bool,
+    pub tools: Option<Vec<ToolDefinition>>,
+    pub extra_params: HashMap<String, serde_json::Value>,
+}
+```
+
+Common response format:
+```rust
+pub struct InvocationResponse {
+    pub id: String,
+    pub choices: Vec<Choice>,
+    pub usage: Usage,
+    pub finish_reason: FinishReason,
+}
+```
+
+#### Scenario: Normalize OpenAI request
+- **WHEN** caller invokes OpenAI provider with common request format
+- **THEN** plugin transforms to OpenAI-specific format
+- **AND** handles OpenAI-specific parameters in `extra_params`
+
+#### Scenario: Normalize Anthropic response
+- **WHEN** Anthropic provider returns response
+- **THEN** plugin transforms to common response format
+- **AND** maps Anthropic-specific fields to common schema

--- a/openspec/changes/add-model-provider-cred-store-oagw/specs/oagw/spec.md
+++ b/openspec/changes/add-model-provider-cred-store-oagw/specs/oagw/spec.md
@@ -1,0 +1,662 @@
+## ADDED Requirements
+
+### Requirement: oagw module responsibility
+The system SHALL provide an `oagw` gateway module with **pluggable co-loaded protocol/auth/streaming implementations** responsible for invoking outbound remote API calls in a reusable way.
+
+The `oagw` module SHALL:
+- Manage tenant-scoped outbound route/link configuration.
+- Delegate actual invocation to a selected plugin implementation.
+- Provide error normalization for known protocols.
+
+#### Scenario: Reusable outbound invocation
+- **WHEN** a module needs to call an external HTTP API
+- **THEN** it can delegate to `oagw` instead of implementing its own transport/auth logic
+
+### Requirement: oagw GTS schemas and instances registration
+The system SHALL register the following GTS schemas in `types_registry` during gateway startup:
+- `gts.x.core.oagw.proto.v1~`
+- `gts.x.core.oagw.stream_proto.v1~`
+- `gts.x.core.oagw.auth_type.v1~`
+- `gts.x.core.oagw.strategy.v1~`
+
+Each schema SHALL define:
+- `id: GtsInstanceId`
+- `display_name: string`
+- `description?: string`
+- `priority?: int` (lower wins)`
+
+Well-known instances SHALL be loaded from `oagw/.../gts/*.instances.json` and registered during gateway `init()`.
+
+priority is used to select the best protocol for a given route, e.g. HTTP/3 if supported by downstream would have lower priority than HTTP/2.
+
+Well-known route protocol instances SHOULD include:
+- `gts.x.core.oagw.proto.v1~x.core.http.http11.v1`
+- `gts.x.core.oagw.proto.v1~x.core.http.http2.v1`
+- `gts.x.core.oagw.proto.v1~x.core.http.http3.v1`
+- `gts.x.core.oagw.proto.v1~x.core.http.sse.v1`
+
+Well-known strategy instances SHOULD include:
+- `gts.x.core.oagw.strategy.v1~x.core._.sticky_session.v1`
+- `gts.x.core.oagw.strategy.v1~x.core._.round_robin.v1`
+
+Auth type schemas and instances SHOULD be treated analogously to protocol/strategy schemas:
+- The `gts.x.core.oagw.auth_type.v1~` schema defines the shape of an auth mechanism.
+- Well-known auth type instances define a stable set of supported auth behaviors.
+- An `outbound_api_route` references exactly one `auth_type_gts_id`, allowing tenants to select behavior without hardcoding.
+
+#### Scenario: Startup registration
+- **WHEN** `oagw` gateway `init()` runs
+- **THEN** it registers the listed schemas and shipped instances in `types_registry`
+
+#### Scenario: Sticky session strategy
+- **GIVEN** a link is configured with `strategy_gts_id` = `gts.x.core.oagw.strategy.v1~x.core._.sticky_session.v1`
+- **WHEN** `oagw` selects a link for a given tenant
+- **THEN** it SHOULD try to stick to the previously selected link for that tenant
+
+#### Scenario: Round robin strategy
+- **GIVEN** a link is configured with `strategy_gts_id` = `gts.x.core.oagw.strategy.v1~x.core._.round_robin.v1`
+- **WHEN** `oagw` selects a link for a given tenant
+- **THEN** it SHOULD distribute invocations across links for the same route
+
+### Requirement: oagw persistence model
+The system SHALL persist anonymous objects (UUID IDs) in the `oagw` database.
+
+#### Database tables (logical), managed by OAGW gateway module
+- `outbound_api_route`
+  - `id uuid pk`
+  - `tenant_id uuid not null`
+  - `base_url text not null`
+  - `rate_limit_req_per_min int not null default 1000`
+  - `auth_type_gts_id text not null` (schema: `gts.x.core.oagw.auth_type.v1~`)
+
+- `outbound_api_route_supported_protocol`
+  - `id uuid pk`
+  - `route_id uuid not null fk outbound_api_route(id)`
+  - `protocol_gts_id text not null` (list of supported protocols, schema: `gts.x.core.oagw.proto.v1~`)
+
+- `outbound_api_link`
+  - `id uuid pk`
+  - `tenant_id uuid not null`
+  - `secret_ref uuid not null` (logical/not-physical FK to `cred_store.secret_store.id`)
+  - `route_id uuid not null fk outbound_api_route(id)`
+  - `secret_type_gts_id text not null` (schema: `gts.x.core.cred_store.secret_type.v1~`)
+  - `enabled bool not null`
+  - `priority int not null`
+  - `strategy_gts_id text not null` (schema: `gts.x.core.oagw.strategy.v1~`)
+
+- `outbound_api_route_limits`
+  - `id uuid pk`
+  - `tenant_id uuid not null`
+  - `link_id uuid null unique (logical FK to outbound_api_link.id)` (can be per link)
+  - `route_id uuid null unique (logical FK to outbound_api_route.id)` (... or per route)
+  - `connection_timeout_ms int not null default 5000` (5s to establish connection)
+  - `request_timeout_ms int not null default 30000` (30s total request duration)
+  - `idle_timeout_ms int not null default 60000` (60s idle connection reuse)
+  - `circuit_breaker_threshold int not null default 5`
+  - `circuit_breaker_timeout_sec int not null default 30`
+  - `circuit_breaker_success_threshold int not null default 2`
+  - `max_concurrent_requests int not null default 100`
+  - `max_request_size_bytes int not null default 10485760` (10 MB)
+  - `max_response_size_bytes int not null default 104857600` (100 MB)
+  - `rate_limit_per_min int not null default 1000`
+
+#### Scenario: Configure link for a tenant
+- **WHEN** a tenant configures an outbound link
+- **THEN** the link references a `cred_store` secret by UUID
+
+### Requirement: oagw gateway API (Rust-native)
+The system SHALL expose a Rust-native API (ClientHub) named `OagwApi`.
+
+The API SHALL:
+- Accept `&SecurityCtx` for every method.
+- Allow selecting an outbound link and invoking requests through it.
+- Support non-streaming and streaming responses.
+
+The Rust-native API SHOULD expose two shapes:
+- Unary (synchronous) invocation: request/response completes with a single response value.
+- Streaming (asynchronous) invocation: response is a stream of items.
+
+The Rust-native API SHOULD support streaming over:
+- HTTP SSE (`gts.x.core.oagw.proto.v1~x.core.http.sse.v1`) as a server-to-client stream.
+
+#### Scenario: Rust-native unary invocation
+- **WHEN** a consumer calls `OagwApi::invoke_unary(ctx, request)`
+- **THEN** the gateway resolves an eligible plugin and executes a single request/response exchange
+
+#### Scenario: Rust-native streaming invocation
+- **WHEN** a consumer calls `OagwApi::invoke_stream(ctx, request)`
+- **THEN** the gateway resolves an eligible plugin and returns a stream of response items
+
+#### Scenario: Rust-native invocation
+- **WHEN** a consumer calls `OagwApi::invoke(ctx, request)`
+- **THEN** the gateway resolves an eligible plugin and executes the request
+
+### Requirement: oagw unary vs streaming Rust API shape
+The system SHALL define a contract model for outbound invocations that supports both unary and streaming responses.
+
+The Rust-native API SHOULD define method shapes similar to:
+- `invoke_unary(&self, ctx: &SecurityCtx, req: OagwInvokeRequest) -> Result<OagwInvokeResponse, OagwError>`
+- `invoke_stream(&self, ctx: &SecurityCtx, req: OagwInvokeRequest) -> Result<OagwResponseStream, OagwError>`
+
+The streaming response type SHOULD be compatible with `futures::Stream`, enabling transport-independent composition.
+
+#### Scenario: Streaming response as futures::Stream
+- **WHEN** a consumer uses `invoke_stream`
+- **THEN** it can process response items incrementally using backpressure-aware `Stream` combinators
+
+### Requirement: oagw REST API
+The system SHALL expose REST endpoints:
+- `GET/POST /oagw/v1/routes`
+- `GET/PATCH/DELETE /oagw/v1/routes/{routeId}`
+- `GET/POST /oagw/v1/links`
+- `GET/PATCH/DELETE /oagw/v1/links/{linkId}`
+- `POST /oagw/v1/invoke`
+
+#### Scenario: REST invoke
+- **WHEN** a client POSTs to `/oagw/v1/invoke` with a link id and request payload
+- **THEN** `oagw` executes the request via the selected plugin
+- **AND** returns normalized errors using RFC-9457 Problem Details
+
+### Requirement: oagw plugin interface and selection
+The system SHALL define an `oagw` plugin interface.
+
+Each plugin SHALL report:
+- Supported route protocols (instances of `gts.x.core.oagw.proto.v1~`).
+- Supported stream protocols (instances of `gts.x.core.oagw.stream_proto.v1~`).
+- Supported auth types (instances of `gts.x.core.oagw.auth_type.v1~`).
+- Supported strategies (instances of `gts.x.core.oagw.strategy.v1~`).
+- Plugin priority (lower wins).
+
+The gateway SHALL choose the eligible plugin with the lowest priority.
+
+The gateway SHOULD implement sticky session selection keyed by:
+- `(tenant_id, user_id)` when available.
+
+#### Scenario: Eligible plugin selection
+- **GIVEN** an outbound link requiring protocol P and auth type A
+- **WHEN** `oagw` resolves its plugin
+- **THEN** it filters to plugins supporting (P, A)
+- **AND** selects the lowest-priority plugin
+
+### Requirement: oagw protocol and transport implementation libraries
+The system SHALL define the Rust libraries used for outbound transport per selected protocol.
+
+For outbound HTTP (`http11`, `http2`) the gateway SHOULD use:
+- `reqwest` for request construction and execution.
+- `modkit::http::TracedClient` to inject OpenTelemetry trace context into outbound calls.
+
+For outbound HTTP/3 (`http3`) the gateway SHOULD use an HTTP/3-capable Rust client library.
+
+For outbound SSE (`sse`) the gateway SHOULD:
+- Use `reqwest` for initiating the HTTP request.
+- Use an SSE-compatible client implementation to parse `text/event-stream` frames into stream items.
+
+### Requirement: oagw auth mechanisms, token exchange, and caching
+The system SHALL define how outbound authentication is produced for each outbound call.
+
+The gateway SHALL treat outbound auth configuration as data:
+- A route references an auth type instance via `auth_type_gts_id`.
+- A link references secret material via `secret_ref` and `secret_type_gts_id`.
+
+Outbound auth material SHOULD be resolved using `cred_store` and SHOULD NOT be embedded directly into `oagw` tables.
+
+#### Token exchange model
+When the inbound request is authenticated with an end-user token, the gateway MAY need to exchange it for an outbound token.
+
+If token exchange is required, the gateway SHOULD implement RFC 8693 OAuth 2.0 Token Exchange against a configured identity provider.
+
+The gateway SHOULD cache exchanged tokens.
+
+Caching behavior SHOULD:
+- Use an in-memory cache keyed by `(tenant_id, user_id, route_id, auth_type_gts_id, requested_scopes)`.
+- Store tokens with TTL derived from the token `exp` claim minus a safety skew.
+- Deduplicate concurrent exchanges for the same cache key.
+
+#### Scenario: Exchanged token cache hit
+- **GIVEN** an exchanged outbound token exists in cache for `(tenant_id, user_id, route_id, auth_type, scopes)`
+- **WHEN** the tenant invokes the same route again
+- **THEN** `oagw` reuses the cached token
+- **AND** does not call the identity provider
+
+#### Scenario: Exchanged token cache miss
+- **GIVEN** no cached outbound token exists
+- **WHEN** the tenant invokes the route
+- **THEN** `oagw` exchanges the inbound identity token for an outbound token
+- **AND** caches the result until its effective expiry
+
+#### Auth library mapping (non-exhaustive)
+The system SHOULD implement outbound auth using common, audited Rust libraries:
+- OAuth2 client credentials / token exchange: `oauth2` (for token acquisition flows)
+- JWT validation/parsing (when needed for caching/expiry decisions): `jsonwebtoken`
+- Static headers / API keys: `http` header types and `reqwest` request builders
+
+#### Scenario: Outbound auth derived from link secret
+- **GIVEN** a link references `secret_ref` and `secret_type_gts_id`
+- **WHEN** the gateway prepares the outbound request
+- **THEN** it loads secret material from `cred_store` using the reference
+- **AND** applies it to the request according to `auth_type_gts_id`
+
+### Requirement: Caller-controlled retry semantics
+The system SHALL treat retries as an explicit caller-provided policy.
+
+The gateway MUST NOT perform implicit retries.
+
+The gateway MAY perform retries **within a single invocation** only when explicitly requested by the caller via a declarative `RetryIntent`.
+
+The retry state MUST be ephemeral and live only within the invocation context.
+
+#### Scenario: No implicit retry
+- **WHEN** the caller provides no `RetryIntent` (or `max_attempts = 1`)
+- **THEN** the gateway executes exactly one outbound attempt
+
+#### Scenario: Retry intent enables bounded retries
+- **GIVEN** a caller provides `RetryIntent.max_attempts > 1`
+- **WHEN** the first attempt fails with a condition matching `RetryIntent.retry_on`
+- **THEN** the gateway MAY retry within the same invocation until attempts are exhausted
+- **AND** the response MUST include the attempt number that produced the returned result
+
+### Requirement: oagw audit logging
+The system SHALL maintain an audit log for all outbound invocations.
+
+#### Database table: outbound_api_audit_log
+- `id uuid pk`
+- `tenant_id uuid not null`
+- `user_id uuid null`
+- `route_id uuid not null`
+- `link_id uuid not null`
+- `operation text not null` (HTTP method)
+- `target_url text not null`
+- `status_code int null` (HTTP status)
+- `duration_ms int not null`
+- `error_message text null`
+- `trace_id text not null`
+- `timestamp timestamptz not null`
+
+**Indexes:**
+- `(tenant_id, timestamp desc)` for tenant audit queries
+- `(route_id, timestamp desc)` for route-specific audit trail
+- `(link_id, timestamp desc)` for link performance analysis
+
+NOTE: table parititioning and archiving and retention policies are not specified in this document. It's a subject for future improvements.
+
+The system SHALL define audit logging guarantees.
+
+Guarantee options are:
+- best-effort
+- guaranteed
+- fail-closed
+
+If audit logging is synchronous, the system SHALL enforce an upper bound on audit log latency.
+
+#### Scenario: Audit latency budget
+- **WHEN** the audit subsystem exceeds the maximum configured latency budget
+- **THEN** the gateway applies the configured guarantee mode (best-effort drop, guaranteed wait, or fail-closed)
+
+#### Scenario: Audit successful invocation
+- **WHEN** oagw invokes external API successfully
+- **THEN** logs (tenant_id, route_id, link_id, status_code, duration_ms, timestamp)
+- **AND** includes OpenTelemetry trace_id from current span
+
+#### Scenario: Audit failed invocation
+- **WHEN** oagw invocation fails (timeout, 500 error)
+- **THEN** logs error details for troubleshooting
+- **AND** records error_message and status_code
+
+### Requirement: oagw observability
+The system SHALL expose Prometheus-compatible metrics.
+
+Required metrics (using `metrics` crate):
+- `oagw.invocations_total` (counter, labels: tenant_id, route_id, status)
+- `oagw.request.duration_msec` (histogram, labels: route_id, protocol)
+- `oagw.errors_total` (counter, labels: error_type, route_id)
+- `oagw.active_connections` (gauge, labels: route_id)
+- `oagw.circuit_breaker.opened` (counter, labels: link_id)
+- `oagw.circuit_breaker.state` (gauge, labels: link_id)
+- `oagw.bytes_sent_total` (counter, labels: tenant_id, route_id, link_id)
+- `oagw.bytes_received_total` (counter, labels: tenant_id, route_id, link_id)
+- `oagw.token_cache.hit_total` (counter)
+- `oagw.token_cache.miss_total` (counter)
+- `oagw.token_cache.size` (gauge)
+
+Implementation SHALL use `metrics` and `metrics-exporter-prometheus` crates.
+
+#### Scenario: Metrics collection
+- **WHEN** outbound invocation completes
+- **THEN** system increments appropriate counters
+- **AND** records latency histogram
+- **AND** metrics are exposed at GET /metrics endpoint
+
+### Requirement: oagw health checks
+The system SHALL expose health check endpoints.
+
+REST endpoints:
+- `GET /oagw/v1/health` - Liveness probe
+- `GET /oagw/v1/ready` - Readiness probe (checks core dependencies like DB)
+- `GET /oagw/v1/routes/{routeId}/health` - Route-specific health check
+
+The `/oagw/v1/health` and `/oagw/v1/ready` endpoints access is not protected by any role.
+
+#### Scenario: Health check
+- **WHEN** `GET /oagw/v1/health` is called
+- **AND** no role is required
+- **THEN** returns 200 OK if system is health
+
+#### Scenario: Readiness check
+- **WHEN** `GET /oagw/v1/ready` is called
+- **AND** no role is required
+- **THEN** returns 200 OK if system can serve traffic
+- **AND** includes results of core dependency checks
+
+#### Scenario: Check downstream health
+- **WHEN** `GET /oagw/v1/routes/{routeId}/health` is called
+- **THEN** access is protected by role `gts.x.core.idp.role.v1~x.oagw.route.health.v1` assigned
+- **AND** system tests connectivity to all links for that route
+- **AND** returns aggregated health status
+
+### Requirement: oagw tracing integration
+The system SHALL integrate with OpenTelemetry for distributed tracing.
+
+All operations SHALL create spans with attributes:
+- `tenant_id`
+- `user_id` (if available)
+- `route_id`
+- `link_id`
+- `protocol`
+- `auth_type`
+- `target_url`
+- `http.method` (for HTTP)
+- `http.status_code` (for HTTP)
+
+Implementation SHALL use `tracing` and `tracing-opentelemetry` crates.
+
+#### Scenario: Trace outbound invocation
+- **WHEN** outbound invocation is performed
+- **THEN** system creates OpenTelemetry span with all relevant attributes
+- **AND** span is linked to parent trace context
+- **AND** errors are recorded as span events
+
+### Requirement: oagw circuit breaker
+The system SHALL implement circuit breaker state globally or per tenant-scoped link to prevent cascade failures.
+
+Circuit breaker state MUST be hierarchically scoped per `(provider_id, route_id, tenant_id, link_id)`.
+
+The system MAY maintain an aggregate breaker signal per `(tenant_id, route_id)` only for reporting and health aggregation.
+
+#### Extended table: outbound_api_link
+- Add: `circuit_breaker_threshold int not null default 5`
+- Add: `circuit_breaker_timeout_sec int not null default 30`
+- Add: `circuit_breaker_success_threshold int not null default 2`
+
+Circuit breaker configuration:
+- **Failure threshold:** 5 consecutive failures (configurable per link)
+- **Timeout:** 30 seconds (half-open state)
+- **Success threshold:** 2 successes to close
+- **Configurable:** module config file parameters can override these defaults
+
+Implementation SHOULD use `failsafe` or `tower` crate.
+
+#### Scenario: Circuit breaker opens
+- **GIVEN** link L fails 5 consecutive times
+- **WHEN** circuit breaker opens
+- **THEN** subsequent requests to L fail-fast (503)
+- **AND** system tries next eligible link (if available)
+- **AND** after 30s, circuit enters half-open state
+
+#### Scenario: Fallback to alternate link
+- **GIVEN** primary link has open circuit breaker
+- **WHEN** oagw selects link for invocation
+- **THEN** gateway skips primary and selects next highest-priority link
+
+#### Scenario: Circuit breaker recovery
+- **GIVEN** circuit breaker is half-open
+- **WHEN** 2 consecutive calls succeed
+- **THEN** circuit breaker closes
+- **AND** normal operation resumes
+
+### Requirement: oagw resource limits
+The system SHALL enforce resource limits per route.
+
+The system SHALL define explicit backpressure and buffering limits for unary and streaming requests.
+
+#### Scenario: Enforce per-invocation inflight bytes
+- **WHEN** the response body stream exceeds the configured per-invocation inflight byte budget
+- **THEN** the gateway aborts the stream and returns a stream abort error
+
+#### Scenario: Enforce concurrent request limit
+- **GIVEN** route R has 100 active requests
+- **WHEN** 101st request arrives
+- **THEN** gateway returns 429 Too Many Requests
+- **AND** includes Retry-After header
+
+#### Scenario: Enforce request size limit
+- **WHEN** client attempts to send 20 MB request payload
+- **AND** route limit is 10 MB
+- **THEN** gateway returns 413 Payload Too Large before sending to downstream
+
+NOTE: limits above are per route, configurable globally in module config or per tenant in database (`outbound_api_route_limits`).
+
+#### Scenario: Enforce response size limit
+- **WHEN** downstream returns response exceeding max_response_size_bytes
+- **THEN** gateway aborts response stream
+- **AND** returns 502 Bad Gateway to client
+
+### Requirement: oagw timeout configuration
+The system SHALL support granular timeout settings per link.
+
+#### Scenario: Connection timeout
+- **WHEN** TCP connection to link takes > 5s (configured in `outbound_api_link.connection_timeout_ms`)
+- **THEN** gateway aborts connection attempt
+- **AND** tries next link or returns 504 Gateway Timeout
+
+#### Scenario: Request timeout
+- **WHEN** request takes > 30s (including all retries, configured in `outbound_api_link`)
+- **THEN** gateway cancels request
+- **AND** returns 504 Gateway Timeout to client
+
+#### Scenario: Idle connection reuse
+- **WHEN** HTTP connection is idle for > 60s (configured in `outbound_api_link`)
+- **THEN** gateway closes connection
+- **AND** establishes new connection for next request
+
+### Requirement: oagw streaming error handling
+The system SHALL handle mid-stream errors gracefully.
+
+#### Scenario: SSE stream interruption
+- **WHEN** SSE stream from downstream breaks mid-stream
+- **THEN** gateway closes client stream with error event
+- **AND** logs partial stream duration and bytes received
+
+The streaming contract SHALL be treated as a stream of results.
+
+Stream items MUST be shaped as `Result<Chunk, StreamAbort>`.
+
+`StreamAbort` MUST include:
+- abort_reason (network | protocol | auth | timeout)
+- resumable: bool
+- resume_hint (e.g., Last-Event-ID)
+
+#### Scenario: Stream timeout
+- **WHEN** streaming response stalls (no data for > configured in `outbound_api_link.idle_timeout_ms`)
+- **THEN** gateway terminates stream
+- **AND** returns timeout error to client
+
+### Requirement: oagw token cache implementation
+The system SHALL implement token caching using in-memory LRU cache.
+
+Implementation SHOULD use `moka` crate for high-performance caching.
+
+Cache configuration:
+- **Max capacity:** 10,000 entries
+- **TTL:** Derived from token `exp` claim minus 60s safety margin
+- **Max TTL:** 3600s (1 hour)
+
+Cache key SHALL include:
+- `(tenant_id, user_id, route_id, auth_type_gts_id, scopes)`
+
+#### Scenario: Token TTL respects JWT exp claim
+- **WHEN** token exchange returns JWT with exp = 1 hour
+- **THEN** cache TTL = exp - 60s (safety margin)
+- **AND** token is evicted before actual expiry
+
+#### Scenario: Token cache eviction
+- **WHEN** cache reaches max capacity
+- **THEN** least recently used tokens are evicted
+- **AND** next access triggers fresh token exchange
+
+### Requirement: oagw token cache invalidation
+The system SHALL support manual token cache invalidation.
+
+REST endpoint:
+- `DELETE /oagw/v1/routes/{routeId}/cache/tokens` - Clear cached tokens for route
+
+#### Scenario: Clear cached tokens after credential rotation
+- **WHEN** admin rotates credentials for route R
+- **THEN** admin calls `DELETE /oagw/v1/routes/{R}/cache/tokens`
+- **AND** all cached tokens for R are evicted
+- **AND** next invocation triggers fresh token exchange
+
+#### Scenario: Clear all tokens for tenant
+- **WHEN** tenant credentials are compromised
+- **THEN** admin can clear all tenant tokens via cache flush
+- **AND** all active tokens are invalidated immediately
+
+### Requirement: oagw protocol version selection
+The system SHALL automatically select optimal protocol version.
+
+#### Scenario: Automatic HTTP/2 vs HTTP/3 selection
+- **GIVEN** route supports both `http2` and `http3` protocols
+- **WHEN** oagw initiates connection based on protocol GTS id with lower priority
+- **THEN** attempts HTTP/3 (QUIC) first if supported by downstream
+- **AND** falls back to HTTP/2 if HTTP/3 negotiation fails
+
+#### Scenario: Force protocol version
+- **WHEN** link explicitly specifies `protocol_gts_id = ... http11`
+- **THEN** gateway MUST use HTTP/1.1 only (no automatic upgrade)
+
+#### Scenario: Protocol negotiation failure
+- **WHEN** client requires protocol P but downstream doesn't support it
+- **THEN** gateway returns 502 Bad Gateway
+- **AND** error detail specifies protocol mismatch
+
+### Requirement: oagw response caching (optional)
+The system MAY support response caching for idempotent GET requests.
+
+#### Extended table: outbound_api_route
+- Add: `cache_ttl_sec int null` (NULL = no caching)
+
+Cache key SHALL include:
+- `(route_id, request_path, query_params, relevant_headers)`
+
+Implementation SHOULD use `moka` crate.
+
+#### Scenario: Cache GET response
+- **GIVEN** route has `cache_ttl_sec = 300` (5 min)
+- **WHEN** client performs GET request
+- **THEN** gateway caches response for 5 minutes
+- **AND** subsequent identical GET requests return cached response
+
+#### Scenario: Cache invalidation on mutation
+- **WHEN** client performs POST/PUT/DELETE on cached route
+- **THEN** gateway invalidates cached GET responses for that route
+
+#### Scenario: Respect Cache-Control headers
+- **WHEN** downstream response includes `Cache-Control: no-store`
+- **THEN** gateway bypasses cache regardless of route configuration
+
+### Requirement: oagw error taxonomy
+The system SHALL define comprehensive error types using RFC 9457 Problem Details defined in the modkit unified system.
+
+Error types SHALL include errors with appropriate GTS identifier:
+- `LinkUnavailable`: All links for route are down
+- `CircuitBreakerOpen`: Circuit breaker prevents invocation
+- `ConnectionTimeout`: Cannot establish connection
+- `RequestTimeout`: Request exceeded timeout
+- `RateLimitExceeded`: Route rate limit hit
+- `PayloadTooLarge`: Request or response size exceeded
+- `ProtocolError`: Protocol negotiation or parsing failed
+- `AuthenticationFailed`: Cannot obtain or refresh token
+- `DownstreamError`: Downstream returned error status
+
+#### Scenario: Link unavailable error
+- **WHEN** all eligible links are unavailable (circuit breakers open)
+- **THEN** gateway returns 503 Service Unavailable
+- **AND** includes Problem Detail with type `urn:oagw:error:link-unavailable`
+- **AND** lists affected link IDs
+
+#### Scenario: Rate limit error
+- **WHEN** route rate limit is exceeded
+- **THEN** gateway returns 429 Too Many Requests
+- **AND** includes `Retry-After` header with seconds until reset
+
+### Requirement: oagw rate limiting
+The system SHALL enforce rate limits per route using token bucket algorithm.
+
+Implementation SHOULD use `governor` crate.
+
+Rate limits SHALL be configurable per route (default: 1000 req/min).
+There must be global limit and per-tenant limit provided in `outbound_api_route`.
+
+The system SHALL support distributed rate limiting for multi-instance deployments.
+
+#### Scenario: Distributed rate limiting with Redis
+- **GIVEN** the deployment runs multiple gateway instances
+- **WHEN** rate limiting is enforced for `(tenant_id, route_id)`
+- **THEN** the system uses a Redis-backed shared limiter to ensure consistent quotas across instances
+
+### Requirement: outbound TLS and credential lifecycle
+The system SHALL define outbound TLS and credential refresh behavior.
+
+#### Scenario: TLS certificate validation
+- **WHEN** the gateway makes an outbound HTTPS request
+- **THEN** it validates the remote certificate chain by default
+
+#### Scenario: Credential rotation for long-lived streams
+- **WHEN** credentials referenced from `cred_store` rotate
+- **THEN** new invocations use the latest secret material
+- **AND** long-lived SSE streams require an explicit caller-initiated restart to pick up the new credentials
+
+#### Scenario: Rate limit enforcement
+- **GIVEN** route R has rate limit 1000 req/min
+- **WHEN** client exceeds limit
+- **THEN** gateway returns 429 Too Many Requests
+- **AND** includes Retry-After header
+
+#### Scenario: Per-tenant rate limiting
+- **GIVEN** route R has per-tenant limit configured
+- **WHEN** tenant T exceeds its quota
+- **THEN** only tenant T is rate limited
+- **AND** other tenants continue normally
+
+### Requirement: oagw OData support
+The system SHALL implement OData query capabilities per ModKit conventions.
+
+REST endpoints SHALL support:
+- `$skip` and `$top` for pagination
+- `$filter` for filtering
+- `$orderby` for sorting
+- `$select` for field projection
+
+Implementation SHALL use `modkit::api::OperationBuilder` OData support.
+
+#### Scenario: Paginated route list
+- **WHEN** GET /oagw/v1/routes?$skip=20&$top=10
+- **THEN** returns routes 21-30
+- **AND** includes `@odata.nextLink` for pagination
+
+#### Scenario: Filter links by route
+- **WHEN** GET /oagw/v1/links?$filter=route_id eq '550e8400-e29b-41d4-a716-446655440000'
+- **THEN** returns only links for that route
+
+### Requirement: oagw SLOs (Service Level Objectives)
+The system SHOULD target:
+- **Availability:** 99.9% (excluding planned maintenance and downstream failures)
+- **Latency:**
+  - p50: < 100ms overhead (excluding downstream latency)
+  - p95: < 200ms overhead
+  - p99: < 500ms overhead
+- **Error rate:** < 0.1% (excluding downstream errors)
+
+#### Scenario: SLO monitoring
+- **WHEN** operations team reviews SLO dashboard
+- **THEN** metrics show p95 latency overhead, error rate, and uptime
+- **AND** alerts trigger if SLO thresholds are breached

--- a/openspec/changes/add-model-provider-cred-store-oagw/tasks.md
+++ b/openspec/changes/add-model-provider-cred-store-oagw/tasks.md
@@ -1,0 +1,15 @@
+## 1. Specification (this change)
+- [ ] 1.1 Define module responsibilities and boundaries for `model_provider`, `cred_store`, and `oagw`.
+- [ ] 1.2 Define complete domain models (GTS schemas/instances + anonymous DB entities) for all three modules.
+- [ ] 1.3 Define gateway (Rust native + REST) contracts for all three modules.
+- [ ] 1.4 Define gateway↔plugin contracts and plugin selection rules.
+- [ ] 1.5 Define module startup procedure for GTS schema + instance registration (and dependency ordering).
+- [ ] 1.6 Provide OpenAPI 3.1 specifications for the three REST APIs (paths + components).
+- [ ] 1.7 Run `openspec validate add-model-provider-cred-store-oagw --strict` and fix all issues.
+
+## 2. Follow-up implementation (out of scope for this proposal)
+- [ ] 2.1 Create module crates following `guidelines/NEW_MODULE.md` (SDK + gateway + plugins).
+- [ ] 2.2 Implement DB migrations and repositories using `modkit-db` Secure ORM.
+- [ ] 2.3 Implement REST handlers + OpenAPI wiring with `OperationBuilder`.
+- [ ] 2.4 Implement plugin discovery and selection using `types_registry` + `ClientHub` scoped clients.
+- [ ] 2.5 Add end-to-end tests and example plugins (OpenAI, Vault, HTTP/SSE).


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#220](https://github.com/cyberfabric/cyberware-rust/pull/220) | **Author:** Artifizer | **Opened:** 2026-01-08T20:09:47Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

This code just illustrates what we need to support inside OAGW:

- Add OAGW intent/actual design docs and scenarios
- Introduce oagw-sdk crate with public API, models, retry, and GTS types
- Add oagw-gw gateway module with REST API, domain service, infra, and DB migrations
- Wire OAGW into hyperspot-server (Cargo.toml, registered_modules.rs, quickstart config)
- Scaffold default OAGW plugin crate for HTTP-based outbound calls

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#220 -->