### PR TITLE
[PR #1908] feat(usage-collector): [2/6] add emitter, gateway, REST client, and noop storage plugin crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,6 +2663,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cyberware-noop-usage-collector-plugin"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "cyberware-modkit",
+ "cyberware-modkit-macros",
+ "cyberware-modkit-security",
+ "cyberware-types-registry-sdk",
+ "cyberware-usage-collector-sdk",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "cyberware-oagw"
 version = "0.2.25"
 dependencies = [
@@ -3075,6 +3094,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cyberware-usage-collector"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "chrono",
+ "cyberware-authz-resolver-sdk",
+ "cyberware-modkit",
+ "cyberware-modkit-canonical-errors",
+ "cyberware-modkit-db",
+ "cyberware-modkit-macros",
+ "cyberware-modkit-odata",
+ "cyberware-modkit-security",
+ "cyberware-modkit-utils",
+ "cyberware-types-registry-sdk",
+ "cyberware-usage-collector-sdk",
+ "cyberware-usage-emitter",
+ "http",
+ "parking_lot",
+ "sea-orm-migration",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tracing",
+ "utoipa",
+ "uuid",
+]
+
+[[package]]
 name = "cyberware-usage-collector-sdk"
 version = "0.1.0"
 dependencies = [
@@ -3091,6 +3143,26 @@ dependencies = [
  "serde_json",
  "tokio",
  "utoipa",
+ "uuid",
+]
+
+[[package]]
+name = "cyberware-usage-emitter"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "cyberware-authz-resolver-sdk",
+ "cyberware-modkit-canonical-errors",
+ "cyberware-modkit-db",
+ "cyberware-modkit-security",
+ "cyberware-usage-collector-sdk",
+ "sea-orm-migration",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,10 @@ members = [
     "modules/system/oagw/oagw-sdk",
     "modules/mini-chat/mini-chat-sdk",
     "modules/mini-chat/mini-chat",
+    "modules/system/usage-collector/plugins/noop-usage-collector-plugin",
+    "modules/system/usage-collector/usage-collector",
     "modules/system/usage-collector/usage-collector-sdk",
+    "modules/system/usage-collector/usage-emitter",
 ]
 exclude = ["tools/fuzz"]
 resolver = "3"
@@ -257,7 +260,9 @@ credstore-sdk = { package = "cyberware-credstore-sdk", version = "0.1.24", path 
 mini-chat-sdk = { package = "cyberware-mini-chat-sdk", version = "0.10.6", path = "modules/mini-chat/mini-chat-sdk" }
 
 # usage-collector
+usage-collector = { package = "cyberware-usage-collector", version = "0.1.0", path = "modules/system/usage-collector/usage-collector" }
 usage-collector-sdk = { package = "cyberware-usage-collector-sdk", version = "0.1.0", path = "modules/system/usage-collector/usage-collector-sdk" }
+usage-emitter = { package = "cyberware-usage-emitter", version = "0.1.0", path = "modules/system/usage-collector/usage-emitter" }
 
 # system modules
 grpc_hub = { package = "cyberware-grpc-hub", version = "0.2.6", path = "modules/system/grpc-hub" }

--- a/modules/system/usage-collector/plugins/noop-usage-collector-plugin/Cargo.toml
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-plugin/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "cyberware-noop-usage-collector-plugin"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "No-op usage-collector plugin for development and testing"
+readme = "README.md"
+keywords = ["cyberfabric", "cyberware", "cyberware-system"]
+categories = ["development-tools"]
+
+[lib]
+name = "noop_usage_collector_plugin"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Local dependencies
+types-registry-sdk = { workspace = true }
+usage-collector-sdk = { workspace = true }
+
+# ModKit dependencies
+modkit = { workspace = true }
+modkit-macros = { workspace = true }
+
+# Async runtime
+async-trait = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+[dev-dependencies]
+# ModKit dependencies
+modkit-security = { workspace = true }
+
+# Data structures
+chrono = { workspace = true }
+uuid = { workspace = true }
+
+# Async runtime
+tokio = { workspace = true }

--- a/modules/system/usage-collector/plugins/noop-usage-collector-plugin/README.md
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-plugin/README.md
@@ -1,0 +1,35 @@
+# No-op Usage Collector Storage Plugin
+
+> **Development and testing plugin** — discards all usage records. It is not a production storage backend.
+
+No-op implementation of the usage-collector storage plugin contract: the gateway can resolve a plugin instance and call `create_usage_record`, but no data is retained.
+
+## Purpose
+
+Use this plugin when you want the usage-collector module and emitters to run without configuring a real storage implementation. Typical cases:
+
+- Local development and smoke tests
+- CI pipelines that exercise the ingestion path only
+- Demos where durable usage history is unnecessary
+
+**Do not use when you need metering data to be stored or queried.**
+
+## Configuration
+
+Add the plugin section under your module configuration:
+
+```yaml
+modules:
+  noop-usage-collector-plugin:
+    config:
+      vendor: "cyberfabric"
+      priority: 100
+```
+
+`vendor` must match the usage-collector gateway configuration so the gateway selects this instance.
+
+## Testing
+
+```bash
+cargo test -p cyberware-usage-collector-plugin
+```

--- a/modules/system/usage-collector/plugins/noop-usage-collector-plugin/src/config.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-plugin/src/config.rs
@@ -1,0 +1,28 @@
+//! Configuration for the no-op usage-collector storage plugin.
+
+use serde::Deserialize;
+
+/// Plugin configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct NoopUsageCollectorConfig {
+    /// Vendor name (must match the usage-collector gateway `vendor`).
+    pub vendor: String,
+
+    /// Plugin priority (lower = higher priority when multiple instances exist).
+    pub priority: i16,
+}
+
+impl Default for NoopUsageCollectorConfig {
+    fn default() -> Self {
+        Self {
+            vendor: "cyberfabric".to_owned(),
+            priority: 100,
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "config_tests.rs"]
+mod config_tests;

--- a/modules/system/usage-collector/plugins/noop-usage-collector-plugin/src/config_tests.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-plugin/src/config_tests.rs
@@ -1,0 +1,31 @@
+use super::*;
+
+#[test]
+fn configured_values_override_serde_defaults() {
+    // Pair each field with a value distinct from its Default so the assertion fails if
+    // serde silently falls back to the Default impl instead of using the configured value.
+    let default_cfg = NoopUsageCollectorConfig::default();
+    assert_ne!(default_cfg.vendor, "acme");
+    assert_ne!(default_cfg.priority, 10);
+
+    let json = r#"{"vendor": "acme", "priority": 10}"#;
+    let cfg: NoopUsageCollectorConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(cfg.vendor, "acme");
+    assert_eq!(cfg.priority, 10);
+}
+
+#[test]
+fn serde_default_applies_default_vendor_and_priority() {
+    let cfg: NoopUsageCollectorConfig = serde_json::from_str("{}").unwrap();
+    assert_eq!(
+        cfg.vendor, "cyberfabric",
+        "serde(default) must use Default impl"
+    );
+    assert_eq!(cfg.priority, 100, "serde(default) must use Default impl");
+}
+
+#[test]
+fn rejects_unknown_fields() {
+    let json = r#"{"vendor": "x", "priority": 1, "unexpected": true}"#;
+    assert!(serde_json::from_str::<NoopUsageCollectorConfig>(json).is_err());
+}

--- a/modules/system/usage-collector/plugins/noop-usage-collector-plugin/src/domain/client.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-plugin/src/domain/client.rs
@@ -1,0 +1,13 @@
+use async_trait::async_trait;
+
+use usage_collector_sdk::models::UsageRecord;
+use usage_collector_sdk::{UsageCollectorError, UsageCollectorPluginClientV1};
+
+use super::service::Service;
+
+#[async_trait]
+impl UsageCollectorPluginClientV1 for Service {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+}

--- a/modules/system/usage-collector/plugins/noop-usage-collector-plugin/src/domain/mod.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-plugin/src/domain/mod.rs
@@ -1,0 +1,4 @@
+mod client;
+pub mod service;
+
+pub use service::Service;

--- a/modules/system/usage-collector/plugins/noop-usage-collector-plugin/src/domain/service.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-plugin/src/domain/service.rs
@@ -1,0 +1,7 @@
+//! No-op usage-collector storage domain service.
+
+use modkit_macros::domain_model;
+
+/// Stateless service backing the storage plugin client; records are not retained.
+#[domain_model]
+pub struct Service;

--- a/modules/system/usage-collector/plugins/noop-usage-collector-plugin/src/lib.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-plugin/src/lib.rs
@@ -1,0 +1,20 @@
+//! No-op Usage Collector Storage Plugin
+//!
+//! Registers a [`usage_collector_sdk::UsageCollectorPluginClientV1`] implementation that
+//! accepts `create_usage_record` calls and drops all data. Use when the usage-collector gateway should run
+//! end-to-end without a real storage backend.
+//!
+//! ## Configuration
+//!
+//! ```yaml
+//! modules:
+//!   noop_usage_collector_storage_plugin:
+//!     config:
+//!       vendor: "cyberfabric"
+//!       priority: 100
+//! ```
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+mod config;
+mod domain;
+mod module;

--- a/modules/system/usage-collector/plugins/noop-usage-collector-plugin/src/module.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-plugin/src/module.rs
@@ -1,0 +1,73 @@
+//! No-op usage-collector storage plugin module.
+//!
+//! Registers a GTS plugin instance in the types registry and exposes
+//! [`usage_collector_sdk::UsageCollectorPluginClientV1`] under a scope keyed by that instance.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use modkit::Module;
+use modkit::client_hub::ClientScope;
+use modkit::context::ModuleCtx;
+use modkit::gts::BaseModkitPluginV1;
+use tracing::info;
+use types_registry_sdk::{RegisterResult, TypesRegistryClient};
+use usage_collector_sdk::{UsageCollectorPluginClientV1, UsageCollectorPluginSpecV1};
+
+use crate::config::NoopUsageCollectorConfig;
+use crate::domain::Service;
+
+/// No-op usage-collector storage plugin for development and testing.
+#[modkit::module(
+    name = "noop-usage-collector-plugin",
+    deps = ["types-registry", "usage-collector"]
+)]
+#[derive(Default)]
+struct NoopUsageCollectorPlugin;
+
+// @cpt-dod:cpt-cf-usage-collector-dod-sdk-and-ingest-core-noop-plugin:p1
+#[async_trait]
+impl Module for NoopUsageCollectorPlugin {
+    async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        let cfg: NoopUsageCollectorConfig = ctx.config_or_default()?;
+        info!(
+            %cfg.vendor,
+            cfg.priority,
+            "Loaded {} configuration",
+            Self::MODULE_NAME,
+        );
+
+        let instance_id = UsageCollectorPluginSpecV1::gts_make_instance_id(
+            "cf.core._.noop_usage_collector_storage_plugin.v1",
+        );
+
+        let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
+        let instance = BaseModkitPluginV1::<UsageCollectorPluginSpecV1> {
+            id: instance_id.clone(),
+            vendor: cfg.vendor.clone(),
+            priority: cfg.priority,
+            properties: UsageCollectorPluginSpecV1,
+        };
+        let instance_json = serde_json::to_value(&instance)?;
+
+        let results = registry.register(vec![instance_json]).await?;
+        RegisterResult::ensure_all_ok(&results)?;
+
+        let service = Service;
+
+        let api: Arc<dyn UsageCollectorPluginClientV1> = Arc::new(service);
+        ctx.client_hub()
+            .register_scoped::<dyn UsageCollectorPluginClientV1>(
+                ClientScope::gts_id(&instance_id),
+                api,
+            );
+
+        info!(
+            %instance_id,
+            "Registered {}",
+            Self::MODULE_NAME,
+        );
+
+        Ok(())
+    }
+}

--- a/modules/system/usage-collector/usage-collector/Cargo.toml
+++ b/modules/system/usage-collector/usage-collector/Cargo.toml
@@ -1,0 +1,78 @@
+[package]
+name = "cyberware-usage-collector"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Usage Collector gateway"
+readme = "README.md"
+keywords = ["cyberfabric", "cyberware", "cyberware-system"]
+categories = ["development-tools"]
+
+[lib]
+name = "usage_collector"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Local dependencies
+authz-resolver-sdk = { workspace = true }
+types-registry-sdk = { workspace = true }
+usage-collector-sdk = { workspace = true }
+usage-emitter = { workspace = true }
+
+# ModKit dependencies
+modkit = { workspace = true }
+modkit-canonical-errors = { workspace = true }
+modkit-db = { workspace = true, features = ["preview-outbox"] }
+modkit-macros = { workspace = true }
+modkit-security = { workspace = true }
+modkit-utils = { workspace = true, features = ["humantime-serde"] }
+
+# REST
+axum = { workspace = true }
+http = { workspace = true }
+utoipa = { workspace = true }
+
+# Data structures
+chrono = { workspace = true }
+uuid = { workspace = true }
+
+# Async runtime
+async-trait = { workspace = true }
+tokio = { workspace = true }
+
+# Synchronous locking
+parking_lot = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+
+# Serialization
+base64 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+# DB
+sea-orm-migration = { workspace = true }
+
+[dev-dependencies]
+# Local dependencies
+types-registry-sdk = { workspace = true, features = ["test-util"] }
+
+# ModKit dependencies
+modkit-db = { workspace = true, features = ["sqlite"] }
+modkit-odata = { workspace = true }
+
+# HTTP testing
+tower = { workspace = true }
+
+# Async runtime
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/modules/system/usage-collector/usage-collector/README.md
+++ b/modules/system/usage-collector/usage-collector/README.md
@@ -1,0 +1,46 @@
+# Usage Collector
+
+> **Gateway module** — hosts the Usage Collector gateway in-process: registers the storage-plugin GTS schema with `types-registry`, resolves the active storage plugin by `vendor`, exposes `dyn UsageCollectorClientV1` in `ClientHub` for the outbox delivery path, and serves a REST API for out-of-process emitters.
+
+ModKit module `usage-collector`: central ingest for usage observations (`UsageRecord`) from the outbox pipeline (`usage-emitter`) and delegation to the selected `UsageCollectorPluginClientV1` implementation.
+
+## Overview
+
+At startup the module:
+
+- Registers `UsageCollectorPluginSpecV1` in the types registry so storage backends can be declared as GTS instances.
+- Builds the domain `Service` that lists plugin instances, picks one for the configured `vendor`, and forwards `create_usage_record` calls with a bounded timeout.
+- Registers **`UsageCollectorLocalClient`** as `dyn UsageCollectorClientV1` so code in the **same binary** can call `create_usage_record` and `get_module_config` (which filters the metrics whitelist to only the metrics allowed for the calling module) without a network hop.
+- Initializes the embedded **`UsageEmitterRuntime`** (from `usage-emitter`) and registers it as `dyn UsageEmitterRuntimeV1` in `ClientHub`; the runtime owns the outbox worker and vends module-scoped `UsageEmitterFactory` instances via `runtime.factory(module_name)`; each factory's `.with_*().authorize(subject)` chain produces a per-call `UsageEmitter` that handles PDP authorization and the outbox delivery path before forwarding records to the local client.
+
+Source modules should emit through **`usage-emitter`** (PDP + outbox). This crate implements the gateway side of `UsageCollectorClientV1::create_usage_record` and the storage-plugin selection logic.
+
+## Dependencies
+
+- **At least one storage plugin** — a module that registers `dyn UsageCollectorPluginClientV1` in `ClientHub` for the GTS instance id chosen for your `vendor`. For dev/tests, see **`cyberware-noop-usage-collector-plugin`**.
+
+## Configuration
+
+`vendor` must match the `vendor` field on the storage plugin GTS content so `choose_plugin_instance` selects the right instance. `plugin_timeout` bounds each `create_usage_record` call; exceeded waits become `UsageCollectorError::DeadlineExceeded`. `emitter` holds nested `UsageEmitterConfig` for outbox and authorization tuning. `metrics` is a whitelist of allowed metric names, each with a `kind` (`gauge` or `counter`) and an optional `modules` list (if absent, all modules may emit that metric). `max_metadata_bytes` caps the serialized size of `UsageRecord.metadata` (default `8192`, max `1_048_576`; `0` disables metadata entirely); the value is published via `get_module_config` and enforced by the emitter.
+
+```yaml
+modules:
+  usage-collector:
+    config:
+      vendor: "cyberfabric"
+      plugin_timeout: "5s"
+      emitter:
+        # UsageEmitterConfig fields (outbox, auth tuning)
+      metrics:
+        "storage.bytes_used":
+          kind: "gauge"
+          modules: ["storage-service"]   # omit to allow all modules
+        "api.requests":
+          kind: "counter"
+```
+
+## Testing
+
+```bash
+cargo test -p cyberware-usage-collector
+```

--- a/modules/system/usage-collector/usage-collector/src/api/mod.rs
+++ b/modules/system/usage-collector/usage-collector/src/api/mod.rs
@@ -1,0 +1,3 @@
+//! API layer for the usage-collector module.
+
+pub mod rest;

--- a/modules/system/usage-collector/usage-collector/src/api/rest/dto.rs
+++ b/modules/system/usage-collector/usage-collector/src/api/rest/dto.rs
@@ -1,0 +1,64 @@
+//! REST DTOs for the usage-collector gateway.
+
+use chrono::{DateTime, Utc};
+use usage_collector_sdk::models::{Subject, UsageKind};
+use uuid::Uuid;
+
+/// Request body to create one usage record (ingest).
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(request)]
+pub struct CreateUsageRecordRequest {
+    /// Name of the module emitting this record.
+    pub module: String,
+    /// Tenant that owns the record.
+    pub tenant_id: Uuid,
+    /// Logical type of the metered resource.
+    pub resource_type: String,
+    /// Identifier of the metered resource instance.
+    pub resource_id: Uuid,
+    /// Subject (user or service) performing the request.
+    /// `None` when no subject context is available; PDP subject validation is skipped in that case.
+    /// Wire shape is nested: `{ "subject": { "id": "...", "type": "user" } }`; the `subject` key
+    /// is absent when there is no subject. A payload providing `type` without `id` is structurally
+    /// unrepresentable and fails to decode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject: Option<Subject>,
+    /// Metric name for this observation.
+    pub metric: String,
+    /// Idempotency key. Required for counter metrics (non-empty); optional for gauge metrics —
+    /// when omitted for a gauge, the gateway generates a UUID while building the record. Counter
+    /// records without a key are rejected with `422 Unprocessable Entity`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idempotency_key: Option<String>,
+    /// Numeric value for this usage observation.
+    pub value: f64,
+    /// Observation timestamp (UTC).
+    pub timestamp: DateTime<Utc>,
+    /// Optional caller-supplied metadata. Serialized size MUST NOT exceed the
+    /// per-deployment `max_metadata_bytes` limit (default `8192`, configurable in
+    /// the `[modules.<module>]` server config in range `0..=1 MiB`; `0` disables
+    /// metadata entirely). Callers can read the effective limit from
+    /// `GET /usage-collector/v1/modules/{name}/config` (`max_metadata_bytes`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// One allowed metric entry in a module config response.
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(response)]
+pub struct AllowedMetricResponse {
+    /// Metric name.
+    pub name: String,
+    /// Gauge vs counter semantics.
+    pub kind: UsageKind,
+}
+
+/// Response body for the get-module-config endpoint.
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(response)]
+pub struct ModuleConfigResponse {
+    /// Metrics the module is allowed to emit.
+    pub allowed_metrics: Vec<AllowedMetricResponse>,
+    /// Maximum serialized size of `UsageRecord.metadata` enforced by the emitter (`0` disables metadata).
+    pub max_metadata_bytes: u32,
+}

