### PR TITLE
[PR #1919] feat(usage-collector): [3/6] add REST client crate for remote ingest delivery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3127,6 +3127,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cyberware-usage-collector-rest-client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "cyberware-authn-resolver-sdk",
+ "cyberware-authz-resolver-sdk",
+ "cyberware-modkit",
+ "cyberware-modkit-db",
+ "cyberware-modkit-http",
+ "cyberware-modkit-macros",
+ "cyberware-modkit-security",
+ "cyberware-usage-collector-sdk",
+ "cyberware-usage-emitter",
+ "http",
+ "http-body-util",
+ "httpmock",
+ "sea-orm-migration",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower",
+ "tracing",
+ "tracing-test",
+ "url",
+ "uuid",
+ "zeroize",
+]
+
+[[package]]
 name = "cyberware-usage-collector-sdk"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ members = [
     "modules/mini-chat/mini-chat",
     "modules/system/usage-collector/plugins/noop-usage-collector-plugin",
     "modules/system/usage-collector/usage-collector",
+    "modules/system/usage-collector/usage-collector-rest-client",
     "modules/system/usage-collector/usage-collector-sdk",
     "modules/system/usage-collector/usage-emitter",
 ]
@@ -249,6 +250,7 @@ cyberware-system-sdk-directory = { version = "0.1.35", path = "libs/system-sdks/
 account-management-sdk = { package = "cyberware-account-management-sdk", version = "0.1.1", path = "modules/system/account-management/account-management-sdk" }
 types-registry-sdk = { package = "cyberware-types-registry-sdk", version = "0.2.2", path = "modules/system/types-registry/types-registry-sdk" }
 tenant-resolver-sdk = { package = "cyberware-tenant-resolver-sdk", version = "0.3.6", path = "modules/system/tenant-resolver/tenant-resolver-sdk" }
+authn-resolver-sdk = { package = "cyberware-authn-resolver-sdk", version = "0.3.16", path = "modules/system/authn-resolver/authn-resolver-sdk" }
 authz-resolver-sdk = { package = "cyberware-authz-resolver-sdk", version = "0.3.6", path = "modules/system/authz-resolver/authz-resolver-sdk" }
 resource-group-sdk = { package = "cyberware-resource-group-sdk", version = "0.1.3", path = "modules/system/resource-group/resource-group-sdk" }
 oagw-sdk = { package = "cyberware-oagw-sdk", version = "0.5.1", path = "modules/system/oagw/oagw-sdk" }
@@ -261,6 +263,7 @@ mini-chat-sdk = { package = "cyberware-mini-chat-sdk", version = "0.10.6", path 
 
 # usage-collector
 usage-collector = { package = "cyberware-usage-collector", version = "0.1.0", path = "modules/system/usage-collector/usage-collector" }
+usage-collector-rest-client = { package = "cyberware-usage-collector-rest-client", version = "0.1.0", path = "modules/system/usage-collector/usage-collector-rest-client" }
 usage-collector-sdk = { package = "cyberware-usage-collector-sdk", version = "0.1.0", path = "modules/system/usage-collector/usage-collector-sdk" }
 usage-emitter = { package = "cyberware-usage-emitter", version = "0.1.0", path = "modules/system/usage-collector/usage-emitter" }
 

--- a/modules/system/usage-collector/docs/features/0002-cpt-cf-usage-collector-feature-rest-ingest.md
+++ b/modules/system/usage-collector/docs/features/0002-cpt-cf-usage-collector-feature-rest-ingest.md
@@ -1,0 +1,312 @@
+---
+cpt:
+  version: "1.11"
+  changelog:
+    - version: "1.11"
+      date: "2026-05-16"
+      changes:
+        - "Re-align with the updated `cpt-cf-usage-collector-feature-sdk-and-ingest-core` emitter and error semantics after rebase: (a) `ClientHub` registration key is `dyn UsageEmitterRuntimeV1` (the layer-1 runtime) — `UsageEmitterFactoryV1` is not a trait that exists, the factory is the cloneable layer-2 `UsageEmitterFactory` obtained via `runtime.factory(module_name)`. Out-of-process sources now drive the three-layer chain `runtime.factory(MODULE_NAME).with_*().authorize(ctx, resource_id, resource_type)?` then `usage_record_builder()?.build()? → enqueue(record)` / `enqueue_in(db, record)`. Updated §1.1, §1.2, §2 Module Init Flow output, §3 `inst-init-6` (`UsageEmitter` → `UsageEmitterRuntime::build(...)`) and `inst-init-7` (registration key), §5 DoD body for `UsageCollectorRestClientModule`, and §6 AC. (b) Module Config Retrieval Flow (REST) — the factory's `.authorize()` step propagates non-`NotFound` variants from `get_module_config()` unchanged per Feature 1 `inst-authz-5a`; the emitter no longer collapses them to `UsageEmitterError::Internal`. §2 Error Scenarios rewritten to list `ServiceUnavailable` (transport / 401 / 5xx), `DeadlineExceeded` (timeout), `ResourceExhausted` (429), and `PermissionDenied` (403) propagation paths; `inst-cfg-rem-6a` now enumerates the explicit HTTP-status → canonical-variant mappings (`401`→`ServiceUnavailable`, `403`→`ModuleConfigError::permission_denied()`, `429`→`ModuleConfigError::resource_exhausted()`, `5xx`→`ServiceUnavailable`, timeout→`ModuleConfigError::deadline_exceeded()`, transport / residual `HttpError` variants→`ServiceUnavailable`, any other unexpected status→`Internal`) and corrects the stale `inst-authz-5b` cross-reference to `inst-authz-5a`; §5 DoD body and §6 AC for `get_module_config()` extended with the same explicit mapping list. (c) `UsageRecord` JSON shape — the legacy `subject_id` / `subject_type` field pair has been replaced by a single nested `subject: Option<Subject>` object (Feature 1 `inst-enq-8`); `inst-rem-5` updated to describe the nested serialization (absent when `None`, `\"subject\": { \"id\": \"...\", \"type\": \"...\" }` when `Some`, with the inner `type` itself absent when `Subject.r#type` is `None`)."
+    - version: "1.10"
+      date: "2026-05-10"
+      changes:
+        - "§5 DoD `BearerTokenAuthLayer` bullet: widen the AuthN-resolver-originated outcome collapse so the narrative matches `bearer_token_auth_layer.rs`. All AuthN-resolver-originated outcomes — transient resolver failures, permanent credential rejection (`Unauthorized` / `NoPluginAvailable`), and the post-exchange missing-token guard when the returned `SecurityContext` carries no bearer token — collapse to `HttpError::Transport(Box<AuthNResolverError>)`. In addition, an invalid token byte sequence yields `HttpError::InvalidHeaderValue`, which the REST client maps to `ServiceUnavailable` via the residual non-Transport, non-Timeout arm (already covered by the `create_usage_record()` mapping list — this is now stated explicitly in the layer description). No code change."
+    - version: "1.9"
+      date: "2026-05-10"
+      changes:
+        - "Document the bearer-token Tower middleware architecture (RESEARCH-diverge issue G) and the flat `infra/` crate layout (RESEARCH-diverge issue J). Token acquisition + `Authorization` header injection are now a per-request `tower::Layer` (`BearerTokenAuthLayer`), wired into the shared `HttpClient` via `HttpClientBuilder::with_auth_layer(...)`; the REST client's `create_usage_record()` / `get_module_config()` issue plain `.post(...).send()` / `.get(...).send()` calls. The layer collapses transient AuthN failures and permanent credential rejection alike to `HttpError::Transport`, which `rest_client.rs` maps to `ServiceUnavailable` (preserves the previous `inst-rem-3a` / `inst-rem-4a` mapping). Updates: §2 Remote Usage Emission Flow steps `inst-rem-2` / `inst-rem-3` / `inst-rem-4` and Module Config Retrieval Flow step `inst-cfg-rem-2`; §3 REST Client Module Initialization step `inst-init-5` (HTTP client built with `BearerTokenAuthLayer` injected via `with_auth_layer`); §5 DoD body for `UsageCollectorRestClient` (token acquisition is performed by the `BearerTokenAuthLayer`; the REST client method itself only issues the HTTP request). Crate layout: §5 DoD body now reflects the flat `infra/` module (`rest_client.rs`, `bearer_token_auth_layer.rs`, plus tests + `test_support.rs`); the previous `api/rest/dto.rs` DTO layer has been removed — the client serializes `usage_collector_sdk::models::UsageRecord` directly. Public surface: `pub use config::UsageCollectorRestClientConfig; pub use infra::UsageCollectorRestClient;`."
+    - version: "1.8"
+      date: "2026-05-10"
+      changes:
+        - "Align emitter trait name with the implemented crate surface (RESEARCH-diverge issue C): `UsageEmitterV1` → `UsageEmitterFactoryV1` across §1 Overview, §2 Module Init Flow output, §3 inst-init-7, §5 DoD body for `UsageCollectorRestClientModule`, and §6 AC for `ClientHub` availability. The factory trait is the `ClientHub` registration key shared with Feature 1."
+    - version: "1.7"
+      date: "2026-05-10"
+      changes:
+        - "Complete v1.6 canonical-taxonomy alignment by fixing two missed sites that still referenced the nonexistent `ModuleNotFound` variant: §5 DoD body for the `usage-collector-rest-client` crate (`maps 404 to ModuleNotFound` → `maps 404 to NotFound (built via ModuleConfigError::not_found(module_name))`) and §6 AC for `get_module_config()` (`returns ModuleNotFound on 404` → `returns NotFound (built via ModuleConfigError::not_found(module_name)) on 404`). v1.6 updated §2 and `inst-cfg-rem-5a`/`-6a` but missed the DoD body and AC."
+    - version: "1.6"
+      date: "2026-05-10"
+      changes:
+        - "Align Module Config Retrieval Flow (REST) with the canonical taxonomy (`UsageEmitterError = UsageCollectorError = CanonicalError`; resource-scoped builder `ModuleConfigError`): §2 Error Scenarios — `UsageEmitterError::ModuleNotConfigured` → `UsageEmitterError::NotFound` (built via `ModuleConfigError::not_found()`); `inst-cfg-rem-5a` — `UsageCollectorError::ModuleNotFound(module_name)` (nonexistent variant) → `UsageCollectorError::NotFound` (built via `ModuleConfigError::not_found(module_name)`); `inst-cfg-rem-6a` — clarify that infrastructure failures are surfaced as `UsageCollectorError::Internal` / `ServiceUnavailable` / `DeadlineExceeded` per the canonical taxonomy."
+    - version: "1.5"
+      date: "2026-05-08"
+      changes:
+        - "Replace legacy `UsageCollectorError` variant names with their `CanonicalError` equivalents across §2 Error Scenarios, §2 Steps (`inst-rem-3a / 4a / 6a / 7a / 9a / 10a`), §5 DoD mapping list, §5 Permanent credential rejection, and §6 AC: `Unavailable` → `ServiceUnavailable`; `PluginTimeout` (HTTP timeout) → `DeadlineExceeded`; `PluginTimeout` (HTTP 429) → `ResourceExhausted`; `PluginTimeout` (HTTP 5xx) → `ServiceUnavailable`; `AuthorizationFailed` (HTTP 401) → `ServiceUnavailable`. `UsageCollectorError = CanonicalError` no longer exposes `PluginTimeout` / `AuthorizationFailed` builders. `HandlerResult::Retry` vs `Reject` routing is preserved by `delivery_handler.rs` (`DeadlineExceeded` / `ResourceExhausted` / `ServiceUnavailable` → Retry; everything else → Reject)."
+    - version: "1.4"
+      date: "2026-05-08"
+      changes:
+        - "Ratify AuthN permanent-rejection retry semantics in `inst-rem-4 / 4a`: both transient AuthN failures and permanent credential rejection (`Unauthorized` / `NoPluginAvailable`) map to `Unavailable` and Retry; permanent rejection is NOT auto-dead-lettered — operator recovery via token-acquisition `WARN` logs and retry-rate metrics; §2 Error Scenarios and §5 DoD updated"
+        - "Split 401 (Retry / fresh token) from 403 (Reject / `PermissionDenied`) across DoD mapping list, §2 Error Scenarios, and `inst-rem-11a` — 403 now dead-letters as `PermissionDenied`; `inst-rem-9` (401 retry) unchanged in identity"
+        - "Remove `request_timeout` from §5 Configuration table and from `inst-init-5` — `UsageCollectorRestClientConfig` does not declare it; HTTP client built with `HttpClientConfig::default()`"
+        - "Rename `base_url` → `collector_url` (typed `URL`, required, no default) across §2 / §5 / TLS sub-section / AC; trim-trailing-slash language replaced with explicit path-replacement semantics in `inst-init-5`"
+        - "Flatten `client_id` / `client_secret` / `scopes` rows replaced with nested `oauth.{client_id,client_secret,scopes}` block in §5 Configuration; `inst-init-1` and Data Protection paragraph updated to `oauth.*` field names"
+    - version: "1.3"
+      date: "2026-04-29"
+      changes:
+        - "Document TLS/HTTPS requirements for base_url: add Security sub-section to §5 and AC item for startup behaviour on http:// scheme with non-localhost host (SEC-FDESIGN-004)"
+    - version: "1.2"
+      date: "2026-04-29"
+      changes:
+        - "Document at-least-once delivery idempotency semantics: add duplicate-delivery note to DoD §5 and flow error scenario, add AC item for idempotent upsert on idempotency_key (REL-FDESIGN-003)"
+    - version: "1.1"
+      date: "2026-04-29"
+      changes:
+        - "Add module_name URL percent-encoding requirement to inst-cfg-rem-3 (SEC-FDESIGN-003)"
+    - version: "1.0"
+      date: "2026-04-28"
+      changes:
+        - "Initial feature specification"
+---
+
+# Feature: REST Client & Remote Ingest Delivery
+
+<!-- toc -->
+
+- [1. Feature Context](#1-feature-context)
+  - [1.1 Overview](#11-overview)
+  - [1.2 Purpose](#12-purpose)
+  - [1.3 Actors](#13-actors)
+  - [1.4 References](#14-references)
+- [2. Actor Flows (CDSL)](#2-actor-flows-cdsl)
+  - [Remote Usage Emission Flow](#remote-usage-emission-flow)
+  - [Module Config Retrieval Flow (REST)](#module-config-retrieval-flow-rest)
+- [3. Processes / Business Logic (CDSL)](#3-processes--business-logic-cdsl)
+  - [REST Client Module Initialization](#rest-client-module-initialization)
+- [4. States (CDSL)](#4-states-cdsl)
+- [5. Definitions of Done](#5-definitions-of-done)
+  - [`usage-collector-rest-client` Crate](#usage-collector-rest-client-crate)
+  - [TLS/HTTPS Configuration](#tlshttps-configuration)
+- [6. Acceptance Criteria](#6-acceptance-criteria)
+- [7. Non-Applicability Notes](#7-non-applicability-notes)
+
+<!-- /toc -->
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-featstatus-rest-ingest`
+<!-- STATUS: IMPLEMENTED — all p1 DoD items and all CDSL blocks are [x]. -->
+
+<!-- reference to DECOMPOSITION entry -->
+- [x] `p1` - `cpt-cf-usage-collector-feature-rest-ingest`
+
+## 1. Feature Context
+
+### 1.1 Overview
+
+Enables out-of-process usage sources to emit records using the same `UsageEmitterRuntimeV1` API as in-process sources by providing the `usage-collector-rest-client` crate, which delivers records to the collector gateway over HTTP with service-to-service bearer token authentication.
+
+### 1.2 Purpose
+
+Implements the remote delivery counterpart to Feature 1's in-process delivery path. Out-of-process sources retrieve `dyn UsageEmitterRuntimeV1` from `ClientHub` and drive the same three-layer Runtime / Factory / Emitter chain as in-process sources — `runtime.factory(MODULE_NAME).with_*().authorize(ctx, resource_id, resource_type)?` followed by `usage_record_builder()?.build()?` and `enqueue(record)` / `enqueue_in(db, record)`; only the outbox delivery hop differs — the background pipeline HTTP-POSTs each record to the gateway ingest endpoint instead of calling it in-process. The `usage-collector-rest-client` crate registers `dyn UsageEmitterRuntimeV1` in `ClientHub`, backed by `UsageCollectorRestClient` implementing `UsageCollectorClientV1`.
+
+**Requirements**: `cpt-cf-usage-collector-fr-rest-ingestion`
+
+**NFR targets**: See PRD §NFRs; `cpt-cf-usage-collector-nfr-recovery` constrains `outbox_backoff_max` to below 15 minutes.
+
+**Principles**: `cpt-cf-usage-collector-principle-fail-closed`, `cpt-cf-usage-collector-principle-tenant-from-ctx`
+
+**Constraints**: `cpt-cf-usage-collector-constraint-security-context`, `cpt-cf-usage-collector-constraint-modkit`, `cpt-cf-usage-collector-constraint-outbox-infra`
+
+### 1.3 Actors
+
+**Actors** (defined in PRD.md):
+
+- `cpt-cf-usage-collector-actor-usage-source` — out-of-process usage source emitting records via the REST client
+
+### 1.4 References
+
+- **PRD**: [PRD.md](../PRD.md)
+- **Design**: [DESIGN.md](../DESIGN.md)
+- **DECOMPOSITION**: [DECOMPOSITION.md](../DECOMPOSITION.md)
+- **Dependencies**: `cpt-cf-usage-collector-feature-sdk-and-ingest-core`
+
+## 2. Actor Flows (CDSL)
+
+**Sequences**: `cpt-cf-usage-collector-seq-emit-remote`
+
+### Remote Usage Emission Flow
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-flow-rest-ingest-remote-emit`
+
+**Actor**: `cpt-cf-usage-collector-actor-usage-source` (out-of-process)
+
+**Success Scenarios**:
+- Outbox delivers record to gateway; gateway returns 204 No Content; outbox advances partition cursor
+
+**Error Scenarios**:
+- AuthN resolver unavailable → transient; outbox retries with exponential backoff
+- Client credentials permanently rejected by AuthN resolver (`Unauthorized` / `NoPluginAvailable`) → mapped to `UsageCollectorError::ServiceUnavailable` (same as the transient case); outbox retries indefinitely. The message is **not** auto-dead-lettered — operators detect this via token-acquisition `WARN` logs and retry-rate metrics, then rotate or repair credentials to clear the retry loop
+- Gateway returns 401 (token expired or invalid) → mapped to `UsageCollectorError::ServiceUnavailable`; transient — next attempt acquires a fresh bearer token
+- Gateway returns 429 → mapped to `UsageCollectorError::ResourceExhausted`; transient — outbox retries with exponential backoff
+- Gateway returns 5xx → mapped to `UsageCollectorError::ServiceUnavailable`; transient — outbox retries with exponential backoff
+- Gateway returns 403 Forbidden (gateway PDP denied the forwarder's service identity) → permanent; message moved to dead-letter store as `PermissionDenied`
+- Gateway returns any other 4xx (excluding 401, 403, and 429) → permanent; message moved to dead-letter store as `Internal`
+- Gateway 204 on duplicate delivery (same `idempotency_key`) → idempotent; storage layer performs no-op upsert; outbox advances cursor normally
+
+**Steps**:
+1. [x] - `p1` - Outbox background pipeline calls REST client `UsageCollectorClientV1::create_usage_record(record)` for each ready outbox message - `inst-rem-1`
+2. [x] - `p1` - For each outgoing HTTP request, the shared `BearerTokenAuthLayer` (a `tower::Layer` wired into the REST client's `HttpClient` via `HttpClientBuilder::with_auth_layer(...)`) acquires a bearer token from the platform AuthN resolver via client credentials flow and injects an `Authorization: Bearer <token>` header before the request reaches the network — token acquisition is **not** performed inline in `create_usage_record()`; the REST client method itself only issues `.post(url).json(&record).send()` - `inst-rem-2`
+3. [x] - `p1` - **IF** the layer's call to `AuthNResolverClient::exchange_client_credentials` returns a transient error (service temporarily unreachable, network failure, or any error other than credential rejection) - `inst-rem-3`
+   1. [x] - `p1` - The layer collapses the failure to `HttpError::Transport`; `rest_client.rs` maps the transport error to `UsageCollectorError::ServiceUnavailable`; outbox library applies exponential backoff retry. The layer also emits a `WARN` `tracing` event with the underlying error for operator monitoring - `inst-rem-3a`
+4. [x] - `p1` - **IF** the layer's call to `AuthNResolverClient::exchange_client_credentials` rejects credentials as permanently invalid (`Unauthorized`) OR no AuthN plugin is registered (`NoPluginAvailable`) - `inst-rem-4`
+   1. [x] - `p1` - The layer collapses the failure to `HttpError::Transport` — identical to the transient case in `inst-rem-3a` — and `rest_client.rs` returns `UsageCollectorError::ServiceUnavailable`; outbox library applies exponential backoff retry. Permanent rejection is **NOT** auto-dead-lettered: recovery is operator-driven via the layer's token-acquisition `WARN` log events and retry-rate metrics; operators MUST rotate or repair the configured credentials to clear the retry loop - `inst-rem-4a`
+5. [x] - `p1` - HTTP POST `POST /usage-collector/v1/records` with the serialized `UsageRecord` JSON body — the `Authorization: Bearer <token>` header is injected by the `BearerTokenAuthLayer` per `inst-rem-2`, not by the REST client method; `subject` (`Option<Subject>`) and `metadata` serialize as absent JSON fields when `None` (not as `null`), and when `subject` is `Some` it is emitted as a nested object `"subject": { "id": "...", "type": "..." }` with the inner `type` itself absent when `Subject.r#type` is `None` - `inst-rem-5`
+6. [x] - `p1` - **IF** HTTP request times out - `inst-rem-6`
+   1. [x] - `p1` - **RETURN** `UsageCollectorError::DeadlineExceeded`; outbox retries with exponential backoff; `outbox_backoff_max` MUST be configured below 15 minutes to satisfy `cpt-cf-usage-collector-nfr-recovery` - `inst-rem-6a`
+7. [x] - `p1` - **IF** HTTP transport error (connection refused, DNS failure, TLS error, or other non-timeout network error) - `inst-rem-7`
+   1. [x] - `p1` - **RETURN** `UsageCollectorError::ServiceUnavailable`; outbox retries with exponential backoff - `inst-rem-7a`
+8. [x] - `p1` - **IF** gateway returns 204 No Content - `inst-rem-8`
+   1. [x] - `p1` - **RETURN** `Ok(())`; outbox advances partition cursor — record is confirmed delivered - `inst-rem-8a`
+9. [x] - `p1` - **IF** gateway returns 401 Unauthenticated (token invalid or expired) - `inst-rem-9`
+   1. [x] - `p1` - **RETURN** `UsageCollectorError::ServiceUnavailable`; outbox retries — next attempt acquires a fresh bearer token; no record is lost - `inst-rem-9a`
+10. [x] - `p1` - **IF** gateway returns 429 Too Many Requests or any 5xx - `inst-rem-10`
+    1. [x] - `p1` - **RETURN** `UsageCollectorError::ResourceExhausted` for 429 OR `UsageCollectorError::ServiceUnavailable` for 5xx; outbox retries with exponential backoff in both cases - `inst-rem-10a`
+11. [x] - `p1` - **IF** gateway returns any other 4xx (excluding 401 and 429) - `inst-rem-11`
+    1. [x] - `p1` - **RETURN** `UsageCollectorError::PermissionDenied` for 403 Forbidden (gateway PDP denied the forwarder's service identity) **OR** `UsageCollectorError::Internal` for any remaining 4xx; in both cases outbox moves message to dead-letter store and surfaces via monitoring - `inst-rem-11a`
+
+### Module Config Retrieval Flow (REST)
+
+- [x] `p2` - **ID**: `cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config`
+
+**Actor**: `cpt-cf-usage-collector-actor-usage-source`
+
+**Success Scenarios**:
+- Gateway returns `ModuleConfig` with the static `allowed_metrics` list for the requesting module
+
+**Error Scenarios**:
+- Module not registered in gateway static config → gateway returns 404; REST client returns `UsageCollectorError::NotFound` (built via `ModuleConfigError::not_found()`); the factory's `.authorize()` step surfaces `UsageEmitterError::NotFound`
+- AuthN resolver temporarily unavailable, transport failure, gateway 401, or gateway 5xx → REST client returns `UsageCollectorError::ServiceUnavailable`; the factory's `.authorize()` step propagates it unchanged per `inst-authz-5a`
+- Request deadline exceeded → REST client returns `UsageCollectorError::DeadlineExceeded` (built via `ModuleConfigError::deadline_exceeded()`); propagated unchanged per `inst-authz-5a`
+- Gateway rate-limits the lookup (HTTP 429) → REST client returns `UsageCollectorError::ResourceExhausted` (built via `ModuleConfigError::resource_exhausted()`); propagated unchanged per `inst-authz-5a`
+- Caller is rejected by the gateway (HTTP 403) → REST client returns `UsageCollectorError::PermissionDenied` (built via `ModuleConfigError::permission_denied()`); propagated unchanged per `inst-authz-5a`
+
+**Steps**:
+1. [x] - `p2` - During the factory's `.authorize()` step (phase 1), the emitter calls `UsageCollectorClientV1::get_module_config(module_name)` on the REST client - `inst-cfg-rem-1`
+2. [x] - `p2` - The shared `BearerTokenAuthLayer` (the same Tower layer used by the remote-emit flow) acquires a bearer token from the platform AuthN resolver via client credentials flow and injects an `Authorization: Bearer <token>` header before the request reaches the network — `get_module_config()` itself only issues a plain `.get(url).send()` - `inst-cfg-rem-2`
+3. [x] - `p2` - HTTP GET `GET /usage-collector/v1/modules/{module_name}/config`;
+   the `Authorization: Bearer <token>` header is injected by the
+   `BearerTokenAuthLayer` per `inst-cfg-rem-2`, not by the REST client method;
+   `module_name` MUST be percent-encoded (URL percent-encoding) when
+   interpolated into the URL path - `inst-cfg-rem-3`
+4. [x] - `p2` - **IF** gateway returns 200 OK - `inst-cfg-rem-4`
+   1. [x] - `p2` - Deserialize response body into `ModuleConfig`; **RETURN** `Ok(ModuleConfig { module_name, allowed_metrics })` - `inst-cfg-rem-4a`
+5. [x] - `p2` - **IF** gateway returns 404 Not Found - `inst-cfg-rem-5`
+   1. [x] - `p2` - **RETURN** `UsageCollectorError::NotFound` (built via `ModuleConfigError::not_found(module_name)`); emitter surfaces `UsageEmitterError::NotFound` - `inst-cfg-rem-5a`
+6. [x] - `p2` - **IF** any other error (transport failure, 4xx other than 404, 5xx, timeout) - `inst-cfg-rem-6`
+   1. [x] - `p2` - **RETURN** the matching canonical variant: 401 → `UsageCollectorError::ServiceUnavailable`; 403 → `UsageCollectorError::PermissionDenied` (built via `ModuleConfigError::permission_denied()`); 429 → `UsageCollectorError::ResourceExhausted` (built via `ModuleConfigError::resource_exhausted()`); 5xx → `UsageCollectorError::ServiceUnavailable`; `HttpError::Timeout` / `HttpError::DeadlineExceeded` → `UsageCollectorError::DeadlineExceeded` (built via `ModuleConfigError::deadline_exceeded()`); `HttpError::Transport(_)` (carrying both genuine transport failures and any AuthN-resolver-originated outcomes collapsed by the `BearerTokenAuthLayer`) and any residual non-Transport, non-Timeout `HttpError` variants → `UsageCollectorError::ServiceUnavailable`; any other unexpected HTTP status → `UsageCollectorError::Internal`. The factory's `.authorize()` step propagates the variant unchanged per `inst-authz-5a` so the source module can map a transient gateway outage to HTTP 503 / 504 (or rate-limit to HTTP 429) instead of an opaque 500 - `inst-cfg-rem-6a`
+
+## 3. Processes / Business Logic (CDSL)
+
+### REST Client Module Initialization
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-algo-rest-ingest-module-init`
+
+**Input**: `ModuleCtx` (config, `ClientHub`, DB connection)
+
+**Output**: `dyn UsageEmitterRuntimeV1` registered in `ClientHub`; outbox schema migrations registered via `DatabaseCapability`
+
+**Steps**:
+1. [x] - `p1` - Load and validate `UsageCollectorRestClientConfig` from `ModuleCtx`; required fields `oauth.client_id` and `oauth.client_secret` must be non-empty; fail module startup with descriptive error on missing or invalid config - `inst-init-1`
+2. [x] - `p1` - Acquire DB connection from `ModuleCtx`; fail module startup if DB is not available - `inst-init-2`
+3. [x] - `p1` - Retrieve `AuthNResolverClient` from `ClientHub`; fail module startup if not registered - `inst-init-3`
+4. [x] - `p1` - Retrieve `AuthZResolverClient` from `ClientHub`; fail module startup if not registered - `inst-init-4`
+5. [x] - `p1` - Construct `UsageCollectorRestClient` from config and `AuthNResolverClient`: build a `BearerTokenAuthLayer` from the resolver client and the configured `oauth.*` client credentials, then build `HttpClient` with default `HttpClientConfig` and inject the layer via `HttpClientBuilder::with_auth_layer(|svc| ServiceBuilder::new().layer(layer).service(svc).boxed_clone())` so every outbound request acquires a fresh bearer token and carries an `Authorization` header before reaching the network. Any path component of `collector_url` is replaced by the fixed REST routes (`/usage-collector/v1/records`, `/usage-collector/v1/modules/{module_name}/config`) — only the scheme + host[:port] are honored - `inst-init-5`
+6. [x] - `p1` - Build `UsageEmitterRuntime` (layer 1) via `UsageEmitterRuntime::build(cfg.emitter, db, AuthZResolverClient, UsageCollectorRestClient)` — the runtime owns the source's outbox worker (`OutboxHandle`); the outbox background pipeline will call `create_usage_record()` on the REST client for each delivery attempt - `inst-init-6`
+7. [x] - `p1` - Register `dyn UsageEmitterRuntimeV1` in `ClientHub` — out-of-process sources retrieve the runtime at initialization and drive the three-layer Runtime / Factory / Emitter chain via `runtime.factory(MODULE_NAME).with_*().authorize(ctx, resource_id, resource_type)?` then `usage_record_builder()?.build()? → enqueue(record)` / `enqueue_in(db, record)` - `inst-init-7`
+
+**DatabaseCapability**: `migrations()` returns `modkit_db::outbox::outbox_migrations()` — this module owns the source's local outbox queue; the same schema migration set as the in-process path applies.
+
+## 4. States (CDSL)
+
+Not applicable for this feature. No new entity state machines are introduced by the REST client. `UsageRecord.status` transitions (`active` → `inactive`) remain owned by Feature 8. The outbox message lifecycle is managed by the `modkit-db` outbox library and is not a domain state machine defined here.
+
+## 5. Definitions of Done
+
+### `usage-collector-rest-client` Crate
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-dod-rest-ingest-rest-client-crate`
+
+The system **MUST** implement the `usage-collector-rest-client` crate providing:
+
+- A flat module layout under `src/`: `config.rs` (public `UsageCollectorRestClientConfig`), `module.rs` (the `UsageCollectorRestClientModule`), and `infra/` containing `rest_client.rs` (the `UsageCollectorClientV1` implementation), `bearer_token_auth_layer.rs` (the Tower auth layer described below), plus tests and `test_support.rs`. The crate's public surface is exactly `pub use config::UsageCollectorRestClientConfig;` and `pub use infra::UsageCollectorRestClient;` — no separate `api/rest/` layer or hand-written request/response DTOs are exposed; the client serializes `usage_collector_sdk::models::UsageRecord` directly.
+- `UsageCollectorRestClientModule` implementing `Module::init()`: loads `UsageCollectorRestClientConfig`, acquires `AuthNResolverClient` and `AuthZResolverClient` from `ClientHub`, constructs `UsageCollectorRestClient` (which builds the `BearerTokenAuthLayer` and the configured `HttpClient` internally), builds the layer-1 `UsageEmitterRuntime` via `UsageEmitterRuntime::build(cfg.emitter, db, authorization, collector)` backed by the REST client, and registers `dyn UsageEmitterRuntimeV1` in `ClientHub`. The factory and emitter layers (`UsageEmitterFactory`, `UsageEmitter`) are obtained per-call-site by source modules via `runtime.factory(MODULE_NAME).with_*().authorize(ctx, resource_id, resource_type)?`.
+- `BearerTokenAuthLayer` (a `tower::Layer` defined in `src/infra/bearer_token_auth_layer.rs`) is the single place that performs token acquisition for outbound requests: for each call it invokes `AuthNResolverClient::exchange_client_credentials(&credentials)` with the configured `oauth.*` client credentials, reads the bearer token from the returned `SecurityContext`, and injects a sensitive `Authorization: Bearer <token>` header before the request reaches the network. All AuthN-resolver-originated outcomes — transient resolver failures, permanent credential rejection (`Unauthorized` / `NoPluginAvailable`), and the post-exchange missing-token guard when the returned `SecurityContext` carries no bearer token — are collapsed to `HttpError::Transport(Box<AuthNResolverError>)`; the layer also emits a `WARN` `tracing::warn!` event with the underlying error so operators can detect permanent rejection. In addition, an invalid token byte sequence (token text that cannot form a valid header value) yields `HttpError::InvalidHeaderValue`, which `UsageCollectorRestClient::create_usage_record()` maps to `ServiceUnavailable` via the residual non-Transport, non-Timeout arm. The layer is wired into the shared `HttpClient` via `HttpClientBuilder::with_auth_layer(|svc| ServiceBuilder::new().layer(layer).service(svc).boxed_clone())` in `UsageCollectorRestClient::new(...)`.
+- `UsageCollectorRestClient` implementing `UsageCollectorClientV1::create_usage_record()`: HTTP-POSTs the serialized `UsageRecord` to `POST /usage-collector/v1/records` via the shared `HttpClient` — the `Authorization` header is injected by the `BearerTokenAuthLayer`, so the method body issues a plain `.post(url).json(&record)?.send().await`. Maps `204` to `Ok(())`; maps `401` to `ServiceUnavailable` (triggers Retry — next attempt acquires a fresh bearer token via the layer); maps `403` to `PermissionDenied` (triggers Reject — gateway PDP denied the forwarder's service identity); maps `429` to `ResourceExhausted` (triggers Retry); maps `5xx` to `ServiceUnavailable` (triggers Retry); maps other `4xx` to `Internal` (triggers Reject); maps `HttpError::Timeout` / `HttpError::DeadlineExceeded` to `DeadlineExceeded` (triggers Retry); maps `HttpError::Transport(_)` — which carries **both** genuine transport failures **and** all AuthN resolver errors (transient failures and permanent credential rejection alike, collapsed by the layer) — and any residual non-Transport, non-Timeout `HttpError` variants (`InvalidHeaderValue`, `BodyTooLarge`, `Tls`, …) to `ServiceUnavailable` (triggers Retry). Retry vs Reject routing is performed by `delivery_handler.rs`, which dispatches `DeadlineExceeded` / `ResourceExhausted` / `ServiceUnavailable` to `HandlerResult::Retry` and everything else to `HandlerResult::Reject`.
+- `UsageCollectorRestClient` implementing `UsageCollectorClientV1::get_module_config()`: HTTP-GETs `GET /usage-collector/v1/modules/{module_name}/config` via the shared `HttpClient` — the `Authorization` header is injected by the `BearerTokenAuthLayer`, so the method body issues a plain `.get(url).send().await`; deserializes `200` into `ModuleConfig`; maps `404` to `NotFound` (built via `ModuleConfigError::not_found(module_name)`); maps `401` to `ServiceUnavailable`; maps `403` to `PermissionDenied` (built via `ModuleConfigError::permission_denied()`); maps `429` to `ResourceExhausted` (built via `ModuleConfigError::resource_exhausted()`); maps `5xx` to `ServiceUnavailable`; maps `HttpError::Timeout` / `HttpError::DeadlineExceeded` to `DeadlineExceeded` (built via `ModuleConfigError::deadline_exceeded()`); maps `HttpError::Transport(_)` and any residual non-Transport, non-Timeout `HttpError` variants to `ServiceUnavailable`; maps any other unexpected HTTP status to `Internal`. The factory's `.authorize()` step propagates these variants unchanged per Feature 1 `inst-authz-5a` so the source module can map a transient gateway outage to HTTP 503 / 504 (or rate-limit to HTTP 429) instead of an opaque 500.
+- `DatabaseCapability::migrations()` returning `modkit_db::outbox::outbox_migrations()` — owns the source's local outbox schema.
+
+**Implements**:
+- `cpt-cf-usage-collector-flow-rest-ingest-remote-emit`
+- `cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config`
+- `cpt-cf-usage-collector-algo-rest-ingest-module-init`
+- `cpt-cf-usage-collector-component-rest-client`
+
+**Constraints**: `cpt-cf-usage-collector-constraint-security-context`, `cpt-cf-usage-collector-constraint-modkit`, `cpt-cf-usage-collector-constraint-outbox-infra`
+
+**Touches**:
+- API: `POST /usage-collector/v1/records` (client-side HTTP delivery), `GET /usage-collector/v1/modules/{module_name}/config` (client-side config fetch)
+- DB: outbox queue in source's local DB — same schema as in-process path (`cpt-cf-usage-collector-dbtable-outbox`)
+- Entities: `UsageRecord`, `ModuleConfig`
+
+**Configuration**:
+
+| Parameter | Type | Default | Required | Notes |
+|-----------|------|---------|----------|-------|
+| `collector_url` | URL | — | Yes | Hierarchical URL (scheme + host[:port]); any path component is replaced by the REST client routes |
+| `oauth` | `OAuthConfig` | — | Yes | Nested OAuth2 client-credentials block; see sub-rows below |
+| `oauth.client_id` | string | — | Yes | OAuth2 client identifier |
+| `oauth.client_secret` | secret string | — | Yes | Env-expanded; never logged |
+| `oauth.scopes` | list\<string\> | `[]` | No | OAuth2 scopes; IdP defaults when empty |
+| `emitter` | `UsageEmitterConfig` | defaults | No | Outbox/authorization tuning; `outbox_backoff_max` MUST be below 15 minutes |
+
+**Delivery guarantees**: At-least-once delivery via the source's transactional outbox — identical to the in-process path. A bearer token is acquired on each delivery attempt, so expired tokens trigger retry with a fresh token and do not cause permanent record loss. All records durably committed to the source's local outbox are guaranteed to eventually reach the gateway. At-least-once delivery via the transactional outbox may produce duplicate `create_usage_record()` calls on retry after a network timeout or transient failure. The gateway **MUST** deduplicate repeated deliveries of the same record via idempotent upsert on `idempotency_key`; a second delivery of the same record **MUST** be a no-op at the storage layer.
+
+**Observability**: Structured log events MUST be emitted for: token acquisition failure (`WARN`), delivery retry (`INFO`), dead-letter routing (`ERROR`). Outbox queue depth and delivery attempt count are surfaced via the same metrics as the in-process path. Bearer tokens and client secrets MUST NOT appear in log output.
+
+**Permanent credential rejection**: When the AuthN resolver rejects the configured client credentials as permanently invalid (`Unauthorized`) or no AuthN plugin is registered (`NoPluginAvailable`), the REST client maps the failure to `UsageCollectorError::ServiceUnavailable` — the same mapping as the transient case — and the outbox retries indefinitely. Permanent rejection is **NOT** auto-dead-lettered; recovery is operator-driven. Operators MUST monitor token-acquisition `WARN` log events and retry-rate metrics, then rotate or repair the configured `oauth.client_id` / `oauth.client_secret` to clear the retry loop.
+
+**Data Protection**: Bearer tokens are short-lived credentials managed by the AuthN resolver; this crate holds them only for the duration of a single delivery attempt and does not persist or cache them. `oauth.client_secret` is stored as `SecretString` and is not exposed in logs or error messages.
+
+### TLS/HTTPS Configuration
+
+- [x] `p1` - **ID**: `cpt-cf-dod-rest-ingest-tls-config`
+
+The system **MUST** enforce the following transport security requirements for the `collector_url` configuration field:
+
+- In production environments, `collector_url` **MUST** use the `https://` scheme. An `http://` scheme is permitted only when the host resolves to a localhost or loopback address (`127.0.0.1`, `::1`, or `localhost`) — exclusively for development and testing environments.
+- TLS certificate validation is enforced by the HTTP client by default. Disabling certificate validation or trusting a self-signed certificate **MUST** require an explicit operator opt-in (for example, via a dedicated configuration flag); silent trust-all behaviour is prohibited.
+- The module **MUST** emit a startup warning (`WARN` level) when `collector_url` uses the `http://` scheme with a non-localhost host, or **MUST** refuse to start with a descriptive configuration validation error, consistent with the platform security baseline.
+
+**Implements**:
+- `cpt-cf-usage-collector-dod-rest-ingest-rest-client-crate`
+
+**Constraints**: `cpt-cf-usage-collector-constraint-security-context`
+
+## 6. Acceptance Criteria
+
+- [ ] Out-of-process source retrieves `dyn UsageEmitterRuntimeV1` from `ClientHub` after `usage-collector-rest-client` `init()` completes; the three-layer `runtime.factory(MODULE_NAME).with_*().authorize(ctx, resource_id, resource_type)?` chain and the subsequent `usage_record_builder()?.build()? → enqueue(record)` / `enqueue_in(db, record)` calls behave identically to the in-process path
+- [ ] `BearerTokenAuthLayer` (a `tower::Layer` defined in `src/infra/bearer_token_auth_layer.rs`) is wired into the REST client's `HttpClient` via `HttpClientBuilder::with_auth_layer(...)`; every outbound request to the gateway carries an `Authorization: Bearer <token>` header obtained by the layer's call to `AuthNResolverClient::exchange_client_credentials(&credentials)` — neither `create_usage_record()` nor `get_module_config()` perform token acquisition or header injection inline
+- [ ] The crate's public surface is exactly `pub use config::UsageCollectorRestClientConfig;` and `pub use infra::UsageCollectorRestClient;` — there is no separate `api/rest/` module, no hand-written request/response DTOs, and the client serializes `usage_collector_sdk::models::UsageRecord` directly
+- [ ] Gateway 204 No Content causes `HandlerResult::Success`; outbox partition cursor advances and the outbox row is deleted
+- [ ] Gateway 401 causes retry — next delivery attempt acquires a fresh bearer token; a temporarily expired token does not cause permanent record loss
+- [ ] Gateway 429 causes `HandlerResult::Retry` via `ResourceExhausted`; gateway 5xx causes `HandlerResult::Retry` via `ServiceUnavailable`; outbox applies exponential backoff
+- [ ] Gateway 403 Forbidden causes `HandlerResult::Reject` via `PermissionDenied`; message is moved to dead-letter store
+- [ ] Gateway 4xx (excluding 401, 403, and 429) causes `HandlerResult::Reject` via `Internal`; message is moved to dead-letter store
+- [ ] AuthN resolver transient failure (network error, service restart) causes `HandlerResult::Retry` via `ServiceUnavailable`; records in the source outbox are not lost
+- [ ] AuthN resolver permanent credential rejection (`Unauthorized` / `NoPluginAvailable`) causes `HandlerResult::Retry` via `ServiceUnavailable` — the same mapping as the transient case — and the message is **not** auto-dead-lettered; recovery requires operator intervention via token-acquisition `WARN` logs and retry-rate metrics
+- [ ] HTTP timeout causes `HandlerResult::Retry` via `DeadlineExceeded`; network transport errors cause `HandlerResult::Retry` via `ServiceUnavailable`
+- [ ] `get_module_config()` returns `ModuleConfig` on gateway 200 OK; returns `NotFound` (built via `ModuleConfigError::not_found(module_name)`) on 404; returns `PermissionDenied` (built via `ModuleConfigError::permission_denied()`) on 403; returns `ResourceExhausted` (built via `ModuleConfigError::resource_exhausted()`) on 429; returns `ServiceUnavailable` on 401 and 5xx; returns `DeadlineExceeded` (built via `ModuleConfigError::deadline_exceeded()`) on HTTP timeout; the factory's `.authorize()` step propagates each variant unchanged per Feature 1 `inst-authz-5a`
+- [ ] `DatabaseCapability::migrations()` registers outbox schema migrations; source's local outbox is created on module startup
+- [ ] Missing or invalid `oauth.client_id` / `oauth.client_secret` configuration causes `init()` to fail with a descriptive error; the process does not start
+- [ ] Bearer token and `oauth.client_secret` do not appear in log output or error messages
+- [ ] `create_usage_record()` called twice with the same `idempotency_key` produces gateway 204 on both attempts; the second delivery is a no-op at the storage layer (idempotent upsert on `idempotency_key`)
+- [ ] A `collector_url` configured with an `http://` scheme pointing to a non-localhost host either causes `init()` to fail with a descriptive configuration validation error or emits a `WARN`-level startup warning; this behaviour is documented in the crate README and is consistent with the platform security baseline (SEC-FDESIGN-004)
+
+**Test data requirements**:
+(1) AuthN resolver stub must support transient (`Unavailable`) and permanent (`Unauthorized`, `NoPluginAvailable`) error simulation.
+(2) Gateway HTTP stub must be configurable to return 204, 401, 403, 429, 500, and 404 for `POST /records` and `GET /modules/{name}/config`.
+(3) Integration tests verify the full outbox-to-gateway delivery path with the REST client transport using a gateway stub.
+
+## 7. Non-Applicability Notes
+
+**COMPL (Regulatory & Privacy Compliance)**: Not applicable. The REST client transmits the same opaque UUIDs and numeric values as the in-process path. Bearer tokens are short-lived and not stored. No regulated personal data is introduced by this crate.
+
+**UX (User Experience & Accessibility)**: Not applicable. This feature provides a Rust library crate and a machine-to-machine HTTP client. There is no user-facing UI, no end-user interaction, and no accessibility requirements.
+
+**State Management**: Not applicable. No new entity lifecycle or state machines are introduced. `UsageRecord.status` transitions remain owned by Feature 8 (Operator Operations).

--- a/modules/system/usage-collector/usage-collector-rest-client/Cargo.toml
+++ b/modules/system/usage-collector/usage-collector-rest-client/Cargo.toml
@@ -1,0 +1,81 @@
+[package]
+name = "cyberware-usage-collector-rest-client"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "REST client module for usage-collector"
+readme = "README.md"
+keywords = ["cyberfabric", "cyberware", "cyberware-system"]
+categories = ["development-tools"]
+
+[lib]
+name = "usage_collector_rest_client"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Local dependencies
+authz-resolver-sdk = { workspace = true }
+authn-resolver-sdk = { workspace = true }
+usage-collector-sdk = { workspace = true }
+usage-emitter = { workspace = true }
+
+# ModKit dependencies
+modkit = { workspace = true }
+modkit-db = { workspace = true, features = ["preview-outbox"] }
+modkit-macros = { workspace = true }
+modkit-http = { workspace = true }
+
+# HTTP types
+http = { workspace = true }
+http-body-util = { workspace = true }
+
+# Tower middleware
+tower = { workspace = true, features = ["util"] }
+
+# Async runtime
+async-trait = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Data structures
+chrono = { workspace = true }
+uuid = { workspace = true }
+
+# Secrets
+secrecy = { workspace = true }
+zeroize = { workspace = true }
+
+# URL parsing and encoding
+url = { workspace = true, features = ["serde"] }
+
+# Logging
+tracing = { workspace = true }
+
+# DB
+sea-orm-migration = { workspace = true }
+
+[dev-dependencies]
+# ModKit dependencies
+modkit-security = { workspace = true }
+
+# Async runtime
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+# HTTP mocking
+httpmock = { workspace = true }
+
+# HTTP types
+bytes = { workspace = true }
+
+# Log capture for tests
+tracing-test = { workspace = true, features = ["no-env-filter"] }

--- a/modules/system/usage-collector/usage-collector-rest-client/README.md
+++ b/modules/system/usage-collector/usage-collector-rest-client/README.md
@@ -1,0 +1,45 @@
+# Usage Collector REST Client
+
+> **Separate-binary bridge** — builds a `UsageCollectorRestClient` that forwards `create_usage_record` and `get_module_config` calls to a remote usage-collector REST API, authenticated with a bearer token from `AuthNResolverClient::exchange_client_credentials`.
+
+ModKit module `usage-collector-rest-client`: builds [`UsageCollectorRestClient`](src/infra/rest_client.rs) at init, resolves `dyn AuthNResolverClient` and `dyn AuthZResolverClient` from `ClientHub`, then wires it into `UsageEmitterRuntime` (registered as `dyn UsageEmitterRuntimeV1`). The module also implements `DatabaseCapability` and provides outbox migrations required by `UsageEmitter`.
+
+## Dependencies
+
+- The remote binary must expose the usage-collector REST API at `collector_url`.
+
+## Configuration
+
+`collector_url` and the nested `oauth.client_id` / `oauth.client_secret` are **required** (no defaults). Optional fields:
+
+- `oauth.scopes` — default `[]` (IdP default scopes)
+- `emitter` — nested [`UsageEmitterConfig`](../usage-emitter/src/config.rs); all fields are optional:
+  - `authorization_max_age` — default `30s`
+  - `outbox_queue` — default `"usage-records"`
+  - `outbox_partition_count` — default `4` (must be a power of 2 in 1–64)
+
+HTTP transport tuning is not exposed; the client is built with `HttpClientConfig::default()`.
+
+```yaml
+modules:
+  usage-collector-rest-client:
+    config:
+      # required
+      collector_url: "http://collector.internal:8080"
+      oauth:
+        client_id: "my-service"
+        client_secret: "${MY_SERVICE_SECRET}"
+        # optional
+        scopes: ["usage-collector:write"]
+      # optional
+      emitter:
+        authorization_max_age: "30s"
+        outbox_queue: "usage-records"
+        outbox_partition_count: 4
+```
+
+## Testing
+
+```bash
+cargo test -p cyberware-usage-collector-rest-client
+```

--- a/modules/system/usage-collector/usage-collector-rest-client/src/config.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/src/config.rs
@@ -1,0 +1,133 @@
+//! Configuration for the REST `usage-collector-client` module.
+
+use std::fmt;
+
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+use tracing::warn;
+use url::{Host, Url};
+use usage_emitter::UsageEmitterConfig;
+
+/// `OAuth2` client credentials and scope configuration.
+#[derive(Clone, Deserialize, modkit_macros::ExpandVars)]
+#[serde(deny_unknown_fields)]
+pub struct OAuthConfig {
+    /// `OAuth2` client identifier for s2s authentication.
+    pub client_id: String,
+
+    /// `OAuth2` client secret for s2s authentication.
+    #[expand_vars]
+    pub client_secret: SecretString,
+
+    /// `OAuth2` scopes to request (empty = `IdP` default scopes).
+    #[serde(default)]
+    pub scopes: Vec<String>,
+}
+
+impl fmt::Debug for OAuthConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OAuthConfig")
+            .field("client_id", &"[REDACTED]")
+            .field("client_secret", &"[REDACTED]")
+            .field("scopes", &self.scopes)
+            .finish()
+    }
+}
+
+/// Module configuration.
+#[derive(Clone, Deserialize, modkit_macros::ExpandVars)]
+#[serde(deny_unknown_fields)]
+pub struct UsageCollectorRestClientConfig {
+    /// URL of the usage-collector REST service.
+    pub collector_url: Url,
+
+    /// `OAuth2` credentials and scope configuration.
+    #[expand_vars]
+    pub oauth: OAuthConfig,
+
+    /// Outbox/authorization tuning for the embedded usage emitter.
+    #[serde(default)]
+    pub emitter: UsageEmitterConfig,
+}
+
+impl fmt::Debug for UsageCollectorRestClientConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UsageCollectorRestClientConfig")
+            .field("collector_url", &self.collector_url.as_str())
+            .field("oauth", &self.oauth)
+            .field("emitter", &self.emitter)
+            .finish()
+    }
+}
+
+impl UsageCollectorRestClientConfig {
+    /// Validates the configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `collector_url` is not a hierarchical URL, or if
+    /// `client_id` / `client_secret` are empty or whitespace-only.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.collector_url.cannot_be_a_base() {
+            anyhow::bail!(
+                "collector_url must be a hierarchical URL with a host \
+                 (e.g. https://host:port), got: {}",
+                self.collector_url
+            );
+        }
+        if self.oauth.client_id.trim().is_empty() {
+            anyhow::bail!("client_id must not be empty");
+        }
+        if self.oauth.client_secret.expose_secret().trim().is_empty() {
+            anyhow::bail!("client_secret must not be empty");
+        }
+        // @cpt-dod:cpt-cf-dod-rest-ingest-tls-config:p1
+        // @cpt-begin:cpt-cf-dod-rest-ingest-tls-config:p1:inst-tls-check
+        if is_insecure_non_loopback_http(&self.collector_url) {
+            warn!(
+                %self.collector_url,
+                "collector_url uses http:// with a non-localhost host \u{2014} use https:// in production for secure transport",
+            );
+        }
+        // @cpt-end:cpt-cf-dod-rest-ingest-tls-config:p1:inst-tls-check
+        Ok(())
+    }
+}
+
+/// Returns `true` when `url` uses the `http://` scheme with a host that
+/// is **not** a loopback address.
+///
+/// Loopback hosts recognised here:
+/// - any IPv4 in `127.0.0.0/8` and the IPv6 `::1`
+/// - `localhost` (case-insensitive), with or without a trailing dot
+/// - any subdomain of `localhost` per RFC 6761 § 6.3 (e.g. `foo.localhost`)
+///
+/// This is used by the module initialisation to decide whether to emit a
+/// `WARN`-level log message about insecure transport configuration
+/// (`cpt-cf-dod-rest-ingest-tls-config`).
+fn is_insecure_non_loopback_http(url: &Url) -> bool {
+    if url.scheme() != "http" {
+        return false;
+    }
+    match url.host() {
+        Some(Host::Ipv4(address)) => !address.is_loopback(),
+        Some(Host::Ipv6(address)) => !address.is_loopback(),
+        Some(Host::Domain(domain)) => !is_localhost_domain(domain),
+        None => true,
+    }
+}
+
+/// `true` when `domain` is `localhost` or a subdomain of it, per RFC 6761 § 6.3.
+/// Comparison is case-insensitive and tolerates a single trailing dot (FQDN form).
+fn is_localhost_domain(domain: &str) -> bool {
+    let trimmed = domain.strip_suffix('.').unwrap_or(domain);
+    trimmed.eq_ignore_ascii_case("localhost")
+        || trimmed
+            .rsplit_once('.')
+            .is_some_and(|(_, tld)| tld.eq_ignore_ascii_case("localhost"))
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "config_tests.rs"]
+mod config_tests;

--- a/modules/system/usage-collector/usage-collector-rest-client/src/config_tests.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/src/config_tests.rs
@@ -1,0 +1,286 @@
+use url::Url;
+
+use super::{UsageCollectorRestClientConfig, is_insecure_non_loopback_http};
+
+const CLIENT_ID: &str = "CLIENT_ID";
+const CLIENT_SECRET: &str = "CLIENT_SECRET";
+
+fn valid_cfg_json() -> serde_json::Value {
+    serde_json::json!({
+        "collector_url": "http://127.0.0.1:8080",
+        "oauth": {
+            "client_id": CLIENT_ID,
+            "client_secret": CLIENT_SECRET
+        }
+    })
+}
+
+#[test]
+fn collector_url_is_parsed_as_url() {
+    let json = serde_json::json!({
+        "collector_url": "http://collector:9090",
+        "oauth": {"client_id": CLIENT_ID, "client_secret": CLIENT_SECRET}
+    });
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_value(json).unwrap();
+    assert_eq!(cfg.collector_url.host_str(), Some("collector"));
+    assert_eq!(cfg.collector_url.port(), Some(9090));
+}
+
+#[test]
+fn scopes_default_to_empty() {
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_value(valid_cfg_json()).unwrap();
+    assert!(cfg.oauth.scopes.is_empty());
+}
+
+#[test]
+fn scopes_can_be_set_via_serde() {
+    let json = serde_json::json!({
+        "collector_url": "http://127.0.0.1:8080",
+        "oauth": {
+            "client_id": CLIENT_ID,
+            "client_secret": CLIENT_SECRET,
+            "scopes": ["read:usage", "write:usage"]
+        }
+    });
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_value(json).unwrap();
+    assert_eq!(cfg.oauth.scopes, ["read:usage", "write:usage"]);
+}
+
+#[test]
+fn collector_url_is_required() {
+    let json = serde_json::json!({
+        "oauth": {"client_id": CLIENT_ID, "client_secret": CLIENT_SECRET}
+    });
+    assert!(serde_json::from_value::<UsageCollectorRestClientConfig>(json).is_err());
+}
+
+#[test]
+fn client_id_is_required() {
+    let json = serde_json::json!({
+        "collector_url": "http://127.0.0.1:8080",
+        "oauth": {"client_secret": CLIENT_SECRET}
+    });
+    assert!(serde_json::from_value::<UsageCollectorRestClientConfig>(json).is_err());
+}
+
+#[test]
+fn client_secret_is_required() {
+    let json = serde_json::json!({
+        "collector_url": "http://127.0.0.1:8080",
+        "oauth": {"client_id": CLIENT_ID}
+    });
+    assert!(serde_json::from_value::<UsageCollectorRestClientConfig>(json).is_err());
+}
+
+#[test]
+fn rejects_unknown_fields() {
+    let json = serde_json::json!({
+        "collector_url": "http://127.0.0.1:8080",
+        "oauth": {"client_id": CLIENT_ID, "client_secret": CLIENT_SECRET},
+        "extra": true
+    });
+    assert!(serde_json::from_value::<UsageCollectorRestClientConfig>(json).is_err());
+}
+
+// validate: collector_url checks
+
+#[test]
+fn validate_rejects_non_hierarchical_collector_url() {
+    // "cannot-be-a-base" (opaque) URLs like data: have no host or path hierarchy.
+    let json = serde_json::json!({
+        "collector_url": "data:text/plain,hello",
+        "oauth": {"client_id": CLIENT_ID, "client_secret": CLIENT_SECRET}
+    });
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_value(json).unwrap();
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("hierarchical"),
+        "error must mention hierarchical URL, got: {err}"
+    );
+}
+
+// validate: S2S credential checks
+
+#[test]
+fn validate_rejects_empty_client_id() {
+    let json = serde_json::json!({
+        "collector_url": "http://127.0.0.1:8080",
+        "oauth": {"client_id": "", "client_secret": CLIENT_SECRET}
+    });
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_value(json).unwrap();
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("client_id"),
+        "error must mention client_id, got: {err}"
+    );
+}
+
+#[test]
+fn validate_rejects_whitespace_only_client_id() {
+    let json = serde_json::json!({
+        "collector_url": "http://127.0.0.1:8080",
+        "oauth": {"client_id": "   ", "client_secret": CLIENT_SECRET}
+    });
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_value(json).unwrap();
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("client_id"),
+        "error must mention client_id, got: {err}"
+    );
+}
+
+#[test]
+fn validate_rejects_empty_client_secret() {
+    let json = serde_json::json!({
+        "collector_url": "http://127.0.0.1:8080",
+        "oauth": {"client_id": CLIENT_ID, "client_secret": ""}
+    });
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_value(json).unwrap();
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("client_secret"),
+        "error must mention client_secret, got: {err}"
+    );
+}
+
+#[test]
+fn validate_rejects_whitespace_only_client_secret() {
+    let json = serde_json::json!({
+        "collector_url": "http://127.0.0.1:8080",
+        "oauth": {"client_id": CLIENT_ID, "client_secret": "   "}
+    });
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_value(json).unwrap();
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("client_secret"),
+        "error must mention client_secret, got: {err}"
+    );
+}
+
+#[test]
+fn validate_accepts_valid_credentials() {
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_value(valid_cfg_json()).unwrap();
+    assert!(cfg.validate().is_ok());
+}
+
+#[test]
+fn debug_output_redacts_oauth_credentials() {
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_value(valid_cfg_json()).unwrap();
+    let debug = format!("{cfg:?}");
+    assert!(
+        !debug.contains(CLIENT_ID),
+        "Debug output must not contain client_id value, got: {debug}"
+    );
+    assert!(
+        !debug.contains(CLIENT_SECRET),
+        "Debug output must not contain client_secret value, got: {debug}"
+    );
+    assert!(
+        debug.contains("[REDACTED]"),
+        "Debug output must contain [REDACTED], got: {debug}"
+    );
+}
+
+// cpt-cf-dod-rest-ingest-tls-config: TLS/HTTPS startup check
+//
+// Two-layer coverage:
+//   1. `is_insecure_non_loopback_http_predicate` — table-driven unit check of the
+//      helper itself (one test, one input list).
+//   2. `validate_emits_warn_for_insecure_non_loopback_http` — end-to-end check
+//      that `validate()` actually emits a WARN event for an insecure config.
+//      This is the test the DoD signs off on; the helper-only check would still
+//      pass if `validate()` silently dropped its warning.
+
+#[test]
+fn is_insecure_non_loopback_http_predicate() {
+    // (url, expected_insecure)
+    let cases: &[(&str, bool)] = &[
+        // non-loopback http → insecure
+        ("http://example.com", true),
+        ("http://example.com:8080", true),
+        // loopback hostnames / addresses → not flagged
+        ("http://localhost", false),
+        ("http://localhost:8080", false),
+        ("http://LocalHost:8080", false), // case-insensitive
+        ("http://localhost.", false),     // trailing-dot FQDN
+        ("http://localhost.:8080", false),
+        ("http://foo.localhost", false), // RFC 6761 § 6.3 subdomain
+        ("http://foo.bar.localhost:8080", false),
+        ("http://foo.localhost.", false), // subdomain with trailing dot
+        // names containing "localhost" as a non-tail label are NOT loopback
+        ("http://localhost.example.com", true),
+        ("http://notlocalhost", true),
+        ("http://127.0.0.1:8080", false),
+        ("http://127.0.0.2:8080", false),
+        ("http://127.0.0.255:8080", false),
+        ("http://127.255.255.1:8080", false), // full 127.0.0.0/8 per RFC 1122
+        ("http://[::1]:8080", false),         // IPv6 loopback
+        // non-loopback IPv6 → insecure (pin the `!address.is_loopback()` branch in
+        // the `Host::Ipv6(_)` arm — a regression that hard-coded `false` there
+        // would be caught here).
+        ("http://[2001:db8::1]:8080", true),
+        // https is always allowed
+        ("https://example.com", false),
+        ("https://collector.internal:443", false),
+    ];
+
+    for (raw, expected) in cases {
+        let url = Url::parse(raw).unwrap();
+        assert_eq!(
+            is_insecure_non_loopback_http(&url),
+            *expected,
+            "{raw}: expected insecure={expected}",
+        );
+    }
+}
+
+#[test]
+#[tracing_test::traced_test]
+fn validate_emits_warn_for_insecure_non_loopback_http() {
+    // cpt-cf-dod-rest-ingest-tls-config
+    // Drives the real `validate()` path so a regression that drops the WARN
+    // (or accepts http://example.com silently) is caught.
+    let json = serde_json::json!({
+        "collector_url": "http://example.com",
+        "oauth": {"client_id": CLIENT_ID, "client_secret": CLIENT_SECRET}
+    });
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_value(json).unwrap();
+    cfg.validate()
+        .expect("validate must accept (warn, not fail) http://example.com");
+
+    // tracing-test's `logs_contain` matches a substring across all captured
+    // events for the current test; pin both the URL and the "http://" marker
+    // so an unrelated info/debug line cannot satisfy the assertion alone.
+    assert!(
+        logs_contain("http://example.com"),
+        "validate() must emit a WARN mentioning the insecure collector_url",
+    );
+}
+
+#[test]
+#[tracing_test::traced_test]
+fn validate_does_not_warn_for_https() {
+    let json = serde_json::json!({
+        "collector_url": "https://collector.internal",
+        "oauth": {"client_id": CLIENT_ID, "client_secret": CLIENT_SECRET}
+    });
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_value(json).unwrap();
+    cfg.validate().unwrap();
+
+    assert!(
+        !logs_contain("collector_url uses http://"),
+        "validate() must not warn when the collector_url is https://",
+    );
+}
+
+#[test]
+#[tracing_test::traced_test]
+fn validate_does_not_warn_for_http_loopback() {
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_value(valid_cfg_json()).unwrap();
+    cfg.validate().unwrap();
+
+    assert!(
+        !logs_contain("collector_url uses http://"),
+        "validate() must not warn for the loopback default config",
+    );
+}

--- a/modules/system/usage-collector/usage-collector-rest-client/src/infra/bearer_token_auth_layer.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/src/infra/bearer_token_auth_layer.rs
@@ -1,0 +1,153 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use authn_resolver_sdk::{AuthNResolverClient, AuthNResolverError, ClientCredentialsRequest};
+use http::header::AUTHORIZATION;
+use http::{HeaderValue, Request, Response};
+use modkit_http::HttpError;
+use secrecy::ExposeSecret;
+use tower::{Layer, Service};
+
+#[derive(Clone)]
+pub struct BearerTokenAuthLayer {
+    authn_client: Arc<dyn AuthNResolverClient>,
+    credentials: Arc<ClientCredentialsRequest>,
+}
+
+impl BearerTokenAuthLayer {
+    pub fn new(
+        authn_client: Arc<dyn AuthNResolverClient>,
+        credentials: ClientCredentialsRequest,
+    ) -> Self {
+        Self {
+            authn_client,
+            credentials: Arc::new(credentials),
+        }
+    }
+}
+
+impl<S> Layer<S> for BearerTokenAuthLayer {
+    type Service = BearerTokenAuthService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        BearerTokenAuthService {
+            inner,
+            authn_client: Arc::clone(&self.authn_client),
+            credentials: Arc::clone(&self.credentials),
+        }
+    }
+}
+
+pub struct BearerTokenAuthService<S> {
+    inner: S,
+    authn_client: Arc<dyn AuthNResolverClient>,
+    credentials: Arc<ClientCredentialsRequest>,
+}
+
+impl<S: Clone> Clone for BearerTokenAuthService<S> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            authn_client: Arc::clone(&self.authn_client),
+            credentials: Arc::clone(&self.credentials),
+        }
+    }
+}
+
+impl<S, B, ResBody> Service<Request<B>> for BearerTokenAuthService<S>
+where
+    S: Service<Request<B>, Response = Response<ResBody>, Error = HttpError>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send,
+    B: Send + 'static,
+    ResBody: Send + 'static,
+{
+    type Response = Response<ResBody>;
+    type Error = HttpError;
+    type Future = Pin<Box<dyn Future<Output = Result<Response<ResBody>, HttpError>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<B>) -> Self::Future {
+        let authn_client = Arc::clone(&self.authn_client);
+        let credentials = Arc::clone(&self.credentials);
+
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        Box::pin(async move {
+            // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-2
+            // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-2
+            // Acquire a bearer token via OAuth2 client-credentials before each delivery /
+            // module-config request. Both REST flows share this single Tower layer so the
+            // same code implements step `inst-rem-2` (remote emit) and `inst-cfg-rem-2`
+            // (module-config fetch).
+            let auth_result = authn_client
+                .exchange_client_credentials(&credentials)
+                .await
+                // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-3
+                // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-4
+                // Both transient AuthN failures (`inst-rem-3`) and permanent credential
+                // rejection (`inst-rem-4`: `Unauthorized` / `NoPluginAvailable`) collapse to
+                // `HttpError::Transport`, which the REST client maps to
+                // `UsageCollectorError::ServiceUnavailable` so the outbox retries (the
+                // RETURN actions `inst-rem-3a` / `inst-rem-4a` happen in `rest_client.rs`).
+                // Permanent rejection is **not** auto-dead-lettered; operators recover via
+                // the `WARN` log here plus retry-rate metrics.
+                .map_err(|e| {
+                    // Logged at DEBUG, not WARN: under an IdP outage the outbox can
+                    // burst-drain pending records and would otherwise emit one identical
+                    // WARN per attempt. Operators rely on outbox retry-rate metrics for
+                    // the alerting signal; the per-attempt event stays around as
+                    // correlation context (including the failing `client_id`).
+                    tracing::debug!(
+                        client_id = %credentials.client_id,
+                        error = ?e,
+                        "token acquisition failed",
+                    );
+                    HttpError::Transport(Box::new(e))
+                })?;
+            // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-4
+            // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-3
+
+            let token = auth_result.security_context.bearer_token().ok_or_else(|| {
+                // Symmetric with the `exchange_client_credentials` failure arm above:
+                // both transient outages and this misconfiguration collapse to
+                // `HttpError::Transport` → `ServiceUnavailable` and retry forever at
+                // the outbox. Without a log, the only operator-visible signal is a
+                // retry-rate spike. WARN (not DEBUG) because — unlike a transient IdP
+                // outage — this is a permanent setup error that needs human action,
+                // so the per-attempt amplification under burst-drain is acceptable.
+                tracing::warn!(
+                    client_id = %credentials.client_id,
+                    "client credentials exchange succeeded but SecurityContext has no bearer token",
+                );
+                HttpError::Transport(Box::new(AuthNResolverError::Internal(
+                    "client credentials exchange succeeded but SecurityContext has no bearer token"
+                        .to_owned(),
+                )))
+            })?;
+            // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-2
+            // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-2
+
+            let raw = zeroize::Zeroizing::new(format!("Bearer {}", token.expose_secret()));
+            let mut hv = HeaderValue::from_str(&raw).map_err(HttpError::InvalidHeaderValue)?;
+            hv.set_sensitive(true);
+
+            req.headers_mut().insert(AUTHORIZATION, hv);
+
+            inner.call(req).await
+        })
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "bearer_token_auth_layer_tests.rs"]
+mod bearer_token_auth_layer_tests;

--- a/modules/system/usage-collector/usage-collector-rest-client/src/infra/bearer_token_auth_layer_tests.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/src/infra/bearer_token_auth_layer_tests.rs
@@ -1,0 +1,218 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+
+use authn_resolver_sdk::{AuthNResolverError, ClientCredentialsRequest};
+use bytes::Bytes;
+use http::header::AUTHORIZATION;
+use http::{HeaderValue, Request, Response, StatusCode};
+use http_body_util::Full;
+use modkit_http::HttpError;
+use tower::{Layer, Service};
+
+use super::super::test_support::MockAuthN;
+use super::BearerTokenAuthLayer;
+
+fn make_creds() -> ClientCredentialsRequest {
+    ClientCredentialsRequest {
+        client_id: "test-client".to_owned(),
+        client_secret: "test-secret".to_owned().into(),
+        scopes: vec![],
+    }
+}
+
+#[derive(Clone)]
+struct CapturingService {
+    captured: Arc<Mutex<Option<HeaderValue>>>,
+}
+
+impl Service<Request<Full<Bytes>>> for CapturingService {
+    type Response = Response<Full<Bytes>>;
+    type Error = HttpError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request<Full<Bytes>>) -> Self::Future {
+        let captured = Arc::clone(&self.captured);
+        let hv = req.headers().get(AUTHORIZATION).cloned();
+        Box::pin(async move {
+            *captured.lock().unwrap() = hv;
+            Ok(Response::builder()
+                .status(StatusCode::OK)
+                .body(Full::new(Bytes::new()))
+                .unwrap())
+        })
+    }
+}
+
+#[tokio::test]
+async fn injects_sensitive_authorization_header() {
+    let captured = Arc::new(Mutex::new(None));
+    let inner = CapturingService {
+        captured: Arc::clone(&captured),
+    };
+    let layer = BearerTokenAuthLayer::new(MockAuthN::with_token("test-bearer-token"), make_creds());
+    let mut svc = layer.layer(inner);
+
+    let req = Request::builder()
+        .uri("http://example.com/test")
+        .body(Full::new(Bytes::new()))
+        .unwrap();
+
+    svc.call(req).await.unwrap();
+
+    let hv = captured
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("Authorization header not set");
+    assert_eq!(hv.to_str().unwrap(), "Bearer test-bearer-token");
+    assert!(
+        hv.is_sensitive(),
+        "Authorization header value must be marked sensitive"
+    );
+}
+
+#[tokio::test]
+async fn authn_error_propagates_as_http_transport_error() {
+    let captured = Arc::new(Mutex::new(None));
+    let inner = CapturingService { captured };
+    let layer = BearerTokenAuthLayer::new(MockAuthN::unauthorized(), make_creds());
+    let mut svc = layer.layer(inner);
+
+    let req = Request::builder()
+        .uri("http://example.com/test")
+        .body(Full::new(Bytes::new()))
+        .unwrap();
+
+    let err = svc.call(req).await.unwrap_err();
+    assert!(
+        matches!(err, HttpError::Transport(_)),
+        "expected Transport error, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn authn_error_propagates_and_downcasts_as_auth_n_resolver_error() {
+    let captured = Arc::new(Mutex::new(None));
+    let inner = CapturingService { captured };
+    let layer = BearerTokenAuthLayer::new(MockAuthN::unauthorized(), make_creds());
+    let mut svc = layer.layer(inner);
+
+    let req = Request::builder()
+        .uri("http://example.com/test")
+        .body(Full::new(Bytes::new()))
+        .unwrap();
+
+    let err = svc.call(req).await.unwrap_err();
+    if let HttpError::Transport(boxed) = err {
+        let auth_err = boxed
+            .downcast::<AuthNResolverError>()
+            .expect("should downcast to AuthNResolverError");
+        assert!(
+            matches!(*auth_err, AuthNResolverError::Unauthorized(_)),
+            "expected Unauthorized variant, got: {:?}",
+            *auth_err
+        );
+    } else {
+        panic!("expected Transport error");
+    }
+}
+
+#[tokio::test]
+async fn authn_no_plugin_propagates_as_http_transport_with_no_plugin_variant() {
+    // `AuthNResolverError::NoPluginAvailable` is a permanent misconfiguration
+    // (no AuthN plugin registered), but the layer still wraps it as
+    // `HttpError::Transport` so the REST client's `Transport → ServiceUnavailable`
+    // arm classifies it as transient at the outbox level — operators recover
+    // via the per-attempt DEBUG log plus retry-rate metrics. Pin the downcast
+    // so a future refactor that special-cases `NoPluginAvailable` (e.g. maps it
+    // to a permanent variant) is caught here.
+    let captured = Arc::new(Mutex::new(None));
+    let inner = CapturingService { captured };
+    let layer = BearerTokenAuthLayer::new(MockAuthN::no_plugin(), make_creds());
+    let mut svc = layer.layer(inner);
+
+    let req = Request::builder()
+        .uri("http://example.com/test")
+        .body(Full::new(Bytes::new()))
+        .unwrap();
+
+    let err = svc.call(req).await.unwrap_err();
+    if let HttpError::Transport(boxed) = err {
+        let auth_err = boxed
+            .downcast::<AuthNResolverError>()
+            .expect("should downcast to AuthNResolverError");
+        assert!(
+            matches!(*auth_err, AuthNResolverError::NoPluginAvailable),
+            "expected NoPluginAvailable variant, got: {:?}",
+            *auth_err
+        );
+    } else {
+        panic!("expected Transport error");
+    }
+}
+
+#[tokio::test]
+async fn authn_token_acquisition_failed_propagates_as_http_transport() {
+    // `TokenAcquisitionFailed` covers IdP-side rejection (invalid client creds,
+    // unsupported grant). Same envelope as `Unauthorized` / `NoPluginAvailable`
+    // — Transport-wrapped at the layer, then mapped to ServiceUnavailable by
+    // the REST client. Pin the downcast for regression coverage.
+    let captured = Arc::new(Mutex::new(None));
+    let inner = CapturingService { captured };
+    let layer = BearerTokenAuthLayer::new(MockAuthN::token_acquisition_failed(), make_creds());
+    let mut svc = layer.layer(inner);
+
+    let req = Request::builder()
+        .uri("http://example.com/test")
+        .body(Full::new(Bytes::new()))
+        .unwrap();
+
+    let err = svc.call(req).await.unwrap_err();
+    if let HttpError::Transport(boxed) = err {
+        let auth_err = boxed
+            .downcast::<AuthNResolverError>()
+            .expect("should downcast to AuthNResolverError");
+        assert!(
+            matches!(*auth_err, AuthNResolverError::TokenAcquisitionFailed(_)),
+            "expected TokenAcquisitionFailed variant, got: {:?}",
+            *auth_err
+        );
+    } else {
+        panic!("expected Transport error");
+    }
+}
+
+#[tokio::test]
+async fn missing_bearer_token_returns_transport_error_with_internal_variant() {
+    let captured = Arc::new(Mutex::new(None));
+    let inner = CapturingService { captured };
+    let layer = BearerTokenAuthLayer::new(MockAuthN::without_token(), make_creds());
+    let mut svc = layer.layer(inner);
+
+    let req = Request::builder()
+        .uri("http://example.com/test")
+        .body(Full::new(Bytes::new()))
+        .unwrap();
+
+    let err = svc.call(req).await.unwrap_err();
+    if let HttpError::Transport(boxed) = err {
+        let auth_err = boxed
+            .downcast::<AuthNResolverError>()
+            .expect("should downcast to AuthNResolverError");
+        assert!(
+            matches!(*auth_err, AuthNResolverError::Internal(_)),
+            "expected Internal variant, got: {:?}",
+            *auth_err
+        );
+    } else {
+        panic!("expected Transport error, got: {err:?}");
+    }
+}

--- a/modules/system/usage-collector/usage-collector-rest-client/src/infra/mod.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/src/infra/mod.rs
@@ -1,0 +1,18 @@
+//! Infrastructure adapters (HTTP, external clients).
+//!
+//! `infra` is a private (`mod infra;` in `lib.rs`) implementation detail of the
+//! crate. The `pub` on the submodules and re-exports below is therefore bounded
+//! by `infra`'s own visibility — these types are reachable from siblings
+//! (`module.rs`) and from within `infra`, but not from outside the crate.
+//! Clippy's `redundant_pub_crate` lint enforces plain `pub` rather than
+//! `pub(crate)` in this position.
+
+pub use bearer_token_auth_layer::BearerTokenAuthLayer;
+pub use rest_client::UsageCollectorRestClient;
+
+mod bearer_token_auth_layer;
+mod rest_client;
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+pub mod test_support;

--- a/modules/system/usage-collector/usage-collector-rest-client/src/infra/rest_client.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/src/infra/rest_client.rs
@@ -1,0 +1,395 @@
+//! REST client wiring and [`usage_collector_sdk::UsageCollectorClientV1`] implementation.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use authn_resolver_sdk::{AuthNResolverClient, ClientCredentialsRequest};
+use http::StatusCode;
+use http_body_util::BodyExt;
+use modkit_http::{
+    HttpClient, HttpClientBuilder, HttpClientConfig, HttpError, HttpResponse, InvalidUriKind,
+};
+use tower::ServiceExt;
+use tracing::debug;
+use url::Url;
+use usage_collector_sdk::models::UsageRecord;
+use usage_collector_sdk::{
+    ModuleConfig, ModuleConfigError, UsageCollectorClientV1, UsageCollectorError, UsageRecordError,
+};
+
+use crate::config::UsageCollectorRestClientConfig;
+use crate::infra::BearerTokenAuthLayer;
+
+// @cpt-dod:cpt-cf-usage-collector-dod-rest-ingest-rest-client-crate:p1
+/// REST-backed [`usage_collector_sdk::UsageCollectorClientV1`].
+///
+/// The configured `collector_url` is treated as a **base URL** whose path is
+/// preserved as a prefix; the API segments (`usage-collector/v1/...`) are
+/// appended to it. So `https://gw.example.com/usage/` resolves records to
+/// `https://gw.example.com/usage/usage-collector/v1/records`.
+pub struct UsageCollectorRestClient {
+    records_url: Url,
+    modules_prefix: Url,
+    http_client: HttpClient,
+}
+
+impl UsageCollectorRestClient {
+    /// Build a client from module config and the shared `AuthN` resolver.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP client cannot be constructed, or if
+    /// `collector_url` is not hierarchical (caught earlier by
+    /// [`UsageCollectorRestClientConfig::validate`]).
+    pub fn new(
+        cfg: &UsageCollectorRestClientConfig,
+        authn_client: Arc<dyn AuthNResolverClient>,
+    ) -> Result<Self, modkit_http::HttpError> {
+        let credentials = ClientCredentialsRequest {
+            client_id: cfg.oauth.client_id.clone(),
+            client_secret: cfg.oauth.client_secret.clone(),
+            scopes: cfg.oauth.scopes.clone(),
+        };
+        let layer = BearerTokenAuthLayer::new(authn_client, credentials);
+        let http_client = HttpClientBuilder::with_config(HttpClientConfig::default())
+            .with_auth_layer(move |svc| {
+                tower::ServiceBuilder::new()
+                    .layer(layer)
+                    .service(svc)
+                    .boxed_clone()
+            })
+            .build()?;
+
+        let records_url = build_url(&cfg.collector_url, &["usage-collector", "v1", "records"])?;
+        let modules_prefix = build_url(&cfg.collector_url, &["usage-collector", "v1", "modules"])?;
+
+        Ok(Self {
+            records_url,
+            modules_prefix,
+            http_client,
+        })
+    }
+}
+
+/// Appends `segments` to `base`'s path, preserving any existing prefix.
+///
+/// A trailing empty segment in `base` (e.g. `https://host/prefix/`) is removed
+/// before appending so the result is `https://host/prefix/<seg1>/<seg2>/...`
+/// rather than `https://host/prefix//<seg1>/...`.
+///
+/// Returns [`HttpError::InvalidUri`] (kind [`InvalidUriKind::ParseError`]) if
+/// `base` is a `cannot_be_a_base` URL (e.g. `data:`), so the caller can
+/// propagate a structured error without re-encoding diagnostic strings.
+fn build_url(base: &Url, segments: &[&str]) -> Result<Url, HttpError> {
+    let mut url = base.clone();
+    {
+        let mut path = url
+            .path_segments_mut()
+            .map_err(|()| HttpError::InvalidUri {
+                url: base.to_string(),
+                kind: InvalidUriKind::ParseError,
+                reason: "collector_url cannot be a base".to_owned(),
+            })?;
+        path.pop_if_empty().extend(segments);
+    }
+    Ok(url)
+}
+
+// @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-6
+/// Maps a transport-layer [`HttpError`] to a [`UsageCollectorError`].
+///
+/// Shared by both [`UsageCollectorClientV1::create_usage_record`] and
+/// [`UsageCollectorClientV1::get_module_config`] so the classification stays
+/// in lockstep when new [`HttpError`] variants are added. The `deadline`
+/// closure is the only call-site-specific behaviour: it builds the
+/// `DeadlineExceeded` from the resource-scoped error type
+/// ([`UsageRecordError`] for the records flow, [`ModuleConfigError`] for the
+/// config flow), preserving the canonical resource type in the GTS prefix.
+fn map_transport_err(
+    e: HttpError,
+    deadline: impl FnOnce(&str) -> UsageCollectorError,
+) -> UsageCollectorError {
+    match e {
+        // `BearerTokenAuthLayer` wraps every AuthN resolver failure (transient or
+        // permanent credential rejection) as `HttpError::Transport`, so this arm
+        // returns the `ServiceUnavailable` mapping for `inst-rem-3a`/`inst-rem-4a`.
+        // Genuine HTTP transport errors (connection refused, DNS failure, TLS
+        // failure, …) flow through the same arm and satisfy `inst-rem-7a`.
+        HttpError::Transport(_)
+        | HttpError::Tls(_)
+        | HttpError::Overloaded
+        | HttpError::ServiceClosed => UsageCollectorError::service_unavailable()
+            .with_detail(format!("REST request failed: {e}"))
+            .create(),
+        // Timeout variants map to DeadlineExceeded to keep the circuit-breaker
+        // semantics intact across both endpoints.
+        HttpError::Timeout(_) | HttpError::DeadlineExceeded(_) => {
+            deadline("HTTP request deadline exceeded")
+        }
+        // Permanent client-side / encoding bugs (BodyTooLarge, InvalidHeaderValue,
+        // InvalidUri, Json, FormEncode, …) would fail the same way on every
+        // retry. Map to `Internal` so the outbox dead-letters instead of looping
+        // forever on a poison record.
+        other => UsageCollectorError::internal(format!("REST request failed: {other}")).create(),
+    }
+}
+// @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-6
+
+/// Maps a non-success HTTP `status` from the usage collector to a
+/// [`UsageCollectorError`].
+///
+/// Shared by both [`UsageCollectorClientV1::create_usage_record`] and
+/// [`UsageCollectorClientV1::get_module_config`] so the classification of the
+/// status codes both endpoints handle identically (401, 5xx, catch-all) stays
+/// in lockstep when new codes (e.g. 503 Retry-After, 408 Request Timeout) need
+/// special handling. The `permission_denied` and `resource_exhausted` closures
+/// build the resource-scoped variants from [`UsageRecordError`] /
+/// [`ModuleConfigError`] so the canonical resource type stays in the GTS prefix.
+///
+/// Per-endpoint status codes that diverge from this map (e.g. 422 →
+/// `InvalidArgument` for records) must be handled by the caller *before*
+/// invoking this helper.
+fn map_status_err(
+    status: StatusCode,
+    body: &str,
+    permission_denied: impl FnOnce(String) -> UsageCollectorError,
+    resource_exhausted: impl FnOnce(String) -> UsageCollectorError,
+) -> UsageCollectorError {
+    match status {
+        // 401 is transient: the bearer token may have expired between acquisition
+        // and the request reaching the gateway. The next delivery attempt acquires
+        // a fresh token.
+        StatusCode::UNAUTHORIZED => UsageCollectorError::service_unavailable()
+            .with_detail(format!(
+                "usage collector rejected request with HTTP {}: {body}",
+                StatusCode::UNAUTHORIZED
+            ))
+            .create(),
+        // 403 is permanent: the gateway PDP denied the forwarder's service identity.
+        StatusCode::FORBIDDEN => permission_denied(format!(
+            "usage collector rejected request with HTTP {}: {body}",
+            StatusCode::FORBIDDEN
+        )),
+        // 429 and 5xx are transient — mapped to ResourceExhausted/ServiceUnavailable
+        // to trigger retry at the outbox level.
+        StatusCode::TOO_MANY_REQUESTS => {
+            resource_exhausted(format!("rate limit exceeded by usage collector: {body}"))
+        }
+        s if s.is_server_error() => UsageCollectorError::service_unavailable()
+            .with_detail(format!("usage collector returned HTTP {s}: {body}"))
+            .create(),
+        // Residual 4xx / unexpected statuses are permanent — dead-letter via Internal.
+        status => UsageCollectorError::internal(format!(
+            "unexpected HTTP status from usage collector: {status}: {body}"
+        ))
+        .create(),
+    }
+}
+
+#[async_trait]
+impl UsageCollectorClientV1 for UsageCollectorRestClient {
+    // @cpt-flow:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1
+    async fn create_usage_record(&self, record: UsageRecord) -> Result<(), UsageCollectorError> {
+        // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-1
+        // inst-dlv-4: called from DeliveryHandler::handle — see delivery_handler.rs
+
+        // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-5
+        let response = self
+            .http_client
+            .post(self.records_url.as_str())
+            .json(&record)
+            .map_err(|e| {
+                UsageCollectorError::internal(format!("failed to serialize usage record: {e}"))
+                    .create()
+            })?
+            .send()
+            .await
+            // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-3a
+            // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-4a
+            // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-7a
+            // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-7
+            // Transport / TLS / overload / service-closed → ServiceUnavailable (retry).
+            // Timeout / DeadlineExceeded → UsageRecordError::deadline_exceeded (retry).
+            // Everything else (encoding bugs, oversized bodies) → Internal (dead-letter).
+            // Implementation is shared with `get_module_config` via `map_transport_err`.
+            .map_err(|e| {
+                map_transport_err(e, |msg| UsageRecordError::deadline_exceeded(msg).create())
+            })?;
+        // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-7
+        // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-7a
+        // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-4a
+        // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-3a
+
+        match response.status() {
+            // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-8
+            StatusCode::NO_CONTENT => Ok(()),
+            // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-8
+            status => {
+                let body = truncated_response_body(response).await;
+                match status {
+                    // inst-dlv-7: 422 specifically signals validation failure on the submitted
+                    // record; surface it as `InvalidArgument` so operators triaging see the
+                    // semantic class rather than a generic Internal. Endpoint-specific —
+                    // the rest of the status map is shared via `map_status_err`.
+                    // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-11
+                    StatusCode::UNPROCESSABLE_ENTITY => Err(UsageRecordError::invalid_argument()
+                        .with_constraint(format!(
+                            "usage collector rejected record with HTTP {}: {body}",
+                            StatusCode::UNPROCESSABLE_ENTITY
+                        ))
+                        .create()),
+                    // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-11
+                    // 401/403/429/5xx/catch-all are mapped via the shared helper. Trace markers:
+                    //   inst-rem-9  → 401   (transient ServiceUnavailable)
+                    //   inst-rem-11 → 403   (permanent PermissionDenied via UsageRecordError)
+                    //               + catch-all 4xx (permanent Internal — the `inst-rem-11a` half)
+                    //   inst-rem-10 → 429 + 5xx (transient — retry at outbox)
+                    // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-9
+                    // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-10
+                    // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-11
+                    status => Err(map_status_err(
+                        status,
+                        &body,
+                        |reason| {
+                            UsageRecordError::permission_denied()
+                                .with_reason(reason)
+                                .create()
+                        },
+                        |quota| {
+                            UsageRecordError::resource_exhausted(
+                                "usage collector rejected request: rate limit exceeded",
+                            )
+                            .with_quota_violation("requests", quota)
+                            .create()
+                        },
+                    )),
+                    // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-11
+                    // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-10
+                    // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-9
+                }
+            }
+        }
+        // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-5
+        // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-1
+    }
+
+    // @cpt-flow:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2
+    async fn get_module_config(
+        &self,
+        module_name: &str,
+    ) -> Result<ModuleConfig, UsageCollectorError> {
+        // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-1
+
+        // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-3
+        let mut url = self.modules_prefix.clone();
+        url.path_segments_mut()
+            .map_err(|()| {
+                UsageCollectorError::internal("collector_url is not a hierarchical URL").create()
+            })?
+            .extend([module_name, "config"]);
+        // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-3
+
+        let response = self
+            .http_client
+            .get(url.as_str())
+            .send()
+            .await
+            // Mapping is shared with `create_usage_record` via `map_transport_err`;
+            // only the deadline factory differs (resource-scoped `ModuleConfigError`).
+            .map_err(|e| {
+                map_transport_err(e, |msg| ModuleConfigError::deadline_exceeded(msg).create())
+            })?;
+
+        match response.status() {
+            // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-4
+            StatusCode::OK => response.json::<ModuleConfig>().await.map_err(|e| {
+                UsageCollectorError::internal(format!(
+                    "failed to parse module config response: {e}"
+                ))
+                .create()
+            }),
+            // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-4
+            // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-5
+            StatusCode::NOT_FOUND => Err(ModuleConfigError::not_found(format!(
+                "module '{module_name}' is not configured"
+            ))
+            .with_resource(module_name)
+            .create()),
+            // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-5
+            // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-6
+            status => {
+                let body = truncated_response_body(response).await;
+                // 401/403/429/5xx/catch-all are mapped via the shared helper so the
+                // classification stays in lockstep with `create_usage_record`.
+                Err(map_status_err(
+                    status,
+                    &body,
+                    |reason| {
+                        ModuleConfigError::permission_denied()
+                            .with_reason(reason)
+                            .create()
+                    },
+                    |quota| {
+                        ModuleConfigError::resource_exhausted(
+                            "usage collector rejected request: rate limit exceeded",
+                        )
+                        .with_quota_violation("requests", quota)
+                        .create()
+                    },
+                ))
+            } // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-6
+        }
+        // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-1
+    }
+}
+
+/// Reads up to 4 KiB of an error response body for diagnostics, then stops.
+///
+/// Buffering the full body — even when only the first 4 KiB is ever surfaced
+/// in the error message — would let a hostile or misbehaving collector pin
+/// arbitrarily large allocations on every 4xx/5xx (which is on the retry hot
+/// path). Instead we walk the body frame-by-frame, copy at most `MAX` bytes
+/// into the diagnostic buffer, and drop the rest by tearing down the response.
+///
+/// The collected bytes are truncated on a valid UTF-8 boundary before
+/// conversion so the resulting string never carries a partial codepoint or
+/// a `U+FFFD` replacement injected mid-sequence.
+async fn truncated_response_body(response: HttpResponse) -> String {
+    const MAX: usize = 4_096;
+    let mut body = std::pin::pin!(response.into_body());
+    let mut collected: Vec<u8> = Vec::with_capacity(MAX);
+    while collected.len() < MAX {
+        match body.frame().await {
+            Some(Ok(frame)) => {
+                if let Some(chunk) = frame.data_ref() {
+                    let remaining = MAX - collected.len();
+                    let take = chunk.len().min(remaining);
+                    collected.extend_from_slice(&chunk[..take]);
+                }
+            }
+            Some(Err(e)) => {
+                debug!(error = ?e, "failed to read usage collector response body for diagnostics");
+                return format!("<body unreadable: {e}>");
+            }
+            None => break,
+        }
+    }
+    // Trim trailing bytes that fall inside an incomplete UTF-8 codepoint so the
+    // resulting String never carries a partial sequence or a synthesised
+    // `U+FFFD` replacement codepoint from `from_utf8_lossy`.
+    match std::str::from_utf8(&collected) {
+        Ok(s) => s.to_owned(),
+        Err(e) => {
+            let valid_up_to = e.valid_up_to();
+            // `valid_up_to()` returns the prefix length that is guaranteed-valid
+            // UTF-8; converting that slice with `from_utf8_lossy` is therefore
+            // allocation-only (no replacement codepoints).
+            String::from_utf8_lossy(&collected[..valid_up_to]).into_owned()
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "rest_client_tests.rs"]
+mod rest_client_tests;

--- a/modules/system/usage-collector/usage-collector-rest-client/src/infra/rest_client_tests.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/src/infra/rest_client_tests.rs
@@ -1,0 +1,800 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use authn_resolver_sdk::AuthNResolverClient;
+use http::StatusCode;
+use httpmock::prelude::*;
+use modkit_http::{HttpError, InvalidUriKind};
+use serde_json::json;
+use usage_collector_sdk::models::{Subject, UsageKind, UsageRecord};
+use usage_collector_sdk::{
+    ModuleConfig, ModuleConfigError, UsageCollectorClientV1, UsageCollectorError, UsageRecordError,
+};
+use uuid::Uuid;
+
+use super::super::test_support::{MockAuthN, test_cfg, test_record};
+use super::{UsageCollectorRestClient, map_transport_err};
+
+// --- Integration tests with mock HTTP server ---
+
+fn make_client(base_url: &str, authn: Arc<dyn AuthNResolverClient>) -> UsageCollectorRestClient {
+    UsageCollectorRestClient::new(&test_cfg(base_url), authn).unwrap()
+}
+
+#[tokio::test]
+async fn new_returns_invalid_uri_for_opaque_collector_url() {
+    // `cannot_be_a_base()` URLs (e.g. `data:`) parse as a valid `Url` but cannot
+    // host path segments. `UsageCollectorRestClient::new` must surface that as
+    // `HttpError::InvalidUri` rather than panicking. This path is not reachable
+    // through the normal config flow because `validate()` rejects it earlier,
+    // but `new()` does not require `validate()` to have run.
+    let cfg = test_cfg("data:text/plain,x");
+    let Err(err) = UsageCollectorRestClient::new(&cfg, MockAuthN::with_token("tok")) else {
+        panic!("expected HttpError::InvalidUri, got Ok(...)");
+    };
+    let HttpError::InvalidUri { url, kind, .. } = err else {
+        panic!("expected HttpError::InvalidUri, got: {err:?}");
+    };
+    assert_eq!(url, "data:text/plain,x");
+    assert!(matches!(kind, InvalidUriKind::ParseError));
+}
+
+#[tokio::test]
+async fn create_usage_record_success_on_204() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(204);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    assert!(client.create_usage_record(test_record()).await.is_ok());
+    mock.assert();
+}
+
+#[tokio::test]
+async fn create_usage_record_sends_bearer_token_header() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/usage-collector/v1/records")
+            .header("authorization", "Bearer my-token");
+        then.status(204);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("my-token"));
+    client.create_usage_record(test_record()).await.unwrap();
+    mock.assert();
+}
+
+// Two representative AuthN-failure cases — a permanent rejection
+// (`Unauthorized`) and a transient one (`ServiceUnavailable`). Both must
+// collapse to `ServiceUnavailable` at the REST boundary so the outbox retries,
+// and the Display must preserve the underlying AuthN cause for diagnostics.
+// The remaining AuthN error variants (NoPlugin / TokenAcquisitionFailed /
+// without_token) are covered by `bearer_token_auth_layer_tests` where each
+// variant's Transport wrapping is asserted distinctly.
+
+#[tokio::test]
+async fn create_usage_record_authn_unauthorized_returns_service_unavailable() {
+    let server = MockServer::start();
+    let client = make_client(&server.base_url(), MockAuthN::unauthorized());
+
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageCollectorError::ServiceUnavailable { .. }
+    ));
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unauthorized") && msg.contains("bad credentials"),
+        "Display must preserve the AuthN cause, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn create_usage_record_authn_service_unavailable_returns_service_unavailable() {
+    // ServiceUnavailable is transient: the identity service is temporarily unreachable.
+    let server = MockServer::start();
+    let client = make_client(&server.base_url(), MockAuthN::service_unavailable());
+
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageCollectorError::ServiceUnavailable { .. }
+    ));
+    let msg = err.to_string();
+    assert!(
+        msg.contains("service unavailable")
+            && msg.contains("identity service temporarily unreachable"),
+        "Display must preserve the AuthN cause, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn create_usage_record_server_401_returns_service_unavailable() {
+    // 401 is transient — expired token; next attempt acquires a fresh bearer token (inst-rem-9)
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(401).body("token-expired-marker");
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageCollectorError::ServiceUnavailable { .. }
+    ));
+    let msg = err.to_string();
+    assert!(
+        msg.contains("401") && msg.contains("token-expired-marker"),
+        "Display must include the HTTP status and a marker from the response body, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn create_usage_record_server_403_returns_permission_denied() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(403).body("forbidden-marker");
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    // The PDP-denial reason must capture the upstream body so operators can see
+    // which policy fired; a regression that drops the reason text would still
+    // satisfy a bare `matches!` check on the variant.
+    let UsageCollectorError::PermissionDenied { ctx, .. } = &err else {
+        panic!("expected PermissionDenied, got: {err:?}");
+    };
+    assert!(
+        ctx.reason.contains("403") && ctx.reason.contains("forbidden-marker"),
+        "PermissionDenied reason must include the HTTP status and a marker from the response body, got: {}",
+        ctx.reason
+    );
+}
+
+#[tokio::test]
+async fn create_usage_record_server_429_returns_resource_exhausted() {
+    // 429 is transient — delivery handler will Retry (inst-dlv-6)
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(429).body("quota-exceeded-marker");
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    let UsageCollectorError::ResourceExhausted { ctx, .. } = &err else {
+        panic!("expected ResourceExhausted, got: {err:?}");
+    };
+    // The quota_violation payload must capture the body so operators can see
+    // which limit was hit — a regression that drops it would leave only the
+    // hard-coded "rate limit exceeded" string with no actionable detail.
+    assert_eq!(ctx.violations.len(), 1);
+    assert_eq!(ctx.violations[0].subject, "requests");
+    assert!(
+        ctx.violations[0]
+            .description
+            .contains("quota-exceeded-marker"),
+        "quota violation description must contain a marker from the response body, got: {}",
+        ctx.violations[0].description
+    );
+}
+
+#[tokio::test]
+async fn create_usage_record_server_500_returns_service_unavailable() {
+    // 500 is transient — delivery handler will Retry (inst-dlv-6)
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(500).body("server-error-marker");
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageCollectorError::ServiceUnavailable { .. }
+    ));
+    let msg = err.to_string();
+    assert!(
+        msg.contains("500") && msg.contains("server-error-marker"),
+        "Display must include the HTTP status and a marker from the response body, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn create_usage_record_server_500_with_large_non_ascii_body_is_truncated_safely() {
+    // 4-byte UTF-8 codepoint ("🦀"), repeated to comfortably exceed 4 KiB.
+    const CRAB: &str = "\u{1F980}";
+
+    // The error path reads up to 4 KiB of the response body for diagnostics
+    // and must truncate on a UTF-8 char boundary so the resulting String
+    // never panics or contains invalid UTF-8. Non-ASCII characters (here:
+    // 4-byte emoji) ensure the byte boundary at MAX=4096 falls inside a
+    // multi-byte sequence on at least one of them.
+    let server = MockServer::start();
+    let large_body: String = CRAB.repeat(2_000); // 2000 * 4 = 8000 bytes
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(500).body(&large_body);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    let UsageCollectorError::ServiceUnavailable { detail, .. } = &err else {
+        panic!("expected ServiceUnavailable, got: {err:?}");
+    };
+
+    // The detail string contains a fixed prefix ("usage collector returned HTTP 500: ")
+    // followed by the truncated body. Pin the body portion to the 4 KiB cap rather
+    // than the original 8 000-byte upper bound, which gave the truncation a 2x slack
+    // it never needed.
+    let prefix = format!(
+        "usage collector returned HTTP {}: ",
+        StatusCode::from_u16(500).unwrap()
+    );
+    let body_part = detail.strip_prefix(&prefix).unwrap_or_else(|| {
+        panic!("detail must start with the HTTP-status prefix {prefix:?}, got: {detail:?}")
+    });
+    assert!(
+        body_part.len() <= 4_096,
+        "body portion must be <= 4 KiB cap, got {} bytes",
+        body_part.len()
+    );
+    // The truncation must respect UTF-8 char boundaries: the body portion
+    // must consist of whole crab emojis only, with at least one present.
+    assert!(
+        body_part.contains(CRAB),
+        "truncated body must still contain at least one full crab codepoint"
+    );
+    assert!(
+        body_part.chars().all(|c| c.to_string() == CRAB),
+        "truncated body must not contain partial or replacement codepoints"
+    );
+}
+
+#[tokio::test]
+async fn create_usage_record_server_422_returns_invalid_argument() {
+    // 422 specifically signals schema/validation failure of the submitted
+    // record — semantically distinct from "Internal" (which is what the
+    // generic 4xx catch-all returns). Operators triaging a stuck record
+    // benefit from the explicit InvalidArgument class.
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(422).body("unprocessable-marker");
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    let UsageCollectorError::InvalidArgument { ctx, .. } = &err else {
+        panic!("expected InvalidArgument, got: {err:?}");
+    };
+    let serialized = serde_json::to_string(ctx).unwrap();
+    assert!(
+        serialized.contains("422") && serialized.contains("unprocessable-marker"),
+        "InvalidArgument context must include the HTTP status and a marker from the response body, got: {serialized}",
+    );
+}
+
+#[tokio::test]
+async fn create_usage_record_server_400_returns_internal() {
+    // Unexpected 4xx is permanent
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(400).body("bad-request-marker");
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    // Internal errors deliberately hide their detail from Display (the canonical
+    // envelope serves a redacted message to clients). The original status and
+    // body live in `ctx.description`, which operators see via tracing.
+    let UsageCollectorError::Internal { ctx, .. } = &err else {
+        panic!("expected Internal, got: {err:?}");
+    };
+    assert!(
+        ctx.description.contains("400") && ctx.description.contains("bad-request-marker"),
+        "Internal description must include the HTTP status and a marker from the response body, got: {}",
+        ctx.description
+    );
+}
+
+#[tokio::test]
+async fn create_usage_record_base_url_trailing_slash_root_path_is_used() {
+    // With no path prefix, a trailing slash on collector_url must not produce
+    // a doubled '/' or an extra empty segment — the request should still hit
+    // exactly `/usage-collector/v1/records` at the origin root.
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(204);
+    });
+
+    let url_with_slash = format!("{}/", server.base_url());
+    let client = make_client(&url_with_slash, MockAuthN::with_token("tok"));
+    assert!(client.create_usage_record(test_record()).await.is_ok());
+    mock.assert();
+}
+
+#[tokio::test]
+async fn create_usage_record_preserves_collector_url_path_prefix() {
+    // Operators may configure a collector URL that already includes a path
+    // prefix (e.g. behind an ingress at https://gw/usage/). The API segments
+    // must be appended to that prefix rather than wiping it.
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/usage/usage-collector/v1/records");
+        then.status(204);
+    });
+
+    let url_with_prefix = format!("{}/usage/", server.base_url());
+    let client = make_client(&url_with_prefix, MockAuthN::with_token("tok"));
+    assert!(client.create_usage_record(test_record()).await.is_ok());
+    mock.assert();
+}
+
+#[tokio::test]
+async fn get_module_config_preserves_collector_url_path_prefix() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage/usage-collector/v1/modules/mod-x/config");
+        then.status(200)
+            .json_body(json!({"allowed_metrics": [], "max_metadata_bytes": 0}));
+    });
+
+    let url_with_prefix = format!("{}/usage/", server.base_url());
+    let client = make_client(&url_with_prefix, MockAuthN::with_token("tok"));
+    client.get_module_config("mod-x").await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn create_usage_record_sends_subject_fields_when_present() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/usage-collector/v1/records")
+            .body_includes("\"subject\"")
+            .body_includes("\"type\":\"test.subject\"");
+        then.status(204);
+    });
+
+    let record = UsageRecord {
+        subject: Some(Subject::with_type(Uuid::nil(), "test.subject")),
+        ..test_record()
+    };
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    client.create_usage_record(record).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn create_usage_record_omits_subject_fields_when_absent() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/usage-collector/v1/records")
+            .body_excludes("\"subject\"");
+        then.status(204);
+    });
+
+    let record = UsageRecord {
+        subject: None,
+        ..test_record()
+    };
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    client.create_usage_record(record).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn get_module_config_success() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/my-module/config");
+        then.status(200)
+            .json_body(json!({"allowed_metrics": [], "max_metadata_bytes": 0}));
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let cfg = client.get_module_config("my-module").await.unwrap();
+    assert!(cfg.allowed_metrics.is_empty());
+    mock.assert();
+}
+
+#[tokio::test]
+async fn get_module_config_sends_bearer_token_header() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/mod-x/config")
+            .header("authorization", "Bearer cfg-token");
+        then.status(200)
+            .json_body(json!({"allowed_metrics": [], "max_metadata_bytes": 0}));
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("cfg-token"));
+    client.get_module_config("mod-x").await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn get_module_config_server_401_returns_service_unavailable() {
+    // 401 is transient — expired token; next attempt acquires a fresh bearer token (inst-rem-9)
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/mod-x/config");
+        then.status(401).body("cfg-token-expired-marker");
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.get_module_config("mod-x").await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageCollectorError::ServiceUnavailable { .. }
+    ));
+    let msg = err.to_string();
+    assert!(
+        msg.contains("401") && msg.contains("cfg-token-expired-marker"),
+        "Display must include the HTTP status and a marker from the response body, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn get_module_config_server_404_returns_not_found() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/unknown-mod/config");
+        then.status(404);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.get_module_config("unknown-mod").await.unwrap_err();
+    // The queried module_name must surface on the NotFound variant — both as
+    // `resource_name` (consumed by the canonical-error envelope) and in
+    // `detail` (operator diagnostics). A regression that loses either would
+    // still satisfy a bare `matches!` check on the variant.
+    let UsageCollectorError::NotFound {
+        detail,
+        resource_name,
+        ..
+    } = &err
+    else {
+        panic!("expected NotFound, got: {err:?}");
+    };
+    assert_eq!(
+        resource_name.as_deref(),
+        Some("unknown-mod"),
+        "NotFound resource_name must echo the queried module_name"
+    );
+    assert!(
+        detail.contains("unknown-mod"),
+        "NotFound detail must reference the queried module_name, got: {detail}"
+    );
+}
+
+#[tokio::test]
+async fn get_module_config_server_403_returns_permission_denied() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/mod-x/config");
+        then.status(403).body("cfg-forbidden-marker");
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.get_module_config("mod-x").await.unwrap_err();
+    // Symmetric with the records-path 403 test: the PDP-denial reason must
+    // carry the upstream body so operators can see which policy fired.
+    let UsageCollectorError::PermissionDenied { ctx, .. } = &err else {
+        panic!("expected PermissionDenied, got: {err:?}");
+    };
+    assert!(
+        ctx.reason.contains("403") && ctx.reason.contains("cfg-forbidden-marker"),
+        "PermissionDenied reason must include the HTTP status and a marker from the response body, got: {}",
+        ctx.reason
+    );
+}
+
+#[tokio::test]
+async fn get_module_config_server_429_returns_resource_exhausted() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/mod-x/config");
+        then.status(429).body("cfg-quota-exceeded-marker");
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.get_module_config("mod-x").await.unwrap_err();
+    let UsageCollectorError::ResourceExhausted { ctx, .. } = &err else {
+        panic!("expected ResourceExhausted, got: {err:?}");
+    };
+    assert_eq!(ctx.violations.len(), 1);
+    assert_eq!(ctx.violations[0].subject, "requests");
+    assert!(
+        ctx.violations[0]
+            .description
+            .contains("cfg-quota-exceeded-marker"),
+        "quota violation description must contain a marker from the response body, got: {}",
+        ctx.violations[0].description
+    );
+}
+
+#[tokio::test]
+async fn get_module_config_server_500_returns_service_unavailable() {
+    // 500 from the config endpoint is transient
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/mod-x/config");
+        then.status(500).body("cfg-server-error-marker");
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.get_module_config("mod-x").await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageCollectorError::ServiceUnavailable { .. }
+    ));
+    let msg = err.to_string();
+    assert!(
+        msg.contains("500") && msg.contains("cfg-server-error-marker"),
+        "Display must include the HTTP status and a marker from the response body, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn get_module_config_server_400_returns_internal() {
+    // Unexpected 4xx is permanent
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/mod-x/config");
+        then.status(400).body("cfg-bad-request-marker");
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.get_module_config("mod-x").await.unwrap_err();
+    // See create_usage_record_server_400_returns_internal — Internal hides
+    // the detail from Display; the marker lives in `ctx.description`.
+    let UsageCollectorError::Internal { ctx, .. } = &err else {
+        panic!("expected Internal, got: {err:?}");
+    };
+    assert!(
+        ctx.description.contains("400") && ctx.description.contains("cfg-bad-request-marker"),
+        "Internal description must include the HTTP status and a marker from the response body, got: {}",
+        ctx.description
+    );
+}
+
+#[tokio::test]
+async fn get_module_config_invalid_json_response_returns_internal() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/mod-x/config");
+        then.status(200).body("not-json");
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.get_module_config("mod-x").await.unwrap_err();
+    // The interesting behavior is that the JSON parse error is preserved in
+    // `ctx.description` for diagnostics — a regression that mapped parse errors
+    // to a generic empty `Internal` would still satisfy a bare `matches!` check.
+    let UsageCollectorError::Internal { ctx, .. } = &err else {
+        panic!("expected Internal, got: {err:?}");
+    };
+    assert!(
+        ctx.description
+            .contains("failed to parse module config response"),
+        "Internal description must include the parse-error marker, got: {}",
+        ctx.description
+    );
+}
+
+#[tokio::test]
+async fn get_module_config_returns_allowed_metrics() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/my-mod/config");
+        then.status(200).json_body(json!({
+            "allowed_metrics": [
+                {"name": "cpu.usage", "kind": "gauge"},
+                {"name": "req.count", "kind": "counter"}
+            ],
+            "max_metadata_bytes": 0
+        }));
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let ModuleConfig {
+        allowed_metrics,
+        max_metadata_bytes: _,
+    } = client.get_module_config("my-mod").await.unwrap();
+    assert_eq!(allowed_metrics.len(), 2);
+    assert_eq!(allowed_metrics[0].name, "cpu.usage");
+    assert_eq!(allowed_metrics[0].kind, UsageKind::Gauge);
+    assert_eq!(allowed_metrics[1].name, "req.count");
+    assert_eq!(allowed_metrics[1].kind, UsageKind::Counter);
+}
+
+// inst-cfg-rem-3: percent-encoding of module_name in get_module_config URL path
+
+#[tokio::test]
+async fn get_module_config_percent_encodes_slash_in_module_name() {
+    // inst-cfg-rem-3
+    // A module_name containing a '/' MUST be percent-encoded in the URL path
+    // segment so the raw '/' does not appear unencoded, and the server receives
+    // the encoded form '%2F' rather than an extra path separator.
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/my%2Fmodule/config");
+        then.status(200)
+            .json_body(json!({"allowed_metrics": [], "max_metadata_bytes": 0}));
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let result = client.get_module_config("my/module").await;
+    assert!(
+        result.is_ok(),
+        "expected Ok but got Err: {result:?} — the mock server only matches '%2F', \
+         so a failure here means the slash was not percent-encoded"
+    );
+    mock.assert();
+}
+
+#[tokio::test]
+async fn get_module_config_percent_encodes_space_in_module_name() {
+    // inst-cfg-rem-3
+    // A module_name containing a space MUST be percent-encoded ('%20') in the
+    // URL path segment.
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/my%20module/config");
+        then.status(200)
+            .json_body(json!({"allowed_metrics": [], "max_metadata_bytes": 0}));
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let result = client.get_module_config("my module").await;
+    assert!(
+        result.is_ok(),
+        "expected Ok but got Err: {result:?} — the mock only matches '%20', \
+         so a failure means the space was not percent-encoded"
+    );
+    mock.assert();
+}
+
+// Two representative AuthN-failure cases on the module-config path.
+// See the create_usage_record_authn_* tests for rationale; the remaining
+// AuthN variants are covered by `bearer_token_auth_layer_tests`.
+
+#[tokio::test]
+async fn get_module_config_authn_unauthorized_returns_service_unavailable() {
+    let server = MockServer::start();
+    let client = make_client(&server.base_url(), MockAuthN::unauthorized());
+
+    let err = client.get_module_config("mod-x").await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageCollectorError::ServiceUnavailable { .. }
+    ));
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unauthorized") && msg.contains("bad credentials"),
+        "Display must preserve the AuthN cause, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn get_module_config_authn_service_unavailable_returns_service_unavailable() {
+    // ServiceUnavailable is transient: the identity service is temporarily unreachable.
+    let server = MockServer::start();
+    let client = make_client(&server.base_url(), MockAuthN::service_unavailable());
+
+    let err = client.get_module_config("mod-x").await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageCollectorError::ServiceUnavailable { .. }
+    ));
+    let msg = err.to_string();
+    assert!(
+        msg.contains("service unavailable")
+            && msg.contains("identity service temporarily unreachable"),
+        "Display must preserve the AuthN cause, got: {msg}"
+    );
+}
+
+// --- Unit tests for the transport-error → UsageCollectorError mapping helper ---
+//
+// The transport-error classifier is shared between `create_usage_record` and
+// `get_module_config`, so the production code path that materialises e.g. a
+// `HttpError::Timeout` from the underlying tower stack is the same — the only
+// per-endpoint difference is the resource-scoped `deadline_exceeded` factory.
+// Driving the helper directly with synthesised `HttpError` values is far more
+// reliable than racing a real-clock timeout through `httpmock`, and keeps the
+// load-bearing `inst-rem-6` arm covered against accidental regressions.
+
+#[test]
+fn map_transport_err_timeout_uses_records_deadline_factory() {
+    // inst-rem-6: Timeout must classify as DeadlineExceeded so the delivery
+    // handler retries instead of dead-lettering on a transient stall.
+    let err = map_transport_err(HttpError::Timeout(Duration::from_millis(50)), |msg| {
+        UsageRecordError::deadline_exceeded(msg).create()
+    });
+    let UsageCollectorError::DeadlineExceeded { resource_type, .. } = &err else {
+        panic!("expected UsageCollectorError::DeadlineExceeded, got: {err:?}");
+    };
+    // Resource type comes from `UsageRecordError`'s GTS prefix, anchoring the
+    // mapping to the records endpoint rather than the modules endpoint.
+    let rt = resource_type
+        .as_deref()
+        .expect("resource-scoped DeadlineExceeded must carry a resource_type");
+    assert!(
+        rt.contains("usage.record"),
+        "DeadlineExceeded must be scoped to the usage-record resource type, got: {rt}"
+    );
+}
+
+#[test]
+fn map_transport_err_deadline_exceeded_uses_records_deadline_factory() {
+    // The total-deadline variant (across all retries) must funnel through the
+    // same factory as a per-attempt Timeout — otherwise a circuit breaker that
+    // matches on `UsageCollectorError::DeadlineExceeded` would silently miss
+    // exhausted-deadline failures on the records path.
+    let err = map_transport_err(
+        HttpError::DeadlineExceeded(Duration::from_millis(50)),
+        |msg| UsageRecordError::deadline_exceeded(msg).create(),
+    );
+    assert!(
+        matches!(err, UsageCollectorError::DeadlineExceeded { .. }),
+        "expected DeadlineExceeded, got: {err:?}"
+    );
+}
+
+#[test]
+fn map_transport_err_timeout_uses_module_config_deadline_factory() {
+    // Symmetric to the records-path test above: the config endpoint must
+    // surface its own resource-scoped DeadlineExceeded so operators triaging
+    // a stuck config fetch see the module_config resource type rather than
+    // usage.record.
+    let err = map_transport_err(HttpError::Timeout(Duration::from_millis(50)), |msg| {
+        ModuleConfigError::deadline_exceeded(msg).create()
+    });
+    let UsageCollectorError::DeadlineExceeded { resource_type, .. } = &err else {
+        panic!("expected UsageCollectorError::DeadlineExceeded, got: {err:?}");
+    };
+    let rt = resource_type
+        .as_deref()
+        .expect("resource-scoped DeadlineExceeded must carry a resource_type");
+    assert!(
+        rt.contains("module_config"),
+        "DeadlineExceeded must be scoped to the module_config resource type, got: {rt}"
+    );
+}
+
+#[test]
+fn map_transport_err_deadline_exceeded_uses_module_config_deadline_factory() {
+    let err = map_transport_err(
+        HttpError::DeadlineExceeded(Duration::from_millis(50)),
+        |msg| ModuleConfigError::deadline_exceeded(msg).create(),
+    );
+    assert!(
+        matches!(err, UsageCollectorError::DeadlineExceeded { .. }),
+        "expected DeadlineExceeded, got: {err:?}"
+    );
+}

