### PR TITLE
[PR #73] Draft: WIP test(modkit): exclude test code from coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
+  workflow_dispatch:
+
 
 # Cancel previous runs for the same ref to save CI minutes.
 concurrency:
@@ -199,7 +201,8 @@ jobs:
         run: cargo deny check
 
   coverage:
-    if: false
+    # if: github.event_name == 'workflow_dispatch'
+    if: true
     name: Code Coverage (cargo-llvm-cov)
     runs-on: ubuntu-latest
     steps:
@@ -212,53 +215,27 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust toolchain (with llvm-tools)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
         with:
           components: llvm-tools-preview
-
-      - name: Cache Cargo/target
-        uses: Swatinem/rust-cache@v2
-
-      - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.5
-
-      - name: Prepare sccache dir
-        shell: bash
-        run: |
-          echo "SCCACHE_DIR=$RUNNER_TEMP/sccache" >> "$GITHUB_ENV"
-          mkdir -p "$RUNNER_TEMP/sccache"
-
-      - name: Cache sccache artifacts
-        if: runner.os != 'macOS'
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}/sccache
-          key: sccache-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            sccache-${{ runner.os }}-
-
-      - name: Probe sccache & set RUSTC_WRAPPER
-        shell: bash
-        run: |
-          if sccache --start-server >/dev/null 2>&1; then
-            echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-            echo "SCCACHE_OK=1" >> "$GITHUB_ENV"
-          else
-            echo "sccache failed, falling back to plain rustc"
-            echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
-            echo "SCCACHE_OK=0" >> "$GITHUB_ENV"
-          fi
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov
 
+      - name: Inspect free disk space before coverage
+        run: df -h
+
       # Generate lcov.info for upload. Customize flags/features as needed.
       - name: Coverage (lcov)
+        env:
+          RUSTFLAGS: "-C debuginfo=0"
+          CARGO_LLVM_COV_TARGET_DIR: llvm-cov-target
+          CARGO_LLVM_COV_BUILD_DIR: llvm-cov-build
         run: |
           cargo llvm-cov clean --workspace
-          cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+          cargo +nightly llvm-cov --workspace --lcov --output-path lcov.info
 
       # Upload to Codecov; do not fail CI if Codecov is down/misconfigured.
       - name: Upload to Codecov

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,6 +2585,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "static_assertions",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ unsafe_code = "forbid"
 unused_mut = "warn"
 noop_method_call = "warn"
 unused_import_braces = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 
 [workspace.lints.clippy]
 # See clippy rules details https://rust-lang.github.io/rust-clippy/master/index.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,6 +217,7 @@ testcontainers = "0.26"
 testcontainers-modules = { version = "0.14", features = ["postgres", "mysql"] }
 httpmock = "0.8"
 hyper = "1.3"
+static_assertions = "1.1"
 
 # Other utilities
 rand = "0.9"

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -14,6 +14,7 @@ name = "modkit"
 [features]
 # Enable the runner and the runtime integration by default.
 default = ["otel"]
+coverage_nightly = []
 
 # OpenTelemetry support for distributed tracing
 otel = ["opentelemetry", "opentelemetry_sdk", "tracing-opentelemetry", "tracing-subscriber", "opentelemetry-otlp", "tonic"]

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -74,5 +74,6 @@ tonic = { workspace = true, optional = true }
 tower = { workspace = true }
 trybuild = { workspace = true }
 httpmock = { workspace = true }
+static_assertions = { workspace = true }
 
 

