### PR TITLE
[PR #1892] feat(account-management): in-process Tenant Resolver plugin + hierarchy integrity + platform bootstrap

### DIFF
--- a/modules/system/account-management/account-management/Cargo.toml
+++ b/modules/system/account-management/account-management/Cargo.toml
@@ -63,6 +63,7 @@ postgres = []
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "test-util"] }
+types-registry-sdk = { workspace = true, features = ["test-util"] }
 proptest = "1.5"
 # `no-env-filter` accepts events with `target: "am.*"` (otherwise the
 # default `{crate}=trace` filter rejects custom targets, hiding the

--- a/modules/system/account-management/account-management/src/lib.rs
+++ b/modules/system/account-management/account-management/src/lib.rs
@@ -55,6 +55,7 @@ pub mod config;
 pub mod domain;
 pub mod infra;
 pub mod module;
+pub(crate) mod tr_plugin;
 
 pub use domain::error::DomainError;
 pub use domain::metrics::{

--- a/modules/system/account-management/account-management/src/module.rs
+++ b/modules/system/account-management/account-management/src/module.rs
@@ -64,6 +64,11 @@ use crate::infra::rg::RgResourceOwnershipChecker;
 use crate::infra::storage::migrations::Migrator;
 use crate::infra::storage::repo_impl::{AmDbProvider, TenantRepoImpl};
 use crate::infra::types_registry::GtsTenantTypeChecker;
+use crate::tr_plugin::PluginImpl as TrPluginImpl;
+use modkit::client_hub::ClientScope;
+use modkit::gts::BaseModkitPluginV1;
+use tenant_resolver_sdk::{TenantResolverPluginClient, TenantResolverPluginSpecV1};
+use types_registry_sdk::RegisterResult;
 
 type ConcreteService = TenantService<TenantRepoImpl>;
 
@@ -532,7 +537,59 @@ impl Module for AccountManagementModule {
             enforcer,
             cfg,
         );
-        service = service.with_types_registry(types_registry);
+        service = service.with_types_registry(Arc::clone(&types_registry));
+
+        // Tenant Resolver Plugin (in-process, AM-co-located).
+        //
+        // Run BEFORE `self.service.set(...)` below: TR-plugin GTS
+        // registration involves a network round-trip to types-registry
+        // and is fallible (serialization, registry contract violation,
+        // transient unavailability). Publishing AM's `service` to its
+        // `OnceLock` first would leave the module half-initialized
+        // and non-retriable on TR-plugin failure (the OnceLock would
+        // already be taken). Doing TR registration first preserves the
+        // "init() either fully succeeds or fully fails" contract.
+        //
+        // The plugin owns no state of its own; it borrows AM's `Db` and
+        // the already-resolved `TypesRegistryClient`. Registration order:
+        //   1. Build `PluginImpl` from the shared deps.
+        //   2. Register a `BaseModkitPluginV1<TenantResolverPluginSpecV1>`
+        //      instance in types-registry so the Tenant Resolver gateway
+        //      can discover it.
+        //   3. Bind the plugin under a scoped `ClientHub` entry keyed by
+        //      its GTS instance id, matching the pattern in
+        //      `static-tr-plugin` and `rg-tr-plugin`.
+        //
+        // Co-location rationale (DESIGN §1.1): the plugin's correctness
+        // depends on AM-writer invariants beyond the two-table schema
+        // (transactional `(tenants, tenant_closure)` maintenance, barrier
+        // materialization over `(ancestor, descendant]`, provisioning
+        // lifecycle), which a standalone crate could not validate at
+        // runtime.
+        let tr_plugin = Arc::new(TrPluginImpl::new(db_raw.db(), Arc::clone(&types_registry)));
+        let tr_instance_id = TenantResolverPluginSpecV1::gts_make_instance_id(
+            "cf.builtin.account_management_tenant_resolver.plugin.v1",
+        );
+        let tr_instance = BaseModkitPluginV1::<TenantResolverPluginSpecV1> {
+            id: tr_instance_id.clone(),
+            vendor: "cyberfabric".to_owned(),
+            priority: 100,
+            properties: TenantResolverPluginSpecV1,
+        };
+        let tr_instance_json = serde_json::to_value(&tr_instance)
+            .map_err(|e| anyhow::anyhow!("tr-plugin: serialize instance failed: {e}"))?;
+        let tr_results = types_registry.register(vec![tr_instance_json]).await?;
+        RegisterResult::ensure_all_ok(&tr_results)?;
+        let tr_api: Arc<dyn TenantResolverPluginClient> = tr_plugin;
+        ctx.client_hub()
+            .register_scoped::<dyn TenantResolverPluginClient>(
+                ClientScope::gts_id(&tr_instance_id),
+                tr_api,
+            );
+        info!(
+            tr_plugin_instance_id = %tr_instance_id,
+            "tenant-resolver plugin registered (in-process, AM-co-located)"
+        );
 
         // Drain the pre-init hook buffer into the service and
         // publish the service through `OnceLock` *under the same

--- a/modules/system/account-management/account-management/src/tr_plugin/error_map.rs
+++ b/modules/system/account-management/account-management/src/tr_plugin/error_map.rs
@@ -1,0 +1,79 @@
+//! Error-mapping helpers between `modkit-db` / `sea_orm` failures and
+//! the SDK error taxonomy.
+//!
+//! The plugin only ever surfaces two SDK variants from these helpers:
+//! [`TenantResolverError::TenantNotFound`] (constructed by call sites
+//! that distinguish "no row" from "transient failure") and
+//! [`TenantResolverError::Internal`] (every transient backend failure —
+//! DESIGN §3.8 + FEATURE §5 "Error-Taxonomy Delegation"). DB and pool
+//! failures map to `Internal` rather than `ServiceUnavailable` because
+//! `ServiceUnavailable` is reserved for recoverable outages with a
+//! retry hint; opaque storage failures do not carry that hint so
+//! `Internal` is the safer surface.
+//!
+//! # Information leakage
+//!
+//! These helpers deliberately surface **opaque** strings on the SDK
+//! boundary — backend error details (SQL fragments, connection-pool
+//! state, scope diagnostics) are emitted via `tracing::warn!` for
+//! operator visibility but never returned to the plugin caller.
+//! Otherwise the same plugin in front of, e.g., a misconfigured pool
+//! would leak DSN-shaped strings to gateway clients.
+
+use modkit_db::DbError;
+use modkit_db::secure::ScopeError;
+use sea_orm::DbErr;
+use tenant_resolver_sdk::TenantResolverError;
+
+const STORAGE_INTERNAL_MSG: &str = "tenant resolver storage failure";
+const SCOPE_INTERNAL_MSG: &str = "tenant resolver scope failure";
+
+/// Convert a raw `sea_orm::DbErr` into a transient SDK error. The
+/// detailed cause is logged server-side; only an opaque marker is
+/// returned to the plugin caller.
+#[must_use]
+pub(super) fn db_err_to_tr_err(err: &DbErr) -> TenantResolverError {
+    tracing::warn!(
+        target: "tr_plugin",
+        error = %err,
+        "tr-plugin storage read failed"
+    );
+    TenantResolverError::Internal(STORAGE_INTERNAL_MSG.to_owned())
+}
+
+/// Convert a `modkit-db` `DbError` (covers `Sea`, `Pool`,
+/// `ConnRequestedInsideTx`, etc.) into a transient SDK error.
+#[must_use]
+pub(super) fn modkit_db_err_to_tr_err(err: &DbError) -> TenantResolverError {
+    tracing::warn!(
+        target: "tr_plugin",
+        error = %err,
+        "tr-plugin storage unavailable"
+    );
+    TenantResolverError::Internal(STORAGE_INTERNAL_MSG.to_owned())
+}
+
+/// Convert a `ScopeError` produced by the secure-extension layer into
+/// a transient SDK error. The plugin always passes
+/// `AccessScope::allow_all()`, so `Invalid` / `Denied` /
+/// `TenantNotInScope` are not expected on the SDK path; if they ever
+/// surface they indicate an invariant violation and are logged as
+/// `warn` for operator audit while the SDK boundary still receives an
+/// opaque message.
+#[must_use]
+pub(super) fn scope_err_to_tr_err(err: &ScopeError) -> TenantResolverError {
+    if let ScopeError::Db(db) = err {
+        return db_err_to_tr_err(db);
+    }
+    let (event, reason): (&'static str, Option<&'static str>) = match err {
+        ScopeError::Db(_) => unreachable!("handled above"),
+        ScopeError::Invalid(msg) => ("tr-plugin storage scope invalid", Some(msg)),
+        ScopeError::Denied(msg) => ("tr-plugin storage scope denied", Some(msg)),
+        ScopeError::TenantNotInScope { .. } => (
+            "tr-plugin storage scope tenant_not_in_scope (allow_all expected)",
+            None,
+        ),
+    };
+    tracing::warn!(target: "tr_plugin", reason = ?reason, "{event}");
+    TenantResolverError::Internal(SCOPE_INTERNAL_MSG.to_owned())
+}

--- a/modules/system/account-management/account-management/src/tr_plugin/mod.rs
+++ b/modules/system/account-management/account-management/src/tr_plugin/mod.rs
@@ -1,0 +1,24 @@
+//! Tenant Resolver Plugin — in-process query facade over AM-owned
+//! `tenants` and `tenant_closure`.
+//!
+//! Co-located with AM (rather than shipped as a standalone crate) so
+//! the plugin can rely on AM-writer invariants directly: transactional
+//! `(tenants, tenant_closure)` maintenance, self-row existence, barrier
+//! materialization over `(ancestor, descendant]`, and provisioning
+//! lifecycle semantics. See `docs/tr-plugin/DESIGN.md` §1.1 for the
+//! co-location rationale.
+//!
+//! The plugin owns no schema, no migration, no cache, and no REST
+//! surface. It implements the `TenantResolverPluginClient` SDK trait
+//! and registers a scoped binding in `ClientHub` from
+//! [`crate::AccountManagementModule::init`]. Every SDK call resolves
+//! to one or two indexed reads against AM-owned storage; tenant-type
+//! reverse-hydration is delegated to `TypesRegistryClient` (which owns
+//! the cache for that mapping).
+
+mod error_map;
+mod plugin_impl;
+mod projection;
+mod queries;
+
+pub use plugin_impl::PluginImpl;

--- a/modules/system/account-management/account-management/src/tr_plugin/mod.rs
+++ b/modules/system/account-management/account-management/src/tr_plugin/mod.rs
@@ -22,3 +22,6 @@ mod projection;
 mod queries;
 
 pub use plugin_impl::PluginImpl;
+
+#[cfg(test)]
+mod tests;

--- a/modules/system/account-management/account-management/src/tr_plugin/plugin_impl.rs
+++ b/modules/system/account-management/account-management/src/tr_plugin/plugin_impl.rs
@@ -1,0 +1,131 @@
+//! `TenantResolverPluginClient` implementation backed by AM-owned
+//! `tenants` + `tenant_closure`.
+//!
+//! Each trait method delegates to the matching free function in
+//! [`super::queries`], threading both the shared AM `Db` handle and
+//! the `TypesRegistryClient` used for `tenant_type` reverse-resolution.
+//! Wiring to AM's `init()` is in [`crate::module`].
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use modkit_db::Db;
+use modkit_security::SecurityContext;
+use tenant_resolver_sdk::{
+    GetAncestorsOptions, GetAncestorsResponse, GetDescendantsOptions, GetDescendantsResponse,
+    GetTenantsOptions, IsAncestorOptions, TenantId, TenantInfo, TenantResolverError,
+    TenantResolverPluginClient,
+};
+use types_registry_sdk::TypesRegistryClient;
+
+/// In-process Tenant Resolver plugin co-located with AM.
+///
+/// Holds a clone of AM's `Db` handle (the plugin shares AM's pool —
+/// DESIGN §3.5 calls for a dedicated read-only role, but provisioning
+/// that role is an operator concern that lands once we have a
+/// connection-pool-per-role abstraction in `modkit-db`) and a
+/// `TypesRegistryClient` used by `super::queries` to reverse-resolve
+/// `tenant_type_uuid → tenant_type` on every result.
+///
+/// # `SecurityContext` parameter
+///
+/// All trait methods accept `_ctx: &SecurityContext` but do not use it
+/// directly. Authorization is the gateway's responsibility (DESIGN §4.2
+/// "Trust Boundary"): the gateway authenticates the caller and decides
+/// whether to forward the request to the plugin; the plugin trusts that
+/// projection and reads from storage unconditionally under
+/// `AccessScope::allow_all()`. The `_ctx` prefix signals this intentional
+/// delegation rather than an accidental omission.
+pub struct PluginImpl {
+    /// Shared `Db` handle. `Db` is `Clone` (Arc-backed) so this is
+    /// cheap; `Arc<Db>` is intentional here so the plugin can be
+    /// stored behind `Arc<dyn TenantResolverPluginClient>` without a
+    /// further indirection on each call.
+    db: Arc<Db>,
+    /// Types Registry client used to reverse-resolve
+    /// `tenant_type_uuid → tenant_type` (DESIGN §3.4). Mirrors AM's
+    /// `service::resolve_tenant_type` policy: registry failures
+    /// degrade to `tenant_type: None` with a `tracing::warn`, never
+    /// failing the SDK call.
+    types_registry: Arc<dyn TypesRegistryClient>,
+}
+
+impl PluginImpl {
+    /// Build the plugin from AM's already-resolved dependencies.
+    ///
+    /// Called from `AccountManagementModule::init` after the AM
+    /// `TypesRegistryClient` and `Db` have been resolved from
+    /// `ClientHub` / `ModuleCtx` respectively.
+    #[must_use]
+    pub fn new(db: Db, types_registry: Arc<dyn TypesRegistryClient>) -> Self {
+        Self {
+            db: Arc::new(db),
+            types_registry,
+        }
+    }
+}
+
+#[async_trait]
+impl TenantResolverPluginClient for PluginImpl {
+    async fn get_tenant(
+        &self,
+        _ctx: &SecurityContext,
+        id: TenantId,
+    ) -> Result<TenantInfo, TenantResolverError> {
+        super::queries::get_tenant(&self.db, &self.types_registry, id).await
+    }
+
+    async fn get_root_tenant(
+        &self,
+        _ctx: &SecurityContext,
+    ) -> Result<TenantInfo, TenantResolverError> {
+        super::queries::get_root_tenant(&self.db, &self.types_registry).await
+    }
+
+    async fn get_tenants(
+        &self,
+        _ctx: &SecurityContext,
+        ids: &[TenantId],
+        options: &GetTenantsOptions,
+    ) -> Result<Vec<TenantInfo>, TenantResolverError> {
+        super::queries::get_tenants(&self.db, &self.types_registry, ids, &options.status).await
+    }
+
+    async fn get_ancestors(
+        &self,
+        _ctx: &SecurityContext,
+        id: TenantId,
+        options: &GetAncestorsOptions,
+    ) -> Result<GetAncestorsResponse, TenantResolverError> {
+        super::queries::get_ancestors(&self.db, &self.types_registry, id, options.barrier_mode)
+            .await
+    }
+
+    async fn get_descendants(
+        &self,
+        _ctx: &SecurityContext,
+        id: TenantId,
+        options: &GetDescendantsOptions,
+    ) -> Result<GetDescendantsResponse, TenantResolverError> {
+        super::queries::get_descendants(
+            &self.db,
+            &self.types_registry,
+            id,
+            options.barrier_mode,
+            &options.status,
+            options.max_depth,
+        )
+        .await
+    }
+
+    async fn is_ancestor(
+        &self,
+        _ctx: &SecurityContext,
+        ancestor_id: TenantId,
+        descendant_id: TenantId,
+        options: &IsAncestorOptions,
+    ) -> Result<bool, TenantResolverError> {
+        super::queries::is_ancestor(&self.db, ancestor_id, descendant_id, options.barrier_mode)
+            .await
+    }
+}

--- a/modules/system/account-management/account-management/src/tr_plugin/projection.rs
+++ b/modules/system/account-management/account-management/src/tr_plugin/projection.rs
@@ -1,0 +1,132 @@
+//! AM-row to SDK-type projection helpers and provisioning-invisibility
+//! filter construction.
+//!
+//! Every projection here is a pure function: AM column values in,
+//! SDK type out. Provisioning rows are filtered out structurally at
+//! query time via [`tenants_visible_status_condition`] /
+//! [`closure_visible_status_condition`]; the projection helpers
+//! themselves trust that the caller has already excluded provisioning
+//! rows from the row set they pass in.
+//!
+//! # `tenant_type` reverse hydration
+//!
+//! DESIGN §3.1 / FEATURE §3 require the public chained `tenant_type`
+//! identifier to be resolved through `TypesRegistryClient`. The
+//! resolution itself happens in [`super::queries`] (which owns the
+//! registry handle and can batch lookups across a page); the
+//! projection helpers here accept the already-resolved
+//! `Option<String>` and place it onto the SDK type. Mirrors AM's
+//! own `service::lower_to_tenant_info` / `lower_to_tenant_page`
+//! pattern (`tenant_type: None` on registry blip — the field is
+//! `Option<String>` precisely to allow graceful degradation).
+
+use sea_orm::{ColumnTrait, Condition};
+use tenant_resolver_sdk::{TenantId, TenantInfo, TenantRef, TenantStatus as SdkTenantStatus};
+
+use crate::domain::tenant::model::TenantStatus as DomainTenantStatus;
+use crate::infra::storage::entity::tenants;
+
+/// Map AM's domain `TenantStatus` (4-variant, includes `Provisioning`)
+/// onto the SDK-visible 3-variant enum. Returns `None` for
+/// `Provisioning` so callers fail closed if a provisioning row ever
+/// reaches projection — by design the query-time filter should prevent
+/// that, but the `None` arm is the defense-in-depth catch.
+#[must_use]
+pub(super) fn map_status_to_sdk(status: DomainTenantStatus) -> Option<SdkTenantStatus> {
+    match status {
+        DomainTenantStatus::Active => Some(SdkTenantStatus::Active),
+        DomainTenantStatus::Suspended => Some(SdkTenantStatus::Suspended),
+        DomainTenantStatus::Deleted => Some(SdkTenantStatus::Deleted),
+        DomainTenantStatus::Provisioning => None,
+    }
+}
+
+/// Map an SDK-visible `TenantStatus` onto AM's `SMALLINT` encoding
+/// (1=Active, 2=Suspended, 3=Deleted). Used when translating
+/// caller-supplied `status` filters into closure / tenants predicates.
+#[must_use]
+pub(super) fn sdk_status_to_smallint(status: SdkTenantStatus) -> i16 {
+    match status {
+        SdkTenantStatus::Active => DomainTenantStatus::Active.as_smallint(),
+        SdkTenantStatus::Suspended => DomainTenantStatus::Suspended.as_smallint(),
+        SdkTenantStatus::Deleted => DomainTenantStatus::Deleted.as_smallint(),
+    }
+}
+
+/// Project a `tenants::Model` row onto the SDK `TenantInfo`.
+///
+/// `tenant_type` is supplied by the caller — resolved via
+/// `TypesRegistryClient::get_type_schema_by_uuid` (single) or
+/// `get_type_schemas_by_uuid` (batched) in `super::queries`. Per
+/// DESIGN §3.4, a registry failure causes the SDK call to fail with
+/// `TenantResolverError::Internal` before this helper is reached, so
+/// callers always pass `Some(...)` on the hot path.
+///
+/// Returns `None` when the row is provisioning (defense-in-depth —
+/// the query layer should already have excluded it) or when its
+/// `status` column carries an out-of-domain value.
+#[must_use]
+pub(super) fn row_to_tenant_info(
+    row: tenants::Model,
+    tenant_type: Option<String>,
+) -> Option<TenantInfo> {
+    let domain_status = DomainTenantStatus::from_smallint(row.status)?;
+    let sdk_status = map_status_to_sdk(domain_status)?;
+    Some(TenantInfo {
+        id: TenantId(row.id),
+        name: row.name,
+        status: sdk_status,
+        tenant_type,
+        parent_id: row.parent_id.map(TenantId),
+        self_managed: row.self_managed,
+    })
+}
+
+/// Project a `tenants::Model` row onto the SDK `TenantRef` (no name).
+///
+/// `tenant_type` and error semantics identical to [`row_to_tenant_info`]:
+/// callers pass `Some(...)` on the hot path (registry failures are
+/// propagated as `Internal` before reaching here); `None` arm is the
+/// defense-in-depth catch for provisioning / out-of-domain-status rows.
+#[must_use]
+pub(super) fn row_to_tenant_ref(
+    row: &tenants::Model,
+    tenant_type: Option<String>,
+) -> Option<TenantRef> {
+    let domain_status = DomainTenantStatus::from_smallint(row.status)?;
+    let sdk_status = map_status_to_sdk(domain_status)?;
+    Some(TenantRef {
+        id: TenantId(row.id),
+        status: sdk_status,
+        tenant_type,
+        parent_id: row.parent_id.map(TenantId),
+        self_managed: row.self_managed,
+    })
+}
+
+/// Build the unconditional provisioning-exclusion predicate on the
+/// `tenants.status` column. Used on every `tenants` read on the SDK
+/// path, regardless of caller-supplied status filter, to enforce
+/// `cpt-cf-tr-plugin-fr-provisioning-invisibility` structurally.
+#[must_use]
+pub(super) fn tenants_visible_status_condition() -> Condition {
+    Condition::all().add(tenants::Column::Status.ne(DomainTenantStatus::Provisioning.as_smallint()))
+}
+
+/// Build the SDK-visible status filter predicate for `tenants.status`.
+/// An empty `statuses` slice means "all SDK-visible statuses" (the
+/// caller still gets the structural provisioning exclusion combined in
+/// at the call site).
+#[must_use]
+pub(super) fn tenants_status_in_condition(statuses: &[SdkTenantStatus]) -> Condition {
+    if statuses.is_empty() {
+        return tenants_visible_status_condition();
+    }
+    let mut any = Condition::any();
+    for s in statuses {
+        any = any.add(tenants::Column::Status.eq(sdk_status_to_smallint(*s)));
+    }
+    Condition::all()
+        .add(any)
+        .add(tenants_visible_status_condition())
+}

--- a/modules/system/account-management/account-management/src/tr_plugin/queries.rs
+++ b/modules/system/account-management/account-management/src/tr_plugin/queries.rs
@@ -1,0 +1,634 @@
+//! Query implementations for `PluginImpl` SDK methods.
+//!
+//! Every function in this module:
+//! - Takes a borrowed [`Db`] handle (the plugin shares AM's pool —
+//!   the dedicated read-only role from DESIGN §3.5 is provisioned
+//!   externally; in-process privilege separation is left for a
+//!   follow-up).
+//! - Uses [`AccessScope::allow_all`] explicitly. AM's `tenants` /
+//!   `tenant_closure` entities are declared `no_tenant, no_resource,
+//!   no_owner, no_type`, so the secure layer adds no implicit
+//!   `WHERE`. The plugin's authorization story is "gateway is
+//!   trusted" (DESIGN §4.2).
+//! - Applies the provisioning-invisibility predicate
+//!   ([`projection::tenants_visible_status_condition`]) on every
+//!   `tenants` read, including existence probes and JOIN-style
+//!   bulk reads. `tenant_closure` already excludes provisioning by
+//!   AM's contract (`descendant_status ∈ {1,2,3}`), so closure-only
+//!   reads do not need a defense-in-depth predicate.
+//! - Hydrates the public `tenant_type` field through
+//!   [`TypesRegistryClient`] using either a single
+//!   `get_type_schema_by_uuid` (single-row results) or a batched
+//!   `get_type_schemas_by_uuid` (page-style results) — mirroring
+//!   `domain::tenant::service::lower_to_tenant_info` /
+//!   `lower_to_tenant_page`. Registry failure degrades to
+//!   `tenant_type: None` with a `tracing::warn` (the SDK field is
+//!   `Option<String>` precisely for this reason).
+//! - Maps `sea_orm::DbErr` / `ScopeError` / `DbError` through the
+//!   helpers in [`super::error_map`] so the SDK boundary only ever
+//!   sees [`TenantResolverError::TenantNotFound`] or
+//!   [`TenantResolverError::Internal`].
+//!
+//! # Pre-order for `get_descendants`
+//!
+//! AM's `tenant_closure` does not carry a pre-order column or a
+//! depth-from-ancestor column. The DESIGN names a "single subtree
+//! recursive read" implemented as a SQL recursive CTE; the secure
+//! `modkit-db` extension does not expose raw `ConnectionTrait`
+//! access today, so the v1 implementation here builds the parent
+//! map in-memory from the **barrier-only** closure subtree
+//! (system-invariants only), walks it pre-order on the client, and
+//! applies the caller's `status_filter` as an emission predicate.
+//! Splitting graph construction (system invariants) from emission
+//! (caller predicate) is required for correctness — folding the
+//! caller predicate into the closure scan would prune whole
+//! branches whose intermediate parent fails the filter even when
+//! deeper descendants match (e.g. `Root → Suspended → Active`
+//! filtered by `[Active]`). The recursive CTE optimization is
+//! tracked as a follow-up once `modkit-db` exposes a safe raw-SQL
+//! hook.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use modkit_db::Db;
+use modkit_db::secure::SecureEntityExt;
+use modkit_security::AccessScope;
+use sea_orm::{ColumnTrait, Condition, EntityTrait, Order};
+use uuid::Uuid;
+
+use tenant_resolver_sdk::{
+    BarrierMode, GetAncestorsResponse, GetDescendantsResponse, TenantId, TenantInfo, TenantRef,
+    TenantResolverError, TenantStatus as SdkTenantStatus,
+};
+use types_registry_sdk::TypesRegistryClient;
+
+use crate::infra::storage::entity::{tenant_closure, tenants};
+
+use super::error_map::{modkit_db_err_to_tr_err, scope_err_to_tr_err};
+use super::projection::{
+    row_to_tenant_info, row_to_tenant_ref, tenants_status_in_condition,
+    tenants_visible_status_condition,
+};
+
+/// Projection failure helper. The projection helpers return `None` in
+/// two cases: a provisioning row reaching them (defense-in-depth — the
+/// query layer should already exclude it) or an out-of-domain `status`
+/// SMALLINT. Both indicate a violation of AM's invariants visible at
+/// read time, so we surface `Internal` per DESIGN §3.8 (with the
+/// internal diagnostic logged server-side rather than embedded in the
+/// SDK error so we don't leak storage shape to plugin consumers).
+fn projection_internal(id: Uuid) -> TenantResolverError {
+    tracing::warn!(
+        target: "tr_plugin",
+        tenant_id = %id,
+        "tenants row failed SDK projection (provisioning leak or out-of-domain status)"
+    );
+    TenantResolverError::Internal("tenant resolver projection failure".to_owned())
+}
+
+/// Resolve a single `tenant_type_uuid` to its chained GTS identifier
+/// via [`TypesRegistryClient::get_type_schema_by_uuid`].
+///
+/// Per DESIGN §3.4 (`cpt-cf-tr-plugin-contract-types-registry-reverse-lookup`)
+/// and the availability table (§5): "Types Registry unavailable → fail with
+/// `TenantResolverError::Internal`; must not return raw UUIDs in place of
+/// public `tenant_type`." The detailed cause is logged server-side.
+async fn resolve_tenant_type_one(
+    registry: &Arc<dyn TypesRegistryClient>,
+    type_uuid: Uuid,
+) -> Result<String, TenantResolverError> {
+    match registry.get_type_schema_by_uuid(type_uuid).await {
+        Ok(schema) => Ok(schema.type_id.as_ref().to_owned()),
+        Err(err) => {
+            tracing::warn!(
+                target: "tr_plugin",
+                tenant_type_uuid = %type_uuid,
+                error = %err,
+                "tenant_type uuid -> chained-id resolution failed"
+            );
+            Err(TenantResolverError::Internal(
+                "tenant resolver tenant_type hydration failed".to_owned(),
+            ))
+        }
+    }
+}
+
+/// Batched companion to [`resolve_tenant_type_one`]. Issues one
+/// `get_type_schemas_by_uuid` round-trip for the *distinct* uuids
+/// extracted from `rows` so latency scales with pages, not rows.
+///
+/// Per DESIGN §3.4 / §5: any per-UUID resolution failure fails the
+/// entire call with `TenantResolverError::Internal` (the plugin must
+/// not return raw UUIDs in place of public chained `tenant_type`).
+async fn resolve_tenant_types_for_rows(
+    registry: &Arc<dyn TypesRegistryClient>,
+    rows: &[tenants::Model],
+) -> Result<HashMap<Uuid, String>, TenantResolverError> {
+    let mut distinct: Vec<Uuid> = rows.iter().map(|r| r.tenant_type_uuid).collect();
+    distinct.sort_unstable();
+    distinct.dedup();
+    if distinct.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let resolved = registry.get_type_schemas_by_uuid(distinct).await;
+    let mut out: HashMap<Uuid, String> = HashMap::with_capacity(resolved.len());
+    for (uuid, res) in resolved {
+        match res {
+            Ok(schema) => {
+                out.insert(uuid, schema.type_id.as_ref().to_owned());
+            }
+            Err(err) => {
+                tracing::warn!(
+                    target: "tr_plugin",
+                    tenant_type_uuid = %uuid,
+                    error = %err,
+                    "tenant_type uuid -> chained-id resolution failed"
+                );
+                return Err(TenantResolverError::Internal(
+                    "tenant resolver tenant_type hydration failed".to_owned(),
+                ));
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Read a single tenant row by id, applying the provisioning-exclusion
+/// predicate. Returns `None` when the row is absent or filtered out by
+/// the provisioning predicate.
+async fn read_tenant_visible(
+    db: &Db,
+    id: Uuid,
+) -> Result<Option<tenants::Model>, TenantResolverError> {
+    let conn = db.conn().map_err(|e| modkit_db_err_to_tr_err(&e))?;
+    tenants::Entity::find()
+        .secure()
+        .scope_with(&AccessScope::allow_all())
+        .filter(
+            Condition::all()
+                .add(tenants::Column::Id.eq(id))
+                .add(tenants_visible_status_condition()),
+        )
+        .one(&conn)
+        .await
+        .map_err(|e| scope_err_to_tr_err(&e))
+}
+
+/// Bulk-read visible tenants by a set of ids. Provisioning rows are
+/// dropped via [`tenants_visible_status_condition`]; the caller is
+/// responsible for deduplicating the input slice.
+async fn read_tenants_visible_bulk(
+    db: &Db,
+    ids: &[Uuid],
+) -> Result<Vec<tenants::Model>, TenantResolverError> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let conn = db.conn().map_err(|e| modkit_db_err_to_tr_err(&e))?;
+    tenants::Entity::find()
+        .secure()
+        .scope_with(&AccessScope::allow_all())
+        .filter(
+            Condition::all()
+                .add(tenants::Column::Id.is_in(ids.iter().copied()))
+                .add(tenants_visible_status_condition()),
+        )
+        .all(&conn)
+        .await
+        .map_err(|e| scope_err_to_tr_err(&e))
+}
+
+/// Phase 3 — `get_tenant`.
+pub(super) async fn get_tenant(
+    db: &Db,
+    registry: &Arc<dyn TypesRegistryClient>,
+    id: TenantId,
+) -> Result<TenantInfo, TenantResolverError> {
+    let row = read_tenant_visible(db, id.0)
+        .await?
+        .ok_or(TenantResolverError::TenantNotFound { tenant_id: id })?;
+    let tenant_type = resolve_tenant_type_one(registry, row.tenant_type_uuid).await?;
+    row_to_tenant_info(row, Some(tenant_type)).ok_or_else(|| projection_internal(id.0))
+}
+
+/// Phase 4 — `get_root_tenant`.
+pub(super) async fn get_root_tenant(
+    db: &Db,
+    registry: &Arc<dyn TypesRegistryClient>,
+) -> Result<TenantInfo, TenantResolverError> {
+    let conn = db.conn().map_err(|e| modkit_db_err_to_tr_err(&e))?;
+    // `.limit(2)` keeps a corrupted multi-root hierarchy from pulling
+    // an unbounded number of rows into memory just to surface the
+    // invariant violation; two rows are enough to distinguish the
+    // 0 / 1 / many cases for the diagnostic below.
+    let mut roots = tenants::Entity::find()
+        .secure()
+        .scope_with(&AccessScope::allow_all())
+        .filter(
+            Condition::all()
+                .add(tenants::Column::ParentId.is_null())
+                .add(tenants_visible_status_condition()),
+        )
+        .order_by(tenants::Column::Id, Order::Asc)
+        .limit(2)
+        .all(&conn)
+        .await
+        .map_err(|e| scope_err_to_tr_err(&e))?;
+
+    match roots.len() {
+        0 => {
+            tracing::warn!(
+                target: "tr_plugin",
+                "am storage has no non-provisioning root tenant (bootstrap incomplete or hierarchy corrupt)"
+            );
+            Err(TenantResolverError::Internal(
+                "tenant resolver root tenant unavailable".to_owned(),
+            ))
+        }
+        1 => {
+            let row = roots.swap_remove(0);
+            let id = row.id;
+            let tenant_type = resolve_tenant_type_one(registry, row.tenant_type_uuid).await?;
+            row_to_tenant_info(row, Some(tenant_type)).ok_or_else(|| projection_internal(id))
+        }
+        _ => {
+            tracing::warn!(
+                target: "tr_plugin",
+                "am storage single-root invariant violated: found multiple non-provisioning root tenants"
+            );
+            Err(TenantResolverError::Internal(
+                "tenant resolver root tenant invariant violated".to_owned(),
+            ))
+        }
+    }
+}
+
+/// Phase 5 — `get_tenants`.
+pub(super) async fn get_tenants(
+    db: &Db,
+    registry: &Arc<dyn TypesRegistryClient>,
+    ids: &[TenantId],
+    status_filter: &[SdkTenantStatus],
+) -> Result<Vec<TenantInfo>, TenantResolverError> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    // Dedup while preserving membership; output order is not required
+    // to match input order per the SDK contract.
+    let mut seen: HashSet<Uuid> = HashSet::with_capacity(ids.len());
+    let unique_ids: Vec<Uuid> = ids
+        .iter()
+        .filter_map(|id| seen.insert(id.0).then_some(id.0))
+        .collect();
+
+    let conn = db.conn().map_err(|e| modkit_db_err_to_tr_err(&e))?;
+    let rows = tenants::Entity::find()
+        .secure()
+        .scope_with(&AccessScope::allow_all())
+        .filter(
+            Condition::all()
+                .add(tenants::Column::Id.is_in(unique_ids))
+                .add(tenants_status_in_condition(status_filter)),
+        )
+        .all(&conn)
+        .await
+        .map_err(|e| scope_err_to_tr_err(&e))?;
+
+    let type_strings = resolve_tenant_types_for_rows(registry, &rows).await?;
+    let mut out = Vec::with_capacity(rows.len());
+    for row in rows {
+        let id = row.id;
+        let tenant_type = type_strings.get(&row.tenant_type_uuid).cloned();
+        out.push(row_to_tenant_info(row, tenant_type).ok_or_else(|| projection_internal(id))?);
+    }
+    Ok(out)
+}
+
+/// Phase 6 — `is_ancestor`.
+pub(super) async fn is_ancestor(
+    db: &Db,
+    ancestor_id: TenantId,
+    descendant_id: TenantId,
+    barrier_mode: BarrierMode,
+) -> Result<bool, TenantResolverError> {
+    // Probe both endpoints exist and are non-provisioning. Use a
+    // single bulk read so the round-trip count stays at 2 indexed
+    // reads (existence probe + closure probe) per call, matching
+    // DESIGN §3.6 `seq-is-ancestor`. An `IN (a, d)` bulk lookup
+    // followed by a HashSet check on the returned ids handles both
+    // the absent and provisioning cases uniformly.
+    let probe_ids = if ancestor_id == descendant_id {
+        vec![ancestor_id.0]
+    } else {
+        vec![ancestor_id.0, descendant_id.0]
+    };
+    let conn = db.conn().map_err(|e| modkit_db_err_to_tr_err(&e))?;
+    let visible: HashSet<Uuid> = tenants::Entity::find()
+        .secure()
+        .scope_with(&AccessScope::allow_all())
+        .filter(
+            Condition::all()
+                .add(tenants::Column::Id.is_in(probe_ids.iter().copied()))
+                .add(tenants_visible_status_condition()),
+        )
+        .all(&conn)
+        .await
+        .map_err(|e| scope_err_to_tr_err(&e))?
+        .into_iter()
+        .map(|r| r.id)
+        .collect();
+    if !visible.contains(&ancestor_id.0) || !visible.contains(&descendant_id.0) {
+        // SDK contract: `TenantNotFound` when either endpoint is
+        // absent. We blame the descendant id; the SDK does not
+        // distinguish which endpoint was missing.
+        let missing = if visible.contains(&ancestor_id.0) {
+            descendant_id
+        } else {
+            ancestor_id
+        };
+        return Err(TenantResolverError::TenantNotFound { tenant_id: missing });
+    }
+    if ancestor_id == descendant_id {
+        // Strict-descendant contract: self is not an ancestor of self.
+        // Returned after the visibility check so callers can still
+        // distinguish "absent" from "self".
+        return Ok(false);
+    }
+
+    // Self-row exclusion is implicit: the self-reference branch above
+    // already returned `Ok(false)` when `ancestor_id == descendant_id`,
+    // so the `(ancestor_id, descendant_id)` pair queried here is always
+    // strict.
+    let mut filter = Condition::all()
+        .add(tenant_closure::Column::AncestorId.eq(ancestor_id.0))
+        .add(tenant_closure::Column::DescendantId.eq(descendant_id.0));
+    if matches!(barrier_mode, BarrierMode::Respect) {
+        filter = filter.add(tenant_closure::Column::Barrier.eq(0_i16));
+    }
+
+    let count = tenant_closure::Entity::find()
+        .secure()
+        .scope_with(&AccessScope::allow_all())
+        .filter(filter)
+        .count(&conn)
+        .await
+        .map_err(|e| scope_err_to_tr_err(&e))?;
+    Ok(count > 0)
+}
+
+/// Phase 7 — `get_ancestors`.
+pub(super) async fn get_ancestors(
+    db: &Db,
+    registry: &Arc<dyn TypesRegistryClient>,
+    id: TenantId,
+    barrier_mode: BarrierMode,
+) -> Result<GetAncestorsResponse, TenantResolverError> {
+    let starting = read_tenant_visible(db, id.0)
+        .await?
+        .ok_or(TenantResolverError::TenantNotFound { tenant_id: id })?;
+
+    // Closure rows for strict ancestors of `id`. Self-row is
+    // excluded by predicate; under `Respect` the barrier filter is
+    // appended so the returned set already obeys
+    // `cpt-cf-tr-plugin-fr-barrier-semantics`.
+    let conn = db.conn().map_err(|e| modkit_db_err_to_tr_err(&e))?;
+    let mut closure_filter = Condition::all()
+        .add(tenant_closure::Column::DescendantId.eq(id.0))
+        .add(tenant_closure::Column::AncestorId.ne(id.0));
+    if matches!(barrier_mode, BarrierMode::Respect) {
+        closure_filter = closure_filter.add(tenant_closure::Column::Barrier.eq(0_i16));
+    }
+    let closure_rows = tenant_closure::Entity::find()
+        .secure()
+        .scope_with(&AccessScope::allow_all())
+        .filter(closure_filter)
+        .all(&conn)
+        .await
+        .map_err(|e| scope_err_to_tr_err(&e))?;
+    let ancestor_ids: Vec<Uuid> = closure_rows.iter().map(|r| r.ancestor_id).collect();
+    let _ = conn;
+
+    // Hydrate ancestors. Provisioning rows are dropped on this read
+    // as defense-in-depth — closure-driven reads can't surface
+    // provisioning by AM's contract, but the explicit predicate
+    // keeps the contract local.
+    let ancestor_rows = read_tenants_visible_bulk(db, &ancestor_ids).await?;
+
+    // Order: depth DESC (direct parent first, root last) with `id`
+    // ASC as tie-break. Ordering happens here because we hydrated
+    // through a bulk-by-id read instead of a JOIN; the two-call shape
+    // is what the secure-extension's per-entity contract permits today.
+    let mut sorted = ancestor_rows;
+    sorted.sort_by(|a, b| b.depth.cmp(&a.depth).then_with(|| a.id.cmp(&b.id)));
+
+    // Hydrate `tenant_type` for the starting tenant + every ancestor
+    // in one batched registry round-trip.
+    let mut all_rows: Vec<tenants::Model> = Vec::with_capacity(sorted.len() + 1);
+    all_rows.push(starting.clone());
+    all_rows.extend_from_slice(&sorted);
+    let type_strings = resolve_tenant_types_for_rows(registry, &all_rows).await?;
+
+    let starting_ref = row_to_tenant_ref(
+        &starting,
+        type_strings.get(&starting.tenant_type_uuid).cloned(),
+    )
+    .ok_or_else(|| projection_internal(id.0))?;
+    let mut ancestors = Vec::with_capacity(sorted.len());
+    for row in &sorted {
+        let tt = type_strings.get(&row.tenant_type_uuid).cloned();
+        ancestors.push(row_to_tenant_ref(row, tt).ok_or_else(|| projection_internal(row.id))?);
+    }
+    Ok(GetAncestorsResponse {
+        tenant: starting_ref,
+        ancestors,
+    })
+}
+
+/// Phase 8 — `get_descendants`.
+///
+/// # Filtering split: graph (system invariants) vs emission (caller predicate)
+///
+/// The closure scan applies **only** system invariants:
+/// `(ancestor_id, descendant_id != ancestor_id)` plus the barrier
+/// predicate when `BarrierMode::Respect`. The closure table already
+/// excludes provisioning by AM's contract
+/// (`descendant_status ∈ {1, 2, 3}`), so the scan returns the
+/// barrier-bounded SDK-visible subtree without folding in the
+/// caller's `status_filter`. Caller status is applied as an
+/// **emission** predicate during the in-memory walk: the graph
+/// remains coherent even when an intermediate parent fails the
+/// caller's filter (e.g. `Root → Suspended → Active` filtered by
+/// `[Active]` correctly yields `Active`).
+///
+/// # Cycle protection
+///
+/// `parent_id` cycles are an AM invariant violation, but the walk
+/// runs on the auth hot path and must fail closed instead of
+/// hanging. A `visited: HashSet<Uuid>` short-circuits any revisit.
+///
+/// # Implementation
+///
+/// 1. Closure-driven probe of the subtree (`barrier` only).
+/// 2. Bulk hydrate the descendant `tenants` rows (defense-in-depth
+///    provisioning predicate applied on the row read).
+/// 3. Build a `parent_id → children` map and walk pre-order from
+///    the starting tenant, bounded by `max_depth`, with
+///    `visited`-based cycle protection.
+/// 4. Emit a node iff its `tenants.status` matches the caller's
+///    `status_filter` (empty = all SDK-visible statuses) per FEATURE
+///    §3 `algo-…-descendant-bounded-preorder`.
+#[allow(
+    clippy::cognitive_complexity,
+    reason = "single linear pipeline (closure scan → bulk hydrate → graph build → tenant_type batch resolve → DFS with cycle/depth/emit predicates) whose stages share state; splitting would only obscure the per-stage docstrings above"
+)]
+pub(super) async fn get_descendants(
+    db: &Db,
+    registry: &Arc<dyn TypesRegistryClient>,
+    id: TenantId,
+    barrier_mode: BarrierMode,
+    status_filter: &[SdkTenantStatus],
+    max_depth: Option<u32>,
+) -> Result<GetDescendantsResponse, TenantResolverError> {
+    let starting = read_tenant_visible(db, id.0)
+        .await?
+        .ok_or(TenantResolverError::TenantNotFound { tenant_id: id })?;
+
+    let conn = db.conn().map_err(|e| modkit_db_err_to_tr_err(&e))?;
+    // System-invariant filter only: ancestor pivot + strict-descendant
+    // exclusion + (optional) barrier. Caller's `status_filter` is
+    // intentionally NOT folded in here — see the top-of-fn doc for the
+    // graph-vs-emission rationale.
+    let mut closure_filter = Condition::all()
+        .add(tenant_closure::Column::AncestorId.eq(id.0))
+        .add(tenant_closure::Column::DescendantId.ne(id.0));
+    if matches!(barrier_mode, BarrierMode::Respect) {
+        closure_filter = closure_filter.add(tenant_closure::Column::Barrier.eq(0_i16));
+    }
+    let closure_rows = tenant_closure::Entity::find()
+        .secure()
+        .scope_with(&AccessScope::allow_all())
+        .filter(closure_filter)
+        .all(&conn)
+        .await
+        .map_err(|e| scope_err_to_tr_err(&e))?;
+
+    // Release the borrowed DbConn before re-acquiring inside the bulk
+    // read — `Db::conn()` short-circuits on an active task-local
+    // transaction guard, so holding two simultaneous borrows is
+    // unnecessary even if the type-level lifetime would permit it.
+    let _ = conn;
+
+    let descendant_ids: Vec<Uuid> = closure_rows.iter().map(|r| r.descendant_id).collect();
+    let descendant_rows = read_tenants_visible_bulk(db, &descendant_ids).await?;
+
+    // Compile the caller's status filter into an O(1) emission
+    // predicate. Empty input means "all SDK-visible statuses".
+    let user_statuses: Option<HashSet<SdkTenantStatus>> = if status_filter.is_empty() {
+        None
+    } else {
+        Some(status_filter.iter().copied().collect())
+    };
+    let emit_allowed = |status: SdkTenantStatus| -> bool {
+        user_statuses
+            .as_ref()
+            .is_none_or(|set| set.contains(&status))
+    };
+
+    // Build id→row and parent_id→children maps from the *full*
+    // barrier-bounded SDK-visible subtree. Sorting children by id ASC
+    // gives a deterministic SDK pre-order without per-node sorting at
+    // walk time.
+    let row_by_id: HashMap<Uuid, tenants::Model> =
+        descendant_rows.into_iter().map(|r| (r.id, r)).collect();
+    let mut children_by_parent: HashMap<Uuid, Vec<Uuid>> = HashMap::with_capacity(row_by_id.len());
+    for row in row_by_id.values() {
+        if let Some(parent) = row.parent_id {
+            children_by_parent.entry(parent).or_default().push(row.id);
+        }
+    }
+    for v in children_by_parent.values_mut() {
+        v.sort_unstable();
+    }
+
+    // Hydrate `tenant_type` for every row we *might* emit (the entire
+    // graph) plus the starting tenant in a single batched
+    // `get_type_schemas_by_uuid` round-trip. Hydrating the whole
+    // graph (rather than only the emit set) is intentional — distinct
+    // tenant_type uuids are typically a small number relative to the
+    // row count, and pre-resolving avoids a second registry round-trip
+    // when a deep emission set straddles many types.
+    let mut hydrate_pool: Vec<tenants::Model> = Vec::with_capacity(row_by_id.len() + 1);
+    hydrate_pool.push(starting.clone());
+    for row in row_by_id.values() {
+        hydrate_pool.push(row.clone());
+    }
+    let type_strings = resolve_tenant_types_for_rows(registry, &hydrate_pool).await?;
+
+    // Pre-order walk from the starting tenant. Iterative stack avoids
+    // unbounded recursion on deep hierarchies. Stack entries are
+    // `(node_id, depth_from_start)`: starting tenant is conceptually
+    // depth 0, its children depth 1, so `max_depth = Some(N)` admits
+    // nodes with `depth_from_start ∈ [1, N]`.
+    //
+    // `visited` provides cycle protection: `parent_id` cycles are an
+    // AM invariant violation, but the walk is on the auth hot path
+    // and must fail closed rather than spin forever on corrupted data.
+    // The starting tenant is pre-marked so a back-edge to it from
+    // some descendant cannot revisit.
+    let mut emitted: Vec<TenantRef> = Vec::with_capacity(row_by_id.len());
+    let mut stack: Vec<(Uuid, u32)> = Vec::new();
+    let mut visited: HashSet<Uuid> = HashSet::with_capacity(row_by_id.len() + 1);
+    visited.insert(id.0);
+
+    if let Some(initial_children) = children_by_parent.get(&id.0) {
+        for child in initial_children.iter().rev() {
+            stack.push((*child, 1));
+        }
+    }
+    while let Some((node_id, depth)) = stack.pop() {
+        if !visited.insert(node_id) {
+            tracing::warn!(
+                target: "tr_plugin",
+                tenant_id = %node_id,
+                pivot = %id.0,
+                "tenant_closure / parent_id graph revisit detected during pre-order walk; \
+                 short-circuiting to avoid unbounded loop (hierarchy invariant violation)"
+            );
+            continue;
+        }
+        if max_depth.is_some_and(|limit| depth > limit) {
+            continue;
+        }
+        let Some(row) = row_by_id.get(&node_id) else {
+            continue;
+        };
+        let Some(domain_status) =
+            crate::domain::tenant::model::TenantStatus::from_smallint(row.status)
+        else {
+            return Err(projection_internal(node_id));
+        };
+        let Some(sdk_status) = super::projection::map_status_to_sdk(domain_status) else {
+            return Err(projection_internal(node_id));
+        };
+        if emit_allowed(sdk_status) {
+            let tt = type_strings.get(&row.tenant_type_uuid).cloned();
+            emitted.push(row_to_tenant_ref(row, tt).ok_or_else(|| projection_internal(node_id))?);
+        }
+        if let Some(children) = children_by_parent.get(&node_id) {
+            for child in children.iter().rev() {
+                stack.push((*child, depth.saturating_add(1)));
+            }
+        }
+    }
+
+    let starting_ref = row_to_tenant_ref(
+        &starting,
+        type_strings.get(&starting.tenant_type_uuid).cloned(),
+    )
+    .ok_or_else(|| projection_internal(id.0))?;
+    Ok(GetDescendantsResponse {
+        tenant: starting_ref,
+        descendants: emitted,
+    })
+}

--- a/modules/system/account-management/account-management/src/tr_plugin/tests.rs
+++ b/modules/system/account-management/account-management/src/tr_plugin/tests.rs
@@ -255,14 +255,10 @@ async fn insert_closure(
         barrier: ActiveValue::Set(barrier),
         descendant_status: ActiveValue::Set(descendant_status),
     };
-    secure_insert::<tenant_closure::Entity>(am, &allow_all(), &conn)
+    secure_insert::<tenant_closure::Entity>(am, &AccessScope::allow_all(), &conn)
         .await
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
     Ok(())
-}
-
-fn allow_all() -> AccessScope {
-    AccessScope::allow_all()
 }
 
 /// Seed a single-root tenant with its self-row.