--- a/modules/system/usage-collector/usage-collector-rest-client/src/infra/test_support.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/src/infra/test_support.rs
@@ -1,0 +1,145 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, dead_code)]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use authn_resolver_sdk::{
+    AuthNResolverClient, AuthNResolverError, AuthenticationResult, ClientCredentialsRequest,
+};
+use chrono::Utc;
+use modkit_security::SecurityContext;
+use serde_json::json;
+use usage_collector_sdk::models::{Subject, UsageKind, UsageRecord};
+use uuid::Uuid;
+
+use crate::config::UsageCollectorRestClientConfig;
+
+pub enum AuthNOutcome {
+    WithToken(String),
+    WithoutToken,
+    Unauthorized,
+    NoPlugin,
+    TokenAcquisitionFailed,
+    ServiceUnavailable,
+}
+
+pub struct MockAuthN {
+    outcome: AuthNOutcome,
+}
+
+impl MockAuthN {
+    pub fn with_token(token: impl Into<String>) -> Arc<Self> {
+        Arc::new(Self {
+            outcome: AuthNOutcome::WithToken(token.into()),
+        })
+    }
+
+    pub fn without_token() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: AuthNOutcome::WithoutToken,
+        })
+    }
+
+    pub fn unauthorized() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: AuthNOutcome::Unauthorized,
+        })
+    }
+
+    pub fn no_plugin() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: AuthNOutcome::NoPlugin,
+        })
+    }
+
+    pub fn token_acquisition_failed() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: AuthNOutcome::TokenAcquisitionFailed,
+        })
+    }
+
+    pub fn service_unavailable() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: AuthNOutcome::ServiceUnavailable,
+        })
+    }
+}
+
+#[async_trait]
+impl AuthNResolverClient for MockAuthN {
+    async fn authenticate(
+        &self,
+        _bearer_token: &str,
+    ) -> Result<AuthenticationResult, AuthNResolverError> {
+        panic!(
+            "MockAuthN::authenticate not supported in these tests; use exchange_client_credentials"
+        )
+    }
+
+    async fn exchange_client_credentials(
+        &self,
+        _request: &ClientCredentialsRequest,
+    ) -> Result<AuthenticationResult, AuthNResolverError> {
+        let nil = Uuid::nil();
+        match &self.outcome {
+            AuthNOutcome::WithToken(token) => {
+                let ctx = SecurityContext::builder()
+                    .subject_id(nil)
+                    .subject_tenant_id(nil)
+                    .bearer_token(token.clone())
+                    .build()
+                    .unwrap();
+                Ok(AuthenticationResult {
+                    security_context: ctx,
+                })
+            }
+            AuthNOutcome::WithoutToken => {
+                let ctx = SecurityContext::builder()
+                    .subject_id(nil)
+                    .subject_tenant_id(nil)
+                    .build()
+                    .unwrap();
+                Ok(AuthenticationResult {
+                    security_context: ctx,
+                })
+            }
+            AuthNOutcome::Unauthorized => Err(AuthNResolverError::Unauthorized(
+                "bad credentials".to_owned(),
+            )),
+            AuthNOutcome::NoPlugin => Err(AuthNResolverError::NoPluginAvailable),
+            AuthNOutcome::TokenAcquisitionFailed => Err(
+                AuthNResolverError::TokenAcquisitionFailed("invalid client credentials".to_owned()),
+            ),
+            AuthNOutcome::ServiceUnavailable => Err(AuthNResolverError::ServiceUnavailable(
+                "identity service temporarily unreachable".to_owned(),
+            )),
+        }
+    }
+}
+
+pub fn test_cfg(collector_url: &str) -> UsageCollectorRestClientConfig {
+    serde_json::from_value(json!({
+        "collector_url": collector_url,
+        "oauth": {
+            "client_id": "test-client",
+            "client_secret": "test-secret"
+        }
+    }))
+    .unwrap()
+}
+
+pub fn test_record() -> UsageRecord {
+    UsageRecord {
+        module: "test-module".to_owned(),
+        tenant_id: Uuid::nil(),
+        resource_type: "vm".to_owned(),
+        resource_id: Uuid::nil(),
+        subject: Some(Subject::with_type(Uuid::nil(), "test.subject")),
+        metric: "cpu.usage".to_owned(),
+        kind: UsageKind::Gauge,
+        idempotency_key: "idem-1".to_owned(),
+        value: 1.5,
+        timestamp: Utc::now(),
+        metadata: None,
+    }
+}

