### PR TITLE
[PR #1787] chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,98 @@ release-plz updates this file in the Release PR.
 
 ### Other
 
+- release (by @github-actions[bot]) - #1780
+
+### Contributors
+
+* @github-actions[bot]
+
+## [0.1.19](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-tr-plugin-v0.1.18...cf-static-tr-plugin-v0.1.19) - 2026-05-01
+
+### Other
+
+- release (by @github-actions[bot]) - #1780
+
+### Contributors
+
+* @github-actions[bot]
+
+## [0.1.16](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-credstore-plugin-v0.1.15...cf-static-credstore-plugin-v0.1.16) - 2026-05-01
+
+### Other
+
+- release (by @github-actions[bot]) - #1780
+
+### Contributors
+
+* @github-actions[bot]
+
+## [0.1.18](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-authz-plugin-v0.1.17...cf-static-authz-plugin-v0.1.18) - 2026-05-01
+
+### Other
+
+- release (by @github-actions[bot]) - #1780
+
+### Contributors
+
+* @github-actions[bot]
+
+## [0.2.9](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-authn-plugin-v0.2.8...cf-static-authn-plugin-v0.2.9) - 2026-05-01
+
+### Other
+
+- release (by @github-actions[bot]) - #1780
+
+### Contributors
+
+* @github-actions[bot]
+
+## [0.1.20](https://github.com/cyberfabric/cyberfabric-core/compare/cf-single-tenant-tr-plugin-v0.1.19...cf-single-tenant-tr-plugin-v0.1.20) - 2026-05-01
+
+### Other
+
+- release (by @github-actions[bot]) - #1780
+
+### Contributors
+
+* @github-actions[bot]
+
+## [0.1.1](https://github.com/cyberfabric/cyberfabric-core/compare/cf-rg-tr-plugin-v0.1.0...cf-rg-tr-plugin-v0.1.1) - 2026-05-01
+
+### Other
+
+- release (by @github-actions[bot]) - #1780
+
+### Contributors
+
+* @github-actions[bot]
+
+## [0.6.8](https://github.com/cyberfabric/cyberfabric-core/compare/cf-modkit-v0.6.7...cf-modkit-v0.6.8) - 2026-05-01
+
+### Other
+
+- release (by @github-actions[bot]) - #1780
+- Merge pull request #1514 from cyberfabric/dependabot/cargo/nix-0.30.1 (by @Artifizer) - #1514
+
+### Contributors
+
+* @github-actions[bot]
+* @Artifizer
+
+## [0.7.2](https://github.com/cyberfabric/cyberfabric-core/compare/cf-modkit-canonical-errors-v0.7.1...cf-modkit-canonical-errors-v0.7.2) - 2026-05-01
+
+### Other
+
+- release (by @github-actions[bot]) - #1780
+
+### Contributors
+
+* @github-actions[bot]
+
+## [0.1.1](https://github.com/cyberfabric/cyberfabric-core/compare/cf-tr-authz-plugin-v0.1.0...cf-tr-authz-plugin-v0.1.1) - 2026-05-01
+
+### Other
+
 - updated the following local packages: cf-modkit, cf-authz-resolver-sdk, cf-tenant-resolver-sdk, cf-types-registry-sdk
 
 ## [0.1.19](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-tr-plugin-v0.1.18...cf-static-tr-plugin-v0.1.19) - 2026-05-01


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#1787](https://github.com/cyberfabric/cyberware-rust/pull/1787) | **Author:** github-actions[bot] | **Opened:** 2026-05-01T20:05:18Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---




## 🤖 New release

* `cf-modkit-canonical-errors`: 0.7.1 -> 0.7.2
* `cf-modkit`: 0.6.7 -> 0.6.8
* `cf-authz-resolver-sdk`: 0.3.3 -> 0.3.4
* `cf-tenant-resolver-sdk`: 0.3.3 -> 0.3.4
* `cf-credstore-sdk`: 0.1.21 -> 0.1.22
* `cf-types-registry-sdk`: 0.2.0 -> 0.2.1
* `cf-oagw`: 0.2.22 -> 0.2.23
* `cf-authn-resolver-sdk`: 0.3.13 -> 0.3.14
* `cf-api-gateway`: 0.2.4 -> 0.2.5
* `cf-authn-resolver`: 0.2.13 -> 0.2.14
* `cf-authz-resolver`: 0.1.20 -> 0.1.21
* `cf-grpc-hub`: 0.2.3 -> 0.2.4
* `cf-credstore`: 0.1.19 -> 0.1.20
* `cf-file-parser`: 0.1.23 -> 0.1.24
* `cf-mini-chat-sdk`: 0.10.3 -> 0.10.4
* `cf-mini-chat`: 0.1.28 -> 0.1.29
* `cf-module-orchestrator`: 0.1.22 -> 0.1.23
* `cf-nodes-registry`: 0.1.22 -> 0.1.23
* `cf-resource-group-sdk`: 0.1.0 -> 0.1.1
* `cf-resource-group`: 0.1.0 -> 0.1.1
* `cf-rg-tr-plugin`: 0.1.0 -> 0.1.1
* `cf-single-tenant-tr-plugin`: 0.1.19 -> 0.1.20
* `cf-static-authn-plugin`: 0.2.8 -> 0.2.9
* `cf-static-authz-plugin`: 0.1.17 -> 0.1.18
* `cf-static-credstore-plugin`: 0.1.15 -> 0.1.16
* `cf-static-tr-plugin`: 0.1.18 -> 0.1.19
* `cf-tenant-resolver`: 0.1.18 -> 0.1.19
* `cf-tr-authz-plugin`: 0.1.0 -> 0.1.1
* `cf-types-registry`: 0.1.19 -> 0.1.20

<details><summary><i><b>Changelog</b></i></summary><p>

## `cf-modkit-canonical-errors`

<blockquote>


## [0.7.2](https://github.com/constructorfabric/cyberfabric-core/compare/cf-modkit-canonical-errors-v0.7.1...cf-modkit-canonical-errors-v0.7.2) - 2026-05-01

### Other

- release (by &#2369;github-actions[bot]) - #3571

### Contributors

* &#2369;github-actions[bot]
</blockquote>

## `cf-modkit`

<blockquote>


## [0.6.8](https://github.com/constructorfabric/cyberfabric-core/compare/cf-modkit-v0.6.7...cf-modkit-v0.6.8) - 2026-05-01

### Other

- release (by &#2369;github-actions[bot]) - #3571
- Merge pull request #3629 from cyberfabric/dependabot/cargo/nix-0.30.1 (by &#2369;Artifizer) - #3629

### Contributors

* &#2369;github-actions[bot]
* &#2369;Artifizer
</blockquote>



















## `cf-rg-tr-plugin`

<blockquote>


## [0.1.1](https://github.com/constructorfabric/cyberfabric-core/compare/cf-rg-tr-plugin-v0.1.0...cf-rg-tr-plugin-v0.1.1) - 2026-05-01

### Other

- release (by &#2369;github-actions[bot]) - #3571

### Contributors

* &#2369;github-actions[bot]
</blockquote>

## `cf-single-tenant-tr-plugin`

<blockquote>


## [0.1.20](https://github.com/constructorfabric/cyberfabric-core/compare/cf-single-tenant-tr-plugin-v0.1.19...cf-single-tenant-tr-plugin-v0.1.20) - 2026-05-01

### Other

- release (by &#2369;github-actions[bot]) - #3571

### Contributors

* &#2369;github-actions[bot]
</blockquote>

## `cf-static-authn-plugin`

<blockquote>


## [0.2.9](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-authn-plugin-v0.2.8...cf-static-authn-plugin-v0.2.9) - 2026-05-01

### Other

- release (by &#2369;github-actions[bot]) - #3571

### Contributors

* &#2369;github-actions[bot]
</blockquote>

## `cf-static-authz-plugin`

<blockquote>


## [0.1.18](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-authz-plugin-v0.1.17...cf-static-authz-plugin-v0.1.18) - 2026-05-01

### Other

- release (by &#2369;github-actions[bot]) - #3571

### Contributors

* &#2369;github-actions[bot]
</blockquote>

## `cf-static-credstore-plugin`

<blockquote>


## [0.1.16](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-credstore-plugin-v0.1.15...cf-static-credstore-plugin-v0.1.16) - 2026-05-01

### Other

- release (by &#2369;github-actions[bot]) - #3571

### Contributors

* &#2369;github-actions[bot]
</blockquote>

## `cf-static-tr-plugin`

<blockquote>


## [0.1.19](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-tr-plugin-v0.1.18...cf-static-tr-plugin-v0.1.19) - 2026-05-01

### Other

- release (by &#2369;github-actions[bot]) - #3571

### Contributors

* &#2369;github-actions[bot]
</blockquote>


## `cf-tr-authz-plugin`

<blockquote>


## [0.1.1](https://github.com/constructorfabric/cyberfabric-core/compare/cf-tr-authz-plugin-v0.1.0...cf-tr-authz-plugin-v0.1.1) - 2026-05-01

### Other

- release (by &#2369;github-actions[bot]) - #3571

### Contributors

* &#2369;github-actions[bot]
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#1787 -->