### PR TITLE
[PR #1810] chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,96 @@ release-plz updates this file in the Release PR.
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/cyberfabric/cyberfabric-core/compare/cf-tr-authz-plugin-v0.1.1...cf-tr-authz-plugin-v0.1.2) - 2026-05-02
+
+### Other
+
+- massive renaming of different artifacts from HyperSport -> CyberFabric to finalize project transition under CyberFabric (by @Artifizer) - #1805
+
+### Contributors
+
+* @Artifizer
+
+## [0.1.20](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-tr-plugin-v0.1.19...cf-static-tr-plugin-v0.1.20) - 2026-05-02
+
+### Other
+
+- massive renaming of different artifacts from HyperSport -> CyberFabric to finalize project transition under CyberFabric (by @Artifizer) - #1805
+
+### Contributors
+
+* @Artifizer
+
+## [0.1.17](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-credstore-plugin-v0.1.16...cf-static-credstore-plugin-v0.1.17) - 2026-05-02
+
+### Other
+
+- massive renaming of different artifacts from HyperSport -> CyberFabric to finalize project transition under CyberFabric (by @Artifizer) - #1805
+
+### Contributors
+
+* @Artifizer
+
+## [0.1.19](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-authz-plugin-v0.1.18...cf-static-authz-plugin-v0.1.19) - 2026-05-02
+
+### Other
+
+- massive renaming of different artifacts from HyperSport -> CyberFabric to finalize project transition under CyberFabric (by @Artifizer) - #1805
+
+### Contributors
+
+* @Artifizer
+
+## [0.2.10](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-authn-plugin-v0.2.9...cf-static-authn-plugin-v0.2.10) - 2026-05-02
+
+### Other
+
+- massive renaming of different artifacts from HyperSport -> CyberFabric to finalize project transition under CyberFabric (by @Artifizer) - #1805
+
+### Contributors
+
+* @Artifizer
+
+## [0.1.21](https://github.com/cyberfabric/cyberfabric-core/compare/cf-single-tenant-tr-plugin-v0.1.20...cf-single-tenant-tr-plugin-v0.1.21) - 2026-05-02
+
+### Other
+
+- massive renaming of different artifacts from HyperSport -> CyberFabric to finalize project transition under CyberFabric (by @Artifizer) - #1805
+
+### Contributors
+
+* @Artifizer
+
+## [0.1.2](https://github.com/cyberfabric/cyberfabric-core/compare/cf-rg-tr-plugin-v0.1.1...cf-rg-tr-plugin-v0.1.2) - 2026-05-02
+
+### Other
+
+- massive renaming of different artifacts from HyperSport -> CyberFabric to finalize project transition under CyberFabric (by @Artifizer) - #1805
+
+### Contributors
+
+* @Artifizer
+
+## [0.6.5](https://github.com/cyberfabric/cyberfabric-core/compare/cf-modkit-http-v0.6.4...cf-modkit-http-v0.6.5) - 2026-05-02
+
+### Other
+
+- update rand 0.9 -> 0.10 (by @Artifizer) - #1783
+
+### Contributors
+
+* @Artifizer
+
+## [0.6.9](https://github.com/cyberfabric/cyberfabric-core/compare/cf-modkit-v0.6.8...cf-modkit-v0.6.9) - 2026-05-02
+
+### Other
+
+- massive renaming of different artifacts from HyperSport -> CyberFabric to finalize project transition under CyberFabric (by @Artifizer) - #1805
+
+### Contributors
+
+* @Artifizer
+
 ## [0.1.1](https://github.com/cyberfabric/cyberfabric-core/compare/cf-tr-authz-plugin-v0.1.0...cf-tr-authz-plugin-v0.1.1) - 2026-05-01
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "cf-api-gateway"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "cf-authn-resolver"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "cf-authn-resolver-sdk"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -1441,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "cf-authz-resolver"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1461,7 +1461,7 @@ dependencies = [
 
 [[package]]
 name = "cf-authz-resolver-sdk"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -1480,7 +1480,7 @@ dependencies = [
 
 [[package]]
 name = "cf-credstore"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "cf-credstore-sdk"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "cf-file-parser"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "cf-grpc-hub"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "cf-mini-chat"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "cf-mini-chat-sdk"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-auth"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "aliri_clock",
  "aliri_tokens",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-http"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "bytes",
  "flate2",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-node-info"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1980,7 +1980,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-transport-grpc"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "cf-modkit-security",
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "cf-module-orchestrator"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2030,7 +2030,7 @@ dependencies = [
 
 [[package]]
 name = "cf-nodes-registry"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2050,7 +2050,7 @@ dependencies = [
 
 [[package]]
 name = "cf-nodes-registry-sdk"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "async-trait",
  "cf-modkit-node-info",
@@ -2060,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "cf-oagw"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "cf-resource-group"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "cf-resource-group-sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -2192,7 +2192,7 @@ dependencies = [
 
 [[package]]
 name = "cf-rg-tr-plugin"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "cf-single-tenant-tr-plugin"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2345,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-authn-plugin"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-authz-plugin"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2384,7 +2384,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-credstore-plugin"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2404,7 +2404,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-tr-plugin"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "cf-system-sdk-directory"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2439,14 +2439,14 @@ dependencies = [
 
 [[package]]
 name = "cf-system-sdks"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "cf-system-sdk-directory",
 ]
 
 [[package]]
 name = "cf-tenant-resolver"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "cf-tenant-resolver-sdk"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "cf-tr-authz-plugin"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2504,7 +2504,7 @@ dependencies = [
 
 [[package]]
 name = "cf-types-registry"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,42 +219,42 @@ verbose_file_reads = "deny"
 
 [workspace.dependencies]
 # libs
-modkit = { package = "cf-modkit", version = "0.6.8", path = "libs/modkit" }
-modkit-http = { package = "cf-modkit-http", version = "0.6.4", path = "libs/modkit-http" }
-modkit-auth = { package = "cf-modkit-auth", version = "0.6.4", path = "libs/modkit-auth" }
+modkit = { package = "cf-modkit", version = "0.6.9", path = "libs/modkit" }
+modkit-http = { package = "cf-modkit-http", version = "0.6.5", path = "libs/modkit-http" }
+modkit-auth = { package = "cf-modkit-auth", version = "0.6.5", path = "libs/modkit-auth" }
 modkit-canonical-errors = { package = "cf-modkit-canonical-errors", version = "0.7.2", path = "libs/modkit-canonical-errors" }
 modkit-canonical-errors-macro = { package = "cf-modkit-canonical-errors-macro", version = "0.6.1", path = "libs/modkit-canonical-errors-macro" }
-modkit-db = { package = "cf-modkit-db", version = "0.8.1", path = "libs/modkit-db" }
+modkit-db = { package = "cf-modkit-db", version = "0.8.2", path = "libs/modkit-db" }
 modkit-db-macros = { package = "cf-modkit-db-macros", version = "0.6.2", path = "libs/modkit-db-macros" }
 modkit-errors = { package = "cf-modkit-errors", version = "0.7.0", path = "libs/modkit-errors" }
 modkit-errors-macro = { package = "cf-modkit-errors-macro", version = "0.6.2", path = "libs/modkit-errors-macro" }
 modkit-macros = { package = "cf-modkit-macros", version = "0.6.2", path = "libs/modkit-macros" }
-modkit-node-info = { package = "cf-modkit-node-info", version = "0.6.3", path = "libs/modkit-node-info" }
+modkit-node-info = { package = "cf-modkit-node-info", version = "0.6.4", path = "libs/modkit-node-info" }
 modkit-odata = { package = "cf-modkit-odata", version = "0.7.1", path = "libs/modkit-odata" }
 modkit-odata-macros = { package = "cf-modkit-odata-macros", version = "0.6.4", path = "libs/modkit-odata-macros" }
 modkit-sdk = { package = "cf-modkit-sdk", version = "0.6.4", path = "libs/modkit-sdk" }
 modkit-security = { package = "cf-modkit-security", version = "0.7.0", path = "libs/modkit-security" }
-modkit-transport-grpc = { package = "cf-modkit-transport-grpc", version = "0.6.3", path = "libs/modkit-transport-grpc" }
+modkit-transport-grpc = { package = "cf-modkit-transport-grpc", version = "0.6.4", path = "libs/modkit-transport-grpc" }
 modkit-utils = { package = "cf-modkit-utils", version = "0.6.3", path = "libs/modkit-utils" }
 
-cf-system-sdks = { version = "0.1.34", path = "libs/system-sdks" }
-cf-system-sdk-directory = { version = "0.1.34", path = "libs/system-sdks/sdks/directory" }
+cf-system-sdks = { version = "0.1.35", path = "libs/system-sdks" }
+cf-system-sdk-directory = { version = "0.1.35", path = "libs/system-sdks/sdks/directory" }
 
 # system modules SDKs
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.1", path = "modules/system/types-registry/types-registry-sdk" }
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.4", path = "modules/system/tenant-resolver/tenant-resolver-sdk" }
-authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.4", path = "modules/system/authz-resolver/authz-resolver-sdk" }
-resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.1", path = "modules/system/resource-group/resource-group-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.5", path = "modules/system/tenant-resolver/tenant-resolver-sdk" }
+authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.5", path = "modules/system/authz-resolver/authz-resolver-sdk" }
+resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.2", path = "modules/system/resource-group/resource-group-sdk" }
 oagw-sdk = { package = "cf-oagw-sdk", version = "0.5.0", path = "modules/system/oagw/oagw-sdk" }
 
 # credstore
-credstore-sdk = { package = "cf-credstore-sdk", version = "0.1.22", path = "modules/credstore/credstore-sdk" }
+credstore-sdk = { package = "cf-credstore-sdk", version = "0.1.23", path = "modules/credstore/credstore-sdk" }
 
 # mini-chat
-mini-chat-sdk = { package = "cf-mini-chat-sdk", version = "0.10.4", path = "modules/mini-chat/mini-chat-sdk" }
+mini-chat-sdk = { package = "cf-mini-chat-sdk", version = "0.10.5", path = "modules/mini-chat/mini-chat-sdk" }
 
 # system modules
-grpc_hub = { package = "cf-grpc-hub", version = "0.2.4", path = "modules/system/grpc-hub" }
+grpc_hub = { package = "cf-grpc-hub", version = "0.2.5", path = "modules/system/grpc-hub" }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/libs/modkit-auth/Cargo.toml
+++ b/libs/modkit-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-auth"
-version = "0.6.4"
+version = "0.6.5"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-db/Cargo.toml
+++ b/libs/modkit-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-db"
-version = "0.8.1"
+version = "0.8.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-http/Cargo.toml
+++ b/libs/modkit-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-http"
-version = "0.6.4"
+version = "0.6.5"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-node-info/Cargo.toml
+++ b/libs/modkit-node-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-node-info"
-version = "0.6.3"
+version = "0.6.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-transport-grpc/Cargo.toml
+++ b/libs/modkit-transport-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-transport-grpc"
-version = "0.6.3"
+version = "0.6.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit"
-version = "0.6.8"
+version = "0.6.9"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/system-sdks/Cargo.toml
+++ b/libs/system-sdks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-system-sdks"
-version = "0.1.34"
+version = "0.1.35"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/system-sdks/sdks/directory/Cargo.toml
+++ b/libs/system-sdks/sdks/directory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-system-sdk-directory"
-version = "0.1.34"
+version = "0.1.35"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/credstore/credstore-sdk/Cargo.toml
+++ b/modules/credstore/credstore-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-credstore-sdk"
 description = "SDK for credstore module: API traits, models, and error definitions"
-version = "0.1.22"
+version = "0.1.23"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/credstore/credstore/Cargo.toml
+++ b/modules/credstore/credstore/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-credstore"
 description = "credstore gateway module"
-version = "0.1.20"
+version = "0.1.21"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/credstore/plugins/static-credstore-plugin/Cargo.toml
+++ b/modules/credstore/plugins/static-credstore-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-static-credstore-plugin"
-version = "0.1.16"
+version = "0.1.17"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -16,7 +16,7 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-credstore-sdk = { package = "cf-credstore-sdk", version = "0.1.22", path = "../../credstore-sdk" }
+credstore-sdk = { package = "cf-credstore-sdk", version = "0.1.23", path = "../../credstore-sdk" }
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.1", path = "../../../system/types-registry/types-registry-sdk" }
 
 # ModKit dependencies

--- a/modules/file-parser/Cargo.toml
+++ b/modules/file-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-file-parser"
-version = "0.1.24"
+version = "0.1.25"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/mini-chat/mini-chat-sdk/Cargo.toml
+++ b/modules/mini-chat/mini-chat-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-mini-chat-sdk"
 description = "SDK for mini-chat: policy plugin traits, models, and errors"
-version = "0.10.4"
+version = "0.10.5"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/mini-chat/mini-chat/Cargo.toml
+++ b/modules/mini-chat/mini-chat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-mini-chat"
 description = "Mini-chat module: multi-tenant AI chat"
-version = "0.1.29"
+version = "0.1.30"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -26,7 +26,7 @@ k8s = ["dep:kube", "dep:k8s-openapi"]
 mini-chat-sdk = { workspace = true }
 
 # AuthN resolver for S2S client credentials exchange
-authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.14", path = "../../system/authn-resolver/authn-resolver-sdk" }
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.15", path = "../../system/authn-resolver/authn-resolver-sdk" }
 
 # AuthZ resolver for authorization (PEP flow)
 authz-resolver-sdk = { workspace = true }

--- a/modules/system/api-gateway/Cargo.toml
+++ b/modules/system/api-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-api-gateway"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ workspace = true
 modkit = { workspace = true }
 modkit-http = { workspace = true }
 modkit-security = { workspace = true }
-authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.14", path = "../authn-resolver/authn-resolver-sdk" }
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.15", path = "../authn-resolver/authn-resolver-sdk" }
 modkit-macros = { workspace = true }
 inventory = { workspace = true }
 anyhow = { workspace = true }

--- a/modules/system/authn-resolver/authn-resolver-sdk/Cargo.toml
+++ b/modules/system/authn-resolver/authn-resolver-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-authn-resolver-sdk"
-version = "0.3.14"
+version = "0.3.15"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/authn-resolver/authn-resolver/Cargo.toml
+++ b/modules/system/authn-resolver/authn-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-authn-resolver"
-version = "0.2.14"
+version = "0.2.15"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.14", path = "../authn-resolver-sdk" }
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.15", path = "../authn-resolver-sdk" }
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.1", path = "../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies

--- a/modules/system/authn-resolver/plugins/static-authn-plugin/Cargo.toml
+++ b/modules/system/authn-resolver/plugins/static-authn-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-static-authn-plugin"
-version = "0.2.9"
+version = "0.2.10"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.14", path = "../../authn-resolver-sdk" }
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.15", path = "../../authn-resolver-sdk" }
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.1", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies

--- a/modules/system/authz-resolver/authz-resolver-sdk/Cargo.toml
+++ b/modules/system/authz-resolver/authz-resolver-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-authz-resolver-sdk"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/authz-resolver/authz-resolver/Cargo.toml
+++ b/modules/system/authz-resolver/authz-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-authz-resolver"
-version = "0.1.21"
+version = "0.1.22"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.4", path = "../authz-resolver-sdk" }
+authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.5", path = "../authz-resolver-sdk" }
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.1", path = "../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies

--- a/modules/system/authz-resolver/plugins/static-authz-plugin/Cargo.toml
+++ b/modules/system/authz-resolver/plugins/static-authz-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-static-authz-plugin"
-version = "0.1.18"
+version = "0.1.19"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.4", path = "../../authz-resolver-sdk" }
+authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.5", path = "../../authz-resolver-sdk" }
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.1", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies

--- a/modules/system/authz-resolver/plugins/tr-authz-plugin/Cargo.toml
+++ b/modules/system/authz-resolver/plugins/tr-authz-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-tr-authz-plugin"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.4", path = "../../authz-resolver-sdk" }
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.4", path = "../../../tenant-resolver/tenant-resolver-sdk" }
+authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.5", path = "../../authz-resolver-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.5", path = "../../../tenant-resolver/tenant-resolver-sdk" }
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.1", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies

--- a/modules/system/grpc-hub/Cargo.toml
+++ b/modules/system/grpc-hub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-grpc-hub"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/module-orchestrator/Cargo.toml
+++ b/modules/system/module-orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-module-orchestrator"
-version = "0.1.23"
+version = "0.1.24"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/nodes-registry/nodes-registry-sdk/Cargo.toml
+++ b/modules/system/nodes-registry/nodes-registry-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-nodes-registry-sdk"
-version = "0.1.20"
+version = "0.1.21"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/nodes-registry/nodes-registry/Cargo.toml
+++ b/modules/system/nodes-registry/nodes-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-nodes-registry"
-version = "0.1.23"
+version = "0.1.24"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -31,4 +31,4 @@ thiserror = { workspace = true }
 modkit = { workspace = true }
 modkit-node-info = { workspace = true }
 modkit-macros = { workspace = true }
-nodes_registry-sdk = { package = "cf-nodes-registry-sdk", version = "0.1.20", path = "../nodes-registry-sdk" }
+nodes_registry-sdk = { package = "cf-nodes-registry-sdk", version = "0.1.21", path = "../nodes-registry-sdk" }

--- a/modules/system/oagw/oagw/Cargo.toml
+++ b/modules/system/oagw/oagw/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-oagw"
 description = "OAGW module - discovers and routes to plugins"
-version = "0.2.23"
+version = "0.2.24"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/resource-group/resource-group-sdk/Cargo.toml
+++ b/modules/system/resource-group/resource-group-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 # Created: 2026-04-16 by Constructor Tech
 [package]
 name = "cf-resource-group-sdk"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/resource-group/resource-group/Cargo.toml
+++ b/modules/system/resource-group/resource-group/Cargo.toml
@@ -1,7 +1,7 @@
 # Created: 2026-04-16 by Constructor Tech
 [package]
 name = "cf-resource-group"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -20,7 +20,7 @@ odata = []
 
 [dependencies]
 # SDK - public API, models, and errors
-resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.1", path = "../resource-group-sdk", features = ["odata"] }
+resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.2", path = "../resource-group-sdk", features = ["odata"] }
 
 # Core dependencies
 anyhow = { workspace = true }

--- a/modules/system/tenant-resolver/plugins/rg-tr-plugin/Cargo.toml
+++ b/modules/system/tenant-resolver/plugins/rg-tr-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-rg-tr-plugin"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.4", path = "../../tenant-resolver-sdk" }
-resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.1", path = "../../../resource-group/resource-group-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.5", path = "../../tenant-resolver-sdk" }
+resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.2", path = "../../../resource-group/resource-group-sdk" }
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.1", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies

--- a/modules/system/tenant-resolver/plugins/single-tenant-tr-plugin/Cargo.toml
+++ b/modules/system/tenant-resolver/plugins/single-tenant-tr-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-single-tenant-tr-plugin"
-version = "0.1.20"
+version = "0.1.21"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.4", path = "../../tenant-resolver-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.5", path = "../../tenant-resolver-sdk" }
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.1", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies

--- a/modules/system/tenant-resolver/plugins/static-tr-plugin/Cargo.toml
+++ b/modules/system/tenant-resolver/plugins/static-tr-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-static-tr-plugin"
-version = "0.1.19"
+version = "0.1.20"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.4", path = "../../tenant-resolver-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.5", path = "../../tenant-resolver-sdk" }
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.1", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies

--- a/modules/system/tenant-resolver/tenant-resolver-sdk/Cargo.toml
+++ b/modules/system/tenant-resolver/tenant-resolver-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-tenant-resolver-sdk"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/tenant-resolver/tenant-resolver/Cargo.toml
+++ b/modules/system/tenant-resolver/tenant-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-tenant-resolver"
-version = "0.1.19"
+version = "0.1.20"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.4", path = "../tenant-resolver-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.5", path = "../tenant-resolver-sdk" }
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.2.1", path = "../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies

--- a/modules/system/types-registry/types-registry/Cargo.toml
+++ b/modules/system/types-registry/types-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-types-registry"
-version = "0.1.20"
+version = "0.1.21"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#1810](https://github.com/cyberfabric/cyberware-rust/pull/1810) | **Author:** github-actions[bot] | **Opened:** 2026-05-02T11:54:21Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---




## 🤖 New release

* `cf-modkit-transport-grpc`: 0.6.3 -> 0.6.4 (✓ API compatible changes)
* `cf-modkit-db`: 0.8.1 -> 0.8.2 (✓ API compatible changes)
* `cf-modkit`: 0.6.8 -> 0.6.9 (✓ API compatible changes)
* `cf-tenant-resolver-sdk`: 0.3.4 -> 0.3.5 (✓ API compatible changes)
* `cf-modkit-http`: 0.6.4 -> 0.6.5 (✓ API compatible changes)
* `cf-oagw`: 0.2.23 -> 0.2.24 (✓ API compatible changes)
* `cf-authn-resolver-sdk`: 0.3.14 -> 0.3.15 (✓ API compatible changes)
* `cf-api-gateway`: 0.2.5 -> 0.2.6 (✓ API compatible changes)
* `cf-authn-resolver`: 0.2.14 -> 0.2.15 (✓ API compatible changes)
* `cf-authz-resolver`: 0.1.21 -> 0.1.22 (✓ API compatible changes)
* `cf-grpc-hub`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `cf-credstore`: 0.1.20 -> 0.1.21 (✓ API compatible changes)
* `cf-file-parser`: 0.1.24 -> 0.1.25 (✓ API compatible changes)
* `cf-mini-chat`: 0.1.29 -> 0.1.30 (✓ API compatible changes)
* `cf-modkit-node-info`: 0.6.3 -> 0.6.4 (✓ API compatible changes)
* `cf-nodes-registry`: 0.1.23 -> 0.1.24 (✓ API compatible changes)
* `cf-rg-tr-plugin`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `cf-single-tenant-tr-plugin`: 0.1.20 -> 0.1.21 (✓ API compatible changes)
* `cf-static-authn-plugin`: 0.2.9 -> 0.2.10 (✓ API compatible changes)
* `cf-static-authz-plugin`: 0.1.18 -> 0.1.19 (✓ API compatible changes)
* `cf-static-credstore-plugin`: 0.1.16 -> 0.1.17 (✓ API compatible changes)
* `cf-static-tr-plugin`: 0.1.19 -> 0.1.20 (✓ API compatible changes)
* `cf-tenant-resolver`: 0.1.19 -> 0.1.20 (✓ API compatible changes)
* `cf-tr-authz-plugin`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `cf-types-registry`: 0.1.20 -> 0.1.21 (✓ API compatible changes)
* `cf-system-sdk-directory`: 0.1.34 -> 0.1.35
* `cf-system-sdks`: 0.1.34 -> 0.1.35
* `cf-authz-resolver-sdk`: 0.3.4 -> 0.3.5
* `cf-credstore-sdk`: 0.1.22 -> 0.1.23
* `cf-modkit-auth`: 0.6.4 -> 0.6.5
* `cf-mini-chat-sdk`: 0.10.4 -> 0.10.5
* `cf-module-orchestrator`: 0.1.23 -> 0.1.24
* `cf-nodes-registry-sdk`: 0.1.20 -> 0.1.21
* `cf-resource-group-sdk`: 0.1.1 -> 0.1.2
* `cf-resource-group`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>



## `cf-modkit`

<blockquote>


## [0.6.9](https://github.com/constructorfabric/cyberfabric-core/compare/cf-modkit-v0.6.8...cf-modkit-v0.6.9) - 2026-05-02

### Other

- massive renaming of different artifacts from HyperSport -> CyberFabric to finalize project transition under CyberFabric (by &#2369;Artifizer) - #3558

### Contributors

* &#2369;Artifizer
</blockquote>


## `cf-modkit-http`

<blockquote>


## [0.6.5](https://github.com/constructorfabric/cyberfabric-core/compare/cf-modkit-http-v0.6.4...cf-modkit-http-v0.6.5) - 2026-05-02

### Other

- update rand 0.9 -> 0.10 (by &#2369;Artifizer) - #3570

### Contributors

* &#2369;Artifizer
</blockquote>












## `cf-rg-tr-plugin`

<blockquote>


## [0.1.2](https://github.com/constructorfabric/cyberfabric-core/compare/cf-rg-tr-plugin-v0.1.1...cf-rg-tr-plugin-v0.1.2) - 2026-05-02

### Other

- massive renaming of different artifacts from HyperSport -> CyberFabric to finalize project transition under CyberFabric (by &#2369;Artifizer) - #3558

### Contributors

* &#2369;Artifizer
</blockquote>

## `cf-single-tenant-tr-plugin`

<blockquote>


## [0.1.21](https://github.com/constructorfabric/cyberfabric-core/compare/cf-single-tenant-tr-plugin-v0.1.20...cf-single-tenant-tr-plugin-v0.1.21) - 2026-05-02

### Other

- massive renaming of different artifacts from HyperSport -> CyberFabric to finalize project transition under CyberFabric (by &#2369;Artifizer) - #3558

### Contributors

* &#2369;Artifizer
</blockquote>

## `cf-static-authn-plugin`

<blockquote>


## [0.2.10](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-authn-plugin-v0.2.9...cf-static-authn-plugin-v0.2.10) - 2026-05-02

### Other

- massive renaming of different artifacts from HyperSport -> CyberFabric to finalize project transition under CyberFabric (by &#2369;Artifizer) - #3558

### Contributors

* &#2369;Artifizer
</blockquote>

## `cf-static-authz-plugin`

<blockquote>


## [0.1.19](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-authz-plugin-v0.1.18...cf-static-authz-plugin-v0.1.19) - 2026-05-02

### Other

- massive renaming of different artifacts from HyperSport -> CyberFabric to finalize project transition under CyberFabric (by &#2369;Artifizer) - #3558

### Contributors

* &#2369;Artifizer
</blockquote>

## `cf-static-credstore-plugin`

<blockquote>


## [0.1.17](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-credstore-plugin-v0.1.16...cf-static-credstore-plugin-v0.1.17) - 2026-05-02

### Other

- massive renaming of different artifacts from HyperSport -> CyberFabric to finalize project transition under CyberFabric (by &#2369;Artifizer) - #3558

### Contributors

* &#2369;Artifizer
</blockquote>

## `cf-static-tr-plugin`

<blockquote>


## [0.1.20](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-tr-plugin-v0.1.19...cf-static-tr-plugin-v0.1.20) - 2026-05-02

### Other

- massive renaming of different artifacts from HyperSport -> CyberFabric to finalize project transition under CyberFabric (by &#2369;Artifizer) - #3558

### Contributors

* &#2369;Artifizer
</blockquote>


## `cf-tr-authz-plugin`

<blockquote>


## [0.1.2](https://github.com/constructorfabric/cyberfabric-core/compare/cf-tr-authz-plugin-v0.1.1...cf-tr-authz-plugin-v0.1.2) - 2026-05-02

### Other

- massive renaming of different artifacts from HyperSport -> CyberFabric to finalize project transition under CyberFabric (by &#2369;Artifizer) - #3558

### Contributors

* &#2369;Artifizer
</blockquote>













</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#1810 -->