--- a/modules/system/usage-collector/usage-collector-rest-client/src/lib.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/src/lib.rs
@@ -1,0 +1,30 @@
+//! `usage-collector-rest-client` crate
+//!
+//! Provides [`UsageCollectorRestClientModule`] — a `ModKit` module that satisfies
+//! the `"usage-collector-client"` dependency when usage is emitted from a **separate**
+//! `CyberFabric` binary that must reach the collector over **HTTP/REST** (Scenario C).
+//!
+//! Each `create_usage_record` exchanges `OAuth2` client credentials via [`AuthNResolverClient`],
+//! reads the bearer token from the returned [`SecurityContext`], and POSTs the record
+//! to `POST {collector_url}/usage-collector/v1/records`.
+//!
+//! ## Configuration
+//!
+//! `collector_url` and `oauth` are required. `scopes` within `oauth` is optional.
+//!
+//! ```yaml
+//! modules:
+//!   usage-collector-rest-client:
+//!     config:
+//!       collector_url: "http://127.0.0.1:8080"
+//!       oauth:
+//!         client_id: "my-client"
+//!         client_secret: "${CLIENT_SECRET}"
+//!         scopes: []
+//! ```
+
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+mod config;
+mod infra;
+mod module;

--- a/modules/system/usage-collector/usage-collector-rest-client/src/module.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/src/module.rs
@@ -1,0 +1,101 @@
+//! `usage-collector-rest-client` `ModKit` module.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use authn_resolver_sdk::AuthNResolverClient;
+use authz_resolver_sdk::AuthZResolverClient;
+use modkit::contracts::DatabaseCapability;
+use modkit::{Module, ModuleCtx};
+use sea_orm_migration::MigrationTrait;
+use tracing::info;
+use usage_emitter::{UsageEmitterRuntime, UsageEmitterRuntimeV1};
+
+use crate::config::UsageCollectorRestClientConfig;
+use crate::infra::UsageCollectorRestClient;
+
+/// Satisfies the `"usage-collector-client"` `ModKit` dependency for separate binaries
+/// by sending usage records to a remote collector REST API with s2s bearer auth.
+#[modkit::module(
+    name = "usage-collector-rest-client",
+    deps = ["authn-resolver", "authz-resolver"],
+    capabilities = [db],
+)]
+#[derive(Default)]
+struct UsageCollectorRestClientModule;
+
+#[async_trait]
+impl Module for UsageCollectorRestClientModule {
+    // @cpt-algo:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1
+    async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-1
+        let cfg: UsageCollectorRestClientConfig = ctx.config_expanded()?;
+        cfg.validate()?;
+        info!(?cfg, "Loaded {} configuration", Self::MODULE_NAME,);
+        // @cpt-end:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-1
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-2
+        let db = ctx
+            .db_required()
+            .map_err(|e| anyhow::anyhow!("{}: db not available: {e}", Self::MODULE_NAME))?
+            .db();
+        // @cpt-end:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-2
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-3
+        let authentication = ctx
+            .client_hub()
+            .get::<dyn AuthNResolverClient>()
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "{}: AuthNResolverClient not registered: {e}",
+                    Self::MODULE_NAME
+                )
+            })?;
+        // @cpt-end:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-3
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-4
+        let authorization = ctx
+            .client_hub()
+            .get::<dyn AuthZResolverClient>()
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "{}: AuthZResolverClient not registered: {e}",
+                    Self::MODULE_NAME
+                )
+            })?;
+        // @cpt-end:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-4
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-5
+        let collector = UsageCollectorRestClient::new(&cfg, authentication).map_err(|e| {
+            anyhow::anyhow!("{}: failed to build HTTP client: {e}", Self::MODULE_NAME)
+        })?;
+        let collector = Arc::new(collector);
+        // @cpt-end:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-5
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-6
+        let runtime = UsageEmitterRuntime::build(cfg.emitter, db, authorization, collector)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "{}: failed to build usage emitter runtime: {e}",
+                    Self::MODULE_NAME
+                )
+            })?;
+        let runtime = Arc::new(runtime);
+        // @cpt-end:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-6
+        // @cpt-begin:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-7
+        ctx.client_hub()
+            .register::<dyn UsageEmitterRuntimeV1>(runtime);
+        // @cpt-end:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-7
+
+        Ok(())
+    }
+}
+
+// @cpt-dod:cpt-cf-usage-collector-dod-rest-ingest-rest-client-crate:p1
+impl DatabaseCapability for UsageCollectorRestClientModule {
+    fn migrations(&self) -> Vec<Box<dyn MigrationTrait>> {
+        info!("Providing {} database migrations", Self::MODULE_NAME);
+        modkit_db::outbox::outbox_migrations()
+    }
+}


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#1919](https://github.com/cyberfabric/cyberware-rust/pull/1919) | **Author:** capybutler | **Opened:** 2026-05-16T07:06:53Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

