### PR TITLE
[PR #887] fix: fail auth validation if exp is missing from claims

### DIFF
--- a/libs/modkit-auth/src/config.rs
+++ b/libs/modkit-auth/src/config.rs
@@ -16,6 +16,11 @@ pub struct AuthConfig {
     #[serde(default)]
     pub audiences: Vec<String>,
 
+    /// Whether the `exp` claim is required (default: `true`).
+    /// Set to `false` to allow tokens without an expiration claim.
+    #[serde(default = "default_require_exp")]
+    pub require_exp: bool,
+
     /// JWKS configuration
     #[serde(default)]
     pub jwks: Option<JwksConfig>,
@@ -25,12 +30,17 @@ fn default_leeway() -> i64 {
     60
 }
 
+fn default_require_exp() -> bool {
+    true
+}
+
 impl Default for AuthConfig {
     fn default() -> Self {
         Self {
-            leeway_seconds: 60,
+            leeway_seconds: default_leeway(),
             issuers: Vec::new(),
             audiences: Vec::new(),
+            require_exp: default_require_exp(),
             jwks: None,
         }
     }
@@ -42,6 +52,7 @@ impl From<&AuthConfig> for ValidationConfig {
             allowed_issuers: config.issuers.clone(),
             allowed_audiences: config.audiences.clone(),
             leeway_seconds: config.leeway_seconds,
+            require_exp: config.require_exp,
         }
     }
 }
@@ -80,6 +91,7 @@ mod tests {
         assert_eq!(config.leeway_seconds, 60);
         assert!(config.issuers.is_empty());
         assert!(config.audiences.is_empty());
+        assert!(config.require_exp);
         assert!(config.jwks.is_none());
     }
 
@@ -89,6 +101,7 @@ mod tests {
             leeway_seconds: 120,
             issuers: vec!["https://auth.example.com".to_owned()],
             audiences: vec!["api".to_owned()],
+            require_exp: true,
             jwks: Some(JwksConfig {
                 uri: "https://auth.example.com/.well-known/jwks.json".to_owned(),
                 refresh_interval_seconds: 300,
@@ -101,6 +114,7 @@ mod tests {
         assert_eq!(deserialized.leeway_seconds, 120);
         assert_eq!(deserialized.issuers, vec!["https://auth.example.com"]);
         assert_eq!(deserialized.audiences, vec!["api"]);
+        assert!(deserialized.require_exp);
         let jwks = deserialized.jwks.expect("jwks should be present");
         assert_eq!(jwks.uri, "https://auth.example.com/.well-known/jwks.json");
         assert_eq!(jwks.refresh_interval_seconds, 300);
@@ -131,12 +145,31 @@ mod tests {
             leeway_seconds: 30,
             issuers: vec!["https://auth.example.com".to_owned()],
             audiences: vec!["api".to_owned()],
+            require_exp: true,
             jwks: None,
         };
         let validation_config = ValidationConfig::from(&auth_config);
         assert_eq!(validation_config.allowed_issuers, auth_config.issuers);
         assert_eq!(validation_config.allowed_audiences, auth_config.audiences);
         assert_eq!(validation_config.leeway_seconds, auth_config.leeway_seconds);
+        assert!(validation_config.require_exp);
+    }
+
+    #[test]
+    fn test_require_exp_defaults_true_when_omitted() {
+        let json = r#"{"leeway_seconds": 60}"#;
+        let config: AuthConfig = serde_json::from_str(json).unwrap();
+        assert!(config.require_exp);
+    }
+
+    #[test]
+    fn test_require_exp_false_propagates_to_validation_config() {
+        let auth_config = AuthConfig {
+            require_exp: false,
+            ..Default::default()
+        };
+        let validation_config = ValidationConfig::from(&auth_config);
+        assert!(!validation_config.require_exp);
     }
 
     #[test]

--- a/libs/modkit-auth/src/validation.rs
+++ b/libs/modkit-auth/src/validation.rs
@@ -14,6 +14,10 @@ pub struct ValidationConfig {
 
     /// Leeway in seconds for time-based validations (exp, nbf)
     pub leeway_seconds: i64,
+
+    /// Whether the `exp` claim is required (default: `true`).
+    /// Set to `false` to allow tokens without an expiration claim.
+    pub require_exp: bool,
 }
 
 impl Default for ValidationConfig {
@@ -22,6 +26,7 @@ impl Default for ValidationConfig {
             allowed_issuers: vec![],
             allowed_audiences: vec![],
             leeway_seconds: 60,
+            require_exp: true,
         }
     }
 }
@@ -31,7 +36,8 @@ impl Default for ValidationConfig {
 /// Checks performed:
 /// 1. **Issuer** (`iss`) — must match one of `config.allowed_issuers` (skipped if empty)
 /// 2. **Audience** (`aud`) — at least one must match `config.allowed_audiences` (skipped if empty)
-/// 3. **Expiration** (`exp`) — must not be in the past (with leeway)
+/// 3. **Expiration** (`exp`) — required by default; must not be in the past (with leeway).
+///    Set `require_exp = false` to accept tokens without an `exp` claim.
 /// 4. **Not Before** (`nbf`) — must not be in the future (with leeway)
 ///
 /// # Errors
@@ -101,6 +107,8 @@ pub fn validate_claims(
         if now > exp_with_leeway {
             return Err(ClaimsError::Expired);
         }
+    } else if config.require_exp {
+        return Err(ClaimsError::MissingClaim(StandardClaim::EXP.to_owned()));
     }
 
     // 4. Validate not-before with leeway
@@ -331,6 +339,7 @@ mod tests {
     fn test_not_yet_valid_fails() {
         let now = time::OffsetDateTime::now_utc();
         let claims = json!({
+            "exp": (now + time::Duration::hours(2)).unix_timestamp(),
             "nbf": (now + time::Duration::hours(1)).unix_timestamp(),
         });
         let config = ValidationConfig::default();
@@ -354,15 +363,45 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_config_accepts_anything() {
-        let claims = json!({ "sub": "anyone", "iss": "any-issuer" });
+    fn test_default_config_accepts_valid_claims_with_exp() {
+        let now = time::OffsetDateTime::now_utc();
+        let claims = json!({
+            "sub": "anyone",
+            "iss": "any-issuer",
+            "exp": (now + time::Duration::hours(1)).unix_timestamp(),
+        });
         let config = ValidationConfig::default();
         assert!(validate_claims(&claims, &config).is_ok());
     }
 
     #[test]
+    fn test_missing_exp_fails() {
+        let claims = json!({ "sub": "user-1" });
+        let config = ValidationConfig::default();
+        let err = validate_claims(&claims, &config).unwrap_err();
+        match err {
+            ClaimsError::MissingClaim(claim) => assert_eq!(claim, StandardClaim::EXP),
+            other => panic!("expected MissingClaim(exp), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_missing_exp_allowed_when_not_required() {
+        let claims = json!({ "sub": "service-token", "iss": "internal" });
+        let config = ValidationConfig {
+            require_exp: false,
+            ..Default::default()
+        };
+        assert!(validate_claims(&claims, &config).is_ok());
+    }
+
+    #[test]
     fn test_audience_array_match() {
-        let claims = json!({ "aud": ["api", "frontend"] });
+        let now = time::OffsetDateTime::now_utc();
+        let claims = json!({
+            "aud": ["api", "frontend"],
+            "exp": (now + time::Duration::hours(1)).unix_timestamp(),
+        });
         let config = ValidationConfig {
             allowed_audiences: vec!["api".to_owned()],
             ..Default::default()
@@ -459,7 +498,11 @@ mod tests {
 
     #[test]
     fn test_nbf_overflow_returns_error() {
-        let claims = json!({ "nbf": MIN_UNIX_TIMESTAMP });
+        let now = time::OffsetDateTime::now_utc();
+        let claims = json!({
+            "exp": (now + time::Duration::hours(1)).unix_timestamp(),
+            "nbf": MIN_UNIX_TIMESTAMP,
+        });
         let config = ValidationConfig {
             leeway_seconds: 60,
             ..Default::default()


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#887](https://github.com/cyberfabric/cyberware-rust/pull/887) | **Author:** ziqwerty | **Opened:** 2026-03-05T10:26:28Z | **Status:** merged on 2026-03-17T22:03:10Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

Closes #2757 

**Problem**
JWT validation skips expiration check entirely when `exp` is missing from the claims. A token without exp is accepted as permanently valid.

**Fix**
Added `require_exp: bool` to `ValidationConfig` and `AuthConfig` (default `true`). When set, missing `exp` returns `ClaimsError::MissingClaim`. Callers issuing non-expiring tokens can opt out with `require_exp: false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JWT token expiration validation configuration. Tokens now require an expiration claim by default to maintain security, but users can optionally configure settings to allow tokens without expiration when needed for specific use cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#887 -->