--- a/modules/system/usage-collector/usage-collector/src/api/rest/handlers.rs
+++ b/modules/system/usage-collector/usage-collector/src/api/rest/handlers.rs
@@ -1,0 +1,181 @@
+//! REST handlers for the usage-collector gateway.
+
+use std::sync::Arc;
+
+use axum::extract::Path;
+use axum::{Extension, Json};
+use http::StatusCode;
+use modkit::api::problem::Problem;
+use modkit_security::SecurityContext;
+use usage_collector_sdk::UsageCollectorError;
+use usage_emitter::UsageEmitterRuntimeV1;
+
+use crate::domain::Service;
+
+use super::dto::{AllowedMetricResponse, CreateUsageRecordRequest, ModuleConfigResponse};
+
+/// Handler for `POST /usage-collector/v1/records`.
+///
+/// # Errors
+/// Returns a [`Problem`] on authorization failure, validation errors, or internal emitter failure.
+#[tracing::instrument(
+    skip_all,
+    fields(
+        module = %req.module,
+        tenant_id = %req.tenant_id,
+        resource_id = %req.resource_id,
+    ),
+)]
+pub async fn handle_create_usage_record(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(runtime): Extension<Arc<dyn UsageEmitterRuntimeV1>>,
+    Json(req): Json<CreateUsageRecordRequest>,
+) -> Result<StatusCode, Problem> {
+    let emitter = authorize_request(&ctx, &runtime, &req).await?;
+
+    let mut builder = emitter
+        .usage_record_builder(req.metric, req.value)
+        .map_err(|e| canonical_error_to_problem(&e))?
+        .with_timestamp(req.timestamp);
+
+    // Normalize whitespace-only keys at the boundary so the builder always sees
+    // `Some(non-empty)` or `None`. A raw whitespace key is treated as missing for gauges
+    // (UUID generated at enqueue time) and surfaces as the canonical InvalidArgument for
+    // counters at validation — consistent across both metric kinds.
+    if let Some(key) = req
+        .idempotency_key
+        .map(|k| k.trim().to_owned())
+        .filter(|k| !k.is_empty())
+    {
+        builder = builder.with_idempotency_key(key);
+    }
+
+    if let Some(meta) = req.metadata {
+        builder = builder.with_metadata(meta);
+    }
+
+    // `usage_record_builder` prefills every required field (module, tenant_id,
+    // resource_id, resource_type, metric, kind, value); the optional setters above
+    // only add fields, never clear required ones — so this `.build()` is currently
+    // unreachable on the error branch. The prefill invariant is regression-tested
+    // by `cyberware-usage-emitter`'s `usage_record_builder_prefills_authorized_fields_for_gauge`
+    // and `usage_record_builder_resolves_counter_kind_from_allowed_metrics` (in
+    // `usage_record_builder_tests.rs`), which assert that `.build()` succeeds after
+    // the prefill alone. We still funnel any future `.build()` error through
+    // `canonical_error_to_problem` so a legitimate failure path keeps the canonical
+    // 4xx contract instead of panicking inside an axum handler.
+    let record = builder
+        .build()
+        .map_err(|e| canonical_error_to_problem(&e))?;
+    emitter
+        .enqueue(record)
+        .await
+        .map_err(|e| canonical_error_to_problem(&e))?;
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-7
+    Ok(StatusCode::NO_CONTENT)
+    // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-7
+}
+
+async fn authorize_request(
+    ctx: &SecurityContext,
+    runtime: &Arc<dyn UsageEmitterRuntimeV1>,
+    req: &CreateUsageRecordRequest,
+) -> Result<usage_emitter::UsageEmitter, Problem> {
+    // Forward the caller's stated subject intent verbatim. `Some(s)` becomes
+    // an explicit binding; `None` becomes the explicit "no subject" choice —
+    // NOT the default-from-context fallback. Substituting the gateway's own
+    // `SecurityContext` subject when the caller sent `None` would silently
+    // attribute the request to the wrong principal at the PDP boundary.
+    let factory = runtime.factory(&req.module).with_tenant(req.tenant_id);
+    let factory = match req.subject.clone() {
+        Some(s) => factory.with_subject(s),
+        None => factory.without_subject(),
+    };
+    factory
+        .authorize(ctx, req.resource_id, &req.resource_type)
+        .await
+        .map_err(|e| canonical_error_to_problem(&e))
+}
+
+/// Handler for `GET /usage-collector/v1/modules/{module_name}/config`.
+///
+/// # Errors
+/// Returns a [`Problem`] if the module is not found or the collector call fails.
+// @cpt-flow:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2
+#[tracing::instrument(skip_all, fields(module = %module_name))]
+pub async fn handle_get_module_config(
+    Path(module_name): Path<String>,
+    Extension(service): Extension<Arc<Service>>,
+) -> Result<Json<ModuleConfigResponse>, Problem> {
+    // @cpt-begin:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-2
+    // Authenticated request received; ModKit pipeline enforces authentication before handler entry.
+    // @cpt-end:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-2
+
+    // @cpt-begin:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-3
+    // Convert DomainError → UsageCollectorError via From, then funnel through the canonical
+    // problem mapping so REST has a single source of truth for HTTP status / detail.
+    let config = service
+        .get_module_config(&module_name)
+        .map_err(|e| canonical_error_to_problem(&UsageCollectorError::from(e)))?;
+    // @cpt-end:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-3
+
+    // @cpt-begin:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-5
+    let response = ModuleConfigResponse {
+        allowed_metrics: config
+            .allowed_metrics
+            .into_iter()
+            .map(|m| AllowedMetricResponse {
+                name: m.name,
+                kind: m.kind,
+            })
+            .collect(),
+        max_metadata_bytes: config.max_metadata_bytes,
+    };
+
+    Ok(Json(response))
+    // @cpt-end:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-5
+}
+
+fn canonical_error_to_problem(e: &UsageCollectorError) -> Problem {
+    // Round-trip through the canonical Problem so its serialized per-category
+    // context (reason / constraint / violations / resource_type / resource_name)
+    // is preserved as an RFC 9457 extension member rather than dropped to a
+    // title/detail pair. Built-in canonical contexts are plain structs and
+    // shouldn't fail to serialize; if they ever do we fall back to a
+    // context-less Problem so the request still returns the correct status.
+    match modkit_canonical_errors::Problem::from_error(e) {
+        Ok(canonical) => {
+            let status =
+                StatusCode::from_u16(canonical.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            Problem::new(status, canonical.title, canonical.detail)
+                .with_type(canonical.problem_type)
+                .with_context(canonical.context)
+        }
+        Err(err) => {
+            // Reaching this branch means a built-in canonical context failed to serialize —
+            // e.g. a new error variant carrying a non-`Serialize`-clean context. The client
+            // still gets the correct status code, but the per-category context (reason /
+            // constraint / violations) is silently dropped. Escalate to `error!` so log-based
+            // alerting fires, and attach a stable `context_serialization_failed` extension on
+            // the returned Problem so operators have a machine-distinguishable signal that
+            // does not depend on log scraping.
+            tracing::error!(
+                error = %err,
+                source_error = %e,
+                "canonical-to-problem conversion failed; falling back to context-less Problem"
+            );
+            Problem::new(
+                StatusCode::from_u16(e.status_code()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                e.title(),
+                e.detail(),
+            )
+            .with_context(serde_json::json!({ "context_serialization_failed": true }))
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "handlers_tests.rs"]
+mod handlers_tests;

--- a/modules/system/usage-collector/usage-collector/src/api/rest/handlers_tests.rs
+++ b/modules/system/usage-collector/usage-collector/src/api/rest/handlers_tests.rs
@@ -1,0 +1,530 @@
+//! Unit tests for REST handlers and `domain_error_to_problem` / `canonical_error_to_problem`.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use authz_resolver_sdk::models::{
+    EvaluationRequest, EvaluationResponse, EvaluationResponseContext,
+};
+use authz_resolver_sdk::{AuthZResolverClient, AuthZResolverError};
+use axum::Extension;
+use axum::Json;
+use axum::extract::Path;
+use chrono::Utc;
+use http::StatusCode;
+use modkit::client_hub::{ClientHub, ClientScope};
+use modkit_db::migration_runner::run_migrations_for_testing;
+use modkit_db::outbox::outbox_migrations;
+use modkit_db::{ConnectOpts, connect_db};
+use modkit_security::SecurityContext;
+use types_registry_sdk::testing::make_test_instance;
+use types_registry_sdk::{
+    GtsInstance, GtsTypeSchema, InstanceQuery, RegisterResult, TypeSchemaQuery,
+    TypesRegistryClient, TypesRegistryError,
+};
+use usage_collector_sdk::{
+    AllowedMetric, ModuleConfig, Subject, UsageCollectorClientV1, UsageCollectorError,
+    UsageCollectorPluginClientV1, UsageCollectorPluginSpecV1, UsageKind, UsageRecord,
+    UsageRecordError,
+};
+use usage_emitter::{UsageEmitterRuntime, UsageEmitterRuntimeV1};
+use uuid::Uuid;
+
+use super::canonical_error_to_problem;
+use super::handle_create_usage_record;
+use super::handle_get_module_config;
+use crate::api::rest::dto::CreateUsageRecordRequest;
+use crate::config::{MetricConfig, UsageCollectorConfig};
+use crate::domain::Service;
+
+// ── canonical_error_to_problem ──────────────────────────────────────
+
+#[test]
+fn canonical_internal_maps_to_500() {
+    let err = UsageCollectorError::internal("something broke").create();
+    let p = canonical_error_to_problem(&err);
+    assert_eq!(p.status, StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[test]
+fn canonical_not_found_maps_to_404() {
+    let err = UsageRecordError::not_found("module not configured")
+        .with_resource("test-module")
+        .create();
+    let p = canonical_error_to_problem(&err);
+    assert_eq!(p.status, StatusCode::NOT_FOUND);
+    assert_eq!(p.detail, "module not configured");
+}
+
+#[test]
+fn canonical_service_unavailable_maps_to_503() {
+    let err = UsageCollectorError::service_unavailable()
+        .with_detail("transport error")
+        .create();
+    let p = canonical_error_to_problem(&err);
+    assert_eq!(p.status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(p.detail, "transport error");
+}
+
+#[test]
+fn canonical_deadline_exceeded_maps_to_504() {
+    let err = UsageRecordError::deadline_exceeded("plugin call timed out").create();
+    let p = canonical_error_to_problem(&err);
+    assert_eq!(p.status, StatusCode::GATEWAY_TIMEOUT);
+}
+
+#[test]
+fn canonical_resource_exhausted_maps_to_429() {
+    let err = UsageRecordError::resource_exhausted("query result too large")
+        .with_quota_violation("rows", "row count exceeds limit")
+        .create();
+    let p = canonical_error_to_problem(&err);
+    assert_eq!(p.status, StatusCode::TOO_MANY_REQUESTS);
+}
+
+// The canonical error's per-category ctx (reason / constraint / resource_*)
+// must survive the Problem mapping as an RFC 9457 extension member, not get
+// flattened into title/detail. Regression guard for MODKIT-ERR-001.
+#[test]
+fn canonical_error_to_problem_preserves_reason_extension() {
+    let err = UsageRecordError::permission_denied()
+        .with_reason("AUTHORIZATION_DENIED")
+        .create();
+    let p = canonical_error_to_problem(&err);
+
+    assert_eq!(p.status, StatusCode::FORBIDDEN);
+    let ctx = p.context.as_ref().expect("context must be populated");
+    assert_eq!(
+        ctx.get("reason").and_then(|v| v.as_str()),
+        Some("AUTHORIZATION_DENIED"),
+        "reason must be preserved as a Problem extension member: {ctx}"
+    );
+}
+
+#[test]
+fn canonical_error_to_problem_preserves_resource_extension() {
+    let err = UsageRecordError::not_found("usage record not found")
+        .with_resource("rec-1")
+        .create();
+    let p = canonical_error_to_problem(&err);
+
+    assert_eq!(p.status, StatusCode::NOT_FOUND);
+    let ctx = p.context.as_ref().expect("context must be populated");
+    assert_eq!(
+        ctx.get("resource_name").and_then(|v| v.as_str()),
+        Some("rec-1"),
+        "resource_name must be preserved as a Problem extension member: {ctx}"
+    );
+    assert_eq!(
+        ctx.get("resource_type").and_then(|v| v.as_str()),
+        Some("gts.cf.core.usage.record.v1~"),
+        "resource_type must be preserved as a Problem extension member: {ctx}"
+    );
+}
+
+// ── service builder helpers ─────────────────────────────────────────
+
+struct StubRegistry {
+    instances: Vec<GtsInstance>,
+}
+
+#[async_trait]
+impl TypesRegistryClient for StubRegistry {
+    async fn register(
+        &self,
+        _: Vec<serde_json::Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
+        Ok(vec![])
+    }
+    async fn register_type_schemas(
+        &self,
+        _: Vec<serde_json::Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
+        Ok(vec![])
+    }
+    async fn get_type_schema(&self, _: &str) -> Result<GtsTypeSchema, TypesRegistryError> {
+        unimplemented!()
+    }
+    async fn get_type_schema_by_uuid(&self, _: Uuid) -> Result<GtsTypeSchema, TypesRegistryError> {
+        unimplemented!()
+    }
+    async fn get_type_schemas(
+        &self,
+        _: Vec<String>,
+    ) -> HashMap<String, Result<GtsTypeSchema, TypesRegistryError>> {
+        unimplemented!()
+    }
+    async fn get_type_schemas_by_uuid(
+        &self,
+        _: Vec<Uuid>,
+    ) -> HashMap<Uuid, Result<GtsTypeSchema, TypesRegistryError>> {
+        unimplemented!()
+    }
+    async fn list_type_schemas(
+        &self,
+        _: TypeSchemaQuery,
+    ) -> Result<Vec<GtsTypeSchema>, TypesRegistryError> {
+        unimplemented!()
+    }
+    async fn register_instances(
+        &self,
+        _: Vec<serde_json::Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
+        Ok(vec![])
+    }
+    async fn get_instance(&self, _: &str) -> Result<GtsInstance, TypesRegistryError> {
+        unimplemented!()
+    }
+    async fn get_instance_by_uuid(&self, _: Uuid) -> Result<GtsInstance, TypesRegistryError> {
+        unimplemented!()
+    }
+    async fn get_instances(
+        &self,
+        _: Vec<String>,
+    ) -> HashMap<String, Result<GtsInstance, TypesRegistryError>> {
+        unimplemented!()
+    }
+    async fn get_instances_by_uuid(
+        &self,
+        _: Vec<Uuid>,
+    ) -> HashMap<Uuid, Result<GtsInstance, TypesRegistryError>> {
+        unimplemented!()
+    }
+    async fn list_instances(
+        &self,
+        _: InstanceQuery,
+    ) -> Result<Vec<GtsInstance>, TypesRegistryError> {
+        Ok(self.instances.clone())
+    }
+}
+
+fn plugin_content(gts_id: &str, vendor: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": gts_id,
+        "vendor": vendor,
+        "priority": 0,
+        "properties": {},
+    })
+}
+
+fn service_with(
+    plugin: Arc<dyn UsageCollectorPluginClientV1>,
+    metrics: HashMap<String, MetricConfig>,
+) -> Arc<Service> {
+    let instance_id = format!(
+        "{}test.usage.mock.handlers_test.v1",
+        UsageCollectorPluginSpecV1::gts_schema_id()
+    );
+    let hub = Arc::new(ClientHub::default());
+    hub.register::<dyn TypesRegistryClient>(Arc::new(StubRegistry {
+        instances: vec![make_test_instance(
+            &instance_id,
+            plugin_content(&instance_id, "cyberfabric"),
+        )],
+    }));
+    hub.register_scoped::<dyn UsageCollectorPluginClientV1>(
+        ClientScope::gts_id(&instance_id),
+        plugin,
+    );
+    Arc::new(Service::new(
+        UsageCollectorConfig {
+            metrics,
+            ..UsageCollectorConfig::default()
+        },
+        hub,
+    ))
+}
+
+fn service_with_plugin(plugin: Arc<dyn UsageCollectorPluginClientV1>) -> Arc<Service> {
+    service_with(plugin, HashMap::new())
+}
+
+struct OkPlugin;
+
+#[async_trait]
+impl UsageCollectorPluginClientV1 for OkPlugin {
+    async fn create_usage_record(&self, _: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+}
+
+// ── handle_get_module_config ──────────────────────────────────────
+
+fn metrics_with(name: &str, kind: UsageKind) -> HashMap<String, MetricConfig> {
+    let mut m = HashMap::new();
+    m.insert(
+        name.to_owned(),
+        MetricConfig {
+            kind,
+            modules: None,
+        },
+    );
+    m
+}
+
+#[tokio::test]
+async fn get_module_config_handler_returns_allowed_metrics() {
+    let svc = service_with(
+        Arc::new(OkPlugin),
+        metrics_with("cpu.usage", UsageKind::Gauge),
+    );
+    let result = handle_get_module_config(Path("my-module".to_owned()), Extension(svc)).await;
+
+    let axum::Json(resp) = result.expect("handler should succeed");
+    assert_eq!(resp.allowed_metrics.len(), 1);
+    assert_eq!(resp.allowed_metrics[0].name, "cpu.usage");
+    assert_eq!(resp.max_metadata_bytes, 8192);
+}
+
+#[tokio::test]
+async fn get_module_config_handler_returns_404_for_unknown_module() {
+    let svc = service_with_plugin(Arc::new(OkPlugin));
+    let result = handle_get_module_config(Path("unknown-module".to_owned()), Extension(svc)).await;
+
+    let err = result.expect_err("handler should return 404");
+    assert_eq!(err.status, StatusCode::NOT_FOUND);
+}
+
+// ── handle_create_usage_record ────────────────────────────────────────────────
+
+/// PDP mock that captures the `subject_id` and `subject_type` resource properties from the
+/// incoming evaluation request, then allows the request to proceed.
+struct CapturingSubjectAuthZ {
+    captured_subject_id: Arc<Mutex<Option<String>>>,
+    captured_subject_type: Arc<Mutex<Option<String>>>,
+}
+
+#[async_trait]
+impl AuthZResolverClient for CapturingSubjectAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let subj_id = request
+            .resource
+            .properties
+            .get("subject_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_owned);
+        let subj_type = request
+            .resource
+            .properties
+            .get("subject_type")
+            .and_then(|v| v.as_str())
+            .map(str::to_owned);
+        *self.captured_subject_id.lock().unwrap() = subj_id;
+        *self.captured_subject_type.lock().unwrap() = subj_type;
+        Ok(EvaluationResponse {
+            decision: true,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+/// Collector that returns a fixed `ModuleConfig` with one allowed metric.
+struct FixedConfigCollector;
+
+#[async_trait]
+impl UsageCollectorClientV1 for FixedConfigCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<ModuleConfig, UsageCollectorError> {
+        Ok(ModuleConfig {
+            allowed_metrics: vec![AllowedMetric {
+                name: "test.gauge".to_owned(),
+                kind: UsageKind::Gauge,
+            }],
+            max_metadata_bytes: 8192,
+        })
+    }
+}
+
+async fn build_handler_runtime(
+    authz: Arc<dyn AuthZResolverClient>,
+) -> Arc<dyn UsageEmitterRuntimeV1> {
+    let db_name = format!("hw_{}", Uuid::new_v4().simple());
+    let url = format!("sqlite:file:{db_name}?mode=memory&cache=shared");
+    let db = connect_db(
+        &url,
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    run_migrations_for_testing(&db, outbox_migrations())
+        .await
+        .unwrap();
+    let runtime = UsageEmitterRuntime::build(
+        usage_emitter::UsageEmitterConfig::default(),
+        db,
+        authz,
+        Arc::new(FixedConfigCollector),
+    )
+    .await
+    .unwrap();
+    Arc::new(runtime) as Arc<dyn UsageEmitterRuntimeV1>
+}
+
+#[tokio::test]
+async fn ingest_handler_passes_subject_fields_to_authorize() {
+    let subject_id = Uuid::new_v4();
+    let subject_type = "test.service_account".to_owned();
+
+    let captured_id: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let captured_type: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let authz = Arc::new(CapturingSubjectAuthZ {
+        captured_subject_id: Arc::clone(&captured_id),
+        captured_subject_type: Arc::clone(&captured_type),
+    });
+
+    let runtime = build_handler_runtime(authz).await;
+
+    let ctx = SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(Uuid::new_v4())
+        .build()
+        .unwrap();
+
+    let req = CreateUsageRecordRequest {
+        module: "test-module".to_owned(),
+        tenant_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        resource_id: Uuid::new_v4(),
+        subject: Some(Subject::with_type(subject_id, subject_type.clone())),
+        metric: "test.gauge".to_owned(),
+        idempotency_key: None,
+        value: 1.0,
+        timestamp: Utc::now(),
+        metadata: None,
+    };
+
+    let result = handle_create_usage_record(Extension(ctx), Extension(runtime), Json(req)).await;
+
+    assert!(result.is_ok(), "handler should succeed: {result:?}");
+
+    assert_eq!(
+        captured_id.lock().unwrap().as_deref(),
+        Some(subject_id.to_string().as_str()),
+        "subject_id must be forwarded to the PDP request"
+    );
+    assert_eq!(
+        captured_type.lock().unwrap().as_deref(),
+        Some(subject_type.as_str()),
+        "subject_type must be forwarded to the PDP request"
+    );
+}
+
+#[tokio::test]
+async fn ingest_handler_succeeds_when_subject_fields_absent() {
+    let captured_id: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let captured_type: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let authz = Arc::new(CapturingSubjectAuthZ {
+        captured_subject_id: Arc::clone(&captured_id),
+        captured_subject_type: Arc::clone(&captured_type),
+    });
+
+    let runtime = build_handler_runtime(authz).await;
+
+    let ctx = SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(Uuid::new_v4())
+        .build()
+        .unwrap();
+
+    let req = CreateUsageRecordRequest {
+        module: "test-module".to_owned(),
+        tenant_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        resource_id: Uuid::new_v4(),
+        subject: None,
+        metric: "test.gauge".to_owned(),
+        idempotency_key: None,
+        value: 1.0,
+        timestamp: Utc::now(),
+        metadata: None,
+    };
+
+    let result = handle_create_usage_record(Extension(ctx), Extension(runtime), Json(req)).await;
+
+    assert!(
+        result.is_ok(),
+        "handler should succeed when subject is absent: {result:?}"
+    );
+
+    // `subject: None` at the wire is the explicit "no subject" intent — the
+    // gateway forwards it via `.without_subject()` on the factory. Per
+    // ADR-0002 (forwarder substitution invariant), the gateway MUST NOT
+    // substitute its own SecurityContext subject for the original caller,
+    // so the PDP request carries neither SUBJECT_ID nor SUBJECT_TYPE.
+    //
+    // The resulting outbox payload is likewise subject-free: the emitter
+    // handle binds `subject = None`, the prefilled builder skips its
+    // `with_subject` step, and the SDK wire format omits the `subject`
+    // field entirely (pinned by `models::tests::usage_record_subject_none_serde`
+    // in usage-collector-sdk).
+    assert!(
+        captured_id.lock().unwrap().is_none(),
+        "subject_id must NOT be forwarded to PDP when wire-level subject is absent (no gateway substitution)"
+    );
+    assert!(
+        captured_type.lock().unwrap().is_none(),
+        "subject_type must NOT be forwarded to PDP when wire-level subject is absent"
+    );
+}
+
+#[tokio::test]
+async fn ingest_handler_succeeds_when_subject_id_present_without_subject_type() {
+    let subject_id = Uuid::new_v4();
+
+    let captured_id: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let captured_type: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let authz = Arc::new(CapturingSubjectAuthZ {
+        captured_subject_id: Arc::clone(&captured_id),
+        captured_subject_type: Arc::clone(&captured_type),
+    });
+
+    let runtime = build_handler_runtime(authz).await;
+
+    let ctx = SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(Uuid::new_v4())
+        .build()
+        .unwrap();
+
+    let req = CreateUsageRecordRequest {
+        module: "test-module".to_owned(),
+        tenant_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        resource_id: Uuid::new_v4(),
+        subject: Some(Subject::new(subject_id)),
+        metric: "test.gauge".to_owned(),
+        idempotency_key: None,
+        value: 1.0,
+        timestamp: Utc::now(),
+        metadata: None,
+    };
+
+    let result = handle_create_usage_record(Extension(ctx), Extension(runtime), Json(req)).await;
+
+    assert!(
+        result.is_ok(),
+        "handler should succeed when subject_type is absent: {result:?}"
+    );
+    assert_eq!(
+        captured_id.lock().unwrap().as_deref(),
+        Some(subject_id.to_string().as_str()),
+        "subject_id must be forwarded to PDP when subject_type is absent"
+    );
+    assert!(
+        captured_type.lock().unwrap().is_none(),
+        "subject_type must not be forwarded to PDP when absent"
+    );
+}

--- a/modules/system/usage-collector/usage-collector/src/api/rest/mod.rs
+++ b/modules/system/usage-collector/usage-collector/src/api/rest/mod.rs
@@ -1,0 +1,5 @@
+//! REST API layer for the usage-collector module.
+
+pub mod dto;
+pub mod handlers;
+pub mod routes;

--- a/modules/system/usage-collector/usage-collector/src/api/rest/routes.rs
+++ b/modules/system/usage-collector/usage-collector/src/api/rest/routes.rs
@@ -1,0 +1,96 @@
+//! Route registration for the usage-collector REST API.
+
+use std::sync::Arc;
+
+use axum::{Extension, Router};
+
+use modkit::api::operation_builder::LicenseFeature;
+use modkit::api::{OpenApiRegistry, OperationBuilder};
+use usage_emitter::UsageEmitterRuntimeV1;
+
+use crate::domain::Service;
+
+use super::dto::{CreateUsageRecordRequest, ModuleConfigResponse};
+use super::handlers;
+
+const API_TAG: &str = "Usage Collector";
+
+struct License;
+
+impl AsRef<str> for License {
+    fn as_ref(&self) -> &'static str {
+        "gts.cf.core.lic.feat.v1~cf.core.global.base.v1"
+    }
+}
+
+impl LicenseFeature for License {}
+
+/// Register all REST routes for the usage-collector module.
+pub fn register_routes(
+    router: Router,
+    openapi: &dyn OpenApiRegistry,
+    runtime: Arc<dyn UsageEmitterRuntimeV1>,
+    service: Arc<Service>,
+) -> Router {
+    let router = OperationBuilder::post("/usage-collector/v1/records")
+        .operation_id("usage_collector.create_usage_record")
+        .summary("Create a usage record")
+        .description(
+            "Accepts a usage record payload and delegates storage to the configured storage plugin.",
+        )
+        .tag(API_TAG)
+        .authenticated()
+        .require_license_features::<License>([])
+        .json_request::<CreateUsageRecordRequest>(openapi, "Usage record to create")
+        .allow_content_types(&["application/json"])
+        .handler(handlers::handle_create_usage_record)
+        .no_content_response(http::StatusCode::NO_CONTENT, "Record accepted and stored")
+        // Validation errors (metadata > 8 KiB, missing/empty idempotency_key for counter,
+        // non-finite value, negative counter value, metric-kind mismatch).
+        .error_400(openapi)
+        // Stale authorization handle (TTL expired between authorize and enqueue).
+        .error_401(openapi)
+        // PDP denial / tenant/resource/module/subject mismatch.
+        .error_403(openapi)
+        // Malformed payload (non-finite numeric literals, invalid nested subject shape, etc.).
+        .error_422(openapi)
+        // Rate limiting propagated from the storage plugin.
+        .error_429(openapi)
+        // Internal failures from the emitter or storage plugin.
+        .error_500(openapi)
+        // Outbox enqueue failure or transient transport error.
+        .problem_response(
+            openapi,
+            http::StatusCode::SERVICE_UNAVAILABLE,
+            "Service Unavailable",
+        )
+        // Plugin call timed out.
+        .problem_response(openapi, http::StatusCode::GATEWAY_TIMEOUT, "Gateway Timeout")
+        .register(router, openapi);
+
+    let router = OperationBuilder::get("/usage-collector/v1/modules/{module_name}/config")
+        .operation_id("usage_collector.get_module_config")
+        .summary("Get module configuration")
+        .description(
+            "Returns the allowed metrics (and future configuration) for the specified module.",
+        )
+        .tag(API_TAG)
+        .authenticated()
+        .require_license_features::<License>([])
+        .path_param("module_name", "Module name")
+        .handler(handlers::handle_get_module_config)
+        .json_response_with_schema::<ModuleConfigResponse>(
+            openapi,
+            http::StatusCode::OK,
+            "Module configuration",
+        )
+        // Missing or invalid bearer token (authenticated route).
+        .error_401(openapi)
+        // Unknown module name.
+        .error_404(openapi)
+        // Internal failures resolving plugin / fetching config.
+        .error_500(openapi)
+        .register(router, openapi);
+
+    router.layer(Extension(runtime)).layer(Extension(service))
+}

--- a/modules/system/usage-collector/usage-collector/src/config.rs
+++ b/modules/system/usage-collector/usage-collector/src/config.rs
@@ -1,0 +1,132 @@
+//! Configuration for the usage-collector gateway module.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use serde::Deserialize;
+use usage_collector_sdk::UsageKind;
+use usage_emitter::UsageEmitterConfig;
+
+/// Per-metric allowed configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricConfig {
+    /// Gauge vs counter semantics.
+    pub kind: UsageKind,
+    /// Modules allowed to emit this metric. If absent, all modules are allowed.
+    pub modules: Option<Vec<String>>,
+}
+
+/// Sliding-window circuit-breaker tuning for the storage plugin proxy.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct CircuitBreakerConfig {
+    /// Number of failures within `window` that will open the circuit.
+    /// Valid range: 1–100. Default: 5.
+    pub failure_threshold: u32,
+
+    /// Rolling window for counting failures.
+    /// Default: 10s.
+    #[serde(with = "modkit_utils::humantime_serde")]
+    pub window: Duration,
+
+    /// Duration to wait in the open state before allowing a half-open probe.
+    /// Valid range: 1s–5m. Default: 30s.
+    #[serde(with = "modkit_utils::humantime_serde")]
+    pub recovery_timeout: Duration,
+}
+
+impl Default for CircuitBreakerConfig {
+    fn default() -> Self {
+        Self {
+            failure_threshold: 5,
+            window: Duration::from_secs(10),
+            recovery_timeout: Duration::from_secs(30),
+        }
+    }
+}
+
+/// Module configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct UsageCollectorConfig {
+    /// Vendor selector used to pick a storage plugin instance from types-registry.
+    pub vendor: String,
+
+    /// Maximum serialized size, in bytes, of a `UsageRecord.metadata` payload.
+    ///
+    /// Published to emitters via `get_module_config` and enforced there. Default:
+    /// `8192`. Upper bound: `1_048_576` (1 MiB). A value of `0` disables metadata
+    /// entirely — any non-None metadata payload will be rejected by the emitter.
+    pub max_metadata_bytes: u32,
+
+    /// Timeout for each storage plugin `create_usage_record()` call.
+    /// Valid range: 100ms–30s. Default: 5s.
+    #[serde(with = "modkit_utils::humantime_serde")]
+    pub plugin_timeout: Duration,
+
+    /// Sliding-window circuit-breaker tuning for the storage plugin proxy.
+    pub circuit_breaker: CircuitBreakerConfig,
+
+    /// Outbox/authorization tuning for the embedded usage emitter.
+    pub emitter: UsageEmitterConfig,
+
+    /// Allowed metrics configuration. Key is the metric name.
+    pub metrics: HashMap<String, MetricConfig>,
+}
+
+impl UsageCollectorConfig {
+    /// Validate operational bounds for the gateway configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when any timeout or circuit-breaker setting falls outside
+    /// the supported range.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.plugin_timeout < std::time::Duration::from_millis(100) {
+            anyhow::bail!("plugin_timeout must be at least 100ms");
+        }
+        if self.plugin_timeout > std::time::Duration::from_secs(30) {
+            anyhow::bail!("plugin_timeout must not exceed 30s");
+        }
+        if self.circuit_breaker.failure_threshold < 1 {
+            anyhow::bail!("circuit_breaker.failure_threshold must be at least 1");
+        }
+        if self.circuit_breaker.failure_threshold > 100 {
+            anyhow::bail!("circuit_breaker.failure_threshold must not exceed 100");
+        }
+        if self.circuit_breaker.window < std::time::Duration::from_millis(100) {
+            anyhow::bail!("circuit_breaker.window must be at least 100ms");
+        }
+        if self.circuit_breaker.recovery_timeout < std::time::Duration::from_secs(1) {
+            anyhow::bail!("circuit_breaker.recovery_timeout must be at least 1s");
+        }
+        if self.circuit_breaker.recovery_timeout > std::time::Duration::from_mins(5) {
+            anyhow::bail!("circuit_breaker.recovery_timeout must not exceed 5min");
+        }
+        self.emitter.validate()?;
+        anyhow::ensure!(
+            self.max_metadata_bytes <= 1_048_576,
+            "max_metadata_bytes must not exceed 1 MiB (1_048_576 bytes)"
+        );
+        Ok(())
+    }
+}
+
+impl Default for UsageCollectorConfig {
+    fn default() -> Self {
+        Self {
+            vendor: "cyberfabric".to_owned(),
+            max_metadata_bytes: 8192,
+            plugin_timeout: Duration::from_secs(5),
+            circuit_breaker: CircuitBreakerConfig::default(),
+            emitter: UsageEmitterConfig::default(),
+            metrics: HashMap::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "config_tests.rs"]
+mod config_tests;

--- a/modules/system/usage-collector/usage-collector/src/config_tests.rs
+++ b/modules/system/usage-collector/usage-collector/src/config_tests.rs
@@ -1,0 +1,233 @@
+use std::time::Duration;
+
+use usage_collector_sdk::UsageKind;
+
+use super::{CircuitBreakerConfig, UsageCollectorConfig};
+
+#[test]
+fn test_validate_rejects_plugin_timeout_zero() {
+    let cfg = UsageCollectorConfig {
+        plugin_timeout: Duration::ZERO,
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("plugin_timeout"),
+        "error must mention plugin_timeout, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_plugin_timeout_above_30s() {
+    let cfg = UsageCollectorConfig {
+        plugin_timeout: Duration::from_secs(31),
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("plugin_timeout"),
+        "error must mention plugin_timeout, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_circuit_breaker_failure_threshold_zero() {
+    let cfg = UsageCollectorConfig {
+        circuit_breaker: CircuitBreakerConfig {
+            failure_threshold: 0,
+            ..CircuitBreakerConfig::default()
+        },
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("circuit_breaker.failure_threshold"),
+        "error must mention circuit_breaker.failure_threshold, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_circuit_breaker_failure_threshold_above_100() {
+    let cfg = UsageCollectorConfig {
+        circuit_breaker: CircuitBreakerConfig {
+            failure_threshold: 101,
+            ..CircuitBreakerConfig::default()
+        },
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("circuit_breaker.failure_threshold"),
+        "error must mention circuit_breaker.failure_threshold, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_plugin_timeout_below_100ms() {
+    let cfg = UsageCollectorConfig {
+        plugin_timeout: Duration::from_millis(50),
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("plugin_timeout"),
+        "error must mention plugin_timeout, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_circuit_breaker_window_below_100ms() {
+    let cfg = UsageCollectorConfig {
+        circuit_breaker: CircuitBreakerConfig {
+            window: Duration::ZERO,
+            ..CircuitBreakerConfig::default()
+        },
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("circuit_breaker.window"),
+        "error must mention circuit_breaker.window, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_circuit_breaker_recovery_timeout_zero() {
+    let cfg = UsageCollectorConfig {
+        circuit_breaker: CircuitBreakerConfig {
+            recovery_timeout: Duration::ZERO,
+            ..CircuitBreakerConfig::default()
+        },
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("circuit_breaker.recovery_timeout"),
+        "error must mention circuit_breaker.recovery_timeout, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_circuit_breaker_recovery_timeout_above_5min() {
+    let cfg = UsageCollectorConfig {
+        circuit_breaker: CircuitBreakerConfig {
+            recovery_timeout: Duration::from_secs(301),
+            ..CircuitBreakerConfig::default()
+        },
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("circuit_breaker.recovery_timeout"),
+        "error must mention circuit_breaker.recovery_timeout, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_accepts_defaults() {
+    let cfg = UsageCollectorConfig::default();
+    assert!(cfg.validate().is_ok());
+}
+
+#[test]
+fn vendor_can_be_overridden_via_serde() {
+    let json = r#"{"vendor": "acme"}"#;
+    let cfg: UsageCollectorConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(cfg.vendor, "acme");
+}
+
+#[test]
+fn serde_default_applies_default_vendor() {
+    let cfg: UsageCollectorConfig = serde_json::from_str("{}").unwrap();
+    assert_eq!(
+        cfg.vendor, "cyberfabric",
+        "serde(default) must use Default impl"
+    );
+}
+
+#[test]
+fn plugin_timeout_can_be_overridden_via_serde() {
+    let json = r#"{"plugin_timeout": "10s"}"#;
+    let cfg: UsageCollectorConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(cfg.plugin_timeout, Duration::from_secs(10));
+}
+
+#[test]
+fn serde_default_applies_default_plugin_timeout() {
+    let cfg: UsageCollectorConfig = serde_json::from_str("{}").unwrap();
+    assert_eq!(
+        cfg.plugin_timeout,
+        Duration::from_secs(5),
+        "serde(default) must use Default impl"
+    );
+}
+
+#[test]
+fn rejects_unknown_fields() {
+    let json = r#"{"vendor": "x", "unexpected": true}"#;
+    assert!(serde_json::from_str::<UsageCollectorConfig>(json).is_err());
+}
+
+#[test]
+fn metrics_config_parses_with_modules() {
+    let json = r#"{"metrics": {"cpu.usage": {"kind": "gauge", "modules": ["mod-a"]}}}"#;
+    let cfg: UsageCollectorConfig = serde_json::from_str(json).unwrap();
+    let m = &cfg.metrics["cpu.usage"];
+    assert!(matches!(m.kind, UsageKind::Gauge));
+    assert_eq!(m.modules.as_deref(), Some(["mod-a".to_owned()].as_slice()));
+}
+
+#[test]
+fn metrics_config_parses_without_modules() {
+    let json = r#"{"metrics": {"req.count": {"kind": "counter"}}}"#;
+    let cfg: UsageCollectorConfig = serde_json::from_str(json).unwrap();
+    let m = &cfg.metrics["req.count"];
+    assert!(matches!(m.kind, UsageKind::Counter));
+    assert!(m.modules.is_none());
+}
+
+#[test]
+fn omitted_max_metadata_bytes_deserializes_to_default() {
+    // Exercises the `#[serde(default)]` wiring on `UsageCollectorConfig`:
+    // deployments that omit `max_metadata_bytes` must inherit the Default impl
+    // rather than failing to parse or silently picking up serde's `0`.
+    let cfg: UsageCollectorConfig = serde_json::from_str("{}").unwrap();
+    assert_eq!(
+        cfg.max_metadata_bytes,
+        UsageCollectorConfig::default().max_metadata_bytes,
+        "missing `max_metadata_bytes` should fall back to the struct default"
+    );
+    // And the deserialized config must still validate, so the default
+    // remains within the bounds enforced by `validate()`.
+    cfg.validate()
+        .expect("default config must satisfy validate()");
+}
+
+#[test]
+fn test_validate_accepts_max_metadata_bytes_boundary_values() {
+    for value in [0u32, 1, 8192, 1_048_576] {
+        let cfg = UsageCollectorConfig {
+            max_metadata_bytes: value,
+            ..UsageCollectorConfig::default()
+        };
+        assert!(
+            cfg.validate().is_ok(),
+            "validate() must accept max_metadata_bytes = {value}"
+        );
+    }
+}
+
+#[test]
+fn test_validate_rejects_max_metadata_bytes_above_1_mib() {
+    let cfg = UsageCollectorConfig {
+        max_metadata_bytes: 1_048_577,
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "max_metadata_bytes must not exceed 1 MiB (1_048_576 bytes)"
+    );
+}

--- a/modules/system/usage-collector/usage-collector/src/domain/circuit_breaker.rs
+++ b/modules/system/usage-collector/usage-collector/src/domain/circuit_breaker.rs
@@ -1,0 +1,224 @@
+//! Sliding-window circuit breaker used by the usage-collector domain service.
+//!
+//! Wraps fallible async calls to the storage plugin so that repeated
+//! infrastructure failures stop hammering an unhealthy backend, while
+//! caller-induced errors do not trip the breaker.
+//!
+//! The single entry point is [`CircuitBreaker::execute`], which acquires a
+//! permit, invokes the closure, classifies the result, and updates breaker
+//! state atomically.
+
+#![deny(clippy::await_holding_lock)]
+
+use std::time::Instant;
+
+use parking_lot::Mutex;
+use tracing::{info, warn};
+use usage_collector_sdk::UsageCollectorError;
+
+use super::error::DomainError;
+use crate::config::CircuitBreakerConfig;
+
+#[derive(Debug)]
+enum State {
+    Closed,
+    Open { opened_at: Instant },
+    HalfOpen,
+}
+
+#[derive(Debug)]
+struct Inner {
+    config: CircuitBreakerConfig,
+    state: State,
+    failure_timestamps: Vec<Instant>,
+}
+
+impl Inner {
+    /// Atomically check whether the next call may proceed and (if so) update
+    /// state for an in-flight probe.
+    ///
+    /// Returns `Ok(was_probe)` — `true` when the caller is the single
+    /// `HalfOpen` probe, `false` for normal `Closed` traffic — or
+    /// `Err(DomainError::CircuitOpen)` when the circuit is rejecting calls.
+    fn try_acquire(&mut self) -> Result<bool, DomainError> {
+        match &self.state {
+            State::Closed => Ok(false),
+            State::Open { opened_at } => {
+                if opened_at.elapsed() >= self.config.recovery_timeout {
+                    info!("Circuit breaker transitioning from Open to HalfOpen for probe");
+                    self.state = State::HalfOpen;
+                    Ok(true)
+                } else {
+                    Err(DomainError::CircuitOpen)
+                }
+            }
+            // A probe is already in flight; reject everyone else until it completes.
+            State::HalfOpen => Err(DomainError::CircuitOpen),
+        }
+    }
+
+    fn record_failure(&mut self) {
+        let now = Instant::now();
+
+        // A failure during the HalfOpen probe must re-open unconditionally:
+        // the probe's job is to confirm health, and the threshold/window
+        // bookkeeping does not apply (the window was cleared on entry to Open).
+        if matches!(self.state, State::HalfOpen) {
+            warn!("Circuit breaker re-opening after failed HalfOpen probe");
+            self.state = State::Open { opened_at: now };
+            self.failure_timestamps.clear();
+            return;
+        }
+
+        self.failure_timestamps
+            .retain(|t| now.duration_since(*t) < self.config.window);
+        self.failure_timestamps.push(now);
+
+        let failures_in_window = self.failure_timestamps.len();
+
+        if failures_in_window >= self.config.failure_threshold as usize {
+            match self.state {
+                State::Closed => {
+                    warn!(
+                        failures_in_window,
+                        threshold = self.config.failure_threshold,
+                        "Circuit breaker opening after too many failures within the rolling window"
+                    );
+                    self.state = State::Open { opened_at: now };
+                    self.failure_timestamps.clear();
+                }
+                // HalfOpen is handled above; Open already at opened_at — resetting
+                // would prevent recovery under sustained load.
+                State::Open { .. } | State::HalfOpen => {}
+            }
+        }
+    }
+
+    fn record_success(&mut self) {
+        match self.state {
+            State::HalfOpen => {
+                info!(
+                    "Circuit breaker transitioning from HalfOpen to Closed after successful probe"
+                );
+                self.state = State::Closed;
+                self.failure_timestamps.clear();
+            }
+            State::Closed => {
+                self.failure_timestamps.clear();
+            }
+            State::Open { .. } => {
+                warn!("Circuit breaker received success while Open; resetting to Closed");
+                self.state = State::Closed;
+                self.failure_timestamps.clear();
+            }
+        }
+    }
+}
+
+/// Sliding-window circuit breaker.
+///
+/// Opens after `failure_threshold` failures within the rolling `window`,
+/// stays open for `recovery_timeout`, then admits one probe call. Any
+/// non-success during a probe re-opens the circuit; a successful probe
+/// closes it.
+pub struct CircuitBreaker {
+    inner: Mutex<Inner>,
+}
+
+impl CircuitBreaker {
+    #[must_use]
+    pub fn new(config: CircuitBreakerConfig) -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                config,
+                state: State::Closed,
+                failure_timestamps: Vec::new(),
+            }),
+        }
+    }
+
+    /// Run `f` under the breaker.
+    ///
+    /// Returns `DomainError::CircuitOpen` without invoking `f` if the circuit
+    /// is rejecting calls. Otherwise executes `f` and records the outcome:
+    /// infrastructure-shaped errors count as failures, caller-induced errors
+    /// are ignored, and during a `HalfOpen` probe any non-success re-opens the
+    /// circuit.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any `DomainError` returned by `f`, or `DomainError::CircuitOpen`
+    /// when the circuit is open.
+    pub async fn execute<F, Fut, T>(&self, f: F) -> Result<T, DomainError>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<T, DomainError>>,
+    {
+        // The lock guard returned by `self.inner.lock()` MUST be dropped before
+        // the `.await` below — holding a `parking_lot::Mutex` guard across an
+        // await point would block the executor thread on every contended call.
+        // The temporary-drop rule on this single-expression `let` is load-bearing:
+        // a refactor to `let mut g = self.inner.lock(); let was_probe = g.try_acquire()?; … f().await`
+        // would silently violate it. The module-scoped `#[deny(clippy::await_holding_lock)]`
+        // above is the static guard against that regression.
+        let was_probe = self.inner.lock().try_acquire()?;
+
+        let result = f().await;
+
+        let mut inner = self.inner.lock();
+        match &result {
+            Ok(_) => inner.record_success(),
+            Err(e) if is_health_failure(e) => inner.record_failure(),
+            // HalfOpen is strict: any non-success during the probe re-opens.
+            Err(_) if was_probe => inner.record_failure(),
+            // Caller-induced error in Closed state — leave breaker untouched.
+            Err(_) => {}
+        }
+
+        result
+    }
+}
+
+/// Returns `true` when `err` indicates plugin/infrastructure ill-health and
+/// must trip the circuit breaker. Caller-induced errors return `false`.
+fn is_health_failure(err: &DomainError) -> bool {
+    match err {
+        DomainError::TypesRegistryUnavailable(_)
+        | DomainError::ClientHub(_)
+        | DomainError::PluginNotFound { .. }
+        | DomainError::PluginUnavailable { .. }
+        | DomainError::Timeout
+        | DomainError::Internal(_) => true,
+        DomainError::Plugin(canonical) => is_canonical_health_failure(canonical),
+        // Already-open or invalid-config errors are not new failure signals.
+        DomainError::CircuitOpen
+        | DomainError::InvalidPluginInstance { .. }
+        | DomainError::ModuleNotConfigured { .. } => false,
+    }
+}
+
+/// Canonical-error variants that the breaker treats as plugin ill-health.
+///
+/// Kept aligned with [`crate::infra`] / `usage-emitter`'s `DeliveryHandler` retry set so
+/// the two layers don't contradict each other: there, `ServiceUnavailable` and
+/// `DeadlineExceeded` are retried (recoverable infra failures), while `Internal`,
+/// `Unknown`, and `DataLoss` are dead-lettered (permanent — serious defect, unrecognized
+/// error space, or unrecoverable corruption). Tripping the breaker on the latter would
+/// open the ingest path for problems that cannot be fixed by waiting and would
+/// double-classify the same canonical variants as both transient and permanent.
+///
+/// Genuine transient infra conditions on the local-client side (plugin not ready, types
+/// registry down, transport errors) surface through the dedicated `DomainError` variants
+/// in [`is_health_failure`] above, not through `Plugin(Internal { .. })`.
+fn is_canonical_health_failure(err: &UsageCollectorError) -> bool {
+    matches!(
+        err,
+        UsageCollectorError::ServiceUnavailable { .. }
+            | UsageCollectorError::DeadlineExceeded { .. }
+    )
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "circuit_breaker_tests.rs"]
+mod circuit_breaker_tests;

--- a/modules/system/usage-collector/usage-collector/src/domain/circuit_breaker_tests.rs
+++ b/modules/system/usage-collector/usage-collector/src/domain/circuit_breaker_tests.rs
@@ -1,0 +1,261 @@
+#![allow(clippy::let_underscore_must_use)]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use usage_collector_sdk::UsageRecordError;
+
+use super::CircuitBreaker;
+use crate::config::CircuitBreakerConfig;
+use crate::domain::DomainError;
+
+fn cb(threshold: u32, window: Duration, recovery: Duration) -> CircuitBreaker {
+    CircuitBreaker::new(CircuitBreakerConfig {
+        failure_threshold: threshold,
+        window,
+        recovery_timeout: recovery,
+    })
+}
+
+fn unavailable() -> DomainError {
+    DomainError::PluginUnavailable {
+        gts_id: "test".to_owned(),
+        reason: "simulated".to_owned(),
+    }
+}
+
+fn caller_error() -> DomainError {
+    DomainError::Plugin(
+        UsageRecordError::invalid_argument()
+            .with_format("bad input")
+            .create(),
+    )
+}
+
+#[tokio::test]
+async fn closed_circuit_passes_calls_through() {
+    let cb = cb(2, Duration::from_secs(10), Duration::from_millis(1));
+    let result: Result<u32, DomainError> = cb.execute(|| async { Ok(42) }).await;
+    assert_eq!(result.unwrap(), 42);
+}
+
+#[tokio::test]
+async fn opens_after_threshold_failures() {
+    let cb = cb(2, Duration::from_secs(10), Duration::from_millis(1));
+
+    for _ in 0..2 {
+        let _ = cb.execute(|| async { Err::<(), _>(unavailable()) }).await;
+    }
+
+    // Next call must be rejected without invoking the closure.
+    let invoked = Arc::new(AtomicUsize::new(0));
+    let invoked_c = Arc::clone(&invoked);
+    let err = cb
+        .execute(move || {
+            let invoked = Arc::clone(&invoked_c);
+            async move {
+                invoked.fetch_add(1, Ordering::SeqCst);
+                Ok::<(), DomainError>(())
+            }
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, DomainError::CircuitOpen));
+    assert_eq!(invoked.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn caller_errors_do_not_open_the_circuit() {
+    let cb = cb(2, Duration::from_secs(10), Duration::from_millis(1));
+
+    for _ in 0..5 {
+        let _ = cb.execute(|| async { Err::<(), _>(caller_error()) }).await;
+    }
+
+    // Circuit must still be closed: a successful call goes through.
+    let result: Result<u32, DomainError> = cb.execute(|| async { Ok(1) }).await;
+    assert_eq!(result.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn deadline_exceeded_counts_as_failure() {
+    let cb = cb(2, Duration::from_secs(10), Duration::from_millis(1));
+
+    for _ in 0..2 {
+        let _ = cb
+            .execute(|| async { Err::<(), _>(DomainError::Timeout) })
+            .await;
+    }
+
+    let err = cb
+        .execute(|| async { Ok::<(), DomainError>(()) })
+        .await
+        .unwrap_err();
+    assert!(matches!(err, DomainError::CircuitOpen));
+}
+
+#[tokio::test]
+async fn internal_error_counts_as_failure() {
+    let cb = cb(2, Duration::from_secs(10), Duration::from_millis(1));
+
+    for _ in 0..2 {
+        let _ = cb
+            .execute(|| async { Err::<(), _>(DomainError::Internal("boom".to_owned())) })
+            .await;
+    }
+
+    let err = cb
+        .execute(|| async { Ok::<(), DomainError>(()) })
+        .await
+        .unwrap_err();
+    assert!(matches!(err, DomainError::CircuitOpen));
+}
+
+#[tokio::test]
+async fn successful_probe_closes_circuit() {
+    let cb = cb(1, Duration::from_secs(10), Duration::from_millis(1));
+
+    let _ = cb.execute(|| async { Err::<(), _>(unavailable()) }).await;
+
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    cb.execute(|| async { Ok::<(), DomainError>(()) })
+        .await
+        .expect("probe should succeed");
+
+    cb.execute(|| async { Ok::<(), DomainError>(()) })
+        .await
+        .expect("circuit should be closed after successful probe");
+}
+
+#[tokio::test]
+async fn failed_probe_reopens_circuit() {
+    let cb = cb(1, Duration::from_secs(10), Duration::from_millis(1));
+
+    let _ = cb.execute(|| async { Err::<(), _>(unavailable()) }).await;
+
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    let _ = cb.execute(|| async { Err::<(), _>(unavailable()) }).await;
+
+    let invoked = Arc::new(AtomicUsize::new(0));
+    let invoked_c = Arc::clone(&invoked);
+    let err = cb
+        .execute(move || {
+            let invoked = Arc::clone(&invoked_c);
+            async move {
+                invoked.fetch_add(1, Ordering::SeqCst);
+                Ok::<(), DomainError>(())
+            }
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, DomainError::CircuitOpen));
+    assert_eq!(invoked.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn probe_with_caller_error_reopens_circuit() {
+    // HalfOpen is strict: any non-success during the probe (including caller-induced)
+    // re-opens the circuit, because the probe's job is to confirm health.
+    let cb = cb(1, Duration::from_secs(10), Duration::from_millis(1));
+
+    let _ = cb.execute(|| async { Err::<(), _>(unavailable()) }).await;
+
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    let _ = cb.execute(|| async { Err::<(), _>(caller_error()) }).await;
+
+    let err = cb
+        .execute(|| async { Ok::<(), DomainError>(()) })
+        .await
+        .unwrap_err();
+    assert!(matches!(err, DomainError::CircuitOpen));
+}
+
+#[tokio::test]
+async fn failed_probe_reopens_under_default_threshold() {
+    // Regression: with threshold > 1, a single failed probe must still
+    // re-open the circuit. The rolling-window counter is cleared when the
+    // breaker enters Open, so a probe failure on its own can never satisfy
+    // `failures_in_window >= threshold` — without an unconditional re-open
+    // for HalfOpen the breaker would stay stuck forever.
+    let cb = cb(5, Duration::from_secs(10), Duration::from_millis(1));
+
+    for _ in 0..5 {
+        let _ = cb.execute(|| async { Err::<(), _>(unavailable()) }).await;
+    }
+
+    tokio::time::sleep(Duration::from_millis(5)).await;
+    let _ = cb.execute(|| async { Err::<(), _>(unavailable()) }).await;
+
+    // The breaker must now reject calls (Open), not stall in HalfOpen.
+    let invoked = Arc::new(AtomicUsize::new(0));
+    let invoked_c = Arc::clone(&invoked);
+    let err = cb
+        .execute(move || {
+            let invoked = Arc::clone(&invoked_c);
+            async move {
+                invoked.fetch_add(1, Ordering::SeqCst);
+                Ok::<(), DomainError>(())
+            }
+        })
+        .await
+        .unwrap_err();
+    assert!(matches!(err, DomainError::CircuitOpen));
+    assert_eq!(invoked.load(Ordering::SeqCst), 0);
+
+    // After another recovery window a successful probe must restore the breaker.
+    tokio::time::sleep(Duration::from_millis(5)).await;
+    cb.execute(|| async { Ok::<(), DomainError>(()) })
+        .await
+        .expect("probe should succeed and close the breaker");
+    cb.execute(|| async { Ok::<(), DomainError>(()) })
+        .await
+        .expect("breaker should be usable after recovery");
+}
+
+#[tokio::test]
+async fn half_open_admits_only_one_concurrent_probe() {
+    let cb = Arc::new(cb(1, Duration::from_secs(10), Duration::from_millis(1)));
+
+    let _ = cb.execute(|| async { Err::<(), _>(unavailable()) }).await;
+
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    let invoked = Arc::new(AtomicUsize::new(0));
+    let mut set = tokio::task::JoinSet::new();
+    for _ in 0..3 {
+        let cb = Arc::clone(&cb);
+        let invoked = Arc::clone(&invoked);
+        set.spawn(async move {
+            cb.execute(move || {
+                let invoked = Arc::clone(&invoked);
+                async move {
+                    invoked.fetch_add(1, Ordering::SeqCst);
+                    // Yield so other tasks see HalfOpen before we close it.
+                    tokio::task::yield_now().await;
+                    Ok::<(), DomainError>(())
+                }
+            })
+            .await
+        });
+    }
+
+    let mut ok = 0usize;
+    let mut rejected = 0usize;
+    while let Some(res) = set.join_next().await {
+        match res.unwrap() {
+            Ok(()) => ok += 1,
+            Err(DomainError::CircuitOpen) => rejected += 1,
+            Err(other) => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    assert_eq!(invoked.load(Ordering::SeqCst), 1);
+    assert_eq!(ok, 1);
+    assert_eq!(rejected, 2);
+}

--- a/modules/system/usage-collector/usage-collector/src/domain/error.rs
+++ b/modules/system/usage-collector/usage-collector/src/domain/error.rs
@@ -1,0 +1,112 @@
+//! Domain errors for the usage-collector gateway.
+
+use modkit_macros::domain_model;
+use usage_collector_sdk::{ModuleConfigError, UsageCollectorError, UsageRecordError};
+
+/// Internal domain errors for the usage-collector gateway service.
+///
+/// Mapped to [`UsageCollectorError`] at the [`super::UsageCollectorLocalClient`]
+/// boundary and to HTTP problems at the REST handler boundary.
+#[domain_model]
+#[derive(thiserror::Error, Debug)]
+pub enum DomainError {
+    #[error("types registry is not available: {0}")]
+    TypesRegistryUnavailable(#[source] types_registry_sdk::TypesRegistryError),
+
+    #[error("client hub error: {0}")]
+    ClientHub(#[source] modkit::client_hub::ClientHubError),
+
+    #[error("no plugin instances found for vendor '{vendor}'")]
+    PluginNotFound { vendor: String },
+
+    #[error("invalid plugin instance content for '{gts_id}': {reason}")]
+    InvalidPluginInstance { gts_id: String, reason: String },
+
+    #[error("plugin not available for '{gts_id}': {reason}")]
+    PluginUnavailable { gts_id: String, reason: String },
+
+    #[error("plugin call timed out")]
+    Timeout,
+
+    #[error("circuit breaker open")]
+    CircuitOpen,
+
+    #[error("module '{module}' not configured")]
+    ModuleNotConfigured { module: String },
+
+    #[error("plugin error: {0}")]
+    Plugin(#[source] UsageCollectorError),
+
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+impl From<types_registry_sdk::TypesRegistryError> for DomainError {
+    fn from(e: types_registry_sdk::TypesRegistryError) -> Self {
+        Self::TypesRegistryUnavailable(e)
+    }
+}
+
+impl From<modkit::client_hub::ClientHubError> for DomainError {
+    fn from(e: modkit::client_hub::ClientHubError) -> Self {
+        Self::ClientHub(e)
+    }
+}
+
+impl From<modkit::plugins::ChoosePluginError> for DomainError {
+    fn from(e: modkit::plugins::ChoosePluginError) -> Self {
+        match e {
+            modkit::plugins::ChoosePluginError::InvalidPluginInstance { gts_id, reason } => {
+                Self::InvalidPluginInstance { gts_id, reason }
+            }
+            modkit::plugins::ChoosePluginError::PluginNotFound { vendor, .. } => {
+                Self::PluginNotFound { vendor }
+            }
+        }
+    }
+}
+
+impl From<DomainError> for UsageCollectorError {
+    fn from(e: DomainError) -> Self {
+        match e {
+            DomainError::Plugin(canonical) => canonical,
+            DomainError::ModuleNotConfigured { module } => {
+                ModuleConfigError::not_found("module not configured")
+                    .with_resource(&module)
+                    .create()
+            }
+            DomainError::Timeout => {
+                UsageRecordError::deadline_exceeded("plugin call timed out").create()
+            }
+            DomainError::CircuitOpen => UsageCollectorError::service_unavailable()
+                .with_detail("circuit breaker open")
+                .create(),
+            DomainError::PluginNotFound { vendor } => UsageCollectorError::service_unavailable()
+                .with_detail(format!("no plugin instances found for vendor '{vendor}'"))
+                .create(),
+            DomainError::PluginUnavailable { gts_id, reason } => {
+                UsageCollectorError::service_unavailable()
+                    .with_detail(format!("plugin not available for '{gts_id}': {reason}"))
+                    .create()
+            }
+            DomainError::InvalidPluginInstance { gts_id, reason } => UsageCollectorError::internal(
+                format!("invalid plugin instance '{gts_id}': {reason}"),
+            )
+            .create(),
+            DomainError::TypesRegistryUnavailable(source) => {
+                UsageCollectorError::service_unavailable()
+                    .with_detail(format!("types registry is not available: {source}"))
+                    .create()
+            }
+            DomainError::ClientHub(source) => {
+                UsageCollectorError::internal(format!("client hub error: {source}")).create()
+            }
+            DomainError::Internal(reason) => UsageCollectorError::internal(reason).create(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "error_tests.rs"]
+mod error_tests;

--- a/modules/system/usage-collector/usage-collector/src/domain/error_tests.rs
+++ b/modules/system/usage-collector/usage-collector/src/domain/error_tests.rs
@@ -1,0 +1,151 @@
+use std::time::Duration;
+
+use modkit::client_hub::{ClientHub, ClientHubError};
+use types_registry_sdk::{TypesRegistryClient, TypesRegistryError};
+use usage_collector_sdk::UsageRecordError;
+
+use super::*;
+
+/// Variant tag for table-driven assertions about which canonical arm a domain
+/// error is mapped to.
+#[derive(Debug, PartialEq, Eq)]
+enum CanonicalKind {
+    NotFound,
+    DeadlineExceeded,
+    ServiceUnavailable,
+    Internal,
+    ResourceExhausted,
+}
+
+fn kind_of(err: &UsageCollectorError) -> CanonicalKind {
+    match err {
+        UsageCollectorError::NotFound { .. } => CanonicalKind::NotFound,
+        UsageCollectorError::DeadlineExceeded { .. } => CanonicalKind::DeadlineExceeded,
+        UsageCollectorError::ServiceUnavailable { .. } => CanonicalKind::ServiceUnavailable,
+        UsageCollectorError::Internal { .. } => CanonicalKind::Internal,
+        UsageCollectorError::ResourceExhausted { .. } => CanonicalKind::ResourceExhausted,
+        other => panic!("unexpected canonical variant: {other:?}"),
+    }
+}
+
+/// `ClientHubError`'s only public-constructible variants come from the hub itself
+/// (the `TypeKey` field has no public constructor); produce one by querying an
+/// empty hub.
+fn sample_client_hub_error() -> ClientHubError {
+    ClientHub::default()
+        .get::<dyn TypesRegistryClient>()
+        .err()
+        .expect("empty hub must return ClientHubError::NotFound")
+}
+
+/// Canonical `Internal` variant scrubs the caller-supplied detail and replaces it with
+/// a fixed sanitized string, so detail assertions on `Internal`-mapped arms must compare
+/// against that fixed text rather than the upstream message.
+const INTERNAL_DETAIL: &str = "An internal error occurred. Please retry later.";
+
+#[test]
+fn from_domain_error_table() {
+    let cases: Vec<(DomainError, CanonicalKind, &str)> = vec![
+        (
+            DomainError::TypesRegistryUnavailable(TypesRegistryError::Internal(
+                "registry offline".to_owned(),
+            )),
+            CanonicalKind::ServiceUnavailable,
+            "types registry is not available: Internal error: registry offline",
+        ),
+        (
+            DomainError::ClientHub(sample_client_hub_error()),
+            CanonicalKind::Internal,
+            INTERNAL_DETAIL,
+        ),
+        (
+            DomainError::ModuleNotConfigured {
+                module: "billing".to_owned(),
+            },
+            CanonicalKind::NotFound,
+            "module not configured",
+        ),
+        (
+            DomainError::Timeout,
+            CanonicalKind::DeadlineExceeded,
+            "plugin call timed out",
+        ),
+        (
+            DomainError::CircuitOpen,
+            CanonicalKind::ServiceUnavailable,
+            "circuit breaker open",
+        ),
+        (
+            DomainError::PluginNotFound {
+                vendor: "acme".to_owned(),
+            },
+            CanonicalKind::ServiceUnavailable,
+            "no plugin instances found for vendor 'acme'",
+        ),
+        (
+            DomainError::PluginUnavailable {
+                gts_id: "gts.x.v1~inst".to_owned(),
+                reason: "client missing".to_owned(),
+            },
+            CanonicalKind::ServiceUnavailable,
+            "plugin not available for 'gts.x.v1~inst': client missing",
+        ),
+        (
+            DomainError::InvalidPluginInstance {
+                gts_id: "gts.x.v1~inst".to_owned(),
+                reason: "missing field".to_owned(),
+            },
+            CanonicalKind::Internal,
+            INTERNAL_DETAIL,
+        ),
+        (
+            DomainError::Internal("boom".to_owned()),
+            CanonicalKind::Internal,
+            INTERNAL_DETAIL,
+        ),
+    ];
+
+    for (input, expected_kind, expected_detail) in cases {
+        let label = format!("{input:?}");
+        let canonical: UsageCollectorError = input.into();
+        assert_eq!(
+            kind_of(&canonical),
+            expected_kind,
+            "variant mismatch for case {label}",
+        );
+        assert!(
+            canonical.detail().contains(expected_detail),
+            "detail mismatch for case {label}: got '{}', expected to contain '{expected_detail}'",
+            canonical.detail(),
+        );
+    }
+}
+
+#[test]
+fn from_domain_plugin_preserves_canonical() {
+    let canonical = UsageRecordError::resource_exhausted("rows exceed limit")
+        .with_quota_violation("rows", "too many")
+        .create();
+    let mapped: UsageCollectorError = DomainError::Plugin(canonical).into();
+    assert_eq!(kind_of(&mapped), CanonicalKind::ResourceExhausted);
+}
+
+#[test]
+fn from_types_registry_error_carries_source() {
+    let inner = TypesRegistryError::ServiceUnavailable {
+        message: "still initializing".to_owned(),
+        retry_after: Duration::from_secs(1),
+    };
+    let domain: DomainError = inner.into();
+    let source = std::error::Error::source(&domain).expect("source chain must be preserved");
+    assert!(source.to_string().contains("still initializing"));
+}
+
+#[test]
+fn from_client_hub_error_carries_source() {
+    let inner = sample_client_hub_error();
+    let inner_msg = inner.to_string();
+    let domain: DomainError = inner.into();
+    let source = std::error::Error::source(&domain).expect("source chain must be preserved");
+    assert_eq!(source.to_string(), inner_msg);
+}

--- a/modules/system/usage-collector/usage-collector/src/domain/local_client.rs
+++ b/modules/system/usage-collector/usage-collector/src/domain/local_client.rs
@@ -1,0 +1,53 @@
+//! Local (in-process) client for the usage-collector gateway.
+//!
+//! Wraps a [`Service`] and translates [`DomainError`] to the canonical
+//! [`UsageCollectorError`] for consumption via `ClientHub`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use modkit_macros::domain_model;
+use usage_collector_sdk::{ModuleConfig, UsageCollectorClientV1, UsageCollectorError, UsageRecord};
+
+use super::service::Service;
+
+/// Local client wrapping the usage-collector service.
+///
+/// Registered in `ClientHub` by the usage-collector module during `init()` so
+/// that the embedded emitter (and any other in-process consumer) can call the
+/// gateway through the public `dyn UsageCollectorClientV1` trait.
+#[domain_model]
+pub struct UsageCollectorLocalClient {
+    svc: Arc<Service>,
+}
+
+impl UsageCollectorLocalClient {
+    #[must_use]
+    pub fn new(svc: Arc<Service>) -> Self {
+        Self { svc }
+    }
+}
+
+// @cpt-algo:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:p1
+// @cpt-dod:cpt-cf-usage-collector-dod-sdk-and-ingest-core-gateway-crate:p1
+#[async_trait]
+impl UsageCollectorClientV1 for UsageCollectorLocalClient {
+    async fn create_usage_record(&self, record: UsageRecord) -> Result<(), UsageCollectorError> {
+        self.svc
+            .create_usage_record(record)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn get_module_config(
+        &self,
+        module_name: &str,
+    ) -> Result<ModuleConfig, UsageCollectorError> {
+        self.svc.get_module_config(module_name).map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "local_client_tests.rs"]
+mod local_client_tests;

--- a/modules/system/usage-collector/usage-collector/src/domain/local_client_tests.rs
+++ b/modules/system/usage-collector/usage-collector/src/domain/local_client_tests.rs
@@ -1,0 +1,70 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use modkit::client_hub::ClientHub;
+use usage_collector_sdk::{UsageCollectorClientV1, UsageCollectorError, UsageKind};
+
+use super::{Service, UsageCollectorLocalClient};
+use crate::config::{MetricConfig, UsageCollectorConfig};
+
+#[tokio::test]
+async fn module_not_configured_maps_to_canonical_not_found() {
+    let svc = Arc::new(Service::new(
+        UsageCollectorConfig::default(),
+        Arc::new(ClientHub::default()),
+    ));
+    let client = UsageCollectorLocalClient::new(svc);
+    let err = client.get_module_config("unknown").await.unwrap_err();
+    assert!(matches!(err, UsageCollectorError::NotFound { .. }));
+}
+
+#[tokio::test]
+async fn module_config_returns_allowed_metrics() {
+    let mut metrics = HashMap::new();
+    metrics.insert(
+        "cpu.usage".to_owned(),
+        MetricConfig {
+            kind: UsageKind::Gauge,
+            modules: None,
+        },
+    );
+    let svc = Arc::new(Service::new(
+        UsageCollectorConfig {
+            metrics,
+            ..UsageCollectorConfig::default()
+        },
+        Arc::new(ClientHub::default()),
+    ));
+    let client = UsageCollectorLocalClient::new(svc);
+    let cfg = client.get_module_config("any-module").await.unwrap();
+    assert_eq!(cfg.allowed_metrics.len(), 1);
+    assert_eq!(cfg.allowed_metrics[0].name, "cpu.usage");
+    assert_eq!(cfg.allowed_metrics[0].kind, UsageKind::Gauge);
+    assert_eq!(cfg.max_metadata_bytes, 8192);
+}
+
+#[tokio::test]
+async fn module_config_preserves_counter_kind() {
+    // Exercises the Counter arm of the `kind` mapping in `Service::get_module_config`
+    // so a future regression that hardwires `kind: UsageKind::Gauge` is caught.
+    let mut metrics = HashMap::new();
+    metrics.insert(
+        "requests.total".to_owned(),
+        MetricConfig {
+            kind: UsageKind::Counter,
+            modules: None,
+        },
+    );
+    let svc = Arc::new(Service::new(
+        UsageCollectorConfig {
+            metrics,
+            ..UsageCollectorConfig::default()
+        },
+        Arc::new(ClientHub::default()),
+    ));
+    let client = UsageCollectorLocalClient::new(svc);
+    let cfg = client.get_module_config("any-module").await.unwrap();
+    assert_eq!(cfg.allowed_metrics.len(), 1);
+    assert_eq!(cfg.allowed_metrics[0].name, "requests.total");
+    assert_eq!(cfg.allowed_metrics[0].kind, UsageKind::Counter);
+}

--- a/modules/system/usage-collector/usage-collector/src/domain/mod.rs
+++ b/modules/system/usage-collector/usage-collector/src/domain/mod.rs
@@ -1,0 +1,10 @@
+//! Gateway domain: [`Service`], [`UsageCollectorLocalClient`] and authorization utilities.
+
+mod circuit_breaker;
+mod error;
+mod local_client;
+mod service;
+
+pub use error::DomainError;
+pub use local_client::UsageCollectorLocalClient;
+pub use service::Service;

--- a/modules/system/usage-collector/usage-collector/src/domain/service.rs
+++ b/modules/system/usage-collector/usage-collector/src/domain/service.rs
@@ -1,0 +1,188 @@
+//! Domain service for the usage-collector gateway.
+//!
+//! Resolves the configured GTS storage plugin lazily on first call,
+//! wraps each plugin invocation in a [`CircuitBreaker`] with a per-call
+//! timeout, and exposes ingest and module-config operations
+//! returning [`DomainError`].
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use modkit::client_hub::{ClientHub, ClientScope};
+use modkit::plugins::{GtsPluginSelector, choose_plugin_instance};
+use modkit::telemetry::ThrottledLog;
+use modkit_macros::domain_model;
+use tokio::time::timeout;
+use tracing::{info, warn};
+use types_registry_sdk::{InstanceQuery, TypesRegistryClient};
+use usage_collector_sdk::{
+    AllowedMetric, ModuleConfig, UsageCollectorError, UsageCollectorPluginClientV1,
+    UsageCollectorPluginSpecV1, UsageRecord,
+};
+
+use super::circuit_breaker::CircuitBreaker;
+use super::error::DomainError;
+use crate::config::UsageCollectorConfig;
+
+/// Throttle interval for unavailable plugin warnings.
+const UNAVAILABLE_LOG_THROTTLE: Duration = Duration::from_secs(10);
+
+/// Usage-collector gateway domain service.
+#[domain_model]
+pub struct Service {
+    hub: Arc<ClientHub>,
+    config: UsageCollectorConfig,
+    selector: GtsPluginSelector,
+    unavailable_log_throttle: ThrottledLog,
+    circuit_breaker: CircuitBreaker,
+}
+
+impl Service {
+    #[must_use]
+    pub fn new(config: UsageCollectorConfig, hub: Arc<ClientHub>) -> Self {
+        let circuit_breaker = CircuitBreaker::new(config.circuit_breaker.clone());
+        Self {
+            hub,
+            config,
+            selector: GtsPluginSelector::new(),
+            unavailable_log_throttle: ThrottledLog::new(UNAVAILABLE_LOG_THROTTLE),
+            circuit_breaker,
+        }
+    }
+
+    /// Lazily resolves and returns the storage plugin client.
+    ///
+    /// # Errors
+    ///
+    /// - [`DomainError::PluginNotFound`] if no plugin matches the configured vendor.
+    /// - [`DomainError::PluginUnavailable`] if the plugin client is not yet registered.
+    /// - [`DomainError::TypesRegistryUnavailable`] if the registry call fails.
+    async fn get_plugin(&self) -> Result<Arc<dyn UsageCollectorPluginClientV1>, DomainError> {
+        let instance_id = self.selector.get_or_init(|| self.resolve_plugin()).await?;
+        let scope = ClientScope::gts_id(instance_id.as_ref());
+
+        if let Some(client) = self
+            .hub
+            .try_get_scoped::<dyn UsageCollectorPluginClientV1>(&scope)
+        {
+            Ok(client)
+        } else {
+            if self.unavailable_log_throttle.should_log() {
+                warn!(
+                    plugin_gts_id = %instance_id,
+                    vendor = %self.config.vendor,
+                    "Plugin client not registered yet"
+                );
+            }
+            Err(DomainError::PluginUnavailable {
+                gts_id: instance_id.to_string(),
+                reason: "client not registered yet".into(),
+            })
+        }
+    }
+
+    #[tracing::instrument(skip_all, fields(vendor = %self.config.vendor))]
+    async fn resolve_plugin(&self) -> Result<String, DomainError> {
+        info!("Resolving usage-collector plugin");
+
+        let registry = self.hub.get::<dyn TypesRegistryClient>()?;
+
+        let plugin_type_id = UsageCollectorPluginSpecV1::gts_schema_id().clone();
+
+        let instances = registry
+            .list_instances(InstanceQuery::new().with_pattern(format!("{plugin_type_id}*")))
+            .await?;
+
+        let gts_id = choose_plugin_instance::<UsageCollectorPluginSpecV1>(
+            &self.config.vendor,
+            instances.iter().map(|e| (e.id.as_ref(), &e.object)),
+        )?;
+        info!(plugin_gts_id = %gts_id, "Selected usage-collector plugin instance");
+
+        Ok(gts_id)
+    }
+
+    /// Run a plugin call under the circuit breaker with the configured timeout.
+    async fn call_plugin<F, Fut, T>(&self, f: F) -> Result<T, DomainError>
+    where
+        F: FnOnce(Arc<dyn UsageCollectorPluginClientV1>) -> Fut,
+        Fut: std::future::Future<Output = Result<T, UsageCollectorError>>,
+    {
+        self.circuit_breaker
+            .execute(|| async {
+                let plugin = self.get_plugin().await?;
+                match timeout(self.config.plugin_timeout, f(plugin)).await {
+                    Ok(Ok(value)) => Ok(value),
+                    Ok(Err(canonical)) => Err(DomainError::Plugin(canonical)),
+                    Err(_) => Err(DomainError::Timeout),
+                }
+            })
+            .await
+    }
+
+    /// Forward a usage record to the storage plugin.
+    ///
+    /// # Errors
+    ///
+    /// - [`DomainError::CircuitOpen`] when the circuit breaker is rejecting calls.
+    /// - [`DomainError::Timeout`] when the plugin call exceeds the configured timeout.
+    /// - [`DomainError::Plugin`] when the plugin returns an error.
+    /// - Plugin-resolution errors (see [`Service::get_plugin`]).
+    pub async fn create_usage_record(&self, record: UsageRecord) -> Result<(), DomainError> {
+        self.call_plugin(|plugin| async move { plugin.create_usage_record(record).await })
+            .await
+    }
+
+    // @cpt-flow:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2
+    // @cpt-algo:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2
+    /// Return the static per-module metric configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DomainError::ModuleNotConfigured`] when the module has no allowed metrics.
+    pub fn get_module_config(&self, module_name: &str) -> Result<ModuleConfig, DomainError> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-1
+        // Authentication is enforced by the ModKit pipeline (`.authenticated()` in routes.rs);
+        // unauthenticated requests are rejected before this function is reached.
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-1
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-2
+        let allowed_metrics: Vec<AllowedMetric> = self
+            .config
+            .metrics
+            .iter()
+            .filter(|(_, cfg)| {
+                cfg.modules
+                    .as_ref()
+                    .is_none_or(|mods| mods.iter().any(|m| m == module_name))
+            })
+            .map(|(name, cfg)| AllowedMetric {
+                name: name.clone(),
+                kind: cfg.kind,
+            })
+            .collect();
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-2
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-3
+        if allowed_metrics.is_empty() {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-3a
+            return Err(DomainError::ModuleNotConfigured {
+                module: module_name.to_owned(),
+            });
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-3a
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-3
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-4
+        Ok(ModuleConfig {
+            allowed_metrics,
+            max_metadata_bytes: self.config.max_metadata_bytes,
+        })
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-4
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "service_tests.rs"]
+mod service_tests;

--- a/modules/system/usage-collector/usage-collector/src/domain/service_tests.rs
+++ b/modules/system/usage-collector/usage-collector/src/domain/service_tests.rs
@@ -1,0 +1,551 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use chrono::Utc;
+use modkit::client_hub::{ClientHub, ClientScope};
+use types_registry_sdk::testing::make_test_instance;
+use types_registry_sdk::{
+    GtsInstance, GtsTypeSchema, InstanceQuery, RegisterResult, TypeSchemaQuery,
+    TypesRegistryClient, TypesRegistryError,
+};
+use usage_collector_sdk::{
+    Subject, UsageCollectorError, UsageCollectorPluginClientV1, UsageCollectorPluginSpecV1,
+    UsageKind, UsageRecord,
+};
+use uuid::Uuid;
+
+use super::Service;
+use crate::config::{CircuitBreakerConfig, MetricConfig, UsageCollectorConfig};
+use crate::domain::DomainError;
+
+// ── MockRegistry ──────────────────────────────────────────────────
+
+struct MockRegistry {
+    instances: Vec<GtsInstance>,
+    list_calls: std::sync::atomic::AtomicUsize,
+}
+
+impl MockRegistry {
+    fn new(instances: Vec<GtsInstance>) -> Self {
+        Self {
+            instances,
+            list_calls: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TypesRegistryClient for MockRegistry {
+    async fn register(
+        &self,
+        _entities: Vec<serde_json::Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
+        Ok(vec![])
+    }
+
+    async fn register_type_schemas(
+        &self,
+        _type_schemas: Vec<serde_json::Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
+        Ok(vec![])
+    }
+
+    async fn get_type_schema(&self, _type_id: &str) -> Result<GtsTypeSchema, TypesRegistryError> {
+        unimplemented!()
+    }
+
+    async fn get_type_schema_by_uuid(
+        &self,
+        _type_uuid: Uuid,
+    ) -> Result<GtsTypeSchema, TypesRegistryError> {
+        unimplemented!()
+    }
+
+    async fn get_type_schemas(
+        &self,
+        _type_ids: Vec<String>,
+    ) -> HashMap<String, Result<GtsTypeSchema, TypesRegistryError>> {
+        unimplemented!()
+    }
+
+    async fn get_type_schemas_by_uuid(
+        &self,
+        _type_uuids: Vec<Uuid>,
+    ) -> HashMap<Uuid, Result<GtsTypeSchema, TypesRegistryError>> {
+        unimplemented!()
+    }
+
+    async fn list_type_schemas(
+        &self,
+        _query: TypeSchemaQuery,
+    ) -> Result<Vec<GtsTypeSchema>, TypesRegistryError> {
+        unimplemented!()
+    }
+
+    async fn register_instances(
+        &self,
+        _instances: Vec<serde_json::Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
+        Ok(vec![])
+    }
+
+    async fn get_instance(&self, _id: &str) -> Result<GtsInstance, TypesRegistryError> {
+        unimplemented!()
+    }
+
+    async fn get_instance_by_uuid(&self, _uuid: Uuid) -> Result<GtsInstance, TypesRegistryError> {
+        unimplemented!()
+    }
+
+    async fn get_instances(
+        &self,
+        _ids: Vec<String>,
+    ) -> HashMap<String, Result<GtsInstance, TypesRegistryError>> {
+        unimplemented!()
+    }
+
+    async fn get_instances_by_uuid(
+        &self,
+        _uuids: Vec<Uuid>,
+    ) -> HashMap<Uuid, Result<GtsInstance, TypesRegistryError>> {
+        unimplemented!()
+    }
+
+    async fn list_instances(
+        &self,
+        _query: InstanceQuery,
+    ) -> Result<Vec<GtsInstance>, TypesRegistryError> {
+        self.list_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(self.instances.clone())
+    }
+}
+
+struct OkPlugin;
+
+#[async_trait::async_trait]
+impl UsageCollectorPluginClientV1 for OkPlugin {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+}
+
+fn plugin_content(gts_id: &str, vendor: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": gts_id,
+        "vendor": vendor,
+        "priority": 0,
+        "properties": {}
+    })
+}
+
+fn hub_with_plugin(
+    instance_id: &str,
+    vendor: &str,
+    plugin: Arc<dyn UsageCollectorPluginClientV1>,
+) -> Arc<ClientHub> {
+    let hub = Arc::new(ClientHub::default());
+    let instance = make_test_instance(instance_id, plugin_content(instance_id, vendor));
+    let reg: Arc<dyn TypesRegistryClient> = Arc::new(MockRegistry::new(vec![instance]));
+    hub.register::<dyn TypesRegistryClient>(reg);
+    hub.register_scoped::<dyn UsageCollectorPluginClientV1>(
+        ClientScope::gts_id(instance_id),
+        plugin,
+    );
+    hub
+}
+
+fn make_service() -> Service {
+    let instance_id = format!(
+        "{}test.usage.mock.svc_test.v1",
+        UsageCollectorPluginSpecV1::gts_schema_id()
+    );
+    let hub = hub_with_plugin(&instance_id, "cyberfabric", Arc::new(OkPlugin));
+    Service::new(UsageCollectorConfig::default(), hub)
+}
+
+fn make_service_with_vendor(hub: Arc<ClientHub>, vendor: &str) -> Service {
+    Service::new(
+        UsageCollectorConfig {
+            vendor: vendor.to_owned(),
+            ..UsageCollectorConfig::default()
+        },
+        hub,
+    )
+}
+
+fn record(tenant_id: Uuid) -> UsageRecord {
+    UsageRecord {
+        tenant_id,
+        module: "test-module".to_owned(),
+        metric: "test.metric".to_owned(),
+        kind: UsageKind::Gauge,
+        value: 1.0,
+        resource_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        subject: Some(Subject::with_type(Uuid::nil(), "test.subject")),
+        idempotency_key: Uuid::new_v4().to_string(),
+        timestamp: Utc::now(),
+        metadata: None,
+    }
+}
+
+#[tokio::test]
+async fn create_usage_record_delegates_to_plugin() {
+    let svc = make_service();
+    assert!(
+        svc.create_usage_record(record(Uuid::new_v4()))
+            .await
+            .is_ok()
+    );
+}
+
+// ── plugin timeout ────────────────────────────────────────────────
+
+struct SlowPlugin;
+
+#[async_trait::async_trait]
+impl UsageCollectorPluginClientV1 for SlowPlugin {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        tokio::time::sleep(Duration::from_mins(1)).await;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn plugin_timeout_returns_timeout_error() {
+    let instance_id = format!(
+        "{}test.usage.mock.svc_test.v1",
+        UsageCollectorPluginSpecV1::gts_schema_id()
+    );
+    let hub = hub_with_plugin(&instance_id, "cyberfabric", Arc::new(SlowPlugin));
+    let svc = Service::new(
+        UsageCollectorConfig {
+            vendor: "cyberfabric".to_owned(),
+            plugin_timeout: Duration::from_millis(1),
+            ..UsageCollectorConfig::default()
+        },
+        hub,
+    );
+    let err = svc
+        .create_usage_record(record(Uuid::new_v4()))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, DomainError::Timeout),
+        "expected Timeout, got {err:?}"
+    );
+}
+
+// ── GTS plugin resolution caching ─────────────────────────────────
+
+#[tokio::test]
+async fn gts_plugin_selector_calls_registry_only_once_across_multiple_create_usage_records() {
+    let instance_id = format!(
+        "{}test.usage.mock.svc_test.v1",
+        UsageCollectorPluginSpecV1::gts_schema_id()
+    );
+    let reg = Arc::new(MockRegistry::new(vec![make_test_instance(
+        &instance_id,
+        plugin_content(&instance_id, "cyberfabric"),
+    )]));
+    let hub = Arc::new(ClientHub::default());
+    hub.register::<dyn TypesRegistryClient>(Arc::clone(&reg) as Arc<dyn TypesRegistryClient>);
+    hub.register_scoped::<dyn UsageCollectorPluginClientV1>(
+        ClientScope::gts_id(&instance_id),
+        Arc::new(OkPlugin),
+    );
+    let svc = make_service_with_vendor(hub, "cyberfabric");
+    let tenant = Uuid::new_v4();
+
+    svc.create_usage_record(record(tenant)).await.unwrap();
+    svc.create_usage_record(record(tenant)).await.unwrap();
+    svc.create_usage_record(record(tenant)).await.unwrap();
+
+    assert_eq!(
+        reg.list_calls.load(Ordering::SeqCst),
+        1,
+        "GTS registry should be queried exactly once after initial resolution"
+    );
+}
+
+// ── no plugin registered in hub ───────────────────────────────────
+
+#[tokio::test]
+async fn no_plugin_client_in_hub_returns_unavailable_error() {
+    let instance_id = format!(
+        "{}test.usage.mock.svc_test.v1",
+        UsageCollectorPluginSpecV1::gts_schema_id()
+    );
+    let hub = Arc::new(ClientHub::default());
+    let instance = make_test_instance(&instance_id, plugin_content(&instance_id, "cyberfabric"));
+    let reg: Arc<dyn TypesRegistryClient> = Arc::new(MockRegistry::new(vec![instance]));
+    hub.register::<dyn TypesRegistryClient>(reg);
+    // plugin client NOT registered
+    let svc = make_service_with_vendor(hub, "cyberfabric");
+    let err = svc
+        .create_usage_record(record(Uuid::new_v4()))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, DomainError::PluginUnavailable { .. }));
+}
+
+// ── get_module_config ─────────────────────────────────────────────
+
+fn config_with_metrics(metrics: HashMap<String, MetricConfig>) -> UsageCollectorConfig {
+    UsageCollectorConfig {
+        metrics,
+        ..UsageCollectorConfig::default()
+    }
+}
+
+#[tokio::test]
+async fn get_module_config_returns_not_configured_when_no_metrics_configured() {
+    let svc = Service::new(
+        UsageCollectorConfig::default(),
+        Arc::new(ClientHub::default()),
+    );
+    let err = svc.get_module_config("any-module").unwrap_err();
+    assert!(matches!(err, DomainError::ModuleNotConfigured { .. }));
+}
+
+#[tokio::test]
+async fn get_module_config_returns_metric_when_modules_restriction_is_absent() {
+    let mut metrics = HashMap::new();
+    metrics.insert(
+        "cpu.usage".to_owned(),
+        MetricConfig {
+            kind: UsageKind::Gauge,
+            modules: None,
+        },
+    );
+    let svc = Service::new(config_with_metrics(metrics), Arc::new(ClientHub::default()));
+    let cfg = svc.get_module_config("any-module").unwrap();
+    assert_eq!(cfg.allowed_metrics.len(), 1);
+    assert_eq!(cfg.allowed_metrics[0].name, "cpu.usage");
+    assert!(matches!(cfg.allowed_metrics[0].kind, UsageKind::Gauge));
+    assert_eq!(cfg.max_metadata_bytes, 8192);
+}
+
+#[tokio::test]
+async fn get_module_config_returns_metric_when_module_is_in_allow_list() {
+    let mut metrics = HashMap::new();
+    metrics.insert(
+        "req.count".to_owned(),
+        MetricConfig {
+            kind: UsageKind::Counter,
+            modules: Some(vec!["my-module".to_owned()]),
+        },
+    );
+    let svc = Service::new(config_with_metrics(metrics), Arc::new(ClientHub::default()));
+    let cfg = svc.get_module_config("my-module").unwrap();
+    assert_eq!(cfg.allowed_metrics.len(), 1);
+    assert_eq!(cfg.allowed_metrics[0].name, "req.count");
+    assert!(matches!(cfg.allowed_metrics[0].kind, UsageKind::Counter));
+    assert_eq!(cfg.max_metadata_bytes, 8192);
+}
+
+#[tokio::test]
+async fn get_module_config_returns_not_configured_when_module_not_in_allow_list() {
+    let mut metrics = HashMap::new();
+    metrics.insert(
+        "cpu.usage".to_owned(),
+        MetricConfig {
+            kind: UsageKind::Gauge,
+            modules: Some(vec!["other-module".to_owned()]),
+        },
+    );
+    let svc = Service::new(config_with_metrics(metrics), Arc::new(ClientHub::default()));
+    let err = svc.get_module_config("my-module").unwrap_err();
+    assert!(matches!(err, DomainError::ModuleNotConfigured { .. }));
+}
+
+#[tokio::test]
+async fn get_module_config_returns_only_matching_metrics_from_mixed_config() {
+    let mut metrics = HashMap::new();
+    metrics.insert(
+        "cpu.usage".to_owned(),
+        MetricConfig {
+            kind: UsageKind::Gauge,
+            modules: None,
+        },
+    );
+    metrics.insert(
+        "disk.io".to_owned(),
+        MetricConfig {
+            kind: UsageKind::Counter,
+            modules: Some(vec!["storage".to_owned()]),
+        },
+    );
+    let config = UsageCollectorConfig {
+        max_metadata_bytes: 16384,
+        metrics,
+        ..UsageCollectorConfig::default()
+    };
+    let svc = Service::new(config, Arc::new(ClientHub::default()));
+    let cfg = svc.get_module_config("my-module").unwrap();
+    assert_eq!(cfg.allowed_metrics.len(), 1);
+    assert_eq!(cfg.allowed_metrics[0].name, "cpu.usage");
+    assert_eq!(cfg.max_metadata_bytes, 16384);
+}
+
+// ── circuit breaker ──────────────────────────────────────────────────────────
+
+/// A storage plugin that always returns a transient error.
+struct FailPlugin;
+
+#[async_trait::async_trait]
+impl UsageCollectorPluginClientV1 for FailPlugin {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Err(UsageCollectorError::service_unavailable()
+            .with_detail("simulated transient failure")
+            .create())
+    }
+}
+
+/// A storage plugin that counts every invocation via an atomic counter.
+struct CountingPlugin {
+    counter: Arc<AtomicUsize>,
+    should_fail: bool,
+}
+
+impl CountingPlugin {
+    fn failing(counter: Arc<AtomicUsize>) -> Self {
+        Self {
+            counter,
+            should_fail: true,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl UsageCollectorPluginClientV1 for CountingPlugin {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        self.counter.fetch_add(1, Ordering::SeqCst);
+        if self.should_fail {
+            Err(UsageCollectorError::service_unavailable()
+                .with_detail("simulated transient failure")
+                .create())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+fn make_cb_service(
+    plugin: Arc<dyn UsageCollectorPluginClientV1>,
+    threshold: u32,
+    window: Duration,
+    recovery: Duration,
+) -> Service {
+    let instance_id = format!(
+        "{}test.usage.mock.cb_test.v1",
+        UsageCollectorPluginSpecV1::gts_schema_id()
+    );
+    let hub = hub_with_plugin(&instance_id, "cyberfabric", plugin);
+    Service::new(
+        UsageCollectorConfig {
+            vendor: "cyberfabric".to_owned(),
+            circuit_breaker: CircuitBreakerConfig {
+                failure_threshold: threshold,
+                window,
+                recovery_timeout: recovery,
+            },
+            ..UsageCollectorConfig::default()
+        },
+        hub,
+    )
+}
+
+#[tokio::test]
+async fn circuit_opens_after_n_consecutive_failures() {
+    let threshold = 2u32;
+    let svc = make_cb_service(
+        Arc::new(FailPlugin),
+        threshold,
+        Duration::from_secs(10),
+        Duration::from_millis(1),
+    );
+
+    for _ in 0..threshold {
+        drop(svc.create_usage_record(record(Uuid::new_v4())).await);
+    }
+
+    let err = svc
+        .create_usage_record(record(Uuid::new_v4()))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, DomainError::CircuitOpen),
+        "expected CircuitOpen after {threshold} failures, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn open_circuit_rejects_without_calling_plugin() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let threshold = 2u32;
+    let svc = make_cb_service(
+        Arc::new(CountingPlugin::failing(Arc::clone(&counter))),
+        threshold,
+        Duration::from_secs(10),
+        Duration::from_millis(1),
+    );
+
+    for _ in 0..threshold {
+        drop(svc.create_usage_record(record(Uuid::new_v4())).await);
+    }
+    let calls_to_open = counter.load(Ordering::SeqCst);
+
+    for _ in 0..3 {
+        let err = svc
+            .create_usage_record(record(Uuid::new_v4()))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, DomainError::CircuitOpen));
+    }
+
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        calls_to_open,
+        "plugin must not be invoked while circuit is open"
+    );
+}
+
+#[tokio::test]
+async fn failed_probe_reopens_circuit() {
+    let threshold = 1u32;
+    let svc = make_cb_service(
+        Arc::new(FailPlugin),
+        threshold,
+        Duration::from_secs(10),
+        Duration::from_millis(1),
+    );
+
+    drop(svc.create_usage_record(record(Uuid::new_v4())).await);
+
+    let err = svc
+        .create_usage_record(record(Uuid::new_v4()))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, DomainError::CircuitOpen));
+
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    // Probe call: Open → HalfOpen, then fails → re-opens. Returns the plugin error.
+    let probe_err = svc
+        .create_usage_record(record(Uuid::new_v4()))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(probe_err, DomainError::Plugin(_)),
+        "probe should propagate plugin error, got {probe_err:?}"
+    );
+
+    let err = svc
+        .create_usage_record(record(Uuid::new_v4()))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, DomainError::CircuitOpen));
+}

--- a/modules/system/usage-collector/usage-collector/src/lib.rs
+++ b/modules/system/usage-collector/usage-collector/src/lib.rs
@@ -1,0 +1,11 @@
+//! Usage Collector gateway.
+//!
+//! Centralized ingest for usage records from the SDK outbox pipeline and
+//! delegation to the GTS-selected storage plugin.
+
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+pub mod api;
+pub mod config;
+pub mod domain;
+mod module;

--- a/modules/system/usage-collector/usage-collector/src/module.rs
+++ b/modules/system/usage-collector/usage-collector/src/module.rs
@@ -1,0 +1,130 @@
+//! Usage-collector gateway `ModKit` module.
+
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+use authz_resolver_sdk::AuthZResolverClient;
+use axum::Router;
+use modkit::api::OpenApiRegistry;
+use modkit::contracts::{DatabaseCapability, RestApiCapability};
+use modkit::{Module, ModuleCtx};
+use sea_orm_migration::MigrationTrait;
+use tracing::info;
+use types_registry_sdk::{RegisterResult, TypesRegistryClient};
+use usage_collector_sdk::UsageCollectorPluginSpecV1;
+use usage_emitter::{UsageEmitterRuntime, UsageEmitterRuntimeV1};
+
+use crate::api::rest::routes;
+use crate::config::UsageCollectorConfig;
+use crate::domain::{Service, UsageCollectorLocalClient};
+
+/// Usage collector gateway: registers plugin schema, resolves plugins via GTS,
+/// exposes `dyn UsageCollectorClientV1` for outbox delivery, and wires REST endpoints
+/// via `DatabaseCapability` and `RestApiCapability`.
+#[modkit::module(
+    name = "usage-collector",
+    deps = ["authz-resolver", "types-registry"],
+    capabilities = [db, rest],
+)]
+#[derive(Default)]
+pub struct UsageCollectorModule {
+    /// Gateway service stored during `init()` for use in `register_rest()`.
+    service: OnceLock<Arc<Service>>,
+}
+
+#[async_trait]
+impl Module for UsageCollectorModule {
+    #[tracing::instrument(skip_all, fields(vendor))]
+    async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        let cfg: UsageCollectorConfig = ctx.config_or_default()?;
+        cfg.validate()?;
+        tracing::Span::current().record("vendor", &cfg.vendor);
+        info!(
+            cfg.vendor,
+            ?cfg.plugin_timeout,
+            "Loaded {} configuration",
+            Self::MODULE_NAME,
+        );
+
+        let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
+        let schema_str = UsageCollectorPluginSpecV1::gts_schema_with_refs_as_string();
+        let schema_json: serde_json::Value = serde_json::from_str(&schema_str)?;
+        let results = registry.register(vec![schema_json]).await?;
+        RegisterResult::ensure_all_ok(&results)?;
+        info!(
+            schema_id = %UsageCollectorPluginSpecV1::gts_schema_id(),
+            "Registered {} plugin schema in types-registry",
+            Self::MODULE_NAME,
+        );
+
+        let db = ctx
+            .db_required()
+            .map_err(|e| anyhow::anyhow!("{}: db not available: {e}", Self::MODULE_NAME))?
+            .db();
+
+        let authz = ctx
+            .client_hub()
+            .get::<dyn AuthZResolverClient>()
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "{}: AuthZResolverClient not registered: {e}",
+                    Self::MODULE_NAME
+                )
+            })?;
+
+        let service = Service::new(cfg.clone(), ctx.client_hub());
+        let service = Arc::new(service);
+        self.service
+            .set(Arc::clone(&service))
+            .map_err(|_| anyhow::anyhow!("{} module already initialized", Self::MODULE_NAME))?;
+
+        let collector = UsageCollectorLocalClient::new(service);
+        let collector = Arc::new(collector);
+
+        let runtime = UsageEmitterRuntime::build(cfg.emitter, db, authz, collector).await?;
+        let runtime = Arc::new(runtime);
+        ctx.client_hub()
+            .register::<dyn UsageEmitterRuntimeV1>(runtime);
+
+        Ok(())
+    }
+}
+
+impl DatabaseCapability for UsageCollectorModule {
+    fn migrations(&self) -> Vec<Box<dyn MigrationTrait>> {
+        info!("Providing {} database migrations", Self::MODULE_NAME);
+        modkit_db::outbox::outbox_migrations()
+    }
+}
+
+impl RestApiCapability for UsageCollectorModule {
+    fn register_rest(
+        &self,
+        ctx: &ModuleCtx,
+        router: Router,
+        openapi: &dyn OpenApiRegistry,
+    ) -> anyhow::Result<Router> {
+        tracing::info!("Registering {} REST routes", Self::MODULE_NAME);
+
+        let runtime = ctx
+            .client_hub()
+            .get::<dyn UsageEmitterRuntimeV1>()
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "{}: UsageEmitterRuntimeV1 not registered: {e}",
+                    Self::MODULE_NAME
+                )
+            })?;
+
+        let service = self
+            .service
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("{}: service not initialized", Self::MODULE_NAME))?;
+        let service = Arc::clone(service);
+
+        let router = routes::register_routes(router, openapi, runtime, service);
+        tracing::info!("{} REST routes registered", Self::MODULE_NAME);
+
+        Ok(router)
+    }
+}

--- a/modules/system/usage-collector/usage-collector/tests/common/mod.rs
+++ b/modules/system/usage-collector/usage-collector/tests/common/mod.rs
@@ -1,0 +1,400 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use authz_resolver_sdk::constraints::{Constraint, InPredicate, Predicate};
+use authz_resolver_sdk::models::{
+    EvaluationRequest, EvaluationResponse, EvaluationResponseContext,
+};
+use authz_resolver_sdk::{AuthZResolverClient, AuthZResolverError, DenyReason};
+use axum::routing::{get, post};
+use axum::{Extension, Router};
+use modkit::client_hub::{ClientHub, ClientScope};
+use modkit_db::migration_runner::run_migrations_for_testing;
+use modkit_db::outbox::outbox_migrations;
+use modkit_db::{ConnectOpts, connect_db};
+use modkit_security::SecurityContext;
+use modkit_security::access_scope::pep_properties;
+use types_registry_sdk::testing::make_test_instance;
+use types_registry_sdk::{
+    GtsInstance, GtsTypeSchema, InstanceQuery, RegisterResult, TypeSchemaQuery,
+    TypesRegistryClient, TypesRegistryError,
+};
+use usage_collector::api::rest::handlers::{handle_create_usage_record, handle_get_module_config};
+use usage_collector::config::{MetricConfig, UsageCollectorConfig};
+use usage_collector::domain::Service;
+use usage_collector_sdk::{
+    AllowedMetric, ModuleConfig, UsageCollectorClientV1, UsageCollectorError,
+    UsageCollectorPluginClientV1, UsageCollectorPluginSpecV1, UsageKind, UsageRecord,
+};
+use usage_emitter::{
+    UsageEmitterConfig, UsageEmitterFactory, UsageEmitterRuntime, UsageEmitterRuntimeV1,
+};
+use uuid::Uuid;
+
+// ── AuthZ mocks ───────────────────────────────────────────────────────────────
+
+pub struct MockAuthZResolverClient {
+    allow: bool,
+    tenant_id: Uuid,
+}
+
+impl MockAuthZResolverClient {
+    pub fn allow(tenant_id: Uuid) -> Self {
+        Self {
+            allow: true,
+            tenant_id,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn deny() -> Self {
+        Self {
+            allow: false,
+            tenant_id: Uuid::nil(),
+        }
+    }
+}
+
+#[async_trait]
+impl AuthZResolverClient for MockAuthZResolverClient {
+    async fn evaluate(
+        &self,
+        _request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        if self.allow {
+            Ok(EvaluationResponse {
+                decision: true,
+                context: EvaluationResponseContext {
+                    constraints: vec![Constraint {
+                        predicates: vec![Predicate::In(InPredicate::new(
+                            pep_properties::OWNER_TENANT_ID,
+                            [self.tenant_id],
+                        ))],
+                    }],
+                    ..EvaluationResponseContext::default()
+                },
+            })
+        } else {
+            Ok(EvaluationResponse {
+                decision: false,
+                context: EvaluationResponseContext {
+                    deny_reason: Some(DenyReason {
+                        error_code: "POLICY_DENIED".to_owned(),
+                        details: None,
+                    }),
+                    ..EvaluationResponseContext::default()
+                },
+            })
+        }
+    }
+}
+
+// ── Collector mocks (used by the embedded emitter only) ───────────────────────
+
+pub struct EmitterCollector {
+    config: ModuleConfig,
+}
+
+impl EmitterCollector {
+    fn new() -> Self {
+        Self::with_metrics(vec![AllowedMetric {
+            name: "test.gauge".to_owned(),
+            kind: UsageKind::Gauge,
+        }])
+    }
+
+    fn with_metrics(metrics: Vec<AllowedMetric>) -> Self {
+        Self {
+            config: ModuleConfig {
+                allowed_metrics: metrics,
+                max_metadata_bytes: 8192,
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl UsageCollectorClientV1 for EmitterCollector {
+    async fn create_usage_record(&self, _: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+    async fn get_module_config(&self, _: &str) -> Result<ModuleConfig, UsageCollectorError> {
+        Ok(self.config.clone())
+    }
+}
+
+// ── Plugin mock ───────────────────────────────────────────────────────────────
+
+pub struct MockUsageCollectorPluginClientV1;
+
+impl MockUsageCollectorPluginClientV1 {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl UsageCollectorPluginClientV1 for MockUsageCollectorPluginClientV1 {
+    async fn create_usage_record(&self, _: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+}
+
+// ── Service builder ───────────────────────────────────────────────────────────
+
+struct StubRegistry {
+    instances: Vec<GtsInstance>,
+}
+
+#[async_trait]
+impl TypesRegistryClient for StubRegistry {
+    async fn register(
+        &self,
+        _: Vec<serde_json::Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
+        Ok(vec![])
+    }
+    async fn register_type_schemas(
+        &self,
+        _: Vec<serde_json::Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
+        Ok(vec![])
+    }
+    async fn get_type_schema(&self, _: &str) -> Result<GtsTypeSchema, TypesRegistryError> {
+        unimplemented!()
+    }
+    async fn get_type_schema_by_uuid(&self, _: Uuid) -> Result<GtsTypeSchema, TypesRegistryError> {
+        unimplemented!()
+    }
+    async fn get_type_schemas(
+        &self,
+        _: Vec<String>,
+    ) -> HashMap<String, Result<GtsTypeSchema, TypesRegistryError>> {
+        unimplemented!()
+    }
+    async fn get_type_schemas_by_uuid(
+        &self,
+        _: Vec<Uuid>,
+    ) -> HashMap<Uuid, Result<GtsTypeSchema, TypesRegistryError>> {
+        unimplemented!()
+    }
+    async fn list_type_schemas(
+        &self,
+        _: TypeSchemaQuery,
+    ) -> Result<Vec<GtsTypeSchema>, TypesRegistryError> {
+        unimplemented!()
+    }
+    async fn register_instances(
+        &self,
+        _: Vec<serde_json::Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
+        Ok(vec![])
+    }
+    async fn get_instance(&self, _: &str) -> Result<GtsInstance, TypesRegistryError> {
+        unimplemented!()
+    }
+    async fn get_instance_by_uuid(&self, _: Uuid) -> Result<GtsInstance, TypesRegistryError> {
+        unimplemented!()
+    }
+    async fn get_instances(
+        &self,
+        _: Vec<String>,
+    ) -> HashMap<String, Result<GtsInstance, TypesRegistryError>> {
+        unimplemented!()
+    }
+    async fn get_instances_by_uuid(
+        &self,
+        _: Vec<Uuid>,
+    ) -> HashMap<Uuid, Result<GtsInstance, TypesRegistryError>> {
+        unimplemented!()
+    }
+    async fn list_instances(
+        &self,
+        _: InstanceQuery,
+    ) -> Result<Vec<GtsInstance>, TypesRegistryError> {
+        Ok(self.instances.clone())
+    }
+}
+
+fn plugin_content(gts_id: &str, vendor: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": gts_id,
+        "vendor": vendor,
+        "priority": 0,
+        "properties": {},
+    })
+}
+
+#[allow(dead_code)]
+pub fn build_service(
+    plugin: Arc<dyn UsageCollectorPluginClientV1>,
+    metrics: HashMap<String, MetricConfig>,
+) -> Arc<Service> {
+    let instance_id = format!(
+        "{}test.usage.mock.harness_test.v1",
+        UsageCollectorPluginSpecV1::gts_schema_id()
+    );
+    let hub = Arc::new(ClientHub::default());
+    hub.register::<dyn TypesRegistryClient>(Arc::new(StubRegistry {
+        instances: vec![make_test_instance(
+            &instance_id,
+            plugin_content(&instance_id, "cyberfabric"),
+        )],
+    }));
+    hub.register_scoped::<dyn UsageCollectorPluginClientV1>(
+        ClientScope::gts_id(&instance_id),
+        plugin,
+    );
+    Arc::new(Service::new(
+        UsageCollectorConfig {
+            metrics,
+            ..UsageCollectorConfig::default()
+        },
+        hub,
+    ))
+}
+
+// ── Emitter mock ──────────────────────────────────────────────────────────────
+
+/// Wraps a real [`UsageEmitterRuntime`] because [`usage_emitter::UsageEmitter::new`] is
+/// `pub(crate)`. Implements [`UsageEmitterRuntimeV1`] by delegating `factory(...)` to the
+/// wrapped runtime so callers exercise the real factory layer through the mock runtime.
+pub struct MockUsageEmitterRuntimeV1(UsageEmitterRuntime);
+
+impl MockUsageEmitterRuntimeV1 {
+    pub async fn with_allow_authz() -> Self {
+        let authz: Arc<dyn AuthZResolverClient> =
+            Arc::new(MockAuthZResolverClient::allow(Uuid::new_v4()));
+        Self(build_real_runtime(authz, EmitterCollector::new()).await)
+    }
+
+    #[allow(dead_code)]
+    pub async fn with_deny_authz() -> Self {
+        let authz: Arc<dyn AuthZResolverClient> = Arc::new(MockAuthZResolverClient::deny());
+        Self(build_real_runtime(authz, EmitterCollector::new()).await)
+    }
+
+    #[allow(dead_code)]
+    pub async fn with_allow_authz_and_metrics(metrics: Vec<AllowedMetric>) -> Self {
+        let authz: Arc<dyn AuthZResolverClient> =
+            Arc::new(MockAuthZResolverClient::allow(Uuid::new_v4()));
+        Self(build_real_runtime(authz, EmitterCollector::with_metrics(metrics)).await)
+    }
+}
+
+impl UsageEmitterRuntimeV1 for MockUsageEmitterRuntimeV1 {
+    fn factory(&self, module_name: &str) -> UsageEmitterFactory {
+        self.0.factory(module_name)
+    }
+}
+
+async fn build_real_runtime(
+    authz: Arc<dyn AuthZResolverClient>,
+    emitter_collector: EmitterCollector,
+) -> UsageEmitterRuntime {
+    let db_name = format!("uc_gw_{}", Uuid::new_v4().simple());
+    let url = format!("sqlite:file:{db_name}?mode=memory&cache=shared");
+    let db = connect_db(
+        &url,
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    run_migrations_for_testing(&db, outbox_migrations())
+        .await
+        .unwrap();
+    let collector: Arc<dyn UsageCollectorClientV1> = Arc::new(emitter_collector);
+    UsageEmitterRuntime::build(UsageEmitterConfig::default(), db, authz, collector)
+        .await
+        .unwrap()
+}
+
+// ── AppHarness ────────────────────────────────────────────────────────────────
+
+pub struct AppHarness {
+    pub router: Router,
+}
+
+impl AppHarness {
+    #[allow(dead_code)]
+    pub async fn new() -> Self {
+        let runtime = Arc::new(MockUsageEmitterRuntimeV1::with_allow_authz().await)
+            as Arc<dyn UsageEmitterRuntimeV1>;
+        let authz: Arc<dyn AuthZResolverClient> =
+            Arc::new(MockAuthZResolverClient::allow(Uuid::new_v4()));
+        let plugin: Arc<dyn UsageCollectorPluginClientV1> =
+            Arc::new(MockUsageCollectorPluginClientV1::new());
+        let service = build_service(plugin, HashMap::new());
+        Self::build(runtime, service, authz)
+    }
+
+    #[allow(dead_code)]
+    pub fn with_emitter(runtime: Arc<dyn UsageEmitterRuntimeV1>) -> Self {
+        let authz: Arc<dyn AuthZResolverClient> =
+            Arc::new(MockAuthZResolverClient::allow(Uuid::new_v4()));
+        let plugin: Arc<dyn UsageCollectorPluginClientV1> =
+            Arc::new(MockUsageCollectorPluginClientV1::new());
+        let service = build_service(plugin, HashMap::new());
+        Self::build(runtime, service, authz)
+    }
+
+    #[allow(dead_code)]
+    pub async fn with_metrics(metrics: HashMap<String, MetricConfig>) -> Self {
+        let runtime = Arc::new(MockUsageEmitterRuntimeV1::with_allow_authz().await)
+            as Arc<dyn UsageEmitterRuntimeV1>;
+        let authz: Arc<dyn AuthZResolverClient> =
+            Arc::new(MockAuthZResolverClient::allow(Uuid::new_v4()));
+        let plugin: Arc<dyn UsageCollectorPluginClientV1> =
+            Arc::new(MockUsageCollectorPluginClientV1::new());
+        let service = build_service(plugin, metrics);
+        Self::build(runtime, service, authz)
+    }
+
+    /// Build a harness whose emitter resolves the given allowed-metrics list when callers
+    /// authorize a module. Use this to exercise counter / gauge validation rules end-to-end
+    /// from the HTTP boundary.
+    #[allow(dead_code)]
+    pub async fn with_emitter_metrics(metrics: Vec<AllowedMetric>) -> Self {
+        let runtime =
+            Arc::new(MockUsageEmitterRuntimeV1::with_allow_authz_and_metrics(metrics).await)
+                as Arc<dyn UsageEmitterRuntimeV1>;
+        let authz: Arc<dyn AuthZResolverClient> =
+            Arc::new(MockAuthZResolverClient::allow(Uuid::new_v4()));
+        let plugin: Arc<dyn UsageCollectorPluginClientV1> =
+            Arc::new(MockUsageCollectorPluginClientV1::new());
+        let service = build_service(plugin, HashMap::new());
+        Self::build(runtime, service, authz)
+    }
+
+    fn build(
+        runtime: Arc<dyn UsageEmitterRuntimeV1>,
+        service: Arc<Service>,
+        authz: Arc<dyn AuthZResolverClient>,
+    ) -> Self {
+        let ctx = SecurityContext::builder()
+            .subject_id(Uuid::new_v4())
+            .subject_tenant_id(Uuid::new_v4())
+            .build()
+            .unwrap();
+        let router = Router::new()
+            .route(
+                "/usage-collector/v1/records",
+                post(handle_create_usage_record),
+            )
+            .route(
+                "/usage-collector/v1/modules/{module_name}/config",
+                get(handle_get_module_config),
+            )
+            .layer(Extension(runtime))
+            .layer(Extension(service))
+            .layer(Extension(authz))
+            .layer(Extension(ctx));
+        Self { router }
+    }
+}

--- a/modules/system/usage-collector/usage-collector/tests/create_record_tests.rs
+++ b/modules/system/usage-collector/usage-collector/tests/create_record_tests.rs
@@ -1,0 +1,222 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use chrono::Utc;
+use http::{Method, Request, StatusCode};
+use tower::ServiceExt;
+use usage_collector_sdk::{AllowedMetric, UsageKind};
+use usage_emitter::UsageEmitterRuntimeV1;
+use uuid::Uuid;
+
+use common::{AppHarness, MockUsageEmitterRuntimeV1};
+
+#[tokio::test]
+async fn create_record_happy_path() {
+    let runtime = Arc::new(MockUsageEmitterRuntimeV1::with_allow_authz().await)
+        as Arc<dyn UsageEmitterRuntimeV1>;
+    let harness = AppHarness::with_emitter(runtime);
+
+    let body = serde_json::json!({
+        "module": "test-module",
+        "tenant_id": Uuid::new_v4(),
+        "resource_type": "test.resource",
+        "resource_id": Uuid::new_v4(),
+        "metric": "test.gauge",
+        "value": 1.0,
+        "timestamp": Utc::now().to_rfc3339(),
+    });
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/usage-collector/v1/records")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+
+    let response = harness.router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn create_record_metadata_too_large() {
+    let harness = AppHarness::new().await;
+
+    let large_value = "a".repeat(9000);
+    let body = serde_json::json!({
+        "module": "test-module",
+        "tenant_id": Uuid::new_v4(),
+        "resource_type": "test.resource",
+        "resource_id": Uuid::new_v4(),
+        "metric": "test.gauge",
+        "value": 1.0,
+        "timestamp": Utc::now().to_rfc3339(),
+        "metadata": {"key": large_value},
+    });
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/usage-collector/v1/records")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+
+    let response = harness.router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn create_record_emitter_authorization_failed() {
+    let runtime = Arc::new(MockUsageEmitterRuntimeV1::with_deny_authz().await)
+        as Arc<dyn UsageEmitterRuntimeV1>;
+    let harness = AppHarness::with_emitter(runtime);
+
+    let body = serde_json::json!({
+        "module": "test-module",
+        "tenant_id": Uuid::new_v4(),
+        "resource_type": "test.resource",
+        "resource_id": Uuid::new_v4(),
+        "metric": "test.gauge",
+        "value": 1.0,
+        "timestamp": Utc::now().to_rfc3339(),
+    });
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/usage-collector/v1/records")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+
+    let response = harness.router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+// ── Idempotency / value / kind boundary cases (RUST-TEST-001) ─────────────────
+//
+// The handler trims `idempotency_key` whitespace and filters empties to `None` before
+// reaching the builder. For a counter that None propagates to `String::default()` and is
+// rejected with InvalidArgument; for a gauge the builder regenerates a fresh UUID and the
+// record is accepted. These tests pin both branches at the HTTP boundary, plus the negative
+// counter value path that lives only in the unit tests today.
+
+fn counter_metric() -> Vec<AllowedMetric> {
+    vec![AllowedMetric {
+        name: "test.counter".to_owned(),
+        kind: UsageKind::Counter,
+    }]
+}
+
+fn gauge_metric() -> Vec<AllowedMetric> {
+    vec![AllowedMetric {
+        name: "test.gauge".to_owned(),
+        kind: UsageKind::Gauge,
+    }]
+}
+
+async fn post_record(harness: AppHarness, body: serde_json::Value) -> StatusCode {
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/usage-collector/v1/records")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    harness.router.oneshot(request).await.unwrap().status()
+}
+
+fn base_body(metric: &str, value: f64) -> serde_json::Value {
+    serde_json::json!({
+        "module": "test-module",
+        "tenant_id": Uuid::new_v4(),
+        "resource_type": "test.resource",
+        "resource_id": Uuid::new_v4(),
+        "metric": metric,
+        "value": value,
+        "timestamp": Utc::now().to_rfc3339(),
+    })
+}
+
+#[tokio::test]
+async fn create_record_counter_with_whitespace_idempotency_key_returns_400() {
+    let harness = AppHarness::with_emitter_metrics(counter_metric()).await;
+    let mut body = base_body("test.counter", 1.0);
+    body["idempotency_key"] = serde_json::Value::String("   \t ".to_owned());
+    assert_eq!(post_record(harness, body).await, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn create_record_counter_without_idempotency_key_returns_400() {
+    let harness = AppHarness::with_emitter_metrics(counter_metric()).await;
+    let body = base_body("test.counter", 1.0);
+    assert_eq!(post_record(harness, body).await, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn create_record_gauge_with_whitespace_idempotency_key_succeeds() {
+    // For gauges the whitespace key normalises to `None` at the handler and the builder
+    // regenerates a UUID — the request succeeds with 204.
+    let harness = AppHarness::with_emitter_metrics(gauge_metric()).await;
+    let mut body = base_body("test.gauge", 1.0);
+    body["idempotency_key"] = serde_json::Value::String("   ".to_owned());
+    assert_eq!(post_record(harness, body).await, StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn create_record_counter_with_negative_value_returns_400() {
+    let harness = AppHarness::with_emitter_metrics(counter_metric()).await;
+    let mut body = base_body("test.counter", -1.0);
+    body["idempotency_key"] = serde_json::Value::String("key-1".to_owned());
+    assert_eq!(post_record(harness, body).await, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn create_record_gauge_with_nan_value_returns_400() {
+    let harness = AppHarness::with_emitter_metrics(gauge_metric()).await;
+    // serde_json refuses to serialise NaN, so emit the JSON manually.
+    let body_str = format!(
+        r#"{{"module":"test-module","tenant_id":"{}","resource_type":"test.resource","resource_id":"{}","metric":"test.gauge","value":NaN,"timestamp":"{}"}}"#,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Utc::now().to_rfc3339()
+    );
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/usage-collector/v1/records")
+        .header("content-type", "application/json")
+        .body(Body::from(body_str))
+        .unwrap();
+    // NaN is not valid JSON, so the JSON extractor rejects with 422 long before reaching
+    // the validator. This pins the boundary behaviour: a non-finite numeric literal cannot
+    // sneak through the HTTP layer. Document the actual returned code rather than asserting
+    // a hypothetical 400.
+    let status = harness.router.oneshot(request).await.unwrap().status();
+    assert!(
+        status == StatusCode::BAD_REQUEST || status == StatusCode::UNPROCESSABLE_ENTITY,
+        "expected 400 or 422 for NaN payload, got {status}"
+    );
+}
+
+#[tokio::test]
+async fn create_record_invalid_subject_id_uuid() {
+    let harness = AppHarness::new().await;
+
+    let body = serde_json::json!({
+        "module": "test-module",
+        "tenant_id": Uuid::new_v4(),
+        "resource_type": "test.resource",
+        "resource_id": Uuid::new_v4(),
+        "subject": { "id": "not-a-valid-uuid" },
+        "metric": "test.gauge",
+        "value": 1.0,
+        "timestamp": Utc::now().to_rfc3339(),
+    });
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/usage-collector/v1/records")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+
+    let response = harness.router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}

--- a/modules/system/usage-collector/usage-collector/tests/module_config_tests.rs
+++ b/modules/system/usage-collector/usage-collector/tests/module_config_tests.rs
@@ -1,0 +1,57 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use std::collections::HashMap;
+
+use axum::body::{Body, to_bytes};
+use http::{Method, Request, StatusCode};
+use tower::ServiceExt;
+use usage_collector::config::MetricConfig;
+use usage_collector_sdk::UsageKind;
+
+use common::AppHarness;
+
+#[tokio::test]
+async fn module_config_found() {
+    let mut metrics = HashMap::new();
+    metrics.insert(
+        "cpu.usage".to_owned(),
+        MetricConfig {
+            kind: UsageKind::Gauge,
+            modules: None,
+        },
+    );
+    let harness = AppHarness::with_metrics(metrics).await;
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/usage-collector/v1/modules/my-module/config")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = harness.router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let metrics = json["allowed_metrics"].as_array().unwrap();
+    assert_eq!(metrics.len(), 1);
+    assert_eq!(metrics[0]["name"], "cpu.usage");
+    assert_eq!(json["max_metadata_bytes"], serde_json::json!(8192));
+}
+
+#[tokio::test]
+async fn module_config_not_found() {
+    // Default harness has no metrics configured → service returns ModuleNotConfigured → 404.
+    let harness = AppHarness::new().await;
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/usage-collector/v1/modules/unknown-module/config")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = harness.router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}

--- a/modules/system/usage-collector/usage-emitter/Cargo.toml
+++ b/modules/system/usage-collector/usage-emitter/Cargo.toml
@@ -1,0 +1,59 @@
+[package]
+name = "cyberware-usage-emitter"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Durable usage emission: two-phase PDP authorization, transactional outbox enqueue, async delivery to the collector"
+readme = "README.md"
+keywords = ["cyberfabric", "cyberware", "cyberware-system"]
+categories = ["development-tools"]
+
+[lib]
+name = "usage_emitter"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Local dependencies
+authz-resolver-sdk = { workspace = true }
+usage-collector-sdk = { workspace = true }
+
+# ModKit dependencies
+modkit-canonical-errors = { workspace = true }
+modkit-db = { workspace = true, features = ["preview-outbox"] }
+modkit-security = { workspace = true }
+
+# Async runtime
+async-trait = { workspace = true }
+tokio = { workspace = true }
+
+# Data structures
+chrono = { workspace = true }
+uuid = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+# DB
+sea-orm-migration = { workspace = true }
+
+[dev-dependencies]
+# ModKit dependencies
+modkit-db = { workspace = true, features = ["sqlite"] }
+
+# Async runtime
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+# Data structures
+chrono = { workspace = true }

--- a/modules/system/usage-collector/usage-emitter/README.md
+++ b/modules/system/usage-collector/usage-emitter/README.md
@@ -1,0 +1,162 @@
+# Usage Emitter
+
+> **Emitter library** — three-layer Runtime/Factory/Emitter model: process-wide runtime, module-scoped factory, per-call-site authorized emitter, transactional outbox enqueue, and async delivery to the usage collector.
+
+A plain library crate (no `#[modkit::module]`). Each host module (`usage-collector`, `usage-collector-rest-client`, future gRPC client) calls `UsageEmitterRuntime::build(config, db, authz, collector)` in its own `init()` and registers the result as `dyn UsageEmitterRuntimeV1` in `ClientHub`.
+
+## Why there is no `usage-emitter-sdk` crate
+
+The rest of the workspace follows an "impl crate + thin SDK crate" pattern (`usage-collector` /
+`usage-collector-sdk`, `tenant-resolver` / `tenant-resolver-sdk`, `account-management` /
+`account-management-sdk`), where the SDK crate publishes only the trait + DTOs and consumers
+depend on it instead of the impl crate. `usage-emitter` intentionally diverges and ships as a
+single crate. Reasons:
+
+- **The public trait is not separable from the impl.** `UsageEmitterRuntimeV1::factory`
+  returns a concrete `UsageEmitterFactory`, which in turn produces a concrete `UsageEmitter`
+  and `UsageRecordBuilder`. These types carry private state (`db`, `outbox`, `issued_at`,
+  `allowed_metrics`) that is what makes the security invariant below enforceable — they cannot
+  be reduced to opaque trait objects without losing the type-state authorization handle.
+  Consumers therefore always use the trait *and* the concrete types together.
+- **`UsageCollectorClientV1` is deliberately not in `ClientHub`.** Other modules publish a
+  client trait that any module can resolve; here the collector client is supplied to
+  `UsageEmitterRuntime::build` and stays private. There is no "SDK-only consumer" shape — a
+  consumer either builds and registers the runtime (then it transitively depends on
+  `modkit-db`, the outbox runtime, PDP wiring, and `tokio` anyway) or it resolves
+  `dyn UsageEmitterRuntimeV1` from the hub, in which case it only needs the trait *plus* the
+  concrete `UsageEmitterFactory`/`UsageEmitter`/`UsageRecordBuilder` chain to do anything
+  useful.
+- **Test consumers don't need a thinner crate.** Mocks for `UsageEmitterRuntimeV1` wrap a real
+  `UsageEmitterRuntime` against an in-memory SQLite (see
+  `usage-collector/tests/common/mod.rs`) because every meaningful test path exercises the
+  outbox enqueue. A trait-only SDK crate would not remove that requirement.
+
+If a future consumer appears that only depends on the trait shape and a small set of DTOs (e.g.
+a gRPC façade re-publishing the API), revisit this decision and extract the trait into
+`usage-emitter-sdk` at that point.
+
+## Security invariant
+
+`UsageCollectorClientV1` is **never** registered in `ClientHub`. It is supplied to `UsageEmitterRuntime::build` as a constructor argument and stays private inside the runtime. Only `dyn UsageEmitterRuntimeV1` is published to the hub, so the sole path a source module has to the collector is through a PDP-authorized, tenant/resource-bound `UsageEmitter::enqueue*`. The PDP resource type and action constants (`gts.x.core.usage.record.v1 / create`) are `pub(crate)` in this crate and cannot be referenced externally. `UsageRecordBuilder` is publicly constructible via `UsageRecordBuilder::new()` and performs no authorization checks — it is plain data, and the invariant is preserved because `enqueue` / `enqueue_in` re-validate every field of the resulting `UsageRecord` against the `UsageEmitter` handle (module, tenant, resource, subject, allowed-metrics, value/idempotency rules) before any outbox write.
+
+## API
+
+The three layers in order:
+
+| Layer | Item | Description |
+|-------|------|-------------|
+| 1 | `UsageEmitterRuntimeV1` | Process-wide trait. Obtain from `ClientHub`. Call `runtime.factory(MODULE_NAME)` once (e.g. in `init()`) to get a module-scoped `UsageEmitterFactory`. |
+| 1 | `UsageEmitterRuntime` | Concrete implementation of `UsageEmitterRuntimeV1`; built with `UsageEmitterRuntime::build`; owns the outbox worker, the gateway client, the PDP resolver, and shared `Arc`s. |
+| 2 | `UsageEmitterFactory` | Module-scoped, cheaply cloneable. Module name is fixed at `runtime.factory(name)` and immutable thereafter. Apply per-call scope overrides via `.with_tenant(...)`, `.with_subject(...)`, `.with_subject_id(...)`, `.without_subject()`, or `.with_subject_opt(id, ty)`; then call `.authorize(ctx, resource_id, resource_type)` to run PDP authorization and obtain a `UsageEmitter`. |
+| 3 | `UsageEmitter` | Per-call-site, authorized handle returned by `factory.authorize(...)`. Call `enqueue` / `enqueue_in` with a pre-built `UsageRecord`, or `usage_record_builder(metric, value)` to obtain a prefilled `UsageRecordBuilder`. No further PDP calls in the hot path. |
+| — | `UsageRecordBuilder` | Plain builder. Construct via `UsageRecordBuilder::new()` or `UsageEmitter::usage_record_builder(metric, value)?` (which prefills `module`, `tenant_id`, `resource_id` / `resource_type`, `subject_id` / `subject_type`, `metric` + `kind`, and `value` from the authorized handle). Setters: `with_module`, `with_tenant_id`, `with_metric(name, kind)`, `with_value`, `with_resource(id, type)`, `with_subject(id, type)` / `with_subject_id(id)`, `with_idempotency_key`, `with_timestamp`, `with_metadata`. Call `.build()` to obtain a `UsageRecord`. |
+| — | `UsageEmitterConfig` | Tunable authorization TTL, outbox queue name, partition count. Embedded in the host module's own config struct. |
+| — | `CanonicalError` | Error type returned by all emitter methods. Re-exported from `modkit-canonical-errors`. |
+
+## Emitting a usage record
+
+```rust
+use usage_emitter::{UsageEmitter, UsageEmitterFactory, UsageEmitterRuntimeV1};
+
+// In init(): obtain the runtime from ClientHub and store a factory bound to this module.
+let runtime = hub.get::<dyn UsageEmitterRuntimeV1>()?;
+let emitter_factory: UsageEmitterFactory = runtime.factory(Self::MODULE_NAME);
+
+// In a handler — authorize for this call site (single PDP call + allowed-metrics fetch;
+// the returned UsageEmitter is valid for UsageEmitterConfig::authorization_max_age).
+let emitter: UsageEmitter = emitter_factory
+    .clone()
+    .authorize(&ctx, resource_id, &resource_type)
+    .await?;
+
+// Build a record (the builder is prefilled from the authorized emitter — metric kind is
+// resolved from the allowed-metrics list; an unknown metric returns an error here) and
+// enqueue on the emitter's DB connection.
+let record = emitter
+    .usage_record_builder("requests", 1.0)?
+    .build()?;
+emitter.enqueue(record).await?;
+
+// Enqueue inside a caller transaction (atomic with your write).
+// let record = emitter.usage_record_builder("requests", 1.0)?.build()?;
+// emitter.enqueue_in(&txn, record).await?;
+
+// Optional: set idempotency key, timestamp, or metadata before calling .build().
+// let record = emitter
+//     .usage_record_builder("requests", 1.0)?
+//     .with_idempotency_key("key123")
+//     .with_timestamp(Utc::now())
+//     .build()?;
+// emitter.enqueue(record).await?;
+
+// Emit with overrides — explicit tenant + no subject (e.g. system jobs).
+// let emitter = emitter_factory
+//     .clone()
+//     .with_tenant(target_tenant)
+//     .without_subject()
+//     .authorize(&ctx, resource_id, "system_job")
+//     .await?;
+
+// Forwarder / REST ingest — explicit subject from the request body.
+// let emitter = emitter_factory
+//     .clone()
+//     .with_tenant(req.tenant_id)
+//     .with_subject_opt(req.subject_id, req.subject_type.as_deref())?
+//     .authorize(&ctx, req.resource_id, &req.resource_type)
+//     .await?;
+
+// `UsageRecordBuilder::new()` can also be used standalone — every required field
+// (`module`, `tenant_id`, `metric`, `value`, `resource_id`, `resource_type`) must
+// then be set explicitly via the corresponding `with_*` setter; `.build()` returns
+// `UsageEmitterError::InvalidArgument` listing any missing fields.
+```
+
+## Configuration
+
+`UsageEmitterConfig` is embedded in the host module's own config struct with `#[serde(default)]`, so all fields are optional in YAML:
+
+```yaml
+modules:
+  usage-collector:         # or usage-collector-rest-client
+    config:
+      emitter:
+        authorization_max_age: "30s"   # default
+        outbox_queue: "usage-records"  # default
+        outbox_partition_count: 4      # default; power of 2 in 1–64
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `authorization_max_age` | `30s` | Maximum age of a `UsageEmitter` handle before `enqueue*` rejects it with `AuthorizationExpired` |
+| `outbox_queue` | `usage-records` | Outbox queue name |
+| `outbox_partition_count` | `4` | Partition count (power of 2 in 1–64) |
+
+## Error handling
+
+```rust
+use usage_emitter::CanonicalError;
+
+match emitter.enqueue(record).await {
+    Ok(()) => {}
+    Err(CanonicalError::PermissionDenied { .. }) => { /* PDP denied or authorization expired */ }
+    Err(CanonicalError::Internal { .. }) => { /* metric not allowed, non-finite value, or runtime error */ }
+    Err(CanonicalError::ServiceUnavailable { .. }) => { /* outbox DB write failed or transient outage */ }
+    Err(e) => { /* other canonical error */ }
+}
+```
+
+## Background delivery
+
+The outbox worker dequeues from the queue configured via `outbox_queue` (host overrides apply) and calls `UsageCollectorClientV1::create_usage_record` per message:
+
+- **`Ok`** — message acknowledged
+- **`DeadlineExceeded`** / **`ResourceExhausted`** / **`ServiceUnavailable`** — transient (plugin timeout, rate limit, HTTP 5xx, circuit breaker open, transport error); message is retried
+- **Other errors** — permanent (`Unauthenticated`, `PermissionDenied`, `NotFound`, `Internal`); message is dead-lettered
+
+Delivery is independent of the request that enqueued the record and survives process restarts through the durable outbox.
+
+## Testing
+
+```bash
+devbox run cargo test -p cyberware-usage-emitter
+```

--- a/modules/system/usage-collector/usage-emitter/src/api.rs
+++ b/modules/system/usage-collector/usage-emitter/src/api.rs
@@ -1,0 +1,28 @@
+/// Source-facing trait for the process-lifetime usage-emitter runtime.
+///
+/// Obtain from `ClientHub`: `hub.get::<dyn UsageEmitterRuntimeV1>()?`
+///
+/// Registered in `ClientHub` by the host module (`usage-collector` for in-process
+/// delivery, `usage-collector-rest-client` for HTTP delivery to a remote collector).
+/// The runtime owns the outbox worker and shared Arcs for the entire process.
+///
+/// Call [`Self::factory`] with the module's name constant to obtain a
+/// [`crate::domain::factory::UsageEmitterFactory`] bound to that module. Modules store
+/// one factory per module and clone it per call to apply scope overrides via the fluent
+/// `.with_*()` chain before invoking `.authorize()`.
+///
+/// # Crate shape note
+///
+/// This trait is intentionally published from the implementation crate
+/// (`cyberware-usage-emitter`) rather than a thin `*-sdk` crate. The trait returns a
+/// concrete [`crate::domain::factory::UsageEmitterFactory`], which in turn produces
+/// concrete [`crate::domain::emitter::UsageEmitter`] /
+/// [`crate::domain::usage_record_builder::UsageRecordBuilder`] handles carrying private
+/// state that enforces the security invariant — those types cannot be reduced to opaque
+/// trait objects. Consumers therefore always need the trait *and* the concrete types
+/// together; splitting into trait-SDK + impl crates would not remove the impl-crate
+/// dependency. See the crate-level `lib.rs` docs and `README.md` for the full rationale.
+pub trait UsageEmitterRuntimeV1: Send + Sync {
+    /// Obtain a [`UsageEmitterFactory`] bound to `module_name`.
+    fn factory(&self, module_name: &str) -> crate::domain::factory::UsageEmitterFactory;
+}

--- a/modules/system/usage-collector/usage-emitter/src/config.rs
+++ b/modules/system/usage-collector/usage-emitter/src/config.rs
@@ -1,0 +1,100 @@
+use std::time::Duration;
+
+use serde::Deserialize;
+
+/// Configuration for [`crate::UsageEmitterRuntime`].
+///
+/// Host modules embed this inside their own config struct and forward it to
+/// [`crate::UsageEmitterRuntime::build`]. All fields have sensible defaults so
+/// `#[serde(default)]` on the embedding struct is sufficient for zero-config usage.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct UsageEmitterConfig {
+    /// Maximum age of an [`crate::UsageEmitter`] handle after
+    /// [`crate::UsageEmitterFactory::authorize`] before
+    /// [`crate::UsageEmitter::enqueue`] / [`crate::UsageEmitter::enqueue_in`]
+    /// reject it with `UsageEmitterError::Unauthenticated`.
+    pub authorization_max_age: Duration,
+
+    /// Outbox queue name for usage records delivered to the collector.
+    pub outbox_queue: String,
+
+    /// Number of outbox partitions. Must be a power of 2 in 1-64.
+    pub outbox_partition_count: u16,
+
+    /// Maximum exponential-backoff delay for outbox delivery retries.
+    ///
+    /// Maps to [`modkit_db::outbox::WorkerTuning::retry_max`].
+    /// MUST remain below 15 minutes to satisfy `cpt-cf-usage-collector-nfr-recovery`
+    /// (inst-dlv-6a / inst-emit-10a).
+    pub outbox_backoff_max: Duration,
+
+    /// Per-call timeout applied to each external call made during
+    /// [`crate::UsageEmitterFactory::authorize`] — the PDP `access_scope_with` call and the
+    /// [`usage_collector_sdk::UsageCollectorClientV1::get_module_config`] call.
+    ///
+    /// When the trait is implemented by a REST/remote client, an unresponsive backend would
+    /// otherwise stall every authorize-and-emit caller indefinitely. An elapsed timeout maps to
+    /// [`usage_collector_sdk::UsageRecordError::deadline_exceeded`] so it surfaces as the
+    /// canonical `DeadlineExceeded` variant (HTTP 504 at the REST boundary).
+    pub authorize_call_timeout: Duration,
+}
+
+impl Default for UsageEmitterConfig {
+    fn default() -> Self {
+        Self {
+            authorization_max_age: Duration::from_secs(30),
+            outbox_queue: "usage-records".to_owned(),
+            outbox_partition_count: 4,
+            outbox_backoff_max: Duration::from_mins(10), // 10 minutes — well below the 15-minute NFR ceiling
+            authorize_call_timeout: Duration::from_secs(5),
+        }
+    }
+}
+
+impl UsageEmitterConfig {
+    /// # Errors
+    ///
+    /// Returns an error when any configuration field is invalid.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !self.outbox_queue.trim().is_empty(),
+            "outbox_queue must not be empty"
+        );
+        anyhow::ensure!(
+            (1..=64).contains(&self.outbox_partition_count)
+                && self.outbox_partition_count.is_power_of_two(),
+            "outbox_partition_count must be a power of 2 in 1-64, got {}",
+            self.outbox_partition_count
+        );
+        anyhow::ensure!(
+            !self.authorization_max_age.is_zero(),
+            "authorization_max_age must be > 0"
+        );
+        anyhow::ensure!(
+            self.outbox_backoff_max > Duration::ZERO,
+            "outbox_backoff_max must be greater than zero"
+        );
+        anyhow::ensure!(
+            self.outbox_backoff_max < Duration::from_mins(15),
+            "outbox_backoff_max must be below 15 minutes (cpt-cf-usage-collector-nfr-recovery), got {:?}",
+            self.outbox_backoff_max
+        );
+        anyhow::ensure!(
+            !self.authorize_call_timeout.is_zero(),
+            "authorize_call_timeout must be > 0"
+        );
+        anyhow::ensure!(
+            self.authorize_call_timeout <= Duration::from_secs(30),
+            "authorize_call_timeout must not exceed 30s, got {:?}",
+            self.authorize_call_timeout
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "config_tests.rs"]
+mod config_tests;

--- a/modules/system/usage-collector/usage-emitter/src/config_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/src/config_tests.rs
@@ -1,0 +1,116 @@
+use std::time::Duration;
+
+use super::UsageEmitterConfig;
+
+#[test]
+fn validate_accepts_defaults() {
+    UsageEmitterConfig::default().validate().unwrap();
+}
+
+#[test]
+fn validate_rejects_empty_outbox_queue() {
+    let cfg = UsageEmitterConfig {
+        outbox_queue: "   ".to_owned(),
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("outbox_queue"));
+}
+
+#[test]
+fn validate_rejects_invalid_outbox_partition_count_zero() {
+    let cfg = UsageEmitterConfig {
+        outbox_partition_count: 0,
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("outbox_partition_count"));
+}
+
+#[test]
+fn validate_rejects_invalid_outbox_partition_count_not_power_of_two() {
+    let cfg = UsageEmitterConfig {
+        outbox_partition_count: 3,
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("outbox_partition_count"));
+}
+
+#[test]
+fn validate_rejects_invalid_outbox_partition_count_above_64() {
+    let cfg = UsageEmitterConfig {
+        outbox_partition_count: 65,
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("outbox_partition_count"));
+}
+
+#[test]
+fn validate_rejects_zero_authorization_max_age() {
+    let cfg = UsageEmitterConfig {
+        authorization_max_age: Duration::ZERO,
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("authorization_max_age"));
+}
+
+#[test]
+fn validate_rejects_zero_outbox_backoff_max() {
+    let cfg = UsageEmitterConfig {
+        outbox_backoff_max: Duration::ZERO,
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("outbox_backoff_max"));
+}
+
+#[test]
+fn validate_rejects_outbox_backoff_max_at_or_above_15_minutes() {
+    let cfg = UsageEmitterConfig {
+        outbox_backoff_max: Duration::from_mins(15),
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("outbox_backoff_max"));
+}
+
+#[test]
+fn validate_accepts_outbox_backoff_max_below_15_minutes() {
+    let cfg = UsageEmitterConfig {
+        outbox_backoff_max: Duration::from_secs(899),
+        ..UsageEmitterConfig::default()
+    };
+    cfg.validate().unwrap();
+}
+
+#[test]
+fn validate_rejects_zero_authorize_call_timeout() {
+    let cfg = UsageEmitterConfig {
+        authorize_call_timeout: Duration::ZERO,
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("authorize_call_timeout"));
+}
+
+#[test]
+fn validate_rejects_authorize_call_timeout_above_30s() {
+    let cfg = UsageEmitterConfig {
+        authorize_call_timeout: Duration::from_secs(31),
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("authorize_call_timeout"));
+}
+
+#[test]
+fn validate_accepts_authorize_call_timeout_at_30s() {
+    let cfg = UsageEmitterConfig {
+        authorize_call_timeout: Duration::from_secs(30),
+        ..UsageEmitterConfig::default()
+    };
+    cfg.validate().unwrap();
+}

--- a/modules/system/usage-collector/usage-emitter/src/domain/emitter.rs
+++ b/modules/system/usage-collector/usage-emitter/src/domain/emitter.rs
@@ -1,0 +1,388 @@
+use std::sync::Arc;
+use std::time::Instant;
+
+use modkit_db::Db;
+use modkit_db::outbox::Outbox;
+use modkit_db::secure::DBRunner;
+use tracing::{debug, error};
+use usage_collector_sdk::error::UsageRecordError;
+use usage_collector_sdk::models::{AllowedMetric, Subject, UsageKind, UsageRecord};
+use uuid::Uuid;
+
+use crate::config::UsageEmitterConfig;
+use crate::domain::usage_record_builder::UsageRecordBuilder;
+use crate::error::UsageEmitterError;
+
+/// Upper bound on free-form string fields inside a [`UsageRecord`] enqueued by
+/// the emitter. Without this, a caller (REST gateway or in-process module) could
+/// emit a multi-megabyte `module` / `metric` / `resource_type` / `idempotency_key` /
+/// `subject.type` that would be serialized into the outbox payload, persisted, and
+/// fanned out to every downstream consumer. 4 KiB is generous for legitimate
+/// identifiers (UUIDs, dotted names) and small enough that nothing downstream is
+/// asked to store a pathological value.
+///
+/// Enforced at the emitter rather than at the REST DTO boundary because the
+/// emitter is the only common gate — in-process modules construct
+/// [`UsageRecord`]s and call [`UsageEmitter::enqueue`]/[`enqueue_in`] without
+/// going through the REST layer.
+const MAX_RECORD_FIELD_LEN: usize = 4096;
+
+/// Emitter state after successful PDP authorization; call [`Self::enqueue`] or
+/// [`Self::enqueue_in`] on the returned handle.
+///
+/// Constructed via [`crate::UsageEmitterFactory::authorize`]; callers cannot forge handles.
+pub struct UsageEmitter {
+    pub(crate) config: Arc<UsageEmitterConfig>,
+    pub(crate) db: Db,
+    pub(crate) outbox: Arc<Outbox>,
+    pub(crate) module: String,
+    pub(crate) tenant_id: Uuid,
+    pub(crate) resource_id: Uuid,
+    pub(crate) resource_type: String,
+    pub(crate) allowed_metrics: Vec<AllowedMetric>,
+    pub(crate) max_metadata_bytes: u32,
+    pub(crate) subject: Option<Subject>,
+    pub(crate) issued_at: Instant,
+}
+
+impl UsageEmitter {
+    /// Enqueue a usage record using this emitter's database connection.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageEmitterError`] when obtaining a connection fails, the authorization handle
+    /// expired, or the outbox enqueue fails.
+    pub async fn enqueue(&self, record: UsageRecord) -> Result<(), UsageEmitterError> {
+        // Outbox carve-out: `modkit_db::outbox::Outbox::enqueue` is framework-internal
+        // transactional messaging that targets `modkit_outbox_incoming`/`_outbox`. Those tables
+        // have no tenant or resource columns, so `AccessScope`/`SecureConn` filtering does not
+        // apply; the outbox API takes any `DBRunner` directly. Using `db.conn()` here is
+        // intentional and consistent with the modkit-db outbox contract.
+        let conn = self.db.conn().map_err(|e| {
+            UsageEmitterError::internal(format!("{:#}", anyhow::Error::new(e))).create()
+        })?;
+        self.enqueue_in(&conn, record).await
+    }
+
+    /// Enqueue a usage record on the given database runner (connection or transaction).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageEmitterError`] when the authorization handle expired, the record does not
+    /// match the authorized tenant/resource, the metric is not allowed for this module, a counter
+    /// record has a negative value, or the outbox enqueue fails.
+    #[tracing::instrument(
+        skip_all,
+        fields(
+            module = %self.module,
+            tenant_id = %self.tenant_id,
+            resource_id = %self.resource_id,
+            resource_type = %self.resource_type,
+            metric = %record.metric,
+        ),
+    )]
+    pub async fn enqueue_in(
+        &self,
+        db: &(dyn DBRunner + Sync),
+        mut record: UsageRecord,
+    ) -> Result<(), UsageEmitterError> {
+        Self::validate_field_lengths(&record)?;
+        self.validate_authorization_freshness()?;
+        self.validate_authorized_tenant(&record)?;
+        self.validate_authorized_resource(&record)?;
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-6
+        self.validate_authorized_module(&record)?;
+        self.validate_authorized_subject(&record)?;
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-6
+        self.validate_allowed_metric(&record)?;
+        self.validate_metric_kind(&record)?;
+        Self::validate_counter_value(&record)?;
+        Self::validate_counter_idempotency_key(&record)?;
+        self.validate_metadata_size(&record)?;
+        // Generate a UUID idempotency key for gauge records when the caller
+        // omitted (or blanked) one. Counter records keep an empty key here so
+        // `validate_counter_idempotency_key` can reject them with the canonical
+        // `InvalidArgument` error.
+        Self::generate_gauge_idempotency_key(&mut record);
+
+        // Fold the full 128-bit tenant UUID down to 32 bits via XOR before
+        // taking the partition modulo. Using only the leading byte is uniform
+        // for v4 but clusters under v7 (time-prefixed), where IDs minted in
+        // the same ms share leading bytes and would all land on the same
+        // partition.
+        let n = record.tenant_id.as_u128();
+        #[allow(clippy::cast_possible_truncation)]
+        let folded = (n as u32) ^ ((n >> 32) as u32) ^ ((n >> 64) as u32) ^ ((n >> 96) as u32);
+        let partition = folded % u32::from(self.config.outbox_partition_count);
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-8
+        let payload = serde_json::to_vec(&record).map_err(|e| {
+            UsageEmitterError::internal(format!(
+                "payload serialization failed: {:#}",
+                anyhow::Error::new(e)
+            ))
+            .create()
+        })?;
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-8
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-9
+        self.outbox
+            .enqueue(
+                db,
+                &self.config.outbox_queue,
+                partition,
+                payload,
+                "usage-collector.record.v1",
+            )
+            .await
+            .map_err(|e| {
+                // The canonical `ServiceUnavailable` error has no `#[source]` slot, so
+                // wrapping the outbox error in `Problem.detail` strips the original
+                // `#[source]` chain (sqlx, sea-orm, etc.). Log the original error here
+                // so operators retain the full chain for debugging.
+                error!(error = ?e, "outbox enqueue failed");
+                UsageEmitterError::service_unavailable()
+                    .with_detail(format!("outbox error: {:#}", anyhow::Error::new(e)))
+                    .create()
+            })?;
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-9
+
+        debug!(%self.tenant_id, "usage record enqueued");
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-10
+        Ok(())
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-10
+    }
+
+    fn validate_field_lengths(record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        fn check(name: &str, value: &str) -> Result<(), UsageEmitterError> {
+            if value.len() > MAX_RECORD_FIELD_LEN {
+                return Err(UsageRecordError::invalid_argument()
+                    .with_constraint(format!(
+                        "{name} length {} exceeds the {MAX_RECORD_FIELD_LEN}-byte limit",
+                        value.len(),
+                    ))
+                    .create());
+            }
+            Ok(())
+        }
+        check("module", &record.module)?;
+        check("metric", &record.metric)?;
+        check("resource_type", &record.resource_type)?;
+        check("idempotency_key", &record.idempotency_key)?;
+        if let Some(s) = &record.subject
+            && let Some(ty) = &s.r#type
+        {
+            check("subject.type", ty)?;
+        }
+        Ok(())
+    }
+
+    fn validate_authorization_freshness(&self) -> Result<(), UsageEmitterError> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-1
+        let elapsed = self.issued_at.elapsed();
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-1
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-2
+        if elapsed > self.config.authorization_max_age {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-2a
+            return Err(UsageEmitterError::unauthenticated()
+                .with_reason("emit authorization token has expired")
+                .create());
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-2a
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-2
+        Ok(())
+    }
+
+    fn validate_authorized_tenant(&self, record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        if record.tenant_id != self.tenant_id {
+            return Err(UsageRecordError::permission_denied()
+                .with_reason("usage record tenant_id does not match authorized tenant")
+                .create());
+        }
+        Ok(())
+    }
+
+    fn validate_authorized_resource(&self, record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        if record.resource_id != self.resource_id {
+            return Err(UsageRecordError::permission_denied()
+                .with_reason("usage record resource_id does not match authorized resource")
+                .create());
+        }
+
+        if record.resource_type != self.resource_type {
+            return Err(UsageRecordError::permission_denied()
+                .with_reason("usage record resource_type does not match authorized resource")
+                .create());
+        }
+
+        Ok(())
+    }
+
+    fn validate_authorized_module(&self, record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        if record.module != self.module {
+            return Err(UsageRecordError::permission_denied()
+                .with_reason("record module does not match authorized token")
+                .create());
+        }
+        Ok(())
+    }
+
+    fn validate_authorized_subject(&self, record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        if record.subject != self.subject {
+            return Err(UsageRecordError::permission_denied()
+                .with_reason("record subject does not match authorized token")
+                .create());
+        }
+        Ok(())
+    }
+
+    fn validate_allowed_metric(&self, record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-3
+        let metric_allowed = self.allowed_metrics.iter().any(|m| m.name == record.metric);
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-3
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-4
+        if !metric_allowed {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-4a
+            return Err(UsageRecordError::permission_denied()
+                .with_reason(format!(
+                    "metric not allowed for this module: {}",
+                    record.metric
+                ))
+                .create());
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-4a
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-4
+        Ok(())
+    }
+
+    fn validate_metric_kind(&self, record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        if let Some(allowed) = self
+            .allowed_metrics
+            .iter()
+            .find(|m| m.name == record.metric)
+            && allowed.kind != record.kind
+        {
+            return Err(UsageRecordError::invalid_argument()
+                .with_constraint(format!(
+                    "metric '{}' expects kind {:?} but record specifies {:?}",
+                    record.metric, allowed.kind, record.kind
+                ))
+                .create());
+        }
+        Ok(())
+    }
+
+    fn validate_counter_value(record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        if !record.value.is_finite() {
+            return Err(UsageRecordError::invalid_argument()
+                .with_constraint(format!("value must be finite, got: {}", record.value))
+                .create());
+        }
+        if record.kind == UsageKind::Counter && record.value < 0.0 {
+            return Err(UsageRecordError::invalid_argument()
+                .with_constraint(format!(
+                    "counter value must be non-negative, got: {}",
+                    record.value
+                ))
+                .create());
+        }
+        Ok(())
+    }
+
+    fn validate_counter_idempotency_key(record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-5
+        if record.kind == UsageKind::Counter && record.idempotency_key.trim().is_empty() {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-5a
+            return Err(UsageRecordError::invalid_argument()
+                .with_constraint("counter records require a non-empty idempotency_key")
+                .create());
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-5a
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-5
+        Ok(())
+    }
+
+    fn validate_metadata_size(&self, record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-7
+        if let Some(ref metadata) = record.metadata {
+            let len = serde_json::to_vec(metadata)
+                .map_err(|e| {
+                    UsageRecordError::invalid_argument()
+                        .with_constraint(format!("metadata is not serializable: {e}"))
+                        .create()
+                })?
+                .len();
+            if len > self.max_metadata_bytes as usize {
+                // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-7a
+                return Err(UsageRecordError::invalid_argument()
+                    .with_constraint(format!(
+                        "metadata byte length {len} exceeds the {limit}-byte limit",
+                        limit = self.max_metadata_bytes
+                    ))
+                    .create());
+                // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-7a
+            }
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-7
+        Ok(())
+    }
+
+    /// Replaces a blank/whitespace idempotency key on gauge records with a freshly
+    /// generated UUID; counter records pass through unchanged so the counter-key
+    /// invariant is enforced by [`UsageEmitter::validate_counter_idempotency_key`].
+    fn generate_gauge_idempotency_key(record: &mut UsageRecord) {
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-5b
+        if record.kind == UsageKind::Gauge && record.idempotency_key.trim().is_empty() {
+            record.idempotency_key = Uuid::new_v4().to_string();
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-5b
+    }
+
+    /// Starts a [`UsageRecordBuilder`] prefilled from this authorization handle.
+    ///
+    /// The returned builder has `module`, `tenant_id`, `resource_id`,
+    /// `resource_type`, `subject`, `metric`, `kind`, and
+    /// `value` already set. The caller may then chain optional setters
+    /// ([`UsageRecordBuilder::with_idempotency_key`],
+    /// [`UsageRecordBuilder::with_timestamp`], [`UsageRecordBuilder::with_metadata`])
+    /// and call [`UsageRecordBuilder::build`] to obtain a [`UsageRecord`] suitable
+    /// for [`Self::enqueue`] / [`Self::enqueue_in`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageEmitterError::PermissionDenied`] when `metric` is not in the
+    /// allowed-metrics list for this module — propagating the same metric-allowed
+    /// invariant as [`Self::enqueue_in`] so callers fail early rather than after
+    /// building the record.
+    pub fn usage_record_builder(
+        &self,
+        metric: impl Into<String>,
+        value: f64,
+    ) -> Result<UsageRecordBuilder, UsageEmitterError> {
+        let metric = metric.into();
+        let Some(allowed) = self.allowed_metrics.iter().find(|m| m.name == metric) else {
+            return Err(UsageRecordError::permission_denied()
+                .with_reason(format!("metric not allowed for this module: {metric}"))
+                .create());
+        };
+
+        let mut builder = UsageRecordBuilder::new()
+            .with_module(self.module.clone())
+            .with_tenant_id(self.tenant_id)
+            .with_resource(self.resource_id, self.resource_type.clone())
+            .with_metric(metric, allowed.kind)
+            .with_value(value);
+        if let Some(s) = &self.subject {
+            builder = builder.with_subject(s.clone());
+        }
+        Ok(builder)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "emitter_tests.rs"]
+mod emitter_tests;

--- a/modules/system/usage-collector/usage-emitter/src/domain/emitter_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/src/domain/emitter_tests.rs
@@ -1,0 +1,199 @@
+//! Crate-internal `UsageEmitter` tests.
+//!
+//! The full enqueue-validation matrix (mismatched tenant/resource/module/subject,
+//! metric rules, expired auth, ...) lives in `tests/emitter_tests.rs`, which
+//! exercises the same checks through the real factory → authorize → enqueue
+//! path. This file is restricted to cases that genuinely need crate-internal
+//! access — primarily varying `UsageEmitter.max_metadata_bytes` (a
+//! `pub(crate)` field) without rebuilding a runtime around a custom collector.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use modkit_db::migration_runner::run_migrations_for_testing;
+use modkit_db::outbox::{
+    LeasedMessageHandler, MessageResult, Outbox, OutboxHandle, OutboxMessage, Partitions,
+    outbox_migrations,
+};
+use modkit_db::{ConnectOpts, Db, connect_db};
+use usage_collector_sdk::models::{AllowedMetric, Subject, UsageKind, UsageRecord};
+use uuid::Uuid;
+
+use super::UsageEmitter;
+use crate::config::UsageEmitterConfig;
+use crate::error::UsageEmitterError;
+
+struct NoopHandler;
+
+#[async_trait]
+impl LeasedMessageHandler for NoopHandler {
+    async fn handle(&self, _msg: &OutboxMessage) -> MessageResult {
+        MessageResult::Ok
+    }
+}
+
+async fn build_db(name: &str) -> Db {
+    let url = format!("sqlite:file:{name}?mode=memory&cache=shared");
+    let db = connect_db(
+        &url,
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    run_migrations_for_testing(&db, outbox_migrations())
+        .await
+        .unwrap();
+    db
+}
+
+async fn build_outbox(db: Db) -> OutboxHandle {
+    let cfg = UsageEmitterConfig::default();
+    Outbox::builder(db)
+        .queue(
+            cfg.outbox_queue.as_str(),
+            Partitions::of(cfg.outbox_partition_count),
+        )
+        .leased(NoopHandler)
+        .start()
+        .await
+        .unwrap()
+}
+
+const FIXTURE_RESOURCE_TYPE: &str = "test.resource";
+
+struct Fixture {
+    db: Db,
+    _handle: OutboxHandle,
+    emitter: UsageEmitter,
+    tenant: Uuid,
+    resource_id: Uuid,
+}
+
+impl Fixture {
+    async fn build_with_max_metadata_bytes(name: &str, max_metadata_bytes: u32) -> Self {
+        let db = build_db(name).await;
+        let handle = build_outbox(db.clone()).await;
+        let outbox = Arc::clone(handle.outbox());
+        let tenant = Uuid::new_v4();
+        let resource_id = Uuid::new_v4();
+        let allowed_metrics = vec![
+            AllowedMetric {
+                name: "test.gauge".to_owned(),
+                kind: UsageKind::Gauge,
+            },
+            AllowedMetric {
+                name: "test.counter".to_owned(),
+                kind: UsageKind::Counter,
+            },
+        ];
+        let emitter = UsageEmitter {
+            config: Arc::new(UsageEmitterConfig::default()),
+            db: db.clone(),
+            outbox,
+            module: "test-module".to_owned(),
+            tenant_id: tenant,
+            resource_id,
+            resource_type: FIXTURE_RESOURCE_TYPE.to_owned(),
+            allowed_metrics,
+            max_metadata_bytes,
+            subject: Some(Subject::with_type(Uuid::nil(), "test.subject")),
+            issued_at: Instant::now(),
+        };
+        Self {
+            db,
+            _handle: handle,
+            emitter,
+            tenant,
+            resource_id,
+        }
+    }
+
+    fn record(&self) -> UsageRecord {
+        UsageRecord {
+            tenant_id: self.tenant,
+            module: "test-module".to_owned(),
+            metric: "test.gauge".to_owned(),
+            kind: UsageKind::Gauge,
+            value: 1.0,
+            resource_id: self.resource_id,
+            resource_type: FIXTURE_RESOURCE_TYPE.to_owned(),
+            subject: Some(Subject::with_type(Uuid::nil(), "test.subject")),
+            idempotency_key: Uuid::new_v4().to_string(),
+            timestamp: Utc::now(),
+            metadata: None,
+        }
+    }
+
+    fn conn(&self) -> modkit_db::DbConn<'_> {
+        self.db.conn().unwrap()
+    }
+}
+
+#[tokio::test]
+async fn enqueue_rejects_metadata_above_configured_limit_below_default() {
+    // 2 KiB payload against a 1024-byte limit: must be rejected with the
+    // configured limit reflected in the error string.
+    let f = Fixture::build_with_max_metadata_bytes("ap_metadata_limit_1024", 1024).await;
+    let record = UsageRecord {
+        metadata: Some(serde_json::Value::String("x".repeat(2048))),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    let UsageEmitterError::InvalidArgument { detail, .. } = &err else {
+        panic!("expected InvalidArgument, got {err:?}");
+    };
+    assert!(
+        detail.contains("exceeds the 1024-byte limit"),
+        "error must reference the configured limit (1024); got `{detail}`"
+    );
+}
+
+#[tokio::test]
+async fn enqueue_accepts_metadata_below_configured_limit_above_default() {
+    // 9 KiB payload would be rejected at the old hardcoded 8192 limit but
+    // must be accepted when the configured limit is 16 384.
+    let f = Fixture::build_with_max_metadata_bytes("ap_metadata_limit_16k", 16_384).await;
+    let record = UsageRecord {
+        metadata: Some(serde_json::Value::String("x".repeat(9 * 1024))),
+        ..f.record()
+    };
+    f.emitter.enqueue_in(&f.conn(), record).await.unwrap();
+}
+
+#[tokio::test]
+async fn enqueue_rejects_any_non_none_metadata_when_limit_is_zero() {
+    // `max_metadata_bytes == 0` means metadata is disabled. Even
+    // `Value::Null` (which serializes as `b"null"`, four bytes) exceeds 0
+    // and must be rejected with `exceeds the 0-byte limit`.
+    let f = Fixture::build_with_max_metadata_bytes("ap_metadata_limit_zero_null", 0).await;
+    let record = UsageRecord {
+        metadata: Some(serde_json::Value::Null),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    let UsageEmitterError::InvalidArgument { detail, .. } = &err else {
+        panic!("expected InvalidArgument, got {err:?}");
+    };
+    assert!(
+        detail.contains("exceeds the 0-byte limit"),
+        "error must reference the configured limit (0); got `{detail}`"
+    );
+}
+
+#[tokio::test]
+async fn enqueue_accepts_record_without_metadata_when_limit_is_zero() {
+    // `metadata: None` carries no payload, so `max_metadata_bytes == 0`
+    // must still accept the record — the disabled-metadata config does not
+    // bar records that simply omit metadata.
+    let f = Fixture::build_with_max_metadata_bytes("ap_metadata_limit_zero_none", 0).await;
+    let record = UsageRecord {
+        metadata: None,
+        ..f.record()
+    };
+    f.emitter.enqueue_in(&f.conn(), record).await.unwrap();
+}

--- a/modules/system/usage-collector/usage-emitter/src/domain/factory.rs
+++ b/modules/system/usage-collector/usage-emitter/src/domain/factory.rs
@@ -1,0 +1,273 @@
+use std::sync::Arc;
+use std::time::Instant;
+
+use authz_resolver_sdk::AuthZResolverClient;
+use authz_resolver_sdk::models::BarrierMode;
+use authz_resolver_sdk::pep::{AccessRequest, PolicyEnforcer};
+use modkit_db::Db;
+use modkit_db::outbox::Outbox;
+use modkit_security::{SecurityContext, pep_properties};
+use tokio::time::timeout;
+use tracing::warn;
+use usage_collector_sdk::UsageCollectorClientV1;
+use usage_collector_sdk::authz;
+use usage_collector_sdk::error::UsageRecordError;
+use usage_collector_sdk::models::Subject;
+use uuid::Uuid;
+
+use crate::config::UsageEmitterConfig;
+use crate::domain::emitter::UsageEmitter;
+use crate::error::{UsageEmitterError, enforcer_error_to_emitter_error};
+
+/// Build a [`Subject`] from a [`SecurityContext`].
+///
+/// Free function (not a `From` impl) because Rust orphan rules (E0117) forbid
+/// `impl From<&SecurityContext> for Subject` here — both types are foreign to
+/// this crate. Colocated with the factory since it is the sole consumer.
+fn subject_from_ctx(ctx: &SecurityContext) -> Subject {
+    Subject {
+        id: ctx.subject_id(),
+        r#type: ctx.subject_type().map(str::to_owned),
+    }
+}
+
+/// Caller intent for the subject identity bound to the next `.authorize()` call.
+///
+/// Three legal states match the wire/PDP contract:
+///
+/// - `DefaultFromCtx` — neither `.with_subject(...)` nor `.without_subject()` was
+///   called. The factory falls back to `SecurityContext`-derived subject at
+///   `.authorize()` time. This is the default for in-process modules whose
+///   caller identity *is* the subject.
+/// - `Explicit(Some(s))` — caller passed an explicit subject via
+///   `.with_subject(s)`. The PDP receives that exact subject; the gateway/
+///   forwarder identity is never substituted.
+/// - `Explicit(None)` — caller explicitly opted out via `.without_subject()`.
+///   No `SUBJECT_ID`/`SUBJECT_TYPE` is sent to the PDP and the resulting
+///   `UsageEmitter` has `subject = None`.
+///
+/// This three-state split is the only way to distinguish "default from
+/// context" from "explicit no subject" — `Option<Subject>` collapses both
+/// into the same `None`, which silently substitutes the gateway's own
+/// `SecurityContext` subject and violates the forwarder-substitution
+/// invariant.
+#[derive(Clone, Debug, Default)]
+pub enum SubjectChoice {
+    /// Resolve from `SecurityContext` at `.authorize()` time.
+    #[default]
+    DefaultFromCtx,
+    /// Caller-supplied: `Some(s)` = use exactly `s`; `None` = no subject at all.
+    Explicit(Option<Subject>),
+}
+
+/// Module-bound producer of [`UsageEmitter`] handles.
+///
+/// Obtained from [`crate::api::UsageEmitterRuntimeV1::factory`]. Each module stores one
+/// factory bound to its `MODULE_NAME` at init and clones it per call to apply tenant /
+/// subject overrides via the fluent `.with_*()` chain. The terminal `.authorize()` runs
+/// PDP authorization and fetches allowed metrics, returning a post-authorize handle.
+///
+/// `module` is fixed at construction time and cannot be overridden, preserving the
+/// compile-time invariant that a factory cannot emit under the wrong module.
+#[derive(Clone)]
+pub struct UsageEmitterFactory {
+    // shared Arcs cloned from the runtime
+    pub(crate) config: Arc<UsageEmitterConfig>,
+    pub(crate) db: Db,
+    pub(crate) authz: Arc<dyn AuthZResolverClient>,
+    pub(crate) collector: Arc<dyn UsageCollectorClientV1>,
+    pub(crate) outbox: Arc<Outbox>,
+    // immutable scope (set at construction by runtime.factory(name))
+    pub(crate) module: String,
+    // overridable scope (resolved at .authorize() time)
+    pub(crate) tenant: Option<Uuid>,
+    pub(crate) subject: SubjectChoice,
+}
+
+impl UsageEmitterFactory {
+    /// Override the tenant for the next [`Self::authorize`] call.
+    ///
+    /// Without this, tenant defaults to `ctx.subject_tenant_id()`.
+    #[must_use]
+    pub fn with_tenant(mut self, t: Uuid) -> Self {
+        self.tenant = Some(t);
+        self
+    }
+
+    /// Bind an explicit caller-supplied [`Subject`] for the next [`Self::authorize`] call.
+    ///
+    /// The PDP receives this exact subject; gateways / forwarders MUST use this
+    /// method (not the ctx-default fallback) so their own service identity is
+    /// never substituted for the original caller's.
+    #[must_use]
+    pub fn with_subject(mut self, subject: Subject) -> Self {
+        self.subject = SubjectChoice::Explicit(Some(subject));
+        self
+    }
+
+    /// Explicitly emit without any subject identity for the next [`Self::authorize`] call.
+    ///
+    /// `SUBJECT_ID` / `SUBJECT_TYPE` are omitted from the PDP request and the
+    /// resulting [`UsageEmitter`] has `subject = None`. Distinct from the
+    /// default (neither `with_subject` nor `without_subject` called), which
+    /// falls back to the `SecurityContext`-derived subject at authorize time.
+    #[must_use]
+    pub fn without_subject(mut self) -> Self {
+        self.subject = SubjectChoice::Explicit(None);
+        self
+    }
+
+    /// Run PDP authorization and fetch allowed metrics, returning a time-limited
+    /// [`UsageEmitter`] handle bound to the module name, tenant, metered
+    /// resource, and subject identity.
+    ///
+    /// Tenant defaults to `ctx.subject_tenant_id()` when not overridden via
+    /// [`Self::with_tenant`]. Subject is resolved per the table in
+    /// `RESEARCH-emitter-runtime.md`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageEmitterError`] if PDP denies, the module is not configured, or the
+    /// collector call fails.
+    // @cpt-algo:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1
+    #[tracing::instrument(
+        skip_all,
+        fields(
+            module = %self.module,
+            resource_id = %resource_id,
+            resource_type = %resource_type,
+        ),
+    )]
+    pub async fn authorize(
+        &self,
+        ctx: &SecurityContext,
+        resource_id: Uuid,
+        resource_type: &str,
+    ) -> Result<UsageEmitter, UsageEmitterError> {
+        // Resolve tenant: explicit override or default to ctx's home tenant.
+        let tenant_id = self.tenant.unwrap_or_else(|| ctx.subject_tenant_id());
+
+        // Resolve subject per the three-state intent (see SubjectChoice docs).
+        let subject = match &self.subject {
+            SubjectChoice::Explicit(s) => s.clone(),
+            SubjectChoice::DefaultFromCtx => Some(subject_from_ctx(ctx)),
+        };
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-2
+        // PDP request shape — both opt-outs are deliberate and load-bearing:
+        //
+        // * `require_constraints(false)` — usage emission is authorize-once-per-call-site
+        //   and re-validates module / tenant / resource / subject / allowed-metrics
+        //   in-memory at every `UsageEmitter::enqueue_in` (see `emitter.rs` validators).
+        //   The PDP's role here is the allow/deny decision; it does not return additional
+        //   constraint expressions for the emitter to apply later. Asking for constraints
+        //   we never consume would incur compilation cost on every emit for no policy
+        //   benefit. (Contrast: the query path on the gateway *does* enforce returned
+        //   constraints as filters — see DESIGN.md §"Authorize each query".)
+        //
+        // * `BarrierMode::Ignore` — the emitter is invoked by trusted source modules (and
+        //   the gateway forwarder) emitting usage *for* a target tenant that may be a
+        //   self-managed / barriered sub-tenant of the caller's context. With
+        //   `BarrierMode::Respect`, a self-managed child barrier would hide its ancestor
+        //   chain from the PDP's tenant traversal and deny all cross-barrier emit — even
+        //   though the caller is a platform-level component (gateway / system job)
+        //   acting on the platform's behalf rather than a tenant user. The PDP itself
+        //   remains the sole authority: the allow/deny still depends on the policy
+        //   evaluation of OWNER_TENANT_ID, RESOURCE_ID/TYPE, MODULE, and SUBJECT_ID/TYPE
+        //   properties; ignoring the barrier only widens the candidate evaluation set,
+        //   it does not bypass the decision. See `tests/emitter_tests.rs::
+        //   authorize_sends_barrier_mode_ignore_to_pdp` and
+        //   `authorize_allows_subtenant_when_pdp_allows_extra_tenant` for the contract.
+        let mut request = AccessRequest::new()
+            .require_constraints(false)
+            .barrier_mode(BarrierMode::Ignore)
+            .resource_property(pep_properties::OWNER_TENANT_ID, tenant_id)
+            .resource_property(authz::properties::RESOURCE_ID, resource_id)
+            .resource_property(authz::properties::RESOURCE_TYPE, resource_type)
+            .resource_property(authz::properties::MODULE, self.module.clone());
+        if let Some(s) = &subject {
+            request = request.resource_property(authz::properties::SUBJECT_ID, s.id.to_string());
+            if let Some(ty) = &s.r#type {
+                request = request.resource_property(authz::properties::SUBJECT_TYPE, ty.as_str());
+            }
+        }
+        let enforcer = PolicyEnforcer::new(Arc::clone(&self.authz));
+        let pdp_call = enforcer.access_scope_with(
+            ctx,
+            &authz::USAGE_RECORD,
+            authz::actions::CREATE,
+            None,
+            &request,
+        );
+        let Ok(pdp_result) = timeout(self.config.authorize_call_timeout, pdp_call).await else {
+            warn!(
+                tenant_id = %tenant_id,
+                timeout = ?self.config.authorize_call_timeout,
+                "PDP authorization call exceeded authorize_call_timeout",
+            );
+            return Err(UsageRecordError::deadline_exceeded(
+                "PDP authorization call exceeded authorize_call_timeout",
+            )
+            .create());
+        };
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-2
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-3
+        if let Err(e) = pdp_result {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-3a
+            return Err(enforcer_error_to_emitter_error(e));
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-3a
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-3
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-4
+        // @cpt-begin:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-1
+        let Ok(module_cfg_result) = timeout(
+            self.config.authorize_call_timeout,
+            self.collector.get_module_config(&self.module),
+        )
+        .await
+        else {
+            warn!(
+                tenant_id = %tenant_id,
+                timeout = ?self.config.authorize_call_timeout,
+                "collector get_module_config call exceeded authorize_call_timeout",
+            );
+            return Err(UsageRecordError::deadline_exceeded(
+                "collector get_module_config call exceeded authorize_call_timeout",
+            )
+            .create());
+        };
+        // @cpt-end:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-1
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-4
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-5
+        let module_cfg = module_cfg_result?;
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-5
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-6
+        let authorized = UsageEmitter {
+            config: Arc::clone(&self.config),
+            db: self.db.clone(),
+            outbox: Arc::clone(&self.outbox),
+            module: self.module.clone(),
+            tenant_id,
+            resource_id,
+            resource_type: resource_type.to_owned(),
+            allowed_metrics: module_cfg.allowed_metrics,
+            max_metadata_bytes: module_cfg.max_metadata_bytes,
+            subject,
+            issued_at: Instant::now(),
+        };
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-6
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-7
+        Ok(authorized)
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-7
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "factory_tests.rs"]
+mod factory_tests;

--- a/modules/system/usage-collector/usage-emitter/src/domain/factory_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/src/domain/factory_tests.rs
@@ -1,0 +1,192 @@
+//! Crate-internal `UsageEmitterFactory` tests.
+//!
+//! The broad authorize matrix (allow/deny/failing `AuthZ`, PDP property
+//! assertions, subject/without_subject/default-from-ctx, collector error
+//! propagation, barrier-mode) lives in `tests/emitter_tests.rs`, which builds
+//! a runtime through the real `UsageEmitterRuntime::build` path. This file is
+//! restricted to cases that genuinely need crate-internal access:
+//!
+//! - direct unit tests for `enforcer_error_to_emitter_error`, a `pub(crate)`
+//!   mapper that is not re-exported and cannot be exercised through the public
+//!   factory API; and
+//! - `authorize_populates_max_metadata_bytes_from_module_config`, which reads
+//!   the `pub(crate)` `UsageEmitter.max_metadata_bytes` field directly to prove
+//!   the factory plumbed it from the collector response rather than
+//!   substituting a local default.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use authz_resolver_sdk::models::{
+    EvaluationRequest, EvaluationResponse, EvaluationResponseContext,
+};
+use authz_resolver_sdk::pep::ConstraintCompileError;
+use authz_resolver_sdk::{AuthZResolverClient, AuthZResolverError, DenyReason, EnforcerError};
+use modkit_db::migration_runner::run_migrations_for_testing;
+use modkit_db::outbox::outbox_migrations;
+use modkit_db::{ConnectOpts, Db, connect_db};
+use modkit_security::SecurityContext;
+use usage_collector_sdk::UsageCollectorClientV1;
+use usage_collector_sdk::models::UsageRecord;
+use uuid::Uuid;
+
+use super::UsageEmitterFactory;
+use crate::api::UsageEmitterRuntimeV1;
+use crate::config::UsageEmitterConfig;
+use crate::domain::runtime::UsageEmitterRuntime;
+use crate::error::{UsageEmitterError, enforcer_error_to_emitter_error};
+
+const TEST_MODULE: &str = "test-module";
+
+// ── Mocks (crate-internal `UsageEmitterError` is the collector error type) ────
+
+struct AllowAllAuthZ;
+
+#[async_trait]
+impl AuthZResolverClient for AllowAllAuthZ {
+    async fn evaluate(
+        &self,
+        _request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        Ok(EvaluationResponse {
+            decision: true,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+/// Returns a non-default `max_metadata_bytes` so the factory-plumbing test can
+/// prove the emitter copies the field from the collector response rather than
+/// substituting a local default.
+struct NoopCollectorWith4096;
+
+#[async_trait]
+impl UsageCollectorClientV1 for NoopCollectorWith4096 {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageEmitterError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<usage_collector_sdk::ModuleConfig, UsageEmitterError> {
+        Ok(usage_collector_sdk::ModuleConfig {
+            allowed_metrics: vec![],
+            max_metadata_bytes: 4096,
+        })
+    }
+}
+
+async fn build_db(name: &str) -> Db {
+    let url = format!("sqlite:file:{name}?mode=memory&cache=shared");
+    let db = connect_db(
+        &url,
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    run_migrations_for_testing(&db, outbox_migrations())
+        .await
+        .unwrap();
+    db
+}
+
+async fn build_factory(db: Db, authz: Arc<dyn AuthZResolverClient>) -> UsageEmitterFactory {
+    let runtime = UsageEmitterRuntime::build(
+        UsageEmitterConfig::default(),
+        db,
+        authz,
+        Arc::new(NoopCollectorWith4096),
+    )
+    .await
+    .unwrap();
+    runtime.factory(TEST_MODULE)
+}
+
+fn make_ctx() -> SecurityContext {
+    SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(Uuid::new_v4())
+        .build()
+        .unwrap()
+}
+
+// ── enforcer_error_to_emitter_error ──────────────────────────────────────────
+
+#[test]
+fn enforcer_denied_without_reason_uses_authorization_denied_fallback() {
+    let err = enforcer_error_to_emitter_error(EnforcerError::Denied { deny_reason: None });
+    let UsageEmitterError::PermissionDenied { ctx, .. } = err else {
+        panic!("expected PermissionDenied");
+    };
+    assert_eq!(ctx.reason, "AUTHORIZATION_DENIED");
+}
+
+#[test]
+fn enforcer_denied_forwards_deny_reason_error_code() {
+    let deny_reason = Some(DenyReason {
+        error_code: "ERR_FORBIDDEN".to_owned(),
+        details: Some("tenant not allowed".to_owned()),
+    });
+    let err = enforcer_error_to_emitter_error(EnforcerError::Denied { deny_reason });
+    let UsageEmitterError::PermissionDenied { ctx, .. } = err else {
+        panic!("expected PermissionDenied");
+    };
+    assert_eq!(
+        ctx.reason, "ERR_FORBIDDEN",
+        "PDP `deny_reason.error_code` must be surfaced as the canonical reason"
+    );
+}
+
+#[test]
+fn enforcer_denied_forwards_error_code_when_details_absent() {
+    let deny_reason = Some(DenyReason {
+        error_code: "ERR_FORBIDDEN".to_owned(),
+        details: None,
+    });
+    let err = enforcer_error_to_emitter_error(EnforcerError::Denied { deny_reason });
+    let UsageEmitterError::PermissionDenied { ctx, .. } = err else {
+        panic!("expected PermissionDenied");
+    };
+    assert_eq!(ctx.reason, "ERR_FORBIDDEN");
+}
+
+#[test]
+fn enforcer_compile_failed_maps_to_permission_denied() {
+    let err = enforcer_error_to_emitter_error(EnforcerError::CompileFailed(
+        ConstraintCompileError::ConstraintsRequiredButAbsent,
+    ));
+    assert!(matches!(err, UsageEmitterError::PermissionDenied { .. }));
+}
+
+#[test]
+fn enforcer_evaluation_failed_maps_to_permission_denied() {
+    let err = enforcer_error_to_emitter_error(EnforcerError::EvaluationFailed(
+        AuthZResolverError::Internal("rpc error".to_owned()),
+    ));
+    assert!(matches!(err, UsageEmitterError::PermissionDenied { .. }));
+}
+
+// ── max_metadata_bytes plumbing (reads `pub(crate)` emitter field) ───────────
+
+#[tokio::test]
+async fn authorize_populates_max_metadata_bytes_from_module_config() {
+    // `NoopCollectorWith4096::get_module_config` returns
+    // `max_metadata_bytes: 4096` (a non-default value). The authorized
+    // emitter must surface that exact value, proving the factory copies the
+    // field from the collector response rather than substituting a local
+    // default. The field is `pub(crate)` and cannot be inspected from an
+    // out-of-crate integration test.
+    let db = build_db("emit_max_metadata_bytes_plumbed").await;
+    let factory = build_factory(db, Arc::new(AllowAllAuthZ)).await;
+    let ctx = make_ctx();
+    let emitter = factory
+        .clone()
+        .authorize(&ctx, Uuid::new_v4(), "test.resource")
+        .await
+        .unwrap();
+    assert_eq!(emitter.max_metadata_bytes, 4096);
+}

--- a/modules/system/usage-collector/usage-emitter/src/domain/mod.rs
+++ b/modules/system/usage-collector/usage-emitter/src/domain/mod.rs
@@ -1,0 +1,4 @@
+pub mod emitter;
+pub mod factory;
+pub mod runtime;
+pub mod usage_record_builder;

--- a/modules/system/usage-collector/usage-emitter/src/domain/runtime.rs
+++ b/modules/system/usage-collector/usage-emitter/src/domain/runtime.rs
@@ -1,0 +1,96 @@
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use authz_resolver_sdk::AuthZResolverClient;
+use modkit_db::Db;
+use modkit_db::outbox::{Outbox, OutboxHandle, Partitions, WorkerTuning};
+use usage_collector_sdk::UsageCollectorClientV1;
+
+use crate::api::UsageEmitterRuntimeV1;
+use crate::config::UsageEmitterConfig;
+use crate::domain::factory::{SubjectChoice, UsageEmitterFactory};
+use crate::infra::delivery_handler::DeliveryHandler;
+
+/// Process-lifetime owner of the usage-emitter pipeline.
+///
+/// Owns the outbox worker, shared Arcs, and validated configuration. Registered in
+/// `ClientHub` as `dyn UsageEmitterRuntimeV1`. Each call to
+/// [`UsageEmitterRuntimeV1::factory`] hands out a module-bound
+/// [`UsageEmitterFactory`] that source modules clone per call to apply scope overrides
+/// and then `.authorize()` to obtain a [`crate::UsageEmitter`].
+pub struct UsageEmitterRuntime {
+    config: Arc<UsageEmitterConfig>,
+    db: Db,
+    authz: Arc<dyn AuthZResolverClient>,
+    collector: Arc<dyn UsageCollectorClientV1>,
+    outbox: Arc<Outbox>,
+    _worker: OutboxHandle, // keeps the background task alive for process lifetime
+}
+
+impl UsageEmitterRuntime {
+    /// Build a [`UsageEmitterRuntime`] and start the background outbox worker.
+    ///
+    /// Validates `config`, registers the `usage-records` queue, attaches
+    /// `delivery_handler` for async delivery to `collector`, and wires the
+    /// [`authz_resolver_sdk::pep::PolicyEnforcer`] for per-call PDP checks.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the configuration is invalid or if the outbox worker fails to
+    /// start (e.g. DB unavailable or queue registration fails).
+    pub async fn build(
+        config: UsageEmitterConfig,
+        db: Db,
+        authz: Arc<dyn AuthZResolverClient>,
+        collector: Arc<dyn UsageCollectorClientV1>,
+    ) -> anyhow::Result<Self> {
+        config.validate()?;
+
+        let delivery_handler = DeliveryHandler::new(Arc::clone(&collector));
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-6a
+        let processor_tuning =
+            WorkerTuning::processor_default().retry_max(config.outbox_backoff_max);
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-6a
+
+        let outbox_handle = Outbox::builder(db.clone())
+            .processor_tuning(processor_tuning)
+            .queue(
+                &config.outbox_queue,
+                Partitions::of(config.outbox_partition_count),
+            )
+            .leased(delivery_handler)
+            .start()
+            .await
+            .context("usage-emitter: failed to start outbox worker")?;
+
+        let outbox = Arc::clone(outbox_handle.outbox());
+
+        Ok(Self {
+            config: Arc::new(config),
+            db,
+            authz,
+            collector,
+            outbox,
+            _worker: outbox_handle,
+        })
+    }
+}
+
+impl UsageEmitterRuntimeV1 for UsageEmitterRuntime {
+    fn factory(&self, module_name: &str) -> UsageEmitterFactory {
+        UsageEmitterFactory {
+            config: Arc::clone(&self.config),
+            db: self.db.clone(),
+            authz: Arc::clone(&self.authz),
+            collector: Arc::clone(&self.collector),
+            outbox: Arc::clone(&self.outbox),
+            module: module_name.to_owned(),
+            tenant: None,
+            // Default = "resolve from SecurityContext at authorize() time"
+            // — the caller has not yet called `.with_subject(...)` or
+            // `.without_subject()`. See `SubjectChoice` docs for the three-state contract.
+            subject: SubjectChoice::DefaultFromCtx,
+        }
+    }
+}

--- a/modules/system/usage-collector/usage-emitter/src/domain/usage_record_builder.rs
+++ b/modules/system/usage-collector/usage-emitter/src/domain/usage_record_builder.rs
@@ -1,0 +1,224 @@
+//! Standalone fluent builder for [`UsageRecord`].
+//!
+//! [`UsageRecordBuilder`] is intentionally "dumb": it holds optional fields, exposes
+//! `with_*` setters, and assembles a [`UsageRecord`] via [`Self::build`] without
+//! consulting any [`UsageEmitter`](crate::UsageEmitter) state.
+//!
+//! Two construction paths are supported:
+//!
+//! - [`UsageEmitter::usage_record_builder`](crate::UsageEmitter::usage_record_builder)
+//!   returns a builder with `module`, `tenant_id`, `resource_id` / `resource_type`,
+//!   `subject` (when present on the authorized handle), `metric` (with `kind`
+//!   resolved from the authorized allowed-metrics list), and `value` already
+//!   populated.
+//! - [`UsageRecordBuilder::new`] starts an empty builder for callers that need to
+//!   assemble a record outside of an authorized handle (e.g. tests).
+//!
+//! Either way, the resulting [`UsageRecord`] is then passed to
+//! [`UsageEmitter::enqueue`](crate::UsageEmitter::enqueue) or
+//! [`UsageEmitter::enqueue_in`](crate::UsageEmitter::enqueue_in)
+//! for validation and outbox enqueue.
+
+use chrono::{DateTime, Utc};
+use serde_json::Value as JsonValue;
+use usage_collector_sdk::error::UsageRecordError;
+use usage_collector_sdk::models::{Subject, UsageKind, UsageRecord};
+use uuid::Uuid;
+
+use crate::error::UsageEmitterError;
+
+/// Fluent builder that assembles a [`UsageRecord`] from independent setters.
+///
+/// The builder performs no authorization, no metric-allowed-list checking, and no
+/// transactional work. Validation happens at
+/// [`UsageEmitter::enqueue`](crate::UsageEmitter::enqueue) /
+/// [`enqueue_in`](crate::UsageEmitter::enqueue_in) time.
+#[derive(Debug, Default, Clone)]
+pub struct UsageRecordBuilder {
+    module: Option<String>,
+    tenant_id: Option<Uuid>,
+    metric: Option<String>,
+    kind: Option<UsageKind>,
+    value: Option<f64>,
+    resource_id: Option<Uuid>,
+    resource_type: Option<String>,
+    subject: Option<Subject>,
+    idempotency_key: Option<String>,
+    timestamp: Option<DateTime<Utc>>,
+    metadata: Option<JsonValue>,
+}
+
+impl UsageRecordBuilder {
+    /// Starts an empty builder. All required fields must be set via `with_*` before
+    /// calling [`Self::build`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the source module name.
+    #[must_use]
+    pub fn with_module(mut self, module: impl Into<String>) -> Self {
+        self.module = Some(module.into());
+        self
+    }
+
+    /// Sets the tenant that owns the usage observation.
+    #[must_use]
+    pub fn with_tenant_id(mut self, tenant_id: Uuid) -> Self {
+        self.tenant_id = Some(tenant_id);
+        self
+    }
+
+    /// Sets the metric name and its kind (gauge vs counter).
+    #[must_use]
+    pub fn with_metric(mut self, name: impl Into<String>, kind: UsageKind) -> Self {
+        self.metric = Some(name.into());
+        self.kind = Some(kind);
+        self
+    }
+
+    /// Sets the numeric value.
+    #[must_use]
+    pub fn with_value(mut self, value: f64) -> Self {
+        self.value = Some(value);
+        self
+    }
+
+    /// Sets the metered resource (instance id + logical type).
+    #[must_use]
+    pub fn with_resource(mut self, id: Uuid, resource_type: impl Into<String>) -> Self {
+        self.resource_id = Some(id);
+        self.resource_type = Some(resource_type.into());
+        self
+    }
+
+    /// Sets the subject (user or service) acting on the resource.
+    ///
+    /// Subject is optional and may be omitted entirely by simply not calling
+    /// this setter; the resulting record carries `subject = None`, and the
+    /// factory's `.authorize()` step omits `SUBJECT_ID` / `SUBJECT_TYPE`
+    /// from the PDP request accordingly. Construct the [`Subject`] via
+    /// [`Subject::new`] (id only) or [`Subject::with_type`] (id + logical
+    /// type) before passing it in.
+    #[must_use]
+    pub fn with_subject(mut self, subject: Subject) -> Self {
+        self.subject = Some(subject);
+        self
+    }
+
+    /// Sets a caller-provided idempotency key.
+    ///
+    /// Required (non-empty) for counter metrics — enforced by
+    /// [`UsageEmitter::enqueue_in`](crate::UsageEmitter::enqueue_in).
+    /// Optional for gauge metrics; when omitted or blank, the emitter generates a UUID
+    /// at enqueue time.
+    #[must_use]
+    pub fn with_idempotency_key(mut self, key: impl Into<String>) -> Self {
+        self.idempotency_key = Some(key.into());
+        self
+    }
+
+    /// Sets the observation timestamp. If omitted, [`Utc::now`] is used at [`Self::build`] time.
+    #[must_use]
+    pub fn with_timestamp(mut self, timestamp: DateTime<Utc>) -> Self {
+        self.timestamp = Some(timestamp);
+        self
+    }
+
+    /// Sets optional metadata JSON. The serialized-size limit is enforced by the
+    /// emitter at enqueue time using the value `ModuleConfig.max_metadata_bytes`
+    /// returned by `get_module_config`.
+    #[must_use]
+    pub fn with_metadata(mut self, metadata: JsonValue) -> Self {
+        self.metadata = Some(metadata);
+        self
+    }
+
+    /// Assembles a [`UsageRecord`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageEmitterError::InvalidArgument`] when any required field
+    /// (`module`, `tenant_id`, `metric`, `value`, `resource_id`, `resource_type`)
+    /// is missing; the error's constraint message enumerates the missing fields.
+    pub fn build(self) -> Result<UsageRecord, UsageEmitterError> {
+        let Self {
+            module,
+            tenant_id,
+            metric,
+            kind,
+            value,
+            resource_id,
+            resource_type,
+            subject,
+            idempotency_key,
+            timestamp,
+            metadata,
+        } = self;
+
+        match (
+            module,
+            tenant_id,
+            metric,
+            kind,
+            value,
+            resource_id,
+            resource_type,
+        ) {
+            (
+                Some(module),
+                Some(tenant_id),
+                Some(metric),
+                Some(kind),
+                Some(value),
+                Some(resource_id),
+                Some(resource_type),
+            ) => Ok(UsageRecord {
+                module,
+                tenant_id,
+                metric,
+                kind,
+                value,
+                resource_id,
+                resource_type,
+                subject,
+                idempotency_key: idempotency_key.unwrap_or_default(),
+                timestamp: timestamp.unwrap_or_else(Utc::now),
+                metadata,
+            }),
+            (module, tenant_id, metric, kind, value, resource_id, resource_type) => {
+                let mut missing: Vec<&'static str> = Vec::new();
+                if module.is_none() {
+                    missing.push("module");
+                }
+                if tenant_id.is_none() {
+                    missing.push("tenant_id");
+                }
+                if metric.is_none() || kind.is_none() {
+                    missing.push("metric");
+                }
+                if value.is_none() {
+                    missing.push("value");
+                }
+                if resource_id.is_none() {
+                    missing.push("resource_id");
+                }
+                if resource_type.is_none() {
+                    missing.push("resource_type");
+                }
+                Err(UsageRecordError::invalid_argument()
+                    .with_constraint(format!(
+                        "UsageRecordBuilder is missing required field(s): {}",
+                        missing.join(", ")
+                    ))
+                    .create())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "usage_record_builder_tests.rs"]
+mod usage_record_builder_tests;

--- a/modules/system/usage-collector/usage-emitter/src/domain/usage_record_builder_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/src/domain/usage_record_builder_tests.rs
@@ -1,0 +1,479 @@
+use std::sync::Arc;
+use std::time::Instant;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use modkit_db::migration_runner::run_migrations_for_testing;
+use modkit_db::outbox::{
+    LeasedMessageHandler, MessageResult, Outbox, OutboxHandle, OutboxMessage, Partitions,
+    outbox_migrations,
+};
+use modkit_db::{ConnectOpts, Db, connect_db};
+use usage_collector_sdk::models::{AllowedMetric, Subject, UsageKind, UsageRecord};
+use uuid::Uuid;
+
+use crate::config::UsageEmitterConfig;
+use crate::domain::emitter::UsageEmitter;
+use crate::domain::usage_record_builder::UsageRecordBuilder;
+use crate::error::UsageEmitterError;
+
+// ── Infrastructure ────────────────────────────────────────────────────────────
+
+struct NoopHandler;
+
+#[async_trait]
+impl LeasedMessageHandler for NoopHandler {
+    async fn handle(&self, _msg: &OutboxMessage) -> MessageResult {
+        MessageResult::Ok
+    }
+}
+
+async fn build_db(name: &str) -> Db {
+    let url = format!("sqlite:file:{name}?mode=memory&cache=shared");
+    let db = connect_db(
+        &url,
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    run_migrations_for_testing(&db, outbox_migrations())
+        .await
+        .unwrap();
+    db
+}
+
+async fn build_outbox(db: Db) -> OutboxHandle {
+    let cfg = UsageEmitterConfig::default();
+    Outbox::builder(db)
+        .queue(
+            cfg.outbox_queue.as_str(),
+            Partitions::of(cfg.outbox_partition_count),
+        )
+        .leased(NoopHandler)
+        .start()
+        .await
+        .unwrap()
+}
+
+// ── Test fixture ──────────────────────────────────────────────────────────────
+
+struct Fixture {
+    db: Db,
+    _handle: OutboxHandle,
+    emitter: UsageEmitter,
+    tenant_id: Uuid,
+    resource_id: Uuid,
+}
+
+impl Fixture {
+    async fn build(name: &str) -> Self {
+        let db = build_db(name).await;
+        let handle = build_outbox(db.clone()).await;
+        let tenant_id = Uuid::new_v4();
+        let resource_id = Uuid::new_v4();
+        let allowed_metrics = vec![
+            AllowedMetric {
+                name: "test.gauge".to_owned(),
+                kind: UsageKind::Gauge,
+            },
+            AllowedMetric {
+                name: "test.counter".to_owned(),
+                kind: UsageKind::Counter,
+            },
+        ];
+        let emitter = UsageEmitter {
+            config: Arc::new(UsageEmitterConfig::default()),
+            db: db.clone(),
+            outbox: Arc::clone(handle.outbox()),
+            module: "test-module".to_owned(),
+            tenant_id,
+            resource_id,
+            resource_type: "test.resource".to_owned(),
+            allowed_metrics,
+            max_metadata_bytes: 8192,
+            subject: Some(Subject::with_type(Uuid::nil(), "test.subject")),
+            issued_at: Instant::now(),
+        };
+        Self {
+            db,
+            _handle: handle,
+            emitter,
+            tenant_id,
+            resource_id,
+        }
+    }
+
+    fn conn(&self) -> modkit_db::DbConn<'_> {
+        self.db.conn().unwrap()
+    }
+}
+
+// ── Standalone builder (dumb) ─────────────────────────────────────────────────
+
+fn full_builder() -> UsageRecordBuilder {
+    UsageRecordBuilder::new()
+        .with_module("test-module")
+        .with_tenant_id(Uuid::new_v4())
+        .with_metric("test.gauge", UsageKind::Gauge)
+        .with_value(1.0)
+        .with_resource(Uuid::new_v4(), "test.resource")
+}
+
+#[test]
+fn build_succeeds_with_all_required_fields() {
+    let record = full_builder().build().expect("required fields populated");
+    assert_eq!(record.module, "test-module");
+    assert_eq!(record.metric, "test.gauge");
+    assert_eq!(record.kind, UsageKind::Gauge);
+    assert!((record.value - 1.0).abs() < f64::EPSILON);
+    assert!(record.idempotency_key.is_empty());
+    assert!(record.subject.is_none());
+}
+
+#[test]
+fn build_defaults_timestamp_to_now() {
+    let before = Utc::now();
+    let record = full_builder().build().unwrap();
+    let after = Utc::now();
+    assert!(record.timestamp >= before && record.timestamp <= after);
+}
+
+#[test]
+fn build_uses_provided_timestamp() {
+    let ts = DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let record = full_builder().with_timestamp(ts).build().unwrap();
+    assert_eq!(record.timestamp, ts);
+}
+
+#[test]
+fn build_carries_subject_for_all_shapes() {
+    let id = Uuid::new_v4();
+    let cases: Vec<(&str, Option<Subject>)> = vec![
+        ("none", None),
+        ("id only", Some(Subject::new(id))),
+        ("id + type", Some(Subject::with_type(id, "test.subject"))),
+    ];
+    for (label, subject) in cases {
+        let mut builder = full_builder();
+        if let Some(s) = subject.clone() {
+            builder = builder.with_subject(s);
+        }
+        let record = builder.build().unwrap();
+        assert_eq!(
+            record.subject, subject,
+            "case `{label}` must carry the expected subject"
+        );
+    }
+}
+
+// `with_metric` is the only non-trivial overwrite — it sets two correlated
+// fields (`metric` *and* `kind`) and the second call must overwrite both.
+// Single-field setters reduce to `Option::Some(_) = …` and are compiler-guaranteed.
+#[test]
+fn build_with_metric_called_twice_overwrites_both_name_and_kind() {
+    let record = full_builder()
+        .with_metric("test.gauge", UsageKind::Gauge)
+        .with_metric("test.counter", UsageKind::Counter)
+        .with_idempotency_key("idem")
+        .build()
+        .expect("required fields populated");
+    assert_eq!(record.metric, "test.counter");
+    assert_eq!(record.kind, UsageKind::Counter);
+}
+
+#[test]
+fn build_rejects_missing_required_fields_and_lists_them() {
+    let err = UsageRecordBuilder::new().build().unwrap_err();
+    let UsageEmitterError::InvalidArgument { detail, .. } = &err else {
+        panic!("expected InvalidArgument, got {err:?}");
+    };
+    for field in [
+        "module",
+        "tenant_id",
+        "metric",
+        "value",
+        "resource_id",
+        "resource_type",
+    ] {
+        assert!(
+            detail.contains(field),
+            "missing-field error must mention `{field}`; got `{detail}`"
+        );
+    }
+}
+
+#[test]
+fn build_rejects_only_partial_missing_fields() {
+    let err = UsageRecordBuilder::new()
+        .with_module("m")
+        .with_tenant_id(Uuid::new_v4())
+        .with_metric("test.gauge", UsageKind::Gauge)
+        .with_value(1.0)
+        // resource omitted
+        .build()
+        .unwrap_err();
+    let UsageEmitterError::InvalidArgument { detail, .. } = &err else {
+        panic!("expected InvalidArgument, got {err:?}");
+    };
+    assert!(detail.contains("resource_id"));
+    assert!(detail.contains("resource_type"));
+    assert!(
+        !detail.contains("module"),
+        "fields already set must not appear: {detail}"
+    );
+}
+
+// ── usage_record_builder() prefill from UsageEmitter ──────────────────────────
+
+#[tokio::test]
+async fn usage_record_builder_prefills_authorized_fields_for_gauge() {
+    let f = Fixture::build("urb_prefill_gauge").await;
+    let record = f
+        .emitter
+        .usage_record_builder("test.gauge", 7.0)
+        .expect("metric is allowed")
+        .build()
+        .expect("required fields prefilled");
+    assert_eq!(record.module, "test-module");
+    assert_eq!(record.tenant_id, f.tenant_id);
+    assert_eq!(record.resource_id, f.resource_id);
+    assert_eq!(record.resource_type, "test.resource");
+    assert_eq!(record.metric, "test.gauge");
+    assert_eq!(record.kind, UsageKind::Gauge);
+    assert!((record.value - 7.0).abs() < f64::EPSILON);
+    assert_eq!(
+        record.subject,
+        Some(Subject::with_type(Uuid::nil(), "test.subject"))
+    );
+}
+
+#[tokio::test]
+async fn usage_record_builder_resolves_counter_kind_from_allowed_metrics() {
+    let f = Fixture::build("urb_prefill_counter").await;
+    let record = f
+        .emitter
+        .usage_record_builder("test.counter", 1.0)
+        .unwrap()
+        .with_idempotency_key("idem-key")
+        .build()
+        .unwrap();
+    assert_eq!(record.kind, UsageKind::Counter);
+    assert_eq!(record.idempotency_key, "idem-key");
+}
+
+#[tokio::test]
+async fn usage_record_builder_rejects_unknown_metric() {
+    let f = Fixture::build("urb_unknown_metric").await;
+    let err = f
+        .emitter
+        .usage_record_builder("unknown.metric", 1.0)
+        .unwrap_err();
+    assert!(
+        matches!(err, UsageEmitterError::PermissionDenied { .. }),
+        "expected PermissionDenied for unknown metric, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn usage_record_builder_omits_subject_when_emitter_has_none() {
+    let db = build_db("urb_no_subject").await;
+    let handle = build_outbox(db.clone()).await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let emitter = UsageEmitter {
+        config: Arc::new(UsageEmitterConfig::default()),
+        db: db.clone(),
+        outbox: Arc::clone(handle.outbox()),
+        module: "test-module".to_owned(),
+        tenant_id,
+        resource_id,
+        resource_type: "test.resource".to_owned(),
+        allowed_metrics: vec![AllowedMetric {
+            name: "test.gauge".to_owned(),
+            kind: UsageKind::Gauge,
+        }],
+        max_metadata_bytes: 8192,
+        subject: None,
+        issued_at: Instant::now(),
+    };
+    let record = emitter
+        .usage_record_builder("test.gauge", 1.0)
+        .unwrap()
+        .build()
+        .unwrap();
+    assert!(record.subject.is_none());
+}
+
+// ── End-to-end: builder → emitter.enqueue_in ─────────────────────────────────
+
+#[tokio::test]
+async fn built_gauge_record_enqueues_successfully() {
+    let f = Fixture::build("urb_e2e_gauge").await;
+    let record = f
+        .emitter
+        .usage_record_builder("test.gauge", 42.0)
+        .unwrap()
+        .build()
+        .unwrap();
+    f.emitter.enqueue_in(&f.conn(), record).await.unwrap();
+}
+
+#[tokio::test]
+async fn built_counter_record_enqueues_with_idempotency_key() {
+    let f = Fixture::build("urb_e2e_counter").await;
+    let record = f
+        .emitter
+        .usage_record_builder("test.counter", 1.0)
+        .unwrap()
+        .with_idempotency_key("idem-key")
+        .build()
+        .unwrap();
+    f.emitter.enqueue_in(&f.conn(), record).await.unwrap();
+}
+
+#[tokio::test]
+async fn built_counter_record_without_idempotency_key_is_rejected_at_enqueue() {
+    let f = Fixture::build("urb_e2e_counter_no_idem").await;
+    let record = f
+        .emitter
+        .usage_record_builder("test.counter", 1.0)
+        .unwrap()
+        .build()
+        .unwrap();
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidArgument { .. }));
+}
+
+#[tokio::test]
+async fn built_counter_record_with_negative_value_is_rejected_at_enqueue() {
+    let f = Fixture::build("urb_e2e_counter_negative").await;
+    let record = f
+        .emitter
+        .usage_record_builder("test.counter", -1.0)
+        .unwrap()
+        .with_idempotency_key("idem-key")
+        .build()
+        .unwrap();
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidArgument { .. }));
+}
+
+#[tokio::test]
+async fn built_gauge_record_with_negative_value_is_accepted() {
+    let f = Fixture::build("urb_e2e_gauge_negative").await;
+    let record = f
+        .emitter
+        .usage_record_builder("test.gauge", -5.0)
+        .unwrap()
+        .build()
+        .unwrap();
+    f.emitter.enqueue_in(&f.conn(), record).await.unwrap();
+}
+
+// ── Gauge UUID fallback at enqueue time ──────────────────────────────────────
+
+#[tokio::test]
+async fn gauge_with_blank_idempotency_key_gets_uuid_at_enqueue() {
+    use std::sync::Mutex;
+
+    struct CaptureHandler {
+        captured: Arc<Mutex<Option<Vec<u8>>>>,
+    }
+
+    #[async_trait]
+    impl LeasedMessageHandler for CaptureHandler {
+        async fn handle(&self, msg: &OutboxMessage) -> MessageResult {
+            *self.captured.lock().unwrap() = Some(msg.payload.clone());
+            MessageResult::Ok
+        }
+    }
+
+    let name = "urb_gauge_uuid_fallback";
+    let url = format!("sqlite:file:{name}?mode=memory&cache=shared");
+    let db = connect_db(
+        &url,
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    run_migrations_for_testing(&db, outbox_migrations())
+        .await
+        .unwrap();
+
+    let captured: Arc<Mutex<Option<Vec<u8>>>> = Arc::new(Mutex::new(None));
+    let cfg = UsageEmitterConfig::default();
+    let handle = Outbox::builder(db.clone())
+        .queue(
+            cfg.outbox_queue.as_str(),
+            Partitions::of(cfg.outbox_partition_count),
+        )
+        .leased(CaptureHandler {
+            captured: Arc::clone(&captured),
+        })
+        .start()
+        .await
+        .unwrap();
+
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let emitter = UsageEmitter {
+        config: Arc::new(cfg),
+        db: db.clone(),
+        outbox: Arc::clone(handle.outbox()),
+        module: "test-module".to_owned(),
+        tenant_id,
+        resource_id,
+        resource_type: "test.resource".to_owned(),
+        allowed_metrics: vec![AllowedMetric {
+            name: "test.gauge".to_owned(),
+            kind: UsageKind::Gauge,
+        }],
+        max_metadata_bytes: 8192,
+        subject: Some(Subject::with_type(Uuid::nil(), "test.subject")),
+        issued_at: Instant::now(),
+    };
+
+    {
+        let record = emitter
+            .usage_record_builder("test.gauge", 1.0)
+            .unwrap()
+            .with_idempotency_key("")
+            .build()
+            .unwrap();
+        let conn = db.conn().unwrap();
+        emitter.enqueue_in(&conn, record).await.unwrap();
+    }
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if captured.lock().unwrap().is_some() {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for outbox delivery"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    let payload = captured.lock().unwrap().take().unwrap();
+    let record: UsageRecord = serde_json::from_slice(&payload).unwrap();
+    assert!(
+        !record.idempotency_key.is_empty(),
+        "gauge records with blank caller key must receive a generated UUID, got empty string"
+    );
+    assert!(
+        Uuid::parse_str(&record.idempotency_key).is_ok(),
+        "gauge idempotency_key fallback must be a valid UUID, got {:?}",
+        record.idempotency_key
+    );
+    drop(handle);
+}

--- a/modules/system/usage-collector/usage-emitter/src/error.rs
+++ b/modules/system/usage-collector/usage-emitter/src/error.rs
@@ -1,0 +1,65 @@
+//! Error types for the usage emitter crate.
+//!
+//! [`UsageEmitterError`] is a type alias over [`CanonicalError`]: emitter operations report
+//! failures using the canonical error taxonomy used elsewhere in the platform, so callers can
+//! match on `CanonicalError::PermissionDenied`, `CanonicalError::Unauthenticated`, etc., without
+//! a crate-specific error enum.
+
+use authz_resolver_sdk::{DenyReason, EnforcerError};
+use modkit_canonical_errors::CanonicalError;
+use tracing::{debug, error};
+use usage_collector_sdk::error::UsageRecordError;
+
+/// Errors returned by the usage emitter pipeline.
+///
+/// Alias of [`CanonicalError`] — pattern-match on its variants directly.
+pub type UsageEmitterError = CanonicalError;
+
+fn permission_denied(reason: &str) -> UsageEmitterError {
+    UsageRecordError::permission_denied()
+        .with_reason(reason)
+        .create()
+}
+
+fn map_denied(deny_reason: Option<DenyReason>) -> UsageEmitterError {
+    let Some(d) = deny_reason else {
+        return permission_denied("AUTHORIZATION_DENIED");
+    };
+    debug!(
+        pdp_error_code = %d.error_code,
+        pdp_details = d.details.as_deref().unwrap_or(""),
+        "PDP explicit deny",
+    );
+    permission_denied(&d.error_code)
+}
+
+/// Maps a PDP [`EnforcerError`] to a fail-closed [`UsageEmitterError`].
+///
+/// All enforcer outcomes (denial, compile failure, evaluation failure) map to
+/// [`CanonicalError::PermissionDenied`] so that PDP infrastructure issues never
+/// leak as availability problems to source modules. When the PDP attached a
+/// [`DenyReason`], its `error_code` becomes the canonical `reason` (surfaced to
+/// clients via Problem) and `details` are logged for diagnostics; otherwise the
+/// reason falls back to `AUTHORIZATION_DENIED`.
+#[allow(clippy::needless_pass_by_value)]
+pub fn enforcer_error_to_emitter_error(e: EnforcerError) -> UsageEmitterError {
+    match e {
+        EnforcerError::Denied { deny_reason } => map_denied(deny_reason),
+        EnforcerError::CompileFailed(source) => {
+            error!(
+                pdp_error_variant = "CompileFailed",
+                error = %source,
+                "PDP constraint compilation failed; access denied (fail-closed)",
+            );
+            permission_denied("AUTHORIZATION_DENIED")
+        }
+        EnforcerError::EvaluationFailed(source) => {
+            error!(
+                pdp_error_variant = "EvaluationFailed",
+                error = %source,
+                "PDP policy evaluation failed; access denied (fail-closed)",
+            );
+            permission_denied("AUTHORIZATION_DENIED")
+        }
+    }
+}

--- a/modules/system/usage-collector/usage-emitter/src/infra/delivery_handler.rs
+++ b/modules/system/usage-collector/usage-emitter/src/infra/delivery_handler.rs
@@ -1,0 +1,117 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use modkit_db::outbox::{LeasedMessageHandler, MessageResult, OutboxMessage};
+use tracing::{debug, error, info, warn};
+use usage_collector_sdk::UsageCollectorClientV1;
+use usage_collector_sdk::UsageCollectorError;
+use usage_collector_sdk::models::UsageRecord;
+
+/// Outbox delivery handler that forwards dequeued usage records to the usage collector,
+/// calling [`UsageCollectorClientV1::create_usage_record`] once per message.
+///
+/// Implements [`LeasedMessageHandler`]:
+/// - Deserialization failures dead-letter the message (permanent: corrupt payload).
+/// - Transient collector errors trigger retry: [`UsageCollectorError::DeadlineExceeded`],
+///   [`UsageCollectorError::ResourceExhausted`], and
+///   [`UsageCollectorError::ServiceUnavailable`] (timeout, rate limiting, transport
+///   failure, or server-side condition that is expected to recover). The retry set is
+///   restricted to canonically-retryable gRPC variants.
+/// - `Cancelled` and `Aborted` are also retried (concurrency conflict / client
+///   cancellation are recoverable on a later attempt).
+/// - Caller-induced collector errors dead-letter the message (permanent): `InvalidArgument`,
+///   `Unauthenticated`, `PermissionDenied`, `NotFound`, `AlreadyExists`,
+///   `FailedPrecondition`, `OutOfRange`, `Unimplemented`. Retrying these would loop forever.
+/// - `Internal`, `Unknown`, and `DataLoss` dead-letter the message (permanent). Per gRPC
+///   canonical semantics they signal serious defects, an unrecognized error space, or
+///   unrecoverable corruption — none of which improve with retry. Real transient infra
+///   conditions (plugin not ready, types registry down, circuit breaker open, transport
+///   errors) surface as `ServiceUnavailable` instead (see `domain/error.rs`). Dead-lettering
+///   preserves the message for operator inspection rather than burning the retry budget on
+///   unfixable errors.
+pub struct DeliveryHandler {
+    collector: Arc<dyn UsageCollectorClientV1>,
+}
+
+impl DeliveryHandler {
+    #[must_use]
+    pub fn new(collector: Arc<dyn UsageCollectorClientV1>) -> Self {
+        Self { collector }
+    }
+}
+
+#[async_trait]
+impl LeasedMessageHandler for DeliveryHandler {
+    // @cpt-algo:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1
+    // @cpt-flow:cpt-cf-usage-collector-flow-sdk-and-ingest-core-emit:p1
+    async fn handle(&self, msg: &OutboxMessage) -> MessageResult {
+        // Processor may pass several messages per lease cycle (see WorkerTuning::batch_size);
+        // this handler still delivers each payload individually.
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-1
+        let record = match serde_json::from_slice::<UsageRecord>(&msg.payload) {
+            Ok(r) => r,
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-2
+            Err(err) => {
+                warn!(
+                    msg.seq,
+                    msg.partition_id,
+                    %err,
+                    "usage record deserialization failed"
+                );
+                // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-2a
+                return MessageResult::Reject(format!("{:#}", anyhow::Error::new(err)));
+                // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-2a
+            } // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-2
+        };
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-1
+
+        // inst-dlv-3: gateway ingest request assembly from UsageRecord fields is performed
+        // inside UsageCollectorClientV1::create_usage_record — see rest_client.rs
+        // (UsageRecord IS the request at this layer; DTO assembly is an implementation detail
+        //  of the REST client adapter).
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-4
+        let delivery_result = self.collector.create_usage_record(record).await;
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-4
+
+        match delivery_result {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-5
+            Ok(()) => {
+                debug!("usage record delivered to collector");
+                // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-5a
+                MessageResult::Ok
+                // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-5a
+            }
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-5
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-6
+            Err(
+                e @ (UsageCollectorError::DeadlineExceeded { .. }
+                | UsageCollectorError::ResourceExhausted { .. }
+                | UsageCollectorError::ServiceUnavailable { .. }
+                | UsageCollectorError::Cancelled { .. }
+                | UsageCollectorError::Aborted { .. }),
+            ) => {
+                // Retry set is restricted to canonically-retryable gRPC variants;
+                // see the type-level doc comment for the full rationale.
+                info!(error = %e, "transient collector delivery error; will retry");
+                // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-6a
+                MessageResult::Retry
+                // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-6a
+            }
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-6
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-7
+            Err(e) => {
+                error!(error = %e, "permanent collector delivery error; dead-lettering message");
+                // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-7a
+                MessageResult::Reject(format!("{:#}", anyhow::Error::new(e)))
+                // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-7a
+            } // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-7
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "delivery_handler_tests.rs"]
+mod delivery_handler_tests;

--- a/modules/system/usage-collector/usage-emitter/src/infra/delivery_handler_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/src/infra/delivery_handler_tests.rs
@@ -1,0 +1,332 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use modkit_db::outbox::{LeasedMessageHandler, MessageResult, OutboxMessage};
+use usage_collector_sdk::models::{Subject, UsageKind, UsageRecord};
+use usage_collector_sdk::{UsageCollectorClientV1, UsageCollectorError, UsageRecordError};
+use uuid::Uuid;
+
+use super::DeliveryHandler;
+
+enum CollectorOutcome {
+    Ok,
+    Transient,
+    Permanent,
+    Unavailable,
+    ResourceExhausted,
+    Internal,
+    Unknown,
+    DataLoss,
+    Cancelled,
+    Aborted,
+    InvalidArgument,
+    PermissionDenied,
+    NotFound,
+}
+
+struct MockCollector {
+    outcome: CollectorOutcome,
+}
+
+impl MockCollector {
+    fn ok() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: CollectorOutcome::Ok,
+        })
+    }
+
+    fn transient() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: CollectorOutcome::Transient,
+        })
+    }
+
+    fn permanent() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: CollectorOutcome::Permanent,
+        })
+    }
+
+    fn unavailable() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: CollectorOutcome::Unavailable,
+        })
+    }
+
+    fn resource_exhausted() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: CollectorOutcome::ResourceExhausted,
+        })
+    }
+
+    fn with_outcome(outcome: CollectorOutcome) -> Arc<Self> {
+        Arc::new(Self { outcome })
+    }
+}
+
+#[async_trait]
+impl UsageCollectorClientV1 for MockCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        match self.outcome {
+            CollectorOutcome::Ok => Ok(()),
+            CollectorOutcome::Transient => {
+                Err(UsageRecordError::deadline_exceeded("plugin timed out").create())
+            }
+            CollectorOutcome::Permanent => Err(UsageCollectorError::unauthenticated()
+                .with_reason("permanent")
+                .create()),
+            CollectorOutcome::Unavailable => {
+                Err(UsageCollectorError::service_unavailable().create())
+            }
+            CollectorOutcome::ResourceExhausted => Err(UsageRecordError::resource_exhausted(
+                "rate limited by gateway",
+            )
+            .with_quota_violation("requests", "rate limit exceeded")
+            .create()),
+            CollectorOutcome::Internal => Err(UsageCollectorError::internal("boom").create()),
+            CollectorOutcome::Unknown => Err(UsageRecordError::unknown("???").create()),
+            CollectorOutcome::DataLoss => Err(UsageRecordError::data_loss("data loss detected")
+                .with_resource("rec-1")
+                .create()),
+            CollectorOutcome::Cancelled => Err(UsageRecordError::cancelled().create()),
+            CollectorOutcome::Aborted => Err(UsageRecordError::aborted("concurrency conflict")
+                .with_reason("concurrency conflict on receiver")
+                .create()),
+            CollectorOutcome::InvalidArgument => Err(UsageRecordError::invalid_argument()
+                .with_constraint("bad input")
+                .create()),
+            CollectorOutcome::PermissionDenied => Err(UsageRecordError::permission_denied()
+                .with_reason("denied")
+                .create()),
+            CollectorOutcome::NotFound => Err(UsageRecordError::not_found("missing")
+                .with_resource("rec-1")
+                .create()),
+        }
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<usage_collector_sdk::ModuleConfig, UsageCollectorError> {
+        Ok(usage_collector_sdk::ModuleConfig {
+            allowed_metrics: vec![],
+            max_metadata_bytes: 8192,
+        })
+    }
+}
+
+fn valid_usage_record() -> UsageRecord {
+    UsageRecord {
+        tenant_id: Uuid::new_v4(),
+        module: "test-module".to_owned(),
+        metric: "test.metric".to_owned(),
+        kind: UsageKind::Gauge,
+        value: 1.0,
+        resource_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        subject: Some(Subject::with_type(Uuid::nil(), "test.subject")),
+        idempotency_key: Uuid::new_v4().to_string(),
+        timestamp: Utc::now(),
+        metadata: None,
+    }
+}
+
+fn make_msg(payload_bytes: Vec<u8>) -> OutboxMessage {
+    OutboxMessage {
+        partition_id: 0,
+        seq: 1,
+        payload: payload_bytes,
+        payload_type: "application/json".to_owned(),
+        created_at: Utc::now(),
+        attempts: 0,
+    }
+}
+
+fn handler(collector: Arc<dyn UsageCollectorClientV1>) -> DeliveryHandler {
+    DeliveryHandler::new(collector)
+}
+
+#[tokio::test]
+async fn handle_invalid_json_payload_is_rejected() {
+    let h = handler(MockCollector::ok());
+    let msg = make_msg(b"not-json".to_vec());
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Reject(_)));
+}
+
+#[tokio::test]
+async fn handle_collector_transient_error_returns_retry() {
+    let h = handler(MockCollector::transient());
+    let payload = serde_json::to_vec(&valid_usage_record()).unwrap();
+    let msg = make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Retry));
+}
+
+#[tokio::test]
+async fn handle_collector_permanent_error_returns_reject() {
+    let h = handler(MockCollector::permanent());
+    let payload = serde_json::to_vec(&valid_usage_record()).unwrap();
+    let msg = make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Reject(_)));
+}
+
+#[tokio::test]
+async fn handle_collector_unavailable_error_returns_retry() {
+    let h = handler(MockCollector::unavailable());
+    let payload = serde_json::to_vec(&valid_usage_record()).unwrap();
+    let msg = make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Retry));
+}
+
+#[tokio::test]
+async fn handle_collector_resource_exhausted_error_returns_retry() {
+    let h = handler(MockCollector::resource_exhausted());
+    let payload = serde_json::to_vec(&valid_usage_record()).unwrap();
+    let msg = make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Retry));
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExpectedDisposition {
+    Ok,
+    Retry,
+    Reject,
+}
+
+async fn assert_outcome(outcome: CollectorOutcome, expected: ExpectedDisposition) {
+    let h = handler(MockCollector::with_outcome(outcome));
+    let payload = serde_json::to_vec(&valid_usage_record()).unwrap();
+    let msg = make_msg(payload);
+    let got = h.handle(&msg).await;
+    let got_disposition = match got {
+        MessageResult::Ok => ExpectedDisposition::Ok,
+        MessageResult::Retry => ExpectedDisposition::Retry,
+        MessageResult::Reject(_) => ExpectedDisposition::Reject,
+    };
+    assert_eq!(got_disposition, expected, "delivery disposition mismatch");
+}
+
+// Canonically-retryable errors must retry: DeadlineExceeded, ResourceExhausted,
+// ServiceUnavailable (covered above), plus Cancelled and Aborted.
+
+#[tokio::test]
+async fn handle_collector_cancelled_error_returns_retry() {
+    assert_outcome(CollectorOutcome::Cancelled, ExpectedDisposition::Retry).await;
+}
+
+#[tokio::test]
+async fn handle_collector_aborted_error_returns_retry() {
+    assert_outcome(CollectorOutcome::Aborted, ExpectedDisposition::Retry).await;
+}
+
+// Internal / Unknown / DataLoss are canonically permanent and must dead-letter:
+// serious defects, unrecognized error space, or unrecoverable corruption never
+// improve with retry.
+
+#[tokio::test]
+async fn handle_collector_internal_error_is_rejected() {
+    assert_outcome(CollectorOutcome::Internal, ExpectedDisposition::Reject).await;
+}
+
+#[tokio::test]
+async fn handle_collector_unknown_error_is_rejected() {
+    assert_outcome(CollectorOutcome::Unknown, ExpectedDisposition::Reject).await;
+}
+
+#[tokio::test]
+async fn handle_collector_data_loss_error_is_rejected() {
+    assert_outcome(CollectorOutcome::DataLoss, ExpectedDisposition::Reject).await;
+}
+
+// Caller-induced errors must dead-letter (retrying would loop forever).
+
+#[tokio::test]
+async fn handle_collector_invalid_argument_error_is_rejected() {
+    assert_outcome(
+        CollectorOutcome::InvalidArgument,
+        ExpectedDisposition::Reject,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn handle_collector_permission_denied_error_is_rejected() {
+    assert_outcome(
+        CollectorOutcome::PermissionDenied,
+        ExpectedDisposition::Reject,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn handle_collector_not_found_error_is_rejected() {
+    assert_outcome(CollectorOutcome::NotFound, ExpectedDisposition::Reject).await;
+}
+
+#[tokio::test]
+async fn handle_success_returns_ok() {
+    let h = handler(MockCollector::ok());
+    let payload = serde_json::to_vec(&valid_usage_record()).unwrap();
+    let msg = make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Ok));
+}
+
+// ── Subject fields deserialization ────────────────────────────────────────────
+
+struct CapturingCollector {
+    captured: Arc<Mutex<Option<UsageRecord>>>,
+}
+
+impl CapturingCollector {
+    fn new(captured: Arc<Mutex<Option<UsageRecord>>>) -> Arc<Self> {
+        Arc::new(Self { captured })
+    }
+}
+
+#[async_trait]
+impl UsageCollectorClientV1 for CapturingCollector {
+    async fn create_usage_record(&self, record: UsageRecord) -> Result<(), UsageCollectorError> {
+        *self.captured.lock().unwrap() = Some(record);
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<usage_collector_sdk::ModuleConfig, UsageCollectorError> {
+        Ok(usage_collector_sdk::ModuleConfig {
+            allowed_metrics: vec![],
+            max_metadata_bytes: 8192,
+        })
+    }
+}
+
+#[tokio::test]
+async fn handle_delivery_preserves_subject_fields_through_deserialization() {
+    let known_subject = Subject::with_type(Uuid::new_v4(), "real.subject");
+    let record = UsageRecord {
+        subject: Some(known_subject.clone()),
+        ..valid_usage_record()
+    };
+
+    let captured: Arc<Mutex<Option<UsageRecord>>> = Arc::new(Mutex::new(None));
+    let collector = CapturingCollector::new(Arc::clone(&captured));
+    let h = handler(collector);
+    let payload = serde_json::to_vec(&record).unwrap();
+    let msg = make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Ok));
+
+    let received = captured
+        .lock()
+        .unwrap()
+        .take()
+        .expect("collector must have received the record");
+    assert_eq!(received.subject, Some(known_subject));
+}

--- a/modules/system/usage-collector/usage-emitter/src/infra/mod.rs
+++ b/modules/system/usage-collector/usage-emitter/src/infra/mod.rs
@@ -1,0 +1,2 @@
+// @cpt-dod:cpt-cf-usage-collector-dod-sdk-and-ingest-core-emitter-crate:p1
+pub mod delivery_handler;

--- a/modules/system/usage-collector/usage-emitter/src/lib.rs
+++ b/modules/system/usage-collector/usage-emitter/src/lib.rs
@@ -1,0 +1,55 @@
+//! Durable usage emission for source modules.
+//!
+//! Provides the complete emitter pipeline: module-scoped PDP authorization, transactional
+//! outbox enqueue, and async delivery to the usage collector via `modkit-db` outbox workers.
+//!
+//! # Crate shape: single crate, not trait-SDK + impl
+//!
+//! Unlike other modules in the workspace, `usage-emitter` deliberately ships as a single
+//! crate (trait + concrete types together) rather than a thin `*-sdk` crate. The trait
+//! [`UsageEmitterRuntimeV1`] returns a concrete [`UsageEmitterFactory`], which produces a
+//! concrete [`UsageEmitter`] and [`UsageRecordBuilder`]; these types carry private state
+//! (`db`, `outbox`, `issued_at`, `allowed_metrics`) that the security invariant relies on,
+//! so they cannot be reduced to opaque trait objects without losing the type-state
+//! authorization handle. Every consumer therefore depends on the trait *and* the concrete
+//! types simultaneously — splitting would not remove the impl-crate dependency. See the
+//! crate `README.md` ("Why there is no `usage-emitter-sdk` crate") for the full rationale.
+//!
+//! # Usage
+//!
+//! Source modules should not construct [`UsageEmitterFactory`] directly. The `usage-collector`
+//! or `usage-collector-rest-client` `ModKit` module builds and registers
+//! `dyn UsageEmitterRuntimeV1` in `ClientHub` during `init()`.
+//!
+//! ```ignore
+//! // In init():
+//! let runtime = hub.get::<dyn UsageEmitterRuntimeV1>()?;
+//! let factory = runtime.factory(Self::MODULE_NAME);
+//!
+//! // In a handler:
+//! let emitter = factory
+//!     .clone()
+//!     .authorize(&ctx, resource_id, "resource_type")
+//!     .await?;
+//! let record = emitter
+//!     .usage_record_builder("requests", 1.0)?
+//!     .build()?;
+//! emitter.enqueue(record).await?;
+//! ```
+
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+mod api;
+mod config;
+mod domain;
+mod error;
+mod infra;
+
+pub use api::UsageEmitterRuntimeV1;
+pub use config::UsageEmitterConfig;
+pub use domain::emitter::UsageEmitter;
+pub use domain::factory::UsageEmitterFactory;
+pub use domain::runtime::UsageEmitterRuntime;
+pub use domain::usage_record_builder::UsageRecordBuilder;
+pub use error::UsageEmitterError;
+pub use infra::delivery_handler::DeliveryHandler;

--- a/modules/system/usage-collector/usage-emitter/tests/common/mod.rs
+++ b/modules/system/usage-collector/usage-emitter/tests/common/mod.rs
@@ -1,0 +1,100 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, dead_code)]
+
+use async_trait::async_trait;
+use authz_resolver_sdk::models::{
+    EvaluationRequest, EvaluationResponse, EvaluationResponseContext,
+};
+use authz_resolver_sdk::{AuthZResolverClient, AuthZResolverError};
+use modkit_db::migration_runner::run_migrations_for_testing;
+use modkit_db::outbox::outbox_migrations;
+use modkit_db::{ConnectOpts, Db, connect_db};
+use modkit_security::SecurityContext;
+use usage_collector_sdk::models::UsageRecord;
+use usage_collector_sdk::{UsageCollectorClientV1, UsageCollectorError};
+use uuid::Uuid;
+
+pub async fn build_db(name: &str) -> Db {
+    let url = format!("sqlite:file:{name}?mode=memory&cache=shared");
+    let db = connect_db(
+        &url,
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    run_migrations_for_testing(&db, outbox_migrations())
+        .await
+        .unwrap();
+    db
+}
+
+pub struct NoopCollector;
+
+#[async_trait]
+impl UsageCollectorClientV1 for NoopCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<usage_collector_sdk::ModuleConfig, UsageCollectorError> {
+        Ok(usage_collector_sdk::ModuleConfig {
+            allowed_metrics: vec![],
+            max_metadata_bytes: 8192,
+        })
+    }
+}
+
+pub struct AllowAllAuthZ;
+
+#[async_trait]
+impl AuthZResolverClient for AllowAllAuthZ {
+    async fn evaluate(
+        &self,
+        _request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        Ok(EvaluationResponse {
+            decision: true,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+pub struct DenyAllAuthZ;
+
+#[async_trait]
+impl AuthZResolverClient for DenyAllAuthZ {
+    async fn evaluate(
+        &self,
+        _request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        Ok(EvaluationResponse {
+            decision: false,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+pub struct FailingAuthZ;
+
+#[async_trait]
+impl AuthZResolverClient for FailingAuthZ {
+    async fn evaluate(
+        &self,
+        _request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        Err(AuthZResolverError::Internal("PDP unavailable".to_owned()))
+    }
+}
+
+pub fn make_ctx() -> SecurityContext {
+    SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(Uuid::new_v4())
+        .build()
+        .unwrap()
+}

--- a/modules/system/usage-collector/usage-emitter/tests/emitter_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/tests/emitter_tests.rs
@@ -1,0 +1,863 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use authz_resolver_sdk::models::{
+    BarrierMode, EvaluationRequest, EvaluationResponse, EvaluationResponseContext,
+};
+use authz_resolver_sdk::{AuthZResolverClient, AuthZResolverError};
+use chrono::Utc;
+use modkit_db::Db;
+use modkit_security::pep_properties;
+use usage_collector_sdk::models::{AllowedMetric, Subject, UsageKind, UsageRecord};
+use usage_collector_sdk::{UsageCollectorClientV1, UsageCollectorError, UsageRecordError};
+use usage_emitter::{
+    UsageEmitter, UsageEmitterConfig, UsageEmitterError, UsageEmitterFactory, UsageEmitterRuntime,
+    UsageEmitterRuntimeV1,
+};
+use uuid::Uuid;
+
+const TEST_MODULE: &str = "test-module";
+const FIXTURE_RESOURCE_TYPE: &str = "test.resource";
+
+// ── Test-specific AuthZ mocks ─────────────────────────────────────────────────
+
+struct AllowOwnerTenantIfInSet {
+    extra_allowed: Vec<Uuid>,
+}
+
+#[async_trait]
+impl AuthZResolverClient for AllowOwnerTenantIfInSet {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let subject_tenant = request
+            .subject
+            .properties
+            .get("tenant_id")
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok());
+
+        let Some(subject_tenant) = subject_tenant else {
+            return Ok(EvaluationResponse {
+                decision: false,
+                context: EvaluationResponseContext::default(),
+            });
+        };
+
+        let owner = request
+            .resource
+            .properties
+            .get(pep_properties::OWNER_TENANT_ID)
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok());
+
+        let Some(owner) = owner else {
+            return Ok(EvaluationResponse {
+                decision: false,
+                context: EvaluationResponseContext::default(),
+            });
+        };
+
+        let allowed = owner == subject_tenant || self.extra_allowed.contains(&owner);
+        Ok(EvaluationResponse {
+            decision: allowed,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+struct AssertBarrierIgnoreAuthZ;
+
+#[async_trait]
+impl AuthZResolverClient for AssertBarrierIgnoreAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let barrier = request
+            .context
+            .tenant_context
+            .as_ref()
+            .expect("tenant_context set by AccessRequest::barrier_mode")
+            .barrier_mode;
+        assert_eq!(barrier, BarrierMode::Ignore);
+        Ok(EvaluationResponse {
+            decision: true,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+struct AssertModulePropertyAuthZ {
+    expected_module: String,
+    matched: Arc<Mutex<bool>>,
+}
+
+#[async_trait]
+impl AuthZResolverClient for AssertModulePropertyAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let module_val = request
+            .resource
+            .properties
+            .get("module")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let ok = module_val == self.expected_module;
+        *self.matched.lock().unwrap() = ok;
+        Ok(EvaluationResponse {
+            decision: ok,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+struct AssertSubjectPropertiesAuthZ {
+    expected_subject_id: String,
+    expected_subject_type: String,
+    matched: Arc<Mutex<bool>>,
+}
+
+#[async_trait]
+impl AuthZResolverClient for AssertSubjectPropertiesAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let subj_id = request
+            .resource
+            .properties
+            .get("subject_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let subj_type = request
+            .resource
+            .properties
+            .get("subject_type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let ok = subj_id == self.expected_subject_id && subj_type == self.expected_subject_type;
+        *self.matched.lock().unwrap() = ok;
+        Ok(EvaluationResponse {
+            decision: ok,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+/// Captures the `SUBJECT_ID` / `SUBJECT_TYPE` resource properties as `Option<String>` so
+/// tests can distinguish "property absent" from "property present with some value".
+/// Always allows.
+struct CapturingSubjectPropertiesAuthZ {
+    captured_subject_id: Arc<Mutex<Option<String>>>,
+    captured_subject_type: Arc<Mutex<Option<String>>>,
+}
+
+#[async_trait]
+impl AuthZResolverClient for CapturingSubjectPropertiesAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let subj_id = request
+            .resource
+            .properties
+            .get("subject_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_owned);
+        let subj_type = request
+            .resource
+            .properties
+            .get("subject_type")
+            .and_then(|v| v.as_str())
+            .map(str::to_owned);
+        *self.captured_subject_id.lock().unwrap() = subj_id;
+        *self.captured_subject_type.lock().unwrap() = subj_type;
+        Ok(EvaluationResponse {
+            decision: true,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+// ── Test-specific collector mocks ─────────────────────────────────────────────
+
+struct FailingCollector {
+    error: fn() -> UsageCollectorError,
+}
+
+#[async_trait]
+impl UsageCollectorClientV1 for FailingCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<usage_collector_sdk::ModuleConfig, UsageCollectorError> {
+        Err((self.error)())
+    }
+}
+
+/// Collector returning a fixed set of allowed metrics so the merged enqueue-side fixture
+/// can exercise gauge/counter metric validation. Used by the `Fixture` struct below.
+struct FixtureCollector;
+
+#[async_trait]
+impl UsageCollectorClientV1 for FixtureCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<usage_collector_sdk::ModuleConfig, UsageCollectorError> {
+        Ok(usage_collector_sdk::ModuleConfig {
+            allowed_metrics: vec![
+                AllowedMetric {
+                    name: "test.gauge".to_owned(),
+                    kind: UsageKind::Gauge,
+                },
+                AllowedMetric {
+                    name: "test.counter".to_owned(),
+                    kind: UsageKind::Counter,
+                },
+            ],
+            max_metadata_bytes: 8192,
+        })
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async fn build_factory(name: &str, authz: Arc<dyn AuthZResolverClient>) -> UsageEmitterFactory {
+    let db = common::build_db(name).await;
+    let runtime = UsageEmitterRuntime::build(
+        UsageEmitterConfig::default(),
+        db,
+        authz,
+        Arc::new(common::NoopCollector),
+    )
+    .await
+    .unwrap();
+    runtime.factory(TEST_MODULE)
+}
+
+async fn build_factory_with_collector(
+    name: &str,
+    authz: Arc<dyn AuthZResolverClient>,
+    collector: Arc<dyn UsageCollectorClientV1>,
+) -> UsageEmitterFactory {
+    let db = common::build_db(name).await;
+    let runtime = UsageEmitterRuntime::build(UsageEmitterConfig::default(), db, authz, collector)
+        .await
+        .unwrap();
+    runtime.factory(TEST_MODULE)
+}
+
+// ── Tests (factory-side: PDP authorize behaviour) ─────────────────────────────
+
+#[tokio::test]
+async fn build_creates_emitter_with_valid_config() {
+    build_factory("emit_build", Arc::new(common::AllowAllAuthZ)).await;
+}
+
+#[tokio::test]
+async fn authorize_returns_handle_on_allow_all_authz() {
+    let factory = build_factory("emit_authz_allow", Arc::new(common::AllowAllAuthZ)).await;
+    let ctx = common::make_ctx();
+    factory
+        .clone()
+        .authorize(&ctx, Uuid::new_v4(), "test.resource")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn authorize_returns_error_on_deny_all_authz() {
+    let factory = build_factory("emit_authz_deny", Arc::new(common::DenyAllAuthZ)).await;
+    let ctx = common::make_ctx();
+    let Err(err) = factory
+        .clone()
+        .authorize(&ctx, Uuid::new_v4(), "test.resource")
+        .await
+    else {
+        panic!("expected authorization to fail");
+    };
+    assert!(matches!(err, UsageEmitterError::PermissionDenied { .. }));
+}
+
+#[tokio::test]
+async fn authorize_returns_permission_denied_on_authz_failure() {
+    let factory = build_factory("emit_authz_fail", Arc::new(common::FailingAuthZ)).await;
+    let ctx = common::make_ctx();
+    let Err(err) = factory
+        .clone()
+        .authorize(&ctx, Uuid::new_v4(), "test.resource")
+        .await
+    else {
+        panic!("expected authorization to fail");
+    };
+    assert!(matches!(err, UsageEmitterError::PermissionDenied { .. }));
+}
+
+#[tokio::test]
+async fn authorize_denies_when_pdp_rejects_owner_tenant() {
+    let factory = build_factory(
+        "emit_pdp_deny_foreign",
+        Arc::new(AllowOwnerTenantIfInSet {
+            extra_allowed: vec![],
+        }),
+    )
+    .await;
+
+    let subject_tenant = Uuid::new_v4();
+    let foreign_tenant = Uuid::new_v4();
+    let ctx = modkit_security::SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(subject_tenant)
+        .build()
+        .unwrap();
+
+    let Err(err) = factory
+        .clone()
+        .with_tenant(foreign_tenant)
+        .with_subject(Subject::with_type(Uuid::new_v4(), "test.subject"))
+        .authorize(&ctx, Uuid::new_v4(), "test.resource")
+        .await
+    else {
+        panic!("expected authorization to fail");
+    };
+    assert!(matches!(err, UsageEmitterError::PermissionDenied { .. }));
+}
+
+#[tokio::test]
+async fn authorize_allows_subtenant_when_pdp_allows_extra_tenant() {
+    let parent = Uuid::new_v4();
+    let child = Uuid::new_v4();
+    let factory = build_factory(
+        "emit_pdp_allow_child",
+        Arc::new(AllowOwnerTenantIfInSet {
+            extra_allowed: vec![child],
+        }),
+    )
+    .await;
+
+    let ctx = modkit_security::SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(parent)
+        .build()
+        .unwrap();
+
+    factory
+        .clone()
+        .with_tenant(child)
+        .with_subject(Subject::with_type(Uuid::new_v4(), "test.subject"))
+        .authorize(&ctx, Uuid::new_v4(), "test.resource")
+        .await
+        .expect("PDP allows emit for allowed sub-tenant");
+}
+
+#[tokio::test]
+async fn authorize_sends_barrier_mode_ignore_to_pdp() {
+    let factory = build_factory("emit_barrier_ignore", Arc::new(AssertBarrierIgnoreAuthZ)).await;
+    let ctx = common::make_ctx();
+    factory
+        .clone()
+        .with_tenant(ctx.subject_tenant_id())
+        .with_subject(Subject::with_type(Uuid::new_v4(), "test.subject"))
+        .authorize(&ctx, Uuid::new_v4(), "test.resource")
+        .await
+        .expect("barrier assert + allow");
+}
+
+#[tokio::test]
+async fn authorize_propagates_collector_deadline_exceeded() {
+    let factory = build_factory_with_collector(
+        "emit_collector_timeout",
+        Arc::new(common::AllowAllAuthZ),
+        Arc::new(FailingCollector {
+            error: || UsageRecordError::deadline_exceeded("plugin timed out").create(),
+        }),
+    )
+    .await;
+    let ctx = common::make_ctx();
+    let result = factory
+        .clone()
+        .authorize(&ctx, Uuid::new_v4(), "test.resource")
+        .await;
+    assert!(matches!(
+        result,
+        Err(UsageEmitterError::DeadlineExceeded { .. })
+    ));
+}
+
+#[tokio::test]
+async fn authorize_propagates_collector_service_unavailable() {
+    let factory = build_factory_with_collector(
+        "emit_collector_unavailable",
+        Arc::new(common::AllowAllAuthZ),
+        Arc::new(FailingCollector {
+            error: || UsageEmitterError::service_unavailable().create(),
+        }),
+    )
+    .await;
+    let ctx = common::make_ctx();
+    let result = factory
+        .clone()
+        .authorize(&ctx, Uuid::new_v4(), "test.resource")
+        .await;
+    assert!(matches!(
+        result,
+        Err(UsageEmitterError::ServiceUnavailable { .. })
+    ));
+}
+
+#[tokio::test]
+async fn authorize_propagates_collector_internal_error() {
+    let factory = build_factory_with_collector(
+        "emit_collector_internal",
+        Arc::new(common::AllowAllAuthZ),
+        Arc::new(FailingCollector {
+            error: || UsageEmitterError::internal("unexpected state").create(),
+        }),
+    )
+    .await;
+    let ctx = common::make_ctx();
+    let result = factory
+        .clone()
+        .authorize(&ctx, Uuid::new_v4(), "test.resource")
+        .await;
+    assert!(matches!(result, Err(UsageEmitterError::Internal { .. })));
+}
+
+#[tokio::test]
+async fn authorize_propagates_collector_resource_exhausted() {
+    let factory = build_factory_with_collector(
+        "emit_collector_resource_exhausted",
+        Arc::new(common::AllowAllAuthZ),
+        Arc::new(FailingCollector {
+            error: || {
+                UsageRecordError::resource_exhausted("rate limited")
+                    .with_quota_violation("requests", "rate limit exceeded")
+                    .create()
+            },
+        }),
+    )
+    .await;
+    let ctx = common::make_ctx();
+    let result = factory
+        .clone()
+        .authorize(&ctx, Uuid::new_v4(), "test.resource")
+        .await;
+    assert!(matches!(
+        result,
+        Err(UsageEmitterError::ResourceExhausted { .. })
+    ));
+}
+
+#[tokio::test]
+async fn authorize_pdp_request_includes_module_resource_property() {
+    let matched = Arc::new(Mutex::new(false));
+    let factory = build_factory(
+        "emit_module_prop",
+        Arc::new(AssertModulePropertyAuthZ {
+            expected_module: TEST_MODULE.to_owned(),
+            matched: Arc::clone(&matched),
+        }),
+    )
+    .await;
+    let ctx = common::make_ctx();
+    drop(
+        factory
+            .clone()
+            .with_tenant(ctx.subject_tenant_id())
+            .with_subject(Subject::with_type(Uuid::new_v4(), "test.subject"))
+            .authorize(&ctx, Uuid::new_v4(), "test.resource")
+            .await,
+    );
+    assert!(
+        *matched.lock().unwrap(),
+        "PDP request must include MODULE resource property equal to the module name"
+    );
+}
+
+#[tokio::test]
+async fn authorize_pdp_request_includes_subject_id_and_subject_type_resource_properties() {
+    let matched = Arc::new(Mutex::new(false));
+    let subject_id = Uuid::new_v4();
+    let subject_type = "test.subject.type".to_owned();
+    let factory = build_factory(
+        "emit_subject_props",
+        Arc::new(AssertSubjectPropertiesAuthZ {
+            expected_subject_id: subject_id.to_string(),
+            expected_subject_type: subject_type.clone(),
+            matched: Arc::clone(&matched),
+        }),
+    )
+    .await;
+    let ctx = common::make_ctx();
+    drop(
+        factory
+            .clone()
+            .with_tenant(ctx.subject_tenant_id())
+            .with_subject(Subject::with_type(subject_id, subject_type))
+            .authorize(&ctx, Uuid::new_v4(), "test.resource")
+            .await,
+    );
+    assert!(
+        *matched.lock().unwrap(),
+        "PDP request must include SUBJECT_ID and SUBJECT_TYPE resource properties"
+    );
+}
+
+#[tokio::test]
+async fn authorize_without_subject_omits_subject_properties_from_pdp_request() {
+    // `.without_subject()` is the explicit "no subject" intent: PDP receives
+    // neither SUBJECT_ID nor SUBJECT_TYPE, regardless of what the
+    // SecurityContext carries. This is the contract used by gateways /
+    // forwarders to faithfully represent a caller that did not supply a
+    // subject — never substituting the gateway's own ctx identity.
+    let captured_id: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let captured_type: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let factory = build_factory(
+        "emit_without_subject_pdp_props",
+        Arc::new(CapturingSubjectPropertiesAuthZ {
+            captured_subject_id: Arc::clone(&captured_id),
+            captured_subject_type: Arc::clone(&captured_type),
+        }),
+    )
+    .await;
+    let ctx = common::make_ctx();
+    factory
+        .clone()
+        .with_tenant(ctx.subject_tenant_id())
+        .without_subject()
+        .authorize(&ctx, Uuid::new_v4(), "test.resource")
+        .await
+        .expect("authorize must succeed when PDP allows and no subject is bound");
+    assert!(
+        captured_id.lock().unwrap().is_none(),
+        "PDP must receive no SUBJECT_ID when `without_subject()` is used"
+    );
+    assert!(
+        captured_type.lock().unwrap().is_none(),
+        "PDP must receive no SUBJECT_TYPE when `without_subject()` is used"
+    );
+    // The downstream wire shape is pinned in the SDK models tests
+    // (`usage_record_subject_none_serde`): a `UsageRecord` whose
+    // `subject = None` serializes with the `subject` field omitted, so an
+    // emitter bound via `.without_subject()` produces an outbox payload
+    // that carries no subject — there is no other path from this emitter
+    // handle into a record that carries a subject.
+}
+
+#[tokio::test]
+async fn authorize_default_subject_choice_falls_back_to_ctx_subject_in_pdp() {
+    // Neither `.with_subject(...)` nor `.without_subject()` was called —
+    // this is the `SubjectChoice::DefaultFromCtx` default for in-process
+    // modules whose caller identity *is* the subject. The PDP must receive
+    // the ctx-derived SUBJECT_ID. Ctx in this test has no subject type, so
+    // SUBJECT_TYPE must be absent.
+    let captured_id: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let captured_type: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let factory = build_factory(
+        "emit_default_subject_props_fallback",
+        Arc::new(CapturingSubjectPropertiesAuthZ {
+            captured_subject_id: Arc::clone(&captured_id),
+            captured_subject_type: Arc::clone(&captured_type),
+        }),
+    )
+    .await;
+    let ctx = common::make_ctx();
+    factory
+        .clone()
+        .with_tenant(ctx.subject_tenant_id())
+        .authorize(&ctx, Uuid::new_v4(), "test.resource")
+        .await
+        .expect("ctx-derived subject is sent and PDP allows");
+    assert_eq!(
+        captured_id.lock().unwrap().as_deref(),
+        Some(ctx.subject_id().to_string().as_str()),
+        "PDP must receive the ctx-derived SUBJECT_ID when neither with_subject nor without_subject was called"
+    );
+    assert!(
+        captured_type.lock().unwrap().is_none(),
+        "PDP must omit SUBJECT_TYPE when ctx has no subject type"
+    );
+}
+
+// ── Enqueue-side fixture (merged from tests/authorized_emitter_tests.rs) ──────
+
+struct Fixture {
+    db: Db,
+    _runtime: UsageEmitterRuntime,
+    emitter: UsageEmitter,
+    tenant: Uuid,
+    resource_id: Uuid,
+}
+
+impl Fixture {
+    async fn build(name: &str) -> Self {
+        Self::build_with_config(name, UsageEmitterConfig::default()).await
+    }
+
+    async fn build_with_config(name: &str, config: UsageEmitterConfig) -> Self {
+        let db = common::build_db(name).await;
+        let runtime = UsageEmitterRuntime::build(
+            config,
+            db.clone(),
+            Arc::new(common::AllowAllAuthZ),
+            Arc::new(FixtureCollector),
+        )
+        .await
+        .unwrap();
+
+        let ctx = common::make_ctx();
+        let tenant = ctx.subject_tenant_id();
+        let resource_id = Uuid::new_v4();
+
+        let emitter = runtime
+            .factory(TEST_MODULE)
+            .with_tenant(tenant)
+            .with_subject(Subject::with_type(Uuid::nil(), "test.subject"))
+            .authorize(&ctx, resource_id, FIXTURE_RESOURCE_TYPE)
+            .await
+            .unwrap();
+
+        Self {
+            db,
+            _runtime: runtime,
+            emitter,
+            tenant,
+            resource_id,
+        }
+    }
+
+    fn record(&self) -> UsageRecord {
+        UsageRecord {
+            tenant_id: self.tenant,
+            module: TEST_MODULE.to_owned(),
+            metric: "test.gauge".to_owned(),
+            kind: UsageKind::Gauge,
+            value: 1.0,
+            resource_id: self.resource_id,
+            resource_type: FIXTURE_RESOURCE_TYPE.to_owned(),
+            subject: Some(Subject::with_type(Uuid::nil(), "test.subject")),
+            idempotency_key: Uuid::new_v4().to_string(),
+            timestamp: Utc::now(),
+            metadata: None,
+        }
+    }
+
+    fn record_with_kind(&self, kind: UsageKind, value: f64) -> UsageRecord {
+        let metric = match kind {
+            UsageKind::Gauge => "test.gauge",
+            UsageKind::Counter => "test.counter",
+        }
+        .to_owned();
+        UsageRecord {
+            metric,
+            kind,
+            value,
+            ..self.record()
+        }
+    }
+
+    fn conn(&self) -> modkit_db::DbConn<'_> {
+        self.db.conn().unwrap()
+    }
+}
+
+// ── Expiry ────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_expired_authorization() {
+    let f = Fixture::build_with_config(
+        "ap_expired",
+        UsageEmitterConfig {
+            authorization_max_age: Duration::from_nanos(1),
+            ..Default::default()
+        },
+    )
+    .await;
+    let err = f
+        .emitter
+        .enqueue_in(&f.conn(), f.record())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, UsageEmitterError::Unauthenticated { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_accepts_usage_record() {
+    let f = Fixture::build("ap_pos_val").await;
+    f.emitter.enqueue_in(&f.conn(), f.record()).await.unwrap();
+}
+
+// ── Authorization scope ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_tenant() {
+    let f = Fixture::build("ap_bad_tenant").await;
+    let record = UsageRecord {
+        tenant_id: Uuid::new_v4(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::PermissionDenied { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_resource_id() {
+    let f = Fixture::build("ap_bad_res").await;
+    let record = UsageRecord {
+        resource_id: Uuid::new_v4(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::PermissionDenied { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_resource_type() {
+    let f = Fixture::build("ap_bad_rt").await;
+    let record = UsageRecord {
+        resource_type: "other.resource".to_owned(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::PermissionDenied { .. }));
+}
+
+// ── Counter value ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_negative_counter_value() {
+    let f = Fixture::build("ap_neg_ctr").await;
+    let record = f.record_with_kind(UsageKind::Counter, -1.0);
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidArgument { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_accepts_zero_counter_value() {
+    let f = Fixture::build("ap_zero_ctr").await;
+    f.emitter
+        .enqueue_in(&f.conn(), f.record_with_kind(UsageKind::Counter, 0.0))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn enqueue_accepts_negative_gauge_value() {
+    let f = Fixture::build("ap_neg_gauge").await;
+    f.emitter
+        .enqueue_in(&f.conn(), f.record_with_kind(UsageKind::Gauge, -1.0))
+        .await
+        .unwrap();
+}
+
+// ── Metric validation ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_metric_not_in_allowed_list() {
+    let f = Fixture::build("ap_metric_disallowed").await;
+    let record = UsageRecord {
+        metric: "not.allowed.metric".to_owned(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::PermissionDenied { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_rejects_metric_kind_mismatch() {
+    let f = Fixture::build("ap_kind_mismatch").await;
+    let record = UsageRecord {
+        metric: "test.counter".to_owned(),
+        kind: UsageKind::Gauge,
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidArgument { .. }));
+}
+
+// ── Module and subject mismatch rejection ─────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_module() {
+    let f = Fixture::build("ap_bad_module").await;
+    let record = UsageRecord {
+        module: "wrong-module".to_owned(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::PermissionDenied { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_subject_id() {
+    let f = Fixture::build("ap_bad_subj_id").await;
+    let record = UsageRecord {
+        subject: Some(Subject::with_type(Uuid::new_v4(), "test.subject")),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::PermissionDenied { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_subject_type() {
+    let f = Fixture::build("ap_bad_subj_type").await;
+    let record = UsageRecord {
+        subject: Some(Subject::with_type(Uuid::nil(), "other.subject")),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::PermissionDenied { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_accepts_record_when_module_and_subject_match_token() {
+    let f = Fixture::build("ap_match_ok").await;
+    f.emitter.enqueue_in(&f.conn(), f.record()).await.unwrap();
+}
+
+// ── Counter idempotency key ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_counter_record_with_empty_idempotency_key() {
+    let f = Fixture::build("ap_ctr_empty_key").await;
+    let record = UsageRecord {
+        metric: "test.counter".to_owned(),
+        kind: UsageKind::Counter,
+        idempotency_key: String::new(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidArgument { .. }));
+}
+
+// ── Metadata size (default 8192 limit from FixtureCollector) ──────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_record_with_oversized_metadata() {
+    let f = Fixture::build("ap_metadata_large").await;
+    let record = UsageRecord {
+        metadata: Some(serde_json::Value::String("x".repeat(8193))),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidArgument { .. }));
+}


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#1908](https://github.com/cyberfabric/cyberware-rust/pull/1908) | **Author:** capybutler | **Opened:** 2026-05-15T11:26:46Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

Introduces the core ingest-path crates completing Feature 1 (SDK & Ingest Core):

- `usage-emitter`: two-phase PDP authorization (`authorize_for` / `authorize`), `UsageRecordBuilder` fluent API, transactional outbox enqueue (`enqueue` / `enqueue_in`), and async delivery worker forwarding to `UsageCollectorClientV1`. The security invariant ensures `UsageCollectorClientV1` is never published to `ClientHub`; source modules can only reach the collector through a PDP-authorized, tenant/resource-bound `AuthorizedUsageEmitter`.

- `usage-collector`: gateway ModKit module; resolves the active storage plugin by vendor, registers `UsageCollectorLocalClient` as `dyn UsageCollectorClientV1`, wires in the embedded emitter, and serves the REST ingestion API for out-of-process callers.

- `noop-usage-collector-storage-plugin`: discard-all storage plugin for local dev, CI, and smoke tests.

Updates DESIGN, DECOMPOSITION, and Feature 1 spec (→ v1.4) to reflect the implemented emitter API (`authorized.build_usage_record(...).enqueue()`), correct entity locations, and mark all p1 DoD items and CDSL blocks complete (status: IMPLEMENTED).

## PR Train
| # | PR | Description | Lines |
|---|---|------------|------:|
| 1 | [1907](https://github.com/constructorfabric/cyberfabric-core/issues/1907) | Feature 1 (Core SDK, Emitter & In-Process Ingest): SDK + docs | ~2500 |
| 2 | [1908 (**this**)](https://github.com/constructorfabric/cyberfabric-core/issues/1908) | Feature 1 (Core SDK, Emitter & In-Process Ingest): `usage-collector` gateway + `usage-emitter` + `noop-usage-collector-storage-plugin` | ~8000 |
| 3 | [1919](https://github.com/constructorfabric/cyberfabric-core/issues/1919) | Feature 2 (REST Client & Remote Ingest Delivery) | ~2800 |
| 4 | [1926](https://github.com/constructorfabric/cyberfabric-core/issues/1926) | Feature 3 (Query API) | ~6000 |
| 5 | [1927](https://github.com/constructorfabric/cyberfabric-core/issues/1927) | Feature 4 (TimescaleDB plugin) | ~7700 |
| 6 | [1835](https://github.com/constructorfabric/cyberfabric-core/issues/1835) | e2e tests | ~1500 |
|   |  | ... to be continued ... | |

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No linting errors (`cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::perf`)
- [x] Code is properly formatted (`cargo fmt`)
- [x] `cpt validate` — all checks passed
- [x] Tests pass (`cargo nextest run --workspace`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added usage collection infrastructure with REST API endpoints for recording and querying usage metrics
  * Introduced usage emission pipeline with authorization and validation for metric tracking
  * Added development/testing storage backend for usage record handling

* **Chores**
  * Registered new usage collection workspace modules and dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#1908 -->