### PR TITLE
[PR #1927] feat(usage-collector): [5/6] add TimescaleDB production storage plugin

### DIFF
--- a/.cypilot/config/artifacts.toml
+++ b/.cypilot/config/artifacts.toml
@@ -9,6 +9,8 @@ patterns = ["modules/system/resource-group/docs/rust-traits.md"]
 reason = "Ignore usage-collector codebase and features — code traceability markers added incrementally across PR train. Remove after all PRs merged."
 patterns = [
   "modules/system/usage-collector/plugins/noop-usage-collector-plugin/src/*",
+  "modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/*",
+  "modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/tests/*",
   "modules/system/usage-collector/usage-collector/src/*",
   "modules/system/usage-collector/usage-collector/tests/*",
   "modules/system/usage-collector/usage-collector-rest-client/src/*",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3037,6 +3037,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "cyberware-timescaledb-usage-collector-plugin"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "cyberware-modkit",
+ "cyberware-modkit-canonical-errors",
+ "cyberware-modkit-macros",
+ "cyberware-modkit-odata",
+ "cyberware-modkit-security",
+ "cyberware-types-registry-sdk",
+ "cyberware-usage-collector-sdk",
+ "humantime",
+ "opentelemetry",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "testcontainers",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "cyberware-tr-authz-plugin"
 version = "0.1.3"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ members = [
     "modules/mini-chat/mini-chat-sdk",
     "modules/mini-chat/mini-chat",
     "modules/system/usage-collector/plugins/noop-usage-collector-plugin",
+    "modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin",
     "modules/system/usage-collector/usage-collector",
     "modules/system/usage-collector/usage-collector-rest-client",
     "modules/system/usage-collector/usage-collector-sdk",

--- a/modules/system/usage-collector/docs/ADR/0003-cpt-cf-usage-collector-adr-timescaledb-plugin-raw-sqlx.md
+++ b/modules/system/usage-collector/docs/ADR/0003-cpt-cf-usage-collector-adr-timescaledb-plugin-raw-sqlx.md
@@ -1,0 +1,129 @@
+<!-- Updated: 2026-05-19 by Constructor Tech -->
+
+# ADR-0003: Bypass `SecureConn` / `SecureORM` in the TimescaleDB Storage Plugin
+
+
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [Route every access through `SecureConn` / `SecureORM`](#route-every-access-through-secureconn--secureorm)
+  - [Raw `sqlx::PgPool` with a scope-fragment translator as the authorization boundary](#raw-sqlxpgpool-with-a-scope-fragment-translator-as-the-authorization-boundary)
+  - [Wait for a TimescaleDB-aware `SecureORM` extension before shipping the plugin](#wait-for-a-timescaledb-aware-secureorm-extension-before-shipping-the-plugin)
+- [More Information](#more-information)
+  - [Implementation notes](#implementation-notes)
+- [Review Cadence](#review-cadence)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
+**ID**: `cpt-cf-usage-collector-adr-timescaledb-plugin-raw-sqlx`
+
+## Context and Problem Statement
+
+`MODKIT-SEC-001` requires every module's database access to go through `SecureConn` / `SecureORM`, which composes authorization (`AccessScope` predicates) into the underlying SeaORM query and rejects un-scoped reads at the framework boundary. The TimescaleDB production storage plugin cannot satisfy that contract end-to-end: it owns TimescaleDB-specific DDL that has no `SecureORM` equivalent (`CREATE EXTENSION`, `create_hypertable`, `CREATE MATERIALIZED VIEW ... WITH (timescaledb.continuous)`, `add_continuous_aggregate_policy`, `add_retention_policy`), a cross-partition `usage_idempotency_keys` plain table whose dedup semantics rely on a two-step transaction rather than `ON CONFLICT` on the hypertable, and a dynamically-built aggregation / pagination SQL surface in `infra/pg_query_port.rs` that emits positional `$N` binds composed against a translator-generated `WHERE` fragment. None of those paths can be expressed through SeaORM today, so a strict reading of `MODKIT-SEC-001` would block the plugin from ever landing.
+
+## Decision Drivers
+
+* The plugin owns TimescaleDB DDL (`create_hypertable`, continuous aggregates, retention/policy jobs) that `SecureORM` does not model and cannot model without a TimescaleDB-specific extension
+* Authorization for usage records is read-time, scope-based, and tenant-partitioned — every read composes an `AccessScope` predicate that the framework's PDP already produced upstream, so the substantive authorization decision is **not** what `SecureConn` would add; what `SecureConn` would add is uniform enforcement
+* Cross-partition idempotency on `usage_records` requires a transaction across two tables (`usage_idempotency_keys` claim + hypertable insert); SeaORM has no idiomatic equivalent for the claim half because the partition column constraint precludes `ON CONFLICT` on `usage_records`
+* The aggregation query surface is dynamic (group-by dimension, time bucket, aggregation function, filter shape) and composes a positional-bind SQL string — expressible as raw `sqlx` but not as a SeaORM entity query
+* The framework lint `de0706_no_direct_sqlx` must be suppressed crate-wide for any plugin that takes this approach, and that suppression must be justified in a checked-in document so reviewers can audit the deviation without re-deriving the trade-off
+
+## Considered Options
+
+* Route every access through `SecureConn` / `SecureORM`
+* Raw `sqlx::PgPool` with a scope-fragment translator as the authorization boundary
+* Wait for a TimescaleDB-aware `SecureORM` extension before shipping the plugin
+
+## Decision Outcome
+
+Chosen option: "Raw `sqlx::PgPool` with a scope-fragment translator as the authorization boundary", because it is the only option that lets the plugin own the TimescaleDB DDL and dynamic-aggregation surface it needs while preserving a single, auditable authorization invariant (`scope_to_sql` in `domain/scope.rs`) that every read and write goes through. The framework lint is suppressed crate-wide at `src/infra/mod.rs` and `src/module.rs`; this ADR is the checked-in record of the trade-off the suppression acknowledges.
+
+### Consequences
+
+* Good, because the plugin can own TimescaleDB-specific DDL and policies in `infra/migrations.rs`, `infra/continuous_aggregate.rs`, and `infra/retention.rs` without having to fork the platform's ORM stack
+* Good, because the authorization invariant is concentrated in one file (`domain/scope.rs::scope_to_sql`) and one composition point per read path — easier to audit, easier to unit-test, and the translator fails closed on empty `AccessScope` and rejects `InGroup` / `InGroupSubtree` predicates rather than silently dropping them (returning `ScopeTranslationError::UnsupportedPredicate`, mapped to `PermissionDenied` at the public boundary)
+* Good, because dynamic aggregation SQL stays in one place (`infra/pg_query_port.rs::build_aggregation_sql`) with positional `$N` binds and no string interpolation of user-controlled values, keeping the SQL-injection surface flat and reviewable
+* Good, because the noop plugin path stays available unchanged — the deviation is scoped to this one production plugin
+* Bad, because future contributors must remember that the `de0706_no_direct_sqlx` allow is intentional in this crate and not a drift to be cleaned up; the ADR + README are the durable signal
+* Bad, because the plugin does not benefit from cross-cutting `SecureConn` features added later (e.g., per-query tracing, audit hooks at the framework boundary) without explicit plumbing
+* Bad, because correctness of authorization depends on every read path actually calling `scope_to_sql`; this is a code-review invariant rather than a type-system one
+
+### Confirmation
+
+* Code review: every read path that produces a `WHERE` clause composes it through `scope_to_sql` (`domain/scope.rs`); no read path constructs `WHERE` text directly
+* Code review: every dynamic SQL site in `infra/pg_query_port.rs` uses positional `$N` binds; no `format!`-into-SQL of caller-supplied values outside of identifier whitelists (aggregation function, group-by column, time-bucket interval — each validated against an enum or fixed set)
+* Unit tests: `domain/scope.rs` rejects empty scopes (`ScopeTranslationError::EmptyScope`) and `InGroup` / `InGroupSubtree` predicates (`ScopeTranslationError::UnsupportedPredicate`); error mapping at the public boundary surfaces `PermissionDenied`
+* Lint: `#![allow(de0706_no_direct_sqlx)]` appears only in `src/infra/mod.rs` and `src/module.rs` (the plugin bootstrap), nowhere else, and is documented at the point of suppression
+
+## Pros and Cons of the Options
+
+### Route every access through `SecureConn` / `SecureORM`
+
+Implement every read and write through the framework's `SecureORM` wrapper, even for the TimescaleDB-specific operations.
+
+* Good, because uniform enforcement of `MODKIT-SEC-001` with no plugin-specific deviation
+* Good, because the plugin benefits from future cross-cutting features added at the `SecureConn` boundary
+* Bad, because TimescaleDB DDL (`create_hypertable`, continuous-aggregate views with `WITH (timescaledb.continuous)`, retention/policy jobs) is not expressible through SeaORM today and would require forking or extending the framework's ORM stack before the plugin can land
+* Bad, because the cross-partition idempotency claim cannot be expressed as `ON CONFLICT` on the hypertable; the two-step transaction has no idiomatic SeaORM equivalent
+* Bad, because the dynamic-aggregation query surface (group-by dimension, time bucket, aggregation function, filter shape) is awkward to express as SeaORM entity queries; the resulting code would be less reviewable for SQL-injection risk than positional-bind raw SQL
+
+### Raw `sqlx::PgPool` with a scope-fragment translator as the authorization boundary
+
+Use raw `sqlx::PgPool` for all reads, writes, and DDL. Concentrate authorization in `domain/scope.rs::scope_to_sql`, which converts an `AccessScope` into a positional-bind `WHERE` fragment and fails closed on empty scopes and unsupported predicates. Suppress `de0706_no_direct_sqlx` crate-wide and document the deviation in this ADR.
+
+* Good, because the plugin owns the TimescaleDB-specific DDL and dynamic-aggregation surface it needs without forking the framework
+* Good, because the authorization invariant is concentrated and unit-testable, and the translator fails closed
+* Good, because the SQL-injection surface stays small — positional binds for all caller-supplied values, identifier whitelists for the small set of dynamic identifiers
+* Bad, because the deviation must be tracked durably (this ADR) so future contributors do not "fix" the allow lint and silently break the design
+* Bad, because correctness depends on every read path actually using the translator; this is a code-review invariant rather than a type-level one
+
+### Wait for a TimescaleDB-aware `SecureORM` extension before shipping the plugin
+
+Defer the plugin until the framework grows a TimescaleDB-aware `SecureORM` extension that can model hypertables, continuous aggregates, retention policies, and the cross-partition idempotency pattern natively.
+
+* Good, because the plugin would land with full `MODKIT-SEC-001` compliance and no per-crate deviation
+* Bad, because no such extension exists or is scoped, and the production storage plugin is on the critical path for the usage-collector subsystem
+* Bad, because the framework would acquire a TimescaleDB-specific surface area on behalf of a single plugin, conflating framework concerns with vendor specifics
+
+## More Information
+
+The framework lint `de0706_no_direct_sqlx` is suppressed at:
+
+- `src/infra/mod.rs` — covers `pg_insert_port.rs`, `pg_query_port.rs`, `migrations.rs`, `continuous_aggregate.rs`, `retention.rs`
+- `src/module.rs` — covers the bootstrap path that constructs the `PgPool` and registers the plugin client with the gateway
+
+The authorization translator lives at `src/domain/scope.rs::scope_to_sql`. It returns a `ScopeFragment` (a positional-bind `WHERE` fragment + the matching argument list); callers compose the fragment into the read SQL and bind the arguments in order. Rejected predicates surface as `ScopeTranslationError::UnsupportedPredicate`, mapped to `UsageCollectorError::PermissionDenied` at the public boundary.
+
+### Implementation notes
+
+The plugin's `Debug` impl on `Config` redacts `database_url`. The `database_url` field is the only secret the plugin handles; everything else (pool size, retention window, aggregation bucket) is non-sensitive.
+
+The plugin does not write SQL anywhere except `src/infra/` and migrations; the domain layer (`src/domain/`) is pure and contains no SQL strings. This separation is what keeps the deviation reviewable: a reader auditing authorization only needs to read `domain/scope.rs` and confirm that every `infra/` SQL site composes the resulting fragment.
+
+## Review Cadence
+
+This decision is stable as long as the framework's `SecureORM` lacks first-class TimescaleDB support. Revisit if:
+
+- A TimescaleDB-aware `SecureConn` / `SecureORM` extension lands in the framework with first-class support for hypertables, continuous aggregates, retention policies, and a cross-partition idempotency idiom
+- The plugin acquires a second authorization boundary (e.g., row-level group membership) that the scope-fragment translator cannot express, weakening the "one auditable boundary" argument
+- A future plugin needs to reuse the same deviation, in which case the trade-off should be lifted to a framework-level policy rather than a per-plugin ADR
+
+## Traceability
+
+- **PRD**: [PRD.md](../PRD.md)
+- **DESIGN**: [DESIGN.md](../DESIGN.md)
+- **FEATURE**: [features/0004-cpt-cf-usage-collector-feature-production-storage-plugin.md](../features/0004-cpt-cf-usage-collector-feature-production-storage-plugin.md)
+
+This decision directly addresses the following requirements or design elements:
+
+* `cpt-cf-usage-collector-feature-production-storage-plugin` — formalizes the trade-off the feature spec assumed when it specified TimescaleDB-specific DDL and a dynamic-aggregation surface
+* `cpt-cf-usage-collector-component-storage-plugin` — the storage-plugin component owns the deviation; consumers see only the canonical `UsageCollectorPluginClientV1` contract
+* `cpt-cf-usage-collector-principle-fail-closed` — the scope-fragment translator fails closed on empty `AccessScope` and unsupported predicates, preserving the fail-closed invariant `SecureConn` would otherwise enforce

--- a/modules/system/usage-collector/docs/DECOMPOSITION.md
+++ b/modules/system/usage-collector/docs/DECOMPOSITION.md
@@ -9,7 +9,7 @@
   - [2.1 Core SDK, Emitter & In-Process Ingest ⏳ HIGH](#21-core-sdk-emitter--in-process-ingest--high)
   - [2.2 REST Client & Remote Ingest Delivery ⏳ HIGH](#22-rest-client--remote-ingest-delivery--high)
   - [2.3 Usage Query API 🔄 IN_PROGRESS](#23-usage-query-api--in_progress)
-  - [2.4 Production Storage Plugin ⏳ HIGH](#24-production-storage-plugin--high)
+  - [2.4 Production Storage Plugin ✅ HIGH](#24-production-storage-plugin--high)
   - [2.5 Usage Type System ⏳ HIGH](#25-usage-type-system--high)
   - [2.6 Emission Rate Limiting ⏳ HIGH](#26-emission-rate-limiting--high)
   - [2.7 Retention Policy Management ⏳ MEDIUM](#27-retention-policy-management--medium)
@@ -259,9 +259,10 @@ The Usage Collector DESIGN is decomposed into 8 features following a build-from-
 
 ---
 
-### 2.4 [Production Storage Plugin](features/production-storage-plugin/) ⏳ HIGH
+### 2.4 [Production Storage Plugin](features/production-storage-plugin/) ✅ HIGH
 
-- [ ] `p1` - **ID**: `cpt-cf-usage-collector-feature-production-storage-plugin`
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-feature-production-storage-plugin`
+<!-- STATUS: IMPLEMENTED — all p1 DoD items verified and implemented (plugin crate `cyberware-timescaledb-usage-collector-plugin`, schema migrations, continuous aggregate, idempotent ingest with `usage_idempotency_keys` claim, scope-to-SQL translation, query routing between `usage_agg_1h` and the raw hypertable, cursor-based raw pagination, GTS registration, hexagonal internal layout via `InsertPort` / `QueryPort` / `PluginMetrics`, Level 1 inline unit tests in `src/domain/client_tests.rs`, Level 2 integration tests in `tests/integration.rs` gated by `--features integration`). Feature spec lives at `docs/features/0004-cpt-cf-usage-collector-feature-production-storage-plugin.md`. Retention enforcement (`nfr-retention`, `RetentionPolicy`) and operator write operations (backfill, amendment, deactivation, watermarks) are explicitly deferred to F7/F8 per the spec's §6 Non-Applicability Notes. -->
 
 - **Type**: Plugin Interface
 
@@ -270,43 +271,43 @@ The Usage Collector DESIGN is decomposed into 8 features following a build-from-
 - **Depends On**: `cpt-cf-usage-collector-feature-sdk-and-ingest-core`, `cpt-cf-usage-collector-feature-query-api`
 
 - **Scope**:
-  - First production plugin crate implementing the full storage plugin trait
-  - Idempotent record ingest keyed on idempotency key; counter delta accumulation semantics
-  - Aggregation query pushdown to the storage engine with optional pre-aggregated acceleration; cursor-based raw query pagination with tenant and dimension filtering
-  - Operator write operations: backfill ingest, record amendment, record deactivation
-  - Retention enforcement and watermark retrieval operations
-  - GTS schema registration, database schema migrations, encrypted connections to the storage backend
+  - First production plugin crate (`cyberware-timescaledb-usage-collector-plugin` at `modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/`) implementing the full `UsageCollectorPluginClientV1` trait
+  - Idempotent record ingest keyed on `(tenant_id, idempotency_key)` via a two-step `usage_idempotency_keys` + `usage_records` transaction; counter delta accumulation semantics (no separate accumulation table; persistent total = `SUM(value)`)
+  - Aggregation query pushdown with routing between the `usage_agg_1h` continuous aggregate (low-cardinality dimensions) and the raw `usage_records` hypertable (high-cardinality `resource_id` / `subject_id` filters or GROUP BY); cursor-based raw query pagination with stable `(timestamp, id)` keyset ordering
+  - `AccessScope` → SQL translator preserving OR-of-ANDs PDP constraint structure; fail-closed on empty scope and on `InGroup` / `InGroupSubtree` predicates
+  - GTS schema registration (`UsageCollectorStoragePluginSpecV1`), idempotent TimescaleDB schema migrations, TLS-enforced `sqlx::PgPool` connections to the storage backend
 
 - **Out of scope**:
   - No-op plugin (Feature 1)
   - Second storage backend
+  - Retention enforcement, retention policy CRUD (Feature 7)
+  - Operator write operations — backfill ingest, record amendment, record deactivation, watermark retrieval (Feature 8)
 
 - **Requirements Covered**:
 
-  - [ ] `p1` - `cpt-cf-usage-collector-fr-pluggable-storage`
-  - [ ] `p1` - `cpt-cf-usage-collector-nfr-query-latency`
-  - [ ] `p1` - `cpt-cf-usage-collector-nfr-throughput`
-  - [ ] `p1` - `cpt-cf-usage-collector-nfr-rpo` (applies-to: all — F4 must independently satisfy the RPO constraint via durable storage backend)
-  - [ ] `p1` - `cpt-cf-usage-collector-nfr-recovery` (applies-to: all — F4 must independently satisfy recovery via storage backend durability guarantees)
-  - [ ] `p1` - `cpt-cf-usage-collector-nfr-retention`
+  - [x] `p1` - `cpt-cf-usage-collector-fr-pluggable-storage` (applies-to: all — F4 ships the first production implementation of the storage-plugin trait; capability remains `[ ]` in PRD until F1's noop plugin and gateway plugin-resolution also land)
+  - [x] `p1` - `cpt-cf-usage-collector-nfr-query-latency` (applies-to: all — F4 owns the performance-meeting query path; F3 defers verification of this NFR to F4 per PERF-FDESIGN-004)
+  - [x] `p1` - `cpt-cf-usage-collector-nfr-throughput` (applies-to: all — F4 owns the throughput-meeting ingest path at the storage layer)
+  - [x] `p1` - `cpt-cf-usage-collector-nfr-rpo` (applies-to: all — F4 must independently satisfy the RPO constraint via durable storage backend)
+  - [x] `p1` - `cpt-cf-usage-collector-nfr-recovery` (applies-to: all — F4 must independently satisfy recovery via storage backend durability guarantees)
 
 - **Design Principles Covered**:
 
-  - [ ] `p1` - `cpt-cf-usage-collector-principle-pluggable-storage`
+  - [x] `p1` - `cpt-cf-usage-collector-principle-pluggable-storage` (applies-to: all — F4 instantiates the pluggability principle by being the first production plugin distinct from the noop)
 
 - **Design Constraints Covered**:
 
-  - [ ] `p1` - `cpt-cf-usage-collector-constraint-single-plugin`
-  - [ ] `p1` - `cpt-cf-usage-collector-constraint-types-registry` (GTS schema for plugin registration)
-  - [ ] `p1` - `cpt-cf-usage-collector-constraint-encryption`
+  - [x] `p1` - `cpt-cf-usage-collector-constraint-single-plugin` (applies-to: all — F4 occupies the single active-plugin slot; constraint enforcement at gateway resolution belongs to F1)
+  - [x] `p1` - `cpt-cf-usage-collector-constraint-types-registry` (GTS schema for plugin registration)
+  - [x] `p1` - `cpt-cf-usage-collector-constraint-encryption` (TLS-only `PgPool` connection enforced by plugin configuration; encryption at rest governed by platform infrastructure policy)
+  - [x] `p1` - `cpt-cf-usage-collector-constraint-or-of-ands-preservation` (scope-to-sql translator preserves OR-of-ANDs PDP constraint structure)
 
 - **Domain Model Entities**:
   - `UsageRecord` — USES: UsageRecord (defined in F1) — reads and persists records for storage
-  - `RetentionPolicy` (enforced by plugin)
 
 - **Design Components**:
 
-  - [ ] `p1` - `cpt-cf-usage-collector-component-storage-plugin` (production implementation)
+  - [x] `p1` - `cpt-cf-usage-collector-component-storage-plugin` (production implementation)
 
 - **API**:
   - None (internal plugin interface only)
@@ -319,14 +320,12 @@ The Usage Collector DESIGN is decomposed into 8 features following a build-from-
 
 - **Data**:
   - `usage-records` table (primary storage: idempotent upsert on ingest, read for aggregation and raw queries)
-  - [ ] `cpt-cf-usage-collector-dbtable-records`
-  - [ ] `cpt-cf-usage-collector-dbtable-counter-accumulation`
+  - [x] `cpt-cf-usage-collector-dbtable-records`
 
 - **Phases/Milestones**:
-  - Phase 1: Storage backend selection (ClickHouse or TimescaleDB) and schema design
-  - Phase 2: Ingest operations — idempotent upsert, counter delta accumulation, GTS schema registration, migrations
-  - Phase 3: Query operations — aggregation pushdown, cursor-based raw pagination
-  - Phase 4: Operator write operations — backfill ingest, record amendment, deactivation, watermarks, retention enforcement
+  - Phase 1: TimescaleDB schema design — hypertable for `usage_records`, separate `usage_idempotency_keys` plain table for cross-partition deduplication, four composite indexes, `usage_agg_1h` continuous aggregate, GTS schema registration
+  - Phase 2: Ingest operations — two-step idempotent transaction, counter delta accumulation via `SUM(value)`, migrations
+  - Phase 3: Query operations — aggregation routing between continuous aggregate and raw hypertable, `(timestamp, id)` keyset cursor pagination
 
 ---
 

--- a/modules/system/usage-collector/docs/DESIGN.md
+++ b/modules/system/usage-collector/docs/DESIGN.md
@@ -93,6 +93,7 @@ Once records arrive at the gateway, they are persisted via the active storage pl
 |--------|-----------------|
 | `cpt-cf-usage-collector-adr-scoped-emit-source` | `UsageEmitterRuntimeV1.factory(MODULE_NAME)` returns a `UsageEmitterFactory` bound to the source module's authoritative name; the factory stamps source identity on every per-call `UsageEmitter` it produces |
 | `cpt-cf-usage-collector-adr-two-phase-emit-authz` | `factory.with_*().authorize(ctx, resource_id, resource_type)` calls the PDP before any DB transaction; `usage_record_builder(metric, value)?.build()? → enqueue(record)` evaluates returned constraints in-memory inside the transaction — no network I/O on the critical emission path |
+| `cpt-cf-usage-collector-adr-timescaledb-plugin-raw-sqlx` | The TimescaleDB production storage plugin bypasses `SecureConn` / `SecureORM` and uses raw `sqlx::PgPool` with a `scope_to_sql` translator (`domain/scope.rs`) as the single authorization boundary; required because TimescaleDB DDL (`create_hypertable`, continuous aggregates, retention policies), the cross-partition idempotency-key claim transaction, and the dynamic aggregation SQL surface have no SeaORM equivalent. Scoped to this one plugin crate; the `de0706_no_direct_sqlx` lint is suppressed crate-wide with this ADR as the durable justification |
 
 ### 1.3 Architecture Layers
 

--- a/modules/system/usage-collector/docs/features/0004-cpt-cf-usage-collector-feature-production-storage-plugin.md
+++ b/modules/system/usage-collector/docs/features/0004-cpt-cf-usage-collector-feature-production-storage-plugin.md
@@ -1,0 +1,558 @@
+---
+cpt:
+  version: "1.13"
+  changelog:
+    - version: "1.13"
+      date: "2026-05-18"
+      changes:
+        - "Port the spec onto the current branch and adopt the cyberware-/no-storage- naming map from Phase 1 of the production-storage-plugin port plan. Renamed every plugin path, crate name, lib name, and companion-plugin reference: `plugins/timescaledb-usage-collector-storage-plugin/...` → `plugins/timescaledb-usage-collector-plugin/...`; `cf-timescaledb-usage-collector-storage-plugin` → `cyberware-timescaledb-usage-collector-plugin` (Cargo `[package].name`); `timescaledb_usage_collector_storage_plugin` → `timescaledb_usage_collector_plugin` (Cargo `[lib].name`); `noop-usage-collector-storage-plugin` → `noop-usage-collector-plugin`. Updated TOC anchor for the §4 Plugin Crate DoD heading. CPT IDs (`cpt-cf-usage-collector-feature-production-storage-plugin`, `cpt-cf-usage-collector-algo-production-storage-plugin-*`, `cpt-cf-usage-collector-dod-production-storage-plugin-*`, `cpt-cf-usage-collector-flow-production-storage-plugin-*`, `cpt-cf-usage-collector-component-storage-plugin`) are unchanged — they are artifact identifiers in the cypilot registry, not Cargo/path identifiers."
+    - version: "1.12"
+      date: "2026-05-10"
+      changes:
+        - "Document the plugin's hexagonal-style internal layout (RESEARCH-diverge issues N, O, P): added a `Plugin internal layout` paragraph at the head of §3 covering the three plugin-internal output ports — `domain/insert_port.rs::InsertPort`, `domain/query_port.rs::QueryPort`, `domain/metrics.rs::PluginMetrics` — their production adapters in `infra/` (`pg_insert_port.rs`, `pg_query_port.rs`, `otel_metrics.rs::OtelPluginMetrics`), and the role of `domain/error.rs::StoragePluginError` and `domain/error.rs::ScopeTranslationError` as plugin-internal error taxonomies that are mapped to canonical `UsageCollectorError` variants at the public boundary. Reframed every §3 algorithm step that mentions `ScopeTranslationError::EmptyScope` / `ScopeTranslationError::UnsupportedPredicate` as references to the plugin-internal taxonomy (already present in `inst-qagg-1` / `inst-qraw-1`; now also stated next to `inst-s2s-1` and `inst-s2s-3b-i`). Reframed the §5 AC line that mentioned `ScopeTranslationError::UnsupportedPredicate` so it asserts the public observable behaviour (the plugin returns `UsageCollectorError::PermissionDenied`) and notes the plugin-internal taxonomy as an implementation detail. Added a `UsageCollectorError = CanonicalError` clarifying note to the `create_usage_record` Output paragraph and to the §4 Ingest Operations and Query Operations DoD bodies so the alias relationship is explicit at every public-boundary callout. Added a `PluginMetrics` paragraph to the §4 Testing & Observability DoD listing the trait surface and the OTel adapter that owns metric instrument construction. RESEARCH-diverge issues M, N, O, P."
+    - version: "1.11"
+      date: "2026-05-10"
+      changes:
+        - "Correct the `service_unavailable` builder reference to match the actual impl. v1.10 documented the resource-scoped builder `UsageRecordError::service_unavailable()`, but the impl uses the un-scoped builder `CanonicalError::service_unavailable()` (`plugins/timescaledb-usage-collector-plugin/src/domain/client.rs:113`, `plugins/timescaledb-usage-collector-plugin/src/infra/pg_query_port.rs:333`, `plugins/timescaledb-usage-collector-plugin/src/infra/pg_query_port.rs:549`) — there is no deliberate plan to add resource scoping to transient DB failures. Replaced `UsageRecordError::service_unavailable()` → `CanonicalError::service_unavailable()` at five sites: §2 Error Scenarios for `inst-flow-ing` (line ~172), `inst-flow-ing-4` (line ~178), `inst-cur-5` (line ~248), `inst-qagg-5` (line ~305), and `inst-qraw-6` (line ~333). The `permission_denied` builder is unaffected — `UsageRecordError::permission_denied()` is the actual impl call at `pg_query_port.rs:90,418`, so `inst-qagg-1`, `inst-qraw-1`, and §6 AC line 513 remain correct as-is."
+    - version: "1.10"
+      date: "2026-05-10"
+      changes:
+        - "Align UsageCollectorError variants with the canonical taxonomy (UsageCollectorError = CanonicalError; resource-scoped builder UsageRecordError). Replaced legacy variant names across §2 Error Scenarios, §3 inst-flow-ing-2/4, §3 inst-cur-1/2/3/4/5, §3 inst-qagg-1/5, §3 inst-qraw-1/6, and §6 AC: `Unavailable` → `ServiceUnavailable` (built via `UsageRecordError::service_unavailable()`); `AuthorizationFailed` → `PermissionDenied` (built via `UsageRecordError::permission_denied()`); `Internal` retained as-is (already canonical). `ScopeTranslationError` is plugin-internal and is mapped to `PermissionDenied` at the plugin's public boundary."
+    - version: "1.9"
+      date: "2026-05-03"
+      changes:
+        - "Replace bespoke Cursor/PagedResult types with modkit-odata equivalents: update query_raw Input (cursor: Option<CursorV1>), Output (Result<Page<UsageRecord>, ...>), Cursor encoding paragraph, inst-qraw-2 (CursorV1 key extraction), inst-qraw-7 (CursorV1::encode), and inst-qraw-8 (Page::new return)."
+    - version: "1.8"
+      date: "2026-05-03"
+      changes:
+        - "Align FEATURE doc with TimescaleDB integration fixes: replace inst-mig-8 partial-unique-index description with usage_idempotency_keys plain-table description; update inst-mig-2 id column to describe composite PRIMARY KEY (id, timestamp); update inst-cur-3, inst-flow-ing-3, dod-ingest-ops to describe two-step transaction for idempotent ingest; change continuous aggregate start offset from 2 hours to 3 hours in inst-cagg-2, §3 input block, and dod-schema-migrations; add @cpt-begin/@cpt-end markers for inst-mig-8 in migrations.rs."
+    - version: "1.7"
+      date: "2026-05-03"
+      changes:
+        - "Issue #5: Replace inline SQL DDL/DML in 12 algorithm steps with prose descriptions (MAINT-FDESIGN-NO-001): inst-mig-1 through inst-mig-8, inst-cagg-1 through inst-cagg-3, inst-qraw-4"
+    - version: "1.6"
+      date: "2026-05-03"
+      changes:
+        - "Remove stale F7/F8 column references: status='active' from inst-cagg-1, inst-qagg-3, inst-qraw-3; status='active'/version=1 from inst-cur-6 (columns absent from inst-mig-2 schema since v1.4)"
+    - version: "1.5"
+      date: "2026-05-03"
+      changes:
+        - "Issue #2: Remove stale F7/F8 references from §1.2 Purpose (operator backfill/amendment/deactivation, retention enforcement, watermark retrieval), §1.2 Requirements (nfr-retention), dod-plugin-crate Touches (RetentionPolicy entity), dod-schema-migrations body (retention_policies table) and Touches (retention_policies DB, RetentionPolicy entity), dod-encryption-and-gts Encryption paragraph (enforce_retention sentence); add explicit Out-of-Scope paragraph in §7 listing deferred F7/F8 capabilities"
+        - "Issue #4: Add formal AC for InGroup/InGroupSubtree predicate rejection to §6 Acceptance Criteria"
+    - version: "1.4"
+      date: "2026-05-01"
+      changes:
+        - "Remove remaining F7/F8 leakage: retention_policies table step (inst-mig-9) from schema-migrations; status/inactive_at/version columns from usage_records (inst-mig-2); Operator Operations & Retention DoD section; F7/F8 Testing & Observability DoD references; 4 F7/F8 Acceptance Criteria (deactivate, enforce_retention, amend version conflict, tenant retention)"
+    - version: "1.3"
+      date: "2026-05-01"
+      changes:
+        - "Remove F7/F8 out-of-scope content: Retention Policy Configuration flow (F7), Backfill Ingest flow (F8), backfill_ingest algo (F8), amend_record algo (F8), deactivate_record algo (F8), get_watermarks algo (F8), enforce_retention algo (F7), Usage Record Lifecycle state machine (F8)"
+    - version: "1.2"
+      date: "2026-05-01"
+      changes:
+        - "Add §2 Actor Flows: operator-schema-migration, operator-retention-configure, operator-backfill, storage-backend-ingest (resolves ARCH-FDESIGN-003)"
+    - version: "1.1"
+      date: "2026-05-01"
+      changes:
+        - "Add §5 Definitions of Done, §6 Acceptance Criteria, §7 Non-Applicability Notes"
+    - version: "1.0"
+      date: "2026-05-01"
+      changes:
+        - "Initial feature specification"
+---
+
+# Feature: Production Storage Plugin (TimescaleDB)
+
+<!-- toc -->
+
+- [1. Feature Context](#1-feature-context)
+  - [1.1 Overview](#11-overview)
+  - [1.2 Purpose](#12-purpose)
+  - [1.3 Actors](#13-actors)
+  - [1.4 References](#14-references)
+- [2. Actor Flows (CDSL)](#2-actor-flows-cdsl)
+  - [Operator: Schema Migration](#operator-schema-migration)
+  - [Storage Backend: Ingest Record](#storage-backend-ingest-record)
+- [3. Processes / Business Logic (CDSL)](#3-processes--business-logic-cdsl)
+  - [Schema Migrations](#schema-migrations)
+  - [Continuous Aggregate — 1h Bucket Pre-Aggregation](#continuous-aggregate--1h-bucket-pre-aggregation)
+  - [`create_usage_record` — Idempotent Ingest](#create_usage_record--idempotent-ingest)
+  - [`AccessScope` → SQL Translator](#accessscope--sql-translator)
+  - [`query_aggregated` — Aggregation Query with Routing](#query_aggregated--aggregation-query-with-routing)
+  - [`query_raw` — Cursor-Based Raw Record Pagination](#query_raw--cursor-based-raw-record-pagination)
+- [4. Definitions of Done](#4-definitions-of-done)
+  - [Plugin Crate (`cyberware-timescaledb-usage-collector-plugin`)](#plugin-crate-cyberware-timescaledb-usage-collector-plugin)
+  - [Schema & Migrations](#schema--migrations)
+  - [Ingest Operations](#ingest-operations)
+  - [Query Operations](#query-operations)
+  - [Encryption & GTS Registration](#encryption--gts-registration)
+  - [Testing & Observability](#testing--observability)
+- [5. Acceptance Criteria](#5-acceptance-criteria)
+- [6. Non-Applicability Notes](#6-non-applicability-notes)
+
+<!-- /toc -->
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-featstatus-production-storage-plugin`
+
+<!-- reference to DECOMPOSITION entry -->
+- [x] `p1` - `cpt-cf-usage-collector-feature-production-storage-plugin`
+
+## 1. Feature Context
+
+### 1.1 Overview
+
+Implements the production TimescaleDB storage plugin for the usage-collector
+gateway: a full `UsageCollectorPluginClientV1` implementation providing
+durable, high-throughput record persistence, aggregation query pushdown via
+continuous aggregates, cursor-based raw pagination, operator write operations,
+and configurable retention enforcement backed by TimescaleDB hypertable
+partitioning.
+
+### 1.2 Purpose
+
+Delivers the first production storage backend enabling the usage-collector
+gateway to meet its throughput, latency, and recovery objectives. Covers
+the TimescaleDB plugin crate (`cyberware-timescaledb-usage-collector-plugin`):
+GTS schema registration, database schema migrations, idempotent ingest with
+counter delta accumulation, aggregation and raw query delegation.
+
+**Requirements**: `cpt-cf-usage-collector-fr-pluggable-storage`,
+`cpt-cf-usage-collector-nfr-query-latency` (≤ 500ms p95 for 30-day
+single-tenant aggregation), `cpt-cf-usage-collector-nfr-throughput`
+(≥ 10,000 records/sec sustained), `cpt-cf-usage-collector-nfr-rpo`
+(RPO = 0 for committed records), `cpt-cf-usage-collector-nfr-recovery`
+(RTO ≤ 15 min from backend recovery)
+
+**Principles**: `cpt-cf-usage-collector-principle-pluggable-storage`
+
+**Constraints**: `cpt-cf-usage-collector-constraint-single-plugin`,
+`cpt-cf-usage-collector-constraint-types-registry`,
+`cpt-cf-usage-collector-constraint-encryption`
+
+### 1.3 Actors
+
+| Actor | Role in Feature |
+|-------|-----------------|
+| `cpt-cf-usage-collector-actor-platform-operator` | Selects TimescaleDB as the active plugin via operator configuration; initiates schema migrations; configures retention policies per usage type and per tenant |
+| `cpt-cf-usage-collector-actor-storage-backend` | TimescaleDB receives usage records for durable persistence; responds to aggregation pushdown, cursor-based raw pagination, watermark queries, and retention enforcement operations |
+
+### 1.4 References
+
+- **PRD**: [PRD.md](../PRD.md)
+- **Design**: [DESIGN.md](../DESIGN.md)
+- **DECOMPOSITION**: [DECOMPOSITION.md](../DECOMPOSITION.md)
+- **Dependencies**: `cpt-cf-usage-collector-feature-sdk-and-ingest-core`,
+  `cpt-cf-usage-collector-feature-query-api`
+
+## 2. Actor Flows (CDSL)
+
+### Operator: Schema Migration
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-flow-production-storage-plugin-operator-schema-migration`
+
+**Actor**: `cpt-cf-usage-collector-actor-platform-operator`
+
+**Success Scenarios**:
+- Migration completes and all schema objects are present; plugin confirms readiness
+
+**Error Scenarios**:
+- TimescaleDB extension unavailable; operator receives `MigrationError` with diagnostic
+- Continuous aggregate setup fails; operator receives `MigrationError::ContinuousAggregateSetupFailed`
+
+**Steps**:
+1. [x] - `p1` - Platform operator invokes the plugin migration command (CLI or gateway startup flag) - `inst-flow-smig-1`
+2. [x] - `p1` - Plugin executes the idempotent migration sequence: `cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations` - `inst-flow-smig-2`
+3. [x] - `p1` - **IF** migration succeeds — plugin logs `INFO` confirming all schema objects are present - `inst-flow-smig-3`
+   1. [x] - `p1` - Plugin executes continuous aggregate setup: `cpt-cf-usage-collector-algo-production-storage-plugin-continuous-aggregate` - `inst-flow-smig-3a`
+   2. [x] - `p1` - **IF** continuous aggregate setup succeeds — **RETURN** success feedback to operator - `inst-flow-smig-3b`
+   3. [x] - `p1` - **IF** continuous aggregate setup fails — log `ERROR` with `MigrationError::ContinuousAggregateSetupFailed`; **RETURN** failure feedback to operator - `inst-flow-smig-3c`
+4. [x] - `p1` - **IF** migration fails (e.g., extension unavailable) — log `ERROR` with `MigrationError` details; **RETURN** failure feedback to operator - `inst-flow-smig-4`
+
+---
+
+### Storage Backend: Ingest Record
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-flow-production-storage-plugin-storage-backend-ingest`
+
+**Actor**: `cpt-cf-usage-collector-actor-storage-backend`
+
+**Success Scenarios**:
+- Record inserted or confirmed as duplicate; `Ok(())` returned to gateway
+
+**Error Scenarios**:
+- Counter record missing `idempotency_key` or has negative `value`; `UsageCollectorError::Internal` returned
+- Transient DB failure; `UsageCollectorError::ServiceUnavailable` (built via `CanonicalError::service_unavailable()`) returned; gateway circuit breaker records the failure
+
+**Steps**:
+1. [x] - `p1` - Gateway calls `create_usage_record(UsageRecord)` on the plugin - `inst-flow-ing-1`
+2. [x] - `p1` - Plugin validates: `value >= 0` for counter records; `idempotency_key` present for counter records; **IF** either fails — **RETURN** `UsageCollectorError::Internal` - `inst-flow-ing-2`
+3. [x] - `p1` - Plugin executes idempotent INSERT: `cpt-cf-usage-collector-algo-production-storage-plugin-create-usage-record` — deduplication via a two-step transaction against the `usage_idempotency_keys` table (ON CONFLICT DO NOTHING on the key row, then INSERT into `usage_records` if the key was newly claimed) - `inst-flow-ing-3`
+4. [x] - `p1` - **IF** DB returns a transient error — **RETURN** `UsageCollectorError::ServiceUnavailable` (built via `CanonicalError::service_unavailable()`); gateway circuit breaker records the failure; outbox retries delivery - `inst-flow-ing-4`
+5. [x] - `p1` - **RETURN** `Ok(())` — record inserted or confirmed duplicate; no distinction exposed to caller - `inst-flow-ing-5`
+
+## 3. Processes / Business Logic (CDSL)
+
+Internal system functions and procedures that do not interact with actors directly. These are the core plugin algorithms: database schema management, pre-aggregation maintenance, idempotent record ingest, and authorization scope translation.
+
+**Plugin internal layout**: the `UsageCollectorPluginClientV1` impl in the domain layer (`domain/client.rs::TimescaleDbPluginClient`) holds `Arc`-shared handles to three plugin-internal output ports — none of these ports is part of the public crate surface. (a) `domain/insert_port.rs::InsertPort::insert_usage_record(&UsageRecord) -> Result<u64, StoragePluginError>` is the write-side port; the production adapter `infra/pg_insert_port.rs` runs the two-step `usage_idempotency_keys` claim + `usage_records` INSERT (`inst-cur-3`, `inst-flow-ing-3`) over `sqlx::PgPool`. (b) `domain/query_port.rs::QueryPort::{query_aggregated, query_raw}` is the read-side port; the production adapter `infra/pg_query_port.rs` composes the `scope_to_sql` translator (`domain/scope.rs`) with the routing/keyset SQL emitted by `inst-qagg-*` / `inst-qraw-*`. (c) `domain/metrics.rs::PluginMetrics` is the OTel-style metric output port (`record_ingestion_success`, `record_ingestion_error`, `record_ingestion_latency_ms`, `record_dedup`, `record_schema_validation_error`, `record_query_latency_ms`); the production adapter `infra/otel_metrics.rs::OtelPluginMetrics` constructs the OpenTelemetry counters and histograms documented in DESIGN §3.8. A `domain/metrics.rs::NoopMetrics` implementation ships alongside the production adapter for unit tests and fallback initialization. The plugin-internal error taxonomies are also defined in the domain layer: `domain/error.rs::StoragePluginError` (`InvalidRecord`, `Transient`, `Configuration`, `Migration`, `ContinuousAggregateSetupFailed`, `RetentionPolicySetupFailed`, `QueryFailed`, `ConnectionPool`) categorises `sqlx`/migration/configuration failures coming out of the infra layer, and `domain/error.rs::ScopeTranslationError` (`EmptyScope`, `UnsupportedPredicate { kind }`) is the shape of failures returned by `scope_to_sql`. Both enums are private to the plugin crate and never appear in `UsageCollectorPluginClientV1` signatures — the trait return type is `UsageCollectorError` (= `CanonicalError`), and `domain/client.rs` translates the plugin-internal variants at the boundary: `StoragePluginError::Transient` → `UsageCollectorError::ServiceUnavailable` (built via `CanonicalError::service_unavailable()`), `StoragePluginError::InvalidRecord` for the unexpected-unique-constraint path → `UsageCollectorError::Internal` (`CanonicalError::internal()`), other `StoragePluginError` variants → `UsageCollectorError::Internal`, validation rejections in `client.rs` itself → `UsageRecordError::invalid_argument()`, and `ScopeTranslationError` (any variant) → `UsageCollectorError::PermissionDenied` (built via `UsageRecordError::permission_denied()`). All `inst-s2s-*`, `inst-qagg-*`, `inst-qraw-*` step references to `ScopeTranslationError::EmptyScope` and `ScopeTranslationError::UnsupportedPredicate` below are descriptions of the plugin-internal taxonomy, not the public return type.
+
+### Schema Migrations
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations`
+
+**Input**: `sqlx::PgPool` — connection pool to the TimescaleDB instance; migration runner invoked by the platform operator at plugin startup or on explicit migration command
+
+**Output**: `Result<(), MigrationError>` — all schema objects created or already present; idempotent (safe to re-run)
+
+**Steps**:
+1. [x] - `p1` - Ensure the TimescaleDB extension is installed in the database; the operation is idempotent and safe to re-run on an already-configured instance — `inst-mig-1`
+2. [x] - `p1` - Create the `usage_records` table with the following columns: `id` (UUID, required, auto-generated via `gen_random_uuid()`; part of composite PRIMARY KEY `(id, timestamp)` required by TimescaleDB hypertable partitioning), `tenant_id` (UUID, required), `module` (text, required), `kind` (text, `'counter'` or `'gauge'`), `metric` (text, required), `value` (numeric, required), `timestamp` (timestamptz, required), `idempotency_key` (nullable text; non-null enforced at upsert level for counter records), `resource_id` (UUID, required), `resource_type` (text, required), `subject_id` (nullable UUID), `subject_type` (nullable text), `ingested_at` (timestamptz, defaults to current time), `metadata` (nullable JSONB); if the table already exists, skip — `inst-mig-2`
+3. [x] - `p1` - Convert `usage_records` into a TimescaleDB hypertable partitioned on `timestamp`; use the idempotent form (`if_not_exists`) to allow safe re-runs on an already-converted table — `inst-mig-3`
+4. [x] - `p1` - Create a composite index on `(tenant_id, timestamp DESC)` named `idx_usage_records_tenant_time`; this is the mandatory primary filter index driving all time-range scans; idempotent — `inst-mig-4`
+5. [x] - `p1` - Create a composite index on `(tenant_id, metric, timestamp DESC)` named `idx_usage_records_tenant_metric_time`; supports `usage_type` filter in aggregation and raw queries; idempotent — `inst-mig-5`
+6. [x] - `p1` - Create a composite index on `(tenant_id, subject_id, timestamp DESC)` named `idx_usage_records_tenant_subject_time`; supports `subject` filter in aggregation and raw queries; idempotent — `inst-mig-6`
+7. [x] - `p1` - Create a composite index on `(tenant_id, resource_id, timestamp DESC)` named `idx_usage_records_tenant_resource_time`; supports `resource` filter in aggregation and raw queries; idempotent — `inst-mig-7`
+8. [x] - `p1` - Create a plain table `usage_idempotency_keys` with columns `tenant_id` (UUID, required) and `idempotency_key` (text, required), with `PRIMARY KEY (tenant_id, idempotency_key)`; this table is the cross-partition deduplication store for idempotent counter records; a separate plain table is required because TimescaleDB rejects unique indexes that omit the partition column on a hypertable; idempotent (`CREATE TABLE IF NOT EXISTS`) — `inst-mig-8`
+9. [x] - `p1` - **RETURN** `Ok(())` — all schema objects are present and indexes are consistent - `inst-mig-9`
+
+**Implements**: `cpt-cf-usage-collector-fr-pluggable-storage` (plugin owns its schema lifecycle), `cpt-cf-usage-collector-nfr-query-latency` (four composite indexes satisfy §3.7 mandate)
+
+**Constraints**: `cpt-cf-usage-collector-constraint-encryption` (TLS-only `PgPool` connection enforced by plugin configuration; encryption at rest governed by platform infrastructure policy)
+
+---
+
+### Continuous Aggregate — 1h Bucket Pre-Aggregation
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-algo-production-storage-plugin-continuous-aggregate`
+
+**Input**: `sqlx::PgPool` — invoked as part of schema migrations after the hypertable exists; `continuous_aggregate_refresh_interval` operational parameter (default: 30-minute schedule, 3-hour start offset, 1-hour end offset)
+
+**Output**: `Result<(), MigrationError>` — `usage_agg_1h` continuous aggregate view and refresh policy created or already present; idempotent
+
+**Operational parameter**: `continuous_aggregate_refresh_interval` — maximum refresh lag between latest ingested records and the pre-aggregated view; default schedule produces at most ~30 min lag; MUST be documented in plugin operator documentation and surfaced as a queryable parameter per DESIGN §3.7
+
+**Steps**:
+1. [x] - `p1` - Create the `usage_agg_1h` continuous aggregate materialized view over `usage_records`, grouping by 1-hour time buckets (`timestamp`), `tenant_id`, `metric`, `module`, `resource_type`, and `subject_type`; aggregate columns: sum of `value`, count of records, min of `value`, max of `value`; exclude `resource_id` and `subject_id` from GROUP BY to prevent cardinality explosion; `AVG` is not stored — computed at query time as `sum / NULLIF(count, 0)` for correctness across bucket merges; defer initial data population (`WITH NO DATA`); if the view already exists, skip — `inst-cagg-1`
+2. [x] - `p1` - Register an automated refresh policy for `usage_agg_1h`: schedule interval 30 minutes, start offset 3 hours, end offset 1 hour; if a policy already exists, skip — `inst-cagg-2`
+3. [x] - `p1` - **IF** the view was newly created (not already present) — trigger an initial manual refresh to populate historical data up to 1 hour before the current time — `inst-cagg-3`
+4. [x] - `p1` - Verify the view exists and the refresh policy is registered; **IF** verification fails — **RETURN** `MigrationError::ContinuousAggregateSetupFailed` - `inst-cagg-4`
+5. [x] - `p1` - **RETURN** `Ok(())` - `inst-cagg-5`
+
+**Implements**: `cpt-cf-usage-collector-fr-pluggable-storage` (plugin-owned acceleration structure), `cpt-cf-usage-collector-nfr-query-latency` (pre-aggregation meets ≤ 500ms p95 for 30-day single-tenant aggregation without `resource_id`/`subject_id` GROUP BY)
+
+**Constraints**: `cpt-cf-usage-collector-nfr-rpo` (continuous aggregate is an acceleration structure only; the `usage_records` hypertable remains the authoritative source of truth with RPO = 0 for committed records; aggregate eventual consistency lag bounded by `continuous_aggregate_refresh_interval`)
+
+---
+
+### `create_usage_record` — Idempotent Ingest
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-algo-production-storage-plugin-create-usage-record`
+
+**Input**: `UsageRecord` — deserialized from gateway ingest payload; fields: `tenant_id`, `module`, `kind` (`'counter'` or `'gauge'`), `metric`, `value`, `timestamp`, `idempotency_key` (non-null for counter records; nullable for gauge records), `resource_id`, `resource_type`, `subject_id` (nullable), `subject_type` (nullable), `metadata` (nullable JSONB)
+
+**Output**: `Result<(), UsageCollectorError>` — `Ok(())` on successful insert or confirmed duplicate; error on constraint violation or transient DB failure. `UsageCollectorError` is a type alias for `modkit_canonical_errors::CanonicalError`; the steps below identify each return value via the canonical variant name (`Internal`, `ServiceUnavailable`, `PermissionDenied`, …) along with the actual builder used at the public boundary (`UsageRecordError::*` for resource-scoped failures attributable to a specific `UsageRecord`; `CanonicalError::*` otherwise — both produce values that satisfy the trait return type).
+
+**Counter-delta semantics**: for `kind = 'counter'`, each record's `value` is a non-negative delta contribution. The record is stored as-is alongside other deltas. The persistent total for any `(tenant_id, metric)` pair is `SUM(value)` over all active records — no separate accumulation table or running total is maintained. This matches DESIGN §3.7 Counter Accumulation.
+
+**Steps**:
+1. [x] - `p1` - Validate `value >= 0` when `kind = 'counter'`; **IF** negative — **RETURN** `UsageCollectorError::Internal` (gateway enforces this before calling the plugin, but the plugin re-validates as a defensive check) - `inst-cur-1`
+2. [x] - `p1` - Validate `idempotency_key` is present (non-null, non-empty) when `kind = 'counter'`; **IF** absent — **RETURN** `UsageCollectorError::Internal` - `inst-cur-2`
+3. [x] - `p1` - Open a transaction; INSERT into `usage_idempotency_keys (tenant_id, idempotency_key)` ON CONFLICT DO NOTHING; if 0 rows were claimed (duplicate key), rollback and return immediately (record already stored); otherwise INSERT the record into `usage_records` with all fields and commit the transaction. This two-step approach is required because TimescaleDB rejects unique indexes on `usage_records` that omit the partition column - `inst-cur-3`
+4. [x] - `p1` - **IF** DB operation returns a unique constraint violation on a column other than the idempotency index (unexpected schema conflict) — **RETURN** `UsageCollectorError::Internal` - `inst-cur-4`
+5. [x] - `p1` - **IF** DB operation returns a transient error (connection lost, pool timeout, serialization failure) — **RETURN** `UsageCollectorError::ServiceUnavailable` (built via `CanonicalError::service_unavailable()`); the gateway circuit breaker records this failure and the outbox library retries delivery - `inst-cur-5`
+6. [x] - `p1` - Set `ingested_at = now()` at DB INSERT time (not passed from caller) - `inst-cur-6`
+7. [x] - `p1` - **RETURN** `Ok(())` — record inserted or confirmed as duplicate via idempotency key; no distinction exposed to caller - `inst-cur-7`
+
+**Implements**: `cpt-cf-usage-collector-fr-pluggable-storage` (implements `UsageCollectorPluginClientV1::create_usage_record`), `cpt-cf-usage-collector-fr-counter-semantics` (stores each delta record as-is; persistent total computed as SUM of active deltas; upsert target `(tenant_id, idempotency_key)` enforces at-most-once delivery per key)
+
+**Constraints**: `cpt-cf-usage-collector-nfr-throughput` (≥ 10,000 records/sec sustained; single-row INSERT is the hot path for gauge records; counter records use a two-step transaction (idempotency-key INSERT + usage_records INSERT) which adds one extra round-trip per counter record; connection pool size and hypertable chunk cache govern throughput ceiling), `cpt-cf-usage-collector-nfr-rpo` (INSERT inside a DB transaction; committed record has RPO = 0)
+
+---
+
+### `AccessScope` → SQL Translator
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql`
+
+**Input**: `AccessScope` — compiled from PDP constraints by the gateway before delegating to the plugin; structure: `Vec<ConstraintGroup>` where each `ConstraintGroup` contains `Vec<Predicate>`; predicates include `TenantId(Vec<Uuid>)`, `ResourceId(Vec<Uuid>)`, `ResourceType(Vec<String>)`, `InGroup { group_id }`, `InGroupSubtree { group_id }`
+
+**Output**: `Result<(String, Vec<SqlValue>), ScopeTranslationError>` — SQL WHERE fragment string (ready for embedding in a `WHERE (...)` clause) and a positional bind-parameter list; the fragment combines constraint groups with OR and predicates within each group with AND
+
+**OR-of-ANDs preservation**: the translator MUST compile each `ConstraintGroup` into a separate AND branch and combine branches with OR. Flattening multiple groups into a single AND set is a security violation (`cpt-cf-usage-collector-constraint-or-of-ands-preservation`) — it widens access beyond the PDP-authorized scope.
+
+**Steps**:
+1. [x] - `p1` - **IF** `scope.groups` is empty — **RETURN** `ScopeTranslationError::EmptyScope` (plugin-internal taxonomy; the calling operation translates this to `UsageCollectorError::PermissionDenied` at the public boundary — see `inst-qagg-1` / `inst-qraw-1`); callers must fail closed on empty scope (no constraints = deny all) - `inst-s2s-1`
+2. [x] - `p1` - Initialize `group_fragments: Vec<String>` and `bind_params: Vec<SqlValue>` - `inst-s2s-2`
+3. [x] - `p1` - **FOR EACH** `group` in `scope.groups` - `inst-s2s-3`
+   1. [x] - `p1` - Initialize `predicate_fragments: Vec<String>` for this group - `inst-s2s-3a`
+   2. [x] - `p1` - **FOR EACH** `predicate` in `group.predicates` - `inst-s2s-3b`
+      1. [x] - `p1` - **IF** predicate is `InGroup` or `InGroupSubtree` — **RETURN** `ScopeTranslationError::UnsupportedPredicate { kind: "InGroup/InGroupSubtree" }` (plugin-internal taxonomy; the calling operation translates this to `UsageCollectorError::PermissionDenied` at the public boundary — see `inst-qagg-1` / `inst-qraw-1`); these predicates require gateway pre-flattening before plugin invocation and are not supported at the plugin SQL translation layer - `inst-s2s-3b-i`
+      2. [x] - `p1` - **IF** predicate is `TenantId(ids)` — append `tenant_id = ANY($N)` (or `tenant_id = $N` for single value) and bind `ids` - `inst-s2s-3b-ii`
+      3. [x] - `p1` - **IF** predicate is `ResourceId(ids)` — append `resource_id = ANY($N)` and bind `ids` - `inst-s2s-3b-iii`
+      4. [x] - `p1` - **IF** predicate is `ResourceType(types)` — append `resource_type = ANY($N)` and bind `types` - `inst-s2s-3b-iv`
+   3. [x] - `p1` - Join `predicate_fragments` with ` AND `; wrap in parentheses: `(pred1 AND pred2 ...)`; append to `group_fragments` - `inst-s2s-3c`
+4. [x] - `p1` - Join `group_fragments` with ` OR `; wrap entire expression in outer parentheses: `(group1 OR group2 ...)`; this is the final SQL WHERE fragment - `inst-s2s-4`
+5. [x] - `p1` - **RETURN** `Ok((sql_fragment, bind_params))` - `inst-s2s-5`
+
+**Implements**: `cpt-cf-usage-collector-constraint-or-of-ands-preservation` (each PDP constraint group compiles to a separate AND branch; branches combined with OR; flattening is explicitly prohibited)
+
+**Constraints**: `cpt-cf-usage-collector-principle-pluggable-storage` (translator is plugin-internal using raw `sqlx`; gateway does not inspect or manipulate the SQL fragment); `InGroup`/`InGroupSubtree` predicate rejection MUST be a hard error, not a silent omission, to preserve fail-closed security posture
+
+---
+
+### `query_aggregated` — Aggregation Query with Routing
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-algo-production-storage-plugin-query-aggregated`
+
+**Input**: `AggregationQuery` — fields: `scope: AccessScope` (compiled from PDP constraints), `time_range: (DateTime<Utc>, DateTime<Utc>)`, `function: AggregationFn` (`Sum | Count | Min | Max | Avg`), `group_by: Vec<GroupByDimension>` (`TimeBucket(BucketSize) | UsageType | Subject | Resource | Source`), `bucket_size: Option<BucketSize>` (required when `group_by` includes `TimeBucket`), optional user filters: `metric`, `resource_id`, `resource_type`, `subject_id`, `subject_type`, `source`
+
+**Output**: `Result<Vec<AggregationResult>, UsageCollectorError>` — aggregated result rows; empty vec for time ranges with no matching records; error on scope translation failure or DB failure
+
+**Routing decision**: queries are routed to the `usage_agg_1h` continuous aggregate when all active user filters are on dimensions present in that view (`metric`, `resource_type`, `subject_type`, `source` / `module`); queries are routed to the raw `usage_records` hypertable when `resource_id` or `subject_id` is present as a user filter or GROUP BY dimension — these high-cardinality dimensions are intentionally excluded from `usage_agg_1h` (see `cpt-cf-usage-collector-algo-production-storage-plugin-continuous-aggregate`, `inst-cagg-1`)
+
+**AVG composability**: `Avg` is not stored in the continuous aggregate; it is computed at query time as `SUM(sum_val) / NULLIF(SUM(cnt_val), 0)` over the pre-aggregated rows; this formula is mathematically correct across bucket merges (unlike averaging per-bucket averages)
+
+**Steps**:
+1. [x] - `p1` - Translate `scope` via `cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql`; **IF** translation returns `ScopeTranslationError` (plugin-internal taxonomy) — **RETURN** `UsageCollectorError::PermissionDenied` (built via `UsageRecordError::permission_denied()`); the call site must fail closed on empty or untranslatable scope - `inst-qagg-1`
+2. [x] - `p1` - **IF** `resource_id` or `subject_id` is present in user filters OR `group_by` includes `Resource` (meaning `resource_id`) OR `group_by` includes `Subject` (meaning `subject_id`) — **ROUTE TO** raw hypertable path (step 3); **ELSE** — **ROUTE TO** continuous aggregate path (step 4) - `inst-qagg-2`
+3. [x] - `p1` - **[Raw hypertable path]** Build SELECT query against `usage_records`; apply WHERE clause: scope SQL fragment AND `timestamp >= $start AND timestamp <= $end` AND optional filters (`metric`, `resource_id`, `resource_type`, `subject_id`, `subject_type`, `source`); build GROUP BY from `query.group_by` dimensions; build SELECT expressions using `query.function` (`SUM(value)`, `COUNT(*)`, `MIN(value)`, `MAX(value)`, or `AVG(value)` directly on raw records); apply `ORDER BY` on bucket start when `TimeBucket` is in `group_by`; **GO TO** step 5 - `inst-qagg-3`
+4. [x] - `p1` - **[Continuous aggregate path]** Build SELECT query against `usage_agg_1h`; apply WHERE clause: scope SQL fragment AND `bucket >= $start AND bucket <= $end` AND optional filters (`metric`, `resource_type`, `subject_type`, `source`); build GROUP BY from `query.group_by` dimensions (mapped to aggregate columns: `bucket` for `TimeBucket`, `metric` for `UsageType`, `subject_type` for `Subject`, `resource_type` for `Resource`, `module` for `Source`); build SELECT expressions from pre-aggregated columns: `SUM(sum_val)` for `Sum`, `SUM(cnt_val)` for `Count`, `MIN(min_val)` for `Min`, `MAX(max_val)` for `Max`, `SUM(sum_val) / NULLIF(SUM(cnt_val), 0)` for `Avg`; apply `ORDER BY bucket_start` when `TimeBucket` is in `group_by`; **GO TO** step 5 - `inst-qagg-4`
+5. [x] - `p1` - Execute the constructed query with all bind parameters using `sqlx::PgPool`; **IF** DB returns transient error — **RETURN** `UsageCollectorError::ServiceUnavailable` (built via `CanonicalError::service_unavailable()`) - `inst-qagg-5`
+6. [x] - `p1` - Map result rows to `Vec<AggregationResult>`; set `function` field to `query.function`; populate optional dimension fields (`bucket_start`, `usage_type`, `subject_id`, `subject_type`, `resource_id`, `resource_type`, `source`) only when the corresponding `GroupByDimension` was present in `query.group_by`; absent dimensions MUST be `None` - `inst-qagg-6`
+7. [x] - `p1` - **RETURN** `Ok(results)` — empty vec is a valid result for time ranges with no matching data - `inst-qagg-7`
+
+**Implements**: `cpt-cf-usage-collector-fr-pluggable-storage` (implements `UsageCollectorPluginClientV1::query_aggregated`), `cpt-cf-usage-collector-nfr-query-latency` (continuous aggregate path meets ≤ 500ms p95 for 30-day single-tenant aggregation on low-cardinality dimensions; raw hypertable path used only when high-cardinality filters are present and the acceleration structure is inapplicable)
+
+**Constraints**: `cpt-cf-usage-collector-constraint-or-of-ands-preservation` (scope SQL fragment preserves OR-of-ANDs structure via `scope-to-sql`; never flattened)
+
+---
+
+### `query_raw` — Cursor-Based Raw Record Pagination
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-algo-production-storage-plugin-query-raw`
+
+**Input**: `RawQuery` — fields: `scope: AccessScope` (compiled from PDP constraints), `time_range: (DateTime<Utc>, DateTime<Utc>)`, optional user filters: `metric`, `resource_id`, `resource_type`, `subject_id`, `cursor: Option<CursorV1>` (opaque to caller; keyset cursor from `modkit-odata` encodes `(timestamp, id)` composite position), `page_size: usize`
+
+**Output**: `Result<Page<UsageRecord>, UsageCollectorError>` — page of active records plus optional next cursor in `page_info`; empty page when all records exhausted; error on scope translation failure or DB failure
+
+**Cursor encoding**: the cursor is a `CursorV1` from `modkit-odata` — a base64url-encoded keyset cursor with `k=[timestamp_rfc3339, id_uuid]`, `o=Asc`, `s="+timestamp,+id"`, `d="fwd"`; opaque to API callers; the plugin owns encoding via `CursorV1::encode()` and decoding via `CursorV1::decode()`; a `None` cursor means first page
+
+**Cursor stability**: `id` is the stable tiebreaker within records sharing the same timestamp, ensuring no skipped or duplicated rows under concurrent inserts mid-pagination; the condition `(timestamp > $cursor_ts) OR (timestamp = $cursor_ts AND id > $cursor_id)` is a tuple comparison that never double-counts ties
+
+**Steps**:
+1. [x] - `p1` - Translate `scope` via `cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql`; **IF** translation returns `ScopeTranslationError` (plugin-internal taxonomy) — **RETURN** `UsageCollectorError::PermissionDenied` (built via `UsageRecordError::permission_denied()`) - `inst-qraw-1`
+2. [x] - `p1` - **IF** `query.cursor` is `Some(cursor)` — extract `timestamp: DateTime<Utc>` from `cursor.k[0]` (parsed as RFC3339) and `id: Uuid` from `cursor.k[1]`; the cursor string is decoded into `CursorV1` at the REST deserialization layer before the plugin is invoked, so no decode error can occur here - `inst-qraw-2`
+3. [x] - `p1` - Build SELECT query against `usage_records`; always include in WHERE: scope SQL fragment AND `timestamp >= $start AND timestamp <= $end`; append optional user filters when present: `AND metric = $metric`, `AND resource_id = $resource_id`, `AND resource_type = $resource_type`, `AND subject_id = $subject_id` - `inst-qraw-3`
+4. [x] - `p1` - **IF** cursor is present — append a keyset advancement condition that selects records strictly after the cursor position using tuple comparison on `(timestamp, id)`: records with a later timestamp, or records with the same timestamp and a later `id`; this condition never skips or double-counts rows under concurrent inserts; **IF** cursor is absent — no cursor condition is appended (first page) — `inst-qraw-4`
+5. [x] - `p1` - Append `ORDER BY timestamp ASC, id ASC LIMIT $page_size + 1`; fetching one extra row is the sentinel used to detect whether more pages exist without a separate COUNT query; `page_size` is bounded at the gateway layer (e.g., max 1000); `id` is the tiebreaker ensuring deterministic ordering for records sharing the same timestamp - `inst-qraw-5`
+6. [x] - `p1` - Execute the query with all bind parameters; **IF** DB returns transient error — **RETURN** `UsageCollectorError::ServiceUnavailable` (built via `CanonicalError::service_unavailable()`) - `inst-qraw-6`
+7. [x] - `p1` - Map result rows to `Vec<UsageRecord>`; **IF** `rows.len() > page_size` — there are more pages; truncate to `page_size` rows; take the last retained row's `(timestamp, id)`, construct `CursorV1 { k: [timestamp.to_rfc3339(), id.to_string()], o: SortDir::Asc, s: "+timestamp,+id".to_string(), f: None, d: "fwd".to_string() }` and encode via `CursorV1::encode()` to produce the opaque cursor string; **ELSE** (page exhausted) — set next cursor to `None` - `inst-qraw-7`
+8. [x] - `p1` - **RETURN** `Ok(Page::new(records, PageInfo { next_cursor: cursor_str, prev_cursor: None, limit: query.page_size as u64 }))` — empty `records` with `next_cursor = None` is a valid exhausted-page response - `inst-qraw-8`
+
+**Implements**: `cpt-cf-usage-collector-fr-pluggable-storage` (implements `UsageCollectorPluginClientV1::query_raw`), `cpt-cf-usage-collector-nfr-query-latency` (keyset cursor with TimescaleDB chunk pruning on time range avoids full-table scans; the `(tenant_id, timestamp)` index drives the seek)
+
+**Constraints**: `cpt-cf-usage-collector-constraint-or-of-ands-preservation` (scope SQL fragment preserves OR-of-ANDs structure via `scope-to-sql`; cursor is opaque to callers and MUST NOT be inspected or modified by the gateway)
+
+---
+
+## 4. Definitions of Done
+
+Specific implementation tasks derived from the algorithms above.
+
+### Plugin Crate (`cyberware-timescaledb-usage-collector-plugin`)
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-dod-production-storage-plugin-plugin-crate`
+
+The system **MUST** implement the `cyberware-timescaledb-usage-collector-plugin` crate providing: a full `UsageCollectorPluginClientV1` implementation registered via the `UsageCollectorStoragePluginSpecV1` GTS schema; a `SecureConn`-managed `sqlx::PgPool` connection pool with configurable size and timeout; startup validation that rejects missing `database_url` or failed TLS negotiation as hard errors; and registration with the gateway `ClientHub` via GTS discovery at startup.
+
+**Implements**:
+- `cpt-cf-usage-collector-component-storage-plugin`
+
+**Constraints**: `cpt-cf-usage-collector-constraint-single-plugin`, `cpt-cf-usage-collector-constraint-types-registry`
+
+**Touches**:
+- Crate: `cyberware-timescaledb-usage-collector-plugin`
+- Entities: `UsageRecord`
+
+**Configuration**:
+
+| Parameter | Type | Valid range | Default | Validation | Runtime-changeable |
+|-----------|------|-------------|---------|------------|--------------------|
+| `database_url` | String | valid PostgreSQL URL | — | MUST be present; TLS required (`sslmode=require` or equivalent) | No — requires restart |
+| `pool_size_min` | u32 | 1–64 | 2 | must be ≥ 1 | No |
+| `pool_size_max` | u32 | 1–128 | 16 | must be ≥ `pool_size_min` | No |
+| `retention_default` | duration | 7 days – 7 years | 365 days | must be in `[7d, 7y]` | No |
+| `connection_timeout` | duration | 1s–60s | 10s | must be > 0 | No |
+
+All parameters are static and require a plugin restart to change. No feature flags are used; the plugin is selected exclusively by operator configuration (GTS resolution at gateway startup).
+
+**Health & diagnostics**: The plugin MUST report `storage_health_status = 1` (healthy) when the connection pool can execute a liveness probe against TimescaleDB and `storage_health_status = 0` (unreachable) otherwise. This metric feeds the platform-level readiness check (`/health/ready`). First-level troubleshooting: (1) verify `database_url` is reachable from the gateway host; (2) check `storage_health_status` metric; (3) inspect structured logs for pool exhaustion or TLS handshake errors; (4) confirm TimescaleDB has the `timescaledb` extension installed.
+
+**Audit logging**: Plugin registration and successful GTS schema resolution are logged at `INFO`. Startup failures (connection pool creation, TLS negotiation, GTS registration) are logged at `ERROR` with the error type only — `database_url` and credentials MUST NOT appear in log output. No per-operation audit is produced at the plugin layer; audit of individual record operations is delegated to the gateway audit layer per `cpt-cf-usage-collector-constraint-no-business-logic`.
+
+---
+
+### Schema & Migrations
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-dod-production-storage-plugin-schema-migrations`
+
+The system **MUST** implement idempotent schema migrations that: enable the `timescaledb` extension; create the `usage_records` hypertable with all required columns and four composite indexes and a separate `usage_idempotency_keys` plain table for cross-partition idempotency deduplication; and create the `usage_agg_1h` continuous aggregate with a 30-minute scheduled refresh policy and a 3-hour start / 1-hour end offset. All migration steps MUST be idempotent and safe to re-run on an already-migrated schema without error.
+
+**Implements**:
+- `cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations`
+- `cpt-cf-usage-collector-algo-production-storage-plugin-continuous-aggregate`
+
+**Constraints**: `cpt-cf-usage-collector-constraint-single-plugin`, `cpt-cf-usage-collector-constraint-types-registry`
+
+**Touches**:
+- DB: `usage_records` (hypertable), `usage_agg_1h` (continuous aggregate), `usage_idempotency_keys` (plain table)
+- Entities: `UsageRecord`
+
+**Resource management**: The migration runner holds a single pool connection during the migration sequence and releases it immediately on completion or error. Continuous aggregate creation uses `WITH NO DATA` to defer the initial population to the scheduled refresh policy; the migration-time manual refresh is bounded by the volume of existing data. All DDL steps use idempotency guards (`IF NOT EXISTS` / `if_not_exists`) to prevent duplicate-object errors.
+
+**Recovery**: Schema migrations are forward-only — rollback of a partially applied migration requires manual DBA intervention. If continuous aggregate setup fails, the error surfaces at gateway startup with a `MigrationError::ContinuousAggregateSetupFailed` diagnostic; the operator must resolve the TimescaleDB configuration issue and restart. Historical data present before the first migration run is included in the migration-time manual refresh.
+
+**Data access patterns**: All schema objects are created via DDL operations only; no data queries are issued during migration. TimescaleDB automatically propagates new indexes to existing hypertable chunks via its chunk inheritance mechanism.
+
+---
+
+### Ingest Operations
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-dod-production-storage-plugin-ingest-ops`
+
+The system **MUST** implement the idempotent ingest write path: `create_usage_record` persisting a single record using a two-step transaction: INSERT into `usage_idempotency_keys` ON CONFLICT DO NOTHING, early return on 0 rows claimed, then INSERT into `usage_records`; and `scope_to_sql` translating the PDP `AccessScope` to a SQL WHERE fragment that preserves the OR-of-ANDs structure of the original PDP constraint groups. Counter records require a non-null `idempotency_key` and a non-negative `value`; these are enforced defensively at the plugin layer even if the gateway pre-validates. The two-step DB write MUST live behind the plugin-internal `domain/insert_port.rs::InsertPort` trait so `domain/client.rs` depends only on the port; the production adapter `infra/pg_insert_port.rs` wraps `sqlx::PgPool`. Returns from the port use the plugin-internal `StoragePluginError` enum and are translated at the public boundary (`Transient` → `UsageCollectorError::ServiceUnavailable` via `CanonicalError::service_unavailable()`; `InvalidRecord` on the unexpected-unique-constraint path → `UsageCollectorError::Internal`; other variants → `UsageCollectorError::Internal`).
+
+**Implements**:
+- `cpt-cf-usage-collector-algo-production-storage-plugin-create-usage-record`
+- `cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql`
+
+**Constraints**: `cpt-cf-usage-collector-constraint-or-of-ands-preservation`, `cpt-cf-usage-collector-constraint-no-business-logic`
+
+**Touches**:
+- DB: `usage_records`
+- Entities: `UsageRecord`
+
+**Concurrency**: The idempotent upsert is safe under concurrent inserts — duplicate records sharing the same `(tenant_id, idempotency_key)` are silently dropped without error, matching the at-most-once delivery semantic of the outbox pipeline. No row-level locks are held beyond the implicit single-row INSERT lock; TimescaleDB hypertable chunk routing is lock-free for non-overlapping time ranges.
+
+**Audit logging**: Individual ingest operations are not audited at the plugin layer — audit of ingest API calls is delegated to the platform-wide API audit layer. Plugin-level structured log events: `INFO` on successful insert, `DEBUG` on idempotency deduplication, `WARN` on `InvalidRecord` validation failure, `ERROR` on unexpected constraint violations. The `usage_dedup_total` metric MUST be incremented for each deduplicated record.
+
+**Observability**: `usage_ingestion_total` MUST be incremented with `status = "success"` for each inserted record and `status = "dedup"` for each deduplicated record. `usage_ingestion_latency_ms` MUST be recorded as a histogram observation per `create_usage_record` invocation. `usage_schema_validation_errors_total` MUST be incremented for each `InvalidRecord` return.
+
+---
+
+### Query Operations
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-dod-production-storage-plugin-query-ops`
+
+The system **MUST** implement the two read operations: `query_aggregated` routing to the `usage_agg_1h` continuous aggregate when all active filters are on low-cardinality dimensions (`metric`, `resource_type`, `subject_type`, `source`) and falling back to the raw `usage_records` hypertable when `resource_id` or `subject_id` is present in filters or GROUP BY dimensions; and `query_raw` delivering cursor-based pagination with stable keyset ordering on `(timestamp, id)`. Both operations apply the PDP `AccessScope` via `scope_to_sql` before query construction and fail closed on scope translation errors. The read SQL path MUST live behind the plugin-internal `domain/query_port.rs::QueryPort` trait (`query_aggregated`, `query_raw`); the production adapter `infra/pg_query_port.rs` composes the `scope_to_sql` translator with the routing/keyset SQL and returns `UsageCollectorError` directly (= `CanonicalError`). `ScopeTranslationError` from `scope_to_sql` is plugin-internal and is mapped to `UsageCollectorError::PermissionDenied` (built via `UsageRecordError::permission_denied()`) at the public boundary per `inst-qagg-1` / `inst-qraw-1`.
+
+**Implements**:
+- `cpt-cf-usage-collector-algo-production-storage-plugin-query-aggregated`
+- `cpt-cf-usage-collector-algo-production-storage-plugin-query-raw`
+- `cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql`
+
+**Constraints**: `cpt-cf-usage-collector-constraint-or-of-ands-preservation`, `cpt-cf-usage-collector-constraint-types-registry`
+
+**Touches**:
+- DB: `usage_records`, `usage_agg_1h`
+- Entities: `UsageRecord`, `AggregationResult`
+
+**Concurrency**: The `query_raw` keyset cursor on `(timestamp, id)` is stable under concurrent inserts — new records inserted mid-pagination are picked up in later pages without skipping or duplicating earlier rows. No shared lock is held between pages. `query_aggregated` operates on snapshot-consistent data within the query transaction; concurrent inserts may not appear in in-progress aggregate results but do not corrupt them.
+
+**Observability**: `usage_query_latency_ms` MUST be recorded as a histogram observation per invocation, labeled with `query_type = "aggregated"` or `query_type = "raw"`. The routing decision (continuous aggregate vs raw hypertable) SHOULD be logged at `DEBUG` level with the triggering dimension.
+
+**Data access patterns**: The continuous aggregate path is the primary hot path for billing and reporting queries — it reads from `usage_agg_1h` (pre-aggregated, indexed on `bucket`, `tenant_id`, `metric`) to meet the 500ms p95 latency target. The raw hypertable fallback uses the `(tenant_id, timestamp)` composite index for time-range seeks. The `query_raw` keyset pagination uses the same `(tenant_id, timestamp)` index plus the `id` tiebreaker for cursor stability.
+
+---
+
+### Encryption & GTS Registration
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-dod-production-storage-plugin-encryption-and-gts`
+
+The system **MUST** enforce TLS for all connections to TimescaleDB by requiring `sslmode=require` (or equivalent) in the connection parameters; plaintext connections MUST be rejected at pool initialization as a hard startup error. The plugin MUST register its GTS schema (`UsageCollectorStoragePluginSpecV1`) at startup; registration failure is also a hard startup error. Encryption at rest is governed by platform infrastructure policy (encrypted tablespace or OS-level encryption); no per-record key management is required for non-PII usage data.
+
+**Implements**:
+- `cpt-cf-usage-collector-component-storage-plugin`
+
+**Constraints**: `cpt-cf-usage-collector-constraint-encryption`, `cpt-cf-usage-collector-constraint-types-registry`
+
+**Touches**:
+- GTS registry: `UsageCollectorStoragePluginSpecV1`
+- Channel: TLS-only connection to TimescaleDB
+
+**Encryption**: All plugin connections to TimescaleDB MUST use TLS; the `database_url` is managed via `SecureConn` and MUST NOT appear in logs or error messages. Encryption at rest is mandatory and governed by platform infrastructure policy (encrypted tablespace or OS-level encryption for the TimescaleDB data directory). Encryption key management is the responsibility of the platform secret management system.
+
+**Audit logging**: GTS schema registration is logged at `INFO` on success. Startup failures (TLS rejection, GTS registration failure) are logged at `ERROR` with the error type only — connection string and credentials MUST NOT be included. No per-record encryption audit is required for non-PII usage data.
+
+---
+
+### Testing & Observability
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-dod-production-storage-plugin-testing-and-observability`
+
+The system **MUST** implement a two-level test suite: Level 1 inline unit tests (no DB) in `src/domain/client_tests.rs` covering all validation branches, error paths, and mock boundaries; Level 2 integration tests in `tests/integration.rs` gated with `#[cfg(feature = "integration")]` and run via `cargo test --features integration`, using a `timescale/timescaledb:latest-pg16` container via `testcontainers::GenericImage`. All DESIGN §3.8 metrics owned by the storage plugin MUST be emitted correctly and verified in both test levels (via mock registry in unit tests; via real registry in integration tests).
+
+**Implements**:
+- `cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations`
+- `cpt-cf-usage-collector-algo-production-storage-plugin-continuous-aggregate`
+- `cpt-cf-usage-collector-algo-production-storage-plugin-create-usage-record`
+- `cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql`
+- `cpt-cf-usage-collector-algo-production-storage-plugin-query-aggregated`
+- `cpt-cf-usage-collector-algo-production-storage-plugin-query-raw`
+- `cpt-cf-usage-collector-component-storage-plugin`
+
+**Constraints**: `cpt-cf-usage-collector-constraint-single-plugin`, `cpt-cf-usage-collector-constraint-types-registry`, `cpt-cf-usage-collector-constraint-encryption`, `cpt-cf-usage-collector-constraint-or-of-ands-preservation`
+
+**Touches**:
+- Crates: `cyberware-timescaledb-usage-collector-plugin` (unit: `src/domain/client_tests.rs`; integration: `tests/integration.rs`)
+- Metrics: `usage_ingestion_total`, `usage_ingestion_latency_ms`, `usage_dedup_total`, `usage_schema_validation_errors_total`, `usage_query_latency_ms`, `storage_health_status` (DESIGN §3.8)
+
+**Observability**: All DESIGN §3.8 metrics owned by the storage plugin MUST be emitted: `usage_ingestion_total` (per-tenant, per-status counter), `usage_ingestion_latency_ms` (histogram per invocation), `usage_dedup_total` (per-tenant deduplication counter), `usage_query_latency_ms` (per-query-type histogram), `storage_health_status` (gauge; 1 = healthy, 0 = unreachable). Structured log events MUST carry `correlation_id`, `tenant_id`, operation type, and handler latency. PII exclusion: record `value`, `metadata`, `subject_id`, and `resource_id` MUST NOT appear in structured log fields.
+
+**`PluginMetrics` port**: metric emission MUST be encapsulated behind the plugin-internal `domain/metrics.rs::PluginMetrics` trait so the `domain/client.rs` plugin client can be unit-tested without a metric backend. The trait surface is `record_ingestion_success`, `record_ingestion_error`, `record_ingestion_latency_ms(elapsed_ms)`, `record_dedup`, `record_schema_validation_error`, and `record_query_latency_ms(query_type, elapsed_ms)`. The production adapter `infra/otel_metrics.rs::OtelPluginMetrics` constructs the OpenTelemetry counters and histograms (`usage_ingestion_total`, `usage_ingestion_errors_total`, `usage_ingestion_latency_ms`, `usage_dedup_total`, `usage_schema_validation_errors_total`, `usage_query_latency_ms`) listed above; instrument creation lives exclusively in the adapter, not in `domain/client.rs`. A `domain/metrics.rs::NoopMetrics` implementation MUST ship alongside the production adapter for unit tests and fallback initialization. The `PluginMetrics` trait, `OtelPluginMetrics`, and `NoopMetrics` are plugin-internal — they are not part of the public crate surface.
+
+**Health & diagnostics**: The integration test suite MUST include a health-check test verifying `storage_health_status = 1` when the pool is connected and `storage_health_status = 0` after the connection is interrupted.
+
+**Resource management**: Integration tests MUST use the `testcontainers` container drop handle to clean up the TimescaleDB container at test teardown; no persistent containers between test runs. Unit tests require no external resources.
+
+## 5. Acceptance Criteria
+
+- [ ] Given N concurrent `create_usage_record` calls with the same `(tenant_id, idempotency_key)`, exactly one row persists in `usage_records`; all calls return `Ok(())`
+- [ ] Counter total for a `(tenant_id, metric)` pair returned by `query_aggregated` equals the sum of all active record values; no separate running total is maintained
+- [ ] A gauge record is stored with its exact submitted value; no accumulation is applied at ingest time; `query_aggregated(Avg)` on a single gauge record returns that stored value
+- [ ] `query_aggregated` routes to `usage_agg_1h` when all active filters are on low-cardinality dimensions (`metric`, `resource_type`, `subject_type`, `source`); it routes to the raw `usage_records` hypertable when `resource_id` or `subject_id` is present in filters or GROUP BY
+- [ ] `query_raw` with a valid cursor returns records in stable ascending `(timestamp, id)` order; no rows are skipped or duplicated when concurrent inserts occur between pages
+- [ ] `query_aggregated` via the continuous aggregate path on a 30-day single-tenant time range completes within 500ms p95, meeting `cpt-cf-usage-collector-nfr-query-latency`
+- [ ] `create_usage_record` sustains ≥ 10,000 records/sec under representative load, meeting `cpt-cf-usage-collector-nfr-throughput`
+- [ ] `scope_to_sql` with an `AccessScope` containing multiple `ConstraintGroup` entries generates a WHERE fragment where each group is a distinct AND branch and branches are combined with OR; no group flattening occurs
+- [ ] Plugin startup fails with a descriptive error (no credentials in message) when `database_url` is missing, TLS negotiation is rejected, or GTS schema registration fails; the gateway process does not start
+- [ ] Level 2 integration tests pass when run with `cargo test --features integration` against a freshly migrated `timescale/timescaledb:latest-pg16` container
+- [ ] When the `AccessScope` passed to `query_aggregated` or `query_raw` contains any `InGroup` or `InGroupSubtree` predicate, the operation returns `UsageCollectorError::PermissionDenied` (built via `UsageRecordError::permission_denied()`) at the public boundary and executes no SQL. (Implementation detail: the plugin-internal `scope_to_sql` translator returns `ScopeTranslationError::UnsupportedPredicate { kind }` and the calling operation maps it to `PermissionDenied` per `inst-qagg-1` / `inst-qraw-1`. `ScopeTranslationError` is not part of the public crate surface.)
+
+**Test data requirements**:
+(1) At least one tenant with counter records spanning three or more 1-hour time buckets across a > 30-day window and one tenant with gauge records.
+(2) Idempotency collision test: submit ≥ 5 concurrent `create_usage_record` calls with the same `(tenant_id, idempotency_key)`; verify exactly one row in `usage_records`.
+(3) Cursor stability test: establish a baseline page of records, insert additional records with timestamps in the already-paged range, verify that the next page does not contain duplicates or skip expected records.
+
+**Test coverage guidance**:
+Unit (`src/domain/client_tests.rs`): `create_usage_record` — valid counter insert, valid gauge insert, negative counter value rejected, missing `idempotency_key` for counter rejected, transient DB error path; `scope_to_sql` — single group, multiple groups (OR-of-ANDs preserved), empty scope (fail-closed), `InGroup` predicate rejection.
+Integration (`tests/integration.rs`, `--features integration`): schema migration idempotency (run migration twice, verify no error); idempotent upsert under concurrent inserts; `query_aggregated` routing (continuous aggregate vs raw hypertable); `query_raw` cursor stability under concurrent inserts; health-check metric (`storage_health_status`).
+E2E: deferred — the full emitter → gateway → plugin → TimescaleDB path is covered by integration tests; a compose-based e2e suite is out of scope for this feature.
+Performance: measure `create_usage_record` throughput against `cpt-cf-usage-collector-nfr-throughput` (≥ 10,000 records/sec) and `query_aggregated` p95 latency against `cpt-cf-usage-collector-nfr-query-latency` (≤ 500ms) using representative data volumes in the integration environment.
+
+**Success metrics**:
+(1) All unit and Level 2 integration tests pass on CI via `cargo test --features integration`.
+(2) `create_usage_record` throughput ≥ 10,000 records/sec under sustained load on representative hardware.
+(3) `query_aggregated` (continuous aggregate path, 30-day window, single tenant) p95 latency ≤ 500ms on representative data volume.
+(4) Zero unexpected constraint violations in production; deduplication rate observable via `usage_dedup_total` metric.
+
+## 6. Non-Applicability Notes
+
+**Out of Scope (Deferred to F7/F8)**. The following capabilities are explicitly out of scope for this feature and are deferred to their respective feature specifications: operator backfill/amendment/deactivation (`backfill_ingest`, `amend_record`, `deactivate_record`) — deferred to F8; retention enforcement (`enforce_retention`) — deferred to F7; watermark retrieval (`get_watermarks`) — deferred to F8. None of these operations are implemented, referenced, or tested by this feature.
+
+**UX (User Experience & Accessibility)**. Not applicable. This feature implements a Rust plugin crate exposing a machine-to-machine `UsageCollectorPluginClientV1` trait. There is no user-facing UI, no end-user interaction model, no user-visible error messages, and no accessibility requirements.
+
+**COMPL (Regulatory & Privacy Compliance)**. Not applicable at the feature level. Tenant identifiers (`tenant_id`, `resource_id`, `subject_id`) are opaque billing UUIDs — not regulated personal data under the project's data classification policy. Encryption in transit is enforced by `cpt-cf-usage-collector-constraint-encryption` (TLS to TimescaleDB); encryption at rest is governed by platform infrastructure policy. Data retention compliance is implemented by `enforce_retention` per `cpt-cf-usage-collector-nfr-retention` (7 days – 7 years). No consent handling, data subject rights, or cross-border transfer considerations apply to opaque billing metrics.
+
+**BIZ (Business Logic)**. Not applicable. The storage plugin contains no business logic per `cpt-cf-usage-collector-constraint-no-business-logic`. Record metadata is stored as opaque JSONB without indexing or interpretation. Pricing, rating, billing rules, invoice generation, and quota enforcement are the responsibility of downstream consumers; the plugin stores and retrieves records as-is.
+
+**INT (External Integrations beyond TimescaleDB)**. Not applicable. The plugin's sole external integration is TimescaleDB. There are no message brokers, external APIs, webhooks, or secondary datastores. Audit event publishing (`WriteAuditEvent`) is delegated to the gateway layer, not the plugin.

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/Cargo.toml
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/Cargo.toml
@@ -1,0 +1,67 @@
+[package]
+name = "cyberware-timescaledb-usage-collector-plugin"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "TimescaleDB production plugin for the usage-collector gateway"
+readme = "README.md"
+keywords = ["cyberfabric", "cyberware", "cyberware-system"]
+categories = ["database"]
+
+[lib]
+name = "timescaledb_usage_collector_plugin"
+
+[features]
+integration = []
+
+[lints]
+workspace = true
+
+[dependencies]
+# Local dependencies
+types-registry-sdk = { workspace = true }
+usage-collector-sdk = { workspace = true }
+
+# ModKit dependencies
+modkit = { workspace = true }
+modkit-macros = { workspace = true }
+modkit-odata = { workspace = true }
+modkit-security = { workspace = true }
+
+# Async runtime
+async-trait = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+modkit-canonical-errors = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Database
+sqlx = { workspace = true, features = ["postgres", "uuid", "chrono", "json"] }
+
+# Data structures
+uuid = { workspace = true, features = ["v4"] }
+chrono = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+# Observability
+opentelemetry = { workspace = true }
+
+# Async runtime
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+
+# Duration parsing for config deserialization
+humantime = { workspace = true }
+
+[dev-dependencies]
+testcontainers = { workspace = true }

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/README.md
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/README.md
@@ -1,0 +1,46 @@
+# cyberware-timescaledb-usage-collector-plugin
+
+Production TimescaleDB storage plugin for the cyberware usage-collector subsystem.
+This crate implements the `UsageCollectorPluginClientV1` contract from
+`usage-collector-sdk`, persisting usage records into a TimescaleDB hypertable and
+serving aggregation queries via continuous aggregates and raw cursor-paginated
+reads. It targets durable high-throughput ingest with bounded connection-pool
+sizing, retention policy management, and OpenTelemetry-based observability.
+Configure via the `timescaledb-usage-collector-plugin` module config block
+(see the crate docs for the schema). The key must match the ModKit module name
+(`#[modkit::module(name = "timescaledb-usage-collector-plugin")]`) because
+`ctx.config()` reads `modules.<module-name>.config` verbatim.
+
+## Architectural deviation: raw sqlx instead of `SecureConn`
+
+This plugin deliberately bypasses the framework's `SecureConn` / `SecureORM`
+abstraction (which `MODKIT-SEC-001` requires for module DB access) because
+the storage paths it implements have no SecureORM equivalent: the
+TimescaleDB-specific DDL (`CREATE EXTENSION`, `create_hypertable`,
+`CREATE MATERIALIZED VIEW ... WITH (timescaledb.continuous)`,
+`add_continuous_aggregate_policy`, `add_retention_policy`), the cross-partition
+idempotency-key table, and the dynamically-built aggregation / pagination SQL
+in `infra/pg_query_port.rs` all need direct `sqlx::PgPool` access. The
+framework lint `de0706_no_direct_sqlx` is suppressed crate-wide in
+`infra/` and at the module bootstrap (`src/module.rs`) to acknowledge this.
+
+The substitute boundary for authorization is the scope-fragment translator in
+`domain/scope.rs`: every read and write composes the WHERE clause through
+`scope_to_sql`, which fails closed on empty scopes and rejects `InGroup` /
+`InGroupSubtree` predicates rather than silently dropping them. That fragment
+— and not `SecureConn` — is the authorization invariant this plugin commits
+to. The full trade-off (including the conditions under which a
+SecureConn-equivalent for TimescaleDB DDL would be preferred) is recorded in
+[ADR-0003](../../docs/ADR/0003-cpt-cf-usage-collector-adr-timescaledb-plugin-raw-sqlx.md).
+
+## Operational notes
+
+- **Idempotency-key cleanup is in-process and periodic.**
+  `setup_retention_policy` (`src/infra/retention.rs`) installs a TimescaleDB
+  retention policy on `usage_records` that runs continuously. The companion
+  `usage_idempotency_keys` table is a plain table with no hypertable retention
+  job, so the plugin issues the equivalent `DELETE` once at startup and then
+  again on a recurring interval from a background task in `module.rs`
+  (`run_idempotency_cleanup_loop`). Operators who prefer a database-side
+  schedule can additionally install a TimescaleDB user-defined `add_job`
+  running the same statement.

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/config.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/config.rs
@@ -1,0 +1,176 @@
+//! Configuration for the `TimescaleDB` usage-collector plugin.
+
+use std::fmt;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+const ONE_HOUR_SECS: u64 = 3_600;
+const SEVEN_DAYS_SECS: u64 = 7 * 24 * 3_600;
+const THIRTY_DAYS_SECS: u64 = 30 * 24 * 3_600;
+const SEVEN_YEARS_SECS: u64 = 7 * 365 * 24 * 3_600;
+
+fn default_pool_size_min() -> u32 {
+    2
+}
+
+fn default_pool_size_max() -> u32 {
+    16
+}
+
+fn default_retention_default() -> Duration {
+    Duration::from_hours(8760)
+}
+
+fn default_idempotency_retention() -> Duration {
+    Duration::from_secs(SEVEN_DAYS_SECS)
+}
+
+fn default_connection_timeout() -> Duration {
+    Duration::from_secs(10)
+}
+
+fn deserialize_duration<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    humantime::parse_duration(&s).map_err(serde::de::Error::custom)
+}
+
+/// Plugin configuration.
+///
+/// All parameters are static and require a plugin restart to change.
+/// `database_url` must include `sslmode=require`, `sslmode=verify-ca`, or
+/// `sslmode=verify-full`; plaintext connections are rejected.
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TimescaleDbConfig {
+    /// `PostgreSQL` connection URL. Must include `sslmode=require`,
+    /// `sslmode=verify-ca`, or `sslmode=verify-full`.
+    #[serde(default)]
+    pub database_url: String,
+
+    /// Minimum connection pool size (1–64). Default: 2.
+    #[serde(default = "default_pool_size_min")]
+    pub pool_size_min: u32,
+
+    /// Maximum connection pool size (1–128). Must be >= `pool_size_min`. Default: 16.
+    #[serde(default = "default_pool_size_max")]
+    pub pool_size_max: u32,
+
+    /// Default data retention period (7 days – 7 years). Default: 365 days.
+    #[serde(
+        default = "default_retention_default",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub retention_default: Duration,
+
+    /// Connection acquisition timeout (1s – 60s). Default: 10s.
+    #[serde(
+        default = "default_connection_timeout",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub connection_timeout: Duration,
+
+    /// Retention period for `usage_idempotency_keys` rows (1h – 30 days). Default: 7 days.
+    ///
+    /// Distinct from `retention_default`, which controls the hypertable
+    /// retention policy. Idempotency dedup windows are bounded by client retry
+    /// horizons (typically hours to a few days); reusing the data-retention
+    /// window here would grow `usage_idempotency_keys` linearly with ingest
+    /// volume and slow the periodic `DELETE` over time.
+    #[serde(
+        default = "default_idempotency_retention",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub idempotency_retention: Duration,
+}
+
+impl fmt::Debug for TimescaleDbConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TimescaleDbConfig")
+            .field("database_url", &"[redacted]")
+            .field("pool_size_min", &self.pool_size_min)
+            .field("pool_size_max", &self.pool_size_max)
+            .field("retention_default", &self.retention_default)
+            .field("connection_timeout", &self.connection_timeout)
+            .field("idempotency_retention", &self.idempotency_retention)
+            .finish()
+    }
+}
+
+impl TimescaleDbConfig {
+    /// Validates all configuration parameters.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `database_url` is missing or its effective `sslmode`
+    /// is not one of `require`, `verify-ca`, or `verify-full`, pool sizes are
+    /// out of range, or timeouts are out of range.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.database_url.is_empty() {
+            anyhow::bail!("database_url is required");
+        }
+        // Parse the query string to find the effective sslmode (last occurrence wins, matching
+        // how the PostgreSQL driver resolves duplicate parameters).
+        let sslmode = self.database_url.split_once('?').and_then(|(_, qs)| {
+            qs.split('&')
+                .rfind(|p| p.split_once('=').is_some_and(|(k, _)| k == "sslmode"))
+                .and_then(|p| p.split_once('=').map(|(_, v)| v))
+        });
+        match sslmode {
+            Some("require" | "verify-ca" | "verify-full") => {}
+            _ => anyhow::bail!(
+                "database_url must include sslmode=require, sslmode=verify-ca, or sslmode=verify-full for TLS enforcement"
+            ),
+        }
+        if self.pool_size_min < 1 {
+            anyhow::bail!("pool_size_min must be >= 1, got {}", self.pool_size_min);
+        }
+        if self.pool_size_min > 64 {
+            anyhow::bail!("pool_size_min must be <= 64, got {}", self.pool_size_min);
+        }
+        if self.pool_size_max < self.pool_size_min {
+            anyhow::bail!(
+                "pool_size_max ({}) must be >= pool_size_min ({})",
+                self.pool_size_max,
+                self.pool_size_min
+            );
+        }
+        if self.pool_size_max > 128 {
+            anyhow::bail!("pool_size_max must be <= 128, got {}", self.pool_size_max);
+        }
+        let min_retention = Duration::from_secs(SEVEN_DAYS_SECS);
+        let max_retention = Duration::from_secs(SEVEN_YEARS_SECS);
+        if self.retention_default < min_retention || self.retention_default > max_retention {
+            anyhow::bail!("retention_default must be between 7 days and 7 years");
+        }
+        if self.connection_timeout < Duration::from_secs(1)
+            || self.connection_timeout > Duration::from_mins(1)
+        {
+            anyhow::bail!("connection_timeout must be between 1s and 60s");
+        }
+        let min_idem_retention = Duration::from_secs(ONE_HOUR_SECS);
+        let max_idem_retention = Duration::from_secs(THIRTY_DAYS_SECS);
+        if self.idempotency_retention < min_idem_retention
+            || self.idempotency_retention > max_idem_retention
+        {
+            anyhow::bail!("idempotency_retention must be between 1 hour and 30 days");
+        }
+        Ok(())
+    }
+}
+
+impl Default for TimescaleDbConfig {
+    fn default() -> Self {
+        Self {
+            database_url: String::new(),
+            pool_size_min: default_pool_size_min(),
+            pool_size_max: default_pool_size_max(),
+            retention_default: default_retention_default(),
+            connection_timeout: default_connection_timeout(),
+            idempotency_retention: default_idempotency_retention(),
+        }
+    }
+}

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/domain/client.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/domain/client.rs
@@ -1,0 +1,151 @@
+//! `TimescaleDB` storage plugin client.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use async_trait::async_trait;
+use modkit_macros::domain_model;
+use usage_collector_sdk::error::UsageRecordError;
+use usage_collector_sdk::models::{
+    AggregationQuery, AggregationResult, RawQuery, UsageKind, UsageRecord,
+};
+use usage_collector_sdk::{Page, UsageCollectorError, UsageCollectorPluginClientV1};
+
+use crate::domain::insert_port::InsertPort;
+use crate::domain::metrics::PluginMetrics;
+use crate::domain::query_port::QueryPort;
+
+/// Storage plugin client backed by a `TimescaleDB` connection pool.
+#[domain_model]
+pub struct TimescaleDbPluginClient {
+    insert_port: Arc<dyn InsertPort>,
+    query_port: Arc<dyn QueryPort>,
+    metrics: Arc<dyn PluginMetrics>,
+}
+
+impl TimescaleDbPluginClient {
+    /// Creates a new client wrapping the given insert port, query port, and metrics port.
+    pub fn new(
+        insert_port: Arc<dyn InsertPort>,
+        query_port: Arc<dyn QueryPort>,
+        metrics: Arc<dyn PluginMetrics>,
+    ) -> Self {
+        Self {
+            insert_port,
+            query_port,
+            metrics,
+        }
+    }
+}
+
+#[async_trait]
+impl UsageCollectorPluginClientV1 for TimescaleDbPluginClient {
+    // @cpt-algo:cpt-cf-usage-collector-algo-production-storage-plugin-create-usage-record:p1
+    // @cpt-flow:cpt-cf-usage-collector-flow-production-storage-plugin-storage-backend-ingest:p1
+    async fn create_usage_record(&self, record: UsageRecord) -> Result<(), UsageCollectorError> {
+        let start = Instant::now();
+
+        // @cpt-begin:cpt-cf-usage-collector-flow-production-storage-plugin-storage-backend-ingest:p1:inst-flow-ing-1
+        // Plugin entry point; called by the gateway when delegating record storage.
+        // @cpt-end:cpt-cf-usage-collector-flow-production-storage-plugin-storage-backend-ingest:p1:inst-flow-ing-1
+
+        // @cpt-begin:cpt-cf-usage-collector-flow-production-storage-plugin-storage-backend-ingest:p1:inst-flow-ing-2
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-create-usage-record:p1:inst-cur-1
+        if !record.value.is_finite() {
+            self.metrics.record_schema_validation_error();
+            return Err(UsageRecordError::invalid_argument()
+                .with_constraint(format!("value must be finite, got: {}", record.value))
+                .create());
+        }
+        if record.kind == UsageKind::Counter && record.value < 0.0 {
+            self.metrics.record_schema_validation_error();
+            return Err(UsageRecordError::invalid_argument()
+                .with_constraint(format!(
+                    "counter value must be non-negative, got: {}",
+                    record.value
+                ))
+                .create());
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-create-usage-record:p1:inst-cur-1
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-create-usage-record:p1:inst-cur-2
+        if record.kind == UsageKind::Counter && record.idempotency_key.trim().is_empty() {
+            self.metrics.record_schema_validation_error();
+            return Err(UsageRecordError::invalid_argument()
+                .with_constraint("counter records require a non-empty idempotency_key")
+                .create());
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-create-usage-record:p1:inst-cur-2
+        // @cpt-end:cpt-cf-usage-collector-flow-production-storage-plugin-storage-backend-ingest:p1:inst-flow-ing-2
+
+        // @cpt-begin:cpt-cf-usage-collector-flow-production-storage-plugin-storage-backend-ingest:p1:inst-flow-ing-3
+        let result = self.insert_port.insert_usage_record(&record).await;
+        // @cpt-end:cpt-cf-usage-collector-flow-production-storage-plugin-storage-backend-ingest:p1:inst-flow-ing-3
+
+        let rows_affected = match result {
+            Ok(n) => n,
+            Err(e) => {
+                // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-create-usage-record:p1:inst-cur-4
+                // @cpt-begin:cpt-cf-usage-collector-flow-production-storage-plugin-storage-backend-ingest:p1:inst-flow-ing-4
+                // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-create-usage-record:p1:inst-cur-5
+                self.metrics.record_ingestion_error();
+                self.metrics
+                    .record_ingestion_latency_ms(start.elapsed().as_secs_f64() * 1000.0);
+                return Err(e.into());
+                // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-create-usage-record:p1:inst-cur-5
+                // @cpt-end:cpt-cf-usage-collector-flow-production-storage-plugin-storage-backend-ingest:p1:inst-flow-ing-4
+                // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-create-usage-record:p1:inst-cur-4
+            }
+        };
+
+        let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+        self.metrics.record_ingestion_latency_ms(elapsed_ms);
+        if rows_affected == 0 {
+            self.metrics.record_dedup();
+        } else {
+            self.metrics.record_ingestion_success();
+        }
+
+        // @cpt-begin:cpt-cf-usage-collector-flow-production-storage-plugin-storage-backend-ingest:p1:inst-flow-ing-5
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-create-usage-record:p1:inst-cur-7
+        Ok(())
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-create-usage-record:p1:inst-cur-7
+        // @cpt-end:cpt-cf-usage-collector-flow-production-storage-plugin-storage-backend-ingest:p1:inst-flow-ing-5
+    }
+
+    // @cpt-algo:cpt-cf-usage-collector-algo-production-storage-plugin-query-aggregated:p1
+    async fn query_aggregated(
+        &self,
+        query: AggregationQuery,
+    ) -> Result<Vec<AggregationResult>, UsageCollectorError> {
+        let start = Instant::now();
+        let result = self.query_port.query_aggregated(query).await;
+        self.metrics
+            .record_query_latency_ms("aggregated", start.elapsed().as_secs_f64() * 1000.0);
+        if result.is_ok() {
+            self.metrics.record_query_success("aggregated");
+        } else {
+            self.metrics.record_query_error("aggregated");
+        }
+        result
+    }
+
+    // @cpt-algo:cpt-cf-usage-collector-algo-production-storage-plugin-query-raw:p1
+    async fn query_raw(&self, query: RawQuery) -> Result<Page<UsageRecord>, UsageCollectorError> {
+        let start = Instant::now();
+        let result = self.query_port.query_raw(query).await;
+        self.metrics
+            .record_query_latency_ms("raw", start.elapsed().as_secs_f64() * 1000.0);
+        if result.is_ok() {
+            self.metrics.record_query_success("raw");
+        } else {
+            self.metrics.record_query_error("raw");
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "client_tests.rs"]
+mod client_tests;

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/domain/client_tests.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/domain/client_tests.rs
@@ -1,0 +1,887 @@
+// @cpt-dod:cpt-cf-usage-collector-dod-production-storage-plugin-testing-and-observability
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use modkit_security::AccessScope;
+use uuid::Uuid;
+
+use usage_collector_sdk::models::{
+    AggregationFn, AggregationQuery, AggregationResult, RawQuery, UsageKind, UsageRecord,
+};
+use usage_collector_sdk::{Page, PageInfo, UsageCollectorError, UsageCollectorPluginClientV1};
+
+use super::TimescaleDbPluginClient;
+use crate::domain::error::StoragePluginError;
+use crate::domain::insert_port::InsertPort;
+use crate::domain::metrics::PluginMetrics;
+use crate::domain::query_port::QueryPort;
+
+// ── Mock: insert port ─────────────────────────────────────────────────────────
+
+#[derive(Clone, Copy)]
+enum InsertBehavior {
+    Success(u64),
+    PoolTimeout,
+    QueryFailed,
+    UnexpectedUniqueViolation,
+}
+
+struct MockInsertPort {
+    behavior: InsertBehavior,
+    captured_value: Option<Arc<Mutex<f64>>>,
+}
+
+impl MockInsertPort {
+    fn success(rows: u64) -> Arc<Self> {
+        Arc::new(Self {
+            behavior: InsertBehavior::Success(rows),
+            captured_value: None,
+        })
+    }
+
+    fn pool_timeout() -> Arc<Self> {
+        Arc::new(Self {
+            behavior: InsertBehavior::PoolTimeout,
+            captured_value: None,
+        })
+    }
+
+    fn query_failed() -> Arc<Self> {
+        Arc::new(Self {
+            behavior: InsertBehavior::QueryFailed,
+            captured_value: None,
+        })
+    }
+
+    fn unexpected_unique_violation() -> Arc<Self> {
+        Arc::new(Self {
+            behavior: InsertBehavior::UnexpectedUniqueViolation,
+            captured_value: None,
+        })
+    }
+
+    fn capturing(cap: Arc<Mutex<f64>>) -> Arc<Self> {
+        Arc::new(Self {
+            behavior: InsertBehavior::Success(1),
+            captured_value: Some(cap),
+        })
+    }
+}
+
+#[async_trait]
+impl InsertPort for MockInsertPort {
+    async fn insert_usage_record(&self, record: &UsageRecord) -> Result<u64, StoragePluginError> {
+        if let Some(ref cap) = self.captured_value {
+            *cap.lock().unwrap() = record.value;
+        }
+        match self.behavior {
+            InsertBehavior::Success(n) => Ok(n),
+            InsertBehavior::PoolTimeout => Err(StoragePluginError::Transient(Box::new(
+                std::io::Error::other("pool timed out"),
+            ))),
+            InsertBehavior::QueryFailed => Err(StoragePluginError::QueryFailed(Box::new(
+                std::io::Error::other("mock non-transient query failure"),
+            ))),
+            InsertBehavior::UnexpectedUniqueViolation => {
+                Err(StoragePluginError::UnexpectedUniqueViolation(Box::new(
+                    std::io::Error::other("mock unique violation after claim"),
+                )))
+            }
+        }
+    }
+}
+
+// ── Mock: query port ──────────────────────────────────────────────────────────
+
+struct MockQueryPort {
+    agg_fail: bool,
+    raw_fail: bool,
+    captured_agg: Mutex<Option<AggregationQuery>>,
+    captured_raw: Mutex<Option<RawQuery>>,
+    // `agg_response` and `raw_response` are set once at construction and only
+    // read thereafter, so they do not need interior mutability — the previous
+    // `Mutex` wrapping locked on every async call and obscured that
+    // read-only-after-construction contract.
+    agg_response: Vec<AggregationResult>,
+    raw_response: Page<UsageRecord>,
+}
+
+impl MockQueryPort {
+    fn build(
+        agg_fail: bool,
+        raw_fail: bool,
+        agg_response: Vec<AggregationResult>,
+        raw_response: Page<UsageRecord>,
+    ) -> Self {
+        Self {
+            agg_fail,
+            raw_fail,
+            captured_agg: Mutex::new(None),
+            captured_raw: Mutex::new(None),
+            agg_response,
+            raw_response,
+        }
+    }
+
+    fn new(agg_fail: bool, raw_fail: bool) -> Self {
+        Self::build(agg_fail, raw_fail, vec![], Page::empty(10))
+    }
+
+    fn success() -> Arc<Self> {
+        Arc::new(Self::new(false, false))
+    }
+    fn agg_failing() -> Arc<Self> {
+        Arc::new(Self::new(true, false))
+    }
+    fn raw_failing() -> Arc<Self> {
+        Arc::new(Self::new(false, true))
+    }
+
+    fn with_agg_response(response: Vec<AggregationResult>) -> Arc<Self> {
+        Arc::new(Self::build(false, false, response, Page::empty(10)))
+    }
+
+    fn with_raw_response(response: Page<UsageRecord>) -> Arc<Self> {
+        Arc::new(Self::build(false, false, vec![], response))
+    }
+}
+
+#[async_trait]
+impl QueryPort for MockQueryPort {
+    async fn query_aggregated(
+        &self,
+        query: AggregationQuery,
+    ) -> Result<Vec<AggregationResult>, UsageCollectorError> {
+        *self.captured_agg.lock().unwrap() = Some(query);
+        if self.agg_fail {
+            Err(UsageCollectorError::service_unavailable()
+                .with_detail("mock transient")
+                .create())
+        } else {
+            Ok(self.agg_response.clone())
+        }
+    }
+
+    async fn query_raw(&self, query: RawQuery) -> Result<Page<UsageRecord>, UsageCollectorError> {
+        *self.captured_raw.lock().unwrap() = Some(query);
+        if self.raw_fail {
+            Err(UsageCollectorError::service_unavailable()
+                .with_detail("mock transient")
+                .create())
+        } else {
+            Ok(self.raw_response.clone())
+        }
+    }
+}
+
+// ── Mock: metrics ─────────────────────────────────────────────────────────────
+
+#[derive(Default)]
+struct MockMetrics {
+    ingestion_success: AtomicU32,
+    ingestion_error: AtomicU32,
+    ingestion_latency_called: AtomicU32,
+    query_latency_called: AtomicU32,
+    query_success_aggregated: AtomicU32,
+    query_success_raw: AtomicU32,
+    query_error_aggregated: AtomicU32,
+    query_error_raw: AtomicU32,
+    dedup: AtomicU32,
+    schema_validation_errors: AtomicU32,
+}
+
+impl PluginMetrics for MockMetrics {
+    fn record_ingestion_success(&self) {
+        self.ingestion_success.fetch_add(1, Ordering::SeqCst);
+    }
+    fn record_ingestion_error(&self) {
+        self.ingestion_error.fetch_add(1, Ordering::SeqCst);
+    }
+    fn record_ingestion_latency_ms(&self, _elapsed_ms: f64) {
+        self.ingestion_latency_called.fetch_add(1, Ordering::SeqCst);
+    }
+    fn record_dedup(&self) {
+        self.dedup.fetch_add(1, Ordering::SeqCst);
+    }
+    fn record_schema_validation_error(&self) {
+        self.schema_validation_errors.fetch_add(1, Ordering::SeqCst);
+    }
+    fn record_query_latency_ms(&self, _query_type: &str, _elapsed_ms: f64) {
+        self.query_latency_called.fetch_add(1, Ordering::SeqCst);
+    }
+    fn record_query_success(&self, query_type: &str) {
+        match query_type {
+            "aggregated" => {
+                self.query_success_aggregated.fetch_add(1, Ordering::SeqCst);
+            }
+            "raw" => {
+                self.query_success_raw.fetch_add(1, Ordering::SeqCst);
+            }
+            other => panic!("unexpected query_type for success: {other}"),
+        }
+    }
+    fn record_query_error(&self, query_type: &str) {
+        match query_type {
+            "aggregated" => {
+                self.query_error_aggregated.fetch_add(1, Ordering::SeqCst);
+            }
+            "raw" => {
+                self.query_error_raw.fetch_add(1, Ordering::SeqCst);
+            }
+            other => panic!("unexpected query_type for error: {other}"),
+        }
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn make_client(
+    insert_port: Arc<dyn InsertPort>,
+    metrics: Arc<MockMetrics>,
+) -> TimescaleDbPluginClient {
+    TimescaleDbPluginClient::new(insert_port, MockQueryPort::success(), metrics)
+}
+
+fn make_client_q(
+    query_port: Arc<dyn QueryPort>,
+    metrics: Arc<MockMetrics>,
+) -> TimescaleDbPluginClient {
+    TimescaleDbPluginClient::new(MockInsertPort::success(0), query_port, metrics)
+}
+
+fn base_counter_record() -> UsageRecord {
+    UsageRecord {
+        module: "test-module".to_owned(),
+        tenant_id: Uuid::new_v4(),
+        metric: "test.cpu".to_owned(),
+        kind: UsageKind::Counter,
+        value: 1.0,
+        resource_id: Uuid::new_v4(),
+        resource_type: "vm".to_owned(),
+        subject: None,
+        idempotency_key: "idem-key-1".to_owned(),
+        timestamp: Utc::now(),
+        metadata: None,
+    }
+}
+
+fn base_gauge_record() -> UsageRecord {
+    UsageRecord {
+        kind: UsageKind::Gauge,
+        idempotency_key: String::new(),
+        ..base_counter_record()
+    }
+}
+
+// ── create_usage_record tests ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_create_usage_record_valid_counter() {
+    // Scenario: valid counter insert — DB mock returns 1 row affected
+    let metrics = Arc::new(MockMetrics::default());
+    let client = make_client(MockInsertPort::success(1), metrics.clone());
+
+    let result = client.create_usage_record(base_counter_record()).await;
+
+    assert!(result.is_ok());
+    assert_eq!(
+        metrics.ingestion_success.load(Ordering::SeqCst),
+        1,
+        "ingestion_success counter"
+    );
+    assert_eq!(
+        metrics.ingestion_latency_called.load(Ordering::SeqCst),
+        1,
+        "latency histogram"
+    );
+}
+
+#[tokio::test]
+async fn test_create_usage_record_valid_gauge() {
+    // Scenario: valid gauge insert — DB mock returns 1 row affected
+    let metrics = Arc::new(MockMetrics::default());
+    let client = make_client(MockInsertPort::success(1), metrics.clone());
+
+    let result = client.create_usage_record(base_gauge_record()).await;
+
+    assert!(result.is_ok());
+    assert_eq!(
+        metrics.ingestion_success.load(Ordering::SeqCst),
+        1,
+        "ingestion_success counter"
+    );
+}
+
+#[tokio::test]
+async fn test_create_usage_record_negative_counter_value_rejected() {
+    // Scenario: counter with negative value rejected before any DB call
+    let metrics = Arc::new(MockMetrics::default());
+    let client = make_client(MockInsertPort::success(0), metrics.clone());
+    let record = UsageRecord {
+        value: -1.0,
+        ..base_counter_record()
+    };
+
+    let result = client.create_usage_record(record).await;
+
+    assert!(
+        matches!(result, Err(UsageCollectorError::InvalidArgument { .. })),
+        "expected InvalidArgument error for negative counter value"
+    );
+    assert_eq!(
+        metrics.schema_validation_errors.load(Ordering::SeqCst),
+        1,
+        "validation error counter"
+    );
+    assert_eq!(
+        metrics.ingestion_success.load(Ordering::SeqCst),
+        0,
+        "no success on validation failure"
+    );
+}
+
+#[tokio::test]
+async fn test_create_usage_record_missing_idempotency_key_for_counter_rejected() {
+    // Scenario: counter without idempotency_key rejected before any DB call
+    let metrics = Arc::new(MockMetrics::default());
+    let client = make_client(MockInsertPort::success(0), metrics.clone());
+    let record = UsageRecord {
+        idempotency_key: String::new(),
+        ..base_counter_record()
+    };
+
+    let result = client.create_usage_record(record).await;
+
+    assert!(
+        matches!(result, Err(UsageCollectorError::InvalidArgument { .. })),
+        "expected InvalidArgument error for missing idempotency_key"
+    );
+    assert_eq!(
+        metrics.schema_validation_errors.load(Ordering::SeqCst),
+        1,
+        "validation error counter"
+    );
+    assert_eq!(
+        metrics.ingestion_success.load(Ordering::SeqCst),
+        0,
+        "no success on validation failure"
+    );
+}
+
+#[tokio::test]
+async fn test_create_usage_record_query_failed_maps_to_internal() {
+    // Pins the classification: a non-transient `QueryFailed` from the insert
+    // port must surface as `UsageCollectorError::Internal`, not as
+    // `ServiceUnavailable`. The integration suite exercises real-DB unique
+    // violations but does not assert the mapped variant; this mock-based
+    // test is where the contract lives so a regression that swapped the
+    // mapping (e.g. routed `23505` through the transient path) is caught
+    // here before it ever reaches the production storage backend.
+    let metrics = Arc::new(MockMetrics::default());
+    let client = make_client(MockInsertPort::query_failed(), metrics.clone());
+
+    let result = client.create_usage_record(base_counter_record()).await;
+
+    assert!(
+        matches!(result, Err(UsageCollectorError::Internal { .. })),
+        "non-transient QueryFailed must map to Internal, got: {result:?}"
+    );
+    assert_eq!(
+        metrics.ingestion_error.load(Ordering::SeqCst),
+        1,
+        "ingestion_error counter must record the failure"
+    );
+    assert_eq!(
+        metrics.ingestion_success.load(Ordering::SeqCst),
+        0,
+        "no success on non-transient error"
+    );
+}
+
+#[tokio::test]
+async fn test_create_usage_record_unexpected_unique_violation_maps_to_internal() {
+    // Pins the classification of the post-claim unique violation path: it
+    // signals an internal invariant break (the idempotency-key claim said
+    // the slot was free, then the records insert collided anyway), so it
+    // must surface as `Internal`. A regression that routed this through the
+    // transient path would mask a genuine bug behind a retry loop.
+    let metrics = Arc::new(MockMetrics::default());
+    let client = make_client(
+        MockInsertPort::unexpected_unique_violation(),
+        metrics.clone(),
+    );
+
+    let result = client.create_usage_record(base_counter_record()).await;
+
+    assert!(
+        matches!(result, Err(UsageCollectorError::Internal { .. })),
+        "UnexpectedUniqueViolation must map to Internal, got: {result:?}"
+    );
+    assert_eq!(
+        metrics.ingestion_error.load(Ordering::SeqCst),
+        1,
+        "ingestion_error counter must record the failure"
+    );
+    assert_eq!(
+        metrics.ingestion_success.load(Ordering::SeqCst),
+        0,
+        "no success on internal error"
+    );
+}
+
+#[tokio::test]
+async fn test_create_usage_record_transient_db_error() {
+    // Scenario: DB mock returns pool-timeout (transient); mapped to Unavailable
+    let metrics = Arc::new(MockMetrics::default());
+    let client = make_client(MockInsertPort::pool_timeout(), metrics.clone());
+
+    let result = client.create_usage_record(base_counter_record()).await;
+
+    assert!(
+        matches!(result, Err(UsageCollectorError::ServiceUnavailable { .. })),
+        "transient error must map to Unavailable"
+    );
+    assert_eq!(
+        metrics.ingestion_error.load(Ordering::SeqCst),
+        1,
+        "ingestion_error counter"
+    );
+    assert_eq!(
+        metrics.ingestion_success.load(Ordering::SeqCst),
+        0,
+        "no success on transient error"
+    );
+}
+
+#[tokio::test]
+async fn test_create_usage_record_idempotent_insert() {
+    // Scenario: DB mock returns 0 rows affected (ON CONFLICT DO NOTHING); dedup recorded
+    let metrics = Arc::new(MockMetrics::default());
+    let client = make_client(MockInsertPort::success(0), metrics.clone());
+
+    let result = client.create_usage_record(base_counter_record()).await;
+
+    assert!(result.is_ok());
+    assert_eq!(
+        metrics.dedup.load(Ordering::SeqCst),
+        1,
+        "dedup counter must be incremented"
+    );
+    assert_eq!(
+        metrics.ingestion_success.load(Ordering::SeqCst),
+        0,
+        "success not reported for dedup"
+    );
+}
+
+#[tokio::test]
+async fn test_create_usage_record_gauge_no_accumulation() {
+    // Scenario: gauge value passed to insert equals submitted value — no accumulation applied
+    let captured = Arc::new(Mutex::new(0.0_f64));
+    let port = MockInsertPort::capturing(captured.clone());
+    let metrics = Arc::new(MockMetrics::default());
+    let client = make_client(port, metrics);
+
+    let submitted_value = 42.75_f64;
+    let record = UsageRecord {
+        value: submitted_value,
+        ..base_gauge_record()
+    };
+    client.create_usage_record(record).await.unwrap();
+
+    let stored = *captured.lock().unwrap();
+    assert!(
+        (stored - submitted_value).abs() < f64::EPSILON,
+        "gauge value must not be accumulated or transformed before insert",
+    );
+}
+
+// `scope_to_sql` is covered by its own tests in `domain/scope.rs`; this file
+// exercises the client wiring around it.
+
+// ── query path tests ──────────────────────────────────────────────────────────
+
+fn base_agg_query() -> AggregationQuery {
+    AggregationQuery {
+        scope: AccessScope::for_tenant(Uuid::new_v4()),
+        time_range: (Utc::now() - chrono::Duration::hours(1), Utc::now()),
+        function: AggregationFn::Sum,
+        group_by: vec![],
+        bucket_size: None,
+        usage_type: None,
+        resource_id: None,
+        resource_type: None,
+        subject_id: None,
+        subject_type: None,
+        source: None,
+    }
+}
+
+fn base_raw_query() -> RawQuery {
+    RawQuery {
+        scope: AccessScope::for_tenant(Uuid::new_v4()),
+        time_range: (Utc::now() - chrono::Duration::hours(1), Utc::now()),
+        usage_type: None,
+        resource_id: None,
+        resource_type: None,
+        subject_type: None,
+        subject_id: None,
+        cursor: None,
+        page_size: 10,
+    }
+}
+
+#[tokio::test]
+async fn test_query_aggregated_forwards_query_and_returns_response() {
+    // Pins both the latency-recording side effect and the wiring: the query the
+    // client receives must reach the port unchanged, and the port's response must
+    // travel back to the caller unchanged. A regression that swapped the query or
+    // dropped the result would slip past a "just check latency" assertion.
+    let scope_tid = Uuid::new_v4();
+    let expected_query = AggregationQuery {
+        scope: AccessScope::for_tenant(scope_tid),
+        time_range: (Utc::now() - chrono::Duration::hours(2), Utc::now()),
+        function: AggregationFn::Sum,
+        group_by: vec![],
+        bucket_size: None,
+        usage_type: Some("test.metric".to_owned()),
+        resource_id: None,
+        resource_type: None,
+        subject_id: None,
+        subject_type: None,
+        source: Some("billing".to_owned()),
+    };
+    let expected_response = vec![AggregationResult {
+        function: AggregationFn::Sum,
+        value: 42.0,
+        bucket_start: None,
+        usage_type: Some("test.metric".to_owned()),
+        subject_id: None,
+        subject_type: None,
+        resource_id: None,
+        resource_type: None,
+        source: Some("billing".to_owned()),
+    }];
+    let metrics = Arc::new(MockMetrics::default());
+    let port = MockQueryPort::with_agg_response(expected_response.clone());
+    let client = make_client_q(port.clone(), metrics.clone());
+
+    let result = client.query_aggregated(expected_query.clone()).await;
+
+    let returned = result.expect("aggregated query must succeed");
+    // `AggregationResult` only derives `PartialEq` inside the SDK's test cfg;
+    // compare every field explicitly so a regression that zeroed any of them
+    // during plugin-side mapping fails this test.
+    assert_eq!(returned.len(), expected_response.len());
+    let r = &returned[0];
+    let e = &expected_response[0];
+    assert_eq!(r.function, e.function);
+    assert!((r.value - e.value).abs() < f64::EPSILON);
+    assert_eq!(r.bucket_start, e.bucket_start);
+    assert_eq!(r.usage_type, e.usage_type);
+    assert_eq!(r.subject_id, e.subject_id);
+    assert_eq!(r.subject_type, e.subject_type);
+    assert_eq!(r.resource_id, e.resource_id);
+    assert_eq!(r.resource_type, e.resource_type);
+    assert_eq!(r.source, e.source);
+
+    let captured = port
+        .captured_agg
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("port should have captured query");
+    assert_eq!(captured.usage_type, expected_query.usage_type);
+    assert_eq!(captured.source, expected_query.source);
+    assert_eq!(captured.function, expected_query.function);
+    assert_eq!(captured.time_range, expected_query.time_range);
+
+    assert_eq!(
+        metrics.query_latency_called.load(Ordering::SeqCst),
+        1,
+        "query latency must be recorded on success"
+    );
+    assert_eq!(
+        metrics.query_success_aggregated.load(Ordering::SeqCst),
+        1,
+        "aggregated query success counter must increment on Ok"
+    );
+    assert_eq!(
+        metrics.query_error_aggregated.load(Ordering::SeqCst),
+        0,
+        "aggregated query error counter must not increment on Ok"
+    );
+}
+
+#[tokio::test]
+async fn test_query_aggregated_error_propagates_and_records_latency() {
+    let metrics = Arc::new(MockMetrics::default());
+    let port = MockQueryPort::agg_failing();
+    let client = make_client_q(port.clone(), metrics.clone());
+
+    let query = base_agg_query();
+    let result = client.query_aggregated(query.clone()).await;
+
+    assert!(
+        matches!(result, Err(UsageCollectorError::ServiceUnavailable { .. })),
+        "agg_failing mock must propagate the ServiceUnavailable error variant"
+    );
+    let captured = port
+        .captured_agg
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("port should observe the forwarded query even on failure");
+    assert_eq!(captured.time_range, query.time_range);
+    assert_eq!(
+        metrics.query_latency_called.load(Ordering::SeqCst),
+        1,
+        "query latency must be recorded even on error"
+    );
+    assert_eq!(
+        metrics.query_error_aggregated.load(Ordering::SeqCst),
+        1,
+        "aggregated query error counter must increment on Err"
+    );
+    assert_eq!(
+        metrics.query_success_aggregated.load(Ordering::SeqCst),
+        0,
+        "aggregated query success counter must not increment on Err"
+    );
+}
+
+#[tokio::test]
+async fn test_query_raw_forwards_query_and_returns_response() {
+    let expected_query = base_raw_query();
+    let expected_record = UsageRecord {
+        value: 17.0,
+        ..base_counter_record()
+    };
+    let expected_page = Page::new(
+        vec![expected_record.clone()],
+        PageInfo {
+            next_cursor: Some("next-cursor".to_owned()),
+            prev_cursor: None,
+            limit: 10,
+        },
+    );
+
+    let metrics = Arc::new(MockMetrics::default());
+    let port = MockQueryPort::with_raw_response(expected_page.clone());
+    let client = make_client_q(port.clone(), metrics.clone());
+
+    let result = client.query_raw(expected_query.clone()).await;
+
+    let returned = result.expect("raw query must succeed");
+    // `UsageRecord` derives `PartialEq`; compare every field explicitly so a
+    // regression that zeroed `subject`, `metric`, `tenant_id`, etc. during
+    // plugin-side mapping fails this test instead of slipping past a "just
+    // check value" assertion. `value` uses an explicit epsilon because
+    // `PartialEq` on `f64` is `==` (NaN-bites — finite here, but pinning the
+    // pattern keeps future record fixtures safe).
+    assert_eq!(returned.items.len(), 1);
+    let r = &returned.items[0];
+    let e = &expected_record;
+    assert_eq!(r.module, e.module);
+    assert_eq!(r.tenant_id, e.tenant_id);
+    assert_eq!(r.metric, e.metric);
+    assert_eq!(r.kind, e.kind);
+    assert!((r.value - e.value).abs() < f64::EPSILON);
+    assert_eq!(r.resource_id, e.resource_id);
+    assert_eq!(r.resource_type, e.resource_type);
+    assert_eq!(r.subject, e.subject);
+    assert_eq!(r.idempotency_key, e.idempotency_key);
+    assert_eq!(r.timestamp, e.timestamp);
+    assert_eq!(r.metadata, e.metadata);
+    assert_eq!(
+        returned.page_info.next_cursor.as_deref(),
+        Some("next-cursor")
+    );
+    assert_eq!(
+        returned.page_info.prev_cursor,
+        expected_page.page_info.prev_cursor
+    );
+    assert_eq!(returned.page_info.limit, expected_page.page_info.limit);
+
+    let captured = port
+        .captured_raw
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("port should have captured query");
+    assert_eq!(captured.page_size, expected_query.page_size);
+    assert_eq!(captured.time_range, expected_query.time_range);
+
+    assert_eq!(
+        metrics.query_latency_called.load(Ordering::SeqCst),
+        1,
+        "query latency must be recorded on success"
+    );
+    assert_eq!(
+        metrics.query_success_raw.load(Ordering::SeqCst),
+        1,
+        "raw query success counter must increment on Ok"
+    );
+    assert_eq!(
+        metrics.query_error_raw.load(Ordering::SeqCst),
+        0,
+        "raw query error counter must not increment on Ok"
+    );
+}
+
+#[tokio::test]
+async fn test_query_raw_error_propagates_and_records_latency() {
+    let metrics = Arc::new(MockMetrics::default());
+    let port = MockQueryPort::raw_failing();
+    let client = make_client_q(port.clone(), metrics.clone());
+
+    let query = base_raw_query();
+    let result = client.query_raw(query.clone()).await;
+
+    assert!(
+        matches!(result, Err(UsageCollectorError::ServiceUnavailable { .. })),
+        "raw_failing mock must propagate the ServiceUnavailable error variant"
+    );
+    let captured = port
+        .captured_raw
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("port should observe the forwarded query even on failure");
+    assert_eq!(captured.page_size, query.page_size);
+    assert_eq!(
+        metrics.query_latency_called.load(Ordering::SeqCst),
+        1,
+        "query latency must be recorded even on error"
+    );
+    assert_eq!(
+        metrics.query_error_raw.load(Ordering::SeqCst),
+        1,
+        "raw query error counter must increment on Err"
+    );
+    assert_eq!(
+        metrics.query_success_raw.load(Ordering::SeqCst),
+        0,
+        "raw query success counter must not increment on Err"
+    );
+}
+
+#[tokio::test]
+async fn test_create_usage_record_nan_rejected() {
+    // Production guard at client.rs: `record.value.is_finite()` rejects NaN
+    // before any DB call. Covers the schema_validation_errors path for NaN.
+    let metrics = Arc::new(MockMetrics::default());
+    let client = make_client(MockInsertPort::success(0), metrics.clone());
+    let record = UsageRecord {
+        value: f64::NAN,
+        ..base_gauge_record()
+    };
+
+    let result = client.create_usage_record(record).await;
+
+    assert!(
+        matches!(result, Err(UsageCollectorError::InvalidArgument { .. })),
+        "expected InvalidArgument error for NaN value"
+    );
+    assert_eq!(
+        metrics.schema_validation_errors.load(Ordering::SeqCst),
+        1,
+        "validation error counter must increment for NaN"
+    );
+    assert_eq!(
+        metrics.ingestion_success.load(Ordering::SeqCst),
+        0,
+        "no success on validation failure"
+    );
+}
+
+#[tokio::test]
+async fn test_create_usage_record_positive_infinity_rejected() {
+    // Production guard at client.rs: `record.value.is_finite()` rejects +Inf
+    // before any DB call. Split from the -Inf case so a regression that
+    // accepts one but rejects the other surfaces with a precise failure site.
+    let metrics = Arc::new(MockMetrics::default());
+    let client = make_client(MockInsertPort::success(0), metrics.clone());
+    let record = UsageRecord {
+        value: f64::INFINITY,
+        ..base_gauge_record()
+    };
+
+    let result = client.create_usage_record(record).await;
+
+    assert!(
+        matches!(result, Err(UsageCollectorError::InvalidArgument { .. })),
+        "expected InvalidArgument error for +Inf value"
+    );
+    assert_eq!(
+        metrics.schema_validation_errors.load(Ordering::SeqCst),
+        1,
+        "validation error counter must increment for +Inf"
+    );
+    assert_eq!(
+        metrics.ingestion_success.load(Ordering::SeqCst),
+        0,
+        "no success on validation failure"
+    );
+}
+
+#[tokio::test]
+async fn test_create_usage_record_negative_infinity_rejected() {
+    // Production guard at client.rs: `record.value.is_finite()` rejects -Inf
+    // before any DB call. Split from the +Inf case so a regression that
+    // accepts one but rejects the other surfaces with a precise failure site.
+    let metrics = Arc::new(MockMetrics::default());
+    let client = make_client(MockInsertPort::success(0), metrics.clone());
+    let record = UsageRecord {
+        value: f64::NEG_INFINITY,
+        ..base_gauge_record()
+    };
+
+    let result = client.create_usage_record(record).await;
+
+    assert!(
+        matches!(result, Err(UsageCollectorError::InvalidArgument { .. })),
+        "expected InvalidArgument error for -Inf value"
+    );
+    assert_eq!(
+        metrics.schema_validation_errors.load(Ordering::SeqCst),
+        1,
+        "validation error counter must increment for -Inf"
+    );
+    assert_eq!(
+        metrics.ingestion_success.load(Ordering::SeqCst),
+        0,
+        "no success on validation failure"
+    );
+}
+
+#[tokio::test]
+async fn test_create_usage_record_negative_gauge_allowed() {
+    // Gauges are allowed to carry negative values (e.g. delta-style metrics).
+    // Only counters enforce non-negativity at the validation layer; this test
+    // pins that contract so a future change cannot tighten it silently.
+    let metrics = Arc::new(MockMetrics::default());
+    let client = make_client(MockInsertPort::success(1), metrics.clone());
+    let record = UsageRecord {
+        value: -3.5,
+        ..base_gauge_record()
+    };
+
+    let result = client.create_usage_record(record).await;
+
+    assert!(result.is_ok(), "negative gauge values must be accepted");
+    assert_eq!(
+        metrics.schema_validation_errors.load(Ordering::SeqCst),
+        0,
+        "no validation error for a negative gauge"
+    );
+    assert_eq!(
+        metrics.ingestion_success.load(Ordering::SeqCst),
+        1,
+        "success counter must increment for a valid gauge insert"
+    );
+}

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/domain/error.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/domain/error.rs
@@ -1,0 +1,216 @@
+//! Error types for the `TimescaleDB` storage plugin.
+use modkit_macros::domain_model;
+
+use thiserror::Error;
+use usage_collector_sdk::{UsageCollectorError, UsageRecordError};
+
+/// Boxed, type-erased source error preserved for `std::error::Error::source()`.
+///
+/// Domain models cannot reference `sqlx::Error` directly (infrastructure
+/// dependency banned by `#[domain_model]`), so infra layers box the
+/// underlying database error into this alias before constructing a
+/// [`StoragePluginError`]. Walking `source()` on the resulting error still
+/// reaches the original `sqlx::Error` for triage, and the infra wrapper's
+/// `Display` includes the SQLSTATE.
+pub type SourceError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// Stable reason codes embedded in the detail of mapped [`UsageCollectorError`]s.
+///
+/// Operators triaging a production failure can grep for these strings to
+/// distinguish a migration failure from a continuous-aggregate setup failure
+/// from a query failure without parsing the prose detail.
+mod reason {
+    pub const MIGRATION: &str = "STORAGE_MIGRATION_FAILED";
+    pub const CAGG_SETUP: &str = "STORAGE_CAGG_SETUP_FAILED";
+    pub const RETENTION_SETUP: &str = "STORAGE_RETENTION_SETUP_FAILED";
+    pub const QUERY: &str = "STORAGE_QUERY_FAILED";
+    pub const CONNECTION_POOL: &str = "STORAGE_CONNECTION_POOL";
+    pub const UNEXPECTED_UNIQUE: &str = "STORAGE_UNEXPECTED_UNIQUE_VIOLATION";
+    pub const CONFIGURATION: &str = "STORAGE_CONFIGURATION";
+    pub const TRANSIENT: &str = "STORAGE_TRANSIENT";
+}
+
+/// Errors produced by the `TimescaleDB` storage plugin.
+///
+/// Variants that originate from a `sqlx::Error` carry the original error as a
+/// `#[source]`, so `std::error::Error::source()` walks the chain and the
+/// SQLSTATE on `sqlx::Error::Database` is reachable for triage. The
+/// `From<StoragePluginError> for UsageCollectorError` impl folds the chain
+/// (including the SQLSTATE) into the public detail string with a stable
+/// reason-code prefix.
+#[derive(Debug, Error)]
+#[domain_model]
+pub enum StoragePluginError {
+    /// A record field failed validation (e.g. negative counter value, missing idempotency key).
+    #[error("invalid record: {0}")]
+    InvalidRecord(String),
+
+    /// A `usage_records` insert collided with an existing row on the
+    /// `(tenant_id, idempotency_key)` index *after* the idempotency-key claim
+    /// said the slot was free. This is an internal invariant break — callers
+    /// upstream of the claim must have re-issued the same key concurrently.
+    #[error("unexpected unique constraint violation")]
+    UnexpectedUniqueViolation(#[source] SourceError),
+
+    /// A transient database error (connection lost, pool timeout, serialization failure).
+    #[error("transient database error")]
+    Transient(#[source] SourceError),
+
+    /// A configuration error detected at startup (missing URL, TLS rejected, etc.).
+    #[error("configuration error: {0}")]
+    Configuration(String),
+
+    /// A schema migration step failed.
+    #[error("schema migration failed: {context}")]
+    Migration {
+        context: String,
+        #[source]
+        source: SourceError,
+    },
+
+    /// The continuous aggregate setup step failed.
+    ///
+    /// `source` is `None` for post-setup invariant checks that do not bubble
+    /// up an underlying database error (e.g. the view exists but the refresh
+    /// policy is missing).
+    #[error("continuous aggregate setup failed: {context}")]
+    ContinuousAggregateSetupFailed {
+        context: String,
+        #[source]
+        source: Option<SourceError>,
+    },
+
+    /// The retention policy setup step failed.
+    #[error("retention policy setup failed: {context}")]
+    RetentionPolicySetupFailed {
+        context: String,
+        #[source]
+        source: SourceError,
+    },
+
+    /// A query against the database failed.
+    #[error("query failed")]
+    QueryFailed(#[source] SourceError),
+
+    /// Row decoding, argument binding, or a structural overflow encountered
+    /// while constructing or unpacking a query failed. Distinct from
+    /// [`QueryFailed`] because the underlying error is not a `sqlx::Error`
+    /// reaching the database — it is a serialization-layer fault on either
+    /// side of the wire. Routed through the same `STORAGE_QUERY_FAILED`
+    /// reason-code prefix so operators can grep one string for any
+    /// query-pipeline issue.
+    #[error("query serialization error: {context}")]
+    Serialization {
+        context: String,
+        #[source]
+        source: SourceError,
+    },
+
+    /// A connection pool error (pool exhausted, pool creation failed, etc.).
+    #[error("connection pool error: {0}")]
+    ConnectionPool(String),
+}
+
+/// Type alias for migration-related errors.
+pub type MigrationError = StoragePluginError;
+
+/// Builds an operator-facing detail string that walks the `source()` chain of
+/// `err`. The infra-layer database wrapper (`crate::infra::db_error::DbError`)
+/// embeds the SQLSTATE in its `Display`, so a generic chain walk surfaces it
+/// without needing to downcast to `sqlx::Error` from the domain layer.
+///
+/// Without this walk, `format!("{err}")` only renders the top-level
+/// `Display`, hiding the underlying database error we deliberately preserved
+/// on the variant.
+fn render_source_chain(err: &(dyn std::error::Error + 'static)) -> String {
+    let mut rendered = err.to_string();
+    let mut current = err.source();
+    while let Some(src) = current {
+        rendered.push_str(": ");
+        rendered.push_str(&src.to_string());
+        current = src.source();
+    }
+    rendered
+}
+
+impl From<StoragePluginError> for UsageCollectorError {
+    fn from(err: StoragePluginError) -> Self {
+        match &err {
+            StoragePluginError::InvalidRecord(msg) => UsageRecordError::invalid_argument()
+                .with_constraint(format!("invalid record: {msg}"))
+                .create(),
+            StoragePluginError::UnexpectedUniqueViolation(_) => {
+                tracing::warn!(
+                    error = %err,
+                    "unexpected unique constraint violation in usage_records"
+                );
+                UsageCollectorError::internal(format!(
+                    "[{}] {}",
+                    reason::UNEXPECTED_UNIQUE,
+                    render_source_chain(&err)
+                ))
+                .create()
+            }
+            StoragePluginError::Transient(_) => UsageCollectorError::service_unavailable()
+                .with_detail(format!(
+                    "[{}] {}",
+                    reason::TRANSIENT,
+                    render_source_chain(&err)
+                ))
+                .create(),
+            StoragePluginError::Configuration(msg) => UsageCollectorError::internal(format!(
+                "[{}] configuration error: {msg}",
+                reason::CONFIGURATION
+            ))
+            .create(),
+            StoragePluginError::Migration { .. } => UsageCollectorError::internal(format!(
+                "[{}] {}",
+                reason::MIGRATION,
+                render_source_chain(&err)
+            ))
+            .create(),
+            StoragePluginError::ContinuousAggregateSetupFailed { .. } => {
+                UsageCollectorError::internal(format!(
+                    "[{}] {}",
+                    reason::CAGG_SETUP,
+                    render_source_chain(&err)
+                ))
+                .create()
+            }
+            StoragePluginError::RetentionPolicySetupFailed { .. } => {
+                UsageCollectorError::internal(format!(
+                    "[{}] {}",
+                    reason::RETENTION_SETUP,
+                    render_source_chain(&err)
+                ))
+                .create()
+            }
+            StoragePluginError::QueryFailed(_) | StoragePluginError::Serialization { .. } => {
+                UsageCollectorError::internal(format!(
+                    "[{}] {}",
+                    reason::QUERY,
+                    render_source_chain(&err)
+                ))
+                .create()
+            }
+            StoragePluginError::ConnectionPool(msg) => UsageCollectorError::internal(format!(
+                "[{}] connection pool error: {msg}",
+                reason::CONNECTION_POOL
+            ))
+            .create(),
+        }
+    }
+}
+
+/// Errors produced by the scope-to-SQL translator.
+#[derive(Debug, Error)]
+#[domain_model]
+pub enum ScopeTranslationError {
+    /// The scope has no constraints — callers must fail closed on empty scope.
+    #[error("empty scope: access denied")]
+    EmptyScope,
+
+    /// A predicate type that cannot be translated to SQL (e.g. InGroup/InGroupSubtree).
+    #[error("unsupported predicate: {kind}")]
+    UnsupportedPredicate { kind: String },
+}

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/domain/insert_port.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/domain/insert_port.rs
@@ -1,0 +1,14 @@
+//! Insert port abstraction for testable DB writes.
+//!
+//! Decouples `create_usage_record` from `PgPool` so unit tests can inject
+//! a mock without a live database.
+
+use async_trait::async_trait;
+use usage_collector_sdk::models::UsageRecord;
+
+use crate::domain::error::StoragePluginError;
+
+#[async_trait]
+pub trait InsertPort: Send + Sync {
+    async fn insert_usage_record(&self, record: &UsageRecord) -> Result<u64, StoragePluginError>;
+}

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/domain/metrics.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/domain/metrics.rs
@@ -1,0 +1,36 @@
+//! Plugin metrics output port.
+use modkit_macros::domain_model;
+
+/// Observable metrics port for the `TimescaleDB` storage plugin.
+///
+/// Implementations live in `src/infra/` (e.g. OpenTelemetry counters).
+/// The domain client depends only on this trait for testability.
+pub trait PluginMetrics: Send + Sync {
+    fn record_ingestion_success(&self);
+    fn record_ingestion_error(&self);
+    fn record_ingestion_latency_ms(&self, elapsed_ms: f64);
+    fn record_dedup(&self);
+    fn record_schema_validation_error(&self);
+    fn record_query_latency_ms(&self, query_type: &str, elapsed_ms: f64);
+    fn record_query_success(&self, query_type: &str);
+    fn record_query_error(&self, query_type: &str);
+}
+
+/// No-op metrics implementation for integration tests and fallback initialization.
+///
+/// Only constructed by the integration test crate (gated behind the
+/// `integration` feature); the production wiring uses `OtelPluginMetrics`.
+#[cfg_attr(not(feature = "integration"), allow(dead_code))]
+#[domain_model]
+pub struct NoopMetrics;
+
+impl PluginMetrics for NoopMetrics {
+    fn record_ingestion_success(&self) {}
+    fn record_ingestion_error(&self) {}
+    fn record_ingestion_latency_ms(&self, _elapsed_ms: f64) {}
+    fn record_dedup(&self) {}
+    fn record_schema_validation_error(&self) {}
+    fn record_query_latency_ms(&self, _query_type: &str, _elapsed_ms: f64) {}
+    fn record_query_success(&self, _query_type: &str) {}
+    fn record_query_error(&self, _query_type: &str) {}
+}

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/domain/mod.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/domain/mod.rs
@@ -1,0 +1,6 @@
+pub mod client;
+pub mod error;
+pub mod insert_port;
+pub mod metrics;
+pub mod query_port;
+pub mod scope;

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/domain/query_port.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/domain/query_port.rs
@@ -1,0 +1,13 @@
+use async_trait::async_trait;
+use usage_collector_sdk::models::{AggregationQuery, AggregationResult, RawQuery, UsageRecord};
+use usage_collector_sdk::{Page, UsageCollectorError};
+
+#[async_trait]
+pub trait QueryPort: Send + Sync {
+    async fn query_aggregated(
+        &self,
+        query: AggregationQuery,
+    ) -> Result<Vec<AggregationResult>, UsageCollectorError>;
+
+    async fn query_raw(&self, query: RawQuery) -> Result<Page<UsageRecord>, UsageCollectorError>;
+}

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/domain/scope.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/domain/scope.rs
@@ -1,0 +1,231 @@
+//! `AccessScope` → SQL WHERE fragment translator.
+
+use modkit_macros::domain_model;
+use modkit_security::{AccessScope, ScopeFilter, ScopeValue, pep_properties};
+use uuid::Uuid;
+
+use crate::domain::error::ScopeTranslationError;
+
+/// Property name for the resource identifier used in usage records.
+const PROP_RESOURCE_ID: &str = "resource_id";
+
+/// Property name for the resource type used in usage records.
+const PROP_RESOURCE_TYPE: &str = "resource_type";
+
+/// Property name for the source module used in usage records.
+const PROP_MODULE: &str = "module";
+
+/// Property name for the subject identifier used in usage records.
+const PROP_SUBJECT_ID: &str = "subject_id";
+
+/// Property name for the subject type used in usage records.
+const PROP_SUBJECT_TYPE: &str = "subject_type";
+
+/// A typed SQL bind parameter produced by [`scope_to_sql`].
+///
+/// Callers bind these values positionally to a sqlx query in the order they appear
+/// in the returned `Vec<SqlValue>`.
+#[derive(Debug, Clone, PartialEq)]
+#[domain_model]
+pub enum SqlValue {
+    Uuid(Uuid),
+    UuidArray(Vec<Uuid>),
+    Text(String),
+    TextArray(Vec<String>),
+}
+
+/// Returns `true` when any filter in `scope` constrains the row-level
+/// `resource_id` or `subject_id` columns. The continuous aggregate
+/// (`usage_agg_1h`) groups those columns out — see `infra/continuous_aggregate.rs`
+/// — so any query whose scope filters on them must execute against the raw
+/// hypertable or the generated SQL will reference columns that don't exist on
+/// the view. Centralised here so the property-name constants stay private to
+/// this module.
+#[must_use]
+pub fn scope_constrains_record_ids(scope: &AccessScope) -> bool {
+    scope.constraints().iter().any(|c| {
+        c.filters()
+            .iter()
+            .any(|f| f.property() == PROP_RESOURCE_ID || f.property() == PROP_SUBJECT_ID)
+    })
+}
+
+// @cpt-algo:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1
+/// Translate an `AccessScope` into a SQL WHERE fragment and positional bind parameters.
+///
+/// The returned fragment is ready to embed in `WHERE (<fragment>)`. Bind parameters
+/// must be appended after any pre-existing parameters the caller already has.
+///
+/// # Errors
+///
+/// Returns [`ScopeTranslationError::EmptyScope`] when the scope has no constraints
+/// (deny-all or allow-all — callers must fail closed in both cases).
+///
+/// Returns [`ScopeTranslationError::UnsupportedPredicate`] when the scope contains
+/// `InGroup`/`InGroupSubtree` predicates or an unrecognised property name.
+pub fn scope_to_sql(scope: &AccessScope) -> Result<(String, Vec<SqlValue>), ScopeTranslationError> {
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-1
+    if scope.constraints().is_empty() {
+        return Err(ScopeTranslationError::EmptyScope);
+    }
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-1
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-2
+    let mut group_fragments: Vec<String> = Vec::new();
+    let mut bind_params: Vec<SqlValue> = Vec::new();
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-2
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-3
+    for constraint in scope.constraints() {
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-3a
+        let mut predicate_fragments: Vec<String> = Vec::new();
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-3a
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-3b
+        for filter in constraint.filters() {
+            // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-3b-i
+            // Early variant rejection keeps the "InGroup/InGroupSubtree" error label
+            // independent of which property the filter targets. `build_uuid_filter`
+            // and `build_text_filter` also enforce the same invariant locally — so a
+            // future refactor that bypasses this loop still cannot smuggle an
+            // unsupported variant past the SQL builders.
+            if matches!(
+                filter,
+                ScopeFilter::InGroup(_) | ScopeFilter::InGroupSubtree(_)
+            ) {
+                return Err(ScopeTranslationError::UnsupportedPredicate {
+                    kind: "InGroup/InGroupSubtree".to_owned(),
+                });
+            }
+            // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-3b-i
+
+            let param_n = bind_params.len() + 1;
+
+            // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-3b-ii
+            // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-3b-iii
+            // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-3b-iv
+            let property = filter.property();
+            let (frag, val) = match property {
+                pep_properties::OWNER_TENANT_ID => build_uuid_filter(filter, param_n, "tenant_id")?,
+                PROP_RESOURCE_ID => build_uuid_filter(filter, param_n, "resource_id")?,
+                PROP_RESOURCE_TYPE => build_text_filter(filter, param_n, "resource_type")?,
+                PROP_MODULE => build_text_filter(filter, param_n, "module")?,
+                PROP_SUBJECT_ID => build_uuid_filter(filter, param_n, "subject_id")?,
+                PROP_SUBJECT_TYPE => build_text_filter(filter, param_n, "subject_type")?,
+                other => {
+                    return Err(ScopeTranslationError::UnsupportedPredicate {
+                        kind: format!("unknown property: {other}"),
+                    });
+                }
+            };
+            predicate_fragments.push(frag);
+            bind_params.push(val);
+            // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-3b-iv
+            // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-3b-iii
+            // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-3b-ii
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-3b
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-3c
+        if predicate_fragments.is_empty() {
+            return Err(ScopeTranslationError::EmptyScope);
+        }
+        group_fragments.push(format!("({})", predicate_fragments.join(" AND ")));
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-3c
+    }
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-3
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-4
+    let sql_fragment = format!("({})", group_fragments.join(" OR "));
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-4
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-5
+    Ok((sql_fragment, bind_params))
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-scope-to-sql:p1:inst-s2s-5
+}
+
+fn build_uuid_filter(
+    filter: &ScopeFilter,
+    param_n: usize,
+    column: &str,
+) -> Result<(String, SqlValue), ScopeTranslationError> {
+    match filter {
+        ScopeFilter::Eq(f) => {
+            let uuid =
+                f.value()
+                    .as_uuid()
+                    .ok_or_else(|| ScopeTranslationError::UnsupportedPredicate {
+                        kind: format!("non-UUID value for {column}"),
+                    })?;
+            Ok((format!("{column} = ${param_n}"), SqlValue::Uuid(uuid)))
+        }
+        ScopeFilter::In(f) => {
+            let uuids: Result<Vec<Uuid>, ScopeTranslationError> = f
+                .values()
+                .iter()
+                .map(|v| {
+                    v.as_uuid()
+                        .ok_or_else(|| ScopeTranslationError::UnsupportedPredicate {
+                            kind: format!("non-UUID value for {column}"),
+                        })
+                })
+                .collect();
+            Ok((
+                format!("{column} = ANY(${param_n})"),
+                SqlValue::UuidArray(uuids?),
+            ))
+        }
+        ScopeFilter::InGroup(_) | ScopeFilter::InGroupSubtree(_) => {
+            Err(ScopeTranslationError::UnsupportedPredicate {
+                kind: "InGroup/InGroupSubtree".to_owned(),
+            })
+        }
+    }
+}
+
+fn build_text_filter(
+    filter: &ScopeFilter,
+    param_n: usize,
+    column: &str,
+) -> Result<(String, SqlValue), ScopeTranslationError> {
+    // Mirror `build_uuid_filter`'s type discipline: a misconfigured PDP that
+    // surfaces a non-string scope value (e.g. `ScopeValue::Uuid`) on a text
+    // column must produce a translator error here, not a silently stringified
+    // value that reaches the DB as a row mismatch.
+    fn require_string(value: &ScopeValue, column: &str) -> Result<String, ScopeTranslationError> {
+        match value {
+            ScopeValue::String(s) => Ok(s.clone()),
+            _ => Err(ScopeTranslationError::UnsupportedPredicate {
+                kind: format!("non-text value for {column}"),
+            }),
+        }
+    }
+
+    match filter {
+        ScopeFilter::Eq(f) => {
+            let text = require_string(f.value(), column)?;
+            Ok((format!("{column} = ${param_n}"), SqlValue::Text(text)))
+        }
+        ScopeFilter::In(f) => {
+            let texts: Result<Vec<String>, ScopeTranslationError> = f
+                .values()
+                .iter()
+                .map(|v| require_string(v, column))
+                .collect();
+            Ok((
+                format!("{column} = ANY(${param_n})"),
+                SqlValue::TextArray(texts?),
+            ))
+        }
+        ScopeFilter::InGroup(_) | ScopeFilter::InGroupSubtree(_) => {
+            Err(ScopeTranslationError::UnsupportedPredicate {
+                kind: "InGroup/InGroupSubtree".to_owned(),
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "scope_tests.rs"]
+mod scope_tests;

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/domain/scope_tests.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/domain/scope_tests.rs
@@ -1,0 +1,177 @@
+use super::*;
+use modkit_security::{AccessScope, ScopeConstraint, ScopeFilter, ScopeValue, pep_properties};
+use uuid::Uuid;
+
+fn uid() -> Uuid {
+    Uuid::new_v4()
+}
+
+#[test]
+fn test_scope_to_sql_empty_scope_fail_closed() {
+    let scope = AccessScope::deny_all();
+    assert!(matches!(
+        scope_to_sql(&scope),
+        Err(ScopeTranslationError::EmptyScope)
+    ));
+}
+
+#[test]
+fn test_scope_to_sql_unconstrained_scope_fail_closed() {
+    let scope = AccessScope::allow_all();
+    assert!(matches!(
+        scope_to_sql(&scope),
+        Err(ScopeTranslationError::EmptyScope)
+    ));
+}
+
+#[test]
+fn test_scope_to_sql_single_group() {
+    let tid = uid();
+    let scope = AccessScope::for_tenant(tid);
+    let (sql, params) = scope_to_sql(&scope).unwrap();
+    assert!(sql.contains("tenant_id = ANY($1)"), "sql: {sql}");
+    assert_eq!(params.len(), 1);
+    assert_eq!(params[0], SqlValue::UuidArray(vec![tid]));
+}
+
+#[test]
+fn test_scope_to_sql_multiple_groups_or_of_ands_preserved() {
+    let tid1 = uid();
+    let tid2 = uid();
+    let scope = AccessScope::from_constraints(vec![
+        ScopeConstraint::new(vec![ScopeFilter::in_uuids(
+            pep_properties::OWNER_TENANT_ID,
+            vec![tid1],
+        )]),
+        ScopeConstraint::new(vec![ScopeFilter::in_uuids(
+            pep_properties::OWNER_TENANT_ID,
+            vec![tid2],
+        )]),
+    ]);
+    let (sql, params) = scope_to_sql(&scope).unwrap();
+    // Must have exactly one OR joining two AND-groups
+    assert!(sql.contains(" OR "), "sql must contain OR: {sql}");
+    assert_eq!(params.len(), 2, "each group contributes one bind param");
+    // Must be wrapped in outer parens
+    assert!(sql.starts_with('(') && sql.ends_with(')'), "sql: {sql}");
+}
+
+#[test]
+fn test_scope_to_sql_ingroup_predicate_rejection() {
+    let scope = AccessScope::single(ScopeConstraint::new(vec![ScopeFilter::in_group(
+        pep_properties::OWNER_TENANT_ID,
+        vec![ScopeValue::Uuid(uid())],
+    )]));
+    match scope_to_sql(&scope) {
+        Err(ScopeTranslationError::UnsupportedPredicate { kind }) => {
+            assert!(kind.contains("InGroup"), "kind: {kind}");
+        }
+        other => panic!("expected UnsupportedPredicate, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_scope_to_sql_resource_id_filter() {
+    let rid = uid();
+    let scope = AccessScope::single(ScopeConstraint::new(vec![ScopeFilter::in_uuids(
+        PROP_RESOURCE_ID,
+        vec![rid],
+    )]));
+    let (sql, params) = scope_to_sql(&scope).unwrap();
+    assert!(sql.contains("resource_id = ANY($1)"), "sql: {sql}");
+    assert_eq!(params[0], SqlValue::UuidArray(vec![rid]));
+}
+
+#[test]
+fn test_scope_to_sql_resource_type_filter() {
+    let scope = AccessScope::single(ScopeConstraint::new(vec![ScopeFilter::r#in(
+        PROP_RESOURCE_TYPE,
+        vec![ScopeValue::String("vm".to_owned())],
+    )]));
+    let (sql, params) = scope_to_sql(&scope).unwrap();
+    assert!(sql.contains("resource_type = ANY($1)"), "sql: {sql}");
+    assert_eq!(params[0], SqlValue::TextArray(vec!["vm".to_owned()]));
+}
+
+#[test]
+fn test_scope_to_sql_module_filter() {
+    let scope = AccessScope::single(ScopeConstraint::new(vec![ScopeFilter::r#in(
+        PROP_MODULE,
+        vec![ScopeValue::String("billing".to_owned())],
+    )]));
+    let (sql, params) = scope_to_sql(&scope).unwrap();
+    assert!(sql.contains("module = ANY($1)"), "sql: {sql}");
+    assert_eq!(params[0], SqlValue::TextArray(vec!["billing".to_owned()]));
+}
+
+#[test]
+fn test_scope_to_sql_subject_id_filter() {
+    let sid = uid();
+    let scope = AccessScope::single(ScopeConstraint::new(vec![ScopeFilter::in_uuids(
+        PROP_SUBJECT_ID,
+        vec![sid],
+    )]));
+    let (sql, params) = scope_to_sql(&scope).unwrap();
+    assert!(sql.contains("subject_id = ANY($1)"), "sql: {sql}");
+    assert_eq!(params[0], SqlValue::UuidArray(vec![sid]));
+}
+
+#[test]
+fn test_scope_to_sql_subject_type_filter() {
+    let scope = AccessScope::single(ScopeConstraint::new(vec![ScopeFilter::r#in(
+        PROP_SUBJECT_TYPE,
+        vec![ScopeValue::String("user".to_owned())],
+    )]));
+    let (sql, params) = scope_to_sql(&scope).unwrap();
+    assert!(sql.contains("subject_type = ANY($1)"), "sql: {sql}");
+    assert_eq!(params[0], SqlValue::TextArray(vec!["user".to_owned()]));
+}
+
+#[test]
+fn test_scope_to_sql_rejects_uuid_value_on_text_column_eq() {
+    // A PDP that surfaces a UUID-typed value against a text column must
+    // produce an UnsupportedPredicate (mirrors `build_uuid_filter`'s
+    // discipline) instead of silently stringifying the UUID.
+    let scope = AccessScope::single(ScopeConstraint::new(vec![ScopeFilter::eq(
+        PROP_RESOURCE_TYPE,
+        ScopeValue::Uuid(uid()),
+    )]));
+    match scope_to_sql(&scope) {
+        Err(ScopeTranslationError::UnsupportedPredicate { kind }) => {
+            assert!(kind.contains("non-text"), "kind: {kind}");
+            assert!(kind.contains("resource_type"), "kind: {kind}");
+        }
+        other => panic!("expected UnsupportedPredicate, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_scope_to_sql_rejects_uuid_value_on_text_column_in() {
+    let scope = AccessScope::single(ScopeConstraint::new(vec![ScopeFilter::r#in(
+        PROP_SUBJECT_TYPE,
+        vec![ScopeValue::Uuid(uid())],
+    )]));
+    match scope_to_sql(&scope) {
+        Err(ScopeTranslationError::UnsupportedPredicate { kind }) => {
+            assert!(kind.contains("non-text"), "kind: {kind}");
+            assert!(kind.contains("subject_type"), "kind: {kind}");
+        }
+        other => panic!("expected UnsupportedPredicate, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_scope_to_sql_multi_predicate_and_within_group() {
+    let tid = uid();
+    let rid = uid();
+    let scope = AccessScope::single(ScopeConstraint::new(vec![
+        ScopeFilter::in_uuids(pep_properties::OWNER_TENANT_ID, vec![tid]),
+        ScopeFilter::in_uuids(PROP_RESOURCE_ID, vec![rid]),
+    ]));
+    let (sql, params) = scope_to_sql(&scope).unwrap();
+    assert!(
+        sql.contains(" AND "),
+        "sql must AND predicates within group: {sql}"
+    );
+    assert_eq!(params.len(), 2);
+}

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/continuous_aggregate.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/continuous_aggregate.rs
@@ -1,0 +1,144 @@
+//! Continuous aggregate setup for the `TimescaleDB` storage plugin.
+
+use sqlx::PgPool;
+
+use crate::domain::error::MigrationError;
+use crate::infra::db_error::DbError;
+
+/// Name of the 1-hour continuous aggregate view this plugin creates and reads.
+///
+/// Centralised here so `pg_query_port` and any future readers can address the
+/// view by symbolic name rather than re-typing a string literal (a mismatch
+/// would silently route reads to a non-existent view).
+pub const CONTINUOUS_AGGREGATE_VIEW: &str = "usage_agg_1h";
+
+// @cpt-algo:cpt-cf-usage-collector-algo-production-storage-plugin-continuous-aggregate:p1
+/// # Errors
+///
+/// Returns [`MigrationError`] if any DDL or policy registration statement fails.
+pub async fn setup_continuous_aggregate(pool: &PgPool) -> Result<(), MigrationError> {
+    fn cagg_err(context: &str) -> impl Fn(sqlx::Error) -> MigrationError + '_ {
+        move |source| MigrationError::ContinuousAggregateSetupFailed {
+            context: context.to_owned(),
+            source: Some(DbError::boxed(source)),
+        }
+    }
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-continuous-aggregate:p1:inst-cagg-1
+    let view_existed: bool = sqlx::query_scalar(
+        "SELECT EXISTS (
+            SELECT 1 FROM timescaledb_information.continuous_aggregates
+            WHERE view_name = 'usage_agg_1h'
+        )",
+    )
+    .fetch_one(pool)
+    .await
+    .map_err(cagg_err("failed to check if usage_agg_1h exists"))?;
+
+    if !view_existed {
+        sqlx::query(
+            "CREATE MATERIALIZED VIEW IF NOT EXISTS usage_agg_1h \
+             WITH (timescaledb.continuous) AS \
+             SELECT \
+                 time_bucket('1 hour', timestamp) AS bucket, \
+                 tenant_id, \
+                 metric, \
+                 module, \
+                 resource_type, \
+                 subject_type, \
+                 SUM(value)  AS sum_val, \
+                 COUNT(*)    AS cnt_val, \
+                 MIN(value)  AS min_val, \
+                 MAX(value)  AS max_val \
+             FROM usage_records \
+             GROUP BY bucket, tenant_id, metric, module, resource_type, subject_type \
+             WITH NO DATA",
+        )
+        .execute(pool)
+        .await
+        .map_err(cagg_err(
+            "failed to create usage_agg_1h continuous aggregate view",
+        ))?;
+    }
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-continuous-aggregate:p1:inst-cagg-1
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-continuous-aggregate:p1:inst-cagg-2
+    // Capture the returned job id from `add_continuous_aggregate_policy`
+    // instead of `.execute`-ing it. A non-NULL, positive job id is the
+    // function's documented success signal — whether the policy is created
+    // here or already exists under `if_not_exists => true`, the call returns
+    // the existing job id. This avoids relying on the internal `proc_name`
+    // symbol (`policy_refresh_continuous_aggregate`) during post-setup
+    // verification, which changes between TimescaleDB majors and would turn
+    // an upgrade into a hard startup failure for a healthy plugin.
+    let policy_job_id: Option<i32> = sqlx::query_scalar(
+        "SELECT add_continuous_aggregate_policy( \
+             'usage_agg_1h', \
+             start_offset      => INTERVAL '3 hours', \
+             end_offset        => INTERVAL '1 hour', \
+             schedule_interval => INTERVAL '30 minutes', \
+             if_not_exists     => true \
+         )",
+    )
+    .fetch_one(pool)
+    .await
+    .map_err(cagg_err(
+        "failed to register refresh policy for usage_agg_1h",
+    ))?;
+    let job_id = policy_job_id.ok_or_else(|| MigrationError::ContinuousAggregateSetupFailed {
+        context: "add_continuous_aggregate_policy returned NULL job id".to_owned(),
+        source: None,
+    })?;
+    if job_id <= 0 {
+        return Err(MigrationError::ContinuousAggregateSetupFailed {
+            context: format!(
+                "add_continuous_aggregate_policy returned non-positive job id: {job_id}"
+            ),
+            source: None,
+        });
+    }
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-continuous-aggregate:p1:inst-cagg-2
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-continuous-aggregate:p1:inst-cagg-3
+    if !view_existed {
+        sqlx::query(
+            "CALL refresh_continuous_aggregate('usage_agg_1h', NULL, now() - INTERVAL '1 hour')",
+        )
+        .execute(pool)
+        .await
+        .map_err(cagg_err(
+            "failed to trigger initial refresh of usage_agg_1h",
+        ))?;
+    }
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-continuous-aggregate:p1:inst-cagg-3
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-continuous-aggregate:p1:inst-cagg-4
+    // View verification reads the public `continuous_aggregates` information
+    // view — its shape is part of TimescaleDB's documented API. The refresh
+    // policy was already verified above via the job id captured from
+    // `add_continuous_aggregate_policy`, so we do not re-query
+    // `timescaledb_information.jobs` here (the previous `proc_name` filter
+    // relied on an internal symbol that is not a stable contract across
+    // TimescaleDB majors).
+    let view_exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS (
+            SELECT 1 FROM timescaledb_information.continuous_aggregates
+            WHERE view_name = 'usage_agg_1h'
+        )",
+    )
+    .fetch_one(pool)
+    .await
+    .map_err(cagg_err("failed to verify usage_agg_1h view exists"))?;
+
+    if !view_exists {
+        return Err(MigrationError::ContinuousAggregateSetupFailed {
+            context: "post-setup verification failed: usage_agg_1h view not found".to_owned(),
+            source: None,
+        });
+    }
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-continuous-aggregate:p1:inst-cagg-4
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-continuous-aggregate:p1:inst-cagg-5
+    Ok(())
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-continuous-aggregate:p1:inst-cagg-5
+}

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/db_error.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/db_error.rs
@@ -1,0 +1,38 @@
+//! Infra-layer wrapper that boxes a `sqlx::Error` while exposing its
+//! SQLSTATE in `Display`, and forwards `source()` to the original error so
+//! the chain remains walkable from the domain layer.
+
+use crate::domain::error::SourceError;
+
+/// Wrapper around `sqlx::Error` that surfaces the SQLSTATE in its `Display`.
+///
+/// Domain errors hold a [`SourceError`] (`Box<dyn Error + Send + Sync>`) so
+/// they remain free of `sqlx` types; this wrapper bridges the layers so the
+/// generic chain walker in `domain::error::render_source_chain` still emits
+/// the SQLSTATE that operators need for triage.
+#[derive(Debug)]
+pub struct DbError(sqlx::Error);
+
+impl DbError {
+    #[must_use]
+    pub fn boxed(e: sqlx::Error) -> SourceError {
+        Box::new(Self(e))
+    }
+}
+
+impl std::fmt::Display for DbError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let sqlx::Error::Database(db) = &self.0
+            && let Some(code) = db.code()
+        {
+            return write!(f, "{} (sqlstate={code})", self.0);
+        }
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for DbError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/migrations.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/migrations.rs
@@ -1,0 +1,217 @@
+//! Schema migration runner for the `TimescaleDB` storage plugin.
+
+use sqlx::PgPool;
+
+use crate::domain::error::MigrationError;
+use crate::infra::db_error::DbError;
+
+// @cpt-algo:cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations:p1
+/// # Errors
+///
+/// Returns [`MigrationError`] if any DDL statement fails against the database.
+///
+/// All migration statements execute inside a single transaction so a mid-sequence
+/// failure rolls back to the pre-migration schema. Without the transaction, an
+/// `IF NOT EXISTS` re-run can still leave the database in a partially-migrated
+/// state — for example with the hypertable created but later indexes missing —
+/// and a subsequent retry must reach the failing step before its IF NOT EXISTS
+/// short-circuits do any work. `PostgreSQL` and `TimescaleDB` both support DDL
+/// inside transactions for every operation used here (`CREATE EXTENSION`,
+/// `CREATE TABLE`, `create_hypertable()`, `CREATE INDEX`, `ALTER TABLE`).
+pub async fn run_migrations(pool: &PgPool) -> Result<(), MigrationError> {
+    // Local helper: build a Migration error tagged with the failing statement.
+    // Keeping it inside the function (rather than associated/free) avoids
+    // exposing a stringly-typed migration builder in the public error surface.
+    fn migration_err(context: &str) -> impl Fn(sqlx::Error) -> MigrationError + '_ {
+        move |source| MigrationError::Migration {
+            context: context.to_owned(),
+            source: DbError::boxed(source),
+        }
+    }
+
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(migration_err("failed to begin migration transaction"))?;
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations:p1:inst-mig-1
+    sqlx::query("CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE")
+        .execute(&mut *tx)
+        .await
+        .map_err(migration_err("failed to create timescaledb extension"))?;
+
+    // `gen_random_uuid()` is built into PostgreSQL 13+, but on PG12 and older it
+    // lives in `pgcrypto`. Ensure the extension is present so the
+    // `usage_records.id` default works on both — no-op on PG13+ where the
+    // function is core.
+    sqlx::query("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+        .execute(&mut *tx)
+        .await
+        .map_err(migration_err("failed to create pgcrypto extension"))?;
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations:p1:inst-mig-1
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations:p1:inst-mig-2
+    // The `chk_subject_id_present_when_type` constraint mirrors the SDK's
+    // `Subject` invariant (id required, type optional): a row with
+    // `subject_type IS NOT NULL AND subject_id IS NULL` cannot be reconstructed
+    // into a `Subject` on read, so the read path would silently drop the type.
+    // Enforcing it at write time means a future external writer that bypasses
+    // the insert port fails loudly instead of producing reads with missing
+    // authorization context.
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS usage_records (
+            id              UUID        NOT NULL DEFAULT gen_random_uuid(),
+            tenant_id       UUID        NOT NULL,
+            module          TEXT        NOT NULL,
+            kind            TEXT        NOT NULL CHECK (kind IN ('counter', 'gauge')),
+            metric          TEXT        NOT NULL,
+            value           NUMERIC     NOT NULL,
+            timestamp       TIMESTAMPTZ NOT NULL,
+            idempotency_key TEXT,
+            resource_id     UUID        NOT NULL,
+            resource_type   TEXT        NOT NULL,
+            subject_id      UUID,
+            subject_type    TEXT,
+            ingested_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            metadata        JSONB,
+            PRIMARY KEY (id, timestamp),
+            CONSTRAINT chk_subject_id_present_when_type
+                CHECK (subject_type IS NULL OR subject_id IS NOT NULL)
+        )",
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(migration_err("failed to create usage_records table"))?;
+
+    // Idempotent attach for pre-existing tables: the `CREATE TABLE IF NOT EXISTS`
+    // above is a no-op when the table already exists, so a database created by
+    // a prior plugin version would not pick up the constraint without this.
+    sqlx::query(
+        "DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'chk_subject_id_present_when_type'
+            ) THEN
+                ALTER TABLE usage_records
+                ADD CONSTRAINT chk_subject_id_present_when_type
+                CHECK (subject_type IS NULL OR subject_id IS NOT NULL);
+            END IF;
+        END;
+        $$",
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(migration_err(
+        "failed to attach chk_subject_id_present_when_type",
+    ))?;
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations:p1:inst-mig-2
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations:p1:inst-mig-3
+    sqlx::query("SELECT create_hypertable('usage_records', 'timestamp', if_not_exists => true)")
+        .execute(&mut *tx)
+        .await
+        .map_err(migration_err(
+            "failed to convert usage_records to hypertable",
+        ))?;
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations:p1:inst-mig-3
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations:p1:inst-mig-4
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_usage_records_tenant_time \
+         ON usage_records (tenant_id, timestamp DESC)",
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(migration_err(
+        "failed to create idx_usage_records_tenant_time",
+    ))?;
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations:p1:inst-mig-4
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations:p1:inst-mig-5
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_usage_records_tenant_metric_time \
+         ON usage_records (tenant_id, metric, timestamp DESC)",
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(migration_err(
+        "failed to create idx_usage_records_tenant_metric_time",
+    ))?;
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations:p1:inst-mig-5
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations:p1:inst-mig-6
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_usage_records_tenant_subject_time \
+         ON usage_records (tenant_id, subject_id, timestamp DESC)",
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(migration_err(
+        "failed to create idx_usage_records_tenant_subject_time",
+    ))?;
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations:p1:inst-mig-6
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations:p1:inst-mig-7
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_usage_records_tenant_resource_time \
+         ON usage_records (tenant_id, resource_id, timestamp DESC)",
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(migration_err(
+        "failed to create idx_usage_records_tenant_resource_time",
+    ))?;
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations:p1:inst-mig-7
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations:p1:inst-mig-8
+    // Separate plain table for idempotency deduplication. TimescaleDB requires all
+    // unique indexes on a hypertable to include the partition column (timestamp), so
+    // cross-partition idempotency cannot be enforced with a partial index on usage_records.
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS usage_idempotency_keys (
+            tenant_id       UUID NOT NULL,
+            idempotency_key TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, idempotency_key)
+        )",
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(migration_err(
+        "failed to create usage_idempotency_keys table",
+    ))?;
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations:p1:inst-mig-8
+
+    // Add created_at to idempotency_keys for bounded cleanup; safe to run on existing tables.
+    sqlx::query(
+        "ALTER TABLE usage_idempotency_keys \
+         ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()",
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(migration_err(
+        "failed to add created_at to usage_idempotency_keys",
+    ))?;
+
+    // Index on created_at so the periodic cleanup in `cleanup_idempotency_keys`
+    // can drive its `DELETE ... WHERE created_at < NOW() - interval` predicate
+    // off an index rather than a full-table scan. Without it the hourly cleanup
+    // grows with table size and competes with ingest on a busy database.
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_usage_idempotency_keys_created_at \
+         ON usage_idempotency_keys (created_at)",
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(migration_err(
+        "failed to create idx_usage_idempotency_keys_created_at",
+    ))?;
+
+    tx.commit()
+        .await
+        .map_err(migration_err("failed to commit migration transaction"))?;
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations:p1:inst-mig-9
+    Ok(())
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-schema-migrations:p1:inst-mig-9
+}

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/mod.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/mod.rs
@@ -1,0 +1,53 @@
+// This storage plugin owns its database schema, hypertable, continuous aggregate
+// and retention policy. Those are TimescaleDB-specific DDLs and policy calls
+// that have no SecureORM/SecureConn equivalent — the framework lint that bans
+// raw sqlx in ModKit modules is therefore deliberately disabled inside infra/.
+// Access control is enforced at the query-builder layer (see `domain/scope.rs`,
+// which produces a non-empty WHERE fragment from the PDP-compiled `AccessScope`
+// and rejects empty scopes/InGroup predicates) — every read/write in this crate
+// flows through that scope fragment.
+//
+// MODKIT-DEVIATION: de0706_no_direct_sqlx (a.k.a. MODKIT-DB-002 / MODKIT-SEC-001).
+// The allow is module-wide because every file under `infra/` legitimately
+// needs direct sqlx access (DDL helpers, dynamic aggregation/pagination SQL,
+// retention policy, plain-table idempotency cleanup). The substitute boundary
+// is `domain::scope::scope_to_sql`, which fails closed on empty scopes and
+// rejects `InGroup`/`InGroupSubtree` predicates. See the
+// "Architectural deviation" section in `../../README.md` and ADR-0003
+// (`../../../../docs/ADR/0003-cpt-cf-usage-collector-adr-timescaledb-plugin-raw-sqlx.md`)
+// for the full rationale. Maintainers adding new files under `infra/` MUST
+// consult those docs before relying on this allow; in particular, no new file
+// under `infra/` may bypass the `scope_to_sql` boundary for tenant-scoped reads
+// or writes.
+#![allow(unknown_lints, de0706_no_direct_sqlx)]
+
+pub mod continuous_aggregate;
+pub mod db_error;
+pub mod migrations;
+pub mod otel_metrics;
+pub mod pg_insert_port;
+pub mod pg_query_port;
+pub mod retention;
+
+/// Returns `true` when `e` represents a transient `PostgreSQL` failure that the
+/// caller should treat as retryable.
+///
+/// Transient SQLSTATE codes covered:
+/// - `40001` `serialization_failure` / `40P01` `deadlock_detected`
+/// - `57P03` `cannot_connect_now` / `53300` `too_many_connections`
+/// - `08006` `connection_failure` / `08001` `sqlclient_unable_to_establish_sqlconnection`
+///
+/// `sqlx::Error::PoolTimedOut`, `PoolClosed`, and `Io(_)` are also classified as
+/// transient. Single source of truth shared by `pg_insert_port` and
+/// `pg_query_port` so the two paths can't drift.
+#[must_use]
+pub fn is_transient_pg_error(e: &sqlx::Error) -> bool {
+    match e {
+        sqlx::Error::PoolTimedOut | sqlx::Error::PoolClosed | sqlx::Error::Io(_) => true,
+        sqlx::Error::Database(db_err) => matches!(
+            db_err.code().as_deref(),
+            Some("40001" | "40P01" | "57P03" | "53300" | "08006" | "08001")
+        ),
+        _ => false,
+    }
+}

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/otel_metrics.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/otel_metrics.rs
@@ -1,0 +1,97 @@
+//! OpenTelemetry-backed implementation of [`PluginMetrics`].
+
+use opentelemetry::KeyValue;
+use opentelemetry::global;
+use opentelemetry::metrics::{Counter, Histogram};
+
+use crate::domain::metrics::PluginMetrics;
+
+pub struct OtelPluginMetrics {
+    ingestion_total: Counter<u64>,
+    ingestion_errors_total: Counter<u64>,
+    ingestion_latency_ms: Histogram<f64>,
+    dedup_total: Counter<u64>,
+    schema_validation_errors_total: Counter<u64>,
+    query_latency_ms: Histogram<f64>,
+    query_total: Counter<u64>,
+    query_errors_total: Counter<u64>,
+}
+
+impl Default for OtelPluginMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OtelPluginMetrics {
+    #[must_use]
+    pub fn new() -> Self {
+        let meter = global::meter("timescaledb-usage-collector-storage-plugin");
+        Self {
+            ingestion_total: meter.u64_counter("usage_ingestion_total").build(),
+            ingestion_errors_total: meter.u64_counter("usage_ingestion_errors_total").build(),
+            ingestion_latency_ms: meter.f64_histogram("usage_ingestion_latency_ms").build(),
+            dedup_total: meter.u64_counter("usage_dedup_total").build(),
+            schema_validation_errors_total: meter
+                .u64_counter("usage_schema_validation_errors_total")
+                .build(),
+            query_latency_ms: meter.f64_histogram("usage_query_latency_ms").build(),
+            query_total: meter.u64_counter("usage_query_total").build(),
+            query_errors_total: meter.u64_counter("usage_query_errors_total").build(),
+        }
+    }
+}
+
+impl PluginMetrics for OtelPluginMetrics {
+    fn record_ingestion_success(&self) {
+        self.ingestion_total
+            .add(1, &[KeyValue::new("status", "success")]);
+    }
+
+    fn record_ingestion_error(&self) {
+        self.ingestion_errors_total.add(1, &[]);
+    }
+
+    fn record_ingestion_latency_ms(&self, elapsed_ms: f64) {
+        self.ingestion_latency_ms.record(elapsed_ms, &[]);
+    }
+
+    fn record_dedup(&self) {
+        self.dedup_total.add(1, &[]);
+        self.ingestion_total
+            .add(1, &[KeyValue::new("status", "dedup")]);
+    }
+
+    fn record_schema_validation_error(&self) {
+        self.schema_validation_errors_total.add(1, &[]);
+    }
+
+    fn record_query_latency_ms(&self, query_type: &str, elapsed_ms: f64) {
+        self.query_latency_ms.record(
+            elapsed_ms,
+            &[KeyValue::new("query_type", query_type.to_owned())],
+        );
+    }
+
+    fn record_query_success(&self, query_type: &str) {
+        self.query_total.add(
+            1,
+            &[
+                KeyValue::new("query_type", query_type.to_owned()),
+                KeyValue::new("status", "success"),
+            ],
+        );
+    }
+
+    fn record_query_error(&self, query_type: &str) {
+        self.query_total.add(
+            1,
+            &[
+                KeyValue::new("query_type", query_type.to_owned()),
+                KeyValue::new("status", "error"),
+            ],
+        );
+        self.query_errors_total
+            .add(1, &[KeyValue::new("query_type", query_type.to_owned())]);
+    }
+}

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/pg_insert_port.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/pg_insert_port.rs
@@ -1,0 +1,161 @@
+//! `PostgreSQL` implementation of the insert port.
+
+use async_trait::async_trait;
+use sqlx::PgPool;
+use usage_collector_sdk::models::{UsageKind, UsageRecord};
+
+use crate::domain::error::StoragePluginError;
+use crate::domain::insert_port::InsertPort;
+use crate::infra::db_error::DbError;
+use crate::infra::is_transient_pg_error;
+
+/// Whether the record carries a non-blank idempotency key.
+///
+/// Mirrors the trim/empty discipline applied at `domain::client` so the
+/// idempotency-claim transaction is only taken for keys that the domain
+/// layer would also consider present. A future caller bypassing the domain
+/// client (e.g. an integration test or a new ingest path) cannot smuggle a
+/// whitespace-only key into the claim table through this port.
+fn idempotency_key_is_present(record: &UsageRecord) -> bool {
+    !record.idempotency_key.trim().is_empty()
+}
+
+fn classify_insert_error(e: sqlx::Error) -> StoragePluginError {
+    if is_transient_pg_error(&e) {
+        return StoragePluginError::Transient(DbError::boxed(e));
+    }
+    if let sqlx::Error::Database(ref db_err) = e
+        && db_err.code().as_deref() == Some("23505")
+    {
+        return StoragePluginError::UnexpectedUniqueViolation(DbError::boxed(e));
+    }
+    StoragePluginError::QueryFailed(DbError::boxed(e))
+}
+
+pub struct PgInsertPort {
+    pool: PgPool,
+}
+
+impl PgInsertPort {
+    #[must_use]
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+const INSERT_RECORD_SQL: &str = "INSERT INTO usage_records (
+        tenant_id, module, kind, metric, value, timestamp, idempotency_key,
+        resource_id, resource_type, subject_id, subject_type, metadata, ingested_at
+    )
+    VALUES (
+        $1, $2, $3, $4, $5::numeric, $6, NULLIF($7, ''),
+        $8, $9, $10, $11, $12, NOW()
+    )";
+
+#[async_trait]
+impl InsertPort for PgInsertPort {
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-create-usage-record:p1:inst-cur-6
+    // ingested_at is set via NOW() in the INSERT SQL — not populated from the caller
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-create-usage-record:p1:inst-cur-6
+    // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-create-usage-record:p1:inst-cur-3
+    async fn insert_usage_record(&self, record: &UsageRecord) -> Result<u64, StoragePluginError> {
+        let kind_str = match record.kind {
+            UsageKind::Counter => "counter",
+            UsageKind::Gauge => "gauge",
+        };
+        let metadata_json = record.metadata.as_ref();
+        let subject_id = record.subject.as_ref().map(|s| s.id);
+        let subject_type = record.subject.as_ref().and_then(|s| s.r#type.clone());
+
+        // TimescaleDB unique indexes must include the partition column (timestamp), so
+        // cross-partition idempotency is enforced via a separate plain table inside a
+        // transaction instead of an ON CONFLICT clause on usage_records.
+        if record.kind == UsageKind::Counter && idempotency_key_is_present(record) {
+            let mut tx = self.pool.begin().await.map_err(classify_insert_error)?;
+
+            let claimed = sqlx::query(
+                "INSERT INTO usage_idempotency_keys (tenant_id, idempotency_key) \
+                 VALUES ($1, $2) \
+                 ON CONFLICT (tenant_id, idempotency_key) DO NOTHING",
+            )
+            .bind(record.tenant_id)
+            .bind(&record.idempotency_key)
+            .execute(&mut *tx)
+            .await
+            .map_err(classify_insert_error)?
+            .rows_affected();
+
+            if claimed == 0 {
+                if let Err(e) = tx.rollback().await {
+                    // Rollback failure on the dedup path leaves the connection's
+                    // transaction state ambiguous: the idempotency-key claim may
+                    // have committed or may still be open. Returning `Ok(0)`
+                    // (the normal dedup signal) would let the caller treat this
+                    // as a successful dedup while the next caller on the same
+                    // connection inherits the ambiguous state. Surfacing it as
+                    // `Transient` instead drops the transaction (sqlx marks the
+                    // connection broken so it is not returned to the pool) and
+                    // tells the caller the operation can be safely retried —
+                    // the next attempt will hit the existing claim (if it
+                    // committed) and dedup correctly, or re-claim cleanly (if
+                    // the rollback eventually took effect).
+                    //
+                    // `idempotency_key` is caller-supplied and frequently
+                    // carries request IDs or other user-controllable values,
+                    // so it is deliberately excluded from the structured
+                    // fields to bound log-index cardinality and avoid
+                    // surfacing PII-adjacent identifiers on this hot path.
+                    tracing::warn!(
+                        error = %e,
+                        tenant_id = %record.tenant_id,
+                        module = %record.module,
+                        "rollback failed after idempotency key conflict; surfacing as transient"
+                    );
+                    return Err(StoragePluginError::Transient(DbError::boxed(e)));
+                }
+                return Ok(0);
+            }
+
+            let rows = sqlx::query(INSERT_RECORD_SQL)
+                .bind(record.tenant_id)
+                .bind(&record.module)
+                .bind(kind_str)
+                .bind(&record.metric)
+                .bind(record.value)
+                .bind(record.timestamp)
+                .bind(&record.idempotency_key)
+                .bind(record.resource_id)
+                .bind(&record.resource_type)
+                .bind(subject_id)
+                .bind(&subject_type)
+                .bind(metadata_json)
+                .execute(&mut *tx)
+                .await
+                .map_err(classify_insert_error)?
+                .rows_affected();
+
+            tx.commit().await.map_err(classify_insert_error)?;
+            return Ok(rows);
+        }
+
+        let result = sqlx::query(INSERT_RECORD_SQL)
+            .bind(record.tenant_id)
+            .bind(&record.module)
+            .bind(kind_str)
+            .bind(&record.metric)
+            .bind(record.value)
+            .bind(record.timestamp)
+            .bind(&record.idempotency_key)
+            .bind(record.resource_id)
+            .bind(&record.resource_type)
+            .bind(subject_id)
+            .bind(&subject_type)
+            .bind(metadata_json)
+            .execute(&self.pool)
+            .await
+            .map_err(classify_insert_error)?;
+
+        Ok(result.rows_affected())
+    }
+    // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-create-usage-record:p1:inst-cur-3
+}

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/pg_query_port.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/pg_query_port.rs
@@ -1,0 +1,934 @@
+//! `PostgreSQL` implementation of the query port.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Timelike, Utc};
+use sqlx::PgPool;
+use sqlx::Row as _;
+use sqlx::postgres::{PgArguments, PgRow};
+use usage_collector_sdk::cursor_filter::{
+    RawQueryFilters, raw_query_effective_order, raw_query_filter_hash,
+};
+use usage_collector_sdk::models::{
+    AggregationFn, AggregationQuery, AggregationResult, BucketSize, GroupByDimension, RawQuery,
+    Subject, UsageKind, UsageRecord,
+};
+use usage_collector_sdk::{
+    CursorV1, Page, PageInfo, SortDir, UsageCollectorError, UsageRecordError,
+};
+use uuid::Uuid;
+
+use crate::domain::error::{ScopeTranslationError, StoragePluginError};
+use crate::domain::query_port::QueryPort;
+use crate::domain::scope::{SqlValue, scope_constrains_record_ids, scope_to_sql};
+use crate::infra::continuous_aggregate::CONTINUOUS_AGGREGATE_VIEW;
+use crate::infra::db_error::DbError;
+use crate::infra::is_transient_pg_error;
+
+/// Routes a `sqlx::Error` through [`StoragePluginError`] so the SQLSTATE and
+/// `source()` chain are preserved in the rendered [`UsageCollectorError`]
+/// detail. Without this round-trip the bare `format!("storage error: {e}")`
+/// loses the database error code at the API boundary.
+fn classify_query_error(e: sqlx::Error) -> UsageCollectorError {
+    if is_transient_pg_error(&e) {
+        StoragePluginError::Transient(DbError::boxed(e)).into()
+    } else {
+        StoragePluginError::QueryFailed(DbError::boxed(e)).into()
+    }
+}
+
+fn map_scope_error(err: &ScopeTranslationError) -> UsageCollectorError {
+    // Both variants collapse into the same public `PermissionDenied` reason so
+    // the API boundary does not leak which authorization predicate failed.
+    // Operators triaging a 403 still need to distinguish "PDP returned empty
+    // scope (fail-closed)" from "PDP emitted an InGroup/InGroupSubtree
+    // predicate this plugin cannot translate" from "PDP used an unknown
+    // property name" — three very different bugs (auth misconfig vs feature
+    // gap vs name drift). Emit a structured warn here so the diagnostic
+    // survives in logs even though the public error carries only the stable
+    // reason code.
+    tracing::warn!(
+        reason = ?err,
+        "scope translation rejected query; returning PermissionDenied"
+    );
+    match err {
+        ScopeTranslationError::EmptyScope | ScopeTranslationError::UnsupportedPredicate { .. } => {
+            UsageRecordError::permission_denied()
+                .with_reason("AUTHORIZATION_DENIED")
+                .create()
+        }
+    }
+}
+
+/// Maximum number of rows `query_aggregated` may return.
+///
+/// Sourced as a plugin-side constant because the HEAD SDK's `AggregationQuery`
+/// no longer carries `max_rows`; the gateway-configured `MAX_AGG_ROWS` is the
+/// platform-recommended ceiling (see `usage_collector_sdk::plugin_api`
+/// docstring on `query_aggregated`). Phase 6 may move this into plugin
+/// configuration without changing the byte-identical resource-exhausted
+/// detail string.
+const MAX_AGG_ROWS: usize = 10_000;
+
+/// Maximum number of rows `query_raw` may return per page.
+///
+/// Mirrors the symmetric ceiling already applied to `query_aggregated` via
+/// `MAX_AGG_ROWS`. Without this bound a caller can request `u32::MAX` rows;
+/// the resulting `LIMIT page_size + 1` is a full-scan ceiling the database
+/// will happily evaluate.
+const MAX_RAW_PAGE_SIZE: u32 = 10_000;
+
+pub struct PgQueryPort {
+    pool: PgPool,
+    max_agg_rows: usize,
+}
+
+impl PgQueryPort {
+    #[must_use]
+    pub fn new(pool: PgPool) -> Self {
+        Self {
+            pool,
+            max_agg_rows: MAX_AGG_ROWS,
+        }
+    }
+
+    /// Test-only constructor that overrides the aggregation row cap.
+    ///
+    /// Production code uses [`PgQueryPort::new`], which binds the cap to the
+    /// platform-recommended [`MAX_AGG_ROWS`]. Integration tests use this
+    /// constructor with a small cap so the cost-control invariant can be
+    /// exercised without emitting > 10 000 rows.
+    #[cfg(feature = "integration")]
+    #[must_use]
+    pub fn new_with_max_agg_rows(pool: PgPool, max_agg_rows: usize) -> Self {
+        Self { pool, max_agg_rows }
+    }
+}
+
+fn add_arg<T>(args: &mut PgArguments, value: T) -> Result<(), UsageCollectorError>
+where
+    T: for<'q> sqlx::Encode<'q, sqlx::Postgres> + sqlx::Type<sqlx::Postgres>,
+{
+    use sqlx::Arguments as _;
+    args.add(value).map_err(|e| {
+        StoragePluginError::Serialization {
+            context: "SQL argument binding failed".to_owned(),
+            source: e,
+        }
+        .into()
+    })
+}
+
+/// Decodes column `col` from `row` as `T`, mapping `sqlx::Error` to a uniform
+/// `UsageCollectorError::Internal` carrying the column name. Centralising this
+/// keeps the row-decode sites in `query_aggregated` / `query_raw` to one line
+/// each and ensures every decode error surfaces the same wording.
+fn decode<'r, T>(row: &'r PgRow, col: &str) -> Result<T, UsageCollectorError>
+where
+    T: sqlx::Decode<'r, sqlx::Postgres> + sqlx::Type<sqlx::Postgres>,
+{
+    row.try_get::<T, _>(col).map_err(|e| {
+        StoragePluginError::Serialization {
+            context: format!("row decode error ({col})"),
+            source: DbError::boxed(e),
+        }
+        .into()
+    })
+}
+
+fn raw_agg_expr(func: AggregationFn) -> &'static str {
+    match func {
+        AggregationFn::Sum => "SUM(value)::float8 AS agg_value",
+        AggregationFn::Count => "COUNT(*)::float8 AS agg_value",
+        AggregationFn::Min => "MIN(value)::float8 AS agg_value",
+        AggregationFn::Max => "MAX(value)::float8 AS agg_value",
+        AggregationFn::Avg => "AVG(value)::float8 AS agg_value",
+    }
+}
+
+fn cagg_agg_expr(func: AggregationFn) -> &'static str {
+    match func {
+        AggregationFn::Sum => "SUM(sum_val)::float8 AS agg_value",
+        AggregationFn::Count => "SUM(cnt_val)::float8 AS agg_value",
+        AggregationFn::Min => "MIN(min_val)::float8 AS agg_value",
+        AggregationFn::Max => "MAX(max_val)::float8 AS agg_value",
+        AggregationFn::Avg => "(SUM(sum_val) / NULLIF(SUM(cnt_val), 0))::float8 AS agg_value",
+    }
+}
+
+fn bucket_size_to_pg_interval(size: BucketSize) -> &'static str {
+    match size {
+        BucketSize::Minute => "1 minute",
+        BucketSize::Hour => "1 hour",
+        BucketSize::Day => "1 day",
+        BucketSize::Week => "1 week",
+        BucketSize::Month => "1 month",
+    }
+}
+
+/// Per-path knobs for building an aggregation SELECT.
+///
+/// The raw-hypertable path and the continuous-aggregate path differ only in the
+/// table, time column, aggregation expression, and whether the row-level
+/// `resource_id` / `subject_id` columns are visible (the CAGG groups them out).
+/// Centralising those knobs lets a single SQL assembler serve both branches.
+struct AggSqlVariant {
+    /// Table / view name to SELECT from.
+    table: &'static str,
+    /// Time column on the table/view (`timestamp` for raw, `bucket` for the CAGG).
+    time_col: &'static str,
+    /// Per-function aggregation expression, including the `AS agg_value` alias.
+    agg_expr: &'static str,
+    /// Whether `resource_id` / `subject_id` are visible (only on the raw path).
+    /// Controls both SELECT/GROUP BY projection and WHERE-clause id filters.
+    has_id_columns: bool,
+    /// Upper-bound comparator for the time-range filter.
+    ///
+    /// The raw path uses `<=` (closed interval over individual record timestamps).
+    /// The CAGG path uses `<` so the bucket at `end` — which covers
+    /// `[end, end + 1h)` and therefore extends past the requested range — is
+    /// excluded; a raw-record boundary correction (see `boundary_correction`)
+    /// then UNIONs in records at exactly `timestamp = end`, restoring the
+    /// closed-interval contract the spec requires.
+    end_op: &'static str,
+    /// Whether to UNION the bucket-aligned aggregate with a raw boundary
+    /// projection. Only the CAGG path sets this — the raw path is already
+    /// closed-interval through its `<=` comparator.
+    boundary_correction: bool,
+}
+
+/// Predicate: is the requested time range safely served by the 1-hour CAGG?
+///
+/// The CAGG path is only correct when:
+/// * both endpoints are aligned to hour boundaries — otherwise the bucket at
+///   each endpoint contains records outside the requested range and the result
+///   is under- or over-counted;
+/// * the end is no later than the materialized horizon (`now - 1 hour`,
+///   matching the refresh policy `end_offset`) — otherwise the unrefreshed
+///   tail of the request is silently empty under
+///   `timescaledb.materialized_only = true` (the `TimescaleDB` ≥ 2.13 default).
+///
+/// When either condition fails the caller must route to the raw hypertable.
+///
+/// `now` is injected (rather than read inline via `Utc::now()`) so the
+/// materialized-horizon edge is unit-testable without race-prone
+/// `Utc::now() ± Duration::hours(N)` workarounds. Production call sites pass
+/// `Utc::now()`; tests pin it.
+fn cagg_safe_range(start: DateTime<Utc>, end: DateTime<Utc>, now: DateTime<Utc>) -> bool {
+    fn hour_aligned(t: DateTime<Utc>) -> bool {
+        t.minute() == 0 && t.second() == 0 && t.nanosecond() == 0
+    }
+    let materialized_horizon = now - chrono::Duration::hours(1);
+    hour_aligned(start) && hour_aligned(end) && end <= materialized_horizon
+}
+
+/// Pre-bound positional parameter indices the caller has already added to `args`
+/// for the inclusive time-range filter.
+#[derive(Copy, Clone)]
+struct TimeRangeArgs {
+    start_idx: usize,
+    end_idx: usize,
+}
+
+/// Rejects the case where the caller supplied both `bucket_size` and a
+/// `GroupByDimension::TimeBucket(bs)` but the two carry different `BucketSize`s.
+/// Extracted so this contract can be unit-tested without a `PgPool`.
+fn validate_bucket_size_consistency(
+    bucket_size: Option<BucketSize>,
+    group_by: &[GroupByDimension],
+) -> Result<(), UsageCollectorError> {
+    let Some(requested) = bucket_size else {
+        return Ok(());
+    };
+    for d in group_by {
+        if let GroupByDimension::TimeBucket(group_bs) = d
+            && *group_bs != requested
+        {
+            return Err(UsageRecordError::invalid_argument()
+                .with_constraint(
+                    "bucket_size must match group_by TimeBucket size when both are set",
+                )
+                .create());
+        }
+    }
+    Ok(())
+}
+
+/// Builds the `FROM` sub-query that UNIONs the bucket-aligned CAGG aggregate
+/// with the boundary records from the raw hypertable.
+///
+/// The CAGG view groups raw records into half-open hour intervals
+/// (`[bucket, bucket + 1h)`). Using `bucket <= $end` on a closed-interval
+/// request would include all of `[end, end + 1h)` — a full extra bucket beyond
+/// the requested range. Using `bucket < $end` is bucket-correct but silently
+/// excludes records at exactly `timestamp = end`, which the raw path WOULD
+/// include (its `timestamp <= $end` predicate is inclusive).
+///
+/// Restore the closed-interval contract by UNION ALL'ing the bucket-aligned
+/// aggregate with a raw-table projection of the boundary records, casting each
+/// raw row into pre-aggregated shape so the outer SUM/MIN/MAX over
+/// `sum_val`/`cnt_val`/`min_val`/`max_val` merges them transparently. The
+/// routing guard `cagg_safe_range` already keeps both endpoints hour-aligned,
+/// so `time_bucket('1 hour', $end)` collapses to `$end` and the boundary rows
+/// land in the correct bucket key.
+///
+/// The CAGG path is only taken when `resource_id` and `subject_id` are absent
+/// from both filters and scope (see `use_raw_path` upstream), so every clause
+/// in `filter_sql` references columns present on both `usage_agg_1h` and
+/// `usage_records`.
+fn build_cagg_boundary_corrected_from(
+    table: &str,
+    time_col: &str,
+    filter_sql: &str,
+    time_start_idx: usize,
+    time_end_idx: usize,
+) -> String {
+    format!(
+        "(SELECT bucket, metric, module, resource_type, subject_type, \
+              sum_val, cnt_val, min_val, max_val \
+          FROM {table} \
+          WHERE {filter_sql} AND {time_col} >= ${time_start_idx} \
+              AND {time_col} < ${time_end_idx} \
+          UNION ALL \
+          SELECT time_bucket('1 hour', timestamp) AS bucket, metric, module, \
+              resource_type, subject_type, \
+              value AS sum_val, 1::bigint AS cnt_val, value AS min_val, \
+              value AS max_val \
+          FROM usage_records \
+          WHERE {filter_sql} AND timestamp = ${time_end_idx}) AS unified"
+    )
+}
+
+fn build_aggregation_sql(
+    variant: &AggSqlVariant,
+    query: &AggregationQuery,
+    scope_sql: &str,
+    args: &mut PgArguments,
+    param_idx: &mut usize,
+    time_range: TimeRangeArgs,
+    max_agg_rows: usize,
+) -> Result<String, UsageCollectorError> {
+    let AggSqlVariant {
+        table,
+        time_col,
+        agg_expr,
+        has_id_columns,
+        end_op,
+        boundary_correction,
+    } = *variant;
+    let TimeRangeArgs {
+        start_idx: time_start_idx,
+        end_idx: time_end_idx,
+    } = time_range;
+    let time_bucket_size = query.group_by.iter().find_map(|d| match d {
+        GroupByDimension::TimeBucket(bs) => Some(*bs),
+        _ => None,
+    });
+    let has_time_bucket = time_bucket_size.is_some();
+    let has_usage_type = query.group_by.contains(&GroupByDimension::UsageType);
+    let has_subject = query.group_by.contains(&GroupByDimension::Subject);
+    let has_resource = query.group_by.contains(&GroupByDimension::Resource);
+    let has_source = query.group_by.contains(&GroupByDimension::Source);
+
+    let mut select_cols: Vec<String> = Vec::new();
+    let mut group_by_exprs: Vec<String> = Vec::new();
+
+    if let Some(bs) = time_bucket_size {
+        let interval = bucket_size_to_pg_interval(bs);
+        select_cols.push(format!(
+            "time_bucket('{interval}', {time_col}) AS bucket_start"
+        ));
+        group_by_exprs.push(format!("time_bucket('{interval}', {time_col})"));
+    }
+    if has_usage_type {
+        select_cols.push("metric AS usage_type".to_owned());
+        group_by_exprs.push("metric".to_owned());
+    }
+    if has_subject {
+        if has_id_columns {
+            select_cols.push("subject_id".to_owned());
+            group_by_exprs.push("subject_id".to_owned());
+        }
+        select_cols.push("subject_type".to_owned());
+        group_by_exprs.push("subject_type".to_owned());
+    }
+    if has_resource {
+        if has_id_columns {
+            select_cols.push("resource_id".to_owned());
+            group_by_exprs.push("resource_id".to_owned());
+        }
+        select_cols.push("resource_type".to_owned());
+        group_by_exprs.push("resource_type".to_owned());
+    }
+    if has_source {
+        select_cols.push("module AS source".to_owned());
+        group_by_exprs.push("module".to_owned());
+    }
+    select_cols.push(agg_expr.to_owned());
+
+    let select_clause = select_cols.join(", ");
+
+    // Non-time filter clauses (scope + optional column filters). These bind
+    // once and are referenced verbatim in both halves of the CAGG UNION ALL
+    // boundary correction, so each filter parameter is added exactly once.
+    let mut filter_clauses: Vec<String> = vec![scope_sql.to_owned()];
+
+    if let Some(ref metric) = query.usage_type {
+        *param_idx += 1;
+        filter_clauses.push(format!("metric = ${param_idx}"));
+        add_arg(args, metric.clone())?;
+    }
+    if has_id_columns && let Some(resource_id) = query.resource_id {
+        *param_idx += 1;
+        filter_clauses.push(format!("resource_id = ${param_idx}"));
+        add_arg(args, resource_id)?;
+    }
+    if let Some(ref resource_type) = query.resource_type {
+        *param_idx += 1;
+        filter_clauses.push(format!("resource_type = ${param_idx}"));
+        add_arg(args, resource_type.clone())?;
+    }
+    if has_id_columns && let Some(subject_id) = query.subject_id {
+        *param_idx += 1;
+        filter_clauses.push(format!("subject_id = ${param_idx}"));
+        add_arg(args, subject_id)?;
+    }
+    if let Some(ref subject_type) = query.subject_type {
+        *param_idx += 1;
+        filter_clauses.push(format!("subject_type = ${param_idx}"));
+        add_arg(args, subject_type.clone())?;
+    }
+    if let Some(ref source) = query.source {
+        *param_idx += 1;
+        filter_clauses.push(format!("module = ${param_idx}"));
+        add_arg(args, source.clone())?;
+    }
+
+    let filter_sql = filter_clauses.join(" AND ");
+
+    *param_idx += 1;
+    let limit_idx = *param_idx;
+    let max_rows_limit = i64::try_from(max_agg_rows)
+        .map_err(|e| -> UsageCollectorError {
+            StoragePluginError::Serialization {
+                context: "row limit overflow".to_owned(),
+                source: Box::new(e),
+            }
+            .into()
+        })?
+        .saturating_add(1);
+    add_arg(args, max_rows_limit)?;
+
+    let order_clause = if has_time_bucket {
+        " ORDER BY bucket_start ASC"
+    } else {
+        ""
+    };
+    let group_clause = if group_by_exprs.is_empty() {
+        String::new()
+    } else {
+        format!(" GROUP BY {}", group_by_exprs.join(", "))
+    };
+
+    let (from_clause, where_clause) = if boundary_correction {
+        let unified = build_cagg_boundary_corrected_from(
+            table,
+            time_col,
+            &filter_sql,
+            time_start_idx,
+            time_end_idx,
+        );
+        (unified, String::from("TRUE"))
+    } else {
+        let mut where_clauses = Vec::with_capacity(filter_clauses.len() + 2);
+        where_clauses.push(scope_sql.to_owned());
+        where_clauses.push(format!("{time_col} >= ${time_start_idx}"));
+        where_clauses.push(format!("{time_col} {end_op} ${time_end_idx}"));
+        for clause in filter_clauses.iter().skip(1) {
+            where_clauses.push(clause.clone());
+        }
+        (table.to_owned(), where_clauses.join(" AND "))
+    };
+
+    Ok(format!(
+        "SELECT {select_clause} FROM {from_clause} WHERE {where_clause}{group_clause}{order_clause} LIMIT ${limit_idx}"
+    ))
+}
+
+#[allow(clippy::too_many_lines)]
+#[async_trait]
+impl QueryPort for PgQueryPort {
+    // @cpt-algo:cpt-cf-usage-collector-algo-production-storage-plugin-query-aggregated:p1
+    async fn query_aggregated(
+        &self,
+        query: AggregationQuery,
+    ) -> Result<Vec<AggregationResult>, UsageCollectorError> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-query-aggregated:p1:inst-qagg-1
+        let (scope_sql, scope_params) =
+            scope_to_sql(&query.scope).map_err(|e| map_scope_error(&e))?;
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-query-aggregated:p1:inst-qagg-1
+
+        let group_by = &query.group_by;
+
+        // The gateway validates only that `bucket_size` is present when `group_by`
+        // contains `TimeBucket(_)`; it does NOT cross-check that the two carry the
+        // same `BucketSize`. Without this guard, a mismatched pair would drive
+        // CAGG-vs-raw routing from `bucket_size` while the emitted SQL buckets by
+        // `TimeBucket(bs)` — two sources of truth disagreeing silently. Reject
+        // the inconsistency at the plugin boundary so the failure mode is a clean
+        // `InvalidArgument`, not a wrong result set.
+        validate_bucket_size_consistency(query.bucket_size, group_by)?;
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-query-aggregated:p1:inst-qagg-2
+        // The continuous aggregate's buckets are already aligned to 1 hour; rebucketing them
+        // at minute granularity yields sparse hour-aligned rows with no data in between.
+        // Sub-hour requests must fall back to the raw hypertable.
+        let cagg_too_coarse = matches!(query.bucket_size, Some(BucketSize::Minute))
+            || group_by
+                .iter()
+                .any(|d| matches!(d, GroupByDimension::TimeBucket(BucketSize::Minute)));
+        // The CAGG view groups out `resource_id` / `subject_id`, so any
+        // scope-level filter on those columns must execute against the raw
+        // hypertable. Without this check the generated SQL would reference
+        // columns that do not exist on the view and fail at runtime.
+        let unsafe_time_range =
+            !cagg_safe_range(query.time_range.0, query.time_range.1, Utc::now());
+        let filter_resource = query.resource_id.is_some();
+        let filter_subject = query.subject_id.is_some();
+        let group_resource = group_by.contains(&GroupByDimension::Resource);
+        let group_subject = group_by.contains(&GroupByDimension::Subject);
+        let scope_constrains_ids = scope_constrains_record_ids(&query.scope);
+        let use_raw_path = filter_resource
+            || filter_subject
+            || group_resource
+            || group_subject
+            || cagg_too_coarse
+            || scope_constrains_ids
+            || unsafe_time_range;
+        // Emit each routing predicate as its own structured field so an
+        // operator can distinguish "raw path because filter on resource_id"
+        // from "raw path because end is inside the unmaterialized window" —
+        // a routing surprise (e.g. a dashboard suddenly slower because every
+        // query falls back to raw) is diagnosable from this single event.
+        tracing::debug!(
+            use_raw_path,
+            cagg_too_coarse,
+            unsafe_time_range,
+            scope_constrains_ids,
+            filter_resource,
+            filter_subject,
+            group_resource,
+            group_subject,
+            "query_aggregated routing decision"
+        );
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-query-aggregated:p1:inst-qagg-2
+
+        let mut args = PgArguments::default();
+        let mut param_idx: usize = 0;
+
+        for sv in scope_params {
+            param_idx += 1;
+            match sv {
+                SqlValue::Uuid(u) => add_arg(&mut args, u)?,
+                SqlValue::UuidArray(v) => add_arg(&mut args, v)?,
+                SqlValue::Text(s) => add_arg(&mut args, s)?,
+                SqlValue::TextArray(v) => add_arg(&mut args, v)?,
+            }
+        }
+
+        let time_start_idx = param_idx + 1;
+        param_idx += 1;
+        add_arg(&mut args, query.time_range.0)?;
+        let time_end_idx = param_idx + 1;
+        param_idx += 1;
+        add_arg(&mut args, query.time_range.1)?;
+
+        let has_time_bucket = group_by
+            .iter()
+            .any(|d| matches!(d, GroupByDimension::TimeBucket(_)));
+        let has_usage_type = group_by.contains(&GroupByDimension::UsageType);
+        let has_subject = group_by.contains(&GroupByDimension::Subject);
+        let has_resource = group_by.contains(&GroupByDimension::Resource);
+        let has_source = group_by.contains(&GroupByDimension::Source);
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-query-aggregated:p1:inst-qagg-3
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-query-aggregated:p1:inst-qagg-4
+        let variant = if use_raw_path {
+            AggSqlVariant {
+                table: "usage_records",
+                time_col: "timestamp",
+                agg_expr: raw_agg_expr(query.function),
+                has_id_columns: true,
+                end_op: "<=",
+                boundary_correction: false,
+            }
+        } else {
+            AggSqlVariant {
+                table: CONTINUOUS_AGGREGATE_VIEW,
+                time_col: "bucket",
+                agg_expr: cagg_agg_expr(query.function),
+                has_id_columns: false,
+                end_op: "<",
+                boundary_correction: true,
+            }
+        };
+        let sql = build_aggregation_sql(
+            &variant,
+            &query,
+            &scope_sql,
+            &mut args,
+            &mut param_idx,
+            TimeRangeArgs {
+                start_idx: time_start_idx,
+                end_idx: time_end_idx,
+            },
+            self.max_agg_rows,
+        )?;
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-query-aggregated:p1:inst-qagg-3
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-query-aggregated:p1:inst-qagg-4
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-query-aggregated:p1:inst-qagg-5
+        let rows = sqlx::query_with(&sql, args)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(classify_query_error)?;
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-query-aggregated:p1:inst-qagg-5
+
+        // Reject before decode: the SQL `LIMIT` is `max_agg_rows + 1` so an
+        // overflow is observable here without spending the work of decoding
+        // 10 001 rows into `AggregationResult`s that we are about to discard.
+        // The cap is the cost-control invariant; enforcing it after decode
+        // would do exactly the work the cap was meant to prevent.
+        if rows.len() > self.max_agg_rows {
+            return Err(
+                UsageRecordError::resource_exhausted("query result too large")
+                    .with_quota_violation("rows", "query result row count exceeds limit")
+                    .create(),
+            );
+        }
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-query-aggregated:p1:inst-qagg-6
+        let results: Vec<AggregationResult> = rows
+            .iter()
+            .map(|row| -> Result<AggregationResult, UsageCollectorError> {
+                // Columns that are conditionally selected but NOT NULL in the schema
+                // (bucket_start, usage_type/metric, resource_id, resource_type, source/module)
+                // are read as `T` so decode errors propagate; only `subject_id` and
+                // `subject_type` are NULLable in the underlying table and use `Option<T>`.
+                let value = decode::<f64>(row, "agg_value")?;
+                let bucket_start = if has_time_bucket {
+                    Some(decode(row, "bucket_start")?)
+                } else {
+                    None
+                };
+                let usage_type = if has_usage_type {
+                    Some(decode(row, "usage_type")?)
+                } else {
+                    None
+                };
+                let subject_id = if has_subject && use_raw_path {
+                    decode::<Option<Uuid>>(row, "subject_id")?
+                } else {
+                    None
+                };
+                let subject_type = if has_subject {
+                    decode::<Option<String>>(row, "subject_type")?
+                } else {
+                    None
+                };
+                let resource_id = if has_resource && use_raw_path {
+                    Some(decode(row, "resource_id")?)
+                } else {
+                    None
+                };
+                let resource_type = if has_resource {
+                    Some(decode(row, "resource_type")?)
+                } else {
+                    None
+                };
+                let source = if has_source {
+                    Some(decode(row, "source")?)
+                } else {
+                    None
+                };
+                Ok(AggregationResult {
+                    function: query.function,
+                    value,
+                    bucket_start,
+                    usage_type,
+                    subject_id,
+                    subject_type,
+                    resource_id,
+                    resource_type,
+                    source,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-query-aggregated:p1:inst-qagg-6
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-query-aggregated:p1:inst-qagg-7
+        Ok(results)
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-query-aggregated:p1:inst-qagg-7
+    }
+
+    // @cpt-algo:cpt-cf-usage-collector-algo-production-storage-plugin-query-raw:p1
+    async fn query_raw(&self, query: RawQuery) -> Result<Page<UsageRecord>, UsageCollectorError> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-query-raw:p1:inst-qraw-1
+        let (scope_sql, scope_params) =
+            scope_to_sql(&query.scope).map_err(|e| map_scope_error(&e))?;
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-query-raw:p1:inst-qraw-1
+
+        // Hash is computed lazily — only at the two sites that consume it
+        // (cursor-drift detection and next-page cursor emission). The
+        // first-page common case (no cursor and no overflow) does not need
+        // it; eager computation would do the work the cap was meant to
+        // skip. The hash is deterministic for a given filter set, so the
+        // (at most) two computations stay self-consistent across the
+        // request's lifetime.
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-query-raw:p1:inst-qraw-2
+        let cursor_pos: Option<(DateTime<Utc>, Uuid)> = query
+            .cursor
+            .as_ref()
+            .map(|c| {
+                if c.d != "fwd" {
+                    return Err(UsageRecordError::invalid_argument()
+                        .with_constraint("cursor drift: backward pagination not supported")
+                        .create());
+                }
+                if c.o != SortDir::Asc {
+                    return Err(UsageRecordError::invalid_argument()
+                        .with_constraint("cursor drift: sort direction mismatch")
+                        .create());
+                }
+                if c.s != raw_query_effective_order().to_signed_tokens() {
+                    return Err(UsageRecordError::invalid_argument()
+                        .with_constraint("cursor drift: sort signature mismatch")
+                        .create());
+                }
+                let expected_filter_hash = raw_query_filter_hash(&RawQueryFilters::from(&query));
+                match c.f.as_deref() {
+                    Some(h) if h == expected_filter_hash => {}
+                    _ => {
+                        return Err(UsageRecordError::invalid_argument()
+                            .with_constraint("cursor drift: filter set has changed")
+                            .create());
+                    }
+                }
+                let ts_str = c.k.first().ok_or_else(|| {
+                    UsageRecordError::invalid_argument()
+                        .with_constraint("cursor missing timestamp key")
+                        .create()
+                })?;
+                let id_str = c.k.get(1).ok_or_else(|| {
+                    UsageRecordError::invalid_argument()
+                        .with_constraint("cursor missing id key")
+                        .create()
+                })?;
+                let ts = ts_str.parse::<DateTime<Utc>>().map_err(|e| {
+                    UsageRecordError::invalid_argument()
+                        .with_constraint(format!("cursor timestamp parse error: {e}"))
+                        .create()
+                })?;
+                let id = id_str.parse::<Uuid>().map_err(|e| {
+                    UsageRecordError::invalid_argument()
+                        .with_constraint(format!("cursor id parse error: {e}"))
+                        .create()
+                })?;
+                Ok::<_, UsageCollectorError>((ts, id))
+            })
+            .transpose()?;
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-query-raw:p1:inst-qraw-2
+
+        let mut args = PgArguments::default();
+        let mut param_idx: usize = 0;
+
+        for sv in scope_params {
+            param_idx += 1;
+            match sv {
+                SqlValue::Uuid(u) => add_arg(&mut args, u)?,
+                SqlValue::UuidArray(v) => add_arg(&mut args, v)?,
+                SqlValue::Text(s) => add_arg(&mut args, s)?,
+                SqlValue::TextArray(v) => add_arg(&mut args, v)?,
+            }
+        }
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-query-raw:p1:inst-qraw-3
+        let time_start_idx = param_idx + 1;
+        param_idx += 1;
+        add_arg(&mut args, query.time_range.0)?;
+        let time_end_idx = param_idx + 1;
+        param_idx += 1;
+        add_arg(&mut args, query.time_range.1)?;
+
+        let mut where_clauses: Vec<String> = Vec::new();
+        where_clauses.push(scope_sql);
+        where_clauses.push(format!("timestamp >= ${time_start_idx}"));
+        where_clauses.push(format!("timestamp <= ${time_end_idx}"));
+
+        if let Some(ref metric) = query.usage_type {
+            param_idx += 1;
+            where_clauses.push(format!("metric = ${param_idx}"));
+            add_arg(&mut args, metric.clone())?;
+        }
+        if let Some(resource_id) = query.resource_id {
+            param_idx += 1;
+            where_clauses.push(format!("resource_id = ${param_idx}"));
+            add_arg(&mut args, resource_id)?;
+        }
+        if let Some(ref resource_type) = query.resource_type {
+            param_idx += 1;
+            where_clauses.push(format!("resource_type = ${param_idx}"));
+            add_arg(&mut args, resource_type.clone())?;
+        }
+        if let Some(subject_id) = query.subject_id {
+            param_idx += 1;
+            where_clauses.push(format!("subject_id = ${param_idx}"));
+            add_arg(&mut args, subject_id)?;
+        }
+        if let Some(ref subject_type) = query.subject_type {
+            param_idx += 1;
+            where_clauses.push(format!("subject_type = ${param_idx}"));
+            add_arg(&mut args, subject_type.clone())?;
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-query-raw:p1:inst-qraw-3
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-query-raw:p1:inst-qraw-4
+        if let Some((cursor_ts, cursor_id)) = cursor_pos {
+            let ts_idx = param_idx + 1;
+            param_idx += 1;
+            let id_idx = param_idx + 1;
+            param_idx += 1;
+            add_arg(&mut args, cursor_ts)?;
+            add_arg(&mut args, cursor_id)?;
+            where_clauses.push(format!(
+                "(timestamp > ${ts_idx} OR (timestamp = ${ts_idx} AND id > ${id_idx}))"
+            ));
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-query-raw:p1:inst-qraw-4
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-query-raw:p1:inst-qraw-5
+        if query.page_size < 1 {
+            return Err(UsageRecordError::invalid_argument()
+                .with_constraint("page_size must be >= 1")
+                .create());
+        }
+        if query.page_size > MAX_RAW_PAGE_SIZE {
+            return Err(UsageRecordError::invalid_argument()
+                .with_constraint(format!(
+                    "page_size must be <= {MAX_RAW_PAGE_SIZE}, got: {}",
+                    query.page_size
+                ))
+                .create());
+        }
+        param_idx += 1;
+        let page_size_idx = param_idx;
+        let page_size = i64::from(query.page_size);
+        add_arg(&mut args, page_size + 1)?;
+
+        let where_clause = where_clauses.join(" AND ");
+        let sql = format!(
+            "SELECT id, tenant_id, module, kind, metric, value::float8 AS value, timestamp, \
+             idempotency_key, resource_id, resource_type, subject_id, subject_type, metadata \
+             FROM usage_records \
+             WHERE {where_clause} \
+             ORDER BY timestamp ASC, id ASC \
+             LIMIT ${page_size_idx}"
+        );
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-query-raw:p1:inst-qraw-5
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-query-raw:p1:inst-qraw-6
+        let rows = sqlx::query_with(&sql, args)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(classify_query_error)?;
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-query-raw:p1:inst-qraw-6
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-query-raw:p1:inst-qraw-7
+        let page_size_usize = query.page_size as usize;
+        let has_more = rows.len() > page_size_usize;
+        let rows_page = if has_more {
+            &rows[..page_size_usize]
+        } else {
+            &rows[..]
+        };
+
+        let next_cursor: Option<String> = if has_more {
+            if let Some(last_row) = rows_page.last() {
+                let last_ts: DateTime<Utc> = decode(last_row, "timestamp")?;
+                let last_id: Uuid = decode(last_row, "id")?;
+                let cursor = CursorV1 {
+                    k: vec![last_ts.to_rfc3339(), last_id.to_string()],
+                    o: SortDir::Asc,
+                    s: raw_query_effective_order().to_signed_tokens(),
+                    f: Some(raw_query_filter_hash(&RawQueryFilters::from(&query))),
+                    d: "fwd".to_owned(),
+                };
+                Some(cursor.encode().map_err(|e| -> UsageCollectorError {
+                    StoragePluginError::Serialization {
+                        context: "cursor encode error".to_owned(),
+                        source: Box::new(e),
+                    }
+                    .into()
+                })?)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let records: Vec<UsageRecord> = rows_page
+            .iter()
+            .map(|row| -> Result<UsageRecord, UsageCollectorError> {
+                let kind_str: String = decode(row, "kind")?;
+                let kind = match kind_str.as_str() {
+                    "counter" => UsageKind::Counter,
+                    "gauge" => UsageKind::Gauge,
+                    other => {
+                        return Err(UsageCollectorError::internal(format!(
+                            "unknown kind value in storage: {other}"
+                        ))
+                        .create());
+                    }
+                };
+                let subject_id: Option<Uuid> = decode(row, "subject_id")?;
+                let subject_type: Option<String> = decode(row, "subject_type")?;
+                let subject = subject_id.map(|id| Subject {
+                    id,
+                    r#type: subject_type,
+                });
+                Ok(UsageRecord {
+                    module: decode(row, "module")?,
+                    tenant_id: decode(row, "tenant_id")?,
+                    metric: decode(row, "metric")?,
+                    kind,
+                    value: decode::<f64>(row, "value")?,
+                    resource_id: decode(row, "resource_id")?,
+                    resource_type: decode(row, "resource_type")?,
+                    subject,
+                    idempotency_key: decode::<Option<String>>(row, "idempotency_key")?
+                        .unwrap_or_default(),
+                    timestamp: decode(row, "timestamp")?,
+                    metadata: decode::<Option<serde_json::Value>>(row, "metadata")?,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-query-raw:p1:inst-qraw-7
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-production-storage-plugin-query-raw:p1:inst-qraw-8
+        Ok(Page::new(
+            records,
+            PageInfo {
+                next_cursor,
+                prev_cursor: None,
+                limit: u64::from(query.page_size),
+            },
+        ))
+        // @cpt-end:cpt-cf-usage-collector-algo-production-storage-plugin-query-raw:p1:inst-qraw-8
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "pg_query_port_tests.rs"]
+mod pg_query_port_tests;

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/pg_query_port_tests.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/pg_query_port_tests.rs
@@ -1,0 +1,120 @@
+use super::*;
+
+#[test]
+fn map_scope_error_empty_scope_maps_to_permission_denied() {
+    let err = map_scope_error(&ScopeTranslationError::EmptyScope);
+    assert!(
+        matches!(err, UsageCollectorError::PermissionDenied { .. }),
+        "expected PermissionDenied, got: {err:?}"
+    );
+}
+
+#[test]
+fn map_scope_error_unsupported_predicate_maps_to_permission_denied() {
+    let err = map_scope_error(&ScopeTranslationError::UnsupportedPredicate {
+        kind: "InGroup/InGroupSubtree".to_owned(),
+    });
+    assert!(
+        matches!(err, UsageCollectorError::PermissionDenied { .. }),
+        "expected PermissionDenied, got: {err:?}"
+    );
+}
+
+fn at(h: u32, m: u32, s: u32, ns: u32) -> DateTime<Utc> {
+    chrono::NaiveDate::from_ymd_opt(2026, 1, 1)
+        .unwrap()
+        .and_hms_nano_opt(h, m, s, ns)
+        .unwrap()
+        .and_utc()
+}
+
+/// Pinned "now" anchor far enough past the test times that the
+/// materialized-horizon check is satisfied unconditionally, so the
+/// alignment-only tests below isolate the alignment predicate.
+fn pinned_now() -> DateTime<Utc> {
+    // Day after the `at(...)` anchor — materialized horizon is `now - 1h`
+    // which is still well after any 2026-01-01 fixture time.
+    chrono::NaiveDate::from_ymd_opt(2026, 1, 2)
+        .unwrap()
+        .and_hms_nano_opt(0, 0, 0, 0)
+        .unwrap()
+        .and_utc()
+}
+
+#[test]
+fn cagg_safe_range_rejects_non_hour_aligned_start() {
+    let start = at(10, 30, 0, 0);
+    let end = at(11, 0, 0, 0);
+    assert!(!cagg_safe_range(start, end, pinned_now()));
+}
+
+#[test]
+fn cagg_safe_range_rejects_non_hour_aligned_end() {
+    let start = at(10, 0, 0, 0);
+    let end = at(11, 0, 0, 1);
+    assert!(!cagg_safe_range(start, end, pinned_now()));
+}
+
+#[test]
+fn cagg_safe_range_rejects_end_inside_unmaterialized_window() {
+    // `now` is fixed; `end` is one nanosecond past the materialized
+    // horizon (`now - 1h`). Deterministic; no clock racing.
+    let now = at(12, 0, 0, 0);
+    let start = at(9, 0, 0, 0);
+    let end = at(11, 0, 0, 1);
+    assert!(!cagg_safe_range(start, end, now));
+}
+
+#[test]
+fn cagg_safe_range_rejects_end_exactly_one_ns_past_horizon() {
+    // Pins the horizon boundary: `end == now - 1h` is accepted (see the
+    // _accepts_ test below), `end == now - 1h + 1ns` is rejected.
+    let now = at(12, 0, 0, 0);
+    let start = at(9, 0, 0, 0);
+    let end = at(11, 0, 0, 0) + chrono::Duration::nanoseconds(1);
+    assert!(!cagg_safe_range(start, end, now));
+}
+
+#[test]
+fn validate_bucket_size_accepts_consistent_pair() {
+    let group_by = vec![GroupByDimension::TimeBucket(BucketSize::Hour)];
+    assert!(validate_bucket_size_consistency(Some(BucketSize::Hour), &group_by).is_ok());
+}
+
+#[test]
+fn validate_bucket_size_accepts_missing_bucket_size() {
+    let group_by = vec![GroupByDimension::TimeBucket(BucketSize::Hour)];
+    // Gateway already rejects this case; the plugin-side check just falls
+    // through because there is no `bucket_size` to compare.
+    assert!(validate_bucket_size_consistency(None, &group_by).is_ok());
+}
+
+#[test]
+fn validate_bucket_size_accepts_absent_time_bucket_dim() {
+    // `bucket_size` without a `TimeBucket` dim is a no-op for routing; the
+    // current `cagg_too_coarse` check still consumes it. Don't reject here.
+    let group_by = vec![GroupByDimension::UsageType];
+    assert!(validate_bucket_size_consistency(Some(BucketSize::Hour), &group_by).is_ok());
+}
+
+#[test]
+fn validate_bucket_size_rejects_mismatch() {
+    let group_by = vec![GroupByDimension::TimeBucket(BucketSize::Day)];
+    let err = validate_bucket_size_consistency(Some(BucketSize::Hour), &group_by)
+        .expect_err("mismatch must be rejected");
+    assert!(
+        matches!(err, UsageCollectorError::InvalidArgument { .. }),
+        "expected InvalidArgument, got: {err:?}"
+    );
+}
+
+#[test]
+fn cagg_safe_range_accepts_hour_aligned_materialized_range() {
+    // `end` is hour-aligned and exactly at the materialized horizon
+    // (`now - 1h`); the upper-bound check is `end <= horizon` so this is
+    // the inclusive edge case.
+    let now = at(12, 0, 0, 0);
+    let end = at(11, 0, 0, 0);
+    let start = at(9, 0, 0, 0);
+    assert!(cagg_safe_range(start, end, now));
+}

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/retention.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/retention.rs
@@ -1,0 +1,135 @@
+//! Retention policy setup for the `TimescaleDB` storage plugin.
+
+use std::time::Duration;
+
+use sqlx::PgPool;
+
+use crate::domain::error::StoragePluginError;
+use crate::infra::db_error::DbError;
+
+/// Applies the `TimescaleDB` retention policy to `usage_records` and prunes
+/// expired rows from `usage_idempotency_keys`.
+///
+/// The `usage_records` retention policy is installed as a `TimescaleDB` job and
+/// runs continuously. The `usage_idempotency_keys` table has no equivalent
+/// hypertable retention policy because it is a plain table, so its cleanup is
+/// driven separately — once here at startup, then periodically by the plugin's
+/// background cleanup task (see [`cleanup_idempotency_keys`]).
+///
+/// `idempotency_retention` is intentionally distinct from `retention`: the
+/// hypertable retention window can be measured in months or years, while
+/// idempotency dedup windows only need to cover client retry horizons (hours
+/// to a few days). Coupling them would grow `usage_idempotency_keys` linearly
+/// with ingest volume and slow the periodic `DELETE`.
+///
+/// # Errors
+///
+/// Returns [`StoragePluginError`] if any statement fails.
+pub async fn setup_retention_policy(
+    pool: &PgPool,
+    retention: Duration,
+    idempotency_retention: Duration,
+) -> Result<(), StoragePluginError> {
+    let interval = format!("{} seconds", retention.as_secs());
+
+    let retention_err = |context: &'static str| {
+        move |e: sqlx::Error| StoragePluginError::RetentionPolicySetupFailed {
+            context: context.to_owned(),
+            source: DbError::boxed(e),
+        }
+    };
+
+    // Reconcile the existing retention policy with the configured duration.
+    //
+    // `add_retention_policy(..., if_not_exists => true)` is a no-op when a
+    // policy is already registered — so an operator who restarts with a new
+    // `retention_default` would silently keep running the old policy. Query
+    // the existing job, compare its `drop_after` against the configured value
+    // (compared in `INTERVAL` space so `"3600 seconds"` matches `"01:00:00"`),
+    // and reinstall the policy only when it actually differs.
+    let existing: Option<(i32, Option<String>)> = sqlx::query_as(
+        "SELECT job_id, config->>'drop_after' \
+         FROM timescaledb_information.jobs \
+         WHERE proc_name = 'policy_retention' \
+           AND hypertable_name = 'usage_records' \
+         LIMIT 1",
+    )
+    .fetch_optional(pool)
+    .await
+    .map_err(retention_err("failed to query existing retention policy"))?;
+
+    match existing {
+        Some((job_id, Some(current))) => {
+            let matches_config: bool = sqlx::query_scalar("SELECT $1::interval = $2::interval")
+                .bind(&current)
+                .bind(&interval)
+                .fetch_one(pool)
+                .await
+                .map_err(retention_err(
+                    "failed to compare existing retention interval with configured value",
+                ))?;
+            if !matches_config {
+                let mut tx = pool.begin().await.map_err(retention_err(
+                    "failed to begin retention reconciliation transaction",
+                ))?;
+                sqlx::query("SELECT delete_job($1)")
+                    .bind(job_id)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(retention_err("failed to delete stale retention policy job"))?;
+                sqlx::query("SELECT add_retention_policy('usage_records', $1::interval)")
+                    .bind(&interval)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(retention_err(
+                        "failed to install reconciled retention policy",
+                    ))?;
+                tx.commit()
+                    .await
+                    .map_err(retention_err("failed to commit retention reconciliation"))?;
+            }
+        }
+        _ => {
+            sqlx::query(
+                "SELECT add_retention_policy('usage_records', $1::interval, if_not_exists => true)",
+            )
+            .bind(&interval)
+            .execute(pool)
+            .await
+            .map_err(retention_err(
+                "failed to add retention policy for usage_records",
+            ))?;
+        }
+    }
+
+    cleanup_idempotency_keys(pool, idempotency_retention).await?;
+
+    Ok(())
+}
+
+/// Deletes rows from `usage_idempotency_keys` older than `retention`.
+///
+/// Intended to be invoked both at startup (from [`setup_retention_policy`]) and
+/// on a recurring schedule by the plugin's background cleanup task, so the
+/// table stays bounded on long-running processes.
+///
+/// # Errors
+///
+/// Returns [`StoragePluginError::RetentionPolicySetupFailed`] if the statement fails.
+pub async fn cleanup_idempotency_keys(
+    pool: &PgPool,
+    retention: Duration,
+) -> Result<u64, StoragePluginError> {
+    let interval = format!("{} seconds", retention.as_secs());
+    let rows =
+        sqlx::query("DELETE FROM usage_idempotency_keys WHERE created_at < NOW() - $1::interval")
+            .bind(&interval)
+            .execute(pool)
+            .await
+            .map_err(|e| StoragePluginError::RetentionPolicySetupFailed {
+                context: "failed to clean up expired idempotency keys".to_owned(),
+                source: DbError::boxed(e),
+            })?
+            .rows_affected();
+    Ok(rows)
+}

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/lib.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/lib.rs
@@ -1,0 +1,74 @@
+//! `TimescaleDB` Usage Collector Plugin
+//!
+//! A production [`usage_collector_sdk::UsageCollectorPluginClientV1`] implementation
+//! backed by `TimescaleDB` for durable high-throughput usage record persistence,
+//! aggregation query pushdown via continuous aggregates, and cursor-based raw pagination.
+//!
+//! ## Configuration
+//!
+//! `database_url` must include `sslmode=require`, `sslmode=verify-ca`, or
+//! `sslmode=verify-full`; plaintext connections are rejected by [`config::TimescaleDbConfig::validate`].
+//!
+//! The top-level key under `modules` MUST match the `ModKit` module name
+//! declared in `#[modkit::module(name = "timescaledb-usage-collector-plugin")]`
+//! because `ctx.config()` reads `modules.<module-name>.config` verbatim.
+//!
+//! ```yaml
+//! modules:
+//!   timescaledb-usage-collector-plugin:
+//!     config:
+//!       database_url: "postgres://user:pass@host/db?sslmode=require"
+//!       pool_size_min: 2
+//!       pool_size_max: 16
+//!       retention_default: "365days"
+//!       connection_timeout: "10s"
+//! ```
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+mod config;
+pub(crate) mod domain;
+pub(crate) mod infra;
+mod module;
+
+/// Re-exports of crate-internal types for integration tests living in
+/// `tests/`. Gated by the `integration` feature so the plugin's public API
+/// surface remains the `usage_collector_sdk::UsageCollectorPluginClientV1`
+/// trait it registers via the client hub (see MODKIT-CORE-001).
+///
+/// External crates must not import from `__integration_test_api` outside of
+/// the integration test crate of this plugin.
+#[cfg(feature = "integration")]
+#[doc(hidden)]
+pub mod __integration_test_api {
+    pub mod domain {
+        pub mod client {
+            pub use crate::domain::client::TimescaleDbPluginClient;
+        }
+        pub mod insert_port {
+            pub use crate::domain::insert_port::InsertPort;
+        }
+        pub mod metrics {
+            pub use crate::domain::metrics::{NoopMetrics, PluginMetrics};
+        }
+        pub mod query_port {
+            pub use crate::domain::query_port::QueryPort;
+        }
+    }
+    pub mod infra {
+        pub mod continuous_aggregate {
+            pub use crate::infra::continuous_aggregate::setup_continuous_aggregate;
+        }
+        pub mod migrations {
+            pub use crate::infra::migrations::run_migrations;
+        }
+        pub mod pg_insert_port {
+            pub use crate::infra::pg_insert_port::PgInsertPort;
+        }
+        pub mod pg_query_port {
+            pub use crate::infra::pg_query_port::PgQueryPort;
+        }
+    }
+    pub mod module {
+        pub use crate::module::health_check_for_tests;
+    }
+}

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/module.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/module.rs
@@ -1,0 +1,431 @@
+//! `TimescaleDB` usage-collector plugin module.
+//!
+//! Registers a GTS plugin instance in the types registry and exposes
+//! [`usage_collector_sdk::UsageCollectorPluginClientV1`] backed by a `TimescaleDB` connection pool.
+//!
+//! The framework lint banning raw sqlx is suppressed in this file because the
+//! plugin bootstrap is the only place that legitimately constructs the pool and
+//! issues the TimescaleDB-specific liveness probe; everything else flows
+//! through `infra::*` ports.
+//
+// MODKIT-DEVIATION: de0706_no_direct_sqlx (a.k.a. MODKIT-DB-002 / MODKIT-SEC-001).
+// The allow is file-wide because the bootstrap + supervised background tasks all
+// need direct sqlx access (PgPoolOptions, `SELECT 1` liveness probe, cleanup
+// loop). The substitute authorization boundary is the scope-fragment translator
+// in `domain/scope.rs` — see the "Architectural deviation" section in
+// `README.md` and ADR-0003 (`../../docs/ADR/0003-cpt-cf-usage-collector-adr-timescaledb-plugin-raw-sqlx.md`)
+// for the full rationale and the conditions under which a SecureConn-equivalent
+// would be preferred. Maintainers extending this file MUST consult those docs
+// before adding sqlx code paths outside the bootstrap + supervisor concerns.
+#![allow(unknown_lints, de0706_no_direct_sqlx)]
+
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use async_trait::async_trait;
+use modkit::Module;
+use modkit::client_hub::ClientScope;
+use modkit::context::ModuleCtx;
+use modkit::gts::BaseModkitPluginV1;
+use opentelemetry::KeyValue;
+use opentelemetry::global;
+use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
+use std::future::Future;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info, warn};
+use types_registry_sdk::{RegisterResult, TypesRegistryClient};
+use usage_collector_sdk::{UsageCollectorPluginClientV1, UsageCollectorPluginSpecV1};
+
+use crate::config::TimescaleDbConfig;
+use crate::domain::client::TimescaleDbPluginClient;
+use crate::infra::continuous_aggregate::setup_continuous_aggregate;
+use crate::infra::migrations::run_migrations;
+use crate::infra::otel_metrics::OtelPluginMetrics;
+use crate::infra::pg_insert_port::PgInsertPort;
+use crate::infra::pg_query_port::PgQueryPort;
+use crate::infra::retention::{cleanup_idempotency_keys, setup_retention_policy};
+
+/// `TimescaleDB` production storage plugin for the usage-collector gateway.
+///
+/// `deps` declares the runtime startup-order — the gateway and types-registry
+/// modules must initialize before this plugin so it can register its spec and
+/// the produced client trait. This is intentionally distinct from the Cargo
+/// dependency graph (which only references `usage-collector-sdk`, not the
+/// `usage-collector` binary crate).
+#[modkit::module(
+    name = "timescaledb-usage-collector-plugin",
+    deps = ["types-registry", "usage-collector"]
+)]
+#[derive(Default)]
+struct TimescaleDbUsageCollectorPlugin;
+
+#[async_trait]
+impl Module for TimescaleDbUsageCollectorPlugin {
+    // @cpt-dod:cpt-cf-usage-collector-dod-production-storage-plugin-plugin-crate:p1
+    // @cpt-dod:cpt-cf-usage-collector-dod-production-storage-plugin-encryption-and-gts:p1
+    // @cpt-flow:cpt-cf-usage-collector-flow-production-storage-plugin-operator-schema-migration:p1
+    async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        // @cpt-begin:cpt-cf-usage-collector-flow-production-storage-plugin-operator-schema-migration:p1:inst-flow-smig-1
+        // Entry point: platform operator has invoked plugin startup (CLI or gateway startup flag).
+        // @cpt-end:cpt-cf-usage-collector-flow-production-storage-plugin-operator-schema-migration:p1:inst-flow-smig-1
+
+        // @cpt-begin:cpt-cf-usage-collector-dod-production-storage-plugin-plugin-crate:p1:inst-validate-config
+        // Errors propagate with `.context(..)` so a single log point at the module
+        // loader records each failure once. We do not also `inspect_err(..)` here:
+        // double-logging the same error at multiple layers inflates operator-facing
+        // log volume during startup failures.
+        let cfg: TimescaleDbConfig = ctx
+            .config()
+            .context("TimescaleDB plugin configuration load failed")?;
+        cfg.validate()
+            .context("TimescaleDB plugin configuration validation failed")?;
+        // @cpt-end:cpt-cf-usage-collector-dod-production-storage-plugin-plugin-crate:p1:inst-validate-config
+
+        // @cpt-begin:cpt-cf-usage-collector-dod-production-storage-plugin-encryption-and-gts:p1:inst-build-secure-conn
+        // TLS is enforced: database_url validated above to contain sslmode=require.
+        // The URL is captured here and never written to logs or error messages.
+        let database_url = cfg.database_url.clone();
+        // @cpt-end:cpt-cf-usage-collector-dod-production-storage-plugin-encryption-and-gts:p1:inst-build-secure-conn
+
+        // @cpt-begin:cpt-cf-usage-collector-dod-production-storage-plugin-plugin-crate:p1:inst-build-pool
+        let pool = PgPoolOptions::new()
+            .min_connections(cfg.pool_size_min)
+            .max_connections(cfg.pool_size_max)
+            .acquire_timeout(cfg.connection_timeout)
+            .connect(&database_url)
+            .await
+            .map_err(|e| anyhow::Error::from(e).context("connection pool initialization failed"))?;
+        // @cpt-end:cpt-cf-usage-collector-dod-production-storage-plugin-plugin-crate:p1:inst-build-pool
+
+        // @cpt-begin:cpt-cf-usage-collector-flow-production-storage-plugin-operator-schema-migration:p1:inst-flow-smig-2
+        // @cpt-begin:cpt-cf-usage-collector-dod-production-storage-plugin-plugin-crate:p1:inst-run-migrations
+        // @cpt-begin:cpt-cf-usage-collector-flow-production-storage-plugin-operator-schema-migration:p1:inst-flow-smig-4
+        run_migrations(&pool)
+            .await
+            .map_err(|e| anyhow::Error::from(e).context("schema migration failed"))?;
+        // @cpt-end:cpt-cf-usage-collector-flow-production-storage-plugin-operator-schema-migration:p1:inst-flow-smig-4
+        // @cpt-end:cpt-cf-usage-collector-dod-production-storage-plugin-plugin-crate:p1:inst-run-migrations
+        // @cpt-end:cpt-cf-usage-collector-flow-production-storage-plugin-operator-schema-migration:p1:inst-flow-smig-2
+
+        // @cpt-begin:cpt-cf-usage-collector-flow-production-storage-plugin-operator-schema-migration:p1:inst-flow-smig-3
+        info!("TimescaleDB schema migration completed; all schema objects are present");
+        // @cpt-end:cpt-cf-usage-collector-flow-production-storage-plugin-operator-schema-migration:p1:inst-flow-smig-3
+
+        // @cpt-begin:cpt-cf-usage-collector-flow-production-storage-plugin-operator-schema-migration:p1:inst-flow-smig-3a
+        // @cpt-begin:cpt-cf-usage-collector-dod-production-storage-plugin-plugin-crate:p1:inst-setup-continuous-aggregate
+        // @cpt-begin:cpt-cf-usage-collector-flow-production-storage-plugin-operator-schema-migration:p1:inst-flow-smig-3c
+        setup_continuous_aggregate(&pool)
+            .await
+            .map_err(|e| anyhow::Error::from(e).context("continuous aggregate setup failed"))?;
+        // @cpt-end:cpt-cf-usage-collector-flow-production-storage-plugin-operator-schema-migration:p1:inst-flow-smig-3c
+        // @cpt-end:cpt-cf-usage-collector-dod-production-storage-plugin-plugin-crate:p1:inst-setup-continuous-aggregate
+        // @cpt-end:cpt-cf-usage-collector-flow-production-storage-plugin-operator-schema-migration:p1:inst-flow-smig-3a
+
+        // @cpt-begin:cpt-cf-usage-collector-flow-production-storage-plugin-operator-schema-migration:p1:inst-flow-smig-3b
+        info!("TimescaleDB continuous aggregate setup complete; returning success to operator");
+        // @cpt-end:cpt-cf-usage-collector-flow-production-storage-plugin-operator-schema-migration:p1:inst-flow-smig-3b
+
+        setup_retention_policy(&pool, cfg.retention_default, cfg.idempotency_retention)
+            .await
+            .map_err(|e| anyhow::Error::from(e).context("retention policy setup failed"))?;
+
+        let instance_id = UsageCollectorPluginSpecV1::gts_make_instance_id(
+            "cf.core._.timescaledb_usage_collector_plugin.v1",
+        );
+
+        let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
+        let instance = BaseModkitPluginV1::<UsageCollectorPluginSpecV1> {
+            id: instance_id.clone(),
+            vendor: "virtuozzo".to_owned(),
+            priority: 10,
+            properties: UsageCollectorPluginSpecV1,
+        };
+        let instance_json =
+            serde_json::to_value(&instance).context("GTS instance JSON encoding failed")?;
+
+        // @cpt-begin:cpt-cf-usage-collector-dod-production-storage-plugin-encryption-and-gts:p1:inst-register-gts
+        let results = registry
+            .register(vec![instance_json])
+            .await
+            .map_err(|e| anyhow::Error::from(e).context("GTS registration failed"))?;
+        RegisterResult::ensure_all_ok(&results)
+            .context("GTS registration rejected for TimescaleDB plugin")?;
+        info!(%instance_id, "GTS registration successful for TimescaleDB plugin");
+        // @cpt-end:cpt-cf-usage-collector-dod-production-storage-plugin-encryption-and-gts:p1:inst-register-gts
+
+        let insert_port: Arc<dyn crate::domain::insert_port::InsertPort> =
+            Arc::new(PgInsertPort::new(pool.clone()));
+        let query_port: Arc<dyn crate::domain::query_port::QueryPort> =
+            Arc::new(PgQueryPort::new(pool.clone()));
+        let metrics: Arc<dyn crate::domain::metrics::PluginMetrics> =
+            Arc::new(OtelPluginMetrics::new());
+        let client = TimescaleDbPluginClient::new(insert_port, query_port, metrics);
+        let api: Arc<dyn UsageCollectorPluginClientV1> = Arc::new(client);
+
+        // @cpt-begin:cpt-cf-usage-collector-dod-production-storage-plugin-plugin-crate:p1:inst-register-client
+        ctx.client_hub()
+            .register_scoped::<dyn UsageCollectorPluginClientV1>(
+                ClientScope::gts_id(&instance_id),
+                api,
+            );
+        // @cpt-end:cpt-cf-usage-collector-dod-production-storage-plugin-plugin-crate:p1:inst-register-client
+
+        info!(
+            %instance_id,
+            "TimescaleDB usage-collector plugin started successfully"
+        );
+
+        // The background loops terminate cleanly on cancellation; no JoinHandles
+        // are retained on the module struct because the runtime shuts the tasks
+        // down with the module. To avoid silently losing panics or unexpected
+        // exits, each task is wrapped by a supervisor that awaits its
+        // JoinHandle and emits a tracing event on completion / panic — see
+        // `supervise_background_task` (RUST-OBS-001 / RUST-ASYNC-001).
+        supervise_background_task(
+            "storage_health_check",
+            run_health_check_loop(pool.clone(), ctx.cancellation_token().clone()),
+        );
+        supervise_background_task(
+            "idempotency_cleanup",
+            run_idempotency_cleanup_loop(
+                pool,
+                cfg.idempotency_retention,
+                ctx.cancellation_token().clone(),
+            ),
+        );
+
+        Ok(())
+    }
+}
+
+/// Spawns `task` and a supervisor that observes its completion.
+///
+/// The supervisor awaits the inner `JoinHandle` and emits a structured log on
+/// completion: `info` for a clean exit, `error` for a panic, `warn` for a
+/// cancellation from outside the task. Without this wrapper, a panicking
+/// background loop is swallowed by tokio and the gauge / cleanup work stops
+/// with no operator-visible signal.
+fn supervise_background_task<F>(name: &'static str, task: F)
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    let handle = tokio::spawn(task);
+    tokio::spawn(async move {
+        match handle.await {
+            Ok(()) => info!(task = name, "background task exited"),
+            Err(e) if e.is_cancelled() => {
+                warn!(task = name, "background task cancelled by runtime");
+            }
+            Err(e) => {
+                // tokio captures the panic payload in `JoinError`; surface it
+                // so the operator sees why the loop stopped instead of just
+                // observing a stale gauge.
+                error!(task = name, error = %e, "background task panicked");
+            }
+        }
+    });
+}
+
+// OpenTelemetry gauges retain their last recorded value indefinitely on the
+// reader side, so once this loop exits with `reason=pool_closed` the metric
+// keeps that value until the process restarts. Downstream dashboards/alerts
+// that need to distinguish "process exited" from "process still reporting"
+// should monitor the absence of fresh readings (staleness), not the gauge
+// value alone. See finding RUST-ASYNC-001.
+async fn run_health_check_loop(pool: PgPool, cancel: CancellationToken) {
+    let meter = global::meter("timescaledb-usage-collector-plugin");
+    let gauge = meter.f64_gauge("storage_health_status").build();
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
+    // Default Burst behavior would fire a flurry of catch-up ticks after a
+    // runtime pause (debug breakpoint, GC pause, host suspend/resume),
+    // emitting a burst of `SELECT 1` probes and gauge readings. Delay paces
+    // the next tick to a full period after the resume instead.
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // Tracks the most recently observed reason so failure logs are emitted on
+    // transition only: a sustained outage would otherwise produce ~120
+    // `error!` lines per hour at identical content, drowning out unrelated
+    // signal in operator logs. The gauge still records every tick so dashboards
+    // detect outages via staleness, not via log volume.
+    let mut last_reason: Option<&'static str> = None;
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => break,
+            _ = interval.tick() => {}
+        }
+        if pool.is_closed() {
+            // Distinct from a probe failure: the pool has been shut down and no further
+            // queries will succeed. Tagged so dashboards can separate shutdown from outage.
+            gauge.record(0.0_f64, &[KeyValue::new("reason", "pool_closed")]);
+            break;
+        }
+        let (_, reason, error_detail) = health_check(&pool, &gauge).await;
+        log_health_transition(last_reason, reason, error_detail.as_deref());
+        last_reason = Some(reason);
+    }
+}
+
+/// Severity decision for a health-check tick given the prior tick's reason.
+/// Pulled out as a pure function so it can be unit-tested without the
+/// tracing-macro expansion that drove the loop's cognitive-complexity warning.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum HealthLog {
+    InitialFailure,
+    PersistentFailure,
+    Recovery,
+    Healthy,
+}
+
+fn classify_health_transition(
+    last_reason: Option<&'static str>,
+    reason: &'static str,
+) -> HealthLog {
+    match (last_reason, reason) {
+        (Some("probe_failed"), "probe_failed") => HealthLog::PersistentFailure,
+        (_, "probe_failed") => HealthLog::InitialFailure,
+        (Some("probe_failed"), "healthy") => HealthLog::Recovery,
+        _ => HealthLog::Healthy,
+    }
+}
+
+// The four `tracing` macros below each expand to enough code that clippy
+// flags this small match as "complex"; the same allow is used on
+// `run_idempotency_cleanup_loop` above for the same reason.
+#[allow(clippy::cognitive_complexity)]
+fn log_health_transition(
+    last_reason: Option<&'static str>,
+    reason: &'static str,
+    error_detail: Option<&str>,
+) {
+    let detail = error_detail.unwrap_or("");
+    match classify_health_transition(last_reason, reason) {
+        HealthLog::InitialFailure => {
+            error!(error_chain = %detail, "TimescaleDB health check failed");
+        }
+        HealthLog::PersistentFailure => {
+            debug!("TimescaleDB health check still failing");
+        }
+        HealthLog::Recovery => {
+            info!("TimescaleDB health check recovered");
+        }
+        HealthLog::Healthy => {
+            debug!("TimescaleDB health check passed");
+        }
+    }
+}
+
+/// Interval between successive idempotency-key cleanup passes.
+///
+/// One hour is far less frequent than ingest pressure on the table but easily
+/// frequent enough to keep growth bounded across multi-day process lifetimes.
+const IDEMPOTENCY_CLEANUP_INTERVAL: std::time::Duration = std::time::Duration::from_hours(1);
+
+/// Periodically deletes expired rows from `usage_idempotency_keys`.
+///
+/// `setup_retention_policy` runs the same cleanup once at startup; this task
+/// keeps it from accumulating on long-running processes since the plain table
+/// has no `TimescaleDB` retention job attached to it.
+#[allow(clippy::cognitive_complexity)]
+async fn run_idempotency_cleanup_loop(
+    pool: PgPool,
+    retention: std::time::Duration,
+    cancel: CancellationToken,
+) {
+    let mut interval = tokio::time::interval(IDEMPOTENCY_CLEANUP_INTERVAL);
+    // Pace the next tick a full period after a runtime pause instead of
+    // bursting catch-up DELETEs. Same rationale as the health-check loop.
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // Skip the immediate first tick — startup already issued the same DELETE.
+    interval.tick().await;
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => break,
+            _ = interval.tick() => {}
+        }
+        if pool.is_closed() {
+            info!(
+                task = "idempotency_cleanup",
+                "pool closed; exiting cleanup loop"
+            );
+            break;
+        }
+        match cleanup_idempotency_keys(&pool, retention).await {
+            Ok(rows) => {
+                debug!(rows_deleted = rows, "idempotency-key cleanup completed");
+            }
+            Err(e) => {
+                error!(error = %e, "idempotency-key cleanup failed");
+            }
+        }
+    }
+}
+
+/// Executes a liveness probe against the pool and emits the `storage_health_status` gauge.
+///
+/// Emits `1.0` (with `reason=healthy`) on success and `0.0` (with `reason=probe_failed`) on
+/// transient probe failure. A separate `reason=pool_closed` reading is emitted by the loop
+/// when the pool itself has been shut down.
+///
+/// Returns `(value, reason, error_detail)` so the caller decides log level: the
+/// loop suppresses repeated `error!` lines during sustained outages (see
+/// `run_health_check_loop`'s `last_reason` tracking), while
+/// `health_check_for_tests` asserts on the `(value, reason)` contract directly.
+/// `error_detail` carries the full source chain (top-level `Display` + nested
+/// causes) so SQLSTATE survives into the log line when the caller does log.
+async fn health_check(
+    pool: &PgPool,
+    gauge: &opentelemetry::metrics::Gauge<f64>,
+) -> (f64, &'static str, Option<String>) {
+    match sqlx::query("SELECT 1").execute(pool).await {
+        Ok(_) => {
+            gauge.record(1.0_f64, &[KeyValue::new("reason", "healthy")]);
+            (1.0, "healthy", None)
+        }
+        Err(e) => {
+            gauge.record(0.0_f64, &[KeyValue::new("reason", "probe_failed")]);
+            // Walk the source chain so the SQLSTATE (carried by the
+            // sqlx::Error::Database arm) and any further-nested cause survive
+            // into the operator-facing log line — without this the operator
+            // would only see the top-level Display ("pool timed out", "encode
+            // error", …) and could not triage probe failures from logs alone.
+            let chain = render_error_chain(&e);
+            let detail = format!("{e}: {chain}");
+            (0.0, "probe_failed", Some(detail))
+        }
+    }
+}
+
+/// Walks `std::error::Error::source()` for `err` and joins each link with `: `,
+/// mirroring the formatting used by `domain::error::render_source_chain` so
+/// log readers see the same shape across the plugin.
+fn render_error_chain(err: &(dyn std::error::Error + 'static)) -> String {
+    let mut rendered = err.to_string();
+    let mut current = err.source();
+    while let Some(src) = current {
+        rendered.push_str(": ");
+        rendered.push_str(&src.to_string());
+        current = src.source();
+    }
+    rendered
+}
+
+/// Test-only wrapper around [`health_check`] that constructs its own gauge,
+/// so integration tests can pin the `(value, reason)` contract emitted to
+/// `storage_health_status` for healthy and probe-failed states without
+/// touching the global OpenTelemetry exporter.
+#[cfg(feature = "integration")]
+pub async fn health_check_for_tests(pool: &PgPool) -> (f64, &'static str) {
+    let meter = global::meter("timescaledb-usage-collector-plugin-test");
+    let gauge = meter.f64_gauge("storage_health_status").build();
+    if pool.is_closed() {
+        gauge.record(0.0_f64, &[KeyValue::new("reason", "pool_closed")]);
+        return (0.0, "pool_closed");
+    }
+    let (value, reason, _) = health_check(pool, &gauge).await;
+    (value, reason)
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "module_tests.rs"]
+mod module_tests;

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/module_tests.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/module_tests.rs
@@ -1,0 +1,49 @@
+use super::{HealthLog, classify_health_transition};
+
+#[test]
+fn first_failure_after_healthy_is_initial_failure() {
+    assert_eq!(
+        classify_health_transition(Some("healthy"), "probe_failed"),
+        HealthLog::InitialFailure
+    );
+}
+
+#[test]
+fn first_failure_at_startup_is_initial_failure() {
+    assert_eq!(
+        classify_health_transition(None, "probe_failed"),
+        HealthLog::InitialFailure
+    );
+}
+
+#[test]
+fn repeated_failure_is_persistent_failure() {
+    assert_eq!(
+        classify_health_transition(Some("probe_failed"), "probe_failed"),
+        HealthLog::PersistentFailure
+    );
+}
+
+#[test]
+fn recovery_from_failure_is_recovery() {
+    assert_eq!(
+        classify_health_transition(Some("probe_failed"), "healthy"),
+        HealthLog::Recovery
+    );
+}
+
+#[test]
+fn healthy_to_healthy_is_healthy() {
+    assert_eq!(
+        classify_health_transition(Some("healthy"), "healthy"),
+        HealthLog::Healthy
+    );
+}
+
+#[test]
+fn first_healthy_is_healthy() {
+    assert_eq!(
+        classify_health_transition(None, "healthy"),
+        HealthLog::Healthy
+    );
+}

--- a/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/tests/integration.rs
+++ b/modules/system/usage-collector/plugins/timescaledb-usage-collector-plugin/tests/integration.rs
@@ -1,0 +1,2616 @@
+// @cpt-dod:cpt-cf-usage-collector-dod-production-storage-plugin-testing-and-observability:p10
+//! Level 2 integration tests for the `TimescaleDB` usage-collector storage plugin.
+//!
+//! Run with:
+//!   cargo test -p cyberware-timescaledb-usage-collector-plugin --features integration
+
+#![cfg(feature = "integration")]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Timelike, Utc};
+use modkit_odata::CursorV1;
+use modkit_security::{AccessScope, ScopeConstraint, ScopeFilter, pep_properties};
+use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
+use testcontainers::core::{ContainerPort, WaitFor};
+use testcontainers::{
+    ContainerAsync, ContainerRequest, GenericImage, ImageExt, runners::AsyncRunner,
+};
+use usage_collector_sdk::models::{
+    AggregationFn, AggregationQuery, BucketSize, GroupByDimension, RawQuery, Subject, UsageKind,
+    UsageRecord,
+};
+use usage_collector_sdk::{UsageCollectorError, UsageCollectorPluginClientV1};
+use uuid::Uuid;
+
+use timescaledb_usage_collector_plugin::__integration_test_api::domain::client::TimescaleDbPluginClient;
+use timescaledb_usage_collector_plugin::__integration_test_api::domain::insert_port::InsertPort;
+use timescaledb_usage_collector_plugin::__integration_test_api::domain::metrics::{
+    NoopMetrics, PluginMetrics,
+};
+use timescaledb_usage_collector_plugin::__integration_test_api::domain::query_port::QueryPort;
+use timescaledb_usage_collector_plugin::__integration_test_api::infra::continuous_aggregate::setup_continuous_aggregate;
+use timescaledb_usage_collector_plugin::__integration_test_api::infra::migrations::run_migrations;
+use timescaledb_usage_collector_plugin::__integration_test_api::infra::pg_insert_port::PgInsertPort;
+use timescaledb_usage_collector_plugin::__integration_test_api::infra::pg_query_port::PgQueryPort;
+use timescaledb_usage_collector_plugin::__integration_test_api::module::health_check_for_tests;
+
+// ── Container and pool setup ──────────────────────────────────────────────────
+
+struct TestDb {
+    _container: ContainerAsync<GenericImage>,
+    pool: PgPool,
+}
+
+fn timescaledb_image() -> GenericImage {
+    GenericImage::new("timescale/timescaledb", "latest-pg16")
+        .with_exposed_port(ContainerPort::Tcp(5432))
+        .with_wait_for(WaitFor::message_on_stderr(
+            "database system is ready to accept connections",
+        ))
+}
+
+/// Starts a `TimescaleDB` container, waits for it to be ready, runs migrations,
+/// sets up the continuous aggregate, and returns the container drop handle and pool.
+async fn setup_container_and_pool() -> TestDb {
+    let container = ContainerRequest::from(timescaledb_image())
+        .with_env_var("POSTGRES_PASSWORD", "testpass")
+        .with_env_var("POSTGRES_USER", "testuser")
+        .with_env_var("POSTGRES_DB", "testdb")
+        .start()
+        .await
+        .expect("failed to start timescaledb container");
+
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("failed to get mapped port for 5432");
+
+    let url = format!("postgres://testuser:testpass@127.0.0.1:{port}/testdb");
+
+    let pool = connect_with_retry(&url, 60).await;
+
+    run_migrations(&pool)
+        .await
+        .expect("schema migration failed");
+    setup_continuous_aggregate(&pool)
+        .await
+        .expect("continuous aggregate setup failed");
+
+    TestDb {
+        _container: container,
+        pool,
+    }
+}
+
+async fn connect_with_retry(url: &str, timeout_secs: u64) -> PgPool {
+    let deadline = std::time::Instant::now() + Duration::from_secs(timeout_secs);
+    loop {
+        match PgPoolOptions::new()
+            .max_connections(5)
+            .acquire_timeout(Duration::from_secs(5))
+            .connect(url)
+            .await
+        {
+            Ok(pool) => return pool,
+            Err(_) if std::time::Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+            Err(e) => panic!("timed out waiting for database: {e}"),
+        }
+    }
+}
+
+// ── Client construction helper ────────────────────────────────────────────────
+
+fn make_client(pool: &PgPool) -> TimescaleDbPluginClient {
+    let insert_port: Arc<dyn InsertPort> = Arc::new(PgInsertPort::new(pool.clone()));
+    let query_port: Arc<dyn QueryPort> = Arc::new(PgQueryPort::new(pool.clone()));
+    let metrics: Arc<dyn PluginMetrics> = Arc::new(NoopMetrics);
+    TimescaleDbPluginClient::new(insert_port, query_port, metrics)
+}
+
+/// Like [`make_client`], but constructs the query port with an injected
+/// `max_agg_rows` cap so the cost-control invariant can be exercised without
+/// inserting > 10 000 rows. Used by `query_aggregated_result_too_large_small_cap`.
+fn make_client_with_max_agg_rows(pool: &PgPool, max_agg_rows: usize) -> TimescaleDbPluginClient {
+    let insert_port: Arc<dyn InsertPort> = Arc::new(PgInsertPort::new(pool.clone()));
+    let query_port: Arc<dyn QueryPort> = Arc::new(PgQueryPort::new_with_max_agg_rows(
+        pool.clone(),
+        max_agg_rows,
+    ));
+    let metrics: Arc<dyn PluginMetrics> = Arc::new(NoopMetrics);
+    TimescaleDbPluginClient::new(insert_port, query_port, metrics)
+}
+
+// ── CAGG-path test helpers ────────────────────────────────────────────────────
+
+/// Returns a timestamp `hours_back` hours before `now()`, floored to the hour.
+///
+/// The CAGG path requires hour-aligned endpoints and an end no later than the
+/// materialized horizon (`now - 1h`). Tests that exercise the CAGG path build
+/// their timestamps from this helper so the routing predicate
+/// (`cagg_safe_range`) keeps the query on the CAGG instead of silently
+/// downgrading it to the raw hypertable.
+fn aligned_past_hour(hours_back: i64) -> DateTime<Utc> {
+    let target = Utc::now() - chrono::Duration::hours(hours_back);
+    target
+        .with_minute(0)
+        .unwrap()
+        .with_second(0)
+        .unwrap()
+        .with_nanosecond(0)
+        .unwrap()
+}
+
+// ── Test-record factory ───────────────────────────────────────────────────────
+
+fn counter_record(tenant_id: Uuid, resource_id: Uuid, key: &str) -> UsageRecord {
+    UsageRecord {
+        module: "integration-test".to_owned(),
+        tenant_id,
+        metric: "test.cpu".to_owned(),
+        kind: UsageKind::Counter,
+        value: 10.0,
+        resource_id,
+        resource_type: "vm".to_owned(),
+        subject: None,
+        idempotency_key: key.to_owned(),
+        timestamp: Utc::now(),
+        metadata: None,
+    }
+}
+
+// ── Test 1: migration_idempotency ─────────────────────────────────────────────
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn migration_idempotency() {
+    let db = setup_container_and_pool().await;
+
+    // Second run must succeed (migrations are idempotent)
+    run_migrations(&db.pool)
+        .await
+        .expect("second migration run must succeed - migrations are not idempotent");
+
+    // Verify hypertable exists after both runs
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM timescaledb_information.hypertables \
+         WHERE hypertable_name = 'usage_records'",
+    )
+    .fetch_one(&db.pool)
+    .await
+    .expect("failed to query timescaledb_information.hypertables");
+
+    assert_eq!(
+        count, 1,
+        "usage_records hypertable must exist after idempotent migration"
+    );
+
+    // The hypertable check above survives even if every `CREATE INDEX IF NOT EXISTS`
+    // or `ADD COLUMN IF NOT EXISTS` step silently regresses on the second pass —
+    // those are the steps most likely to break under future TimescaleDB or
+    // PostgreSQL version changes. Assert each one explicitly.
+    let expected_indexes = [
+        ("usage_records", "idx_usage_records_tenant_time"),
+        ("usage_records", "idx_usage_records_tenant_metric_time"),
+        ("usage_records", "idx_usage_records_tenant_subject_time"),
+        ("usage_records", "idx_usage_records_tenant_resource_time"),
+        (
+            "usage_idempotency_keys",
+            "idx_usage_idempotency_keys_created_at",
+        ),
+    ];
+    for (table_name, idx_name) in expected_indexes {
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS ( \
+                 SELECT 1 FROM pg_indexes \
+                 WHERE schemaname = 'public' \
+                 AND tablename = $1 \
+                 AND indexname = $2 \
+             )",
+        )
+        .bind(table_name)
+        .bind(idx_name)
+        .fetch_one(&db.pool)
+        .await
+        .expect("failed to query pg_indexes");
+        assert!(
+            exists,
+            "{idx_name} must still exist on {table_name} after idempotent migration",
+        );
+    }
+
+    // `usage_idempotency_keys.created_at` is added via `ADD COLUMN IF NOT EXISTS`;
+    // verify the column survives the second pass with the expected type so the
+    // periodic cleanup `DELETE … WHERE created_at < NOW() - $1::interval` keeps
+    // working.
+    let created_at_type: Option<String> = sqlx::query_scalar(
+        "SELECT data_type FROM information_schema.columns \
+         WHERE table_schema = 'public' \
+         AND table_name = 'usage_idempotency_keys' \
+         AND column_name = 'created_at'",
+    )
+    .fetch_optional(&db.pool)
+    .await
+    .expect("failed to query information_schema.columns");
+    assert_eq!(
+        created_at_type.as_deref(),
+        Some("timestamp with time zone"),
+        "usage_idempotency_keys.created_at must remain timestamptz after idempotent migration"
+    );
+}
+
+// ── Test 2: concurrent_upsert_exactly_one_row ─────────────────────────────────
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn concurrent_upsert_exactly_one_row() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let idempotency_key = format!("idem-{}", Uuid::new_v4());
+
+    let client = Arc::new(make_client(&db.pool));
+
+    // Spawn 5 concurrent tasks each inserting the same record
+    let handles: Vec<_> = (0..5)
+        .map(|_| {
+            let c = client.clone();
+            let record = counter_record(tenant_id, resource_id, &idempotency_key);
+            tokio::spawn(async move { c.create_usage_record(record).await })
+        })
+        .collect();
+
+    for handle in handles {
+        handle
+            .await
+            .expect("task panicked")
+            .expect("create_usage_record returned error under concurrent upsert");
+    }
+
+    // Exactly one row must persist for the idempotency key
+    let row_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM usage_records WHERE tenant_id = $1 AND idempotency_key = $2",
+    )
+    .bind(tenant_id)
+    .bind(&idempotency_key)
+    .fetch_one(&db.pool)
+    .await
+    .expect("row count query failed");
+
+    assert_eq!(
+        row_count, 1,
+        "exactly one row must persist under concurrent inserts with the same idempotency key"
+    );
+}
+
+// ── Additional helpers ────────────────────────────────────────────────────────
+
+fn counter_record_with_value(
+    tenant_id: Uuid,
+    resource_id: Uuid,
+    key: &str,
+    value: f64,
+) -> UsageRecord {
+    UsageRecord {
+        value,
+        ..counter_record(tenant_id, resource_id, key)
+    }
+}
+
+// ── Test 5: health_check_metric ───────────────────────────────────────────────
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn health_check_metric() {
+    // Drives the production `health_check` function directly (rather than
+    // re-implementing `SELECT 1` here) and pins the `(value, reason)` tuple
+    // emitted to `storage_health_status` for each operational state. A
+    // regression that, say, mislabels a probe failure as `healthy` or fails
+    // to detect `pool_closed` would slip past the previous test, which only
+    // covered the sqlx layer.
+    let db = setup_container_and_pool().await;
+
+    // Healthy pool → (1.0, "healthy")
+    let (value, reason) = health_check_for_tests(&db.pool).await;
+    assert!(
+        (value - 1.0).abs() < f64::EPSILON,
+        "healthy pool must report storage_health_status=1.0, got {value}"
+    );
+    assert_eq!(reason, "healthy");
+
+    // Closed pool → (0.0, "pool_closed"); distinct from probe_failed so
+    // dashboards can separate operator-initiated shutdown from outage.
+    db.pool.close().await;
+    let (value, reason) = health_check_for_tests(&db.pool).await;
+    assert!(
+        value.abs() < f64::EPSILON,
+        "closed pool must report storage_health_status=0.0, got {value}"
+    );
+    assert_eq!(reason, "pool_closed");
+}
+
+// ── Group A: all 5 aggregation functions on the raw path ──────────────────────
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_raw_sum() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    for (i, val) in [(0u32, 10.0f64), (1, 20.0), (2, 30.0)] {
+        client
+            .create_usage_record(counter_record_with_value(
+                tenant_id,
+                resource_id,
+                &format!("sum-raw-{i}"),
+                val,
+            ))
+            .await
+            .expect("insert failed");
+    }
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: Some(resource_id),
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 60.0).abs() < 1e-6,
+        "expected sum=60.0, got {}",
+        results[0].value
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_raw_count() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    for i in 0u32..3 {
+        client
+            .create_usage_record(counter_record(
+                tenant_id,
+                resource_id,
+                &format!("count-raw-{i}"),
+            ))
+            .await
+            .expect("insert failed");
+    }
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Count,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: Some(resource_id),
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 3.0).abs() < 1e-6,
+        "expected count=3.0, got {}",
+        results[0].value
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_raw_min() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    for (i, val) in [(0u32, 10.0f64), (1, 20.0), (2, 30.0)] {
+        client
+            .create_usage_record(counter_record_with_value(
+                tenant_id,
+                resource_id,
+                &format!("min-raw-{i}"),
+                val,
+            ))
+            .await
+            .expect("insert failed");
+    }
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Min,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: Some(resource_id),
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 10.0).abs() < 1e-6,
+        "expected min=10.0, got {}",
+        results[0].value
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_raw_max() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    for (i, val) in [(0u32, 10.0f64), (1, 20.0), (2, 30.0)] {
+        client
+            .create_usage_record(counter_record_with_value(
+                tenant_id,
+                resource_id,
+                &format!("max-raw-{i}"),
+                val,
+            ))
+            .await
+            .expect("insert failed");
+    }
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Max,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: Some(resource_id),
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 30.0).abs() < 1e-6,
+        "expected max=30.0, got {}",
+        results[0].value
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_raw_avg() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    for (i, val) in [(0u32, 10.0f64), (1, 20.0), (2, 30.0)] {
+        client
+            .create_usage_record(counter_record_with_value(
+                tenant_id,
+                resource_id,
+                &format!("avg-raw-{i}"),
+                val,
+            ))
+            .await
+            .expect("insert failed");
+    }
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Avg,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: Some(resource_id),
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 20.0).abs() < 1e-6,
+        "expected avg=20.0, got {}",
+        results[0].value
+    );
+}
+
+// ── Group B: all 5 aggregation functions on the cagg path ─────────────────────
+
+async fn cagg_refresh(pool: &sqlx::PgPool) {
+    sqlx::query(
+        "CALL refresh_continuous_aggregate(\
+             'usage_agg_1h', \
+             (NOW() - INTERVAL '5 hours')::timestamptz, \
+             (NOW() - INTERVAL '1 hour')::timestamptz\
+         )",
+    )
+    .execute(pool)
+    .await
+    .expect("manual cagg refresh failed");
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_cagg_sum() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let past_ts = aligned_past_hour(3);
+    let time_range = (
+        past_ts - chrono::Duration::hours(1),
+        past_ts + chrono::Duration::hours(2),
+    );
+
+    for (i, val) in [(0u32, 10.0f64), (1, 20.0), (2, 30.0)] {
+        let mut r =
+            counter_record_with_value(tenant_id, resource_id, &format!("sum-cagg-{i}"), val);
+        r.timestamp = past_ts;
+        client.create_usage_record(r).await.expect("insert failed");
+    }
+    cagg_refresh(&db.pool).await;
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 60.0).abs() < 1e-6,
+        "expected cagg sum=60.0, got {}",
+        results[0].value
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_cagg_count() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let past_ts = aligned_past_hour(3);
+    let time_range = (
+        past_ts - chrono::Duration::hours(1),
+        past_ts + chrono::Duration::hours(2),
+    );
+
+    for i in 0u32..3 {
+        let mut r = counter_record(tenant_id, resource_id, &format!("count-cagg-{i}"));
+        r.timestamp = past_ts;
+        client.create_usage_record(r).await.expect("insert failed");
+    }
+    cagg_refresh(&db.pool).await;
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Count,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 3.0).abs() < 1e-6,
+        "expected cagg count=3.0, got {}",
+        results[0].value
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_cagg_min() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let past_ts = aligned_past_hour(3);
+    let time_range = (
+        past_ts - chrono::Duration::hours(1),
+        past_ts + chrono::Duration::hours(2),
+    );
+
+    for (i, val) in [(0u32, 10.0f64), (1, 20.0), (2, 30.0)] {
+        let mut r =
+            counter_record_with_value(tenant_id, resource_id, &format!("min-cagg-{i}"), val);
+        r.timestamp = past_ts;
+        client.create_usage_record(r).await.expect("insert failed");
+    }
+    cagg_refresh(&db.pool).await;
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Min,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 10.0).abs() < 1e-6,
+        "expected cagg min=10.0, got {}",
+        results[0].value
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_cagg_max() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let past_ts = aligned_past_hour(3);
+    let time_range = (
+        past_ts - chrono::Duration::hours(1),
+        past_ts + chrono::Duration::hours(2),
+    );
+
+    for (i, val) in [(0u32, 10.0f64), (1, 20.0), (2, 30.0)] {
+        let mut r =
+            counter_record_with_value(tenant_id, resource_id, &format!("max-cagg-{i}"), val);
+        r.timestamp = past_ts;
+        client.create_usage_record(r).await.expect("insert failed");
+    }
+    cagg_refresh(&db.pool).await;
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Max,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 30.0).abs() < 1e-6,
+        "expected cagg max=30.0, got {}",
+        results[0].value
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_cagg_avg() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let past_ts = aligned_past_hour(3);
+    let time_range = (
+        past_ts - chrono::Duration::hours(1),
+        past_ts + chrono::Duration::hours(2),
+    );
+
+    for (i, val) in [(0u32, 10.0f64), (1, 20.0), (2, 30.0)] {
+        let mut r =
+            counter_record_with_value(tenant_id, resource_id, &format!("avg-cagg-{i}"), val);
+        r.timestamp = past_ts;
+        client.create_usage_record(r).await.expect("insert failed");
+    }
+    cagg_refresh(&db.pool).await;
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Avg,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 20.0).abs() < 1e-6,
+        "expected cagg avg=20.0, got {}",
+        results[0].value
+    );
+}
+
+// ── CAGG end-boundary inclusion ───────────────────────────────────────────────
+
+/// Regression test for the closed-interval contract on the CAGG path.
+///
+/// The CAGG view buckets records into half-open hour intervals; with no
+/// boundary correction, a record at exactly `timestamp = time_range.1`
+/// (hour-aligned) is filed in bucket `time_range.1` which the WHERE
+/// `bucket < $end` excludes — silently undercounting billing totals. The raw
+/// path would include it via `timestamp <= $end`. This test inserts one
+/// record squarely inside the period and one at exactly the upper bound,
+/// then asserts the CAGG-routed `Sum` matches both records.
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_cagg_includes_end_boundary_record() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+
+    // Pick a fully-materialised window: end is 2h in the past (≥ 1h ago, the
+    // CAGG horizon), start is 4h in the past. Both endpoints are hour-aligned
+    // so `cagg_safe_range` keeps the query on the CAGG path.
+    let end_ts = aligned_past_hour(2);
+    let start_ts = aligned_past_hour(4);
+    let mid_ts = aligned_past_hour(3);
+
+    // One record inside the period, one at exactly the closed-interval upper
+    // bound. Without the boundary correction the boundary record is dropped.
+    let mut inside = counter_record_with_value(tenant_id, resource_id, "cagg-boundary-inside", 7.0);
+    inside.timestamp = mid_ts;
+    client
+        .create_usage_record(inside)
+        .await
+        .expect("insert mid failed");
+
+    let mut boundary = counter_record_with_value(tenant_id, resource_id, "cagg-boundary-end", 11.0);
+    boundary.timestamp = end_ts;
+    client
+        .create_usage_record(boundary)
+        .await
+        .expect("insert boundary failed");
+
+    cagg_refresh(&db.pool).await;
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range: (start_ts, end_ts),
+            function: AggregationFn::Sum,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 18.0).abs() < 1e-6,
+        "expected cagg sum=18.0 (7.0 inside + 11.0 at end boundary), got {}",
+        results[0].value
+    );
+}
+
+// ── Phase 9 helpers ───────────────────────────────────────────────────────────
+
+fn record_with_subject(
+    tenant_id: Uuid,
+    resource_id: Uuid,
+    subject_id: Uuid,
+    key: &str,
+) -> UsageRecord {
+    UsageRecord {
+        subject: Some(Subject::with_type(subject_id, "user")),
+        ..counter_record(tenant_id, resource_id, key)
+    }
+}
+
+// ── Test 3: query_aggregated_routing_decision ─────────────────────────────────
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_routing_decision() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+
+    // Insert 3 records from 3 hours ago so they land in a past 1-hour cagg bucket
+    let past_ts = aligned_past_hour(3);
+    for i in 0..3u32 {
+        let mut record = counter_record(tenant_id, resource_id, &format!("cagg-key-{i}"));
+        record.timestamp = past_ts;
+        client
+            .create_usage_record(record)
+            .await
+            .expect("insert failed");
+    }
+
+    // Refresh the cagg to materialise the inserted data
+    sqlx::query(
+        "CALL refresh_continuous_aggregate(\
+             'usage_agg_1h', \
+             (NOW() - INTERVAL '5 hours')::timestamptz, \
+             (NOW() - INTERVAL '1 hour')::timestamptz\
+         )",
+    )
+    .execute(&db.pool)
+    .await
+    .expect("manual cagg refresh failed");
+
+    // Time range covers the inserted data and the cagg bucket
+    let time_range = (
+        past_ts - chrono::Duration::hours(1),
+        past_ts + chrono::Duration::hours(2),
+    );
+
+    // Raw hypertable path: resource_id filter forces routing to usage_records
+    let raw_results = client
+        .query_aggregated(AggregationQuery {
+            scope: scope.clone(),
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: Some(resource_id),
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("raw hypertable path query failed");
+
+    assert_eq!(
+        raw_results.len(),
+        1,
+        "raw hypertable path must return exactly one aggregated row"
+    );
+    assert!(
+        (raw_results[0].value - 30.0).abs() < 1e-6,
+        "raw hypertable path must return sum=30.0, got {}",
+        raw_results[0].value
+    );
+
+    // Continuous aggregate path: no resource_id/subject_id → routed to usage_agg_1h
+    let cagg_results = client
+        .query_aggregated(AggregationQuery {
+            scope: scope.clone(),
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("continuous aggregate path query failed");
+
+    assert_eq!(
+        cagg_results.len(),
+        1,
+        "continuous aggregate path must return exactly one aggregated row"
+    );
+    assert!(
+        (cagg_results[0].value - 30.0).abs() < 1e-6,
+        "continuous aggregate path must return sum=30.0 after manual refresh, got {}",
+        cagg_results[0].value
+    );
+}
+
+// ── Test 4: cursor_stability_under_concurrent_inserts ─────────────────────────
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn cursor_stability_under_concurrent_inserts() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = Arc::new(make_client(&db.pool));
+    let scope = AccessScope::for_tenant(tenant_id);
+
+    // Baseline: insert 5 records with distinct timestamps inside the query range
+    let base_ts = Utc::now() - chrono::Duration::hours(2);
+    let query_range = (
+        base_ts - chrono::Duration::minutes(1),
+        base_ts + chrono::Duration::hours(1),
+    );
+
+    for i in 0..5u32 {
+        let mut record = counter_record(tenant_id, resource_id, &format!("stable-{i}"));
+        record.timestamp = base_ts + chrono::Duration::minutes(i64::from(i));
+        client
+            .create_usage_record(record)
+            .await
+            .expect("baseline insert failed");
+    }
+
+    // Get the first page (3 records)
+    let first_page = client
+        .query_raw(RawQuery {
+            scope: scope.clone(),
+            time_range: query_range,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_type: None,
+            subject_id: None,
+            cursor: None,
+            page_size: 3,
+        })
+        .await
+        .expect("first page query failed");
+
+    assert_eq!(
+        first_page.items.len(),
+        3,
+        "first page must contain 3 records"
+    );
+    let cursor_str = first_page
+        .page_info
+        .next_cursor
+        .expect("cursor must be present when page_size equals result count");
+    let cursor =
+        CursorV1::decode(&cursor_str).expect("cursor string from page 1 must be a valid CursorV1");
+
+    // Concurrently insert 3 records OUTSIDE the query range so they cannot affect pagination
+    let outside_ts = base_ts + chrono::Duration::hours(2);
+    let c = client.clone();
+    let outside_handle = tokio::spawn(async move {
+        for i in 0..3u32 {
+            let mut r = counter_record(tenant_id, resource_id, &format!("outside-{i}"));
+            r.timestamp = outside_ts + chrono::Duration::minutes(i64::from(i));
+            c.create_usage_record(r)
+                .await
+                .expect("outside-range insert failed");
+        }
+    });
+
+    // Get the second page using the cursor from page 1
+    let second_page = client
+        .query_raw(RawQuery {
+            scope: scope.clone(),
+            time_range: query_range,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_type: None,
+            subject_id: None,
+            cursor: Some(cursor),
+            page_size: 3,
+        })
+        .await
+        .expect("second page query failed");
+
+    outside_handle
+        .await
+        .expect("outside-range insert task panicked");
+
+    assert_eq!(
+        second_page.items.len(),
+        2,
+        "second page must contain the remaining 2 records; concurrent outside-range inserts must not appear"
+    );
+    assert!(
+        second_page.page_info.next_cursor.is_none(),
+        "no next cursor expected after the last page is exhausted"
+    );
+}
+
+// ── Group C: GroupByDimension variants ────────────────────────────────────────
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_group_by_usage_type_raw() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    client
+        .create_usage_record(counter_record(tenant_id, resource_id, "gbu-type-raw-1"))
+        .await
+        .expect("insert failed");
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![GroupByDimension::UsageType],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: Some(resource_id),
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].usage_type, Some("test.cpu".to_owned()));
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_group_by_usage_type_cagg() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let past_ts = aligned_past_hour(3);
+    let time_range = (
+        past_ts - chrono::Duration::hours(1),
+        past_ts + chrono::Duration::hours(2),
+    );
+
+    let mut r = counter_record(tenant_id, resource_id, "gbu-type-cagg-1");
+    r.timestamp = past_ts;
+    client.create_usage_record(r).await.expect("insert failed");
+    cagg_refresh(&db.pool).await;
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![GroupByDimension::UsageType],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        results[0].usage_type.is_some(),
+        "expected usage_type to be populated on cagg path"
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_group_by_resource() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    client
+        .create_usage_record(counter_record(tenant_id, resource_id, "gbr-raw-1"))
+        .await
+        .expect("insert failed");
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![GroupByDimension::Resource],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].resource_id, Some(resource_id));
+    assert_eq!(results[0].resource_type, Some("vm".to_owned()));
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_group_by_subject() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let subject_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    client
+        .create_usage_record(record_with_subject(
+            tenant_id,
+            resource_id,
+            subject_id,
+            "gbs-raw-1",
+        ))
+        .await
+        .expect("insert failed");
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![GroupByDimension::Subject],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].subject_id, Some(subject_id));
+    assert_eq!(results[0].subject_type, Some("user".to_owned()));
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_group_by_source() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    client
+        .create_usage_record(counter_record(tenant_id, resource_id, "gbsrc-raw-1"))
+        .await
+        .expect("insert failed");
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![GroupByDimension::Source],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: Some(resource_id),
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].source, Some("integration-test".to_owned()));
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_group_by_time_bucket_raw() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    client
+        .create_usage_record(counter_record(tenant_id, resource_id, "gbtb-raw-1"))
+        .await
+        .expect("insert failed");
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![GroupByDimension::TimeBucket(BucketSize::Hour)],
+            bucket_size: Some(BucketSize::Hour),
+            usage_type: None,
+            resource_id: Some(resource_id),
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert!(!results.is_empty(), "expected at least one result row");
+    assert!(
+        results[0].bucket_start.is_some(),
+        "expected bucket_start to be populated"
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_group_by_time_bucket_cagg() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let past_ts = aligned_past_hour(3);
+    let time_range = (
+        past_ts - chrono::Duration::hours(1),
+        past_ts + chrono::Duration::hours(2),
+    );
+
+    let mut r = counter_record(tenant_id, resource_id, "gbtb-cagg-1");
+    r.timestamp = past_ts;
+    client.create_usage_record(r).await.expect("insert failed");
+    cagg_refresh(&db.pool).await;
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![GroupByDimension::TimeBucket(BucketSize::Hour)],
+            bucket_size: Some(BucketSize::Hour),
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert!(!results.is_empty(), "expected at least one result row");
+    assert!(
+        results[0].bucket_start.is_some(),
+        "expected bucket_start to be populated on cagg path"
+    );
+}
+
+// ── Group D: query_aggregated filters on the raw path ─────────────────────────
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_filter_usage_type_raw() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    // Insert "test.cpu" (value 10) and "test.mem" (value 20)
+    client
+        .create_usage_record(counter_record_with_value(
+            tenant_id,
+            resource_id,
+            "fut-cpu-1",
+            10.0,
+        ))
+        .await
+        .expect("insert failed");
+    let mut mem_rec = counter_record_with_value(tenant_id, resource_id, "fut-mem-1", 20.0);
+    mem_rec.metric = "test.mem".to_owned();
+    client
+        .create_usage_record(mem_rec)
+        .await
+        .expect("insert failed");
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: Some("test.cpu".to_owned()),
+            resource_id: Some(resource_id),
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 10.0).abs() < 1e-6,
+        "expected only test.cpu sum=10.0, got {}",
+        results[0].value
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_filter_resource_type_raw() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    // 2 "vm" records (value 10 each) and 1 "disk" record (value 20)
+    client
+        .create_usage_record(counter_record_with_value(
+            tenant_id,
+            resource_id,
+            "frt-vm-1",
+            10.0,
+        ))
+        .await
+        .expect("insert failed");
+    client
+        .create_usage_record(counter_record_with_value(
+            tenant_id,
+            resource_id,
+            "frt-vm-2",
+            10.0,
+        ))
+        .await
+        .expect("insert failed");
+    let mut disk_rec = counter_record_with_value(tenant_id, resource_id, "frt-disk-1", 20.0);
+    disk_rec.resource_type = "disk".to_owned();
+    client
+        .create_usage_record(disk_rec)
+        .await
+        .expect("insert failed");
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: Some(resource_id),
+            resource_type: Some("vm".to_owned()),
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 20.0).abs() < 1e-6,
+        "expected vm sum=20.0, got {}",
+        results[0].value
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_filter_subject_type_raw() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let subject_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    // 1 record with subject_type "user" (value 10) and 1 without (value 20)
+    client
+        .create_usage_record(record_with_subject(
+            tenant_id,
+            resource_id,
+            subject_id,
+            "fst-user-1",
+        ))
+        .await
+        .expect("insert failed");
+    client
+        .create_usage_record(counter_record_with_value(
+            tenant_id,
+            resource_id,
+            "fst-none-1",
+            20.0,
+        ))
+        .await
+        .expect("insert failed");
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: Some(resource_id),
+            resource_type: None,
+            subject_id: None,
+            subject_type: Some("user".to_owned()),
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 10.0).abs() < 1e-6,
+        "expected user-only sum=10.0, got {}",
+        results[0].value
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_filter_source_raw() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    // 1 record from "mod-a" (value 10) and 1 from "mod-b" (value 20)
+    client
+        .create_usage_record(counter_record_with_value(
+            tenant_id,
+            resource_id,
+            "fsrc-a-1",
+            10.0,
+        ))
+        .await
+        .expect("insert failed");
+    let mut mod_b = counter_record_with_value(tenant_id, resource_id, "fsrc-b-1", 20.0);
+    mod_b.module = "mod-b".to_owned();
+    client
+        .create_usage_record(mod_b)
+        .await
+        .expect("insert failed");
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: Some(resource_id),
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: Some("integration-test".to_owned()),
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 10.0).abs() < 1e-6,
+        "expected integration-test-only sum=10.0, got {}",
+        results[0].value
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_filter_multi_raw() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    // (cpu, vm, 10), (cpu, disk, 15), (mem, vm, 20), (mem, disk, 25)
+    client
+        .create_usage_record(counter_record_with_value(
+            tenant_id,
+            resource_id,
+            "fmulti-cv-1",
+            10.0,
+        ))
+        .await
+        .expect("insert failed");
+    let mut cpu_disk = counter_record_with_value(tenant_id, resource_id, "fmulti-cd-1", 15.0);
+    cpu_disk.resource_type = "disk".to_owned();
+    client
+        .create_usage_record(cpu_disk)
+        .await
+        .expect("insert failed");
+    let mut mem_vm = counter_record_with_value(tenant_id, resource_id, "fmulti-mv-1", 20.0);
+    mem_vm.metric = "test.mem".to_owned();
+    client
+        .create_usage_record(mem_vm)
+        .await
+        .expect("insert failed");
+    let mut mem_disk = counter_record_with_value(tenant_id, resource_id, "fmulti-md-1", 25.0);
+    mem_disk.metric = "test.mem".to_owned();
+    mem_disk.resource_type = "disk".to_owned();
+    client
+        .create_usage_record(mem_disk)
+        .await
+        .expect("insert failed");
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: Some("test.cpu".to_owned()),
+            resource_id: Some(resource_id),
+            resource_type: Some("vm".to_owned()),
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 10.0).abs() < 1e-6,
+        "expected multi-filter sum=10.0, got {}",
+        results[0].value
+    );
+}
+
+// ── Group E: query_aggregated filters on the cagg path ────────────────────────
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_filter_usage_type_cagg() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let past_ts = aligned_past_hour(3);
+    let time_range = (
+        past_ts - chrono::Duration::hours(1),
+        past_ts + chrono::Duration::hours(2),
+    );
+
+    let mut cpu_rec = counter_record_with_value(tenant_id, resource_id, "fute-cpu-1", 10.0);
+    cpu_rec.timestamp = past_ts;
+    client
+        .create_usage_record(cpu_rec)
+        .await
+        .expect("insert failed");
+    let mut mem_rec = counter_record_with_value(tenant_id, resource_id, "fute-mem-1", 20.0);
+    mem_rec.metric = "test.mem".to_owned();
+    mem_rec.timestamp = past_ts;
+    client
+        .create_usage_record(mem_rec)
+        .await
+        .expect("insert failed");
+    cagg_refresh(&db.pool).await;
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: Some("test.cpu".to_owned()),
+            resource_id: None,
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 10.0).abs() < 1e-6,
+        "expected cagg usage_type filter sum=10.0, got {}",
+        results[0].value
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_filter_resource_type_cagg() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let past_ts = aligned_past_hour(3);
+    let time_range = (
+        past_ts - chrono::Duration::hours(1),
+        past_ts + chrono::Duration::hours(2),
+    );
+
+    let mut vm_rec = counter_record_with_value(tenant_id, resource_id, "frte-vm-1", 10.0);
+    vm_rec.timestamp = past_ts;
+    client
+        .create_usage_record(vm_rec)
+        .await
+        .expect("insert failed");
+    let mut disk_rec = counter_record_with_value(tenant_id, resource_id, "frte-disk-1", 20.0);
+    disk_rec.resource_type = "disk".to_owned();
+    disk_rec.timestamp = past_ts;
+    client
+        .create_usage_record(disk_rec)
+        .await
+        .expect("insert failed");
+    cagg_refresh(&db.pool).await;
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: None,
+            resource_type: Some("vm".to_owned()),
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 10.0).abs() < 1e-6,
+        "expected cagg resource_type filter sum=10.0, got {}",
+        results[0].value
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_filter_subject_type_cagg() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let subject_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let past_ts = aligned_past_hour(3);
+    let time_range = (
+        past_ts - chrono::Duration::hours(1),
+        past_ts + chrono::Duration::hours(2),
+    );
+
+    let mut user_rec = record_with_subject(tenant_id, resource_id, subject_id, "fste-user-1");
+    user_rec.timestamp = past_ts;
+    client
+        .create_usage_record(user_rec)
+        .await
+        .expect("insert failed");
+    let mut none_rec = counter_record_with_value(tenant_id, resource_id, "fste-none-1", 20.0);
+    none_rec.timestamp = past_ts;
+    client
+        .create_usage_record(none_rec)
+        .await
+        .expect("insert failed");
+    cagg_refresh(&db.pool).await;
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_id: None,
+            subject_type: Some("user".to_owned()),
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 10.0).abs() < 1e-6,
+        "expected cagg subject_type filter sum=10.0, got {}",
+        results[0].value
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_filter_source_cagg() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let past_ts = aligned_past_hour(3);
+    let time_range = (
+        past_ts - chrono::Duration::hours(1),
+        past_ts + chrono::Duration::hours(2),
+    );
+
+    let mut a_rec = counter_record_with_value(tenant_id, resource_id, "fsrce-a-1", 10.0);
+    a_rec.timestamp = past_ts;
+    client
+        .create_usage_record(a_rec)
+        .await
+        .expect("insert failed");
+    let mut b_rec = counter_record_with_value(tenant_id, resource_id, "fsrce-b-1", 20.0);
+    b_rec.module = "mod-b".to_owned();
+    b_rec.timestamp = past_ts;
+    client
+        .create_usage_record(b_rec)
+        .await
+        .expect("insert failed");
+    cagg_refresh(&db.pool).await;
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: Some("integration-test".to_owned()),
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 10.0).abs() < 1e-6,
+        "expected cagg source filter sum=10.0, got {}",
+        results[0].value
+    );
+}
+
+// ── Group F: query_aggregated scope isolation ──────────────────────────────────
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_scope_isolation() {
+    let db = setup_container_and_pool().await;
+    let tenant_a = Uuid::new_v4();
+    let tenant_b = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope_a = AccessScope::for_tenant(tenant_a);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    // Same resource_id, different tenants
+    client
+        .create_usage_record(counter_record_with_value(
+            tenant_a,
+            resource_id,
+            "scope-a-1",
+            10.0,
+        ))
+        .await
+        .expect("insert tenant_a failed");
+    client
+        .create_usage_record(counter_record_with_value(
+            tenant_b,
+            resource_id,
+            "scope-b-1",
+            20.0,
+        ))
+        .await
+        .expect("insert tenant_b failed");
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope: scope_a,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: Some(resource_id),
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 10.0).abs() < 1e-6,
+        "expected only tenant_a sum=10.0, got {}",
+        results[0].value
+    );
+}
+
+// ── Group G: QueryResultTooLarge ──────────────────────────────────────────────
+//
+// SDK drift: fe5e58dc passed `max_rows: 2` on `AggregationQuery` to force the
+// plugin to exceed the row cap. HEAD's `AggregationQuery` no longer carries
+// `max_rows`; the plugin enforces a hard internal cap of `MAX_AGG_ROWS = 10_000`
+// (see `src/infra/pg_query_port.rs`). Exercising the cap therefore requires
+// emitting > 10_000 distinct grouping rows, which is impractical inside a
+// per-test container and would dwarf the rest of the suite's runtime. The test
+// is preserved at parity with fe5e58dc but `#[ignore]`-gated so it compiles and
+// the `#[tokio::test]` count matches; the assertion path is reworked to use
+// `MAX_AGG_ROWS + 1` distinct resource ids if a developer opts into running it.
+#[cfg(feature = "integration")]
+#[ignore = "exercising MAX_AGG_ROWS=10_000 cap requires > 10k distinct rows; \
+            kept for fe5e58dc parity but skipped in default runs"]
+#[tokio::test]
+async fn query_aggregated_result_too_large() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    // Insert MAX_AGG_ROWS + 1 records with distinct resource_ids → group by
+    // Resource yields > MAX_AGG_ROWS rows, tripping the plugin-side cap.
+    for i in 0u32..10_001 {
+        let rid = Uuid::new_v4();
+        client
+            .create_usage_record(counter_record(tenant_id, rid, &format!("too-large-{i}")))
+            .await
+            .expect("insert failed");
+    }
+
+    let result = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![GroupByDimension::Resource],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await;
+
+    assert!(
+        matches!(result, Err(ref e) if matches!(e, UsageCollectorError::ResourceExhausted { .. })),
+        "expected QueryResultTooLarge, got {result:?}"
+    );
+}
+
+// Same cost-control invariant as `query_aggregated_result_too_large`, but with
+// the row cap injected via `PgQueryPort::new_with_max_agg_rows` so we can trip
+// the cap with a handful of rows. Runs in default integration CI (no
+// `#[ignore]`) so a regression that silently drops the cap fails the build.
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_result_too_large_small_cap() {
+    const SMALL_CAP: usize = 3;
+
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let client = make_client_with_max_agg_rows(&db.pool, SMALL_CAP);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    for i in 0..=SMALL_CAP {
+        let rid = Uuid::new_v4();
+        client
+            .create_usage_record(counter_record(tenant_id, rid, &format!("small-cap-{i}")))
+            .await
+            .expect("insert failed");
+    }
+
+    let result = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![GroupByDimension::Resource],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await;
+
+    assert!(
+        matches!(result, Err(ref e) if matches!(e, UsageCollectorError::ResourceExhausted { .. })),
+        "expected ResourceExhausted with cap={SMALL_CAP}, got {result:?}"
+    );
+}
+
+// ── Group H: query_raw filters ────────────────────────────────────────────────
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_raw_filter_usage_type() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    client
+        .create_usage_record(counter_record(tenant_id, resource_id, "rut-cpu-1"))
+        .await
+        .expect("insert failed");
+    let mut mem_rec = counter_record(tenant_id, resource_id, "rut-mem-1");
+    mem_rec.metric = "test.mem".to_owned();
+    client
+        .create_usage_record(mem_rec)
+        .await
+        .expect("insert failed");
+
+    let page = client
+        .query_raw(RawQuery {
+            scope,
+            time_range,
+            usage_type: Some("test.cpu".to_owned()),
+            resource_id: None,
+            resource_type: None,
+            subject_type: None,
+            subject_id: None,
+            cursor: None,
+            page_size: 100,
+        })
+        .await
+        .expect("query_raw failed");
+
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].metric, "test.cpu");
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_raw_filter_resource_id() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id_a = Uuid::new_v4();
+    let resource_id_b = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    client
+        .create_usage_record(counter_record(tenant_id, resource_id_a, "rrid-a-1"))
+        .await
+        .expect("insert failed");
+    client
+        .create_usage_record(counter_record(tenant_id, resource_id_b, "rrid-b-1"))
+        .await
+        .expect("insert failed");
+
+    let page = client
+        .query_raw(RawQuery {
+            scope,
+            time_range,
+            usage_type: None,
+            resource_id: Some(resource_id_a),
+            resource_type: None,
+            subject_type: None,
+            subject_id: None,
+            cursor: None,
+            page_size: 100,
+        })
+        .await
+        .expect("query_raw failed");
+
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].resource_id, resource_id_a);
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_raw_filter_resource_type() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    client
+        .create_usage_record(counter_record(tenant_id, resource_id, "rrtype-vm-1"))
+        .await
+        .expect("insert failed");
+    let mut disk_rec = counter_record(tenant_id, resource_id, "rrtype-disk-1");
+    disk_rec.resource_type = "disk".to_owned();
+    client
+        .create_usage_record(disk_rec)
+        .await
+        .expect("insert failed");
+
+    let page = client
+        .query_raw(RawQuery {
+            scope,
+            time_range,
+            usage_type: None,
+            resource_id: None,
+            resource_type: Some("vm".to_owned()),
+            subject_type: None,
+            subject_id: None,
+            cursor: None,
+            page_size: 100,
+        })
+        .await
+        .expect("query_raw failed");
+
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].resource_type, "vm");
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_raw_filter_subject_id() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let subject_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    client
+        .create_usage_record(record_with_subject(
+            tenant_id,
+            resource_id,
+            subject_id,
+            "rsid-with-1",
+        ))
+        .await
+        .expect("insert failed");
+    client
+        .create_usage_record(counter_record(tenant_id, resource_id, "rsid-without-1"))
+        .await
+        .expect("insert failed");
+
+    let page = client
+        .query_raw(RawQuery {
+            scope,
+            time_range,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_type: None,
+            subject_id: Some(subject_id),
+            cursor: None,
+            page_size: 100,
+        })
+        .await
+        .expect("query_raw failed");
+
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(
+        page.items[0].subject.as_ref().map(|s| s.id),
+        Some(subject_id)
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_raw_filter_subject_type() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let subject_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    client
+        .create_usage_record(record_with_subject(
+            tenant_id,
+            resource_id,
+            subject_id,
+            "rst-user-1",
+        ))
+        .await
+        .expect("insert failed");
+    client
+        .create_usage_record(counter_record(tenant_id, resource_id, "rst-none-1"))
+        .await
+        .expect("insert failed");
+
+    let page = client
+        .query_raw(RawQuery {
+            scope,
+            time_range,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_type: Some("user".to_owned()),
+            subject_id: None,
+            cursor: None,
+            page_size: 100,
+        })
+        .await
+        .expect("query_raw failed");
+
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(
+        page.items[0]
+            .subject
+            .as_ref()
+            .and_then(|s| s.r#type.clone()),
+        Some("user".to_owned())
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_raw_scope_isolation() {
+    let db = setup_container_and_pool().await;
+    let tenant_a = Uuid::new_v4();
+    let tenant_b = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope_a = AccessScope::for_tenant(tenant_a);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    client
+        .create_usage_record(counter_record(tenant_a, resource_id, "rscope-a-1"))
+        .await
+        .expect("insert tenant_a failed");
+    client
+        .create_usage_record(counter_record(tenant_b, resource_id, "rscope-b-1"))
+        .await
+        .expect("insert tenant_b failed");
+
+    let page = client
+        .query_raw(RawQuery {
+            scope: scope_a,
+            time_range,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_type: None,
+            subject_id: None,
+            cursor: None,
+            page_size: 100,
+        })
+        .await
+        .expect("query_raw failed");
+
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(
+        page.items[0].tenant_id, tenant_a,
+        "must only return tenant_a records"
+    );
+}
+
+// ── Group I: create_usage_record validation errors ────────────────────────────
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn create_record_negative_counter_value() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+
+    let mut record = counter_record(tenant_id, resource_id, "neg-val-key");
+    record.value = -1.0;
+
+    let err = client.create_usage_record(record).await.unwrap_err();
+    assert!(
+        matches!(err, UsageCollectorError::InvalidArgument { .. }),
+        "expected InvalidArgument error for negative counter value, got {err:?}"
+    );
+}
+
+// ── Regression: scope-level resource_id / subject_id forces raw path ──────────
+//
+// The continuous aggregate (`usage_agg_1h`) groups out `resource_id` and
+// `subject_id`. A previous version of `query_aggregated` decided whether to
+// hit the CAGG using only query-level `resource_id` / `subject_id` filters,
+// so a caller whose PDP-compiled scope constrained those columns (with no
+// explicit resource/subject filter or group-by in the query) produced SQL
+// that referenced columns absent on the view, failing at runtime. These
+// tests pin that the routing now inspects scope contents too.
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_scope_constrained_resource_id_succeeds() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+
+    let scope = AccessScope::from_constraints(vec![ScopeConstraint::new(vec![
+        ScopeFilter::in_uuids(pep_properties::OWNER_TENANT_ID, vec![tenant_id]),
+        ScopeFilter::in_uuids("resource_id", vec![resource_id]),
+    ])]);
+
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    for (i, val) in [(0u32, 10.0f64), (1, 20.0), (2, 30.0)] {
+        client
+            .create_usage_record(counter_record_with_value(
+                tenant_id,
+                resource_id,
+                &format!("scope-rid-{i}"),
+                val,
+            ))
+            .await
+            .expect("insert failed");
+    }
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated must succeed when scope filters by resource_id");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 60.0).abs() < 1e-6,
+        "expected sum=60.0, got {}",
+        results[0].value
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_scope_constrained_subject_id_succeeds() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let subject_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+
+    let scope = AccessScope::from_constraints(vec![ScopeConstraint::new(vec![
+        ScopeFilter::in_uuids(pep_properties::OWNER_TENANT_ID, vec![tenant_id]),
+        ScopeFilter::in_uuids("subject_id", vec![subject_id]),
+    ])]);
+
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::hours(1),
+        now + chrono::Duration::hours(1),
+    );
+
+    for (i, val) in [(0u32, 10.0f64), (1, 20.0), (2, 30.0)] {
+        let mut record =
+            counter_record_with_value(tenant_id, resource_id, &format!("scope-sid-{i}"), val);
+        record.subject = Some(Subject {
+            id: subject_id,
+            r#type: Some("user".to_owned()),
+        });
+        client
+            .create_usage_record(record)
+            .await
+            .expect("insert failed");
+    }
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated must succeed when scope filters by subject_id");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 60.0).abs() < 1e-6,
+        "expected sum=60.0, got {}",
+        results[0].value
+    );
+}
+
+/// `query_aggregated` with a low-cardinality dimension shape but a time range
+/// that overlaps the unmaterialized window (current hour) must fall back to
+/// the raw hypertable rather than silently return an empty / stale CAGG
+/// result. Without the fall-back, the CAGG view (which under
+/// `materialized_only = true` exposes only refreshed buckets up to
+/// `now - 1h`) would miss the just-inserted records and the caller would see
+/// a zero-row result.
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn query_aggregated_current_hour_routes_to_raw() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+    let scope = AccessScope::for_tenant(tenant_id);
+    let now = Utc::now();
+    let time_range = (
+        now - chrono::Duration::minutes(30),
+        now + chrono::Duration::minutes(30),
+    );
+
+    for (i, val) in [(0u32, 10.0f64), (1, 20.0), (2, 30.0)] {
+        let mut r =
+            counter_record_with_value(tenant_id, resource_id, &format!("current-hour-{i}"), val);
+        r.timestamp = now;
+        client.create_usage_record(r).await.expect("insert failed");
+    }
+    // Deliberately do NOT call cagg_refresh — the CAGG cannot materialize the
+    // current hour anyway (`end_offset = 1h` in the refresh policy).
+
+    let results = client
+        .query_aggregated(AggregationQuery {
+            scope,
+            time_range,
+            function: AggregationFn::Sum,
+            group_by: vec![],
+            bucket_size: None,
+            usage_type: None,
+            resource_id: None,
+            resource_type: None,
+            subject_id: None,
+            subject_type: None,
+            source: None,
+        })
+        .await
+        .expect("query_aggregated failed");
+
+    assert_eq!(results.len(), 1);
+    assert!(
+        (results[0].value - 60.0).abs() < 1e-6,
+        "current-hour low-cardinality query must fall back to raw and return sum=60.0, got {}",
+        results[0].value
+    );
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn create_record_empty_idempotency_key() {
+    let db = setup_container_and_pool().await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let client = make_client(&db.pool);
+
+    let record = counter_record(tenant_id, resource_id, "");
+
+    let err = client.create_usage_record(record).await.unwrap_err();
+    assert!(
+        matches!(err, UsageCollectorError::InvalidArgument { .. }),
+        "expected InvalidArgument error for empty idempotency_key, got {err:?}"
+    );
+}


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#1927](https://github.com/cyberfabric/cyberware-rust/pull/1927) | **Author:** capybutler | **Opened:** 2026-05-18T03:41:12Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

Implements Feature 4 — Production Storage Plugin (`timescaledb-usage-collector-storage-plugin`),
a production `UsageCollectorPluginClientV1` backed by TimescaleDB.

- **Schema & migrations** — idempotent `usage_records` hypertable (composite PK on `id + timestamp`),
  `usage_idempotency_keys` deduplication table (plain table with unique constraint on idempotency key);
  SeaORM migration scaffolding runs at plugin startup and is idempotent
- **Ingest** — two-step transaction: insert idempotency key first (conflict = skip), then upsert
  record with SUM-based counter delta accumulation; no separate accumulation table
- **Aggregation query** — routes to 1-hour continuous-aggregate view when bucket size ≥ 1 h and
  time range is fully materialized, falls back to raw hypertable otherwise
- **Raw pagination** — cursor-based (OpaqueV1 cursor, keyed on `(timestamp, id)`), with tenant and
  dimension filtering; uses modkit-odata `Page<UsageRecord>` / `CursorV1`
- **`AccessScope` → SQL translator** — preserves OR-of-ANDs PDP constraint structure;
  rejects `InGroup`/`InGroupSubtree` predicates (not applicable to usage records)
- **GTS registration** — registers a `UsageCollectorStoragePluginSpecV1` instance with the types
  registry on startup; enforces `sslmode=require|verify-ca|verify-full` in `database_url`
- **OTel metrics** — ingest/query counters + latency histograms + `storage_health_status` gauge
  (liveness probe loop every 30 s)
- **Integration tests** — Level 2 suite with testcontainers (real TimescaleDB); covers ingest
  idempotency, counter accumulation, aggregation routing, raw pagination, scope filtering
- **Supporting changes** — `modkit-odata`: skip-serializing-if for optional cursor fields in
  `PageInfo`; DECOMPOSITION.md: F4 marked complete (✅)

Closes: `cpt-cf-usage-collector-feature-production-storage-plugin` (p1)

## PR Train
| # | PR | Description | Lines |
|---|---|------------|------:|
| 1 | [1907](https://github.com/constructorfabric/cyberfabric-core/issues/1907) | Feature 1 (Core SDK, Emitter & In-Process Ingest): SDK + docs | ~2500 |
| 2 | [1908](https://github.com/constructorfabric/cyberfabric-core/issues/1908) | Feature 1 (Core SDK, Emitter & In-Process Ingest): `usage-collector` gateway + `usage-emitter` + `noop-usage-collector-storage-plugin` | ~8000 |
| 3 | [1919](https://github.com/constructorfabric/cyberfabric-core/issues/1919) | Feature 2 (REST Client & Remote Ingest Delivery) | ~2800 |
| 4 | [1926](https://github.com/constructorfabric/cyberfabric-core/issues/1926) | Feature 3 (Query API) | ~6000 |
| 5 | [1927 (**this**)](https://github.com/constructorfabric/cyberfabric-core/issues/1927) | Feature 4 (TimescaleDB plugin) | ~7700 |
| 6 | [1835](https://github.com/constructorfabric/cyberfabric-core/issues/1835) | e2e tests | ~1500 |
|   |  | ... to be continued ... | |


## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No linting errors (`cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::perf`)
- [x] Code is properly formatted (`cargo fmt`)
- [x] `cpt validate` — all checks passed
- [x] Tests pass (`cargo nextest run --workspace`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TimescaleDB storage backend implementation with durable persistence
  * Cursor-based pagination for raw usage data queries
  * Continuous aggregate support for efficient aggregated query execution
  * Database retention policy management and enforcement
  * Production-grade storage plugin with schema validation and deduplication support

* **Documentation**
  * Feature specifications updated with comprehensive implementation details
  * Decomposition documentation updated and marked complete

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#1927 -->