### PR TITLE
[PR #1735] feat(modkit): operation-level OAuth scopes for authenticated routes

### DIFF
--- a/libs/modkit/src/api/openapi_registry.rs
+++ b/libs/modkit/src/api/openapi_registry.rs
@@ -292,10 +292,10 @@ impl OpenApiRegistryImpl {
             op = op.responses(responses.build());
 
             // Add security requirement if operation requires authentication
-            if spec.authenticated {
+            if spec.auth_mode.is_authenticated() {
                 let sec_req = utoipa::openapi::security::SecurityRequirement::new(
                     "bearerAuth",
-                    Vec::<String>::new(),
+                    spec.required_scopes.clone(),
                 );
                 op = op.security(sec_req);
             }
@@ -471,7 +471,7 @@ fn collect_refs_from_json(value: &serde_json::Value, refs: &mut HashSet<String>)
 mod tests {
     use super::*;
     use crate::api::operation_builder::{
-        OperationSpec, ParamLocation, ParamSpec, ResponseSpec, VendorExtensions,
+        AuthMode, OperationSpec, ParamLocation, ParamSpec, ResponseSpec, VendorExtensions,
     };
     use http::Method;
 
@@ -501,12 +501,12 @@ mod tests {
                 schema_name: None,
             }],
             handler_id: "get_test".to_owned(),
-            authenticated: false,
-            is_public: false,
+            auth_mode: AuthMode::Unset,
             rate_limit: None,
             allowed_request_content_types: None,
             vendor_extensions: VendorExtensions::default(),
             license_requirement: None,
+            required_scopes: Vec::new(),
         };
 
         registry.register_operation(&spec);
@@ -564,12 +564,12 @@ mod tests {
                 schema_name: None,
             }],
             handler_id: "get_users_id".to_owned(),
-            authenticated: false,
-            is_public: false,
+            auth_mode: AuthMode::Authenticated,
             rate_limit: None,
             allowed_request_content_types: None,
             vendor_extensions: VendorExtensions::default(),
             license_requirement: None,
+            required_scopes: vec!["users.read".to_owned()],
         };
 
         registry.register_operation(&spec);
@@ -585,6 +585,10 @@ mod tests {
         let get_op = paths.get("/users/{id}").unwrap().get("get").unwrap();
         assert_eq!(get_op.get("operationId").unwrap(), "get_user");
         assert_eq!(get_op.get("summary").unwrap(), "Get user by ID");
+        assert_eq!(
+            get_op.pointer("/security/0/bearerAuth/0").unwrap(),
+            "users.read"
+        );
     }
 
     #[test]
@@ -624,12 +628,12 @@ mod tests {
                 schema_name: None,
             }],
             handler_id: "post_upload".to_owned(),
-            authenticated: false,
-            is_public: false,
+            auth_mode: AuthMode::Unset,
             rate_limit: None,
             allowed_request_content_types: Some(vec!["application/octet-stream"]),
             vendor_extensions: VendorExtensions::default(),
             license_requirement: None,
+            required_scopes: Vec::new(),
         };
 
         registry.register_operation(&spec);
@@ -703,12 +707,12 @@ mod tests {
                 schema_name: None,
             }],
             handler_id: "get_test".to_owned(),
-            authenticated: false,
-            is_public: false,
+            auth_mode: AuthMode::Unset,
             rate_limit: None,
             allowed_request_content_types: None,
             vendor_extensions: VendorExtensions::default(),
             license_requirement: None,
+            required_scopes: Vec::new(),
         };
         spec.vendor_extensions.x_odata_filter = Some(filter);
         spec.vendor_extensions.x_odata_orderby = Some(order_by);

