### PR TITLE
[PR #810] Add separate profiling server with CPU pprof endpoint, REAL-163

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +76,15 @@ name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
 
 [[package]]
 name = "aliri"
@@ -499,6 +517,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,8 +687,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
 dependencies = [
- "prost",
- "prost-types",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
  "tonic",
  "tonic-prost",
  "ureq 3.2.0",
@@ -671,7 +704,7 @@ dependencies = [
  "bollard-buildkit-proto",
  "bytes",
  "chrono",
- "prost",
+ "prost 0.14.3",
  "serde",
  "serde_json",
  "serde_repr",
@@ -814,7 +847,7 @@ dependencies = [
  "encoding_rs",
  "fast-float2",
  "log",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "zip 4.6.1",
 ]
@@ -869,7 +902,7 @@ dependencies = [
  "cf-modkit-security",
  "cf-modkit-transport-grpc",
  "cf-system-sdks",
- "prost",
+ "prost 0.14.3",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -1153,6 +1186,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "parking_lot",
+ "pprof",
  "regex",
  "schemars 1.2.1",
  "sea-orm-migration",
@@ -1705,7 +1739,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "cf-modkit-transport-grpc",
- "prost",
+ "prost 0.14.3",
  "tokio",
  "tonic",
  "tonic-prost",
@@ -2016,6 +2050,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2247,6 +2290,15 @@ name = "debug_unsafe"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
 
 [[package]]
 name = "deflate64"
@@ -2573,6 +2625,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2755,6 +2827,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2790,7 +2880,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3019,6 +3109,12 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -3269,7 +3365,7 @@ dependencies = [
  "hash32",
  "rustc_version",
  "serde",
- "spin",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -3284,6 +3380,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -3554,6 +3656,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tracing",
  "types",
  "users-info",
@@ -3739,6 +3842,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferno"
+version = "0.11.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
+dependencies = [
+ "ahash 0.8.12",
+ "indexmap 2.13.0",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml 0.26.0",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "inherent"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3791,6 +3912,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3801,6 +3933,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3930,7 +4071,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -4156,6 +4297,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "mimalloc"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4204,7 +4354,7 @@ dependencies = [
  "httparse",
  "memchr",
  "mime",
- "spin",
+ "spin 0.9.8",
  "version_check",
 ]
 
@@ -4250,6 +4400,17 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -4388,6 +4549,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4480,6 +4651,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "odata-params"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4549,7 +4729,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.14.3",
  "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
@@ -4565,7 +4745,7 @@ checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.14.3",
  "tonic",
  "tonic-prost",
 ]
@@ -4832,11 +5012,21 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap 2.13.0",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
 ]
@@ -4946,7 +5136,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -5009,6 +5199,32 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "pprof"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
+dependencies = [
+ "aligned-vec",
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "once_cell",
+ "prost 0.12.6",
+ "prost-build 0.12.6",
+ "prost-derive 0.12.6",
+ "sha2",
+ "smallvec 1.15.1",
+ "spin 0.10.0",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "pptx-to-md"
@@ -5107,12 +5323,43 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.3",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+dependencies = [
+ "bytes",
+ "heck 0.5.0",
+ "itertools 0.12.1",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph 0.6.5",
+ "prettyplease",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
 ]
 
 [[package]]
@@ -5122,13 +5369,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
- "petgraph",
+ "petgraph 0.8.3",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
@@ -5138,15 +5385,37 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-derive"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+dependencies = [
+ "prost 0.12.6",
 ]
 
 [[package]]
@@ -5155,7 +5424,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost",
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -5220,6 +5489,15 @@ dependencies = [
  "wasi",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -5591,6 +5869,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5708,6 +5995,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -6469,6 +6762,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spinning_top"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6723,6 +7025,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
 name = "stringmetrics"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6787,6 +7095,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
 dependencies = [
  "is_ci",
+]
+
+[[package]]
+name = "symbolic-common"
+version = "12.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "751a2823d606b5d0a7616499e4130a516ebd01a44f39811be2b9600936509c23"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b237cfbe320601dd24b4ac817a5b68bb28f5508e33f08d42be0682cadc8ac9"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
 ]
 
 [[package]]
@@ -6933,7 +7264,7 @@ dependencies = [
  "etcetera 0.11.0",
  "ferroid",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "memchr",
  "parse-display",
@@ -7276,7 +7607,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.14.3",
  "tonic",
 ]
 
@@ -7288,8 +7619,8 @@ checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build",
- "prost-types",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
  "quote",
  "syn 2.0.117",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -484,3 +484,6 @@ gts-macros = "0.8.2"
 
 # GTS validator
 gts-validator = "0.8.2"
+
+# CPU profiling (pprof-compatible)
+pprof = { version = "0.15", default-features = false, features = ["flamegraph", "prost-codec", "cpp"] }

--- a/apps/hyperspot-server/Cargo.toml
+++ b/apps/hyperspot-server/Cargo.toml
@@ -19,6 +19,7 @@ static-authn = ["dep:static-authn-plugin"]
 static-authz = ["dep:static-authz-plugin"]
 static-credstore = ["dep:static-credstore-plugin"]
 otel = ["modkit/otel"]
+profiling = ["modkit/profiling"]
 
 [dependencies]
 mimalloc = { version = "0.1" }
@@ -55,6 +56,7 @@ credstore = { package = "cf-credstore", path = "../../modules/credstore/credstor
 
 anyhow = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 tracing = { workspace = true }
 clap = { workspace = true }
 

--- a/apps/hyperspot-server/src/main.rs
+++ b/apps/hyperspot-server/src/main.rs
@@ -141,7 +141,29 @@ async fn main() -> Result<()> {
 
     // Dispatch subcommands (default: run)
     match cli.command.as_ref().unwrap_or(&Commands::Run) {
-        Commands::Run => run_server(config).await,
+        Commands::Run => {
+            // Start profiling server before the main runtime (if enabled and compiled in)
+            #[cfg(all(unix, feature = "profiling"))]
+            let profiling_cancel = {
+                let cancel = tokio_util::sync::CancellationToken::new();
+                if config.tracing.profiling.enabled {
+                    modkit::telemetry::profiling::start_profiling_server(
+                        &config.tracing.profiling,
+                        cancel.clone(),
+                    )
+                    .await?;
+                }
+                cancel
+            };
+
+            let result = run_server(config).await;
+
+            // Cancel the profiling server when the main runtime exits
+            #[cfg(all(unix, feature = "profiling"))]
+            profiling_cancel.cancel();
+
+            result
+        }
         Commands::Check => check_config(&config),
         Commands::Migrate => run_migrate(config).await,
     }

--- a/config/quickstart.yaml
+++ b/config/quickstart.yaml
@@ -280,6 +280,14 @@ tracing:
   logs_correlation:
     inject_trace_ids_into_logs: true
 
+  # CPU profiling (requires --features profiling)
+  # Spawns a separate HTTP server with pprof-compatible endpoints.
+  profiling:
+    enabled: false
+    address: "127.0.0.1"
+    port: 6060
+    auth_token: "${PROFILING_TOKEN}"
+
 # Example configurations for different database scenarios:
 #
 # Example 1: PostgreSQL server with multiple modules

--- a/docs/PROFILING.md
+++ b/docs/PROFILING.md
@@ -1,0 +1,148 @@
+# CPU Profiling
+
+On-demand CPU profiling for incident analysis in production and pre-production environments.
+
+## Overview
+
+HyperSpot embeds a [pprof-rs](https://github.com/tikv/pprof-rs)-based CPU profiler
+that exposes pprof-compatible endpoints on a **separate internal HTTP server**.
+Profiles can be collected without restarting the process and analyzed with standard
+tools (`go tool pprof`, Grafana Pyroscope, speedscope, etc.).
+
+## Prerequisites
+
+The binary must be compiled with the `profiling` Cargo feature:
+
+```bash
+cargo build --release --features profiling
+```
+
+Without this feature, profiling code is not compiled into the binary at all.
+
+## Configuration
+
+Profiling is configured under the `tracing.profiling` section in YAML:
+
+```yaml
+tracing:
+  profiling:
+    enabled: true
+    address: "127.0.0.1"   # Bind address (default: 127.0.0.1)
+    port: 6060              # Bind port (default: 6060)
+    auth_token: "${PROFILING_TOKEN}"  # Optional bearer token
+```
+
+### Environment variable overrides
+
+All fields can be overridden via environment variables:
+
+| Field | Env var | Example |
+|-------|---------|---------|
+| `enabled` | `APP__TRACING__PROFILING__ENABLED` | `true` |
+| `address` | `APP__TRACING__PROFILING__ADDRESS` | `0.0.0.0` |
+| `port` | `APP__TRACING__PROFILING__PORT` | `6060` |
+| `auth_token` | `APP__TRACING__PROFILING__AUTH_TOKEN` | `my-secret` |
+
+The `auth_token` field also supports `${ENV_VAR}` expansion syntax (like database passwords).
+
+### Defaults
+
+| Field | Default |
+|-------|---------|
+| `enabled` | `false` |
+| `address` | `127.0.0.1` |
+| `port` | `6060` |
+| `auth_token` | none (no auth) |
+
+## Endpoints
+
+| Endpoint | Content-Type | Description |
+|----------|-------------|-------------|
+| `GET /debug/pprof/profile` | `application/octet-stream` | CPU profile in pprof protobuf format |
+| `GET /debug/pprof/flamegraph` | `image/svg+xml` | CPU profile as interactive flamegraph SVG |
+
+### Query parameters
+
+| Param | Default | Max | Description |
+|-------|---------|-----|-------------|
+| `seconds` | 30 | 300 | Profiling duration in seconds |
+| `frequency` | 99 | 999 | Sampling frequency in Hz |
+
+## Collecting profiles
+
+### pprof protobuf (for `go tool pprof` / Grafana)
+
+```bash
+# Collect a 30-second CPU profile
+curl -o profile.pb http://127.0.0.1:6060/debug/pprof/profile?seconds=30
+
+# With authentication
+curl -H "Authorization: Bearer $PROFILING_TOKEN" \
+     -o profile.pb http://127.0.0.1:6060/debug/pprof/profile?seconds=30
+
+# Analyze with go tool pprof
+go tool pprof -http=:8080 profile.pb
+```
+
+### Flamegraph SVG
+
+```bash
+# Collect and open in browser
+curl -o flamegraph.svg http://127.0.0.1:6060/debug/pprof/flamegraph?seconds=30
+open flamegraph.svg  # macOS
+```
+
+### In Kubernetes
+
+```bash
+# Port-forward the profiling port
+kubectl port-forward pod/hyperspot-abc123 6060:6060
+
+# Then collect from localhost
+curl -o profile.pb http://127.0.0.1:6060/debug/pprof/profile?seconds=30
+```
+
+## Security
+
+### Network isolation
+
+By default the profiling server binds to `127.0.0.1` (localhost only), which means
+it is **not accessible from outside the container/host**. Use `kubectl port-forward`
+or SSH tunnels to access it remotely.
+
+If you must bind to `0.0.0.0` (e.g., for sidecar access), protect the port with a
+Kubernetes `NetworkPolicy`:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-profiling-external
+spec:
+  podSelector:
+    matchLabels:
+      app: hyperspot
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              role: sre-tools
+      ports:
+        - port: 6060
+```
+
+### Authentication
+
+Set `auth_token` to require a `Authorization: Bearer <token>` header on all
+profiling requests. The token value supports `${ENV_VAR}` expansion so you
+can inject it from a Kubernetes secret.
+
+## Limitations
+
+- **CPU profiling only** — heap/memory profiling is not available because the
+  project uses `mimalloc` (heap profiling requires `jemalloc` with `prof` support).
+- **Linux-optimized** — signal-based sampling (`perf_event_open` / `SIGPROF`) works
+  best on Linux. On macOS the profiler compiles and runs but produces lower-fidelity
+  results. A warning is logged on non-Linux platforms.
+- **Single profile at a time** — concurrent profile requests will run overlapping
+  profiler guards; for best results, collect one profile at a time.

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -49,6 +49,9 @@ bootstrap = [
     "dep:enable-ansi-support",
 ]
 
+# CPU profiling via pprof-rs (separate HTTP server with flamegraph + protobuf output)
+profiling = ["dep:pprof"]
+
 [dependencies]
 # Project-local crates
 modkit-macros = { workspace = true }
@@ -118,6 +121,8 @@ tonic = { workspace = true, optional = true }
 # Unix-specific dependencies for graceful process termination
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29", default-features = false, features = ["signal"] }
+# CPU profiling support (optional, Unix-only — pprof uses signals)
+pprof = { workspace = true, optional = true }
 
 [build-dependencies]
 zip = { version = "2.3", default-features = false, features = ["deflate"] }

--- a/libs/modkit/src/telemetry/config.rs
+++ b/libs/modkit/src/telemetry/config.rs
@@ -1,6 +1,7 @@
-//! OpenTelemetry tracing configuration types
+//! Telemetry configuration types
 //!
-//! These types define the configuration structure for OpenTelemetry distributed tracing.
+//! These types define the configuration structure for OpenTelemetry distributed tracing
+//! and CPU profiling.
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -16,6 +17,49 @@ pub struct TracingConfig {
     pub resource: Option<HashMap<String, String>>,
     pub http: Option<HttpOpts>,
     pub logs_correlation: Option<LogsCorrelation>,
+    /// CPU profiling configuration (separate HTTP server).
+    #[serde(default)]
+    pub profiling: ProfilingConfig,
+}
+
+/// CPU profiling configuration.
+///
+/// When enabled, a separate HTTP server is spawned exposing pprof-compatible
+/// endpoints for on-demand CPU profiling. Requires the `profiling` Cargo feature.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ProfilingConfig {
+    /// Enable the profiling HTTP server at runtime.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Bind address for the profiling server.
+    #[serde(default = "default_profiling_address")]
+    pub address: String,
+    /// Bind port for the profiling server.
+    #[serde(default = "default_profiling_port")]
+    pub port: u16,
+    /// Optional bearer token for endpoint authentication.
+    /// Supports `${ENV_VAR}` expansion.
+    #[serde(default)]
+    pub auth_token: Option<String>,
+}
+
+impl Default for ProfilingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            address: default_profiling_address(),
+            port: default_profiling_port(),
+            auth_token: None,
+        }
+    }
+}
+
+fn default_profiling_address() -> String {
+    "127.0.0.1".to_owned()
+}
+
+const fn default_profiling_port() -> u16 {
+    6060
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, Copy)]

--- a/libs/modkit/src/telemetry/mod.rs
+++ b/libs/modkit/src/telemetry/mod.rs
@@ -1,12 +1,18 @@
-//! Telemetry utilities for OpenTelemetry integration
+//! Telemetry utilities for OpenTelemetry integration and CPU profiling
 //!
 //! This module provides utilities for setting up and configuring
-//! OpenTelemetry tracing layers for distributed tracing.
+//! OpenTelemetry tracing layers for distributed tracing, and
+//! on-demand CPU profiling via pprof-compatible endpoints.
 
 pub mod config;
 pub mod init;
 pub mod throttled_log;
 
-pub use config::{Exporter, HttpOpts, LogsCorrelation, Propagation, Sampler, TracingConfig};
+pub use config::{
+    Exporter, HttpOpts, LogsCorrelation, ProfilingConfig, Propagation, Sampler, TracingConfig,
+};
+
+#[cfg(all(unix, feature = "profiling"))]
+pub mod profiling;
 pub use init::{init_tracing, shutdown_tracing};
 pub use throttled_log::ThrottledLog;

--- a/libs/modkit/src/telemetry/profiling.rs
+++ b/libs/modkit/src/telemetry/profiling.rs
@@ -1,0 +1,373 @@
+//! CPU profiling server with pprof-compatible endpoints.
+//!
+//! Spawns a separate HTTP server exposing:
+//! - `GET /debug/pprof/profile` — CPU profile in pprof protobuf format
+//! - `GET /debug/pprof/flamegraph` — CPU profile as flamegraph SVG
+//!
+//! Query parameters (both endpoints):
+//! - `seconds` — profiling duration (default: 30, max: 300)
+//! - `frequency` — sampling frequency in Hz (default: 99, max: 999)
+//!
+//! The server binds to a configurable address/port (default `127.0.0.1:6060`)
+//! and optionally requires a bearer token for authentication.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use axum::extract::Query;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::{Router, middleware, routing::get};
+use serde::Deserialize;
+use tokio_util::sync::CancellationToken;
+
+use super::config::ProfilingConfig;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_SECONDS: u64 = 30;
+const MAX_SECONDS: u64 = 300;
+const DEFAULT_FREQUENCY: i32 = 99;
+const MAX_FREQUENCY: i32 = 999;
+
+// ---------------------------------------------------------------------------
+// Query params
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct ProfileParams {
+    seconds: Option<u64>,
+    frequency: Option<i32>,
+}
+
+impl ProfileParams {
+    fn seconds(&self) -> u64 {
+        self.seconds
+            .unwrap_or(DEFAULT_SECONDS)
+            .clamp(1, MAX_SECONDS)
+    }
+
+    fn frequency(&self) -> i32 {
+        self.frequency
+            .unwrap_or(DEFAULT_FREQUENCY)
+            .clamp(1, MAX_FREQUENCY)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ${ENV_VAR} expansion for auth_token
+// ---------------------------------------------------------------------------
+
+fn expand_env_vars(input: &str) -> Result<String> {
+    let mut result = input.to_owned();
+    // Match ${VAR_NAME} patterns
+    while let Some(start) = result.find("${") {
+        let Some(end) = result[start..].find('}') else {
+            break;
+        };
+        let var_name = &result[start + 2..start + end];
+        let value = std::env::var(var_name)
+            .with_context(|| format!("Environment variable '{var_name}' not found"))?;
+        result.replace_range(start..=start + end, &value);
+    }
+    Ok(result)
+}
+
+// ---------------------------------------------------------------------------
+// Auth middleware
+// ---------------------------------------------------------------------------
+
+async fn auth_middleware(
+    axum::extract::State(expected_token): axum::extract::State<String>,
+    headers: HeaderMap,
+    request: axum::extract::Request,
+    next: middleware::Next,
+) -> Response {
+    let authorized = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .is_some_and(|token| token == expected_token);
+
+    if authorized {
+        next.run(request).await
+    } else {
+        (StatusCode::UNAUTHORIZED, "Unauthorized").into_response()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async fn handle_profile(Query(params): Query<ProfileParams>) -> Response {
+    let seconds = params.seconds();
+    let frequency = params.frequency();
+
+    tracing::info!(seconds, frequency, "Starting CPU profile collection");
+
+    match collect_profile(seconds, frequency).await {
+        Ok(data) => (
+            StatusCode::OK,
+            [("content-type", "application/octet-stream")],
+            data,
+        )
+            .into_response(),
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to collect CPU profile");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to collect profile: {e}"),
+            )
+                .into_response()
+        }
+    }
+}
+
+async fn handle_flamegraph(Query(params): Query<ProfileParams>) -> Response {
+    let seconds = params.seconds();
+    let frequency = params.frequency();
+
+    tracing::info!(seconds, frequency, "Starting flamegraph collection");
+
+    match collect_flamegraph(seconds, frequency).await {
+        Ok(svg) => (StatusCode::OK, [("content-type", "image/svg+xml")], svg).into_response(),
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to generate flamegraph");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to generate flamegraph: {e}"),
+            )
+                .into_response()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Profile collection
+// ---------------------------------------------------------------------------
+
+async fn collect_profile(seconds: u64, frequency: i32) -> Result<Vec<u8>> {
+    emit_platform_warning();
+
+    let guard = pprof::ProfilerGuardBuilder::default()
+        .frequency(frequency)
+        .blocklist(&["libc", "libgcc", "pthread", "vdso"])
+        .build()
+        .context("Failed to build profiler guard")?;
+
+    tokio::time::sleep(Duration::from_secs(seconds)).await;
+
+    let report = guard.report().build().context("Failed to build report")?;
+    let profile = report.pprof().context("Failed to generate pprof profile")?;
+
+    let mut buf = Vec::new();
+    pprof::protos::Message::encode(&profile, &mut buf)
+        .context("Failed to encode pprof protobuf")?;
+
+    tracing::info!(
+        bytes = buf.len(),
+        seconds,
+        frequency,
+        "CPU profile collected"
+    );
+    Ok(buf)
+}
+
+async fn collect_flamegraph(seconds: u64, frequency: i32) -> Result<Vec<u8>> {
+    emit_platform_warning();
+
+    let guard = pprof::ProfilerGuardBuilder::default()
+        .frequency(frequency)
+        .blocklist(&["libc", "libgcc", "pthread", "vdso"])
+        .build()
+        .context("Failed to build profiler guard")?;
+
+    tokio::time::sleep(Duration::from_secs(seconds)).await;
+
+    let report = guard.report().build().context("Failed to build report")?;
+
+    let mut svg = Vec::new();
+    report
+        .flamegraph(&mut svg)
+        .context("Failed to generate flamegraph SVG")?;
+
+    tracing::info!(
+        bytes = svg.len(),
+        seconds,
+        frequency,
+        "Flamegraph SVG generated"
+    );
+    Ok(svg)
+}
+
+fn emit_platform_warning() {
+    #[cfg(not(target_os = "linux"))]
+    tracing::warn!(
+        "CPU profiling has limited fidelity on non-Linux platforms. \
+         Signal-based sampling works best on Linux."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Server startup
+// ---------------------------------------------------------------------------
+
+/// Start the profiling HTTP server in a background task.
+///
+/// The server binds to `{config.address}:{config.port}` **before returning**,
+/// so any bind failure (port in use, permission denied, etc.) is propagated
+/// to the caller. The actual serve loop runs in a spawned background task
+/// that shuts down gracefully when the provided `CancellationToken` is
+/// cancelled.
+///
+/// # Errors
+///
+/// Returns an error if address parsing fails, `auth_token` environment
+/// variable expansion fails, or the TCP listener cannot bind.
+pub async fn start_profiling_server(
+    config: &ProfilingConfig,
+    cancel: CancellationToken,
+) -> Result<()> {
+    let addr: SocketAddr = format!("{}:{}", config.address, config.port)
+        .parse()
+        .with_context(|| {
+            format!(
+                "Invalid profiling bind address: {}:{}",
+                config.address, config.port
+            )
+        })?;
+
+    let resolved_token = config
+        .auth_token
+        .as_deref()
+        .map(expand_env_vars)
+        .transpose()
+        .context("Failed to expand profiling auth_token")?;
+
+    let router = build_router(resolved_token);
+
+    tracing::info!(
+        %addr,
+        auth = config.auth_token.is_some(),
+        "Starting profiling server"
+    );
+
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .with_context(|| format!("Failed to bind profiling server on {addr}"))?;
+
+    tracing::info!(%addr, "Profiling server listening");
+
+    tokio::spawn(async move {
+        let server = axum::serve(listener, router).with_graceful_shutdown(async move {
+            cancel.cancelled().await;
+            tracing::info!("Profiling server shutting down");
+        });
+
+        if let Err(e) = server.await {
+            tracing::error!(error = %e, "Profiling server error");
+        }
+    });
+
+    Ok(())
+}
+
+fn build_router(auth_token: Option<String>) -> Router {
+    let routes = Router::new()
+        .route("/debug/pprof/profile", get(handle_profile))
+        .route("/debug/pprof/flamegraph", get(handle_flamegraph));
+
+    if let Some(token) = auth_token {
+        routes.layer(middleware::from_fn_with_state(token, auth_middleware))
+    } else {
+        routes
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_profile_params_defaults() {
+        let params = ProfileParams {
+            seconds: None,
+            frequency: None,
+        };
+        assert_eq!(params.seconds(), DEFAULT_SECONDS);
+        assert_eq!(params.frequency(), DEFAULT_FREQUENCY);
+    }
+
+    #[test]
+    fn test_profile_params_clamping() {
+        let params = ProfileParams {
+            seconds: Some(999),
+            frequency: Some(9999),
+        };
+        assert_eq!(params.seconds(), MAX_SECONDS);
+        assert_eq!(params.frequency(), MAX_FREQUENCY);
+    }
+
+    #[test]
+    fn test_profile_params_min_clamping() {
+        let params = ProfileParams {
+            seconds: Some(0),
+            frequency: Some(0),
+        };
+        assert_eq!(params.seconds(), 1);
+        assert_eq!(params.frequency(), 1);
+    }
+
+    #[test]
+    fn test_expand_env_vars_no_vars() {
+        let result = expand_env_vars("plain-token").expect("should succeed");
+        assert_eq!(result, "plain-token");
+    }
+
+    #[test]
+    fn test_expand_env_vars_with_env() {
+        let var_name = "TEST_PROFILING_TOKEN_EXPAND_8273";
+        temp_env::with_var(var_name, Some("secret123"), || {
+            let input = format!("${{{var_name}}}");
+            let result = expand_env_vars(&input).expect("should expand");
+            assert_eq!(result, "secret123");
+        });
+    }
+
+    #[test]
+    fn test_expand_env_vars_missing() {
+        let result = expand_env_vars("${NONEXISTENT_PROFILING_VAR_12345}");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_default_profiling_config() {
+        let config = ProfilingConfig::default();
+        assert!(!config.enabled);
+        assert_eq!(config.address, "127.0.0.1");
+        assert_eq!(config.port, 6060);
+        assert!(config.auth_token.is_none());
+    }
+
+    #[test]
+    fn test_build_router_no_auth() {
+        let router = build_router(None);
+        // Smoke test: router should build without panicking
+        drop(router);
+    }
+
+    #[test]
+    fn test_build_router_with_auth() {
+        let router = build_router(Some("test-token".to_owned()));
+        drop(router);
+    }
+}


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#810](https://github.com/cyberfabric/cyberware-rust/pull/810) | **Author:** genericaccount-de | **Opened:** 2026-02-28T17:04:39Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

Add separate profiling server with CPU pprof endpoint.

REAL-163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-demand CPU profiling for performance analysis (opt-in, disabled by default)
  * Local profiling server with bearer-token support, default bind 127.0.0.1:6060
  * Two endpoints: CPU profile export (pprof) and flamegraph visualization
  * Configurable sampling frequency and collection duration; profiling can be enabled via a feature toggle (Unix-only)

* **Documentation**
  * Added a detailed profiling guide covering configuration, auth, usage, and deployment notes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#810 -->