- Adds `cf-usage-collector-rest-client` crate: a ModKit module for out-of-process
  binaries that must deliver usage records to a remote collector gateway over HTTP
  instead of in-process.
- `UsageCollectorRestClientModule::init()` loads config, acquires `AuthNResolverClient`
  and `AuthZResolverClient` from `ClientHub`, builds `UsageCollectorRestClient`
  with a configured `HttpClient`, wires it into `UsageEmitter`, and registers
  `UsageEmitterV1` — identical surface API to the in-process path.
- `UsageCollectorRestClient` implements `UsageCollectorClientV1`:
  - `create_usage_record`: acquires a fresh bearer token per attempt, POSTs to
    `POST /usage-collector/v1/records`; maps `204→Ok`, `401/403→AuthorizationFailed`,
    `429/5xx→PluginTimeout` (Retry), other `4xx→Internal` (Reject),
    timeouts→`PluginTimeout`, transport errors→`Unavailable`.
  - `get_module_config`: GETs `GET /usage-collector/v1/modules/{module_name}/config`
    with percent-encoded module name; maps `200→ModuleConfig`, `404→ModuleNotFound`.
  - AuthN errors: `Unauthorized/NoPluginAvailable` → permanent reject;
    all others → transient retry.
- `DatabaseCapability::migrations()` returns `outbox_migrations()` — the module owns
  the source's local outbox queue.