--- a/libs/modkit/src/api/operation_builder.rs
+++ b/libs/modkit/src/api/operation_builder.rs
@@ -73,9 +73,21 @@ pub mod state {
     #[derive(Debug, Clone, Copy)]
     pub struct AuthNotSet;
 
-    /// Marker for auth requirement set (either `authenticated` or public)
+    /// Marker for an explicitly public route (auth decided, none required).
+    ///
+    /// Reached via `.public()`. Scope-related builders (`required_scope`,
+    /// `require_license_features`, ...) are intentionally **not** available
+    /// in this state.
     #[derive(Debug, Clone, Copy)]
     pub struct AuthSet;
+
+    /// Marker for an authenticated route (auth decided, bearer token required).
+    ///
+    /// Reached via `.authenticated()`. This is the only state in which
+    /// `required_scope(...)` and `require_license_features(...)` are
+    /// available, so `.public().required_scope(...)` will not compile.
+    #[derive(Debug, Clone, Copy)]
+    pub struct AuthRequired;
 
     /// Marker for license requirement not yet set
     #[derive(Debug, Clone, Copy)]
@@ -86,12 +98,48 @@ pub mod state {
     pub struct LicenseSet;
 }
 
+/// Runtime auth requirement on an [`OperationSpec`].
+///
+/// The type-state builder is the source of truth at compile time; this
+/// enum is the materialized record consumed by registries (`OpenAPI`, route
+/// policy) at runtime. The three variants make the prior
+/// `(authenticated: bool, is_public: bool)` pair total: `Unset` is the
+/// intermediate state during builder construction; `Public` and
+/// `Authenticated` are the only states a successfully `register()`ed
+/// operation can be in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthMode {
+    /// Auth requirement not yet declared. Cannot reach `register()` —
+    /// the type-state machine forces a transition into `Public` or
+    /// `Authenticated` before registration.
+    Unset,
+    /// Public route — no authentication required.
+    Public,
+    /// Authenticated route — bearer/OAuth credentials required.
+    Authenticated,
+}
+
+impl AuthMode {
+    /// Whether this route requires authentication.
+    #[must_use]
+    pub fn is_authenticated(self) -> bool {
+        matches!(self, Self::Authenticated)
+    }
+
+    /// Whether this route is explicitly public (no auth).
+    #[must_use]
+    pub fn is_public(self) -> bool {
+        matches!(self, Self::Public)
+    }
+}
+
 /// Internal trait mapping handler state to the concrete router slot type.
 /// For `Missing` there is no router slot; for `Present` it is `MethodRouter<S>`.
 /// Private sealed trait to enforce the implementation is only visible within this module.
 mod sealed {
     pub trait Sealed {}
     pub trait SealedAuth {}
+    pub trait SealedAuthDecided {}
     pub trait SealedLicenseReq {}
 }
 