--- a/libs/modkit/src/api/error_layer.rs
+++ b/libs/modkit/src/api/error_layer.rs
@@ -175,6 +175,7 @@ impl IntoProblem for anyhow::Error {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit/src/api/mod.rs
+++ b/libs/modkit/src/api/mod.rs
@@ -14,6 +14,7 @@ pub mod response;
 pub mod trace_layer;
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod odata_policy_tests;
 
 pub use error::ApiError;

--- a/libs/modkit/src/api/odata.rs
+++ b/libs/modkit/src/api/odata.rs
@@ -238,5 +238,6 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 #[path = "odata_tests.rs"]
 mod odata_tests;

--- a/libs/modkit/src/api/odata/error.rs
+++ b/libs/modkit/src/api/odata/error.rs
@@ -121,6 +121,7 @@ pub fn odata_error_to_problem(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit/src/api/odata_policy_tests.rs
+++ b/libs/modkit/src/api/odata_policy_tests.rs
@@ -1,6 +1,7 @@
 //! Tests for cursor+orderby policy enforcement
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::super::odata::*;
     use axum::http::{request::Parts, Uri};

--- a/libs/modkit/src/api/odata_tests.rs
+++ b/libs/modkit/src/api/odata_tests.rs
@@ -1,4 +1,5 @@
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use crate::api::odata::*;
     use axum::extract::FromRequestParts;

--- a/libs/modkit/src/api/openapi_registry.rs
+++ b/libs/modkit/src/api/openapi_registry.rs
@@ -1,7 +1,16 @@
-//! OpenAPI registry for schema and operation management
+//! OpenAPI registry for schema and operation management.
 //!
-//! This module provides a standalone OpenAPI registry that collects operation specs
-//! and schemas, and builds a complete OpenAPI document from them.
+//! This module acts as a central repository for API operations and data schemas.
+//! It allows distributed registration of endpoints (e.g., from different modules or handlers)
+//! and their associated data types.
+//!
+//! # Flow
+//! 1. **Registration**: Handlers register their operations via `register_operation`.
+//! 2. **Schema Collection**: Data types used in requests/responses are registered via `ensure_schema`.
+//! 3. **Generation**: The `build_openapi` method aggregates all registered data into a standard OpenAPI 3.0 document.
+//!
+//! This design decouples the definition of API logic from the generation of documentation,
+//! enabling automatic discovery and documentation of available endpoints.
 
 use anyhow::Result;
 use arc_swap::ArcSwap;
@@ -45,7 +54,11 @@ impl Default for OpenApiInfo {
     }
 }
 
-/// OpenAPI registry trait for operation and schema registration
+/// Interface for registering API operations and schemas.
+///
+/// This trait allows different parts of the application to register their API capabilities
+/// without knowing the concrete storage mechanism. It is typically used by
+/// route handlers or module initialization logic to declare what endpoints they expose.
 pub trait OpenApiRegistry: Send + Sync {
     /// Register an API operation specification
     fn register_operation(&self, spec: &operation_builder::OperationSpec);
@@ -59,7 +72,11 @@ pub trait OpenApiRegistry: Send + Sync {
     fn as_any(&self) -> &dyn std::any::Any;
 }
 
-/// Helper function to call ensure_schema with proper type information
+/// Registers a type and its dependencies into the registry.
+///
+/// This helper ensures that a type `T` (which implements `ToSchema`) and all its
+/// nested types are added to the registry's component section. It returns the
+/// component name, which can be used to reference the schema in operations.
 pub fn ensure_schema<T: utoipa::ToSchema + utoipa::PartialSchema + 'static>(
     registry: &dyn OpenApiRegistry,
 ) -> String {
@@ -79,7 +96,12 @@ pub fn ensure_schema<T: utoipa::ToSchema + utoipa::PartialSchema + 'static>(
     registry.ensure_schema_raw(&root_name, collected)
 }
 
-/// Implementation of OpenAPI registry with lock-free data structures
+/// Thread-safe implementation of the OpenAPI registry.
+///
+/// Uses `DashMap` for concurrent operation registration and `ArcSwap` for
+/// lock-free schema reads, making it suitable for use in a multi-threaded
+/// web server environment where operations might be registered during startup
+/// or dynamically.
 pub struct OpenApiRegistryImpl {
     /// Store operation specs keyed by "METHOD:path"
     pub operation_specs: DashMap<String, operation_builder::OperationSpec>,
@@ -96,7 +118,14 @@ impl OpenApiRegistryImpl {
         }
     }
 
-    /// Build OpenAPI specification from registered operations and components
+    /// Generates the complete OpenAPI specification.
+    ///
+    /// Aggregates all registered operations and schemas into a `utoipa::openapi::OpenApi` object.
+    /// This includes:
+    /// - Converting internal operation specs to OpenAPI paths and operations.
+    /// - Mapping parameters, request bodies, and responses.
+    /// - collecting all referenced schemas into the `components` section.
+    /// - Applying global metadata (title, version, etc.).
     ///
     /// # Arguments
     /// * `info` - OpenAPI document metadata (title, version, description)
@@ -384,8 +413,42 @@ impl OpenApiRegistry for OpenApiRegistryImpl {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use crate::api::operation_builder::{OperationSpec, ParamLocation, ParamSpec, ResponseSpec};
+    use crate::api::operation_builder::{
+        OperationSpec, ParamLocation, ParamSpec, RateLimitSpec, ResponseSpec,
+    };
     use http::Method;
+
+    // Helper function to create a minimal operation spec for testing
+    fn minimal_op(path: &str, handler_id: &str) -> OperationSpec {
+        OperationSpec {
+            method: Method::GET,
+            path: path.to_string(),
+            operation_id: Some(handler_id.to_string()),
+            summary: None,
+            description: None,
+            tags: vec![],
+            params: vec![],
+            request_body: None,
+            responses: vec![ResponseSpec {
+                status: 200,
+                content_type: "application/json",
+                description: "Success".to_string(),
+                schema_name: None,
+            }],
+            handler_id: handler_id.to_string(),
+            sec_requirement: None,
+            is_public: false,
+            rate_limit: None,
+            allowed_request_content_types: None,
+        }
+    }
+
+    // Test schema struct for schema linking tests
+    #[derive(utoipa::ToSchema, serde::Serialize)]
+    struct TestModel {
+        id: i32,
+        name: String,
+    }
 
     #[test]
     fn test_registry_creation() {
@@ -562,5 +625,472 @@ mod tests {
 
         // Verify required flag
         assert_eq!(request_body.get("required").unwrap(), true);
+    }
+
+    #[test]
+    fn operation_references_registered_schema() {
+        let registry = OpenApiRegistryImpl::new();
+
+        // Register schema
+        ensure_schema::<TestModel>(&registry);
+
+        // Register operation that references the schema
+        let mut op = minimal_op("/model", "get_model");
+        op.responses[0].schema_name = Some("TestModel".to_string());
+        registry.register_operation(&op);
+
+        // Build and verify
+        let doc = registry.build_openapi(&OpenApiInfo::default()).unwrap();
+        let json = serde_json::to_value(&doc).unwrap();
+
+        // Verify schema exists in components
+        assert!(
+            json.pointer("/components/schemas/TestModel").is_some(),
+            "Schema should be registered in components"
+        );
+
+        // Verify operation references the schema
+        let ref_path =
+            json.pointer("/paths/~1model/get/responses/200/content/application~1json/schema/$ref");
+        assert!(ref_path.is_some(), "Operation should reference schema");
+        assert_eq!(
+            ref_path.unwrap().as_str().unwrap(),
+            "#/components/schemas/TestModel",
+            "Reference should point to correct schema"
+        );
+    }
+
+    #[test]
+    fn security_requirement_generates_bearer_auth_scheme() {
+        let registry = OpenApiRegistryImpl::new();
+
+        // Register operation with security requirement
+        let mut op = minimal_op("/secure", "secure_op");
+        op.sec_requirement = Some(crate::api::operation_builder::OperationSecRequirement {
+            resource: "test".to_string(),
+            action: "read".to_string(),
+        });
+        registry.register_operation(&op);
+
+        let doc = registry.build_openapi(&OpenApiInfo::default()).unwrap();
+        let json = serde_json::to_value(&doc).unwrap();
+
+        // Verify security scheme is defined in components
+        let security_scheme = json.pointer("/components/securitySchemes/bearerAuth");
+        assert!(
+            security_scheme.is_some(),
+            "Bearer auth security scheme should be defined"
+        );
+
+        // Verify scheme type
+        let scheme_type = json.pointer("/components/securitySchemes/bearerAuth/type");
+        assert_eq!(
+            scheme_type.unwrap().as_str().unwrap(),
+            "http",
+            "Security scheme should be http type"
+        );
+
+        // Verify operation has security requirement
+        let operation_security = json.pointer("/paths/~1secure/get/security");
+        assert!(
+            operation_security.is_some(),
+            "Operation should have security requirement"
+        );
+
+        // Verify bearerAuth is in the security array
+        let security_array = operation_security.unwrap().as_array().unwrap();
+        assert!(
+            !security_array.is_empty(),
+            "Security array should not be empty"
+        );
+        assert!(
+            security_array[0].get("bearerAuth").is_some(),
+            "Security should reference bearerAuth"
+        );
+    }
+
+    #[test]
+    fn rate_limit_metadata_generates_vendor_extensions() {
+        let registry = OpenApiRegistryImpl::new();
+
+        // Register operation with rate limit
+        let mut op = minimal_op("/limited", "limited_op");
+        op.rate_limit = Some(RateLimitSpec {
+            rps: 10,
+            burst: 20,
+            in_flight: 5,
+        });
+        registry.register_operation(&op);
+
+        let doc = registry.build_openapi(&OpenApiInfo::default()).unwrap();
+        let json = serde_json::to_value(&doc).unwrap();
+
+        // Verify vendor extensions are present
+        let operation = json.pointer("/paths/~1limited/get").unwrap();
+
+        assert_eq!(
+            operation.get("x-rate-limit-rps").unwrap().as_u64().unwrap(),
+            10,
+            "Rate limit RPS should be in extensions"
+        );
+        assert_eq!(
+            operation
+                .get("x-rate-limit-burst")
+                .unwrap()
+                .as_u64()
+                .unwrap(),
+            20,
+            "Rate limit burst should be in extensions"
+        );
+        assert_eq!(
+            operation
+                .get("x-in-flight-limit")
+                .unwrap()
+                .as_u64()
+                .unwrap(),
+            5,
+            "In-flight limit should be in extensions"
+        );
+    }
+
+    #[test]
+    fn schema_conflict_uses_latest_version() {
+        let registry = OpenApiRegistryImpl::new();
+
+        // Register first version of schema
+        let schema_v1 = Schema::Object(
+            ObjectBuilder::new()
+                .schema_type(SchemaType::Type(utoipa::openapi::schema::Type::String))
+                .build(),
+        );
+        registry.ensure_schema_raw(
+            "ConflictSchema",
+            vec![("ConflictSchema".into(), RefOr::T(schema_v1))],
+        );
+
+        // Register second version (different schema)
+        let schema_v2 = Schema::Object(
+            ObjectBuilder::new()
+                .schema_type(SchemaType::Type(utoipa::openapi::schema::Type::Integer))
+                .build(),
+        );
+        registry.ensure_schema_raw(
+            "ConflictSchema",
+            vec![("ConflictSchema".into(), RefOr::T(schema_v2))],
+        );
+
+        // Verify the latest version is stored
+        let stored = registry.components_registry.load();
+        let final_schema = stored.get("ConflictSchema").unwrap();
+
+        let json = serde_json::to_value(final_schema).unwrap();
+        assert_eq!(
+            json.get("type").unwrap().as_str().unwrap(),
+            "integer",
+            "Schema should be updated to latest version (integer)"
+        );
+    }
+
+    #[test]
+    fn schema_identical_registration_skips_duplicate() {
+        let registry = OpenApiRegistryImpl::new();
+
+        // Register schema twice with identical content
+        let schema = Schema::Object(
+            ObjectBuilder::new()
+                .schema_type(SchemaType::Type(utoipa::openapi::schema::Type::String))
+                .build(),
+        );
+
+        registry.ensure_schema_raw(
+            "IdenticalSchema",
+            vec![("IdenticalSchema".into(), RefOr::T(schema.clone()))],
+        );
+        registry.ensure_schema_raw(
+            "IdenticalSchema",
+            vec![("IdenticalSchema".into(), RefOr::T(schema))],
+        );
+
+        // Verify only one entry exists
+        let stored = registry.components_registry.load();
+        assert_eq!(stored.len(), 1, "Should only have one schema entry");
+        assert!(
+            stored.contains_key("IdenticalSchema"),
+            "Schema should be present"
+        );
+    }
+
+    #[test]
+    fn multiple_operations_with_different_methods_on_same_path() {
+        let registry = OpenApiRegistryImpl::new();
+
+        // Register GET operation
+        let get_op = minimal_op("/resource", "get_resource");
+        registry.register_operation(&get_op);
+
+        // Register POST operation on same path
+        let mut post_op = minimal_op("/resource", "create_resource");
+        post_op.method = Method::POST;
+        registry.register_operation(&post_op);
+
+        let doc = registry.build_openapi(&OpenApiInfo::default()).unwrap();
+        let json = serde_json::to_value(&doc).unwrap();
+
+        // Verify both operations exist on the same path
+        let path = json.pointer("/paths/~1resource").unwrap();
+        assert!(path.get("get").is_some(), "GET operation should exist");
+        assert!(path.get("post").is_some(), "POST operation should exist");
+
+        // Verify operation IDs are correct
+        assert_eq!(
+            path.get("get")
+                .unwrap()
+                .get("operationId")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "get_resource"
+        );
+        assert_eq!(
+            path.get("post")
+                .unwrap()
+                .get("operationId")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "create_resource"
+        );
+    }
+
+    #[test]
+    fn axum_path_conversion_to_openapi_format() {
+        let registry = OpenApiRegistryImpl::new();
+
+        // Register operation with Axum-style wildcard path parameter
+        let op = minimal_op("/static/{*file_path}", "get_static");
+        registry.register_operation(&op);
+
+        let doc = registry.build_openapi(&OpenApiInfo::default()).unwrap();
+        let json = serde_json::to_value(&doc).unwrap();
+
+        // Verify wildcard path is normalized to OpenAPI format
+        assert!(
+            json.pointer("/paths/~1static~1{file_path}").is_some(),
+            "Wildcard paths should drop the * when converted to OpenAPI"
+        );
+    }
+
+    #[test]
+    fn request_body_multipart_file_generates_proper_schema() {
+        use crate::api::operation_builder::RequestBodySchema;
+
+        let registry = OpenApiRegistryImpl::new();
+        let mut op = minimal_op("/upload", "upload_handler");
+        op.method = Method::POST;
+        op.request_body = Some(crate::api::operation_builder::RequestBodySpec {
+            content_type: "multipart/form-data",
+            description: Some("File upload".to_string()),
+            schema: RequestBodySchema::MultipartFile {
+                field_name: "document".to_string(),
+            },
+            required: true,
+        });
+
+        registry.register_operation(&op);
+        let doc = registry.build_openapi(&OpenApiInfo::default()).unwrap();
+        let json = serde_json::to_value(&doc).unwrap();
+
+        // Verify multipart/form-data content type
+        let content = json
+            .pointer("/paths/~1upload/post/requestBody/content/multipart~1form-data")
+            .expect("Multipart content should exist");
+
+        // Verify schema structure
+        let schema = content.get("schema").unwrap();
+        assert_eq!(
+            schema.get("type").unwrap().as_str().unwrap(),
+            "object",
+            "Multipart schema should be object type"
+        );
+
+        // Verify field is present
+        let properties = schema.get("properties").unwrap();
+        assert!(
+            properties.get("document").is_some(),
+            "Field 'document' should be in properties"
+        );
+
+        // Verify field is binary
+        let field_schema = properties.get("document").unwrap();
+        assert_eq!(
+            field_schema.get("type").unwrap().as_str().unwrap(),
+            "string"
+        );
+        assert_eq!(
+            field_schema.get("format").unwrap().as_str().unwrap(),
+            "binary"
+        );
+
+        // Verify required array
+        let required = schema.get("required").unwrap().as_array().unwrap();
+        assert!(required.contains(&serde_json::json!("document")));
+    }
+
+    #[test]
+    fn request_body_inline_object_generates_empty_schema() {
+        use crate::api::operation_builder::RequestBodySchema;
+
+        let registry = OpenApiRegistryImpl::new();
+        let mut op = minimal_op("/dynamic", "dynamic_handler");
+        op.method = Method::POST;
+        op.request_body = Some(crate::api::operation_builder::RequestBodySpec {
+            content_type: "application/json",
+            description: Some("Dynamic object".to_string()),
+            schema: RequestBodySchema::InlineObject,
+            required: false,
+        });
+
+        registry.register_operation(&op);
+        let doc = registry.build_openapi(&OpenApiInfo::default()).unwrap();
+        let json = serde_json::to_value(&doc).unwrap();
+
+        // Verify inline object generates empty object schema
+        let schema = json
+            .pointer("/paths/~1dynamic/post/requestBody/content/application~1json/schema")
+            .expect("Request body schema should exist");
+
+        assert_eq!(
+            schema.get("type").unwrap().as_str().unwrap(),
+            "object",
+            "Inline object should be object type"
+        );
+    }
+
+    #[test]
+    fn response_with_non_json_content_type() {
+        let registry = OpenApiRegistryImpl::new();
+        let mut op = minimal_op("/download", "download_file");
+        op.responses = vec![ResponseSpec {
+            status: 200,
+            content_type: "application/pdf",
+            description: "PDF document".to_string(),
+            schema_name: None,
+        }];
+
+        registry.register_operation(&op);
+        let doc = registry.build_openapi(&OpenApiInfo::default()).unwrap();
+        let json = serde_json::to_value(&doc).unwrap();
+
+        // Verify non-JSON response uses string type with custom format
+        let response = json
+            .pointer("/paths/~1download/get/responses/200")
+            .expect("Response should exist");
+
+        let content = response
+            .get("content")
+            .unwrap()
+            .get("application/pdf")
+            .expect("PDF content type should exist");
+
+        let schema = content.get("schema").unwrap();
+        assert_eq!(schema.get("type").unwrap().as_str().unwrap(), "string");
+        assert_eq!(
+            schema.get("format").unwrap().as_str().unwrap(),
+            "application/pdf"
+        );
+    }
+
+    #[test]
+    fn response_without_schema_generates_empty_object() {
+        let registry = OpenApiRegistryImpl::new();
+        let mut op = minimal_op("/status", "get_status");
+        op.responses = vec![ResponseSpec {
+            status: 200,
+            content_type: "application/json",
+            description: "Status response".to_string(),
+            schema_name: None,
+        }];
+
+        registry.register_operation(&op);
+        let doc = registry.build_openapi(&OpenApiInfo::default()).unwrap();
+        let json = serde_json::to_value(&doc).unwrap();
+
+        // Verify response without schema_name generates empty object
+        let schema = json
+            .pointer("/paths/~1status/get/responses/200/content/application~1json/schema")
+            .expect("Response schema should exist");
+
+        assert_eq!(
+            schema.get("type").unwrap().as_str().unwrap(),
+            "object",
+            "Default schema should be empty object"
+        );
+    }
+
+    #[test]
+    fn http_methods_put_delete_patch_are_supported() {
+        let registry = OpenApiRegistryImpl::new();
+
+        // PUT
+        let mut put_op = minimal_op("/item", "update_item");
+        put_op.method = Method::PUT;
+        registry.register_operation(&put_op);
+
+        // DELETE
+        let mut delete_op = minimal_op("/item", "delete_item");
+        delete_op.method = Method::DELETE;
+        registry.register_operation(&delete_op);
+
+        // PATCH
+        let mut patch_op = minimal_op("/item", "patch_item");
+        patch_op.method = Method::PATCH;
+        registry.register_operation(&patch_op);
+
+        let doc = registry.build_openapi(&OpenApiInfo::default()).unwrap();
+        let json = serde_json::to_value(&doc).unwrap();
+
+        let path = json.pointer("/paths/~1item").expect("Path should exist");
+
+        assert!(
+            path.get("put").is_some(),
+            "PUT operation should be registered"
+        );
+        assert!(
+            path.get("delete").is_some(),
+            "DELETE operation should be registered"
+        );
+        assert!(
+            path.get("patch").is_some(),
+            "PATCH operation should be registered"
+        );
+
+        // Verify operation IDs
+        assert_eq!(
+            path.get("put")
+                .unwrap()
+                .get("operationId")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "update_item"
+        );
+        assert_eq!(
+            path.get("delete")
+                .unwrap()
+                .get("operationId")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "delete_item"
+        );
+        assert_eq!(
+            path.get("patch")
+                .unwrap()
+                .get("operationId")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "patch_item"
+        );
     }
 }

--- a/libs/modkit/src/api/openapi_registry.rs
+++ b/libs/modkit/src/api/openapi_registry.rs
@@ -381,6 +381,7 @@ impl OpenApiRegistry for OpenApiRegistryImpl {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use crate::api::operation_builder::{OperationSpec, ParamLocation, ParamSpec, ResponseSpec};

--- a/libs/modkit/src/api/operation_builder.rs
+++ b/libs/modkit/src/api/operation_builder.rs
@@ -1231,6 +1231,7 @@ where
 // Tests
 // -------------------------------------------------------------------------------------------------
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use axum::Json;

--- a/libs/modkit/src/api/problem.rs
+++ b/libs/modkit/src/api/problem.rs
@@ -29,6 +29,7 @@ pub fn internal_error(detail: impl Into<String>) -> Problem {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use axum::response::IntoResponse;

--- a/libs/modkit/src/api/trace_layer.rs
+++ b/libs/modkit/src/api/trace_layer.rs
@@ -57,6 +57,7 @@ impl WithRequestContext for Problem {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit/src/client_hub.rs
+++ b/libs/modkit/src/client_hub.rs
@@ -180,6 +180,7 @@ impl ClientHub {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit/src/config.rs
+++ b/libs/modkit/src/config.rs
@@ -116,6 +116,7 @@ pub fn module_config_required<T: DeserializeOwned>(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use serde::Deserialize;

--- a/libs/modkit/src/context.rs
+++ b/libs/modkit/src/context.rs
@@ -7,6 +7,48 @@ use crate::config::{module_config_or_default, ConfigError, ConfigProvider};
 
 // Note: runtime-dependent features are conditionally compiled
 
+/// Module execution context - the primary interface for modules to access runtime resources.
+///
+/// This context is passed to all module lifecycle methods (`init`, `register_rest`, etc.)
+/// and provides access to:
+/// - **Configuration**: Type-safe config loading via `config()`
+/// - **Database**: Per-module DB handle via `db_required()` or `db_optional()`
+/// - **Service Discovery**: ClientHub for registering/consuming other modules' APIs
+/// - **Lifecycle**: Cancellation token for graceful shutdown coordination
+///
+/// # Lifecycle Flows
+///
+/// ## Flow A: Module Initialization (`Module::init`)
+/// ```ignore
+/// async fn init(&self, ctx: &ModuleCtx) -> Result<()> {
+///     // 1. Load typed configuration
+///     let cfg: MyConfig = ctx.config()?;
+///     
+///     // 2. Get database handle (fails if not configured)
+///     let db = ctx.db_required()?;
+///     
+///     // 3. Register public API for other modules
+///     ctx.client_hub().register(Arc::new(MyService::new(db)));
+///     
+///     // 4. Consume other modules' APIs
+///     let other = ctx.client_hub().get::<dyn OtherApi>()?;
+///     Ok(())
+/// }
+/// ```
+///
+/// ## Flow B: Background Tasks (`StatefulModule::start`)
+/// ```ignore
+/// async fn start(&self, cancel: CancellationToken) -> Result<()> {
+///     // Use cancellation token from init to coordinate shutdown
+///     tokio::select! {
+///         _ = self.background_task() => {},
+///         _ = cancel.cancelled() => {
+///             // Clean shutdown
+///         }
+///     }
+///     Ok(())
+/// }
+/// ```
 #[derive(Clone)]
 pub struct ModuleCtx {
     module_name: Arc<str>,
@@ -16,10 +58,24 @@ pub struct ModuleCtx {
     db_handle: Option<Arc<modkit_db::DbHandle>>,
 }
 
-/// Builder for creating module-scoped contexts with resolved database handles.
+/// Factory for creating per-module execution contexts.
 ///
-/// This builder internally uses DbManager to resolve per-module DbHandle instances
-/// at build time, ensuring ModuleCtx contains only the final, ready-to-use handle.
+/// **Internal use only** - created by `HostRuntime` during startup with global singletons.
+///
+/// # Responsibility
+/// Resolves module-specific resources (especially DB handles) at context creation time,
+/// ensuring each `ModuleCtx` contains only ready-to-use resources without exposing the
+/// underlying `DbManager` to modules.
+///
+/// # Usage Pattern
+/// ```ignore
+/// // Runtime creates builder once at startup
+/// let builder = ModuleContextBuilder::new(config, client_hub, cancel, db_manager);
+///
+/// // Before each lifecycle phase, resolve context for that module
+/// let ctx = builder.for_module("users_info").await?;
+/// module.init(&ctx).await?;
+/// ```
 pub struct ModuleContextBuilder {
     config_provider: Arc<dyn ConfigProvider>,
     client_hub: Arc<crate::client_hub::ClientHub>,
@@ -42,7 +98,10 @@ impl ModuleContextBuilder {
         }
     }
 
-    /// Build a module-scoped context, resolving the DbHandle for the given module.
+    /// Resolve a module-scoped context with DB handle (if configured).
+    ///
+    /// Queries `DbManager` for this module's database configuration and creates
+    /// a ready-to-use `ModuleCtx`. If the module has no DB config, `db_optional()` returns `None`.
     pub async fn for_module(&self, module_name: &str) -> anyhow::Result<ModuleCtx> {
         let db_handle = if let Some(mgr) = &self.db_manager {
             mgr.get(module_name).await?
@@ -90,20 +149,50 @@ impl ModuleCtx {
         &*self.config_provider
     }
 
+    /// Access the service registry for inter-module communication.
+    ///
+    /// **Register** your module's public API during `init()` so other modules can discover it:
+    /// ```ignore
+    /// ctx.client_hub().register(Arc::new(MyApiImpl));
+    /// ```
+    ///
+    /// **Consume** other modules' APIs:
+    /// ```ignore
+    /// let other_api = ctx.client_hub().get::<dyn OtherModuleApi>()?;
+    /// ```
     #[inline]
     pub fn client_hub(&self) -> &crate::client_hub::ClientHub {
         &self.client_hub
     }
 
+    /// Get the cancellation token for graceful shutdown coordination.
+    ///
+    /// Store this during `init()` and use it in `StatefulModule::start()` to detect when
+    /// the runtime is shutting down:
+    /// ```ignore
+    /// tokio::select! {
+    ///     _ = my_loop() => {},
+    ///     _ = cancel.cancelled() => { /* cleanup */ }
+    /// }
+    /// ```
     #[inline]
     pub fn cancellation_token(&self) -> &CancellationToken {
         &self.cancellation_token
     }
 
+    /// Get database handle if configured for this module.
+    ///
+    /// Returns `None` if:
+    /// - Module has no `database` section in config
+    /// - Runtime was started with `DbOptions::None`
     pub fn db_optional(&self) -> Option<Arc<modkit_db::DbHandle>> {
         self.db_handle.clone()
     }
 
+    /// Get database handle or fail if not configured.
+    ///
+    /// Use this in modules that declare `capabilities = [db]` and cannot function without a database.
+    /// Returns error if module has no `database` config section or runtime has `DbOptions::None`.
     pub fn db_required(&self) -> anyhow::Result<Arc<modkit_db::DbHandle>> {
         self.db_handle.clone().ok_or_else(|| {
             anyhow::anyhow!(
@@ -141,7 +230,11 @@ impl ModuleCtx {
     }
 
     /// Get the raw JSON value of the module's config section.
-    /// Returns the 'config' field from: modules.<name> = { database: ..., config: ... }
+    ///
+    /// Use this when you need dynamic config inspection or when `config::<T>()` deserialization
+    /// is not suitable. Prefer the typed `config()` method for normal use cases.
+    ///
+    /// Returns the 'config' field from: `modules.<name> = { database: ..., config: ... }`
     pub fn raw_config(&self) -> &serde_json::Value {
         use std::sync::LazyLock;
 
@@ -159,8 +252,10 @@ impl ModuleCtx {
         &EMPTY
     }
 
-    /// Create a derivative context with the same references but a different DB handle.
-    /// This allows reusing the stable base context while providing per-module DB access.
+    /// Create a derivative context with a different DB handle.
+    ///
+    /// Useful for testing or when a module needs to access another module's database.
+    /// All other references (config, client_hub, cancellation) are shallow-cloned.
     pub fn with_db(&self, db: Arc<modkit_db::DbHandle>) -> ModuleCtx {
         ModuleCtx {
             module_name: self.module_name.clone(),
@@ -171,8 +266,9 @@ impl ModuleCtx {
         }
     }
 
-    /// Create a derivative context with the same references but no DB handle.
-    /// Useful for modules that don't require database access.
+    /// Create a derivative context without a DB handle.
+    ///
+    /// Primarily used in testing scenarios where database access should be explicitly unavailable.
     pub fn without_db(&self) -> ModuleCtx {
         ModuleCtx {
             module_name: self.module_name.clone(),
@@ -236,7 +332,7 @@ mod tests {
     }
 
     #[test]
-    fn test_module_ctx_config_with_valid_config() {
+    fn module_ctx_config_with_valid_config() {
         let provider = Arc::new(MockConfigProvider::new());
         let ctx = ModuleCtx::new(
             "test_module",
@@ -256,7 +352,7 @@ mod tests {
     }
 
     #[test]
-    fn test_module_ctx_config_returns_default_for_missing_module() {
+    fn module_ctx_config_returns_default_for_missing_module() {
         let provider = Arc::new(MockConfigProvider::new());
         let ctx = ModuleCtx::new(
             "nonexistent_module",
@@ -271,5 +367,346 @@ mod tests {
 
         let config = result.unwrap();
         assert_eq!(config, TestConfig::default());
+    }
+
+    // Database Access Flows
+
+    #[test]
+    fn db_required_returns_handle_when_present() {
+        // Create a minimal mock DB handle - we just need the type, not a real connection
+        let db_manager = create_mock_db_manager();
+        let provider = Arc::new(MockConfigProvider::new());
+        let ctx = ModuleCtx::new(
+            "test_module",
+            provider,
+            Arc::new(crate::client_hub::ClientHub::default()),
+            CancellationToken::new(),
+            Some(db_manager.clone()),
+        );
+
+        let result = ctx.db_required();
+        assert!(
+            result.is_ok(),
+            "db_required should succeed when DB is present"
+        );
+        assert!(Arc::ptr_eq(&result.unwrap(), &db_manager));
+    }
+
+    #[test]
+    fn db_required_fails_when_missing() {
+        let ctx = ModuleCtx::new(
+            "no_db_module",
+            Arc::new(MockConfigProvider::new()),
+            Arc::new(crate::client_hub::ClientHub::default()),
+            CancellationToken::new(),
+            None,
+        );
+
+        let err = ctx.db_required().unwrap_err();
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains("Database is not configured"),
+            "Error should mention database is not configured, got: {err_msg}"
+        );
+        assert!(
+            err_msg.contains("no_db_module"),
+            "Error should mention module name, got: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn db_optional_returns_some_when_present() {
+        let db_manager = create_mock_db_manager();
+        let ctx = ModuleCtx::new(
+            "test_module",
+            Arc::new(MockConfigProvider::new()),
+            Arc::new(crate::client_hub::ClientHub::default()),
+            CancellationToken::new(),
+            Some(db_manager.clone()),
+        );
+
+        let result = ctx.db_optional();
+        assert!(
+            result.is_some(),
+            "db_optional should return Some when DB is present"
+        );
+        // Verify it's the same Arc instance
+        assert!(Arc::ptr_eq(&result.unwrap(), &db_manager));
+    }
+
+    #[test]
+    fn db_optional_returns_none_when_missing() {
+        let ctx = ModuleCtx::new(
+            "test_module",
+            Arc::new(MockConfigProvider::new()),
+            Arc::new(crate::client_hub::ClientHub::default()),
+            CancellationToken::new(),
+            None,
+        );
+
+        let result = ctx.db_optional();
+        assert!(
+            result.is_none(),
+            "db_optional should return None when DB is absent"
+        );
+    }
+
+    // Derivative Context Flows
+
+    #[test]
+    fn with_db_creates_new_context_with_db() {
+        let original_ctx = ModuleCtx::new(
+            "test_module",
+            Arc::new(MockConfigProvider::new()),
+            Arc::new(crate::client_hub::ClientHub::default()),
+            CancellationToken::new(),
+            None,
+        );
+
+        assert!(
+            original_ctx.db_optional().is_none(),
+            "Original should not have DB"
+        );
+
+        let new_db = create_mock_db_manager();
+        let new_ctx = original_ctx.with_db(new_db.clone());
+
+        // New context should have the DB
+        assert!(
+            new_ctx.db_optional().is_some(),
+            "New context should have DB"
+        );
+        assert!(Arc::ptr_eq(&new_ctx.db_optional().unwrap(), &new_db));
+
+        // Original should be unchanged (immutability)
+        assert!(
+            original_ctx.db_optional().is_none(),
+            "Original context should remain unchanged"
+        );
+
+        // Verify other fields are preserved
+        assert_eq!(new_ctx.module_name(), original_ctx.module_name());
+    }
+
+    #[test]
+    fn without_db_removes_db_handle() {
+        let db_manager = create_mock_db_manager();
+        let original_ctx = ModuleCtx::new(
+            "test_module",
+            Arc::new(MockConfigProvider::new()),
+            Arc::new(crate::client_hub::ClientHub::default()),
+            CancellationToken::new(),
+            Some(db_manager),
+        );
+
+        assert!(
+            original_ctx.db_optional().is_some(),
+            "Original should have DB"
+        );
+
+        let new_ctx = original_ctx.without_db();
+
+        // New context should not have DB
+        assert!(
+            new_ctx.db_optional().is_none(),
+            "New context should not have DB"
+        );
+
+        // Original should be unchanged (immutability)
+        assert!(
+            original_ctx.db_optional().is_some(),
+            "Original context should remain unchanged"
+        );
+
+        // Verify other fields are preserved
+        assert_eq!(new_ctx.module_name(), original_ctx.module_name());
+    }
+
+    // Context Accessors
+
+    #[test]
+    fn module_name_accessor() {
+        let ctx = ModuleCtx::new(
+            "my_test_module",
+            Arc::new(MockConfigProvider::new()),
+            Arc::new(crate::client_hub::ClientHub::default()),
+            CancellationToken::new(),
+            None,
+        );
+
+        assert_eq!(ctx.module_name(), "my_test_module");
+    }
+
+    #[test]
+    fn client_hub_returns_correct_instance() {
+        let hub = Arc::new(crate::client_hub::ClientHub::default());
+        let hub_ptr = Arc::as_ptr(&hub);
+
+        let ctx = ModuleCtx::new(
+            "test_module",
+            Arc::new(MockConfigProvider::new()),
+            hub.clone(),
+            CancellationToken::new(),
+            None,
+        );
+
+        // Verify we get the same ClientHub instance back
+        let returned_hub = ctx.client_hub();
+        assert_eq!(returned_hub as *const _ as *const (), hub_ptr as *const ());
+    }
+
+    #[test]
+    fn cancellation_token_propagation() {
+        let token = CancellationToken::new();
+        let ctx = ModuleCtx::new(
+            "test_module",
+            Arc::new(MockConfigProvider::new()),
+            Arc::new(crate::client_hub::ClientHub::default()),
+            token.clone(),
+            None,
+        );
+
+        let ctx_token = ctx.cancellation_token();
+        assert!(
+            !ctx_token.is_cancelled(),
+            "Token should not be cancelled initially"
+        );
+
+        // Cancel the original token
+        token.cancel();
+
+        // Context's token should also be cancelled
+        assert!(
+            ctx_token.is_cancelled(),
+            "Context token should be cancelled when original is cancelled"
+        );
+    }
+
+    #[test]
+    fn current_module_returns_module_name() {
+        let ctx = ModuleCtx::new(
+            "test_module",
+            Arc::new(MockConfigProvider::new()),
+            Arc::new(crate::client_hub::ClientHub::default()),
+            CancellationToken::new(),
+            None,
+        );
+
+        assert_eq!(ctx.current_module(), Some("test_module"));
+    }
+
+    // ModuleContextBuilder flows
+
+    #[test]
+    fn context_builder_without_db_manager_disables_db_access() {
+        let config_provider: Arc<dyn ConfigProvider> = Arc::new(MockConfigProvider::new());
+        let client_hub = Arc::new(crate::client_hub::ClientHub::default());
+        let builder =
+            ModuleContextBuilder::new(config_provider, client_hub, CancellationToken::new(), None);
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let ctx = rt.block_on(async { builder.for_module("test_module").await.unwrap() });
+
+        assert!(ctx.db_optional().is_none());
+    }
+
+    #[test]
+    fn context_builder_with_db_manager_resolves_db_handle() {
+        let config_provider: Arc<dyn ConfigProvider> = Arc::new(MockConfigProvider::new());
+        let client_hub = Arc::new(crate::client_hub::ClientHub::default());
+        let db_manager = create_test_db_manager();
+
+        let builder = ModuleContextBuilder::new(
+            config_provider,
+            client_hub,
+            CancellationToken::new(),
+            Some(db_manager),
+        );
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let ctx = rt.block_on(async { builder.for_module("test_module").await.unwrap() });
+
+        let db = ctx
+            .db_required()
+            .expect("Builder should attach DB handle when manager exists");
+        assert_eq!(db.engine(), modkit_db::DbEngine::Sqlite);
+        // DSN might be normalized (e.g. "sqlite://:memory:" vs "sqlite::memory:"), so we check key components
+        assert_eq!(db.dsn(), "sqlite://:memory:");
+    }
+
+    // Raw Config Access
+
+    #[test]
+    fn raw_config_returns_config_section() {
+        let provider = Arc::new(MockConfigProvider::new());
+        let ctx = ModuleCtx::new(
+            "test_module",
+            provider,
+            Arc::new(crate::client_hub::ClientHub::default()),
+            CancellationToken::new(),
+            None,
+        );
+
+        let raw = ctx.raw_config();
+        assert!(raw.is_object(), "raw_config should return an object");
+        assert_eq!(raw["api_key"], "secret123");
+        assert_eq!(raw["timeout_ms"], 5000);
+    }
+
+    #[test]
+    fn raw_config_returns_empty_for_missing_module() {
+        let ctx = ModuleCtx::new(
+            "nonexistent",
+            Arc::new(MockConfigProvider::new()),
+            Arc::new(crate::client_hub::ClientHub::default()),
+            CancellationToken::new(),
+            None,
+        );
+
+        let raw = ctx.raw_config();
+        assert!(raw.is_object(), "raw_config should return an empty object");
+        assert_eq!(raw.as_object().unwrap().len(), 0);
+    }
+
+    // Helper function to create a mock DB handle for testing
+    fn create_mock_db_manager() -> Arc<modkit_db::DbHandle> {
+        use figment::{providers::Serialized, Figment};
+
+        let figment = Figment::new().merge(Serialized::defaults(json!({
+            "modules": {
+                "test_module": {
+                    "database": {
+                        "dsn": "sqlite::memory:",
+                        "params": {
+                            "journal_mode": "WAL"
+                        }
+                    }
+                }
+            }
+        })));
+
+        let home_dir = std::path::PathBuf::from("/tmp/test");
+        let manager = modkit_db::DbManager::from_figment(figment, home_dir).unwrap();
+
+        // Create a simple blocking runtime for test
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async { manager.get("test_module").await.unwrap().unwrap() })
+    }
+
+    fn create_test_db_manager() -> Arc<modkit_db::DbManager> {
+        use figment::{providers::Serialized, Figment};
+
+        let figment = Figment::new().merge(Serialized::defaults(json!({
+            "modules": {
+                "test_module": {
+                    "database": {
+                        "dsn": "sqlite::memory:"
+                    }
+                }
+            }
+        })));
+
+        let home_dir = std::path::PathBuf::from("/tmp/test");
+        Arc::new(modkit_db::DbManager::from_figment(figment, home_dir).unwrap())
     }
 }

--- a/libs/modkit/src/context.rs
+++ b/libs/modkit/src/context.rs
@@ -185,6 +185,7 @@ impl ModuleCtx {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use serde::Deserialize;

--- a/libs/modkit/src/directory.rs
+++ b/libs/modkit/src/directory.rs
@@ -67,6 +67,7 @@ impl DirectoryApi for LocalDirectoryApi {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use crate::runtime::{Endpoint, ModuleInstance, ModuleManager};

--- a/libs/modkit/src/http/client.rs
+++ b/libs/modkit/src/http/client.rs
@@ -105,6 +105,7 @@ impl Default for TracedClient {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use httpmock::prelude::*;

--- a/libs/modkit/src/http/otel.rs
+++ b/libs/modkit/src/http/otel.rs
@@ -131,6 +131,7 @@ mod imp {
 pub use imp::{inject_current_span, set_parent_from_headers};
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use tracing::info_span;

--- a/libs/modkit/src/http/sse.rs
+++ b/libs/modkit/src/http/sse.rs
@@ -141,6 +141,7 @@ impl<T: Clone + Send + 'static> SseBroadcaster<T> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use futures::StreamExt;

--- a/libs/modkit/src/lib.rs
+++ b/libs/modkit/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 //! # ModKit - Declarative Module System
 //!
 //! A unified crate for building modular applications with declarative module definitions.
@@ -133,4 +135,5 @@ pub use runtime::{
 };
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests;

--- a/libs/modkit/src/lifecycle.rs
+++ b/libs/modkit/src/lifecycle.rs
@@ -611,6 +611,7 @@ impl<T: Runnable> Drop for WithLifecycle<T> {
 // ----- Tests -----------------------------------------------------------------
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU32, Ordering as AOrd};

--- a/libs/modkit/src/registry.rs
+++ b/libs/modkit/src/registry.rs
@@ -543,6 +543,7 @@ pub enum RegistryError {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use std::sync::Arc;

--- a/libs/modkit/src/result.rs
+++ b/libs/modkit/src/result.rs
@@ -23,6 +23,7 @@ use crate::api::problem::Problem;
 pub type ApiResult<T = ()> = Result<T, Problem>;
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit/src/runtime/backend.rs
+++ b/libs/modkit/src/runtime/backend.rs
@@ -59,6 +59,7 @@ impl std::fmt::Debug for InstanceHandle {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/libs/modkit/src/runtime/backends/local.rs
+++ b/libs/modkit/src/runtime/backends/local.rs
@@ -148,6 +148,7 @@ impl ModuleRuntimeBackend for LocalProcessBackend {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/libs/modkit/src/runtime/host_runtime.rs
+++ b/libs/modkit/src/runtime/host_runtime.rs
@@ -433,6 +433,7 @@ impl HostRuntime {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use crate::context::ModuleCtx;

--- a/libs/modkit/src/runtime/module_manager.rs
+++ b/libs/modkit/src/runtime/module_manager.rs
@@ -381,6 +381,7 @@ impl Default for ModuleManager {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use std::thread::sleep;

--- a/libs/modkit/src/runtime/tests.rs
+++ b/libs/modkit/src/runtime/tests.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(coverage_nightly, coverage(off))]
 //! Tests for runtime lifecycle ready/timeout/cancel scenarios
 
 use crate::lifecycle::{Lifecycle, Status, StopReason};

--- a/libs/modkit/src/telemetry/init.rs
+++ b/libs/modkit/src/telemetry/init.rs
@@ -370,6 +370,7 @@ pub async fn otel_connectivity_probe(_cfg: &serde_json::Value) -> anyhow::Result
 // ===== tests ==================================================================
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use modkit_bootstrap::config::{Exporter, Sampler, TracingConfig};

--- a/libs/modkit/src/tests.rs
+++ b/libs/modkit/src/tests.rs
@@ -1,4 +1,5 @@
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod module_tests {
     use crate::registry::ModuleRegistry;
 

--- a/libs/modkit/tests/macro_tests.rs
+++ b/libs/modkit/tests/macro_tests.rs
@@ -280,23 +280,12 @@ async fn test_full_capabilities() {
     FullFeaturedModule.stop(token).await.unwrap();
 }
 
-#[test]
-fn test_capability_trait_markers() {
-    fn assert_module<T: Module>(_: &T) {}
-    fn assert_db<T: DbModule>(_: &T) {}
-    fn assert_rest<T: RestfulModule>(_: &T) {}
-    fn assert_stateful<T: StatefulModule>(_: &T) {}
+// Compile-time assertions that modules implement the expected traits
+static_assertions::assert_impl_all!(BasicModule: Module);
+static_assertions::assert_impl_all!(DependentModule: Module);
+static_assertions::assert_impl_all!(CustomCtorModule: Module);
 
-    assert_module(&BasicModule);
-    assert_module(&DependentModule);
-    assert_module(&CustomCtorModule::default());
-
-    assert_db(&FullFeaturedModule);
-    assert_db(&DbOnlyModule);
-
-    assert_rest(&FullFeaturedModule);
-    assert_rest(&RestOnlyModule);
-
-    assert_stateful(&FullFeaturedModule);
-    assert_stateful(&StatefulOnlyModule);
-}
+static_assertions::assert_impl_all!(FullFeaturedModule: Module, DbModule, RestfulModule, StatefulModule);
+static_assertions::assert_impl_all!(DbOnlyModule: Module, DbModule);
+static_assertions::assert_impl_all!(RestOnlyModule: Module, RestfulModule);
+static_assertions::assert_impl_all!(StatefulOnlyModule: Module, StatefulModule);

--- a/libs/modkit/tests/typed_builder_compilefail.rs
+++ b/libs/modkit/tests/typed_builder_compilefail.rs
@@ -6,7 +6,6 @@
 //! invalid API operations from compiling.
 
 #[test]
-#[ignore] //TODO: Need to turn it on after fix issue with CR/LF
 fn compile_fail_tests() {
     // On MinGW (windows-gnu), native deps like `ring` may fail to build in trybuild sandboxes.
     // Skip these compile-fail tests in that environment.

--- a/libs/modkit/tests/ui/no_handler.rs
+++ b/libs/modkit/tests/ui/no_handler.rs
@@ -19,6 +19,6 @@ fn main() {
     // This should fail to compile - missing handler
     let _ = OperationBuilder::<_, _, ()>::get("/test")
         .summary("Test endpoint")
-        .json_response(200, "Success")
+        .json_response(http::StatusCode::OK, "Success")
         .register(router, &registry);
 }

--- a/libs/modkit/tests/ui/no_handler.stderr
+++ b/libs/modkit/tests/ui/no_handler.stderr
@@ -1,14 +1,14 @@
-error[E0599]: no method named `register` found for struct `modkit::OperationBuilder<Missing, Present, ()>` in the current scope
+error[E0599]: no method named `register` found for struct `modkit::OperationBuilder<Missing, Present>` in the current scope
   --> tests/ui/no_handler.rs:23:10
    |
 20 |       let _ = OperationBuilder::<_, _, ()>::get("/test")
    |  _____________-
 21 | |         .summary("Test endpoint")
-22 | |         .json_response(200, "Success")
+22 | |         .json_response(http::StatusCode::OK, "Success")
 23 | |         .register(router, &registry);
-   | |         -^^^^^^^^ method not found in `OperationBuilder<Missing, Present, ()>`
+   | |         -^^^^^^^^ method not found in `modkit::OperationBuilder<Missing, Present>`
    | |_________|
    |
    |
    = note: the method was found for
-           - `modkit::OperationBuilder<Present, Present, S>`
+           - `modkit::OperationBuilder<Present, Present, S, AuthSet>`

--- a/libs/modkit/tests/ui/no_handler_no_response.stderr
+++ b/libs/modkit/tests/ui/no_handler_no_response.stderr
@@ -1,4 +1,4 @@
-error[E0599]: no method named `register` found for struct `modkit::OperationBuilder<Missing, Missing, ()>` in the current scope
+error[E0599]: no method named `register` found for struct `modkit::OperationBuilder` in the current scope
   --> tests/ui/no_handler_no_response.rs:23:10
    |
 20 |       let _ = OperationBuilder::<_, _, ()>::get("/test")
@@ -6,9 +6,9 @@ error[E0599]: no method named `register` found for struct `modkit::OperationBuil
 21 | |         .summary("Test endpoint")
 22 | |         .description("A test endpoint")
 23 | |         .register(router, &registry);
-   | |         -^^^^^^^^ method not found in `OperationBuilder<Missing, Missing, ()>`
+   | |         -^^^^^^^^ method not found in `modkit::OperationBuilder`
    | |_________|
    |
    |
    = note: the method was found for
-           - `modkit::OperationBuilder<Present, Present, S>`
+           - `modkit::OperationBuilder<Present, Present, S, AuthSet>`

--- a/libs/modkit/tests/ui/no_response.stderr
+++ b/libs/modkit/tests/ui/no_response.stderr
@@ -1,4 +1,4 @@
-error[E0599]: no method named `register` found for struct `modkit::OperationBuilder<Present, Missing, ()>` in the current scope
+error[E0599]: no method named `register` found for struct `modkit::OperationBuilder<Present>` in the current scope
   --> tests/ui/no_response.rs:25:10
    |
 22 |       let _ = OperationBuilder::<_, _, ()>::get("/test")
@@ -6,9 +6,9 @@ error[E0599]: no method named `register` found for struct `modkit::OperationBuil
 23 | |         .summary("Test endpoint")
 24 | |         .handler(test_handler)
 25 | |         .register(router, &registry);
-   | |         -^^^^^^^^ method not found in `OperationBuilder<Present, Missing, ()>`
+   | |         -^^^^^^^^ method not found in `modkit::OperationBuilder<Present>`
    | |_________|
    |
    |
    = note: the method was found for
-           - `modkit::OperationBuilder<Present, Present, S>`
+           - `modkit::OperationBuilder<Present, Present, S, AuthSet>`


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#73](https://github.com/cyberfabric/cyberware-rust/pull/73) | **Author:** hyphen-2025 | **Opened:** 2025-12-10T21:18:11Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

Default Rust coverage tool includes test code into coverage making coverage metrics not helpful.

Features to exclude mods from coverage are supported only in nightly toolchain.

This is an experimental PR to exclude test code from coverage (only for modkit)

TODO: pin nightly toolchain

```bash
cargo +nightly llvm-cov --package modkit  --features coverage_nightly --html
```
[Baseline coverage report for modkit](https://github.com/user-attachments/files/24088797/coverage-baseline.zip)
```
Function Coverage	 Line Coverage	      Region Coverage
    43.28% (325/751)       39.19% (2557/6524)  40.35% (3642/9027)
    
    Mutation testing results (modkit):
    462 mutants tested in 75m: 155 missed, 144 caught, 162 unviable, 1 timeouts
```

Current state coverage:

```
Function Coverage	Line Coverage	    Region Coverage
     54.73% (411/751).     51.12% (3335/6524)  51.23% (4626/9030)
```

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#73 -->