### PR TITLE
[PR #951] fix(mini-chat): align test provider_model_id with provider_id

### DIFF
--- a/modules/mini-chat/mini-chat/src/domain/service/model_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/model_service_test.rs
@@ -16,7 +16,7 @@ fn mock_catalog() -> Vec<ModelCatalogEntry> {
     vec![
         ModelCatalogEntry {
             model_id: "gpt-5.2".to_owned(),
-            provider_model_id: "azure-gpt-5.2-2025-03".to_owned(),
+            provider_model_id: "gpt-5.2-2025-03-26".to_owned(),
             display_name: "GPT-5.2".to_owned(),
             tier: ModelTier::Premium,
             global_enabled: true,
@@ -33,7 +33,7 @@ fn mock_catalog() -> Vec<ModelCatalogEntry> {
         },
         ModelCatalogEntry {
             model_id: "gpt-5-mini".to_owned(),
-            provider_model_id: "azure-gpt-5-mini-2025-03".to_owned(),
+            provider_model_id: "gpt-5-mini-2025-03-26".to_owned(),
             display_name: "GPT-5 Mini".to_owned(),
             tier: ModelTier::Standard,
             global_enabled: true,
@@ -50,7 +50,7 @@ fn mock_catalog() -> Vec<ModelCatalogEntry> {
         },
         ModelCatalogEntry {
             model_id: "disabled-model".to_owned(),
-            provider_model_id: "azure-disabled-2025-03".to_owned(),
+            provider_model_id: "disabled-model-2025-03-26".to_owned(),
             display_name: "Disabled Model".to_owned(),
             tier: ModelTier::Standard,
             global_enabled: false,

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -1497,7 +1497,7 @@ mod tests {
                     policy_version: 1,
                     model_catalog: vec![mini_chat_sdk::ModelCatalogEntry {
                         model_id: "gpt-5.2".to_owned(),
-                        provider_model_id: "azure-gpt-5.2-2025-03".to_owned(),
+                        provider_model_id: "gpt-5.2-2025-03-26".to_owned(),
                         display_name: "GPT 5.2".to_owned(),
                         tier: mini_chat_sdk::ModelTier::Standard,
                         global_enabled: true,
@@ -1577,7 +1577,7 @@ mod tests {
     fn test_resolved_model() -> ResolvedModel {
         ResolvedModel {
             model_id: "gpt-5.2".into(),
-            provider_model_id: "azure-gpt-5.2-2025-03".into(),
+            provider_model_id: "gpt-5.2-2025-03-26".into(),
             provider_id: "openai".into(),
             display_name: "GPT 5.2".into(),
             tier: "standard".into(),
@@ -2661,7 +2661,7 @@ mod tests {
                 "hello".into(),
                 ResolvedModel {
                     model_id: "gpt-5".into(),
-                    provider_model_id: "azure-gpt-5-2025-03".into(),
+                    provider_model_id: "gpt-5-2025-03-26".into(),
                     provider_id: "openai".into(),
                     display_name: "GPT 5".into(),
                     tier: "premium".into(),

--- a/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
@@ -138,7 +138,7 @@ impl Default for MockModelResolver {
         Self::new(vec![
             ModelCatalogEntry {
                 model_id: "gpt-5.2".to_owned(),
-                provider_model_id: "azure-gpt-5.2-2025-03".to_owned(),
+                provider_model_id: "gpt-5.2-2025-03-26".to_owned(),
                 display_name: "GPT-5.2".to_owned(),
                 tier: mini_chat_sdk::ModelTier::Premium,
                 global_enabled: true,
@@ -155,7 +155,7 @@ impl Default for MockModelResolver {
             },
             ModelCatalogEntry {
                 model_id: "gpt-5-mini".to_owned(),
-                provider_model_id: "azure-gpt-5-mini-2025-03".to_owned(),
+                provider_model_id: "gpt-5-mini-2025-03-26".to_owned(),
                 display_name: "GPT-5 Mini".to_owned(),
                 tier: mini_chat_sdk::ModelTier::Standard,
                 global_enabled: false,


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#951](https://github.com/cyberfabric/cyberware-rust/pull/951) | **Author:** aviator5 | **Opened:** 2026-03-07T21:41:52Z | **Status:** merged on 2026-03-07T21:59:18Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

follow up change for https://github.com/constructorfabric/cyberfabric-core/issues/943#discussion_r2900581487

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated model identifier test data to reflect new naming format across test fixtures and helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#951 -->