### PR TITLE
[PR #802] test(credstore): add unit tests

### DIFF
--- a/modules/credstore/credstore-sdk/src/error.rs
+++ b/modules/credstore/credstore-sdk/src/error.rs
@@ -37,3 +37,58 @@ impl CredStoreError {
         Self::Internal(msg.into())
     }
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_ref_constructor_sets_reason() {
+        let e = CredStoreError::invalid_ref("must not be empty");
+        assert!(
+            matches!(e, CredStoreError::InvalidSecretRef { ref reason } if reason == "must not be empty")
+        );
+        assert_eq!(e.to_string(), "invalid secret reference: must not be empty");
+    }
+
+    #[test]
+    fn service_unavailable_constructor_sets_message() {
+        let e = CredStoreError::service_unavailable("backend down");
+        assert!(matches!(e, CredStoreError::ServiceUnavailable(ref m) if m == "backend down"));
+        assert_eq!(e.to_string(), "service unavailable: backend down");
+    }
+
+    #[test]
+    fn internal_constructor_sets_message() {
+        let e = CredStoreError::internal("unexpected state");
+        assert!(matches!(e, CredStoreError::Internal(ref m) if m == "unexpected state"));
+        assert_eq!(e.to_string(), "internal error: unexpected state");
+    }
+
+    #[test]
+    fn not_found_display() {
+        let e = CredStoreError::NotFound;
+        assert_eq!(e.to_string(), "secret not found");
+    }
+
+    #[test]
+    fn no_plugin_available_display() {
+        let e = CredStoreError::NoPluginAvailable;
+        assert_eq!(e.to_string(), "no plugin available");
+    }
+
+    #[test]
+    fn all_variants_are_debug() {
+        let variants: &[CredStoreError] = &[
+            CredStoreError::InvalidSecretRef { reason: "x".into() },
+            CredStoreError::NotFound,
+            CredStoreError::NoPluginAvailable,
+            CredStoreError::ServiceUnavailable("y".into()),
+            CredStoreError::Internal("z".into()),
+        ];
+        for v in variants {
+            drop(format!("{v:?}"));
+        }
+    }
+}

--- a/modules/credstore/credstore-sdk/src/models.rs
+++ b/modules/credstore/credstore-sdk/src/models.rs
@@ -260,4 +260,80 @@ mod tests {
         assert!(debug.contains("[REDACTED]"));
         assert!(!debug.contains("secret"));
     }
+
+    #[test]
+    fn secret_ref_as_ref_returns_inner_string() {
+        let r = SecretRef::new("my-key").unwrap();
+        assert_eq!(r.as_ref(), "my-key");
+    }
+
+    #[test]
+    fn secret_value_new_stores_bytes() {
+        let val = SecretValue::new(b"hello world".to_vec());
+        assert_eq!(val.as_bytes(), b"hello world");
+    }
+
+    #[test]
+    fn sharing_mode_serde_roundtrip() {
+        for (mode, expected_json) in [
+            (SharingMode::Private, "\"private\""),
+            (SharingMode::Tenant, "\"tenant\""),
+            (SharingMode::Shared, "\"shared\""),
+        ] {
+            let json = serde_json::to_string(&mode).unwrap();
+            assert_eq!(json, expected_json);
+            let back: SharingMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, mode);
+        }
+    }
+
+    #[test]
+    fn sharing_mode_clone_and_copy() {
+        let original = SharingMode::Private;
+        let copied = original; // Copy
+        let cloned = original; // Clone via Copy
+        assert_eq!(original, copied);
+        assert_eq!(original, cloned);
+    }
+
+    #[test]
+    fn get_secret_response_is_inherited_false() {
+        let resp = GetSecretResponse {
+            value: SecretValue::from("s"),
+            owner_tenant_id: Uuid::nil(),
+            sharing: SharingMode::Tenant,
+            is_inherited: false,
+        };
+        assert!(!resp.is_inherited);
+        assert_eq!(resp.sharing, SharingMode::Tenant);
+    }
+
+    #[test]
+    fn secret_value_from_string_stores_bytes() {
+        let val = SecretValue::from(String::from("owned"));
+        assert_eq!(val.as_bytes(), b"owned");
+    }
+
+    #[test]
+    fn secret_value_from_vec_stores_bytes() {
+        let val = SecretValue::from(vec![0xDE, 0xAD]);
+        assert_eq!(val.as_bytes(), &[0xDE, 0xAD]);
+    }
+
+    #[test]
+    fn secret_ref_debug_shows_inner_value() {
+        let r = SecretRef::new("my-key").unwrap();
+        let dbg = format!("{r:?}");
+        assert!(dbg.contains("SecretRef"));
+        assert!(dbg.contains("my-key"));
+    }
+
+    #[test]
+    fn secret_ref_serialize_roundtrip() {
+        let r = SecretRef::new("round-trip").unwrap();
+        let json = serde_json::to_string(&r).unwrap();
+        assert_eq!(json, "\"round-trip\"");
+        let back: SecretRef = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.as_ref(), "round-trip");
+    }
 }