- TLS check: startup WARN when `base_url` uses `http://` with a non-localhost host
  (cpt-cf-dod-rest-ingest-tls-config).
- Adds feature design document `0002-cpt-cf-usage-collector-feature-rest-ingest` (v1.3)
  covering actor flows, business logic, DoD, and acceptance criteria.

## PR Train
| # | PR | Description | Lines |
|---|---|------------|------:|
| 1 | [1907](https://github.com/constructorfabric/cyberfabric-core/issues/1907) | Feature 1 (Core SDK, Emitter & In-Process Ingest): SDK + docs | ~2500 |
| 2 | [1908](https://github.com/constructorfabric/cyberfabric-core/issues/1908) | Feature 1 (Core SDK, Emitter & In-Process Ingest): `usage-collector` gateway + `usage-emitter` + `noop-usage-collector-storage-plugin` | ~8000 |
| 3 | [1919 (**this**)](https://github.com/constructorfabric/cyberfabric-core/issues/1919) | Feature 2 (REST Client & Remote Ingest Delivery) | ~2800 |
| 4 | [1926](https://github.com/constructorfabric/cyberfabric-core/issues/1926) | Feature 3 (Query API) | ~6000 |
| 5 | [1927](https://github.com/constructorfabric/cyberfabric-core/issues/1927) | Feature 4 (TimescaleDB plugin) | ~7700 |
| 6 | [1835](https://github.com/constructorfabric/cyberfabric-core/issues/1835) | e2e tests | ~1500 |
|   |  | ... to be continued ... | |


## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No linting errors (`cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::perf`)
- [x] Code is properly formatted (`cargo fmt`)
- [x] `cpt validate` — all checks passed
- [x] Tests pass (`cargo nextest run --workspace`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added REST client module for remote usage collection with OAuth2 bearer token authentication and configurable request timeouts.
  * Implemented TLS/HTTPS security validation for production deployments.

* **Documentation**
  * Added feature specification and configuration guide for the REST-based usage collector module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#1919 -->