@@ -671,15 +667,21 @@ async fn is_ancestor_missing_endpoint_yields_not_found() {
 
 // ── Tests: barrier semantics ──────────────────────────────────────────────
 //
-// Hierarchy: A (root) → B (self_managed=true, barrier boundary) → C
+// Hierarchy: A (root) → B → C, where the A→B edge carries barrier=1
+// (simulating a self_managed tenant boundary as AM's writer would set it).
+//
+// The plugin only reads `tenant_closure.barrier`; it never inspects
+// `tenants.self_managed` directly. Tests therefore seed the correct
+// barrier values in the closure rows and leave `self_managed=false` on
+// the tenant rows without loss of fidelity.
 //
 // Closure rows:
 //   (A, A, barrier=0)  — self-row
 //   (B, B, barrier=0)  — self-row
 //   (C, C, barrier=0)  — self-row
-//   (A, B, barrier=1)  — barrier=1 because B is self_managed
-//   (B, C, barrier=0)  — within B's subtree, no extra barrier
-//   (A, C, barrier=1)  — A→C crosses the self_managed boundary
+//   (A, B, barrier=1)  — barrier set by AM writer at tenant-B creation
+//   (B, C, barrier=0)  — within B's subtree, no additional barrier
+//   (A, C, barrier=1)  — A→C inherits the barrier from the A→B edge
 
 async fn seed_barrier_tree(db: &Db) -> Result<(Uuid, Uuid, Uuid)> {
     let a = Uuid::new_v4();
@@ -1039,8 +1041,7 @@ async fn registry_fail_get_tenants_yields_internal() {
 #[tokio::test]
 async fn registry_fail_get_ancestors_yields_internal() {
     let db = setup().await.unwrap();
-    let (root, child) = seed_two_level(&db, ACTIVE, ACTIVE).await.unwrap();
-    let _ = root;
+    let (_root, child) = seed_two_level(&db, ACTIVE, ACTIVE).await.unwrap();
 
     let plugin = make_plugin(db, true);
     let err = plugin
@@ -1075,4 +1076,27 @@ async fn registry_fail_get_descendants_yields_internal() {
         .await
         .unwrap_err();
     assert!(matches!(err, TenantResolverError::Internal(_)));
+}
+
+#[tokio::test]
+async fn is_ancestor_not_affected_by_registry_failure() {
+    // `is_ancestor` probes `tenants` for visibility and `tenant_closure` for
+    // the edge — it never calls TypesRegistryClient. A failing registry must
+    // not affect the result.
+    let db = setup().await.unwrap();
+    let (root, child) = seed_two_level(&db, ACTIVE, ACTIVE).await.unwrap();
+
+    let plugin = make_plugin(db, true); // registry always fails
+    let ok = plugin
+        .is_ancestor(
+            &ctx(),
+            TenantId(root),
+            TenantId(child),
+            &IsAncestorOptions {
+                barrier_mode: BarrierMode::Ignore,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(ok, "is_ancestor must not depend on TypesRegistry");
 }

--- a/modules/system/account-management/account-management/src/tr_plugin/tests.rs
+++ b/modules/system/account-management/account-management/src/tr_plugin/tests.rs
@@ -1,0 +1,1078 @@
+//! Integration tests for the `tr_plugin` module.
+//!
+//! Each test spins up a fresh in-memory `SQLite` database, seeds the
+//! `tenants` / `tenant_closure` tables directly, and exercises
+//! `PluginImpl` through the `TenantResolverPluginClient` trait.
+//!
+//! The two registry stubs (`TestRegistry { fail: false/true }`) cover
+//! every call-site the plugin makes against `TypesRegistryClient`:
+//! `get_type_schema_by_uuid` (single) and `get_type_schemas_by_uuid`
+//! (batch). All other trait methods panic — if the plugin ever calls
+//! them unexpectedly the test fails loudly.
+
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::missing_panics_doc,
+    dead_code
+)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use modkit_db::migration_runner::run_migrations_for_testing;
+use modkit_db::secure::secure_insert;
+use modkit_db::{ConnectOpts, Db, connect_db};
+use modkit_security::{AccessScope, SecurityContext};
+use sea_orm::ActiveValue;
+use tenant_resolver_sdk::{
+    BarrierMode, GetAncestorsOptions, GetDescendantsOptions, GetTenantsOptions, IsAncestorOptions,
+    TenantId, TenantResolverError, TenantResolverPluginClient, TenantStatus as SdkStatus,
+};
+use time::OffsetDateTime;
+use types_registry_sdk::TypesRegistryClient;
+use types_registry_sdk::error::TypesRegistryError;
+use types_registry_sdk::models::{
+    GtsInstance, GtsTypeSchema, InstanceQuery, RegisterResult, TypeSchemaQuery,
+};
+use types_registry_sdk::testing::make_test_type_schema;
+use uuid::Uuid;
+
+use sea_orm_migration::MigratorTrait as _;
+
+use super::PluginImpl;
+use crate::Migrator;
+use crate::infra::storage::entity::{tenant_closure, tenants};
+
+// ── Status constants (mirror domain::tenant::model::TenantStatus SMALLINT) ──
+
+const PROVISIONING: i16 = 0;
+const ACTIVE: i16 = 1;
+const SUSPENDED: i16 = 2;
+#[allow(unused)]
+const DELETED: i16 = 3;
+
+// ── Registry stubs ────────────────────────────────────────────────────────
+
+const TEST_TYPE_ID: &str = "gts.cf.core.test.tenant.v1~";
+
+/// Dual-mode stub: when `fail=false` it returns a fixed `GtsTypeSchema` for
+/// any UUID; when `fail=true` every lookup returns `GtsTypeSchemaNotFound`.
+struct TestRegistry {
+    fail: bool,
+}
+
+impl TestRegistry {
+    fn ok() -> Arc<dyn TypesRegistryClient> {
+        Arc::new(Self { fail: false })
+    }
+
+    fn fail() -> Arc<dyn TypesRegistryClient> {
+        Arc::new(Self { fail: true })
+    }
+}
+
+#[async_trait]
+impl TypesRegistryClient for TestRegistry {
+    async fn get_type_schema_by_uuid(
+        &self,
+        _uuid: Uuid,
+    ) -> std::result::Result<GtsTypeSchema, TypesRegistryError> {
+        if self.fail {
+            Err(TypesRegistryError::gts_type_schema_not_found("test"))
+        } else {
+            Ok(make_test_type_schema(TEST_TYPE_ID))
+        }
+    }
+
+    async fn get_type_schemas_by_uuid(
+        &self,
+        uuids: Vec<Uuid>,
+    ) -> HashMap<Uuid, std::result::Result<GtsTypeSchema, TypesRegistryError>> {
+        uuids
+            .into_iter()
+            .map(|u| {
+                let res = if self.fail {
+                    Err(TypesRegistryError::gts_type_schema_not_found("test"))
+                } else {
+                    Ok(make_test_type_schema(TEST_TYPE_ID))
+                };
+                (u, res)
+            })
+            .collect()
+    }
+
+    async fn register(
+        &self,
+        _: Vec<serde_json::Value>,
+    ) -> std::result::Result<Vec<RegisterResult>, TypesRegistryError> {
+        unimplemented!("tr_plugin does not call register")
+    }
+
+    async fn register_type_schemas(
+        &self,
+        _: Vec<serde_json::Value>,
+    ) -> std::result::Result<Vec<RegisterResult>, TypesRegistryError> {
+        unimplemented!("tr_plugin does not call register_type_schemas")
+    }
+
+    async fn get_type_schema(
+        &self,
+        _: &str,
+    ) -> std::result::Result<GtsTypeSchema, TypesRegistryError> {
+        unimplemented!("tr_plugin does not call get_type_schema by string id")
+    }
+
+    async fn get_type_schemas(
+        &self,
+        _: Vec<String>,
+    ) -> HashMap<String, std::result::Result<GtsTypeSchema, TypesRegistryError>> {
+        unimplemented!("tr_plugin does not call get_type_schemas by string ids")
+    }
+
+    async fn list_type_schemas(
+        &self,
+        _: TypeSchemaQuery,
+    ) -> std::result::Result<Vec<GtsTypeSchema>, TypesRegistryError> {
+        unimplemented!("tr_plugin does not call list_type_schemas")
+    }
+
+    async fn register_instances(
+        &self,
+        _: Vec<serde_json::Value>,
+    ) -> std::result::Result<Vec<RegisterResult>, TypesRegistryError> {
+        unimplemented!("tr_plugin does not call register_instances")
+    }
+
+    async fn get_instance(&self, _: &str) -> std::result::Result<GtsInstance, TypesRegistryError> {
+        unimplemented!("tr_plugin does not call get_instance")
+    }
+
+    async fn get_instance_by_uuid(
+        &self,
+        _: Uuid,
+    ) -> std::result::Result<GtsInstance, TypesRegistryError> {
+        unimplemented!("tr_plugin does not call get_instance_by_uuid")
+    }
+
+    async fn get_instances(
+        &self,
+        _: Vec<String>,
+    ) -> HashMap<String, std::result::Result<GtsInstance, TypesRegistryError>> {
+        unimplemented!("tr_plugin does not call get_instances")
+    }
+
+    async fn get_instances_by_uuid(
+        &self,
+        _: Vec<Uuid>,
+    ) -> HashMap<Uuid, std::result::Result<GtsInstance, TypesRegistryError>> {
+        unimplemented!("tr_plugin does not call get_instances_by_uuid")
+    }
+
+    async fn list_instances(
+        &self,
+        _: InstanceQuery,
+    ) -> std::result::Result<Vec<GtsInstance>, TypesRegistryError> {
+        unimplemented!("tr_plugin does not call list_instances")
+    }
+}
+
+// ── Harness helpers ───────────────────────────────────────────────────────
+
+/// Spin up an in-memory `SQLite` DB, run AM migrations, and return the `Db`
+/// handle. The same `Db` is shared between the seed helpers and the plugin
+/// (both use `Arc<DbHandle>` internally via `Db::clone()`).
+async fn setup() -> Result<Db> {
+    let db = connect_db("sqlite::memory:", ConnectOpts::default()).await?;
+    run_migrations_for_testing(&db, Migrator::migrations())
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    Ok(db)
+}
+
+/// Build a `PluginImpl` backed by `db` with the given registry mode.
+fn make_plugin(db: Db, fail_registry: bool) -> PluginImpl {
+    let registry = if fail_registry {
+        TestRegistry::fail()
+    } else {
+        TestRegistry::ok()
+    };
+    PluginImpl::new(db, registry)
+}
+
+/// Anonymous `SecurityContext` — the plugin ignores it per DESIGN §4.2.
+fn ctx() -> SecurityContext {
+    SecurityContext::anonymous()
+}
+
+/// Insert one tenant row directly (bypassing the create-tenant saga).
+async fn insert_tenant(
+    db: &Db,
+    id: Uuid,
+    parent_id: Option<Uuid>,
+    status: i16,
+    depth: i32,
+) -> Result<()> {
+    let conn = db.conn().map_err(|e| anyhow::anyhow!("{e:?}"))?;
+    let now = OffsetDateTime::now_utc();
+    let am = tenants::ActiveModel {
+        id: ActiveValue::Set(id),
+        parent_id: ActiveValue::Set(parent_id),
+        name: ActiveValue::Set(format!("test-{id}")),
+        status: ActiveValue::Set(status),
+        self_managed: ActiveValue::Set(false),
+        tenant_type_uuid: ActiveValue::Set(Uuid::nil()),
+        depth: ActiveValue::Set(depth),
+        created_at: ActiveValue::Set(now),
+        updated_at: ActiveValue::Set(now),
+        deleted_at: ActiveValue::Set(None),
+        deletion_scheduled_at: ActiveValue::Set(None),
+        retention_window_secs: ActiveValue::Set(None),
+        claimed_by: ActiveValue::Set(None),
+        claimed_at: ActiveValue::Set(None),
+        terminal_failure_at: ActiveValue::Set(None),
+    };
+    secure_insert::<tenants::Entity>(am, &AccessScope::allow_all(), &conn)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+    Ok(())
+}
+
+/// Insert one `tenant_closure` row directly.
+async fn insert_closure(
+    db: &Db,
+    ancestor_id: Uuid,
+    descendant_id: Uuid,
+    barrier: i16,
+    descendant_status: i16,
+) -> Result<()> {
+    let conn = db.conn().map_err(|e| anyhow::anyhow!("{e:?}"))?;
+    let am = tenant_closure::ActiveModel {
+        ancestor_id: ActiveValue::Set(ancestor_id),
+        descendant_id: ActiveValue::Set(descendant_id),
+        barrier: ActiveValue::Set(barrier),
+        descendant_status: ActiveValue::Set(descendant_status),
+    };
+    secure_insert::<tenant_closure::Entity>(am, &allow_all(), &conn)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+    Ok(())
+}
+
+fn allow_all() -> AccessScope {
+    AccessScope::allow_all()
+}
+
+/// Seed a single-root tenant with its self-row.
+///
+/// Provisioning tenants have no closure rows by AM's contract
+/// (`tenant_closure.descendant_status IN (1,2,3)` CHECK constraint).
+/// Pass `status = ACTIVE` / `SUSPENDED` / `DELETED` — not `PROVISIONING`.
+async fn seed_root(db: &Db, status: i16) -> Result<Uuid> {
+    assert_ne!(
+        status, PROVISIONING,
+        "seed_root: provisioning roots have no closure rows; use insert_tenant directly"
+    );
+    let root = Uuid::new_v4();
+    insert_tenant(db, root, None, status, 0).await?;
+    insert_closure(db, root, root, 0, status).await?;
+    Ok(root)
+}
+
+/// Seed a two-level tree (root → child) with all required closure rows.
+/// Returns `(root, child)`.
+async fn seed_two_level(db: &Db, root_status: i16, child_status: i16) -> Result<(Uuid, Uuid)> {
+    let root = Uuid::new_v4();
+    let child = Uuid::new_v4();
+    insert_tenant(db, root, None, root_status, 0).await?;
+    insert_tenant(db, child, Some(root), child_status, 1).await?;
+    insert_closure(db, root, root, 0, root_status).await?;
+    insert_closure(db, child, child, 0, child_status).await?;
+    insert_closure(db, root, child, 0, child_status).await?;
+    Ok((root, child))
+}
+
+// ── Tests: get_tenant ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn get_tenant_returns_info() {
+    let db = setup().await.unwrap();
+    let root = seed_root(&db, ACTIVE).await.unwrap();
+
+    let plugin = make_plugin(db, false);
+    let info = plugin.get_tenant(&ctx(), TenantId(root)).await.unwrap();
+
+    assert_eq!(info.id.0, root);
+    assert_eq!(info.status, SdkStatus::Active);
+    assert!(info.parent_id.is_none());
+    assert!(
+        info.tenant_type.is_some(),
+        "registry must hydrate tenant_type"
+    );
+}
+
+#[tokio::test]
+async fn get_tenant_not_found() {
+    let db = setup().await.unwrap();
+    let missing = Uuid::new_v4();
+
+    let plugin = make_plugin(db, false);
+    let err = plugin
+        .get_tenant(&ctx(), TenantId(missing))
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, TenantResolverError::TenantNotFound { .. }),
+        "expected TenantNotFound, got {err:?}"
+    );
+}
+
+// ── Tests: provisioning invisibility ─────────────────────────────────────
+
+#[tokio::test]
+async fn provisioning_hidden_from_get_tenant() {
+    let db = setup().await.unwrap();
+    let id = Uuid::new_v4();
+    // Provisioning tenants have no closure rows (descendant_status CHECK constraint
+    // allows only 1/2/3). The tenant row exists; the status predicate hides it.
+    insert_tenant(&db, id, None, PROVISIONING, 0).await.unwrap();
+
+    let plugin = make_plugin(db, false);
+    let err = plugin.get_tenant(&ctx(), TenantId(id)).await.unwrap_err();
+    assert!(matches!(err, TenantResolverError::TenantNotFound { .. }));
+}
+
+#[tokio::test]
+async fn provisioning_only_root_yields_internal_error() {
+    let db = setup().await.unwrap();
+    // Only row in the DB is a provisioning tenant with parent_id=None.
+    // No closure rows (AM invariant). get_root_tenant must return Internal
+    // because the provisioning-visibility predicate hides it.
+    insert_tenant(&db, Uuid::new_v4(), None, PROVISIONING, 0)
+        .await
+        .unwrap();
+
+    let plugin = make_plugin(db, false);
+    let err = plugin.get_root_tenant(&ctx()).await.unwrap_err();
+    assert!(
+        matches!(err, TenantResolverError::Internal(_)),
+        "expected Internal when no non-provisioning root; got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn provisioning_hidden_from_is_ancestor_as_ancestor() {
+    let db = setup().await.unwrap();
+    let anc = Uuid::new_v4(); // provisioning
+    let desc = Uuid::new_v4(); // active
+    // Provisioning tenants have no closure rows by AM invariant.
+    insert_tenant(&db, anc, None, PROVISIONING, 0)
+        .await
+        .unwrap();
+    insert_tenant(&db, desc, Some(anc), ACTIVE, 1)
+        .await
+        .unwrap();
+    insert_closure(&db, desc, desc, 0, ACTIVE).await.unwrap();
+    // (anc, desc) closure row: descendant_status=ACTIVE is valid, but we omit
+    // it to match AM's invariant that provisioning tenants have no closure rows.
+
+    let plugin = make_plugin(db, false);
+    // The existence check reads tenants with status != PROVISIONING;
+    // anc is filtered → TenantNotFound.
+    let err = plugin
+        .is_ancestor(
+            &ctx(),
+            TenantId(anc),
+            TenantId(desc),
+            &IsAncestorOptions {
+                barrier_mode: BarrierMode::Ignore,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, TenantResolverError::TenantNotFound { .. }));
+}
+
+#[tokio::test]
+async fn provisioning_hidden_from_is_ancestor_as_descendant() {
+    let db = setup().await.unwrap();
+    let anc = Uuid::new_v4(); // active root
+    let desc = Uuid::new_v4(); // provisioning child
+    insert_tenant(&db, anc, None, ACTIVE, 0).await.unwrap();
+    // desc is provisioning: no closure rows (AM invariant + CHECK constraint).
+    insert_tenant(&db, desc, Some(anc), PROVISIONING, 1)
+        .await
+        .unwrap();
+    insert_closure(&db, anc, anc, 0, ACTIVE).await.unwrap();
+
+    let plugin = make_plugin(db, false);
+    // Existence check reads tenants with status != PROVISIONING; desc filtered → TenantNotFound.
+    let err = plugin
+        .is_ancestor(
+            &ctx(),
+            TenantId(anc),
+            TenantId(desc),
+            &IsAncestorOptions {
+                barrier_mode: BarrierMode::Ignore,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, TenantResolverError::TenantNotFound { .. }));
+}
+
+#[tokio::test]
+async fn provisioning_hidden_from_get_tenants() {
+    let db = setup().await.unwrap();
+    let active_id = Uuid::new_v4();
+    let prov_id = Uuid::new_v4();
+    insert_tenant(&db, active_id, None, ACTIVE, 0)
+        .await
+        .unwrap();
+    // prov_id is a provisioning child (non-root to avoid the unique-root constraint).
+    // No closure rows for provisioning tenants.
+    insert_tenant(&db, prov_id, Some(active_id), PROVISIONING, 1)
+        .await
+        .unwrap();
+    insert_closure(&db, active_id, active_id, 0, ACTIVE)
+        .await
+        .unwrap();
+
+    let plugin = make_plugin(db, false);
+    let result = plugin
+        .get_tenants(
+            &ctx(),
+            &[TenantId(active_id), TenantId(prov_id)],
+            &GetTenantsOptions { status: vec![] },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].id.0, active_id);
+}
+
+#[tokio::test]
+async fn provisioning_hidden_from_get_ancestors() {
+    let db = setup().await.unwrap();
+    // Hierarchy: provisioning_root → active_child
+    // get_ancestors(active_child) must return an empty ancestors list because
+    // the provisioning root is filtered by the status predicate on the bulk
+    // tenant read. The closure row (prov_root → child) is valid (descendant_status
+    // = ACTIVE) and will be returned by the closure scan, but the subsequent
+    // bulk tenant hydration excludes prov_root.
+    let prov_root = Uuid::new_v4();
+    let child = Uuid::new_v4();
+    // prov_root: provisioning tenant — no self-row closure (AM invariant).
+    insert_tenant(&db, prov_root, None, PROVISIONING, 0)
+        .await
+        .unwrap();
+    insert_tenant(&db, child, Some(prov_root), ACTIVE, 1)
+        .await
+        .unwrap();
+    insert_closure(&db, child, child, 0, ACTIVE).await.unwrap();
+    // Ancestor row: descendant_status=ACTIVE is valid for the CHECK constraint.
+    insert_closure(&db, prov_root, child, 0, ACTIVE)
+        .await
+        .unwrap();
+
+    let plugin = make_plugin(db, false);
+    let resp = plugin
+        .get_ancestors(
+            &ctx(),
+            TenantId(child),
+            &GetAncestorsOptions {
+                barrier_mode: BarrierMode::Ignore,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.tenant.id.0, child);
+    // prov_root is excluded by the provisioning-invisibility predicate
+    // on the bulk tenant read; ancestor list is empty.
+    assert!(
+        resp.ancestors.is_empty(),
+        "provisioning root must not appear in ancestors"
+    );
+}
+
+#[tokio::test]
+async fn provisioning_start_hidden_from_get_descendants() {
+    let db = setup().await.unwrap();
+    let prov = Uuid::new_v4();
+    // Provisioning tenant — no closure rows (AM invariant + CHECK constraint).
+    insert_tenant(&db, prov, None, PROVISIONING, 0)
+        .await
+        .unwrap();
+
+    let plugin = make_plugin(db, false);
+    let err = plugin
+        .get_descendants(
+            &ctx(),
+            TenantId(prov),
+            &GetDescendantsOptions {
+                barrier_mode: BarrierMode::Ignore,
+                status: vec![],
+                max_depth: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, TenantResolverError::TenantNotFound { .. }));
+}
+
+// ── Tests: get_root_tenant ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn get_root_tenant_finds_single_root() {
+    let db = setup().await.unwrap();
+    let root = seed_root(&db, ACTIVE).await.unwrap();
+
+    let plugin = make_plugin(db, false);
+    let info = plugin.get_root_tenant(&ctx()).await.unwrap();
+    assert_eq!(info.id.0, root);
+}
+
+#[tokio::test]
+async fn get_root_tenant_no_root_yields_internal_error() {
+    let db = setup().await.unwrap();
+    // Empty DB — no tenant rows at all.
+    let plugin = make_plugin(db, false);
+    let err = plugin.get_root_tenant(&ctx()).await.unwrap_err();
+    assert!(matches!(err, TenantResolverError::Internal(_)));
+}
+
+// NOTE: the "multiple roots → Internal" branch of get_root_tenant cannot be
+// exercised on SQLite because the `ux_tenants_single_root` partial unique
+// index (WHERE parent_id IS NULL) prevents a second root row from being
+// inserted. The Postgres harness in `tests/lifecycle_integration_pg.rs` is
+// the right place for that case once the pg feature is available.
+
+// ── Tests: get_tenants ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn get_tenants_deduplicates_input_ids() {
+    let db = setup().await.unwrap();
+    let (root, _child) = seed_two_level(&db, ACTIVE, ACTIVE).await.unwrap();
+
+    let plugin = make_plugin(db, false);
+    // Pass the root ID three times.
+    let result = plugin
+        .get_tenants(
+            &ctx(),
+            &[TenantId(root), TenantId(root), TenantId(root)],
+            &GetTenantsOptions { status: vec![] },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 1, "duplicate IDs must be deduplicated");
+    assert_eq!(result[0].id.0, root);
+}
+
+#[tokio::test]
+async fn get_tenants_status_filter() {
+    let db = setup().await.unwrap();
+    let (root, child) = seed_two_level(&db, ACTIVE, SUSPENDED).await.unwrap();
+
+    let plugin = make_plugin(db, false);
+    let active_only = plugin
+        .get_tenants(
+            &ctx(),
+            &[TenantId(root), TenantId(child)],
+            &GetTenantsOptions {
+                status: vec![SdkStatus::Active],
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(active_only.len(), 1);
+    assert_eq!(active_only[0].id.0, root);
+}
+
+#[tokio::test]
+async fn get_tenants_empty_ids_returns_empty() {
+    let db = setup().await.unwrap();
+    let plugin = make_plugin(db, false);
+    let result = plugin
+        .get_tenants(&ctx(), &[], &GetTenantsOptions { status: vec![] })
+        .await
+        .unwrap();
+    assert!(result.is_empty());
+}
+
+// ── Tests: is_ancestor ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn is_ancestor_direct_parent_returns_true() {
+    let db = setup().await.unwrap();
+    let (root, child) = seed_two_level(&db, ACTIVE, ACTIVE).await.unwrap();
+
+    let plugin = make_plugin(db, false);
+    let ok = plugin
+        .is_ancestor(
+            &ctx(),
+            TenantId(root),
+            TenantId(child),
+            &IsAncestorOptions {
+                barrier_mode: BarrierMode::Ignore,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(ok);
+}
+
+#[tokio::test]
+async fn is_ancestor_self_returns_false() {
+    let db = setup().await.unwrap();
+    let root = seed_root(&db, ACTIVE).await.unwrap();
+
+    let plugin = make_plugin(db, false);
+    let ok = plugin
+        .is_ancestor(
+            &ctx(),
+            TenantId(root),
+            TenantId(root),
+            &IsAncestorOptions {
+                barrier_mode: BarrierMode::Ignore,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(!ok, "self is not an ancestor of self");
+}
+
+#[tokio::test]
+async fn is_ancestor_missing_endpoint_yields_not_found() {
+    let db = setup().await.unwrap();
+    let root = seed_root(&db, ACTIVE).await.unwrap();
+    let missing = Uuid::new_v4();
+
+    let plugin = make_plugin(db, false);
+    let err = plugin
+        .is_ancestor(
+            &ctx(),
+            TenantId(root),
+            TenantId(missing),
+            &IsAncestorOptions {
+                barrier_mode: BarrierMode::Ignore,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, TenantResolverError::TenantNotFound { .. }));
+}
+
+// ── Tests: barrier semantics ──────────────────────────────────────────────
+//
+// Hierarchy: A (root) → B (self_managed=true, barrier boundary) → C
+//
+// Closure rows:
+//   (A, A, barrier=0)  — self-row
+//   (B, B, barrier=0)  — self-row
+//   (C, C, barrier=0)  — self-row
+//   (A, B, barrier=1)  — barrier=1 because B is self_managed
+//   (B, C, barrier=0)  — within B's subtree, no extra barrier
+//   (A, C, barrier=1)  — A→C crosses the self_managed boundary
+
+async fn seed_barrier_tree(db: &Db) -> Result<(Uuid, Uuid, Uuid)> {
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    let c = Uuid::new_v4();
+    insert_tenant(db, a, None, ACTIVE, 0).await?;
+    insert_tenant(db, b, Some(a), ACTIVE, 1).await?;
+    insert_tenant(db, c, Some(b), ACTIVE, 2).await?;
+    // Self-rows
+    insert_closure(db, a, a, 0, ACTIVE).await?;
+    insert_closure(db, b, b, 0, ACTIVE).await?;
+    insert_closure(db, c, c, 0, ACTIVE).await?;
+    // Cross-boundary rows
+    insert_closure(db, a, b, 1, ACTIVE).await?;
+    insert_closure(db, b, c, 0, ACTIVE).await?;
+    insert_closure(db, a, c, 1, ACTIVE).await?;
+    Ok((a, b, c))
+}
+
+#[tokio::test]
+async fn barrier_respect_is_ancestor_blocked() {
+    let db = setup().await.unwrap();
+    let (a, _b, c) = seed_barrier_tree(&db).await.unwrap();
+
+    let plugin = make_plugin(db, false);
+    let ok = plugin
+        .is_ancestor(
+            &ctx(),
+            TenantId(a),
+            TenantId(c),
+            &IsAncestorOptions {
+                barrier_mode: BarrierMode::Respect,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(!ok, "Respect should block cross-barrier ancestry");
+}
+
+#[tokio::test]
+async fn barrier_ignore_is_ancestor_crosses() {
+    let db = setup().await.unwrap();
+    let (a, _b, c) = seed_barrier_tree(&db).await.unwrap();
+
+    let plugin = make_plugin(db, false);
+    let ok = plugin
+        .is_ancestor(
+            &ctx(),
+            TenantId(a),
+            TenantId(c),
+            &IsAncestorOptions {
+                barrier_mode: BarrierMode::Ignore,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(ok, "Ignore should allow cross-barrier ancestry");
+}
+
+#[tokio::test]
+async fn barrier_respect_get_ancestors_clamps_at_barrier() {
+    let db = setup().await.unwrap();
+    let (a, b, c) = seed_barrier_tree(&db).await.unwrap();
+
+    let plugin = make_plugin(db, false);
+    let resp = plugin
+        .get_ancestors(
+            &ctx(),
+            TenantId(c),
+            &GetAncestorsOptions {
+                barrier_mode: BarrierMode::Respect,
+            },
+        )
+        .await
+        .unwrap();
+
+    let ancestor_ids: Vec<Uuid> = resp.ancestors.iter().map(|t| t.id.0).collect();
+    assert!(
+        ancestor_ids.contains(&b),
+        "B (within-barrier ancestor) must appear"
+    );
+    assert!(
+        !ancestor_ids.contains(&a),
+        "A (cross-barrier ancestor) must NOT appear under Respect"
+    );
+}
+
+#[tokio::test]
+async fn barrier_ignore_get_ancestors_crosses_barrier() {
+    let db = setup().await.unwrap();
+    let (a, b, c) = seed_barrier_tree(&db).await.unwrap();
+
+    let plugin = make_plugin(db, false);
+    let resp = plugin
+        .get_ancestors(
+            &ctx(),
+            TenantId(c),
+            &GetAncestorsOptions {
+                barrier_mode: BarrierMode::Ignore,
+            },
+        )
+        .await
+        .unwrap();
+
+    let ancestor_ids: Vec<Uuid> = resp.ancestors.iter().map(|t| t.id.0).collect();
+    assert!(ancestor_ids.contains(&a), "A must appear under Ignore");
+    assert!(ancestor_ids.contains(&b), "B must appear under Ignore");
+}
+
+#[tokio::test]
+async fn barrier_respect_get_descendants_stops_at_boundary() {
+    let db = setup().await.unwrap();
+    let (a, b, c) = seed_barrier_tree(&db).await.unwrap();
+
+    let plugin = make_plugin(db, false);
+    let resp = plugin
+        .get_descendants(
+            &ctx(),
+            TenantId(a),
+            &GetDescendantsOptions {
+                barrier_mode: BarrierMode::Respect,
+                status: vec![],
+                max_depth: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let desc_ids: Vec<Uuid> = resp.descendants.iter().map(|t| t.id.0).collect();
+    assert!(
+        !desc_ids.contains(&b),
+        "B (cross-barrier) must NOT appear under Respect"
+    );
+    assert!(
+        !desc_ids.contains(&c),
+        "C (cross-barrier) must NOT appear under Respect"
+    );
+    assert!(
+        resp.descendants.is_empty(),
+        "A has no non-barrier descendants"
+    );
+}
+
+#[tokio::test]
+async fn barrier_ignore_get_descendants_crosses_boundary() {
+    let db = setup().await.unwrap();
+    let (a, b, c) = seed_barrier_tree(&db).await.unwrap();
+
+    let plugin = make_plugin(db, false);
+    let resp = plugin
+        .get_descendants(
+            &ctx(),
+            TenantId(a),
+            &GetDescendantsOptions {
+                barrier_mode: BarrierMode::Ignore,
+                status: vec![],
+                max_depth: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let desc_ids: Vec<Uuid> = resp.descendants.iter().map(|t| t.id.0).collect();
+    assert!(desc_ids.contains(&b), "B must appear under Ignore");
+    assert!(desc_ids.contains(&c), "C must appear under Ignore");
+}
+
+// ── Tests: status filter semantics ───────────────────────────────────────
+
+#[tokio::test]
+async fn status_filter_does_not_prune_branches() {
+    // Root (Active) → Mid (Suspended) → Leaf (Active)
+    // Filtering by [Active] must still return Leaf even though Mid is
+    // Suspended — the filter is an emission predicate, not a branch prune.
+    let db = setup().await.unwrap();
+    let root = Uuid::new_v4();
+    let mid = Uuid::new_v4();
+    let leaf = Uuid::new_v4();
+    insert_tenant(&db, root, None, ACTIVE, 0).await.unwrap();
+    insert_tenant(&db, mid, Some(root), SUSPENDED, 1)
+        .await
+        .unwrap();
+    insert_tenant(&db, leaf, Some(mid), ACTIVE, 2)
+        .await
+        .unwrap();
+    // Self-rows
+    insert_closure(&db, root, root, 0, ACTIVE).await.unwrap();
+    insert_closure(&db, mid, mid, 0, SUSPENDED).await.unwrap();
+    insert_closure(&db, leaf, leaf, 0, ACTIVE).await.unwrap();
+    // Ancestor rows (barrier=0 everywhere — no self_managed tenant)
+    insert_closure(&db, root, mid, 0, SUSPENDED).await.unwrap();
+    insert_closure(&db, root, leaf, 0, ACTIVE).await.unwrap();
+    insert_closure(&db, mid, leaf, 0, ACTIVE).await.unwrap();
+
+    let plugin = make_plugin(db, false);
+    let resp = plugin
+        .get_descendants(
+            &ctx(),
+            TenantId(root),
+            &GetDescendantsOptions {
+                barrier_mode: BarrierMode::Ignore,
+                status: vec![SdkStatus::Active],
+                max_depth: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let desc_ids: Vec<Uuid> = resp.descendants.iter().map(|t| t.id.0).collect();
+    assert!(
+        desc_ids.contains(&leaf),
+        "Leaf (Active) must be emitted even though Mid (Suspended) is on the path"
+    );
+    assert!(
+        !desc_ids.contains(&mid),
+        "Mid (Suspended) must not be emitted when filter=[Active]"
+    );
+}
+
+// ── Tests: get_descendants max_depth ─────────────────────────────────────
+
+#[tokio::test]
+async fn get_descendants_max_depth_limits_traversal() {
+    // ROOT → CHILD → GRANDCHILD → GREAT
+    let db = setup().await.unwrap();
+    let root = Uuid::new_v4();
+    let child = Uuid::new_v4();
+    let grandchild = Uuid::new_v4();
+    let great = Uuid::new_v4();
+    insert_tenant(&db, root, None, ACTIVE, 0).await.unwrap();
+    insert_tenant(&db, child, Some(root), ACTIVE, 1)
+        .await
+        .unwrap();
+    insert_tenant(&db, grandchild, Some(child), ACTIVE, 2)
+        .await
+        .unwrap();
+    insert_tenant(&db, great, Some(grandchild), ACTIVE, 3)
+        .await
+        .unwrap();
+    // Self-rows
+    for (id, st) in [
+        (root, ACTIVE),
+        (child, ACTIVE),
+        (grandchild, ACTIVE),
+        (great, ACTIVE),
+    ] {
+        insert_closure(&db, id, id, 0, st).await.unwrap();
+    }
+    // Ancestor rows
+    insert_closure(&db, root, child, 0, ACTIVE).await.unwrap();
+    insert_closure(&db, root, grandchild, 0, ACTIVE)
+        .await
+        .unwrap();
+    insert_closure(&db, root, great, 0, ACTIVE).await.unwrap();
+    insert_closure(&db, child, grandchild, 0, ACTIVE)
+        .await
+        .unwrap();
+    insert_closure(&db, child, great, 0, ACTIVE).await.unwrap();
+    insert_closure(&db, grandchild, great, 0, ACTIVE)
+        .await
+        .unwrap();
+
+    let plugin = make_plugin(db, false);
+
+    // max_depth=1 → only CHILD
+    let r1 = plugin
+        .get_descendants(
+            &ctx(),
+            TenantId(root),
+            &GetDescendantsOptions {
+                barrier_mode: BarrierMode::Ignore,
+                status: vec![],
+                max_depth: Some(1),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(r1.descendants.len(), 1);
+    assert_eq!(r1.descendants[0].id.0, child);
+
+    // max_depth=2 → CHILD + GRANDCHILD
+    let r2 = plugin
+        .get_descendants(
+            &ctx(),
+            TenantId(root),
+            &GetDescendantsOptions {
+                barrier_mode: BarrierMode::Ignore,
+                status: vec![],
+                max_depth: Some(2),
+            },
+        )
+        .await
+        .unwrap();
+    let ids2: Vec<Uuid> = r2.descendants.iter().map(|t| t.id.0).collect();
+    assert!(ids2.contains(&child));
+    assert!(ids2.contains(&grandchild));
+    assert!(!ids2.contains(&great));
+
+    // max_depth=None → all three
+    let r_all = plugin
+        .get_descendants(
+            &ctx(),
+            TenantId(root),
+            &GetDescendantsOptions {
+                barrier_mode: BarrierMode::Ignore,
+                status: vec![],
+                max_depth: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(r_all.descendants.len(), 3);
+}
+
+// ── Tests: TypesRegistry failure → Internal ───────────────────────────────
+
+#[tokio::test]
+async fn registry_fail_get_tenant_yields_internal() {
+    let db = setup().await.unwrap();
+    let root = seed_root(&db, ACTIVE).await.unwrap();
+
+    let plugin = make_plugin(db, true);
+    let err = plugin.get_tenant(&ctx(), TenantId(root)).await.unwrap_err();
+    assert!(
+        matches!(err, TenantResolverError::Internal(_)),
+        "registry failure must surface as Internal; got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn registry_fail_get_root_tenant_yields_internal() {
+    let db = setup().await.unwrap();
+    seed_root(&db, ACTIVE).await.unwrap();
+
+    let plugin = make_plugin(db, true);
+    let err = plugin.get_root_tenant(&ctx()).await.unwrap_err();
+    assert!(matches!(err, TenantResolverError::Internal(_)));
+}
+
+#[tokio::test]
+async fn registry_fail_get_tenants_yields_internal() {
+    let db = setup().await.unwrap();
+    let root = seed_root(&db, ACTIVE).await.unwrap();
+
+    let plugin = make_plugin(db, true);
+    let err = plugin
+        .get_tenants(
+            &ctx(),
+            &[TenantId(root)],
+            &GetTenantsOptions { status: vec![] },
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, TenantResolverError::Internal(_)));
+}
+
+#[tokio::test]
+async fn registry_fail_get_ancestors_yields_internal() {
+    let db = setup().await.unwrap();
+    let (root, child) = seed_two_level(&db, ACTIVE, ACTIVE).await.unwrap();
+    let _ = root;
+
+    let plugin = make_plugin(db, true);
+    let err = plugin
+        .get_ancestors(
+            &ctx(),
+            TenantId(child),
+            &GetAncestorsOptions {
+                barrier_mode: BarrierMode::Ignore,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, TenantResolverError::Internal(_)));
+}
+
+#[tokio::test]
+async fn registry_fail_get_descendants_yields_internal() {
+    let db = setup().await.unwrap();
+    let (root, _child) = seed_two_level(&db, ACTIVE, ACTIVE).await.unwrap();
+
+    let plugin = make_plugin(db, true);
+    let err = plugin
+        .get_descendants(
+            &ctx(),
+            TenantId(root),
+            &GetDescendantsOptions {
+                barrier_mode: BarrierMode::Ignore,
+                status: vec![],
+                max_depth: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, TenantResolverError::Internal(_)));
+}

--- a/tools/dylint_lints/Cargo.lock
+++ b/tools/dylint_lints/Cargo.lock
@@ -424,6 +424,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit"
-version = "0.6.8"
+version = "0.6.10"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -600,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-canonical-errors"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "axum 0.8.9",
  "cf-modkit-canonical-errors-macro",
@@ -623,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -676,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors-macro"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -698,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-odata"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "base64",
  "bigdecimal",
@@ -711,14 +720,14 @@ dependencies = [
  "peg",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "uuid",
 ]
 
 [[package]]
 name = "cf-modkit-sdk"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "cf-modkit-odata",
  "cf-modkit-security",
@@ -751,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "cf-system-sdk-directory"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -759,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "cf-system-sdks"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "cf-system-sdk-directory",
 ]
@@ -871,6 +880,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +896,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -932,6 +956,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1292,7 +1325,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1352,10 +1385,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1917,9 +1961,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gts"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349ca150e5a2a61cfe91dda57e841fffa122b876e73f8522b6810630fccebed1"
+checksum = "2a5643b7f259cc57b8822d78e7de34e6e31079a36ffb0a75ee8f685fd53595e5"
 dependencies = [
  "gts-id",
  "jsonschema",
@@ -1936,9 +1980,9 @@ dependencies = [
 
 [[package]]
 name = "gts-id"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "097854f3aade247a143b6f2e8e6f1e7159cf11b0dc01f7d5fbe2d4cefca2cd7b"
+checksum = "c9d8c6ff0c4fcdf993d2279f44a9edf1e66060fe55c59d5ce06b63a6fafaeafa"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2066,7 +2110,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2128,6 +2172,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2652,7 +2705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3643,8 +3696,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -4129,8 +4182,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4146,8 +4199,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4190,7 +4254,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -4297,7 +4361,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "time",
@@ -4336,7 +4400,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -4360,7 +4424,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -4382,7 +4446,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -4425,7 +4489,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -5010,9 +5074,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uncased"


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#1892](https://github.com/cyberfabric/cyberware-rust/pull/1892) | **Author:** diffora | **Opened:** 2026-05-09T19:08:25Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

- Adds the platform-bootstrap saga (`BootstrapService`) with IdP-wait backoff, provisioning-reaper compensation, and non-strict fallback mode
- Adds hierarchy integrity check + auto-repair pipeline (`IntegrityChecker`, `IntegrityCategory`, `RepairReport`) with per-category telemetry
- Adds in-process Tenant Resolver plugin (`tr_plugin`) co-located with AM — implements the full `TenantResolverPluginClient` SDK surface against AM-owned `tenants` + `tenant_closure` tables, with `TypesRegistryClient` batched reverse-hydration and provisioning-invisibility enforcement
- 31 integration tests for `tr_plugin` covering: happy-path reads, provisioning invisibility (all six SDK methods), barrier semantics (`Respect`/`Ignore` on `get_ancestors`, `get_descendants`, `is_ancestor`), status filters, `max_depth` traversal, `TypesRegistry` failure → `Internal`, and `is_ancestor` registry-independence

## Test plan

- [ ] `cargo test -p cf-account-management` — all 31 `tr_plugin` tests pass on SQLite in-memory
- [ ] `cargo test -p cf-account-management --features postgres` — Postgres harness tests (requires Docker)
- [ ] Verify provisioning-invisibility: provisioning rows hidden from all six SDK methods
- [ ] Verify barrier semantics: `BarrierMode::Respect` clamps ancestors/descendants at closure `barrier=1` edges
- [ ] Verify registry failure: all SDK methods except `is_ancestor` return `TenantResolverError::Internal` on registry failure
- [ ] Verify `is_ancestor` registry independence: returns correct bool even when registry always fails

## Notes

Codex review flagged four issues in the bootstrap saga code (commits `43d41ecd` / `f0873f75`), outside the `tr_plugin` scope:
- **[P1]** `config.rs:292` — non-strict bootstrap fallback broken by unconditional `bootstrap.validate()` in `AccountManagementConfig::validate()`
- **[P1]** `bootstrap/service.rs:842` — `check_availability` timeout doesn't race `cancel.cancelled()`, delaying shutdown up to `idp_wait_timeout_secs`
- **[P2]** `module.rs:646` — cancellation error swallowed as benign bootstrap failure in non-strict mode
- **[P2]** `bootstrap/config.rs:157` — `root_name`/`root_tenant_type` validation too shallow (no length/GTS format checks)

These are tracked for a follow-up fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Platform bootstrap saga: Automatic root tenant creation with IdP integration, configurable retry/backoff, and idempotency.
  * Hierarchy integrity check: Periodic snapshot-based validation with single-flight concurrency gating and automatic closure-row repair.
  * Enhanced error handling: Added `IdpUnavailable` and `FeatureDisabled` error variants.

* **Configuration**
  * Added `bootstrap` and `integrity_check` configuration sections for operational control.

* **Infrastructure**
  * New database migration for integrity-check single-flight coordination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#1892 -->