--- a/modules/credstore/credstore/src/config.rs
+++ b/modules/credstore/credstore/src/config.rs
@@ -20,3 +20,34 @@ impl Default for CredStoreConfig {
         }
     }
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_vendor_is_hyperspot() {
+        let cfg = CredStoreConfig::default();
+        assert_eq!(cfg.vendor, "hyperspot");
+    }
+
+    #[test]
+    fn vendor_can_be_overridden_via_serde() {
+        let json = r#"{"vendor": "acme"}"#;
+        let cfg: CredStoreConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.vendor, "acme");
+    }
+
+    #[test]
+    fn empty_object_applies_defaults() {
+        let cfg: CredStoreConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(cfg.vendor, "hyperspot");
+    }
+
+    #[test]
+    fn rejects_unknown_fields() {
+        let json = r#"{"vendor": "x", "unexpected": true}"#;
+        assert!(serde_json::from_str::<CredStoreConfig>(json).is_err());
+    }
+}

--- a/modules/credstore/credstore/src/domain/error.rs
+++ b/modules/credstore/credstore/src/domain/error.rs
@@ -93,3 +93,155 @@ impl From<DomainError> for CredStoreError {
         }
     }
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use modkit::plugins::ChoosePluginError;
+
+    use super::*;
+
+    // ── From<TypesRegistryError> ─────────────────────────────────────────────
+
+    #[test]
+    fn from_types_registry_error_becomes_internal() {
+        let src = types_registry_sdk::TypesRegistryError::internal("oops");
+        let dst = DomainError::from(src);
+        assert!(matches!(dst, DomainError::Internal(_)));
+    }
+
+    // ── From<ClientHubError> ─────────────────────────────────────────────────
+
+    #[test]
+    fn from_client_hub_error_becomes_internal() {
+        // Trigger a real ClientHubError by requesting an unregistered type.
+        let hub = modkit::client_hub::ClientHub::default();
+        let src = hub
+            .get::<dyn types_registry_sdk::TypesRegistryClient>()
+            .err()
+            .unwrap();
+        let dst = DomainError::from(src);
+        assert!(matches!(dst, DomainError::Internal(_)));
+    }
+
+    // ── From<serde_json::Error> ──────────────────────────────────────────────
+
+    #[test]
+    fn from_serde_json_error_becomes_internal() {
+        let src: serde_json::Error = serde_json::from_str::<i32>("not-json").unwrap_err();
+        let dst = DomainError::from(src);
+        assert!(matches!(dst, DomainError::Internal(_)));
+    }
+
+    // ── From<ChoosePluginError> ──────────────────────────────────────────────
+
+    #[test]
+    fn from_choose_plugin_error_not_found_becomes_plugin_not_found() {
+        let src = ChoosePluginError::PluginNotFound {
+            vendor: "acme".into(),
+        };
+        let dst = DomainError::from(src);
+        assert!(matches!(dst, DomainError::PluginNotFound { vendor } if vendor == "acme"));
+    }
+
+    #[test]
+    fn from_choose_plugin_error_invalid_instance_becomes_invalid_plugin_instance() {
+        let src = ChoosePluginError::InvalidPluginInstance {
+            gts_id: "gts.x.core.test.error.v1~".into(),
+            reason: "bad content".into(),
+        };
+        let dst = DomainError::from(src);
+        assert!(
+            matches!(dst, DomainError::InvalidPluginInstance { gts_id, reason }
+                if gts_id == "gts.x.core.test.error.v1~" && reason == "bad content")
+        );
+    }
+
+    // ── From<CredStoreError> for DomainError ─────────────────────────────────
+
+    #[test]
+    fn from_credstore_error_not_found_becomes_not_found() {
+        let dst = DomainError::from(CredStoreError::NotFound);
+        assert!(matches!(dst, DomainError::NotFound));
+    }
+
+    #[test]
+    fn from_credstore_error_no_plugin_available_becomes_plugin_not_found() {
+        let dst = DomainError::from(CredStoreError::NoPluginAvailable);
+        assert!(matches!(dst, DomainError::PluginNotFound { vendor } if vendor == "unknown"));
+    }
+
+    #[test]
+    fn from_credstore_error_service_unavailable_becomes_plugin_unavailable() {
+        let dst = DomainError::from(CredStoreError::ServiceUnavailable("down".into()));
+        assert!(
+            matches!(dst, DomainError::PluginUnavailable { gts_id, reason }
+            if gts_id == "unknown" && reason == "down")
+        );
+    }
+
+    #[test]
+    fn from_credstore_error_invalid_secret_ref_becomes_internal() {
+        let dst = DomainError::from(CredStoreError::InvalidSecretRef {
+            reason: "bad".into(),
+        });
+        assert!(matches!(dst, DomainError::Internal(msg) if msg == "bad"));
+    }
+
+    #[test]
+    fn from_credstore_error_internal_becomes_internal() {
+        let dst = DomainError::from(CredStoreError::Internal("boom".into()));
+        assert!(matches!(dst, DomainError::Internal(msg) if msg == "boom"));
+    }
+
+    // ── From<DomainError> for CredStoreError ────────────────────────────────
+
+    #[test]
+    fn domain_plugin_not_found_becomes_no_plugin_available() {
+        let src = DomainError::PluginNotFound {
+            vendor: "acme".into(),
+        };
+        let dst = CredStoreError::from(src);
+        assert!(matches!(dst, CredStoreError::NoPluginAvailable));
+    }
+
+    #[test]
+    fn domain_invalid_plugin_instance_becomes_internal() {
+        let src = DomainError::InvalidPluginInstance {
+            gts_id: "gts.x.core.test.error.v1~".into(),
+            reason: "bad".into(),
+        };
+        let dst = CredStoreError::from(src);
+        assert!(matches!(dst, CredStoreError::Internal(_)));
+    }
+
+    #[test]
+    fn domain_plugin_unavailable_becomes_service_unavailable() {
+        let src = DomainError::PluginUnavailable {
+            gts_id: "gts.x.core.test.error.v1~".into(),
+            reason: "not ready".into(),
+        };
+        let dst = CredStoreError::from(src);
+        assert!(matches!(dst, CredStoreError::ServiceUnavailable(_)));
+    }
+
+    #[test]
+    fn domain_not_found_becomes_not_found() {
+        let dst = CredStoreError::from(DomainError::NotFound);
+        assert!(matches!(dst, CredStoreError::NotFound));
+    }
+
+    #[test]
+    fn domain_types_registry_unavailable_becomes_internal() {
+        let src = DomainError::TypesRegistryUnavailable("gone".into());
+        let dst = CredStoreError::from(src);
+        assert!(matches!(dst, CredStoreError::Internal(msg) if msg == "gone"));
+    }
+
+    #[test]
+    fn domain_internal_becomes_internal() {
+        let src = DomainError::Internal("err".into());
+        let dst = CredStoreError::from(src);
+        assert!(matches!(dst, CredStoreError::Internal(msg) if msg == "err"));
+    }
+}

