### PR TITLE
[PR #1887] chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,48 @@ release-plz updates this file in the Release PR.
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/cyberfabric/cyberfabric-core/compare/cf-tr-authz-plugin-v0.1.3...cf-tr-authz-plugin-v0.1.4) - 2026-05-09
+
+### Other
+
+- updated the following local packages: cf-modkit, cf-authz-resolver-sdk, cf-tenant-resolver-sdk, cf-types-registry-sdk
+
+## [0.1.22](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-tr-plugin-v0.1.21...cf-static-tr-plugin-v0.1.22) - 2026-05-09
+
+### Other
+
+- updated the following local packages: cf-modkit, cf-tenant-resolver-sdk, cf-types-registry-sdk
+
+## [0.1.19](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-credstore-plugin-v0.1.18...cf-static-credstore-plugin-v0.1.19) - 2026-05-09
+
+### Other
+
+- updated the following local packages: cf-modkit, cf-credstore-sdk, cf-types-registry-sdk
+
+## [0.1.21](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-authz-plugin-v0.1.20...cf-static-authz-plugin-v0.1.21) - 2026-05-09
+
+### Other
+
+- updated the following local packages: cf-modkit, cf-authz-resolver-sdk, cf-types-registry-sdk
+
+## [0.3.1](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-authn-plugin-v0.3.0...cf-static-authn-plugin-v0.3.1) - 2026-05-09
+
+### Other
+
+- updated the following local packages: cf-modkit, cf-types-registry-sdk, cf-authn-resolver-sdk
+
+## [0.1.23](https://github.com/cyberfabric/cyberfabric-core/compare/cf-single-tenant-tr-plugin-v0.1.22...cf-single-tenant-tr-plugin-v0.1.23) - 2026-05-09
+
+### Other
+
+- updated the following local packages: cf-modkit, cf-tenant-resolver-sdk, cf-types-registry-sdk
+
+## [0.1.4](https://github.com/cyberfabric/cyberfabric-core/compare/cf-rg-tr-plugin-v0.1.3...cf-rg-tr-plugin-v0.1.4) - 2026-05-09
+
+### Other
+
+- updated the following local packages: cf-modkit, cf-tenant-resolver-sdk, cf-types-registry-sdk, cf-resource-group-sdk
+
 ## [0.1.1](https://github.com/cyberfabric/cyberfabric-core/compare/cf-account-management-v0.1.0...cf-account-management-v0.1.1) - 2026-05-07
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "cf-account-management"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "cf-account-management-sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "cf-modkit-canonical-errors",
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "cf-api-gateway"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1454,7 +1454,7 @@ dependencies = [
 
 [[package]]
 name = "cf-authn-resolver"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "cf-authn-resolver-sdk"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "cf-authz-resolver"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1511,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "cf-authz-resolver-sdk"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "cf-credstore"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1551,7 +1551,7 @@ dependencies = [
 
 [[package]]
 name = "cf-credstore-sdk"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "cf-file-parser"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "cf-grpc-hub"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "cf-mini-chat"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "cf-mini-chat-sdk"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "cf-module-orchestrator"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "cf-nodes-registry"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "cf-oagw"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "cf-resource-group"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "cf-resource-group-sdk"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -2243,7 +2243,7 @@ dependencies = [
 
 [[package]]
 name = "cf-rg-tr-plugin"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "cf-single-tenant-tr-plugin"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2395,7 +2395,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-authn-plugin"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2415,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-authz-plugin"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2434,7 +2434,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-credstore-plugin"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2454,7 +2454,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-tr-plugin"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2496,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "cf-tenant-resolver"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2517,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "cf-tenant-resolver-sdk"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "cf-tr-authz-plugin"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2554,7 +2554,7 @@ dependencies = [
 
 [[package]]
 name = "cf-types-registry"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2580,7 +2580,7 @@ dependencies = [
 
 [[package]]
 name = "cf-types-registry-sdk"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "gts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,7 +220,7 @@ verbose_file_reads = "deny"
 
 [workspace.dependencies]
 # libs
-modkit = { package = "cf-modkit", version = "0.6.10", path = "libs/modkit" }
+modkit = { package = "cf-modkit", version = "0.6.11", path = "libs/modkit" }
 modkit-http = { package = "cf-modkit-http", version = "0.6.5", path = "libs/modkit-http" }
 modkit-auth = { package = "cf-modkit-auth", version = "0.7.0", path = "libs/modkit-auth" }
 modkit-canonical-errors = { package = "cf-modkit-canonical-errors", version = "0.7.3", path = "libs/modkit-canonical-errors" }
@@ -242,21 +242,21 @@ cf-system-sdks = { version = "0.1.35", path = "libs/system-sdks" }
 cf-system-sdk-directory = { version = "0.1.35", path = "libs/system-sdks/sdks/directory" }
 
 # system modules SDKs
-account-management-sdk = { package = "cf-account-management-sdk", version = "0.1.1", path = "modules/system/account-management/account-management-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "modules/system/types-registry/types-registry-sdk" }
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.6", path = "modules/system/tenant-resolver/tenant-resolver-sdk" }
-authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.6", path = "modules/system/authz-resolver/authz-resolver-sdk" }
-resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.3", path = "modules/system/resource-group/resource-group-sdk" }
+account-management-sdk = { package = "cf-account-management-sdk", version = "0.1.2", path = "modules/system/account-management/account-management-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "modules/system/types-registry/types-registry-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.7", path = "modules/system/tenant-resolver/tenant-resolver-sdk" }
+authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.7", path = "modules/system/authz-resolver/authz-resolver-sdk" }
+resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.4", path = "modules/system/resource-group/resource-group-sdk" }
 oagw-sdk = { package = "cf-oagw-sdk", version = "0.5.1", path = "modules/system/oagw/oagw-sdk" }
 
 # credstore
-credstore-sdk = { package = "cf-credstore-sdk", version = "0.1.24", path = "modules/credstore/credstore-sdk" }
+credstore-sdk = { package = "cf-credstore-sdk", version = "0.1.25", path = "modules/credstore/credstore-sdk" }
 
 # mini-chat
-mini-chat-sdk = { package = "cf-mini-chat-sdk", version = "0.10.6", path = "modules/mini-chat/mini-chat-sdk" }
+mini-chat-sdk = { package = "cf-mini-chat-sdk", version = "0.10.7", path = "modules/mini-chat/mini-chat-sdk" }
 
 # system modules
-grpc_hub = { package = "cf-grpc-hub", version = "0.2.6", path = "modules/system/grpc-hub" }
+grpc_hub = { package = "cf-grpc-hub", version = "0.2.7", path = "modules/system/grpc-hub" }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit"
-version = "0.6.10"
+version = "0.6.11"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/credstore/credstore-sdk/Cargo.toml
+++ b/modules/credstore/credstore-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-credstore-sdk"
 description = "SDK for credstore module: API traits, models, and error definitions"
-version = "0.1.24"
+version = "0.1.25"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/credstore/credstore/Cargo.toml
+++ b/modules/credstore/credstore/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-credstore"
 description = "credstore gateway module"
-version = "0.1.22"
+version = "0.1.23"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/credstore/plugins/static-credstore-plugin/Cargo.toml
+++ b/modules/credstore/plugins/static-credstore-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-static-credstore-plugin"
-version = "0.1.18"
+version = "0.1.19"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -16,8 +16,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-credstore-sdk = { package = "cf-credstore-sdk", version = "0.1.24", path = "../../credstore-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../../../system/types-registry/types-registry-sdk" }
+credstore-sdk = { package = "cf-credstore-sdk", version = "0.1.25", path = "../../credstore-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../../../system/types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/file-parser/Cargo.toml
+++ b/modules/file-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-file-parser"
-version = "0.1.26"
+version = "0.1.27"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/mini-chat/mini-chat-sdk/Cargo.toml
+++ b/modules/mini-chat/mini-chat-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-mini-chat-sdk"
 description = "SDK for mini-chat: policy plugin traits, models, and errors"
-version = "0.10.6"
+version = "0.10.7"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/mini-chat/mini-chat/Cargo.toml
+++ b/modules/mini-chat/mini-chat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-mini-chat"
 description = "Mini-chat module: multi-tenant AI chat"
-version = "0.1.31"
+version = "0.1.32"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -26,7 +26,7 @@ k8s = ["dep:kube", "dep:k8s-openapi"]
 mini-chat-sdk = { workspace = true }
 
 # AuthN resolver for S2S client credentials exchange
-authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.16", path = "../../system/authn-resolver/authn-resolver-sdk" }
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.17", path = "../../system/authn-resolver/authn-resolver-sdk" }
 
 # AuthZ resolver for authorization (PEP flow)
 authz-resolver-sdk = { workspace = true }

--- a/modules/system/account-management/account-management-sdk/Cargo.toml
+++ b/modules/system/account-management/account-management-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-account-management-sdk"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/account-management/account-management/Cargo.toml
+++ b/modules/system/account-management/account-management/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-account-management"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/api-gateway/Cargo.toml
+++ b/modules/system/api-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-api-gateway"
-version = "0.2.7"
+version = "0.2.8"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ workspace = true
 modkit = { workspace = true }
 modkit-http = { workspace = true }
 modkit-security = { workspace = true }
-authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.16", path = "../authn-resolver/authn-resolver-sdk" }
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.17", path = "../authn-resolver/authn-resolver-sdk" }
 modkit-macros = { workspace = true }
 inventory = { workspace = true }
 anyhow = { workspace = true }

--- a/modules/system/authn-resolver/authn-resolver-sdk/Cargo.toml
+++ b/modules/system/authn-resolver/authn-resolver-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-authn-resolver-sdk"
-version = "0.3.16"
+version = "0.3.17"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/authn-resolver/authn-resolver/Cargo.toml
+++ b/modules/system/authn-resolver/authn-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-authn-resolver"
-version = "0.2.16"
+version = "0.2.17"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.16", path = "../authn-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../../types-registry/types-registry-sdk" }
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.17", path = "../authn-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/authn-resolver/plugins/static-authn-plugin/Cargo.toml
+++ b/modules/system/authn-resolver/plugins/static-authn-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-static-authn-plugin"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.16", path = "../../authn-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../../../types-registry/types-registry-sdk" }
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.17", path = "../../authn-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/authz-resolver/authz-resolver-sdk/Cargo.toml
+++ b/modules/system/authz-resolver/authz-resolver-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-authz-resolver-sdk"
-version = "0.3.6"
+version = "0.3.7"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/authz-resolver/authz-resolver/Cargo.toml
+++ b/modules/system/authz-resolver/authz-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-authz-resolver"
-version = "0.1.23"
+version = "0.1.24"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.6", path = "../authz-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../../types-registry/types-registry-sdk" }
+authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.7", path = "../authz-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/authz-resolver/plugins/static-authz-plugin/Cargo.toml
+++ b/modules/system/authz-resolver/plugins/static-authz-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-static-authz-plugin"
-version = "0.1.20"
+version = "0.1.21"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.6", path = "../../authz-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../../../types-registry/types-registry-sdk" }
+authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.7", path = "../../authz-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/authz-resolver/plugins/tr-authz-plugin/Cargo.toml
+++ b/modules/system/authz-resolver/plugins/tr-authz-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-tr-authz-plugin"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,9 +18,9 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.6", path = "../../authz-resolver-sdk" }
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.6", path = "../../../tenant-resolver/tenant-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../../../types-registry/types-registry-sdk" }
+authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.7", path = "../../authz-resolver-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.7", path = "../../../tenant-resolver/tenant-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/grpc-hub/Cargo.toml
+++ b/modules/system/grpc-hub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-grpc-hub"
-version = "0.2.6"
+version = "0.2.7"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/module-orchestrator/Cargo.toml
+++ b/modules/system/module-orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-module-orchestrator"
-version = "0.1.25"
+version = "0.1.26"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/nodes-registry/nodes-registry/Cargo.toml
+++ b/modules/system/nodes-registry/nodes-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-nodes-registry"
-version = "0.1.25"
+version = "0.1.26"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/oagw/oagw/Cargo.toml
+++ b/modules/system/oagw/oagw/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-oagw"
 description = "OAGW module - discovers and routes to plugins"
-version = "0.2.25"
+version = "0.2.26"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/resource-group/resource-group-sdk/Cargo.toml
+++ b/modules/system/resource-group/resource-group-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 # Created: 2026-04-16 by Constructor Tech
 [package]
 name = "cf-resource-group-sdk"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/resource-group/resource-group/Cargo.toml
+++ b/modules/system/resource-group/resource-group/Cargo.toml
@@ -1,7 +1,7 @@
 # Created: 2026-04-16 by Constructor Tech
 [package]
 name = "cf-resource-group"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -20,7 +20,7 @@ odata = []
 
 [dependencies]
 # SDK - public API, models, and errors
-resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.3", path = "../resource-group-sdk", features = ["odata"] }
+resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.4", path = "../resource-group-sdk", features = ["odata"] }
 
 # Core dependencies
 anyhow = { workspace = true }

--- a/modules/system/tenant-resolver/plugins/rg-tr-plugin/Cargo.toml
+++ b/modules/system/tenant-resolver/plugins/rg-tr-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-rg-tr-plugin"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,9 +18,9 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.6", path = "../../tenant-resolver-sdk" }
-resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.3", path = "../../../resource-group/resource-group-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../../../types-registry/types-registry-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.7", path = "../../tenant-resolver-sdk" }
+resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.4", path = "../../../resource-group/resource-group-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/tenant-resolver/plugins/single-tenant-tr-plugin/Cargo.toml
+++ b/modules/system/tenant-resolver/plugins/single-tenant-tr-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-single-tenant-tr-plugin"
-version = "0.1.22"
+version = "0.1.23"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.6", path = "../../tenant-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../../../types-registry/types-registry-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.7", path = "../../tenant-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/tenant-resolver/plugins/static-tr-plugin/Cargo.toml
+++ b/modules/system/tenant-resolver/plugins/static-tr-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-static-tr-plugin"
-version = "0.1.21"
+version = "0.1.22"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.6", path = "../../tenant-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../../../types-registry/types-registry-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.7", path = "../../tenant-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/tenant-resolver/tenant-resolver-sdk/Cargo.toml
+++ b/modules/system/tenant-resolver/tenant-resolver-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-tenant-resolver-sdk"
-version = "0.3.6"
+version = "0.3.7"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/tenant-resolver/tenant-resolver/Cargo.toml
+++ b/modules/system/tenant-resolver/tenant-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-tenant-resolver"
-version = "0.1.21"
+version = "0.1.22"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.6", path = "../tenant-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../../types-registry/types-registry-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.7", path = "../tenant-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/types-registry/types-registry-sdk/Cargo.toml
+++ b/modules/system/types-registry/types-registry-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-types-registry-sdk"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/types-registry/types-registry/Cargo.toml
+++ b/modules/system/types-registry/types-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-types-registry"
-version = "0.1.22"
+version = "0.1.23"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -19,7 +19,7 @@ doctest = false
 
 [dependencies]
 # SDK - public API, models, and errors
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.2", path = "../types-registry-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.3", path = "../types-registry-sdk" }
 
 # GTS types (from git dependency)
 gts = { workspace = true }


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#1887](https://github.com/cyberfabric/cyberware-rust/pull/1887) | **Author:** github-actions[bot] | **Opened:** 2026-05-09T11:08:25Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---




## 🤖 New release

* `cf-modkit`: 0.6.10 -> 0.6.11 (✓ API compatible changes)
* `cf-authz-resolver-sdk`: 0.3.6 -> 0.3.7 (✓ API compatible changes)
* `cf-tenant-resolver-sdk`: 0.3.6 -> 0.3.7 (✓ API compatible changes)
* `cf-credstore-sdk`: 0.1.24 -> 0.1.25 (✓ API compatible changes)
* `cf-types-registry-sdk`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `cf-oagw`: 0.2.25 -> 0.2.26 (✓ API compatible changes)
* `cf-authn-resolver-sdk`: 0.3.16 -> 0.3.17 (✓ API compatible changes)
* `cf-mini-chat-sdk`: 0.10.6 -> 0.10.7 (✓ API compatible changes)
* `cf-resource-group-sdk`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `cf-types-registry`: 0.1.22 -> 0.1.23 (✓ API compatible changes)
* `cf-account-management-sdk`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `cf-account-management`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `cf-api-gateway`: 0.2.7 -> 0.2.8
* `cf-authn-resolver`: 0.2.16 -> 0.2.17
* `cf-authz-resolver`: 0.1.23 -> 0.1.24
* `cf-grpc-hub`: 0.2.6 -> 0.2.7
* `cf-credstore`: 0.1.22 -> 0.1.23
* `cf-file-parser`: 0.1.26 -> 0.1.27
* `cf-mini-chat`: 0.1.31 -> 0.1.32
* `cf-module-orchestrator`: 0.1.25 -> 0.1.26
* `cf-nodes-registry`: 0.1.25 -> 0.1.26
* `cf-resource-group`: 0.1.3 -> 0.1.4
* `cf-rg-tr-plugin`: 0.1.3 -> 0.1.4
* `cf-single-tenant-tr-plugin`: 0.1.22 -> 0.1.23
* `cf-static-authn-plugin`: 0.3.0 -> 0.3.1
* `cf-static-authz-plugin`: 0.1.20 -> 0.1.21
* `cf-static-credstore-plugin`: 0.1.18 -> 0.1.19
* `cf-static-tr-plugin`: 0.1.21 -> 0.1.22
* `cf-tenant-resolver`: 0.1.21 -> 0.1.22
* `cf-tr-authz-plugin`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `cf-modkit`

<blockquote>


## [0.6.11](https://github.com/constructorfabric/cyberfabric-core/compare/cf-modkit-v0.6.10...cf-modkit-v0.6.11) - 2026-05-09

### Other

- update Cargo.toml dependencies
</blockquote>










## `cf-account-management-sdk`

<blockquote>


## [0.1.2](https://github.com/constructorfabric/cyberfabric-core/compare/cf-account-management-sdk-v0.1.1...cf-account-management-sdk-v0.1.2) - 2026-05-09

### Other

- update Cargo.toml dependencies
</blockquote>

## `cf-account-management`

<blockquote>


## [0.1.2](https://github.com/constructorfabric/cyberfabric-core/compare/cf-account-management-v0.1.1...cf-account-management-v0.1.2) - 2026-05-09

### Other

- update Cargo.toml dependencies
</blockquote>











## `cf-rg-tr-plugin`

<blockquote>


## [0.1.4](https://github.com/constructorfabric/cyberfabric-core/compare/cf-rg-tr-plugin-v0.1.3...cf-rg-tr-plugin-v0.1.4) - 2026-05-09

### Other

- updated the following local packages: cf-modkit, cf-tenant-resolver-sdk, cf-types-registry-sdk, cf-resource-group-sdk
</blockquote>

## `cf-single-tenant-tr-plugin`

<blockquote>


## [0.1.23](https://github.com/constructorfabric/cyberfabric-core/compare/cf-single-tenant-tr-plugin-v0.1.22...cf-single-tenant-tr-plugin-v0.1.23) - 2026-05-09

### Other

- updated the following local packages: cf-modkit, cf-tenant-resolver-sdk, cf-types-registry-sdk
</blockquote>

## `cf-static-authn-plugin`

<blockquote>


## [0.3.1](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-authn-plugin-v0.3.0...cf-static-authn-plugin-v0.3.1) - 2026-05-09

### Other

- updated the following local packages: cf-modkit, cf-types-registry-sdk, cf-authn-resolver-sdk
</blockquote>

## `cf-static-authz-plugin`

<blockquote>


## [0.1.21](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-authz-plugin-v0.1.20...cf-static-authz-plugin-v0.1.21) - 2026-05-09

### Other

- updated the following local packages: cf-modkit, cf-authz-resolver-sdk, cf-types-registry-sdk
</blockquote>

## `cf-static-credstore-plugin`

<blockquote>


## [0.1.19](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-credstore-plugin-v0.1.18...cf-static-credstore-plugin-v0.1.19) - 2026-05-09

### Other

- updated the following local packages: cf-modkit, cf-credstore-sdk, cf-types-registry-sdk
</blockquote>

## `cf-static-tr-plugin`

<blockquote>


## [0.1.22](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-tr-plugin-v0.1.21...cf-static-tr-plugin-v0.1.22) - 2026-05-09

### Other

- updated the following local packages: cf-modkit, cf-tenant-resolver-sdk, cf-types-registry-sdk
</blockquote>


## `cf-tr-authz-plugin`

<blockquote>


## [0.1.4](https://github.com/constructorfabric/cyberfabric-core/compare/cf-tr-authz-plugin-v0.1.3...cf-tr-authz-plugin-v0.1.4) - 2026-05-09

### Other

- updated the following local packages: cf-modkit, cf-authz-resolver-sdk, cf-tenant-resolver-sdk, cf-types-registry-sdk
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#1887 -->