@@ -102,14 +150,28 @@ pub trait HandlerSlot<S>: sealed::Sealed {
 /// Sealed trait for auth state markers
 pub trait AuthState: sealed::SealedAuth {}
 
+/// Sealed trait for auth-decided markers — implemented by both `AuthSet`
+/// (public) and `AuthRequired` (authenticated). Used as the bound on
+/// `register()` so registration is allowed for either route kind, but not
+/// before the auth requirement has been declared.
+pub trait AuthDecided: AuthState + sealed::SealedAuthDecided {}
+
 impl sealed::Sealed for Missing {}
 impl sealed::Sealed for Present {}
 
 impl sealed::SealedAuth for state::AuthNotSet {}
 impl sealed::SealedAuth for state::AuthSet {}
+impl sealed::SealedAuth for state::AuthRequired {}
 
 impl AuthState for state::AuthNotSet {}
 impl AuthState for state::AuthSet {}
+impl AuthState for state::AuthRequired {}
+
+impl sealed::SealedAuthDecided for state::AuthSet {}
+impl sealed::SealedAuthDecided for state::AuthRequired {}
+
+impl AuthDecided for state::AuthSet {}
+impl AuthDecided for state::AuthRequired {}
 
 pub trait LicenseState: sealed::SealedLicenseReq {}
 
@@ -126,7 +188,7 @@ impl<S> HandlerSlot<S> for Present {
     type Slot = MethodRouter<S>;
 }
 
-pub use state::{AuthNotSet, AuthSet, LicenseNotSet, LicenseSet, Missing, Present};
+pub use state::{AuthNotSet, AuthRequired, AuthSet, LicenseNotSet, LicenseSet, Missing, Present};
 
 /// Parameter specification for API operations
 #[derive(Clone, Debug)]
@@ -205,11 +267,16 @@ pub struct OperationSpec {
     pub responses: Vec<ResponseSpec>,
     /// Internal handler id; can be used by registry/generator to map a handler identity
     pub handler_id: String,
-    /// Whether this operation requires authentication.
-    /// `true` = authenticated endpoint, `false` = public endpoint.
-    pub authenticated: bool,
-    /// Explicitly mark route as public (no auth required)
-    pub is_public: bool,
+    /// Auth requirement for this operation.
+    ///
+    /// Replaces the prior `(authenticated: bool, is_public: bool)` pair, which
+    /// admitted invalid `(true, true)` and `(false, false)` runtime states. The
+    /// type-state builder enforces a single transition into `Public` or
+    /// `Authenticated`; the [`AuthMode::Unset`] variant only exists as the
+    /// intermediate state between `OperationBuilder::*` constructors and
+    /// `.authenticated()`/`.public()`. By the time `register()` accepts the
+    /// builder, `auth_mode` is guaranteed to be `Public` or `Authenticated`.
+    pub auth_mode: AuthMode,
     /// Optional rate & concurrency limits for this operation
     pub rate_limit: Option<RateLimitSpec>,
     /// Optional whitelist of allowed request Content-Type values (without parameters).
@@ -221,6 +288,9 @@ pub struct OperationSpec {
     /// `OpenAPI` vendor extensions (x-*)
     pub vendor_extensions: VendorExtensions,
     pub license_requirement: Option<LicenseReqSpec>,
+    /// OAuth/bearer scopes required by this operation. Empty means
+    /// authentication is required but no route-specific scope is declared.
+    pub required_scopes: Vec<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -387,7 +457,7 @@ pub use crate::api::openapi_registry::{OpenApiRegistry, ensure_schema};
 /// - `H`: Handler state (Missing | Present)
 /// - `R`: Response state (Missing | Present)
 /// - `S`: Router state type (what you put into `Router::with_state(S)`).
-/// - `A`: Auth state (`AuthNotSet` | `AuthSet`)
+/// - `A`: Auth state (`AuthNotSet` | `AuthSet` (public) | `AuthRequired` (authenticated))
 /// - `L`: License requirement state (`LicenseNotSet` | `LicenseSet`)
 #[must_use]
 pub struct OperationBuilder<H = Missing, R = Missing, S = (), A = AuthNotSet, L = LicenseNotSet>
@@ -431,12 +501,12 @@ impl<S> OperationBuilder<Missing, Missing, S, AuthNotSet> {
                 request_body: None,
                 responses: Vec::new(),
                 handler_id,
-                authenticated: false,
-                is_public: false,
+                auth_mode: AuthMode::Unset,
                 rate_limit: None,
                 allowed_request_content_types: None,
                 vendor_extensions: VendorExtensions::default(),
                 license_requirement: None,
+                required_scopes: Vec::new(),
             },
             method_router: (), // no router in Missing state
             _has_handler: PhantomData,
@@ -500,7 +570,7 @@ where
 
     /// Require per-route rate and concurrency limits.
     /// Stores metadata for the gateway to enforce.
-    pub fn require_rate_limit(&mut self, rps: u32, burst: u32, in_flight: u32) -> &mut Self {
+    pub fn require_rate_limit(mut self, rps: u32, burst: u32, in_flight: u32) -> Self {
         self.spec.rate_limit = Some(RateLimitSpec {
             rps,
             burst,
@@ -803,8 +873,12 @@ where
     }
 }
 
-/// License requirement setting — transitions `LicenseNotSet` -> `LicenseSet`
-impl<H, R, S> OperationBuilder<H, R, S, AuthSet, LicenseNotSet>
+/// License requirement setting — transitions `LicenseNotSet` -> `LicenseSet`.
+///
+/// Only available on authenticated builders (`AuthRequired`); public routes
+/// reach `LicenseSet` directly via `.public()` and have no use for these
+/// methods.
+impl<H, R, S> OperationBuilder<H, R, S, AuthRequired, LicenseNotSet>
 where
     H: HandlerSlot<S>,
 {
@@ -823,7 +897,7 @@ where
     pub fn require_license_features<F>(
         mut self,
         licenses: impl IntoIterator<Item = F>,
-    ) -> OperationBuilder<H, R, S, AuthSet, LicenseSet>
+    ) -> OperationBuilder<H, R, S, AuthRequired, LicenseSet>
     where
         F: LicenseFeature,
     {
@@ -853,7 +927,87 @@ where
     ///
     /// This transitions from `LicenseNotSet` to `LicenseSet` without
     /// attaching any license requirement.
-    pub fn no_license_required(self) -> OperationBuilder<H, R, S, AuthSet, LicenseSet> {
+    pub fn no_license_required(self) -> OperationBuilder<H, R, S, AuthRequired, LicenseSet> {
+        OperationBuilder {
+            spec: self.spec,
+            method_router: self.method_router,
+            _has_handler: self._has_handler,
+            _has_response: self._has_response,
+            _state: self._state,
+            _auth_state: self._auth_state,
+            _license_state: PhantomData,
+        }
+    }
+
+    /// Declare a bearer/OAuth scope required by this authenticated operation.
+    /// Can be chained to declare multiple scopes; each call appends one scope.
+    /// Records route-policy metadata for generated `OpenAPI` and satisfies the
+    /// license-declaration requirement.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `scope` is empty or whitespace-only after `Into<String>`
+    /// conversion. Such values would emit `bearerAuth: [""]` in the generated
+    /// `OpenAPI` security requirement and configure a route as
+    /// "authenticated, but with no scope check" — which is almost never the
+    /// caller's intent. Public routes should use `.public()` instead. The
+    /// scope is stored verbatim (no trimming) so a padded literal like
+    /// `" foo "` would mismatch the gateway's scope check; pass the exact
+    /// string the gateway expects.
+    pub fn required_scope(
+        mut self,
+        scope: impl Into<String>,
+    ) -> OperationBuilder<H, R, S, AuthRequired, LicenseSet> {
+        let scope = scope.into();
+        assert!(
+            !scope.trim().is_empty(),
+            "required_scope with empty or whitespace-only argument is almost certainly a bug; \
+             use .public() for unauthenticated routes or pass a non-empty scope literal"
+        );
+        self.spec.required_scopes.push(scope);
+        OperationBuilder {
+            spec: self.spec,
+            method_router: self.method_router,
+            _has_handler: self._has_handler,
+            _has_response: self._has_response,
+            _state: self._state,
+            _auth_state: self._auth_state,
+            _license_state: PhantomData,
+        }
+    }
+}
+
+/// Additional scope chaining once the license requirement has been declared.
+///
+/// Mirrors the `LicenseNotSet` impl so that endpoints can be both
+/// license-gated (via `require_license_features` / `no_license_required`)
+/// and scope-gated, and so multiple `required_scope(...)` calls can be
+/// chained as the doc on that method advertises.
+///
+/// Restricted to `AuthRequired` so `.public().required_scope(...)` does not
+/// compile — public routes have no scope semantics.
+impl<H, R, S> OperationBuilder<H, R, S, AuthRequired, LicenseSet>
+where
+    H: HandlerSlot<S>,
+{
+    /// Declare an additional bearer/OAuth scope on a builder that has already
+    /// transitioned to `LicenseSet`. Each call appends one scope.
+    ///
+    /// # Panics
+    ///
+    /// Same empty/whitespace-only-scope guard as the `LicenseNotSet` impl —
+    /// see that `required_scope` for the rationale.
+    pub fn required_scope(
+        mut self,
+        scope: impl Into<String>,
+    ) -> OperationBuilder<H, R, S, AuthRequired, LicenseSet> {
+        let scope = scope.into();
+        assert!(
+            !scope.trim().is_empty(),
+            "required_scope with empty or whitespace-only argument is almost certainly a bug; \
+             use .public() for unauthenticated routes or pass a non-empty scope literal"
+        );
+        self.spec.required_scopes.push(scope);
         OperationBuilder {
             spec: self.spec,
             method_router: self.method_router,
@@ -867,7 +1021,7 @@ where
 }
 
 // -------------------------------------------------------------------------------------------------
-// Auth requirement setting — transitions AuthNotSet -> AuthSet
+// Auth requirement setting — transitions AuthNotSet -> AuthRequired (authenticated) or AuthSet (public)
 // -------------------------------------------------------------------------------------------------
 impl<H, R, S, L> OperationBuilder<H, R, S, AuthNotSet, L>
 where
@@ -880,7 +1034,9 @@ where
     /// Scope enforcement (which scopes are needed) is configured at the
     /// gateway level, not per-route.
     ///
-    /// This method transitions from `AuthNotSet` to `AuthSet` state.
+    /// This method transitions from `AuthNotSet` to `AuthRequired` state,
+    /// which is the only state where `required_scope(...)` and
+    /// `require_license_features(...)` are available.
     ///
     /// # Example
     /// ```rust
@@ -923,9 +1079,8 @@ where
     /// #   unimplemented!()
     /// # }
     /// ```
-    pub fn authenticated(mut self) -> OperationBuilder<H, R, S, AuthSet, L> {
-        self.spec.authenticated = true;
-        self.spec.is_public = false;
+    pub fn authenticated(mut self) -> OperationBuilder<H, R, S, AuthRequired, L> {
+        self.spec.auth_mode = AuthMode::Authenticated;
         OperationBuilder {
             spec: self.spec,
             method_router: self.method_router,
@@ -940,7 +1095,10 @@ where
     /// Mark this route as public (no authentication required).
     ///
     /// This explicitly opts out of the `require_auth_by_default` setting.
-    /// This method transitions from `AuthNotSet` to `AuthSet` state.
+    /// This method transitions from `AuthNotSet` to `AuthSet` (the
+    /// "public" decided state) and to `LicenseSet` directly, since public
+    /// routes have no license or scope requirements. Calling
+    /// `.required_scope(...)` after `.public()` will not compile.
     ///
     /// # Example
     /// ```rust
@@ -960,9 +1118,16 @@ where
     ///     .register(router, &registry);
     /// # let _ = router;
     /// ```
+    ///
+    /// Public routes cannot declare scopes — this is enforced at compile time:
+    /// ```compile_fail
+    /// # use modkit::api::operation_builder::OperationBuilder;
+    /// let _ = OperationBuilder::<_, _, ()>::get("/x")
+    ///     .public()
+    ///     .required_scope("nope");
+    /// ```
     pub fn public(mut self) -> OperationBuilder<H, R, S, AuthSet, LicenseSet> {
-        self.spec.is_public = true;
-        self.spec.authenticated = false;
+        self.spec.auth_mode = AuthMode::Public;
         OperationBuilder {
             spec: self.spec,
             method_router: self.method_router,
@@ -1532,9 +1697,10 @@ where
 // -------------------------------------------------------------------------------------------------
 // Registration — only available when handler, response, AND auth are all set
 // -------------------------------------------------------------------------------------------------
-impl<S> OperationBuilder<Present, Present, S, AuthSet, LicenseSet>
+impl<S, A> OperationBuilder<Present, Present, S, A, LicenseSet>
 where
     S: Clone + Send + Sync + 'static,
+    A: AuthDecided,
 {
     /// Register the operation with the router and `OpenAPI` registry.
     ///
@@ -1822,8 +1988,7 @@ mod tests {
             .handler(test_handler)
             .json_response(http::StatusCode::OK, "Success");
 
-        assert!(builder.spec.authenticated);
-        assert!(!builder.spec.is_public);
+        assert_eq!(builder.spec.auth_mode, AuthMode::Authenticated);
     }
 
     #[test]
@@ -1846,7 +2011,58 @@ mod tests {
             .json_response(http::StatusCode::OK, "OK");
 
         assert!(builder.spec.license_requirement.is_none());
-        assert!(!builder.spec.is_public);
+        assert_eq!(builder.spec.auth_mode, AuthMode::Authenticated);
+    }
+
+    #[tokio::test]
+    async fn required_scope_records_scope_and_allows_register() {
+        // The test name promises that `.required_scope(...)` lands the
+        // builder in a state where `.register(...)` is callable; exercise
+        // that compile-time contract end-to-end (not just a state
+        // inspection) so a future refactor that breaks the type-state
+        // path fails the test, not just code review.
+        let registry = MockRegistry::new();
+        let router = Router::new();
+
+        let _router = OperationBuilder::<Missing, Missing, ()>::get("/tests/v1/test")
+            .authenticated()
+            .required_scope("tests.read")
+            .handler(test_handler)
+            .json_response(http::StatusCode::OK, "OK")
+            .register(router, &registry);
+
+        let ops = registry.operations.lock().unwrap();
+        assert_eq!(ops.len(), 1);
+        let op = &ops[0];
+        assert!(op.license_requirement.is_none());
+        assert_eq!(op.required_scopes, vec!["tests.read".to_owned()]);
+        assert_eq!(op.auth_mode, AuthMode::Authenticated);
+    }
+
+    #[test]
+    #[should_panic(expected = "almost certainly a bug")]
+    fn required_scope_empty_panics_in_release() {
+        // Guard the runtime check, not just the debug-build one: an empty
+        // scope reaching `register()` would emit `bearerAuth: [""]` in
+        // production OpenAPI, so the assert must fire in release builds too.
+        drop(
+            OperationBuilder::<Missing, Missing, ()>::get("/tests/v1/test")
+                .authenticated()
+                .required_scope(""),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "almost certainly a bug")]
+    fn required_scope_whitespace_only_panics_in_release() {
+        // Same rationale as the empty case: a whitespace-only literal would
+        // pollute the OpenAPI security requirement and never match a real
+        // gateway scope check, so reject it loudly rather than store it.
+        drop(
+            OperationBuilder::<Missing, Missing, ()>::get("/tests/v1/test")
+                .authenticated()
+                .required_scope("   "),
+        );
     }
 
     #[test]

--- a/modules/system/api-gateway/src/middleware/mime_validation.rs
+++ b/modules/system/api-gateway/src/middleware/mime_validation.rs
@@ -137,7 +137,7 @@ pub async fn mime_validation_middleware(
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use modkit::api::operation_builder::VendorExtensions;
+    use modkit::api::operation_builder::{AuthMode, VendorExtensions};
 
     #[test]
     fn test_build_mime_validation_map() {
@@ -161,9 +161,9 @@ mod tests {
             }),
             responses: vec![],
             handler_id: "test".to_owned(),
-            authenticated: false,
-            is_public: false,
+            auth_mode: AuthMode::Unset,
             license_requirement: None,
+            required_scopes: Vec::new(),
             rate_limit: None,
             allowed_request_content_types: Some(vec!["multipart/form-data", "application/pdf"]),
             vendor_extensions: VendorExtensions::default(),

--- a/modules/system/api-gateway/src/module.rs
+++ b/modules/system/api-gateway/src/module.rs
@@ -12,6 +12,7 @@ use anyhow::Result;
 use axum::http::Method;
 use axum::middleware::from_fn_with_state;
 use axum::{Router, extract::DefaultBodyLimit, middleware::from_fn, routing::get};
+use modkit::api::operation_builder::AuthMode;
 use modkit::api::{OpenApiRegistry, OpenApiRegistryImpl};
 use modkit::lifecycle::ReadySignal;
 use parking_lot::Mutex;
@@ -148,12 +149,31 @@ impl ApiGateway {
 
             let route_key = (spec.method.clone(), spec.path.clone());
 
-            if spec.authenticated {
-                authenticated_routes.insert(route_key.clone());
-            }
-
-            if spec.is_public {
-                public_routes.insert(route_key);
+            match spec.auth_mode {
+                AuthMode::Authenticated => {
+                    authenticated_routes.insert(route_key);
+                }
+                AuthMode::Public => {
+                    public_routes.insert(route_key);
+                }
+                AuthMode::Unset => {
+                    // Unreachable through `OperationBuilder`: `register()` is
+                    // bounded on `AuthDecided`, so any spec produced by the
+                    // type-state builder is `Public` or `Authenticated`.
+                    // Reaching this arm means a registration path bypassed
+                    // the builder (e.g., direct struct construction calling
+                    // `register_operation` on the registry trait), in which
+                    // case silently dropping the route would let it fall
+                    // through to `require_auth_by_default` — a config-
+                    // dependent default rather than a declared one. Fail
+                    // fast at startup with a clear pointer at the offender.
+                    return Err(anyhow::anyhow!(
+                        "OperationSpec for {} {} reached the gateway with auth_mode = Unset; \
+                         registration bypassed the OperationBuilder type-state machine",
+                        spec.method,
+                        spec.path,
+                    ));
+                }
             }
         }
 

--- a/modules/system/api-gateway/tests/http_metrics_tests.rs
+++ b/modules/system/api-gateway/tests/http_metrics_tests.rs
@@ -203,9 +203,8 @@ async fn metrics_capture_mime_rejection() -> Result<()> {
     let api = api_gateway::ApiGateway::default();
     api.init(&ctx).await?;
 
-    let mut builder = OperationBuilder::post("/tests/v1/items");
-    builder.require_rate_limit(1000, 1000, 64);
-    let router = builder
+    let router = OperationBuilder::post("/tests/v1/items")
+        .require_rate_limit(1000, 1000, 64)
         .operation_id("test:create-item")
         .summary("Create item")
         .public()
@@ -267,9 +266,8 @@ async fn metrics_capture_rate_limit() -> Result<()> {
     let api = api_gateway::ApiGateway::default();
     api.init(&ctx).await?;
 
-    let mut builder = OperationBuilder::get("/tests/v1/limited");
-    builder.require_rate_limit(1, 1, 64);
-    let router = builder
+    let router = OperationBuilder::get("/tests/v1/limited")
+        .require_rate_limit(1, 1, 64)
         .operation_id("test:limited")
         .summary("Rate-limited endpoint")
         .public()

--- a/modules/system/api-gateway/tests/middleware_order.rs
+++ b/modules/system/api-gateway/tests/middleware_order.rs
@@ -73,9 +73,8 @@ async fn real_middlewares_observe_documented_order() -> Result<()> {
 
     // Register an endpoint that enables both MIME validation and rate limiting.
     let mut router = Router::new();
-    let mut builder = OperationBuilder::post("/tests/v1/middleware-order");
-    builder.require_rate_limit(1, 1, 64);
-    router = builder
+    router = OperationBuilder::post("/tests/v1/middleware-order")
+        .require_rate_limit(1, 1, 64)
         .operation_id("test:middleware-order")
         .summary("Middleware order test endpoint")
         .public()
@@ -192,9 +191,8 @@ async fn real_middlewares_observe_documented_order_with_prefix() -> Result<()> {
 
     // Register an endpoint that enables both MIME validation and rate limiting.
     let mut router = Router::new();
-    let mut builder = OperationBuilder::post("/tests/v1/middleware-order");
-    builder.require_rate_limit(1, 1, 64);
-    router = builder
+    router = OperationBuilder::post("/tests/v1/middleware-order")
+        .require_rate_limit(1, 1, 64)
         .operation_id("test:middleware-order")
         .summary("Middleware order test endpoint")
         .public()

--- a/modules/system/api-gateway/tests/mime_validation_integration.rs
+++ b/modules/system/api-gateway/tests/mime_validation_integration.rs
@@ -20,7 +20,7 @@ use tower::ServiceExt; // for oneshot
 use api_gateway::middleware::mime_validation::{
     build_mime_validation_map, mime_validation_middleware,
 };
-use modkit::api::operation_builder::VendorExtensions;
+use modkit::api::operation_builder::{AuthMode, VendorExtensions};
 
 /// Helper to extract Problem from response
 async fn extract_problem(response: axum::response::Response) -> Problem {
@@ -49,9 +49,9 @@ async fn test_middleware_allows_configured_content_type() {
         request_body: None,
         responses: vec![],
         handler_id: "test".to_owned(),
-        authenticated: false,
-        is_public: true,
+        auth_mode: AuthMode::Public,
         license_requirement: None,
+        required_scopes: Vec::new(),
         rate_limit: None,
         allowed_request_content_types: Some(vec!["application/json"]),
         vendor_extensions: VendorExtensions::default(),
@@ -94,9 +94,9 @@ async fn test_middleware_strips_content_type_parameters() {
         request_body: None,
         responses: vec![],
         handler_id: "test".to_owned(),
-        authenticated: false,
-        is_public: true,
+        auth_mode: AuthMode::Public,
         license_requirement: None,
+        required_scopes: Vec::new(),
         rate_limit: None,
         allowed_request_content_types: Some(vec!["application/json"]),
         vendor_extensions: VendorExtensions::default(),
@@ -139,9 +139,9 @@ async fn test_middleware_rejects_disallowed_content_type() {
         request_body: None,
         responses: vec![],
         handler_id: "test".to_owned(),
-        authenticated: false,
-        is_public: true,
+        auth_mode: AuthMode::Public,
         license_requirement: None,
+        required_scopes: Vec::new(),
         rate_limit: None,
         allowed_request_content_types: Some(vec!["application/json"]),
         vendor_extensions: VendorExtensions::default(),
@@ -190,9 +190,9 @@ async fn test_middleware_rejects_missing_content_type() {
         request_body: None,
         responses: vec![],
         handler_id: "test".to_owned(),
-        authenticated: false,
-        is_public: true,
+        auth_mode: AuthMode::Public,
         license_requirement: None,
+        required_scopes: Vec::new(),
         rate_limit: None,
         allowed_request_content_types: Some(vec!["multipart/form-data"]),
         vendor_extensions: VendorExtensions::default(),
@@ -265,9 +265,9 @@ async fn test_middleware_allows_multiple_content_types() {
         request_body: None,
         responses: vec![],
         handler_id: "test".to_owned(),
-        authenticated: false,
-        is_public: true,
+        auth_mode: AuthMode::Public,
         license_requirement: None,
+        required_scopes: Vec::new(),
         rate_limit: None,
         allowed_request_content_types: Some(vec![
             "application/json",

--- a/modules/system/api-gateway/tests/rate_limit_tests.rs
+++ b/modules/system/api-gateway/tests/rate_limit_tests.rs
@@ -77,9 +77,8 @@ impl RestApiCapability for RateLimitedModule {
         openapi: &dyn OpenApiRegistry,
     ) -> Result<axum::Router> {
         // Route with strict rate limit: 1 RPS, burst 1
-        let mut builder = OperationBuilder::get("/tests/v1/limited");
-        builder.require_rate_limit(1, 1, 2);
-        let router = builder
+        let router = OperationBuilder::get("/tests/v1/limited")
+            .require_rate_limit(1, 1, 2)
             .operation_id("test:limited")
             .summary("Strictly rate-limited endpoint")
             .public()
@@ -88,9 +87,8 @@ impl RestApiCapability for RateLimitedModule {
             .register(router, openapi);
 
         // Route with low in-flight limit
-        let mut builder = OperationBuilder::get("/tests/v1/slow");
-        builder.require_rate_limit(100, 100, 2);
-        let router = builder
+        let router = OperationBuilder::get("/tests/v1/slow")
+            .require_rate_limit(100, 100, 2)
             .operation_id("test:slow")
             .summary("Slow endpoint with low in-flight limit")
             .public()
@@ -221,8 +219,7 @@ async fn test_rate_limit_metadata_stored() {
     let api_gateway = api_gateway::ApiGateway::default();
     let router = Router::<()>::new();
 
-    let mut builder = OperationBuilder::get("/tests/v1/test");
-    builder.require_rate_limit(10, 20, 5);
+    let builder = OperationBuilder::get("/tests/v1/test").require_rate_limit(10, 20, 5);
 
     let spec = builder.spec();
     assert!(spec.rate_limit.is_some(), "Rate limit should be set");


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#1735](https://github.com/cyberfabric/cyberware-rust/pull/1735) | **Author:** diffora | **Opened:** 2026-04-28T14:38:22Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

- Replaced the `(authenticated, is_public)` booleans on `OperationSpec` with an `AuthMode` enum.
- Added a `.required_scope(...)` builder method gated by a new `AuthRequired` type-state — `.public().required_scope(...)` no longer compiles.
- Required scopes are now emitted into the OpenAPI `bearerAuth` security requirement.
- api-gateway routing fails fast on `AuthMode::Unset`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API Gateway now detects incomplete authentication configuration at startup, preventing runtime issues through fail-fast validation.

* **Improvements**
  * Enhanced authentication scope validation and handling to ensure more robust permission enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#1735 -->