--- a/modules/credstore/credstore/src/domain/local_client.rs
+++ b/modules/credstore/credstore/src/domain/local_client.rs
@@ -50,3 +50,153 @@ impl CredStoreClientV1 for CredStoreLocalClient {
             .map_err(|e| log_and_convert("get", e))
     }
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use std::sync::Arc;
+
+    use credstore_sdk::{
+        CredStorePluginClientV1, CredStorePluginSpecV1, SecretMetadata, SecretValue, SharingMode,
+    };
+    use modkit::client_hub::{ClientHub, ClientScope};
+    use types_registry_sdk::{GtsEntity, TypesRegistryClient};
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::domain::Service;
+    use crate::domain::test_support::{MockPlugin, MockRegistry, test_ctx};
+
+    fn make_client() -> CredStoreLocalClient {
+        let hub = Arc::new(ClientHub::default());
+        let svc = Arc::new(Service::new(hub, "hyperspot".into()));
+        CredStoreLocalClient::new(svc)
+    }
+
+    fn make_wired_client(plugin: Arc<dyn CredStorePluginClientV1>) -> CredStoreLocalClient {
+        let instance_id = format!(
+            "{}test._.local_client_test.v1",
+            CredStorePluginSpecV1::gts_schema_id()
+        );
+        let hub = Arc::new(ClientHub::default());
+
+        let entity = GtsEntity {
+            id: Uuid::nil(),
+            gts_id: instance_id.clone(),
+            segments: vec![],
+            is_schema: false,
+            content: serde_json::json!({
+                "id": instance_id,
+                "vendor": "hyperspot",
+                "priority": 0,
+                "properties": {}
+            }),
+            description: None,
+        };
+        let reg: Arc<dyn TypesRegistryClient> = Arc::new(MockRegistry::new(vec![entity]));
+        hub.register::<dyn TypesRegistryClient>(reg);
+        hub.register_scoped::<dyn CredStorePluginClientV1>(
+            ClientScope::gts_id(&instance_id),
+            plugin,
+        );
+
+        let svc = Arc::new(Service::new(hub, "hyperspot".into()));
+        CredStoreLocalClient::new(svc)
+    }
+
+    // ── construction ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn new_constructs_client() {
+        let _client = make_client();
+    }
+
+    // ── CredStoreClientV1::get — error path ──────────────────────────────────
+
+    #[tokio::test]
+    async fn get_trait_impl_propagates_service_error() {
+        let client = make_client();
+        let key = SecretRef::new("test-key").unwrap();
+        // Hub is empty → TypesRegistryUnavailable → CredStoreError::Internal
+        let result = client.get(&test_ctx(), &key).await;
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), CredStoreError::Internal(_)));
+    }
+
+    // ── CredStoreClientV1::get — happy paths ─────────────────────────────────
+
+    #[tokio::test]
+    async fn get_trait_impl_returns_some_on_success() {
+        let meta = SecretMetadata {
+            value: SecretValue::from("val"),
+            owner_id: Uuid::nil(),
+            sharing: SharingMode::Tenant,
+            owner_tenant_id: Uuid::nil(),
+        };
+        let client = make_wired_client(MockPlugin::returns(Some(&meta)));
+        let key = SecretRef::new("key").unwrap();
+        let resp = client.get(&test_ctx(), &key).await.unwrap();
+        let resp = resp.expect("expected Some");
+        assert_eq!(resp.value.as_bytes(), b"val");
+        assert!(!resp.is_inherited);
+    }
+
+    #[tokio::test]
+    async fn get_trait_impl_returns_none_when_plugin_returns_none() {
+        let client = make_wired_client(MockPlugin::returns(None));
+        let key = SecretRef::new("missing").unwrap();
+        let resp = client.get(&test_ctx(), &key).await.unwrap();
+        assert!(resp.is_none());
+    }
+
+    // ── log_and_convert ──────────────────────────────────────────────────────
+
+    #[test]
+    fn log_and_convert_not_found_returns_cred_store_not_found() {
+        let e = log_and_convert("get", DomainError::NotFound);
+        assert!(matches!(e, CredStoreError::NotFound));
+    }
+
+    #[test]
+    fn log_and_convert_plugin_not_found_returns_no_plugin_available() {
+        let e = log_and_convert(
+            "get",
+            DomainError::PluginNotFound {
+                vendor: "acme".into(),
+            },
+        );
+        assert!(matches!(e, CredStoreError::NoPluginAvailable));
+    }
+
+    #[test]
+    fn log_and_convert_plugin_unavailable_returns_service_unavailable() {
+        let src = DomainError::PluginUnavailable {
+            gts_id: "gts.x.core.test.error.v1~".into(),
+            reason: "not ready".into(),
+        };
+        let e = log_and_convert("get", src);
+        assert!(matches!(e, CredStoreError::ServiceUnavailable(_)));
+    }
+
+    #[test]
+    fn log_and_convert_internal_returns_internal() {
+        let e = log_and_convert("get", DomainError::Internal("boom".into()));
+        assert!(matches!(e, CredStoreError::Internal(_)));
+    }
+
+    #[test]
+    fn log_and_convert_types_registry_unavailable_returns_internal() {
+        let e = log_and_convert("get", DomainError::TypesRegistryUnavailable("gone".into()));
+        assert!(matches!(e, CredStoreError::Internal(_)));
+    }
+
+    #[test]
+    fn log_and_convert_invalid_plugin_instance_returns_internal() {
+        let src = DomainError::InvalidPluginInstance {
+            gts_id: "gts.x.core.test.error.v1~".into(),
+            reason: "bad json".into(),
+        };
+        let e = log_and_convert("get", src);
+        assert!(matches!(e, CredStoreError::Internal(_)));
+    }
+}

