### PR TITLE
[PR #1816] feat(usage-collector): [3/6] add REST client crate for remote ingest delivery

### DIFF
--- a/.cypilot/config/artifacts.toml
+++ b/.cypilot/config/artifacts.toml
@@ -6,6 +6,17 @@ reason = "Ignore rust-traits.md — reference document for planned Rust SDK cont
 patterns = ["modules/system/resource-group/docs/rust-traits.md"]
 
 [[ignore]]
+reason = "Ignore usage-collector codebase and features — code traceability markers added incrementally across PR train. Remove after all PRs merged."
+patterns = [
+  "modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/*",
+  "modules/system/usage-collector/usage-collector/src/*",
+  "modules/system/usage-collector/usage-collector-rest-client/src/*",
+  "modules/system/usage-collector/usage-collector-sdk/src/*",
+  "modules/system/usage-collector/usage-emitter/src/*",
+  "modules/system/usage-collector/docs/features/*",
+]
+
+[[ignore]]
 reason = "Ignore 'modules/system' parent directory — not a module, only a grouping for system submodules."
 patterns = ["modules/system"]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2093,6 +2093,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cf-noop-usage-collector-storage-plugin"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cf-modkit",
+ "cf-modkit-macros",
+ "cf-types-registry-sdk",
+ "cf-usage-collector-sdk",
+ "chrono",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "cf-oagw"
 version = "0.2.23"
 dependencies = [
@@ -2573,6 +2591,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cf-usage-collector"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "cf-authz-resolver-sdk",
+ "cf-modkit",
+ "cf-modkit-db",
+ "cf-modkit-macros",
+ "cf-modkit-security",
+ "cf-modkit-utils",
+ "cf-types-registry-sdk",
+ "cf-usage-collector-sdk",
+ "cf-usage-emitter",
+ "chrono",
+ "http",
+ "sea-orm-migration",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tracing",
+ "utoipa",
+ "uuid",
+]
+
+[[package]]
 name = "cf-usage-collector-sdk"
 version = "0.1.0"
 dependencies = [
@@ -2587,6 +2634,26 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "utoipa",
+ "uuid",
+]
+
+[[package]]
+name = "cf-usage-emitter"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cf-authz-resolver-sdk",
+ "cf-modkit-db",
+ "cf-modkit-security",
+ "cf-usage-collector-sdk",
+ "chrono",
+ "sea-orm-migration",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2620,6 +2620,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "cf-usage-collector-rest-client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cf-authn-resolver-sdk",
+ "cf-authz-resolver-sdk",
+ "cf-modkit",
+ "cf-modkit-db",
+ "cf-modkit-http",
+ "cf-modkit-macros",
+ "cf-modkit-security",
+ "cf-modkit-utils",
+ "cf-usage-collector-sdk",
+ "cf-usage-emitter",
+ "chrono",
+ "http",
+ "httpmock",
+ "sea-orm-migration",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "url",
+ "urlencoding",
+ "uuid",
+]
+
+[[package]]
 name = "cf-usage-collector-sdk"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,6 +2573,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cf-usage-collector-sdk"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "cf-modkit",
+ "chrono",
+ "gts",
+ "gts-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "utoipa",
+ "uuid",
+]
+
+[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ members = [
     "modules/mini-chat/mini-chat",
     "modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin",
     "modules/system/usage-collector/usage-collector",
+    "modules/system/usage-collector/usage-collector-rest-client",
     "modules/system/usage-collector/usage-collector-sdk",
     "modules/system/usage-collector/usage-emitter",
 ]
@@ -262,6 +263,7 @@ mini-chat-sdk = { package = "cf-mini-chat-sdk", version = "0.10.4", path = "modu
 
 # usage-collector
 usage-collector = { package = "cf-usage-collector", version = "0.1.0", path = "modules/system/usage-collector/usage-collector" }
+usage-collector-rest-client = { package = "cf-usage-collector-rest-client", version = "0.1.0", path = "modules/system/usage-collector/usage-collector-rest-client" }
 usage-collector-sdk = { package = "cf-usage-collector-sdk", version = "0.1.0", path = "modules/system/usage-collector/usage-collector-sdk" }
 usage-emitter = { package = "cf-usage-emitter", version = "0.1.0", path = "modules/system/usage-collector/usage-emitter" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ members = [
     "modules/system/oagw/oagw-sdk",
     "modules/mini-chat/mini-chat-sdk",
     "modules/mini-chat/mini-chat",
+    "modules/system/usage-collector/usage-collector-sdk",
 ]
 exclude = ["tools/fuzz"]
 resolver = "3"
@@ -254,6 +255,9 @@ credstore-sdk = { package = "cf-credstore-sdk", version = "0.1.22", path = "modu
 
 # mini-chat
 mini-chat-sdk = { package = "cf-mini-chat-sdk", version = "0.10.4", path = "modules/mini-chat/mini-chat-sdk" }
+
+# usage-collector
+usage-collector-sdk = { package = "cf-usage-collector-sdk", version = "0.1.0", path = "modules/system/usage-collector/usage-collector-sdk" }
 
 # system modules
 grpc_hub = { package = "cf-grpc-hub", version = "0.2.4", path = "modules/system/grpc-hub" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,10 @@ members = [
     "modules/system/oagw/oagw-sdk",
     "modules/mini-chat/mini-chat-sdk",
     "modules/mini-chat/mini-chat",
+    "modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin",
+    "modules/system/usage-collector/usage-collector",
     "modules/system/usage-collector/usage-collector-sdk",
+    "modules/system/usage-collector/usage-emitter",
 ]
 exclude = ["tools/fuzz"]
 resolver = "3"
@@ -246,6 +249,7 @@ cf-system-sdk-directory = { version = "0.1.34", path = "libs/system-sdks/sdks/di
 account-management-sdk = { package = "cf-account-management-sdk", version = "0.1.0", path = "modules/system/account-management/account-management-sdk" }
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.1", path = "modules/system/types-registry/types-registry-sdk" }
 tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.4", path = "modules/system/tenant-resolver/tenant-resolver-sdk" }
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.14", path = "modules/system/authn-resolver/authn-resolver-sdk" }
 authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.4", path = "modules/system/authz-resolver/authz-resolver-sdk" }
 resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.1", path = "modules/system/resource-group/resource-group-sdk" }
 oagw-sdk = { package = "cf-oagw-sdk", version = "0.5.0", path = "modules/system/oagw/oagw-sdk" }
@@ -257,7 +261,9 @@ credstore-sdk = { package = "cf-credstore-sdk", version = "0.1.22", path = "modu
 mini-chat-sdk = { package = "cf-mini-chat-sdk", version = "0.10.4", path = "modules/mini-chat/mini-chat-sdk" }
 
 # usage-collector
+usage-collector = { package = "cf-usage-collector", version = "0.1.0", path = "modules/system/usage-collector/usage-collector" }
 usage-collector-sdk = { package = "cf-usage-collector-sdk", version = "0.1.0", path = "modules/system/usage-collector/usage-collector-sdk" }
+usage-emitter = { package = "cf-usage-emitter", version = "0.1.0", path = "modules/system/usage-collector/usage-emitter" }
 
 # system modules
 grpc_hub = { package = "cf-grpc-hub", version = "0.2.4", path = "modules/system/grpc-hub" }

--- a/modules/system/usage-collector/docs/ADR/0001-cpt-cf-usage-collector-adr-scoped-emit-source.md
+++ b/modules/system/usage-collector/docs/ADR/0001-cpt-cf-usage-collector-adr-scoped-emit-source.md
@@ -47,40 +47,40 @@ Chosen option: "`for_module()` scoped client bound once at module init", because
 
 ### Consequences
 
-* Good, because call sites remain clean — `emit(ctx, record)` carries no source boilerplate
+* Good, because call sites remain clean — `build_usage_record(...).enqueue()` carries no source boilerplate
 * Good, because the `for_module()` call in module init is the single, auditable point where source is declared, using the compile-time `MODULE_NAME` constant rather than a free-form string
-* Good, because the SDK can enforce metric prefix consistency at `emit()` time and fail fast in the source process before the outbox is written
+* Good, because the emitter validates the metric against the allowed-metrics list at `enqueue()` time and fails fast in the source process before the outbox is written
 * Good, because the module name used for attribution is the same authoritative name registered in the module orchestrator, not a separately maintained string
-* Bad, because consuming modules must store a `ScopedUsageCollectorClientV1` wrapper rather than the raw `UsageCollectorClientV1` trait object — a minor change to client storage conventions
+* Bad, because consuming modules must store a `ScopedUsageEmitter` wrapper rather than the raw `UsageCollectorClientV1` trait object — a minor change to client storage conventions
 * Bad, because source attribution remains self-asserted — a developer can deliberately pass any module name to `for_module()`; this is acceptable given the internal threat model but would not withstand adversarial bypass
 
 ### Confirmation
 
 * Code review: verify each consuming module calls `for_module()` with its own `MODULE_NAME` constant (e.g., `LlmGatewayModule::MODULE_NAME`), not another module's constant
-* SDK unit tests: verify `ScopedUsageCollectorClientV1::emit()` returns an error when the metric name does not start with the declared source module prefix
-* Integration test: verify that emitting a metric with a mismatched prefix (e.g., a file-storage scoped client emitting `llm-gateway.tokens.input`) is rejected at the SDK level before reaching the outbox
+* SDK unit tests: verify `ScopedUsageEmitter::authorize_for()` followed by `build_usage_record(...).enqueue()` returns `UsageEmitterError::MetricNotAllowed` when the metric name is not in the `allowed_metrics` list for the declared source module
+* Integration test: verify that emitting a metric not present in the module's `allowed_metrics` config (e.g., a file-storage scoped emitter attempting to emit `llm-gateway.tokens.input`) is rejected at the SDK level before reaching the outbox
 
 ## Pros and Cons of the Options
 
 ### Per-call source declaration on `emit()` or `UsageRecord`
 
-Pass `source_module` as an explicit parameter to `emit()` or as a required field on `UsageRecord` on every call.
+Pass `source_module` as an explicit parameter to `enqueue()` or as a required field on `UsageRecord` on every call.
 
 * Good, because source attribution is explicit and visible at every call site
 * Good, because no additional wrapper type is required
-* Bad, because every `emit()` call site carries a repetitive boilerplate parameter
-* Bad, because there is no single auditable binding point — the correct module name must be passed correctly across every emit call, increasing the risk of copy-paste errors
+* Bad, because every `enqueue()` call site carries a repetitive boilerplate parameter
+* Bad, because there is no single auditable binding point — the correct module name must be passed correctly across every enqueue call, increasing the risk of copy-paste errors
 * Bad, because there is no natural place to derive the value from `Self::MODULE_NAME`; the call site must supply it manually each time
 
 ### `for_module()` scoped client bound once at module init
 
-The SDK exposes `for_module(name: &str) -> ScopedUsageCollectorClientV1`. Each consuming module calls this once during initialization with `Self::MODULE_NAME` and stores the scoped client. The `ScopedUsageCollectorClientV1` stamps the declared source on every `emit()` and validates the metric prefix.
+The `UsageEmitterV1` trait exposes `for_module(name: &str) -> ScopedUsageEmitter`. Each consuming module calls this once during initialization with `Self::MODULE_NAME` and stores the scoped emitter. The `ScopedUsageEmitter` stamps the declared source on every `enqueue()` and validates the metric against the module's `allowed_metrics` list fetched from the gateway during `authorize_for()`.
 
 * Good, because source attribution is declared once, from the authoritative compile-time constant
-* Good, because call sites are clean — `emit(ctx, record)` with no source parameter
+* Good, because call sites are clean — `build_usage_record(...).enqueue()` with no source parameter
 * Good, because the binding is code-review-auditable in one location (module init)
-* Good, because metric prefix enforcement happens automatically on every emit without call-site involvement
-* Bad, because consuming modules store a `ScopedUsageCollectorClientV1` instead of the raw trait object
+* Good, because allowed-metrics validation happens automatically on every enqueue without call-site involvement
+* Bad, because consuming modules store a `ScopedUsageEmitter` instead of the raw `UsageEmitterV1` trait object
 
 ### Convention-only, no SDK-level source tracking
 
@@ -110,8 +110,8 @@ This decision is stable for the initial release. Revisit if:
 
 This decision directly addresses the following requirements or design elements:
 
-* `cpt-cf-usage-collector-component-sdk` — adds `for_module()` to the SDK component's responsibility scope, returning a `ScopedUsageCollectorClientV1` that binds source attribution and enforces metric prefix at emit time
-* `cpt-cf-usage-collector-interface-sdk-trait` — `for_module()` extends the SDK public interface, returning a `ScopedUsageCollectorClientV1`
-* `cpt-cf-usage-collector-interface-scoped-client` — `ScopedUsageCollectorClientV1` is the type consuming modules store and use for emission; it binds `MODULE_NAME` and validates metric prefix at `emit()` time
+* `cpt-cf-usage-collector-component-emitter` — adds `for_module()` to the emitter component's responsibility scope, returning a `ScopedUsageEmitter` that binds source attribution and validates metrics against the allowed-metrics list
+* `cpt-cf-usage-collector-interface-emitter-trait` — `for_module()` is the entry point on `UsageEmitterV1`, returning a `ScopedUsageEmitter`
+* `cpt-cf-usage-collector-interface-scoped-emitter` — `ScopedUsageEmitter` is the type consuming modules store and use for emission; it binds `MODULE_NAME` and validates the metric against the allowed-metrics list during `authorize_for()`
 * `cpt-cf-usage-collector-principle-fail-closed` — the SDK fails closed on metric prefix mismatch, rejecting the emit before the outbox is written
 * `cpt-cf-usage-collector-fr-ingestion` — source attribution is part of the ingestion record, enabling per-module metric auditing at the gateway and storage layers

--- a/modules/system/usage-collector/docs/ADR/0002-cpt-cf-usage-collector-adr-two-phase-emit-authz.md
+++ b/modules/system/usage-collector/docs/ADR/0002-cpt-cf-usage-collector-adr-two-phase-emit-authz.md
@@ -15,7 +15,7 @@
   - [PDP call synchronously at `emit()` time (inside or adjacent to DB transaction)](#pdp-call-synchronously-at-emit-time-inside-or-adjacent-to-db-transaction)
   - [Authorization deferred to gateway at delivery time (dispatcher → gateway)](#authorization-deferred-to-gateway-at-delivery-time-dispatcher--gateway)
   - [Pre-loaded static SDK policy (config-based metric allowlist, no PDP)](#pre-loaded-static-sdk-policy-config-based-metric-allowlist-no-pdp)
-  - [Two-phase PDP: `authorize_emit()` before transaction + in-memory constraint evaluation at `emit()`](#two-phase-pdp-authorize_emit-before-transaction--in-memory-constraint-evaluation-at-emit)
+  - [Two-phase PDP: `authorize_for()` before transaction + in-memory constraint evaluation at `enqueue()`](#two-phase-pdp-authorize_for-before-transaction--in-memory-constraint-evaluation-at-enqueue)
 - [More Information](#more-information)
   - [TOCTOU Window Analysis](#toctou-window-analysis)
   - [Performance Budget](#performance-budget)
@@ -36,7 +36,7 @@ The SDK's `emit()` call must persist usage records to the local outbox within th
 * Authorization checks MUST NOT be performed inside an open DB transaction — network calls holding DB locks violate platform conventions and degrade source service throughput
 * Authorization errors MUST be surfaced to the source service's caller at request time, before any domain operation is committed
 * The system MUST fail closed on authorization failure (`cpt-cf-usage-collector-principle-fail-closed`)
-* The `ScopedUsageCollectorClientV1` from ADR 0001 (`cpt-cf-usage-collector-adr-scoped-emit-source`) is already instantiated per source module and holds the source module identity — it is the natural owner of emit authorization logic
+* The `ScopedUsageEmitter` from ADR 0001 (`cpt-cf-usage-collector-adr-scoped-emit-source`) is already instantiated per source module and holds the source module identity — it is the natural owner of emit authorization logic
 * The existing `authz-resolver-sdk` `PolicyEnforcer` / `AuthZResolverClient` must be reused without introducing new authorization primitives
 
 ## Considered Options
@@ -44,42 +44,42 @@ The SDK's `emit()` call must persist usage records to the local outbox within th
 * PDP call synchronously at `emit()` time (inside or adjacent to DB transaction)
 * Authorization deferred to gateway at delivery time (dispatcher → gateway)
 * Pre-loaded static SDK policy (config-based metric allowlist, no PDP)
-* Two-phase PDP: `authorize_emit()` before transaction returns `EmitAuthorization`; `emit()` evaluates constraints in-memory
+* Two-phase PDP: `authorize_for()` before transaction returns `AuthorizedUsageEmitter`; `emit()` evaluates constraints in-memory
 
 ## Decision Outcome
 
-Chosen option: "Two-phase PDP: `authorize_emit()` before transaction + in-memory constraint evaluation at `emit()`", because it is the only option that satisfies all three constraints simultaneously: no network call inside a DB transaction, immediate failure feedback at request time, and reuse of the existing platform PDP infrastructure.
+Chosen option: "Two-phase PDP: `authorize_for()` before transaction + in-memory constraint evaluation at `enqueue()`", because it is the only option that satisfies all three constraints simultaneously: no network call inside a DB transaction, immediate failure feedback at request time, and reuse of the existing platform PDP infrastructure.
 
-`ScopedUsageCollectorClientV1` gains two responsibilities:
+`ScopedUsageEmitter` gains two responsibilities:
 
-1. `authorize_emit(ctx, metric_name: &str) -> Result<EmitAuthorization, EmitError>` — called before the DB transaction opens; contacts the PDP for the given metric, fetches the registered usage type schema for `metric_name` from types-registry, and returns an opaque `EmitAuthorization` token on success, or propagates a denial error immediately.
-2. `emit(ctx, record, &EmitAuthorization)` — called inside the DB transaction; evaluates the pre-fetched constraints against the record in-memory (no I/O), then inserts the outbox row.
+1. `authorize_for(ctx, tenant_id, resource_id, resource_type) -> Result<AuthorizedUsageEmitter, UsageEmitterError>` — called before the DB transaction opens; contacts the PDP for `USAGE_RECORD`/`CREATE`, fetches the allowed-metrics configuration for the module from the gateway; returns an `AuthorizedUsageEmitter` token on success, or propagates a denial error immediately.
+2. `build_usage_record(metric, value).enqueue()` — called inside the DB transaction; evaluates the pre-fetched constraints against the record in-memory (no I/O), then inserts the outbox row.
 
-The `EmitAuthorization` type wraps the PDP response constraints (`Vec<Constraint>` from `authz-resolver-sdk`) and is opaque to the calling module. A denial from the PDP is surfaced as an `Err` from `authorize_emit()`, so `EmitAuthorization` is only constructed on success. In-memory constraint evaluation uses the existing `Constraint` / `Predicate` types (`Eq`, `In`) from `authz-resolver-sdk`, evaluated against `UsageRecord` fields without SQL compilation.
+The `AuthorizedUsageEmitter` type carries the PDP permit result, the authorized `tenant_id`/`resource_id`/`resource_type`, and the allowed-metrics list fetched from the gateway; it is opaque to the calling module. A denial from the PDP is surfaced as an `Err` from `authorize_for()`, so `AuthorizedUsageEmitter` is only constructed on success. In-memory constraint evaluation uses the `allowed_metrics` list to validate metric names and kinds against the `UsageRecord` fields without any network I/O.
 
-`EmitAuthorization` includes `issued_at: Instant` (set at construction time) and `nonce: u64` (randomly generated per call). `emit()` calls `EmitAuthorization::validate_freshness()` as the first step before any constraint evaluation or outbox INSERT; if `issued_at.elapsed() > MAX_AUTH_AGE`, `emit()` returns `EmitError::AuthorizationExpired`. `MAX_AUTH_AGE` is a compile-time constant set to 30 seconds — well above any normal request handler duration and well below the minimum operationally meaningful policy propagation delay. This provides runtime enforcement of the single-use, single-request constraint without relying solely on code review.
+`AuthorizedUsageEmitter` includes `issued_at: Instant` (set at construction time). `enqueue()` calls `AuthorizedUsageEmitter::validate_authorization_freshness()` as the first step before any constraint evaluation or outbox INSERT; if `issued_at.elapsed() > authorization_max_age`, `enqueue()` returns `UsageEmitterError::AuthorizationExpired`. The `authorization_max_age` is a configurable field on `UsageEmitterConfig` (default 30 seconds) — well above any normal request handler duration and well below the minimum operationally meaningful policy propagation delay. This provides runtime enforcement of the single-request constraint without relying solely on code review.
 
 ### Consequences
 
 * Good, because the PDP call happens before any DB transaction opens — no network I/O holds DB locks
-* Good, because authorization errors are surfaced at request time via `authorize_emit()` failure — the source caller receives an immediate, meaningful error before any domain operation commits
-* Good, because `emit()` performs only in-memory constraint evaluation and an outbox INSERT — no external calls on the critical emission path
-* Good, because the implementation reuses `authz-resolver-sdk` constraint types and `PolicyEnforcer::build_request_with()` without introducing new authorization primitives
-* Good, because `ScopedUsageCollectorClientV1` (established in ADR 0001) is the natural and auditable owner of `authorize_emit()`, which already carries the source module identifier for PDP resource property attribution
-* Good, because `EmitAuthorization` is opaque to consuming modules — no authz concepts leak into business code at call sites
-* Bad, because source services must call `authorize_emit()` once per request that may emit usage — adds one PDP round-trip per request on the non-transaction path
-* Bad, because `emit()` gains a required `&EmitAuthorization` argument, changing the SDK API surface relative to a naive `emit(ctx, record)` signature
-* Bad, because in-memory constraint evaluation requires a new evaluator in the SDK (`EmitAuthorization::is_satisfied_by`) — the existing framework only compiles constraints to SQL via `AccessScope`
-* Bad, because when the platform PDP (`authz-resolver`) is unavailable, `authorize_emit()` returns an error and all usage emission from the source fails for the duration of the outage — this is an intentional fail-closed behavior per `cpt-cf-usage-collector-principle-fail-closed`, but it couples usage metering availability to PDP availability; PDP uptime must be treated as a hard dependency for usage sources
+* Good, because authorization errors are surfaced at request time via `authorize_for()` failure — the source caller receives an immediate, meaningful error before any domain operation commits
+* Good, because `enqueue()` performs only in-memory constraint evaluation and an outbox INSERT — no external calls on the critical emission path
+* Good, because the implementation reuses `authz-resolver-sdk` `PolicyEnforcer` for the PDP call without introducing new authorization primitives
+* Good, because `ScopedUsageEmitter` (established in ADR 0001) is the natural and auditable owner of `authorize_for()`, which already carries the source module identifier for PDP resource property attribution
+* Good, because `AuthorizedUsageEmitter` is opaque to consuming modules — no authz concepts leak into business code at call sites
+* Bad, because source services must call `authorize_for()` once per request that may emit usage — adds one PDP round-trip per request on the non-transaction path
+* Bad, because the emission call site changes from a simple `emit(ctx, record)` to `authorize_for()` → `build_usage_record(...).enqueue()`, changing the SDK API surface
+* Bad, because in-memory allowed-metrics validation requires per-metric list lookup added to the `AuthorizedUsageEmitter` — the existing framework only compiles PDP constraints to SQL via `AccessScope`
+* Bad, because when the platform PDP (`authz-resolver`) is unavailable, `authorize_for()` returns an error and all usage emission from the source fails for the duration of the outage — this is an intentional fail-closed behavior per `cpt-cf-usage-collector-principle-fail-closed`, but it couples usage metering availability to PDP availability; PDP uptime must be treated as a hard dependency for usage sources
 
 ### Confirmation
 
-* Unit tests: `authorize_emit()` propagates PDP denial (`decision: false`) as `EmitError::Denied` without inserting any outbox row
-* Unit tests: `emit()` with an `EmitAuthorization` whose constraints exclude the record's metric name returns `EmitError::ConstraintViolation` without inserting any outbox row
-* Unit tests: `emit()` with empty constraints (unconstrained `EmitAuthorization`) succeeds and inserts the outbox row
-* Unit tests: `emit()` with an `EmitAuthorization` whose `issued_at` is older than `MAX_AUTH_AGE` returns `EmitError::AuthorizationExpired` without inserting any outbox row
-* Unit tests: two successive calls to `emit()` with the same `EmitAuthorization` instance both succeed when within `MAX_AUTH_AGE`; the nonce field is present but freshness enforcement is time-based, not single-use (replay within the window is bounded to one request lifetime by construction)
-* Integration test: source service calls `authorize_emit()` before opening a DB transaction, then calls `emit()` inside the transaction — confirms no PDP or other network calls occur while the transaction is open
+* Unit tests: `authorize_for()` propagates PDP denial as `UsageEmitterError::AuthorizationFailed` without inserting any outbox row
+* Unit tests: `enqueue()` with an `AuthorizedUsageEmitter` whose allowed-metrics list excludes the record's metric name returns `UsageEmitterError::MetricNotAllowed` without inserting any outbox row
+* Unit tests: `enqueue()` with an allowed-metrics list that includes the record's metric succeeds and inserts the outbox row
+* Unit tests: `enqueue()` with an `AuthorizedUsageEmitter` whose `issued_at` is older than `authorization_max_age` returns `UsageEmitterError::AuthorizationExpired` without inserting any outbox row
+* Unit tests: two successive calls to `enqueue()` with the same `AuthorizedUsageEmitter` instance both succeed when within `authorization_max_age`; freshness enforcement is time-based, not single-use (replay within the window is bounded to one request lifetime by construction)
+* Integration test: source service calls `authorize_for()` before opening a DB transaction, then calls `build_usage_record(...).enqueue()` inside the transaction — confirms no PDP or other network calls occur while the transaction is open
 
 ## Pros and Cons of the Options
 
@@ -113,50 +113,50 @@ Encode the allowed metric names for each source service in SDK initialization co
 * Bad, because policy changes require redeploying source services to take effect — no dynamic policy enforcement
 * Bad, because deviates from the platform-wide PDP pattern used across all other CyberFabric modules
 
-### Two-phase PDP: `authorize_emit()` before transaction + in-memory constraint evaluation at `emit()`
+### Two-phase PDP: `authorize_for()` before transaction + in-memory constraint evaluation at `enqueue()`
 
 Separate the PDP call (network, async, before the transaction) from the constraint check (in-memory, synchronous, inside the transaction). See Decision Outcome for full description.
 
 * Good, because PDP call happens outside the DB transaction — no lock contention
-* Good, because `emit()` is fast — only in-memory evaluation and outbox INSERT
+* Good, because `enqueue()` is fast — only in-memory evaluation and outbox INSERT
 * Good, because authorization failures surface immediately at request time
 * Good, because reuses existing `authz-resolver-sdk` infrastructure and constraint types
 * Bad, because requires one PDP call per request that may emit usage
-* Bad, because `emit()` API changes to accept `&EmitAuthorization`
+* Bad, because the emission call site changes from a simple `emit(ctx, record)` to a two-step `authorize_for()` + `build_usage_record(...).enqueue()` API
 
 ## More Information
 
-The constraint evaluation logic uses `authz-resolver-sdk`'s existing `Constraint` / `Predicate` types. The PDP request sent by `authorize_emit()` uses `PolicyEnforcer::build_request_with()` directly — bypassing `access_scope_with()` — to obtain raw `Vec<Constraint>` without SQL compilation, since evaluation targets an in-memory `UsageRecord` struct rather than a database query. The `source_module` identifier (from ADR 0001) is included as a resource property in the PDP evaluation request, enabling metric-namespace-scoped policies in the PDP.
+The PDP request sent by `authorize_for()` uses `PolicyEnforcer::access_scope_with()` with `require_constraints(false)` — a permit/deny decision suffices; raw constraint evaluation was replaced by the allowed-metrics list fetched from the gateway via `get_module_config()`. The `tenant_id`, `resource_id`, and `resource_type` are included as resource properties in the PDP evaluation request. The `source_module` identifier (from ADR 0001) is baked into `ScopedUsageEmitter` and attached to every PDP request, enabling source-scoped policies in the PDP.
 
 Per-request PDP calls are chosen over request-level caching for simplicity and consistency with the platform pattern used in other modules (see `examples/modkit/users-info`). Caching can be introduced in a future ADR if PDP call volume proves to be a concern at scale.
 
 ### TOCTOU Window Analysis
 
-A time-of-check/time-of-use (TOCTOU) window exists between `authorize_emit()` (PDP call) and `emit()` (constraint evaluation). If an authorization policy is revoked or tightened in this window, `emit()` will evaluate constraints from the now-stale `EmitAuthorization` and may permit an emission that would be denied under the updated policy.
+A time-of-check/time-of-use (TOCTOU) window exists between `authorize_for()` (PDP call) and `enqueue()` (constraint evaluation). If an authorization policy is revoked or tightened in this window, `enqueue()` will evaluate constraints from the now-stale `AuthorizedUsageEmitter` and may permit an emission that would be denied under the updated policy.
 
 This window is accepted under the following rationale:
 
 - The window duration is bounded by the request handler execution time — typically well under 500ms in the absence of pathological application code — which is too short for routine policy changes to be operationally targeted at individual requests
 - PDP policy changes are administrative operations with propagation delays of their own; expecting sub-second policy revocation enforcement across all active request contexts is beyond the operational model of the platform PDP
-- The fail-closed principle applies to the next request: any subsequent `authorize_emit()` call will observe the updated policy and deny immediately
-- Reusing `EmitAuthorization` across request boundaries is explicitly prohibited (see Confirmation); each request obtains a fresh token, bounding maximum staleness to one request lifetime
+- The fail-closed principle applies to the next request: any subsequent `authorize_for()` call will observe the updated policy and deny immediately
+- Reusing `AuthorizedUsageEmitter` across request boundaries is explicitly prohibited (see Confirmation); each request obtains a fresh token, bounding maximum staleness to one request lifetime
 
-To minimize exposure, `EmitAuthorization` MUST NOT be cached or reused across request handlers. Runtime enforcement is provided by the freshness check in `emit()`: tokens older than `MAX_AUTH_AGE` (30 seconds) are rejected with `EmitError::AuthorizationExpired`. This bounds maximum staleness to `MAX_AUTH_AGE` regardless of call-site behavior, eliminating reliance on code review for TOCTOU window closure.
+To minimize exposure, `AuthorizedUsageEmitter` MUST NOT be cached or reused across request handlers. Runtime enforcement is provided by the freshness check in `enqueue()`: tokens older than `authorization_max_age` (default 30 seconds, configurable) are rejected with `UsageEmitterError::AuthorizationExpired`. This bounds maximum staleness to `MAX_AUTH_AGE` regardless of call-site behavior, eliminating reliance on code review for TOCTOU window closure.
 
 ### Performance Budget
 
-`authorize_emit()` introduces one synchronous PDP round-trip per request on the non-transaction path. To satisfy `cpt-cf-usage-collector-nfr-ingestion-latency` (p95 ≤ 200ms for the full emit path including the domain operation), the combined latency budget for `authorize_emit()` is bounded by the following heuristic:
+`authorize_for()` introduces one synchronous PDP round-trip per request on the non-transaction path. To satisfy `cpt-cf-usage-collector-nfr-ingestion-latency` (p95 ≤ 200ms for the full emit path including the domain operation), the combined latency budget for `authorize_for()` is bounded by the following heuristic:
 
-- Local DB insert (`emit()`) plus domain operation: ~50ms typical
+- Local DB insert (`enqueue()`) plus domain operation: ~50ms typical
 - PDP call budget: ≤ 100ms p95 to leave ≥ 50ms headroom against the 200ms threshold
 
-`authorize_emit()` MUST use a network timeout of ≤ 150ms to ensure a slow or unresponsive PDP does not breach the ingestion latency NFR. This timeout MUST be configurable and MUST default to 150ms or lower. If the PDP does not respond within the timeout, `authorize_emit()` MUST return `EmitError::Denied` (fail-closed).
+`authorize_for()` MUST use a network timeout of ≤ 150ms to ensure a slow or unresponsive PDP does not breach the ingestion latency NFR. This timeout MUST be configurable and MUST default to 150ms or lower. If the PDP does not respond within the timeout, `authorize_for()` MUST return `UsageEmitterError::AuthorizationFailed` (fail-closed).
 
 ## Review Cadence
 
 This decision is stable. Revisit if:
 
-- PDP round-trip volume at scale justifies introducing request-level caching of `EmitAuthorization` tokens — this would require a new ADR defining cache TTL, invalidation, and stale-token risk
+- PDP round-trip volume at scale justifies introducing request-level caching of `AuthorizedUsageEmitter` tokens — this would require a new ADR defining cache TTL, invalidation, and stale-token risk
 - The ingestion latency NFR tightens below 200ms such that the PDP latency budget must be re-evaluated
 - A platform-wide change to the PDP infrastructure (e.g., local sidecar PDP) materially changes the round-trip cost, potentially eliminating the TOCTOU concern and the "Bad" PDP-unavailability consequence
 
@@ -168,10 +168,10 @@ This decision is stable. Revisit if:
 This decision directly addresses the following requirements or design elements:
 
 * `cpt-cf-usage-collector-fr-ingestion` — preserves quick ingestion by keeping the outbox INSERT on the critical path and moving the PDP call off it
-* `cpt-cf-usage-collector-fr-tenant-attribution` — `authorize_emit()` passes the subject's tenant context to the PDP, ensuring tenant-aware authorization at the point of emission
-* `cpt-cf-usage-collector-fr-tenant-isolation` — PDP constraints returned by `authorize_emit()` can enforce tenant-scoped metric restrictions, evaluated before any record enters the outbox
-* `cpt-cf-usage-collector-principle-fail-closed` — denial from the PDP propagates as an `Err` from `authorize_emit()`; no record is enqueued on authorization failure
-* `cpt-cf-usage-collector-principle-source-side-persistence` — the outbox INSERT in `emit()` remains within the caller's DB transaction; only in-memory evaluation is added inside the transaction boundary
-* `cpt-cf-usage-collector-component-sdk` — `authorize_emit()` and `EmitAuthorization` extend the SDK component's responsibility scope
-* `cpt-cf-usage-collector-interface-scoped-client` — `ScopedUsageCollectorClientV1` gains `authorize_emit(ctx, metric_name: &str) -> Result<EmitAuthorization, EmitError>` and the `EmitAuthorization` type; `emit()` gains a required `&EmitAuthorization` parameter
-* `cpt-cf-usage-collector-adr-scoped-emit-source` — this decision builds on ADR 0001: `ScopedUsageCollectorClientV1` is the owner of `authorize_emit()`, using the `source_module` it already holds for PDP resource property attribution
+* `cpt-cf-usage-collector-fr-tenant-attribution` — `authorize_for()` passes the subject's tenant context to the PDP, ensuring tenant-aware authorization at the point of emission
+* `cpt-cf-usage-collector-fr-tenant-isolation` — PDP constraints returned by `authorize_for()` can enforce tenant-scoped metric restrictions, evaluated before any record enters the outbox
+* `cpt-cf-usage-collector-principle-fail-closed` — denial from the PDP propagates as an `Err` from `authorize_for()`; no record is enqueued on authorization failure
+* `cpt-cf-usage-collector-principle-source-side-persistence` — the outbox INSERT in `enqueue()` remains within the caller's DB transaction; only in-memory evaluation is added inside the transaction boundary
+* `cpt-cf-usage-collector-component-emitter` — `authorize_for()` and `AuthorizedUsageEmitter` extend the emitter component's responsibility scope
+* `cpt-cf-usage-collector-interface-scoped-emitter` — `ScopedUsageEmitter` gains `authorize_for(ctx, tenant_id, resource_id, resource_type) -> Result<AuthorizedUsageEmitter, UsageEmitterError>`; `build_usage_record(metric, value).enqueue()` performs in-memory validation within the caller's transaction
+* `cpt-cf-usage-collector-adr-scoped-emit-source` — this decision builds on ADR 0001: `ScopedUsageEmitter` is the owner of `authorize_for()`, using the `source_module` it already holds for PDP resource property attribution

--- a/modules/system/usage-collector/docs/DECOMPOSITION.md
+++ b/modules/system/usage-collector/docs/DECOMPOSITION.md
@@ -1,0 +1,598 @@
+# DECOMPOSITION — Usage Collector
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-status-overall`
+
+<!-- toc -->
+
+- [1. Overview](#1-overview)
+- [2. Entries](#2-entries)
+  - [2.1 Core SDK, Emitter & In-Process Ingest ⏳ HIGH](#21-core-sdk-emitter--in-process-ingest--high)
+  - [2.2 REST Client & Remote Ingest Delivery ⏳ HIGH](#22-rest-client--remote-ingest-delivery--high)
+  - [2.3 Usage Query API ⏳ HIGH](#23-usage-query-api--high)
+  - [2.4 Production Storage Plugin ⏳ HIGH](#24-production-storage-plugin--high)
+  - [2.5 Usage Type System ⏳ HIGH](#25-usage-type-system--high)
+  - [2.6 Emission Rate Limiting ⏳ HIGH](#26-emission-rate-limiting--high)
+  - [2.7 Retention Policy Management ⏳ MEDIUM](#27-retention-policy-management--medium)
+  - [2.8 Operator Operations, Watermarks & Audit ⏳ MEDIUM](#28-operator-operations-watermarks--audit--medium)
+- [3. Feature Dependencies](#3-feature-dependencies)
+
+<!-- /toc -->
+
+## 1. Overview
+
+The Usage Collector DESIGN is decomposed into 8 features following a build-from-bottom-up strategy. The foundation layer (Feature 1) establishes the core SDK, emitter, in-process ingest pipeline, static metric configuration, and a no-op storage plugin that together enable end-to-end usage emission for in-process sources. The remote delivery layer (Feature 2) extends this to out-of-process sources via the REST client. Query capability (Feature 3) and the first production storage plugin (Feature 4) unlock real aggregation and raw query workflows. The type system (Feature 5) replaces static metric configuration with dynamic types-registry-backed validation. Rate limiting (Feature 6) adds per-source emission controls. Operator capabilities (Features 7–8) complete the system with retention management and the operator-initiated write operations (backfill, amendment, deactivation, watermarks, audit events).
+
+**Decomposition Strategy**:
+
+- Features grouped by functional cohesion (related capabilities together)
+- Dependencies follow the SDK → emitter → gateway → plugin layering from the DESIGN
+- Features 1–2 reflect the preliminary implementation already in progress; Features 3–8 are not yet started
+
+**Deliberate Omissions**: None. All DESIGN components, sequences, data entities, FRs, principles, and constraints are covered.
+
+## 2. Entries
+
+### 2.1 [Core SDK, Emitter & In-Process Ingest](features/sdk-and-ingest-core/) ⏳ HIGH
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-feature-sdk-and-ingest-core`
+<!-- STATUS: IN_PROGRESS — all p1 DoD items implemented; one p1 instruction gap (inst-authz-1: no-open-transaction assertion deferred — requires modkit-db framework API change). -->
+
+- **Type**: Service
+
+- **Purpose**: Establish the core data model, delivery traits, two-phase authorization emitter, transactional outbox pipeline, gateway ingest handler, static metric configuration, and no-op storage plugin. Delivers the complete in-process emission path from `authorize_for()` through the outbox background pipeline to the gateway and plugin. This is the prerequisite for all other features.
+
+- **Depends On**: None
+
+- **Scope**:
+  - `usage-collector-sdk` crate: client and plugin-client trait definitions, shared usage record model types, GTS schema for plugin registration, error types
+  - `usage-emitter` crate: scoped emitter with two-phase authorization flow (pre-authorization and per-record authorization), transactional outbox enqueue, background outbox delivery handler
+  - `usage-collector` gateway crate: plugin resolution via GTS with timeout enforcement, outbox queue registration and schema migrations, record ingest endpoint, module config fetch endpoint, static metric configuration
+  - `noop-usage-collector-storage-plugin` crate: no-op storage plugin implementation for tests and local development
+  - Owns authorization check on all inbound requests via `component-gateway`
+  <!-- Metrics Config Boundary: F1 owns collection config (what data to collect, sampling rates, collection intervals); F5 owns reporting/export config (exporters, dashboards, alerting thresholds) -->
+
+- **Out of scope**:
+  - Remote HTTP delivery (Feature 2)
+  - Query API (Feature 3)
+  - Real storage backend plugins (Feature 4)
+  - Types-registry type validation (Feature 5)
+  - Rate limiting enforcement (Feature 6)
+
+- **Requirements Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-ingestion`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-idempotency`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-delivery-guarantee`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-counter-semantics`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-gauge-semantics`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-tenant-attribution`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-resource-attribution`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-subject-attribution`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-tenant-isolation`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-ingestion-authorization`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-pluggable-storage`
+  - [ ] `p2` - `cpt-cf-usage-collector-fr-record-metadata`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-availability`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-ingestion-latency`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-authentication`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-authorization`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-scalability`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-fault-tolerance`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-recovery` (owner: F1)
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-graceful-degradation`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-rpo` (owner: F1)
+
+- **Design Principles Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-source-side-persistence`
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-pluggable-storage`
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-tenant-from-ctx`
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-fail-closed`
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-scoped-source-attribution`
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-two-phase-authz`
+
+- **Design Constraints Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-outbox-infra`
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-single-plugin`
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-modkit`
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-security-context`
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-no-business-logic`
+
+- **Domain Model Entities**:
+  - `UsageRecord` — DEFINES: UsageRecord schema (canonical data model for usage events)
+  - `AuthorizedUsageEmitter`
+  - `ModuleConfig` / `AllowedMetric`
+
+- **Design Components**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-component-sdk`
+  - [ ] `p1` - `cpt-cf-usage-collector-component-emitter`
+    > **Owner**: F1 — initialises and configures the emitter
+    > **Used by**: F5 (type validation in authorize_for), F6 (SDK-side quota check in authorize_for)
+  - [ ] `p1` - `cpt-cf-usage-collector-component-gateway`
+    > **Owner**: F1 — initialises and configures the gateway; owns authorization check on all inbound requests
+    > **Used by**: F2 (passes pre-authenticated requests through), F3 (query handlers), F5 (defense-in-depth validation + types endpoint), F6 (gateway-side rate limiting), F7 (retention policy CRUD), F8 (backfill, amendment, deactivation, watermarks, audit)
+  - [ ] `p1` - `cpt-cf-usage-collector-component-storage-plugin` (noop only)
+    > **Owner**: F4 — implements the full production storage plugin trait
+    > **Used by**: F1 (noop implementation only), F3 (query operations), F7 (enforce_retention), F8 (backfill_ingest, amend_record, deactivate_record, get_watermarks)
+
+- **API**:
+  - POST /usage-collector/v1/records
+  - GET /usage-collector/v1/modules/{module_name}/config
+
+- **Sequences**:
+
+  - `cpt-cf-usage-collector-seq-emit`  <!-- Shared Sequence Participation: F1 role = initiator (triggers emission — authorizes and enqueues the record into the outbox) -->
+
+- **Data**:
+  - `usage-records` table (written by storage plugin on ingest)
+  - [ ] `cpt-cf-usage-collector-dbtable-outbox`
+
+- **Phases/Milestones**:
+  - Phase 1: SDK crate (`usage-collector-sdk`) — core traits, data model, error types
+  - Phase 2: Emitter crate (`usage-emitter`) — two-phase authorization, outbox enqueue, background delivery
+  - Phase 3: Gateway crate (`usage-collector`) — plugin resolution, ingest endpoint, config endpoint, static metric config
+  - Phase 4: No-op storage plugin (`noop-usage-collector-storage-plugin`) — test/local-dev plugin
+
+---
+
+### 2.2 [REST Client & Remote Ingest Delivery](features/rest-ingest/) ⏳ HIGH
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-feature-rest-ingest`
+
+- **Type**: Service
+
+- **Purpose**: Enable out-of-process usage sources to emit records using the same `UsageEmitterV1` API as in-process sources. The `usage-collector-rest-client` crate registers `UsageEmitterV1` in `ClientHub` backed by an HTTP client that acquires a bearer token from the AuthN resolver and POSTs records to the gateway ingest endpoint with identical authorization and validation semantics.
+
+- **Depends On**: `cpt-cf-usage-collector-feature-sdk-and-ingest-core`
+
+- **Scope**:
+  - `usage-collector-rest-client` crate: `UsageCollectorRestClient` implementing `UsageCollectorClientV1`, bearer token acquisition via authn-resolver (client credentials flow), HTTP POST to `POST /usage-collector/v1/records`, outbox schema migrations registration, `HandlerResult` mapping (Retry on 5xx/429/network errors; Reject on permanent 4xx)
+  - Gateway two-level authorization model for REST ingestion: service-to-service bearer token authentication of the forwarder plus gateway-level PDP check against the forwarder's service identity
+
+- **Out of scope**:
+  - In-process emission pipeline (Feature 1)
+  - Query endpoints (Feature 3)
+  - Re-evaluation of the original caller's authorization context from F1 — the gateway performs service-to-service bearer token authentication of the forwarder and a gateway-level PDP check against the forwarder's service identity, but does NOT duplicate or re-check the authorization decisions already made upstream for the original caller
+
+- **Requirements Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-rest-ingestion`
+
+- **Design Principles Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-fail-closed`
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-tenant-from-ctx`
+
+- **Design Constraints Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-security-context`
+
+- **Domain Model Entities**:
+  - `UsageRecord` — USES: UsageRecord (defined in F1) — reads records for delivery
+
+- **Design Components**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-component-rest-client`
+
+- **API**:
+  - POST /usage-collector/v1/records (client-side outbox delivery)
+  - GET /usage-collector/v1/modules/{module_name}/config (client-side config fetch)
+
+- **Sequences**:
+
+  - `cpt-cf-usage-collector-seq-emit-remote`
+
+- **Data**:
+  - None (stateless delivery hop; records persisted in source's local outbox)
+
+- **Phases/Milestones**: none
+
+---
+
+### 2.3 [Usage Query API](features/query-api/) ⏳ HIGH
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-feature-query-api`
+
+- **Type**: REST API Layer
+
+- **Purpose**: Enable authorized consumers to retrieve aggregated and raw usage data from the gateway so tenants and operators can inspect, audit, and act on collected usage records.
+
+- **Depends On**: `cpt-cf-usage-collector-feature-sdk-and-ingest-core`
+
+- **Scope**:
+  - `usage-collector-sdk` additions: `AggregationQuery`, `AggregationResult`, `RawQuery`, `PagedResult` types; `query_aggregated` and `query_raw` operations on `UsageCollectorPluginClientV1`
+  - `usage-collector` gateway: `GET /usage-collector/v1/aggregated` handler (tenant from SecurityContext, PDP authorization + constraint application, delegation to plugin), `GET /usage-collector/v1/raw` handler (same authorization pattern, cursor-based pagination)
+  - Plugin trait query operations: `query_aggregated` (aggregation functions SUM/COUNT/MIN/MAX/AVG, optional filters, GROUP BY dimensions pushed down to storage engine), `query_raw` (tenant-scoped, optional filters, cursor pagination)
+
+- **Out of scope**:
+  - Ingest pipeline (Feature 1)
+  - Production storage backend implementation (Feature 4)
+  - Watermark metadata query (Feature 8)
+
+- **Requirements Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-query-aggregation`
+  - [ ] `p2` - `cpt-cf-usage-collector-fr-query-raw`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-workload-isolation`
+
+- **Design Principles Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-fail-closed`
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-tenant-from-ctx`
+
+- **Design Constraints Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-security-context`
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-no-business-logic`
+
+- **Domain Model Entities**:
+  - `AggregationQuery`
+  - `AggregationResult`
+  - `RawQuery`
+
+- **Design Components**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-component-gateway` (query handlers)
+  - [ ] `p1` - `cpt-cf-usage-collector-component-storage-plugin` (query operations)
+
+- **API**:
+  - GET /usage-collector/v1/aggregated
+  - GET /usage-collector/v1/raw
+
+- **Sequences**:
+
+  - `cpt-cf-usage-collector-seq-query-aggregated`
+  - `cpt-cf-usage-collector-seq-query-raw`
+
+- **Data**:
+  - `usage-records` table (read by storage plugin for aggregation and raw queries)
+
+- **Phases/Milestones**: none
+
+---
+
+### 2.4 [Production Storage Plugin](features/production-storage-plugin/) ⏳ HIGH
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-feature-production-storage-plugin`
+
+- **Type**: Plugin Interface
+
+- **Purpose**: Provide durable, high-throughput storage for usage records so the system can meet its throughput, latency, and recovery objectives with a real storage backend instead of the no-op placeholder.
+
+- **Depends On**: `cpt-cf-usage-collector-feature-sdk-and-ingest-core`, `cpt-cf-usage-collector-feature-query-api`
+
+- **Scope**:
+  - First production plugin crate implementing the full storage plugin trait
+  - Idempotent record ingest keyed on idempotency key; counter delta accumulation semantics
+  - Aggregation query pushdown to the storage engine with optional pre-aggregated acceleration; cursor-based raw query pagination with tenant and dimension filtering
+  - Operator write operations: backfill ingest, record amendment, record deactivation
+  - Retention enforcement and watermark retrieval operations
+  - GTS schema registration, database schema migrations, encrypted connections to the storage backend
+
+- **Out of scope**:
+  - No-op plugin (Feature 1)
+  - Second storage backend
+
+- **Requirements Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-pluggable-storage`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-query-latency`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-throughput`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-rpo` (applies-to: all — F4 must independently satisfy the RPO constraint via durable storage backend)
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-recovery` (applies-to: all — F4 must independently satisfy recovery via storage backend durability guarantees)
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-retention`
+
+- **Design Principles Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-pluggable-storage`
+
+- **Design Constraints Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-single-plugin`
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-types-registry` (GTS schema for plugin registration)
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-encryption`
+
+- **Domain Model Entities**:
+  - `UsageRecord` — USES: UsageRecord (defined in F1) — reads and persists records for storage
+  - `RetentionPolicy` (enforced by plugin)
+
+- **Design Components**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-component-storage-plugin` (production implementation)
+
+- **API**:
+  - None (internal plugin interface only)
+
+- **Sequences**:
+
+  - `cpt-cf-usage-collector-seq-emit` (storage write path)  <!-- Shared Sequence Participation: F4 role = buffer (persists the record durably via the production storage plugin) -->
+  - `cpt-cf-usage-collector-seq-query-aggregated` (storage read path)
+  - `cpt-cf-usage-collector-seq-query-raw` (storage read path)
+
+- **Data**:
+  - `usage-records` table (primary storage: idempotent upsert on ingest, read for aggregation and raw queries)
+  - [ ] `cpt-cf-usage-collector-dbtable-records`
+  - [ ] `cpt-cf-usage-collector-dbtable-counter-accumulation`
+
+- **Phases/Milestones**:
+  - Phase 1: Storage backend selection (ClickHouse or TimescaleDB) and schema design
+  - Phase 2: Ingest operations — idempotent upsert, counter delta accumulation, GTS schema registration, migrations
+  - Phase 3: Query operations — aggregation pushdown, cursor-based raw pagination
+  - Phase 4: Operator write operations — backfill ingest, record amendment, deactivation, watermarks, retention enforcement
+
+---
+
+### 2.5 [Usage Type System](features/type-system/) ⏳ HIGH
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-feature-type-system`
+
+- **Type**: Service
+
+- **Purpose**: Ensure every emitted record conforms to a registered usage type schema so invalid or unknown metric kinds are rejected before reaching the storage backend and operators can register custom measuring units.
+
+- **Depends On**: `cpt-cf-usage-collector-feature-sdk-and-ingest-core`
+
+- **Scope**:
+  - `usage-emitter`: fetch registered usage type schema from types-registry during `authorize_for()` phase 1; validate the record against the schema in-memory before the outbox INSERT; surface validation failures as `UsageEmitterError` before any domain operation is committed
+  - `usage-collector` gateway: defense-in-depth schema validation on ingest before delegating to plugin; `POST /usage-collector/v1/types` endpoint delegating entirely to types-registry for custom usage type registration (name, metric kind, unit label)
+  - `UsageType` domain entity (owned by types-registry; fetched by emitter and gateway)
+
+- **Out of scope**:
+  - Static `metrics` config from Feature 1 (retained as the allowed-metrics list; type schemas are now sourced from types-registry)
+  - Storage plugin implementation (Feature 4)
+
+- **Requirements Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-type-validation`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-custom-units`
+
+- **Design Principles Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-fail-closed`
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-two-phase-authz`
+
+- **Design Constraints Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-types-registry`
+
+- **Domain Model Entities**:
+  - `UsageType`
+
+- **Design Components**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-component-emitter` (type validation in authorize_for)
+  - [ ] `p1` - `cpt-cf-usage-collector-component-gateway` (defense-in-depth validation + types endpoint)
+
+- **API**:
+  - POST /usage-collector/v1/types
+
+- **Sequences**:
+
+  - `cpt-cf-usage-collector-seq-emit` (type validation in phase 1)  <!-- Shared Sequence Participation: F5 role = monitor (validates record schema before outbox INSERT; observes emission health via defense-in-depth gateway check) -->
+  <!-- Metrics Config Boundary: F5 owns reporting/export config (exporters, dashboards, alerting thresholds); F1 owns collection config (what data to collect, sampling rates, collection intervals) -->
+
+- **Data**:
+  - None (type schemas managed in types-registry, not locally)
+
+- **Phases/Milestones**:
+  - Phase 1: Emitter integration — types-registry fetch and in-memory schema validation in `authorize_for()` phase 1
+  - Phase 2: Gateway integration — defense-in-depth validation on ingest and `POST /usage-collector/v1/types` delegation endpoint
+
+---
+
+### 2.6 [Emission Rate Limiting](features/rate-limiting/) ⏳ HIGH
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-feature-rate-limiting`
+
+- **Type**: Service
+
+- **Purpose**: Prevent outbox flooding by enforcing per-source emission quotas at SDK `authorize_for()` phase 1 before any transaction opens. Supplement with per-(source, tenant) rate limit enforcement at the gateway on ingest to protect the storage backend from quota-exhausting sources.
+
+- **Depends On**: `cpt-cf-usage-collector-feature-sdk-and-ingest-core`
+
+- **Scope**:
+  - `usage-emitter` phase 1 extension: `authorize_for()` fetches the current source-level emission quota and window snapshot from the gateway; `enqueue()` evaluates the quota in-memory and rejects before the outbox INSERT if the source quota is exhausted
+  - `usage-collector` gateway ingest extension: per-(source, tenant) rate limit check on `POST /usage-collector/v1/records`
+  - Rate limit configuration: configurable window and quota per source module set via static deployment configuration (no public REST configuration endpoint in this feature)
+  - Observability: rejected emissions surfaced via pluggable metrics interface
+
+- **Out of scope**:
+  - Backfill rate limiting (separate independent rate limits, Feature 8)
+  - Type validation (Feature 5)
+
+- **Requirements Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-rate-limiting`
+
+- **Design Principles Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-two-phase-authz`
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-fail-closed`
+
+- **Design Constraints Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-security-context`
+
+- **Domain Model Entities**:
+  - None (quota window state managed by the gateway, not a named domain entity)
+
+- **Design Components**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-component-emitter` (SDK-side quota check in authorize_for)
+  - [ ] `p1` - `cpt-cf-usage-collector-component-gateway` (gateway-side per-(source, tenant) rate limiting)
+
+- **API**:
+  - None (internal enforcement; no public configuration endpoint in this feature)
+
+- **Sequences**:
+
+  - `cpt-cf-usage-collector-seq-emit` (quota check in phase 1)  <!-- Shared Sequence Participation: F6 role = rate-gate (throttles emission rate — rejects at authorize_for phase 1 when source quota is exhausted before outbox INSERT) -->
+  <!-- Rate Limit vs Quota Boundary: F6 enforces short-window per-(source, tenant) rate limits on real-time ingest; F8 enforces long-window per-tenant quota limits via backfill and operator-controlled caps -->
+
+- **Data**:
+  - None (quota tracking is in-memory or in the gateway's local state)
+
+- **Phases/Milestones**:
+  - Phase 1: Emitter-side quota check — `authorize_for()` extension with quota fetch and in-memory evaluation
+  - Phase 2: Gateway-side rate limiting — per-(source, tenant) check on ingest endpoint and observability integration
+
+---
+
+### 2.7 [Retention Policy Management](features/retention-policies/) ⏳ MEDIUM
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-feature-retention-policies`
+
+- **Type**: Background Task
+
+- **Purpose**: Allow platform operators to configure data retention policies at global, per-tenant, and per-usage-type scopes. Enforce these policies via the storage plugin using storage-native TTL or scheduled deletion, with a mandatory global default that cannot be deleted.
+
+- **Depends On**: `cpt-cf-usage-collector-feature-sdk-and-ingest-core`, `cpt-cf-usage-collector-feature-production-storage-plugin`
+
+- **Scope**:
+  - `RetentionPolicy` domain entity: scope (`global` / `tenant` / `usage-type`), target identifier, retention duration
+  - Gateway REST API: `GET /usage-collector/v1/retention` (list), `PUT /usage-collector/v1/retention/{scope}` (create/update), `DELETE /usage-collector/v1/retention/{scope}` (non-global only; global default deletion rejected)
+  - Precedence rule enforcement: per-usage-type > per-tenant > global
+  - Plugin `enforce_retention` operation: permanent hard delete of expired records via storage-native TTL or scheduled deletion; triggered by the gateway on a background schedule
+  - `inactive` status is reserved for operator amendment (Feature 8) and MUST NOT be used by retention enforcement
+
+- **Out of scope**:
+  - Amendment and deactivation (Feature 8)
+  - Rate limiting (Feature 6)
+
+- **Requirements Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-retention-policies`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-retention`
+
+- **Design Principles Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-fail-closed`
+
+- **Design Constraints Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-security-context`
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-no-business-logic`
+
+- **Domain Model Entities**:
+  - `RetentionPolicy`
+
+- **Design Components**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-component-gateway` (retention policy CRUD)
+  - [ ] `p1` - `cpt-cf-usage-collector-component-storage-plugin` (enforce_retention)
+
+- **API**:
+  - GET /usage-collector/v1/retention
+  - PUT /usage-collector/v1/retention/{scope}
+  - DELETE /usage-collector/v1/retention/{scope}
+
+- **Sequences**:
+  - None (policy management is synchronous CRUD; enforcement runs as a background task)
+
+- **Data**:
+  - `retention-policies` table (retention policy CRUD and enforcement state)
+
+- **Phases/Milestones**:
+  - Phase 1: `RetentionPolicy` domain entity, gateway REST API (GET/PUT/DELETE), precedence rule enforcement
+  - Phase 2: Plugin `enforce_retention` operation — background schedule integration and storage-native TTL/deletion
+
+---
+
+### 2.8 [Operator Operations, Watermarks & Audit](features/operator-ops/) ⏳ MEDIUM
+
+- [ ] `p2` - **ID**: `cpt-cf-usage-collector-feature-operator-ops`
+
+- **Type**: Service
+
+- **Purpose**: Complete the operator-facing capability set: backfill for historical record ingestion with a gateway-local outbox pipeline and independent rate limits, individual record amendment and deactivation, watermark metadata exposure for external reconciliation, and structured `WriteAuditEvent` emission to `audit_service` for every operator-initiated write.
+
+- **Depends On**: `cpt-cf-usage-collector-feature-sdk-and-ingest-core`, `cpt-cf-usage-collector-feature-query-api`, `cpt-cf-usage-collector-feature-production-storage-plugin`
+
+- **Scope**:
+  - Backfill: `POST /usage-collector/v1/backfill`; PDP authorization for specified `tenant_id`; configurable time boundary enforcement (max window default 90 days, future tolerance default 5 min, elevated authz beyond max window); gateway-local backfill outbox (`Outbox::enqueue_batch` within handler transaction); internal `MessageHandler` calling `plugin.backfill_ingest()`; independent rate limits and lower processing priority relative to real-time ingest; `202 Accepted` response
+  - Amendment: `PATCH /usage-collector/v1/records/{id}`; PDP authorization; `plugin.amend_record()` with optimistic concurrency
+  - Deactivation: `POST /usage-collector/v1/records/{id}/deactivate`; PDP authorization; `plugin.deactivate_record()` (sets `status = inactive`, record retained for audit)
+  - Watermarks: `GET /usage-collector/v1/metadata/watermarks`; calls `plugin.get_watermarks()` returning per-source and per-tenant event counts and latest ingested timestamps
+  - Audit: `WriteAuditEvent` emitted to platform `audit_service` after each completed operator write (backfill on outbox commit, amendment, deactivation); best-effort with ≤2s timeout; emission failures logged and monitored but do not roll back or fail the primary operation
+
+- **Out of scope**:
+  - Retention policy management (Feature 7)
+  - Rate limiting for real-time ingest (Feature 6)
+  <!-- Rate Limit vs Quota Boundary: F8 enforces long-window per-tenant quota limits (backfill rate limits, operator-controlled write caps); F6 enforces short-window per-(source, tenant) rate limits on real-time ingest -->
+
+- **Requirements Covered**:
+
+  - [ ] `p2` - `cpt-cf-usage-collector-fr-backfill-api`
+  - [ ] `p2` - `cpt-cf-usage-collector-fr-event-amendment`
+  - [ ] `p3` - `cpt-cf-usage-collector-fr-backfill-boundaries`
+  - [ ] `p3` - `cpt-cf-usage-collector-fr-metadata-exposure`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-audit`
+
+- **Design Principles Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-fail-closed`
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-tenant-from-ctx`
+
+- **Design Constraints Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-security-context`
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-no-business-logic`
+
+- **Domain Model Entities**:
+  - `BackfillOperation`
+  - `WriteAuditEvent`
+
+- **Design Components**:
+
+  - [ ] `p2` - `cpt-cf-usage-collector-component-gateway` (backfill, amendment, deactivation, watermarks, audit)
+  - [ ] `p2` - `cpt-cf-usage-collector-component-storage-plugin` (backfill_ingest, amend_record, deactivate_record, get_watermarks)
+
+- **API**:
+  - POST /usage-collector/v1/backfill
+  - PATCH /usage-collector/v1/records/{id}
+  - POST /usage-collector/v1/records/{id}/deactivate
+  - GET /usage-collector/v1/metadata/watermarks
+
+- **Sequences**:
+
+  - `cpt-cf-usage-collector-seq-backfill`
+  - `cpt-cf-usage-collector-seq-amend`
+  - `cpt-cf-usage-collector-seq-deactivate`
+
+- **Data**:
+  - `usage-records` table (amendment and deactivation write path; watermarks read)
+
+- **Phases/Milestones**:
+  - Phase 1: Backfill endpoint (`POST /usage-collector/v1/backfill`) — gateway-local outbox, `backfill_ingest`, configurable time boundaries, independent rate limits
+  - Phase 2: Amendment (`PATCH /usage-collector/v1/records/{id}`) and deactivation (`POST /usage-collector/v1/records/{id}/deactivate`)
+  - Phase 3: Watermarks endpoint (`GET /usage-collector/v1/metadata/watermarks`) and structured `WriteAuditEvent` emission
+
+---
+
+## 3. Feature Dependencies
+
+```text
+cpt-cf-usage-collector-feature-sdk-and-ingest-core  (foundation)
+    ├─→ cpt-cf-usage-collector-feature-rest-ingest
+    ├─→ cpt-cf-usage-collector-feature-type-system
+    ├─→ cpt-cf-usage-collector-feature-rate-limiting
+    ├─→ cpt-cf-usage-collector-feature-query-api
+    │       └─→ cpt-cf-usage-collector-feature-production-storage-plugin
+    │               ├─→ cpt-cf-usage-collector-feature-retention-policies  (also ←F1)
+    │               └─→ cpt-cf-usage-collector-feature-operator-ops         (also ←F1, ←F3)
+    └─→ (see above: F7 depends on F1+F4; F8 depends on F1+F3+F4)
+```
+
+**Dependency Rationale**:
+
+- `cpt-cf-usage-collector-feature-rest-ingest` requires `cpt-cf-usage-collector-feature-sdk-and-ingest-core`: the REST client implements `UsageCollectorClientV1` defined in the SDK and delivers records to the gateway ingest endpoint introduced in Feature 1.
+- `cpt-cf-usage-collector-feature-query-api` requires `cpt-cf-usage-collector-feature-sdk-and-ingest-core`: query operations extend the `UsageCollectorPluginClientV1` trait and add gateway handlers that follow the same PDP + plugin delegation pattern established in Feature 1.
+- `cpt-cf-usage-collector-feature-production-storage-plugin` requires `cpt-cf-usage-collector-feature-sdk-and-ingest-core` and `cpt-cf-usage-collector-feature-query-api`: a production plugin must implement all plugin trait operations including `query_aggregated` and `query_raw` introduced in Feature 3.
+- `cpt-cf-usage-collector-feature-type-system` requires `cpt-cf-usage-collector-feature-sdk-and-ingest-core`: type validation integrates into the `authorize_for()` phase 1 flow and gateway ingest handler established in Feature 1; independent of query and plugin features.
+- `cpt-cf-usage-collector-feature-rate-limiting` requires `cpt-cf-usage-collector-feature-sdk-and-ingest-core`: quota checks extend the `authorize_for()` phase 1 flow and gateway ingest handler from Feature 1; independent of query and plugin features.
+- `cpt-cf-usage-collector-feature-retention-policies` requires `cpt-cf-usage-collector-feature-sdk-and-ingest-core` and `cpt-cf-usage-collector-feature-production-storage-plugin`: retention enforcement calls `plugin.enforce_retention()` which requires a real storage backend.
+- `cpt-cf-usage-collector-feature-operator-ops` requires `cpt-cf-usage-collector-feature-sdk-and-ingest-core`, `cpt-cf-usage-collector-feature-query-api`, and `cpt-cf-usage-collector-feature-production-storage-plugin`: backfill introduces a gateway-local outbox queue; amendment and deactivation extend the plugin write trait; watermarks extend the plugin query interface; all require a real storage backend.
+- `cpt-cf-usage-collector-feature-rest-ingest`, `cpt-cf-usage-collector-feature-type-system`, and `cpt-cf-usage-collector-feature-rate-limiting` are independent of each other and can be developed in parallel after Feature 1.
+- `cpt-cf-usage-collector-feature-retention-policies` and `cpt-cf-usage-collector-feature-operator-ops` are independent of each other and can be developed in parallel after Feature 4.

--- a/modules/system/usage-collector/docs/DESIGN.md
+++ b/modules/system/usage-collector/docs/DESIGN.md
@@ -1,3 +1,30 @@
+---
+cpt:
+  kind: DESIGN
+  version: "0.3.0"
+  changelog:
+    - version: "0.3.0"
+      date: "2026-04-28"
+      changes:
+        - "Made subject_id and subject_type optional (Option<T>) in UsageRecord; updated PDP authorization algorithm to skip subject properties when both fields are absent"
+        - "fr-subject-attribution (§1.2): updated to reflect optional-subject contract; PDP subject validation skipped when both fields are None"
+        - "cpt-cf-usage-collector-principle-two-phase-authz (§2.1): AuthorizedUsageEmitter bound context updated to reflect Option<T> subject fields"
+        - "UsageRecord relationships (§3.1): removed 'always derived from SecurityContext'; updated to optional-subject contract"
+        - "SDK emit() bullet (§3.2): replaced 'captures subject from SecurityContext' with optional-subject conditional logic"
+        - "Scoped Emit Client emit() operation (§3.3): updated to optional-subject contract"
+        - "Emit Usage Record sequence (§3.6): replaced single capture step with conditional alt branch for optional subject"
+    - version: "0.2.0"
+      date: "2026-04-27"
+      changes:
+        - "fr-subject-attribution (§1.2): subject identity now accepted from payload with PDP authz; falls back to SecurityContext when not supplied"
+        - "cpt-cf-usage-collector-principle-two-phase-authz (§2.1): bound context extended with subject_id and subject_type; AuthorizedUsageEmitter described as carrying subject identity"
+        - "AuthorizedUsageEmitter (§3.1): token description includes subject_id and subject_type as bound fields"
+    - version: "0.1.0"
+      date: "2026-04-01"
+      changes:
+        - "Initial design"
+---
+
 # Technical Design — Usage Collector
 
 
@@ -30,9 +57,14 @@
 
 Usage Collector follows the ModKit Gateway + Plugins pattern. The gateway module (`usage-collector`) is the single centralized service that receives usage records, enforces tenant isolation, and delegates all storage operations to the active plugin. Backend-specific persistence and query logic for ClickHouse or TimescaleDB is encapsulated in storage plugins that register via the GTS type system and are selected by operator configuration. The gateway contains no backend-specific logic.
 
-The SDK crate (`usage-collector-sdk`) defines two trait boundaries: `UsageCollectorClientV1` for usage sources and consumers, and `UsageCollectorPluginClientV1` for storage backend implementations. When a usage source emits a record, the SDK persists it to the source's local database within the same transaction as the caller's domain operation (transactional outbox pattern). The SDK initializes and owns an `OutboxHandle` whose background pipeline automatically delivers enqueued records to the collector gateway, providing at-least-once delivery even when the collector is temporarily unavailable.
+The SDK crate (`usage-collector-sdk`) defines two trait boundaries: `UsageCollectorClientV1` for delivery to the collector gateway (not registered in ClientHub — passing it through the hub would allow any module to push unvalidated records, bypassing authorization), and `UsageCollectorPluginClientV1` for storage backend implementations. The `usage-emitter` crate exposes `UsageEmitterV1`, registered in ClientHub by either the gateway module (in-process delivery) or `usage-collector-rest-client` (HTTP delivery to a remote collector); usage sources call `for_module()` on it to obtain a `ScopedUsageEmitter`. When a usage source emits a record, the emitter persists it to the source's local database within the same transaction as the caller's domain operation (transactional outbox pattern). The outbox background pipeline automatically delivers enqueued records to the collector gateway, providing at-least-once delivery even when the collector is temporarily unavailable.
 
-Once records arrive at the gateway, they are persisted via the active storage plugin and become available for aggregation and raw queries. All query operations are scoped to the authenticated tenant derived from the caller's SecurityContext. For ingest, tenant attribution is PDP-authorized at emit time: standard sources emit for their own tenant (derived from SecurityContext); sources explicitly authorized by the PDP to act on behalf of multiple tenants supply the target tenant in the record, which is validated against PDP-returned constraints before the outbox INSERT and re-validated at gateway ingest as a defense-in-depth check.
+There are two supported deployment modes, differing only in how the outbox background pipeline delivers records:
+
+- **In-process mode** (`usage-collector` registers `UsageEmitterV1`): the background delivery pipeline calls the gateway's `UsageCollectorLocalClient` directly as a Rust function call. Used when the usage source and the collector gateway run in the same process.
+- **Remote mode** (`usage-collector-rest-client` registers `UsageEmitterV1`): the background delivery pipeline sends an authenticated HTTP POST to the gateway's ingest endpoint (`POST /usage-collector/v1/records`), acquiring a bearer token via the platform AuthN resolver before each request. Used when the usage source runs in a separate process or service binary. The emit path (`authorize_for()` → `enqueue()`) is identical; only the delivery hop differs.
+
+Once records arrive at the gateway, they are persisted via the active storage plugin and become available for aggregation and raw queries. All query operations are scoped to the authenticated tenant derived from the caller's SecurityContext. For ingest, tenant attribution is PDP-authorized at emit time via the `USAGE_RECORD`/`CREATE` operation — the PDP decision covers both same-tenant and subtenant scenarios; the gateway does not perform a second tenant check on delivery.
 
 ### 1.2 Architecture Drivers
 
@@ -41,28 +73,28 @@ Once records arrive at the gateway, they are persisted via the active storage pl
 | Requirement | Design Response |
 |-------------|-----------------|
 | `cpt-cf-usage-collector-fr-ingestion` | SDK `emit()` persists record to local outbox within the caller's transaction; outbox library background pipeline delivers to gateway |
-| `cpt-cf-usage-collector-fr-idempotency` | Counter records require a non-null idempotency key; `emit()` rejects counter records without one (`EmitError::MissingIdempotencyKey`) before any outbox INSERT; gauge records accept a null key; idempotency key is carried in the outbox payload; storage plugin performs idempotent upsert on non-null keys at delivery |
+| `cpt-cf-usage-collector-fr-idempotency` | Counter records require a non-null idempotency key; `build_usage_record().enqueue()` rejects counter records without one (`UsageEmitterError::InvalidRecord`) before any outbox INSERT; gauge records auto-generate a UUID key when none is supplied; idempotency key is carried in the outbox payload; storage plugin performs idempotent upsert on non-null keys at delivery |
 | `cpt-cf-usage-collector-fr-delivery-guarantee` | Transactional outbox in source's local DB; outbox library retries with exponential backoff; messages that exhaust retry budget are moved to the dead-letter store and surfaced via monitoring |
-| `cpt-cf-usage-collector-fr-counter-semantics` | `ScopedUsageCollectorClientV1.emit()` rejects counter records with a negative value or a missing idempotency key before inserting the outbox row; delta records are stored per-event; the persistent total for a (tenant, metric) pair is the SUM of all active delta records — see §3.7 Counter Accumulation for the full strategy including plugin-level acceleration options |
-| `cpt-cf-usage-collector-fr-gauge-semantics` | Gauge records carry `metric_kind = gauge`; `emit()` applies no monotonicity validation; storage plugin stores values as-is |
-| `cpt-cf-usage-collector-fr-tenant-attribution` | `emit()` uses `record.tenant_id` as supplied by the caller and validates it against PDP constraints in `EmitAuthorization`: if the PDP returned a tenant `In` constraint, `record.tenant_id` must be a member of the allowed set; if no tenant constraint was returned, `record.tenant_id` must equal `ctx.subject_tenant_id()` (preserving standard single-tenant behavior). The validated `tenant_id` is stamped into the outbox row. Gateway validates tenant attribution on ingest: when `record.tenant_id ≠ ctx.subject_tenant_id()`, the gateway calls the PDP with `context_tenant_id(record.tenant_id)` and action `"emit_on_behalf"` to re-authorize before delegating to the plugin. |
-| `cpt-cf-usage-collector-fr-resource-attribution` | `UsageRecord` carries optional `resource_id` and `resource_type` fields; persisted in outbox payload and storage backend; gateway and plugin pass them through without interpretation |
-| `cpt-cf-usage-collector-fr-subject-attribution` | `ScopedUsageCollectorClientV1.emit()` captures `subject_id` and `subject_type` from the authenticated SecurityContext and includes them in the outbox payload; never accepted from request payload |
+| `cpt-cf-usage-collector-fr-counter-semantics` | `AuthorizedUsageEmitter.enqueue()` rejects counter records with a negative value or a missing idempotency key before inserting the outbox row; delta records are stored per-event; the persistent total for a (tenant, metric) pair is the SUM of all active delta records — see §3.7 Counter Accumulation for the full strategy including plugin-level acceleration options |
+| `cpt-cf-usage-collector-fr-gauge-semantics` | Gauge records carry `kind = gauge`; `enqueue()` applies no monotonicity validation; storage plugin stores values as-is |
+| `cpt-cf-usage-collector-fr-tenant-attribution` | The caller supplies `tenant_id` explicitly to `authorize_for()` (or the subject's home tenant is used via `authorize()`); the PDP `USAGE_RECORD`/`CREATE` check at that point authorizes the caller to emit for the specified tenant, covering both same-tenant and subtenant cases. The authorized `tenant_id` is bound into the `AuthorizedUsageEmitter` token and stamped into every outbox row produced by that token. The gateway accepts the `tenant_id` from the delivered record without a second PDP check. |
+| `cpt-cf-usage-collector-fr-resource-attribution` | `UsageRecord` carries required `resource_id` (UUID) and `resource_type` (string) fields; both are mandatory at emit time; persisted in outbox payload and storage backend; gateway and plugin pass them through without interpretation |
+| `cpt-cf-usage-collector-fr-subject-attribution` | Subject attribution is optional per usage record. `subject_id` and `subject_type` are `Option<T>` fields in `UsageRecord`. When supplied in the request payload, they are accepted with PDP authorization (via `authorize_for()`). When absent from the payload, they may be derived from `SecurityContext` via the `authorize()` convenience path. When both are `None`, PDP subject properties are omitted from the authorization request and subject validation is skipped entirely. |
 | `cpt-cf-usage-collector-fr-tenant-isolation` | Gateway enforces tenant scoping on all read and write operations; plugins filter by tenant ID; system fails closed on authorization failure |
-| `cpt-cf-usage-collector-fr-ingestion-authorization` | `ScopedUsageCollectorClientV1.authorize_emit()` calls the platform PDP before any transaction opens; returned `EmitAuthorization` carries PDP constraints (including an optional tenant `In` constraint for sources authorized to emit for multiple tenants), source-level rate limit quota snapshot, and the registered usage type schema — all evaluated in-memory by `emit()` before the outbox INSERT; denied or constraint-violating emissions are rejected before any record is persisted |
+| `cpt-cf-usage-collector-fr-ingestion-authorization` | `ScopedUsageEmitter.authorize_for()` / `ScopedUsageEmitter.authorize()` calls the platform PDP (`USAGE_RECORD`/`CREATE`) before any transaction opens; a denial is surfaced immediately with no record persisted; the returned `AuthorizedUsageEmitter` token carries the allowed-metrics list and authorization context evaluated in-memory by `enqueue()` before the outbox INSERT |
 | `cpt-cf-usage-collector-fr-pluggable-storage` | Gateway resolves active plugin via GTS; plugin implements write and read traits; operator selects backend via configuration |
 | `cpt-cf-usage-collector-fr-query-aggregation` | Gateway enforces PDP decision + constraint on each query; exposes aggregation query API with optional filters (usage type, subject, resource, source) and configurable GROUP BY dimensions (time bucket, usage type, subject, resource, source); delegates to plugin, which pushes aggregation (SUM, COUNT, MIN, MAX, AVG) and grouping down to the storage engine |
 | `cpt-cf-usage-collector-fr-query-raw` | Gateway enforces PDP decision + constraint on each query; exposes raw query API with optional filters (usage type, subject, resource) and cursor-based pagination; delegates to plugin |
 | `cpt-cf-usage-collector-fr-record-metadata` | Gateway enforces configurable 8 KB metadata size limit at ingest; plugin stores metadata as-is in a dedicated payload column; metadata is returned in query results without interpretation |
 | `cpt-cf-usage-collector-fr-retention-policies` | Gateway manages retention policy configuration (global, per-tenant, per-usage-type); plugin enforces retention via storage-native TTL or scheduled deletion |
-| `cpt-cf-usage-collector-fr-backfill-api` | Gateway accepts backfill requests and bulk-inserts historical records via the plugin; gateway calls the platform PDP to authorize the caller for the specified `tenant_id` before accepting the request — callers whose SecurityContext tenant differs from the requested `tenant_id` require a dedicated cross-tenant backfill PDP permission and the PDP must return a constraint that includes the target tenant; a PDP denial or constraint violation returns `403 PERMISSION_DENIED` immediately; existing records in the range are not modified; backfill path operates with independent rate limits; gateway emits `WriteAuditEvent` to `audit_service` on completion |
+| `cpt-cf-usage-collector-fr-backfill-api` | Gateway accepts backfill requests and bulk-inserts historical records via the plugin; gateway calls the platform PDP to authorize the caller for the specified `tenant_id` before accepting the request; a PDP denial returns `403 PERMISSION_DENIED` immediately; existing records in the range are not modified; backfill path operates with independent rate limits; gateway emits `WriteAuditEvent` to `audit_service` on completion |
 | `cpt-cf-usage-collector-fr-event-amendment` | Gateway exposes amendment and deactivation endpoints for individual events; plugin updates record status fields; gateway emits `WriteAuditEvent` to `audit_service` on each operation |
 | `cpt-cf-usage-collector-fr-audit` | Gateway emits a structured `WriteAuditEvent` to platform `audit_service` on every operator-initiated write (backfill, amendment, deactivation); event includes common envelope (operation, actor_id, tenant_id, timestamp, justification) and operation-specific context; no audit data is stored locally |
 | `cpt-cf-usage-collector-fr-backfill-boundaries` | Gateway enforces configurable maximum backfill window (default 90 days) and future timestamp tolerance (default 5 minutes); requests beyond the maximum window require elevated authorization verified before any plugin operation |
 | `cpt-cf-usage-collector-fr-metadata-exposure` | Gateway exposes a watermark API endpoint; plugin queries per-source and per-tenant event counts and latest ingested timestamps to populate the response |
-| `cpt-cf-usage-collector-fr-type-validation` | `authorize_emit()` fetches the registered usage type schema from types-registry; `emit()` validates the record against it in-memory before the outbox INSERT, rejecting invalid records immediately; gateway retains schema validation as a defense-in-depth check on delivered records before delegating to the plugin |
+| `cpt-cf-usage-collector-fr-type-validation` | `authorize_for()` fetches the registered usage type schema from types-registry; `enqueue()` validates the record against it in-memory before the outbox INSERT, rejecting invalid records immediately; gateway retains schema validation as a defense-in-depth check on delivered records before delegating to the plugin |
 | `cpt-cf-usage-collector-fr-custom-units` | Gateway exposes a usage type registration endpoint that delegates to types-registry; operator configures authorization policies per usage type after registration |
-| `cpt-cf-usage-collector-fr-rate-limiting` | `authorize_emit()` fetches the current source-level emission quota and window snapshot for the source module before any transaction opens; `emit()` evaluates the quota in-memory and rejects the emission before the outbox INSERT if the source quota is exhausted; gateway enforces per-(source, tenant) quota on ingest when `record.tenant_id` is known; rejections are surfaced via operational monitoring; rate limit configuration is managed by the platform operator |
+| `cpt-cf-usage-collector-fr-rate-limiting` | `authorize_for()` fetches the current source-level emission quota and window snapshot for the source module before any transaction opens; `enqueue()` evaluates the quota in-memory and rejects the emission before the outbox INSERT if the source quota is exhausted; gateway enforces per-(source, tenant) quota on ingest when `record.tenant_id` is known; rejections are surfaced via operational monitoring; rate limit configuration is managed by the platform operator |
 
 #### NFR Allocation
 
@@ -71,48 +103,64 @@ Once records arrive at the gateway, they are persisted via the active storage pl
 | `cpt-cf-usage-collector-nfr-query-latency` | Aggregation queries over 30-day range complete within 500ms at p95 | Storage Plugin | Aggregation pushed down to storage engine; plugins SHOULD maintain pre-aggregated acceleration structures (ClickHouse `AggregatingMergeTree` view, TimescaleDB continuous aggregate) to meet this threshold at production record volumes — see §3.7 Counter Accumulation for the full strategy and consistency model | Benchmark test with 30-day synthetic dataset at target production record volume at p95 |
 | `cpt-cf-usage-collector-nfr-availability` | 99.95% monthly availability for ingestion endpoints | Gateway, SDK | Stateless gateway enables horizontal replication; the SDK's outbox pipeline absorbs temporary gateway unavailability, preserving record capture continuity; liveness probes and graceful shutdown ensure fast instance recovery | SLO tracking on gateway uptime; synthetic availability probes on ingestion endpoint |
 | `cpt-cf-usage-collector-nfr-throughput` | ≥ 10,000 records/sec sustained ingestion | Gateway, Storage Plugin | Gateway dispatches records to the storage plugin for batched idempotent upsert; plugin pushes bulk INSERTs to append-optimized storage (ClickHouse column store, TimescaleDB hypertable); stateless gateway scales horizontally | Sustained load test at 10,000 records/sec for 10 minutes; verify no records lost and no latency degradation |
-| `cpt-cf-usage-collector-nfr-ingestion-latency` | Ingestion completes within 200ms at p95 | SDK | `emit()` is a local DB INSERT within the caller's transaction — no network I/O on the critical emission path; p95 latency is bounded by local DB write speed, well within the 200ms threshold | Benchmark `emit()` p95 latency under representative concurrent load |
+| `cpt-cf-usage-collector-nfr-ingestion-latency` | Ingestion completes within 200ms at p95 | SDK | `authorized.build_usage_record(...).enqueue()` is a local DB INSERT within the caller's transaction — no network I/O on the critical emission path; p95 latency is bounded by local DB write speed, well within the 200ms threshold | Benchmark `authorized.build_usage_record(...).enqueue()` p95 latency under representative concurrent load |
 | `cpt-cf-usage-collector-nfr-workload-isolation` | Ingestion p95 ≤ 200ms during concurrent query and retention workloads | Gateway, Storage Plugin | Query and retention workloads run on separate handler paths from the ingest handler; retention enforcement runs as a scheduled background task with lower priority; plugins leverage storage-native query prioritization (ClickHouse query priority classes, TimescaleDB resource groups) to prevent analytical workloads from starving ingest writes | Measure ingest p95 under concurrent aggregation queries and retention enforcement; verify it remains within `cpt-cf-usage-collector-nfr-ingestion-latency` threshold |
 | `cpt-cf-usage-collector-nfr-authentication` | Zero unauthenticated API access | Gateway | All gateway endpoints require a valid authenticated SecurityContext; unauthenticated requests are rejected by the ModKit request pipeline before any handler or plugin is invoked | Integration tests verifying all endpoints return a rejection for requests without valid authentication credentials |
-| `cpt-cf-usage-collector-nfr-authorization` | Zero unauthorized data access or write | Gateway, SDK | SDK `authorize_emit()` contacts the platform PDP before any transaction opens; gateway enforces PDP authorization on all query, backfill, amendment, and deactivation endpoints and applies returned constraints as additional query filters; system fails closed on any authorization failure (`cpt-cf-usage-collector-principle-fail-closed`) | Integration tests verifying unauthorized ingestion, query, backfill, and amendment requests are rejected with no data exposed or modified |
+| `cpt-cf-usage-collector-nfr-authorization` | Zero unauthorized data access or write | Gateway, Emitter | `ScopedUsageEmitter.authorize_for()` contacts the platform PDP (`USAGE_RECORD`/`CREATE`) before any transaction opens; gateway enforces PDP authorization on all query, backfill, amendment, and deactivation endpoints and applies returned constraints as additional query filters; system fails closed on any authorization failure (`cpt-cf-usage-collector-principle-fail-closed`) | Integration tests verifying unauthorized ingestion, query, backfill, and amendment requests are rejected with no data exposed or modified |
 | `cpt-cf-usage-collector-nfr-scalability` | Linear throughput scaling with added instances | Gateway | Gateway is stateless — all per-request state is carried in SecurityContext and request payload; horizontal scaling is achieved by adding gateway instances behind a load balancer with no coordination required | Load test demonstrating linear throughput increase as gateway instance count is increased from 1 to N |
-| `cpt-cf-usage-collector-nfr-fault-tolerance` | Zero data loss for durably captured records during storage backend failures | SDK, Gateway | The SDK's outbox pipeline retries failed gateway deliveries with exponential backoff; gateway retries plugin persist calls on transient storage errors; records durably captured in the source outbox are guaranteed to eventually reach the storage backend; messages that exhaust retry budget are moved to the dead-letter store and surfaced via operational monitoring | Chaos test: take storage backend offline, verify outbox rows survive and are delivered on recovery with zero data loss |
+| `cpt-cf-usage-collector-nfr-fault-tolerance` | Zero data loss for durably captured records during storage backend failures | SDK, Gateway | The SDK's outbox pipeline retries failed gateway deliveries with exponential backoff; gateway retries plugin `create_usage_record` calls on transient storage errors; records durably captured in the source outbox are guaranteed to eventually reach the storage backend; messages that exhaust retry budget are moved to the dead-letter store and surfaced via operational monitoring | Chaos test: take storage backend offline, verify outbox rows survive and are delivered on recovery with zero data loss |
 | `cpt-cf-usage-collector-nfr-recovery` | RTO ≤ 15 minutes from storage backend recovery | SDK, Gateway | The outbox library resumes delivery automatically once the gateway becomes reachable again; gateway re-establishes plugin connection on storage recovery without restart; the RTO bound is determined by the outbox retry schedule — `backoff_max` MUST be configured below 15 minutes to meet this threshold | Chaos test: restore storage backend after outage, measure elapsed time from backend availability to full outbox drain and query availability; verify elapsed time ≤ 15 minutes |
 | `cpt-cf-usage-collector-nfr-retention` | Configurable retention from 7 days to 7 years | Storage Plugin | Retention policy configuration is managed by the gateway; plugin enforces retention via storage-native TTL expressions (ClickHouse) or scheduled deletion (TimescaleDB); policies apply at global, per-tenant, and per-usage-type scope | Test retention enforcement for each plugin: records older than the configured duration are removed within the enforcement window |
-| `cpt-cf-usage-collector-nfr-graceful-degradation` | Zero ingestion failures due to downstream consumer unavailability | SDK | `emit()` writes to the source's local database within the caller's transaction — no runtime dependency on the collector or any downstream consumer; the outbox pipeline delivers asynchronously, fully decoupling the source's emission path from collector and consumer uptime | Integration test: take the collector gateway offline; verify sources continue emitting without errors and records are delivered on gateway recovery |
-| `cpt-cf-usage-collector-nfr-rpo` | RPO = 0 for all records for which `emit()` returned `Ok` | SDK | `emit()` calls `Outbox::enqueue()` within the caller's DB transaction — a record is durable the moment that transaction commits; no committed record can be lost by a subsequent gateway restart, dispatcher crash, or storage outage, because the outbox row persists independently in the source's local DB until confirmed delivered | Test: call `emit()` successfully, kill the gateway process immediately after commit, restart gateway; verify the record is delivered and queryable with no data loss |
+| `cpt-cf-usage-collector-nfr-graceful-degradation` | Zero ingestion failures due to downstream consumer unavailability | SDK | `authorized.build_usage_record(...).enqueue()` writes to the source's local database within the caller's transaction — no runtime dependency on the collector or any downstream consumer; the outbox pipeline delivers asynchronously, fully decoupling the source's emission path from collector and consumer uptime | Integration test: take the collector gateway offline; verify sources continue emitting without errors and records are delivered on gateway recovery |
+| `cpt-cf-usage-collector-nfr-rpo` | RPO = 0 for all records for which `authorized.build_usage_record(...).enqueue()` returned `Ok` | SDK | `authorized.build_usage_record(...).enqueue()` calls `Outbox::enqueue()` within the caller's DB transaction — a record is durable the moment that transaction commits; no committed record can be lost by a subsequent gateway restart, dispatcher crash, or storage outage, because the outbox row persists independently in the source's local DB until confirmed delivered | Test: call `authorized.build_usage_record(...).enqueue()` successfully, kill the gateway process immediately after commit, restart gateway; verify the record is delivered and queryable with no data loss |
 
 #### Key ADRs
 
 | ADR ID | Decision Summary |
 |--------|-----------------|
-| `cpt-cf-usage-collector-adr-scoped-emit-source` | `UsageCollectorClientV1.for_module()` returns a `ScopedUsageCollectorClientV1` bound to the source module's authoritative name; scoped client stamps source identity on every emit |
-| `cpt-cf-usage-collector-adr-two-phase-emit-authz` | `authorize_emit()` calls the PDP before any DB transaction; `emit()` evaluates returned constraints in-memory inside the transaction — no network I/O on the critical emission path |
+| `cpt-cf-usage-collector-adr-scoped-emit-source` | `UsageEmitterV1.for_module()` returns a `ScopedUsageEmitter` bound to the source module's authoritative name; scoped emitter stamps source identity on every emit |
+| `cpt-cf-usage-collector-adr-two-phase-emit-authz` | `authorize_for()` / `authorize()` calls the PDP before any DB transaction; `build_usage_record().enqueue()` evaluates returned constraints in-memory inside the transaction — no network I/O on the critical emission path |
 
 ### 1.3 Architecture Layers
 
-```
+**In-process mode** (source and gateway in the same process):
+
+```text
 ┌────────────────────────────────────────────────────────────────┐
-│                    Usage Sources                               │
-│            (LLM Gateway, Compute Service, etc.)                │
+│  Usage Source (same process as gateway)                        │
 ├────────────────────────────────────────────────────────────────┤
-│  usage-collector-sdk  │  emit() + outbox enqueue + delivery    │
+│  usage-emitter        │  UsageEmitterV1 (ClientHub); scoped    │
+│                       │  emit + outbox enqueue + delivery      │
+├────────────────────────────────────────────────────────────────┤
+│  usage-collector-sdk  │  UsageCollectorClientV1 (delivery);    │
+│                       │  UsageCollectorPluginClientV1 (plugin) │
 ├────────────────────────────────────────────────────────────────┤
 │  usage-collector      │  Gateway: ingest, query, tenant iso.   │
+│                       │  outbox bootstrap + migrations         │
 ├────────────────────────────────────────────────────────────────┤
 │  Plugins              │  Backend-specific storage adapters     │
-│  ┌──────────────────────┐  ┌───────────────────────────────┐   │
-│  │ clickhouse-plugin    │  │ timescaledb-plugin            │   │
-│  └──────────────────────┘  └───────────────────────────────┘   │
-├────────────────────────────────────────────────────────────────┤
-│  External              │  ClickHouse, TimescaleDB              │
 └────────────────────────────────────────────────────────────────┘
+```
+
+**Remote mode** (source and gateway in separate processes):
+
+```text
+┌─────────────────────────────────┐   ┌───────────────────────────────┐
+│  Usage Source Process           │   │  Collector Process            │
+│                                 │   │                               │
+│  usage-emitter                  │   │  usage-collector (gateway)    │
+│  usage-collector-rest-client    │──►│  POST /usage-collector/v1/    │
+│  (UsageEmitterV1 in ClientHub;  │   │  records (bearer token auth)  │
+│   HTTP delivery via authN token)│   │                               │
+└─────────────────────────────────┘   └───────────────────────────────┘
 ```
 
 | Layer | Responsibility | Technology |
 |-------|---------------|------------|
-| SDK | Emit API; outbox enqueue; owns `OutboxHandle` whose background pipeline automatically delivers records to the gateway | Rust crate (`usage-collector-sdk`), modkit-db outbox |
-| Gateway | Ingest, query, aggregation API; tenant isolation; plugin resolution | Rust crate (`usage-collector`), Axum |
+| Emitter | Source-facing emit API (`UsageEmitterV1`); `ScopedUsageEmitter` / `AuthorizedUsageEmitter`; two-phase auth; outbox enqueue; background delivery pipeline | Rust crate (`usage-emitter`), modkit-db outbox |
+| SDK | `UsageCollectorClientV1` delivery trait (not in ClientHub); `UsageCollectorPluginClientV1` plugin trait; shared model types | Rust crate (`usage-collector-sdk`) |
+| REST Client | Remote `UsageCollectorClientV1` implementation; registers `UsageEmitterV1` in ClientHub for out-of-process sources; acquires bearer token via AuthN resolver and HTTP-POSTs records to the gateway ingest endpoint | Rust crate (`usage-collector-rest-client`) |
+| Gateway | Ingest, query, aggregation API; tenant isolation; plugin resolution; outbox queue registration and schema migrations; registers `UsageEmitterV1` for in-process sources | Rust crate (`usage-collector`), Axum |
 | Plugins | Backend-specific record persistence and aggregation queries | Rust crates, ClickHouse / TimescaleDB drivers |
 | External | Durable time-series storage and query execution | ClickHouse or TimescaleDB |
 
@@ -136,7 +184,7 @@ All storage operations — write, aggregation query, and raw query — are deleg
 
 - [ ] `p1` - **ID**: `cpt-cf-usage-collector-principle-tenant-from-ctx`
 
-Tenant identity for usage attribution is always PDP-authorized — never freely accepted from request payloads. For standard sources, the SDK derives the tenant from `SecurityContext.subject_tenant_id()` and validates that `record.tenant_id` matches. For sources explicitly authorized by the PDP to emit on behalf of multiple tenants, the PDP returns a tenant `In` constraint; `emit()` validates `record.tenant_id` against that constraint before the outbox INSERT. The gateway re-validates tenant attribution independently on every ingest delivery. Queries are always scoped to the authenticated tenant from SecurityContext.
+Tenant identity for usage attribution is always PDP-authorized — never freely accepted from request payloads. The caller supplies the target `tenant_id` to `authorize_for()` (or uses the subject's home tenant via `authorize()`); the PDP `USAGE_RECORD`/`CREATE` decision covers both same-tenant and subtenant scenarios. The authorized `tenant_id` is bound into the `AuthorizedUsageEmitter` token and cannot be changed per-record. The gateway accepts the `tenant_id` from delivered records without re-checking. Queries are always scoped to the authenticated tenant from SecurityContext.
 
 #### Fail-Closed Security
 
@@ -152,7 +200,7 @@ On any authorization failure, the system rejects the request. No fallback to per
 
 **ADRs**: `cpt-cf-usage-collector-adr-scoped-emit-source`
 
-Each consuming module obtains a `ScopedUsageCollectorClientV1` by calling `for_module()` once at module initialization, passing its compile-time `MODULE_NAME` constant. The scoped client stamps every outbox row with the source module identity. Which metrics a source is permitted to emit is governed by authz policy. Source identity is never supplied per-call.
+Each consuming module obtains a `ScopedUsageEmitter` by calling `UsageEmitterV1::for_module()` once at module initialization, passing its compile-time `MODULE_NAME` constant. The scoped emitter stamps every outbox row with the source module identity. Which metrics a source is permitted to emit is governed by authz policy. Source identity is never supplied per-call.
 
 #### Two-Phase Emit
 
@@ -160,14 +208,14 @@ Each consuming module obtains a `ScopedUsageCollectorClientV1` by calling `for_m
 
 **ADRs**: `cpt-cf-usage-collector-adr-two-phase-emit-authz`
 
-Any logic that requires communication with external modules is consolidated in phase 1 (`authorize_emit()`), called before any DB transaction opens. Phase 1 accumulates all constraints and state into the returned `EmitAuthorization` token. Phase 2 (`emit()`) applies every accumulated constraint in-memory inside the caller's DB transaction — no external calls on the critical emission path.
+Any logic that requires communication with external modules is consolidated in phase 1 (`authorize_for()` / `authorize()`), called before any DB transaction opens. Phase 1 accumulates all constraints and state into the returned `AuthorizedUsageEmitter` token. Phase 2 (`build_usage_record().enqueue()`) applies every accumulated constraint in-memory inside the caller's DB transaction — no external calls on the critical emission path.
 
-`EmitAuthorization` acts as a pre-fetched, in-memory contract for the emission. It currently carries:
-- **PDP authorization constraints**: the platform PDP decision and any returned `Constraint` predicates, evaluated against the `UsageRecord` fields; for sources authorized to emit for multiple tenants, the PDP returns a tenant `In` constraint listing the allowed target tenant IDs
-- **Rate limit state**: the source-level emission quota and current window snapshot for the source module
-- **Usage type schema**: the registered schema for the metric being emitted, used for in-memory record validation
+`AuthorizedUsageEmitter` acts as a pre-fetched, in-memory contract for the emission. It currently carries:
+- **PDP authorization result**: the platform PDP permit decision for `USAGE_RECORD`/`CREATE` for the specified tenant and resource
+- **Allowed metrics list**: the set of metrics the source module is permitted to emit, fetched from the gateway during phase 1
+- **Bound context**: the authorized `tenant_id`, `resource_id`, `resource_type`, `subject_id`, and `subject_type` — every record produced by this token is stamped with these values; `subject_id` and `subject_type` are `Option<T>`; when both are `None`, PDP subject validation is skipped; when supplied (from payload with PDP authorization via `authorize_for()`, or from `SecurityContext` via `authorize()`), PDP subject properties are included and subject validation runs
 
-Any future requirement that depends on external state at emit time MUST be resolved in phase 1 and included in `EmitAuthorization`, not deferred to phase 2. A denial, quota exhaustion, or validation failure from `authorize_emit()` surfaces immediately to the caller as an error before any domain operation is committed.
+Any future requirement that depends on external state at emit time MUST be resolved in phase 1 and included in `AuthorizedUsageEmitter`, not deferred to phase 2. A denial, quota exhaustion, or validation failure from `authorize_for()` surfaces immediately to the caller as an error before any domain operation is committed.
 
 ### 2.2 Constraints
 
@@ -175,7 +223,7 @@ Any future requirement that depends on external state at emit time MUST be resol
 
 - [ ] `p1` - **ID**: `cpt-cf-usage-collector-constraint-outbox-infra`
 
-The SDK requires the modkit-db outbox schema to be present in the source's local database. The schema is installed by running `outbox_migrations()` from `modkit_db::outbox` as part of the source module's migration set. Usage sources that do not have a local database managed by modkit-db cannot use the SDK directly.
+The `usage-collector` gateway module registers the outbox queue and applies the modkit-db outbox schema migrations via its `DatabaseCapability::migrations()` implementation. Source modules that emit usage in-process MUST declare `usage-collector` as a ModKit dependency so that the outbox schema is applied automatically as part of the gateway's migration set. Usage sources that do not have a local database managed by modkit-db cannot use the emitter.
 
 #### Single Active Plugin
 
@@ -219,26 +267,26 @@ All plugin connections to ClickHouse and TimescaleDB MUST use TLS; connection pa
 
 **Technology**: Rust structs
 
-**Location**: [`modules/system/usage-collector-sdk/src/types.rs`](../../usage-collector-sdk/src/types.rs)
+**Location**: [`modules/system/usage-collector/usage-collector-sdk/`](../../usage-collector/usage-collector-sdk/)
 
 **Core Entities**:
 
 | Entity | Description | Schema |
 |--------|-------------|--------|
-| `UsageRecord` | Single measurement of resource consumption: tenant ID, source module, metric kind (counter/gauge), metric name, numeric value, timestamp; idempotency key (required for counter metrics, optional for gauge metrics), resource ID/type, subject ID/type, metadata (opaque JSON); status (`active` \| `inactive`) | [`usage-collector-sdk/src/types.rs`](../../usage-collector-sdk/src/types.rs) |
-| `AggregationQuery` | Query parameters: tenant ID (derived from SecurityContext), time range (mandatory), aggregation function (SUM/COUNT/MIN/MAX/AVG); optional filters: usage type, subject (subject_id, subject_type), resource (resource_id, resource_type), source; optional GROUP BY dimensions: time bucket granularity, usage type, subject, resource, source | [`usage-collector-sdk/src/types.rs`](../../usage-collector-sdk/src/types.rs) |
-| `AggregationResult` | Result row: aggregation function applied, aggregated numeric value; dimension values present for each active GROUP BY dimension: time bucket start timestamp (when grouped by time), usage type (when grouped by usage type), subject ID + subject type (when grouped by subject), resource ID + resource type (when grouped by resource), source module (when grouped by source); absent dimensions are null | [`usage-collector-sdk/src/types.rs`](../../usage-collector-sdk/src/types.rs) |
-| `RawQuery` | Raw record query parameters: tenant ID (derived from SecurityContext), time range (mandatory), optional pagination cursor; optional filters: usage type, subject (subject_id, subject_type), resource (resource_id, resource_type) | [`usage-collector-sdk/src/types.rs`](../../usage-collector-sdk/src/types.rs) |
-| `EmitAuthorization` | Opaque token returned by `authorize_emit()`; carries all constraints evaluated in-memory by `emit()`: PDP authorization constraints (`Vec<Constraint>`, may include a tenant `In` constraint for sources authorized to emit for multiple tenants), source-level rate limit quota snapshot (emission count, window bounds, and configured limit for the source module), the registered usage type schema for the metric being emitted, and a monotonic issuance timestamp with a random nonce. `emit()` verifies the token has not exceeded its maximum age before evaluating any other constraint. | [`usage-collector-sdk/src/types.rs`](../../usage-collector-sdk/src/types.rs) |
-| `RetentionPolicy` | Retention rule: scope (`global` \| `tenant` \| `usage-type`), target identifier, retention duration. The global policy is mandatory and cannot be deleted; it applies when no more-specific policy matches. Precedence: per-usage-type > per-tenant > global. | [`usage-collector-sdk/src/types.rs`](../../usage-collector-sdk/src/types.rs) |
-| `BackfillOperation` | Backfill request: operator identity, target `tenant_id` (PDP-authorized: gateway verifies the caller is permitted to backfill for the specified tenant; cross-tenant operations require a dedicated PDP permission and the returned constraint must include the target tenant), usage type, time range, historical records to insert | [`usage-collector-sdk/src/types.rs`](../../usage-collector-sdk/src/types.rs) |
-| `WriteAuditEvent` | Structured event emitted to platform `audit_service` for each operator-initiated write: operation type (`backfill` \| `amend` \| `deactivate`), actor_id, tenant_id, timestamp, justification, and a `WriteAuditContext` variant with operation-specific context — backfill: (usage type, time range, records added); amendment: (record ID, changed fields before/after); deactivation: (record ID). Not stored locally. | [`usage-collector-sdk/src/types.rs`](../../usage-collector-sdk/src/types.rs) |
+| `UsageRecord` | Single measurement of resource consumption: tenant ID, source module (`module` field), metric kind (`kind` field: counter/gauge), metric name, numeric value, timestamp; idempotency key (required for counter metrics, optional for gauge metrics), resource ID and resource type (both required), subject ID/type, metadata (opaque JSON); status (`active` \| `inactive`) | [`usage-collector-sdk/src/models.rs`](../../usage-collector/usage-collector-sdk/src/models.rs) |
+| `AggregationQuery` | Query parameters: tenant ID (derived from SecurityContext), time range (mandatory), aggregation function (SUM/COUNT/MIN/MAX/AVG); optional filters: usage type, subject (subject_id, subject_type), resource (resource_id, resource_type), source; optional GROUP BY dimensions: time bucket granularity, usage type, subject, resource, source | `AggregationQuery` is not yet present in the SDK (target-state) |
+| `AggregationResult` | Result row: aggregation function applied, aggregated numeric value; dimension values present for each active GROUP BY dimension: time bucket start timestamp (when grouped by time), usage type (when grouped by usage type), subject ID + subject type (when grouped by subject), resource ID + resource type (when grouped by resource), source module (when grouped by source); absent dimensions are null | `AggregationResult` is not yet present in the SDK (target-state) |
+| `RawQuery` | Raw record query parameters: tenant ID (derived from SecurityContext), time range (mandatory), optional pagination cursor; optional filters: usage type, subject (subject_id, subject_type), resource (resource_id, resource_type) | `RawQuery` is not yet present in the SDK (target-state) |
+| `AuthorizedUsageEmitter` | Time-limited authorization handle returned by `authorize_for()` / `authorize()`; carries the PDP permit result, the authorized `tenant_id`/`resource_id`/`resource_type`, the subject identity (`subject_id`/`subject_type`) bound at authorization time (accepted from the caller with PDP authorization or derived from `SecurityContext` when absent), the allowed-metrics list for the source module, and a monotonic issuance timestamp. `enqueue()` verifies the token has not exceeded its maximum age before proceeding. | `AuthorizedUsageEmitter` is not yet present in the SDK (target-state); see `usage-emitter` crate |
+| `RetentionPolicy` | Retention rule: scope (`global` \| `tenant` \| `usage-type`), target identifier, retention duration. The global policy is mandatory and cannot be deleted; it applies when no more-specific policy matches. Precedence: per-usage-type > per-tenant > global. | `RetentionPolicy` is not yet present in the SDK (target-state) |
+| `BackfillOperation` | Backfill request: operator identity, target `tenant_id` (PDP-authorized: gateway verifies the caller is permitted to backfill for the specified tenant before accepting the request), usage type, time range, historical records to insert | `BackfillOperation` is not yet present in the SDK (target-state) |
+| `WriteAuditEvent` | Structured event emitted to platform `audit_service` for each operator-initiated write: operation type (`backfill` \| `amend` \| `deactivate`), actor_id, tenant_id, timestamp, justification, and a `WriteAuditContext` variant with operation-specific context — backfill: (usage type, time range, records added); amendment: (record ID, changed fields before/after); deactivation: (record ID). Not stored locally. | `WriteAuditEvent` is not yet present in the SDK (target-state) |
 | `UsageType` | Registered usage type schema: type identifier, metric kind, unit label, validation rules | types-registry |
 
 **Relationships**:
 - `UsageRecord` belongs to exactly one tenant via `tenant_id`
-- `UsageRecord` optionally belongs to one resource via `resource_id`/`resource_type`
-- `UsageRecord` optionally belongs to one subject via `subject_id`/`subject_type`, always derived from SecurityContext
+- `UsageRecord` belongs to exactly one resource via `resource_id`/`resource_type` (both required)
+- `UsageRecord` optionally belongs to one subject via `subject_id`/`subject_type`; when present, subject is accepted from the request payload with PDP authorization or derived from `SecurityContext` via `authorize()`; when absent (both fields `None`), the record carries no subject attribution and PDP subject validation is skipped
 - `UsageRecord` carries optional `metadata` (opaque JSON); persisted and returned as-is without interpretation
 - `UsageRecord` status is `active` on creation; transitions to `inactive` on operator-initiated deactivation or amendment
 - `AggregationResult` carries dimension values only for dimensions active in the originating `AggregationQuery`; a query with no GROUP BY returns a single row with all dimension fields null
@@ -251,13 +299,22 @@ All plugin connections to ClickHouse and TimescaleDB MUST use TLS; connection pa
 
 ```mermaid
 graph TD
-    subgraph Source["Usage Source Process"]
-        App[Application Code]
-        SDK[usage-collector-sdk]
-        LDB[(Local DB)]
+    subgraph InProcess["In-Process Mode (source + gateway same process)"]
+        App1[Application Code]
+        Emitter1[usage-emitter]
+        LDB1[(Local DB)]
+        GW1[Gateway / UsageCollectorLocalClient]
     end
 
-    subgraph Collector["Usage Collector"]
+    subgraph Remote["Remote Mode (source in separate process)"]
+        App2[Application Code]
+        Emitter2[usage-emitter]
+        LDB2[(Local DB)]
+        RC[usage-collector-rest-client]
+        AuthN[authn-resolver]
+    end
+
+    subgraph Collector["Collector Process"]
         GW[Gateway]
         Plugin[Storage Plugin]
     end
@@ -268,34 +325,40 @@ graph TD
 
     Consumer[Usage Consumer]
 
-    App -->|emit| SDK
-    SDK -->|enqueue within caller tx| LDB
-    SDK -->|"deliver (outbox pipeline)"| GW
+    App1 -->|"authorize_for / enqueue"| Emitter1
+    Emitter1 -->|enqueue within caller tx| LDB1
+    Emitter1 -->|"outbox pipeline → in-process call"| GW1
+    GW1 --> GW
+
+    App2 -->|"authorize_for / enqueue"| Emitter2
+    Emitter2 -->|enqueue within caller tx| LDB2
+    Emitter2 -->|outbox pipeline| RC
+    RC -->|acquire token| AuthN
+    RC -->|"POST /usage-collector/v1/records (bearer)"| GW
+
     GW -->|write| Plugin
-    Plugin -->|persist| DB
+    Plugin -->|create_usage_record| DB
     Consumer -->|query| GW
     GW -->|read| Plugin
     Plugin -->|aggregate / paginate| DB
 ```
 
-#### Usage Collector SDK
+#### Usage Emitter
 
-- [ ] `p1` - **ID**: `cpt-cf-usage-collector-component-sdk`
-
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-component-emitter`
 
 ##### Why this component exists
 
-Provides the public API for usage sources to emit records. Handles transactional outbox persistence in the source's local database, decoupling sources from collector availability.
+Provides the source-facing API for emitting usage records. Registered in `ClientHub` as `UsageEmitterV1` by either the gateway module (in-process delivery) or `usage-collector-rest-client` (HTTP delivery to a remote collector). Handles two-phase authorization and transactional outbox persistence, decoupling sources from collector availability.
 
 ##### Responsibility scope
 
-- At SDK initialization: register the `"usage-records"` outbox queue (idempotent, 4 partitions), start the decoupled outbox pipeline with the SDK's internal delivery handler, and retain the resulting `OutboxHandle` for the process lifetime — no explicit shutdown coordination is required
-- Expose `for_module(name) -> ScopedUsageCollectorClientV1` on `UsageCollectorClientV1`; each consuming module calls this once at initialization with its compile-time `MODULE_NAME` constant
-- `ScopedUsageCollectorClientV1.authorize_emit(ctx, metric_name)` — called before any DB transaction opens; calls the platform PDP (authz constraints for the given metric, which may include a tenant `In` constraint for sources authorized to emit for multiple tenants), fetches the current source-level rate limit quota snapshot, and retrieves the registered usage type schema for `metric_name` from types-registry; returns an opaque `EmitAuthorization` token on success or an error on denial / quota exhaustion
-- `ScopedUsageCollectorClientV1.emit(ctx, record, &EmitAuthorization)` — called inside the caller's DB transaction; first verifies the token has not exceeded its maximum age (`EmitError::AuthorizationExpired` on expiry); then validates metric semantics (rejects counter records with a negative value or a missing idempotency key), captures subject ID and type from SecurityContext, stamps source module identity, then evaluates all `EmitAuthorization` constraints in-memory in order: usage type schema validation, source-level rate limit quota check, PDP constraint satisfaction (including tenant validation: if a tenant `In` constraint is present, `record.tenant_id` must be a member of the allowed set; if no tenant constraint is present, `record.tenant_id` must equal `ctx.subject_tenant_id()`); rejects before the outbox enqueue on any failure; on success stamps the outbox row with `record.tenant_id` and calls `Outbox::enqueue()` within the caller's transaction
-- Serialize the usage record (tenant ID, source module, metric kind, idempotency key, resource attribution, subject attribution) to bytes as the outbox payload with `payload_type = "usage-collector.record.v1"`
+- Expose `UsageEmitterV1::for_module(name) -> ScopedUsageEmitter`; each consuming module retrieves `UsageEmitterV1` from `ClientHub` and calls `for_module()` once at initialization with its compile-time `MODULE_NAME` constant
+- `ScopedUsageEmitter::authorize_for(ctx, tenant_id, resource_id, resource_type)` and `ScopedUsageEmitter::authorize(ctx, resource_id, resource_type)` — called before any DB transaction opens; call the platform PDP for `USAGE_RECORD`/`CREATE`, fetch the allowed-metrics configuration for this module from the gateway (`get_module_config()`); return an `AuthorizedUsageEmitter` token on success, or error on PDP denial / module not configured
+- `AuthorizedUsageEmitter::build_usage_record(metric, value).enqueue()` — called inside the caller's DB transaction; first verifies the token has not exceeded its maximum age (`EmitError::AuthorizationExpired` on expiry); then validates metric semantics (rejects counter records with a negative value or a missing idempotency key), reads optional `subject_id` and `subject_type` from the authorization context (both are `None` when neither caller-supplied via `authorize_for()` nor derivable from `SecurityContext`), stamps source module identity, then evaluates all `EmitAuthorization` constraints in-memory in order: usage type schema validation, source-level rate limit quota check, PDP constraint satisfaction (including tenant validation: if a tenant `In` constraint is present, `record.tenant_id` must be a member of the allowed set; if no tenant constraint is present, `record.tenant_id` must equal `ctx.subject_tenant_id()`); rejects before the outbox enqueue on any failure; on success stamps the outbox row with `record.tenant_id` and calls `Outbox::enqueue()` within the caller's transaction
+- Serialize the usage record (tenant ID, module, kind, idempotency key, resource attribution, subject attribution) to bytes as the outbox payload with `payload_type = "usage-collector.record.v1"`
 - Pass optional metadata field through to the payload without interpretation; enforce the configurable size limit (default 8 KB) before enqueuing
-- Internally implement a `MessageHandler` that the outbox library calls for each ready message: deserialize the payload, assemble a gateway ingest request, call `persist()`, and return `HandlerResult::Success` on confirmation, `HandlerResult::Retry` on transient failure, or `HandlerResult::Reject` on permanent non-retriable failure (e.g. deserialization error, gateway 400); `backoff_max` MUST be configured below 15 minutes to satisfy `cpt-cf-usage-collector-nfr-recovery`
+- Internally implement a `MessageHandler` that the outbox library calls for each ready message: deserialize the payload, assemble a gateway ingest request, call `UsageCollectorClientV1::create_usage_record()`, and return `HandlerResult::Success` on confirmation, `HandlerResult::Retry` on transient failure, or `HandlerResult::Reject` on permanent non-retriable failure (e.g. deserialization error, gateway 400); `backoff_max` MUST be configured below 15 minutes to satisfy `cpt-cf-usage-collector-nfr-recovery`
 
 ##### Responsibility boundaries
 
@@ -305,7 +368,34 @@ Provides the public API for usage sources to emit records. Handles transactional
 
 ##### Related components (by ID)
 
-- `cpt-cf-usage-collector-component-gateway` — delivery target for outbox messages
+- `cpt-cf-usage-collector-component-gateway` — delivery target for outbox messages; also constructs and registers `UsageEmitterV1` in `ClientHub` during `init()`
+
+---
+
+#### Usage Collector SDK
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-component-sdk`
+
+##### Why this component exists
+
+Defines the shared trait and model boundaries. `UsageCollectorClientV1` is the delivery trait implemented by the gateway's local client and remote REST client; it is **not** registered in `ClientHub` to prevent bypassing the authorized-emitter path. `UsageCollectorPluginClientV1` is the storage plugin trait.
+
+##### Responsibility scope
+
+- Define `UsageCollectorClientV1` with `create_usage_record()` and `get_module_config()` operations
+- Define `UsageCollectorPluginClientV1` with storage plugin operations
+- Define shared model types (`UsageRecord`, `ModuleConfig`, `AllowedMetric`, `UsageKind`, etc.)
+- Define GTS schema for storage plugin registration (`UsageCollectorStoragePluginSpecV1`)
+
+##### Responsibility boundaries
+
+- Does NOT contain emit, authorization, or outbox logic — those are in `cpt-cf-usage-collector-component-emitter`
+- Does NOT register anything in `ClientHub`
+
+##### Related components (by ID)
+
+- `cpt-cf-usage-collector-component-emitter` — consumes `UsageCollectorClientV1` for outbox delivery
+- `cpt-cf-usage-collector-component-gateway` — implements `UsageCollectorClientV1` via its local client
 
 #### Gateway
 
@@ -317,18 +407,19 @@ The centralized entry point for receiving delivered records and serving aggregat
 
 ##### Responsibility scope
 
-- Accept ingest requests from the SDK's outbox delivery pipeline
-- Derive and enforce tenant ID from SecurityContext on all query operations; on ingest, validate tenant attribution: when `record.tenant_id == ctx.subject_tenant_id()`, accept without additional check; when `record.tenant_id ≠ ctx.subject_tenant_id()`, call the PDP with `context_tenant_id(record.tenant_id)` and action `"emit_on_behalf"` — reject the record if the PDP denies (fail-closed); enforce per-(source, tenant) rate limits on ingest once the record's target tenant is known
+- Register the `"usage-records"` outbox queue (4 partitions, configurable) and apply outbox schema migrations (`outbox_migrations()` from `modkit_db::outbox`) via `DatabaseCapability::migrations()` during module init; construct and register `UsageEmitterV1` in `ClientHub` during `init()`
+- Accept ingest requests from the emitter's outbox delivery pipeline
+- Derive and enforce tenant ID from SecurityContext on all query operations; on ingest, accept the `tenant_id` from the delivered record without a second PDP check — tenant attribution was authorized at emit time via `USAGE_RECORD`/`CREATE`; enforce per-(source, tenant) rate limits on ingest
 - Resolve the active storage plugin via GTS
 - Expose aggregation and raw query API to usage consumers
 - Authorize each query via the platform PDP: verify the caller is permitted to query; apply PDP-returned constraints as additional query filters before delegating to the plugin
 - Delegate all storage reads and writes to the resolved plugin
 - Fail closed on authorization failures — no permissive fallback
 - Enforce configurable per-call timeout for all plugin operations (default 5 s); if a plugin call does not complete within the timeout, the gateway returns an error and does not retry within the same request — for ingest, retry is handled by the outbox library on the SDK side
-- Apply a circuit breaker per storage plugin instance: open the circuit after 5 consecutive plugin call failures within a 10-second window; return `503 Service Unavailable` while the circuit is open; probe with a single call after a configurable half-open interval (default 30 s)
+- Apply a circuit breaker per storage plugin instance: open the circuit after 5 consecutive plugin call failures within a 10-second window; return `503 Service Unavailable` while the circuit is open; admit exactly one probe call after a configurable half-open interval (default 30 s); all other concurrent requests during the half-open window are rejected until the probe completes
 - Enforce configurable metadata size limit (default 8 KB) at ingest; reject oversized records before delegating to plugin
 - Validate each inbound record against the schema registered in types-registry before delegating to plugin (defense-in-depth; primary validation occurs at SDK `emit()` time before the outbox INSERT)
-- Accept operator backfill requests; call the platform PDP to verify the caller is authorized to backfill for the specified `tenant_id` before accepting the request — a PDP denial or a `tenant_id` that violates the returned constraint returns `403 PERMISSION_DENIED` immediately; callers whose SecurityContext tenant differs from the requested `tenant_id` require a dedicated cross-tenant backfill PDP permission; validate time boundaries and authorization; enqueue each backfill record as a separate outbox message via `Outbox::enqueue_batch()` within the handler transaction; emit `WriteAuditEvent` to `audit_service` once all records are committed to the outbox; respond `202 Accepted` to the caller
+- Accept operator backfill requests; call the platform PDP to verify the caller is authorized to backfill for the specified `tenant_id` before accepting the request; a PDP denial returns `403 PERMISSION_DENIED` immediately; validate time boundaries and authorization; enqueue each backfill record as a separate outbox message via `Outbox::enqueue_batch()` within the handler transaction; emit `WriteAuditEvent` to `audit_service` once all records are committed to the outbox; respond `202 Accepted` to the caller
 - Internally implement a `MessageHandler` for the backfill outbox that the outbox library calls for each individual backfill record: deserialize the payload into a single `UsageRecord`, call `plugin.backfill_ingest()`, and return `HandlerResult::Success` on confirmation, `HandlerResult::Retry` on transient plugin failure, or `HandlerResult::Reject` on permanent failure; `backoff_max` bounds retry duration; delivery throughput to the plugin is naturally rate-limited by the outbox partition count and `msg_batch_size`
 - Expose amendment and deactivation endpoints for individual usage records; emit `WriteAuditEvent` to `audit_service` on each operation
 - Enforce configurable backfill time boundaries (max window, future tolerance); require elevated authorization for requests beyond the max window
@@ -346,6 +437,38 @@ The centralized entry point for receiving delivered records and serving aggregat
 
 - `cpt-cf-usage-collector-component-sdk` — inbound delivery via the SDK's outbox pipeline
 - `cpt-cf-usage-collector-component-storage-plugin` — delegates all storage operations to plugin
+
+#### REST Client
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-component-rest-client`
+
+##### Why this component exists
+
+Enables usage sources that run in a separate process or service binary (i.e., out-of-process from the collector gateway) to emit records using the same `UsageEmitterV1` API as in-process sources. The source's emit path and outbox persistence are identical; only the delivery hop is different — the outbox background pipeline POSTs each record to the gateway's HTTP ingest endpoint instead of calling it in-process.
+
+##### Responsibility scope
+
+- Register `UsageEmitterV1` in `ClientHub` during `init()`, backed by a `UsageCollectorRestClient` as the `UsageCollectorClientV1` implementation
+- Implement `UsageCollectorClientV1::create_usage_record()`: acquire a bearer token from the platform AuthN resolver (client credentials flow), then HTTP POST the record to `POST /usage-collector/v1/records`; return `HandlerResult::Retry` on network or transient HTTP errors (5xx, 429); return `HandlerResult::Reject` on permanent errors (4xx excluding 429)
+- Implement `UsageCollectorClientV1::get_module_config()`: HTTP GET `GET /usage-collector/v1/modules/{module_name}/config` with bearer token; called by `ScopedUsageEmitter.authorize_for()` during phase 1
+- Apply outbox schema migrations (same `outbox_migrations()` call as the in-process path) — this module owns the source's outbox, not the gateway
+
+##### Responsibility boundaries
+
+- Does NOT bypass the transactional outbox — `enqueue()` always writes to the source's local DB first; HTTP delivery happens asynchronously via the outbox background pipeline
+- Does NOT perform authorization — `authorize_for()` is still called by the source and contacts the PDP directly; this component only handles delivery
+- Does NOT implement gateway-side logic — it is a thin HTTP client over `UsageCollectorClientV1`
+
+##### Delivery guarantees
+
+Delivery guarantees are the same as in-process mode: at-least-once via the transactional outbox. The REST client transport adds a bearer token acquisition step and a network hop per delivery attempt. Token acquisition failures are treated as transient and trigger exponential backoff retry. All records durably committed to the source's local outbox are guaranteed to eventually reach the gateway.
+
+##### Related components (by ID)
+
+- `cpt-cf-usage-collector-component-emitter` — consumes this component's `UsageCollectorClientV1` for outbox delivery
+- `cpt-cf-usage-collector-component-gateway` — HTTP delivery target; exposes the ingest and module-config endpoints consumed by this component
+
+---
 
 #### Storage Plugin
 
@@ -380,35 +503,59 @@ Provides a backend-specific implementation for persisting and querying usage rec
 
 ### 3.3 API Contracts
 
-#### SDK Trait (`UsageCollectorClientV1`)
+#### Emitter Trait (`UsageEmitterV1`)
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-interface-emitter-trait`
+
+**Technology**: Rust trait in `usage-emitter` crate; registered in `ClientHub` by the gateway module (in-process) or `usage-collector-rest-client` (HTTP)
+**Data Format**: Rust types shared with SDK
+
+**Operations**:
+
+| Operation | Caller | Description |
+|-----------|--------|-------------|
+| `for_module(name)` | Usage source at init | Returns a `ScopedUsageEmitter` bound to the source module's authoritative name |
+
+#### Scoped Emitter (`ScopedUsageEmitter`)
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-interface-scoped-emitter`
+
+**Technology**: Rust struct in `usage-emitter` crate; obtained exclusively via `UsageEmitterV1::for_module()`
+**Data Format**: Rust types shared with SDK
+
+**Operations**:
+
+| Operation | Caller | Description |
+|-----------|--------|-------------|
+| `authorize_for(ctx, tenant_id, resource_id, resource_type)` | Usage source (before transaction) | Calls the platform PDP for `USAGE_RECORD`/`CREATE` with the specified tenant and resource; fetches allowed metrics for this module from the gateway (`get_module_config()`); returns `AuthorizedUsageEmitter` on success, or `UsageEmitterError` on denial / module not configured; never called inside an open DB transaction |
+| `authorize(ctx, resource_id, resource_type)` | Usage source (before transaction) | Convenience wrapper for `authorize_for` using `ctx.subject_tenant_id()` as `tenant_id` |
+
+#### Authorized Emitter (`AuthorizedUsageEmitter`)
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-interface-authorized-emitter`
+
+**Technology**: Rust struct in `usage-emitter` crate; obtained exclusively via `ScopedUsageEmitter::authorize_for()` / `authorize()`; time-limited token
+
+**Operations**:
+
+| Operation | Caller | Description |
+|-----------|--------|-------------|
+| `build_usage_record(metric, value)` | Usage source (within transaction) | Entry point for the fluent builder; binds metric name and value to the authorized context |
+| `.enqueue()` (on builder) | Usage source (within transaction) | Validates metric semantics (rejects counter records with a negative value or a missing idempotency key), reads optional `subject_id` and `subject_type` from the authorization context (`None` when neither caller-supplied via `authorize_for()` nor derived from `SecurityContext`), then evaluates all `EmitAuthorization` constraints in-memory: schema validation, source-level rate limit quota, PDP constraint satisfaction including tenant validation (tenant `In` constraint present → `record.tenant_id ∈ allowed set`; no tenant constraint → `record.tenant_id == ctx.subject_tenant_id()`); when `subject_id` and `subject_type` are both `None`, PDP subject properties are omitted from the authorization request and subject validation is skipped; stamps outbox row with `record.tenant_id` on success; returns `EmitError::MissingIdempotencyKey`, `EmitError::SchemaViolation`, `EmitError::RateLimitExceeded`, or `EmitError::ConstraintViolation` on failure — no outbox INSERT on any error |
+
+#### Delivery Trait (`UsageCollectorClientV1`)
 
 - [ ] `p1` - **ID**: `cpt-cf-usage-collector-interface-sdk-trait`
 
-**Technology**: Rust trait in `usage-collector-sdk` crate
-**Data Format**: Rust types (`UsageRecord`, `AggregationQuery`, `AggregationResult`, `RawQuery`, `PagedResult`)
+**Technology**: Rust trait in `usage-collector-sdk` crate; **not** registered in `ClientHub`; implemented by `UsageCollectorLocalClient` (gateway) and `usage-collector-rest-client`
+**Data Format**: Rust types (`UsageRecord`, `ModuleConfig`)
 
 **Operations**:
 
 | Operation | Caller | Description |
 |-----------|--------|-------------|
-| `for_module(name)` | Usage source at init | Returns a `ScopedUsageCollectorClientV1` bound to the source module's authoritative name |
-| `persist(records)` | SDK (outbox delivery handler) | Delivers a batch of records to the collector gateway; idempotent on `idempotency_key` |
-| `query_aggregated(ctx, query)` | Usage consumer | Returns aggregated usage data scoped to the authenticated tenant |
-| `query_raw(ctx, query)` | Usage consumer | Returns paginated raw usage records scoped to the authenticated tenant |
-
-#### Scoped Emit Client (`ScopedUsageCollectorClientV1`)
-
-- [ ] `p1` - **ID**: `cpt-cf-usage-collector-interface-scoped-client`
-
-**Technology**: Rust struct in `usage-collector-sdk` crate; obtained exclusively via `UsageCollectorClientV1::for_module()`
-**Data Format**: Rust types shared with SDK trait
-
-**Operations**:
-
-| Operation | Caller | Description |
-|-----------|--------|-------------|
-| `authorize_emit(ctx, metric_name)` | Usage source (before transaction) | Calls the platform PDP for the given metric (PDP may return a tenant `In` constraint for sources authorized to emit for multiple tenants), fetches the source-level rate limit quota snapshot, and fetches the registered usage type schema for `metric_name` from types-registry; returns `EmitAuthorization` on success, or `EmitError::Denied` / `EmitError::RateLimitExceeded` on failure; never called inside an open DB transaction |
-| `emit(ctx, record, &EmitAuthorization)` | Usage source (within transaction) | Validates metric semantics (rejects counter records with a negative value or a missing idempotency key), captures subject from SecurityContext, then evaluates all `EmitAuthorization` constraints in-memory: schema validation, source-level rate limit quota, PDP constraint satisfaction including tenant validation (tenant `In` constraint present → `record.tenant_id ∈ allowed set`; no tenant constraint → `record.tenant_id == ctx.subject_tenant_id()`); stamps outbox row with `record.tenant_id` on success; returns `EmitError::MissingIdempotencyKey`, `EmitError::SchemaViolation`, `EmitError::RateLimitExceeded`, or `EmitError::ConstraintViolation` on failure — no outbox INSERT on any error |
+| `create_usage_record(record)` | Emitter (outbox delivery handler) | Delivers one record to the collector gateway per outbox message; idempotent on `idempotency_key` |
+| `get_module_config(module_name)` | Emitter (`authorize_for` / `authorize`) | Returns allowed metrics (and future config) for the module; called by the scoped emitter during phase 1 authorization |
 
 #### Plugin Trait
 
@@ -421,7 +568,7 @@ Provides a backend-specific implementation for persisting and querying usage rec
 
 | Operation | Description |
 |-----------|-------------|
-| `persist(records)` | Persists usage records with idempotent upsert on `idempotency_key`; for counter metrics, each record's `value` is a non-negative delta — the record is stored as-is alongside other deltas; the persistent total for any `(tenant_id, metric)` pair is the SUM of all active delta records for that key (see §3.7 Counter Accumulation); for gauge metrics, values are stored as-is |
+| `create_usage_record(record)` | Stores one usage record with idempotent upsert on `idempotency_key`; for counter metrics, each record's `value` is a non-negative delta — the record is stored as-is alongside other deltas; the persistent total for any `(tenant_id, metric)` pair is the SUM of all active delta records for that key (see §3.7 Counter Accumulation); for gauge metrics, values are stored as-is |
 | `query_aggregated(ctx, query)` | Executes aggregation query within the storage engine; applies optional filters (usage type, subject, resource, source) and GROUP BY dimensions from `AggregationQuery`; pushes aggregation and grouping down to the storage engine |
 | `query_raw(ctx, query)` | Executes raw record query with cursor-based pagination; applies optional filters (usage type, subject, resource) from `RawQuery`; scoped to tenant |
 | `backfill_ingest(ctx, tenant, usage_type, records)` | Bulk-inserts historical records with idempotent upsert on `idempotency_key`; does not modify existing records |
@@ -439,18 +586,20 @@ Provides a backend-specific implementation for persisting and querying usage rec
 
 **Endpoints Overview**:
 
-| Method  | Path                                | Description                                                                                 | Stability |
-| ------- | ----------------------------------- | ------------------------------------------------------------------------------------------- | --------- |
-| `GET`   | `/v1/usage/aggregated`              | Query aggregated usage data for the authenticated tenant                                    | stable    |
-| `GET`   | `/v1/usage/raw`                     | Query raw usage records with cursor-based pagination for the authenticated tenant           | stable    |
-| `POST`  | `/v1/usage/backfill`                | Operator-initiated bulk insert of historical records for a tenant and usage type time range | stable    |
-| `PATCH` | `/v1/usage/records/{id}`            | Amend mutable fields on an individual active record                                         | stable    |
-| `POST`  | `/v1/usage/records/{id}/deactivate` | Deactivate an individual record (marks inactive, retains for audit)                         | stable    |
-| `GET`   | `/v1/usage/metadata/watermarks`     | Per-source and per-tenant event counts and latest timestamps                                | stable    |
-| `POST`  | `/v1/usage/types`                   | Register a custom usage type (name, metric kind, unit label); delegates to types-registry   | stable    |
-| `GET`   | `/v1/usage/retention`               | List configured retention policies                                                          | stable    |
-| `PUT`   | `/v1/usage/retention/{scope}`       | Create or update a retention policy for a scope (global / tenant / usage-type)              | stable    |
-| `DELETE` | `/v1/usage/retention/{scope}`      | Delete a non-global retention policy for a scope (tenant / usage-type); the global default policy cannot be deleted | stable    |
+| Method  | Path                                              | Description                                                                                 | Stability |
+| ------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------- | --------- |
+| `POST`  | `/usage-collector/v1/records`                     | Create a usage record; accepts payload and delegates storage to the configured plugin       | stable    |
+| `GET`   | `/usage-collector/v1/modules/{module_name}/config`| Allowed metrics (and future config) for the specified source module                         | stable    |
+| `GET`   | `/usage-collector/v1/aggregated`                  | Query aggregated usage data for the authenticated tenant                                    | stable    |
+| `GET`   | `/usage-collector/v1/raw`                         | Query raw usage records with cursor-based pagination for the authenticated tenant           | stable    |
+| `POST`  | `/usage-collector/v1/backfill`                    | Operator-initiated bulk insert of historical records for a tenant and usage type time range | stable    |
+| `PATCH` | `/usage-collector/v1/records/{id}`                | Amend mutable fields on an individual active record                                         | stable    |
+| `POST`  | `/usage-collector/v1/records/{id}/deactivate`     | Deactivate an individual record (marks inactive, retains for audit)                         | stable    |
+| `GET`   | `/usage-collector/v1/metadata/watermarks`         | Per-source and per-tenant event counts and latest timestamps                                | stable    |
+| `POST`  | `/usage-collector/v1/types`                       | Register a custom usage type (name, metric kind, unit label); delegates to types-registry   | stable    |
+| `GET`   | `/usage-collector/v1/retention`                   | List configured retention policies                                                          | stable    |
+| `PUT`   | `/usage-collector/v1/retention/{scope}`           | Create or update a retention policy for a scope (global / tenant / usage-type)              | stable    |
+| `DELETE`| `/usage-collector/v1/retention/{scope}`           | Delete a non-global retention policy for a scope (tenant / usage-type); the global default policy cannot be deleted | stable |
 
 #### Error Handling
 
@@ -471,10 +620,11 @@ All endpoints are **stable** (prefixed `/v1/`). Backward compatibility is guaran
 
 | Dependency Module | Interface Used | Purpose |
 |-------------------|----------------|---------|
-| modkit-db | `modkit_db::outbox` — `Outbox::enqueue()`, `OutboxHandle`, `outbox_migrations()`, dead-letter API | Durable outbox persistence, automatic background delivery pipeline, and dead-letter management for at-least-once delivery |
-| types-registry | GTS type system — plugin schema registration and instance resolution; types-registry SDK — usage type schema retrieval | Storage plugin discovery and instantiation at runtime; usage type schema fetching for in-memory validation at emit time (called by `ScopedUsageCollectorClientV1.authorize_emit()`) |
+| modkit-db | `modkit_db::outbox` — `Outbox::enqueue()`, `OutboxHandle`, `outbox_migrations()`, dead-letter API | Durable outbox persistence, automatic background delivery pipeline, and dead-letter management for at-least-once delivery; `outbox_migrations()` is applied by the gateway module (in-process) or the `usage-collector-rest-client` module (remote) |
+| types-registry | GTS type system — plugin schema registration and instance resolution; types-registry SDK — usage type schema retrieval | Storage plugin discovery and instantiation at runtime; usage type schema fetching for in-memory validation at emit time (called by `ScopedUsageEmitter.authorize_for()`) |
 | SecurityContext | Platform security primitive | Tenant identity, subject identity derivation and authorization enforcement on all operations |
-| authz-resolver | `authz-resolver-sdk` — `PolicyEnforcer` / `AuthZResolverClient` | Platform PDP for ingestion authorization; called by `ScopedUsageCollectorClientV1.authorize_emit()` to verify the source module is permitted to emit the target metrics |
+| authz-resolver | `authz-resolver-sdk` — `PolicyEnforcer` / `AuthZResolverClient` | Platform PDP for ingestion authorization; called by `ScopedUsageEmitter.authorize_for()` to verify the source module is permitted to emit for the target tenant and resource |
+| authn-resolver | `authn-resolver-sdk` — `AuthNResolverClient` | Bearer token acquisition (client credentials flow) for HTTP delivery by `usage-collector-rest-client`; used once per delivery attempt by the outbox background pipeline |
 
 **Dependency Rules** (per project conventions):
 - No circular dependencies
@@ -534,49 +684,51 @@ All endpoints are **stable** (prefixed `/v1/`). Backward compatibility is guaran
 ```mermaid
 sequenceDiagram
     participant App as Usage Source
-    participant SC as ScopedUsageCollectorClientV1
+    participant CH as ClientHub
+    participant UE as UsageEmitterV1
+    participant SC as ScopedUsageEmitter
+    participant AE as AuthorizedUsageEmitter
     participant PDP as authz-resolver (PDP)
-    participant TR as types-registry
+    participant GW as UC Gateway (UsageCollectorClientV1)
     participant LDB as Local DB
-    participant OB as Outbox Pipeline (SDK background)
-    participant GW as UC Gateway
+    participant OB as Outbox Pipeline (background)
     participant Plugin as Storage Plugin
     participant DB as ClickHouse / TimescaleDB
 
-    Note over App,SC: Module init (once)
-    App->>SC: for_module(MODULE_NAME)
+    Note over App,UE: Module init (once); gateway init() has registered UsageEmitterV1 in ClientHub
+    App->>CH: get::<dyn UsageEmitterV1>()
+    CH-->>App: &UsageEmitterV1
+    App->>UE: for_module(MODULE_NAME)
+    UE-->>App: ScopedUsageEmitter
 
     Note over App,LDB: Per-request, before transaction
-    App->>SC: authorize_emit(ctx, metric_name)
-    SC->>PDP: evaluate policy (source_module, metric_name)
-    SC->>TR: fetch schema for metric_name
-    SC->>SC: fetch source-level quota snapshot
-    PDP-->>SC: constraints (incl. optional tenant In constraint) | Denied
-    TR-->>SC: schema
-    SC-->>App: Ok(EmitAuthorization{constraints, schema, quota}) | Err(Denied | RateLimitExceeded)
+    App->>SC: authorize_for(ctx, tenant_id, resource_id, resource_type)
+    SC->>PDP: USAGE_RECORD/CREATE (source_module, tenant_id, resource)
+    SC->>GW: get_module_config(module_name) → allowed metrics
+    PDP-->>SC: permit | deny
+    GW-->>SC: ModuleConfig{allowed_metrics}
+    SC-->>App: Ok(AuthorizedUsageEmitter{tenant_id, resource_id, resource_type}) | Err(UsageEmitterError)
 
     Note over App,LDB: Inside caller's DB transaction
-    App->>SC: emit(ctx, record{tenant_id=T}, &auth)
-    SC->>SC: validate metric semantics (counter ≥ 0, gauge any)
-    SC->>SC: capture subject_id / subject_type from SecurityContext
-    SC->>SC: validate record against schema
-    SC->>SC: check source-level quota (emission count within window limit)
-    SC->>SC: evaluate PDP constraints incl. tenant: In constraint → record.tenant_id ∈ allowed set; no constraint → record.tenant_id == ctx.subject_tenant_id()
-    SC->>LDB: Outbox::enqueue(tenant_id=record.tenant_id) within caller's tx
-    LDB-->>SC: ok
-    SC-->>App: Ok | Err(SchemaViolation | RateLimitExceeded | ConstraintViolation)
+    App->>AE: build_usage_record("metric", value).enqueue()
+    AE->>AE: verify token freshness
+    AE->>AE: validate metric in allowed list
+    AE->>AE: validate metric semantics (counter ≥ 0, counter requires idempotency_key)
+    alt subject_id supplied in authorize_for() call
+        AE->>AE: validate subject identity via PDP (already in AuthorizedUsageEmitter token)
+        AE->>AE: bind caller-supplied subject_id / subject_type from token
+    else subject_id not supplied
+        AE->>AE: derive subject_id / subject_type from SecurityContext
+    end
+    AE->>LDB: Outbox::enqueue(record{tenant_id, resource_id, resource_type}) within caller's tx
+    LDB-->>AE: ok
+    AE-->>App: Ok | Err(UsageEmitterError)
 
     Note over OB: Outbox library background pipeline
-    OB->>GW: MessageHandler::handle() → persist(records)
+    OB->>GW: MessageHandler::handle() → create_usage_record(record)
     GW->>GW: validate SecurityContext
-    alt record.tenant_id == ctx.subject_tenant_id()
-        GW->>GW: tenant attribution valid (standard path)
-    else record.tenant_id ≠ ctx.subject_tenant_id()
-        GW->>PDP: emit_on_behalf? (source, record.tenant_id)
-        PDP-->>GW: permit | deny
-    end
     GW->>GW: enforce per-(source, tenant) rate limit
-    GW->>Plugin: persist(records)
+    GW->>Plugin: create_usage_record(record)
     Plugin->>DB: INSERT (idempotent upsert on idempotency_key)
     DB-->>Plugin: ok
     Plugin-->>GW: ok
@@ -584,7 +736,53 @@ sequenceDiagram
     Note over OB: On transient failure: HandlerResult::Retry → exponential backoff<br/>On permanent failure: HandlerResult::Reject → dead-letter store
 ```
 
-**Description**: At module initialization, the usage source calls `for_module()` to obtain a `ScopedUsageCollectorClientV1` bound to its platform identity. For each request that will emit usage, it calls `authorize_emit()` before opening any DB transaction — the scoped client contacts the PDP, fetches the registered usage type schema from types-registry, and fetches the current source-level rate limit quota snapshot; it returns an `EmitAuthorization` token bundling all three (including any tenant `In` constraint from the PDP for sources authorized to emit for multiple tenants), or an immediate `Denied` or `RateLimitExceeded` error. Inside the caller's transaction, `emit()` validates metric semantics, captures subject identity, evaluates all constraints in-memory including tenant validation (`record.tenant_id` must satisfy the PDP tenant constraint or equal `ctx.subject_tenant_id()` if no constraint was returned), and on success stamps the outbox row with `record.tenant_id` and calls `Outbox::enqueue()`. The outbox library's background pipeline then automatically picks up enqueued messages and invokes the SDK's internal `MessageHandler`. The gateway validates tenant attribution on delivery: standard records (where `record.tenant_id == ctx.subject_tenant_id()`) are accepted directly; cross-tenant records trigger a PDP `emit_on_behalf` check per unique target tenant in the batch before plugin delivery. The gateway also enforces per-(source, tenant) rate limits at this point. On `HandlerResult::Success` the outbox advances the partition cursor; on `HandlerResult::Retry` it applies exponential backoff and re-delivers; on `HandlerResult::Reject` it moves the message to the dead-letter store.
+**Description**: At module initialization, the usage source retrieves `UsageEmitterV1` from `ClientHub` (registered by the gateway module during service startup) and calls `for_module()` to obtain a `ScopedUsageEmitter` bound to its platform identity. For each request that will emit usage, it calls `authorize_for()` (or `authorize()` for the subject's home tenant) before opening any DB transaction — the scoped emitter contacts the PDP for `USAGE_RECORD`/`CREATE` with the specified `tenant_id` and resource, and fetches the allowed-metrics list from the gateway; it returns an `AuthorizedUsageEmitter` with the authorized `tenant_id`, `resource_id`, and `resource_type` bound in, or an immediate error on PDP denial. Inside the caller's transaction, `build_usage_record().enqueue()` validates metric semantics and allowed-list membership, resolves optional subject identity — when `subject_id`/`subject_type` are supplied to `authorize_for()`, the token carries the caller-supplied values accepted with PDP authorization; when not supplied, `subject_id`/`subject_type` are derived from `SecurityContext` at `enqueue()` time — stamps the bound context, and calls `Outbox::enqueue()`. The outbox library's background pipeline then automatically picks up enqueued messages and invokes the emitter's internal `MessageHandler`, calling `UsageCollectorClientV1::create_usage_record()` on the gateway. The gateway accepts the `tenant_id` from the delivered record without a second PDP check — tenant attribution was authorized at emit time. On `HandlerResult::Success` the outbox advances the partition cursor; on `HandlerResult::Retry` it applies exponential backoff and re-delivers; on `HandlerResult::Reject` it moves the message to the dead-letter store.
+
+#### Emit Usage Record — Remote Delivery (REST Client)
+
+**ID**: `cpt-cf-usage-collector-seq-emit-remote`
+
+**Use cases**: `cpt-cf-usage-collector-usecase-emit` (remote deployment mode)
+
+**Actors**: `cpt-cf-usage-collector-actor-usage-source` (out-of-process)
+
+The emit path (`authorize_for()` → `build_usage_record().enqueue()`) is identical to the in-process sequence. The difference is in the outbox delivery step: the background pipeline calls the REST client's `create_usage_record()`, which acquires a bearer token and HTTP-POSTs to the gateway.
+
+```mermaid
+sequenceDiagram
+    participant OB as Outbox Pipeline (background)
+    participant RC as UsageCollectorRestClient
+    participant AuthN as authn-resolver
+    participant GW as UC Gateway (HTTP)
+    participant Plugin as Storage Plugin
+    participant DB as ClickHouse / TimescaleDB
+
+    Note over OB: Outbox library background pipeline (source process)
+    OB->>RC: MessageHandler::handle() → create_usage_record(record)
+    RC->>AuthN: acquire bearer token (client credentials)
+    AuthN-->>RC: Bearer <token>
+    RC->>GW: POST /usage-collector/v1/records (Authorization: Bearer <token>, body: UsageRecord)
+    alt token invalid or expired
+        GW-->>RC: 401 Unauthenticated
+        RC-->>OB: HandlerResult::Retry
+    else permanent error (4xx except 429)
+        GW-->>RC: 4xx
+        RC-->>OB: HandlerResult::Reject → dead-letter store
+    else transient error (5xx, 429, network)
+        GW-->>RC: 5xx / timeout
+        RC-->>OB: HandlerResult::Retry → exponential backoff
+    else success
+        GW->>GW: validate SecurityContext; enforce rate limit
+        GW->>Plugin: create_usage_record(record)
+        Plugin->>DB: INSERT (idempotent upsert on idempotency_key)
+        DB-->>Plugin: ok
+        Plugin-->>GW: ok
+        GW-->>RC: 204 No Content
+        RC-->>OB: HandlerResult::Success (outbox advances cursor)
+    end
+```
+
+**Description**: The source's outbox background pipeline invokes the REST client's `MessageHandler`. The REST client acquires a bearer token from the platform AuthN resolver (client credentials flow) before each delivery attempt — token acquisition failure is treated as transient and triggers retry. The record is HTTP-POSTed to the gateway's ingest endpoint with the bearer token in the `Authorization` header. The gateway processes the ingest request identically to the in-process path: validates the security context, enforces rate limits, and delegates to the storage plugin. On `204 No Content` the outbox advances the partition cursor. On permanent 4xx (excluding 429) the message is moved to the dead-letter store. All other errors trigger exponential backoff retry. At-least-once delivery is guaranteed for all records durably committed to the source outbox.
 
 #### Query Aggregated Usage
 
@@ -602,7 +800,7 @@ sequenceDiagram
     participant Plugin as Storage Plugin
     participant DB as ClickHouse / TimescaleDB
 
-    Consumer->>GW: GET /usage/aggregated (ctx, query params)
+    Consumer->>GW: GET /usage-collector/v1/aggregated (ctx, query params)
     GW->>GW: derive tenant_id from SecurityContext
     GW->>PDP: authorize query (ctx, tenant, usage_type?)
     PDP-->>GW: decision + constraints
@@ -632,7 +830,7 @@ sequenceDiagram
     participant Plugin as Storage Plugin
     participant DB as ClickHouse / TimescaleDB
 
-    Consumer->>GW: GET /usage/raw (ctx, time range, filters, cursor)
+    Consumer->>GW: GET /usage-collector/v1/raw (ctx, time range, filters, cursor)
     GW->>GW: derive tenant_id from SecurityContext
     GW->>PDP: authorize query (ctx, tenant, usage_type?)
     PDP-->>GW: decision + constraints
@@ -664,7 +862,7 @@ sequenceDiagram
     participant DB as ClickHouse / TimescaleDB
     participant AS as audit_service
 
-    Op->>GW: POST /usage/backfill (tenant_id, usage_type, range, records)
+    Op->>GW: POST /usage-collector/v1/backfill (tenant_id, usage_type, range, records)
     GW->>PDP: authorize backfill for tenant_id (actor from SecurityContext)
     alt PDP denies or tenant_id violates returned constraint
         PDP-->>GW: deny
@@ -694,7 +892,7 @@ sequenceDiagram
     Note over OB: On transient failure: HandlerResult::Retry → exponential backoff<br/>On permanent failure: HandlerResult::Reject → dead-letter store
 ```
 
-**Description**: Platform operator submits a backfill request specifying `tenant_id`, usage type, time range, and historical records to insert. The gateway first calls the platform PDP to verify the caller is authorized to backfill for the specified `tenant_id`; a PDP denial or a `tenant_id` that violates the returned constraint returns `403 PERMISSION_DENIED` immediately without touching the outbox. Callers whose SecurityContext tenant differs from the requested `tenant_id` require a dedicated cross-tenant backfill PDP permission; the PDP must return a constraint that includes the target tenant. After PDP authorization succeeds, the gateway enforces time boundaries and requires elevated authorization for windows exceeding the configured maximum. On successful validation, the gateway enqueues all backfill records to a gateway-local backfill outbox in a single transaction, then emits a `WriteAuditEvent` to `audit_service` and returns `202 Accepted` to the caller. The outbox library's background pipeline then automatically calls the gateway's internal `MessageHandler` for each individual record. The plugin inserts each record using idempotent upsert — existing records are not modified. Real-time ingestion continues uninterrupted throughout the operation.
+**Description**: Platform operator submits a backfill request specifying `tenant_id`, usage type, time range, and historical records to insert. The gateway first calls the platform PDP to verify the caller is authorized to backfill for the specified `tenant_id`; a PDP denial returns `403 PERMISSION_DENIED` immediately without touching the outbox. After PDP authorization succeeds, the gateway enforces time boundaries and requires elevated authorization for windows exceeding the configured maximum. On successful validation, the gateway enqueues all backfill records to a gateway-local backfill outbox in a single transaction, then emits a `WriteAuditEvent` to `audit_service` and returns `202 Accepted` to the caller. The outbox library's background pipeline then automatically calls the gateway's internal `MessageHandler` for each individual record. The plugin inserts each record using idempotent upsert — existing records are not modified. Real-time ingestion continues uninterrupted throughout the operation.
 
 #### Amend Individual Record
 
@@ -713,7 +911,7 @@ sequenceDiagram
     participant DB as ClickHouse / TimescaleDB
     participant AS as audit_service
 
-    Op->>GW: PATCH /usage/records/{id} (ctx, justification, updated fields)
+    Op->>GW: PATCH /usage-collector/v1/records/{id} (ctx, justification, updated fields)
     GW->>GW: derive tenant_id from SecurityContext
     GW->>PDP: authorize amendment (ctx, tenant, record_id)
     PDP-->>GW: permit | deny
@@ -759,7 +957,7 @@ sequenceDiagram
     participant DB as ClickHouse / TimescaleDB
     participant AS as audit_service
 
-    Op->>GW: POST /usage/records/{id}/deactivate (ctx, justification)
+    Op->>GW: POST /usage-collector/v1/records/{id}/deactivate (ctx, justification)
     GW->>GW: derive tenant_id from SecurityContext
     GW->>PDP: authorize deactivation (ctx, tenant, record_id)
     PDP-->>GW: permit | deny
@@ -801,23 +999,25 @@ The outbox schema is owned by the `modkit-db` shared infrastructure and installe
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Tenant owning this usage record |
-| `source_module` | TEXT | Source module name from `ScopedUsageCollectorClientV1` |
-| `metric_kind` | TEXT | `"counter"` or `"gauge"` |
+| `module` | TEXT | Source module name from `ScopedUsageEmitter` |
+| `kind` | TEXT | `"counter"` or `"gauge"` |
 | `metric` | TEXT | Name of the measured resource metric |
 | `value` | NUMERIC | Numeric measurement value |
 | `timestamp` | TIMESTAMPTZ | When the measurement occurred |
-| `idempotency_key` | TEXT | Client-provided deduplication key; non-null for counter records (enforced by `emit()` before enqueue); nullable for gauge records |
-| `resource_id` | UUID (nullable) | Resource instance this record is attributed to |
-| `resource_type` | TEXT (nullable) | Resource type corresponding to `resource_id` |
+| `idempotency_key` | TEXT | Client-provided deduplication key; non-null for counter records (enforced by `enqueue()` before outbox INSERT); nullable for gauge records |
+| `resource_id` | UUID | Resource instance this record is attributed to (required) |
+| `resource_type` | TEXT | Resource type corresponding to `resource_id` (required) |
 | `subject_id` | UUID (nullable) | Subject (user/service account) from SecurityContext |
 | `subject_type` | TEXT (nullable) | Subject type corresponding to `subject_id` |
-| `metadata` | JSON object (nullable) | Optional opaque metadata; size validated by SDK before enqueue (default 8 KB limit) |
+| `metadata` | JSON object (nullable) | Optional opaque metadata; size validated by emitter before enqueue (default 8 KB limit) |
 
-**Payload invariants** (enforced by SDK before `Outbox::enqueue()` is called): `tenant_id`, `source_module`, `metric_kind`, `metric`, `value`, `timestamp` are all non-null. `idempotency_key` is non-null for counter records.
+**Payload invariants** (enforced by emitter before `Outbox::enqueue()` is called): `tenant_id`, `module`, `kind`, `metric`, `value`, `timestamp`, `resource_id`, `resource_type` are all non-null. `idempotency_key` is non-null for counter records.
 
 **Dead letters**: Messages permanently rejected by the SDK's delivery handler (`HandlerResult::Reject`) are moved to the outbox dead-letter store by the library. Dead-letter management (replay, resolve, discard) is available via the `Outbox` dead-letter API.
 
 #### Storage Backend Tables (plugin-owned)
+
+**ID**: `cpt-cf-usage-collector-dbtable-records`
 
 Storage table schemas are defined and owned by each plugin implementation. The gateway does not define, access, or migrate storage tables directly. Each plugin is responsible for its own schema migration lifecycle.
 
@@ -826,14 +1026,14 @@ Storage table schemas are defined and owned by each plugin implementation. The g
 | Column | Purpose |
 |--------|---------|
 | `tenant_id` | Tenant scoping and isolation; required filter on all queries |
-| `source_module` | Source module identity; enables per-module metric auditing |
-| `metric_kind` | `"counter"` or `"gauge"`; governs aggregation semantics |
+| `module` | Source module identity; enables per-module metric auditing |
+| `kind` | `"counter"` or `"gauge"`; governs aggregation semantics |
 | `metric` | Name of the measured resource metric |
 | `value` | Measured numeric value |
 | `timestamp` | Measurement time; primary partitioning and ordering dimension |
 | `idempotency_key` | Deduplication key; NOT NULL for counter records, nullable for gauge records; unique constraint or upsert target per plugin for non-null values |
-| `resource_id` | Resource instance attribution; nullable |
-| `resource_type` | Resource type attribution; nullable |
+| `resource_id` | Resource instance attribution; NOT NULL (required at emit time) |
+| `resource_type` | Resource type attribution; NOT NULL (required at emit time) |
 | `subject_id` | Subject attribution from SecurityContext; nullable |
 | `subject_type` | Subject type attribution; nullable |
 | `ingested_at` | When the collector received and persisted the record |
@@ -850,7 +1050,7 @@ Storage table schemas are defined and owned by each plugin implementation. The g
 | Metric filter index | `(tenant_id, metric, timestamp)` | Supports `usage_type` filter in aggregation and raw queries |
 | Subject filter index | `(tenant_id, subject_id, timestamp)` | Supports `subject` filter in aggregation and raw queries |
 | Resource filter index | `(tenant_id, resource_id, timestamp)` | Supports `resource` filter in aggregation and raw queries |
-| Idempotency deduplication | `(tenant_id, idempotency_key)` — unique or upsert target | Required for idempotent `persist()` and `backfill_ingest()` |
+| Idempotency deduplication | `(tenant_id, idempotency_key)` — unique or upsert target | Required for idempotent `create_usage_record()` and `backfill_ingest()` |
 
 Storage-native index types (ClickHouse sorting key, TimescaleDB btree/brin) are at the plugin's discretion, provided they satisfy the query latency NFR.
 
@@ -860,7 +1060,7 @@ Storage-native index types (ClickHouse sorting key, TimescaleDB btree/brin) are 
 
 Counter semantics (`cpt-cf-usage-collector-fr-counter-semantics`) define the total for a `(tenant_id, metric)` pair as a monotonically increasing value that grows as non-negative deltas are ingested.
 
-**Source of truth — delta records as the persistent store**: The plugin-owned usage records table is the authoritative record of all submitted deltas. There is no separate totals table in the baseline schema. The persistent total for any `(tenant_id, metric)` pair is computed as `SUM(value)` over all active records matching that key for the desired time range. Because all delta values are non-negative (enforced at emit time by `ScopedUsageCollectorClientV1.emit()`), the cumulative SUM is guaranteed to be monotonically increasing.
+**Source of truth — delta records as the persistent store**: The plugin-owned usage records table is the authoritative record of all submitted deltas. There is no separate totals table in the baseline schema. The persistent total for any `(tenant_id, metric)` pair is computed as `SUM(value)` over all active records matching that key for the desired time range. Because all delta values are non-negative (enforced at emit time by `AuthorizedUsageEmitter.enqueue()`), the cumulative SUM is guaranteed to be monotonically increasing.
 
 **Accumulation key vs. full attribution tuple**: `cpt-cf-usage-collector-fr-counter-semantics` scopes the total to `(tenant_id, metric)`. The full record carries additional attribution dimensions — `source_module`, `resource_id`, `resource_type`, `subject_id`, `subject_type` — that enable GROUP BY breakdowns within `query_aggregated`. The counter total per `(tenant_id, metric)` is the SUM across all attribution dimensions for that pair; narrower totals (e.g., per `resource_id`) are query-time GROUP BY variants of the same underlying delta records.
 
@@ -980,7 +1180,7 @@ The outbox pattern implementation relies on the modkit-db outbox infrastructure.
 | **Tampering** | Overwriting existing records on delivery | Idempotent upsert prevents silent overwrite; `version` field enforces optimistic concurrency on amendments; all operator-initiated writes produce a `WriteAuditEvent` to `audit_service` |
 | **Repudiation** | Operator denies issuing a backfill, amendment, or deactivation | `WriteAuditEvent` emitted to `audit_service` for every operator-initiated write; events are not stored locally to prevent local tampering (`cpt-cf-usage-collector-fr-audit`) |
 | **Information Disclosure** | Cross-tenant data access via query API | All queries scoped to the authenticated tenant from `SecurityContext`; PDP constraints applied as additional query filters; system fails closed on any authorization failure (`cpt-cf-usage-collector-principle-fail-closed`) |
-| **Denial of Service** | Outbox flooding or backfill saturation by a single source | Rate limiting enforced by `authorize_emit()` before any transaction (`cpt-cf-usage-collector-fr-rate-limiting`); independent rate limits on the backfill outbox pipeline prevent storage saturation; dead-letter state surfaces unhealthy sources via monitoring |
+| **Denial of Service** | Outbox flooding or backfill saturation by a single source | Rate limiting enforced by `authorize_for()` before any transaction (`cpt-cf-usage-collector-fr-rate-limiting`); independent rate limits on the backfill outbox pipeline prevent storage saturation; dead-letter state surfaces unhealthy sources via monitoring |
 | **Elevation of Privilege** | Accessing oversized backfill windows without elevated authorization | Elevated authorization required for requests exceeding the configured maximum backfill window; all authorization failures result in immediate rejection with no partial operation (`cpt-cf-usage-collector-principle-fail-closed`) |
 
 **Not applicable — Recovery architecture**: Backup strategy, point-in-time recovery, and disaster recovery for ClickHouse and TimescaleDB storage backends are governed by platform infrastructure policy and managed by the platform SRE team; this module's design does not define storage backup topology. The transactional outbox ensures that records durably captured in source outboxes can be re-delivered if storage data is restored from a backup.

--- a/modules/system/usage-collector/docs/PRD.md
+++ b/modules/system/usage-collector/docs/PRD.md
@@ -1,3 +1,22 @@
+---
+cpt:
+  kind: PRD
+  id: cpt-cf-usage-collector-prd
+  version: 0.2.0
+  changelog:
+    - version: 0.2.0
+      date: 2026-04-28
+      changes:
+        - "Updated functional requirements: `subject_id` and `subject_type` are now
+          optional fields; PDP validation is conditional on their presence.
+          Changed requirements: cpt-cf-usage-collector-fr-subject-attribution,
+          cpt-cf-usage-collector-fr-subject-attribution (acceptance criterion)."
+    - version: 0.1.0
+      date: 2026-01-01
+      changes:
+        - Initial version.
+---
+
 # PRD — Usage Collector
 
 
@@ -123,7 +142,7 @@ The Usage Collector addresses this by accepting usage records from sources and p
 
 **ID**: `cpt-cf-usage-collector-actor-usage-source`
 
-- **Role**: Any platform service that produces usage records (e.g., LLM Gateway, Compute Service, API Gateway). Uses the Usage Collector SDK to emit records.
+- **Role**: Any system that produces usage records. This includes in-process platform services using the SDK (e.g., LLM Gateway, Compute Service, API Gateway), remote CyberFabric nodes forwarding collected records via the REST API, and external non-CyberFabric systems submitting records directly via the REST API using OAuth2 client credentials.
 
 #### Usage Consumer
 
@@ -156,7 +175,7 @@ The Usage Collector addresses this by accepting usage records from sources and p
 | `cpt-cf-usage-collector-actor-platform-operator` | Configure and delete retention policies (except global default); submit backfill operations; amend and deactivate individual records; register custom usage types; view watermarks and ingestion metadata | Querying or modifying records belonging to any tenant without an explicit security context; deleting the global default retention policy |
 | `cpt-cf-usage-collector-actor-platform-developer` | Emit usage records via the SDK within the source module's authorized metric namespace and tenant scope | Emitting metrics outside the source module's authorized namespace; attributing records to subjects or resources outside the authorized scope |
 | `cpt-cf-usage-collector-actor-tenant-admin` | Query aggregated and raw usage records scoped to their own tenant; view watermarks for their tenant | Accessing usage data of any other tenant; invoking operator-only operations (backfill, amendment, deactivation, retention policy management) |
-| `cpt-cf-usage-collector-actor-usage-source` | Emit authorized metrics within the source module's namespace via the SDK; the scope of permitted metrics and target tenants is enforced by the platform PDP at emit time — sources authorized only for their own tenant may only emit for that tenant; sources explicitly authorized for multiple tenants may emit records attributed to any tenant within their PDP-returned allowed set | Emitting metrics outside the authorized namespace; emitting records attributed to tenants outside the PDP-authorized scope; bypassing `authorize_emit()`; submitting records attributed to other sources |
+| `cpt-cf-usage-collector-actor-usage-source` | Emit metrics valid for the claimed module type via the SDK or REST API; the scope of permitted target tenants is enforced by the platform PDP at emit time — the caller must be PDP-authorized for the tenant supplied in the record, covering both same-tenant and parent→subtenant scenarios | Emitting records attributed to tenants outside the PDP-authorized scope; emitting metrics not registered for the claimed module type |
 | `cpt-cf-usage-collector-actor-usage-consumer` | Query aggregated and raw usage data scoped to the authenticated tenant; subject to PDP constraint filters | Accessing cross-tenant data; mutating usage records |
 | `cpt-cf-usage-collector-actor-storage-backend` | Receive and persist usage records forwarded by the gateway plugin; respond to query and retention operations initiated by the plugin | Direct access from any actor other than the authorized storage plugin instance |
 | `cpt-cf-usage-collector-actor-types-registry` | Respond to schema registration and validation requests initiated by the gateway | N/A — passive service; does not initiate operations on the Usage Collector |
@@ -198,13 +217,26 @@ No module-specific environment constraints beyond project defaults.
 
 ### 5.1 Usage Ingestion
 
-#### Usage Record Ingestion
+#### SDK Usage Record Ingestion
 
 - [ ] `p1` - **ID**: `cpt-cf-usage-collector-fr-ingestion`
 
-The system **MUST** accept usage records from platform services. Each usage record represents a single measurement of resource consumption attributed to a tenant.
+The system **MUST** accept usage records from in-process platform services via the Usage Collector SDK. Each usage record represents a single measurement of resource consumption attributed to a tenant.
 
 - **Rationale**: Centralizing usage ingestion ensures all downstream consumers operate on the same data.
+- **Actors**: `cpt-cf-usage-collector-actor-usage-source`
+
+#### REST API Usage Record Ingestion
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-fr-rest-ingestion`
+
+The system **MUST** expose a REST API endpoint for usage record submission, enabling remote CyberFabric nodes and external non-CyberFabric systems to submit records over HTTP using OAuth2 client credentials. The REST ingestion path **MUST** be subject to identical PDP authorization and validation rules as the SDK ingestion path.
+
+For trusted CyberFabric forwarder modules (e.g., `usage-collector-rest-client`), a two-level authorization model applies: PDP authorization is enforced at the source side against the original caller's SecurityContext before any record enters the forwarder's outbox; the gateway REST endpoint then authenticates the forwarder via service-to-service bearer token and applies a gateway-level PDP check against the forwarder's service identity. Both checks must pass before any record is accepted for storage.
+
+For external non-CyberFabric systems calling the REST endpoint directly, the gateway PDP check against the caller's OAuth2 identity is the sole authorization boundary.
+
+- **Rationale**: Remote and external sources that cannot embed the SDK — such as remote collection agents forwarding records from distributed locations, or third-party systems integrated with the platform — must be able to contribute usage data through the same authoritative store without requiring a SDK dependency. The two-level model for CyberFabric forwarders preserves per-caller authorization at the source while maintaining gateway-level enforcement against the forwarder's service identity.
 - **Actors**: `cpt-cf-usage-collector-actor-usage-source`
 
 #### Idempotent Ingestion
@@ -264,27 +296,25 @@ The system **MUST** guarantee at-least-once delivery of usage records from sourc
 
 - [ ] `p1` - **ID**: `cpt-cf-usage-collector-fr-tenant-attribution`
 
-The system **MUST** attribute all usage records to a tenant that is authorized by the platform PDP at emit time. For sources that emit only for their own tenant, the tenant is derived from the authenticated SecurityContext. For sources explicitly authorized by the PDP to emit on behalf of multiple tenants (e.g., a platform-level metering agent collecting data from a shared hypervisor), the tenant is taken from the record as supplied by the caller and **MUST** satisfy the PDP-returned tenant constraint evaluated in-memory by `emit()` before the record is accepted. In all cases, tenant identity **MUST NOT** be accepted from request payloads without prior PDP authorization. The gateway **MUST** independently validate tenant attribution on ingest as a defense-in-depth check.
+The system **MUST** attribute all usage records to a tenant supplied by the caller in the request. The system **MUST** authorize the caller's tenant attribution via the platform PDP before any record is accepted, verifying that the authenticated caller is permitted to emit records for the specified tenant. This covers both same-tenant emission and parent→subtenant scenarios (e.g., a platform-level metering agent collecting usage for resources owned by its subtenants). The gateway **MUST** independently validate tenant attribution on ingest as a defense-in-depth check.
 
-- **Rationale**: PDP-gated tenant attribution prevents spoofing while enabling platform-level metering agents that collect usage for resources (e.g., virtual machines) owned by multiple tenants from a single process. Without this capability, such agents would require per-tenant service account credentials, creating operational complexity proportional to tenant count. PDP authorization remains the single source of truth for what tenants any given source is permitted to report for.
+- **Rationale**: Requiring callers to supply the target tenant explicitly supports all emission scenarios — including remote forwarders and external systems that emit records on behalf of multiple tenants — through a single uniform path. PDP authorization remains the security boundary enforcing which tenants a given caller is permitted to report for.
 - **Actors**: `cpt-cf-usage-collector-actor-usage-source`
 
 #### Resource Attribution
 
 - [ ] `p1` - **ID**: `cpt-cf-usage-collector-fr-resource-attribution`
 
-The system **MUST** support attributing usage records to specific resource instances within a tenant, identified by a resource ID and resource type.
+Every usage record **MUST** be attributed to a specific resource instance within a tenant, identified by a resource ID and resource type. Resource attribution is mandatory; the system **MUST** reject records that omit either field.
 
-- **Rationale**: Per-resource attribution enables granular billing, per-resource quota enforcement, and detailed usage analysis at the resource level.
+- **Rationale**: Per-resource attribution enables granular billing, per-resource quota enforcement, and detailed usage analysis at the resource level. Mandatory attribution ensures downstream consumers always have a resource scope to aggregate and filter on, without needing to handle the absence of this field.
 - **Actors**: `cpt-cf-usage-collector-actor-usage-source`
 
 #### Subject Attribution
 
 - [ ] `p1` - **ID**: `cpt-cf-usage-collector-fr-subject-attribution`
 
-The system **MUST** support attributing usage records to a subject (user, service account, or other principal) within a tenant, identified by a subject ID and subject type. Subject attribution **MUST** always be derived from the authenticated SecurityContext — the system **MUST NOT** accept subject identity from request payloads.
-
-Subject attribution is optional per usage record to accommodate system-level resource consumption not attributable to a specific subject (e.g., background jobs where per-user attribution is not meaningful).
+The system **MUST** support attributing usage records to a subject (user, service account, or other principal) within a tenant, identified by a subject ID and subject type. Subject attribution is **optional** per usage record to accommodate system-level resource consumption not attributable to a specific subject (e.g., background jobs where per-user attribution is not meaningful). The system **MUST** accept usage records where `subject_id` and `subject_type` are not provided. When `subject_id` and `subject_type` are provided, the system **MUST** validate them against PDP authorization; when they are absent, PDP subject validation is skipped.
 
 - **Rationale**: Per-subject attribution enables chargeback, per-subject quota enforcement, and visibility into which principals drive consumption within a tenant. Deriving subject identity server-side from SecurityContext prevents spoofing.
 - **Actors**: `cpt-cf-usage-collector-actor-usage-source`
@@ -303,13 +333,16 @@ The system **MUST** enforce strict tenant isolation on all read and write operat
 
 - [ ] `p1` - **ID**: `cpt-cf-usage-collector-fr-ingestion-authorization`
 
-The system **MUST** authorize each usage record emission before it is persisted. Authorization **MUST** verify that the emitting source module is permitted to report the specific metrics being submitted, and that any attributed resource and subject are within the emitting module's authorized scope.
+The system **MUST** authorize each usage record emission before it is persisted. The security boundary for ingestion authorization is the PDP check on the caller's authenticated identity against the target tenant and resource — the system **MUST** verify the caller is permitted to emit records for the specified tenant and resource before any record is accepted.
 
-Each source module has a fixed, platform-assigned identity that is the basis for authorization. A source module **MUST** only be permitted to emit metrics within its authorized domain; emissions outside that domain **MUST** be rejected before any record is persisted.
+The `module` field in a usage record identifies the originating source for attribution and metric validation purposes. Its semantics differ by ingestion path:
 
-Authorization failures **MUST** be surfaced immediately to the caller before any domain operation is committed. The system **MUST** fail closed: unauthorized records are never persisted, and there is no silent discard of denied emissions.
+- **SDK ingestion**: module identity is set in-process at SDK client construction time and is implicitly trusted as the emitting service's own identity.
+- **REST API ingestion**: the `module` field is caller-supplied attribution metadata, accepted on trust. It is used to validate that the emitted metric is registered for the claimed module type (a data quality check), but it is not a security authorization principal — the PDP check on tenant and resource is the authoritative security enforcement.
 
-- **Rationale**: Without ingestion authorization, any module could report usage for metric types it does not own (e.g., a file-storage service reporting LLM token usage) or attribute usage to subjects and resources beyond its authorized scope, leading to inaccurate metering, billing errors, and cross-boundary data pollution. Binding source identity at initialization time rather than per-call makes the authorization scope auditable and eliminates per-call spoofing surface.
+The system **MUST** validate that the emitted metric is registered for the module type claimed in the record, rejecting records that reference metrics not associated with the claimed module. Authorization failures **MUST** be surfaced immediately to the caller before any domain operation is committed. The system **MUST** fail closed: unauthorized records are never persisted, and there is no silent discard of denied emissions.
+
+- **Rationale**: Decoupling module attribution from the authorization security boundary enables the REST ingestion path to support legitimate forwarding scenarios — such as a remote agent relaying records originally produced by multiple named source modules — without requiring per-module credentials. The PDP remains the authoritative enforcement point for what tenants and resources a caller may emit for. Metric validation against the claimed module type preserves data quality by ensuring records carry a plausible and registered module identity.
 - **Actors**: `cpt-cf-usage-collector-actor-usage-source`
 
 ### 5.5 Pluggable Storage
@@ -451,9 +484,9 @@ Routine ingestion and read operations are not audited via `audit_service`.
 
 The system **MUST** enforce rate limits on usage record emission at two levels:
 
-**Source-level (enforced at the SDK, before any outbox INSERT)**: A configurable per-source emission quota limits the total number of records a source module may emit across all tenants within a rate limit window. `authorize_emit()` fetches the current source-level quota snapshot before any DB transaction opens; `emit()` evaluates it in-memory and rejects the emission if the quota is exhausted. This provides low-latency, source-side flood prevention without requiring per-tenant quota pre-fetching at emit time.
+**Source-level (enforced at the SDK, before any outbox INSERT)**: A configurable per-source emission quota limits the total number of records a source module may emit across all tenants within a rate limit window. `authorize_for()` fetches the current source-level quota snapshot before any DB transaction opens; `enqueue()` evaluates it in-memory and rejects the emission if the quota is exhausted. This provides low-latency, source-side flood prevention without requiring per-tenant quota pre-fetching at emit time.
 
-**Per-tenant (enforced at the gateway on ingest)**: A configurable per-(source module, tenant) quota limits the number of records a source may deliver for any single tenant within a rate limit window. The gateway enforces this on the inbound `persist()` call, after the record's `tenant_id` is known. This provides granular per-tenant protection at delivery time.
+**Per-tenant (enforced at the gateway on ingest)**: A configurable per-(source module, tenant) quota limits the number of records a source may deliver for any single tenant within a rate limit window. The gateway enforces this on the inbound `create_usage_record()` call, after the record's `tenant_id` is known. This provides granular per-tenant protection at delivery time.
 
 Rate limits are configured by the platform operator. An operator **MAY** configure a default quota that applies when no explicit entry exists; if neither applies, no rate limit is enforced.
 
@@ -643,6 +676,15 @@ The following commonly applicable NFR categories are not applicable to this modu
 - **Description**: Public interface for emitting usage records and querying aggregated data; technical interface type and crate naming defined in DESIGN.md
 - **Breaking Change Policy**: Unstable during initial development; will stabilize in future version
 
+#### REST Ingestion API
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-interface-rest-ingestion`
+
+- **Type**: HTTP REST API
+- **Stability**: unstable (v0)
+- **Description**: HTTP endpoint for submitting usage records from remote or external sources; authentication via OAuth2 client credentials; request and response schema defined in DESIGN.md
+- **Breaking Change Policy**: Unstable during initial development; will stabilize in future version
+
 ### 7.2 External Integration Contracts
 
 #### Storage Plugin Contract
@@ -734,11 +776,11 @@ The following commonly applicable NFR categories are not applicable to this modu
 - [ ] Duplicate records with the same idempotency key result in a single stored record
 - [ ] Counter records with negative values are rejected at ingestion
 - [ ] Gauge records are stored as-is without monotonicity constraints
-- [ ] Usage records are attributed to the correct tenant, derived from SecurityContext
-- [ ] Usage records can be attributed to a specific resource (resource ID and type)
-- [ ] Usage records can be attributed to a specific subject (subject ID and type), derived from SecurityContext
+- [ ] Incoming usage records include an explicit tenant attribute; the platform PDP validates that the authenticated caller is authorized to emit records for the specified tenant before the record is accepted, and the gateway independently validates tenant attribution on ingest as a defense-in-depth check
+- [ ] Every usage record includes resource attribution (resource ID and type); records without either field are rejected
+- [ ] Usage records can optionally be attributed to a subject (subject ID and type); when supplied with PDP authorization, subject is accepted from the request payload; when absent, PDP subject validation is skipped
 - [ ] Authorization failures are surfaced immediately to the caller; no record is persisted on denial
-- [ ] An `EmitAuthorization` token older than `MAX_AUTH_AGE` (30 seconds) is rejected by `emit()` with an `AuthorizationExpired` error before any record is accepted for delivery
+- [ ] An `AuthorizedUsageEmitter` token older than `MAX_AUTH_AGE` (30 seconds) is rejected by `enqueue()` with an `UsageEmitterError::AuthorizationExpired` error before any record is accepted for delivery
 - [ ] A source module that exceeds its configured emission quota for a given tenant within the current rate limit window is rejected with an actionable error before any record is accepted for delivery
 - [ ] Rate limit configuration can be set per (source module, tenant) pair; a default per-source quota applies when no tenant-specific entry exists
 - [ ] Rate limit enforcement does not degrade ingestion latency for emissions within quota
@@ -768,6 +810,9 @@ The following commonly applicable NFR categories are not applicable to this modu
 - [ ] Every operator-initiated write operation (backfill, amendment, deactivation) emits a structured audit event to the platform `audit_service` with the required common fields and operation-specific context; justification is required and included in every such event
 - [ ] All API operations require authentication; unauthenticated requests are rejected before any operation is performed
 - [ ] Authorization is enforced on all read and write operations; unauthorized requests are rejected and no data is exposed or modified
+- [ ] The REST ingestion endpoint (`cpt-cf-usage-collector-fr-rest-ingestion`) rejects requests from `cpt-cf-usage-collector-actor-usage-source` that carry no bearer token or an invalid/expired OAuth2 client-credentials token with HTTP 401; requests carrying a valid token proceed to PDP evaluation
+- [ ] When a trusted CyberFabric forwarder (e.g., `usage-collector-rest-client`) acting as `cpt-cf-usage-collector-actor-usage-source` submits records via the REST endpoint (`cpt-cf-usage-collector-fr-rest-ingestion`), the source-side PDP check against the original caller's SecurityContext must pass before any record enters the forwarder's outbox, and the gateway-side PDP check against the forwarder's service identity must also pass; a failure at either level causes the record to be rejected
+- [ ] When an external non-CyberFabric `cpt-cf-usage-collector-actor-usage-source` calls the REST ingestion endpoint (`cpt-cf-usage-collector-fr-rest-ingestion`) directly, only the gateway PDP check against the caller's OAuth2 identity is applied; records are accepted when that check passes and rejected otherwise
 - [ ] Throughput scales linearly as additional instances are added
 - [ ] Durably captured records are eventually persisted to the storage backend and available for querying after storage backend recovery
 - [ ] Retention periods can be configured from 7 days to 7 years per usage type and per tenant

--- a/modules/system/usage-collector/docs/features/0001-cpt-cf-usage-collector-feature-sdk-and-ingest-core.md
+++ b/modules/system/usage-collector/docs/features/0001-cpt-cf-usage-collector-feature-sdk-and-ingest-core.md
@@ -1,0 +1,547 @@
+---
+cpt:
+  version: "1.10"
+  changelog:
+    - version: "1.10"
+      date: "2026-04-28"
+      changes:
+        - "Fix backoff_max → outbox_backoff_max rename (6 occurrences at lines 157, 260, 337, 444, 489, 521); rewrite hot-path annotation for get_module_config() to accurately describe REST HTTP GET to inst-cfg-2 and gateway in-memory config serving."
+    - version: "1.9"
+      date: "2026-04-28"
+      changes:
+        - "Make subject_id/subject_type optional in authorize_for() input (Option<Uuid>/Option<String>); update inst-authz-2 to pass SUBJECT_ID/SUBJECT_TYPE conditionally when present; update inst-authz-6 to bind subject as optional into token; update inst-enq-6 to validate subject match conditionally; update inst-enq-8 to note subject fields serialize as absent when None; update DoD emitter and SDK crate descriptions; add acceptance criteria for subject-absent path."
+    - version: "1.8"
+      date: "2026-04-27"
+      changes:
+        - "Add subject_id/subject_type to authorize_for() input; extend PDP call (inst-authz-2) with MODULE+SUBJECT properties; bind subject into token (inst-authz-6); replace SecurityContext capture with token validation in inst-enq-6."
+    - version: "1.7"
+      date: "2026-04-27"
+      changes:
+        - "§3 inst-enq-5, inst-enq-5b: define blank-as-missing semantics for idempotency_key — empty or whitespace-only strings MUST be treated as absent (equivalent to None)"
+    - version: "1.6"
+      date: "2026-04-27"
+      changes:
+        - "§3 authorize-for: added inst-authz-5b — collector infrastructure failures (PluginTimeout, CircuitOpen, Unavailable, Internal) now return UsageEmitterError::Internal instead of AuthorizationFailed; fixes misclassification of retryable failures as 403 policy denials"
+    - version: "1.5"
+      date: "2026-04-27"
+      changes:
+        - "§3 inst-dlv-6: clarified transient failure list to explicitly include connection/transport errors and AuthN service unavailability; introduces UsageCollectorError::Unavailable as the carrier for these cases"
+    - version: "1.4"
+      date: "2026-04-27"
+      changes:
+        - "§3: removed inst-authz-1 (no-open-transaction assertion — not implementable due to platform limitations); renumbered authorize-for steps; marked authorize-for algo [x]"
+        - "§3: added inst-enq-5b code marker; marked step [x]"
+        - "§1: updated featstatus and DECOMP ref to [x] — all p1 DoD items and CDSL blocks complete"
+    - version: "1.3"
+      date: "2026-04-26"
+      changes:
+        - "§3: added queue overflow, message ordering, optional field serialization, and cache integration N/A notes (fixes REL-FDESIGN-004, INT-FDESIGN-004, DATA-FDESIGN-003)"
+        - "§5.2: added data access patterns N/A, data archival N/A, connection management N/A notes (fixes DATA-FDESIGN-001, DATA-FDESIGN-004, INT-FDESIGN-002)"
+        - "§5.3: added recovery, data archival N/A, configuration table, health & diagnostics, encryption constraint deferral (fixes REL-FDESIGN-005, DATA-FDESIGN-004, OPS-FDESIGN-002/003)"
+        - "§2/§3/§5.4: added p2 deferral notes on deferred CDSL items (fix MAINT-FDESIGN-003)"
+        - "§5: added Known Limitations / Technical Debt subsection (fix MAINT-FDESIGN-003)"
+        - "§6: added test data requirements, test coverage guidance, success metrics (fixes TEST-FDESIGN-001/002, BIZ-FDESIGN-002)"
+    - version: "1.2"
+      date: "2026-04-26"
+      changes:
+        - "§3: added hot-path annotation for `authorize_for()` (fix PERF-FDESIGN-001)"
+        - "§5.2: added resource management, concurrency, and observability notes (fixes PERF-FDESIGN-002, PERF-FDESIGN-003, OPS-FDESIGN-001)"
+        - "§5.3: added observability and rollout/rollback notes (fixes OPS-FDESIGN-001, OPS-FDESIGN-004)"
+        - "§1.2: added NFR target reference (fix PERF-FDESIGN-004)"
+    - version: "1.1"
+      date: "2026-04-26"
+      changes:
+        - "§1.3: replaced inline actor definition table with PRD reference list (fix BIZ-FDESIGN-NO-001)"
+        - "§1.2: added `p2` priority annotation to `cpt-cf-usage-collector-fr-record-metadata` (fix SEM-FDESIGN-005)"
+---
+
+# Feature: Core SDK, Emitter & In-Process Ingest
+
+
+<!-- toc -->
+
+- [1. Feature Context](#1-feature-context)
+  - [1.1 Overview](#11-overview)
+  - [1.2 Purpose](#12-purpose)
+  - [1.3 Actors](#13-actors)
+  - [1.4 References](#14-references)
+- [2. Actor Flows (CDSL)](#2-actor-flows-cdsl)
+  - [Usage Emission Flow](#usage-emission-flow)
+  - [Module Config Retrieval Flow](#module-config-retrieval-flow)
+- [3. Processes / Business Logic (CDSL)](#3-processes--business-logic-cdsl)
+  - [Phase 1: `authorize_for()` Authorization](#phase-1-authorize_for-authorization)
+  - [Phase 2: `build_usage_record().enqueue()` — In-Transaction Enqueue](#phase-2-build_usage_recordenqueue--in-transaction-enqueue)
+  - [Outbox Delivery `MessageHandler`](#outbox-delivery-messagehandler)
+  - [Gateway Ingest Handler](#gateway-ingest-handler)
+  - [Static Module Config Resolution](#static-module-config-resolution)
+- [4. States (CDSL)](#4-states-cdsl)
+- [5. Definitions of Done](#5-definitions-of-done)
+  - [SDK Crate (`usage-collector-sdk`)](#sdk-crate-usage-collector-sdk)
+  - [Emitter Crate (`usage-emitter`)](#emitter-crate-usage-emitter)
+  - [Gateway Crate (`usage-collector`) — Ingest & Config](#gateway-crate-usage-collector--ingest--config)
+  - [No-Op Storage Plugin (`noop-usage-collector-storage-plugin`)](#no-op-storage-plugin-noop-usage-collector-storage-plugin)
+  - [Known Limitations / Technical Debt](#known-limitations--technical-debt)
+- [6. Acceptance Criteria](#6-acceptance-criteria)
+- [7. Non-Applicability Notes](#7-non-applicability-notes)
+
+<!-- /toc -->
+
+- [x] `p2` - **ID**: `cpt-cf-usage-collector-featstatus-sdk-and-ingest-core`
+<!-- STATUS: IMPLEMENTED — all p1 DoD items and all CDSL blocks are [x]. -->
+
+<!-- reference to DECOMPOSITION entry -->
+- [x] `p1` - `cpt-cf-usage-collector-feature-sdk-and-ingest-core`
+## 1. Feature Context
+
+### 1.1 Overview
+
+Establishes the core Usage Collector data model, SDK trait boundaries, two-phase authorization emitter, transactional outbox pipeline, gateway ingest handler, static metric configuration, and no-op storage plugin — delivering the complete in-process emission path from `authorize_for()` through the outbox background pipeline to the gateway and plugin.
+
+### 1.2 Purpose
+
+Implements the foundation for all usage collection capabilities. Covers the SDK crate (`usage-collector-sdk`), the emitter crate (`usage-emitter`), the gateway crate (`usage-collector`) ingest and config endpoints, and the no-op storage plugin (`noop-usage-collector-storage-plugin`). This feature is the prerequisite for all other Usage Collector features.
+
+**Requirements**: `cpt-cf-usage-collector-fr-ingestion`, `cpt-cf-usage-collector-fr-idempotency`, `cpt-cf-usage-collector-fr-delivery-guarantee`, `cpt-cf-usage-collector-fr-counter-semantics`, `cpt-cf-usage-collector-fr-gauge-semantics`, `cpt-cf-usage-collector-fr-tenant-attribution`, `cpt-cf-usage-collector-fr-resource-attribution`, `cpt-cf-usage-collector-fr-subject-attribution`, `cpt-cf-usage-collector-fr-tenant-isolation`, `cpt-cf-usage-collector-fr-ingestion-authorization`, `cpt-cf-usage-collector-fr-pluggable-storage`, `cpt-cf-usage-collector-fr-record-metadata` (`p2`), `cpt-cf-usage-collector-nfr-availability`, `cpt-cf-usage-collector-nfr-ingestion-latency`, `cpt-cf-usage-collector-nfr-authentication`, `cpt-cf-usage-collector-nfr-authorization`, `cpt-cf-usage-collector-nfr-scalability`, `cpt-cf-usage-collector-nfr-fault-tolerance`, `cpt-cf-usage-collector-nfr-recovery`, `cpt-cf-usage-collector-nfr-graceful-degradation`, `cpt-cf-usage-collector-nfr-rpo`
+
+**NFR targets (from PRD)**: `cpt-cf-usage-collector-nfr-ingestion-latency`
+and `cpt-cf-usage-collector-nfr-availability` define numeric targets; values
+are defined in PRD §NFRs and are not reproduced here. See PRD for
+response-time and throughput targets.
+
+**Principles**: `cpt-cf-usage-collector-principle-source-side-persistence`, `cpt-cf-usage-collector-principle-pluggable-storage`, `cpt-cf-usage-collector-principle-tenant-from-ctx`, `cpt-cf-usage-collector-principle-fail-closed`, `cpt-cf-usage-collector-principle-scoped-source-attribution`, `cpt-cf-usage-collector-principle-two-phase-authz`
+
+### 1.3 Actors
+
+**Actors** (defined in PRD.md):
+- `cpt-cf-usage-collector-actor-usage-source` — initiates emission flows
+- `cpt-cf-usage-collector-actor-platform-developer` — SDK integrator
+- `cpt-cf-usage-collector-actor-storage-backend` — storage delegation target
+
+### 1.4 References
+
+- **PRD**: [PRD.md](../PRD.md)
+- **Design**: [DESIGN.md](../DESIGN.md)
+- **DECOMPOSITION**: [DECOMPOSITION.md](../DECOMPOSITION.md)
+- **Dependencies**: None
+
+## 2. Actor Flows (CDSL)
+
+### Usage Emission Flow
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-flow-sdk-and-ingest-core-emit`
+
+**Actor**: `cpt-cf-usage-collector-actor-usage-source`
+
+**Success Scenarios**:
+- Record is durably enqueued in the source's local outbox within the caller's DB transaction
+- Outbox background pipeline delivers the record to the gateway; plugin confirms storage
+
+**Error Scenarios**:
+- PDP denies `USAGE_RECORD`/`CREATE` → `UsageEmitterError::AuthorizationDenied`; no outbox INSERT
+- Module not configured → `UsageEmitterError::ModuleNotConfigured`; no outbox INSERT
+- Metric not in allowed list → `UsageEmitterError::MetricNotAllowed`; no outbox INSERT
+- Counter record with negative value or missing idempotency key → `UsageEmitterError::InvalidRecord`; no outbox INSERT
+- `AuthorizedUsageEmitter` token exceeded max age → `UsageEmitterError::AuthorizationExpired`; no outbox INSERT
+- Metadata exceeds 8 KB → `UsageEmitterError::MetadataTooLarge`; no outbox INSERT
+- Outbox delivery fails after retry budget exhausted → message moved to dead-letter store; surfaced via monitoring
+
+**Steps**:
+1. [x] - `p1` - Source retrieves `UsageEmitterV1` from `ClientHub` at module initialization - `inst-emit-1`
+2. [x] - `p1` - Source calls `UsageEmitterV1::for_module(MODULE_NAME)` to obtain a `ScopedUsageEmitter` bound to the source module's identity - `inst-emit-2`
+3. [x] - `p1` - Before opening a DB transaction, source calls `ScopedUsageEmitter::authorize_for(ctx, tenant_id, resource_id, resource_type)` with optional `subject_id` and `subject_type` — triggers phase 1 authorization - `inst-emit-3`
+4. [x] - `p1` - **IF** PDP denies or module is not configured - `inst-emit-4`
+   1. [x] - `p1` - **RETURN** `UsageEmitterError`; no record is persisted - `inst-emit-4a`
+5. [x] - `p1` - **RETURN** `AuthorizedUsageEmitter` token carrying PDP permit, allowed-metrics list, and bound `tenant_id`/`resource_id`/`resource_type` - `inst-emit-5`
+6. [x] - `p1` - Inside the source's DB transaction, source calls `AuthorizedUsageEmitter::build_usage_record(metric, value).enqueue()` — triggers phase 2 enqueue - `inst-emit-6`
+7. [x] - `p1` - **IF** any in-memory validation fails (token expired, metric disallowed, counter invalid, metadata oversized) - `inst-emit-7`
+   1. [x] - `p1` - **RETURN** `UsageEmitterError`; outbox INSERT is not executed - `inst-emit-7a`
+8. [x] - `p1` - Outbox row is inserted into the source's local DB within the caller's transaction, serialized as `payload_type = "usage-collector.record.v1"` - `inst-emit-8`
+9. [x] - `p1` - Outbox background pipeline picks up the row and calls `UsageCollectorClientV1::create_usage_record()` on delivery - `inst-emit-9`
+10. [x] - `p1` - **IF** delivery fails transiently (network error, 5xx, 429) - `inst-emit-10`
+    1. [x] - `p1` - Retry with exponential backoff; `outbox_backoff_max` MUST be configured below 15 minutes - `inst-emit-10a`
+11. [x] - `p1` - **IF** delivery fails permanently (4xx excluding 429) - `inst-emit-11`
+    1. [x] - `p1` - Move message to dead-letter store and surface via monitoring - `inst-emit-11a`
+12. [x] - `p1` - **RETURN** delivery confirmed; record is available at the gateway - `inst-emit-12`
+
+### Module Config Retrieval Flow
+
+- [x] `p2` - **ID**: `cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config`
+
+> _(p2: deferred — static module config reload requires gateway restart; implementing dynamic config reload is out of scope for Feature 1)_
+
+**Actor**: `cpt-cf-usage-collector-actor-usage-source`
+
+**Success Scenarios**:
+- Gateway returns `ModuleConfig` with the static `allowed_metrics` list for the requesting module
+
+**Error Scenarios**:
+- Module not registered in static config → gateway returns 404; `authorize_for()` surfaces `UsageEmitterError::ModuleNotConfigured`
+
+**Steps**:
+1. [x] - `p2` - During `authorize_for()` phase 1, emitter calls `UsageCollectorClientV1::get_module_config(module_name)` - `inst-cfg-1`
+2. [x] - `p2` - Gateway receives `GET /usage-collector/v1/modules/{module_name}/config` authenticated via SecurityContext - `inst-cfg-2`
+3. [x] - `p2` - Gateway looks up static metric configuration for the module - `inst-cfg-3`
+4. [x] - `p2` - **IF** module not in static config - `inst-cfg-4`
+   1. [x] - `p2` - **RETURN** 404; emitter surfaces `UsageEmitterError::ModuleNotConfigured` - `inst-cfg-4a`
+5. [x] - `p2` - **RETURN** `ModuleConfig { module_name, allowed_metrics: [AllowedMetric { name, kind }] }` - `inst-cfg-5`
+
+## 3. Processes / Business Logic (CDSL)
+
+### Phase 1: `authorize_for()` Authorization
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for`
+
+**Input**: `SecurityContext`, `tenant_id: Uuid`, `resource_id: Uuid`, `resource_type: String`, `subject_id: Option<Uuid>`, `subject_type: Option<String>`
+
+**Output**: `Result<AuthorizedUsageEmitter, UsageEmitterError>`
+
+**Hot path**: `authorize_for()` (PDP call + config fetch) is the
+latency-critical path for SDK callers. `get_module_config()` issues a REST
+HTTP GET to the instance-configuration gateway (inst-cfg-2); the gateway
+serves this from static in-memory configuration loaded at startup — no DB
+I/O on the gateway side — so the per-call cost is network latency only, not
+a DB round-trip. Operators should budget one synchronous HTTP round-trip per
+`get_module_config()` call in the hot-path. Batch delivery and N+1 query
+optimisation are not applicable — records are enqueued individually by
+design.
+
+**Steps**:
+1. [x] - `p1` - Call platform PDP: `USAGE_RECORD`/`CREATE`, passing `tenant_id`, `resource_id`/`resource_type` as resource properties, MODULE (the scoped emitter's bound module name) as a resource property, and — **IF** `subject_id` and `subject_type` are present — SUBJECT_ID/SUBJECT_TYPE as resource properties; when absent, PDP subject properties are omitted from the request - `inst-authz-2`
+2. [x] - `p1` - **IF** PDP denies - `inst-authz-3`
+   1. [x] - `p1` - **RETURN** `UsageEmitterError::AuthorizationDenied` - `inst-authz-3a`
+3. [x] - `p1` - Call `get_module_config(module_name)` to fetch `AllowedMetric` list from gateway - `inst-authz-4`
+4. [x] - `p1` - **IF** module not in static config - `inst-authz-5`
+   1. [x] - `p1` - **RETURN** `UsageEmitterError::ModuleNotConfigured` - `inst-authz-5a`
+   2. [x] - `p1` - **ELSE IF** `get_module_config` returns any other error (e.g. plugin timeout, circuit open, unavailable, internal) - **RETURN** `UsageEmitterError::Internal` - `inst-authz-5b`
+5. [x] - `p1` - Bind PDP permit result, allowed-metrics list, `tenant_id`, `resource_id`, `resource_type`, optional `subject_id` (`Option<Uuid>`), optional `subject_type` (`Option<String>`), and issuance timestamp into `AuthorizedUsageEmitter` token - `inst-authz-6`
+6. [x] - `p1` - **RETURN** `AuthorizedUsageEmitter` token - `inst-authz-7`
+
+### Phase 2: `build_usage_record().enqueue()` — In-Transaction Enqueue
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue`
+
+**Input**: `AuthorizedUsageEmitter`, metric name, value, optional idempotency key, optional metadata JSON
+
+**Output**: `Result<(), UsageEmitterError>`
+
+**Optional field serialization**: `metadata` is optional. When absent it serializes as an absent JSON field (not `null`). Deserialization treats absent as `None` with no default substitution. `idempotency_key` is optional from the caller's perspective but is **always present in the serialized record** — when the caller omits it, a UUID v4 is auto-generated before enqueue so the wire format always carries a non-null key. Blank strings (`""` or whitespace-only) are semantically equivalent to `None` for this field and MUST NOT be stored as a valid key.
+
+**Steps**:
+1. [x] - `p1` - Verify `AuthorizedUsageEmitter` token has not exceeded its maximum age - `inst-enq-1`
+2. [x] - `p1` - **IF** token is expired - `inst-enq-2`
+   1. [x] - `p1` - **RETURN** `UsageEmitterError::AuthorizationExpired` - `inst-enq-2a`
+3. [x] - `p1` - Verify metric name is present in the token's allowed-metrics list - `inst-enq-3`
+4. [x] - `p1` - **IF** metric not in allowed list - `inst-enq-4`
+   1. [x] - `p1` - **RETURN** `UsageEmitterError::MetricNotAllowed` - `inst-enq-4a`
+5. [x] - `p1` - **IF** metric kind is `counter` AND (value < 0 OR idempotency_key is None); an empty or whitespace-only string MUST be treated as absent (equivalent to `None`) - `inst-enq-5`
+   1. [x] - `p1` - **RETURN** `UsageEmitterError::InvalidRecord` - `inst-enq-5a`
+5a. [x] - `p1` - **IF** idempotency_key is None (gauge record without caller-supplied key) — generate a UUID v4 and assign it as the idempotency_key; an empty or whitespace-only string MUST be treated as absent and triggers the UUID fallback - `inst-enq-5b`
+6. [x] - `p1` - Validate `record.module` equals the token's bound module name; if mismatch RETURN `UsageEmitterError::InvalidRecord`. **IF** the token's `subject_id`/`subject_type` are present, validate `record.subject_id` and `record.subject_type` match them; if mismatch RETURN `UsageEmitterError::InvalidRecord`. **IF** the token's subject values are `None`, `record.subject_id` and `record.subject_type` MUST also be absent; if present RETURN `UsageEmitterError::InvalidRecord` - `inst-enq-6`
+7. [x] - `p1` - **IF** metadata is present AND byte length > 8192 - `inst-enq-7`
+   1. [x] - `p1` - **RETURN** `UsageEmitterError::MetadataTooLarge` - `inst-enq-7a`
+8. [x] - `p1` - Serialize `UsageRecord` (tenant_id, module, kind, metric, value, idempotency_key, resource_id, resource_type, subject_id, subject_type, metadata, timestamp) with `payload_type = "usage-collector.record.v1"`; `subject_id`, `subject_type`, and `metadata` serialize as absent JSON fields when `None` (not as `null`) - `inst-enq-8`
+9. [x] - `p1` - Call `Outbox::enqueue(payload, payload_type)` within the caller's active DB transaction - `inst-enq-9`
+10. [x] - `p1` - **RETURN** `Ok(())`; record is durably enqueued and delivery proceeds asynchronously - `inst-enq-10`
+
+### Outbox Delivery `MessageHandler`
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery`
+
+**Input**: Serialized outbox message with `payload_type = "usage-collector.record.v1"`
+
+**Output**: `HandlerResult`
+
+**Queue overflow**: The outbox grows as long as the storage plugin is unavailable. No max-rows limit is enforced by this feature — unbounded growth is an operational concern delegated to DB capacity management. `enqueue()` does not apply backpressure to the caller; callers experience DB write latency only. Operators should monitor outbox queue depth (see Observability) and provision DB capacity accordingly.
+
+**Message ordering**: Ordering across the 4 outbox partitions is not guaranteed. Per-partition ordering may be preserved by the `modkit-db` outbox library but is not relied upon by this feature. Idempotency keys on counter records provide at-least-once deduplication at the storage layer.
+
+**Steps**:
+1. [x] - `p1` - Deserialize outbox payload bytes into `UsageRecord` - `inst-dlv-1`
+2. [x] - `p1` - **IF** deserialization fails - `inst-dlv-2`
+   1. [x] - `p1` - **RETURN** `HandlerResult::Reject`; unrecoverable format error — message moved to dead-letter store - `inst-dlv-2a`
+3. [x] - `p1` - Assemble gateway ingest request from `UsageRecord` fields - `inst-dlv-3`
+4. [x] - `p1` - Call `UsageCollectorClientV1::create_usage_record(record)` - `inst-dlv-4`
+5. [x] - `p1` - **IF** call succeeds (204 No Content) - `inst-dlv-5`
+   1. [x] - `p1` - **RETURN** `HandlerResult::Success`; outbox row is deleted - `inst-dlv-5a`
+6. [x] - `p1` - **IF** transient failure (connection/transport error, AuthN service temporarily unreachable, network timeout, 5xx, 429) - `inst-dlv-6`
+   1. [x] - `p1` - **RETURN** `HandlerResult::Retry`; outbox library applies exponential backoff; `outbox_backoff_max` MUST be configured below 15 minutes to satisfy `cpt-cf-usage-collector-nfr-recovery` - `inst-dlv-6a`
+7. [x] - `p1` - **IF** permanent failure (4xx excluding 429) - `inst-dlv-7`
+   1. [x] - `p1` - **RETURN** `HandlerResult::Reject`; message moved to dead-letter store and surfaced via monitoring - `inst-dlv-7a`
+
+### Gateway Ingest Handler
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler`
+
+**Input**: `UsageRecord` delivered by the outbox pipeline, `SecurityContext`
+
+**Output**: 204 No Content or error response
+
+**Steps**:
+1. [x] - `p1` - Enforce metadata size limit: reject if `record.metadata` byte length > 8192 - `inst-gw-1`
+2. [x] - `p1` - Check circuit breaker state for the active plugin instance - `inst-gw-2`
+3. [x] - `p1` - **IF** circuit is open **OR** circuit is in half-open state with a probe already in-flight - `inst-gw-3`
+   1. [x] - `p1` - **RETURN** `503 Service Unavailable` - `inst-gw-3a`
+4. [x] - `p1` - Resolve the active storage plugin via GTS - `inst-gw-4`
+5. [x] - `p1` - Call `plugin.create_usage_record(record)` with configurable timeout (default 5 s) - `inst-gw-5`
+6. [x] - `p1` - **IF** plugin call times out or fails transiently - `inst-gw-6`
+   1. [x] - `p1` - Record failure against circuit breaker; open circuit after 5 consecutive failures within a 10 s window; half-open probe after configurable interval (default 30 s) - `inst-gw-6a`
+   2. [x] - `p1` - **RETURN** transient error; retry is handled by the outbox library on the SDK side - `inst-gw-6b`
+7. [x] - `p1` - **RETURN** 204 No Content on successful plugin confirmation - `inst-gw-7`
+
+### Static Module Config Resolution
+
+- [x] `p2` - **ID**: `cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config`
+
+> _(p2: deferred — static module config reload requires gateway restart; implementing dynamic config reload is out of scope for Feature 1)_
+
+**Input**: `module_name: String`, `SecurityContext`
+
+**Output**: `Result<ModuleConfig, ModuleConfigError>`
+
+**Cache integration**: Not applicable — `ModuleConfig` is loaded from static gateway
+configuration at startup. No runtime caching layer is introduced in this feature.
+
+**Steps**:
+1. [x] - `p2` - Authenticate request via SecurityContext; ModKit pipeline rejects unauthenticated requests before the handler - `inst-cfg-p-1`
+2. [x] - `p2` - Look up module name in the gateway's static `metrics` configuration - `inst-cfg-p-2`
+3. [x] - `p2` - **IF** module not found in static config - `inst-cfg-p-3`
+   1. [x] - `p2` - **RETURN** 404 Not Found - `inst-cfg-p-3a`
+4. [x] - `p2` - **RETURN** `ModuleConfig { module_name, allowed_metrics }` - `inst-cfg-p-4`
+
+## 4. States (CDSL)
+
+Not applicable for this feature. `UsageRecord.status` transitions (`active` → `inactive`) are owned by Feature 8 (operator amendment and deactivation). Outbox message lifecycle is managed by the `modkit-db` outbox library and is not a domain state machine defined here.
+
+## 5. Definitions of Done
+
+### SDK Crate (`usage-collector-sdk`)
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-dod-sdk-and-ingest-core-sdk-crate`
+
+The system **MUST** implement the `usage-collector-sdk` crate providing: `UsageCollectorClientV1` delivery trait (`create_usage_record()`, `get_module_config()`), `UsageCollectorPluginClientV1` plugin trait (`create_usage_record()` write operation), shared model types (`UsageRecord`, `ModuleConfig`, `AllowedMetric`, `UsageKind`, error types), and the GTS schema `UsageCollectorStoragePluginSpecV1` for storage plugin registration.
+
+**Implements**:
+- `cpt-cf-usage-collector-component-sdk`
+
+**Constraints**: `cpt-cf-usage-collector-constraint-modkit`
+
+**Touches**:
+- Entities: `UsageRecord`, `ModuleConfig`, `AllowedMetric`, `UsageKind`
+
+**Data Protection**: `UsageRecord` fields (`tenant_id`, `resource_id`, `resource_type`,
+`subject_id`, `subject_type`) are classified as internal billing identifiers —
+opaque UUIDs and numeric values — not PII under the project's data
+classification policy. `subject_id` and `subject_type` are optional fields (`Option<Uuid>` / `Option<String>`); when absent from a record, no subject attribution is stored. Data minimization: only fields required for billing
+attribution are collected. Data subject deletion rights: not applicable at the
+feature level; delegated to the storage plugin (Feature 4). Encryption at rest
+and in transit: not enforced by this feature; delegated to the storage plugin
+and its infrastructure (Feature 4 — Production Storage Plugin).
+
+### Emitter Crate (`usage-emitter`)
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-dod-sdk-and-ingest-core-emitter-crate`
+
+The system **MUST** implement the `usage-emitter` crate providing: `UsageEmitterV1::for_module(name) -> ScopedUsageEmitter`, `ScopedUsageEmitter::authorize_for()` and `authorize()` (PDP call + module config fetch; `subject_id` and `subject_type` are optional — when absent, PDP subject properties are omitted from the authorization request), `AuthorizedUsageEmitter::build_usage_record().enqueue()` (all in-memory validations + `Outbox::enqueue()` within caller's transaction), the outbox `MessageHandler` with `outbox_backoff_max` configured below 15 minutes, and registration of `UsageEmitterV1` in `ClientHub` during gateway `init()`.
+
+**Implements**:
+- `cpt-cf-usage-collector-flow-sdk-and-ingest-core-emit`
+- `cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for`
+- `cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue`
+- `cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery`
+- `cpt-cf-usage-collector-component-emitter`
+
+**Constraints**: `cpt-cf-usage-collector-constraint-outbox-infra`, `cpt-cf-usage-collector-constraint-security-context`, `cpt-cf-usage-collector-constraint-modkit`
+
+**Touches**:
+- DB: `outbox` (source's local DB, `cpt-cf-usage-collector-dbtable-outbox`)
+- Entities: `UsageRecord`, `AuthorizedUsageEmitter`
+
+**Audit logging**: Calls to `authorize_for()` are not individually audited at
+the SDK boundary — audit of usage-collector ingestion calls is delegated to
+the platform-wide API audit layer. Calls to `POST /usage-collector/v1/records`
+are similarly delegated. No feature-level audit log is produced.
+
+**Resource management**: `AuthorizedUsageEmitter` tokens may be reused for
+multiple `enqueue()` calls within `authorization_max_age` (default 30 s);
+freshness is time-based, not single-use. Tokens are dropped when the owning
+scope exits — no additional cleanup required. DB connection
+pooling for the outbox is fully managed by the `modkit-db` outbox library;
+this feature does not hold connections. `UsageCollectorClientV1` connection
+pool is managed by the ModKit HTTP client; no feature-owned connection
+lifecycle.
+
+**Concurrency**: `authorize_for()` and `enqueue()` are safe for concurrent
+calls — all state is per-call with no shared mutable state in the emitter.
+Rate limiting on `POST /usage-collector/v1/records` is not in scope for
+this feature; it is delegated to the platform API gateway.
+
+**Observability**: Structured log events MUST be emitted for: authorization
+denial (`WARN`), validation failure (`WARN`), delivery retry (`INFO`),
+dead-letter routing (`ERROR`), circuit breaker state transitions
+(`WARN`/`INFO`). Metrics: outbox queue depth, delivery attempt count,
+plugin call latency (histogram), circuit breaker open/closed state (gauge).
+OpenTelemetry trace propagation across the outbox pipeline boundary is
+deferred to a future observability feature; correlation IDs from inbound
+requests are not propagated in this feature.
+
+**Data access patterns**: Not applicable — DB access is fully mediated by the `modkit-db` outbox library. This feature constructs no raw queries; index usage, join patterns, and aggregation patterns are encapsulated by the library.
+
+**Data archival and retention**: Not applicable to this feature. Archival and retention compliance are delegated to the storage plugin implementation and its backing infrastructure. The outbox schema migration is forward-only via `DatabaseCapability::migrations()`; schema rollback is not supported.
+
+**Connection management**: Not applicable — connection management, query parameterization, and
+result handling are fully encapsulated by the `modkit-db` outbox library. This feature constructs
+no raw queries.
+
+### Gateway Crate (`usage-collector`) — Ingest & Config
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-dod-sdk-and-ingest-core-gateway-crate`
+
+The system **MUST** implement in the `usage-collector` gateway crate: outbox queue registration (`"usage-records"`, 4 partitions, configurable) and schema migrations via `DatabaseCapability::migrations()`, `POST /usage-collector/v1/records` ingest handler (metadata size enforcement, GTS plugin resolution with timeout, circuit breaker — 5 failures / 10 s open, 30 s half-open probe), `GET /usage-collector/v1/modules/{module_name}/config` handler (static metric config lookup), and construction + registration of `UsageEmitterV1` (backed by `UsageCollectorLocalClient`) in `ClientHub` during `init()`.
+
+**Implements**:
+- `cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config`
+- `cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler`
+- `cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config`
+- `cpt-cf-usage-collector-component-gateway`
+
+**Constraints**: `cpt-cf-usage-collector-constraint-outbox-infra`, `cpt-cf-usage-collector-constraint-single-plugin`, `cpt-cf-usage-collector-constraint-modkit`, `cpt-cf-usage-collector-constraint-security-context`, `cpt-cf-usage-collector-constraint-no-business-logic`
+
+**Touches**:
+- API: `POST /usage-collector/v1/records`, `GET /usage-collector/v1/modules/{module_name}/config`
+- DB: `outbox` (`"usage-records"` queue, `cpt-cf-usage-collector-dbtable-outbox`)
+- Entities: `UsageRecord`, `ModuleConfig`
+
+**Audit logging**: Calls to `authorize_for()` are not individually audited at
+the SDK boundary — audit of usage-collector ingestion calls is delegated to
+the platform-wide API audit layer. Calls to `POST /usage-collector/v1/records`
+are similarly delegated. No feature-level audit log is produced.
+
+**Security error handling**: The gateway strips internal stack traces before
+returning 4xx/5xx responses to callers. `authorize_for()` timing: constant-time
+response patterns are not applied at the SDK layer; tenant-existence enumeration
+via PDP call timing is mitigated by the PDP's own response-time guarantees.
+Rate limiting on `authorize_for()` calls is out of scope for this feature —
+delegated to the platform gateway rate-limiting layer.
+
+**Observability**: Structured log events MUST be emitted for: authorization
+denial (`WARN`), validation failure (`WARN`), delivery retry (`INFO`),
+dead-letter routing (`ERROR`), circuit breaker state transitions
+(`WARN`/`INFO`). Metrics: outbox queue depth, delivery attempt count,
+plugin call latency (histogram), circuit breaker open/closed state (gauge).
+OpenTelemetry trace propagation across the outbox pipeline boundary is
+deferred to a future observability feature; correlation IDs from inbound
+requests are not propagated in this feature.
+
+**Rollout/rollback**: The outbox schema migration
+(`DatabaseCapability::migrations()`) is forward-only — rollback of the
+schema is not supported. Rollback of the gateway binary to a pre-feature
+version is safe only if no messages have been enqueued; enqueued rows will
+remain in the DB until the migrated gateway is redeployed. No feature flag
+guards the new endpoints in this feature — rollout strategy is managed at
+the platform level via standard deployment controls.
+
+**Recovery**: In-flight outbox messages survive a gateway upgrade — rows are durable in the DB and will be picked up by the restarted process. Circuit breaker state and plugin registration are recovered automatically on gateway restart (stateless configuration). Dead-lettered records: operators inspect via direct DB query on the dead-letter partition; reprocessing requires manual row deletion and re-insertion into the live queue, or a future admin API (out of scope). No compensating transaction is required for the delivery pipeline.
+
+**Data access patterns**: Not applicable — all storage I/O is delegated to the active storage plugin via `UsageCollectorPluginClientV1`. The gateway constructs no raw DB queries; plugin selection, connection pooling, and query execution are fully encapsulated by the plugin implementation.
+
+**Data archival and retention**: Not applicable to this feature. Archival and retention compliance are delegated to the storage plugin implementation and its backing infrastructure. The outbox schema migration is forward-only via `DatabaseCapability::migrations()`; schema rollback is not supported.
+
+**Configuration**:
+
+| Parameter | Type | Valid range | Default | Validation | Runtime-changeable |
+|-----------|------|-------------|---------|------------|--------------------|
+| `outbox_backoff_max` | duration | 1s–15m | 600s (10 min) | must be > 0 and < 900s | No — requires restart |
+| Plugin timeout | duration | 100ms–30s | 5s | must be > 0 | No |
+| Circuit breaker failure threshold | integer | 1–100 | 5 | must be ≥ 1 | No |
+| Circuit breaker recovery timeout | duration | 1s–5m | 30s | must be > 0 | No |
+| Queue partitions | integer | 1–64 | 4 | must be ≥ 1 | No |
+
+No feature flags are used; all configuration is static and requires gateway restart to change.
+
+**Health & diagnostics**: Circuit breaker state is not directly exposed via `GET /health` in this feature — it contributes to the platform-level health aggregate. Outbox queue depth is a recommended monitoring metric (see Observability). First-level troubleshooting: (1) check circuit breaker state via structured logs; (2) inspect outbox queue depth; (3) verify storage plugin connectivity; (4) check dead-letter partition for accumulated records.
+
+`cpt-cf-usage-collector-constraint-encryption` is not enforced by this feature — encryption at
+rest and in transit is deferred to Feature 4 (Production Storage Plugin) which owns the
+production storage backend.
+
+### No-Op Storage Plugin (`noop-usage-collector-storage-plugin`)
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-dod-sdk-and-ingest-core-noop-plugin`
+
+> _(p2: deferred — noop plugin validation is a test-time concern; plugin interface is validated by integration tests)_
+
+The system **MUST** implement the `noop-usage-collector-storage-plugin` crate providing a no-op implementation of `UsageCollectorPluginClientV1` where all write operations succeed without persisting data and all read operations return empty results. Must register via `UsageCollectorStoragePluginSpecV1` GTS schema for selection by operator configuration in test and local-dev deployments.
+
+**Implements**:
+- `cpt-cf-usage-collector-component-storage-plugin` (no-op only)
+
+**Constraints**: `cpt-cf-usage-collector-constraint-single-plugin`, `cpt-cf-usage-collector-constraint-modkit`
+
+**Touches**:
+- Entities: `UsageRecord`
+
+### Known Limitations / Technical Debt
+
+- **Static `ModuleConfig`**: Has no dynamic update mechanism — changes require a gateway restart.
+- **Outbox payload versioning**: Payload type `usage-collector.record.v1` uses an opaque string
+  version with no schema registry or backward-compatibility contract defined in this feature.
+  Payload versioning strategy MUST be documented before Feature 2+ extends the record schema.
+
+## 6. Acceptance Criteria
+
+- [ ] A usage source can call `authorize_for()` and receive an `AuthorizedUsageEmitter` token when the PDP permits `USAGE_RECORD`/`CREATE` for the given tenant and resource
+- [ ] `enqueue()` persists a usage record to the source's local outbox within the caller's DB transaction; the transaction commit is the durability boundary for the record
+- [ ] Counter records without an idempotency key or with a negative value are rejected before the outbox INSERT; no outbox row is created
+- [ ] Gauge records without a caller-supplied idempotency key are accepted; the emitter auto-generates a UUID v4 and the stored record always carries a non-null key
+- [ ] Records with a metric name not in the module's allowed-metrics list are rejected by `enqueue()` in-memory before the outbox INSERT
+- [ ] PDP denial in `authorize_for()` surfaces as `UsageEmitterError::AuthorizationDenied` with no record persisted
+- [ ] The outbox delivery pipeline delivers records to the gateway with at-least-once semantics; transient failures trigger exponential backoff retry with `outbox_backoff_max` configured below 15 minutes
+- [ ] The gateway ingest endpoint enforces the 8 KB metadata limit, resolves the active plugin via GTS, and delegates record persistence with a 5 s default timeout
+- [ ] The circuit breaker opens after 5 consecutive plugin call failures within a 10 s window; the gateway returns `503 Service Unavailable` while open; exactly one probe call is admitted after 30 s, with all other concurrent requests during the half-open window rejected until the probe completes
+- [ ] `GET /usage-collector/v1/modules/{name}/config` returns the static allowed-metrics list for a configured module and 404 for an unknown module
+- [ ] The no-op plugin accepts all write calls with no side effects and returns empty results for reads; integration tests pass with the no-op backend selected
+- [ ] `UsageEmitterV1` is available in `ClientHub` after gateway `init()` completes; sources can call `for_module()` without additional setup
+- [ ] Invalid configuration values (out-of-range `plugin_timeout`,
+  `circuit_breaker_failure_threshold`, `circuit_breaker_recovery_timeout`,
+  or `outbox_backoff_max`) are rejected at module/emitter initialization
+  with a descriptive error; the process does not start.
+- [ ] `authorize_for()` succeeds when `subject_id` and `subject_type` are absent (`None`); the PDP call omits SUBJECT_ID/SUBJECT_TYPE resource properties and returns a valid `AuthorizedUsageEmitter` token with `None` subject fields
+- [ ] `enqueue()` accepts a `UsageRecord` with absent `subject_id`/`subject_type` when the token's subject fields are also absent; the serialized outbox record does not contain `subject_id` or `subject_type` JSON fields
+
+**Test data requirements**:
+(1) Static gateway config must include at least one module with a `counter` metric and one with a
+    `gauge` metric.
+(2) PDP stub must support permit/deny configuration for `USAGE_RECORD`/`CREATE` actions by
+    `tenant_id`/`resource_id` pair.
+(3) Integration tests use `noop-usage-collector-storage-plugin`.
+(4) Idempotency collision test: submit two records with the same `idempotency_key` for the same
+    metric and verify deduplication.
+
+**Test coverage guidance**:
+Unit: `authorize_for()` — PDP permit, PDP deny, token expiry, metric type mismatch;
+      `enqueue()` — each validation branch.
+Integration: full emission flow with noop plugin; circuit breaker open/close cycle;
+             dead-letter routing after max retries.
+E2E: noop plugin store remains empty after transaction commit (noop backend discards all writes; read returns no records).
+Performance baseline: measure `authorize_for()` + `enqueue()` round-trip latency against
+`nfr-ingestion-latency` target using noop backend.
+
+**Success metrics**:
+(1) At-least-once delivery rate ≥ 99.9% under normal conditions within `outbox_backoff_max` window.
+(2) Circuit breaker recovers within 30 s of storage plugin recovery.
+(3) Noop plugin integration test pass rate: 100% on CI.
+
+## 7. Non-Applicability Notes
+
+**COMPL (Regulatory & Privacy Compliance)**: Not applicable. This feature
+processes opaque UUIDs (`tenant_id`, `resource_id`, `subject_id`) and numeric
+counters/gauges for internal billing metrics. No regulated personal data is
+defined at the feature level. No audit trail, consent, data retention, or data
+subject rights apply to this in-process SDK. If future features extend this to
+personal data, COMPL must be revisited.
+
+**UX (User Experience & Accessibility)**: Not applicable. This feature provides
+an in-process SDK library (`usage-collector-sdk`, `usage-emitter`) and a gateway
+service with machine-to-machine REST endpoints. There is no user-facing UI, no
+end-user interaction model, no user-visible error messages, and no accessibility
+requirements.

--- a/modules/system/usage-collector/docs/features/0002-cpt-cf-usage-collector-feature-rest-ingest.md
+++ b/modules/system/usage-collector/docs/features/0002-cpt-cf-usage-collector-feature-rest-ingest.md
@@ -1,0 +1,262 @@
+---
+cpt:
+  version: "1.3"
+  changelog:
+    - version: "1.3"
+      date: "2026-04-29"
+      changes:
+        - "Document TLS/HTTPS requirements for base_url: add Security sub-section to §5 and AC item for startup behaviour on http:// scheme with non-localhost host (SEC-FDESIGN-004)"
+    - version: "1.2"
+      date: "2026-04-29"
+      changes:
+        - "Document at-least-once delivery idempotency semantics: add duplicate-delivery note to DoD §5 and flow error scenario, add AC item for idempotent upsert on idempotency_key (REL-FDESIGN-003)"
+    - version: "1.1"
+      date: "2026-04-29"
+      changes:
+        - "Add module_name URL percent-encoding requirement to inst-cfg-rem-3 (SEC-FDESIGN-003)"
+    - version: "1.0"
+      date: "2026-04-28"
+      changes:
+        - "Initial feature specification"
+---
+
+# Feature: REST Client & Remote Ingest Delivery
+
+<!-- toc -->
+
+- [1. Feature Context](#1-feature-context)
+  - [1.1 Overview](#11-overview)
+  - [1.2 Purpose](#12-purpose)
+  - [1.3 Actors](#13-actors)
+  - [1.4 References](#14-references)
+- [2. Actor Flows (CDSL)](#2-actor-flows-cdsl)
+  - [Remote Usage Emission Flow](#remote-usage-emission-flow)
+  - [Module Config Retrieval Flow (REST)](#module-config-retrieval-flow-rest)
+- [3. Processes / Business Logic (CDSL)](#3-processes--business-logic-cdsl)
+  - [REST Client Module Initialization](#rest-client-module-initialization)
+- [4. States (CDSL)](#4-states-cdsl)
+- [5. Definitions of Done](#5-definitions-of-done)
+  - [`usage-collector-rest-client` Crate](#usage-collector-rest-client-crate)
+- [6. Acceptance Criteria](#6-acceptance-criteria)
+- [7. Non-Applicability Notes](#7-non-applicability-notes)
+
+<!-- /toc -->
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-featstatus-rest-ingest`
+<!-- STATUS: IMPLEMENTED — all p1 DoD items and all CDSL blocks are [x]. -->
+
+<!-- reference to DECOMPOSITION entry -->
+- [x] `p1` - `cpt-cf-usage-collector-feature-rest-ingest`
+
+## 1. Feature Context
+
+### 1.1 Overview
+
+Enables out-of-process usage sources to emit records using the same `UsageEmitterV1` API as in-process sources by providing the `usage-collector-rest-client` crate, which delivers records to the collector gateway over HTTP with service-to-service bearer token authentication.
+
+### 1.2 Purpose
+
+Implements the remote delivery counterpart to Feature 1's in-process delivery path. Out-of-process sources call `authorize_for()` and `enqueue()` identically to in-process sources; only the outbox delivery hop differs — the background pipeline HTTP-POSTs each record to the gateway ingest endpoint instead of calling it in-process. The `usage-collector-rest-client` crate registers `UsageEmitterV1` in `ClientHub`, backed by `UsageCollectorRestClient` implementing `UsageCollectorClientV1`.
+
+**Requirements**: `cpt-cf-usage-collector-fr-rest-ingestion`
+
+**NFR targets**: See PRD §NFRs; `cpt-cf-usage-collector-nfr-recovery` constrains `outbox_backoff_max` to below 15 minutes.
+
+**Principles**: `cpt-cf-usage-collector-principle-fail-closed`, `cpt-cf-usage-collector-principle-tenant-from-ctx`
+
+**Constraints**: `cpt-cf-usage-collector-constraint-security-context`, `cpt-cf-usage-collector-constraint-modkit`, `cpt-cf-usage-collector-constraint-outbox-infra`
+
+### 1.3 Actors
+
+**Actors** (defined in PRD.md):
+
+- `cpt-cf-usage-collector-actor-usage-source` — out-of-process usage source emitting records via the REST client
+
+### 1.4 References
+
+- **PRD**: [PRD.md](../PRD.md)
+- **Design**: [DESIGN.md](../DESIGN.md)
+- **DECOMPOSITION**: [DECOMPOSITION.md](../DECOMPOSITION.md)
+- **Dependencies**: `cpt-cf-usage-collector-feature-sdk-and-ingest-core`
+
+## 2. Actor Flows (CDSL)
+
+**Sequences**: `cpt-cf-usage-collector-seq-emit-remote`
+
+### Remote Usage Emission Flow
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-flow-rest-ingest-remote-emit`
+
+**Actor**: `cpt-cf-usage-collector-actor-usage-source` (out-of-process)
+
+**Success Scenarios**:
+- Outbox delivers record to gateway; gateway returns 204 No Content; outbox advances partition cursor
+
+**Error Scenarios**:
+- AuthN resolver unavailable → transient; outbox retries with exponential backoff
+- Client credentials permanently rejected by AuthN resolver → delivery attempt fails; message rejected to dead-letter store
+- Gateway returns 401 (token expired or invalid) → transient; next attempt acquires a fresh bearer token
+- Gateway returns 429 or 5xx → transient; outbox retries with exponential backoff
+- Gateway returns 4xx (excluding 401 and 429) → permanent; message moved to dead-letter store
+- Gateway 204 on duplicate delivery (same `idempotency_key`) → idempotent; storage layer performs no-op upsert; outbox advances cursor normally
+
+**Steps**:
+1. [x] - `p1` - Outbox background pipeline calls REST client `UsageCollectorClientV1::create_usage_record(record)` for each ready outbox message - `inst-rem-1`
+2. [x] - `p1` - REST client acquires a bearer token from the platform AuthN resolver via client credentials flow - `inst-rem-2`
+3. [x] - `p1` - **IF** AuthN resolver returns a transient error (service temporarily unreachable, network failure, or any error other than credential rejection) - `inst-rem-3`
+   1. [x] - `p1` - **RETURN** `UsageCollectorError::Unavailable`; outbox library applies exponential backoff retry - `inst-rem-3a`
+4. [x] - `p1` - **IF** AuthN resolver rejects credentials as permanently invalid (`Unauthorized`) OR no AuthN plugin is registered (`NoPluginAvailable`) - `inst-rem-4`
+   1. [x] - `p1` - **RETURN** `UsageCollectorError::AuthorizationFailed` or `UsageCollectorError::Internal`; outbox moves message to dead-letter store - `inst-rem-4a`
+5. [x] - `p1` - HTTP POST `POST /usage-collector/v1/records` with `Authorization: Bearer <token>` header and serialized `UsageRecord` JSON body; `subject_id`, `subject_type`, and `metadata` serialize as absent JSON fields when `None` - `inst-rem-5`
+6. [x] - `p1` - **IF** HTTP request times out - `inst-rem-6`
+   1. [x] - `p1` - **RETURN** `UsageCollectorError::PluginTimeout`; outbox retries with exponential backoff; `outbox_backoff_max` MUST be configured below 15 minutes to satisfy `cpt-cf-usage-collector-nfr-recovery` - `inst-rem-6a`
+7. [x] - `p1` - **IF** HTTP transport error (connection refused, DNS failure, TLS error, or other non-timeout network error) - `inst-rem-7`
+   1. [x] - `p1` - **RETURN** `UsageCollectorError::Unavailable`; outbox retries with exponential backoff - `inst-rem-7a`
+8. [x] - `p1` - **IF** gateway returns 204 No Content - `inst-rem-8`
+   1. [x] - `p1` - **RETURN** `Ok(())`; outbox advances partition cursor — record is confirmed delivered - `inst-rem-8a`
+9. [x] - `p1` - **IF** gateway returns 401 Unauthenticated (token invalid or expired) - `inst-rem-9`
+   1. [x] - `p1` - **RETURN** `UsageCollectorError::AuthorizationFailed`; outbox retries — next attempt acquires a fresh bearer token; no record is lost - `inst-rem-9a`
+10. [x] - `p1` - **IF** gateway returns 429 Too Many Requests or any 5xx - `inst-rem-10`
+    1. [x] - `p1` - **RETURN** `UsageCollectorError::PluginTimeout`; outbox retries with exponential backoff - `inst-rem-10a`
+11. [x] - `p1` - **IF** gateway returns any other 4xx (excluding 401 and 429) - `inst-rem-11`
+    1. [x] - `p1` - **RETURN** `UsageCollectorError::Internal`; outbox moves message to dead-letter store and surfaces via monitoring - `inst-rem-11a`
+
+### Module Config Retrieval Flow (REST)
+
+- [x] `p2` - **ID**: `cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config`
+
+**Actor**: `cpt-cf-usage-collector-actor-usage-source`
+
+**Success Scenarios**:
+- Gateway returns `ModuleConfig` with the static `allowed_metrics` list for the requesting module
+
+**Error Scenarios**:
+- Module not registered in gateway static config → gateway returns 404; emitter surfaces `UsageEmitterError::ModuleNotConfigured`
+- AuthN resolver or gateway temporarily unavailable → emitter surfaces `UsageEmitterError::Internal` per `inst-authz-5b`
+
+**Steps**:
+1. [x] - `p2` - During `authorize_for()` phase 1, emitter calls `UsageCollectorClientV1::get_module_config(module_name)` on the REST client - `inst-cfg-rem-1`
+2. [x] - `p2` - REST client acquires a bearer token from the platform AuthN resolver via client credentials flow - `inst-cfg-rem-2`
+3. [x] - `p2` - HTTP GET `GET /usage-collector/v1/modules/{module_name}/config`
+   with `Authorization: Bearer <token>` header; `module_name` MUST be
+   percent-encoded (URL percent-encoding) when interpolated into the URL path - `inst-cfg-rem-3`
+4. [x] - `p2` - **IF** gateway returns 200 OK - `inst-cfg-rem-4`
+   1. [x] - `p2` - Deserialize response body into `ModuleConfig`; **RETURN** `Ok(ModuleConfig { module_name, allowed_metrics })` - `inst-cfg-rem-4a`
+5. [x] - `p2` - **IF** gateway returns 404 Not Found - `inst-cfg-rem-5`
+   1. [x] - `p2` - **RETURN** `UsageCollectorError::ModuleNotFound(module_name)`; emitter surfaces `UsageEmitterError::ModuleNotConfigured` - `inst-cfg-rem-5a`
+6. [x] - `p2` - **IF** any other error (transport failure, 4xx, 5xx) - `inst-cfg-rem-6`
+   1. [x] - `p2` - **RETURN** appropriate `UsageCollectorError` variant; emitter handles per `inst-authz-5b` — infrastructure failures surface as `UsageEmitterError::Internal` - `inst-cfg-rem-6a`
+
+## 3. Processes / Business Logic (CDSL)
+
+### REST Client Module Initialization
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-algo-rest-ingest-module-init`
+
+**Input**: `ModuleCtx` (config, `ClientHub`, DB connection)
+
+**Output**: `UsageEmitterV1` registered in `ClientHub`; outbox schema migrations registered via `DatabaseCapability`
+
+**Steps**:
+1. [x] - `p1` - Load and validate `UsageCollectorRestClientConfig` from `ModuleCtx`; required fields `client_id` and `client_secret` must be non-empty; fail module startup with descriptive error on missing or invalid config - `inst-init-1`
+2. [x] - `p1` - Acquire DB connection from `ModuleCtx`; fail module startup if DB is not available - `inst-init-2`
+3. [x] - `p1` - Retrieve `AuthNResolverClient` from `ClientHub`; fail module startup if not registered - `inst-init-3`
+4. [x] - `p1` - Retrieve `AuthZResolverClient` from `ClientHub`; fail module startup if not registered - `inst-init-4`
+5. [x] - `p1` - Construct `UsageCollectorRestClient` from config and `AuthNResolverClient`; build `HttpClient` with configured `request_timeout` (default 30 s); trim trailing slashes from `base_url` - `inst-init-5`
+6. [x] - `p1` - Build `UsageEmitter` with `AuthZResolverClient`, `UsageCollectorRestClient` as the delivery target, DB connection, and `UsageEmitterConfig` — the emitter owns the source's outbox queue; outbox background pipeline will call `create_usage_record()` on the REST client for each delivery attempt - `inst-init-6`
+7. [x] - `p1` - Register `UsageEmitterV1` in `ClientHub` — out-of-process sources retrieve this emitter at initialization to access the two-phase emission API (`authorize_for()` / `enqueue()`) - `inst-init-7`
+
+**DatabaseCapability**: `migrations()` returns `modkit_db::outbox::outbox_migrations()` — this module owns the source's local outbox queue; the same schema migration set as the in-process path applies.
+
+## 4. States (CDSL)
+
+Not applicable for this feature. No new entity state machines are introduced by the REST client. `UsageRecord.status` transitions (`active` → `inactive`) remain owned by Feature 8. The outbox message lifecycle is managed by the `modkit-db` outbox library and is not a domain state machine defined here.
+
+## 5. Definitions of Done
+
+### `usage-collector-rest-client` Crate
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-dod-rest-ingest-rest-client-crate`
+
+The system **MUST** implement the `usage-collector-rest-client` crate providing:
+
+- `UsageCollectorRestClientModule` implementing `Module::init()`: loads `UsageCollectorRestClientConfig`, acquires `AuthNResolverClient` and `AuthZResolverClient` from `ClientHub`, constructs `UsageCollectorRestClient` with configured `HttpClient`, builds `UsageEmitter` backed by the REST client, and registers `UsageEmitterV1` in `ClientHub`
+- `UsageCollectorRestClient` implementing `UsageCollectorClientV1::create_usage_record()`: acquires a bearer token via the platform AuthN resolver (client credentials flow) before each delivery attempt; HTTP-POSTs the serialized `UsageRecord` to `POST /usage-collector/v1/records` with `Authorization: Bearer <token>`; maps `204` to `Ok(())`; maps `401`/`403` to `AuthorizationFailed`; maps `429`/`5xx` to `PluginTimeout` (triggers Retry); maps other `4xx` to `Internal` (triggers Reject); maps HTTP timeouts to `PluginTimeout`; maps other transport errors to `Unavailable`
+- `UsageCollectorRestClient` implementing `UsageCollectorClientV1::get_module_config()`: acquires a bearer token; HTTP-GETs `GET /usage-collector/v1/modules/{module_name}/config`; deserializes `200` into `ModuleConfig`; maps `404` to `ModuleNotFound`; maps other errors appropriately
+- `DatabaseCapability::migrations()` returning `modkit_db::outbox::outbox_migrations()` — owns the source's local outbox schema
+
+**Implements**:
+- `cpt-cf-usage-collector-flow-rest-ingest-remote-emit`
+- `cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config`
+- `cpt-cf-usage-collector-algo-rest-ingest-module-init`
+- `cpt-cf-usage-collector-component-rest-client`
+
+**Constraints**: `cpt-cf-usage-collector-constraint-security-context`, `cpt-cf-usage-collector-constraint-modkit`, `cpt-cf-usage-collector-constraint-outbox-infra`
+
+**Touches**:
+- API: `POST /usage-collector/v1/records` (client-side HTTP delivery), `GET /usage-collector/v1/modules/{module_name}/config` (client-side config fetch)
+- DB: outbox queue in source's local DB — same schema as in-process path (`cpt-cf-usage-collector-dbtable-outbox`)
+- Entities: `UsageRecord`, `ModuleConfig`
+
+**Configuration**:
+
+| Parameter | Type | Default | Required | Notes |
+|-----------|------|---------|----------|-------|
+| `base_url` | string | `http://127.0.0.1:8080` | No | Trailing slash trimmed |
+| `client_id` | string | — | Yes | OAuth2 client identifier |
+| `client_secret` | secret string | — | Yes | Env-expanded; never logged |
+| `scopes` | list\<string\> | `[]` | No | OAuth2 scopes; IdP defaults when empty |
+| `request_timeout` | duration | `30s` | No | Per-request HTTP timeout |
+| `emitter` | `UsageEmitterConfig` | defaults | No | Outbox/authorization tuning; `outbox_backoff_max` MUST be below 15 minutes |
+
+**Delivery guarantees**: At-least-once delivery via the source's transactional outbox — identical to the in-process path. A bearer token is acquired on each delivery attempt, so expired tokens trigger retry with a fresh token and do not cause permanent record loss. All records durably committed to the source's local outbox are guaranteed to eventually reach the gateway. At-least-once delivery via the transactional outbox may produce duplicate `create_usage_record()` calls on retry after a network timeout or transient failure. The gateway **MUST** deduplicate repeated deliveries of the same record via idempotent upsert on `idempotency_key`; a second delivery of the same record **MUST** be a no-op at the storage layer.
+
+**Observability**: Structured log events MUST be emitted for: token acquisition failure (`WARN`), delivery retry (`INFO`), dead-letter routing (`ERROR`). Outbox queue depth and delivery attempt count are surfaced via the same metrics as the in-process path. Bearer tokens and client secrets MUST NOT appear in log output.
+
+**Data Protection**: Bearer tokens are short-lived credentials managed by the AuthN resolver; this crate holds them only for the duration of a single delivery attempt and does not persist or cache them. `client_secret` is stored as `SecretString` and is not exposed in logs or error messages.
+
+### TLS/HTTPS Configuration
+
+- [x] `p1` - **ID**: `cpt-cf-dod-rest-ingest-tls-config`
+
+The system **MUST** enforce the following transport security requirements for the `base_url` configuration field:
+
+- In production environments, `base_url` **MUST** use the `https://` scheme. An `http://` scheme is permitted only when the host resolves to a localhost or loopback address (`127.0.0.1`, `::1`, or `localhost`) — exclusively for development and testing environments.
+- TLS certificate validation is enforced by the HTTP client by default. Disabling certificate validation or trusting a self-signed certificate **MUST** require an explicit operator opt-in (for example, via a dedicated configuration flag); silent trust-all behaviour is prohibited.
+- The module **MUST** emit a startup warning (`WARN` level) when `base_url` uses the `http://` scheme with a non-localhost host, or **MUST** refuse to start with a descriptive configuration validation error, consistent with the platform security baseline.
+
+**Implements**:
+- `cpt-cf-usage-collector-dod-rest-ingest-rest-client-crate`
+
+**Constraints**: `cpt-cf-usage-collector-constraint-security-context`
+
+## 6. Acceptance Criteria
+
+- [ ] Out-of-process source retrieves `UsageEmitterV1` from `ClientHub` after `usage-collector-rest-client` `init()` completes; `authorize_for()` and `enqueue()` behave identically to the in-process path
+- [ ] `create_usage_record()` acquires a bearer token from the platform AuthN resolver via client credentials before each HTTP POST to `POST /usage-collector/v1/records`
+- [ ] Gateway 204 No Content causes `HandlerResult::Success`; outbox partition cursor advances and the outbox row is deleted
+- [ ] Gateway 401 causes retry — next delivery attempt acquires a fresh bearer token; a temporarily expired token does not cause permanent record loss
+- [ ] Gateway 429 or 5xx causes `HandlerResult::Retry`; outbox applies exponential backoff
+- [ ] Gateway 4xx (excluding 401 and 429) causes `HandlerResult::Reject`; message is moved to dead-letter store
+- [ ] AuthN resolver transient failure (network error, service restart) causes `HandlerResult::Retry`; records in the source outbox are not lost
+- [ ] AuthN resolver permanent credential rejection causes `HandlerResult::Reject`; message is moved to dead-letter store
+- [ ] HTTP timeout causes `HandlerResult::Retry` via `PluginTimeout`; network transport errors cause `HandlerResult::Retry` via `Unavailable`
+- [ ] `get_module_config()` returns `ModuleConfig` on gateway 200 OK; returns `ModuleNotFound` on 404
+- [ ] `DatabaseCapability::migrations()` registers outbox schema migrations; source's local outbox is created on module startup
+- [ ] Missing or invalid `client_id` / `client_secret` configuration causes `init()` to fail with a descriptive error; the process does not start
+- [ ] Bearer token and `client_secret` do not appear in log output or error messages
+- [ ] `create_usage_record()` called twice with the same `idempotency_key` produces gateway 204 on both attempts; the second delivery is a no-op at the storage layer (idempotent upsert on `idempotency_key`)
+- [ ] A `base_url` configured with an `http://` scheme pointing to a non-localhost host either causes `init()` to fail with a descriptive configuration validation error or emits a `WARN`-level startup warning; this behaviour is documented in the crate README and is consistent with the platform security baseline (SEC-FDESIGN-004)
+
+**Test data requirements**:
+(1) AuthN resolver stub must support transient (`Unavailable`) and permanent (`Unauthorized`, `NoPluginAvailable`) error simulation.
+(2) Gateway HTTP stub must be configurable to return 204, 401, 403, 429, 500, and 404 for `POST /records` and `GET /modules/{name}/config`.
+(3) Integration tests verify the full outbox-to-gateway delivery path with the REST client transport using a gateway stub.
+
+## 7. Non-Applicability Notes
+
+**COMPL (Regulatory & Privacy Compliance)**: Not applicable. The REST client transmits the same opaque UUIDs and numeric values as the in-process path. Bearer tokens are short-lived and not stored. No regulated personal data is introduced by this crate.
+
+**UX (User Experience & Accessibility)**: Not applicable. This feature provides a Rust library crate and a machine-to-machine HTTP client. There is no user-facing UI, no end-user interaction, and no accessibility requirements.
+
+**State Management**: Not applicable. No new entity lifecycle or state machines are introduced. `UsageRecord.status` transitions remain owned by Feature 8 (Operator Operations).

--- a/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/Cargo.toml
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "cf-noop-usage-collector-storage-plugin"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "No-op usage-collector storage plugin for development and testing"
+readme = "README.md"
+keywords = ["cyberfabric", "cyberfabric-system"]
+categories = ["development-tools"]
+
+[lib]
+name = "noop_usage_collector_storage_plugin"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Local dependencies
+types-registry-sdk = { workspace = true }
+usage-collector-sdk = { workspace = true }
+
+# ModKit dependencies
+modkit = { workspace = true }
+modkit-macros = { workspace = true }
+
+# Async runtime
+async-trait = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Data structures
+uuid = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+[dev-dependencies]
+# Data structures
+chrono = { workspace = true }
+
+# Async runtime
+tokio = { workspace = true }

--- a/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/README.md
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/README.md
@@ -1,0 +1,35 @@
+# No-op Usage Collector Storage Plugin
+
+> **Development and testing plugin** — discards all usage records. It is not a production storage backend.
+
+No-op implementation of the usage-collector storage plugin contract: the gateway can resolve a plugin instance and call `create_usage_record`, but no data is retained.
+
+## Purpose
+
+Use this plugin when you want the usage-collector module and emitters to run without configuring a real storage implementation. Typical cases:
+
+- Local development and smoke tests
+- CI pipelines that exercise the ingestion path only
+- Demos where durable usage history is unnecessary
+
+**Do not use when you need metering data to be stored or queried.**
+
+## Configuration
+
+Add the plugin section under your module configuration:
+
+```yaml
+modules:
+  noop-usage-collector-storage-plugin:
+    config:
+      vendor: "hyperspot"
+      priority: 100
+```
+
+`vendor` must match the usage-collector gateway configuration so the gateway selects this instance.
+
+## Testing
+
+```bash
+cargo test -p cf-noop-usage-collector-storage-plugin
+```

--- a/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/config.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/config.rs
@@ -1,0 +1,28 @@
+//! Configuration for the no-op usage-collector storage plugin.
+
+use serde::Deserialize;
+
+/// Plugin configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct NoopUsageCollectorStorageConfig {
+    /// Vendor name (must match the usage-collector gateway `vendor`).
+    pub vendor: String,
+
+    /// Plugin priority (lower = higher priority when multiple instances exist).
+    pub priority: i16,
+}
+
+impl Default for NoopUsageCollectorStorageConfig {
+    fn default() -> Self {
+        Self {
+            vendor: "hyperspot".to_owned(),
+            priority: 100,
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "config_tests.rs"]
+mod config_tests;

--- a/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/config_tests.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/config_tests.rs
@@ -1,0 +1,31 @@
+use super::*;
+
+#[test]
+fn vendor_can_be_overridden_via_serde() {
+    let json = r#"{"vendor": "acme", "priority": 100}"#;
+    let cfg: NoopUsageCollectorStorageConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(cfg.vendor, "acme");
+}
+
+#[test]
+fn priority_can_be_overridden_via_serde() {
+    let json = r#"{"vendor": "hyperspot", "priority": 10}"#;
+    let cfg: NoopUsageCollectorStorageConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(cfg.priority, 10);
+}
+
+#[test]
+fn serde_default_applies_default_vendor_and_priority() {
+    let cfg: NoopUsageCollectorStorageConfig = serde_json::from_str("{}").unwrap();
+    assert_eq!(
+        cfg.vendor, "hyperspot",
+        "serde(default) must use Default impl"
+    );
+    assert_eq!(cfg.priority, 100, "serde(default) must use Default impl");
+}
+
+#[test]
+fn rejects_unknown_fields() {
+    let json = r#"{"vendor": "x", "priority": 1, "unexpected": true}"#;
+    assert!(serde_json::from_str::<NoopUsageCollectorStorageConfig>(json).is_err());
+}

--- a/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/domain/client.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/domain/client.rs
@@ -1,0 +1,18 @@
+use async_trait::async_trait;
+
+use usage_collector_sdk::models::UsageRecord;
+use usage_collector_sdk::{UsageCollectorError, UsageCollectorPluginClientV1};
+
+use super::service::Service;
+
+#[async_trait]
+impl UsageCollectorPluginClientV1 for Service {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "client_tests.rs"]
+mod client_tests;

--- a/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/domain/client_tests.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/domain/client_tests.rs
@@ -1,0 +1,42 @@
+use chrono::Utc;
+use usage_collector_sdk::{UsageCollectorPluginClientV1, UsageKind, UsageRecord};
+use uuid::Uuid;
+
+use super::Service;
+
+fn make_record(tenant_id: Uuid) -> UsageRecord {
+    UsageRecord {
+        module: "test-module".to_owned(),
+        tenant_id,
+        metric: "test.metric".to_owned(),
+        kind: UsageKind::Gauge,
+        value: 1.0,
+        resource_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        subject_id: Some(Uuid::nil()),
+        subject_type: Some("test.subject".to_owned()),
+        idempotency_key: Uuid::new_v4().to_string(),
+        timestamp: Utc::now(),
+        metadata: None,
+    }
+}
+
+#[tokio::test]
+async fn create_usage_record_always_returns_ok() {
+    let service = Service::new();
+    let plugin: &dyn UsageCollectorPluginClientV1 = &service;
+    let rec = make_record(Uuid::new_v4());
+    let result = plugin.create_usage_record(rec).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn create_usage_record_multiple_records_all_return_ok() {
+    let service = Service::new();
+    let plugin: &dyn UsageCollectorPluginClientV1 = &service;
+    for _ in 0..5 {
+        let rec = make_record(Uuid::new_v4());
+        let result = plugin.create_usage_record(rec).await;
+        assert!(result.is_ok());
+    }
+}

--- a/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/domain/mod.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/domain/mod.rs
@@ -1,0 +1,4 @@
+mod client;
+pub mod service;
+
+pub use service::Service;

--- a/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/domain/service.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/domain/service.rs
@@ -1,0 +1,14 @@
+//! No-op usage-collector storage domain service.
+
+use modkit_macros::domain_model;
+
+/// Stateless service backing the storage plugin client; records are not retained.
+#[domain_model]
+pub struct Service;
+
+impl Service {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}

--- a/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/lib.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/lib.rs
@@ -1,0 +1,20 @@
+//! No-op Usage Collector Storage Plugin
+//!
+//! Registers a [`usage_collector_sdk::UsageCollectorPluginClientV1`] implementation that
+//! accepts `create_usage_record` calls and drops all data. Use when the usage-collector gateway should run
+//! end-to-end without a real storage backend.
+//!
+//! ## Configuration
+//!
+//! ```yaml
+//! modules:
+//!   noop_usage_collector_storage_plugin:
+//!     config:
+//!       vendor: "hyperspot"
+//!       priority: 100
+//! ```
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+mod config;
+mod domain;
+mod module;

--- a/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/module.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/module.rs
@@ -1,0 +1,73 @@
+//! No-op usage-collector storage plugin module.
+//!
+//! Registers a GTS plugin instance in the types registry and exposes
+//! [`usage_collector_sdk::UsageCollectorPluginClientV1`] under a scope keyed by that instance.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use modkit::Module;
+use modkit::client_hub::ClientScope;
+use modkit::context::ModuleCtx;
+use modkit::gts::BaseModkitPluginV1;
+use tracing::info;
+use types_registry_sdk::{RegisterResult, TypesRegistryClient};
+use usage_collector_sdk::{UsageCollectorPluginClientV1, UsageCollectorStoragePluginSpecV1};
+
+use crate::config::NoopUsageCollectorStorageConfig;
+use crate::domain::Service;
+
+/// No-op usage-collector storage plugin for development and testing.
+#[modkit::module(
+    name = "noop-usage-collector-storage-plugin",
+    deps = ["types-registry", "usage-collector"]
+)]
+#[derive(Default)]
+struct NoopUsageCollectorStoragePlugin;
+
+// @cpt-dod:cpt-cf-usage-collector-dod-sdk-and-ingest-core-noop-plugin:p1
+#[async_trait]
+impl Module for NoopUsageCollectorStoragePlugin {
+    async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        let cfg: NoopUsageCollectorStorageConfig = ctx.config()?;
+        info!(
+            %cfg.vendor,
+            cfg.priority,
+            "Loaded {} configuration",
+            Self::MODULE_NAME,
+        );
+
+        let instance_id = UsageCollectorStoragePluginSpecV1::gts_make_instance_id(
+            "cf.core._.noop_usage_collector_storage_plugin.v1",
+        );
+
+        let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
+        let instance = BaseModkitPluginV1::<UsageCollectorStoragePluginSpecV1> {
+            id: instance_id.clone(),
+            vendor: cfg.vendor.clone(),
+            priority: cfg.priority,
+            properties: UsageCollectorStoragePluginSpecV1,
+        };
+        let instance_json = serde_json::to_value(&instance)?;
+
+        let results = registry.register(vec![instance_json]).await?;
+        RegisterResult::ensure_all_ok(&results)?;
+
+        let service = Service::new();
+
+        let api: Arc<dyn UsageCollectorPluginClientV1> = Arc::new(service);
+        ctx.client_hub()
+            .register_scoped::<dyn UsageCollectorPluginClientV1>(
+                ClientScope::gts_id(&instance_id),
+                api,
+            );
+
+        info!(
+            %instance_id,
+            "Registered {}",
+            Self::MODULE_NAME,
+        );
+
+        Ok(())
+    }
+}

--- a/modules/system/usage-collector/usage-collector-rest-client/Cargo.toml
+++ b/modules/system/usage-collector/usage-collector-rest-client/Cargo.toml
@@ -1,0 +1,76 @@
+[package]
+name = "cf-usage-collector-rest-client"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "REST client module for usage-collector"
+readme = "README.md"
+keywords = ["cyberfabric", "cyberfabric-system"]
+categories = ["development-tools"]
+
+[lib]
+name = "usage_collector_rest_client"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Local dependencies
+authz-resolver-sdk = { workspace = true }
+authn-resolver-sdk = { workspace = true }
+usage-collector-sdk = { workspace = true }
+usage-emitter = { workspace = true }
+
+# ModKit dependencies
+modkit = { workspace = true }
+modkit-db = { workspace = true, features = ["preview-outbox"] }
+modkit-macros = { workspace = true }
+modkit-http = { workspace = true }
+modkit-utils = { workspace = true, features = ["humantime-serde"] }
+
+# HTTP types
+http = { workspace = true }
+
+# Async runtime
+async-trait = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Data structures
+chrono = { workspace = true }
+uuid = { workspace = true }
+
+# Secrets
+secrecy = { workspace = true }
+
+# URL parsing and encoding
+url = { workspace = true }
+urlencoding = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+# DB
+sea-orm-migration = { workspace = true }
+
+[dev-dependencies]
+# ModKit dependencies
+modkit-security = { workspace = true }
+modkit-db = { workspace = true, features = ["sqlite"] }
+
+# Async runtime
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+# HTTP mocking
+httpmock = { workspace = true }
+
+# Usage emitter for delivery handler tests
+usage-emitter = { workspace = true }

--- a/modules/system/usage-collector/usage-collector-rest-client/README.md
+++ b/modules/system/usage-collector/usage-collector-rest-client/README.md
@@ -1,0 +1,44 @@
+# Usage Collector REST Client
+
+> **Separate-binary bridge** — builds a `UsageCollectorRestClient` that forwards `create_usage_record` and `get_module_config` calls to a remote usage-collector REST API, authenticated with a bearer token from `AuthNResolverClient::exchange_client_credentials`.
+
+ModKit module `usage-collector-rest-client`: builds [`UsageCollectorRestClient`](src/infra/rest_client.rs) at init, resolves `dyn AuthNResolverClient` and `dyn AuthZResolverClient` from `ClientHub`, then wires it into `UsageEmitter` (which registers `dyn UsageEmitterV1`). The module also implements `DatabaseCapability` and provides outbox migrations required by `UsageEmitter`.
+
+## Dependencies
+
+- The remote binary must expose the usage-collector REST API at `base_url`.
+
+## Configuration
+
+`client_id` and `client_secret` are **required** (they have no defaults). Optional fields:
+
+- `base_url` — default `http://127.0.0.1:8080`
+- `scopes` — default `[]` (IdP default scopes)
+- `request_timeout` — default `30s`
+- `emitter` — nested [`UsageEmitterConfig`](../usage-emitter/src/config.rs); all fields are optional:
+  - `authorization_max_age` — default `30s`
+  - `outbox_queue` — default `"usage-records"`
+  - `outbox_partition_count` — default `4` (must be a power of 2 in 1–64)
+
+```yaml
+modules:
+  usage-collector-rest-client:
+    config:
+      # required
+      client_id: "my-service"
+      client_secret: "${MY_SERVICE_SECRET}"
+      # optional
+      base_url: "http://collector.internal:8080"
+      scopes: ["usage-collector:write"]
+      request_timeout: "30s"
+      emitter:
+        authorization_max_age: "30s"
+        outbox_queue: "usage-records"
+        outbox_partition_count: 4
+```
+
+## Testing
+
+```bash
+cargo test -p cf-usage-collector-rest-client
+```

--- a/modules/system/usage-collector/usage-collector-rest-client/src/api/mod.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/src/api/mod.rs
@@ -1,0 +1,1 @@
+pub mod rest;

--- a/modules/system/usage-collector/usage-collector-rest-client/src/api/rest/dto.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/src/api/rest/dto.rs
@@ -1,0 +1,26 @@
+//! Wire-format DTOs for the usage-collector REST client.
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use serde_json::Value;
+use usage_collector_sdk::models::UsageKind;
+
+/// JSON body for `POST /usage-collector/v1/records`.
+#[derive(Serialize)]
+pub struct CreateUsageRecordBody {
+    pub module: String,
+    pub tenant_id: uuid::Uuid,
+    pub resource_type: String,
+    pub resource_id: uuid::Uuid,
+    pub metric: String,
+    pub kind: UsageKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject_id: Option<uuid::Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject_type: Option<String>,
+    pub idempotency_key: String,
+    pub value: f64,
+    pub timestamp: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}

--- a/modules/system/usage-collector/usage-collector-rest-client/src/api/rest/mod.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/src/api/rest/mod.rs
@@ -1,0 +1,1 @@
+pub mod dto;

--- a/modules/system/usage-collector/usage-collector-rest-client/src/config.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/src/config.rs
@@ -1,0 +1,91 @@
+//! Configuration for the REST `usage-collector-client` module.
+
+use std::time::Duration;
+
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+use usage_emitter::UsageEmitterConfig;
+
+/// Module configuration.
+#[derive(Debug, Clone, Deserialize, modkit_macros::ExpandVars)]
+#[serde(deny_unknown_fields)]
+pub struct UsageCollectorRestClientConfig {
+    /// Base URL of the usage-collector REST service (no trailing slash).
+    #[serde(default = "default_base_url")]
+    pub base_url: String,
+
+    /// `OAuth2` client identifier for s2s authentication.
+    pub client_id: String,
+
+    /// `OAuth2` client secret for s2s authentication.
+    #[expand_vars]
+    pub client_secret: SecretString,
+
+    /// `OAuth2` scopes to request (empty = `IdP` default scopes).
+    #[serde(default)]
+    pub scopes: Vec<String>,
+
+    /// Per-request HTTP timeout.
+    #[serde(
+        default = "default_request_timeout",
+        with = "modkit_utils::humantime_serde"
+    )]
+    pub request_timeout: Duration,
+
+    /// Outbox/authorization tuning for the embedded usage emitter.
+    #[serde(default)]
+    pub emitter: UsageEmitterConfig,
+}
+
+impl UsageCollectorRestClientConfig {
+    /// Validates S2S credential fields.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `client_id` or `client_secret` is empty or whitespace-only.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.client_id.trim().is_empty() {
+            anyhow::bail!("client_id must not be empty");
+        }
+        if self.client_secret.expose_secret().trim().is_empty() {
+            anyhow::bail!("client_secret must not be empty");
+        }
+        Ok(())
+    }
+}
+
+fn default_base_url() -> String {
+    "http://127.0.0.1:8080".to_owned()
+}
+
+fn default_request_timeout() -> Duration {
+    Duration::from_secs(30)
+}
+
+/// Returns `true` when `base_url` uses the `http://` scheme with a host that
+/// is **not** a loopback address (`127.0.0.1`, `::1`, or `localhost`).
+///
+/// This is used by the module initialisation to decide whether to emit a
+/// `WARN`-level log message about insecure transport configuration
+/// (`cpt-cf-dod-rest-ingest-tls-config`).
+pub fn is_insecure_non_loopback_http(base_url: &str) -> bool {
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    if let Ok(parsed) = url::Url::parse(base_url)
+        && parsed.scheme() == "http"
+    {
+        let is_loopback = match parsed.host() {
+            Some(url::Host::Ipv4(addr)) => addr == Ipv4Addr::LOCALHOST,
+            Some(url::Host::Ipv6(addr)) => addr == Ipv6Addr::LOCALHOST,
+            Some(url::Host::Domain(d)) => d == "localhost",
+            None => false,
+        };
+        return !is_loopback;
+    }
+    false
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "config_tests.rs"]
+mod config_tests;

--- a/modules/system/usage-collector/usage-collector-rest-client/src/config_tests.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/src/config_tests.rs
@@ -1,0 +1,177 @@
+use std::time::Duration;
+
+use super::UsageCollectorRestClientConfig;
+
+#[test]
+fn serde_defaults_apply_for_base_url_and_timeout() {
+    let json = r#"{"client_id": "svc", "client_secret": "secret"}"#;
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(cfg.base_url, "http://127.0.0.1:8080");
+    assert_eq!(cfg.request_timeout, Duration::from_secs(30));
+}
+
+#[test]
+fn base_url_can_be_overridden_via_serde() {
+    let json =
+        r#"{"client_id": "svc", "client_secret": "secret", "base_url": "http://collector:9090"}"#;
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(cfg.base_url, "http://collector:9090");
+}
+
+#[test]
+fn request_timeout_parses_humantime_duration() {
+    let json = r#"{"client_id": "svc", "client_secret": "secret", "request_timeout": "10s"}"#;
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(cfg.request_timeout, Duration::from_secs(10));
+}
+
+#[test]
+fn scopes_default_to_empty() {
+    let json = r#"{"client_id": "svc", "client_secret": "secret"}"#;
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_str(json).unwrap();
+    assert!(cfg.scopes.is_empty());
+}
+
+#[test]
+fn scopes_can_be_set_via_serde() {
+    let json = r#"{"client_id": "svc", "client_secret": "secret", "scopes": ["read:usage", "write:usage"]}"#;
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(cfg.scopes, ["read:usage", "write:usage"]);
+}
+
+#[test]
+fn client_id_is_required() {
+    let json = r#"{"client_secret": "secret"}"#;
+    assert!(serde_json::from_str::<UsageCollectorRestClientConfig>(json).is_err());
+}
+
+#[test]
+fn client_secret_is_required() {
+    let json = r#"{"client_id": "svc"}"#;
+    assert!(serde_json::from_str::<UsageCollectorRestClientConfig>(json).is_err());
+}
+
+#[test]
+fn rejects_unknown_fields() {
+    let json = r#"{"client_id": "svc", "client_secret": "secret", "extra": true}"#;
+    assert!(serde_json::from_str::<UsageCollectorRestClientConfig>(json).is_err());
+}
+
+// validate: S2S credential checks
+
+#[test]
+fn validate_rejects_empty_client_id() {
+    let json = r#"{"client_id": "", "client_secret": "secret"}"#;
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_str(json).unwrap();
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("client_id"),
+        "error must mention client_id, got: {err}"
+    );
+}
+
+#[test]
+fn validate_rejects_whitespace_only_client_id() {
+    let json = r#"{"client_id": "   ", "client_secret": "secret"}"#;
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_str(json).unwrap();
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("client_id"),
+        "error must mention client_id, got: {err}"
+    );
+}
+
+#[test]
+fn validate_rejects_empty_client_secret() {
+    let json = r#"{"client_id": "svc", "client_secret": ""}"#;
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_str(json).unwrap();
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("client_secret"),
+        "error must mention client_secret, got: {err}"
+    );
+}
+
+#[test]
+fn validate_rejects_whitespace_only_client_secret() {
+    let json = r#"{"client_id": "svc", "client_secret": "   "}"#;
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_str(json).unwrap();
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("client_secret"),
+        "error must mention client_secret, got: {err}"
+    );
+}
+
+#[test]
+fn validate_accepts_valid_credentials() {
+    let json = r#"{"client_id": "svc", "client_secret": "secret"}"#;
+    let cfg: UsageCollectorRestClientConfig = serde_json::from_str(json).unwrap();
+    assert!(cfg.validate().is_ok());
+}
+
+// cpt-cf-dod-rest-ingest-tls-config: TLS/HTTPS startup check
+
+#[test]
+fn test_http_non_localhost_emits_warn_or_fails() {
+    // cpt-cf-dod-rest-ingest-tls-config
+    // http:// with a non-loopback host MUST be flagged as insecure so the
+    // module initialisation can emit a WARN or return an error.
+    assert!(
+        super::is_insecure_non_loopback_http("http://example.com"),
+        "http://example.com must be detected as insecure (non-loopback http)"
+    );
+    assert!(
+        super::is_insecure_non_loopback_http("http://example.com:8080"),
+        "http://example.com:8080 must be detected as insecure"
+    );
+}
+
+#[test]
+fn test_http_localhost_is_allowed() {
+    // cpt-cf-dod-rest-ingest-tls-config
+    // http://localhost is a permitted loopback address; must not be flagged.
+    assert!(
+        !super::is_insecure_non_loopback_http("http://localhost:8080"),
+        "http://localhost:8080 is a loopback address and must NOT be flagged as insecure"
+    );
+    assert!(
+        !super::is_insecure_non_loopback_http("http://localhost"),
+        "http://localhost must NOT be flagged as insecure"
+    );
+}
+
+#[test]
+fn test_http_127_0_0_1_is_allowed() {
+    // cpt-cf-dod-rest-ingest-tls-config
+    // http://127.0.0.1 is a loopback address; must not be flagged as insecure.
+    assert!(
+        !super::is_insecure_non_loopback_http("http://127.0.0.1:8080"),
+        "http://127.0.0.1:8080 is a loopback address and must NOT be flagged as insecure"
+    );
+}
+
+#[test]
+fn test_https_always_allowed() {
+    // cpt-cf-dod-rest-ingest-tls-config
+    // https:// with any host (including non-localhost) must NOT be flagged as
+    // insecure — TLS is always acceptable.
+    assert!(
+        !super::is_insecure_non_loopback_http("https://example.com"),
+        "https://example.com must NOT be flagged as insecure"
+    );
+    assert!(
+        !super::is_insecure_non_loopback_http("https://collector.internal:443"),
+        "https://collector.internal:443 must NOT be flagged as insecure"
+    );
+}
+
+#[test]
+fn test_http_ipv6_loopback_is_allowed() {
+    // cpt-cf-dod-rest-ingest-tls-config
+    // http://[::1] is the IPv6 loopback address; must not be flagged as insecure.
+    assert!(
+        !super::is_insecure_non_loopback_http("http://[::1]:8080"),
+        "http://[::1]:8080 is the IPv6 loopback and must NOT be flagged as insecure"
+    );
+}

--- a/modules/system/usage-collector/usage-collector-rest-client/src/infra/mod.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/src/infra/mod.rs
@@ -1,0 +1,5 @@
+//! Infrastructure adapters (HTTP, external clients).
+
+pub use rest_client::UsageCollectorRestClient;
+
+mod rest_client;

--- a/modules/system/usage-collector/usage-collector-rest-client/src/infra/rest_client.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/src/infra/rest_client.rs
@@ -1,0 +1,249 @@
+//! REST client wiring and [`usage_collector_sdk::UsageCollectorClientV1`] implementation.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use authn_resolver_sdk::{AuthNResolverClient, AuthNResolverError, ClientCredentialsRequest};
+use http::StatusCode;
+use modkit_http::{HttpClient, HttpClientBuilder, HttpError};
+use secrecy::{ExposeSecret, SecretString};
+use usage_collector_sdk::models::UsageRecord;
+use usage_collector_sdk::{ModuleConfig, UsageCollectorClientV1, UsageCollectorError};
+
+use crate::api::rest::dto::CreateUsageRecordBody;
+use crate::config::UsageCollectorRestClientConfig;
+
+// @cpt-dod:cpt-cf-usage-collector-dod-rest-ingest-rest-client-crate:p1
+/// REST-backed [`usage_collector_sdk::UsageCollectorClientV1`].
+pub struct UsageCollectorRestClient {
+    http_client: HttpClient,
+    authn_client: Arc<dyn AuthNResolverClient>,
+    client_id: String,
+    client_secret: SecretString,
+    scopes: Vec<String>,
+    base_url: String,
+}
+
+impl UsageCollectorRestClient {
+    /// Build a client from module config and the shared `AuthN` resolver.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP client cannot be constructed.
+    pub fn new(
+        cfg: &UsageCollectorRestClientConfig,
+        authn: Arc<dyn AuthNResolverClient>,
+    ) -> Result<Self, modkit_http::HttpError> {
+        let http_client = HttpClientBuilder::new()
+            .timeout(cfg.request_timeout)
+            .build()?;
+
+        let base_url = cfg.base_url.trim_end_matches('/').to_owned();
+
+        Ok(Self {
+            http_client,
+            authn_client: authn,
+            client_id: cfg.client_id.clone(),
+            client_secret: cfg.client_secret.clone(),
+            scopes: cfg.scopes.clone(),
+            base_url,
+        })
+    }
+
+    async fn bearer_token(&self) -> Result<String, UsageCollectorError> {
+        let request = ClientCredentialsRequest {
+            client_id: self.client_id.clone(),
+            client_secret: self.client_secret.clone(),
+            scopes: self.scopes.clone(),
+        };
+
+        let auth_result = self
+            .authn_client
+            .exchange_client_credentials(&request)
+            .await
+            .map_err(authn_error_to_usage_collector_error)?;
+
+        let token = auth_result
+            .security_context
+            .bearer_token()
+            .ok_or_else(|| {
+                UsageCollectorError::internal(
+                    "AuthN exchange succeeded but SecurityContext has no bearer token",
+                )
+            })?
+            .expose_secret()
+            .to_owned();
+
+        Ok(token)
+    }
+}
+
+#[async_trait]
+impl UsageCollectorClientV1 for UsageCollectorRestClient {
+    // @cpt-flow:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1
+    async fn create_usage_record(&self, record: UsageRecord) -> Result<(), UsageCollectorError> {
+        // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-1
+        // inst-dlv-4: called from DeliveryHandler::handle — see delivery_handler.rs
+        // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-2
+        let token = self.bearer_token().await?;
+        let auth_header = format!("Bearer {token}");
+        // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-2
+
+        // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-5
+        let url = format!("{}/usage-collector/v1/records", self.base_url);
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-3
+        let body = CreateUsageRecordBody {
+            module: record.module,
+            tenant_id: record.tenant_id,
+            resource_type: record.resource_type,
+            resource_id: record.resource_id,
+            metric: record.metric,
+            kind: record.kind,
+            subject_id: record.subject_id,
+            subject_type: record.subject_type,
+            idempotency_key: record.idempotency_key,
+            value: record.value,
+            timestamp: record.timestamp,
+            metadata: record.metadata,
+        };
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-3
+
+        let response = self
+            .http_client
+            .post(&url)
+            .header("authorization", &auth_header)
+            .json(&body)
+            .map_err(|e| {
+                UsageCollectorError::internal(format!("failed to serialize usage record: {e}"))
+            })?
+            .send()
+            .await
+            .map_err(http_send_error_to_usage_collector_error)?;
+
+        match response.status() {
+            // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-8
+            StatusCode::NO_CONTENT => Ok(()),
+            // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-8
+            status => Err(http_status_to_usage_collector_error(status)),
+        }
+        // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-5
+        // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-1
+    }
+
+    // @cpt-flow:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2
+    async fn get_module_config(
+        &self,
+        module_name: &str,
+    ) -> Result<ModuleConfig, UsageCollectorError> {
+        // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-1
+        // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-2
+        let token = self.bearer_token().await?;
+        let auth_header = format!("Bearer {token}");
+        // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-2
+
+        // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-3
+        let encoded_module_name = urlencoding::encode(module_name);
+        let url = format!(
+            "{}/usage-collector/v1/modules/{encoded_module_name}/config",
+            self.base_url
+        );
+        // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-3
+
+        let response = self
+            .http_client
+            .get(&url)
+            .header("authorization", &auth_header)
+            .send()
+            .await
+            .map_err(http_send_error_to_usage_collector_error)?;
+
+        match response.status() {
+            // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-4
+            StatusCode::OK => response.json::<ModuleConfig>().await.map_err(|e| {
+                UsageCollectorError::internal(format!(
+                    "failed to parse module config response: {e}"
+                ))
+            }),
+            // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-4
+            // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-5
+            StatusCode::NOT_FOUND => Err(UsageCollectorError::module_not_found(module_name)),
+            // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-5
+            // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-6
+            status => Err(http_status_to_usage_collector_error(status)),
+            // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-6
+        }
+        // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-fetch-module-config:p2:inst-cfg-rem-1
+    }
+}
+
+fn authn_error_to_usage_collector_error(e: AuthNResolverError) -> UsageCollectorError {
+    match e {
+        // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-4
+        // Permanent: the configured client credentials are actively rejected.
+        AuthNResolverError::Unauthorized(msg) => {
+            UsageCollectorError::authorization_failed(format!("client credentials: {msg}"))
+        }
+        // Permanent misconfiguration: no AuthN plugin is registered in the hub.
+        // Retrying will not help; this requires operator intervention.
+        AuthNResolverError::NoPluginAvailable => UsageCollectorError::internal(
+            "no AuthN plugin available for client credentials exchange",
+        ),
+        // Permanent: an internal error in the AuthN subsystem. Retrying will not fix this.
+        AuthNResolverError::Internal(msg) => UsageCollectorError::unavailable(format!(
+            "AuthN internal error during client credentials exchange: {msg}"
+        )),
+        // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-4
+        // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-3
+        // Transient: the identity service is temporarily unreachable (network outage,
+        // service restart, etc.). Retrying after backoff is appropriate.
+        other => {
+            UsageCollectorError::unavailable(format!("client credentials exchange failed: {other}"))
+        } // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-3
+    }
+}
+
+fn http_send_error_to_usage_collector_error(e: HttpError) -> UsageCollectorError {
+    match e {
+        // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-6
+        // Timeout variants map to PluginTimeout to keep the circuit-breaker semantics intact.
+        HttpError::Timeout(_) | HttpError::DeadlineExceeded(_) => {
+            UsageCollectorError::plugin_timeout()
+        }
+        // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-6
+        // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-7
+        // All other transport-level errors (connection refused, DNS failure, TLS error, etc.)
+        // are transient: the request never reached the server and retrying is appropriate.
+        other => UsageCollectorError::unavailable(format!("REST request failed: {other}")),
+        // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-7
+    }
+}
+
+fn http_status_to_usage_collector_error(status: StatusCode) -> UsageCollectorError {
+    match status {
+        // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-9
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
+            UsageCollectorError::authorization_failed(format!(
+                "usage collector rejected request with HTTP {status}"
+            ))
+        }
+        // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-9
+        // inst-dlv-6: 429 and 5xx are transient — mapped to PluginTimeout to trigger Retry
+        // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-10
+        s if s == StatusCode::TOO_MANY_REQUESTS || s.is_server_error() => {
+            UsageCollectorError::plugin_timeout()
+        }
+        // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-10
+        // inst-dlv-7: other 4xx (excluding 429) and unexpected statuses are permanent
+        // @cpt-begin:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-11
+        _ => UsageCollectorError::internal(format!(
+            "unexpected HTTP status from usage collector: {status}"
+        )),
+        // @cpt-end:cpt-cf-usage-collector-flow-rest-ingest-remote-emit:p1:inst-rem-11
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "rest_client_tests.rs"]
+mod rest_client_tests;

--- a/modules/system/usage-collector/usage-collector-rest-client/src/infra/rest_client_tests.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/src/infra/rest_client_tests.rs
@@ -1,0 +1,553 @@
+use std::error::Error;
+use std::fmt;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use authn_resolver_sdk::{
+    AuthNResolverClient, AuthNResolverError, AuthenticationResult, ClientCredentialsRequest,
+};
+use chrono::Utc;
+use http::StatusCode;
+use httpmock::prelude::*;
+use modkit_http::HttpError;
+use modkit_security::SecurityContext;
+use serde_json::json;
+use usage_collector_sdk::models::{UsageKind, UsageRecord};
+use usage_collector_sdk::{ModuleConfig, UsageCollectorClientV1, UsageCollectorError};
+use uuid::Uuid;
+
+use super::{
+    UsageCollectorRestClient, authn_error_to_usage_collector_error,
+    http_send_error_to_usage_collector_error, http_status_to_usage_collector_error,
+};
+use crate::config::UsageCollectorRestClientConfig;
+
+// --- Error-mapping unit tests (pure, no I/O) ---
+
+#[derive(Debug)]
+struct DummyTransport(&'static str);
+
+impl fmt::Display for DummyTransport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Error for DummyTransport {}
+
+#[test]
+fn http_timeout_maps_to_plugin_timeout() {
+    let err = HttpError::Timeout(Duration::from_secs(5));
+    let out = http_send_error_to_usage_collector_error(err);
+    assert!(matches!(out, UsageCollectorError::PluginTimeout));
+}
+
+#[test]
+fn http_deadline_exceeded_maps_to_plugin_timeout() {
+    let err = HttpError::DeadlineExceeded(Duration::from_secs(30));
+    let out = http_send_error_to_usage_collector_error(err);
+    assert!(matches!(out, UsageCollectorError::PluginTimeout));
+}
+
+#[test]
+fn http_transport_maps_to_unavailable() {
+    let err = HttpError::Transport(Box::new(DummyTransport("connection refused")));
+    let out = http_send_error_to_usage_collector_error(err);
+    assert!(matches!(out, UsageCollectorError::Unavailable { .. }));
+}
+
+#[test]
+fn http_status_unauthorized_maps_to_authorization_failed() {
+    let out = http_status_to_usage_collector_error(StatusCode::UNAUTHORIZED);
+    assert!(matches!(
+        out,
+        UsageCollectorError::AuthorizationFailed { ref message }
+        if message.contains("401")
+    ));
+}
+
+#[test]
+fn http_status_forbidden_maps_to_authorization_failed() {
+    let out = http_status_to_usage_collector_error(StatusCode::FORBIDDEN);
+    assert!(matches!(
+        out,
+        UsageCollectorError::AuthorizationFailed { ref message }
+        if message.contains("403")
+    ));
+}
+
+#[test]
+fn http_status_internal_server_error_maps_to_plugin_timeout() {
+    // 5xx responses are transient — trigger Retry in DeliveryHandler (inst-dlv-6)
+    let out = http_status_to_usage_collector_error(StatusCode::INTERNAL_SERVER_ERROR);
+    assert!(matches!(out, UsageCollectorError::PluginTimeout));
+}
+
+#[test]
+fn http_status_too_many_requests_maps_to_plugin_timeout() {
+    // 429 is transient — trigger Retry in DeliveryHandler (inst-dlv-6)
+    let out = http_status_to_usage_collector_error(StatusCode::TOO_MANY_REQUESTS);
+    assert!(matches!(out, UsageCollectorError::PluginTimeout));
+}
+
+#[test]
+fn http_status_service_unavailable_maps_to_plugin_timeout() {
+    let out = http_status_to_usage_collector_error(StatusCode::SERVICE_UNAVAILABLE);
+    assert!(matches!(out, UsageCollectorError::PluginTimeout));
+}
+
+#[test]
+fn http_status_ok_maps_to_internal() {
+    // Success codes other than 204 are still unexpected for this API.
+    let out = http_status_to_usage_collector_error(StatusCode::OK);
+    assert!(matches!(out, UsageCollectorError::Internal { .. }));
+}
+
+#[test]
+fn authn_unauthorized_maps_to_authorization_failed() {
+    let out = authn_error_to_usage_collector_error(AuthNResolverError::Unauthorized(
+        "invalid client".to_owned(),
+    ));
+    assert!(matches!(
+        out,
+        UsageCollectorError::AuthorizationFailed { ref message }
+        if message.contains("invalid client")
+    ));
+}
+
+#[test]
+fn authn_token_acquisition_failed_maps_to_unavailable() {
+    let out = authn_error_to_usage_collector_error(AuthNResolverError::TokenAcquisitionFailed(
+        "idp down".to_owned(),
+    ));
+    assert!(matches!(out, UsageCollectorError::Unavailable { .. }));
+}
+
+#[test]
+fn authn_no_plugin_maps_to_internal() {
+    let out = authn_error_to_usage_collector_error(AuthNResolverError::NoPluginAvailable);
+    assert!(matches!(out, UsageCollectorError::Internal { .. }));
+}
+
+#[test]
+fn authn_internal_error_maps_to_unavailable() {
+    let out = authn_error_to_usage_collector_error(AuthNResolverError::Internal(
+        "unexpected subsystem error".to_owned(),
+    ));
+    assert!(matches!(out, UsageCollectorError::Unavailable { .. }));
+}
+
+// --- Integration tests with mock HTTP server ---
+
+enum AuthNOutcome {
+    WithToken(String),
+    WithoutToken,
+    Unauthorized,
+    NoPlugin,
+}
+
+struct MockAuthN {
+    outcome: AuthNOutcome,
+}
+
+impl MockAuthN {
+    fn with_token(token: impl Into<String>) -> Arc<Self> {
+        Arc::new(Self {
+            outcome: AuthNOutcome::WithToken(token.into()),
+        })
+    }
+
+    fn without_token() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: AuthNOutcome::WithoutToken,
+        })
+    }
+
+    fn unauthorized() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: AuthNOutcome::Unauthorized,
+        })
+    }
+
+    fn no_plugin() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: AuthNOutcome::NoPlugin,
+        })
+    }
+}
+
+#[async_trait]
+impl AuthNResolverClient for MockAuthN {
+    async fn authenticate(
+        &self,
+        _bearer_token: &str,
+    ) -> Result<AuthenticationResult, AuthNResolverError> {
+        unimplemented!()
+    }
+
+    async fn exchange_client_credentials(
+        &self,
+        _request: &ClientCredentialsRequest,
+    ) -> Result<AuthenticationResult, AuthNResolverError> {
+        let nil = Uuid::nil();
+        match &self.outcome {
+            AuthNOutcome::WithToken(token) => {
+                let ctx = SecurityContext::builder()
+                    .subject_id(nil)
+                    .subject_tenant_id(nil)
+                    .bearer_token(token.clone())
+                    .build()
+                    .unwrap();
+                Ok(AuthenticationResult {
+                    security_context: ctx,
+                })
+            }
+            AuthNOutcome::WithoutToken => {
+                let ctx = SecurityContext::builder()
+                    .subject_id(nil)
+                    .subject_tenant_id(nil)
+                    .build()
+                    .unwrap();
+                Ok(AuthenticationResult {
+                    security_context: ctx,
+                })
+            }
+            AuthNOutcome::Unauthorized => Err(AuthNResolverError::Unauthorized(
+                "bad credentials".to_owned(),
+            )),
+            AuthNOutcome::NoPlugin => Err(AuthNResolverError::NoPluginAvailable),
+        }
+    }
+}
+
+fn test_cfg(base_url: &str) -> UsageCollectorRestClientConfig {
+    serde_json::from_value(json!({
+        "client_id": "test-client",
+        "client_secret": "test-secret",
+        "base_url": base_url
+    }))
+    .unwrap()
+}
+
+fn test_record() -> UsageRecord {
+    UsageRecord {
+        module: "test-module".to_owned(),
+        tenant_id: Uuid::nil(),
+        resource_type: "vm".to_owned(),
+        resource_id: Uuid::nil(),
+        subject_id: Some(Uuid::nil()),
+        subject_type: Some("test.subject".to_owned()),
+        metric: "cpu.usage".to_owned(),
+        kind: UsageKind::Gauge,
+        idempotency_key: "idem-1".to_owned(),
+        value: 1.5,
+        timestamp: Utc::now(),
+        metadata: None,
+    }
+}
+
+fn make_client(base_url: &str, authn: Arc<dyn AuthNResolverClient>) -> UsageCollectorRestClient {
+    UsageCollectorRestClient::new(&test_cfg(base_url), authn).unwrap()
+}
+
+#[tokio::test]
+async fn create_usage_record_success_on_204() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(204);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    assert!(client.create_usage_record(test_record()).await.is_ok());
+}
+
+#[tokio::test]
+async fn create_usage_record_sends_bearer_token_header() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/usage-collector/v1/records")
+            .header("authorization", "Bearer my-token");
+        then.status(204);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("my-token"));
+    client.create_usage_record(test_record()).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn create_usage_record_authn_unauthorized_returns_authorization_failed() {
+    let server = MockServer::start();
+    let client = make_client(&server.base_url(), MockAuthN::unauthorized());
+
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageCollectorError::AuthorizationFailed { .. }
+    ));
+}
+
+#[tokio::test]
+async fn create_usage_record_authn_no_plugin_returns_internal() {
+    let server = MockServer::start();
+    let client = make_client(&server.base_url(), MockAuthN::no_plugin());
+
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    assert!(matches!(err, UsageCollectorError::Internal { .. }));
+}
+
+#[tokio::test]
+async fn create_usage_record_missing_bearer_token_returns_internal() {
+    let server = MockServer::start();
+    let client = make_client(&server.base_url(), MockAuthN::without_token());
+
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    assert!(matches!(err, UsageCollectorError::Internal { .. }));
+}
+
+#[tokio::test]
+async fn create_usage_record_server_401_returns_authorization_failed() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(401);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageCollectorError::AuthorizationFailed { .. }
+    ));
+}
+
+#[tokio::test]
+async fn create_usage_record_server_403_returns_authorization_failed() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(403);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageCollectorError::AuthorizationFailed { .. }
+    ));
+}
+
+#[tokio::test]
+async fn create_usage_record_server_500_returns_plugin_timeout() {
+    // 500 is transient — delivery handler will Retry (inst-dlv-6)
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(500);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    assert!(matches!(err, UsageCollectorError::PluginTimeout));
+}
+
+#[tokio::test]
+async fn create_usage_record_base_url_trailing_slash_is_trimmed() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(204);
+    });
+
+    let url_with_slash = format!("{}/", server.base_url());
+    let client = make_client(&url_with_slash, MockAuthN::with_token("tok"));
+    assert!(client.create_usage_record(test_record()).await.is_ok());
+}
+
+#[tokio::test]
+async fn create_usage_record_sends_subject_fields_when_present() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/usage-collector/v1/records")
+            .body_includes("\"subject_id\"")
+            .body_includes("\"subject_type\"");
+        then.status(204);
+    });
+
+    let record = UsageRecord {
+        subject_id: Some(Uuid::nil()),
+        subject_type: Some("test.subject".to_owned()),
+        ..test_record()
+    };
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    client.create_usage_record(record).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn create_usage_record_omits_subject_fields_when_absent() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/usage-collector/v1/records")
+            .body_excludes("\"subject_id\"")
+            .body_excludes("\"subject_type\"");
+        then.status(204);
+    });
+
+    let record = UsageRecord {
+        subject_id: None,
+        subject_type: None,
+        ..test_record()
+    };
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    client.create_usage_record(record).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn get_module_config_success() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/my-module/config");
+        then.status(200).json_body(json!({"allowed_metrics": []}));
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let cfg = client.get_module_config("my-module").await.unwrap();
+    assert!(cfg.allowed_metrics.is_empty());
+}
+
+#[tokio::test]
+async fn get_module_config_sends_bearer_token_header() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/mod-x/config")
+            .header("authorization", "Bearer cfg-token");
+        then.status(200).json_body(json!({"allowed_metrics": []}));
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("cfg-token"));
+    client.get_module_config("mod-x").await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn get_module_config_server_401_returns_authorization_failed() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/mod-x/config");
+        then.status(401);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.get_module_config("mod-x").await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageCollectorError::AuthorizationFailed { .. }
+    ));
+}
+
+#[tokio::test]
+async fn get_module_config_server_500_returns_plugin_timeout() {
+    // 500 from the config endpoint is transient
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/mod-x/config");
+        then.status(500);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.get_module_config("mod-x").await.unwrap_err();
+    assert!(matches!(err, UsageCollectorError::PluginTimeout));
+}
+
+#[tokio::test]
+async fn get_module_config_invalid_json_response_returns_internal() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/mod-x/config");
+        then.status(200).body("not-json");
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.get_module_config("mod-x").await.unwrap_err();
+    assert!(matches!(err, UsageCollectorError::Internal { .. }));
+}
+
+#[tokio::test]
+async fn get_module_config_returns_allowed_metrics() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/my-mod/config");
+        then.status(200).json_body(json!({
+            "allowed_metrics": [
+                {"name": "cpu.usage", "kind": "gauge"},
+                {"name": "req.count", "kind": "counter"}
+            ]
+        }));
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let ModuleConfig { allowed_metrics } = client.get_module_config("my-mod").await.unwrap();
+    assert_eq!(allowed_metrics.len(), 2);
+    assert_eq!(allowed_metrics[0].name, "cpu.usage");
+    assert_eq!(allowed_metrics[1].name, "req.count");
+}
+
+// inst-cfg-rem-3: percent-encoding of module_name in get_module_config URL path
+
+#[tokio::test]
+async fn get_module_config_percent_encodes_slash_in_module_name() {
+    // inst-cfg-rem-3
+    // A module_name containing a '/' MUST be percent-encoded in the URL path
+    // segment so the raw '/' does not appear unencoded, and the server receives
+    // the encoded form '%2F' rather than an extra path separator.
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/my%2Fmodule/config");
+        then.status(200).json_body(json!({"allowed_metrics": []}));
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let result = client.get_module_config("my/module").await;
+    assert!(
+        result.is_ok(),
+        "expected Ok but got Err: {result:?} — the mock server only matches '%2F', \
+         so a failure here means the slash was not percent-encoded"
+    );
+    mock.assert();
+}
+
+#[tokio::test]
+async fn get_module_config_percent_encodes_space_in_module_name() {
+    // inst-cfg-rem-3
+    // A module_name containing a space MUST be percent-encoded ('%20') in the
+    // URL path segment.
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/my%20module/config");
+        then.status(200).json_body(json!({"allowed_metrics": []}));
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let result = client.get_module_config("my module").await;
+    assert!(
+        result.is_ok(),
+        "expected Ok but got Err: {result:?} — the mock only matches '%20', \
+         so a failure means the space was not percent-encoded"
+    );
+    mock.assert();
+}

--- a/modules/system/usage-collector/usage-collector-rest-client/src/lib.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/src/lib.rs
@@ -1,0 +1,35 @@
+//! `usage-collector-rest-client` crate
+//!
+//! Provides [`UsageCollectorRestClientModule`] — a `ModKit` module that satisfies
+//! the `"usage-collector-client"` dependency when usage is emitted from a **separate**
+//! `CyberFabric` binary that must reach the collector over **HTTP/REST** (Scenario C).
+//!
+//! Each `create_usage_record` exchanges `OAuth2` client credentials via [`AuthNResolverClient`],
+//! reads the bearer token from the returned [`SecurityContext`], and POSTs the record
+//! to `POST {base_url}/usage-collector/v1/records`.
+//!
+//! ## Configuration
+//!
+//! `client_id` and `client_secret` are required. `base_url`, `scopes`, and
+//! `request_timeout` are optional and use defaults when omitted.
+//!
+//! ```yaml
+//! modules:
+//!   usage-collector-rest-client:
+//!     config:
+//!       client_id: "my-client"
+//!       client_secret: "${CLIENT_SECRET}"
+//!       base_url: "http://127.0.0.1:8080"
+//!       scopes: []
+//!       request_timeout: "30s"
+//! ```
+
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+mod api;
+mod config;
+mod infra;
+mod module;
+
+pub use config::UsageCollectorRestClientConfig;
+pub use infra::UsageCollectorRestClient;

--- a/modules/system/usage-collector/usage-collector-rest-client/src/module.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/src/module.rs
@@ -1,0 +1,108 @@
+//! `usage-collector-rest-client` `ModKit` module.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use authn_resolver_sdk::AuthNResolverClient;
+use authz_resolver_sdk::AuthZResolverClient;
+use modkit::contracts::DatabaseCapability;
+use modkit::{Module, ModuleCtx};
+use sea_orm_migration::MigrationTrait;
+use tracing::{info, warn};
+use usage_emitter::{UsageEmitter, UsageEmitterV1};
+
+use crate::config::UsageCollectorRestClientConfig;
+use crate::infra::UsageCollectorRestClient;
+
+/// Satisfies the `"usage-collector-client"` `ModKit` dependency for separate binaries
+/// by sending usage records to a remote collector REST API with s2s bearer auth.
+#[modkit::module(
+    name = "usage-collector-rest-client",
+    deps = ["authn-resolver", "authz-resolver"],
+    capabilities = [db],
+)]
+#[derive(Default)]
+struct UsageCollectorRestClientModule;
+
+#[async_trait]
+impl Module for UsageCollectorRestClientModule {
+    // @cpt-algo:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1
+    async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-1
+        let cfg: UsageCollectorRestClientConfig = ctx.config_expanded()?;
+        cfg.validate()?;
+        info!(
+            %cfg.base_url,
+            ?cfg.request_timeout,
+            "Loaded {} configuration",
+            Self::MODULE_NAME,
+        );
+        // @cpt-end:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-1
+
+        // @cpt-dod:cpt-cf-dod-rest-ingest-tls-config:p1
+        // @cpt-begin:cpt-cf-dod-rest-ingest-tls-config:p1:inst-tls-check
+        if crate::config::is_insecure_non_loopback_http(&cfg.base_url) {
+            warn!(
+                base_url = %cfg.base_url,
+                "base_url uses http:// with a non-localhost host \u{2014} use https:// in production for secure transport",
+            );
+        }
+        // @cpt-end:cpt-cf-dod-rest-ingest-tls-config:p1:inst-tls-check
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-2
+        let db = ctx
+            .db_required()
+            .map_err(|e| anyhow::anyhow!("{}: db not available: {e}", Self::MODULE_NAME))?
+            .db();
+        // @cpt-end:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-2
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-3
+        let authentication = ctx
+            .client_hub()
+            .get::<dyn AuthNResolverClient>()
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "{}: AuthNResolverClient not registered: {e}",
+                    Self::MODULE_NAME
+                )
+            })?;
+        // @cpt-end:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-3
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-4
+        let authorization = ctx
+            .client_hub()
+            .get::<dyn AuthZResolverClient>()
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "{}: AuthZResolverClient not registered: {e}",
+                    Self::MODULE_NAME
+                )
+            })?;
+        // @cpt-end:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-4
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-5
+        let collector = UsageCollectorRestClient::new(&cfg, authentication).map_err(|e| {
+            anyhow::anyhow!("{}: failed to build HTTP client: {e}", Self::MODULE_NAME)
+        })?;
+        let collector = Arc::new(collector);
+        // @cpt-end:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-5
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-6
+        let emitter = UsageEmitter::build(cfg.emitter, db, authorization, collector).await?;
+        let emitter = Arc::new(emitter);
+        // @cpt-end:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-6
+        // @cpt-begin:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-7
+        ctx.client_hub().register::<dyn UsageEmitterV1>(emitter);
+        // @cpt-end:cpt-cf-usage-collector-algo-rest-ingest-module-init:p1:inst-init-7
+
+        Ok(())
+    }
+}
+
+// @cpt-dod:cpt-cf-usage-collector-dod-rest-ingest-rest-client-crate:p1
+impl DatabaseCapability for UsageCollectorRestClientModule {
+    fn migrations(&self) -> Vec<Box<dyn MigrationTrait>> {
+        info!("Providing {} database migrations", Self::MODULE_NAME);
+        modkit_db::outbox::outbox_migrations()
+    }
+}

--- a/modules/system/usage-collector/usage-collector-rest-client/tests/common/mod.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/tests/common/mod.rs
@@ -1,0 +1,116 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, dead_code)]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use authn_resolver_sdk::{
+    AuthNResolverClient, AuthNResolverError, AuthenticationResult, ClientCredentialsRequest,
+};
+use chrono::Utc;
+use modkit_security::SecurityContext;
+use serde_json::json;
+use usage_collector_rest_client::{UsageCollectorRestClient, UsageCollectorRestClientConfig};
+use usage_collector_sdk::models::{UsageKind, UsageRecord};
+use uuid::Uuid;
+
+pub enum MockAuthN {
+    WithToken(String),
+    WithoutToken,
+    Unauthorized,
+    NoPlugin,
+}
+
+impl MockAuthN {
+    pub fn with_token(token: impl Into<String>) -> Arc<Self> {
+        Arc::new(Self::WithToken(token.into()))
+    }
+
+    pub fn without_token() -> Arc<Self> {
+        Arc::new(Self::WithoutToken)
+    }
+
+    pub fn unauthorized() -> Arc<Self> {
+        Arc::new(Self::Unauthorized)
+    }
+
+    pub fn no_plugin() -> Arc<Self> {
+        Arc::new(Self::NoPlugin)
+    }
+}
+
+#[async_trait]
+impl AuthNResolverClient for MockAuthN {
+    async fn authenticate(
+        &self,
+        _bearer_token: &str,
+    ) -> Result<AuthenticationResult, AuthNResolverError> {
+        unimplemented!()
+    }
+
+    async fn exchange_client_credentials(
+        &self,
+        _request: &ClientCredentialsRequest,
+    ) -> Result<AuthenticationResult, AuthNResolverError> {
+        let nil = Uuid::nil();
+        match self {
+            Self::WithToken(token) => {
+                let ctx = SecurityContext::builder()
+                    .subject_id(nil)
+                    .subject_tenant_id(nil)
+                    .bearer_token(token.clone())
+                    .build()
+                    .unwrap();
+                Ok(AuthenticationResult {
+                    security_context: ctx,
+                })
+            }
+            Self::WithoutToken => {
+                let ctx = SecurityContext::builder()
+                    .subject_id(nil)
+                    .subject_tenant_id(nil)
+                    .build()
+                    .unwrap();
+                Ok(AuthenticationResult {
+                    security_context: ctx,
+                })
+            }
+            Self::Unauthorized => Err(AuthNResolverError::Unauthorized(
+                "bad credentials".to_owned(),
+            )),
+            Self::NoPlugin => Err(AuthNResolverError::NoPluginAvailable),
+        }
+    }
+}
+
+pub fn test_cfg(base_url: &str) -> UsageCollectorRestClientConfig {
+    serde_json::from_value(json!({
+        "client_id": "test-client",
+        "client_secret": "test-secret",
+        "base_url": base_url
+    }))
+    .unwrap()
+}
+
+pub fn test_record() -> UsageRecord {
+    UsageRecord {
+        module: "test-module".to_owned(),
+        tenant_id: Uuid::nil(),
+        resource_type: "vm".to_owned(),
+        resource_id: Uuid::nil(),
+        subject_id: Some(Uuid::nil()),
+        subject_type: Some("test.subject".to_owned()),
+        metric: "cpu.usage".to_owned(),
+        kind: UsageKind::Gauge,
+        idempotency_key: "idem-1".to_owned(),
+        value: 1.5,
+        timestamp: Utc::now(),
+        metadata: None,
+    }
+}
+
+pub fn make_client(
+    base_url: &str,
+    authn: Arc<dyn AuthNResolverClient>,
+) -> UsageCollectorRestClient {
+    UsageCollectorRestClient::new(&test_cfg(base_url), authn).expect("client build")
+}

--- a/modules/system/usage-collector/usage-collector-rest-client/tests/delivery_pipeline_tests.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/tests/delivery_pipeline_tests.rs
@@ -1,0 +1,119 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use httpmock::prelude::*;
+use modkit_db::outbox::{LeasedMessageHandler, MessageResult, OutboxMessage};
+use usage_collector_rest_client::UsageCollectorRestClient;
+use usage_collector_sdk::models::UsageRecord;
+use usage_emitter::DeliveryHandler;
+
+use common::{MockAuthN, make_client, test_record};
+
+fn make_outbox_msg(record: &UsageRecord) -> OutboxMessage {
+    OutboxMessage {
+        partition_id: 0,
+        seq: 1,
+        payload: serde_json::to_vec(record).unwrap(),
+        payload_type: "application/json".to_owned(),
+        created_at: Utc::now(),
+        attempts: 0,
+    }
+}
+
+#[tokio::test]
+async fn delivery_handler_with_rest_client_succeeds_on_204() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(204);
+    });
+
+    let client: UsageCollectorRestClient =
+        make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let handler = DeliveryHandler::new(Arc::new(client));
+    let record = test_record();
+    let msg = make_outbox_msg(&record);
+    let result = handler.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Ok));
+}
+
+#[tokio::test]
+async fn delivery_handler_sends_authorization_header_to_collector() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/usage-collector/v1/records")
+            .header("authorization", "Bearer test-token");
+        then.status(204);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("test-token"));
+    let handler = DeliveryHandler::new(Arc::new(client));
+    let record = test_record();
+    let msg = make_outbox_msg(&record);
+    let result = handler.handle(&msg).await;
+    mock.assert();
+    assert!(matches!(result, MessageResult::Ok));
+}
+
+#[tokio::test]
+async fn delivery_handler_with_rest_client_retries_on_server_500() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(500);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let handler = DeliveryHandler::new(Arc::new(client));
+    let record = test_record();
+    let msg = make_outbox_msg(&record);
+    let result = handler.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Retry));
+}
+
+#[tokio::test]
+async fn delivery_handler_with_rest_client_retries_on_server_429() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(429);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let handler = DeliveryHandler::new(Arc::new(client));
+    let record = test_record();
+    let msg = make_outbox_msg(&record);
+    let result = handler.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Retry));
+}
+
+#[tokio::test]
+async fn delivery_handler_with_rest_client_rejects_on_server_401() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(401);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let handler = DeliveryHandler::new(Arc::new(client));
+    let record = test_record();
+    let msg = make_outbox_msg(&record);
+    let result = handler.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Reject(_)));
+}
+
+#[tokio::test]
+async fn delivery_handler_with_rest_client_rejects_on_authn_failure() {
+    let client = make_client("http://localhost:1", MockAuthN::unauthorized());
+    let handler = DeliveryHandler::new(Arc::new(client));
+    let record = test_record();
+    let msg = make_outbox_msg(&record);
+    let result = handler.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Reject(_)));
+}

--- a/modules/system/usage-collector/usage-collector-rest-client/tests/rest_client_tests.rs
+++ b/modules/system/usage-collector/usage-collector-rest-client/tests/rest_client_tests.rs
@@ -1,0 +1,299 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use httpmock::prelude::*;
+use serde_json::json;
+use usage_collector_rest_client::UsageCollectorRestClient;
+use usage_collector_sdk::models::UsageRecord;
+use usage_collector_sdk::{UsageCollectorClientV1, UsageCollectorError};
+use uuid::Uuid;
+
+use common::{MockAuthN, make_client, test_record};
+
+// --- create_usage_record tests ---
+
+#[tokio::test]
+async fn create_usage_record_returns_ok_on_204() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(204);
+    });
+
+    let client: UsageCollectorRestClient =
+        make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    assert!(client.create_usage_record(test_record()).await.is_ok());
+}
+
+#[tokio::test]
+async fn create_usage_record_sends_bearer_token() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/usage-collector/v1/records")
+            .header("authorization", "Bearer my-token");
+        then.status(204);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("my-token"));
+    client.create_usage_record(test_record()).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn create_usage_record_returns_authorization_failed_when_authn_unauthorized() {
+    let server = MockServer::start();
+    let client = make_client(&server.base_url(), MockAuthN::unauthorized());
+
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageCollectorError::AuthorizationFailed { .. }
+    ));
+}
+
+#[tokio::test]
+async fn create_usage_record_returns_internal_when_authn_no_plugin() {
+    let server = MockServer::start();
+    let client = make_client(&server.base_url(), MockAuthN::no_plugin());
+
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    assert!(matches!(err, UsageCollectorError::Internal { .. }));
+}
+
+#[tokio::test]
+async fn create_usage_record_returns_internal_when_no_bearer_token() {
+    let server = MockServer::start();
+    let client = make_client(&server.base_url(), MockAuthN::without_token());
+
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    assert!(matches!(err, UsageCollectorError::Internal { .. }));
+}
+
+#[tokio::test]
+async fn create_usage_record_returns_authorization_failed_on_401() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(401);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageCollectorError::AuthorizationFailed { .. }
+    ));
+}
+
+#[tokio::test]
+async fn create_usage_record_returns_authorization_failed_on_403() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(403);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageCollectorError::AuthorizationFailed { .. }
+    ));
+}
+
+#[tokio::test]
+async fn create_usage_record_returns_plugin_timeout_on_500() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(500);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.create_usage_record(test_record()).await.unwrap_err();
+    assert!(matches!(err, UsageCollectorError::PluginTimeout));
+}
+
+#[tokio::test]
+async fn create_usage_record_trims_trailing_slash_from_base_url() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/usage-collector/v1/records");
+        then.status(204);
+    });
+
+    let url_with_slash = format!("{}/", server.base_url());
+    let client = make_client(&url_with_slash, MockAuthN::with_token("tok"));
+    assert!(client.create_usage_record(test_record()).await.is_ok());
+    mock.assert();
+}
+
+#[tokio::test]
+async fn create_usage_record_sends_subject_fields() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/usage-collector/v1/records")
+            .body_includes("\"subject_id\"")
+            .body_includes("\"subject_type\"");
+        then.status(204);
+    });
+
+    let record = UsageRecord {
+        subject_id: Some(Uuid::nil()),
+        subject_type: Some("test.subject".to_owned()),
+        ..test_record()
+    };
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    client.create_usage_record(record).await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn create_usage_record_omits_subject_fields_when_absent() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/usage-collector/v1/records")
+            .body_excludes("\"subject_id\"")
+            .body_excludes("\"subject_type\"");
+        then.status(204);
+    });
+
+    let record = UsageRecord {
+        subject_id: None,
+        subject_type: None,
+        ..test_record()
+    };
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    client.create_usage_record(record).await.unwrap();
+    mock.assert();
+}
+
+// --- get_module_config tests ---
+
+#[tokio::test]
+async fn get_module_config_returns_config_on_200() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/my-module/config");
+        then.status(200).json_body(json!({"allowed_metrics": []}));
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let cfg = client.get_module_config("my-module").await.unwrap();
+    assert!(cfg.allowed_metrics.is_empty());
+}
+
+#[tokio::test]
+async fn get_module_config_sends_bearer_token() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/mod-x/config")
+            .header("authorization", "Bearer cfg-token");
+        then.status(200).json_body(json!({"allowed_metrics": []}));
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("cfg-token"));
+    client.get_module_config("mod-x").await.unwrap();
+    mock.assert();
+}
+
+#[tokio::test]
+async fn get_module_config_returns_authorization_failed_on_401() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/mod-x/config");
+        then.status(401);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.get_module_config("mod-x").await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageCollectorError::AuthorizationFailed { .. }
+    ));
+}
+
+#[tokio::test]
+async fn get_module_config_returns_plugin_timeout_on_500() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/mod-x/config");
+        then.status(500);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.get_module_config("mod-x").await.unwrap_err();
+    assert!(matches!(err, UsageCollectorError::PluginTimeout));
+}
+
+#[tokio::test]
+async fn get_module_config_returns_internal_on_invalid_json() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/mod-x/config");
+        then.status(200).body("not-json");
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.get_module_config("mod-x").await.unwrap_err();
+    assert!(matches!(err, UsageCollectorError::Internal { .. }));
+}
+
+#[tokio::test]
+async fn get_module_config_returns_module_not_found_on_404() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/missing-mod/config");
+        then.status(404);
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let err = client.get_module_config("missing-mod").await.unwrap_err();
+    assert!(matches!(err, UsageCollectorError::ModuleNotFound { .. }));
+}
+
+#[tokio::test]
+async fn get_module_config_percent_encodes_slash_in_module_name() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/my%2Fmodule/config");
+        then.status(200).json_body(json!({"allowed_metrics": []}));
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let result = client.get_module_config("my/module").await;
+    assert!(
+        result.is_ok(),
+        "expected Ok but got Err: {result:?} — slash was not percent-encoded"
+    );
+    mock.assert();
+}
+
+#[tokio::test]
+async fn get_module_config_percent_encodes_space_in_module_name() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/usage-collector/v1/modules/my%20module/config");
+        then.status(200).json_body(json!({"allowed_metrics": []}));
+    });
+
+    let client = make_client(&server.base_url(), MockAuthN::with_token("tok"));
+    let result = client.get_module_config("my module").await;
+    assert!(
+        result.is_ok(),
+        "expected Ok but got Err: {result:?} — space was not percent-encoded"
+    );
+    mock.assert();
+}

--- a/modules/system/usage-collector/usage-collector-sdk/Cargo.toml
+++ b/modules/system/usage-collector/usage-collector-sdk/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "cf-usage-collector-sdk"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "SDK for usage-collector"
+readme = "README.md"
+keywords = ["cyberfabric", "cyberfabric-system"]
+categories = ["development-tools"]
+
+[lib]
+name = "usage_collector_sdk"
+
+[lints]
+workspace = true
+
+[dependencies]
+# ModKit dependencies
+modkit = { workspace = true }
+
+# Async runtime
+async-trait = { workspace = true }
+
+# Data structures
+chrono = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+utoipa = { workspace = true }
+
+# Error handling
+thiserror = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+schemars = { workspace = true }
+
+# GTS
+gts = { workspace = true }
+gts-macros = { workspace = true }
+
+[dev-dependencies]
+# Async runtime
+tokio = { workspace = true }

--- a/modules/system/usage-collector/usage-collector-sdk/README.md
+++ b/modules/system/usage-collector/usage-collector-sdk/README.md
@@ -1,0 +1,95 @@
+# Usage Collector SDK
+
+Transport-agnostic contracts for the usage-collector module family.
+
+## What this crate provides
+
+| Item | Description |
+|------|-------------|
+| `UsageCollectorClientV1` | Ingest trait implemented by client modules (`usage-collector`, `usage-collector-rest-client`). **Never registered in `ClientHub`** to prevent unauthorized usage emission. |
+| `UsageCollectorPluginClientV1` | Storage-plugin trait implemented by backend plugins. |
+| `UsageRecord`, `UsageKind` | Transport-agnostic models (`UsageRecord` fields are public for direct construction, serde, and tests). |
+| `ModuleConfig`, `AllowedMetric` | Per-module configuration returned by `get_module_config()`; `AllowedMetric` holds a metric name and its `UsageKind`. |
+| `UsageCollectorError` | Error type shared by both traits. |
+| `UsageCollectorStoragePluginSpecV1` | GTS schema for storage plugin registration. |
+
+> **Emitting usage** — use the `usage-emitter` crate, which wraps `UsageCollectorClientV1` with PDP authorization and outbox buffering.
+
+## Usage
+
+### Querying module config
+
+Source modules can fetch their allowed metrics at init time via `UsageCollectorClientV1`:
+
+```rust
+use usage_collector_sdk::UsageCollectorClientV1;
+
+let config = collector.get_module_config("my_module").await?;
+for metric in &config.allowed_metrics {
+    println!("{}: {:?}", metric.name, metric.kind);
+}
+```
+
+### Building a `UsageRecord` directly
+
+For tests, plugins, or offline construction, set fields on `UsageRecord` directly (public struct fields):
+
+```rust
+use chrono::Utc;
+use usage_collector_sdk::{UsageKind, UsageRecord};
+use uuid::Uuid;
+
+let record = UsageRecord {
+    module: "my_module".to_owned(),
+    tenant_id: Uuid::new_v4(),
+    metric: "requests".to_owned(),
+    kind: UsageKind::Counter,
+    value: 1.0,
+    resource_id: Uuid::new_v4(),
+    resource_type: "resource_type".to_owned(),
+    subject_id: Some(Uuid::new_v4()),
+    subject_type: Some("subject_type".to_owned()),
+    idempotency_key: Uuid::new_v4().to_string(),
+    timestamp: Utc::now(),
+    metadata: None,
+};
+```
+
+### Implementing a storage plugin
+
+```rust
+use async_trait::async_trait;
+use usage_collector_sdk::{UsageCollectorError, UsageCollectorPluginClientV1, UsageRecord};
+
+struct MyStoragePlugin { /* ... */ }
+
+#[async_trait]
+impl UsageCollectorPluginClientV1 for MyStoragePlugin {
+    async fn create_usage_record(
+        &self,
+        record: UsageRecord,
+    ) -> Result<(), UsageCollectorError> {
+        // idempotent upsert keyed on record.idempotency_key
+        todo!()
+    }
+}
+```
+
+## Error handling
+
+```rust
+use usage_collector_sdk::UsageCollectorError;
+
+match result {
+    Ok(()) => {}
+    Err(UsageCollectorError::AuthorizationFailed { message }) => { /* PDP denied */ }
+    Err(UsageCollectorError::ModuleNotFound { module_name }) => { /* module has no configured metrics */ }
+    Err(UsageCollectorError::PluginTimeout) => { /* storage plugin timed out */ }
+    Err(UsageCollectorError::CircuitOpen) => { /* storage plugin circuit breaker open */ }
+    Err(UsageCollectorError::Internal { message }) => { /* unexpected error */ }
+}
+```
+
+## Security invariant
+
+`UsageCollectorClientV1` is **never** registered in `ClientHub`. It is passed directly to the emitter via constructor, ensuring the sole path to the collector is through a PDP-authorized emitter.

--- a/modules/system/usage-collector/usage-collector-sdk/src/api.rs
+++ b/modules/system/usage-collector/usage-collector-sdk/src/api.rs
@@ -1,0 +1,38 @@
+use async_trait::async_trait;
+
+use crate::error::UsageCollectorError;
+use crate::models::{ModuleConfig, UsageRecord};
+
+/// Gateway-facing API trait for the usage collector.
+///
+/// Implemented by the gateway module's local client (`UsageCollectorLocalClient`)
+/// and by remote client modules (e.g. `usage-collector-rest-client`).
+///
+/// # Security invariant
+///
+/// This trait is **never** registered in `ClientHub`. Passing it through the hub
+/// would allow any module to push unvalidated records directly to the collector,
+/// bypassing the authorized-emitter path. Always supply it by constructor argument
+/// to the emitter.
+#[async_trait]
+pub trait UsageCollectorClientV1: Send + Sync {
+    /// Create one usage record at the collector gateway (ingest).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageCollectorError`] on transient or permanent delivery failure.
+    async fn create_usage_record(&self, record: UsageRecord) -> Result<(), UsageCollectorError>;
+
+    /// Retrieve per-module configuration from the collector.
+    ///
+    /// Returns the set of metrics `module_name` is allowed to emit.
+    /// Extensible: future versions may include rate limit config, max metadata size, etc.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageCollectorError`] if the module is not configured or the call fails.
+    async fn get_module_config(
+        &self,
+        module_name: &str,
+    ) -> Result<ModuleConfig, UsageCollectorError>;
+}

--- a/modules/system/usage-collector/usage-collector-sdk/src/error.rs
+++ b/modules/system/usage-collector/usage-collector-sdk/src/error.rs
@@ -1,0 +1,86 @@
+/// Errors produced by the usage collector gateway, client trait, and storage plugins.
+#[derive(Debug, thiserror::Error)]
+pub enum UsageCollectorError {
+    /// Authorization or policy denial (e.g. emit-time PDP); retained for API compatibility.
+    #[error("authorization failed: {message}")]
+    AuthorizationFailed {
+        /// Human-readable failure description.
+        message: String,
+    },
+
+    /// Types-registry / plugin resolution / hub wiring failures and other unexpected conditions.
+    #[error("internal error: {message}")]
+    Internal {
+        /// Detail for operators and logs.
+        message: String,
+    },
+
+    /// No metrics are configured for this module in the gateway's static configuration.
+    #[error("module not found in configuration: {module_name}")]
+    ModuleNotFound {
+        /// Name of the module that has no configured metrics.
+        module_name: String,
+    },
+
+    /// Plugin call exceeded the configured timeout.
+    #[error("storage plugin call timed out")]
+    PluginTimeout,
+
+    /// Circuit breaker is open — storage plugin calls are suspended until the recovery window elapses.
+    #[error("storage plugin circuit breaker is open")]
+    CircuitOpen,
+
+    /// Transient infrastructure failure: connection/transport error or a dependent service
+    /// (e.g. the identity/AuthN service) is temporarily unreachable.
+    /// The operation may succeed on retry once the outage resolves.
+    #[error("service unavailable: {message}")]
+    Unavailable {
+        /// Detail for operators and logs.
+        message: String,
+    },
+}
+
+impl UsageCollectorError {
+    #[must_use]
+    pub fn authorization_failed(message: impl Into<String>) -> Self {
+        Self::AuthorizationFailed {
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal {
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn module_not_found(module_name: impl Into<String>) -> Self {
+        Self::ModuleNotFound {
+            module_name: module_name.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn plugin_timeout() -> Self {
+        Self::PluginTimeout
+    }
+
+    #[must_use]
+    pub fn circuit_open() -> Self {
+        Self::CircuitOpen
+    }
+
+    #[must_use]
+    pub fn unavailable(message: impl Into<String>) -> Self {
+        Self::Unavailable {
+            message: message.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "error_tests.rs"]
+mod error_tests;

--- a/modules/system/usage-collector/usage-collector-sdk/src/error_tests.rs
+++ b/modules/system/usage-collector/usage-collector-sdk/src/error_tests.rs
@@ -1,0 +1,57 @@
+use super::*;
+
+#[test]
+fn authorization_failed_constructor_sets_message() {
+    let e = UsageCollectorError::authorization_failed("denied");
+    assert!(
+        matches!(e, UsageCollectorError::AuthorizationFailed { ref message } if message == "denied")
+    );
+}
+
+#[test]
+fn internal_constructor_sets_message() {
+    let e = UsageCollectorError::internal("types-registry: boom");
+    assert!(
+        matches!(e, UsageCollectorError::Internal { ref message } if message == "types-registry: boom")
+    );
+}
+
+#[test]
+fn plugin_timeout_constructor() {
+    let e = UsageCollectorError::plugin_timeout();
+    assert!(matches!(e, UsageCollectorError::PluginTimeout));
+}
+
+#[test]
+fn unavailable_constructor_sets_message() {
+    let e = UsageCollectorError::unavailable("connection refused");
+    assert!(
+        matches!(e, UsageCollectorError::Unavailable { ref message } if message == "connection refused")
+    );
+}
+
+// ── Display ───────────────────────────────────────────────────────
+
+#[test]
+fn display_authorization_failed() {
+    let e = UsageCollectorError::authorization_failed("access denied");
+    assert_eq!(e.to_string(), "authorization failed: access denied");
+}
+
+#[test]
+fn display_internal() {
+    let e = UsageCollectorError::internal("types-registry unavailable");
+    assert_eq!(e.to_string(), "internal error: types-registry unavailable");
+}
+
+#[test]
+fn display_plugin_timeout() {
+    let e = UsageCollectorError::plugin_timeout();
+    assert_eq!(e.to_string(), "storage plugin call timed out");
+}
+
+#[test]
+fn display_unavailable() {
+    let e = UsageCollectorError::unavailable("identity service down");
+    assert_eq!(e.to_string(), "service unavailable: identity service down");
+}

--- a/modules/system/usage-collector/usage-collector-sdk/src/gts.rs
+++ b/modules/system/usage-collector/usage-collector-sdk/src/gts.rs
@@ -1,0 +1,14 @@
+//! GTS schema for usage-collector storage plugin instances.
+
+use gts_macros::struct_to_gts_schema;
+use modkit::gts::BaseModkitPluginV1;
+
+/// GTS type for storage backend plugin instances registered with types-registry.
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = BaseModkitPluginV1,
+    schema_id = "gts.cf.core.modkit.plugin.v1~cf.core.usage_collector.storage_plugin.v1~",
+    description = "Usage Collector storage plugin specification",
+    properties = ""
+)]
+pub struct UsageCollectorStoragePluginSpecV1;

--- a/modules/system/usage-collector/usage-collector-sdk/src/lib.rs
+++ b/modules/system/usage-collector/usage-collector-sdk/src/lib.rs
@@ -1,0 +1,33 @@
+//! Usage Collector SDK
+//!
+//! Transport-agnostic contracts for the usage-collector module family.
+//!
+//! ## What this crate provides
+//!
+//! - [`UsageCollectorClientV1`] — ingest trait implemented by gateway/remote client modules
+//!   (passed by constructor argument to the emitter, never via `ClientHub`).
+//! - [`UsageCollectorPluginClientV1`] — storage-plugin trait implemented by backend plugins.
+//! - [`UsageRecord`], [`UsageKind`], [`ModuleConfig`], [`AllowedMetric`] — transport-agnostic models.
+//! - [`UsageCollectorError`] — error type shared by both traits.
+//! - [`UsageCollectorStoragePluginSpecV1`] — GTS schema for storage plugin registration.
+//!
+//! ## Emitting usage
+//!
+//! Use the `usage-emitter` crate, which wraps [`UsageCollectorClientV1`] with PDP authorization
+//! and outbox buffering.
+
+// @cpt-dod:cpt-cf-usage-collector-dod-sdk-and-ingest-core-sdk-crate:p1
+
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+pub mod api;
+pub mod error;
+pub mod gts;
+pub mod models;
+pub mod plugin_api;
+
+pub use api::UsageCollectorClientV1;
+pub use error::UsageCollectorError;
+pub use gts::UsageCollectorStoragePluginSpecV1;
+pub use models::{AllowedMetric, ModuleConfig, UsageKind, UsageRecord};
+pub use plugin_api::UsageCollectorPluginClientV1;

--- a/modules/system/usage-collector/usage-collector-sdk/src/models.rs
+++ b/modules/system/usage-collector/usage-collector-sdk/src/models.rs
@@ -1,0 +1,72 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Kind of numeric usage observation (gauge vs counter).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum UsageKind {
+    Gauge,
+    Counter,
+}
+
+/// A single allowed metric definition returned by [`crate::UsageCollectorClientV1::get_module_config`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AllowedMetric {
+    /// Metric name.
+    pub name: String,
+    /// Gauge vs counter semantics for this metric.
+    pub kind: UsageKind,
+}
+
+/// Per-module configuration returned by [`crate::UsageCollectorClientV1::get_module_config`].
+///
+/// Extensible: future fields may include rate limit config, max metadata size, etc.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModuleConfig {
+    /// Metrics this module is allowed to emit.
+    pub allowed_metrics: Vec<AllowedMetric>,
+}
+
+/// A single usage record submitted to the collector.
+///
+/// All fields are public for direct construction, serde, and tests.
+/// For emission from source modules, use the `usage-emitter` crate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageRecord {
+    /// Name of the module that emitted this record.
+    pub module: String,
+    /// Tenant that owns this usage observation.
+    pub tenant_id: Uuid,
+    /// Metric name for this observation.
+    pub metric: String,
+    /// Gauge vs counter semantics.
+    pub kind: UsageKind,
+    /// Numeric value for this usage observation.
+    pub value: f64,
+    /// Identifier of the metered resource instance.
+    pub resource_id: Uuid,
+    /// Logical type of the metered resource (e.g. GTS id or domain name).
+    pub resource_type: String,
+    /// Identifier of the subject (user or service) performing the metered action.
+    /// `None` when no subject context is available; PDP validation is skipped in that case.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub subject_id: Option<Uuid>,
+    /// Logical type of the subject (e.g. GTS id or domain name).
+    /// `None` when no subject context is available.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub subject_type: Option<String>,
+    /// Idempotency key for at-least-once delivery.
+    pub idempotency_key: String,
+    /// Timestamp of the observation.
+    pub timestamp: DateTime<Utc>,
+    /// Optional caller-supplied metadata (max 8 192 bytes serialized).
+    /// Absent when not provided; serializes as absent JSON field, not `null`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub metadata: Option<serde_json::Value>,
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "models_tests.rs"]
+mod models_tests;

--- a/modules/system/usage-collector/usage-collector-sdk/src/models_tests.rs
+++ b/modules/system/usage-collector/usage-collector-sdk/src/models_tests.rs
@@ -1,0 +1,61 @@
+use chrono::Utc;
+use uuid::Uuid;
+
+use super::{UsageKind, UsageRecord};
+
+fn make_record() -> UsageRecord {
+    UsageRecord {
+        module: "test-module".to_owned(),
+        tenant_id: Uuid::nil(),
+        metric: "test.metric".to_owned(),
+        kind: UsageKind::Gauge,
+        value: 1.0,
+        resource_id: Uuid::nil(),
+        resource_type: "test.resource".to_owned(),
+        subject_id: Some(Uuid::nil()),
+        subject_type: Some("test.subject".to_owned()),
+        idempotency_key: Uuid::new_v4().to_string(),
+        timestamp: Utc::now(),
+        metadata: None,
+    }
+}
+
+#[test]
+fn usage_record_roundtrip_serde() {
+    let mut rec = make_record();
+    rec.value = 42.0;
+    let json = serde_json::to_string(&rec).unwrap();
+    let deserialized: UsageRecord = serde_json::from_str(&json).unwrap();
+    assert!((deserialized.value - 42.0_f64).abs() < f64::EPSILON);
+    assert_eq!(deserialized.kind, UsageKind::Gauge);
+}
+
+#[test]
+fn usage_record_clone_copies_all_fields() {
+    let rec = make_record();
+    let cloned = rec.clone();
+    assert_eq!(cloned.tenant_id, rec.tenant_id);
+    assert!((cloned.value - rec.value).abs() < f64::EPSILON);
+    assert_eq!(cloned.resource_id, rec.resource_id);
+}
+
+#[test]
+fn usage_record_subject_none_serde() {
+    let rec = UsageRecord {
+        subject_id: None,
+        subject_type: None,
+        ..make_record()
+    };
+    let json = serde_json::to_string(&rec).unwrap();
+    assert!(
+        !json.contains("\"subject_id\""),
+        "subject_id must be absent from JSON when None, got: {json}"
+    );
+    assert!(
+        !json.contains("\"subject_type\""),
+        "subject_type must be absent from JSON when None, got: {json}"
+    );
+    let deserialized: UsageRecord = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized.subject_id, None);
+    assert_eq!(deserialized.subject_type, None);
+}

--- a/modules/system/usage-collector/usage-collector-sdk/src/plugin_api.rs
+++ b/modules/system/usage-collector/usage-collector-sdk/src/plugin_api.rs
@@ -1,0 +1,15 @@
+//! Storage plugin trait for usage-collector backends.
+
+use async_trait::async_trait;
+
+use crate::error::UsageCollectorError;
+use crate::models::UsageRecord;
+
+/// Backend storage adapter for usage records.
+///
+/// Plugins register via GTS; the gateway resolves the active instance and delegates writes.
+#[async_trait]
+pub trait UsageCollectorPluginClientV1: Send + Sync {
+    /// Create one usage record in storage (idempotent upsert where applicable).
+    async fn create_usage_record(&self, record: UsageRecord) -> Result<(), UsageCollectorError>;
+}

--- a/modules/system/usage-collector/usage-collector/Cargo.toml
+++ b/modules/system/usage-collector/usage-collector/Cargo.toml
@@ -1,0 +1,69 @@
+[package]
+name = "cf-usage-collector"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Usage Collector gateway"
+readme = "README.md"
+keywords = ["cyberfabric", "cyberfabric-system"]
+categories = ["development-tools"]
+
+[lib]
+name = "usage_collector"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Local dependencies
+authz-resolver-sdk = { workspace = true }
+types-registry-sdk = { workspace = true }
+usage-collector-sdk = { workspace = true }
+usage-emitter = { workspace = true }
+
+# ModKit dependencies
+modkit = { workspace = true }
+modkit-db = { workspace = true, features = ["preview-outbox"] }
+modkit-macros = { workspace = true }
+modkit-security = { workspace = true }
+modkit-utils = { workspace = true, features = ["humantime-serde"] }
+
+# REST
+axum = { workspace = true }
+http = { workspace = true }
+utoipa = { workspace = true }
+
+# Data structures
+chrono = { workspace = true }
+uuid = { workspace = true }
+
+# Async runtime
+async-trait = { workspace = true }
+tokio = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+# DB
+sea-orm-migration = { workspace = true }
+
+[dev-dependencies]
+# Local dependencies
+types-registry-sdk = { workspace = true, features = ["test-util"] }
+
+# ModKit dependencies
+modkit-db = { workspace = true, features = ["sqlite"] }
+
+# HTTP testing
+tower = { workspace = true }

--- a/modules/system/usage-collector/usage-collector/README.md
+++ b/modules/system/usage-collector/usage-collector/README.md
@@ -1,0 +1,46 @@
+# Usage Collector
+
+> **Gateway module** — hosts the Usage Collector gateway in-process: registers the storage-plugin GTS schema with `types-registry`, resolves the active storage plugin by `vendor`, exposes `dyn UsageCollectorClientV1` in `ClientHub` for the outbox delivery path, and serves a REST API for out-of-process emitters.
+
+ModKit module `usage-collector`: central ingest for usage observations (`UsageRecord`) from the outbox pipeline (`usage-emitter`) and delegation to the selected `UsageCollectorPluginClientV1` implementation.
+
+## Overview
+
+At startup the module:
+
+- Registers `UsageCollectorStoragePluginSpecV1` in the types registry so storage backends can be declared as GTS instances.
+- Builds the domain `Service` that lists plugin instances, picks one for the configured `vendor`, and forwards `create_usage_record` calls with a bounded timeout.
+- Registers **`UsageCollectorLocalClient`** as `dyn UsageCollectorClientV1` so code in the **same binary** can call `create_usage_record` and `get_module_config` (which filters the metrics whitelist to only the metrics allowed for the calling module) without a network hop.
+- Initializes the embedded **`UsageEmitter`** (from `usage-emitter`) and registers it in `ClientHub`; the emitter handles authorization (PDP) and the outbox delivery path before forwarding records to the local client.
+
+Source modules should emit through **`usage-emitter`** (PDP + outbox). This crate implements the gateway side of `UsageCollectorClientV1::create_usage_record` and the storage-plugin selection logic.
+
+## Dependencies
+
+- **At least one storage plugin** — a module that registers `dyn UsageCollectorPluginClientV1` in `ClientHub` for the GTS instance id chosen for your `vendor`. For dev/tests, see **`cf-noop-usage-collector-storage-plugin`**.
+
+## Configuration
+
+`vendor` must match the `vendor` field on the storage plugin GTS content so `choose_plugin_instance` selects the right instance. `plugin_timeout` bounds each `create_usage_record` call; exceeded waits become `UsageCollectorError::PluginTimeout`. `emitter` holds nested `UsageEmitterConfig` for outbox and authorization tuning. `metrics` is a whitelist of allowed metric names, each with a `kind` (`gauge` or `counter`) and an optional `modules` list (if absent, all modules may emit that metric).
+
+```yaml
+modules:
+  usage-collector:
+    config:
+      vendor: "hyperspot"
+      plugin_timeout: "5s"
+      emitter:
+        # UsageEmitterConfig fields (outbox, auth tuning)
+      metrics:
+        "storage.bytes_used":
+          kind: "gauge"
+          modules: ["storage-service"]   # omit to allow all modules
+        "api.requests":
+          kind: "counter"
+```
+
+## Testing
+
+```bash
+cargo test -p cf-usage-collector
+```

--- a/modules/system/usage-collector/usage-collector/src/api/mod.rs
+++ b/modules/system/usage-collector/usage-collector/src/api/mod.rs
@@ -1,0 +1,3 @@
+//! API layer for the usage-collector module.
+
+pub mod rest;

--- a/modules/system/usage-collector/usage-collector/src/api/rest/dto.rs
+++ b/modules/system/usage-collector/usage-collector/src/api/rest/dto.rs
@@ -1,0 +1,57 @@
+//! REST DTOs for the usage-collector gateway.
+
+use chrono::{DateTime, Utc};
+use usage_collector_sdk::models::UsageKind;
+use uuid::Uuid;
+
+/// Request body to create one usage record (ingest).
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(request)]
+pub struct CreateUsageRecordRequest {
+    /// Name of the module emitting this record.
+    pub module: String,
+    /// Tenant that owns the record.
+    pub tenant_id: Uuid,
+    /// Logical type of the metered resource.
+    pub resource_type: String,
+    /// Identifier of the metered resource instance.
+    pub resource_id: Uuid,
+    /// Identifier of the subject (user/service account) performing the request.
+    /// `None` when no subject context is available; PDP subject validation is skipped in that case.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_id: Option<Uuid>,
+    /// Type of the subject (e.g. `"user"`, `"service_account"`).
+    /// `None` when no subject context is available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_type: Option<String>,
+    /// Metric name for this observation.
+    pub metric: String,
+    /// Optional idempotency key; if omitted, one is generated when building the record.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idempotency_key: Option<String>,
+    /// Numeric value for this usage observation.
+    pub value: f64,
+    /// Observation timestamp (UTC).
+    pub timestamp: DateTime<Utc>,
+    /// Optional caller-supplied metadata. Serialized size MUST NOT exceed 8 192 bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// One allowed metric entry in a module config response.
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(response)]
+pub struct AllowedMetricResponse {
+    /// Metric name.
+    pub name: String,
+    /// Gauge vs counter semantics.
+    pub kind: UsageKind,
+}
+
+/// Response body for the get-module-config endpoint.
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(response)]
+pub struct ModuleConfigResponse {
+    /// Metrics the module is allowed to emit.
+    pub allowed_metrics: Vec<AllowedMetricResponse>,
+}

--- a/modules/system/usage-collector/usage-collector/src/api/rest/handlers.rs
+++ b/modules/system/usage-collector/usage-collector/src/api/rest/handlers.rs
@@ -1,0 +1,239 @@
+//! REST handlers for the usage-collector gateway.
+
+use std::sync::Arc;
+
+use axum::extract::Path;
+use axum::{Extension, Json};
+use http::StatusCode;
+use modkit::api::problem::{Problem, internal_error};
+use modkit_security::SecurityContext;
+use usage_collector_sdk::{UsageCollectorClientV1, UsageCollectorError};
+use usage_emitter::{UsageEmitterError, UsageEmitterV1};
+
+use super::dto::{AllowedMetricResponse, CreateUsageRecordRequest, ModuleConfigResponse};
+
+/// Handler for `POST /usage-collector/v1/records`.
+///
+/// # Errors
+/// Returns a [`Problem`] on authorization failure, validation errors, or internal emitter failure.
+pub async fn handle_create_usage_record(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(emitter): Extension<Arc<dyn UsageEmitterV1>>,
+    Json(req): Json<CreateUsageRecordRequest>,
+) -> Result<StatusCode, Problem> {
+    // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-1
+    if let Some(err) = validate_metadata_size(req.metadata.as_ref()) {
+        return Err(err);
+    }
+    // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-1
+
+    let authorized = authorize_request(&ctx, &emitter, &req).await?;
+
+    let mut builder = authorized
+        .build_usage_record(req.metric, req.value)
+        .with_timestamp(req.timestamp);
+
+    if let Some(key) = req.idempotency_key.filter(|k| !k.is_empty()) {
+        builder = builder.with_idempotency_key(key);
+    }
+
+    if let Some(meta) = req.metadata {
+        builder = builder.with_metadata(meta);
+    }
+
+    builder.enqueue().await.map_err(emitter_error_to_problem)?;
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-7
+    Ok(StatusCode::NO_CONTENT)
+    // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-7
+}
+
+fn validate_metadata_size(metadata: Option<&serde_json::Value>) -> Option<Problem> {
+    let meta = metadata?;
+    let byte_len = serde_json::to_vec(meta).map_or(0, |v| v.len());
+    if byte_len > 8192 {
+        tracing::warn!(
+            byte_len,
+            limit = 8192,
+            "Metadata byte length exceeds limit; rejecting record"
+        );
+        return Some(Problem::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Metadata too large",
+            format!("metadata byte length {byte_len} exceeds limit of 8192"),
+        ));
+    }
+    None
+}
+
+async fn authorize_request(
+    ctx: &SecurityContext,
+    emitter: &Arc<dyn UsageEmitterV1>,
+    req: &CreateUsageRecordRequest,
+) -> Result<usage_emitter::AuthorizedUsageEmitter, Problem> {
+    match (&req.subject_id, &req.subject_type) {
+        (None, None) => {
+            // No subject — skip PDP authorization.
+            tracing::debug!("No subject fields present; skipping PDP authorization");
+            emitter
+                .for_module(&req.module)
+                .authorize_for(
+                    ctx,
+                    req.tenant_id,
+                    req.resource_id,
+                    req.resource_type.clone(),
+                    None,
+                    None,
+                )
+                .await
+                .map_err(emitter_error_to_problem)
+        }
+        (Some(subject_id), _) => {
+            // subject_id present (subject_type optional) — authorize via PDP.
+            emitter
+                .for_module(&req.module)
+                .authorize_for(
+                    ctx,
+                    req.tenant_id,
+                    req.resource_id,
+                    req.resource_type.clone(),
+                    Some(*subject_id),
+                    req.subject_type.clone(),
+                )
+                .await
+                .map_err(emitter_error_to_problem)
+        }
+        _ => {
+            // subject_type present without subject_id — invalid.
+            Err(Problem::new(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "Invalid subject",
+                "subject_type requires subject_id to be present",
+            ))
+        }
+    }
+}
+
+/// Handler for `GET /usage-collector/v1/modules/{module_name}/config`.
+///
+/// # Errors
+/// Returns a [`Problem`] if the module is not found or the collector call fails.
+// @cpt-flow:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2
+pub async fn handle_get_module_config(
+    Path(module_name): Path<String>,
+    Extension(collector): Extension<Arc<dyn UsageCollectorClientV1>>,
+) -> Result<Json<ModuleConfigResponse>, Problem> {
+    // @cpt-begin:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-2
+    // Authenticated request received; ModKit pipeline enforces authentication before handler entry.
+    // @cpt-end:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-2
+
+    // @cpt-begin:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-3
+    let result = collector.get_module_config(&module_name).await;
+    // @cpt-end:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-3
+
+    // @cpt-begin:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-4
+    let config = match result {
+        // @cpt-begin:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-4a
+        Err(UsageCollectorError::ModuleNotFound {
+            module_name: ref name,
+        }) => {
+            return Err(Problem::new(
+                StatusCode::NOT_FOUND,
+                "Module not found",
+                format!("module '{name}' is not configured"),
+            ));
+        }
+        // @cpt-end:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-4a
+        Err(UsageCollectorError::PluginTimeout) => {
+            return Err(Problem::new(
+                StatusCode::GATEWAY_TIMEOUT,
+                "Gateway timeout",
+                UsageCollectorError::PluginTimeout.to_string(),
+            ));
+        }
+        Err(UsageCollectorError::CircuitOpen) => {
+            return Err(Problem::new(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Service unavailable",
+                UsageCollectorError::CircuitOpen.to_string(),
+            ));
+        }
+        Err(UsageCollectorError::Unavailable { ref message }) => {
+            return Err(Problem::new(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Service unavailable",
+                message.clone(),
+            ));
+        }
+        Err(e) => return Err(internal_error(e.to_string())),
+        Ok(c) => c,
+    };
+    // @cpt-end:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-4
+
+    // @cpt-begin:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-5
+    let response = ModuleConfigResponse {
+        allowed_metrics: config
+            .allowed_metrics
+            .into_iter()
+            .map(|m| AllowedMetricResponse {
+                name: m.name,
+                kind: m.kind,
+            })
+            .collect(),
+    };
+
+    Ok(Json(response))
+    // @cpt-end:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-5
+}
+
+fn emitter_error_to_problem(e: UsageEmitterError) -> Problem {
+    match e {
+        UsageEmitterError::AuthorizationFailed { message } => {
+            Problem::new(StatusCode::FORBIDDEN, "Forbidden", message)
+        }
+        UsageEmitterError::AuthorizationExpired => {
+            Problem::new(StatusCode::FORBIDDEN, "Forbidden", e.to_string())
+        }
+        UsageEmitterError::InvalidRecord { message } => Problem::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Invalid usage record",
+            message,
+        ),
+        UsageEmitterError::MetricNotAllowed { metric } => Problem::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Metric not allowed",
+            format!("metric not allowed for this module: {metric}"),
+        ),
+        UsageEmitterError::MetricKindMismatch {
+            metric,
+            expected,
+            actual,
+        } => Problem::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Metric kind mismatch",
+            format!("metric '{metric}' expects kind {expected:?} but record specifies {actual:?}"),
+        ),
+        UsageEmitterError::NegativeCounterValue { value } => Problem::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Invalid usage record",
+            format!("counter usage record has a negative value: {value}"),
+        ),
+        UsageEmitterError::MetadataTooLarge { len } => Problem::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Metadata too large",
+            format!("metadata byte length {len} exceeds the 8192-byte limit"),
+        ),
+        UsageEmitterError::ModuleNotConfigured { module_name } => Problem::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Module not configured",
+            format!("module '{module_name}' is not configured in the gateway"),
+        ),
+        UsageEmitterError::Internal { message } => internal_error(message),
+        UsageEmitterError::Outbox(err) => internal_error(err.to_string()),
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "handlers_tests.rs"]
+mod handlers_tests;

--- a/modules/system/usage-collector/usage-collector/src/api/rest/handlers_tests.rs
+++ b/modules/system/usage-collector/usage-collector/src/api/rest/handlers_tests.rs
@@ -1,0 +1,580 @@
+//! Unit tests for REST handlers and `emitter_error_to_problem`.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use authz_resolver_sdk::models::{
+    EvaluationRequest, EvaluationResponse, EvaluationResponseContext,
+};
+use authz_resolver_sdk::{AuthZResolverClient, AuthZResolverError};
+use axum::Extension;
+use axum::Json;
+use axum::extract::Path;
+use chrono::Utc;
+use http::StatusCode;
+use modkit_db::migration_runner::run_migrations_for_testing;
+use modkit_db::outbox::outbox_migrations;
+use modkit_db::{ConnectOpts, connect_db};
+use modkit_security::SecurityContext;
+use usage_collector_sdk::{
+    AllowedMetric, ModuleConfig, UsageCollectorClientV1, UsageCollectorError, UsageKind,
+    UsageRecord,
+};
+use usage_emitter::{UsageEmitter, UsageEmitterError, UsageEmitterV1};
+use uuid::Uuid;
+
+use super::emitter_error_to_problem;
+use super::handle_create_usage_record;
+use super::handle_get_module_config;
+use crate::api::rest::dto::CreateUsageRecordRequest;
+
+// ── emitter_error_to_problem ──────────────────────────────────────
+
+#[test]
+fn authorization_failed_maps_to_forbidden() {
+    let err = UsageEmitterError::authorization_failed("pdp denied");
+    let p = emitter_error_to_problem(err);
+    assert_eq!(p.status, StatusCode::FORBIDDEN);
+    assert_eq!(p.detail, "pdp denied");
+}
+
+#[test]
+fn authorization_expired_maps_to_forbidden() {
+    let err = UsageEmitterError::authorization_expired();
+    let p = emitter_error_to_problem(err);
+    assert_eq!(p.status, StatusCode::FORBIDDEN);
+}
+
+#[test]
+fn invalid_record_maps_to_unprocessable_entity() {
+    let err = UsageEmitterError::invalid_record("missing metric");
+    let p = emitter_error_to_problem(err);
+    assert_eq!(p.status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(p.detail, "missing metric");
+}
+
+#[test]
+fn metric_not_allowed_maps_to_unprocessable_entity() {
+    let err = UsageEmitterError::metric_not_allowed("cpu.usage");
+    let p = emitter_error_to_problem(err);
+    assert_eq!(p.status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert!(
+        p.detail.contains("cpu.usage"),
+        "detail should name the metric"
+    );
+}
+
+#[test]
+fn metric_kind_mismatch_maps_to_unprocessable_entity() {
+    let err =
+        UsageEmitterError::metric_kind_mismatch("req.count", UsageKind::Counter, UsageKind::Gauge);
+    let p = emitter_error_to_problem(err);
+    assert_eq!(p.status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert!(p.detail.contains("req.count"));
+}
+
+#[test]
+fn negative_counter_value_maps_to_unprocessable_entity() {
+    let err = UsageEmitterError::negative_counter_value(-1.5);
+    let p = emitter_error_to_problem(err);
+    assert_eq!(p.status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert!(p.detail.contains("-1.5"));
+}
+
+#[test]
+fn internal_error_maps_to_500() {
+    let err = UsageEmitterError::internal("something broke");
+    let p = emitter_error_to_problem(err);
+    assert_eq!(p.status, StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[test]
+fn outbox_error_maps_to_500() {
+    let err = UsageEmitterError::Outbox(modkit_db::outbox::OutboxError::QueueNotRegistered(
+        "usage".to_owned(),
+    ));
+    let p = emitter_error_to_problem(err);
+    assert_eq!(p.status, StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+// ── handle_get_module_config ──────────────────────────────────────
+
+struct MockCollector {
+    config: ModuleConfig,
+}
+
+#[async_trait]
+impl UsageCollectorClientV1 for MockCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<ModuleConfig, UsageCollectorError> {
+        Ok(self.config.clone())
+    }
+}
+
+struct FailingCollector;
+
+#[async_trait]
+impl UsageCollectorClientV1 for FailingCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Err(UsageCollectorError::internal("unavailable"))
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<ModuleConfig, UsageCollectorError> {
+        Err(UsageCollectorError::internal("unavailable"))
+    }
+}
+
+struct NotFoundCollector;
+
+#[async_trait]
+impl UsageCollectorClientV1 for NotFoundCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        module_name: &str,
+    ) -> Result<ModuleConfig, UsageCollectorError> {
+        Err(UsageCollectorError::module_not_found(module_name))
+    }
+}
+
+struct TimeoutCollector;
+
+#[async_trait]
+impl UsageCollectorClientV1 for TimeoutCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<ModuleConfig, UsageCollectorError> {
+        Err(UsageCollectorError::plugin_timeout())
+    }
+}
+
+struct CircuitOpenCollector;
+
+#[async_trait]
+impl UsageCollectorClientV1 for CircuitOpenCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<ModuleConfig, UsageCollectorError> {
+        Err(UsageCollectorError::circuit_open())
+    }
+}
+
+struct UnavailableCollector;
+
+#[async_trait]
+impl UsageCollectorClientV1 for UnavailableCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<ModuleConfig, UsageCollectorError> {
+        Err(UsageCollectorError::unavailable("transport error"))
+    }
+}
+
+#[tokio::test]
+async fn get_module_config_handler_returns_allowed_metrics() {
+    let collector = Arc::new(MockCollector {
+        config: ModuleConfig {
+            allowed_metrics: vec![AllowedMetric {
+                name: "cpu.usage".to_owned(),
+                kind: UsageKind::Gauge,
+            }],
+        },
+    }) as Arc<dyn UsageCollectorClientV1>;
+
+    let result = handle_get_module_config(Path("my-module".to_owned()), Extension(collector)).await;
+
+    let axum::Json(resp) = result.expect("handler should succeed");
+    assert_eq!(resp.allowed_metrics.len(), 1);
+    assert_eq!(resp.allowed_metrics[0].name, "cpu.usage");
+}
+
+#[tokio::test]
+async fn get_module_config_handler_propagates_collector_error_as_500() {
+    let collector = Arc::new(FailingCollector) as Arc<dyn UsageCollectorClientV1>;
+
+    let result = handle_get_module_config(Path("my-module".to_owned()), Extension(collector)).await;
+
+    let err = result.expect_err("handler should fail");
+    assert_eq!(err.status, StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn get_module_config_handler_returns_404_for_unknown_module() {
+    let collector = Arc::new(NotFoundCollector) as Arc<dyn UsageCollectorClientV1>;
+
+    let result =
+        handle_get_module_config(Path("unknown-module".to_owned()), Extension(collector)).await;
+
+    let err = result.expect_err("handler should return 404");
+    assert_eq!(err.status, StatusCode::NOT_FOUND);
+    assert!(err.detail.contains("unknown-module"));
+}
+
+#[tokio::test]
+async fn get_module_config_handler_returns_504_on_plugin_timeout() {
+    let collector = Arc::new(TimeoutCollector) as Arc<dyn UsageCollectorClientV1>;
+
+    let result =
+        handle_get_module_config(Path("any-module".to_owned()), Extension(collector)).await;
+
+    let err = result.expect_err("handler should fail with 504");
+    assert_eq!(err.status, StatusCode::GATEWAY_TIMEOUT);
+}
+
+#[tokio::test]
+async fn get_module_config_handler_returns_503_on_circuit_open() {
+    let collector = Arc::new(CircuitOpenCollector) as Arc<dyn UsageCollectorClientV1>;
+
+    let result =
+        handle_get_module_config(Path("any-module".to_owned()), Extension(collector)).await;
+
+    let err = result.expect_err("handler should fail with 503");
+    assert_eq!(err.status, StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn get_module_config_handler_returns_503_on_unavailable() {
+    let collector = Arc::new(UnavailableCollector) as Arc<dyn UsageCollectorClientV1>;
+
+    let result =
+        handle_get_module_config(Path("any-module".to_owned()), Extension(collector)).await;
+
+    let err = result.expect_err("handler should fail with 503");
+    assert_eq!(err.status, StatusCode::SERVICE_UNAVAILABLE);
+    assert!(err.detail.contains("transport error"));
+}
+
+#[test]
+fn module_not_configured_maps_to_unprocessable_entity() {
+    let err = UsageEmitterError::module_not_configured("my-module");
+    let p = emitter_error_to_problem(err);
+    assert_eq!(p.status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert!(p.detail.contains("my-module"));
+}
+
+// ── handle_create_usage_record ────────────────────────────────────────────────
+
+/// PDP mock that captures the `subject_id` and `subject_type` resource properties from the
+/// incoming evaluation request, then allows the request to proceed.
+struct CapturingSubjectAuthZ {
+    captured_subject_id: Arc<Mutex<Option<String>>>,
+    captured_subject_type: Arc<Mutex<Option<String>>>,
+}
+
+#[async_trait]
+impl AuthZResolverClient for CapturingSubjectAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let subj_id = request
+            .resource
+            .properties
+            .get("subject_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_owned);
+        let subj_type = request
+            .resource
+            .properties
+            .get("subject_type")
+            .and_then(|v| v.as_str())
+            .map(str::to_owned);
+        *self.captured_subject_id.lock().unwrap() = subj_id;
+        *self.captured_subject_type.lock().unwrap() = subj_type;
+        Ok(EvaluationResponse {
+            decision: true,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+/// Collector that returns a fixed `ModuleConfig` with one allowed metric.
+struct FixedConfigCollector;
+
+#[async_trait]
+impl UsageCollectorClientV1 for FixedConfigCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<ModuleConfig, UsageCollectorError> {
+        Ok(ModuleConfig {
+            allowed_metrics: vec![AllowedMetric {
+                name: "test.gauge".to_owned(),
+                kind: UsageKind::Gauge,
+            }],
+        })
+    }
+}
+
+async fn build_handler_emitter(authz: Arc<dyn AuthZResolverClient>) -> Arc<dyn UsageEmitterV1> {
+    let db_name = format!("hw_{}", Uuid::new_v4().simple());
+    let url = format!("sqlite:file:{db_name}?mode=memory&cache=shared");
+    let db = connect_db(
+        &url,
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    run_migrations_for_testing(&db, outbox_migrations())
+        .await
+        .unwrap();
+    let emitter = UsageEmitter::build(
+        usage_emitter::UsageEmitterConfig::default(),
+        db,
+        authz,
+        Arc::new(FixedConfigCollector),
+    )
+    .await
+    .unwrap();
+    Arc::new(emitter) as Arc<dyn UsageEmitterV1>
+}
+
+#[tokio::test]
+async fn ingest_handler_passes_subject_fields_to_authorize_for() {
+    let subject_id = Uuid::new_v4();
+    let subject_type = "test.service_account".to_owned();
+
+    let captured_id: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let captured_type: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let authz = Arc::new(CapturingSubjectAuthZ {
+        captured_subject_id: Arc::clone(&captured_id),
+        captured_subject_type: Arc::clone(&captured_type),
+    });
+
+    let emitter = build_handler_emitter(authz).await;
+
+    let ctx = SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(Uuid::new_v4())
+        .build()
+        .unwrap();
+
+    let req = CreateUsageRecordRequest {
+        module: "test-module".to_owned(),
+        tenant_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        resource_id: Uuid::new_v4(),
+        subject_id: Some(subject_id),
+        subject_type: Some(subject_type.clone()),
+        metric: "test.gauge".to_owned(),
+        idempotency_key: None,
+        value: 1.0,
+        timestamp: Utc::now(),
+        metadata: None,
+    };
+
+    let result = handle_create_usage_record(Extension(ctx), Extension(emitter), Json(req)).await;
+
+    assert!(result.is_ok(), "handler should succeed: {result:?}");
+
+    assert_eq!(
+        captured_id.lock().unwrap().as_deref(),
+        Some(subject_id.to_string().as_str()),
+        "subject_id must be forwarded to the PDP request"
+    );
+    assert_eq!(
+        captured_type.lock().unwrap().as_deref(),
+        Some(subject_type.as_str()),
+        "subject_type must be forwarded to the PDP request"
+    );
+}
+
+#[tokio::test]
+async fn ingest_handler_succeeds_when_subject_fields_absent() {
+    // Both subject fields absent: handler must skip PDP and return 204.
+    let captured_id: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let captured_type: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let authz = Arc::new(CapturingSubjectAuthZ {
+        captured_subject_id: Arc::clone(&captured_id),
+        captured_subject_type: Arc::clone(&captured_type),
+    });
+
+    let emitter = build_handler_emitter(authz).await;
+
+    let ctx = SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(Uuid::new_v4())
+        .build()
+        .unwrap();
+
+    let req = CreateUsageRecordRequest {
+        module: "test-module".to_owned(),
+        tenant_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        resource_id: Uuid::new_v4(),
+        subject_id: None,
+        subject_type: None,
+        metric: "test.gauge".to_owned(),
+        idempotency_key: None,
+        value: 1.0,
+        timestamp: Utc::now(),
+        metadata: None,
+    };
+
+    let result = handle_create_usage_record(Extension(ctx), Extension(emitter), Json(req)).await;
+
+    assert!(
+        result.is_ok(),
+        "handler should succeed when subject is absent: {result:?}"
+    );
+
+    // PDP was not called with subject properties: captured values remain None.
+    assert!(
+        captured_id.lock().unwrap().is_none(),
+        "subject_id must not be forwarded to PDP when absent"
+    );
+    assert!(
+        captured_type.lock().unwrap().is_none(),
+        "subject_type must not be forwarded to PDP when absent"
+    );
+}
+
+#[tokio::test]
+async fn ingest_handler_succeeds_when_subject_id_present_without_subject_type() {
+    // subject_id present, subject_type absent: valid — must route to PDP and return 204.
+    let subject_id = Uuid::new_v4();
+
+    let captured_id: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let captured_type: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let authz = Arc::new(CapturingSubjectAuthZ {
+        captured_subject_id: Arc::clone(&captured_id),
+        captured_subject_type: Arc::clone(&captured_type),
+    });
+
+    let emitter = build_handler_emitter(authz).await;
+
+    let ctx = SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(Uuid::new_v4())
+        .build()
+        .unwrap();
+
+    let req = CreateUsageRecordRequest {
+        module: "test-module".to_owned(),
+        tenant_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        resource_id: Uuid::new_v4(),
+        subject_id: Some(subject_id),
+        subject_type: None,
+        metric: "test.gauge".to_owned(),
+        idempotency_key: None,
+        value: 1.0,
+        timestamp: Utc::now(),
+        metadata: None,
+    };
+
+    let result = handle_create_usage_record(Extension(ctx), Extension(emitter), Json(req)).await;
+
+    assert!(
+        result.is_ok(),
+        "handler should succeed when subject_type is absent: {result:?}"
+    );
+    assert_eq!(
+        captured_id.lock().unwrap().as_deref(),
+        Some(subject_id.to_string().as_str()),
+        "subject_id must be forwarded to PDP when subject_type is absent"
+    );
+    assert!(
+        captured_type.lock().unwrap().is_none(),
+        "subject_type must not be forwarded to PDP when absent"
+    );
+}
+
+#[tokio::test]
+async fn ingest_handler_returns_error_when_only_subject_type_present() {
+    // Only subject_type present: partial presence must return 422.
+    let authz = Arc::new(CapturingSubjectAuthZ {
+        captured_subject_id: Arc::new(Mutex::new(None)),
+        captured_subject_type: Arc::new(Mutex::new(None)),
+    });
+
+    let emitter = build_handler_emitter(authz).await;
+
+    let ctx = SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(Uuid::new_v4())
+        .build()
+        .unwrap();
+
+    let req = CreateUsageRecordRequest {
+        module: "test-module".to_owned(),
+        tenant_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        resource_id: Uuid::new_v4(),
+        subject_id: None,
+        subject_type: Some("user".to_owned()),
+        metric: "test.gauge".to_owned(),
+        idempotency_key: None,
+        value: 1.0,
+        timestamp: Utc::now(),
+        metadata: None,
+    };
+
+    let result = handle_create_usage_record(Extension(ctx), Extension(emitter), Json(req)).await;
+
+    let err = result.expect_err("handler should return an error for partial subject");
+    assert_eq!(
+        err.status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "partial subject presence must return 422"
+    );
+}
+
+#[test]
+fn ingest_handler_subject_fields_absent_deserializes_to_none() {
+    // `subject_id` and `subject_type` now carry `#[serde(default)]`, so a JSON body
+    // that omits them must deserialize successfully with both fields as `None`.
+    let body_without_subject = serde_json::json!({
+        "module": "test-module",
+        "tenant_id": Uuid::new_v4(),
+        "resource_type": "test.resource",
+        "resource_id": Uuid::new_v4(),
+        "metric": "test.gauge",
+        "value": 1.0,
+        "timestamp": Utc::now()
+    });
+    let result: Result<CreateUsageRecordRequest, _> = serde_json::from_value(body_without_subject);
+    let req = result.expect("deserialization must succeed when subject fields are absent");
+    assert!(
+        req.subject_id.is_none(),
+        "subject_id must be None when absent from JSON"
+    );
+    assert!(
+        req.subject_type.is_none(),
+        "subject_type must be None when absent from JSON"
+    );
+}

--- a/modules/system/usage-collector/usage-collector/src/api/rest/mod.rs
+++ b/modules/system/usage-collector/usage-collector/src/api/rest/mod.rs
@@ -1,0 +1,5 @@
+//! REST API layer for the usage-collector module.
+
+pub mod dto;
+pub mod handlers;
+pub mod routes;

--- a/modules/system/usage-collector/usage-collector/src/api/rest/routes.rs
+++ b/modules/system/usage-collector/usage-collector/src/api/rest/routes.rs
@@ -1,0 +1,73 @@
+//! Route registration for the usage-collector REST API.
+
+use std::sync::Arc;
+
+use axum::{Extension, Router};
+
+use modkit::api::operation_builder::LicenseFeature;
+use modkit::api::{OpenApiRegistry, OperationBuilder};
+use usage_collector_sdk::UsageCollectorClientV1;
+use usage_emitter::UsageEmitterV1;
+
+use super::dto::{CreateUsageRecordRequest, ModuleConfigResponse};
+use super::handlers;
+
+const API_TAG: &str = "Usage Collector";
+
+struct License;
+
+impl AsRef<str> for License {
+    fn as_ref(&self) -> &'static str {
+        "gts.cf.core.lic.feat.v1~cf.core.global.base.v1"
+    }
+}
+
+impl LicenseFeature for License {}
+
+/// Register all REST routes for the usage-collector module.
+pub fn register_routes(
+    router: Router,
+    openapi: &dyn OpenApiRegistry,
+    emitter: Arc<dyn UsageEmitterV1>,
+    collector: Arc<dyn UsageCollectorClientV1>,
+) -> Router {
+    let router = OperationBuilder::post("/usage-collector/v1/records")
+        .operation_id("usage_collector.create_usage_record")
+        .summary("Create a usage record")
+        .description(
+            "Accepts a usage record payload and delegates storage to the configured storage plugin.",
+        )
+        .tag(API_TAG)
+        .authenticated()
+        .require_license_features::<License>([])
+        .json_request::<CreateUsageRecordRequest>(openapi, "Usage record to create")
+        .allow_content_types(&["application/json"])
+        .handler(handlers::handle_create_usage_record)
+        .json_response(http::StatusCode::NO_CONTENT, "Record accepted and stored")
+        .error_403(openapi)
+        .error_422(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    let router = OperationBuilder::get("/usage-collector/v1/modules/{module_name}/config")
+        .operation_id("usage_collector.get_module_config")
+        .summary("Get module configuration")
+        .description(
+            "Returns the allowed metrics (and future configuration) for the specified module.",
+        )
+        .tag(API_TAG)
+        .authenticated()
+        .require_license_features::<License>([])
+        .path_param("module_name", "Module name")
+        .handler(handlers::handle_get_module_config)
+        .json_response_with_schema::<ModuleConfigResponse>(
+            openapi,
+            http::StatusCode::OK,
+            "Module configuration",
+        )
+        .error_404(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    router.layer(Extension(emitter)).layer(Extension(collector))
+}

--- a/modules/system/usage-collector/usage-collector/src/config.rs
+++ b/modules/system/usage-collector/usage-collector/src/config.rs
@@ -1,0 +1,103 @@
+//! Configuration for the usage-collector gateway module.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use serde::Deserialize;
+use usage_collector_sdk::UsageKind;
+use usage_emitter::UsageEmitterConfig;
+
+/// Per-metric allowed configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricConfig {
+    /// Gauge vs counter semantics.
+    pub kind: UsageKind,
+    /// Modules allowed to emit this metric. If absent, all modules are allowed.
+    pub modules: Option<Vec<String>>,
+}
+
+/// Module configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct UsageCollectorConfig {
+    /// Vendor selector used to pick a storage plugin instance from types-registry.
+    pub vendor: String,
+
+    /// Timeout for each storage plugin `create_usage_record()` call.
+    /// Valid range: 100ms–30s. Default: 5s.
+    #[serde(with = "modkit_utils::humantime_serde")]
+    pub plugin_timeout: Duration,
+
+    /// Number of failures within `circuit_breaker_window` that will open the circuit.
+    /// Valid range: 1–100. Default: 5.
+    pub circuit_breaker_failure_threshold: u32,
+
+    /// Rolling window for counting failures.
+    /// Default: 10s.
+    #[serde(with = "modkit_utils::humantime_serde")]
+    pub circuit_breaker_window: Duration,
+
+    /// Duration to wait in the open state before allowing a half-open probe.
+    /// Valid range: 1s–5m. Default: 30s.
+    #[serde(with = "modkit_utils::humantime_serde")]
+    pub circuit_breaker_recovery_timeout: Duration,
+
+    /// Outbox/authorization tuning for the embedded usage emitter.
+    pub emitter: UsageEmitterConfig,
+
+    /// Allowed metrics configuration. Key is the metric name.
+    pub metrics: HashMap<String, MetricConfig>,
+}
+
+impl UsageCollectorConfig {
+    /// Validate operational bounds for the gateway configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when any timeout or circuit-breaker setting falls outside
+    /// the supported range.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.plugin_timeout < std::time::Duration::from_millis(100) {
+            anyhow::bail!("plugin_timeout must be at least 100ms");
+        }
+        if self.plugin_timeout > std::time::Duration::from_secs(30) {
+            anyhow::bail!("plugin_timeout must not exceed 30s");
+        }
+        if self.circuit_breaker_failure_threshold < 1 {
+            anyhow::bail!("circuit_breaker_failure_threshold must be at least 1");
+        }
+        if self.circuit_breaker_failure_threshold > 100 {
+            anyhow::bail!("circuit_breaker_failure_threshold must not exceed 100");
+        }
+        if self.circuit_breaker_window < std::time::Duration::from_millis(100) {
+            anyhow::bail!("circuit_breaker_window must be at least 100ms");
+        }
+        if self.circuit_breaker_recovery_timeout < std::time::Duration::from_secs(1) {
+            anyhow::bail!("circuit_breaker_recovery_timeout must be at least 1s");
+        }
+        if self.circuit_breaker_recovery_timeout > std::time::Duration::from_mins(5) {
+            anyhow::bail!("circuit_breaker_recovery_timeout must not exceed 5min");
+        }
+        Ok(())
+    }
+}
+
+impl Default for UsageCollectorConfig {
+    fn default() -> Self {
+        Self {
+            vendor: "hyperspot".to_owned(),
+            plugin_timeout: Duration::from_secs(5),
+            circuit_breaker_failure_threshold: 5,
+            circuit_breaker_window: Duration::from_secs(10),
+            circuit_breaker_recovery_timeout: Duration::from_secs(30),
+            emitter: UsageEmitterConfig::default(),
+            metrics: HashMap::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "config_tests.rs"]
+mod config_tests;

--- a/modules/system/usage-collector/usage-collector/src/config_tests.rs
+++ b/modules/system/usage-collector/usage-collector/src/config_tests.rs
@@ -1,0 +1,174 @@
+use std::time::Duration;
+
+use usage_collector_sdk::UsageKind;
+
+use super::UsageCollectorConfig;
+
+#[test]
+fn test_validate_rejects_plugin_timeout_zero() {
+    let cfg = UsageCollectorConfig {
+        plugin_timeout: Duration::ZERO,
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("plugin_timeout"),
+        "error must mention plugin_timeout, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_plugin_timeout_above_30s() {
+    let cfg = UsageCollectorConfig {
+        plugin_timeout: Duration::from_secs(31),
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("plugin_timeout"),
+        "error must mention plugin_timeout, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_circuit_breaker_failure_threshold_zero() {
+    let cfg = UsageCollectorConfig {
+        circuit_breaker_failure_threshold: 0,
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("circuit_breaker_failure_threshold"),
+        "error must mention circuit_breaker_failure_threshold, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_circuit_breaker_failure_threshold_above_100() {
+    let cfg = UsageCollectorConfig {
+        circuit_breaker_failure_threshold: 101,
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("circuit_breaker_failure_threshold"),
+        "error must mention circuit_breaker_failure_threshold, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_plugin_timeout_below_100ms() {
+    let cfg = UsageCollectorConfig {
+        plugin_timeout: Duration::from_millis(50),
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("plugin_timeout"),
+        "error must mention plugin_timeout, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_circuit_breaker_window_below_100ms() {
+    let cfg = UsageCollectorConfig {
+        circuit_breaker_window: Duration::ZERO,
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("circuit_breaker_window"),
+        "error must mention circuit_breaker_window, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_circuit_breaker_recovery_timeout_zero() {
+    let cfg = UsageCollectorConfig {
+        circuit_breaker_recovery_timeout: Duration::ZERO,
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("circuit_breaker_recovery_timeout"),
+        "error must mention circuit_breaker_recovery_timeout, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_circuit_breaker_recovery_timeout_above_5min() {
+    let cfg = UsageCollectorConfig {
+        circuit_breaker_recovery_timeout: Duration::from_secs(301),
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("circuit_breaker_recovery_timeout"),
+        "error must mention circuit_breaker_recovery_timeout, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_accepts_defaults() {
+    let cfg = UsageCollectorConfig::default();
+    assert!(cfg.validate().is_ok());
+}
+
+#[test]
+fn vendor_can_be_overridden_via_serde() {
+    let json = r#"{"vendor": "acme"}"#;
+    let cfg: UsageCollectorConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(cfg.vendor, "acme");
+}
+
+#[test]
+fn serde_default_applies_default_vendor() {
+    let cfg: UsageCollectorConfig = serde_json::from_str("{}").unwrap();
+    assert_eq!(
+        cfg.vendor, "hyperspot",
+        "serde(default) must use Default impl"
+    );
+}
+
+#[test]
+fn plugin_timeout_can_be_overridden_via_serde() {
+    let json = r#"{"plugin_timeout": "10s"}"#;
+    let cfg: UsageCollectorConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(cfg.plugin_timeout, Duration::from_secs(10));
+}
+
+#[test]
+fn serde_default_applies_default_plugin_timeout() {
+    let cfg: UsageCollectorConfig = serde_json::from_str("{}").unwrap();
+    assert_eq!(
+        cfg.plugin_timeout,
+        Duration::from_secs(5),
+        "serde(default) must use Default impl"
+    );
+}
+
+#[test]
+fn rejects_unknown_fields() {
+    let json = r#"{"vendor": "x", "unexpected": true}"#;
+    assert!(serde_json::from_str::<UsageCollectorConfig>(json).is_err());
+}
+
+#[test]
+fn metrics_config_parses_with_modules() {
+    let json = r#"{"metrics": {"cpu.usage": {"kind": "gauge", "modules": ["mod-a"]}}}"#;
+    let cfg: UsageCollectorConfig = serde_json::from_str(json).unwrap();
+    let m = &cfg.metrics["cpu.usage"];
+    assert!(matches!(m.kind, UsageKind::Gauge));
+    assert_eq!(m.modules.as_deref(), Some(["mod-a".to_owned()].as_slice()));
+}
+
+#[test]
+fn metrics_config_parses_without_modules() {
+    let json = r#"{"metrics": {"req.count": {"kind": "counter"}}}"#;
+    let cfg: UsageCollectorConfig = serde_json::from_str(json).unwrap();
+    let m = &cfg.metrics["req.count"];
+    assert!(matches!(m.kind, UsageKind::Counter));
+    assert!(m.modules.is_none());
+}

--- a/modules/system/usage-collector/usage-collector/src/domain/local_client.rs
+++ b/modules/system/usage-collector/usage-collector/src/domain/local_client.rs
@@ -1,0 +1,356 @@
+//! Local client registered in `ClientHub` as `dyn UsageCollectorClientV1`.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use modkit::client_hub::{ClientHub, ClientScope};
+use modkit::plugins::{GtsPluginSelector, choose_plugin_instance};
+use modkit::telemetry::ThrottledLog;
+use modkit_macros::domain_model;
+use tokio::sync::Mutex;
+use tokio::time::timeout;
+use tracing::{debug, info, warn};
+use types_registry_sdk::{InstanceQuery, TypesRegistryClient};
+use usage_collector_sdk::AllowedMetric;
+use usage_collector_sdk::ModuleConfig;
+use usage_collector_sdk::{
+    UsageCollectorClientV1, UsageCollectorError, UsageCollectorPluginClientV1,
+    UsageCollectorStoragePluginSpecV1, UsageRecord,
+};
+
+use crate::config::UsageCollectorConfig;
+
+const UNAVAILABLE_LOG_THROTTLE: Duration = Duration::from_secs(10);
+
+/// Circuit breaker state.
+#[domain_model]
+#[derive(Debug)]
+enum CircuitState {
+    /// Normal operation; plugin calls are forwarded.
+    Closed,
+    /// Circuit is open; plugin calls are rejected without attempting the plugin.
+    Open {
+        /// When the circuit was opened (used to compute half-open probe eligibility).
+        opened_at: Instant,
+    },
+    /// A single probe call is in-flight; treat any failure as re-open.
+    HalfOpen,
+}
+
+/// Minimal sliding-window circuit breaker.
+///
+/// Opens after `failure_threshold` failures within the rolling `window`.
+/// Transitions to half-open after `recovery_timeout`.
+#[domain_model]
+#[derive(Debug)]
+struct CircuitBreaker {
+    /// Failure threshold before the circuit opens.
+    failure_threshold: u32,
+    /// Rolling window for failure counting.
+    window: Duration,
+    /// How long to wait in the open state before probing.
+    recovery_timeout: Duration,
+    /// Current circuit state.
+    state: CircuitState,
+    /// Timestamps of recent failures within the current window.
+    failure_timestamps: Vec<Instant>,
+}
+
+impl CircuitBreaker {
+    fn new(failure_threshold: u32, window: Duration, recovery_timeout: Duration) -> Self {
+        Self {
+            failure_threshold,
+            window,
+            recovery_timeout,
+            state: CircuitState::Closed,
+            failure_timestamps: Vec::new(),
+        }
+    }
+
+    /// Returns `true` if the circuit is currently open (caller should return `CircuitOpen`).
+    fn is_open(&mut self) -> bool {
+        match &self.state {
+            CircuitState::Open { opened_at } => {
+                if opened_at.elapsed() >= self.recovery_timeout {
+                    // Transition to half-open to allow a probe.
+                    info!("Circuit breaker transitioning from Open to HalfOpen for probe");
+                    self.state = CircuitState::HalfOpen;
+                    false
+                } else {
+                    true
+                }
+            }
+            CircuitState::Closed => false,
+            // Probe is already in-flight; reject all other callers until the probe completes.
+            CircuitState::HalfOpen => true,
+        }
+    }
+
+    /// Record a failure. Opens the circuit if threshold exceeded within the window.
+    fn record_failure(&mut self) {
+        let now = Instant::now();
+
+        // Prune failures outside the rolling window.
+        self.failure_timestamps
+            .retain(|t| now.duration_since(*t) < self.window);
+
+        self.failure_timestamps.push(now);
+
+        // Failure count is at most u32::MAX; the window prunes old entries so this
+        // count is bounded by `failure_threshold` which is u32.
+        #[allow(clippy::cast_possible_truncation)]
+        let failures_in_window = self.failure_timestamps.len() as u32;
+
+        if failures_in_window >= self.failure_threshold {
+            match self.state {
+                CircuitState::Closed | CircuitState::HalfOpen => {
+                    warn!(
+                        failures_in_window,
+                        threshold = self.failure_threshold,
+                        "Circuit breaker opening after too many failures within the rolling window"
+                    );
+                    self.state = CircuitState::Open { opened_at: now };
+                    self.failure_timestamps.clear();
+                }
+                CircuitState::Open { .. } => {
+                    // Already open; do not reset opened_at — resetting the recovery clock under
+                    // continued failures would prevent the circuit from ever transitioning to HalfOpen.
+                }
+            }
+        }
+    }
+
+    fn is_half_open(&self) -> bool {
+        matches!(self.state, CircuitState::HalfOpen)
+    }
+
+    /// Record a successful call — reset failure window and close circuit.
+    fn record_success(&mut self) {
+        match self.state {
+            CircuitState::HalfOpen => {
+                info!(
+                    "Circuit breaker transitioning from HalfOpen to Closed after successful probe"
+                );
+                self.state = CircuitState::Closed;
+                self.failure_timestamps.clear();
+            }
+            CircuitState::Closed => {
+                self.failure_timestamps.clear();
+            }
+            CircuitState::Open { .. } => {
+                // Should not happen (success while open), but reset to closed.
+                warn!("Circuit breaker received success while Open; resetting to Closed");
+                self.state = CircuitState::Closed;
+                self.failure_timestamps.clear();
+            }
+        }
+    }
+}
+
+/// Local `ClientHub` implementation of [`UsageCollectorClientV1`].
+///
+/// Resolves the configured GTS storage plugin on first use and delegates
+/// record creation to it, while also serving per-module metric config from
+/// the static configuration.
+#[domain_model]
+pub struct UsageCollectorLocalClient {
+    hub: Arc<ClientHub>,
+    selector: GtsPluginSelector,
+    config: UsageCollectorConfig,
+    unavailable_log_throttle: ThrottledLog,
+    circuit_breaker: Mutex<CircuitBreaker>,
+}
+
+impl UsageCollectorLocalClient {
+    #[must_use]
+    pub fn new(config: UsageCollectorConfig, hub: Arc<ClientHub>) -> Self {
+        let cb = CircuitBreaker::new(
+            config.circuit_breaker_failure_threshold,
+            config.circuit_breaker_window,
+            config.circuit_breaker_recovery_timeout,
+        );
+        Self {
+            hub,
+            selector: GtsPluginSelector::new(),
+            config,
+            unavailable_log_throttle: ThrottledLog::new(UNAVAILABLE_LOG_THROTTLE),
+            circuit_breaker: Mutex::new(cb),
+        }
+    }
+
+    async fn get_plugin(
+        &self,
+    ) -> Result<Arc<dyn UsageCollectorPluginClientV1>, UsageCollectorError> {
+        let instance_id = self.selector.get_or_init(|| self.resolve_plugin()).await?;
+        let scope = ClientScope::gts_id(instance_id.as_ref());
+
+        if let Some(client) = self
+            .hub
+            .try_get_scoped::<dyn UsageCollectorPluginClientV1>(&scope)
+        {
+            Ok(client)
+        } else {
+            if self.unavailable_log_throttle.should_log() {
+                warn!(
+                    plugin_gts_id = %instance_id,
+                    self.config.vendor,
+                    "Plugin client not registered yet"
+                );
+            }
+            Err(UsageCollectorError::unavailable(format!(
+                "plugin client not registered for {instance_id}"
+            )))
+        }
+    }
+
+    #[tracing::instrument(skip_all, fields(vendor = %self.config.vendor))]
+    async fn resolve_plugin(&self) -> Result<String, UsageCollectorError> {
+        info!("Resolving usage-collector storage plugin");
+
+        let registry = self
+            .hub
+            .get::<dyn TypesRegistryClient>()
+            .map_err(|e| UsageCollectorError::internal(e.to_string()))?;
+
+        let plugin_type_id = UsageCollectorStoragePluginSpecV1::gts_schema_id().clone();
+
+        let instances = registry
+            .list_instances(InstanceQuery::new().with_pattern(format!("{plugin_type_id}*")))
+            .await
+            .map_err(|e| UsageCollectorError::internal(e.to_string()))?;
+
+        let gts_id = choose_plugin_instance::<UsageCollectorStoragePluginSpecV1>(
+            &self.config.vendor,
+            instances.iter().map(|e| (e.id.as_ref(), &e.object)),
+        )
+        .map_err(|e| UsageCollectorError::internal(e.to_string()))?;
+
+        info!(plugin_gts_id = %gts_id, "Selected usage-collector storage plugin instance");
+        Ok(gts_id)
+    }
+}
+
+// @cpt-algo:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:p1
+// @cpt-dod:cpt-cf-usage-collector-dod-sdk-and-ingest-core-gateway-crate:p1
+#[async_trait]
+impl UsageCollectorClientV1 for UsageCollectorLocalClient {
+    /// # Errors
+    ///
+    /// Returns `UsageCollectorError::CircuitOpen` if the circuit breaker is open.
+    /// Returns `UsageCollectorError::Internal` if no storage plugin is available or
+    /// if the plugin call fails. Returns `UsageCollectorError::PluginTimeout` if the
+    /// plugin does not respond within the configured deadline.
+    async fn create_usage_record(&self, record: UsageRecord) -> Result<(), UsageCollectorError> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-2
+        let (circuit_open, is_probe) = {
+            let mut cb = self.circuit_breaker.lock().await;
+            let open = cb.is_open();
+            let probe = cb.is_half_open();
+            (open, probe)
+        };
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-2
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-3
+        if circuit_open {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-3a
+            warn!("Circuit breaker is open; rejecting usage record without calling plugin");
+            return Err(UsageCollectorError::circuit_open());
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-3a
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-3
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-4
+        let plugin = match self.get_plugin().await {
+            Ok(p) => p,
+            Err(e) => {
+                if is_probe {
+                    self.circuit_breaker.lock().await.record_failure();
+                }
+                return Err(e);
+            }
+        };
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-4
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-5
+        let call = timeout(
+            self.config.plugin_timeout,
+            plugin.create_usage_record(record),
+        );
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-5
+
+        match call.await {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-6
+            Err(_elapsed) => {
+                // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-6a
+                self.circuit_breaker.lock().await.record_failure();
+                // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-6a
+                // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-6b
+                Err(UsageCollectorError::plugin_timeout())
+                // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-6b
+            }
+            Ok(Err(e)) => {
+                if matches!(e, UsageCollectorError::Unavailable { .. }) {
+                    warn!(error = %e, "transient storage plugin failure; recording circuit breaker failure");
+                    self.circuit_breaker.lock().await.record_failure();
+                } else if is_probe {
+                    self.circuit_breaker.lock().await.record_failure();
+                }
+                Err(e)
+            }
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-6
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-7
+            Ok(Ok(())) => {
+                debug!("usage record created successfully");
+                self.circuit_breaker.lock().await.record_success();
+                Ok(())
+            } // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-7
+        }
+    }
+
+    // @cpt-flow:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2
+    // @cpt-algo:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2
+    async fn get_module_config(
+        &self,
+        module_name: &str,
+    ) -> Result<ModuleConfig, UsageCollectorError> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-1
+        // Authentication is enforced by the ModKit pipeline (`.authenticated()` in routes.rs);
+        // unauthenticated requests are rejected before this function is reached.
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-1
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-2
+        let allowed_metrics: Vec<AllowedMetric> = self
+            .config
+            .metrics
+            .iter()
+            .filter(|(_, cfg)| {
+                cfg.modules
+                    .as_ref()
+                    .is_none_or(|mods| mods.iter().any(|m| m == module_name))
+            })
+            .map(|(name, cfg)| AllowedMetric {
+                name: name.clone(),
+                kind: cfg.kind,
+            })
+            .collect();
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-2
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-3
+        if allowed_metrics.is_empty() {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-3a
+            return Err(UsageCollectorError::module_not_found(module_name));
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-3a
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-3
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-4
+        Ok(ModuleConfig { allowed_metrics })
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-4
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "local_client_tests.rs"]
+mod local_client_tests;

--- a/modules/system/usage-collector/usage-collector/src/domain/local_client_tests.rs
+++ b/modules/system/usage-collector/usage-collector/src/domain/local_client_tests.rs
@@ -1,0 +1,788 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use chrono::Utc;
+use modkit::client_hub::{ClientHub, ClientScope};
+use types_registry_sdk::testing::make_test_instance;
+use types_registry_sdk::{
+    GtsInstance, GtsTypeSchema, InstanceQuery, RegisterResult, TypeSchemaQuery,
+    TypesRegistryClient, TypesRegistryError,
+};
+use usage_collector_sdk::UsageCollectorClientV1;
+use usage_collector_sdk::UsageKind;
+use usage_collector_sdk::UsageRecord;
+use usage_collector_sdk::{
+    UsageCollectorError, UsageCollectorPluginClientV1, UsageCollectorStoragePluginSpecV1,
+};
+use uuid::Uuid;
+
+use super::UsageCollectorLocalClient;
+use crate::config::{MetricConfig, UsageCollectorConfig};
+
+// ── MockRegistry ──────────────────────────────────────────────────
+
+struct MockRegistry {
+    instances: Vec<GtsInstance>,
+    list_calls: std::sync::atomic::AtomicUsize,
+}
+
+impl MockRegistry {
+    fn new(instances: Vec<GtsInstance>) -> Self {
+        Self {
+            instances,
+            list_calls: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TypesRegistryClient for MockRegistry {
+    async fn register(
+        &self,
+        _entities: Vec<serde_json::Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
+        Ok(vec![])
+    }
+
+    async fn register_type_schemas(
+        &self,
+        _type_schemas: Vec<serde_json::Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
+        Ok(vec![])
+    }
+
+    async fn get_type_schema(&self, _type_id: &str) -> Result<GtsTypeSchema, TypesRegistryError> {
+        unimplemented!()
+    }
+
+    async fn get_type_schema_by_uuid(
+        &self,
+        _type_uuid: Uuid,
+    ) -> Result<GtsTypeSchema, TypesRegistryError> {
+        unimplemented!()
+    }
+
+    async fn get_type_schemas(
+        &self,
+        _type_ids: Vec<String>,
+    ) -> HashMap<String, Result<GtsTypeSchema, TypesRegistryError>> {
+        unimplemented!()
+    }
+
+    async fn get_type_schemas_by_uuid(
+        &self,
+        _type_uuids: Vec<Uuid>,
+    ) -> HashMap<Uuid, Result<GtsTypeSchema, TypesRegistryError>> {
+        unimplemented!()
+    }
+
+    async fn list_type_schemas(
+        &self,
+        _query: TypeSchemaQuery,
+    ) -> Result<Vec<GtsTypeSchema>, TypesRegistryError> {
+        unimplemented!()
+    }
+
+    async fn register_instances(
+        &self,
+        _instances: Vec<serde_json::Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
+        Ok(vec![])
+    }
+
+    async fn get_instance(&self, _id: &str) -> Result<GtsInstance, TypesRegistryError> {
+        unimplemented!()
+    }
+
+    async fn get_instance_by_uuid(&self, _uuid: Uuid) -> Result<GtsInstance, TypesRegistryError> {
+        unimplemented!()
+    }
+
+    async fn get_instances(
+        &self,
+        _ids: Vec<String>,
+    ) -> HashMap<String, Result<GtsInstance, TypesRegistryError>> {
+        unimplemented!()
+    }
+
+    async fn get_instances_by_uuid(
+        &self,
+        _uuids: Vec<Uuid>,
+    ) -> HashMap<Uuid, Result<GtsInstance, TypesRegistryError>> {
+        unimplemented!()
+    }
+
+    async fn list_instances(
+        &self,
+        _query: InstanceQuery,
+    ) -> Result<Vec<GtsInstance>, TypesRegistryError> {
+        self.list_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(self.instances.clone())
+    }
+}
+
+struct OkPlugin;
+
+#[async_trait::async_trait]
+impl UsageCollectorPluginClientV1 for OkPlugin {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+}
+
+fn plugin_content(gts_id: &str, vendor: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": gts_id,
+        "vendor": vendor,
+        "priority": 0,
+        "properties": {}
+    })
+}
+
+fn hub_with_plugin(
+    instance_id: &str,
+    vendor: &str,
+    plugin: Arc<dyn UsageCollectorPluginClientV1>,
+) -> Arc<ClientHub> {
+    let hub = Arc::new(ClientHub::default());
+    let instance = make_test_instance(instance_id, plugin_content(instance_id, vendor));
+    let reg: Arc<dyn TypesRegistryClient> = Arc::new(MockRegistry::new(vec![instance]));
+    hub.register::<dyn TypesRegistryClient>(reg);
+    hub.register_scoped::<dyn UsageCollectorPluginClientV1>(
+        ClientScope::gts_id(instance_id),
+        plugin,
+    );
+    hub
+}
+
+fn make_client() -> UsageCollectorLocalClient {
+    let instance_id = format!(
+        "{}test.usage.mock.lc_test.v1",
+        UsageCollectorStoragePluginSpecV1::gts_schema_id()
+    );
+    let hub = Arc::new(ClientHub::default());
+    let instance = make_test_instance(&instance_id, plugin_content(&instance_id, "hyperspot"));
+    let reg: Arc<dyn TypesRegistryClient> = Arc::new(MockRegistry::new(vec![instance]));
+    hub.register::<dyn TypesRegistryClient>(reg);
+    hub.register_scoped::<dyn UsageCollectorPluginClientV1>(
+        ClientScope::gts_id(&instance_id),
+        Arc::new(OkPlugin),
+    );
+    UsageCollectorLocalClient::new(UsageCollectorConfig::default(), hub)
+}
+
+fn make_client_with_vendor(hub: Arc<ClientHub>, vendor: &str) -> UsageCollectorLocalClient {
+    UsageCollectorLocalClient::new(
+        UsageCollectorConfig {
+            vendor: vendor.to_owned(),
+            ..UsageCollectorConfig::default()
+        },
+        hub,
+    )
+}
+
+fn record(tenant_id: Uuid) -> UsageRecord {
+    UsageRecord {
+        tenant_id,
+        module: "test-module".to_owned(),
+        metric: "test.metric".to_owned(),
+        kind: UsageKind::Gauge,
+        value: 1.0,
+        resource_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        subject_id: Some(Uuid::nil()),
+        subject_type: Some("test.subject".to_owned()),
+        idempotency_key: Uuid::new_v4().to_string(),
+        timestamp: Utc::now(),
+        metadata: None,
+    }
+}
+
+// PDP validation is enforced at the REST handler layer before the domain client is called.
+// The domain client forwards UsageRecord to the storage plugin without inspecting subject fields.
+fn record_no_subject(tenant_id: Uuid) -> UsageRecord {
+    UsageRecord {
+        tenant_id,
+        module: "test-module".to_owned(),
+        metric: "test.metric".to_owned(),
+        kind: UsageKind::Gauge,
+        value: 1.0,
+        resource_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        subject_id: None,
+        subject_type: None,
+        idempotency_key: Uuid::new_v4().to_string(),
+        timestamp: Utc::now(),
+        metadata: None,
+    }
+}
+
+#[tokio::test]
+async fn create_usage_record_delegates_success_to_plugin() {
+    let client = make_client();
+    let tenant = Uuid::new_v4();
+    let rec = record(tenant);
+    assert!(client.create_usage_record(rec).await.is_ok());
+}
+
+// PDP is enforced at the REST handler layer; the domain client accepts records with or without
+// subject fields and forwards them to the storage plugin unconditionally.
+#[tokio::test]
+async fn create_usage_record_with_no_subject_succeeds() {
+    let client = make_client();
+    let tenant = Uuid::new_v4();
+    let rec = record_no_subject(tenant);
+    assert!(client.create_usage_record(rec).await.is_ok());
+}
+
+#[tokio::test]
+async fn create_usage_record_with_subject_succeeds() {
+    let client = make_client();
+    let tenant = Uuid::new_v4();
+    let rec = record(tenant);
+    assert!(client.create_usage_record(rec).await.is_ok());
+}
+
+// ── plugin timeout ────────────────────────────────────────────────
+
+struct SlowPlugin;
+
+#[async_trait::async_trait]
+impl UsageCollectorPluginClientV1 for SlowPlugin {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        tokio::time::sleep(Duration::from_mins(1)).await;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn plugin_timeout_returns_plugin_timeout_error() {
+    let instance_id = format!(
+        "{}test.usage.mock.lc_test.v1",
+        UsageCollectorStoragePluginSpecV1::gts_schema_id()
+    );
+    let hub = hub_with_plugin(&instance_id, "hyperspot", Arc::new(SlowPlugin));
+    let client = UsageCollectorLocalClient::new(
+        UsageCollectorConfig {
+            vendor: "hyperspot".to_owned(),
+            plugin_timeout: Duration::from_millis(1),
+            ..UsageCollectorConfig::default()
+        },
+        hub,
+    );
+    let tenant = Uuid::new_v4();
+    let rec = record(tenant);
+    let err = client.create_usage_record(rec).await.unwrap_err();
+    assert!(matches!(err, UsageCollectorError::PluginTimeout));
+}
+
+// ── GTS plugin resolution caching ─────────────────────────────────
+
+#[tokio::test]
+async fn gts_plugin_selector_calls_registry_only_once_across_multiple_create_usage_records() {
+    let instance_id = format!(
+        "{}test.usage.mock.lc_test.v1",
+        UsageCollectorStoragePluginSpecV1::gts_schema_id()
+    );
+    let reg = Arc::new(MockRegistry::new(vec![make_test_instance(
+        &instance_id,
+        plugin_content(&instance_id, "hyperspot"),
+    )]));
+    let hub = Arc::new(ClientHub::default());
+    hub.register::<dyn TypesRegistryClient>(Arc::clone(&reg) as Arc<dyn TypesRegistryClient>);
+    hub.register_scoped::<dyn UsageCollectorPluginClientV1>(
+        ClientScope::gts_id(&instance_id),
+        Arc::new(OkPlugin),
+    );
+    let client = make_client_with_vendor(hub, "hyperspot");
+    let tenant = Uuid::new_v4();
+
+    let rec1 = record(tenant);
+    client.create_usage_record(rec1).await.unwrap();
+    let rec2 = record(tenant);
+    client.create_usage_record(rec2).await.unwrap();
+    let rec3 = record(tenant);
+    client.create_usage_record(rec3).await.unwrap();
+
+    assert_eq!(
+        reg.list_calls.load(Ordering::SeqCst),
+        1,
+        "GTS registry should be queried exactly once after initial resolution"
+    );
+}
+
+// ── no plugin registered in hub ───────────────────────────────────
+
+#[tokio::test]
+async fn no_plugin_client_in_hub_returns_unavailable_error() {
+    let instance_id = format!(
+        "{}test.usage.mock.lc_test.v1",
+        UsageCollectorStoragePluginSpecV1::gts_schema_id()
+    );
+    // Register the entity in types-registry but deliberately omit the plugin client.
+    let hub = Arc::new(ClientHub::default());
+    let instance = make_test_instance(&instance_id, plugin_content(&instance_id, "hyperspot"));
+    let reg: Arc<dyn TypesRegistryClient> = Arc::new(MockRegistry::new(vec![instance]));
+    hub.register::<dyn TypesRegistryClient>(reg);
+    // plugin client NOT registered
+    let client = make_client_with_vendor(hub, "hyperspot");
+    let tenant = Uuid::new_v4();
+    let rec = record(tenant);
+    let err = client.create_usage_record(rec).await.unwrap_err();
+    assert!(matches!(err, UsageCollectorError::Unavailable { .. }));
+}
+
+// ── get_module_config ─────────────────────────────────────────────
+
+fn config_with_metrics(metrics: HashMap<String, MetricConfig>) -> UsageCollectorConfig {
+    UsageCollectorConfig {
+        metrics,
+        ..UsageCollectorConfig::default()
+    }
+}
+
+#[tokio::test]
+async fn get_module_config_returns_not_found_when_no_metrics_configured() {
+    let client = UsageCollectorLocalClient::new(
+        UsageCollectorConfig::default(),
+        Arc::new(ClientHub::default()),
+    );
+    let err = client.get_module_config("any-module").await.unwrap_err();
+    assert!(matches!(err, UsageCollectorError::ModuleNotFound { .. }));
+}
+
+#[tokio::test]
+async fn get_module_config_returns_metric_when_modules_restriction_is_absent() {
+    let mut metrics = HashMap::new();
+    metrics.insert(
+        "cpu.usage".to_owned(),
+        MetricConfig {
+            kind: UsageKind::Gauge,
+            modules: None,
+        },
+    );
+    let client = UsageCollectorLocalClient::new(
+        config_with_metrics(metrics),
+        Arc::new(ClientHub::default()),
+    );
+    let cfg = client.get_module_config("any-module").await.unwrap();
+    assert_eq!(cfg.allowed_metrics.len(), 1);
+    assert_eq!(cfg.allowed_metrics[0].name, "cpu.usage");
+    assert!(matches!(cfg.allowed_metrics[0].kind, UsageKind::Gauge));
+}
+
+#[tokio::test]
+async fn get_module_config_returns_metric_when_module_is_in_allow_list() {
+    let mut metrics = HashMap::new();
+    metrics.insert(
+        "req.count".to_owned(),
+        MetricConfig {
+            kind: UsageKind::Counter,
+            modules: Some(vec!["my-module".to_owned()]),
+        },
+    );
+    let client = UsageCollectorLocalClient::new(
+        config_with_metrics(metrics),
+        Arc::new(ClientHub::default()),
+    );
+    let cfg = client.get_module_config("my-module").await.unwrap();
+    assert_eq!(cfg.allowed_metrics.len(), 1);
+    assert_eq!(cfg.allowed_metrics[0].name, "req.count");
+    assert!(matches!(cfg.allowed_metrics[0].kind, UsageKind::Counter));
+}
+
+#[tokio::test]
+async fn get_module_config_returns_not_found_when_module_not_in_allow_list() {
+    let mut metrics = HashMap::new();
+    metrics.insert(
+        "cpu.usage".to_owned(),
+        MetricConfig {
+            kind: UsageKind::Gauge,
+            modules: Some(vec!["other-module".to_owned()]),
+        },
+    );
+    let client = UsageCollectorLocalClient::new(
+        config_with_metrics(metrics),
+        Arc::new(ClientHub::default()),
+    );
+    let err = client.get_module_config("my-module").await.unwrap_err();
+    assert!(matches!(err, UsageCollectorError::ModuleNotFound { .. }));
+}
+
+#[tokio::test]
+async fn get_module_config_returns_only_matching_metrics_from_mixed_config() {
+    let mut metrics = HashMap::new();
+    metrics.insert(
+        "cpu.usage".to_owned(),
+        MetricConfig {
+            kind: UsageKind::Gauge,
+            modules: None,
+        },
+    );
+    metrics.insert(
+        "disk.io".to_owned(),
+        MetricConfig {
+            kind: UsageKind::Counter,
+            modules: Some(vec!["storage".to_owned()]),
+        },
+    );
+    let client = UsageCollectorLocalClient::new(
+        config_with_metrics(metrics),
+        Arc::new(ClientHub::default()),
+    );
+    let cfg = client.get_module_config("my-module").await.unwrap();
+    assert_eq!(cfg.allowed_metrics.len(), 1);
+    assert_eq!(cfg.allowed_metrics[0].name, "cpu.usage");
+}
+
+// ── circuit breaker ──────────────────────────────────────────────────────────
+
+/// A storage plugin that always returns a transient error.
+struct FailPlugin;
+
+#[async_trait::async_trait]
+impl UsageCollectorPluginClientV1 for FailPlugin {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Err(UsageCollectorError::unavailable(
+            "simulated transient failure",
+        ))
+    }
+}
+
+/// A storage plugin that counts every `store` invocation via an atomic counter.
+/// Succeeds or fails depending on the `should_fail` flag.
+struct CountingPlugin {
+    counter: Arc<AtomicUsize>,
+    should_fail: bool,
+}
+
+impl CountingPlugin {
+    fn failing(counter: Arc<AtomicUsize>) -> Self {
+        Self {
+            counter,
+            should_fail: true,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl UsageCollectorPluginClientV1 for CountingPlugin {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        self.counter.fetch_add(1, Ordering::SeqCst);
+        if self.should_fail {
+            Err(UsageCollectorError::unavailable(
+                "simulated transient failure",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Construct a `UsageCollectorLocalClient` backed by the given plugin, with configurable
+/// circuit breaker parameters for fast, deterministic tests.
+fn make_cb_client(
+    plugin: Arc<dyn UsageCollectorPluginClientV1>,
+    threshold: u32,
+    window: Duration,
+    recovery: Duration,
+) -> UsageCollectorLocalClient {
+    let instance_id = format!(
+        "{}test.usage.mock.cb_test.v1",
+        UsageCollectorStoragePluginSpecV1::gts_schema_id()
+    );
+    let hub = hub_with_plugin(&instance_id, "hyperspot", plugin);
+    UsageCollectorLocalClient::new(
+        UsageCollectorConfig {
+            vendor: "hyperspot".to_owned(),
+            circuit_breaker_failure_threshold: threshold,
+            circuit_breaker_window: window,
+            circuit_breaker_recovery_timeout: recovery,
+            ..UsageCollectorConfig::default()
+        },
+        hub,
+    )
+}
+
+/// After N consecutive failures, the (N+1)-th call must return `CircuitOpen`.
+#[tokio::test]
+async fn circuit_opens_after_n_consecutive_failures() {
+    let threshold = 2u32;
+    let client = make_cb_client(
+        Arc::new(FailPlugin),
+        threshold,
+        Duration::from_secs(10),
+        Duration::from_millis(1),
+    );
+
+    for _ in 0..threshold {
+        drop(client.create_usage_record(record(Uuid::new_v4())).await);
+    }
+
+    let err = client
+        .create_usage_record(record(Uuid::new_v4()))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, UsageCollectorError::CircuitOpen),
+        "expected CircuitOpen after {threshold} failures, got {err:?}"
+    );
+}
+
+/// Once the circuit is open, every call must return `CircuitOpen` without invoking the plugin.
+#[tokio::test]
+async fn open_circuit_rejects_without_calling_plugin() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let threshold = 2u32;
+    let client = make_cb_client(
+        Arc::new(CountingPlugin::failing(Arc::clone(&counter))),
+        threshold,
+        Duration::from_secs(10),
+        Duration::from_millis(1),
+    );
+
+    // Drive to open state — these N calls do reach the plugin.
+    for _ in 0..threshold {
+        drop(client.create_usage_record(record(Uuid::new_v4())).await);
+    }
+    let calls_to_open = counter.load(Ordering::SeqCst);
+
+    // All subsequent calls must be rejected without touching the plugin.
+    for _ in 0..3 {
+        let err = client
+            .create_usage_record(record(Uuid::new_v4()))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, UsageCollectorError::CircuitOpen),
+            "expected CircuitOpen, got {err:?}"
+        );
+    }
+
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        calls_to_open,
+        "plugin must not be invoked while circuit is open"
+    );
+}
+
+/// In `HalfOpen` state exactly one concurrent caller is admitted as the probe; all others are
+/// rejected with `CircuitOpen`.
+#[tokio::test]
+async fn half_open_admits_exactly_one_concurrent_probe_others_rejected() {
+    // Use a TogglePlugin: fails during the open-driving phase, then succeeds for the probe.
+    // The probe yields via `tokio::task::yield_now()` so that the other two concurrent tasks
+    // get a chance to call `is_open()` (which sees `HalfOpen` → returns `CircuitOpen`) before
+    // the probe completes and transitions the circuit back to `Closed`.
+    use std::sync::atomic::AtomicBool;
+
+    struct TogglePlugin {
+        counter: Arc<AtomicUsize>,
+        fail: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl UsageCollectorPluginClientV1 for TogglePlugin {
+        async fn create_usage_record(
+            &self,
+            _record: UsageRecord,
+        ) -> Result<(), UsageCollectorError> {
+            self.counter.fetch_add(1, Ordering::SeqCst);
+            if self.fail.load(Ordering::SeqCst) {
+                return Err(UsageCollectorError::unavailable("toggle transient fail"));
+            }
+            // Yield so that other spawned tasks can run and see the HalfOpen state before
+            // this probe completes and closes the circuit.
+            tokio::task::yield_now().await;
+            Ok(())
+        }
+    }
+
+    let threshold = 2u32;
+    let fail_flag = Arc::new(AtomicBool::new(true));
+    let probe_counter = Arc::new(AtomicUsize::new(0));
+    let toggle_plugin = Arc::new(TogglePlugin {
+        counter: Arc::clone(&probe_counter),
+        fail: Arc::clone(&fail_flag),
+    });
+
+    let instance_id = format!(
+        "{}test.usage.mock.cb_halfopen.v1",
+        UsageCollectorStoragePluginSpecV1::gts_schema_id()
+    );
+    let hub = hub_with_plugin(&instance_id, "hyperspot", toggle_plugin);
+    let client = Arc::new(UsageCollectorLocalClient::new(
+        UsageCollectorConfig {
+            vendor: "hyperspot".to_owned(),
+            circuit_breaker_failure_threshold: threshold,
+            circuit_breaker_window: Duration::from_secs(10),
+            circuit_breaker_recovery_timeout: Duration::from_millis(1),
+            ..UsageCollectorConfig::default()
+        },
+        hub,
+    ));
+
+    // Open the circuit.
+    for _ in 0..threshold {
+        drop(client.create_usage_record(record(Uuid::new_v4())).await);
+    }
+    let calls_during_open = probe_counter.load(Ordering::SeqCst);
+
+    // Wait for recovery timeout to elapse so the circuit transitions to HalfOpen on next call.
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    // Switch plugin to succeed so the probe can close the circuit.
+    fail_flag.store(false, Ordering::SeqCst);
+
+    // Fire 3 concurrent calls. Exactly 1 should reach the plugin (the HalfOpen probe);
+    // the other 2 must get `CircuitOpen` because they see the `HalfOpen` state in `is_open()`.
+    let mut set = tokio::task::JoinSet::new();
+    for _ in 0..3 {
+        let c = Arc::clone(&client);
+        set.spawn(async move { c.create_usage_record(record(Uuid::new_v4())).await });
+    }
+
+    let mut circuit_open_count = 0usize;
+    let mut success_count = 0usize;
+    while let Some(result) = set.join_next().await {
+        match result.expect("task panicked") {
+            Ok(()) => success_count += 1,
+            Err(UsageCollectorError::CircuitOpen) => circuit_open_count += 1,
+            Err(e) => panic!("unexpected error: {e:?}"),
+        }
+    }
+
+    // Exactly one probe reached the plugin (the rest were rejected at is_open()).
+    let probe_calls = probe_counter.load(Ordering::SeqCst) - calls_during_open;
+    assert_eq!(
+        probe_calls, 1,
+        "exactly one concurrent call should reach the plugin in HalfOpen"
+    );
+    assert_eq!(success_count, 1, "the single probe should succeed");
+    assert_eq!(
+        circuit_open_count, 2,
+        "the other two callers should get CircuitOpen"
+    );
+}
+
+/// After a successful probe from `HalfOpen`, the circuit closes and the next call succeeds.
+#[tokio::test]
+async fn successful_probe_closes_circuit() {
+    // Use a CountingPlugin that fails for the first `threshold` calls then succeeds.
+    use std::sync::atomic::AtomicBool;
+
+    struct TogglePlugin {
+        fail: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl UsageCollectorPluginClientV1 for TogglePlugin {
+        async fn create_usage_record(
+            &self,
+            _record: UsageRecord,
+        ) -> Result<(), UsageCollectorError> {
+            if self.fail.load(Ordering::SeqCst) {
+                Err(UsageCollectorError::unavailable("toggle transient fail"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    let threshold = 2u32;
+
+    let fail_flag = Arc::new(AtomicBool::new(true));
+    let instance_id = format!(
+        "{}test.usage.mock.cb_close.v1",
+        UsageCollectorStoragePluginSpecV1::gts_schema_id()
+    );
+    let hub = hub_with_plugin(
+        &instance_id,
+        "hyperspot",
+        Arc::new(TogglePlugin {
+            fail: Arc::clone(&fail_flag),
+        }),
+    );
+    let client = UsageCollectorLocalClient::new(
+        UsageCollectorConfig {
+            vendor: "hyperspot".to_owned(),
+            circuit_breaker_failure_threshold: threshold,
+            circuit_breaker_window: Duration::from_secs(10),
+            circuit_breaker_recovery_timeout: Duration::from_millis(1),
+            ..UsageCollectorConfig::default()
+        },
+        hub,
+    );
+
+    // Open the circuit.
+    for _ in 0..threshold {
+        drop(client.create_usage_record(record(Uuid::new_v4())).await);
+    }
+
+    // Wait for recovery timeout; circuit should be ready to transition to HalfOpen.
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    // Switch plugin to succeed so the probe closes the circuit.
+    fail_flag.store(false, Ordering::SeqCst);
+
+    // The probe call: transitions Open → HalfOpen (via is_open()) then succeeds → Closed.
+    client
+        .create_usage_record(record(Uuid::new_v4()))
+        .await
+        .expect("probe call should succeed and close circuit");
+
+    // Next call should also succeed (circuit is Closed).
+    client
+        .create_usage_record(record(Uuid::new_v4()))
+        .await
+        .expect("circuit should be closed after successful probe");
+}
+
+/// After a failed probe from `HalfOpen`, the circuit re-opens and the next call returns `CircuitOpen`.
+#[tokio::test]
+async fn failed_probe_reopens_circuit() {
+    // Use threshold=1 so that a single probe failure immediately re-opens the circuit.
+    let threshold = 1u32;
+    let client = make_cb_client(
+        Arc::new(FailPlugin),
+        threshold,
+        Duration::from_secs(10),
+        Duration::from_millis(1),
+    );
+
+    // Open the circuit with 1 failure.
+    drop(client.create_usage_record(record(Uuid::new_v4())).await);
+
+    // Verify circuit is open.
+    let err = client
+        .create_usage_record(record(Uuid::new_v4()))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, UsageCollectorError::CircuitOpen));
+
+    // Wait for recovery timeout.
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    // The probe call: Open → HalfOpen (via is_open()), then fails → re-opens circuit.
+    let probe_err = client
+        .create_usage_record(record(Uuid::new_v4()))
+        .await
+        .unwrap_err();
+    // The probe itself returns the plugin error, not CircuitOpen.
+    assert!(
+        matches!(probe_err, UsageCollectorError::Unavailable { .. }),
+        "probe should propagate plugin error, got {probe_err:?}"
+    );
+
+    // Next call should see the circuit open again.
+    let err = client
+        .create_usage_record(record(Uuid::new_v4()))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, UsageCollectorError::CircuitOpen),
+        "circuit should be open again after failed probe, got {err:?}"
+    );
+}

--- a/modules/system/usage-collector/usage-collector/src/domain/mod.rs
+++ b/modules/system/usage-collector/usage-collector/src/domain/mod.rs
@@ -1,0 +1,5 @@
+//! Gateway domain: [`UsageCollectorLocalClient`].
+
+mod local_client;
+
+pub use local_client::UsageCollectorLocalClient;

--- a/modules/system/usage-collector/usage-collector/src/lib.rs
+++ b/modules/system/usage-collector/usage-collector/src/lib.rs
@@ -1,0 +1,11 @@
+//! Usage Collector gateway.
+//!
+//! Centralized ingest for usage records from the SDK outbox pipeline and
+//! delegation to the GTS-selected storage plugin.
+
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+pub mod api;
+mod config;
+mod domain;
+mod module;

--- a/modules/system/usage-collector/usage-collector/src/module.rs
+++ b/modules/system/usage-collector/usage-collector/src/module.rs
@@ -1,0 +1,120 @@
+//! Usage-collector gateway `ModKit` module.
+
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+use authz_resolver_sdk::AuthZResolverClient;
+use axum::Router;
+use modkit::api::OpenApiRegistry;
+use modkit::contracts::{DatabaseCapability, RestApiCapability};
+use modkit::{Module, ModuleCtx};
+use sea_orm_migration::MigrationTrait;
+use tracing::info;
+use types_registry_sdk::{RegisterResult, TypesRegistryClient};
+use usage_collector_sdk::{UsageCollectorClientV1, UsageCollectorStoragePluginSpecV1};
+use usage_emitter::{UsageEmitter, UsageEmitterV1};
+
+use crate::api::rest::routes;
+use crate::config::UsageCollectorConfig;
+use crate::domain::UsageCollectorLocalClient;
+
+/// Usage collector gateway: registers storage plugin schema, resolves plugins via GTS,
+/// exposes `dyn UsageCollectorClientV1` for outbox delivery, and wires REST endpoints
+/// via `DatabaseCapability` and `RestApiCapability`.
+#[modkit::module(
+    name = "usage-collector",
+    deps = ["authz-resolver", "types-registry"],
+    capabilities = [db, rest],
+)]
+#[derive(Default)]
+pub struct UsageCollectorModule {
+    /// Stored during `init()` for use in `register_rest()`.
+    collector: OnceLock<Arc<dyn UsageCollectorClientV1>>,
+}
+
+#[async_trait]
+impl Module for UsageCollectorModule {
+    #[tracing::instrument(skip_all, fields(vendor))]
+    async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        let cfg: UsageCollectorConfig = ctx.config_or_default()?;
+        cfg.validate()?;
+        tracing::Span::current().record("vendor", &cfg.vendor);
+        info!(
+            cfg.vendor,
+            ?cfg.plugin_timeout,
+            "Loaded {} configuration",
+            Self::MODULE_NAME,
+        );
+
+        let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
+        let schema_str = UsageCollectorStoragePluginSpecV1::gts_schema_with_refs_as_string();
+        let schema_json: serde_json::Value = serde_json::from_str(&schema_str)?;
+        let results = registry.register(vec![schema_json]).await?;
+        RegisterResult::ensure_all_ok(&results)?;
+        info!(
+            schema_id = %UsageCollectorStoragePluginSpecV1::gts_schema_id(),
+            "Registered {} storage plugin schema in types-registry",
+            Self::MODULE_NAME,
+        );
+
+        let db = ctx
+            .db_required()
+            .map_err(|e| anyhow::anyhow!("{}: db not available: {e}", Self::MODULE_NAME))?
+            .db();
+
+        let authz = ctx
+            .client_hub()
+            .get::<dyn AuthZResolverClient>()
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "{}: AuthZResolverClient not registered: {e}",
+                    Self::MODULE_NAME
+                )
+            })?;
+
+        let collector = UsageCollectorLocalClient::new(cfg.clone(), ctx.client_hub());
+        let collector = Arc::new(collector) as Arc<dyn UsageCollectorClientV1>;
+
+        let emitter = UsageEmitter::build(cfg.emitter, db, authz, Arc::clone(&collector)).await?;
+        ctx.client_hub()
+            .register::<dyn UsageEmitterV1>(Arc::new(emitter));
+
+        self.collector
+            .set(collector)
+            .map_err(|_| anyhow::anyhow!("{}: collector already initialized", Self::MODULE_NAME))?;
+
+        Ok(())
+    }
+}
+
+impl DatabaseCapability for UsageCollectorModule {
+    fn migrations(&self) -> Vec<Box<dyn MigrationTrait>> {
+        info!("Providing {} database migrations", Self::MODULE_NAME);
+        modkit_db::outbox::outbox_migrations()
+    }
+}
+
+impl RestApiCapability for UsageCollectorModule {
+    fn register_rest(
+        &self,
+        ctx: &ModuleCtx,
+        router: Router,
+        openapi: &dyn OpenApiRegistry,
+    ) -> anyhow::Result<Router> {
+        tracing::info!("Registering {} REST routes", Self::MODULE_NAME);
+
+        let emitter = ctx.client_hub().get::<dyn UsageEmitterV1>().map_err(|e| {
+            anyhow::anyhow!("{}: UsageEmitterV1 not registered: {e}", Self::MODULE_NAME)
+        })?;
+
+        let collector = self
+            .collector
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("{}: collector not initialized", Self::MODULE_NAME))?;
+
+        let router = routes::register_routes(router, openapi, emitter, Arc::clone(collector));
+
+        tracing::info!("{} REST routes registered", Self::MODULE_NAME);
+        Ok(router)
+    }
+}

--- a/modules/system/usage-collector/usage-collector/tests/common/mod.rs
+++ b/modules/system/usage-collector/usage-collector/tests/common/mod.rs
@@ -1,0 +1,286 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use authz_resolver_sdk::constraints::{Constraint, InPredicate, Predicate};
+use authz_resolver_sdk::models::{
+    EvaluationRequest, EvaluationResponse, EvaluationResponseContext,
+};
+use authz_resolver_sdk::{AuthZResolverClient, AuthZResolverError, DenyReason};
+use axum::routing::{get, post};
+use axum::{Extension, Router};
+use modkit_db::migration_runner::run_migrations_for_testing;
+use modkit_db::outbox::outbox_migrations;
+use modkit_db::{ConnectOpts, connect_db};
+use modkit_security::SecurityContext;
+use modkit_security::access_scope::pep_properties;
+use usage_collector::api::rest::handlers::{handle_create_usage_record, handle_get_module_config};
+use usage_collector_sdk::{
+    AllowedMetric, ModuleConfig, UsageCollectorClientV1, UsageCollectorError,
+    UsageCollectorPluginClientV1, UsageKind, UsageRecord,
+};
+use usage_emitter::{ScopedUsageEmitter, UsageEmitter, UsageEmitterConfig, UsageEmitterV1};
+use uuid::Uuid;
+
+// ── AuthZ mocks ───────────────────────────────────────────────────────────────
+
+pub struct MockAuthZResolverClient {
+    allow: bool,
+    tenant_id: Uuid,
+}
+
+impl MockAuthZResolverClient {
+    pub fn allow(tenant_id: Uuid) -> Self {
+        Self {
+            allow: true,
+            tenant_id,
+        }
+    }
+
+    pub fn deny() -> Self {
+        Self {
+            allow: false,
+            tenant_id: Uuid::nil(),
+        }
+    }
+}
+
+#[async_trait]
+impl AuthZResolverClient for MockAuthZResolverClient {
+    async fn evaluate(
+        &self,
+        _request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        if self.allow {
+            Ok(EvaluationResponse {
+                decision: true,
+                context: EvaluationResponseContext {
+                    constraints: vec![Constraint {
+                        predicates: vec![Predicate::In(InPredicate::new(
+                            pep_properties::OWNER_TENANT_ID,
+                            [self.tenant_id],
+                        ))],
+                    }],
+                    ..EvaluationResponseContext::default()
+                },
+            })
+        } else {
+            Ok(EvaluationResponse {
+                decision: false,
+                context: EvaluationResponseContext {
+                    deny_reason: Some(DenyReason {
+                        error_code: "POLICY_DENIED".to_owned(),
+                        details: None,
+                    }),
+                    ..EvaluationResponseContext::default()
+                },
+            })
+        }
+    }
+}
+
+// ── Collector mocks ───────────────────────────────────────────────────────────
+
+pub struct MockUsageCollectorClientV1 {
+    pub config: ModuleConfig,
+}
+
+#[async_trait]
+impl UsageCollectorClientV1 for MockUsageCollectorClientV1 {
+    async fn create_usage_record(&self, _: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(&self, _: &str) -> Result<ModuleConfig, UsageCollectorError> {
+        Ok(self.config.clone())
+    }
+}
+
+#[allow(dead_code)]
+pub struct NotFoundCollector;
+
+#[async_trait]
+impl UsageCollectorClientV1 for NotFoundCollector {
+    async fn create_usage_record(&self, _: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        module_name: &str,
+    ) -> Result<ModuleConfig, UsageCollectorError> {
+        Err(UsageCollectorError::module_not_found(module_name))
+    }
+}
+
+// ── Plugin mock ───────────────────────────────────────────────────────────────
+
+pub struct MockUsageCollectorPluginClientV1;
+
+impl MockUsageCollectorPluginClientV1 {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl UsageCollectorPluginClientV1 for MockUsageCollectorPluginClientV1 {
+    async fn create_usage_record(&self, _: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+}
+
+// ── Emitter mock ──────────────────────────────────────────────────────────────
+
+/// Wraps a real `UsageEmitter` because `ScopedUsageEmitter::new()` is `pub(crate)`.
+pub struct MockUsageEmitterV1(UsageEmitter);
+
+impl MockUsageEmitterV1 {
+    pub async fn with_allow_authz() -> Self {
+        let authz: Arc<dyn AuthZResolverClient> =
+            Arc::new(MockAuthZResolverClient::allow(Uuid::new_v4()));
+        Self(build_real_emitter(authz).await)
+    }
+
+    #[allow(dead_code)]
+    pub async fn with_deny_authz() -> Self {
+        let authz: Arc<dyn AuthZResolverClient> = Arc::new(MockAuthZResolverClient::deny());
+        Self(build_real_emitter(authz).await)
+    }
+}
+
+impl UsageEmitterV1 for MockUsageEmitterV1 {
+    fn for_module(&self, module_name: &str) -> ScopedUsageEmitter {
+        self.0.for_module(module_name)
+    }
+}
+
+async fn build_real_emitter(authz: Arc<dyn AuthZResolverClient>) -> UsageEmitter {
+    let db_name = format!("uc_gw_{}", Uuid::new_v4().simple());
+    let url = format!("sqlite:file:{db_name}?mode=memory&cache=shared");
+    let db = connect_db(
+        &url,
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    run_migrations_for_testing(&db, outbox_migrations())
+        .await
+        .unwrap();
+    let collector: Arc<dyn UsageCollectorClientV1> = Arc::new(MockUsageCollectorClientV1 {
+        config: ModuleConfig {
+            allowed_metrics: vec![AllowedMetric {
+                name: "test.gauge".to_owned(),
+                kind: UsageKind::Gauge,
+            }],
+        },
+    });
+    UsageEmitter::build(UsageEmitterConfig::default(), db, authz, collector)
+        .await
+        .unwrap()
+}
+
+// ── AppHarness ────────────────────────────────────────────────────────────────
+
+pub struct AppHarness {
+    pub router: Router,
+}
+
+impl AppHarness {
+    #[allow(dead_code)]
+    pub async fn new() -> Self {
+        let emitter =
+            Arc::new(MockUsageEmitterV1::with_allow_authz().await) as Arc<dyn UsageEmitterV1>;
+        let collector: Arc<dyn UsageCollectorClientV1> = Arc::new(MockUsageCollectorClientV1 {
+            config: ModuleConfig {
+                allowed_metrics: vec![AllowedMetric {
+                    name: "test.gauge".to_owned(),
+                    kind: UsageKind::Gauge,
+                }],
+            },
+        });
+        let authz: Arc<dyn AuthZResolverClient> =
+            Arc::new(MockAuthZResolverClient::allow(Uuid::new_v4()));
+        let plugin: Arc<dyn UsageCollectorPluginClientV1> =
+            Arc::new(MockUsageCollectorPluginClientV1::new());
+        Self::build(emitter, collector, authz, plugin)
+    }
+
+    #[allow(dead_code)]
+    pub fn with_emitter(emitter: Arc<dyn UsageEmitterV1>) -> Self {
+        let collector: Arc<dyn UsageCollectorClientV1> = Arc::new(MockUsageCollectorClientV1 {
+            config: ModuleConfig {
+                allowed_metrics: vec![AllowedMetric {
+                    name: "test.gauge".to_owned(),
+                    kind: UsageKind::Gauge,
+                }],
+            },
+        });
+        let authz: Arc<dyn AuthZResolverClient> =
+            Arc::new(MockAuthZResolverClient::allow(Uuid::new_v4()));
+        let plugin: Arc<dyn UsageCollectorPluginClientV1> =
+            Arc::new(MockUsageCollectorPluginClientV1::new());
+        Self::build(emitter, collector, authz, plugin)
+    }
+
+    #[allow(dead_code)]
+    pub async fn with_collector(collector: Arc<dyn UsageCollectorClientV1>) -> Self {
+        let emitter =
+            Arc::new(MockUsageEmitterV1::with_allow_authz().await) as Arc<dyn UsageEmitterV1>;
+        let authz: Arc<dyn AuthZResolverClient> =
+            Arc::new(MockAuthZResolverClient::allow(Uuid::new_v4()));
+        let plugin: Arc<dyn UsageCollectorPluginClientV1> =
+            Arc::new(MockUsageCollectorPluginClientV1::new());
+        Self::build(emitter, collector, authz, plugin)
+    }
+
+    #[allow(dead_code)]
+    pub async fn with_deny_authz() -> Self {
+        let emitter =
+            Arc::new(MockUsageEmitterV1::with_deny_authz().await) as Arc<dyn UsageEmitterV1>;
+        let collector: Arc<dyn UsageCollectorClientV1> = Arc::new(MockUsageCollectorClientV1 {
+            config: ModuleConfig {
+                allowed_metrics: vec![AllowedMetric {
+                    name: "test.gauge".to_owned(),
+                    kind: UsageKind::Gauge,
+                }],
+            },
+        });
+        let authz: Arc<dyn AuthZResolverClient> = Arc::new(MockAuthZResolverClient::deny());
+        let plugin: Arc<dyn UsageCollectorPluginClientV1> =
+            Arc::new(MockUsageCollectorPluginClientV1::new());
+        Self::build(emitter, collector, authz, plugin)
+    }
+
+    fn build(
+        emitter: Arc<dyn UsageEmitterV1>,
+        collector: Arc<dyn UsageCollectorClientV1>,
+        authz: Arc<dyn AuthZResolverClient>,
+        plugin: Arc<dyn UsageCollectorPluginClientV1>,
+    ) -> Self {
+        let ctx = SecurityContext::builder()
+            .subject_id(Uuid::new_v4())
+            .subject_tenant_id(Uuid::new_v4())
+            .build()
+            .unwrap();
+        let router = Router::new()
+            .route(
+                "/usage-collector/v1/records",
+                post(handle_create_usage_record),
+            )
+            .route(
+                "/usage-collector/v1/modules/{module_name}/config",
+                get(handle_get_module_config),
+            )
+            .layer(Extension(emitter))
+            .layer(Extension(collector))
+            .layer(Extension(authz))
+            .layer(Extension(plugin))
+            .layer(Extension(ctx));
+        Self { router }
+    }
+}

--- a/modules/system/usage-collector/usage-collector/tests/create_record_tests.rs
+++ b/modules/system/usage-collector/usage-collector/tests/create_record_tests.rs
@@ -1,0 +1,140 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use chrono::Utc;
+use http::{Method, Request, StatusCode};
+use tower::ServiceExt;
+use usage_emitter::UsageEmitterV1;
+use uuid::Uuid;
+
+use common::{AppHarness, MockUsageEmitterV1};
+
+#[tokio::test]
+async fn create_record_happy_path() {
+    let emitter = Arc::new(MockUsageEmitterV1::with_allow_authz().await) as Arc<dyn UsageEmitterV1>;
+    let harness = AppHarness::with_emitter(emitter);
+
+    let body = serde_json::json!({
+        "module": "test-module",
+        "tenant_id": Uuid::new_v4(),
+        "resource_type": "test.resource",
+        "resource_id": Uuid::new_v4(),
+        "metric": "test.gauge",
+        "value": 1.0,
+        "timestamp": Utc::now().to_rfc3339(),
+    });
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/usage-collector/v1/records")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+
+    let response = harness.router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn create_record_metadata_too_large() {
+    let harness = AppHarness::new().await;
+
+    let large_value = "a".repeat(9000);
+    let body = serde_json::json!({
+        "module": "test-module",
+        "tenant_id": Uuid::new_v4(),
+        "resource_type": "test.resource",
+        "resource_id": Uuid::new_v4(),
+        "metric": "test.gauge",
+        "value": 1.0,
+        "timestamp": Utc::now().to_rfc3339(),
+        "metadata": {"key": large_value},
+    });
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/usage-collector/v1/records")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+
+    let response = harness.router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+async fn create_record_subject_type_without_subject_id() {
+    let harness = AppHarness::new().await;
+
+    let body = serde_json::json!({
+        "module": "test-module",
+        "tenant_id": Uuid::new_v4(),
+        "resource_type": "test.resource",
+        "resource_id": Uuid::new_v4(),
+        "metric": "test.gauge",
+        "value": 1.0,
+        "timestamp": Utc::now().to_rfc3339(),
+        "subject_type": "user",
+    });
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/usage-collector/v1/records")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+
+    let response = harness.router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+async fn create_record_emitter_authorization_failed() {
+    let emitter = Arc::new(MockUsageEmitterV1::with_deny_authz().await) as Arc<dyn UsageEmitterV1>;
+    let harness = AppHarness::with_emitter(emitter);
+
+    let body = serde_json::json!({
+        "module": "test-module",
+        "tenant_id": Uuid::new_v4(),
+        "resource_type": "test.resource",
+        "resource_id": Uuid::new_v4(),
+        "metric": "test.gauge",
+        "value": 1.0,
+        "timestamp": Utc::now().to_rfc3339(),
+    });
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/usage-collector/v1/records")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+
+    let response = harness.router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn create_record_invalid_subject_id_uuid() {
+    let harness = AppHarness::new().await;
+
+    let body = serde_json::json!({
+        "module": "test-module",
+        "tenant_id": Uuid::new_v4(),
+        "resource_type": "test.resource",
+        "resource_id": Uuid::new_v4(),
+        "subject_id": "not-a-valid-uuid",
+        "metric": "test.gauge",
+        "value": 1.0,
+        "timestamp": Utc::now().to_rfc3339(),
+    });
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/usage-collector/v1/records")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+
+    let response = harness.router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}

--- a/modules/system/usage-collector/usage-collector/tests/module_config_tests.rs
+++ b/modules/system/usage-collector/usage-collector/tests/module_config_tests.rs
@@ -1,0 +1,55 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use std::sync::Arc;
+
+use axum::body::{Body, to_bytes};
+use http::{Method, Request, StatusCode};
+use tower::ServiceExt;
+use usage_collector_sdk::{AllowedMetric, ModuleConfig, UsageCollectorClientV1, UsageKind};
+
+use common::{AppHarness, MockUsageCollectorClientV1, NotFoundCollector};
+
+#[tokio::test]
+async fn module_config_found() {
+    let collector: Arc<dyn UsageCollectorClientV1> = Arc::new(MockUsageCollectorClientV1 {
+        config: ModuleConfig {
+            allowed_metrics: vec![AllowedMetric {
+                name: "cpu.usage".to_owned(),
+                kind: UsageKind::Gauge,
+            }],
+        },
+    });
+    let harness = AppHarness::with_collector(collector).await;
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/usage-collector/v1/modules/my-module/config")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = harness.router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let metrics = json["allowed_metrics"].as_array().unwrap();
+    assert_eq!(metrics.len(), 1);
+    assert_eq!(metrics[0]["name"], "cpu.usage");
+}
+
+#[tokio::test]
+async fn module_config_not_found() {
+    let collector: Arc<dyn UsageCollectorClientV1> = Arc::new(NotFoundCollector);
+    let harness = AppHarness::with_collector(collector).await;
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/usage-collector/v1/modules/unknown-module/config")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = harness.router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}

--- a/modules/system/usage-collector/usage-emitter/Cargo.toml
+++ b/modules/system/usage-collector/usage-emitter/Cargo.toml
@@ -1,0 +1,56 @@
+[package]
+name = "cf-usage-emitter"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Durable usage emission: two-phase PDP authorization, transactional outbox enqueue, async delivery to the collector"
+readme = "README.md"
+keywords = ["cyberfabric", "cyberfabric-system"]
+categories = ["development-tools"]
+
+[lib]
+name = "usage_emitter"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Local dependencies
+authz-resolver-sdk = { workspace = true }
+usage-collector-sdk = { workspace = true }
+
+# ModKit dependencies
+modkit-db = { workspace = true, features = ["preview-outbox"] }
+modkit-security = { workspace = true }
+
+# Async runtime
+async-trait = { workspace = true }
+tokio = { workspace = true }
+
+# Data structures
+chrono = { workspace = true }
+uuid = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+# DB
+sea-orm-migration = { workspace = true }
+
+[dev-dependencies]
+# ModKit dependencies
+modkit-db = { workspace = true, features = ["sqlite"] }
+
+# Data structures
+chrono = { workspace = true }

--- a/modules/system/usage-collector/usage-emitter/README.md
+++ b/modules/system/usage-collector/usage-emitter/README.md
@@ -1,0 +1,110 @@
+# Usage Emitter
+
+> **Emitter library** — two-phase PDP authorization, transactional outbox enqueue, and async delivery to the usage collector.
+
+A plain library crate (no `#[modkit::module]`). Each host module (`usage-collector`, `usage-collector-rest-client`, future gRPC client) calls `UsageEmitter::build(config, db, authz, collector)` in its own `init()` and registers the result as `dyn UsageEmitterV1` in `ClientHub`.
+
+## Security invariant
+
+`UsageCollectorClientV1` is **never** registered in `ClientHub`. It is supplied to `UsageEmitter::build` as a constructor argument and stays private inside the emitter. Only `dyn UsageEmitterV1` is published to the hub, so the sole path a source module has to the collector is through a PDP-authorized, tenant/resource-bound `AuthorizedUsageEmitter::enqueue*`. The PDP resource type and action constants (`gts.x.core.usage.record.v1 / create`) are `pub(crate)` in this crate and cannot be referenced externally.
+
+## API
+
+| Item | Description |
+|------|-------------|
+| `UsageEmitterV1` | Source-facing trait. Obtain from `ClientHub`. Call `for_module(MODULE_NAME)` once (e.g. in `init()`) to get a `ScopedUsageEmitter`. |
+| `UsageEmitter` | Concrete implementation; built with `UsageEmitter::build`. |
+| `ScopedUsageEmitter` | Returned by `for_module`; carries the module name and knows the allowed metrics list. Call `authorize_for` or `authorize` to get a time-limited handle. |
+| `AuthorizedUsageEmitter` | Time-limited handle returned by `authorize` / `authorize_for`. Call `enqueue`, `enqueue_in`, or `build_usage_record`. |
+| `UsageRecordBuilder` | Returned by `AuthorizedUsageEmitter::build_usage_record(metric, value)`; tenant, resource, module, and kind come from the authorized handle. Optionally set `with_idempotency_key` / `with_timestamp`, then `enqueue` / `enqueue_in`. |
+| `UsageEmitterConfig` | Tunable authorization TTL, outbox queue name, partition count. Embedded in the host module's own config struct. |
+| `UsageEmitterError` | Typed errors for authorization, validation, and enqueue phases. |
+
+## Emitting a usage record
+
+```rust
+use usage_emitter::UsageEmitterV1;
+
+// In init(): obtain from ClientHub and scope to this module's name.
+let emitter = hub.get::<dyn UsageEmitterV1>()?;
+let scoped = emitter.for_module(Self::MODULE_NAME);
+
+// In a handler — Phase 1: authorize (calls PDP + fetches allowed metrics;
+// valid for UsageEmitterConfig::authorization_max_age).
+let authorized = scoped
+    .authorize_for(&ctx, tenant_id, resource_id, resource_type.clone())
+    .await?;
+// Or for the subject's home tenant: scoped.authorize(&ctx, resource_id, resource_type).await?
+
+// Phase 2a: build and enqueue on the emitter's DB connection.
+authorized
+    .build_usage_record("requests", 1.0)
+    .enqueue()
+    .await?;
+
+// Phase 2b: enqueue inside a caller transaction (atomic with your write).
+// authorized.build_usage_record("requests", 1.0).enqueue_in(&txn).await?;
+
+// Optional: set idempotency key or timestamp.
+// authorized
+//     .build_usage_record("requests", 1.0)
+//     .with_idempotency_key("key123")
+//     .with_timestamp(Utc::now())
+//     .enqueue()
+//     .await?;
+```
+
+## Configuration
+
+`UsageEmitterConfig` is embedded in the host module's own config struct with `#[serde(default)]`, so all fields are optional in YAML:
+
+```yaml
+modules:
+  usage-collector:         # or usage-collector-rest-client
+    config:
+      emitter:
+        authorization_max_age: "30s"   # default
+        outbox_queue: "usage-records"  # default
+        outbox_partition_count: 4      # default; power of 2 in 1–64
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `authorization_max_age` | `30s` | Maximum age of an `AuthorizedUsageEmitter` handle before `enqueue*` rejects it with `AuthorizationExpired` |
+| `outbox_queue` | `usage-records` | Outbox queue name |
+| `outbox_partition_count` | `4` | Partition count (power of 2 in 1–64) |
+
+## Error handling
+
+```rust
+use usage_emitter::UsageEmitterError;
+
+match authorized.enqueue(record).await {
+    Ok(()) => {}
+    Err(UsageEmitterError::AuthorizationExpired) => { /* re-authorize and retry */ }
+    Err(UsageEmitterError::AuthorizationFailed { message }) => { /* PDP denied */ }
+    Err(UsageEmitterError::MetricNotAllowed { metric }) => { /* metric not configured for this module */ }
+    Err(UsageEmitterError::NegativeCounterValue { value }) => { /* counter delta must be >= 0 */ }
+    Err(UsageEmitterError::InvalidRecord { message }) => { /* incomplete builder / record */ }
+    Err(UsageEmitterError::Outbox(e)) => { /* transactional DB write failed */ }
+    Err(UsageEmitterError::Internal { message }) => { /* unexpected PDP or runtime error */ }
+}
+```
+
+## Background delivery
+
+The outbox worker dequeues from the queue configured via `outbox_queue` (host overrides apply) and calls `UsageCollectorClientV1::create_usage_record` per message:
+
+- **`Ok`** — message acknowledged
+- **`PluginTimeout`** — transient (plugin timeout, HTTP 429, HTTP 5xx); message is retried
+- **`CircuitOpen`** — transient (circuit breaker open); message is retried
+- **`Unavailable`** — transient (connection/transport error, identity service unreachable); message is retried
+- **Other errors** — permanent (`AuthorizationFailed`, `ModuleNotFound`, `Internal`); message is dead-lettered
+
+Delivery is independent of the request that enqueued the record and survives process restarts through the durable outbox.
+
+## Testing
+
+```bash
+devbox run cargo test -p cf-usage-emitter
+```

--- a/modules/system/usage-collector/usage-emitter/src/api.rs
+++ b/modules/system/usage-collector/usage-emitter/src/api.rs
@@ -1,0 +1,33 @@
+use crate::scoped_emitter::ScopedUsageEmitter;
+
+/// Source-facing trait for emitting usage records with module-scoped authorization.
+///
+/// Obtain from `ClientHub`: `hub.get::<dyn UsageEmitterV1>()?`
+///
+/// The emitter is registered in `ClientHub` by the `usage-collector` module (in-process delivery)
+/// or the `usage-collector-rest-client` module (HTTP delivery to a remote collector).
+///
+/// Call [`Self::for_module`] with the module's name constant to obtain a [`ScopedUsageEmitter`]
+/// that carries the module name and knows the allowed metrics for that module.
+///
+/// ```ignore
+/// // In init():
+/// let emitter = hub.get::<dyn UsageEmitterV1>()?;
+/// let scoped = emitter.for_module(Self::MODULE_NAME);
+///
+/// // In handlers:
+/// let authorized = scoped
+///     .authorize(&ctx, resource_id, "resource_type".to_owned())
+///     .await?;
+/// authorized
+///     .build_usage_record("requests", 1.0)
+///     .enqueue()
+///     .await?;
+/// ```
+pub trait UsageEmitterV1: Send + Sync {
+    /// Obtain a [`ScopedUsageEmitter`] bound to `module_name`.
+    ///
+    /// The scoped emitter stores the module name and uses it to fetch the allowed metrics list
+    /// from the collector during [`ScopedUsageEmitter::authorize_for`].
+    fn for_module(&self, module_name: &str) -> ScopedUsageEmitter;
+}

--- a/modules/system/usage-collector/usage-emitter/src/authorized_emitter.rs
+++ b/modules/system/usage-collector/usage-emitter/src/authorized_emitter.rs
@@ -1,0 +1,275 @@
+use std::sync::Arc;
+use std::time::Instant;
+
+use modkit_db::Db;
+use modkit_db::outbox::Outbox;
+use modkit_db::secure::DBRunner;
+use tracing::debug;
+use usage_collector_sdk::models::{AllowedMetric, UsageKind, UsageRecord};
+use uuid::Uuid;
+
+use crate::config::UsageEmitterConfig;
+use crate::error::UsageEmitterError;
+use crate::usage_builder::UsageRecordBuilder;
+
+/// Emitter state after successful PDP authorization; call [`Self::enqueue`] or
+/// [`Self::enqueue_in`] on the returned handle.
+///
+/// Constructed via [`crate::ScopedUsageEmitter::authorize_for`]; callers cannot forge handles.
+pub struct AuthorizedUsageEmitter {
+    config: Arc<UsageEmitterConfig>,
+    pub(crate) db: Db,
+    outbox: Arc<Outbox>,
+    pub(crate) module: String,
+    pub(crate) tenant_id: Uuid,
+    pub(crate) resource_id: Uuid,
+    pub(crate) resource_type: String,
+    pub(crate) allowed_metrics: Vec<AllowedMetric>,
+    pub(crate) subject_id: Option<Uuid>,
+    pub(crate) subject_type: Option<String>,
+    issued_at: Instant,
+}
+
+impl AuthorizedUsageEmitter {
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        config: Arc<UsageEmitterConfig>,
+        db: Db,
+        outbox: Arc<Outbox>,
+        module: String,
+        tenant_id: Uuid,
+        resource_id: Uuid,
+        resource_type: String,
+        allowed_metrics: Vec<AllowedMetric>,
+        subject_id: Option<Uuid>,
+        subject_type: Option<String>,
+    ) -> Self {
+        Self {
+            config,
+            db,
+            outbox,
+            module,
+            tenant_id,
+            resource_id,
+            resource_type,
+            allowed_metrics,
+            subject_id,
+            subject_type,
+            issued_at: Instant::now(),
+        }
+    }
+
+    /// Enqueue a usage record using this emitter's database connection.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageEmitterError`] when obtaining a connection fails, the authorization handle
+    /// expired, or the outbox enqueue fails.
+    pub async fn enqueue(&self, record: UsageRecord) -> Result<(), UsageEmitterError> {
+        let conn = self
+            .db
+            .conn()
+            .map_err(|e| UsageEmitterError::internal(e.to_string()))?;
+        self.enqueue_in(&conn, record).await
+    }
+
+    /// Enqueue a usage record on the given database runner (connection or transaction).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageEmitterError`] when the authorization handle expired, the record does not
+    /// match the authorized tenant/resource, the metric is not allowed for this module, a counter
+    /// record has a negative value, or the outbox enqueue fails.
+    pub async fn enqueue_in(
+        &self,
+        db: &(dyn DBRunner + Sync),
+        record: UsageRecord,
+    ) -> Result<(), UsageEmitterError> {
+        self.validate_authorization_freshness()?;
+        self.validate_authorized_tenant(&record)?;
+        self.validate_authorized_resource(&record)?;
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-6
+        self.validate_authorized_module(&record)?;
+        self.validate_authorized_subject(&record)?;
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-6
+        self.validate_allowed_metric(&record)?;
+        self.validate_metric_kind(&record)?;
+        Self::validate_counter_value(&record)?;
+        Self::validate_counter_idempotency_key(&record)?;
+        Self::validate_metadata_size(&record)?;
+
+        // Derive partition from the first UUID byte for even load distribution across tenants.
+        let bytes = record.tenant_id.as_bytes();
+        let partition = u32::from(bytes[0]) % u32::from(self.config.outbox_partition_count);
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-8
+        let payload = serde_json::to_vec(&record).map_err(|e| {
+            UsageEmitterError::internal(format!("payload serialization failed: {e}"))
+        })?;
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-8
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-9
+        self.outbox
+            .enqueue(
+                db,
+                &self.config.outbox_queue,
+                partition,
+                payload,
+                "usage-collector.record.v1",
+            )
+            .await?;
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-9
+
+        debug!(%self.tenant_id, "usage record enqueued");
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-10
+        Ok(())
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-10
+    }
+
+    fn validate_authorization_freshness(&self) -> Result<(), UsageEmitterError> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-1
+        let elapsed = self.issued_at.elapsed();
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-1
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-2
+        if elapsed > self.config.authorization_max_age {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-2a
+            return Err(UsageEmitterError::authorization_expired());
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-2a
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-2
+        Ok(())
+    }
+
+    fn validate_authorized_tenant(&self, record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        if record.tenant_id != self.tenant_id {
+            return Err(UsageEmitterError::authorization_failed(
+                "usage record tenant_id does not match authorized tenant",
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_authorized_resource(&self, record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        if record.resource_id != self.resource_id {
+            return Err(UsageEmitterError::authorization_failed(
+                "usage record resource_id does not match authorized resource",
+            ));
+        }
+
+        if record.resource_type != self.resource_type {
+            return Err(UsageEmitterError::authorization_failed(
+                "usage record resource_type does not match authorized resource",
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn validate_authorized_module(&self, record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        if record.module != self.module {
+            return Err(UsageEmitterError::invalid_record(
+                "record module does not match authorized token",
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_authorized_subject(&self, record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        if record.subject_id != self.subject_id
+            || record.subject_type.as_deref() != self.subject_type.as_deref()
+        {
+            return Err(UsageEmitterError::invalid_record(
+                "record subject does not match authorized token",
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_allowed_metric(&self, record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-3
+        let metric_allowed = self.allowed_metrics.iter().any(|m| m.name == record.metric);
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-3
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-4
+        if !metric_allowed {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-4a
+            return Err(UsageEmitterError::metric_not_allowed(&record.metric));
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-4a
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-4
+        Ok(())
+    }
+
+    fn validate_metric_kind(&self, record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        if let Some(allowed) = self
+            .allowed_metrics
+            .iter()
+            .find(|m| m.name == record.metric)
+            && allowed.kind != record.kind
+        {
+            return Err(UsageEmitterError::metric_kind_mismatch(
+                &record.metric,
+                allowed.kind,
+                record.kind,
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_counter_value(record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        if record.kind == UsageKind::Counter && record.value < 0.0 {
+            return Err(UsageEmitterError::negative_counter_value(record.value));
+        }
+        Ok(())
+    }
+
+    fn validate_counter_idempotency_key(record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-5
+        if record.kind == UsageKind::Counter && record.idempotency_key.trim().is_empty() {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-5a
+            return Err(UsageEmitterError::invalid_record(
+                "counter records require a non-empty idempotency key",
+            ));
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-5a
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-5
+        Ok(())
+    }
+
+    fn validate_metadata_size(record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-7
+        if let Some(ref metadata) = record.metadata {
+            let len = serde_json::to_vec(metadata)
+                .map_err(|e| {
+                    UsageEmitterError::internal(format!("metadata serialization failed: {e}"))
+                })?
+                .len();
+            if len > 8192 {
+                // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-7a
+                return Err(UsageEmitterError::metadata_too_large(len));
+                // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-7a
+            }
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-7
+        Ok(())
+    }
+
+    /// Starts a [`UsageRecordBuilder`] with `module`, `tenant_id`, `resource_id`, and
+    /// `resource_type` from this authorization handle.
+    #[must_use]
+    pub fn build_usage_record(
+        &self,
+        metric: impl Into<String>,
+        value: f64,
+    ) -> UsageRecordBuilder<'_> {
+        UsageRecordBuilder::new(self, metric, value)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "authorized_emitter_tests.rs"]
+mod authorized_emitter_tests;

--- a/modules/system/usage-collector/usage-emitter/src/authorized_emitter_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/src/authorized_emitter_tests.rs
@@ -1,0 +1,347 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use modkit_db::migration_runner::run_migrations_for_testing;
+use modkit_db::outbox::{
+    LeasedMessageHandler, MessageResult, Outbox, OutboxHandle, OutboxMessage, Partitions,
+    outbox_migrations,
+};
+use modkit_db::{ConnectOpts, Db, connect_db};
+use usage_collector_sdk::models::{UsageKind, UsageRecord};
+use uuid::Uuid;
+
+use super::AuthorizedUsageEmitter;
+use crate::config::UsageEmitterConfig;
+use crate::error::UsageEmitterError;
+
+// ── Infrastructure ────────────────────────────────────────────────────────────
+
+struct NoopHandler;
+
+#[async_trait]
+impl LeasedMessageHandler for NoopHandler {
+    async fn handle(&self, _msg: &OutboxMessage) -> MessageResult {
+        MessageResult::Ok
+    }
+}
+
+async fn build_db(name: &str) -> Db {
+    let url = format!("sqlite:file:{name}?mode=memory&cache=shared");
+    let db = connect_db(
+        &url,
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    run_migrations_for_testing(&db, outbox_migrations())
+        .await
+        .unwrap();
+    db
+}
+
+async fn build_outbox(db: Db) -> OutboxHandle {
+    let cfg = UsageEmitterConfig::default();
+    Outbox::builder(db)
+        .queue(
+            cfg.outbox_queue.as_str(),
+            Partitions::of(cfg.outbox_partition_count),
+        )
+        .leased(NoopHandler)
+        .start()
+        .await
+        .unwrap()
+}
+
+const FIXTURE_RESOURCE_TYPE: &str = "test.resource";
+
+// ── Test fixture ──────────────────────────────────────────────────────────────
+
+struct Fixture {
+    db: Db,
+    _handle: OutboxHandle,
+    emitter: AuthorizedUsageEmitter,
+    tenant: Uuid,
+    resource_id: Uuid,
+}
+
+impl Fixture {
+    async fn build(name: &str) -> Self {
+        Self::build_with_config(name, UsageEmitterConfig::default()).await
+    }
+
+    async fn build_with_config(name: &str, config: UsageEmitterConfig) -> Self {
+        use usage_collector_sdk::models::AllowedMetric;
+
+        let db = build_db(name).await;
+        let handle = build_outbox(db.clone()).await;
+        let outbox = Arc::clone(handle.outbox());
+        let tenant = Uuid::new_v4();
+        let resource_id = Uuid::new_v4();
+        let allowed_metrics = vec![
+            AllowedMetric {
+                name: "test.gauge".to_owned(),
+                kind: UsageKind::Gauge,
+            },
+            AllowedMetric {
+                name: "test.counter".to_owned(),
+                kind: UsageKind::Counter,
+            },
+        ];
+        let emitter = AuthorizedUsageEmitter::new(
+            Arc::new(config),
+            db.clone(),
+            outbox,
+            "test-module".to_owned(),
+            tenant,
+            resource_id,
+            FIXTURE_RESOURCE_TYPE.to_owned(),
+            allowed_metrics,
+            Some(Uuid::nil()),
+            Some("test.subject".to_owned()),
+        );
+        Self {
+            db,
+            _handle: handle,
+            emitter,
+            tenant,
+            resource_id,
+        }
+    }
+
+    fn record(&self) -> UsageRecord {
+        UsageRecord {
+            tenant_id: self.tenant,
+            module: "test-module".to_owned(),
+            metric: "test.gauge".to_owned(),
+            kind: UsageKind::Gauge,
+            value: 1.0,
+            resource_id: self.resource_id,
+            resource_type: FIXTURE_RESOURCE_TYPE.to_owned(),
+            subject_id: Some(Uuid::nil()),
+            subject_type: Some("test.subject".to_owned()),
+            idempotency_key: Uuid::new_v4().to_string(),
+            timestamp: Utc::now(),
+            metadata: None,
+        }
+    }
+
+    fn record_with_kind(&self, kind: UsageKind, value: f64) -> UsageRecord {
+        let metric = match kind {
+            UsageKind::Gauge => "test.gauge",
+            UsageKind::Counter => "test.counter",
+        }
+        .to_owned();
+        UsageRecord {
+            metric,
+            kind,
+            value,
+            ..self.record()
+        }
+    }
+
+    fn conn(&self) -> modkit_db::DbConn<'_> {
+        self.db.conn().unwrap()
+    }
+}
+
+// ── Expiry ────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_expired_authorization() {
+    let f = Fixture::build_with_config(
+        "ap_expired",
+        UsageEmitterConfig {
+            authorization_max_age: Duration::ZERO,
+            ..Default::default()
+        },
+    )
+    .await;
+    let err = f
+        .emitter
+        .enqueue_in(&f.conn(), f.record())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, UsageEmitterError::AuthorizationExpired));
+}
+
+#[tokio::test]
+async fn enqueue_accepts_usage_record() {
+    let f = Fixture::build("ap_pos_val").await;
+    f.emitter.enqueue_in(&f.conn(), f.record()).await.unwrap();
+}
+
+// ── Authorization scope ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_tenant() {
+    let f = Fixture::build("ap_bad_tenant").await;
+    let record = UsageRecord {
+        tenant_id: Uuid::new_v4(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::AuthorizationFailed { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_resource_id() {
+    let f = Fixture::build("ap_bad_res").await;
+    let record = UsageRecord {
+        resource_id: Uuid::new_v4(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::AuthorizationFailed { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_resource_type() {
+    let f = Fixture::build("ap_bad_rt").await;
+    let record = UsageRecord {
+        resource_type: "other.resource".to_owned(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::AuthorizationFailed { .. }));
+}
+
+// ── Counter value ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_negative_counter_value() {
+    let f = Fixture::build("ap_neg_ctr").await;
+    let record = f.record_with_kind(UsageKind::Counter, -1.0);
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageEmitterError::NegativeCounterValue { value } if (value + 1.0).abs() < f64::EPSILON
+    ));
+}
+
+#[tokio::test]
+async fn enqueue_accepts_zero_counter_value() {
+    let f = Fixture::build("ap_zero_ctr").await;
+    f.emitter
+        .enqueue_in(&f.conn(), f.record_with_kind(UsageKind::Counter, 0.0))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn enqueue_accepts_negative_gauge_value() {
+    let f = Fixture::build("ap_neg_gauge").await;
+    f.emitter
+        .enqueue_in(&f.conn(), f.record_with_kind(UsageKind::Gauge, -1.0))
+        .await
+        .unwrap();
+}
+
+// ── Metric validation ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_metric_not_in_allowed_list() {
+    let f = Fixture::build("ap_metric_disallowed").await;
+    let record = UsageRecord {
+        metric: "not.allowed.metric".to_owned(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(
+        matches!(err, UsageEmitterError::MetricNotAllowed { ref metric } if metric == "not.allowed.metric")
+    );
+}
+
+#[tokio::test]
+async fn enqueue_rejects_metric_kind_mismatch() {
+    let f = Fixture::build("ap_kind_mismatch").await;
+    // "test.counter" is registered as Counter; submitting it as Gauge is a kind mismatch.
+    let record = UsageRecord {
+        metric: "test.counter".to_owned(),
+        kind: UsageKind::Gauge,
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageEmitterError::MetricKindMismatch {
+            ref metric,
+            expected: UsageKind::Counter,
+            actual: UsageKind::Gauge,
+        } if metric == "test.counter"
+    ));
+}
+
+// ── Module and subject mismatch rejection ─────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_module() {
+    let f = Fixture::build("ap_bad_module").await;
+    let record = UsageRecord {
+        module: "wrong-module".to_owned(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidRecord { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_subject_id() {
+    let f = Fixture::build("ap_bad_subj_id").await;
+    let record = UsageRecord {
+        subject_id: Some(Uuid::new_v4()), // differs from Some(Uuid::nil()) in the token
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidRecord { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_subject_type() {
+    let f = Fixture::build("ap_bad_subj_type").await;
+    let record = UsageRecord {
+        subject_type: Some("other.subject".to_owned()), // differs from Some("test.subject") in the token
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidRecord { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_accepts_record_when_module_and_subject_match_token() {
+    let f = Fixture::build("ap_match_ok").await;
+    // f.record() already has module="test-module", subject_id=Some(Uuid::nil()), subject_type=Some("test.subject")
+    f.emitter.enqueue_in(&f.conn(), f.record()).await.unwrap();
+}
+
+// ── Counter idempotency key ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_counter_record_with_empty_idempotency_key() {
+    let f = Fixture::build("ap_ctr_empty_key").await;
+    let record = UsageRecord {
+        metric: "test.counter".to_owned(),
+        kind: UsageKind::Counter,
+        idempotency_key: String::new(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidRecord { .. }));
+}
+
+// ── Metadata size ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_record_with_oversized_metadata() {
+    let f = Fixture::build("ap_metadata_large").await;
+    let record = UsageRecord {
+        metadata: Some(serde_json::Value::String("x".repeat(8193))),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::MetadataTooLarge { .. }));
+}

--- a/modules/system/usage-collector/usage-emitter/src/config.rs
+++ b/modules/system/usage-collector/usage-emitter/src/config.rs
@@ -1,0 +1,80 @@
+use std::time::Duration;
+
+use serde::Deserialize;
+
+/// Configuration for [`crate::UsageEmitter`].
+///
+/// Host modules embed this inside their own config struct and forward it to
+/// [`crate::UsageEmitter::build`]. All fields have sensible defaults so
+/// `#[serde(default)]` on the embedding struct is sufficient for zero-config usage.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct UsageEmitterConfig {
+    /// Maximum age of an [`crate::AuthorizedUsageEmitter`] handle after
+    /// [`crate::UsageEmitterV1::authorize`] before
+    /// [`crate::AuthorizedUsageEmitter::enqueue`] / [`crate::AuthorizedUsageEmitter::enqueue_in`]
+    /// reject it with [`crate::UsageEmitterError::AuthorizationExpired`].
+    pub authorization_max_age: Duration,
+
+    /// Outbox queue name for usage records delivered to the collector.
+    pub outbox_queue: String,
+
+    /// Number of outbox partitions. Must be a power of 2 in 1-64.
+    pub outbox_partition_count: u16,
+
+    /// Maximum exponential-backoff delay for outbox delivery retries.
+    ///
+    /// Maps to [`modkit_db::outbox::WorkerTuning::retry_max`].
+    /// MUST remain below 15 minutes to satisfy `cpt-cf-usage-collector-nfr-recovery`
+    /// (inst-dlv-6a / inst-emit-10a).
+    pub outbox_backoff_max: Duration,
+}
+
+impl Default for UsageEmitterConfig {
+    fn default() -> Self {
+        Self {
+            authorization_max_age: Duration::from_secs(30),
+            outbox_queue: "usage-records".to_owned(),
+            outbox_partition_count: 4,
+            outbox_backoff_max: Duration::from_mins(10), // 10 minutes — well below the 15-minute NFR ceiling
+        }
+    }
+}
+
+impl UsageEmitterConfig {
+    /// # Errors
+    ///
+    /// Returns an error when any configuration field is invalid.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !self.outbox_queue.trim().is_empty(),
+            "outbox_queue must not be empty"
+        );
+        anyhow::ensure!(
+            (1..=64).contains(&self.outbox_partition_count)
+                && self.outbox_partition_count.is_power_of_two(),
+            "outbox_partition_count must be a power of 2 in 1-64, got {}",
+            self.outbox_partition_count
+        );
+        anyhow::ensure!(
+            !self.authorization_max_age.is_zero(),
+            "authorization_max_age must be > 0"
+        );
+        anyhow::ensure!(
+            self.outbox_backoff_max > Duration::ZERO,
+            "outbox_backoff_max must be greater than zero"
+        );
+        anyhow::ensure!(
+            self.outbox_backoff_max < Duration::from_mins(15),
+            "outbox_backoff_max must be below 15 minutes (cpt-cf-usage-collector-nfr-recovery), got {:?}",
+            self.outbox_backoff_max
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "config_tests.rs"]
+mod config_tests;

--- a/modules/system/usage-collector/usage-emitter/src/config_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/src/config_tests.rs
@@ -1,0 +1,111 @@
+use std::time::Duration;
+
+use super::UsageEmitterConfig;
+
+#[test]
+fn default_authorization_max_age_is_30_seconds() {
+    let cfg = UsageEmitterConfig::default();
+    assert_eq!(cfg.authorization_max_age, Duration::from_secs(30));
+}
+
+#[test]
+fn default_outbox_queue_is_usage_records() {
+    let cfg = UsageEmitterConfig::default();
+    assert_eq!(cfg.outbox_queue, "usage-records");
+}
+
+#[test]
+fn default_outbox_partition_count_is_4() {
+    let cfg = UsageEmitterConfig::default();
+    assert_eq!(cfg.outbox_partition_count, 4);
+}
+
+#[test]
+fn validate_accepts_defaults() {
+    UsageEmitterConfig::default().validate().unwrap();
+}
+
+#[test]
+fn validate_rejects_empty_outbox_queue() {
+    let cfg = UsageEmitterConfig {
+        outbox_queue: "   ".to_owned(),
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("outbox_queue"));
+}
+
+#[test]
+fn validate_rejects_invalid_outbox_partition_count_zero() {
+    let cfg = UsageEmitterConfig {
+        outbox_partition_count: 0,
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("outbox_partition_count"));
+}
+
+#[test]
+fn validate_rejects_invalid_outbox_partition_count_not_power_of_two() {
+    let cfg = UsageEmitterConfig {
+        outbox_partition_count: 3,
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("outbox_partition_count"));
+}
+
+#[test]
+fn validate_rejects_invalid_outbox_partition_count_above_64() {
+    let cfg = UsageEmitterConfig {
+        outbox_partition_count: 65,
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("outbox_partition_count"));
+}
+
+#[test]
+fn validate_rejects_zero_authorization_max_age() {
+    let cfg = UsageEmitterConfig {
+        authorization_max_age: Duration::ZERO,
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("authorization_max_age"));
+}
+
+#[test]
+fn default_outbox_backoff_max_is_10_minutes() {
+    let cfg = UsageEmitterConfig::default();
+    assert_eq!(cfg.outbox_backoff_max, Duration::from_mins(10));
+}
+
+#[test]
+fn validate_rejects_zero_outbox_backoff_max() {
+    let cfg = UsageEmitterConfig {
+        outbox_backoff_max: Duration::ZERO,
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("outbox_backoff_max"));
+}
+
+#[test]
+fn validate_rejects_outbox_backoff_max_at_or_above_15_minutes() {
+    let cfg = UsageEmitterConfig {
+        outbox_backoff_max: Duration::from_mins(15),
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("outbox_backoff_max"));
+}
+
+#[test]
+fn validate_accepts_outbox_backoff_max_below_15_minutes() {
+    let cfg = UsageEmitterConfig {
+        outbox_backoff_max: Duration::from_secs(899),
+        ..UsageEmitterConfig::default()
+    };
+    cfg.validate().unwrap();
+}

--- a/modules/system/usage-collector/usage-emitter/src/domain/authz.rs
+++ b/modules/system/usage-collector/usage-emitter/src/domain/authz.rs
@@ -1,0 +1,39 @@
+//! PDP resource type and action constants for usage-record authorization.
+
+use authz_resolver_sdk::pep::ResourceType;
+use modkit_security::pep_properties;
+
+/// Property names for usage record ABAC (beyond shared `pep_properties`).
+pub mod properties {
+    /// Metered resource instance identifier (usage record resource property).
+    pub const RESOURCE_ID: &str = "resource_id";
+    /// Metered resource type (usage record resource property).
+    pub const RESOURCE_TYPE: &str = "resource_type";
+    /// Source module identity (usage record resource property).
+    pub const MODULE: &str = "module";
+    /// Subject UUID (usage record resource property).
+    pub const SUBJECT_ID: &str = "subject_id";
+    /// Subject kind (usage record resource property).
+    pub const SUBJECT_TYPE: &str = "subject_type";
+}
+
+/// Usage record resource type used by [`crate::UsageEmitter::authorize_for`].
+///
+/// Resource properties include `owner_tenant_id`, `resource_id`, `resource_type`,
+/// `module`, `subject_id`, and `subject_type`.
+pub const USAGE_RECORD: ResourceType = ResourceType {
+    name: "gts.cf.core.usage.record.v1~",
+    supported_properties: &[
+        pep_properties::OWNER_TENANT_ID,
+        properties::RESOURCE_ID,
+        properties::RESOURCE_TYPE,
+        properties::MODULE,
+        properties::SUBJECT_ID,
+        properties::SUBJECT_TYPE,
+    ],
+};
+
+/// Authorization action name used when calling the PDP.
+pub mod actions {
+    pub const CREATE: &str = "create";
+}

--- a/modules/system/usage-collector/usage-emitter/src/domain/mod.rs
+++ b/modules/system/usage-collector/usage-emitter/src/domain/mod.rs
@@ -1,0 +1,1 @@
+pub mod authz;

--- a/modules/system/usage-collector/usage-emitter/src/emitter.rs
+++ b/modules/system/usage-collector/usage-emitter/src/emitter.rs
@@ -1,0 +1,113 @@
+use std::sync::Arc;
+
+use authz_resolver_sdk::AuthZResolverClient;
+use authz_resolver_sdk::EnforcerError;
+use modkit_db::Db;
+use modkit_db::outbox::WorkerTuning;
+use modkit_db::outbox::{Outbox, OutboxHandle, Partitions};
+use usage_collector_sdk::UsageCollectorClientV1;
+
+use crate::api::UsageEmitterV1;
+use crate::config::UsageEmitterConfig;
+use crate::infra::delivery_handler::DeliveryHandler;
+use crate::scoped_emitter::ScopedUsageEmitter;
+
+/// An emitter that starts the usage outbox worker and issues scoped emit handles.
+///
+/// Constructed via [`UsageEmitter::build`]. Call [`UsageEmitterV1::for_module`] to obtain a
+/// [`ScopedUsageEmitter`] bound to a module name, then use its `authorize_for` / `authorize` to
+/// get a time-limited [`crate::AuthorizedUsageEmitter`].
+pub struct UsageEmitter {
+    config: Arc<UsageEmitterConfig>,
+    db: Db,
+    authz: Arc<dyn AuthZResolverClient>,
+    collector: Arc<dyn UsageCollectorClientV1>,
+    outbox_handle: OutboxHandle,
+}
+
+impl UsageEmitter {
+    /// Build a [`UsageEmitter`] and start the background outbox worker.
+    ///
+    /// Registers the `usage-records` queue, attaches `delivery_handler` for async delivery to
+    /// `collector`, and wires the [`authz_resolver_sdk::pep::PolicyEnforcer`] for per-call PDP checks.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the outbox worker fails to start (e.g. DB unavailable or
+    /// queue registration fails).
+    pub async fn build(
+        config: UsageEmitterConfig,
+        db: Db,
+        authz: Arc<dyn AuthZResolverClient>,
+        collector: Arc<dyn UsageCollectorClientV1>,
+    ) -> anyhow::Result<Self> {
+        config.validate()?;
+
+        let delivery_handler = DeliveryHandler::new(Arc::clone(&collector));
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-6a
+        let processor_tuning =
+            WorkerTuning::processor_default().retry_max(config.outbox_backoff_max);
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-6a
+
+        let outbox_handle = Outbox::builder(db.clone())
+            .processor_tuning(processor_tuning)
+            .queue(
+                &config.outbox_queue,
+                Partitions::of(config.outbox_partition_count),
+            )
+            .leased(delivery_handler)
+            .start()
+            .await
+            .map_err(anyhow::Error::from)?;
+
+        Ok(Self {
+            config: Arc::new(config),
+            db,
+            authz,
+            collector,
+            outbox_handle,
+        })
+    }
+}
+
+impl UsageEmitterV1 for UsageEmitter {
+    fn for_module(&self, module_name: &str) -> ScopedUsageEmitter {
+        ScopedUsageEmitter::new(
+            module_name.to_owned(),
+            Arc::clone(&self.authz),
+            Arc::clone(&self.collector),
+            self.db.clone(),
+            Arc::clone(&self.config),
+            Arc::clone(self.outbox_handle.outbox()),
+        )
+    }
+}
+
+pub fn enforcer_error_to_emitter_error(e: EnforcerError) -> crate::error::UsageEmitterError {
+    use crate::error::UsageEmitterError;
+    use authz_resolver_sdk::EnforcerError;
+    match e {
+        EnforcerError::Denied { deny_reason } => {
+            let message = deny_reason.map_or_else(
+                || "access denied by policy".to_owned(),
+                |r| match r.details {
+                    Some(details) => format!("{}: {}", r.error_code, details),
+                    None => r.error_code,
+                },
+            );
+            UsageEmitterError::authorization_failed(message)
+        }
+        EnforcerError::CompileFailed(_) => {
+            UsageEmitterError::internal("authorization constraint compilation failed")
+        }
+        EnforcerError::EvaluationFailed(_) => {
+            UsageEmitterError::internal("authorization evaluation failed")
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "emitter_tests.rs"]
+mod emitter_tests;

--- a/modules/system/usage-collector/usage-emitter/src/emitter_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/src/emitter_tests.rs
@@ -1,0 +1,711 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use authz_resolver_sdk::models::{
+    BarrierMode, EvaluationRequest, EvaluationResponse, EvaluationResponseContext,
+};
+use authz_resolver_sdk::pep::ConstraintCompileError;
+use authz_resolver_sdk::{AuthZResolverClient, AuthZResolverError, DenyReason, EnforcerError};
+use modkit_db::migration_runner::run_migrations_for_testing;
+use modkit_db::outbox::outbox_migrations;
+use modkit_db::{ConnectOpts, Db, connect_db};
+use modkit_security::SecurityContext;
+use modkit_security::pep_properties;
+use usage_collector_sdk::models::UsageRecord;
+use usage_collector_sdk::{UsageCollectorClientV1, UsageCollectorError};
+use uuid::Uuid;
+
+use super::{UsageEmitter, enforcer_error_to_emitter_error};
+use crate::UsageEmitterV1;
+use crate::config::UsageEmitterConfig;
+use crate::error::UsageEmitterError;
+
+const TEST_MODULE: &str = "test-module";
+
+// ── Mock AuthZ clients ────────────────────────────────────────────────────────
+
+struct AllowAllAuthZ;
+
+#[async_trait]
+impl AuthZResolverClient for AllowAllAuthZ {
+    async fn evaluate(
+        &self,
+        _request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        Ok(EvaluationResponse {
+            decision: true,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+struct DenyAllAuthZ;
+
+#[async_trait]
+impl AuthZResolverClient for DenyAllAuthZ {
+    async fn evaluate(
+        &self,
+        _request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        Ok(EvaluationResponse {
+            decision: false,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+struct FailingAuthZ;
+
+#[async_trait]
+impl AuthZResolverClient for FailingAuthZ {
+    async fn evaluate(
+        &self,
+        _request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        Err(AuthZResolverError::Internal("PDP unavailable".to_owned()))
+    }
+}
+
+/// PDP mock: allow only if `owner_tenant_id` matches the subject's home tenant or an allowed extra id.
+struct AllowOwnerTenantIfInSet {
+    /// Tenants allowed in addition to the subject's `tenant_id` (e.g. sub-tenants).
+    extra_allowed: Vec<Uuid>,
+}
+
+#[async_trait]
+impl AuthZResolverClient for AllowOwnerTenantIfInSet {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let subject_tenant = request
+            .subject
+            .properties
+            .get("tenant_id")
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok());
+
+        let Some(subject_tenant) = subject_tenant else {
+            return Ok(EvaluationResponse {
+                decision: false,
+                context: EvaluationResponseContext::default(),
+            });
+        };
+
+        let owner = request
+            .resource
+            .properties
+            .get(pep_properties::OWNER_TENANT_ID)
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok());
+
+        let Some(owner) = owner else {
+            return Ok(EvaluationResponse {
+                decision: false,
+                context: EvaluationResponseContext::default(),
+            });
+        };
+
+        let allowed = owner == subject_tenant || self.extra_allowed.contains(&owner);
+
+        Ok(EvaluationResponse {
+            decision: allowed,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+/// Asserts `tenant_context.barrier_mode` is `Ignore` and returns allow.
+struct AssertBarrierIgnoreAuthZ;
+
+#[async_trait]
+impl AuthZResolverClient for AssertBarrierIgnoreAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let barrier = request
+            .context
+            .tenant_context
+            .as_ref()
+            .expect("tenant_context set by AccessRequest::barrier_mode")
+            .barrier_mode;
+        assert_eq!(barrier, BarrierMode::Ignore);
+        Ok(EvaluationResponse {
+            decision: true,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+// ── Mock collector ────────────────────────────────────────────────────────────
+
+struct NoopCollector;
+
+#[async_trait]
+impl UsageCollectorClientV1 for NoopCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<usage_collector_sdk::ModuleConfig, UsageCollectorError> {
+        Ok(usage_collector_sdk::ModuleConfig {
+            allowed_metrics: vec![],
+        })
+    }
+}
+
+struct FailingCollector {
+    error: fn() -> UsageCollectorError,
+}
+
+#[async_trait]
+impl UsageCollectorClientV1 for FailingCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<usage_collector_sdk::ModuleConfig, UsageCollectorError> {
+        Err((self.error)())
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async fn build_db(name: &str) -> Db {
+    let url = format!("sqlite:file:{name}?mode=memory&cache=shared");
+    let db = connect_db(
+        &url,
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    run_migrations_for_testing(&db, outbox_migrations())
+        .await
+        .unwrap();
+    db
+}
+
+async fn build_emitter(db: Db, authz: Arc<dyn AuthZResolverClient>) -> UsageEmitter {
+    UsageEmitter::build(
+        UsageEmitterConfig::default(),
+        db,
+        authz,
+        Arc::new(NoopCollector),
+    )
+    .await
+    .unwrap()
+}
+
+async fn build_emitter_with_collector(
+    db: Db,
+    authz: Arc<dyn AuthZResolverClient>,
+    collector: Arc<dyn UsageCollectorClientV1>,
+) -> UsageEmitter {
+    UsageEmitter::build(UsageEmitterConfig::default(), db, authz, collector)
+        .await
+        .unwrap()
+}
+
+fn make_ctx() -> SecurityContext {
+    SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(Uuid::new_v4())
+        .build()
+        .unwrap()
+}
+
+// ── enforcer_error_to_emitter_error ──────────────────────────────────────────
+
+#[test]
+fn enforcer_denied_without_reason_uses_default_message() {
+    let err = enforcer_error_to_emitter_error(EnforcerError::Denied { deny_reason: None });
+    assert!(
+        matches!(err, UsageEmitterError::AuthorizationFailed { ref message } if message == "access denied by policy")
+    );
+}
+
+#[test]
+fn enforcer_denied_with_code_and_details() {
+    let deny_reason = Some(DenyReason {
+        error_code: "ERR_FORBIDDEN".to_owned(),
+        details: Some("tenant not allowed".to_owned()),
+    });
+    let err = enforcer_error_to_emitter_error(EnforcerError::Denied { deny_reason });
+    assert!(
+        matches!(err, UsageEmitterError::AuthorizationFailed { ref message } if message == "ERR_FORBIDDEN: tenant not allowed")
+    );
+}
+
+#[test]
+fn enforcer_denied_with_code_no_details() {
+    let deny_reason = Some(DenyReason {
+        error_code: "ERR_FORBIDDEN".to_owned(),
+        details: None,
+    });
+    let err = enforcer_error_to_emitter_error(EnforcerError::Denied { deny_reason });
+    assert!(
+        matches!(err, UsageEmitterError::AuthorizationFailed { ref message } if message == "ERR_FORBIDDEN")
+    );
+}
+
+#[test]
+fn enforcer_compile_failed_maps_to_internal() {
+    let err = enforcer_error_to_emitter_error(EnforcerError::CompileFailed(
+        ConstraintCompileError::ConstraintsRequiredButAbsent,
+    ));
+    assert!(matches!(err, UsageEmitterError::Internal { .. }));
+}
+
+#[test]
+fn enforcer_evaluation_failed_maps_to_internal() {
+    let err = enforcer_error_to_emitter_error(EnforcerError::EvaluationFailed(
+        AuthZResolverError::Internal("rpc error".to_owned()),
+    ));
+    assert!(matches!(err, UsageEmitterError::Internal { .. }));
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn build_creates_emitter_with_valid_config() {
+    let db = build_db("emit_build").await;
+    build_emitter(db, Arc::new(AllowAllAuthZ)).await;
+}
+
+#[tokio::test]
+async fn authorize_returns_handle_on_allow_all_authz() {
+    let db = build_db("emit_authz_allow").await;
+    let emitter = build_emitter(db, Arc::new(AllowAllAuthZ)).await;
+    let ctx = make_ctx();
+    emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn authorize_returns_error_on_deny_all_authz() {
+    let db = build_db("emit_authz_deny").await;
+    let emitter = build_emitter(db, Arc::new(DenyAllAuthZ)).await;
+    let ctx = make_ctx();
+    let Err(err) = emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await
+    else {
+        panic!("expected authorization to fail");
+    };
+    assert!(matches!(err, UsageEmitterError::AuthorizationFailed { .. }));
+}
+
+#[tokio::test]
+async fn authorize_returns_internal_error_on_authz_failure() {
+    let db = build_db("emit_authz_fail").await;
+    let emitter = build_emitter(db, Arc::new(FailingAuthZ)).await;
+    let ctx = make_ctx();
+    let Err(err) = emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await
+    else {
+        panic!("expected authorization to fail");
+    };
+    assert!(matches!(err, UsageEmitterError::Internal { .. }));
+}
+
+#[tokio::test]
+async fn authorize_for_denies_when_pdp_rejects_owner_tenant() {
+    let db = build_db("emit_pdp_deny_foreign").await;
+    let emitter = build_emitter(
+        db,
+        Arc::new(AllowOwnerTenantIfInSet {
+            extra_allowed: vec![],
+        }),
+    )
+    .await;
+
+    let subject_tenant = Uuid::new_v4();
+    let foreign_tenant = Uuid::new_v4();
+    let ctx = SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(subject_tenant)
+        .build()
+        .unwrap();
+
+    let Err(err) = emitter
+        .for_module(TEST_MODULE)
+        .authorize_for(
+            &ctx,
+            foreign_tenant,
+            Uuid::new_v4(),
+            "test.resource".to_owned(),
+            Some(Uuid::new_v4()),
+            Some("test.subject".to_owned()),
+        )
+        .await
+    else {
+        panic!("expected authorization to fail");
+    };
+    assert!(matches!(err, UsageEmitterError::AuthorizationFailed { .. }));
+}
+
+#[tokio::test]
+async fn authorize_for_allows_subtenant_when_pdp_allows_extra_tenant() {
+    let db = build_db("emit_pdp_allow_child").await;
+    let parent = Uuid::new_v4();
+    let child = Uuid::new_v4();
+    let emitter = build_emitter(
+        db,
+        Arc::new(AllowOwnerTenantIfInSet {
+            extra_allowed: vec![child],
+        }),
+    )
+    .await;
+
+    let ctx = SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(parent)
+        .build()
+        .unwrap();
+
+    emitter
+        .for_module(TEST_MODULE)
+        .authorize_for(
+            &ctx,
+            child,
+            Uuid::new_v4(),
+            "test.resource".to_owned(),
+            Some(Uuid::new_v4()),
+            Some("test.subject".to_owned()),
+        )
+        .await
+        .expect("PDP allows emit for allowed sub-tenant");
+}
+
+#[tokio::test]
+async fn authorize_for_sends_barrier_mode_ignore_to_pdp() {
+    let db = build_db("emit_barrier_ignore").await;
+    let emitter = build_emitter(db, Arc::new(AssertBarrierIgnoreAuthZ)).await;
+    let ctx = make_ctx();
+    emitter
+        .for_module(TEST_MODULE)
+        .authorize_for(
+            &ctx,
+            ctx.subject_tenant_id(),
+            Uuid::new_v4(),
+            "test.resource".to_owned(),
+            Some(Uuid::new_v4()),
+            Some("test.subject".to_owned()),
+        )
+        .await
+        .expect("barrier assert + allow");
+}
+
+// ── Collector infrastructure failures map to Internal (not AuthorizationFailed) ──
+
+#[tokio::test]
+async fn authorize_for_maps_collector_plugin_timeout_to_internal() {
+    let db = build_db("emit_collector_timeout").await;
+    let emitter = build_emitter_with_collector(
+        db,
+        Arc::new(AllowAllAuthZ),
+        Arc::new(FailingCollector {
+            error: UsageCollectorError::plugin_timeout,
+        }),
+    )
+    .await;
+    let ctx = make_ctx();
+    let result = emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await;
+    assert!(matches!(result, Err(UsageEmitterError::Internal { .. })));
+}
+
+#[tokio::test]
+async fn authorize_for_maps_collector_circuit_open_to_internal() {
+    let db = build_db("emit_collector_circuit_open").await;
+    let emitter = build_emitter_with_collector(
+        db,
+        Arc::new(AllowAllAuthZ),
+        Arc::new(FailingCollector {
+            error: UsageCollectorError::circuit_open,
+        }),
+    )
+    .await;
+    let ctx = make_ctx();
+    let result = emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await;
+    assert!(matches!(result, Err(UsageEmitterError::Internal { .. })));
+}
+
+#[tokio::test]
+async fn authorize_for_maps_collector_unavailable_to_internal() {
+    let db = build_db("emit_collector_unavailable").await;
+    let emitter = build_emitter_with_collector(
+        db,
+        Arc::new(AllowAllAuthZ),
+        Arc::new(FailingCollector {
+            error: || UsageCollectorError::unavailable("gateway unreachable"),
+        }),
+    )
+    .await;
+    let ctx = make_ctx();
+    let result = emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await;
+    assert!(matches!(result, Err(UsageEmitterError::Internal { .. })));
+}
+
+#[tokio::test]
+async fn authorize_for_maps_collector_internal_error_to_internal() {
+    let db = build_db("emit_collector_internal").await;
+    let emitter = build_emitter_with_collector(
+        db,
+        Arc::new(AllowAllAuthZ),
+        Arc::new(FailingCollector {
+            error: || UsageCollectorError::internal("unexpected state"),
+        }),
+    )
+    .await;
+    let ctx = make_ctx();
+    let result = emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await;
+    assert!(matches!(result, Err(UsageEmitterError::Internal { .. })));
+}
+
+// ── PDP resource property assertions ─────────────────────────────────────────
+
+/// PDP mock that asserts the MODULE resource property equals the expected value,
+/// denies if the assertion fails, otherwise allows.
+struct AssertModulePropertyAuthZ {
+    expected_module: String,
+    matched: Arc<Mutex<bool>>,
+}
+
+#[async_trait]
+impl AuthZResolverClient for AssertModulePropertyAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        use crate::domain::authz::properties;
+        let module_val = request
+            .resource
+            .properties
+            .get(properties::MODULE)
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let ok = module_val == self.expected_module;
+        *self.matched.lock().unwrap() = ok;
+        Ok(EvaluationResponse {
+            decision: ok,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+/// PDP mock that asserts `SUBJECT_ID` and `SUBJECT_TYPE` resource properties equal
+/// the expected values, denies if either assertion fails, otherwise allows.
+struct AssertSubjectPropertiesAuthZ {
+    expected_subject_id: String,
+    expected_subject_type: String,
+    matched: Arc<Mutex<bool>>,
+}
+
+#[async_trait]
+impl AuthZResolverClient for AssertSubjectPropertiesAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        use crate::domain::authz::properties;
+        let subj_id = request
+            .resource
+            .properties
+            .get(properties::SUBJECT_ID)
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let subj_type = request
+            .resource
+            .properties
+            .get(properties::SUBJECT_TYPE)
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let ok = subj_id == self.expected_subject_id && subj_type == self.expected_subject_type;
+        *self.matched.lock().unwrap() = ok;
+        Ok(EvaluationResponse {
+            decision: ok,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+#[tokio::test]
+async fn authorize_for_pdp_request_includes_module_resource_property() {
+    let matched = Arc::new(Mutex::new(false));
+    let db = build_db("emit_module_prop").await;
+    let emitter = build_emitter(
+        db,
+        Arc::new(AssertModulePropertyAuthZ {
+            expected_module: TEST_MODULE.to_owned(),
+            matched: Arc::clone(&matched),
+        }),
+    )
+    .await;
+    let ctx = make_ctx();
+    drop(
+        emitter
+            .for_module(TEST_MODULE)
+            .authorize_for(
+                &ctx,
+                ctx.subject_tenant_id(),
+                Uuid::new_v4(),
+                "test.resource".to_owned(),
+                Some(Uuid::new_v4()),
+                Some("test.subject".to_owned()),
+            )
+            .await,
+    );
+    assert!(
+        *matched.lock().unwrap(),
+        "PDP request must include MODULE resource property equal to the module name"
+    );
+}
+
+/// PDP mock that asserts `SUBJECT_ID` and `SUBJECT_TYPE` resource properties equal
+/// the expected values (with subject present), denies if either assertion fails, otherwise allows.
+/// This mock documents the "with subject" variant of the subject-properties test.
+#[tokio::test]
+async fn authorize_for_pdp_request_includes_subject_id_and_subject_type_resource_properties() {
+    let matched = Arc::new(Mutex::new(false));
+    let subject_id = Uuid::new_v4();
+    let subject_type = "test.subject.type".to_owned();
+    let db = build_db("emit_subject_props").await;
+    let emitter = build_emitter(
+        db,
+        Arc::new(AssertSubjectPropertiesAuthZ {
+            expected_subject_id: subject_id.to_string(),
+            expected_subject_type: subject_type.clone(),
+            matched: Arc::clone(&matched),
+        }),
+    )
+    .await;
+    let ctx = make_ctx();
+    drop(
+        emitter
+            .for_module(TEST_MODULE)
+            .authorize_for(
+                &ctx,
+                ctx.subject_tenant_id(),
+                Uuid::new_v4(),
+                "test.resource".to_owned(),
+                Some(subject_id),
+                Some(subject_type),
+            )
+            .await,
+    );
+    assert!(
+        *matched.lock().unwrap(),
+        "PDP request must include SUBJECT_ID and SUBJECT_TYPE resource properties with the passed values"
+    );
+}
+
+/// PDP mock that asserts neither `SUBJECT_ID` nor `SUBJECT_TYPE` resource property is present
+/// in the PDP request, returns allow if the assertion passes, deny otherwise.
+struct AssertNoSubjectPropertiesAuthZ {
+    asserted: Arc<Mutex<bool>>,
+}
+
+#[async_trait]
+impl AuthZResolverClient for AssertNoSubjectPropertiesAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        use crate::domain::authz::properties;
+        let has_subject_id = request
+            .resource
+            .properties
+            .contains_key(properties::SUBJECT_ID);
+        let has_subject_type = request
+            .resource
+            .properties
+            .contains_key(properties::SUBJECT_TYPE);
+        let ok = !has_subject_id && !has_subject_type;
+        *self.asserted.lock().unwrap() = ok;
+        Ok(EvaluationResponse {
+            decision: ok,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+#[tokio::test]
+async fn authorize_for_without_subject_succeeds() {
+    let db = build_db("emit_no_subject_allow").await;
+    let emitter = build_emitter(db, Arc::new(AllowAllAuthZ)).await;
+    let ctx = make_ctx();
+    let result = emitter
+        .for_module(TEST_MODULE)
+        .authorize_for(
+            &ctx,
+            ctx.subject_tenant_id(),
+            Uuid::new_v4(),
+            "test.resource".to_owned(),
+            None,
+            None,
+        )
+        .await;
+    assert!(
+        result.is_ok(),
+        "authorize_for with None subject must succeed when PDP allows"
+    );
+}
+
+#[tokio::test]
+async fn authorize_for_pdp_request_omits_subject_properties_when_none() {
+    let asserted = Arc::new(Mutex::new(false));
+    let db = build_db("emit_no_subject_props").await;
+    let emitter = build_emitter(
+        db,
+        Arc::new(AssertNoSubjectPropertiesAuthZ {
+            asserted: Arc::clone(&asserted),
+        }),
+    )
+    .await;
+    let ctx = make_ctx();
+    drop(
+        emitter
+            .for_module(TEST_MODULE)
+            .authorize_for(
+                &ctx,
+                ctx.subject_tenant_id(),
+                Uuid::new_v4(),
+                "test.resource".to_owned(),
+                None,
+                None,
+            )
+            .await,
+    );
+    assert!(
+        *asserted.lock().unwrap(),
+        "PDP request must NOT include SUBJECT_ID or SUBJECT_TYPE resource properties when subject is None"
+    );
+}

--- a/modules/system/usage-collector/usage-emitter/src/error.rs
+++ b/modules/system/usage-collector/usage-emitter/src/error.rs
@@ -1,0 +1,130 @@
+//! Error type for [`crate::ScopedUsageEmitter::authorize_for`],
+//! [`crate::AuthorizedUsageEmitter::enqueue`], [`crate::AuthorizedUsageEmitter::enqueue_in`],
+//! and [`crate::UsageRecordBuilder::enqueue`].
+
+use modkit_db::outbox::OutboxError as ModkitOutboxError;
+use usage_collector_sdk::models::UsageKind;
+
+/// Errors returned from [`crate::ScopedUsageEmitter::authorize_for`],
+/// [`crate::AuthorizedUsageEmitter::enqueue`], [`crate::AuthorizedUsageEmitter::enqueue_in`],
+/// and [`crate::UsageRecordBuilder::enqueue`].
+///
+/// All variants are produced *before* any DB write unless otherwise noted.
+#[derive(Debug, thiserror::Error)]
+pub enum UsageEmitterError {
+    /// The authorized emitter handle exceeded [`crate::UsageEmitterConfig::authorization_max_age`]
+    /// at [`crate::AuthorizedUsageEmitter::enqueue`] / [`crate::AuthorizedUsageEmitter::enqueue_in`]
+    /// evaluation time.
+    #[error("emit authorization token has expired")]
+    AuthorizationExpired,
+
+    /// PDP explicitly denied the source module.
+    #[error("authorization failed: {message}")]
+    AuthorizationFailed { message: String },
+
+    /// Required fields were missing when finishing a [`crate::UsageRecordBuilder`] enqueue path.
+    #[error("invalid usage record: {message}")]
+    InvalidRecord { message: String },
+
+    /// The usage record's kind does not match the registered kind for that metric.
+    #[error("metric '{metric}' expects kind {expected:?} but record specifies {actual:?}")]
+    MetricKindMismatch {
+        metric: String,
+        expected: UsageKind,
+        actual: UsageKind,
+    },
+
+    /// The metric is not in the allowed metrics list for this module.
+    #[error("metric not allowed for this module: {metric}")]
+    MetricNotAllowed { metric: String },
+
+    /// A counter [`usage_collector_sdk::models::UsageRecord`] was submitted with a negative `value`.
+    #[error("counter usage record has a negative value: {value}")]
+    NegativeCounterValue { value: f64 },
+
+    /// PDP communication failures and other unexpected conditions not covered by specific variants.
+    #[error("internal error: {message}")]
+    Internal { message: String },
+
+    /// The module is not registered in the gateway's static metric configuration.
+    #[error("module not configured: {module_name}")]
+    ModuleNotConfigured { module_name: String },
+
+    /// Metadata JSON exceeded the 8192-byte limit.
+    #[error("metadata byte length {len} exceeds the 8192-byte limit")]
+    MetadataTooLarge { len: usize },
+
+    /// Transactional outbox error (DB write failure, queue not registered, etc.).
+    #[error(transparent)]
+    Outbox(#[from] ModkitOutboxError),
+}
+
+impl UsageEmitterError {
+    #[must_use]
+    pub fn authorization_expired() -> Self {
+        Self::AuthorizationExpired
+    }
+
+    #[must_use]
+    pub fn authorization_failed(message: impl Into<String>) -> Self {
+        Self::AuthorizationFailed {
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal {
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn invalid_record(message: impl Into<String>) -> Self {
+        Self::InvalidRecord {
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn metric_kind_mismatch(
+        metric: impl Into<String>,
+        expected: UsageKind,
+        actual: UsageKind,
+    ) -> Self {
+        Self::MetricKindMismatch {
+            metric: metric.into(),
+            expected,
+            actual,
+        }
+    }
+
+    #[must_use]
+    pub fn metric_not_allowed(metric: impl Into<String>) -> Self {
+        Self::MetricNotAllowed {
+            metric: metric.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn negative_counter_value(value: f64) -> Self {
+        Self::NegativeCounterValue { value }
+    }
+
+    #[must_use]
+    pub fn module_not_configured(module_name: impl Into<String>) -> Self {
+        Self::ModuleNotConfigured {
+            module_name: module_name.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn metadata_too_large(len: usize) -> Self {
+        Self::MetadataTooLarge { len }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "error_tests.rs"]
+mod error_tests;

--- a/modules/system/usage-collector/usage-emitter/src/error_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/src/error_tests.rs
@@ -1,0 +1,57 @@
+use usage_collector_sdk::models::UsageKind;
+
+use super::*;
+
+// ── Display ───────────────────────────────────────────────────────
+
+#[test]
+fn display_authorization_expired() {
+    let err = UsageEmitterError::authorization_expired();
+    assert_eq!(err.to_string(), "emit authorization token has expired");
+}
+
+#[test]
+fn display_authorization_failed() {
+    let err = UsageEmitterError::authorization_failed("denied by policy");
+    assert_eq!(err.to_string(), "authorization failed: denied by policy");
+}
+
+#[test]
+fn display_negative_counter_value() {
+    let err = UsageEmitterError::negative_counter_value(-1.0);
+    assert_eq!(
+        err.to_string(),
+        "counter usage record has a negative value: -1"
+    );
+}
+
+#[test]
+fn display_invalid_record() {
+    let err = UsageEmitterError::invalid_record("missing tenant_id");
+    assert_eq!(err.to_string(), "invalid usage record: missing tenant_id");
+}
+
+#[test]
+fn display_metric_kind_mismatch() {
+    let err =
+        UsageEmitterError::metric_kind_mismatch("cpu.usage", UsageKind::Counter, UsageKind::Gauge);
+    assert_eq!(
+        err.to_string(),
+        "metric 'cpu.usage' expects kind Counter but record specifies Gauge"
+    );
+}
+
+#[test]
+fn display_metric_not_allowed() {
+    let err = UsageEmitterError::metric_not_allowed("unknown.metric");
+    assert_eq!(
+        err.to_string(),
+        "metric not allowed for this module: unknown.metric"
+    );
+}
+
+#[test]
+fn display_internal() {
+    let err = UsageEmitterError::internal("connection timeout");
+    assert_eq!(err.to_string(), "internal error: connection timeout");
+}

--- a/modules/system/usage-collector/usage-emitter/src/infra/delivery_handler.rs
+++ b/modules/system/usage-collector/usage-emitter/src/infra/delivery_handler.rs
@@ -1,0 +1,107 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use modkit_db::outbox::{LeasedMessageHandler, MessageResult, OutboxMessage};
+use tracing::{debug, error, info, warn};
+use usage_collector_sdk::models::UsageRecord;
+use usage_collector_sdk::{UsageCollectorClientV1, UsageCollectorError};
+
+/// Outbox delivery handler that forwards dequeued usage records to the usage collector,
+/// calling [`UsageCollectorClientV1::create_usage_record`] once per message.
+///
+/// Implements [`LeasedMessageHandler`]:
+/// - Deserialization failures dead-letter the message (permanent: corrupt payload).
+/// - [`UsageCollectorError::PluginTimeout`], [`UsageCollectorError::CircuitOpen`], and
+///   [`UsageCollectorError::Unavailable`] trigger retry (transient: timeout, open circuit,
+///   connection/transport error, or identity service temporarily unreachable).
+/// - All other collector errors dead-letter the message (permanent: auth denial,
+///   module not configured, or unexpected condition).
+pub struct DeliveryHandler {
+    collector: Arc<dyn UsageCollectorClientV1>,
+}
+
+impl DeliveryHandler {
+    #[must_use]
+    pub fn new(collector: Arc<dyn UsageCollectorClientV1>) -> Self {
+        Self { collector }
+    }
+}
+
+#[async_trait]
+impl LeasedMessageHandler for DeliveryHandler {
+    // @cpt-algo:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1
+    // @cpt-flow:cpt-cf-usage-collector-flow-sdk-and-ingest-core-emit:p1
+    async fn handle(&self, msg: &OutboxMessage) -> MessageResult {
+        // Processor may pass several messages per lease cycle (see WorkerTuning::batch_size);
+        // this handler still delivers each payload individually.
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-1
+        let record_result = serde_json::from_slice::<UsageRecord>(&msg.payload);
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-1
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-2
+        if let Err(ref err) = record_result {
+            warn!(
+                msg.seq,
+                msg.partition_id,
+                %err,
+                "usage record deserialization failed"
+            );
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-2a
+            return MessageResult::Reject(err.to_string());
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-2a
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-2
+
+        // inst-dlv-3: gateway ingest request assembly from UsageRecord fields is performed
+        // inside UsageCollectorClientV1::create_usage_record — see rest_client.rs
+        // (UsageRecord IS the request at this layer; DTO assembly is an implementation detail
+        //  of the REST client adapter).
+        // SAFETY: the Err branch above always returns; this value is Ok.
+        #[allow(clippy::unwrap_used)]
+        let record = record_result.unwrap();
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-4
+        let delivery_result = self.collector.create_usage_record(record).await;
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-4
+
+        match delivery_result {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-5
+            Ok(()) => {
+                debug!("usage record delivered to collector");
+                // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-5a
+                MessageResult::Ok
+                // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-5a
+            }
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-5
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-6
+            Err(
+                e @ (UsageCollectorError::PluginTimeout
+                | UsageCollectorError::CircuitOpen
+                | UsageCollectorError::Unavailable { .. }),
+            ) => {
+                // PluginTimeout: network timeout, HTTP 429, HTTP 5xx (see rest_client.rs).
+                // CircuitOpen: gateway circuit breaker is open; retry after backoff.
+                // Unavailable: connection/transport error or identity service temporarily
+                //   unreachable; the request never reached the gateway (see rest_client.rs).
+                info!(error = %e, "transient collector delivery error; will retry");
+                // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-6a
+                MessageResult::Retry
+                // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-6a
+            }
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-6
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-7
+            Err(e) => {
+                error!(error = %e, "permanent collector delivery error; dead-lettering message");
+                // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-7a
+                MessageResult::Reject(e.to_string())
+                // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-7a
+            } // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-7
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "delivery_handler_tests.rs"]
+mod delivery_handler_tests;

--- a/modules/system/usage-collector/usage-emitter/src/infra/delivery_handler_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/src/infra/delivery_handler_tests.rs
@@ -1,0 +1,211 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use modkit_db::outbox::{LeasedMessageHandler, MessageResult, OutboxMessage};
+use usage_collector_sdk::models::{UsageKind, UsageRecord};
+use usage_collector_sdk::{UsageCollectorClientV1, UsageCollectorError};
+use uuid::Uuid;
+
+use super::DeliveryHandler;
+
+enum CollectorOutcome {
+    Ok,
+    Transient,
+    Permanent,
+    Unavailable,
+}
+
+struct MockCollector {
+    outcome: CollectorOutcome,
+}
+
+impl MockCollector {
+    fn ok() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: CollectorOutcome::Ok,
+        })
+    }
+
+    fn transient() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: CollectorOutcome::Transient,
+        })
+    }
+
+    fn permanent() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: CollectorOutcome::Permanent,
+        })
+    }
+
+    fn unavailable() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: CollectorOutcome::Unavailable,
+        })
+    }
+}
+
+#[async_trait]
+impl UsageCollectorClientV1 for MockCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        match self.outcome {
+            CollectorOutcome::Ok => Ok(()),
+            CollectorOutcome::Transient => Err(UsageCollectorError::plugin_timeout()),
+            CollectorOutcome::Permanent => {
+                Err(UsageCollectorError::authorization_failed("permanent"))
+            }
+            CollectorOutcome::Unavailable => {
+                Err(UsageCollectorError::unavailable("connection refused"))
+            }
+        }
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<usage_collector_sdk::ModuleConfig, UsageCollectorError> {
+        Ok(usage_collector_sdk::ModuleConfig {
+            allowed_metrics: vec![],
+        })
+    }
+}
+
+fn valid_usage_record() -> UsageRecord {
+    UsageRecord {
+        tenant_id: Uuid::new_v4(),
+        module: "test-module".to_owned(),
+        metric: "test.metric".to_owned(),
+        kind: UsageKind::Gauge,
+        value: 1.0,
+        resource_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        subject_id: Some(Uuid::nil()),
+        subject_type: Some("test.subject".to_owned()),
+        idempotency_key: Uuid::new_v4().to_string(),
+        timestamp: Utc::now(),
+        metadata: None,
+    }
+}
+
+fn make_msg(payload_bytes: Vec<u8>) -> OutboxMessage {
+    OutboxMessage {
+        partition_id: 0,
+        seq: 1,
+        payload: payload_bytes,
+        payload_type: "application/json".to_owned(),
+        created_at: Utc::now(),
+        attempts: 0,
+    }
+}
+
+fn handler(collector: Arc<dyn UsageCollectorClientV1>) -> DeliveryHandler {
+    DeliveryHandler::new(collector)
+}
+
+#[tokio::test]
+async fn handle_invalid_json_payload_is_rejected() {
+    let h = handler(MockCollector::ok());
+    let msg = make_msg(b"not-json".to_vec());
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Reject(_)));
+}
+
+#[tokio::test]
+async fn handle_collector_transient_error_returns_retry() {
+    let h = handler(MockCollector::transient());
+    let payload = serde_json::to_vec(&valid_usage_record()).unwrap();
+    let msg = make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Retry));
+}
+
+#[tokio::test]
+async fn handle_collector_permanent_error_returns_reject() {
+    let h = handler(MockCollector::permanent());
+    let payload = serde_json::to_vec(&valid_usage_record()).unwrap();
+    let msg = make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Reject(_)));
+}
+
+#[tokio::test]
+async fn handle_collector_unavailable_error_returns_retry() {
+    let h = handler(MockCollector::unavailable());
+    let payload = serde_json::to_vec(&valid_usage_record()).unwrap();
+    let msg = make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Retry));
+}
+
+#[tokio::test]
+async fn handle_success_returns_ok() {
+    let h = handler(MockCollector::ok());
+    let payload = serde_json::to_vec(&valid_usage_record()).unwrap();
+    let msg = make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Ok));
+}
+
+// ── Subject fields deserialization ────────────────────────────────────────────
+
+struct CapturingCollector {
+    captured: Arc<Mutex<Option<UsageRecord>>>,
+}
+
+impl CapturingCollector {
+    fn new(captured: Arc<Mutex<Option<UsageRecord>>>) -> Arc<Self> {
+        Arc::new(Self { captured })
+    }
+}
+
+#[async_trait]
+impl UsageCollectorClientV1 for CapturingCollector {
+    async fn create_usage_record(&self, record: UsageRecord) -> Result<(), UsageCollectorError> {
+        *self.captured.lock().unwrap() = Some(record);
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<usage_collector_sdk::ModuleConfig, UsageCollectorError> {
+        Ok(usage_collector_sdk::ModuleConfig {
+            allowed_metrics: vec![],
+        })
+    }
+}
+
+#[tokio::test]
+async fn handle_delivery_preserves_subject_fields_through_deserialization() {
+    let known_subject_id = Uuid::new_v4();
+    let record = UsageRecord {
+        subject_id: Some(known_subject_id),
+        subject_type: Some("real.subject".to_owned()),
+        ..valid_usage_record()
+    };
+
+    let captured: Arc<Mutex<Option<UsageRecord>>> = Arc::new(Mutex::new(None));
+    let collector = CapturingCollector::new(Arc::clone(&captured));
+    let h = handler(collector);
+    let payload = serde_json::to_vec(&record).unwrap();
+    let msg = make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Ok));
+
+    let received = captured
+        .lock()
+        .unwrap()
+        .take()
+        .expect("collector must have received the record");
+    assert_eq!(
+        received.subject_id,
+        Some(known_subject_id),
+        "subject_id must survive serialisation round-trip"
+    );
+    assert_eq!(
+        received.subject_type.as_deref(),
+        Some("real.subject"),
+        "subject_type must survive serialisation round-trip"
+    );
+}

--- a/modules/system/usage-collector/usage-emitter/src/infra/mod.rs
+++ b/modules/system/usage-collector/usage-emitter/src/infra/mod.rs
@@ -1,0 +1,2 @@
+// @cpt-dod:cpt-cf-usage-collector-dod-sdk-and-ingest-core-emitter-crate:p1
+pub mod delivery_handler;

--- a/modules/system/usage-collector/usage-emitter/src/lib.rs
+++ b/modules/system/usage-collector/usage-emitter/src/lib.rs
@@ -1,0 +1,46 @@
+//! Durable usage emission for source modules.
+//!
+//! Provides the complete emitter pipeline: module-scoped PDP authorization, transactional
+//! outbox enqueue, and async delivery to the usage collector via `modkit-db` outbox workers.
+//!
+//! # Usage
+//!
+//! Source modules should not construct `UsageEmitter` directly. The `usage-collector`
+//! or `usage-collector-rest-client` `ModKit` module builds and registers
+//! `dyn UsageEmitterV1` in `ClientHub` during `init()`.
+//!
+//! ```ignore
+//! // In init():
+//! let emitter = hub.get::<dyn UsageEmitterV1>()?;
+//! let scoped = emitter.for_module(Self::MODULE_NAME);
+//!
+//! // In a handler:
+//! let authorized = scoped
+//!     .authorize(&ctx, resource_id, "resource_type".to_owned())
+//!     .await?;
+//! authorized
+//!     .build_usage_record("requests", 1.0)
+//!     .enqueue()
+//!     .await?;
+//! ```
+
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+mod api;
+mod authorized_emitter;
+mod config;
+mod domain;
+mod emitter;
+mod error;
+mod infra;
+mod scoped_emitter;
+mod usage_builder;
+
+pub use api::UsageEmitterV1;
+pub use authorized_emitter::AuthorizedUsageEmitter;
+pub use config::UsageEmitterConfig;
+pub use emitter::UsageEmitter;
+pub use error::UsageEmitterError;
+pub use infra::delivery_handler::DeliveryHandler;
+pub use scoped_emitter::ScopedUsageEmitter;
+pub use usage_builder::UsageRecordBuilder;

--- a/modules/system/usage-collector/usage-emitter/src/scoped_emitter.rs
+++ b/modules/system/usage-collector/usage-emitter/src/scoped_emitter.rs
@@ -1,0 +1,188 @@
+use std::sync::Arc;
+
+use authz_resolver_sdk::AuthZResolverClient;
+use authz_resolver_sdk::models::BarrierMode;
+use authz_resolver_sdk::pep::{AccessRequest, PolicyEnforcer};
+use modkit_db::Db;
+use modkit_db::outbox::Outbox;
+use modkit_security::{SecurityContext, pep_properties};
+use usage_collector_sdk::{UsageCollectorClientV1, UsageCollectorError};
+use uuid::Uuid;
+
+use crate::authorized_emitter::AuthorizedUsageEmitter;
+use crate::config::UsageEmitterConfig;
+use crate::domain::authz;
+use crate::emitter::enforcer_error_to_emitter_error;
+use crate::error::UsageEmitterError;
+
+/// A usage emitter scoped to a specific module.
+///
+/// Constructed via [`crate::UsageEmitterV1::for_module`]. Call [`Self::authorize_for`] or
+/// [`Self::authorize`] to obtain a time-limited [`AuthorizedUsageEmitter`] after PDP authorization
+/// and allowed-metrics retrieval for this module.
+///
+/// # Example
+///
+/// ```ignore
+/// // In init():
+/// let scoped = emitter.for_module(Self::MODULE_NAME);
+///
+/// // In a handler (with subject):
+/// let authorized = scoped
+///     .authorize_for(&ctx, tenant_id, resource_id, resource_type, Some(subject_id), Some(subject_type))
+///     .await?;
+/// authorized.build_usage_record("requests", 1.0).enqueue().await?;
+///
+/// // In a handler (without subject):
+/// let authorized = scoped
+///     .authorize_for(&ctx, tenant_id, resource_id, resource_type, None, None)
+///     .await?;
+/// authorized.build_usage_record("requests", 1.0).enqueue().await?;
+/// ```
+#[derive(Clone)]
+pub struct ScopedUsageEmitter {
+    module: String,
+    authz: Arc<dyn AuthZResolverClient>,
+    collector: Arc<dyn UsageCollectorClientV1>,
+    db: Db,
+    config: Arc<UsageEmitterConfig>,
+    outbox: Arc<Outbox>,
+}
+
+impl ScopedUsageEmitter {
+    pub(crate) fn new(
+        module: String,
+        authz: Arc<dyn AuthZResolverClient>,
+        collector: Arc<dyn UsageCollectorClientV1>,
+        db: Db,
+        config: Arc<UsageEmitterConfig>,
+        outbox: Arc<Outbox>,
+    ) -> Self {
+        Self {
+            module,
+            authz,
+            collector,
+            db,
+            config,
+            outbox,
+        }
+    }
+
+    /// Obtain a time-limited [`AuthorizedUsageEmitter`] by calling the PDP for `USAGE_RECORD`/`CREATE`
+    /// and fetching the allowed metrics for this module from the collector.
+    ///
+    /// The returned handle is bound to the module name, tenant, metered resource, and subject
+    /// identity; every enqueued record must match and its metric must be in the allowed list.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageEmitterError`] if PDP denies, the module is not configured, or the collector
+    /// call fails.
+    // @cpt-algo:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1
+    pub async fn authorize_for(
+        &self,
+        ctx: &SecurityContext,
+        tenant_id: Uuid,
+        resource_id: Uuid,
+        resource_type: String,
+        subject_id: Option<Uuid>,
+        subject_type: Option<String>,
+    ) -> Result<AuthorizedUsageEmitter, UsageEmitterError> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-2
+        let mut request = AccessRequest::new()
+            .require_constraints(false)
+            .barrier_mode(BarrierMode::Ignore)
+            .resource_property(pep_properties::OWNER_TENANT_ID, tenant_id)
+            .resource_property(authz::properties::RESOURCE_ID, resource_id)
+            .resource_property(authz::properties::RESOURCE_TYPE, resource_type.as_str())
+            .resource_property(authz::properties::MODULE, self.module.clone());
+        if let Some(ref sid) = subject_id {
+            request = request.resource_property(authz::properties::SUBJECT_ID, sid.to_string());
+        }
+        if let Some(ref stype) = subject_type {
+            request = request.resource_property(authz::properties::SUBJECT_TYPE, stype.as_str());
+        }
+        let pdp_result = PolicyEnforcer::new(Arc::clone(&self.authz))
+            .access_scope_with(
+                ctx,
+                &authz::USAGE_RECORD,
+                authz::actions::CREATE,
+                None,
+                &request,
+            )
+            .await;
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-2
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-3
+        if let Err(e) = pdp_result {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-3a
+            return Err(enforcer_error_to_emitter_error(e));
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-3a
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-3
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-4
+        // @cpt-begin:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-1
+        let module_cfg_result = self.collector.get_module_config(&self.module).await;
+        // @cpt-end:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-1
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-4
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-5
+        let module_cfg = match module_cfg_result {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-5a
+            Err(UsageCollectorError::ModuleNotFound { module_name }) => {
+                return Err(UsageEmitterError::module_not_configured(module_name));
+            }
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-5a
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-5b
+            Err(e) => return Err(UsageEmitterError::internal(e.to_string())),
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-5b
+            Ok(cfg) => cfg,
+        };
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-5
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-6
+        let authorized = AuthorizedUsageEmitter::new(
+            Arc::clone(&self.config),
+            self.db.clone(),
+            Arc::clone(&self.outbox),
+            self.module.clone(),
+            tenant_id,
+            resource_id,
+            resource_type,
+            module_cfg.allowed_metrics,
+            subject_id,
+            subject_type,
+        );
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-6
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-7
+        Ok(authorized)
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-7
+    }
+
+    /// Same as [`Self::authorize_for`] using the subject's home tenant from `ctx`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageEmitterError`] if PDP denies, the module is not configured, or the collector
+    /// call fails.
+    pub async fn authorize(
+        &self,
+        ctx: &SecurityContext,
+        resource_id: Uuid,
+        resource_type: String,
+    ) -> Result<AuthorizedUsageEmitter, UsageEmitterError> {
+        let subject_id = Some(ctx.subject_id());
+        let subject_type = ctx.subject_type().map(str::to_owned);
+        self.authorize_for(
+            ctx,
+            ctx.subject_tenant_id(),
+            resource_id,
+            resource_type,
+            subject_id,
+            subject_type,
+        )
+        .await
+    }
+}

--- a/modules/system/usage-collector/usage-emitter/src/usage_builder.rs
+++ b/modules/system/usage-collector/usage-emitter/src/usage_builder.rs
@@ -1,0 +1,134 @@
+//! [`UsageRecordBuilder`] for chaining optional fields and enqueueing through an
+//! [`AuthorizedUsageEmitter`](crate::AuthorizedUsageEmitter). Tenant, resource, module,
+//! and kind are taken from the authorized handle; kind is resolved from the allowed metrics list.
+//!
+//! Construct via [`AuthorizedUsageEmitter::build_usage_record`](crate::AuthorizedUsageEmitter::build_usage_record).
+
+use chrono::{DateTime, Utc};
+use modkit_db::secure::DBRunner;
+use serde_json::Value as JsonValue;
+use usage_collector_sdk::models::{UsageKind, UsageRecord};
+
+use crate::authorized_emitter::AuthorizedUsageEmitter;
+use crate::error::UsageEmitterError;
+
+/// Fluent builder tied to an [`AuthorizedUsageEmitter`]. Optionally set idempotency key or
+/// timestamp, then [`Self::enqueue`] or [`Self::enqueue_in`].
+///
+/// `kind` is resolved automatically from the allowed metrics list; no `.counter()` or `.gauge()`
+/// call is required.
+pub struct UsageRecordBuilder<'a> {
+    emitter: &'a AuthorizedUsageEmitter,
+    metric: String,
+    idempotency_key: Option<String>,
+    value: f64,
+    timestamp: Option<DateTime<Utc>>,
+    metadata: Option<JsonValue>,
+}
+
+impl<'a> UsageRecordBuilder<'a> {
+    /// Starts a builder with the required `metric` and `value` set.
+    #[must_use]
+    pub fn new(emitter: &'a AuthorizedUsageEmitter, metric: impl Into<String>, value: f64) -> Self {
+        Self {
+            emitter,
+            metric: metric.into(),
+            idempotency_key: None,
+            value,
+            timestamp: None,
+            metadata: None,
+        }
+    }
+
+    /// Sets a caller-provided idempotency key. If omitted, a new UUID string is used on enqueue.
+    #[must_use]
+    pub fn with_idempotency_key(self, key: impl Into<String>) -> Self {
+        Self {
+            idempotency_key: Some(key.into()),
+            ..self
+        }
+    }
+
+    /// Sets the observation timestamp. If omitted, the current UTC time is used on enqueue.
+    #[must_use]
+    pub fn with_timestamp(self, timestamp: DateTime<Utc>) -> Self {
+        Self {
+            timestamp: Some(timestamp),
+            ..self
+        }
+    }
+
+    /// Sets optional metadata JSON. Must serialize to ≤ 8192 bytes or enqueue will return
+    /// [`UsageEmitterError::MetadataTooLarge`].
+    #[must_use]
+    pub fn with_metadata(self, metadata: JsonValue) -> Self {
+        Self {
+            metadata: Some(metadata),
+            ..self
+        }
+    }
+
+    /// Builds, then enqueues on this emitter's database connection.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageEmitterError::InvalidRecord`] if the metric is not in the allowed list,
+    /// or any error from [`AuthorizedUsageEmitter::enqueue_in`].
+    pub async fn enqueue(self) -> Result<(), UsageEmitterError> {
+        let conn = self
+            .emitter
+            .db
+            .conn()
+            .map_err(|e| UsageEmitterError::internal(e.to_string()))?;
+        self.enqueue_in(&conn).await
+    }
+
+    /// Builds, then enqueues on the given database runner (connection or transaction).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageEmitterError::InvalidRecord`] if the metric is not in the allowed list,
+    /// or any error from [`AuthorizedUsageEmitter::enqueue_in`].
+    // @cpt-algo:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1
+    pub async fn enqueue_in(self, db: &(dyn DBRunner + Sync)) -> Result<(), UsageEmitterError> {
+        let kind = self
+            .emitter
+            .allowed_metrics
+            .iter()
+            .find(|m| m.name == self.metric)
+            .map_or(UsageKind::Gauge, |m| m.kind);
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-6
+        let subject_id = self.emitter.subject_id;
+        let subject_type = self.emitter.subject_type.clone();
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-6
+
+        let record = UsageRecord {
+            tenant_id: self.emitter.tenant_id,
+            module: self.emitter.module.clone(),
+            resource_id: self.emitter.resource_id,
+            resource_type: self.emitter.resource_type.clone(),
+            subject_id,
+            subject_type,
+            metric: self.metric,
+            kind,
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-5b
+            idempotency_key: if kind == UsageKind::Gauge {
+                String::new()
+            } else {
+                self.idempotency_key.unwrap_or_default()
+            },
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-5b
+            value: self.value,
+            timestamp: self.timestamp.unwrap_or_else(Utc::now),
+            metadata: self.metadata,
+        };
+
+        self.emitter.enqueue_in(db, record).await
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "usage_builder_tests.rs"]
+mod usage_builder_tests;

--- a/modules/system/usage-collector/usage-emitter/src/usage_builder_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/src/usage_builder_tests.rs
@@ -1,0 +1,457 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use modkit_db::migration_runner::run_migrations_for_testing;
+use modkit_db::outbox::{
+    LeasedMessageHandler, MessageResult, Outbox, OutboxHandle, OutboxMessage, Partitions,
+    outbox_migrations,
+};
+use modkit_db::{ConnectOpts, Db, connect_db};
+use usage_collector_sdk::models::{AllowedMetric, UsageKind, UsageRecord};
+use uuid::Uuid;
+
+use crate::authorized_emitter::AuthorizedUsageEmitter;
+use crate::config::UsageEmitterConfig;
+use crate::error::UsageEmitterError;
+
+// ── Infrastructure ────────────────────────────────────────────────────────────
+
+struct NoopHandler;
+
+#[async_trait]
+impl LeasedMessageHandler for NoopHandler {
+    async fn handle(&self, _msg: &OutboxMessage) -> MessageResult {
+        MessageResult::Ok
+    }
+}
+
+async fn build_db(name: &str) -> Db {
+    let url = format!("sqlite:file:{name}?mode=memory&cache=shared");
+    let db = connect_db(
+        &url,
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    run_migrations_for_testing(&db, outbox_migrations())
+        .await
+        .unwrap();
+    db
+}
+
+async fn build_outbox(db: Db) -> OutboxHandle {
+    let cfg = UsageEmitterConfig::default();
+    Outbox::builder(db)
+        .queue(
+            cfg.outbox_queue.as_str(),
+            Partitions::of(cfg.outbox_partition_count),
+        )
+        .leased(NoopHandler)
+        .start()
+        .await
+        .unwrap()
+}
+
+// ── Test fixture ──────────────────────────────────────────────────────────────
+
+struct Fixture {
+    db: Db,
+    _handle: OutboxHandle,
+    emitter: AuthorizedUsageEmitter,
+    tenant_id: Uuid,
+    resource_id: Uuid,
+}
+
+impl Fixture {
+    async fn build(name: &str) -> Self {
+        let db = build_db(name).await;
+        let handle = build_outbox(db.clone()).await;
+        let tenant_id = Uuid::new_v4();
+        let resource_id = Uuid::new_v4();
+        let allowed_metrics = vec![
+            AllowedMetric {
+                name: "test.gauge".to_owned(),
+                kind: UsageKind::Gauge,
+            },
+            AllowedMetric {
+                name: "test.counter".to_owned(),
+                kind: UsageKind::Counter,
+            },
+        ];
+        let emitter = AuthorizedUsageEmitter::new(
+            Arc::new(UsageEmitterConfig::default()),
+            db.clone(),
+            Arc::clone(handle.outbox()),
+            "test-module".to_owned(),
+            tenant_id,
+            resource_id,
+            "test.resource".to_owned(),
+            allowed_metrics,
+            Some(Uuid::nil()),
+            Some("test.subject".to_owned()),
+        );
+        Self {
+            db,
+            _handle: handle,
+            emitter,
+            tenant_id,
+            resource_id,
+        }
+    }
+
+    fn conn(&self) -> modkit_db::DbConn<'_> {
+        self.db.conn().unwrap()
+    }
+
+    /// Build a valid `UsageRecord` that matches the authorized token fields.
+    fn record(&self) -> UsageRecord {
+        UsageRecord {
+            tenant_id: self.tenant_id,
+            module: "test-module".to_owned(),
+            metric: "test.gauge".to_owned(),
+            kind: UsageKind::Gauge,
+            value: 1.0,
+            resource_id: self.resource_id,
+            resource_type: "test.resource".to_owned(),
+            subject_id: Some(Uuid::nil()),
+            subject_type: Some("test.subject".to_owned()),
+            idempotency_key: Uuid::new_v4().to_string(),
+            timestamp: Utc::now(),
+            metadata: None,
+        }
+    }
+}
+
+// ── Metric kind resolution ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn builder_enqueues_gauge_metric() {
+    let f = Fixture::build("ub_gauge").await;
+    f.emitter
+        .build_usage_record("test.gauge", 42.0)
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn builder_enqueues_counter_metric_with_positive_value() {
+    let f = Fixture::build("ub_counter_pos").await;
+    f.emitter
+        .build_usage_record("test.counter", 1.0)
+        .with_idempotency_key("idem-key")
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn builder_rejects_counter_metric_with_negative_value() {
+    let f = Fixture::build("ub_counter_neg").await;
+    let err = f
+        .emitter
+        .build_usage_record("test.counter", -1.0)
+        .with_idempotency_key("idem-key")
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        UsageEmitterError::NegativeCounterValue { value } if (value + 1.0).abs() < f64::EPSILON
+    ));
+}
+
+#[tokio::test]
+async fn builder_rejects_counter_metric_without_idempotency_key() {
+    let f = Fixture::build("ub_counter_no_idem").await;
+    let err = f
+        .emitter
+        .build_usage_record("test.counter", 1.0)
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidRecord { .. }));
+}
+
+#[tokio::test]
+async fn builder_accepts_gauge_metric_with_negative_value() {
+    let f = Fixture::build("ub_gauge_neg").await;
+    f.emitter
+        .build_usage_record("test.gauge", -5.0)
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn builder_rejects_unknown_metric() {
+    let f = Fixture::build("ub_unknown_metric").await;
+    let err = f
+        .emitter
+        .build_usage_record("unknown.metric", 1.0)
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, UsageEmitterError::MetricNotAllowed { ref metric } if metric == "unknown.metric")
+    );
+}
+
+// ── Optional fields ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn builder_with_idempotency_key_enqueues_successfully() {
+    let f = Fixture::build("ub_idem_key").await;
+    f.emitter
+        .build_usage_record("test.gauge", 1.0)
+        .with_idempotency_key("my-stable-key")
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn builder_with_timestamp_enqueues_successfully() {
+    let f = Fixture::build("ub_timestamp").await;
+    let ts = DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    f.emitter
+        .build_usage_record("test.gauge", 1.0)
+        .with_timestamp(ts)
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn builder_without_optional_fields_enqueues_successfully() {
+    let f = Fixture::build("ub_defaults").await;
+    f.emitter
+        .build_usage_record("test.gauge", 0.0)
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap();
+}
+
+// ── Blank idempotency key handling ────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_counter_with_blank_idempotency_key_is_rejected() {
+    let f = Fixture::build("ub_counter_blank_idem").await;
+    let err = f
+        .emitter
+        .build_usage_record("test.counter", 1.0)
+        .with_idempotency_key("")
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidRecord { .. }));
+}
+
+#[tokio::test]
+async fn test_gauge_with_blank_idempotency_key_uses_uuid_fallback() {
+    use std::sync::{Arc, Mutex};
+    use usage_collector_sdk::models::UsageRecord;
+
+    struct CaptureHandler {
+        captured: Arc<Mutex<Option<Vec<u8>>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl LeasedMessageHandler for CaptureHandler {
+        async fn handle(&self, msg: &OutboxMessage) -> MessageResult {
+            let mut guard = self.captured.lock().unwrap();
+            *guard = Some(msg.payload.clone());
+            MessageResult::Ok
+        }
+    }
+
+    let name = "ub_gauge_blank_idem";
+    let url = format!("sqlite:file:{name}?mode=memory&cache=shared");
+    let db = modkit_db::connect_db(
+        &url,
+        modkit_db::ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    modkit_db::migration_runner::run_migrations_for_testing(
+        &db,
+        modkit_db::outbox::outbox_migrations(),
+    )
+    .await
+    .unwrap();
+
+    let captured: Arc<Mutex<Option<Vec<u8>>>> = Arc::new(Mutex::new(None));
+    let cfg = crate::config::UsageEmitterConfig::default();
+    let handle = Outbox::builder(db.clone())
+        .queue(
+            cfg.outbox_queue.as_str(),
+            Partitions::of(cfg.outbox_partition_count),
+        )
+        .leased(CaptureHandler {
+            captured: Arc::clone(&captured),
+        })
+        .start()
+        .await
+        .unwrap();
+
+    let allowed_metrics = vec![usage_collector_sdk::models::AllowedMetric {
+        name: "test.gauge".to_owned(),
+        kind: usage_collector_sdk::models::UsageKind::Gauge,
+    }];
+    let emitter = crate::authorized_emitter::AuthorizedUsageEmitter::new(
+        Arc::new(cfg),
+        db.clone(),
+        Arc::clone(handle.outbox()),
+        "test-module".to_owned(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        "test.resource".to_owned(),
+        allowed_metrics,
+        Some(Uuid::nil()),
+        Some("test.subject".to_owned()),
+    );
+
+    {
+        let conn = db.conn().unwrap();
+        emitter
+            .build_usage_record("test.gauge", 1.0)
+            .with_idempotency_key("")
+            .enqueue_in(&conn)
+            .await
+            .unwrap();
+    }
+
+    // Wait for the outbox to deliver the message to the handler.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        {
+            let guard = captured.lock().unwrap();
+            if guard.is_some() {
+                break;
+            }
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for outbox delivery"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    let payload = captured.lock().unwrap().take().unwrap();
+    let record: UsageRecord = serde_json::from_slice(&payload).unwrap();
+    assert!(
+        record.idempotency_key.is_empty(),
+        "gauge records must have empty idempotency_key so storage can store NULL"
+    );
+}
+
+// ── Authorization scope mismatch rejection ────────────────────────────────────
+
+#[tokio::test]
+async fn builder_rejects_mismatched_module_name() {
+    let f = Fixture::build("ub_bad_module").await;
+    let record = UsageRecord {
+        module: "wrong-module".to_owned(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::UsageEmitterError::InvalidRecord { .. }),
+        "expected InvalidRecord for mismatched module, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn builder_rejects_mismatched_subject_id() {
+    let f = Fixture::build("ub_bad_subj_id").await;
+    let record = UsageRecord {
+        subject_id: Some(Uuid::new_v4()), // differs from Some(Uuid::nil()) in the token
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::UsageEmitterError::InvalidRecord { .. }),
+        "expected InvalidRecord for mismatched subject_id, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn builder_rejects_mismatched_subject_type() {
+    let f = Fixture::build("ub_bad_subj_type").await;
+    let record = UsageRecord {
+        subject_type: Some("other.subject".to_owned()), // differs from Some("test.subject") in the token
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::UsageEmitterError::InvalidRecord { .. }),
+        "expected InvalidRecord for mismatched subject_type, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn builder_enqueues_record_with_subject() {
+    // The current Fixture always has subject_id/subject_type set (via Uuid::nil() / "test.subject").
+    // After Phase 5, enqueue_in produces Some(subject_id) / Some(subject_type) from the emitter,
+    // and the record built by Fixture::record() matches — enqueue must succeed.
+    let f = Fixture::build("ub_with_subject").await;
+    f.emitter
+        .build_usage_record("test.gauge", 1.0)
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn builder_enqueues_record_without_subject() {
+    // Exercises the no-subject path: both subject_id and subject_type are None.
+    let db = build_db("ub_without_subject").await;
+    let handle = build_outbox(db.clone()).await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let allowed_metrics = vec![AllowedMetric {
+        name: "test.gauge".to_owned(),
+        kind: UsageKind::Gauge,
+    }];
+    let emitter = AuthorizedUsageEmitter::new(
+        Arc::new(UsageEmitterConfig::default()),
+        db.clone(),
+        Arc::clone(handle.outbox()),
+        "test-module".to_owned(),
+        tenant_id,
+        resource_id,
+        "test.resource".to_owned(),
+        allowed_metrics,
+        None, // subject_id absent
+        None, // subject_type absent
+    );
+    // A record with no subject fields must match the None-subject token.
+    let record = UsageRecord {
+        tenant_id,
+        module: "test-module".to_owned(),
+        metric: "test.gauge".to_owned(),
+        kind: UsageKind::Gauge,
+        value: 1.0,
+        resource_id,
+        resource_type: "test.resource".to_owned(),
+        subject_id: None,
+        subject_type: None,
+        idempotency_key: Uuid::new_v4().to_string(),
+        timestamp: chrono::Utc::now(),
+        metadata: None,
+    };
+    let conn = db.conn().unwrap();
+    emitter
+        .enqueue_in(&conn, record)
+        .await
+        .expect("enqueue must succeed when subject is absent in both token and record");
+}

--- a/modules/system/usage-collector/usage-emitter/tests/authorized_emitter_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/tests/authorized_emitter_tests.rs
@@ -1,0 +1,302 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use modkit_db::Db;
+use usage_collector_sdk::models::{AllowedMetric, UsageKind, UsageRecord};
+use usage_collector_sdk::{UsageCollectorClientV1, UsageCollectorError};
+use usage_emitter::{
+    AuthorizedUsageEmitter, UsageEmitter, UsageEmitterConfig, UsageEmitterError, UsageEmitterV1,
+};
+use uuid::Uuid;
+
+const FIXTURE_RESOURCE_TYPE: &str = "test.resource";
+
+// ── Fixture collector that returns specific allowed metrics ───────────────────
+
+struct FixtureCollector;
+
+#[async_trait]
+impl UsageCollectorClientV1 for FixtureCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<usage_collector_sdk::ModuleConfig, UsageCollectorError> {
+        Ok(usage_collector_sdk::ModuleConfig {
+            allowed_metrics: vec![
+                AllowedMetric {
+                    name: "test.gauge".to_owned(),
+                    kind: UsageKind::Gauge,
+                },
+                AllowedMetric {
+                    name: "test.counter".to_owned(),
+                    kind: UsageKind::Counter,
+                },
+            ],
+        })
+    }
+}
+
+// ── Test fixture ──────────────────────────────────────────────────────────────
+
+struct Fixture {
+    db: Db,
+    _emitter: UsageEmitter,
+    emitter: AuthorizedUsageEmitter,
+    tenant: Uuid,
+    resource_id: Uuid,
+}
+
+impl Fixture {
+    async fn build(name: &str) -> Self {
+        Self::build_with_config(name, UsageEmitterConfig::default()).await
+    }
+
+    async fn build_with_config(name: &str, config: UsageEmitterConfig) -> Self {
+        let db = common::build_db(name).await;
+        let emitter_obj = UsageEmitter::build(
+            config,
+            db.clone(),
+            Arc::new(common::AllowAllAuthZ),
+            Arc::new(FixtureCollector),
+        )
+        .await
+        .unwrap();
+
+        let ctx = common::make_ctx();
+        let tenant = ctx.subject_tenant_id();
+        let resource_id = Uuid::new_v4();
+
+        let emitter = emitter_obj
+            .for_module("test-module")
+            .authorize_for(
+                &ctx,
+                tenant,
+                resource_id,
+                FIXTURE_RESOURCE_TYPE.to_owned(),
+                Some(Uuid::nil()),
+                Some("test.subject".to_owned()),
+            )
+            .await
+            .unwrap();
+
+        Self {
+            db,
+            _emitter: emitter_obj,
+            emitter,
+            tenant,
+            resource_id,
+        }
+    }
+
+    fn record(&self) -> UsageRecord {
+        UsageRecord {
+            tenant_id: self.tenant,
+            module: "test-module".to_owned(),
+            metric: "test.gauge".to_owned(),
+            kind: UsageKind::Gauge,
+            value: 1.0,
+            resource_id: self.resource_id,
+            resource_type: FIXTURE_RESOURCE_TYPE.to_owned(),
+            subject_id: Some(Uuid::nil()),
+            subject_type: Some("test.subject".to_owned()),
+            idempotency_key: Uuid::new_v4().to_string(),
+            timestamp: Utc::now(),
+            metadata: None,
+        }
+    }
+
+    fn record_with_kind(&self, kind: UsageKind, value: f64) -> UsageRecord {
+        let metric = match kind {
+            UsageKind::Gauge => "test.gauge",
+            UsageKind::Counter => "test.counter",
+        }
+        .to_owned();
+        UsageRecord {
+            metric,
+            kind,
+            value,
+            ..self.record()
+        }
+    }
+
+    fn conn(&self) -> modkit_db::DbConn<'_> {
+        self.db.conn().unwrap()
+    }
+}
+
+// ── Expiry ────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_expired_authorization() {
+    let f = Fixture::build_with_config(
+        "ap_expired",
+        UsageEmitterConfig {
+            authorization_max_age: Duration::from_nanos(1),
+            ..Default::default()
+        },
+    )
+    .await;
+    let err = f
+        .emitter
+        .enqueue_in(&f.conn(), f.record())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, UsageEmitterError::AuthorizationExpired));
+}
+
+#[tokio::test]
+async fn enqueue_accepts_usage_record() {
+    let f = Fixture::build("ap_pos_val").await;
+    f.emitter.enqueue_in(&f.conn(), f.record()).await.unwrap();
+}
+
+// ── Authorization scope ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_tenant() {
+    let f = Fixture::build("ap_bad_tenant").await;
+    let record = UsageRecord {
+        tenant_id: Uuid::new_v4(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::AuthorizationFailed { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_resource_id() {
+    let f = Fixture::build("ap_bad_res").await;
+    let record = UsageRecord {
+        resource_id: Uuid::new_v4(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::AuthorizationFailed { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_resource_type() {
+    let f = Fixture::build("ap_bad_rt").await;
+    let record = UsageRecord {
+        resource_type: "other.resource".to_owned(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::AuthorizationFailed { .. }));
+}
+
+// ── Counter value ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_negative_counter_value() {
+    let f = Fixture::build("ap_neg_ctr").await;
+    let record = f.record_with_kind(UsageKind::Counter, -1.0);
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageEmitterError::NegativeCounterValue { value } if (value + 1.0).abs() < f64::EPSILON
+    ));
+}
+
+#[tokio::test]
+async fn enqueue_accepts_zero_counter_value() {
+    let f = Fixture::build("ap_zero_ctr").await;
+    f.emitter
+        .enqueue_in(&f.conn(), f.record_with_kind(UsageKind::Counter, 0.0))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn enqueue_accepts_negative_gauge_value() {
+    let f = Fixture::build("ap_neg_gauge").await;
+    f.emitter
+        .enqueue_in(&f.conn(), f.record_with_kind(UsageKind::Gauge, -1.0))
+        .await
+        .unwrap();
+}
+
+// ── Metric validation ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_metric_not_in_allowed_list() {
+    let f = Fixture::build("ap_metric_disallowed").await;
+    let record = UsageRecord {
+        metric: "not.allowed.metric".to_owned(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(
+        matches!(err, UsageEmitterError::MetricNotAllowed { ref metric } if metric == "not.allowed.metric")
+    );
+}
+
+#[tokio::test]
+async fn enqueue_rejects_metric_kind_mismatch() {
+    let f = Fixture::build("ap_kind_mismatch").await;
+    let record = UsageRecord {
+        metric: "test.counter".to_owned(),
+        kind: UsageKind::Gauge,
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageEmitterError::MetricKindMismatch {
+            ref metric,
+            expected: UsageKind::Counter,
+            actual: UsageKind::Gauge,
+        } if metric == "test.counter"
+    ));
+}
+
+// ── Module and subject mismatch rejection ─────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_module() {
+    let f = Fixture::build("ap_bad_module").await;
+    let record = UsageRecord {
+        module: "wrong-module".to_owned(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidRecord { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_subject_id() {
+    let f = Fixture::build("ap_bad_subj_id").await;
+    let record = UsageRecord {
+        subject_id: Some(Uuid::new_v4()),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidRecord { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_subject_type() {
+    let f = Fixture::build("ap_bad_subj_type").await;
+    let record = UsageRecord {
+        subject_type: Some("other.subject".to_owned()),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidRecord { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_accepts_record_when_module_and_subject_match_token() {
+    let f = Fixture::build("ap_match_ok").await;
+    f.emitter.enqueue_in(&f.conn(), f.record()).await.unwrap();
+}

--- a/modules/system/usage-collector/usage-emitter/tests/common/mod.rs
+++ b/modules/system/usage-collector/usage-emitter/tests/common/mod.rs
@@ -1,0 +1,253 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, dead_code)]
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use authz_resolver_sdk::models::{
+    EvaluationRequest, EvaluationResponse, EvaluationResponseContext,
+};
+use authz_resolver_sdk::{AuthZResolverClient, AuthZResolverError};
+use chrono::Utc;
+use modkit_db::migration_runner::run_migrations_for_testing;
+use modkit_db::outbox::{
+    LeasedMessageHandler, MessageResult, Outbox, OutboxHandle, OutboxMessage, Partitions,
+    outbox_migrations,
+};
+use modkit_db::{ConnectOpts, Db, connect_db};
+use modkit_security::SecurityContext;
+use usage_collector_sdk::models::{UsageKind, UsageRecord};
+use usage_collector_sdk::{UsageCollectorClientV1, UsageCollectorError};
+use usage_emitter::UsageEmitterConfig;
+use uuid::Uuid;
+
+// ── Outbox helpers ────────────────────────────────────────────────────────────
+
+struct NoopHandler;
+
+#[async_trait]
+impl LeasedMessageHandler for NoopHandler {
+    async fn handle(&self, _msg: &OutboxMessage) -> MessageResult {
+        MessageResult::Ok
+    }
+}
+
+pub async fn build_db(name: &str) -> Db {
+    let url = format!("sqlite:file:{name}?mode=memory&cache=shared");
+    let db = connect_db(
+        &url,
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    run_migrations_for_testing(&db, outbox_migrations())
+        .await
+        .unwrap();
+    db
+}
+
+pub async fn build_outbox(db: Db) -> OutboxHandle {
+    let cfg = UsageEmitterConfig::default();
+    Outbox::builder(db)
+        .queue(
+            cfg.outbox_queue.as_str(),
+            Partitions::of(cfg.outbox_partition_count),
+        )
+        .leased(NoopHandler)
+        .start()
+        .await
+        .unwrap()
+}
+
+// ── Mock collectors ───────────────────────────────────────────────────────────
+
+enum CollectorOutcome {
+    Ok,
+    Transient,
+    Permanent,
+    Unavailable,
+}
+
+pub struct MockCollector {
+    outcome: CollectorOutcome,
+}
+
+impl MockCollector {
+    pub fn ok() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: CollectorOutcome::Ok,
+        })
+    }
+
+    pub fn transient() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: CollectorOutcome::Transient,
+        })
+    }
+
+    pub fn permanent() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: CollectorOutcome::Permanent,
+        })
+    }
+
+    pub fn unavailable() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: CollectorOutcome::Unavailable,
+        })
+    }
+}
+
+#[async_trait]
+impl UsageCollectorClientV1 for MockCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        match self.outcome {
+            CollectorOutcome::Ok => Ok(()),
+            CollectorOutcome::Transient => Err(UsageCollectorError::plugin_timeout()),
+            CollectorOutcome::Permanent => {
+                Err(UsageCollectorError::authorization_failed("permanent"))
+            }
+            CollectorOutcome::Unavailable => {
+                Err(UsageCollectorError::unavailable("connection refused"))
+            }
+        }
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<usage_collector_sdk::ModuleConfig, UsageCollectorError> {
+        Ok(usage_collector_sdk::ModuleConfig {
+            allowed_metrics: vec![],
+        })
+    }
+}
+
+pub struct NoopCollector;
+
+#[async_trait]
+impl UsageCollectorClientV1 for NoopCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<usage_collector_sdk::ModuleConfig, UsageCollectorError> {
+        Ok(usage_collector_sdk::ModuleConfig {
+            allowed_metrics: vec![],
+        })
+    }
+}
+
+pub struct CapturingCollector {
+    pub captured: Arc<Mutex<Option<UsageRecord>>>,
+}
+
+impl CapturingCollector {
+    pub fn new(captured: Arc<Mutex<Option<UsageRecord>>>) -> Arc<Self> {
+        Arc::new(Self { captured })
+    }
+}
+
+#[async_trait]
+impl UsageCollectorClientV1 for CapturingCollector {
+    async fn create_usage_record(&self, record: UsageRecord) -> Result<(), UsageCollectorError> {
+        *self.captured.lock().unwrap() = Some(record);
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<usage_collector_sdk::ModuleConfig, UsageCollectorError> {
+        Ok(usage_collector_sdk::ModuleConfig {
+            allowed_metrics: vec![],
+        })
+    }
+}
+
+// ── Mock AuthZ ────────────────────────────────────────────────────────────────
+
+pub struct AllowAllAuthZ;
+
+#[async_trait]
+impl AuthZResolverClient for AllowAllAuthZ {
+    async fn evaluate(
+        &self,
+        _request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        Ok(EvaluationResponse {
+            decision: true,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+pub struct DenyAllAuthZ;
+
+#[async_trait]
+impl AuthZResolverClient for DenyAllAuthZ {
+    async fn evaluate(
+        &self,
+        _request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        Ok(EvaluationResponse {
+            decision: false,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+pub struct FailingAuthZ;
+
+#[async_trait]
+impl AuthZResolverClient for FailingAuthZ {
+    async fn evaluate(
+        &self,
+        _request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        Err(AuthZResolverError::Internal("PDP unavailable".to_owned()))
+    }
+}
+
+// ── Record / message helpers ──────────────────────────────────────────────────
+
+pub fn valid_usage_record() -> UsageRecord {
+    UsageRecord {
+        tenant_id: Uuid::new_v4(),
+        module: "test-module".to_owned(),
+        metric: "test.metric".to_owned(),
+        kind: UsageKind::Gauge,
+        value: 1.0,
+        resource_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        subject_id: Some(Uuid::nil()),
+        subject_type: Some("test.subject".to_owned()),
+        idempotency_key: Uuid::new_v4().to_string(),
+        timestamp: Utc::now(),
+        metadata: None,
+    }
+}
+
+pub fn make_msg(payload_bytes: Vec<u8>) -> OutboxMessage {
+    OutboxMessage {
+        partition_id: 0,
+        seq: 1,
+        payload: payload_bytes,
+        payload_type: "application/json".to_owned(),
+        created_at: Utc::now(),
+        attempts: 0,
+    }
+}
+
+pub fn make_ctx() -> SecurityContext {
+    SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(Uuid::new_v4())
+        .build()
+        .unwrap()
+}

--- a/modules/system/usage-collector/usage-emitter/tests/delivery_handler_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/tests/delivery_handler_tests.rs
@@ -1,0 +1,88 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use std::sync::{Arc, Mutex};
+
+use modkit_db::outbox::{LeasedMessageHandler, MessageResult};
+use usage_collector_sdk::models::UsageRecord;
+use usage_emitter::DeliveryHandler;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn handle_invalid_json_payload_is_rejected() {
+    let h = DeliveryHandler::new(common::MockCollector::ok());
+    let msg = common::make_msg(b"not-json".to_vec());
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Reject(_)));
+}
+
+#[tokio::test]
+async fn handle_collector_transient_error_returns_retry() {
+    let h = DeliveryHandler::new(common::MockCollector::transient());
+    let payload = serde_json::to_vec(&common::valid_usage_record()).unwrap();
+    let msg = common::make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Retry));
+}
+
+#[tokio::test]
+async fn handle_collector_permanent_error_returns_reject() {
+    let h = DeliveryHandler::new(common::MockCollector::permanent());
+    let payload = serde_json::to_vec(&common::valid_usage_record()).unwrap();
+    let msg = common::make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Reject(_)));
+}
+
+#[tokio::test]
+async fn handle_collector_unavailable_error_returns_retry() {
+    let h = DeliveryHandler::new(common::MockCollector::unavailable());
+    let payload = serde_json::to_vec(&common::valid_usage_record()).unwrap();
+    let msg = common::make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Retry));
+}
+
+#[tokio::test]
+async fn handle_success_returns_ok() {
+    let h = DeliveryHandler::new(common::MockCollector::ok());
+    let payload = serde_json::to_vec(&common::valid_usage_record()).unwrap();
+    let msg = common::make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Ok));
+}
+
+#[tokio::test]
+async fn handle_delivery_preserves_subject_fields_through_deserialization() {
+    let known_subject_id = Uuid::new_v4();
+    let record = UsageRecord {
+        subject_id: Some(known_subject_id),
+        subject_type: Some("real.subject".to_owned()),
+        ..common::valid_usage_record()
+    };
+
+    let captured: Arc<Mutex<Option<UsageRecord>>> = Arc::new(Mutex::new(None));
+    let collector = common::CapturingCollector::new(Arc::clone(&captured));
+    let h = DeliveryHandler::new(collector);
+    let payload = serde_json::to_vec(&record).unwrap();
+    let msg = common::make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Ok));
+
+    let received = captured
+        .lock()
+        .unwrap()
+        .take()
+        .expect("collector must have received the record");
+    assert_eq!(
+        received.subject_id,
+        Some(known_subject_id),
+        "subject_id must survive serialisation round-trip"
+    );
+    assert_eq!(
+        received.subject_type.as_deref(),
+        Some("real.subject"),
+        "subject_type must survive serialisation round-trip"
+    );
+}

--- a/modules/system/usage-collector/usage-emitter/tests/emitter_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/tests/emitter_tests.rs
@@ -1,0 +1,532 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use authz_resolver_sdk::models::{
+    BarrierMode, EvaluationRequest, EvaluationResponse, EvaluationResponseContext,
+};
+use authz_resolver_sdk::{AuthZResolverClient, AuthZResolverError};
+use modkit_security::pep_properties;
+use usage_collector_sdk::models::UsageRecord;
+use usage_collector_sdk::{UsageCollectorClientV1, UsageCollectorError};
+use usage_emitter::{UsageEmitter, UsageEmitterConfig, UsageEmitterError, UsageEmitterV1};
+use uuid::Uuid;
+
+const TEST_MODULE: &str = "test-module";
+
+// ── Test-specific AuthZ mocks ─────────────────────────────────────────────────
+
+struct AllowOwnerTenantIfInSet {
+    extra_allowed: Vec<Uuid>,
+}
+
+#[async_trait]
+impl AuthZResolverClient for AllowOwnerTenantIfInSet {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let subject_tenant = request
+            .subject
+            .properties
+            .get("tenant_id")
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok());
+
+        let Some(subject_tenant) = subject_tenant else {
+            return Ok(EvaluationResponse {
+                decision: false,
+                context: EvaluationResponseContext::default(),
+            });
+        };
+
+        let owner = request
+            .resource
+            .properties
+            .get(pep_properties::OWNER_TENANT_ID)
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok());
+
+        let Some(owner) = owner else {
+            return Ok(EvaluationResponse {
+                decision: false,
+                context: EvaluationResponseContext::default(),
+            });
+        };
+
+        let allowed = owner == subject_tenant || self.extra_allowed.contains(&owner);
+        Ok(EvaluationResponse {
+            decision: allowed,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+struct AssertBarrierIgnoreAuthZ;
+
+#[async_trait]
+impl AuthZResolverClient for AssertBarrierIgnoreAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let barrier = request
+            .context
+            .tenant_context
+            .as_ref()
+            .expect("tenant_context set by AccessRequest::barrier_mode")
+            .barrier_mode;
+        assert_eq!(barrier, BarrierMode::Ignore);
+        Ok(EvaluationResponse {
+            decision: true,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+struct AssertModulePropertyAuthZ {
+    expected_module: String,
+    matched: Arc<Mutex<bool>>,
+}
+
+#[async_trait]
+impl AuthZResolverClient for AssertModulePropertyAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let module_val = request
+            .resource
+            .properties
+            .get("module")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let ok = module_val == self.expected_module;
+        *self.matched.lock().unwrap() = ok;
+        Ok(EvaluationResponse {
+            decision: ok,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+struct AssertSubjectPropertiesAuthZ {
+    expected_subject_id: String,
+    expected_subject_type: String,
+    matched: Arc<Mutex<bool>>,
+}
+
+#[async_trait]
+impl AuthZResolverClient for AssertSubjectPropertiesAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let subj_id = request
+            .resource
+            .properties
+            .get("subject_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let subj_type = request
+            .resource
+            .properties
+            .get("subject_type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let ok = subj_id == self.expected_subject_id && subj_type == self.expected_subject_type;
+        *self.matched.lock().unwrap() = ok;
+        Ok(EvaluationResponse {
+            decision: ok,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+struct AssertNoSubjectPropertiesAuthZ {
+    asserted: Arc<Mutex<bool>>,
+}
+
+#[async_trait]
+impl AuthZResolverClient for AssertNoSubjectPropertiesAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let has_subject_id = request.resource.properties.contains_key("subject_id");
+        let has_subject_type = request.resource.properties.contains_key("subject_type");
+        let ok = !has_subject_id && !has_subject_type;
+        *self.asserted.lock().unwrap() = ok;
+        Ok(EvaluationResponse {
+            decision: ok,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+// ── Test-specific collector mock ──────────────────────────────────────────────
+
+struct FailingCollector {
+    error: fn() -> UsageCollectorError,
+}
+
+#[async_trait]
+impl UsageCollectorClientV1 for FailingCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<usage_collector_sdk::ModuleConfig, UsageCollectorError> {
+        Err((self.error)())
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async fn build_emitter(name: &str, authz: Arc<dyn AuthZResolverClient>) -> UsageEmitter {
+    let db = common::build_db(name).await;
+    UsageEmitter::build(
+        UsageEmitterConfig::default(),
+        db,
+        authz,
+        Arc::new(common::NoopCollector),
+    )
+    .await
+    .unwrap()
+}
+
+async fn build_emitter_with_collector(
+    name: &str,
+    authz: Arc<dyn AuthZResolverClient>,
+    collector: Arc<dyn UsageCollectorClientV1>,
+) -> UsageEmitter {
+    let db = common::build_db(name).await;
+    UsageEmitter::build(UsageEmitterConfig::default(), db, authz, collector)
+        .await
+        .unwrap()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn build_creates_emitter_with_valid_config() {
+    build_emitter("emit_build", Arc::new(common::AllowAllAuthZ)).await;
+}
+
+#[tokio::test]
+async fn authorize_returns_handle_on_allow_all_authz() {
+    let emitter = build_emitter("emit_authz_allow", Arc::new(common::AllowAllAuthZ)).await;
+    let ctx = common::make_ctx();
+    emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn authorize_returns_error_on_deny_all_authz() {
+    let emitter = build_emitter("emit_authz_deny", Arc::new(common::DenyAllAuthZ)).await;
+    let ctx = common::make_ctx();
+    let Err(err) = emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await
+    else {
+        panic!("expected authorization to fail");
+    };
+    assert!(matches!(err, UsageEmitterError::AuthorizationFailed { .. }));
+}
+
+#[tokio::test]
+async fn authorize_returns_internal_error_on_authz_failure() {
+    let emitter = build_emitter("emit_authz_fail", Arc::new(common::FailingAuthZ)).await;
+    let ctx = common::make_ctx();
+    let Err(err) = emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await
+    else {
+        panic!("expected authorization to fail");
+    };
+    assert!(matches!(err, UsageEmitterError::Internal { .. }));
+}
+
+#[tokio::test]
+async fn authorize_for_denies_when_pdp_rejects_owner_tenant() {
+    let emitter = build_emitter(
+        "emit_pdp_deny_foreign",
+        Arc::new(AllowOwnerTenantIfInSet {
+            extra_allowed: vec![],
+        }),
+    )
+    .await;
+
+    let subject_tenant = Uuid::new_v4();
+    let foreign_tenant = Uuid::new_v4();
+    let ctx = modkit_security::SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(subject_tenant)
+        .build()
+        .unwrap();
+
+    let Err(err) = emitter
+        .for_module(TEST_MODULE)
+        .authorize_for(
+            &ctx,
+            foreign_tenant,
+            Uuid::new_v4(),
+            "test.resource".to_owned(),
+            Some(Uuid::new_v4()),
+            Some("test.subject".to_owned()),
+        )
+        .await
+    else {
+        panic!("expected authorization to fail");
+    };
+    assert!(matches!(err, UsageEmitterError::AuthorizationFailed { .. }));
+}
+
+#[tokio::test]
+async fn authorize_for_allows_subtenant_when_pdp_allows_extra_tenant() {
+    let parent = Uuid::new_v4();
+    let child = Uuid::new_v4();
+    let emitter = build_emitter(
+        "emit_pdp_allow_child",
+        Arc::new(AllowOwnerTenantIfInSet {
+            extra_allowed: vec![child],
+        }),
+    )
+    .await;
+
+    let ctx = modkit_security::SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(parent)
+        .build()
+        .unwrap();
+
+    emitter
+        .for_module(TEST_MODULE)
+        .authorize_for(
+            &ctx,
+            child,
+            Uuid::new_v4(),
+            "test.resource".to_owned(),
+            Some(Uuid::new_v4()),
+            Some("test.subject".to_owned()),
+        )
+        .await
+        .expect("PDP allows emit for allowed sub-tenant");
+}
+
+#[tokio::test]
+async fn authorize_for_sends_barrier_mode_ignore_to_pdp() {
+    let emitter = build_emitter("emit_barrier_ignore", Arc::new(AssertBarrierIgnoreAuthZ)).await;
+    let ctx = common::make_ctx();
+    emitter
+        .for_module(TEST_MODULE)
+        .authorize_for(
+            &ctx,
+            ctx.subject_tenant_id(),
+            Uuid::new_v4(),
+            "test.resource".to_owned(),
+            Some(Uuid::new_v4()),
+            Some("test.subject".to_owned()),
+        )
+        .await
+        .expect("barrier assert + allow");
+}
+
+#[tokio::test]
+async fn authorize_for_maps_collector_plugin_timeout_to_internal() {
+    let emitter = build_emitter_with_collector(
+        "emit_collector_timeout",
+        Arc::new(common::AllowAllAuthZ),
+        Arc::new(FailingCollector {
+            error: UsageCollectorError::plugin_timeout,
+        }),
+    )
+    .await;
+    let ctx = common::make_ctx();
+    let result = emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await;
+    assert!(matches!(result, Err(UsageEmitterError::Internal { .. })));
+}
+
+#[tokio::test]
+async fn authorize_for_maps_collector_circuit_open_to_internal() {
+    let emitter = build_emitter_with_collector(
+        "emit_collector_circuit_open",
+        Arc::new(common::AllowAllAuthZ),
+        Arc::new(FailingCollector {
+            error: UsageCollectorError::circuit_open,
+        }),
+    )
+    .await;
+    let ctx = common::make_ctx();
+    let result = emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await;
+    assert!(matches!(result, Err(UsageEmitterError::Internal { .. })));
+}
+
+#[tokio::test]
+async fn authorize_for_maps_collector_unavailable_to_internal() {
+    let emitter = build_emitter_with_collector(
+        "emit_collector_unavailable",
+        Arc::new(common::AllowAllAuthZ),
+        Arc::new(FailingCollector {
+            error: || UsageCollectorError::unavailable("gateway unreachable"),
+        }),
+    )
+    .await;
+    let ctx = common::make_ctx();
+    let result = emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await;
+    assert!(matches!(result, Err(UsageEmitterError::Internal { .. })));
+}
+
+#[tokio::test]
+async fn authorize_for_maps_collector_internal_error_to_internal() {
+    let emitter = build_emitter_with_collector(
+        "emit_collector_internal",
+        Arc::new(common::AllowAllAuthZ),
+        Arc::new(FailingCollector {
+            error: || UsageCollectorError::internal("unexpected state"),
+        }),
+    )
+    .await;
+    let ctx = common::make_ctx();
+    let result = emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await;
+    assert!(matches!(result, Err(UsageEmitterError::Internal { .. })));
+}
+
+#[tokio::test]
+async fn authorize_for_pdp_request_includes_module_resource_property() {
+    let matched = Arc::new(Mutex::new(false));
+    let emitter = build_emitter(
+        "emit_module_prop",
+        Arc::new(AssertModulePropertyAuthZ {
+            expected_module: TEST_MODULE.to_owned(),
+            matched: Arc::clone(&matched),
+        }),
+    )
+    .await;
+    let ctx = common::make_ctx();
+    drop(
+        emitter
+            .for_module(TEST_MODULE)
+            .authorize_for(
+                &ctx,
+                ctx.subject_tenant_id(),
+                Uuid::new_v4(),
+                "test.resource".to_owned(),
+                Some(Uuid::new_v4()),
+                Some("test.subject".to_owned()),
+            )
+            .await,
+    );
+    assert!(
+        *matched.lock().unwrap(),
+        "PDP request must include MODULE resource property equal to the module name"
+    );
+}
+
+#[tokio::test]
+async fn authorize_for_pdp_request_includes_subject_id_and_subject_type_resource_properties() {
+    let matched = Arc::new(Mutex::new(false));
+    let subject_id = Uuid::new_v4();
+    let subject_type = "test.subject.type".to_owned();
+    let emitter = build_emitter(
+        "emit_subject_props",
+        Arc::new(AssertSubjectPropertiesAuthZ {
+            expected_subject_id: subject_id.to_string(),
+            expected_subject_type: subject_type.clone(),
+            matched: Arc::clone(&matched),
+        }),
+    )
+    .await;
+    let ctx = common::make_ctx();
+    drop(
+        emitter
+            .for_module(TEST_MODULE)
+            .authorize_for(
+                &ctx,
+                ctx.subject_tenant_id(),
+                Uuid::new_v4(),
+                "test.resource".to_owned(),
+                Some(subject_id),
+                Some(subject_type),
+            )
+            .await,
+    );
+    assert!(
+        *matched.lock().unwrap(),
+        "PDP request must include SUBJECT_ID and SUBJECT_TYPE resource properties"
+    );
+}
+
+#[tokio::test]
+async fn authorize_for_without_subject_succeeds() {
+    let emitter = build_emitter("emit_no_subject_allow", Arc::new(common::AllowAllAuthZ)).await;
+    let ctx = common::make_ctx();
+    let result = emitter
+        .for_module(TEST_MODULE)
+        .authorize_for(
+            &ctx,
+            ctx.subject_tenant_id(),
+            Uuid::new_v4(),
+            "test.resource".to_owned(),
+            None,
+            None,
+        )
+        .await;
+    assert!(
+        result.is_ok(),
+        "authorize_for with None subject must succeed when PDP allows"
+    );
+}
+
+#[tokio::test]
+async fn authorize_for_pdp_request_omits_subject_properties_when_none() {
+    let asserted = Arc::new(Mutex::new(false));
+    let emitter = build_emitter(
+        "emit_no_subject_props",
+        Arc::new(AssertNoSubjectPropertiesAuthZ {
+            asserted: Arc::clone(&asserted),
+        }),
+    )
+    .await;
+    let ctx = common::make_ctx();
+    drop(
+        emitter
+            .for_module(TEST_MODULE)
+            .authorize_for(
+                &ctx,
+                ctx.subject_tenant_id(),
+                Uuid::new_v4(),
+                "test.resource".to_owned(),
+                None,
+                None,
+            )
+            .await,
+    );
+    assert!(
+        *asserted.lock().unwrap(),
+        "PDP request must NOT include SUBJECT_ID or SUBJECT_TYPE when subject is None"
+    );
+}


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#1816](https://github.com/cyberfabric/cyberware-rust/pull/1816) | **Author:** capybutler | **Opened:** 2026-05-04T05:51:12Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

- Adds `cf-usage-collector-rest-client` crate: a ModKit module for out-of-process
  binaries that must deliver usage records to a remote collector gateway over HTTP
  instead of in-process.
- `UsageCollectorRestClientModule::init()` loads config, acquires `AuthNResolverClient`
  and `AuthZResolverClient` from `ClientHub`, builds `UsageCollectorRestClient`
  with a configured `HttpClient`, wires it into `UsageEmitter`, and registers
  `UsageEmitterV1` — identical surface API to the in-process path.
- `UsageCollectorRestClient` implements `UsageCollectorClientV1`:
  - `create_usage_record`: acquires a fresh bearer token per attempt, POSTs to
    `POST /usage-collector/v1/records`; maps `204→Ok`, `401/403→AuthorizationFailed`,
    `429/5xx→PluginTimeout` (Retry), other `4xx→Internal` (Reject),
    timeouts→`PluginTimeout`, transport errors→`Unavailable`.
  - `get_module_config`: GETs `GET /usage-collector/v1/modules/{module_name}/config`
    with percent-encoded module name; maps `200→ModuleConfig`, `404→ModuleNotFound`.
  - AuthN errors: `Unauthorized/NoPluginAvailable` → permanent reject;
    all others → transient retry.
- `DatabaseCapability::migrations()` returns `outbox_migrations()` — the module owns
  the source's local outbox queue.
- TLS check: startup WARN when `base_url` uses `http://` with a non-localhost host
  (cpt-cf-dod-rest-ingest-tls-config).
- Adds feature design document `0002-cpt-cf-usage-collector-feature-rest-ingest` (v1.3)
  covering actor flows, business logic, DoD, and acceptance criteria.

## PR Train
| # | PR | Description | Lines |
|---|---|------------|------:|
| 1 | [1620](https://github.com/constructorfabric/cyberfabric-core/issues/1620) | Feature 1 (Core SDK, Emitter & In-Process Ingest): SDK + docs | ~2200 |
| 2 | [1733](https://github.com/constructorfabric/cyberfabric-core/issues/1733) | Feature 1 (Core SDK, Emitter & In-Process Ingest): `usage-collector` gateway + `usage-emitter` + `noop-usage-collector-storage-plugin` | ~7600 |
| 3 | [1816 (**this**)](https://github.com/constructorfabric/cyberfabric-core/issues/1816) | Feature 2 (REST Client & Remote Ingest Delivery) | ~2100 |
| 4 | [1817](https://github.com/constructorfabric/cyberfabric-core/issues/1817) | Feature 3 (Query API) | ~4000 |
| 5 | [1818](https://github.com/constructorfabric/cyberfabric-core/issues/1818) | Feature 4 (TimescaleDB plugin) | ~4700 |
| 6 | [1835](https://github.com/constructorfabric/cyberfabric-core/issues/1835) | e2e tests | ~1500 |
|   |  | ... to be continued ... | |


## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No linting errors (`cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::perf`)
- [x] Code is properly formatted (`cargo fmt`)
- [x] `cpt validate` — all checks passed
- [x] Tests pass (`cargo nextest run --workspace`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added REST client module for remote usage collection with OAuth2 bearer token authentication and configurable request timeouts.
  * Implemented TLS/HTTPS security validation for production deployments.

* **Documentation**
  * Added feature specification and configuration guide for the REST-based usage collector module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#1816 -->