### PR TITLE
[PR #1890] chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,54 @@ release-plz updates this file in the Release PR.
 
 ## [Unreleased]
 
+## [0.6.4](https://github.com/cyberfabric/cyberfabric-core/compare/types-sdk-v0.6.3...types-sdk-v0.6.4) - 2026-05-10
+
+### Other
+
+- updated the following local packages: cf-modkit-odata
+
+## [0.1.4](https://github.com/cyberfabric/cyberfabric-core/compare/cf-tr-authz-plugin-v0.1.3...cf-tr-authz-plugin-v0.1.4) - 2026-05-10
+
+### Other
+
+- updated the following local packages: cf-modkit, cf-authz-resolver-sdk, cf-tenant-resolver-sdk, cf-types-registry-sdk
+
+## [0.1.22](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-tr-plugin-v0.1.21...cf-static-tr-plugin-v0.1.22) - 2026-05-10
+
+### Other
+
+- updated the following local packages: cf-modkit-odata, cf-modkit, cf-tenant-resolver-sdk, cf-types-registry-sdk
+
+## [0.1.19](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-credstore-plugin-v0.1.18...cf-static-credstore-plugin-v0.1.19) - 2026-05-10
+
+### Other
+
+- updated the following local packages: cf-modkit, cf-credstore-sdk, cf-types-registry-sdk
+
+## [0.1.21](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-authz-plugin-v0.1.20...cf-static-authz-plugin-v0.1.21) - 2026-05-10
+
+### Other
+
+- updated the following local packages: cf-modkit, cf-authz-resolver-sdk, cf-types-registry-sdk
+
+## [0.3.1](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-authn-plugin-v0.3.0...cf-static-authn-plugin-v0.3.1) - 2026-05-10
+
+### Other
+
+- updated the following local packages: cf-modkit, cf-types-registry-sdk, cf-authn-resolver-sdk
+
+## [0.1.23](https://github.com/cyberfabric/cyberfabric-core/compare/cf-single-tenant-tr-plugin-v0.1.22...cf-single-tenant-tr-plugin-v0.1.23) - 2026-05-10
+
+### Other
+
+- updated the following local packages: cf-modkit-odata, cf-modkit, cf-tenant-resolver-sdk, cf-types-registry-sdk
+
+## [0.1.4](https://github.com/cyberfabric/cyberfabric-core/compare/cf-rg-tr-plugin-v0.1.3...cf-rg-tr-plugin-v0.1.4) - 2026-05-10
+
+### Other
+
+- updated the following local packages: cf-modkit-odata, cf-modkit, cf-tenant-resolver-sdk, cf-types-registry-sdk, cf-resource-group-sdk
+
 ## [0.1.1](https://github.com/cyberfabric/cyberfabric-core/compare/cf-account-management-v0.1.0...cf-account-management-v0.1.1) - 2026-05-07
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "cf-account-management"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "cf-account-management-sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "cf-modkit-canonical-errors",
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "cf-api-gateway"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "cf-authn-resolver"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "cf-authn-resolver-sdk"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "cf-authz-resolver"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "cf-authz-resolver-sdk"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "cf-credstore"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "cf-credstore-sdk"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "cf-file-parser"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "cf-grpc-hub"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1633,7 +1633,7 @@ dependencies = [
 
 [[package]]
 name = "cf-mini-chat"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "cf-mini-chat-sdk"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1978,7 +1978,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-odata"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "base64 0.22.1",
  "bigdecimal",
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-odata-macros"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "cf-modkit-odata",
  "heck 0.5.0",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-sdk"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "cf-modkit-odata",
  "cf-modkit-odata-macros",
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "cf-module-orchestrator"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "cf-nodes-registry"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "cf-oagw"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "cf-oagw-sdk"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -2203,7 +2203,7 @@ dependencies = [
 
 [[package]]
 name = "cf-resource-group"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "cf-resource-group-sdk"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "cf-rg-tr-plugin"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2387,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "cf-single-tenant-tr-plugin"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-authn-plugin"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2427,7 +2427,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-authz-plugin"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2446,7 +2446,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-credstore-plugin"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2466,7 +2466,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-tr-plugin"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2508,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "cf-tenant-resolver"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2529,7 +2529,7 @@ dependencies = [
 
 [[package]]
 name = "cf-tenant-resolver-sdk"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -2546,7 +2546,7 @@ dependencies = [
 
 [[package]]
 name = "cf-tr-authz-plugin"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "cf-types-registry"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2592,7 +2592,7 @@ dependencies = [
 
 [[package]]
 name = "cf-types-registry-sdk"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "gts",
@@ -9766,7 +9766,7 @@ dependencies = [
 
 [[package]]
 name = "types-sdk"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "async-trait",
  "cf-modkit-odata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,20 +220,20 @@ verbose_file_reads = "deny"
 
 [workspace.dependencies]
 # libs
-modkit = { package = "cf-modkit", version = "0.6.10", path = "libs/modkit" }
+modkit = { package = "cf-modkit", version = "0.6.11", path = "libs/modkit" }
 modkit-http = { package = "cf-modkit-http", version = "0.6.5", path = "libs/modkit-http" }
 modkit-auth = { package = "cf-modkit-auth", version = "0.7.0", path = "libs/modkit-auth" }
 modkit-canonical-errors = { package = "cf-modkit-canonical-errors", version = "0.7.3", path = "libs/modkit-canonical-errors" }
 modkit-canonical-errors-macro = { package = "cf-modkit-canonical-errors-macro", version = "0.6.1", path = "libs/modkit-canonical-errors-macro" }
-modkit-db = { package = "cf-modkit-db", version = "0.8.2", path = "libs/modkit-db" }
+modkit-db = { package = "cf-modkit-db", version = "0.8.3", path = "libs/modkit-db" }
 modkit-db-macros = { package = "cf-modkit-db-macros", version = "0.6.2", path = "libs/modkit-db-macros" }
 modkit-errors = { package = "cf-modkit-errors", version = "0.7.0", path = "libs/modkit-errors" }
 modkit-errors-macro = { package = "cf-modkit-errors-macro", version = "0.6.3", path = "libs/modkit-errors-macro" }
 modkit-macros = { package = "cf-modkit-macros", version = "0.6.2", path = "libs/modkit-macros" }
 modkit-node-info = { package = "cf-modkit-node-info", version = "0.6.4", path = "libs/modkit-node-info" }
-modkit-odata = { package = "cf-modkit-odata", version = "0.8.0", path = "libs/modkit-odata" }
-modkit-odata-macros = { package = "cf-modkit-odata-macros", version = "0.6.5", path = "libs/modkit-odata-macros" }
-modkit-sdk = { package = "cf-modkit-sdk", version = "0.6.5", path = "libs/modkit-sdk" }
+modkit-odata = { package = "cf-modkit-odata", version = "0.8.1", path = "libs/modkit-odata" }
+modkit-odata-macros = { package = "cf-modkit-odata-macros", version = "0.6.6", path = "libs/modkit-odata-macros" }
+modkit-sdk = { package = "cf-modkit-sdk", version = "0.6.6", path = "libs/modkit-sdk" }
 modkit-security = { package = "cf-modkit-security", version = "0.7.0", path = "libs/modkit-security" }
 modkit-transport-grpc = { package = "cf-modkit-transport-grpc", version = "0.6.4", path = "libs/modkit-transport-grpc" }
 modkit-utils = { package = "cf-modkit-utils", version = "0.6.3", path = "libs/modkit-utils" }
@@ -242,21 +242,21 @@ cf-system-sdks = { version = "0.1.35", path = "libs/system-sdks" }
 cf-system-sdk-directory = { version = "0.1.35", path = "libs/system-sdks/sdks/directory" }
 
 # system modules SDKs
-account-management-sdk = { package = "cf-account-management-sdk", version = "0.1.1", path = "modules/system/account-management/account-management-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "modules/system/types-registry/types-registry-sdk" }
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.6", path = "modules/system/tenant-resolver/tenant-resolver-sdk" }
-authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.6", path = "modules/system/authz-resolver/authz-resolver-sdk" }
-resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.3", path = "modules/system/resource-group/resource-group-sdk" }
-oagw-sdk = { package = "cf-oagw-sdk", version = "0.5.1", path = "modules/system/oagw/oagw-sdk" }
+account-management-sdk = { package = "cf-account-management-sdk", version = "0.1.2", path = "modules/system/account-management/account-management-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "modules/system/types-registry/types-registry-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.7", path = "modules/system/tenant-resolver/tenant-resolver-sdk" }
+authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.7", path = "modules/system/authz-resolver/authz-resolver-sdk" }
+resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.4", path = "modules/system/resource-group/resource-group-sdk" }
+oagw-sdk = { package = "cf-oagw-sdk", version = "0.6.0", path = "modules/system/oagw/oagw-sdk" }
 
 # credstore
-credstore-sdk = { package = "cf-credstore-sdk", version = "0.1.24", path = "modules/credstore/credstore-sdk" }
+credstore-sdk = { package = "cf-credstore-sdk", version = "0.1.25", path = "modules/credstore/credstore-sdk" }
 
 # mini-chat
-mini-chat-sdk = { package = "cf-mini-chat-sdk", version = "0.10.6", path = "modules/mini-chat/mini-chat-sdk" }
+mini-chat-sdk = { package = "cf-mini-chat-sdk", version = "0.10.7", path = "modules/mini-chat/mini-chat-sdk" }
 
 # system modules
-grpc_hub = { package = "cf-grpc-hub", version = "0.2.6", path = "modules/system/grpc-hub" }
+grpc_hub = { package = "cf-grpc-hub", version = "0.2.7", path = "modules/system/grpc-hub" }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/libs/modkit-db/Cargo.toml
+++ b/libs/modkit-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-db"
-version = "0.8.2"
+version = "0.8.3"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-odata-macros/Cargo.toml
+++ b/libs/modkit-odata-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-odata-macros"
-version = "0.6.5"
+version = "0.6.6"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-odata/Cargo.toml
+++ b/libs/modkit-odata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-odata"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-sdk/Cargo.toml
+++ b/libs/modkit-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-sdk"
-version = "0.6.5"
+version = "0.6.6"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit"
-version = "0.6.10"
+version = "0.6.11"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/credstore/credstore-sdk/Cargo.toml
+++ b/modules/credstore/credstore-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-credstore-sdk"
 description = "SDK for credstore module: API traits, models, and error definitions"
-version = "0.1.24"
+version = "0.1.25"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/credstore/credstore/Cargo.toml
+++ b/modules/credstore/credstore/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-credstore"
 description = "credstore gateway module"
-version = "0.1.22"
+version = "0.1.23"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/credstore/plugins/static-credstore-plugin/Cargo.toml
+++ b/modules/credstore/plugins/static-credstore-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-static-credstore-plugin"
-version = "0.1.18"
+version = "0.1.19"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -16,8 +16,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-credstore-sdk = { package = "cf-credstore-sdk", version = "0.1.24", path = "../../credstore-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../../../system/types-registry/types-registry-sdk" }
+credstore-sdk = { package = "cf-credstore-sdk", version = "0.1.25", path = "../../credstore-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../../../system/types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/file-parser/Cargo.toml
+++ b/modules/file-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-file-parser"
-version = "0.1.26"
+version = "0.1.27"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/mini-chat/mini-chat-sdk/Cargo.toml
+++ b/modules/mini-chat/mini-chat-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-mini-chat-sdk"
 description = "SDK for mini-chat: policy plugin traits, models, and errors"
-version = "0.10.6"
+version = "0.10.7"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/mini-chat/mini-chat/Cargo.toml
+++ b/modules/mini-chat/mini-chat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-mini-chat"
 description = "Mini-chat module: multi-tenant AI chat"
-version = "0.1.31"
+version = "0.1.32"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -26,7 +26,7 @@ k8s = ["dep:kube", "dep:k8s-openapi"]
 mini-chat-sdk = { workspace = true }
 
 # AuthN resolver for S2S client credentials exchange
-authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.16", path = "../../system/authn-resolver/authn-resolver-sdk" }
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.17", path = "../../system/authn-resolver/authn-resolver-sdk" }
 
 # AuthZ resolver for authorization (PEP flow)
 authz-resolver-sdk = { workspace = true }

--- a/modules/system/account-management/account-management-sdk/Cargo.toml
+++ b/modules/system/account-management/account-management-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-account-management-sdk"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/account-management/account-management/Cargo.toml
+++ b/modules/system/account-management/account-management/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-account-management"
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/api-gateway/Cargo.toml
+++ b/modules/system/api-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-api-gateway"
-version = "0.2.7"
+version = "0.2.8"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ workspace = true
 modkit = { workspace = true }
 modkit-http = { workspace = true }
 modkit-security = { workspace = true }
-authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.16", path = "../authn-resolver/authn-resolver-sdk" }
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.17", path = "../authn-resolver/authn-resolver-sdk" }
 modkit-macros = { workspace = true }
 inventory = { workspace = true }
 anyhow = { workspace = true }

--- a/modules/system/authn-resolver/authn-resolver-sdk/Cargo.toml
+++ b/modules/system/authn-resolver/authn-resolver-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-authn-resolver-sdk"
-version = "0.3.16"
+version = "0.3.17"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/authn-resolver/authn-resolver/Cargo.toml
+++ b/modules/system/authn-resolver/authn-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-authn-resolver"
-version = "0.2.16"
+version = "0.2.17"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.16", path = "../authn-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../../types-registry/types-registry-sdk" }
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.17", path = "../authn-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/authn-resolver/plugins/static-authn-plugin/Cargo.toml
+++ b/modules/system/authn-resolver/plugins/static-authn-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-static-authn-plugin"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.16", path = "../../authn-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../../../types-registry/types-registry-sdk" }
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.17", path = "../../authn-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/authz-resolver/authz-resolver-sdk/Cargo.toml
+++ b/modules/system/authz-resolver/authz-resolver-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-authz-resolver-sdk"
-version = "0.3.6"
+version = "0.3.7"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/authz-resolver/authz-resolver/Cargo.toml
+++ b/modules/system/authz-resolver/authz-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-authz-resolver"
-version = "0.1.23"
+version = "0.1.24"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.6", path = "../authz-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../../types-registry/types-registry-sdk" }
+authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.7", path = "../authz-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/authz-resolver/plugins/static-authz-plugin/Cargo.toml
+++ b/modules/system/authz-resolver/plugins/static-authz-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-static-authz-plugin"
-version = "0.1.20"
+version = "0.1.21"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.6", path = "../../authz-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../../../types-registry/types-registry-sdk" }
+authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.7", path = "../../authz-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/authz-resolver/plugins/tr-authz-plugin/Cargo.toml
+++ b/modules/system/authz-resolver/plugins/tr-authz-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-tr-authz-plugin"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,9 +18,9 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.6", path = "../../authz-resolver-sdk" }
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.6", path = "../../../tenant-resolver/tenant-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../../../types-registry/types-registry-sdk" }
+authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.7", path = "../../authz-resolver-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.7", path = "../../../tenant-resolver/tenant-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/grpc-hub/Cargo.toml
+++ b/modules/system/grpc-hub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-grpc-hub"
-version = "0.2.6"
+version = "0.2.7"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/module-orchestrator/Cargo.toml
+++ b/modules/system/module-orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-module-orchestrator"
-version = "0.1.25"
+version = "0.1.26"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/nodes-registry/nodes-registry/Cargo.toml
+++ b/modules/system/nodes-registry/nodes-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-nodes-registry"
-version = "0.1.25"
+version = "0.1.26"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/oagw/oagw-sdk/Cargo.toml
+++ b/modules/system/oagw/oagw-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-oagw-sdk"
 description = "SDK for the OpenAPI Gateway: API traits, models, and error definitions"
-version = "0.5.1"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/oagw/oagw/Cargo.toml
+++ b/modules/system/oagw/oagw/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-oagw"
 description = "OAGW module - discovers and routes to plugins"
-version = "0.2.25"
+version = "0.2.26"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ fips = ["modkit-http/fips"]
 test-utils = ["axum/ws", "dep:async-stream", "dep:futures", "dep:tower", "dep:rustls", "tokio/net", "tokio/sync", "tokio/rt"]
 
 [dependencies]
-oagw-sdk = { path = "../oagw-sdk", package="cf-oagw-sdk", version = "0.5.1", features = ["axum"] }
+oagw-sdk = { path = "../oagw-sdk", package="cf-oagw-sdk", version = "0.6.0", features = ["axum"] }
 modkit = { workspace = true }
 modkit-auth = { workspace = true }
 modkit-canonical-errors = { workspace = true, features = ["axum"] }

--- a/modules/system/resource-group/resource-group-sdk/Cargo.toml
+++ b/modules/system/resource-group/resource-group-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 # Created: 2026-04-16 by Constructor Tech
 [package]
 name = "cf-resource-group-sdk"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/resource-group/resource-group/Cargo.toml
+++ b/modules/system/resource-group/resource-group/Cargo.toml
@@ -1,7 +1,7 @@
 # Created: 2026-04-16 by Constructor Tech
 [package]
 name = "cf-resource-group"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -20,7 +20,7 @@ odata = []
 
 [dependencies]
 # SDK - public API, models, and errors
-resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.3", path = "../resource-group-sdk", features = ["odata"] }
+resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.4", path = "../resource-group-sdk", features = ["odata"] }
 
 # Core dependencies
 anyhow = { workspace = true }

--- a/modules/system/tenant-resolver/plugins/rg-tr-plugin/Cargo.toml
+++ b/modules/system/tenant-resolver/plugins/rg-tr-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-rg-tr-plugin"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,9 +18,9 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.6", path = "../../tenant-resolver-sdk" }
-resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.3", path = "../../../resource-group/resource-group-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../../../types-registry/types-registry-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.7", path = "../../tenant-resolver-sdk" }
+resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.4", path = "../../../resource-group/resource-group-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/tenant-resolver/plugins/single-tenant-tr-plugin/Cargo.toml
+++ b/modules/system/tenant-resolver/plugins/single-tenant-tr-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-single-tenant-tr-plugin"
-version = "0.1.22"
+version = "0.1.23"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.6", path = "../../tenant-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../../../types-registry/types-registry-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.7", path = "../../tenant-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/tenant-resolver/plugins/static-tr-plugin/Cargo.toml
+++ b/modules/system/tenant-resolver/plugins/static-tr-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-static-tr-plugin"
-version = "0.1.21"
+version = "0.1.22"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.6", path = "../../tenant-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../../../types-registry/types-registry-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.7", path = "../../tenant-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/tenant-resolver/tenant-resolver-sdk/Cargo.toml
+++ b/modules/system/tenant-resolver/tenant-resolver-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-tenant-resolver-sdk"
-version = "0.3.6"
+version = "0.3.7"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/tenant-resolver/tenant-resolver/Cargo.toml
+++ b/modules/system/tenant-resolver/tenant-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-tenant-resolver"
-version = "0.1.21"
+version = "0.1.22"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.6", path = "../tenant-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../../types-registry/types-registry-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.7", path = "../tenant-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/types-registry/types-registry-sdk/Cargo.toml
+++ b/modules/system/types-registry/types-registry-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-types-registry-sdk"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/types-registry/types-registry/Cargo.toml
+++ b/modules/system/types-registry/types-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-types-registry"
-version = "0.1.22"
+version = "0.1.23"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -19,7 +19,7 @@ doctest = false
 
 [dependencies]
 # SDK - public API, models, and errors
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../types-registry-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../types-registry-sdk" }
 
 # GTS types (from git dependency)
 gts = { workspace = true }

--- a/modules/system/types-sdk/Cargo.toml
+++ b/modules/system/types-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "types-sdk"
-version = "0.6.3"
+version = "0.6.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#1890](https://github.com/cyberfabric/cyberware-rust/pull/1890) | **Author:** github-actions[bot] | **Opened:** 2026-05-09T11:46:17Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---




## 🤖 New release

* `cf-modkit-odata`: 0.8.0 -> 0.8.1 (✓ API compatible changes)
* `cf-modkit`: 0.6.10 -> 0.6.11 (✓ API compatible changes)
* `cf-authz-resolver-sdk`: 0.3.6 -> 0.3.7 (✓ API compatible changes)
* `cf-tenant-resolver-sdk`: 0.3.6 -> 0.3.7 (✓ API compatible changes)
* `cf-credstore-sdk`: 0.1.24 -> 0.1.25 (✓ API compatible changes)
* `cf-oagw-sdk`: 0.5.1 -> 0.6.0 (⚠ API breaking changes)
* `cf-types-registry-sdk`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `cf-oagw`: 0.2.25 -> 0.2.26 (✓ API compatible changes)
* `cf-authn-resolver-sdk`: 0.3.16 -> 0.3.17 (✓ API compatible changes)
* `cf-mini-chat-sdk`: 0.10.6 -> 0.10.7 (✓ API compatible changes)
* `cf-resource-group-sdk`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `cf-types-registry`: 0.1.22 -> 0.1.23 (✓ API compatible changes)
* `cf-account-management-sdk`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `cf-account-management`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)
* `cf-modkit-db`: 0.8.2 -> 0.8.3
* `cf-modkit-odata-macros`: 0.6.5 -> 0.6.6
* `cf-modkit-sdk`: 0.6.5 -> 0.6.6
* `cf-api-gateway`: 0.2.7 -> 0.2.8
* `cf-authn-resolver`: 0.2.16 -> 0.2.17
* `cf-authz-resolver`: 0.1.23 -> 0.1.24
* `cf-grpc-hub`: 0.2.6 -> 0.2.7
* `cf-credstore`: 0.1.22 -> 0.1.23
* `cf-file-parser`: 0.1.26 -> 0.1.27
* `cf-mini-chat`: 0.1.31 -> 0.1.32
* `cf-module-orchestrator`: 0.1.25 -> 0.1.26
* `cf-nodes-registry`: 0.1.25 -> 0.1.26
* `cf-resource-group`: 0.1.3 -> 0.1.4
* `cf-rg-tr-plugin`: 0.1.3 -> 0.1.4
* `cf-single-tenant-tr-plugin`: 0.1.22 -> 0.1.23
* `cf-static-authn-plugin`: 0.3.0 -> 0.3.1
* `cf-static-authz-plugin`: 0.1.20 -> 0.1.21
* `cf-static-credstore-plugin`: 0.1.18 -> 0.1.19
* `cf-static-tr-plugin`: 0.1.21 -> 0.1.22
* `cf-tenant-resolver`: 0.1.21 -> 0.1.22
* `cf-tr-authz-plugin`: 0.1.3 -> 0.1.4
* `types-sdk`: 0.6.3 -> 0.6.4

### ⚠ `cf-oagw-sdk` breaking changes

```text
--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field reason of variant ServiceGatewayError::AuthenticationFailed in /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/oagw/oagw-sdk/src/error.rs:22
  field resource_id of variant ServiceGatewayError::GuardRejected in /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/oagw/oagw-sdk/src/error.rs:71
  field gts_id of variant ServiceGatewayError::PluginNotFound in /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/oagw/oagw-sdk/src/error.rs:87
  field gts_id of variant ServiceGatewayError::PluginInUse in /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/oagw/oagw-sdk/src/error.rs:90
  field reason of variant ServiceGatewayError::Forbidden in /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/oagw/oagw-sdk/src/error.rs:98
```

### ⚠ `cf-account-management` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field AccountManagementConfig.bootstrap in /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/account-management/account-management/src/config.rs:46
  field AccountManagementConfig.integrity_check in /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/account-management/account-management/src/config.rs:53

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant DomainError::CrossTenantDenied 17 -> 18 in /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/account-management/account-management/src/domain/error.rs:141
  variant DomainError::ServiceUnavailable 18 -> 19 in /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/account-management/account-management/src/domain/error.rs:159
  variant DomainError::UnsupportedOperation 19 -> 21 in /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/account-management/account-management/src/domain/error.rs:181
  variant DomainError::Internal 21 -> 23 in /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/account-management/account-management/src/domain/error.rs:201
  variant DomainError::CrossTenantDenied 17 -> 18 in /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/account-management/account-management/src/domain/error.rs:141
  variant DomainError::ServiceUnavailable 18 -> 19 in /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/account-management/account-management/src/domain/error.rs:159
  variant DomainError::UnsupportedOperation 19 -> 21 in /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/account-management/account-management/src/domain/error.rs:181
  variant DomainError::Internal 21 -> 23 in /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/account-management/account-management/src/domain/error.rs:201

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant DomainError::AuditAlreadyRunning, previously in file /tmp/.tmprqZCFN/cf-account-management/src/domain/error.rs:178
  variant DomainError::AuditAlreadyRunning, previously in file /tmp/.tmprqZCFN/cf-account-management/src/domain/error.rs:178

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_method_added.ron

Failed in:
  trait method account_management::domain::tenant::repo::TenantRepo::run_integrity_check in file /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/account-management/account-management/src/domain/tenant/repo.rs:438
  trait method account_management::domain::tenant::repo::TenantRepo::repair_derivable_closure_violations in file /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/account-management/account-management/src/domain/tenant/repo.rs:504
  trait method account_management::domain::tenant::TenantRepo::run_integrity_check in file /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/account-management/account-management/src/domain/tenant/repo.rs:438
  trait method account_management::domain::tenant::TenantRepo::repair_derivable_closure_violations in file /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/account-management/account-management/src/domain/tenant/repo.rs:504
  trait method account_management::TenantRepo::run_integrity_check in file /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/account-management/account-management/src/domain/tenant/repo.rs:438
  trait method account_management::TenantRepo::repair_derivable_closure_violations in file /tmp/.tmp4MnSmq/cyberfabric-core/modules/system/account-management/account-management/src/domain/tenant/repo.rs:504
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `cf-modkit`

<blockquote>


## [0.6.11](https://github.com/constructorfabric/cyberfabric-core/compare/cf-modkit-v0.6.10...cf-modkit-v0.6.11) - 2026-05-10

### Other

- Merge pull request #3586 from vgprod/vgprod/1574-crypto-oncelock (by &#2369;Artifizer) - #3586

### Contributors

* &#2369;Artifizer
</blockquote>











## `cf-account-management-sdk`

<blockquote>


## [0.1.2](https://github.com/constructorfabric/cyberfabric-core/compare/cf-account-management-sdk-v0.1.1...cf-account-management-sdk-v0.1.2) - 2026-05-10

### Added

- *(account-management)* hierarchy integrity check + auto-repair + platform-bootstrap saga (by &#2369;diffora)

### Other

- Merge pull request #3524 from diffora/am/03-integrity-and-bootstrap (by &#2369;Artifizer) - #3524

### Contributors

* &#2369;Artifizer
* &#2369;diffora
</blockquote>

## `cf-account-management`

<blockquote>


## [0.2.0](https://github.com/constructorfabric/cyberfabric-core/compare/cf-account-management-v0.1.1...cf-account-management-v0.2.0) - 2026-05-10

### Added

- *(account-management)* hierarchy integrity check + auto-repair + platform-bootstrap saga (by &#2369;diffora)

### Other

- Merge pull request #3524 from diffora/am/03-integrity-and-bootstrap (by &#2369;Artifizer) - #3524

### Contributors

* &#2369;Artifizer
* &#2369;diffora
</blockquote>














## `cf-rg-tr-plugin`

<blockquote>


## [0.1.4](https://github.com/constructorfabric/cyberfabric-core/compare/cf-rg-tr-plugin-v0.1.3...cf-rg-tr-plugin-v0.1.4) - 2026-05-10

### Other

- updated the following local packages: cf-modkit-odata, cf-modkit, cf-tenant-resolver-sdk, cf-types-registry-sdk, cf-resource-group-sdk
</blockquote>

## `cf-single-tenant-tr-plugin`

<blockquote>


## [0.1.23](https://github.com/constructorfabric/cyberfabric-core/compare/cf-single-tenant-tr-plugin-v0.1.22...cf-single-tenant-tr-plugin-v0.1.23) - 2026-05-10

### Other

- updated the following local packages: cf-modkit-odata, cf-modkit, cf-tenant-resolver-sdk, cf-types-registry-sdk
</blockquote>

## `cf-static-authn-plugin`

<blockquote>


## [0.3.1](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-authn-plugin-v0.3.0...cf-static-authn-plugin-v0.3.1) - 2026-05-10

### Other

- updated the following local packages: cf-modkit, cf-types-registry-sdk, cf-authn-resolver-sdk
</blockquote>

## `cf-static-authz-plugin`

<blockquote>


## [0.1.21](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-authz-plugin-v0.1.20...cf-static-authz-plugin-v0.1.21) - 2026-05-10

### Other

- updated the following local packages: cf-modkit, cf-authz-resolver-sdk, cf-types-registry-sdk
</blockquote>

## `cf-static-credstore-plugin`

<blockquote>


## [0.1.19](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-credstore-plugin-v0.1.18...cf-static-credstore-plugin-v0.1.19) - 2026-05-10

### Other

- updated the following local packages: cf-modkit, cf-credstore-sdk, cf-types-registry-sdk
</blockquote>

## `cf-static-tr-plugin`

<blockquote>


## [0.1.22](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-tr-plugin-v0.1.21...cf-static-tr-plugin-v0.1.22) - 2026-05-10

### Other

- updated the following local packages: cf-modkit-odata, cf-modkit, cf-tenant-resolver-sdk, cf-types-registry-sdk
</blockquote>


## `cf-tr-authz-plugin`

<blockquote>


## [0.1.4](https://github.com/constructorfabric/cyberfabric-core/compare/cf-tr-authz-plugin-v0.1.3...cf-tr-authz-plugin-v0.1.4) - 2026-05-10

### Other

- updated the following local packages: cf-modkit, cf-authz-resolver-sdk, cf-tenant-resolver-sdk, cf-types-registry-sdk
</blockquote>

## `types-sdk`

<blockquote>


## [0.6.4](https://github.com/constructorfabric/cyberfabric-core/compare/types-sdk-v0.6.3...types-sdk-v0.6.4) - 2026-05-10

### Other

- updated the following local packages: cf-modkit-odata
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#1890 -->