--- a/modules/credstore/credstore/src/domain/mod.rs
+++ b/modules/credstore/credstore/src/domain/mod.rs
@@ -3,6 +3,8 @@
 pub mod error;
 pub mod local_client;
 pub mod service;
+#[cfg(test)]
+pub mod test_support;
 
 pub use error::DomainError;
 pub use local_client::CredStoreLocalClient;

--- a/modules/credstore/credstore/src/domain/service.rs
+++ b/modules/credstore/credstore/src/domain/service.rs
@@ -126,3 +126,314 @@ impl Service {
         }))
     }
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::Ordering;
+
+    use credstore_sdk::{SecretMetadata, SecretValue, SharingMode};
+    use modkit::client_hub::{ClientHub, ClientScope};
+    use types_registry_sdk::{GtsEntity, TypesRegistryError};
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::domain::test_support::{MockPlugin, MockRegistry, test_ctx};
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    fn empty_hub() -> Arc<ClientHub> {
+        Arc::new(ClientHub::default())
+    }
+
+    /// Build the GTS instance ID string for a credstore plugin test instance.
+    fn test_instance_id() -> String {
+        // schema prefix + instance suffix
+        format!("{}test._.mock.v1", CredStorePluginSpecV1::gts_schema_id())
+    }
+
+    /// Build the JSON content for a `BaseModkitPluginV1`<CredStorePluginSpecV1>
+    /// instance that `choose_plugin_instance` can successfully parse.
+    fn plugin_content(gts_id: &str, vendor: &str) -> serde_json::Value {
+        serde_json::json!({
+            "id": gts_id,
+            "vendor": vendor,
+            "priority": 0,
+            "properties": {}
+        })
+    }
+
+    // ── helper to build a fully-wired hub ────────────────────────────────────
+
+    /// Wires a counting `MockRegistry` and a scoped plugin into a `ClientHub`.
+    /// Returns `(hub, registry_arc)` so tests can inspect `list_calls`.
+    fn hub_with_counting_registry_and_plugin(
+        instance_id: &str,
+        vendor: &str,
+        plugin: Arc<dyn CredStorePluginClientV1>,
+    ) -> (Arc<ClientHub>, Arc<MockRegistry>) {
+        let hub = Arc::new(ClientHub::default());
+
+        let entity = GtsEntity {
+            id: Uuid::nil(),
+            gts_id: instance_id.to_owned(),
+            segments: vec![],
+            is_schema: false,
+            content: plugin_content(instance_id, vendor),
+            description: None,
+        };
+        let registry = Arc::new(MockRegistry::new(vec![entity]));
+        hub.register::<dyn TypesRegistryClient>(registry.clone() as Arc<dyn TypesRegistryClient>);
+
+        hub.register_scoped::<dyn CredStorePluginClientV1>(
+            ClientScope::gts_id(instance_id),
+            plugin,
+        );
+
+        (hub, registry)
+    }
+
+    fn hub_with_registry_and_plugin(
+        instance_id: &str,
+        vendor: &str,
+        plugin: Arc<dyn CredStorePluginClientV1>,
+    ) -> Arc<ClientHub> {
+        hub_with_counting_registry_and_plugin(instance_id, vendor, plugin).0
+    }
+
+    // ── construction ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn new_constructs_service() {
+        let _svc = Service::new(empty_hub(), "hyperspot".into());
+    }
+
+    #[tokio::test]
+    async fn get_returns_registry_unavailable_when_hub_empty() {
+        let svc = Service::new(empty_hub(), "hyperspot".into());
+        let key = SecretRef::new("my-key").unwrap();
+        let err = svc.get(&test_ctx(), &key).await.unwrap_err();
+        assert!(
+            matches!(err, DomainError::TypesRegistryUnavailable(_)),
+            "expected TypesRegistryUnavailable, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_retries_resolution_on_each_call_when_registry_absent() {
+        // GtsPluginSelector does not cache errors, so each call re-attempts resolution.
+        let svc = Service::new(empty_hub(), "hyperspot".into());
+        let key = SecretRef::new("my-key").unwrap();
+        assert!(svc.get(&test_ctx(), &key).await.is_err());
+        assert!(svc.get(&test_ctx(), &key).await.is_err());
+    }
+
+    // ── resolve_plugin ───────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn resolve_plugin_returns_plugin_not_found_when_no_instances() {
+        let hub = Arc::new(ClientHub::default());
+        let registry: Arc<dyn TypesRegistryClient> = Arc::new(MockRegistry::new(vec![]));
+        hub.register::<dyn TypesRegistryClient>(registry);
+
+        let svc = Service::new(hub, "hyperspot".into());
+        let err = svc.resolve_plugin().await.unwrap_err();
+        assert!(
+            matches!(err, DomainError::PluginNotFound { .. }),
+            "expected PluginNotFound, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_plugin_returns_plugin_not_found_when_vendor_mismatch() {
+        let instance_id = test_instance_id();
+        let hub = Arc::new(ClientHub::default());
+        let entity = GtsEntity {
+            id: Uuid::nil(),
+            gts_id: instance_id.clone(),
+            segments: vec![],
+            is_schema: false,
+            content: plugin_content(&instance_id, "other-vendor"),
+            description: None,
+        };
+        let registry: Arc<dyn TypesRegistryClient> = Arc::new(MockRegistry::new(vec![entity]));
+        hub.register::<dyn TypesRegistryClient>(registry);
+
+        let svc = Service::new(hub, "hyperspot".into());
+        let err = svc.resolve_plugin().await.unwrap_err();
+        assert!(
+            matches!(err, DomainError::PluginNotFound { .. }),
+            "expected PluginNotFound, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_plugin_returns_invalid_when_content_malformed() {
+        let instance_id = test_instance_id();
+        let hub = Arc::new(ClientHub::default());
+        let entity = GtsEntity {
+            id: Uuid::nil(),
+            gts_id: instance_id.clone(),
+            segments: vec![],
+            is_schema: false,
+            content: serde_json::json!({ "not": "valid-plugin-content" }),
+            description: None,
+        };
+        let registry: Arc<dyn TypesRegistryClient> = Arc::new(MockRegistry::new(vec![entity]));
+        hub.register::<dyn TypesRegistryClient>(registry);
+
+        let svc = Service::new(hub, "hyperspot".into());
+        let err = svc.resolve_plugin().await.unwrap_err();
+        assert!(
+            matches!(err, DomainError::InvalidPluginInstance { .. }),
+            "expected InvalidPluginInstance, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_plugin_returns_internal_when_registry_list_fails() {
+        let hub = Arc::new(ClientHub::default());
+        let registry: Arc<dyn TypesRegistryClient> = Arc::new(MockRegistry::failing(
+            TypesRegistryError::internal("db down"),
+        ));
+        hub.register::<dyn TypesRegistryClient>(registry);
+
+        let svc = Service::new(hub, "hyperspot".into());
+        let err = svc.resolve_plugin().await.unwrap_err();
+        assert!(
+            matches!(err, DomainError::Internal(ref msg) if msg.contains("db down")),
+            "expected Internal containing 'db down', got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_plugin_succeeds_with_matching_vendor() {
+        let instance_id = test_instance_id();
+        let hub =
+            hub_with_registry_and_plugin(&instance_id, "hyperspot", MockPlugin::returns(None));
+
+        let svc = Service::new(hub, "hyperspot".into());
+        let resolved = svc.resolve_plugin().await.unwrap();
+        assert_eq!(resolved, instance_id);
+    }
+
+    // ── get_plugin ───────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn get_plugin_returns_unavailable_when_not_in_hub() {
+        // Registry resolves successfully, but the scoped client is absent.
+        let instance_id = test_instance_id();
+        let hub = Arc::new(ClientHub::default());
+        let entity = GtsEntity {
+            id: Uuid::nil(),
+            gts_id: instance_id.clone(),
+            segments: vec![],
+            is_schema: false,
+            content: plugin_content(&instance_id, "hyperspot"),
+            description: None,
+        };
+        let registry: Arc<dyn TypesRegistryClient> = Arc::new(MockRegistry::new(vec![entity]));
+        hub.register::<dyn TypesRegistryClient>(registry);
+
+        let svc = Service::new(hub, "hyperspot".into());
+        let err = svc.get_plugin().await.err().expect("expected Err");
+        assert!(
+            matches!(err, DomainError::PluginUnavailable { .. }),
+            "expected PluginUnavailable, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_plugin_returns_client_when_registered() {
+        let instance_id = test_instance_id();
+        let hub =
+            hub_with_registry_and_plugin(&instance_id, "hyperspot", MockPlugin::returns(None));
+
+        let svc = Service::new(hub, "hyperspot".into());
+        // Should succeed — client is registered
+        let _client = svc.get_plugin().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn get_plugin_caches_resolved_instance() {
+        let instance_id = test_instance_id();
+        let (hub, registry) = hub_with_counting_registry_and_plugin(
+            &instance_id,
+            "hyperspot",
+            MockPlugin::returns(None),
+        );
+
+        let svc = Service::new(hub, "hyperspot".into());
+        let p1 = svc.get_plugin().await.unwrap();
+        let p2 = svc.get_plugin().await.unwrap();
+
+        assert_eq!(
+            registry.list_calls.load(Ordering::SeqCst),
+            1,
+            "resolve_plugin should be called exactly once; second call must use cached value"
+        );
+        assert!(
+            Arc::ptr_eq(&p1, &p2),
+            "both calls should return the same plugin Arc (same mock instance)"
+        );
+    }
+
+    // ── get ──────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn get_returns_some_response_on_success() {
+        let instance_id = test_instance_id();
+        let meta = SecretMetadata {
+            value: SecretValue::from("s3cr3t"),
+            owner_id: Uuid::nil(),
+            sharing: SharingMode::Tenant,
+            owner_tenant_id: Uuid::nil(),
+        };
+        let hub = hub_with_registry_and_plugin(
+            &instance_id,
+            "hyperspot",
+            MockPlugin::returns(Some(&meta)),
+        );
+
+        let svc = Service::new(hub, "hyperspot".into());
+        let key = SecretRef::new("my-key").unwrap();
+        let resp = svc.get(&test_ctx(), &key).await.unwrap();
+
+        let resp = resp.expect("expected Some response");
+        assert_eq!(resp.value.as_bytes(), b"s3cr3t");
+        assert_eq!(resp.sharing, SharingMode::Tenant);
+        assert!(!resp.is_inherited, "is_inherited must always be false here");
+        assert_eq!(resp.owner_tenant_id, Uuid::nil());
+    }
+
+    #[tokio::test]
+    async fn get_returns_none_when_plugin_returns_none() {
+        let instance_id = test_instance_id();
+        let hub =
+            hub_with_registry_and_plugin(&instance_id, "hyperspot", MockPlugin::returns(None));
+
+        let svc = Service::new(hub, "hyperspot".into());
+        let key = SecretRef::new("missing-key").unwrap();
+        let result = svc.get(&test_ctx(), &key).await.unwrap();
+        assert!(result.is_none(), "expected None for missing secret");
+    }
+
+    #[tokio::test]
+    async fn get_propagates_plugin_error() {
+        let instance_id = test_instance_id();
+        let hub = hub_with_registry_and_plugin(
+            &instance_id,
+            "hyperspot",
+            MockPlugin::errors_internal("backend failure"),
+        );
+
+        let svc = Service::new(hub, "hyperspot".into());
+        let key = SecretRef::new("any-key").unwrap();
+        let err = svc.get(&test_ctx(), &key).await.unwrap_err();
+        assert!(
+            matches!(err, DomainError::Internal(_)),
+            "expected Internal, got: {err:?}"
+        );
+    }
+}

--- a/modules/credstore/credstore/src/domain/test_support.rs
+++ b/modules/credstore/credstore/src/domain/test_support.rs
@@ -1,0 +1,135 @@
+//! Shared test infrastructure for domain-layer unit tests.
+//!
+//! Provides `MockRegistry` and `MockPlugin` used by both `service` and
+//! `local_client` test modules.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use credstore_sdk::{
+    CredStoreError, CredStorePluginClientV1, SecretMetadata, SecretValue, SharingMode,
+};
+use modkit_security::SecurityContext;
+use types_registry_sdk::{
+    GtsEntity, ListQuery, RegisterResult, TypesRegistryClient, TypesRegistryError,
+};
+use uuid::Uuid;
+
+use credstore_sdk::SecretRef;
+
+// ── SecurityContext ───────────────────────────────────────────────────────────
+
+/// Build a minimal [`SecurityContext`] suitable for unit tests.
+///
+/// # Panics
+///
+/// Panics if the builder fails, which cannot happen with `Uuid::nil()` inputs.
+#[must_use]
+pub fn test_ctx() -> SecurityContext {
+    SecurityContext::builder()
+        .subject_id(Uuid::nil())
+        .subject_tenant_id(Uuid::nil())
+        .build()
+        .unwrap()
+}
+
+// ── MockRegistry ──────────────────────────────────────────────────────────────
+
+pub struct MockRegistry {
+    pub instances: Vec<GtsEntity>,
+    pub list_calls: AtomicUsize,
+    list_error: Option<TypesRegistryError>,
+}
+
+impl MockRegistry {
+    #[must_use]
+    pub fn new(instances: Vec<GtsEntity>) -> Self {
+        Self {
+            instances,
+            list_calls: AtomicUsize::new(0),
+            list_error: None,
+        }
+    }
+
+    #[must_use]
+    pub fn failing(err: TypesRegistryError) -> Self {
+        Self {
+            instances: vec![],
+            list_calls: AtomicUsize::new(0),
+            list_error: Some(err),
+        }
+    }
+}
+
+#[async_trait]
+impl TypesRegistryClient for MockRegistry {
+    async fn list(&self, _query: ListQuery) -> Result<Vec<GtsEntity>, TypesRegistryError> {
+        self.list_calls.fetch_add(1, Ordering::SeqCst);
+        if let Some(ref e) = self.list_error {
+            return Err(e.clone());
+        }
+        Ok(self.instances.clone())
+    }
+
+    async fn get(&self, gts_id: &str) -> Result<GtsEntity, TypesRegistryError> {
+        self.instances
+            .iter()
+            .find(|e| e.gts_id == gts_id)
+            .cloned()
+            .ok_or_else(|| TypesRegistryError::not_found(gts_id))
+    }
+
+    async fn register(
+        &self,
+        _entities: Vec<serde_json::Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
+        Ok(vec![])
+    }
+}
+
+// ── MockPlugin ────────────────────────────────────────────────────────────────
+
+type PluginFn = Arc<dyn Fn() -> Result<Option<SecretMetadata>, CredStoreError> + Send + Sync>;
+
+pub struct MockPlugin {
+    handler: PluginFn,
+}
+
+impl MockPlugin {
+    #[must_use]
+    pub fn returns(meta: Option<&SecretMetadata>) -> Arc<Self> {
+        let bytes = meta.map(|m| m.value.as_bytes().to_vec());
+        let owner_id = meta.map_or(Uuid::nil(), |m| m.owner_id);
+        let sharing = meta.map_or(SharingMode::Tenant, |m| m.sharing);
+        let owner_tenant_id = meta.map_or(Uuid::nil(), |m| m.owner_tenant_id);
+        Arc::new(Self {
+            handler: Arc::new(move || {
+                Ok(bytes.as_ref().map(|b| SecretMetadata {
+                    value: SecretValue::new(b.clone()),
+                    owner_id,
+                    sharing,
+                    owner_tenant_id,
+                }))
+            }),
+        })
+    }
+
+    #[must_use]
+    pub fn errors_internal(msg: &'static str) -> Arc<Self> {
+        Arc::new(Self {
+            handler: Arc::new(move || Err(CredStoreError::Internal(msg.into()))),
+        })
+    }
+}
+
+#[async_trait]
+impl CredStorePluginClientV1 for MockPlugin {
+    async fn get(
+        &self,
+        _ctx: &SecurityContext,
+        _key: &SecretRef,
+    ) -> Result<Option<SecretMetadata>, CredStoreError> {
+        (self.handler)()
+    }
+}


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#802](https://github.com/cyberfabric/cyberware-rust/pull/802) | **Author:** refur-nfn | **Opened:** 2026-02-28T13:06:04Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

Add tests across credstore-sdk and credstore crates covering previously untested code paths:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded unit/integration test coverage across the credential store: error mappings and formatting, config defaults/serde behavior, secret models (construction, serialization, redaction, conversions), local client and domain service flows (plugin/registry scenarios, caching, error propagation), and added reusable test-support helpers and mocks to streamline domain-layer testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#802 -->