### PR TITLE
[PR #739] Canonical Error Design Proposal

### DIFF
--- a/docs/arch/errors/ADR/0001-cpt-cf-adr-canonical-error-impl.md
+++ b/docs/arch/errors/ADR/0001-cpt-cf-adr-canonical-error-impl.md
@@ -1,0 +1,269 @@
+---
+status: accepted
+date: 2026-02-25
+decision-makers: Cyber Fabric Architects Committee
+---
+
+# ADR-0001: Canonical Error Enum with Category-Typed Constructors
+
+**ID**: `cpt-cf-adr-canonical-error-impl`
+
+## Context and Problem Statement
+
+The DESIGN document (`docs/arch/errors/DESIGN.md`) defines 16 canonical error categories with fixed context types as the universal error vocabulary. We need to decide how to
+represent these categories in Rust code, addressing four interrelated concerns: (1) the error type structure itself, (2) how module code constructs errors, (3) how errors map to
+RFC 9457 Problem at the REST boundary, and (4) how errors from underlying libraries (sqlx, sea-orm, serde, reqwest, SDK errors) convert into canonical errors.
+
+Without a canonical error type, each module would define its own ad-hoc error enum with module-specific variants, manual `From` impls for library errors, and a per-module mapping to
+wire formats. This produces inconsistent error shapes across modules, duplicated mapping boilerplate, and no compile-time guarantee that all errors reach the API layer in a canonical form.
+
+## Decision Drivers
+
+* **Single vocabulary**: every module must express errors through the same 16 categories; no module-specific error shapes should leak to API consumers
+* **Ergonomic construction**: creating a canonical error in domain code should be one line with no HTTP details
+* **Zero transport leakage**: domain code must never reference HTTP status codes, gRPC codes, or Problem fields
+* **Library error absorption**: the `?` operator must work to convert common library errors (anyhow, sqlx, serde_json, SDK errors) into canonical errors without manual match arms
+  in every call site
+* **Compile-time safety**: the Problem mapping must be exhaustive (adding a category forces handling the new variant) and the context type per category must be enforced by the type
+  system
+* **Minimal boilerplate**: a struct-per-error approach requiring 15-20 lines per error type is unacceptable
+
+## Considered Options
+
+* Option A: Single `CanonicalError` enum with category-typed variants
+* Option B: Struct-per-error with error trait
+* Option C: Trait object (`Box<dyn CanonicalError>`) with category method
+
+## Decision Outcome
+
+Chosen option: "Option A — Single `CanonicalError` enum with category-typed variants", because it is the only option that provides exhaustive match safety, zero-boilerplate
+construction, a single `From<CanonicalError> for Problem` implementation, and natural `From` impls for library errors, while keeping the total error surface to one enum and a
+handful of context structs.
+
+### Consequences
+
+**Advantages**:
+
+* One `From<CanonicalError> for Problem` impl covers all modules (no per-module mapping needed)
+* Adding a new category is a compiler error everywhere that matches on `CanonicalError` (exhaustive match)
+* `UserResourceError::not_found(id)` is one line, no HTTP details
+* Library errors convert via blanket `From` impls (e.g., `From<anyhow::Error>` maps to `Internal`)
+
+**Disadvantages**:
+
+* All 16 variants live in one enum, which is larger than a single struct (but enum size is bounded by the largest variant, and context types are small)
+* `ErrorInfo.metadata` (HashMap) requires heap allocation, unlike the other context types which are stack-only
+
+### Confirmation
+
+* Code review: every module handler returns `ApiResult<T>` where `ApiResult = Result<T, CanonicalError>`, not `Result<T, Problem>`
+* Compile-time: the `From<CanonicalError> for Problem` match is exhaustive; CI will fail if a category is added without a mapping
+* Lint: a custom clippy lint (or `#[deny(unreachable_patterns)]`) verifies that no module constructs a `Problem` directly, bypassing the canonical path
+
+## Advantages and Disadvantages of the Options
+
+### Option A: Single `CanonicalError` enum with category-typed variants
+
+A single Rust enum with 16 variants, each carrying its category-specific context struct. Construction via associated functions (`CanonicalError::not_found(...)`,
+`CanonicalError::invalid_argument(...)`). A single `From<CanonicalError> for Problem` impl in `modkit-errors` handles the complete REST mapping. Library error absorption via
+`From<T> for CanonicalError` impls.
+
+**Error type structure**:
+
+```rust
+enum CanonicalError {
+    NotFound { ctx: ResourceInfo, message: String, resource_type: Option<String> },
+    InvalidArgument { ctx: Validation, message: String, resource_type: Option<String> },
+    Internal { ctx: DebugInfo, message: String, resource_type: Option<String> },
+    // ... 13 more variants (including ServiceUnavailable, not Unavailable)
+}
+```
+
+**Error creation in module code**:
+
+```rust
+// Resource-scoped errors (via macro-declared types):
+// Declared via attribute macro — generates typed constructors:
+#[resource_error("gts.cf.core.upstreams.upstream.v1")]
+struct UpstreamResourceError;
+
+UpstreamResourceError::not_found(id)
+UpstreamResourceError::already_exists(alias)
+UpstreamResourceError::invalid_argument(Validation::field("alias", "must not be empty"))
+
+// Non-resource errors (direct construction):
+CanonicalError::invalid_argument(Validation::format("request body is not valid JSON"))
+CanonicalError::internal(e)  // blanket From<impl Display>
+```
+
+**Problem mapping** (one impl for all modules):
+
+```rust
+impl From<CanonicalError> for Problem {
+    fn from(err: CanonicalError) -> Self {
+        let (status, title) = match &err {
+            CanonicalError::NotFound { .. } => (404, "Not Found"),
+            CanonicalError::InvalidArgument { .. } => (400, "Invalid Argument"),
+            // ... exhaustive match
+        };
+        Problem::new(status, title, err.message())
+            .with_type(err.gts_type())
+            .with_context(err.context_json())
+    }
+}
+```
+
+**Library error conversion** (blanket impls in `modkit-errors`):
+
+```rust
+impl From<anyhow::Error> for CanonicalError { ... => Internal }
+impl From<serde_json::Error> for CanonicalError { ... => InvalidArgument }
+impl From<sea_orm::DbErr> for CanonicalError { ... => Internal }
+```
+
+**Advantages**:
+
+* Exhaustive match in `From<CanonicalError> for Problem` catches missing mappings at compile time
+* One-line construction: `UpstreamResourceError::not_found(id)`
+* A single `From` impl covers all modules (no per-module mapping needed)
+* Blanket `From` impls for common library errors eliminate repetitive `map_err` calls
+* `message` is a common field across all variants, not duplicated
+* The enum is `Send + Sync + 'static` with no trait objects
+
+**Trade-offs**:
+
+* The enum has 16 variants, which is large but bounded and well-documented
+
+**Disadvantages**:
+
+* `ErrorInfo.metadata` (HashMap) forces a heap allocation even for simple permission errors
+* Adding a 17th category (unlikely but possible) touches the enum, all match arms, and the Problem mapping
+
+### Option B: Struct-per-error with error trait
+
+Each error is a standalone Rust struct implementing an `ErrorSchema` trait with `STATUS` and `TITLE` constants. The error-to-Problem conversion is per-struct via `into_problem()`.
+
+**Error type structure**:
+
+```rust
+struct UserNotFound {
+    r#type: String,
+    resource_name: String,
+}
+
+impl ErrorSchema for UserNotFound {
+    const STATUS: u16 = 404;
+    const TITLE: &'static str = "Not Found";
+    const SCHEMA_ID: &'static str = "gts.cf.core.errors.err.v1~cf.core.errors.not_found.v1~";
+}
+```
+
+**Error creation**:
+
+```rust
+return Err(UserNotFound { r#type: "gts.cf.core.users.user.v1".into(), resource_name: id.to_string() }.into());
+```
+
+**Problem mapping**: each struct implements `ErrorSchema::into_problem(&self) -> Problem`.
+
+**Library error conversion**: no blanket impls; each module manually wraps library errors into specific struct instances.
+
+**Advantages**:
+
+* Each error is self-contained with its own schema
+* Adding a new error requires no changes to existing code
+
+**Disadvantages**:
+
+* 15-20 lines of boilerplate per error type (struct + trait impl)
+* No exhaustive match — impossible to verify all errors are handled
+* No blanket `From` impls for library errors; every module manually maps each library error
+* `STATUS: u16` embeds HTTP details in domain code (violates transport agnosticism)
+* The `Problem` mapping is scattered across dozens of `impl ErrorSchema` blocks instead of one central location
+
+### Option C: Trait object (`Box<dyn CanonicalError>`) with category method
+
+A trait `CanonicalError` with `fn category(&self) -> Category` and `fn context(&self) -> ContextValue`. Errors are `Box<dyn CanonicalError>`. Modules implement the trait for their
+own error types.
+
+**Error type structure**:
+
+```rust
+trait CanonicalError: Error + Send + Sync {
+    fn category(&self) -> Category;
+    fn context(&self) -> ContextValue;
+    fn message(&self) -> &str;
+}
+```
+
+**Error creation** (raw, without helpers):
+
+```rust
+return Err(Box::new(MyNotFoundError { r#type: "gts.cf.core.users.user.v1", id }) as Box<dyn CanonicalError>);
+```
+
+With `From` impls for each concrete error type, the `?` operator and `.into()` shorten this:
+
+```rust
+// Requires: impl From<MyNotFoundError> for Box<dyn CanonicalError>
+return Err(MyNotFoundError { r#type: "gts.cf.core.users.user.v1", id }.into());
+```
+
+A helper constructor on the trait object could reduce it further:
+
+```rust
+// Hypothetical convenience function:
+fn not_found(r#type: &str, id: impl Display) -> Box<dyn CanonicalError> { ... }
+
+return Err(not_found("gts.cf.core.users.user.v1", id));
+```
+
+However, each of these ergonomic layers requires additional boilerplate elsewhere: a `From` impl per concrete error type, or free-standing constructor functions that duplicate what the enum constructors in Option A provide natively.
+
+**Problem mapping**: one `From<Box<dyn CanonicalError>> for Problem` impl that dispatches on `category()`.
+
+**Library error conversion**: wrapper structs that implement `CanonicalError` for each library error type.
+
+**Advantages**:
+
+* Modules can define their own error structs while conforming to the category contract
+* Extensible without modifying the trait
+
+**Disadvantages**:
+
+* `Box<dyn>` heap-allocates every error (even simple ones like `NotFound`)
+* No compile-time exhaustiveness — a module can return any category from any type
+* `category()` returns a runtime value, not enforced by the type system
+* `?` operator requires `From` impls for `Box<dyn CanonicalError>` which are awkward
+* The `CanonicalError` trait would collide with `std::error::Error` trait in scope
+
+## More Information
+
+**Library error blanket impls**:
+
+The following `From` impls ship with `modkit-errors` out of the box:
+
+| Library Type        | Maps To           | Rationale                                                                                                                                       |
+|---------------------|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `anyhow::Error`     | `Internal`        | Untyped errors are internal by definition                                                                                                       |
+| `sea_orm::DbErr`    | `Internal`        | Database errors are infrastructure failures                                                                                                     |
+| `sqlx::Error`       | `Internal`        | Database driver errors are infrastructure failures                                                                                              |
+| `serde_json::Error` | `InvalidArgument` | Serialization failures indicate malformed input (at API boundary) or internal bugs (in domain) — callers can override via explicit construction |
+| `std::io::Error`    | `Internal`        | IO failures are infrastructure errors                                                                                                           |
+
+Modules that need finer-grained mapping (e.g., `sqlx::Error::RowNotFound` → `NotFound`) implement their own `From` instead of relying on the blanket.
+
+## Traceability
+
+- **DESIGN**: [DESIGN.md](../DESIGN.md)
+
+This decision directly addresses the following design elements:
+
+* `cpt-cf-principle-transport-agnosticism` — Option A keeps HTTP/gRPC details out of the enum; transport mapping is in one `From` impl at the boundary
+* `cpt-cf-principle-single-error-gateway` — The `CanonicalError` enum is the single type accepted by API layers
+* `cpt-cf-principle-fixed-context-structures` — Each enum variant carries exactly one context type, enforced by the type system
+* `cpt-cf-principle-fail-safe-fallback` — Blanket `From` impls for library errors ensure unhandled errors map to `Internal`
+* `cpt-cf-constraint-gts-code-format` — GTS identifiers are compile-time constants derived from the variant name
+* `cpt-cf-constraint-macro-gts-construction` — Resource types declared via attribute macros with compile-time GTS format validation
+* `cpt-cf-component-canonical-error` — This ADR defines the implementation approach for this component
+* `cpt-cf-component-rest-mapping` — One exhaustive `From<CanonicalError> for Problem` impl covers all modules

--- a/docs/arch/errors/DESIGN.md
+++ b/docs/arch/errors/DESIGN.md
@@ -1,0 +1,872 @@
+# Technical Design — Universal Error Architecture
+
+## 1. Architecture Overview
+
+### 1.1 Architectural Vision
+
+CyberFabric adopts a transport-agnostic error model inspired by Google's canonical error codes (gRPC status codes). Every error produced anywhere in the platform is expressed as
+one of 16 canonical categories (excluding OK). Each category carries a fixed-structure context payload that describes the error in a machine-readable way. No domain code references
+HTTP status codes, gRPC codes, or any transport-specific detail.
+
+The error categories are the single gateway between business logic and API layers. Modules construct a canonical error with its category-specific context. The API boundary (REST,
+gRPC, SSE) maps that canonical error to the appropriate wire format: RFC 9457 Problem Details for REST, `google.rpc.Status` for gRPC (future), or a JSON event for SSE (future).
+
+This design replaces module-specific ad-hoc error enums with a universal vocabulary. The GTS type system assigns each category a stable, globally unique identifier. Structured
+context types (Validation, ResourceInfo, ErrorInfo, etc.) ensure that every error response carries precisely the metadata consumers need, in a predictable shape, with no risk of
+leaking internal details.
+
+### 1.2 Architecture Drivers
+
+#### Functional Drivers
+
+This is a cross-cutting platform design. Drivers are derived from the [PRD](./PRD.md) and platform-wide concerns.
+
+| Driver                                       | PRD Requirement                             | Design Response                                  |
+|----------------------------------------------|---------------------------------------------|--------------------------------------------------|
+| Consistent error expression across modules   | `cpt-cf-fr-single-error-vocabulary`         | 16 canonical categories with GTS identifiers     |
+| Machine-readable error details for consumers | `cpt-cf-fr-machine-readable-context`        | Fixed context structures per category            |
+| Clean mapping to REST and gRPC wire formats  | `cpt-cf-fr-transport-agnostic-construction` | Transport-specific mapping at the boundary       |
+| Trace correlation in error responses         | `cpt-cf-fr-trace-correlation`               | `trace_id` propagated from request context       |
+| Low-boilerplate error construction           | `cpt-cf-fr-library-error-absorption`        | Typed constructors; blanket `From` impls         |
+| No internal detail leakage                   | `cpt-cf-fr-no-internal-details`             | Fixed fields; `DebugInfo` stripped in production |
+| Error contract as public API surface         | `cpt-cf-fr-error-contract-api-surface`      | Compile-time, snapshots, and semver enforcement  |
+| Catch accidental changes before merge        | `cpt-cf-fr-accidental-change-protection`    | Exhaustive match, snapshots, semver CI gate      |
+
+#### NFR Allocation
+
+| NFR                                    | Design Response                                 | Verification                                   |
+|----------------------------------------|-------------------------------------------------|------------------------------------------------|
+| Consistency: same shape across modules | `CanonicalError` enum + typed contexts only     | Compile: handlers accept only `CanonicalError` |
+| Observability: every error traceable   | `trace_id` from span context on every response  | Integration tests verify `trace_id` presence   |
+| Performance: negligible overhead       | No heap allocation for category selection       | Benchmarks measure error path latency          |
+| Security: no internals in production   | Stack entries stripped; opaque message returned | Security tests verify no stack traces          |
+
+#### Key ADRs
+
+This design supersedes the approach proposed in PR #290. The following ADR defines the implementation approach:
+
+| ADR                                                                                | Summary                                                      |
+|------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| [`cpt-cf-adr-canonical-error-impl`](./ADR/0001-cpt-cf-adr-canonical-error-impl.md) | Typed-variant enum; exhaustive mapping; blanket `From` impls |
+
+### 1.3 Architecture Layers
+
+```text
+Module Domain Logic
+        |
+        v
+CanonicalError { category, message, context, trace_id }
+        |
+        +-------> REST boundary:  CanonicalError -> Problem (RFC 9457)
+        +-------> gRPC boundary:  CanonicalError -> google.rpc.Status (future)
+        +-------> SSE boundary:   CanonicalError -> JSON error event (future)
+```
+
+| Layer                 | Responsibility                                      | Technology                                              |
+|-----------------------|-----------------------------------------------------|---------------------------------------------------------|
+| Domain                | Construct canonical errors from business logic      | `CanonicalError` enum, context structs                  |
+| Error Catalog         | Assign GTS identifiers to categories                | GTS type URIs, compile-time constants                   |
+| REST Mapping          | Convert canonical errors to RFC 9457 Problem        | `From<CanonicalError> for Problem`, Axum `IntoResponse` |
+| gRPC Mapping (future) | Convert canonical errors to gRPC Status             | `From<CanonicalError> for tonic::Status`                |
+| Middleware            | Enrich errors with trace ID, catch unhandled errors | `error_mapping_middleware`                              |
+
+## 2. Principles & Constraints
+
+### 2.1 Design Principles
+
+#### Transport Agnosticism
+
+- [ ] `p1` - **ID**: `cpt-cf-principle-transport-agnosticism`
+
+Domain and SDK code never references HTTP status codes, gRPC codes, or any wire-format detail. The canonical error categories are the only error vocabulary available to business
+logic. Transport-specific mapping happens exclusively at the API boundary.
+
+#### Single Error Gateway
+
+- [ ] `p1` - **ID**: `cpt-cf-principle-single-error-gateway`
+
+The `CanonicalError` type is the only error type accepted by API layers. There is no alternative path for returning errors. This eliminates inconsistent error formats across
+modules and ensures every error response follows the same structure.
+
+#### Fixed Context Structures
+
+- [ ] `p1` - **ID**: `cpt-cf-principle-fixed-context-structures`
+
+Each canonical category has exactly one associated context type with a fixed set of fields. This prevents ad-hoc metadata keys, ensures consumers can parse error details without
+guessing, and makes the error surface auditable at compile time.
+
+#### Catalog-First
+
+- [ ] `p2` - **ID**: `cpt-cf-principle-catalog-first`
+
+Every canonical category has a GTS identifier assigned before any code is written. The catalog is the source of truth for error codes.
+
+#### Fail-Safe Fallback
+
+- [ ] `p2` - **ID**: `cpt-cf-principle-fail-safe-fallback`
+
+Any error that does not match a canonical category is mapped to `internal` with a trace ID. The error middleware catches panics, unhandled rejections, and unknown error types,
+wrapping them as `internal` errors. No error escapes the system without a canonical category.
+
+### 2.2 Constraints
+
+#### RFC 9457 Compliance
+
+- [ ] `p1` - **ID**: `cpt-cf-constraint-rfc9457`
+
+All REST error responses use `Content-Type: application/problem+json` and include the RFC 9457 fields: `type`, `title`, `status`, `detail`, and `instance`. The `type` field carries
+the GTS URI for the error category.
+
+#### GTS Code Format
+
+- [ ] `p1` - **ID**: `cpt-cf-constraint-gts-code-format`
+
+Error category GTS identifiers use the compound GTS type format: `gts.cf.core.errors.err.v1~cf.core.errors.{category}.v1~` where `{category}` is the lowercase canonical category
+name (e.g., `not_found`, `invalid_argument`). The `err.v1` prefix identifies the base error schema and the `~` separator is part of the GTS compound type syntax.
+
+#### No Internal Details in Production
+
+- [ ] `p1` - **ID**: `cpt-cf-constraint-no-internal-details`
+
+`DebugInfo.stack_entries` is populated only when the application runs in debug mode. In production, `internal` and `unknown` errors return an opaque message with a `trace_id` for
+correlation. The `detail` field for `internal` errors contains a generic message, never exception text or stack traces.
+
+#### Error Contract Stability
+
+- [ ] `p1` - **ID**: `cpt-cf-constraint-error-contract-stability`
+
+Every error response consists of **contract parts** (fixed per category) and **variable parts** (per-occurrence). The contract parts — canonical category, context type schema (
+field names and types), GTS identifier, HTTP status code, and title — are part of the public API surface. Changes to contract parts follow the same breaking change policy as
+endpoint signature changes. Variable parts — `detail` message, `instance` path, `trace_id`, and context field values — are not part of the contract and may change freely.
+Specifically:
+
+**Breaking changes** (require major version bump of `cf-modkit-errors`):
+
+- Removing or renaming a canonical category
+- Changing the context type associated with a category
+- Removing or renaming a field in a context type schema
+- Changing the type of a field in a context type schema
+- Changing the GTS identifier of a category
+- Changing the HTTP status code mapped to a category
+
+**Non-breaking changes** (minor version):
+
+- Adding a new optional field to a context type
+- Adding a new canonical category
+
+**Enforcement mechanisms**:
+
+- Exhaustive match on `CanonicalError` enum produces compile errors when categories change
+- Macro-based GTS construction prevents GTS identifier typos and drift (see `cpt-cf-constraint-macro-gts-construction`)
+- Snapshot tests capture the JSON shape of error responses per category; changes require explicit acknowledgment
+- Semver compatibility checks on `cf-modkit-errors` detect breaking changes to public types before merge
+
+#### Macro-Based GTS Construction
+
+- [ ] `p1` - **ID**: `cpt-cf-constraint-macro-gts-construction`
+
+Resource types **must** be declared via attribute macros that associate a GTS identifier with a named type. The macro:
+
+1. **Validates the GTS format at compile time** — rejects strings that do not match the `gts.{prefix}.{path}.v{N}` pattern
+2. **Generates error constructors for 15 canonical categories** — the declared resource type becomes the primary entry point for constructing any error scoped to that resource. The
+   macro generates all categories except `service_unavailable`, which is exclusively a system-level error.
+3. **Tags every generated constructor with `resource_type`** — each generated function calls `.with_resource_type(gts_type)` on the resulting `CanonicalError`, ensuring the
+   resource identity is carried through to the Problem response
+
+**Declaration** (once per resource type, in the module):
+
+```rust
+#[resource_error("gts.cf.core.users.user.v1")]
+struct UserResourceError;
+```
+
+**Usage** (at error sites):
+
+```rust
+// ResourceInfo categories — GTS type baked into the context:
+UserResourceError::not_found(user_id)
+UserResourceError::already_exists(email)
+
+// Other categories — context provided explicitly, resource identity carried by the macro:
+UserResourceError::invalid_argument(Validation::fields([
+FieldViolation::new("email", "must be a valid email address", "INVALID_FORMAT"),
+]))
+UserResourceError::permission_denied(ErrorInfo::new("CROSS_TENANT_ACCESS", "auth.cyberfabric.io"))
+UserResourceError::failed_precondition(PreconditionFailure::new([
+PreconditionViolation::new("STATE", "user.status", "User must be active"),
+]))
+```
+
+For `not_found`, `already_exists`, and `data_loss`, the macro generates a `ResourceInfo` context with the GTS type baked in. For all other generated categories, the macro wraps
+the caller-provided context in a `CanonicalError` and calls `.with_resource_type(gts_type)`. This injects the resource identity into the `context` field of the Problem response,
+allowing consumers to identify which resource an error relates to regardless of the error category. When a direct constructor (`CanonicalError::category(...)`) is used,
+`resource_type` is absent from the context.
+
+**Non-resource errors** (not scoped to a specific resource) use direct `CanonicalError::` constructors:
+
+```rust
+// System-level errors:
+CanonicalError::service_unavailable(RetryInfo::after_seconds(30))
+
+// Malformed request body (no resource context):
+CanonicalError::invalid_argument(Validation::format("request body is not valid JSON"))
+```
+
+Note: categories like `unauthenticated`, `resource_exhausted`, and `unknown` can also be constructed via the macro (which adds `resource_type`) or directly (which omits it),
+depending on whether the error is scoped to a specific resource.
+
+This constraint applies to all context type fields that carry GTS identifiers. Currently, `ResourceInfo.resource_type` is the only such field. `PreconditionViolation.type` (which
+carries free-form precondition categories like `STATE`, `TOS`) is not a GTS identifier and is not subject to this constraint.
+
+## 3. Technical Architecture
+
+### 3.1 Domain Model
+
+**Technology**: Rust enums and structs
+
+**Location**: `libs/modkit-errors/src/`
+
+**Core Entities**:
+
+> All types in `libs/modkit-errors/src/` — `CanonicalError` in `canonical.rs`, all others in `context.rs`. Context types use versioned names (`XxxV1`) with
+> unversioned aliases (`pub type Xxx = XxxV1;`).
+
+| Entity                  | Description                                                                             |
+|-------------------------|-----------------------------------------------------------------------------------------|
+| `CanonicalError`        | Enum with 16 variants, each carrying its category-specific context                      |
+| `Validation`            | Context for `invalid_argument` and `out_of_range`                                       |
+| `FieldViolation`        | Single field validation error within `Validation`                                       |
+| `ResourceInfo`          | Context for `not_found`, `already_exists`, `data_loss`                                  |
+| `ErrorInfo`             | Context for `permission_denied`, `aborted`, `unimplemented`, `unauthenticated`          |
+| `QuotaFailure`          | Context for `resource_exhausted`                                                        |
+| `QuotaViolation`        | Single quota violation within `QuotaFailure`                                            |
+| `PreconditionFailure`   | Context for `failed_precondition`                                                       |
+| `PreconditionViolation` | Single precondition violation within `PreconditionFailure`                              |
+| `DebugInfo`             | Context for `unknown` and `internal`; optional on any category via `.with_debug_info()` |
+| `RetryInfo`             | Context for `service_unavailable`; optionally embedded in `QuotaFailure`                |
+
+**Relationships**:
+
+- `CanonicalError` contains exactly one context type per variant
+- `Validation` contains one or more `FieldViolation` entries
+- `QuotaFailure` contains one or more `QuotaViolation` entries
+- `PreconditionFailure` contains one or more `PreconditionViolation` entries
+- All context types are self-contained value objects with no external dependencies
+
+### 3.2 Component Model
+
+```text
++------------------------------------------------------------------+
+|                       Module Domain Logic                         |
+|  (constructs CanonicalError with category + context)              |
++------------------------------------------------------------------+
+        |
+        v
++------------------------------------------------------------------+
+|                     CanonicalError Enum                           |
+|  libs/modkit-errors/src/canonical.rs                              |
+|                                                                   |
+|  Variants (struct-style, each has ctx + message + resource_type  |
+|            + debug_info):                                        |
+|    Cancelled { message: String, ... }                             |
+|    Unknown { ctx: DebugInfo, ... }                                |
+|    InvalidArgument { ctx: Validation, ... }                       |
+|    DeadlineExceeded { message: String, ... }                      |
+|    NotFound { ctx: ResourceInfo, ... }                            |
+|    AlreadyExists { ctx: ResourceInfo, ... }                       |
+|    PermissionDenied { ctx: ErrorInfo, ... }                       |
+|    ResourceExhausted { ctx: QuotaFailure, ... }                   |
+|    FailedPrecondition { ctx: PreconditionFailure, ... }           |
+|    Aborted { ctx: ErrorInfo, ... }                                |
+|    OutOfRange { ctx: Validation, ... }                            |
+|    Unimplemented { ctx: ErrorInfo, ... }                          |
+|    Internal { ctx: DebugInfo, ... }                               |
+|    ServiceUnavailable { ctx: RetryInfo, ... }                     |
+|    DataLoss { ctx: ResourceInfo, ... }                            |
+|    Unauthenticated { ctx: ErrorInfo, ... }                        |
++------------------------------------------------------------------+
+        |                                    |
+        v                                    v
++-------------------------+    +---------------------------+
+|    REST Mapping Layer   |    |   gRPC Mapping Layer      |
+|  libs/modkit-errors/    |    |   (future)                |
+|  src/problem.rs         |    |                           |
+|                         |    |  CanonicalError           |
+|  CanonicalError         |    |    -> tonic::Status       |
+|    -> Problem (RFC9457) |    |    + detail messages      |
++-------------------------+    +---------------------------+
+        |                                    |
+        v                                    v
++-------------------------+    +---------------------------+
+|  Axum IntoResponse      |    |  tonic IntoResponse       |
+|  application/            |    |  gRPC trailers            |
+|    problem+json          |    |  (future)                 |
++-------------------------+    +---------------------------+
+```
+
+#### Construction Paths
+
+Two entry points converge into the same `CanonicalError` type. Resource-scoped construction (via `#[resource_error]` macro) automatically tags every error with the resource's GTS
+identity. Non-resource construction uses `CanonicalError::` directly, with no resource identity attached. Both paths produce the same enum, which then maps to any transport
+representation.
+
+```text
+ Resource-scoped construction              Non-resource construction
+ ─────────────────────────────             ──────────────────────────
+ #[resource_error("gts...")]               CanonicalError::category(ctx)
+ UserResourceError::not_found(id)          CanonicalError::service_unavailable(...)
+ UserResourceError::permission_denied(ei)  CanonicalError::invalid_argument(...)
+         │                                          │
+         │  .with_resource_type(gts) auto           │  resource_type = None
+         └──────────────┬───────────────────────────┘
+                        │
+                        v
+              ┌─────────────────┐
+              │  CanonicalError  │
+              │  (16 variants)   │
+              └────────┬────────┘
+                       │
+          ┌────────────┼────────────┐
+          v            v            v
+    Problem(REST)  Status(gRPC)  Event(SSE)
+      RFC 9457      (future)     (future)
+```
+
+#### CanonicalError
+
+- [ ] `p1` - **ID**: `cpt-cf-component-canonical-error`
+
+##### Why this component exists
+
+Provides a single, universal error type that all modules use to express failures. Eliminates per-module ad-hoc error enums and ensures every error has a category and structured
+context.
+
+##### Responsibility scope
+
+Owns the 16 canonical error categories. Owns the mapping from category to GTS identifier. Each variant is a struct with three fields: `ctx` (category-specific context type),
+`message: String` (human-readable detail with a sensible default per category), `resource_type: Option<String>` (set by macro-generated constructors, `None` for direct
+constructors), and `debug_info: Option<DebugInfo>` (optional diagnostic context, attached post-construction via builder, `None` by default). Provides ergonomic constructors (one
+per category), builder methods (`with_message()`, `with_resource_type()`, `with_debug_info()`), and accessors (`message()`, `resource_type()`, `debug_info()`,
+`gts_type()`, `status_code()`, `title()`). The `unknown()` constructor is a convenience that takes `impl Into<String>` and wraps it in `DebugInfo` internally. Provides blanket
+`From` implementations for common library error types (`anyhow::Error`, `sea_orm::DbErr`, `sqlx::Error`, `serde_json::Error`, `std::io::Error`) so that the `?` operator propagates
+library errors into canonical categories without per-call-site mapping.
+
+##### Responsibility boundaries
+
+Does not know about HTTP, gRPC, or any transport. Does not perform serialization. Does not enrich errors with trace IDs (that is the middleware's job).
+
+##### Related components (by ID)
+
+- `cpt-cf-component-context-types` — provides the context structs carried by each variant
+- `cpt-cf-component-rest-mapping` — consumes `CanonicalError` and produces `Problem`
+- `cpt-cf-component-error-middleware` — catches unhandled errors and wraps them as `CanonicalError`
+
+#### Context Types
+
+- [ ] `p1` - **ID**: `cpt-cf-component-context-types`
+
+##### Why this component exists
+
+Each canonical category needs structured metadata that consumers can parse predictably. Context types provide fixed-schema payloads per category, following Google's error detail
+model.
+
+##### Responsibility scope
+
+Defines `Validation`, `ResourceInfo`, `ErrorInfo`, `QuotaFailure`, `PreconditionFailure`, `DebugInfo`, and `RetryInfo` structs. All context types use versioned
+naming (`XxxV1`) with unversioned type aliases (e.g., `pub type ResourceInfo = ResourceInfoV1;`) to support future schema evolution. Each struct has a fixed set of public fields
+and provides builder/constructor methods for ergonomic construction. All context types implement the `GtsSchema` trait (via `#[struct_to_gts_schema]` macro) and carry an internal
+`gts_type: GtsSchemaId` field that is skipped during serialization.
+
+##### Responsibility boundaries
+
+Context types are pure data. They do not perform validation, logging, or transport mapping. GTS format validation is performed at compile time by the attribute macro, not at
+runtime by the context type itself.
+
+##### Related components (by ID)
+
+- `cpt-cf-component-canonical-error` — uses context types as variant payloads
+
+#### REST Mapping Layer
+
+- [ ] `p1` - **ID**: `cpt-cf-component-rest-mapping`
+
+##### Why this component exists
+
+The REST API boundary must convert `CanonicalError` into RFC 9457 Problem Details responses. This component owns the category-to-HTTP-status mapping and the serialization of
+context types into the Problem response body.
+
+##### Responsibility scope
+
+Implements `From<CanonicalError> for Problem` and `Problem::from_error(err)` (production mode — omits debug info) and `Problem::from_error_debug(err)` (debug mode — includes debug
+info if present as a top-level `"debug"` key, sibling to `context`). Maps each category to its HTTP status code. Serializes context type fields into the Problem `context` field.
+Sets the `type` field to the GTS URI.
+
+##### Responsibility boundaries
+
+Does not construct canonical errors. Does not handle gRPC or SSE mapping.
+
+##### Related components (by ID)
+
+- `cpt-cf-component-canonical-error` — the input type
+- `cpt-cf-component-error-middleware` — invokes this mapping for unhandled errors
+
+#### Error Middleware
+
+- [ ] `p2` - **ID**: `cpt-cf-component-error-middleware`
+
+##### Why this component exists
+
+Not all errors reach the API handler in canonical form. Panics and framework errors need a catch-all layer that ensures every HTTP response is a well-formed Problem.
+
+##### Responsibility scope
+
+Catches unhandled errors and maps them to `CanonicalError::Internal`. Enriches all error responses with `trace_id` from the request context.
+
+##### Responsibility boundaries
+
+Does not construct domain-specific errors. Does not modify errors that are already canonical.
+
+##### Related components (by ID)
+
+- `cpt-cf-component-rest-mapping` — delegates to for `CanonicalError` to `Problem` conversion
+- `cpt-cf-component-canonical-error` — wraps unhandled errors as `Internal` variant
+
+#### GTS Error Catalog
+
+- [ ] `p2` - **ID**: `cpt-cf-component-gts-catalog`
+
+##### Why this component exists
+
+Each canonical category needs a stable, globally unique GTS identifier for the `type` field in error responses and for cross-system error correlation.
+
+##### Responsibility scope
+
+Defines the 16 GTS identifiers as compile-time constants. Provides lookup from category enum variant to GTS URI string.
+
+##### Responsibility boundaries
+
+Does not define context types or transport mappings. The catalog is a static mapping.
+
+##### Related components (by ID)
+
+- `cpt-cf-component-canonical-error` — uses catalog constants for GTS type URIs
+- `cpt-cf-component-rest-mapping` — reads GTS URI for the Problem `type` field
+
+### 3.3 API Contracts
+
+**Technology**: REST/JSON (RFC 9457)
+
+#### Canonical Error Categories
+
+- [ ] `p1` - **ID**: `cpt-cf-interface-canonical-categories`
+
+**Technology**: Rust enum (internal), JSON (wire)
+
+The 16 canonical error categories, their GTS identifiers, associated context types, and HTTP status mappings:
+
+| #  | Category              | GTS Identifier                                                     | Context Type          | HTTP Status |
+|----|-----------------------|--------------------------------------------------------------------|-----------------------|-------------|
+| 1  | `cancelled`           | `gts.cf.core.errors.err.v1~cf.core.errors.cancelled.v1~`           | `String` (message)    | 499         |
+| 2  | `unknown`             | `gts.cf.core.errors.err.v1~cf.core.errors.unknown.v1~`             | `DebugInfo`           | 500         |
+| 3  | `invalid_argument`    | `gts.cf.core.errors.err.v1~cf.core.errors.invalid_argument.v1~`    | `Validation`          | 400         |
+| 4  | `deadline_exceeded`   | `gts.cf.core.errors.err.v1~cf.core.errors.deadline_exceeded.v1~`   | `String` (message)    | 504         |
+| 5  | `not_found`           | `gts.cf.core.errors.err.v1~cf.core.errors.not_found.v1~`           | `ResourceInfo`        | 404         |
+| 6  | `already_exists`      | `gts.cf.core.errors.err.v1~cf.core.errors.already_exists.v1~`      | `ResourceInfo`        | 409         |
+| 7  | `permission_denied`   | `gts.cf.core.errors.err.v1~cf.core.errors.permission_denied.v1~`   | `ErrorInfo`           | 403         |
+| 8  | `resource_exhausted`  | `gts.cf.core.errors.err.v1~cf.core.errors.resource_exhausted.v1~`  | `QuotaFailure`        | 429         |
+| 9  | `failed_precondition` | `gts.cf.core.errors.err.v1~cf.core.errors.failed_precondition.v1~` | `PreconditionFailure` | 400         |
+| 10 | `aborted`             | `gts.cf.core.errors.err.v1~cf.core.errors.aborted.v1~`             | `ErrorInfo`           | 409         |
+| 11 | `out_of_range`        | `gts.cf.core.errors.err.v1~cf.core.errors.out_of_range.v1~`        | `Validation`          | 400         |
+| 12 | `unimplemented`       | `gts.cf.core.errors.err.v1~cf.core.errors.unimplemented.v1~`       | `ErrorInfo`           | 501         |
+| 13 | `internal`            | `gts.cf.core.errors.err.v1~cf.core.errors.internal.v1~`            | `DebugInfo`           | 500         |
+| 14 | `service_unavailable` | `gts.cf.core.errors.err.v1~cf.core.errors.service_unavailable.v1~` | `RetryInfo`           | 503         |
+| 15 | `data_loss`           | `gts.cf.core.errors.err.v1~cf.core.errors.data_loss.v1~`           | `ResourceInfo`        | 500         |
+| 16 | `unauthenticated`     | `gts.cf.core.errors.err.v1~cf.core.errors.unauthenticated.v1~`     | `ErrorInfo`           | 401         |
+
+#### Context Type Schemas
+
+- [ ] `p1` - **ID**: `cpt-cf-interface-context-schemas`
+
+**Technology**: Rust structs and enums (internal), JSON (wire)
+
+**Validation** (enum) — used by `invalid_argument`, `out_of_range`:
+
+| Variant           | Payload               | Use Case                                                       |
+|-------------------|-----------------------|----------------------------------------------------------------|
+| `FieldViolations` | `Vec<FieldViolation>` | One or more fields failed validation                           |
+| `Format`          | `String`              | Request body is malformed (e.g., invalid JSON, wrong encoding) |
+| `Constraint`      | `String`              | A general constraint was violated (not field-specific)         |
+
+**FieldViolation**:
+
+| Field         | Type     | Description                                                                                                                                                                                |
+|---------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `field`       | `String` | XPath-style dot-separated path to the invalid field, with bracket notation for array indices (e.g., `user.email`, `items[0].name`). Extensions to the path syntax require a design change. |
+| `description` | `String` | Human-readable explanation of why the field is invalid                                                                                                                                     |
+| `reason`      | `String` | Machine-readable reason code, UPPER_SNAKE_CASE (e.g., `INVALID_FORMAT`)                                                                                                                    |
+
+**ResourceInfo** — used by `not_found`, `already_exists`, `data_loss`:
+
+| Field           | Type     | Description                                                          |
+|-----------------|----------|----------------------------------------------------------------------|
+| `resource_type` | `String` | GTS URI (e.g., `gts.cf.core.users.user.v1`). Set by macro or caller. |
+| `resource_name` | `String` | Identifier of the resource (e.g., UUID, name)                        |
+| `description`   | `String` | Human-readable context about the error                               |
+
+**ErrorInfo** — used by `permission_denied`, `aborted`, `unimplemented`, `unauthenticated`:
+
+| Field      | Type                      | Description                                                                             |
+|------------|---------------------------|-----------------------------------------------------------------------------------------|
+| `reason`   | `String`                  | Machine-readable reason, UPPER_SNAKE_CASE (e.g., `TOKEN_EXPIRED`, `SCOPE_INSUFFICIENT`) |
+| `domain`   | `String`                  | Logical grouping (e.g., `auth.cyberfabric.io`, `types-registry`)                        |
+| `metadata` | `HashMap<String, String>` | Arbitrary key-value pairs for additional context                                        |
+
+**QuotaFailure** — used by `resource_exhausted`:
+
+| Field        | Type                  | Description                                                                           |
+|--------------|-----------------------|---------------------------------------------------------------------------------------|
+| `violations` | `Vec<QuotaViolation>` | List of quota violations                                                              |
+| `retry_info` | `Option<RetryInfo>`   | Optional retry guidance (e.g., `Retry-After` header source). Via `.with_retry_info()` |
+
+**QuotaViolation**:
+
+| Field           | Type          | Description                                                              |
+|-----------------|---------------|--------------------------------------------------------------------------|
+| `subject`       | `String`      | What the quota applies to (e.g., `requests_per_minute`, `storage_bytes`) |
+| `description`   | `String`      | Human-readable explanation of the quota violation                        |
+| `limit`         | `Option<u64>` | Quota limit value (e.g., 100). Via `.with_limit()`                       |
+| `remaining`     | `Option<u64>` | Remaining quota at the time of violation. Via `.with_remaining()`        |
+| `reset_seconds` | `Option<u64>` | Seconds until quota resets. Via `.with_reset()`                          |
+
+> The optional `limit`/`remaining`/`reset_seconds` fields enable returning
+> `RateLimit-Policy` and `X-RateLimit-*` headers per the
+> [REST API standard](https://github.com/cyberfabric/DNA/blob/main/REST/API.md#10-rate-limiting--quotas).
+> All three are populated via builder methods — omitting them is valid when
+> the quota system does not expose policy details.
+
+**PreconditionFailure** — used by `failed_precondition`:
+
+| Field        | Type                         | Description                     |
+|--------------|------------------------------|---------------------------------|
+| `violations` | `Vec<PreconditionViolation>` | List of precondition violations |
+
+**PreconditionViolation**:
+
+| Field         | Type     | Description                                             |
+|---------------|----------|---------------------------------------------------------|
+| `type`        | `String` | Precondition category (e.g., `TOS`, `STATE`, `VERSION`) |
+| `subject`     | `String` | What failed the precondition check                      |
+| `description` | `String` | How to resolve the failure                              |
+
+**DebugInfo** — used by `unknown`, `internal`:
+
+| Field           | Type          | Description                                          |
+|-----------------|---------------|------------------------------------------------------|
+| `detail`        | `String`      | Human-readable debug message (generic in production) |
+| `stack_entries` | `Vec<String>` | Stack trace entries (empty in production)            |
+
+**RetryInfo** — used by `service_unavailable`:
+
+| Field                 | Type  | Description                             |
+|-----------------------|-------|-----------------------------------------|
+| `retry_after_seconds` | `u64` | Minimum seconds to wait before retrying |
+
+> `cancelled` and `deadline_exceeded` take a simple message string — no
+> typed context struct. The `trace_id` (always present on every Problem
+> response) is sufficient for request correlation, making a separate
+> `RequestInfo.request_id` redundant. Debug info can be attached optionally
+> via `.with_debug_info()` if needed.
+
+#### RFC 9457 Problem Wire Format
+
+- [ ] `p2` - **ID**: `cpt-cf-interface-problem-wire-format`
+
+**Technology**: JSON (`application/problem+json`)
+
+Every REST error response follows this structure. Each field is classified as **contract** (fixed per category, consumers may depend on it) or **variable** (changes per occurrence,
+consumers must not depend on specific values):
+
+| Field      | Source                   | Part                              | Description                                                                         |
+|------------|--------------------------|-----------------------------------|-------------------------------------------------------------------------------------|
+| `type`     | GTS URI from category    | **Contract**                      | Error type URI (e.g., `gts.cf.core.errors.err.v1~cf.core.errors.not_found.v1~`)     |
+| `title`    | Static per category      | **Contract**                      | Human-readable summary (e.g., "Not Found")                                          |
+| `status`   | HTTP status from mapping | **Contract**                      | HTTP status code as integer                                                         |
+| `detail`   | `CanonicalError.message` | Variable                          | Human-readable explanation of this occurrence                                       |
+| `instance` | Request URI path         | Variable                          | URI identifying this specific occurrence                                            |
+| `trace_id` | Request context          | Variable                          | W3C trace ID for correlation                                                        |
+| `context`  | Serialized context type  | Contract schema / Variable values | Category-specific structured details; includes `resource_type` when resource-scoped |
+
+RFC 9457 defines five standard members (`type`, `title`, `status`, `detail`, `instance`) and explicitly permits **extension members** (RFC 9457 §3.2). The fields `trace_id` and
+`context` are CyberFabric-specific extensions.
+
+The `context` field contains the JSON serialization of the context type associated with the error category. When the error is constructed via a resource-scoped constructor
+(`XxxResourceError::category(...)`), a `resource_type` key is injected into the `context` object identifying the GTS URI of the affected resource. When a direct constructor
+(`CanonicalError::category(...)`) is used, `resource_type` is absent from context.
+
+The **schema** of `context` (field names and types) is contract — it is fixed per category and defined by the context type structs. The **values** within `context` are variable —
+they are filled in by module code per occurrence. Consumers use `type` to determine the schema of `context` and may parse context fields by name, but must not depend on specific
+field values.
+
+### 3.4 Internal Dependencies
+
+| Dependency         | Interface                         | Purpose                                                          |
+|--------------------|-----------------------------------|------------------------------------------------------------------|
+| `cf-modkit`        | `api::prelude`                    | Re-exports `CanonicalError`, `Problem`, `ApiResult` for handlers |
+| `cf-modkit-errors` | `canonical`, `context`, `problem` | Core error types, context structs, REST mapping                  |
+| `gts`              | `GtsSchema` trait                 | Schema trait implemented by all context types                    |
+| `gts-macros`       | `#[struct_to_gts_schema]`         | Derive macro for GTS schema generation on context types          |
+| `gts-id`           | `GtsSchemaId`                     | Validated GTS identifier type used internally by context types   |
+| `schemars`         | JSON Schema support               | JSON Schema generation for context type schemas                  |
+| `tracing`          | `Span::current()`                 | Extract trace ID from span for error enrichment                  |
+
+### 3.5 External Dependencies
+
+Not applicable. The universal error architecture is entirely internal to the CyberFabric platform. It does not depend on external services or systems. Error responses are produced
+locally from in-process error construction and mapping.
+
+### 3.6 Interactions & Sequences
+
+#### Domain Error to REST Response (Happy Error Path)
+
+- [ ] `p1` - **ID**: `cpt-cf-seq-domain-error-to-rest`
+
+A module handler encounters a business error and returns it as a `CanonicalError`. Axum's `IntoResponse` impl converts it to an RFC 9457 Problem response.
+
+```mermaid
+sequenceDiagram
+    actor Client
+    participant Handler as REST Handler
+    participant Domain as Domain Service
+    participant Mapping as REST Mapping
+    participant Axum as Axum Framework
+    Client ->> Handler: GET /users/{id}
+    Handler ->> Domain: get_user(id)
+    Domain -->> Handler: Err(CanonicalError::NotFound(ResourceInfo))
+    Handler -->> Axum: Err(CanonicalError) via ApiResult
+    Axum ->> Mapping: IntoResponse for CanonicalError
+    Mapping ->> Mapping: category -> HTTP 404
+    Mapping ->> Mapping: context -> JSON "context" field
+    Mapping ->> Mapping: GTS URI -> "type" field
+    Mapping ->> Mapping: attach trace_id from span
+    Mapping -->> Axum: Problem response
+    Axum -->> Client: 404 application/problem+json
+```
+
+**Description**: The standard path for returning business errors. The handler uses `?` to propagate `CanonicalError` through `ApiResult<T>`. The `IntoResponse` implementation
+handles the full conversion chain.
+
+#### Unhandled Error to REST Response (Middleware Catch-All)
+
+- [ ] `p1` - **ID**: `cpt-cf-seq-unhandled-error`
+
+An unexpected error (panic or framework error) bypasses the canonical error path. The error middleware catches it and wraps it as an `Internal` canonical error.
+
+```mermaid
+sequenceDiagram
+    actor Client
+    participant Middleware as Error Middleware
+    participant Handler as REST Handler
+    participant Mapping as REST Mapping
+    Client ->> Middleware: request
+    Middleware ->> Handler: forward request
+    Handler -->> Middleware: unhandled error (panic, anyhow, etc.)
+    Middleware ->> Middleware: wrap as CanonicalError::Internal(DebugInfo)
+    Middleware ->> Middleware: strip stack_entries if production
+    Middleware ->> Middleware: attach trace_id
+    Middleware ->> Mapping: convert to Problem
+    Mapping -->> Client: 500 application/problem+json
+```
+
+**Description**: The safety net ensuring no error escapes without a canonical category. In production, the response contains only a generic detail message and a trace ID for log
+correlation.
+
+#### Validation Error with Multiple Field Violations
+
+- [ ] `p2` - **ID**: `cpt-cf-seq-validation-error`
+
+A domain service validates input and accumulates multiple field violations before returning a single `InvalidArgument` error with all violations.
+
+```mermaid
+sequenceDiagram
+    actor Client
+    participant Handler as REST Handler
+    participant Domain as Domain Service
+    participant Mapping as REST Mapping
+    Client ->> Handler: POST /users { email: "", name: "x" }
+    Handler ->> Domain: create_user(req)
+    Domain ->> Domain: validate email -> FieldViolation
+    Domain ->> Domain: validate name -> FieldViolation
+    Domain -->> Handler: Err(CanonicalError::InvalidArgument(Validation { field_violations: [2] }))
+    Handler -->> Mapping: IntoResponse
+    Mapping -->> Client: 400 { type: "gts...invalid_argument.v1", context: { field_violations: [...] } }
+```
+
+**Description**: Demonstrates how validation errors carry structured, machine-readable field-level detail that API consumers can use for form-level error display.
+
+### 3.7 Database schemas & tables
+
+Not applicable. Errors are transient values constructed in-process and serialized to wire format. There are no error-specific database tables. Error persistence (for audit,
+analytics, or debugging) is handled by the observability stack (logging, tracing) which is outside the scope of this design.
+
+## 4. Additional context
+
+### Category Selection Guide
+
+When to use each canonical category:
+
+| Category              | Use When                                                                                            |
+|-----------------------|-----------------------------------------------------------------------------------------------------|
+| `invalid_argument`    | Client sent malformed or invalid input (validation errors, bad format, missing required fields)     |
+| `not_found`           | A specific requested resource does not exist                                                        |
+| `already_exists`      | Client tried to create a resource that already exists                                               |
+| `permission_denied`   | Caller is authenticated but lacks permission for this operation                                     |
+| `unauthenticated`     | Request has no valid authentication credentials                                                     |
+| `failed_precondition` | System is not in the required state (e.g., deleting a non-empty directory, version conflict)        |
+| `aborted`             | Operation aborted due to concurrency conflict (e.g., optimistic lock failure, transaction conflict) |
+| `out_of_range`        | Value is syntactically valid but outside the accepted range (e.g., page number beyond last page)    |
+| `resource_exhausted`  | Quota or rate limit exceeded                                                                        |
+| `service_unavailable` | Service temporarily unavailable; client should retry                                                |
+| `deadline_exceeded`   | Operation did not complete within the allowed time                                                  |
+| `cancelled`           | Operation was cancelled by the caller                                                               |
+| `unimplemented`       | Operation is not supported or not yet implemented                                                   |
+| `internal`            | Unexpected server error (bugs, invariant violations)                                                |
+| `unknown`             | Error from an unknown source or missing error information                                           |
+| `data_loss`           | Unrecoverable data loss or corruption detected                                                      |
+
+### Distinguishing Similar Categories
+
+- **`invalid_argument` vs `failed_precondition`**: `invalid_argument` is for input that would be wrong regardless of system state (e.g., malformed email). `failed_precondition` is
+  for input that is correct but the system is not in the right state to accept it (e.g., publishing an already-published document).
+- **`invalid_argument` vs `out_of_range`**: `out_of_range` is for values that are syntactically valid but semantically outside bounds (e.g., reading past end of list).
+  `invalid_argument` is for values that are structurally wrong.
+- **`not_found` vs `permission_denied`**: If a resource exists but the caller lacks permission, use `permission_denied`. If revealing existence is a security concern, use
+  `not_found`.
+- **`aborted` vs `failed_precondition`**: `aborted` is for transient concurrency issues that the client can retry. `failed_precondition` is for state violations that require the
+  client to take corrective action before retrying.
+- **`service_unavailable` vs `deadline_exceeded`**: `service_unavailable` indicates the service itself is down (retry makes sense). `deadline_exceeded` indicates the operation took
+  too long (may or may not be retryable depending on context).
+- **`internal` vs `unknown`**: `internal` is for errors the server recognizes as its own bugs. `unknown` is for errors from external sources where the category cannot be
+  determined.
+
+### Contract Enforcement Strategy
+
+The PoC (`canonical-errors/CONTRACT_ENFORCEMENT.md`) validates a four-tier approach to preventing accidental contract breaks. Each tier is introduced in the migration phase where
+it becomes relevant:
+
+| Tier                     | Mechanism                                                                                 | Migration phase                    | Status                                             |
+|--------------------------|-------------------------------------------------------------------------------------------|------------------------------------|----------------------------------------------------|
+| **Tier 1: Compile-time** | Typed enum variants, exhaustive `match`, `#[resource_error]` macro, `GtsSchema` constants | Phase 1 (Foundation)               | Implemented in PoC                                 |
+| **Tier 2: Test-time**    | `insta` snapshot tests for all 16 categories, JSON Schema cross-validation                | Phase 1 (task 1.6)                 | Showcase tests in PoC; snapshots added during port |
+| **Tier 3: CI-time**      | `cargo-semver-checks`, schema file diffing, `cargo insta test --check` gate               | Post-Phase 1 (separate workstream) | Not yet implemented                                |
+| **Tier 4: Design-time**  | Single `Problem` conversion point, value-object context types, default messages           | Phase 1 (inherent in architecture) | Implemented in PoC                                 |
+
+**Coverage matrix** (what each tier catches):
+
+| Risk                              | Tier 1 (Compile) | Tier 2 (Test)              | Tier 3 (CI)                   |
+|-----------------------------------|------------------|----------------------------|-------------------------------|
+| Wrong context type for a category | Caught           | —                          | —                             |
+| Missing match arm for new variant | Caught           | —                          | —                             |
+| Field renamed in serialization    | —                | Caught (snapshot)          | Caught (schema diff)          |
+| Default message changed           | —                | Caught (snapshot)          | —                             |
+| Status code changed               | —                | Caught (snapshot)          | —                             |
+| New field added to context type   | —                | Caught (snapshot + schema) | Caught (schema diff)          |
+| Field removed from context type   | Caught (if used) | Caught (snapshot + schema) | Caught (schema diff + semver) |
+| Schema/serialization drift        | —                | Caught (cross-validation)  | —                             |
+| Public type removed or renamed    | Caught           | —                          | Caught (semver)               |
+
+**Potential additions** (not yet committed to, to be evaluated during implementation):
+
+- `#[non_exhaustive]` on `CanonicalError` — allows adding variants without a semver-major bump
+- Sealed `ErrorContext` trait — prevents external crates from creating custom context types
+- Schema file diffing in CI — export GTS schemas to `schemas/*.json`, regenerate and diff on every PR
+
+### SDK Error Boundary
+
+CyberFabric follows a `{module}` / `{module}-sdk` pattern where the `-sdk` crate exposes a trait-based async API that other modules consume via `ClientHub`. All 9 SDK crates
+(`oagw-sdk`, `credstore-sdk`, `types-registry-sdk`, `authn-resolver-sdk`, `authz-resolver-sdk`, `tenant-resolver-sdk`, `types-sdk`, `nodes-registry-sdk`,
+`simple-user-settings-sdk`) currently define domain-specific `thiserror` enums as their public error type.
+
+**Key insight: SDKs are HTTP/gRPC clients.** The `-sdk` crate is not a Rust-to-Rust library boundary — it is a client that calls the module's REST (or future gRPC) API over the
+wire. This means the error flow is a round-trip:
+
+```text
+Server module                              SDK client (consumer module)
+────────────                               ──────────────────────────────
+CanonicalError                             HTTP response
+    │                                          │
+    │  From<CanonicalError> for Problem        │  Problem::try_into_error()
+    v                                          v
+Problem (RFC 9457) ──── HTTP wire ────> CanonicalError (reconstructed)
+```
+
+The domain-specific SDK error enums that exist today (`CredStoreError`, `ServiceGatewayError`, etc.) are **manual, lossy reconstructions** of what the server already sends as a
+structured Problem response. After the canonical error migration, the server returns a Problem with a GTS type URI, structured `context`, and an HTTP status that maps 1:1 to a
+canonical category. The SDK can deserialize this back into a `CanonicalError` losslessly.
+
+**Design decision: SDKs SHALL migrate to `CanonicalError` as their error type.**
+
+After Phase 1 (Foundation), SDKs can implement `Problem → CanonicalError` deserialization — the reverse of `From<CanonicalError> for Problem`. This:
+
+1. **Eliminates 9 ad-hoc error enums** — all SDKs return `Result<T, CanonicalError>`
+2. **Preserves all structured detail** — the `context` field carries the same typed payload (`ResourceInfo`, `ErrorInfo`, `Validation`, etc.) that the server constructed
+3. **Enables transparent error propagation** — a consuming module can propagate SDK errors directly via `?` (since handlers return `Result<T, CanonicalError>`), re-categorize with
+   `match`, or enrich with `.with_message()` / `.with_debug_info()`
+4. **The `resource_type` field identifies which resource failed** — consumers can distinguish a `NotFound` from the credstore vs the types-registry by inspecting the GTS type in
+   `resource_type`, without needing a separate error enum per SDK
+
+**Consumer-side matching:**
+
+```rust
+// Before (ad-hoc SDK error enum):
+match credstore.get( & ctx, & key).await {
+Ok(secret) =>...,
+Err(CredStoreError::NotFound) =>...,
+Err(CredStoreError::ServiceUnavailable(msg)) =>...,
+Err(e) => return Err(CanonicalError::internal(format!("{e}"))),
+}
+
+// After (CanonicalError from SDK):
+match credstore.get( & ctx, & key).await {
+Ok(secret) =>...,
+Err(e) if e.status_code() == 404 =>...,           // not_found
+Err(e) if e.status_code() == 503 =>...,           // service_unavailable
+Err(e) => return Err(e),                            // propagate as-is
+}
+```
+
+**Client-only error variants:** Some current SDK errors represent client-side conditions that never come from the wire (`NoPluginAvailable`, `NotInReadyMode`). These are
+infrastructure lifecycle concerns within the SDK client itself. They map to `CanonicalError::service_unavailable(...)` or `CanonicalError::failed_precondition(...)` at the SDK
+boundary, with the detail captured in the context.
+
+**Migration scope:** SDK error migration is not part of the current 4-phase plan (which covers server-side module migration). It is a follow-up workstream that becomes possible
+after Phase 1 delivers `CanonicalError` + `Problem` with the round-trip deserialization support (`TryFrom<Problem> for CanonicalError`).
+
+### Non-Applicable Checklist Areas
+
+- **Performance Architecture (PERF)**: Not applicable. Error construction is O(1) enum + struct allocation. No caching, pooling, or scaling concerns specific to the error system.
+- **Data Architecture (DATA)**: Not applicable. Errors are transient; no persistent storage. Observability is out of scope.
+- **Operations (OPS)**: Not applicable. Error handling does not introduce deployment topology, infrastructure, or monitoring requirements beyond what the observability stack
+  already provides.
+- **Compliance (COMPL)**: Flexible fields (`ErrorInfo.metadata`, `ResourceInfo.resource_name`, `FieldViolation.field`) may carry user-provided identifiers. Modules MUST apply data
+  minimization when populating these fields — include only identifiers necessary for the consumer to act on the error. The `cpt-cf-constraint-no-internal-details` constraint
+  prevents stack traces and internal detail leakage in production, but does not address PII in context fields. PII handling in error responses follows the platform's data
+  classification policy.
+- **Usability (UX)**: Not applicable. This design covers the API error wire format, not user-facing error display. Frontend error rendering is a consumer concern.
+
+### Deferred Decisions
+
+The following questions are raised in the [PRD §13 Open Questions](./PRD.md#13-open-questions) and are not yet resolved at the design level. They will be addressed during
+implementation:
+
+| Question                                     | Ref   | Notes                                                                                 |
+|----------------------------------------------|-------|---------------------------------------------------------------------------------------|
+| Snapshot: full JSON body or `context` only?  | §13.1 | Library-dependent (`insta` vs custom). Full body thorough; context-only less brittle. |
+| `cargo-semver-checks`: hard gate or warning? | §13.2 | Start as hard gate on `cf-modkit-errors`. Relax if false positives arise.             |
+| `#[resource_error]`: same crate or separate? | §13.3 | Proc-macros need separate crate. Re-export vs distinct dependency TBD.                |
+
+## 5. Traceability
+
+- **ADRs**: [`cpt-cf-adr-canonical-error-impl`](./ADR/0001-cpt-cf-adr-canonical-error-impl.md)
+- **Related**: [guidelines/NEW_MODULE.md — Step 3: Errors Management](../../../guidelines/NEW_MODULE.md#step-3-errors-management)
+- **Supersedes**: PR #290 (`docs/unified-error-system/`)
+- **Existing implementation**: [`libs/modkit-errors/src/problem.rs`](../../../libs/modkit-errors/src/problem.rs)

--- a/docs/arch/errors/PRD.md
+++ b/docs/arch/errors/PRD.md
@@ -1,0 +1,414 @@
+# PRD — Universal Error Architecture
+
+## 1. Overview
+
+### 1.1 Purpose
+
+The `modkit-errors` library provides the universal error vocabulary for the CyberFabric platform. Every error produced by any module is expressed as one of 16 canonical categories,
+each carrying a fixed-structure context payload. Errors are part of the public API surface — every error response is a contract with API consumers. This PRD defines what the error
+system must guarantee: contract stability, canonical categories, machine-readable details, and protection against accidental breaking changes.
+
+### 1.2 Background / Problem Statement
+
+Without a universal error architecture, each module would define its own ad-hoc error types with module-specific variants and manual mappings to wire formats. This produces three
+problems:
+
+1. **Inconsistent error shapes**: API consumers cannot rely on a stable, predictable error format across modules. The same logical error (e.g., "resource not found") may carry
+   different fields, different status codes, or different detail messages depending on which module produced it.
+
+2. **No breaking change detection**: There is no mechanism to detect when a code change alters the error contract — a developer or LLM agent can change an error category, rename a
+   context field, or alter a GTS identifier without triggering any warning. Consumers who depend on specific error shapes break silently.
+
+3. **No contract governance**: Without explicit product requirements around error stability and versioning, the error API surface drifts over time. Design-level documentation alone
+   does not prevent accidental regressions.
+
+### 1.3 Goals (Business Outcomes)
+
+- Zero unreviewed breaking changes to the error API surface per release cycle
+- All modules return errors in the same canonical shape from day one
+- API consumers can implement stable error handling (retry, display, routing) against documented error contracts without fear of silent breakage
+
+### 1.4 Glossary
+
+| Term               | Definition                                                                                                           |
+|--------------------|----------------------------------------------------------------------------------------------------------------------|
+| Canonical Category | One of 16 transport-agnostic error classifications (e.g., `not_found`, `invalid_argument`)                           |
+| Context Type       | Fixed-structure payload per category (e.g., `ResourceInfo`, `Validation`, `ErrorInfo`)                               |
+| GTS Identifier     | Globally unique compound type URI in the GTS system (e.g., `gts.cf.core.errors.err.v1~cf.core.errors.not_found.v1~`) |
+| Contract Part      | Fixed category-level structure: `type`, `title`, `status`, context **schema**. Changes are breaking.                 |
+| Variable Part      | Per-occurrence values: `detail`, `instance`, `trace_id`, context **values**. Not contractual.                        |
+| Error Contract     | Combination of category, context type schema, and GTS identifier (all contract parts)                                |
+| Breaking Change    | Any contract part modification that would break existing consumer error-handling code                                |
+| Snapshot Test      | Automated test capturing the exact error response shape; fails if the shape changes                                  |
+
+## 2. Actors
+
+### 2.1 Human Actors
+
+#### Module Developer
+
+**ID**: `cpt-cf-actor-module-developer`
+
+- **Role**: Writes domain logic in CyberFabric modules. Constructs canonical errors when business rules fail, validation errors occur, or resources are not found.
+- **Needs**: Low-boilerplate error construction with no transport details. Confidence that error construction follows the canonical vocabulary without accidentally introducing
+  breaking changes.
+
+#### API Consumer
+
+**ID**: `cpt-cf-actor-api-consumer`
+
+- **Role**: External or internal client that receives error responses from CyberFabric APIs. Implements error handling logic (retry on `service_unavailable`, display field
+  violations
+  on `invalid_argument`, redirect on `unauthenticated`).
+- **Needs**: Stable, predictable error response shapes. Machine-readable context fields. Confidence that error contracts do not change without versioned notice.
+
+### 2.2 System Actors
+
+#### CI Pipeline
+
+**ID**: `cpt-cf-actor-ci-pipeline`
+
+- **Role**: Automated build and validation system that runs on every commit and pull request. Enforces error contract stability through compile-time checks, snapshot tests, and
+  semver verification.
+
+#### LLM Agent
+
+**ID**: `cpt-cf-actor-llm-agent`
+
+- **Role**: AI coding assistant that generates or modifies code constructing errors. Must be constrained by the same compile-time and CI checks as human developers to prevent
+  accidental error contract changes.
+
+## 3. Operational Concept & Environment
+
+> This is a cross-cutting platform library (`libs/modkit-errors`), not a standalone module. No module-specific environment constraints beyond project defaults.
+
+## 4. Scope
+
+### 4.1 In Scope
+
+- 16 canonical error categories as the single error vocabulary
+- Fixed-structure context types per category
+- Error contract stability requirements and breaking change policy
+- Protection mechanisms against accidental changes (compile-time, snapshot tests, CI gates)
+- GTS identifier assignment and versioning for error categories
+- Public API surface definition for `CanonicalError` and context types
+- Library error absorption (`From` impls for common library errors)
+
+### 4.2 Out of Scope
+
+- Transport-specific mapping implementation (REST/Problem, gRPC/Status) — covered by DESIGN
+- Error UI rendering or client-side error display logic
+- Error analytics, dashboards, or aggregation
+
+## 5. Functional Requirements
+
+> **Testing strategy**: All requirements verified via automated tests (unit, integration, snapshot) unless otherwise specified.
+
+### 5.1 Canonical Error Vocabulary
+
+#### Single Error Vocabulary
+
+- [ ] `p1` - **ID**: `cpt-cf-fr-single-error-vocabulary`
+
+The system **MUST** provide exactly 16 canonical error categories as the only way to express errors in the API layer. No module-specific error types are permitted to reach API
+consumers.
+
+- **Rationale**: API consumers depend on a finite, documented set of error shapes. Allowing ad-hoc error types breaks consumer error-handling code.
+- **Actors**: `cpt-cf-actor-module-developer`, `cpt-cf-actor-api-consumer`
+
+#### Machine-Readable Context
+
+- [ ] `p1` - **ID**: `cpt-cf-fr-machine-readable-context`
+
+Every canonical error **MUST** carry a fixed-structure context type with a schema defined per category. Context type fields are typed and documented. No ad-hoc metadata keys are
+permitted outside the defined schema (except `ErrorInfo.metadata` which is an explicit escape hatch).
+
+- **Rationale**: API consumers parse error details programmatically. Unpredictable field names or missing fields break automated error handling.
+- **Actors**: `cpt-cf-actor-api-consumer`
+
+#### Transport-Agnostic Construction
+
+- [ ] `p1` - **ID**: `cpt-cf-fr-transport-agnostic-construction`
+
+Module code **MUST** construct errors using canonical categories and context types without referencing HTTP status codes, gRPC codes, or any transport-specific detail.
+
+- **Rationale**: Error construction is a domain concern. Transport mapping is an infrastructure concern. Mixing them couples domain logic to a specific transport.
+- **Actors**: `cpt-cf-actor-module-developer`
+
+#### Library Error Absorption
+
+- [ ] `p1` - **ID**: `cpt-cf-fr-library-error-absorption`
+
+The system **MUST** provide `From` implementations for common library error types (`anyhow::Error`, `sea_orm::DbErr`, `sqlx::Error`, `serde_json::Error`, `std::io::Error`) that map
+to appropriate canonical categories. The `?` operator **MUST** work without manual `map_err` in common cases.
+
+- **Rationale**: Repetitive `map_err` calls are boilerplate that developers (and LLM agents) get wrong. Blanket impls ensure consistent mapping.
+- **Actors**: `cpt-cf-actor-module-developer`, `cpt-cf-actor-llm-agent`
+
+#### Trace Correlation
+
+- [ ] `p1` - **ID**: `cpt-cf-fr-trace-correlation`
+
+Every error response **MUST** include a `trace_id` field containing the W3C trace ID from the request context. The trace ID **MUST** be present in both production and debug modes,
+enabling consumers to correlate error responses with support requests and server-side logs.
+
+- **Rationale**: Without a trace ID, consumers cannot reference specific error occurrences when contacting support. Server-side logs are only useful if they can be correlated with
+  the client-visible response.
+- **Actors**: `cpt-cf-actor-api-consumer`
+
+### 5.2 Error Contract Stability
+
+#### Error Contract as API Surface
+
+- [ ] `p1` - **ID**: `cpt-cf-fr-error-contract-api-surface`
+
+Every error response has two distinct parts:
+
+- **Contract part** (stable, category-level): `type` (GTS identifier), `title`, `status`, and the context type **schema** (field names and types). These are fixed per category and
+  identical for every occurrence of that category, regardless of which module produced it.
+- **Variable part** (per-occurrence): `detail`, `instance`, `trace_id`, and the context field **values**. These are filled in by module code, framework, or middleware at the point
+  of error and change with every request.
+
+The contract part **MUST** be treated as public API surface. Any change to a contract part **MUST** follow the same breaking change policy as endpoint signature changes. API
+consumers **MAY** depend on contract parts (match on `type`, branch on `status`, parse context fields by name) but **MUST NOT** depend on variable parts (parse `detail` text, rely
+on specific context values).
+
+- **Rationale**: API consumers write code that matches on error categories, reads context fields by name, and uses GTS identifiers for routing. The contract/variable separation
+  defines the exact boundary of what the error architecture protects and what module code is free to change.
+- **Actors**: `cpt-cf-actor-api-consumer`, `cpt-cf-actor-module-developer`
+
+#### Breaking Change Classification
+
+- [ ] `p1` - **ID**: `cpt-cf-fr-breaking-change-classification`
+
+The following changes to the error system **MUST** be classified as breaking changes:
+
+- Removing or renaming a canonical category
+- Changing the context type associated with a category
+- Removing or renaming a field in a context type schema
+- Changing the type of a field in a context type schema
+- Changing the GTS identifier of a category
+- Changing the HTTP status code mapped to a category
+
+The following changes are non-breaking:
+
+- Adding a new optional field to a context type
+- Adding a new canonical category (additive)
+- **Rationale**: Clear classification prevents ambiguity about what constitutes a breaking change and enables automated enforcement.
+- **Actors**: `cpt-cf-actor-module-developer`, `cpt-cf-actor-ci-pipeline`
+
+#### Accidental Change Protection
+
+- [ ] `p1` - **ID**: `cpt-cf-fr-accidental-change-protection`
+
+The system **MUST** provide automated mechanisms to detect and prevent accidental changes to the error contract:
+
+1. **Compile-time enforcement**: Adding or removing a canonical category **MUST** cause a compile error in all code that matches on the error enum (exhaustive match).
+2. **Macro-based GTS construction**: Context types carrying GTS identifiers (e.g., `ResourceInfo`) **MUST** only be constructable via attribute macros that declare the GTS
+   identifier at the type level. Raw constructors **MUST NOT** be public. The macro **MUST** validate the GTS format at compile time.
+3. **Snapshot tests**: The CI pipeline **MUST** include snapshot tests that capture the exact JSON shape of error responses for each canonical category. Any change to the snapshot
+   **MUST** require explicit developer acknowledgment (snapshot update).
+4. **Semver-aware CI**: The CI pipeline **MUST** run semver compatibility checks on `cf-modkit-errors` to detect breaking changes to public types.
+
+- **Rationale**: Human developers and LLM agents can both accidentally change error shapes. Compile-time checks catch structural changes. Macro-based construction prevents GTS
+  identifier typos and drift. Snapshot tests catch serialization changes. Semver checks catch public API changes.
+- **Actors**: `cpt-cf-actor-ci-pipeline`, `cpt-cf-actor-llm-agent`, `cpt-cf-actor-module-developer`
+
+#### No Internal Details in Production
+
+- [ ] `p1` - **ID**: `cpt-cf-fr-no-internal-details`
+
+Error responses in production **MUST NOT** include stack traces, internal exception messages, database query text, or file paths. The `internal` and `unknown` categories **MUST**
+return an opaque message with a trace ID for correlation. `DebugInfo.stack_entries` **MUST** be populated only in debug mode.
+
+- **Rationale**: Internal details are a security risk (information disclosure) and a stability risk (consumers parsing internal messages as contract).
+- **Actors**: `cpt-cf-actor-api-consumer`
+
+## 6. Non-Functional Requirements
+
+### 6.1 Module-Specific NFRs
+
+#### Compile-Time Category Safety
+
+- [ ] `p1` - **ID**: `cpt-cf-nfr-compile-time-category-safety`
+
+Adding or removing a canonical category **MUST** produce a compile error in all uncovered match sites across the entire codebase. Zero runtime category validation is acceptable —
+all category correctness **MUST** be enforced at compile time.
+
+- **Threshold**: 100% of match sites produce compile errors on category change; zero runtime panics from unhandled categories
+- **Rationale**: Runtime errors from unhandled categories are production incidents. Compile-time enforcement eliminates this class of bugs entirely.
+- **Architecture Allocation**: See DESIGN.md § Principles — exhaustive match on `CanonicalError` enum
+
+#### Error Construction Overhead
+
+- [ ] `p2` - **ID**: `cpt-cf-nfr-error-construction-overhead`
+
+Constructing a canonical error **MUST** not require heap allocation for category selection. Context types that use only fixed fields (all types except `ErrorInfo`) **MUST** be
+stack-allocated.
+
+- **Threshold**: Error construction < 100ns at p99 for stack-only context types
+- **Rationale**: Error paths are latency-sensitive. Heap allocation on every error would degrade p99 latency.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation
+
+## 7. Public Library Interfaces
+
+### 7.1 Public API Surface
+
+#### CanonicalError Enum
+
+- [ ] `p1` - **ID**: `cpt-cf-interface-canonical-error`
+
+- **Type**: Rust enum (`libs/modkit-errors`)
+- **Stability**: stable
+- **Description**: The 16-variant enum representing all canonical error categories. Each variant carries its category-specific context type and a message.
+- **Breaking Change Policy**: Removing/renaming a variant or changing its context type requires a major version bump of `cf-modkit-errors`. Adding a new variant is a minor version
+  change.
+
+#### Context Type Structs
+
+- [ ] `p1` - **ID**: `cpt-cf-interface-context-types`
+
+- **Type**: Rust structs and enums (`libs/modkit-errors`)
+- **Stability**: stable
+- **Description**: Fixed-structure context types: `Validation` (enum), `ResourceInfo`, `ErrorInfo`, `QuotaFailure`, `PreconditionFailure`, `DebugInfo`, `RetryInfo`,
+  and their sub-types: `FieldViolation`, `QuotaViolation`, `PreconditionViolation`.
+- **Breaking Change Policy**: Removing/renaming a field or changing a field type requires a major version bump. Adding a new optional field is a minor version change.
+
+### 7.2 External Integration Contracts
+
+#### Error Response Contract (REST)
+
+- [ ] `p1` - **ID**: `cpt-cf-contract-error-response-rest`
+
+- **Direction**: provided by library to API consumers
+- **Protocol/Format**: HTTP REST, `application/problem+json` (RFC 9457)
+- **Compatibility**: Error response shapes are versioned via GTS identifiers. Breaking changes require a new GTS version suffix. Snapshot tests enforce response shape stability.
+
+## 8. Use Cases
+
+### API Consumer Handles Not Found Error
+
+- [ ] `p1` - **ID**: `cpt-cf-usecase-consumer-handles-not-found`
+
+**Actor**: `cpt-cf-actor-api-consumer`
+
+**Preconditions**:
+
+- Consumer calls a CyberFabric API endpoint requesting a resource by ID
+
+**Main Flow**:
+
+1. API endpoint receives request and queries for the resource
+2. Resource is not found in the data store
+3. Module code constructs `UserResourceError::not_found(id)` using a macro-declared resource type
+4. Error middleware maps the canonical error to RFC 9457 Problem response
+5. Consumer receives `404` with `type`, `title`, `detail`, and `context.type` (GTS identifier), `context.resource_name`
+6. Consumer matches on the GTS type and `resource_name` to display an appropriate message
+
+**Postconditions**:
+
+- Consumer successfully parsed the error using the documented contract
+- No retry attempted (not a transient error)
+
+### CI Detects Accidental Error Contract Change
+
+- [ ] `p1` - **ID**: `cpt-cf-usecase-ci-detects-breaking-change`
+
+**Actor**: `cpt-cf-actor-ci-pipeline`
+
+**Preconditions**:
+
+- A developer or LLM agent submits a PR that modifies a context type field name
+
+**Main Flow**:
+
+1. CI runs `cargo build` — compile-time checks pass (field rename is structurally valid)
+2. CI runs snapshot tests — a snapshot test fails because the JSON shape of the error response changed
+3. CI runs semver check on `cf-modkit-errors` — reports a breaking change in a public type
+4. PR is blocked with clear indication of which error contract changed and why it is breaking
+
+**Postconditions**:
+
+- The accidental breaking change is caught before merge
+- Developer must either revert the change or explicitly update snapshots and bump the major version
+
+**Alternative Flows**:
+
+- **Intentional change**: Developer updates snapshots, bumps version, and adds a changelog entry. CI passes on re-run.
+
+### LLM Agent Constructs Error Safely
+
+- [ ] `p2` - **ID**: `cpt-cf-usecase-llm-constructs-error`
+
+**Actor**: `cpt-cf-actor-llm-agent`
+
+**Preconditions**:
+
+- LLM agent is generating handler code for a new endpoint
+
+**Main Flow**:
+
+1. LLM generates code that returns `UserResourceError::not_found(id)` using a macro-declared resource type
+2. LLM attempts to use a non-existent category — compile error stops it
+3. LLM attempts to pass wrong context type to a category — compile error stops it
+4. LLM attempts to construct `ResourceInfo` with a raw GTS string — compile error stops it (`pub(crate)` constructor)
+5. Code compiles, snapshot tests pass, PR is green
+
+**Postconditions**:
+
+- LLM-generated code follows the canonical error contract
+- No accidental error shape changes introduced
+
+## 9. Acceptance Criteria
+
+**Simplicity for LLMs and Humans**:
+
+- [ ] A developer or LLM agent can construct any canonical error in a single line of code, without consulting HTTP/gRPC documentation
+- [ ] Common library errors propagate through `?` without manual mapping at every call site
+- [ ] The error vocabulary is finite and discoverable — code completion surfaces all available categories
+
+**Extensibility**:
+
+- [ ] New canonical categories can be added without breaking existing consumer error-handling code
+- [ ] New resource types can be declared via macro without modifying the error framework
+  **Accidental Changes Prevention**:
+
+- [ ] Changing a category, context field, or GTS identifier is detected automatically before merge
+- [ ] No error reaches API consumers outside the canonical vocabulary — there is no alternative path
+- [ ] Production error responses for `internal`/`unknown` contain no stack traces, query text, or file paths
+
+## 10. Dependencies
+
+| Dependency              | Description                                                               | Criticality |
+|-------------------------|---------------------------------------------------------------------------|-------------|
+| `libs/modkit-errors`    | Crate where `CanonicalError`, context types, and `From` impls are defined | p1          |
+| GTS Type System         | Provides globally unique identifiers for error categories                 | p1          |
+| `cargo-semver-checks`   | CI tool for detecting breaking changes in public Rust APIs                | p1          |
+| `insta` (or equivalent) | Snapshot testing library for error response shapes                        | p1          |
+| RFC 9457 Problem        | Wire format for REST error responses                                      | p1          |
+
+## 11. Assumptions
+
+- API consumers parse error responses programmatically (not just display the `detail` string)
+- The 16 canonical categories cover all error scenarios across all current and planned modules
+- `cargo-semver-checks` (or equivalent) can detect field-level changes in public structs/enums
+- Snapshot testing is feasible for all 16 categories with representative context payloads
+
+## 12. Risks
+
+| Risk                                 | Impact                             | Mitigation                                               |
+|--------------------------------------|------------------------------------|----------------------------------------------------------|
+| Snapshots become maintenance burden  | Devs skip updates, reducing trust  | One per category; auto-generate from enum                |
+| 16 categories insufficient long-term | Ad-hoc types outside canonical set | Additive categories (minor); macro resource types        |
+| LLM agents bypass compile checks     | Contract violated despite CI gates | Clippy lint on `Problem` construction; review guidelines |
+
+## 13. Open Questions
+
+- What is the exact snapshot format — full JSON response body or just the `context` payload?
+- Should `cargo-semver-checks` be a hard gate (block merge) or a soft warning initially?
+- Should the `#[resource_error]` macro live in `cf-modkit-errors` or in a separate `cf-modkit-errors-macro` crate?
+
+## 14. Traceability
+
+- **Design**: [DESIGN.md](./DESIGN.md)
+- **ADRs**: [ADR/](./ADR/)

--- a/docs/arch/errors/TASKS.md
+++ b/docs/arch/errors/TASKS.md
@@ -1,0 +1,291 @@
+# Migration Plan — Universal Error Architecture
+
+Tracks the migration from the legacy error system (`Problem::new()` / `ErrDef` / `declare_errors!` / `ErrorCode`) to the canonical error architecture defined
+in [DESIGN.md](./DESIGN.md). The PoC at `~/projects/canonical-errors/` validates all core pieces; this plan ports them into production.
+
+## Strategy
+
+Five phases, each independently committable. Phase 1 is purely additive — if the migration stalls, existing code still works.
+
+| Phase                          | What                                   | Breaking?                                               | Commit boundary     |
+|--------------------------------|----------------------------------------|---------------------------------------------------------|---------------------|
+| **1: Foundation**              | Port PoC into `libs/modkit-errors`     | No                                                      | Merge to main       |
+| **2: Example migration**       | Migrate `examples/modkit/users-info/`  | Wire format for users-info only                         | Merge to main       |
+| **3: System module migration** | Migrate all system modules             | Wire format per module                                  | One or more merges  |
+| **4: Legacy removal**          | Remove all legacy error infrastructure | Yes — compile errors for remaining direct Problem usage | Final cleanup merge |
+| **5: Documentation**           | Update all docs to reflect canonical errors | No (docs only)                                      | Parallel with 2–4   |
+
+---
+
+## Phase 1 — Foundation (non-breaking, additive only)
+
+Port PoC into `libs/modkit-errors`. All existing code compiles unchanged after this phase.
+
+### 1.1 Context type structs
+
+> Traces to: `cpt-cf-component-context-types`, `cpt-cf-interface-context-schemas`
+
+- [ ] 1.1.1 Port `ResourceInfoV1` struct with `#[struct_to_gts_schema]`, GTS ID `gts.cf.core.errors.resource_info.v1~`, fields: `resource_type`, `resource_name`, `description`. Add
+  `pub type ResourceInfo = ResourceInfoV1;`
+- [ ] 1.1.2 Port `ErrorInfoV1` struct with GTS ID `gts.cf.core.errors.error_info.v1~`, fields: `reason`, `domain`, `metadata: HashMap<String, String>`. Add `with_metadata(k, v)`
+  builder
+- [ ] 1.1.3 Port `DebugInfoV1` struct with GTS ID `gts.cf.core.errors.debug_info.v1~`, fields: `detail`, `stack_entries: Vec<String>`. Add `with_stack(entries)` builder
+- [ ] 1.1.4 Port `RetryInfoV1` struct with GTS ID `gts.cf.core.errors.retry_info.v1~`, field: `retry_after_seconds: u64`
+- [ ] 1.1.5 ~~Port `RequestInfoV1`~~ — Removed. `cancelled` and `deadline_exceeded` use a plain message string (`trace_id` on Problem is sufficient for correlation)
+- [ ] 1.1.6 Port `FieldViolationV1` struct with GTS ID `gts.cf.core.errors.field_violation.v1~`, fields: `field`, `description`, `reason`
+- [ ] 1.1.7 Port `QuotaViolationV1` and `QuotaFailureV1` structs with GTS IDs
+- [ ] 1.1.8 Port `PreconditionViolationV1` and `PreconditionFailureV1` structs with GTS IDs
+- [ ] 1.1.9 Port `Validation` enum (`FieldViolations`, `Format`, `Constraint`) with manual `GtsSchema` impl and GTS ID `gts.cf.core.errors.validation.v1~`
+- [ ] 1.1.10 Add unit tests for all context types: construction, serialization (verify `gts_type` is skipped), GTS schema generation
+
+### 1.2 CanonicalError enum
+
+> Traces to: `cpt-cf-component-canonical-error`, `cpt-cf-interface-canonical-categories`, `cpt-cf-constraint-gts-code-format`
+
+- [ ] 1.2.1 Port `CanonicalError` enum with 16 struct-style variants, each with `ctx`, `message: String`, `resource_type: Option<String>`, `debug_info: Option<DebugInfo>`
+- [ ] 1.2.2 Port 16 constructors with sensible default messages and `resource_type: None`, `debug_info: None`
+- [ ] 1.2.3 Port `unknown()` convenience constructor that takes `impl Into<String>` and wraps in `DebugInfo`
+- [ ] 1.2.4 Port builder methods: `with_message()`, `with_resource_type()`, `with_debug_info()`
+- [ ] 1.2.5 Port accessors: `message()`, `resource_type()`, `debug_info()`, `gts_type()`, `status_code()`, `title()`
+- [ ] 1.2.6 Port `Display` impl (`"{category}: {message}"`) and derive `Debug`, `Clone`
+- [ ] 1.2.7 Port GTS type constants: 16 compound identifiers in format `gts.cf.core.errors.err.v1~cf.core.errors.{category}.v1~`
+- [ ] 1.2.8 Add unit tests: constructors, builders, accessors, Display format, GTS type mapping, status code mapping for all 16 variants
+
+### 1.3 Problem mapping (coexistence)
+
+> Traces to: `cpt-cf-component-rest-mapping`, `cpt-cf-constraint-rfc9457`, `cpt-cf-interface-problem-wire-format`
+
+- [ ] 1.3.1 Add `context: Option<serde_json::Value>` field to existing `Problem` struct with `#[serde(skip_serializing_if = "Option::is_none")]`
+- [ ] 1.3.2 Add `debug: Option<serde_json::Value>` field to existing `Problem` struct with `#[serde(skip_serializing_if = "Option::is_none")]`
+- [ ] 1.3.3 Change existing `code: String` field to use `#[serde(skip_serializing_if = "String::is_empty")]` (so new-path errors omit it)
+- [ ] 1.3.4 Implement `Problem::from_error(err: CanonicalError) -> Self` — production mode, omits debug info, sets `code` to empty string, `errors` to `None`
+- [ ] 1.3.5 Implement `Problem::from_error_debug(err: CanonicalError) -> Self` — debug mode, includes debug info if present
+- [ ] 1.3.6 Implement `From<CanonicalError> for Problem` delegating to `from_error()`
+- [ ] 1.3.7 Verify existing `Problem::new()`, `with_code()`, `with_errors()` still work (regression tests)
+- [ ] 1.3.8 Add showcase tests: one per category via `from_error`, verifying full JSON shape (no `code`, no `errors`, has `context`)
+- [ ] 1.3.9 Add debug showcase test: `from_error_debug` with `with_debug_info`, verifying `"debug"` key present
+
+### 1.4 `#[resource_error]` attribute macro
+
+> Traces to: `cpt-cf-constraint-macro-gts-construction`
+
+- [ ] 1.4.1 Port `#[resource_error]` proc macro into `libs/modkit-errors-macro/` alongside existing `declare_errors!`
+- [ ] 1.4.2 Port compile-time GTS format validation
+- [ ] 1.4.3 Port 15 constructor generation (all except `service_unavailable`): ResourceInfo categories take `impl Into<String>`, others take context type directly
+- [ ] 1.4.4 Port `.with_resource_type(gts_type)` injection on every generated constructor
+- [ ] 1.4.5 Add compilation tests: valid GTS ID compiles, invalid GTS ID fails with clear error
+- [ ] 1.4.6 Add functional tests: macro-generated constructors produce correct `CanonicalError` variants with `resource_type` set
+
+### 1.5 Blanket `From` impls for library errors
+
+> Traces to: `cpt-cf-component-canonical-error`
+
+- [ ] 1.5.1 Implement `From<anyhow::Error> for CanonicalError` → `Internal` with source error detail in `ctx.detail`, safe default message
+- [ ] 1.5.2 Implement `From<sea_orm::DbErr> for CanonicalError` → `Internal`
+- [ ] 1.5.3 Implement `From<sqlx::Error> for CanonicalError` → `Internal`
+- [ ] 1.5.4 Implement `From<serde_json::Error> for CanonicalError` → `InvalidArgument`
+- [ ] 1.5.5 Implement `From<std::io::Error> for CanonicalError` → `Internal`
+- [ ] 1.5.6 Add tests: each `From` impl preserves source error in context detail, uses safe default message, `?` operator works in `Result<T, CanonicalError>`
+
+### 1.6 Snapshot tests
+
+> Traces to: `cpt-cf-constraint-error-contract-stability`
+
+- [ ] 1.6.1 Add `insta` snapshot test for each of the 16 categories (full JSON output via `Problem::from_error`)
+- [ ] 1.6.2 Add snapshot test for resource-scoped variant (macro-generated, with `resource_type` in context)
+- [ ] 1.6.3 Add snapshot test for debug mode (`Problem::from_error_debug` with `debug_info`)
+
+### 1.7 Re-exports and public API
+
+> Traces to: `cpt-cf-component-canonical-error`
+
+- [ ] 1.7.1 Re-export `CanonicalError`, all context types, and `#[resource_error]` from `libs/modkit-errors/src/lib.rs`
+- [ ] 1.7.2 Verify full `cargo build` of the workspace succeeds — no existing code broken
+- [ ] 1.7.3 Verify full `cargo test` of the workspace succeeds — all existing tests pass
+
+---
+
+## Phase 2 — Example module migration (validate pattern)
+
+Migrate `examples/modkit/users-info/` to prove the migration pattern. After this phase, `users-info` uses `CanonicalError` exclusively. All other modules unchanged.
+
+> Traces to: `cpt-cf-principle-single-error-gateway`, `cpt-cf-constraint-macro-gts-construction`, `cpt-cf-seq-domain-error-to-rest`
+
+- [ ] 2.1 Declare resource types with `#[resource_error("gts.cf.examples.users_info.user.v1")]` (and any other resource types in this module)
+- [ ] 2.2 Replace `From<DomainError> for Problem` with `From<DomainError> for CanonicalError` — map each domain error to the appropriate canonical category with typed context
+- [ ] 2.3 Replace all `Problem::new()` / `ErrorCode::xxx().with_context()` calls with `XxxResourceError::category()` or `CanonicalError::category()` calls
+- [ ] 2.4 Update handler return types from `Result<T, Problem>` to `Result<T, CanonicalError>`
+- [ ] 2.5 Remove `gts/errors.json` and `declare_errors!` invocation from `users-info`
+- [ ] 2.6 Remove `ErrorCode` enum imports
+- [ ] 2.7 Verify `cargo build` and `cargo test` pass for the workspace
+- [ ] 2.8 Verify `users-info` error responses match expected canonical format (manual or integration test)
+
+---
+
+## Phase 3 — System module migration
+
+Migrate each system module. Order: simplest first. Each module follows the same pattern as Phase 2. OAGW is one PR despite being the largest.
+
+### 3.1 file-parser
+
+> Traces to: `cpt-cf-principle-single-error-gateway`, `cpt-cf-seq-domain-error-to-rest`
+
+- [ ] 3.1.1 Declare resource types, replace `From<DomainError> for Problem` with `From<DomainError> for CanonicalError`
+- [ ] 3.1.2 Replace `Problem::new()` calls, update handler return types to `Result<T, CanonicalError>`
+- [ ] 3.1.3 Remove legacy error infrastructure (`gts/errors.json`, `declare_errors!`, `ErrorCode`)
+- [ ] 3.1.4 Verify build and tests pass
+
+### 3.2 simple-user-settings
+
+> Traces to: `cpt-cf-principle-single-error-gateway`, `cpt-cf-seq-domain-error-to-rest`
+
+- [ ] 3.2.1 Declare resource types, replace `From<DomainError> for Problem` with `From<DomainError> for CanonicalError`
+- [ ] 3.2.2 Replace `ErrorCode::xxx().with_context()` calls, update handler return types to `Result<T, CanonicalError>`
+- [ ] 3.2.3 Remove `gts/errors.json`, `declare_errors!`, `ErrorCode`
+- [ ] 3.2.4 Verify build and tests pass
+
+### 3.3 nodes-registry
+
+> Traces to: `cpt-cf-principle-single-error-gateway`, `cpt-cf-seq-domain-error-to-rest`
+
+- [ ] 3.3.1 Declare resource types, replace error mappings
+- [ ] 3.3.2 Replace `Problem::new()` / `ErrorCode` calls, update handler return types to `Result<T, CanonicalError>`
+- [ ] 3.3.3 Remove legacy error infrastructure
+- [ ] 3.3.4 Verify build and tests pass
+
+### 3.4 types-registry
+
+> Traces to: `cpt-cf-principle-single-error-gateway`, `cpt-cf-seq-domain-error-to-rest`
+
+- [ ] 3.4.1 Declare resource types, replace error mappings
+- [ ] 3.4.2 Replace `ErrorCode` calls, update handler return types to `Result<T, CanonicalError>`
+- [ ] 3.4.3 Remove legacy error infrastructure
+- [ ] 3.4.4 Verify build and tests pass
+
+### 3.5 api-gateway
+
+> Traces to: `cpt-cf-principle-single-error-gateway`, `cpt-cf-component-error-middleware`
+
+- [ ] 3.5.1 Replace `Problem::new()` in auth middleware with `CanonicalError::unauthenticated()` / `CanonicalError::permission_denied()`
+- [ ] 3.5.2 Replace `Problem::new()` in license validation middleware
+- [ ] 3.5.3 Replace `Problem::new()` in MIME validation middleware
+- [ ] 3.5.4 Update middleware return types to use `CanonicalError`
+- [ ] 3.5.5 Verify build and tests pass
+
+### 3.6 oagw (single PR)
+
+> Traces to: `cpt-cf-principle-single-error-gateway`, `cpt-cf-seq-domain-error-to-rest`
+
+- [ ] 3.6.1 Declare resource types for all OAGW resources (upstreams, routes, consumers, etc.)
+- [ ] 3.6.2 Replace `From<DomainError> for Problem` with `From<DomainError> for CanonicalError` — map all 15 domain error variants
+- [ ] 3.6.3 Replace all `Problem::new().with_type().with_code()` chains in handler code
+- [ ] 3.6.4 Update handler return types to `Result<T, CanonicalError>`
+- [ ] 3.6.5 Remove error source header handling if it relied on `code` field (or adapt to use `gts_type()`)
+- [ ] 3.6.6 Remove legacy error infrastructure
+- [ ] 3.6.7 Verify build and tests pass
+
+---
+
+## Phase 4 — Legacy removal
+
+All modules are now on `CanonicalError`. Remove legacy infrastructure and finalize the `Problem` struct.
+
+### 4.1 Clean up Problem struct
+
+> Traces to: `cpt-cf-interface-problem-wire-format`, `cpt-cf-constraint-error-contract-stability`
+
+- [ ] 4.1.1 Remove `code: String` field from `Problem`
+- [ ] 4.1.2 Remove `errors: Option<Vec<ValidationViolation>>` field from `Problem`
+- [ ] 4.1.3 Change `context: Option<serde_json::Value>` to `context: serde_json::Value` (non-optional)
+- [ ] 4.1.4 Remove `with_code()` builder method
+- [ ] 4.1.5 Remove `with_errors()` builder method
+- [ ] 4.1.6 Remove or deprecate `Problem::new()` — all construction goes through `CanonicalError`
+- [ ] 4.1.7 Update snapshot tests to reflect final Problem shape
+
+### 4.2 Remove legacy error infrastructure
+
+> Traces to: `cpt-cf-constraint-error-contract-stability`
+
+- [ ] 4.2.1 Remove `ErrDef` struct from `libs/modkit-errors/src/catalog.rs`
+- [ ] 4.2.2 Remove `declare_errors!` macro from `libs/modkit-errors-macro/`
+- [ ] 4.2.3 Remove `ValidationViolation` struct (replaced by `FieldViolation` in `Validation` context)
+- [ ] 4.2.4 Remove `ValidationError` and `ValidationErrorResponse` structs
+- [ ] 4.2.5 Remove convenience constructors from `libs/modkit/src/api/problem.rs` (`bad_request`, `not_found`, `conflict`, `internal_error`)
+- [ ] 4.2.6 Remove all `gts/errors.json` files from modules and examples
+- [ ] 4.2.7 Remove any remaining `ErrorCode` enum references
+
+### 4.3 Final verification
+
+> Traces to: `cpt-cf-constraint-error-contract-stability`, `cpt-cf-principle-single-error-gateway`
+
+- [ ] 4.3.1 `cargo build` — workspace compiles with no legacy error references
+- [ ] 4.3.2 `cargo test` — all tests pass
+- [ ] 4.3.3 Grep verification: zero occurrences of `Problem::new`, `ErrDef`, `declare_errors!`, `ErrorCode`, `with_code()`, `with_errors()` in module code
+- [ ] 4.3.4 Grep verification: zero `gts/errors.json` files in repository
+
+---
+
+## Phase 5 — Documentation updates
+
+Update all documentation to reflect the canonical error architecture. Can run in parallel with Phases 2–4 once Phase 1 is merged.
+
+### 5.1 ModKit Unified System docs
+
+> Primary developer-facing documentation. These are the docs new contributors read first.
+
+- [ ] 5.1.1 Rewrite `docs/modkit_unified_system/05_errors_rfc9457.md` — replace `Problem::new()` / `ProblemType` / `ErrorCode` patterns with `CanonicalError` categories, `#[resource_error]` macro, typed context structs, and `Result<T, CanonicalError>` handler return types
+- [ ] 5.1.2 Update `docs/modkit_unified_system/01_overview.md` — update error handling summary to reference canonical errors instead of raw Problem construction
+- [ ] 5.1.3 Update `docs/modkit_unified_system/03_clienthub_and_plugins.md` — update error handling section to show `CanonicalError` in SDK error boundaries
+- [ ] 5.1.4 Update `docs/modkit_unified_system/04_rest_operation_builder.md` — update error registration examples to reflect canonical error categories
+- [ ] 5.1.5 Update `docs/modkit_unified_system/06_authn_authz_secure_orm.md` — update error handling patterns for auth flows
+- [ ] 5.1.6 Update `docs/modkit_unified_system/07_odata_pagination_select_filter.md` — update OData validation error handling to use `CanonicalError::invalid_argument` with `Validation` context
+- [ ] 5.1.7 Update `docs/modkit_unified_system/10_checklists_and_templates.md` — update error handling checklist and test templates
+- [ ] 5.1.8 Update `docs/modkit_unified_system/README.md` — update framework overview error references
+
+### 5.2 Architecture-level docs
+
+> High-level architecture and project governance docs.
+
+- [ ] 5.2.1 Update `docs/ARCHITECTURE_MANIFEST.md` — update error handling section (RFC-9457 + canonical categories), update `modkit-errors` library description
+- [ ] 5.2.2 Update `docs/REPO_PLAYBOOK.md` — update error handling standards references
+- [ ] 5.2.3 Update `docs/MODULES.md` — update error mapping component descriptions to reference canonical error flow
+
+### 5.3 Authorization docs
+
+> Auth-related docs that define error types and handling.
+
+- [ ] 5.3.1 Update `docs/arch/authorization/DESIGN.md` — map `AuthNResolverError` types to canonical categories
+- [ ] 5.3.2 Update `docs/arch/authorization/AUTHN_JWT_OIDC_PLUGIN.md` — update error handling section to use `CanonicalError::unauthenticated` / `service_unavailable` / `internal`
+- [ ] 5.3.3 Review `docs/arch/authorization/ADR/` — add notes about canonical error alignment where relevant
+
+### 5.4 Checklists and process docs
+
+> Review templates and coding standards.
+
+- [ ] 5.4.1 Update `docs/checklists/DESIGN.md` — update error handling architecture checklist (REL-DESIGN-002)
+- [ ] 5.4.2 Update `docs/checklists/FEATURE.md` — update security error handling (SEC-FDESIGN-006) and error handling completeness (REL-FDESIGN-001) checklists
+- [ ] 5.4.3 Update `docs/checklists/CODING.md` — update explicit error handling standards (ERR-CODE-001)
+- [ ] 5.4.4 Update `docs/checklists/PRD.md` — update error handling expectations (REL-PRD-003)
+
+### 5.5 Module SDK READMEs
+
+> Update after each module is migrated in Phase 3. Track per-module.
+
+- [ ] 5.5.1 Update OAGW SDK README error examples after 3.6 migration
+- [ ] 5.5.2 Update other module SDK READMEs as they migrate (credstore, tenant-resolver, authz-resolver, authn-resolver)
+
+### 5.6 Observability docs
+
+- [ ] 5.6.1 Update `docs/TRACING_SETUP.md` — document canonical error observability (internal vs unknown alerting, trace_id correlation)
+
+---
+
+## Separate workstreams (orthogonal to this migration)
+
+The following items from the original task list are independent of the canonical error migration and will be tracked separately:
+
+- **W3C trace ID extraction** — Replace `tracing::Span::current().id()` (u64 span ID) with a proper W3C trace ID from `opentelemetry` span context. Orthogonal; can be done before,
+  during, or after migration.
+- **Error middleware catch-all** — Catches unhandled errors (panics, framework errors), wraps as `CanonicalError::Internal`, strips `DebugInfo.stack_entries` in production,
+  attaches `trace_id`. Depends on Phase 1 completion.
+- **Semver CI gate** — Run `cargo-semver-checks` on `cf-modkit-errors` in CI. Should be added after Phase 1 snapshot tests are in place.

--- a/docs/arch/errors/examples/batch-composition.md
+++ b/docs/arch/errors/examples/batch-composition.md
@@ -1,0 +1,244 @@
+# Batch Composition — Canonical Errors in Batch Responses
+
+Canonical errors compose naturally with the batch pattern defined in [guidelines/DNA/REST/BATCH.md](../../../../guidelines/DNA/REST/BATCH.md). Each failed item in a batch response
+carries a full RFC 9457 Problem produced from a `CanonicalError`.
+
+> **Key point**: The canonical error model defines what a single error looks like. The batch envelope is a transport-layer concern. No changes to `CanonicalError` are needed for
+> batch support.
+
+---
+
+## Partial Success — Mixed Categories
+
+**Scenario**: Batch-creating three users. One succeeds, one has a duplicate email, one has invalid fields.
+
+```http
+POST /v1/users:batch HTTP/1.1
+Content-Type: application/json
+```
+
+```json
+{
+  "items": [
+    {
+      "idempotency_key": "req-1",
+      "data": { "email": "alice@example.com", "name": "Alice" }
+    },
+    {
+      "idempotency_key": "req-2",
+      "data": { "email": "bob@example.com", "name": "Bob" }
+    },
+    {
+      "idempotency_key": "req-3",
+      "data": { "email": "not-an-email", "name": "" }
+    }
+  ]
+}
+```
+
+```http
+HTTP/1.1 207 Multi-Status
+Content-Type: application/json
+```
+
+```json
+{
+  "items": [
+    {
+      "index": 0,
+      "idempotency_key": "req-1",
+      "status": 201,
+      "location": "/v1/users/01JUSR-ALICE",
+      "etag": "W/\"a1b2c3\"",
+      "data": {
+        "id": "01JUSR-ALICE",
+        "email": "alice@example.com",
+        "name": "Alice"
+      }
+    },
+    {
+      "index": 1,
+      "idempotency_key": "req-2",
+      "status": 409,
+      "error": {
+        "type": "gts.cf.core.errors.err.v1~cf.core.errors.already_exists.v1~",
+        "title": "Already Exists",
+        "status": 409,
+        "detail": "Resource already exists",
+        "instance": "/v1/users:batch#item-1",
+        "trace_id": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+        "context": {
+          "resource_type": "gts.cf.core.users.user.v1",
+          "resource_name": "bob@example.com",
+          "description": "Resource already exists"
+        }
+      }
+    },
+    {
+      "index": 2,
+      "idempotency_key": "req-3",
+      "status": 400,
+      "error": {
+        "type": "gts.cf.core.errors.err.v1~cf.core.errors.invalid_argument.v1~",
+        "title": "Invalid Argument",
+        "status": 400,
+        "detail": "Request validation failed",
+        "instance": "/v1/users:batch#item-2",
+        "trace_id": "b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7",
+        "context": {
+          "field_violations": [
+            {
+              "field": "email",
+              "description": "must be a valid email address",
+              "reason": "INVALID_FORMAT"
+            },
+            {
+              "field": "name",
+              "description": "is required",
+              "reason": "REQUIRED"
+            }
+          ],
+          "resource_type": "gts.cf.core.users.user.v1"
+        }
+      }
+    }
+  ]
+}
+```
+
+**What is happening**:
+
+- **Item 0**: Succeeded → `201 Created` with resource data
+- **Item 1**: `CanonicalError::AlreadyExists(ResourceInfo)` → per-item `409` with full Problem
+- **Item 2**: `CanonicalError::InvalidArgument(Validation::FieldViolations)` → per-item `400` with field violations
+- **Top-level**: `207 Multi-Status` because outcomes are mixed
+
+---
+
+## All Failed — Same Category
+
+When every item fails with the same HTTP status, the top-level status matches.
+
+**Scenario**: Batch-updating two upstreams, both have version conflicts.
+
+```http
+HTTP/1.1 409 Conflict
+Content-Type: application/json
+```
+
+```json
+{
+  "items": [
+    {
+      "index": 0,
+      "status": 409,
+      "error": {
+        "type": "gts.cf.core.errors.err.v1~cf.core.errors.aborted.v1~",
+        "title": "Aborted",
+        "status": 409,
+        "detail": "Operation aborted due to concurrency conflict",
+        "instance": "/v1/upstreams:batch#item-0",
+        "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+        "context": {
+          "resource_type": "gts.cf.oagw.upstreams.upstream.v1",
+          "reason": "OPTIMISTIC_LOCK_FAILURE",
+          "domain": "cf.oagw",
+          "metadata": {
+            "expected_version": "2",
+            "actual_version": "4"
+          }
+        }
+      }
+    },
+    {
+      "index": 1,
+      "status": 409,
+      "error": {
+        "type": "gts.cf.core.errors.err.v1~cf.core.errors.aborted.v1~",
+        "title": "Aborted",
+        "status": 409,
+        "detail": "Operation aborted due to concurrency conflict",
+        "instance": "/v1/upstreams:batch#item-1",
+        "trace_id": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+        "context": {
+          "resource_type": "gts.cf.oagw.upstreams.upstream.v1",
+          "reason": "OPTIMISTIC_LOCK_FAILURE",
+          "domain": "cf.oagw",
+          "metadata": {
+            "expected_version": "1",
+            "actual_version": "3"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+---
+
+## All Failed — Mixed Categories
+
+When all items fail but with different HTTP statuses, the top-level is still `207`.
+
+**Scenario**: Batch-deleting resources — one not found, one permission denied.
+
+```http
+HTTP/1.1 207 Multi-Status
+Content-Type: application/json
+```
+
+```json
+{
+  "items": [
+    {
+      "index": 0,
+      "status": 404,
+      "error": {
+        "type": "gts.cf.core.errors.err.v1~cf.core.errors.not_found.v1~",
+        "title": "Not Found",
+        "status": 404,
+        "detail": "Resource not found",
+        "instance": "/v1/users:batch#item-0",
+        "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+        "context": {
+          "resource_type": "gts.cf.core.users.user.v1",
+          "resource_name": "01JUSR-MISSING",
+          "description": "Resource not found"
+        }
+      }
+    },
+    {
+      "index": 1,
+      "status": 403,
+      "error": {
+        "type": "gts.cf.core.errors.err.v1~cf.core.errors.permission_denied.v1~",
+        "title": "Permission Denied",
+        "status": 403,
+        "detail": "You do not have permission to perform this operation",
+        "instance": "/v1/users:batch#item-1",
+        "trace_id": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+        "context": {
+          "resource_type": "gts.cf.core.users.user.v1",
+          "reason": "CROSS_TENANT_ACCESS",
+          "domain": "auth.cyberfabric.io",
+          "metadata": { }
+        }
+      }
+    }
+  ]
+}
+```
+
+---
+
+## Status Code Summary
+
+Reference from [guidelines/DNA/REST/BATCH.md](../../../../guidelines/DNA/REST/BATCH.md):
+
+| Batch Outcome            | Top-Level HTTP Status       |
+|--------------------------|-----------------------------|
+| All succeeded            | `200 OK` (or `201 Created`) |
+| Partial success/failure  | `207 Multi-Status`          |
+| All failed (same status) | Matching `4xx`              |
+| All failed (mixed)       | `207 Multi-Status`          |

--- a/docs/arch/errors/examples/contract-vs-variable.md
+++ b/docs/arch/errors/examples/contract-vs-variable.md
@@ -1,0 +1,131 @@
+# Contract vs Variable Parts of an Error Response
+
+Every error response has two distinct parts:
+
+- **Contract** (C) — fixed structure that consumers depend on. Changing any contract field is a **breaking change**. Determined by the **category**, not by the occurrence.
+- **Variable** (V) — values filled in by module code per occurrence. These change with every request and are **not part of the contract**.
+
+---
+
+## Field Classification
+
+Which Problem fields are contract, which are variable, and which depend on scope:
+
+| Field            | Part         | Resource-scoped        | Non-resource           | Who provides it                        |
+|------------------|--------------|------------------------|------------------------|----------------------------------------|
+| `type`           | **Contract** | GTS error category URI | GTS error category URI | Framework (from category)              |
+| `title`          | **Contract** | Fixed per category     | Fixed per category     | Framework (from category)              |
+| `status`         | **Contract** | Fixed per category     | Fixed per category     | Framework (from category)              |
+| `context` schema | **Contract** | Fixed per category     | Fixed per category     | Framework (from category)              |
+| `context` values | Variable     | Per-occurrence         | Per-occurrence         | Module code                            |
+| `detail`         | Variable     | Per-occurrence         | Per-occurrence         | Module code (error message)            |
+| `instance`       | Variable     | Per-occurrence         | Per-occurrence         | Framework (request URI)                |
+| `trace_id`       | Variable     | Per-occurrence         | Per-occurrence         | Middleware (from span)                 |
+| `debug`          | Variable     | Debug mode only        | Debug mode only        | Module code (via `.with_debug_info()`) |
+
+> The `debug` field is present only when the application runs in debug mode **and** the error has debug info attached. Consumers MUST NOT depend on its presence, absence, or
+> contents.
+
+> For resource-scoped errors (constructed via `XxxResourceError::category(...)`), `resource_type` is injected into the `context` object rather than appearing as a top-level field.
+
+---
+
+## Complete Response Shape by Category
+
+One row per category. **C** = Contract (breaking if changed), **V** = Variable (per-occurrence). Read any row to know the full response shape.
+
+| #  | Category              | `type` (C)                                                         | `title` (C)         | `status` (C) | Context Type (C)      | `resource_type` (V)                 |
+|----|-----------------------|--------------------------------------------------------------------|---------------------|--------------|-----------------------|-------------------------------------|
+| 1  | `invalid_argument`    | `gts.cf.core.errors.err.v1~cf.core.errors.invalid_argument.v1~`    | Invalid Argument    | 400          | `Validation`          | `gts.cf.core.users.user.v1`         |
+| 2  | `not_found`           | `gts.cf.core.errors.err.v1~cf.core.errors.not_found.v1~`           | Not Found           | 404          | `ResourceInfo`        | `gts.cf.oagw.upstreams.upstream.v1` |
+| 3  | `already_exists`      | `gts.cf.core.errors.err.v1~cf.core.errors.already_exists.v1~`      | Already Exists      | 409          | `ResourceInfo`        | `gts.cf.core.users.user.v1`         |
+| 4  | `permission_denied`   | `gts.cf.core.errors.err.v1~cf.core.errors.permission_denied.v1~`   | Permission Denied   | 403          | `ErrorInfo`           | `gts.cf.core.tenants.tenant.v1`     |
+| 5  | `unauthenticated`     | `gts.cf.core.errors.err.v1~cf.core.errors.unauthenticated.v1~`     | Unauthenticated     | 401          | `ErrorInfo`           | —                                   |
+| 6  | `resource_exhausted`  | `gts.cf.core.errors.err.v1~cf.core.errors.resource_exhausted.v1~`  | Resource Exhausted  | 429          | `QuotaFailure`        | —                                   |
+| 7  | `failed_precondition` | `gts.cf.core.errors.err.v1~cf.core.errors.failed_precondition.v1~` | Failed Precondition | 400          | `PreconditionFailure` | `gts.cf.core.tenants.tenant.v1`     |
+| 8  | `aborted`             | `gts.cf.core.errors.err.v1~cf.core.errors.aborted.v1~`             | Aborted             | 409          | `ErrorInfo`           | `gts.cf.oagw.upstreams.upstream.v1` |
+| 9  | `out_of_range`        | `gts.cf.core.errors.err.v1~cf.core.errors.out_of_range.v1~`        | Out of Range        | 400          | `Validation`          | `gts.cf.core.users.user.v1`         |
+| 10 | `unimplemented`       | `gts.cf.core.errors.err.v1~cf.core.errors.unimplemented.v1~`       | Unimplemented       | 501          | `ErrorInfo`           | `gts.cf.oagw.routes.route.v1`       |
+| 11 | `internal`            | `gts.cf.core.errors.err.v1~cf.core.errors.internal.v1~`            | Internal            | 500          | `DebugInfo`           | `gts.cf.core.users.user.v1`         |
+| 12 | `unknown`             | `gts.cf.core.errors.err.v1~cf.core.errors.unknown.v1~`             | Unknown             | 500          | `DebugInfo`           | —                                   |
+| 13 | `service_unavailable` | `gts.cf.core.errors.err.v1~cf.core.errors.service_unavailable.v1~` | Unavailable         | 503          | `RetryInfo`           | —                                   |
+| 14 | `deadline_exceeded`   | `gts.cf.core.errors.err.v1~cf.core.errors.deadline_exceeded.v1~`   | Deadline Exceeded   | 504          | `String` (message)    | `gts.cf.core.reports.report.v1`     |
+| 15 | `cancelled`           | `gts.cf.core.errors.err.v1~cf.core.errors.cancelled.v1~`           | Cancelled           | 499          | `String` (message)    | `gts.cf.core.reports.report.v1`     |
+| 16 | `data_loss`           | `gts.cf.core.errors.err.v1~cf.core.errors.data_loss.v1~`           | Data Loss           | 500          | `ResourceInfo`        | `gts.cf.core.files.file.v1`         |
+
+> **How to read**: columns 3-6 are **contract** — they never change for a given category. The `resource_type` column is **variable** — the values shown are examples
+> from [rest-responses.md](./rest-responses.md). Categories with **—** are typically system-level errors that use `CanonicalError::` directly (no resource scope). Any category
+> *can* be resource-scoped or not, depending on whether you use `XxxResourceError::` or `CanonicalError::`.
+
+Every row also has these **variable** fields (same for all categories, not shown in the table):
+
+| Field              | Source      | Example                                                         |
+|--------------------|-------------|-----------------------------------------------------------------|
+| `detail`           | Module code | `"Resource already exists"`                                     |
+| `instance`         | Framework   | `"/v1/users"`                                                   |
+| `trace_id`         | Middleware  | `"4bf92f3577b34da6a3ce929d0e0e4736"`                            |
+| `context.*` values | Module code | Varies per context type                                         |
+| `debug`            | Module code | `{ "detail": "...", "stack_entries": [...] }` (debug mode only) |
+
+---
+
+## Context Schema (Contract)
+
+The Context Type column above determines the `context` JSON shape. Full field types:
+
+| Context Type              | Schema                                          | Fields                                                                               | In Categories                                                      |
+|---------------------------|-------------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------|
+| **`Validation`**          | `{ field_violations[] }`                        | `field` `String`, `description` `String`, `reason` `String`                          | `invalid_argument`, `out_of_range`                                 |
+|                           | `{ format }`                                    | `format` `String`                                                                    |                                                                    |
+|                           | `{ constraint }`                                | `constraint` `String`                                                                |                                                                    |
+| **`ResourceInfo`**        | `{ resource_type, resource_name, description }` | `resource_type` `String (GTS URI)`, `resource_name` `String`, `description` `String` | `not_found`, `already_exists`, `data_loss`                         |
+| **`ErrorInfo`**           | `{ reason, domain, metadata }`                  | `reason` `String`, `domain` `String`, `metadata` `Map<String, String>`               | `permission_denied`, `aborted`, `unimplemented`, `unauthenticated` |
+| **`QuotaFailure`**        | `{ violations[] }`                              | `subject` `String`, `description` `String`                                           | `resource_exhausted`                                               |
+| **`PreconditionFailure`** | `{ violations[] }`                              | `type` `String`, `subject` `String`, `description` `String`                          | `failed_precondition`                                              |
+| **`DebugInfo`**           | `{ detail, stack_entries[] }`                   | `detail` `String`, `stack_entries` `[String]`                                        | `internal`, `unknown`                                              |
+| *(message only)*          | `String`                                        | —                                                                                    | `cancelled`, `deadline_exceeded`                                   |
+| **`RetryInfo`**           | `{ retry_after_seconds }`                       | `retry_after_seconds` `u64`                                                          | `service_unavailable`                                              |
+
+---
+
+## Annotated Example
+
+Putting it together for `already_exists` constructed via `UserResourceError::already_exists(...)`:
+
+```json
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.already_exists.v1~", // CONTRACT — fixed for already_exists
+  "title": "Already Exists", // CONTRACT — fixed for already_exists
+  "status": 409, // CONTRACT — fixed for already_exists
+  "detail": "Resource already exists", // variable — per occurrence
+  "instance": "/v1/users", // variable — request URI
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736", // variable — from span
+  "context": {
+    // CONTRACT schema, variable values
+    "resource_type": "gts.cf.core.users.user.v1", //   variable value
+    "resource_name": "alice@example.com", //   variable value
+    "description": "Resource already exists" // variable value
+  }
+}
+```
+
+---
+
+## What This Means for Change Protection
+
+| Change                                                    | Breaking? | Why                                              |
+|-----------------------------------------------------------|-----------|--------------------------------------------------|
+| Rename `context.resource_name` to `context.name`          | **Yes**   | Contract: consumers parse by field name          |
+| Remove `context.description` from `ResourceInfo`          | **Yes**   | Contract: consumers expect this field            |
+| Change `status` from `409` to `400` for `already_exists`  | **Yes**   | Contract: consumers branch on status code        |
+| Change the GTS identifier of a category                   | **Yes**   | Contract: consumers route on `type`              |
+| Change the context type of a category                     | **Yes**   | Contract: consumers expect a specific schema     |
+| Add `context.owner` optional field to `ResourceInfo`      | No        | Additive: consumers ignore unknown fields        |
+| Add a new canonical category                              | No        | Additive: consumers ignore unknown `type` values |
+| Change the `detail` message text                          | No        | Variable: consumers should not parse `detail`    |
+| Change `context.resource_name` value from UUID to slug    | No        | Variable: values are not contractual             |
+| Change `context.resource_type` value for a resource error | No        | Variable: resource identity is per-occurrence    |
+
+> **Rule**: Consumers may depend on **contract** fields (`type`, `title`, `status`, context field names and types). Consumers must **not** depend on **variable** fields (`detail`
+> text, specific context values, `instance` path, `context.resource_type`). This is the boundary between what the error architecture protects and what module code is free to
+> change.

--- a/docs/arch/errors/examples/edge-cases.md
+++ b/docs/arch/errors/examples/edge-cases.md
@@ -1,0 +1,381 @@
+# Edge Cases & Disambiguation Examples
+
+This document covers scenarios where the correct canonical category is non-obvious, security-sensitive, or requires special handling.
+
+> **Resource types**: Examples use macro-declared resource types (see `cpt-cf-constraint-macro-gts-construction`). These generate constructors for **all** canonical categories:
+> ```rust
+> #[resource_error("gts.cf.core.users.user.v1")]
+> struct UserResourceError;
+>
+> #[resource_error("gts.cf.oagw.upstreams.upstream.v1")]
+> struct UpstreamResourceError;
+> ```
+
+---
+
+## Production vs Debug Mode
+
+> **Note**: Debug/production mode switching is handled by error middleware (T10), which is not yet implemented in the PoC. The examples below show the target behavior. Without middleware, the PoC always produces the "Production Mode" output shape: `detail` is the safe generic message from the constructor, while `context.detail` contains the actual error text.
+
+The same `internal` error produces different responses depending on the environment.
+
+### Debug Mode
+
+```http
+HTTP/1.1 500 Internal Server Error
+Content-Type: application/problem+json
+
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.internal.v1~",
+  "title": "Internal",
+  "status": 500,
+  "detail": "column \"email\" of relation \"users\" violates not-null constraint",
+  "instance": "/v1/users",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "detail": "column \"email\" of relation \"users\" violates not-null constraint",
+    "stack_entries": [
+      "cf_users::service::create_user (src/service.rs:42)",
+      "cf_users::handler::post_user (src/handler.rs:18)"
+    ]
+  }
+}
+```
+
+### Production Mode
+
+```http
+HTTP/1.1 500 Internal Server Error
+Content-Type: application/problem+json
+
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.internal.v1~",
+  "title": "Internal",
+  "status": 500,
+  "detail": "An internal error occurred. Please retry later.",
+  "instance": "/v1/users",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "detail": "An internal error occurred. Please retry later.",
+    "stack_entries": []
+  }
+}
+```
+
+> The `trace_id` is always present — consumers use it to correlate with support requests. The actual error details are available only in server logs.
+
+### Debug Info on Non-Internal Errors
+
+Any canonical error category can carry optional debug info via `.with_debug_info()`. This is useful for attaching diagnostic context (SQL queries, cache keys, upstream responses) to errors like `not_found` or `permission_denied` without changing their category or semantics.
+
+```rust
+UserResourceError::not_found("user-123")
+    .with_debug_info(DebugInfo::new("SELECT * FROM users WHERE id = $1 returned 0 rows")
+        .with_stack(vec!["cf_users::repo::find_by_id (src/repo.rs:42)".into()]))
+```
+
+In debug mode (`Problem::from_error_debug(err)`), the response includes a top-level `"debug"` key:
+
+```json
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.not_found.v1~",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "Resource not found",
+  "context": {
+    "resource_type": "gts.cf.core.users.user.v1",
+    "resource_name": "user-123",
+    "description": "Resource not found"
+  },
+  "debug": {
+    "detail": "SELECT * FROM users WHERE id = $1 returned 0 rows",
+    "stack_entries": [
+      "cf_users::repo::find_by_id (src/repo.rs:42)"
+    ]
+  }
+}
+```
+
+In production mode (`Problem::from(err)` or `Problem::from_error(err)`), the `"debug"` key is absent — the response is identical to a normal `not_found`.
+
+---
+
+## not_found vs permission_denied (Security)
+
+When a resource exists but the caller lacks permission, the choice depends on whether revealing the resource's existence is a security risk.
+
+### Default: Return permission_denied
+
+Use when the resource type is not sensitive (caller knows resources exist in general):
+
+```rust
+// Caller is authenticated but not authorized for this tenant's users
+UserResourceError::permission_denied(
+    ErrorInfo::new("CROSS_TENANT_ACCESS", "auth.cyberfabric.io")
+)
+```
+
+```http
+HTTP/1.1 403 Forbidden
+```
+
+### Security-Sensitive: Return not_found
+
+Use when revealing existence leaks information (e.g., user enumeration):
+
+```rust
+// Caller queries another user's private profile — don't confirm it exists
+UserResourceError::not_found(user_id)
+```
+
+```http
+HTTP/1.1 404 Not Found
+```
+
+> **Rule of thumb**: If the caller should not know whether the resource exists, use `not_found`. Document this decision in the module's API specification.
+
+---
+
+## invalid_argument vs failed_precondition
+
+### invalid_argument — Input is wrong regardless of system state
+
+```rust
+// Email format is always invalid, no matter what state the system is in
+CanonicalError::invalid_argument(
+Validation::fields([
+FieldViolation::new("email", "must be a valid email address", "INVALID_FORMAT")
+])
+)
+```
+
+### failed_precondition — Input is valid but system state prevents the operation
+
+```rust
+// The document ID and format are valid, but it's already published
+CanonicalError::failed_precondition(
+PreconditionFailure::new([
+PreconditionViolation::new("STATE", "document.status", "Document is already published; unpublish before editing")
+])
+)
+```
+
+---
+
+## aborted vs failed_precondition
+
+Both signal "can't proceed," but differ in cause and retry strategy.
+
+### aborted — Transient concurrency conflict (retry the same request)
+
+```rust
+// Two users updated the same upstream simultaneously; one gets aborted
+UpstreamResourceError::aborted(
+    ErrorInfo::new("OPTIMISTIC_LOCK_FAILURE", "cf.oagw")
+        .with_metadata("expected_version", "3")
+        .with_metadata("actual_version", "5")
+)
+```
+
+> **Client action**: Re-read the resource, apply changes to the new version, retry.
+
+### failed_precondition — State violation (fix the state, then retry)
+
+```rust
+// Tenant has active users; can't delete until they're removed
+CanonicalError::failed_precondition(
+PreconditionFailure::new([
+PreconditionViolation::new("STATE", "tenant.users", "Remove all active users before deleting the tenant")
+])
+)
+```
+
+> **Client action**: Perform the corrective action described in `description`, then retry.
+
+---
+
+## invalid_argument vs out_of_range
+
+### invalid_argument — Structurally wrong value
+
+```rust
+// "abc" is not a number at all
+CanonicalError::invalid_argument(
+Validation::fields([
+FieldViolation::new("page", "must be a positive integer", "INVALID_TYPE")
+])
+)
+```
+
+### out_of_range — Valid type, but outside accepted bounds
+
+```rust
+// 50 is a valid integer, but the dataset only has 12 pages
+CanonicalError::out_of_range(
+Validation::constraint("Page 50 is beyond the last page (12)")
+)
+```
+
+---
+
+## internal vs unknown
+
+### internal — Server recognizes its own bug
+
+```rust
+// An invariant was violated in our code
+CanonicalError::internal(DebugInfo::new("User record has no tenant_id; data invariant violated"))
+```
+
+### unknown — Error from external source, category undetermined
+
+```rust
+// External SDK returned an opaque error we can't classify
+CanonicalError::unknown("Unexpected response from payment provider")
+```
+
+> Both produce HTTP 500. The distinction matters for observability: `internal` alerts are actionable bugs; `unknown` alerts need investigation to find the source.
+
+---
+
+## Library Error Absorption
+
+> **Note**: Blanket `From` impls for library errors (T7) are not yet in the PoC. The examples below show the target behavior.
+
+Common library errors convert automatically via the `?` operator. No manual mapping needed.
+
+### sqlx / sea_orm → internal
+
+```rust
+async fn get_user(&self, id: Uuid) -> Result<User, CanonicalError> {
+    // sqlx::Error automatically converts to CanonicalError::Internal
+    let user = sqlx::query_as::<_, User>("SELECT * FROM users WHERE id = $1")
+        .bind(id)
+        .fetch_one(&self.pool)
+        .await?;
+    Ok(user)
+}
+```
+
+### serde_json → invalid_argument
+
+```rust
+fn parse_config(raw: &str) -> Result<Config, CanonicalError> {
+    // serde_json::Error automatically converts to CanonicalError::InvalidArgument
+    let config: Config = serde_json::from_str(raw)?;
+    Ok(config)
+}
+```
+
+### Overriding the default mapping
+
+When the blanket mapping is too coarse, construct explicitly:
+
+```rust
+async fn get_user(&self, id: Uuid) -> Result<User, CanonicalError> {
+    match sqlx::query_as::<_, User>("SELECT * FROM users WHERE id = $1")
+        .bind(id)
+        .fetch_one(&self.pool)
+        .await
+    {
+        Ok(user) => Ok(user),
+        Err(sqlx::Error::RowNotFound) => Err(UserResourceError::not_found(id)),
+        Err(e) => Err(e.into()), // other sqlx errors → Internal
+    }
+}
+```
+
+---
+
+## Validation with Multiple Violations (Accumulation Pattern)
+
+Collect all validation errors before returning, so the client can fix everything at once.
+
+```rust
+fn validate_create_user(req: &CreateUserRequest) -> Result<(), CanonicalError> {
+    let mut violations = Vec::new();
+
+    if req.email.is_empty() {
+        violations.push(FieldViolation::new("email", "is required", "REQUIRED"));
+    } else if !is_valid_email(&req.email) {
+        violations.push(FieldViolation::new("email", "must be a valid email address", "INVALID_FORMAT"));
+    }
+
+    if req.name.len() < 2 {
+        violations.push(FieldViolation::new("name", "must be at least 2 characters", "TOO_SHORT"));
+    }
+
+    if req.name.len() > 100 {
+        violations.push(FieldViolation::new("name", "must be at most 100 characters", "TOO_LONG"));
+    }
+
+    if violations.is_empty() {
+        Ok(())
+    } else {
+        Err(UserResourceError::invalid_argument(Validation::fields(violations)))
+    }
+}
+```
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/problem+json
+
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.invalid_argument.v1~",
+  "title": "Invalid Argument",
+  "status": 400,
+  "detail": "Request validation failed",
+  "instance": "/v1/users",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "field_violations": [
+      {
+        "field": "email",
+        "description": "is required",
+        "reason": "REQUIRED"
+      },
+      {
+        "field": "name",
+        "description": "must be at least 2 characters",
+        "reason": "TOO_SHORT"
+      }
+    ],
+    "resource_type": "gts.cf.core.users.user.v1"
+  }
+}
+```
+
+---
+
+## Nested Field Paths
+
+The `field` value in `FieldViolation` uses XPath-style dot-separated paths with bracket notation for array indices. This format is a **contract restriction** — all field references MUST use this syntax. Extensions to the path syntax (e.g., wildcards, predicates) require a design change.
+
+```rust
+CanonicalError::invalid_argument(
+Validation::fields([
+FieldViolation::new("address.zip_code", "must be 5 digits", "INVALID_FORMAT"),
+FieldViolation::new("contacts[0].phone", "must include country code", "INVALID_FORMAT"),
+])
+)
+```
+
+```json
+{
+  "context": {
+    "field_violations": [
+      {
+        "field": "address.zip_code",
+        "description": "must be 5 digits",
+        "reason": "INVALID_FORMAT"
+      },
+      {
+        "field": "contacts[0].phone",
+        "description": "must include country code",
+        "reason": "INVALID_FORMAT"
+      }
+    ]
+  }
+}
+```

--- a/docs/arch/errors/examples/rest-responses.md
+++ b/docs/arch/errors/examples/rest-responses.md
@@ -1,0 +1,802 @@
+# REST Response Examples — All 16 Canonical Categories
+
+Every REST error response uses `Content-Type: application/problem+json` (RFC 9457). This document shows the complete cycle for each canonical category: resource error declaration,
+user code, and wire output.
+
+## How to Read Each Example
+
+Each category follows three steps:
+
+1. **Declaration** — the `#[resource_error]` macro, declared once per resource type in the module
+2. **User Code** — how domain code constructs the error (one-liner at the call site)
+3. **Output** — the RFC 9457 Problem JSON produced by `From<CanonicalError> for Problem`
+
+Categories that are typically not scoped to a specific resource (e.g., `unauthenticated`, `service_unavailable`) use direct `CanonicalError::` constructors instead of a resource
+error
+type.
+
+---
+
+## 1. invalid_argument
+
+**HTTP 400** | **Context**: `Validation` | **GTS**: `gts.cf.core.errors.err.v1~cf.core.errors.invalid_argument.v1~`
+
+Input is wrong regardless of system state — malformed fields, bad format, or violated constraints.
+
+### Declaration
+
+```rust
+#[resource_error("gts.cf.core.users.user.v1")]
+struct UserResourceError;
+```
+
+### User Code — Field Violations
+
+```rust
+UserResourceError::invalid_argument(Validation::fields([
+FieldViolation::new("email", "must be a valid email address", "INVALID_FORMAT"),
+FieldViolation::new("name", "must be between 2 and 100 characters", "OUT_OF_RANGE"),
+]))
+```
+
+### Output
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/problem+json
+
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.invalid_argument.v1~",
+  "title": "Invalid Argument",
+  "status": 400,
+  "detail": "Request validation failed",
+  "instance": "/v1/users",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "field_violations": [
+      {
+        "field": "email",
+        "description": "must be a valid email address",
+        "reason": "INVALID_FORMAT"
+      },
+      {
+        "field": "name",
+        "description": "must be between 2 and 100 characters",
+        "reason": "OUT_OF_RANGE"
+      }
+    ],
+    "resource_type": "gts.cf.core.users.user.v1"
+  }
+}
+```
+
+> **Validation variants**: `Validation` is an enum with three variants. `Validation::fields([...])` for field-level violations (shown above). `Validation::format("...")` for
+> malformed request bodies (e.g., invalid JSON). `Validation::constraint("...")` for general constraint violations that aren't field-specific. Each variant produces a different
+`context` shape — consumers use the `type` field to determine the schema.
+
+<details>
+<summary>Variant: Format (malformed request body, no resource scope)</summary>
+
+```rust
+CanonicalError::invalid_argument(Validation::format("request body is not valid JSON"))
+```
+
+```json
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.invalid_argument.v1~",
+  "title": "Invalid Argument",
+  "status": 400,
+  "detail": "request body is not valid JSON",
+  "instance": "/v1/users",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "format": "request body is not valid JSON"
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>Variant: Constraint (general constraint, no resource scope)</summary>
+
+```rust
+CanonicalError::invalid_argument(Validation::constraint("bulk import cannot exceed 1000 items"))
+```
+
+```json
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.invalid_argument.v1~",
+  "title": "Invalid Argument",
+  "status": 400,
+  "detail": "bulk import cannot exceed 1000 items",
+  "instance": "/v1/users:import",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "constraint": "bulk import cannot exceed 1000 items"
+  }
+}
+```
+
+</details>
+
+---
+
+## 2. not_found
+
+**HTTP 404** | **Context**: `ResourceInfo` | **GTS**: `gts.cf.core.errors.err.v1~cf.core.errors.not_found.v1~`
+
+A specific requested resource does not exist.
+
+### Declaration
+
+```rust
+#[resource_error("gts.cf.oagw.upstreams.upstream.v1")]
+struct UpstreamResourceError;
+```
+
+### User Code
+
+```rust
+UpstreamResourceError::not_found(upstream_id)
+```
+
+### Output
+
+```http
+HTTP/1.1 404 Not Found
+Content-Type: application/problem+json
+
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.not_found.v1~",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "Resource not found",
+  "instance": "/v1/upstreams/01JUPS-MISSING",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "resource_type": "gts.cf.oagw.upstreams.upstream.v1",
+    "resource_name": "01JUPS-MISSING",
+    "description": "Resource not found"
+  }
+}
+```
+
+---
+
+## 3. already_exists
+
+**HTTP 409** | **Context**: `ResourceInfo` | **GTS**: `gts.cf.core.errors.err.v1~cf.core.errors.already_exists.v1~`
+
+Client tried to create a resource that already exists.
+
+### Declaration
+
+```rust
+#[resource_error("gts.cf.core.users.user.v1")]
+struct UserResourceError;
+```
+
+### User Code
+
+```rust
+UserResourceError::already_exists("alice@example.com")
+```
+
+> The macro hardcodes `description` to `"Resource already exists"`. To customize the `detail` field in the Problem output, chain `.with_message("custom detail text")`.
+
+### Output
+
+```http
+HTTP/1.1 409 Conflict
+Content-Type: application/problem+json
+
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.already_exists.v1~",
+  "title": "Already Exists",
+  "status": 409,
+  "detail": "Resource already exists",
+  "instance": "/v1/users",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "resource_type": "gts.cf.core.users.user.v1",
+    "resource_name": "alice@example.com",
+    "description": "Resource already exists"
+  }
+}
+```
+
+---
+
+## 4. permission_denied
+
+**HTTP 403** | **Context**: `ErrorInfo` | **GTS**: `gts.cf.core.errors.err.v1~cf.core.errors.permission_denied.v1~`
+
+Caller is authenticated but lacks permission for this operation.
+
+### Declaration
+
+```rust
+#[resource_error("gts.cf.core.tenants.tenant.v1")]
+struct TenantResourceError;
+```
+
+### User Code
+
+```rust
+TenantResourceError::permission_denied(
+ErrorInfo::new("CROSS_TENANT_ACCESS", "auth.cyberfabric.io")
+)
+```
+
+### Output
+
+```http
+HTTP/1.1 403 Forbidden
+Content-Type: application/problem+json
+
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.permission_denied.v1~",
+  "title": "Permission Denied",
+  "status": 403,
+  "detail": "You do not have permission to perform this operation",
+  "instance": "/v1/tenants/01JTNT-OTHER/users",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "reason": "CROSS_TENANT_ACCESS",
+    "domain": "auth.cyberfabric.io",
+    "metadata": {},
+    "resource_type": "gts.cf.core.tenants.tenant.v1"
+  }
+}
+```
+
+---
+
+## 5. unauthenticated
+
+**HTTP 401** | **Context**: `ErrorInfo` | **GTS**: `gts.cf.core.errors.err.v1~cf.core.errors.unauthenticated.v1~`
+
+Request has no valid authentication credentials. Not scoped to a resource — uses `CanonicalError` directly.
+
+### User Code
+
+```rust
+CanonicalError::unauthenticated(
+ErrorInfo::new("TOKEN_EXPIRED", "auth.cyberfabric.io")
+.with_metadata("expires_at", "2026-02-25T10:00:00Z")
+)
+```
+
+### Output
+
+```http
+HTTP/1.1 401 Unauthorized
+Content-Type: application/problem+json
+
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.unauthenticated.v1~",
+  "title": "Unauthenticated",
+  "status": 401,
+  "detail": "Authentication required",
+  "instance": "/v1/users/me",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "reason": "TOKEN_EXPIRED",
+    "domain": "auth.cyberfabric.io",
+    "metadata": {
+      "expires_at": "2026-02-25T10:00:00Z"
+    }
+  }
+}
+```
+
+---
+
+## 6. resource_exhausted
+
+**HTTP 429** | **Context**: `QuotaFailure` | **GTS**: `gts.cf.core.errors.err.v1~cf.core.errors.resource_exhausted.v1~`
+
+Quota or rate limit exceeded. Typically system-level — uses `CanonicalError` directly.
+
+### User Code
+
+```rust
+CanonicalError::resource_exhausted(QuotaFailure::new([
+QuotaViolation::new(
+"requests_per_minute",
+"Limit of 100 requests per minute exceeded",
+),
+]))
+```
+
+### Output
+
+```http
+HTTP/1.1 429 Too Many Requests
+Content-Type: application/problem+json
+
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.resource_exhausted.v1~",
+  "title": "Resource Exhausted",
+  "status": 429,
+  "detail": "Quota exceeded",
+  "instance": "/v1/users",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "violations": [
+      {
+        "subject": "requests_per_minute",
+        "description": "Limit of 100 requests per minute exceeded"
+      }
+    ]
+  }
+}
+```
+
+---
+
+## 7. failed_precondition
+
+**HTTP 400** | **Context**: `PreconditionFailure` | **GTS**: `gts.cf.core.errors.err.v1~cf.core.errors.failed_precondition.v1~`
+
+System is not in the required state — the input is valid but the operation cannot proceed. Differs from `invalid_argument` (input is wrong regardless of state) and from `aborted` (
+transient concurrency issue).
+
+### Declaration
+
+```rust
+#[resource_error("gts.cf.core.tenants.tenant.v1")]
+struct TenantResourceError;
+```
+
+### User Code
+
+```rust
+TenantResourceError::failed_precondition(PreconditionFailure::new([
+PreconditionViolation::new(
+"STATE",
+"tenant.users",
+"Tenant must have zero active users before deletion",
+),
+]))
+```
+
+### Output
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/problem+json
+
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.failed_precondition.v1~",
+  "title": "Failed Precondition",
+  "status": 400,
+  "detail": "Operation precondition not met",
+  "instance": "/v1/tenants/01JTNT-ABC",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "violations": [
+      {
+        "type": "STATE",
+        "subject": "tenant.users",
+        "description": "Tenant must have zero active users before deletion"
+      }
+    ],
+    "resource_type": "gts.cf.core.tenants.tenant.v1"
+  }
+}
+```
+
+---
+
+## 8. aborted
+
+**HTTP 409** | **Context**: `ErrorInfo` | **GTS**: `gts.cf.core.errors.err.v1~cf.core.errors.aborted.v1~`
+
+Operation aborted due to a transient concurrency conflict. Client should re-read and retry.
+
+### Declaration
+
+```rust
+#[resource_error("gts.cf.oagw.upstreams.upstream.v1")]
+struct UpstreamResourceError;
+```
+
+### User Code
+
+```rust
+UpstreamResourceError::aborted(
+ErrorInfo::new("OPTIMISTIC_LOCK_FAILURE", "cf.oagw")
+.with_metadata("expected_version", "3")
+.with_metadata("actual_version", "5")
+)
+```
+
+### Output
+
+```http
+HTTP/1.1 409 Conflict
+Content-Type: application/problem+json
+
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.aborted.v1~",
+  "title": "Aborted",
+  "status": 409,
+  "detail": "Operation aborted due to concurrency conflict",
+  "instance": "/v1/upstreams/01JUPS-ABC",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "reason": "OPTIMISTIC_LOCK_FAILURE",
+    "domain": "cf.oagw",
+    "metadata": {
+      "expected_version": "3",
+      "actual_version": "5"
+    },
+    "resource_type": "gts.cf.oagw.upstreams.upstream.v1"
+  }
+}
+```
+
+---
+
+## 9. out_of_range
+
+**HTTP 400** | **Context**: `Validation` | **GTS**: `gts.cf.core.errors.err.v1~cf.core.errors.out_of_range.v1~`
+
+Value is syntactically valid but outside the accepted range. Differs from `invalid_argument` (structurally wrong).
+
+### Declaration
+
+```rust
+#[resource_error("gts.cf.core.users.user.v1")]
+struct UserResourceError;
+```
+
+### User Code
+
+```rust
+UserResourceError::out_of_range(
+Validation::constraint("Page 50 is beyond the last page (12)")
+)
+```
+
+### Output
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/problem+json
+
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.out_of_range.v1~",
+  "title": "Out of Range",
+  "status": 400,
+  "detail": "Page 50 is beyond the last page (12)",
+  "instance": "/v1/users?page=50",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "constraint": "Page 50 is beyond the last page (12)",
+    "resource_type": "gts.cf.core.users.user.v1"
+  }
+}
+```
+
+---
+
+## 10. unimplemented
+
+**HTTP 501** | **Context**: `ErrorInfo` | **GTS**: `gts.cf.core.errors.err.v1~cf.core.errors.unimplemented.v1~`
+
+Operation is not supported or not yet implemented.
+
+### Declaration
+
+```rust
+#[resource_error("gts.cf.oagw.routes.route.v1")]
+struct RouteResourceError;
+```
+
+### User Code
+
+```rust
+RouteResourceError::unimplemented(
+ErrorInfo::new("GRPC_ROUTING", "cf.oagw")
+)
+```
+
+### Output
+
+```http
+HTTP/1.1 501 Not Implemented
+Content-Type: application/problem+json
+
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.unimplemented.v1~",
+  "title": "Unimplemented",
+  "status": 501,
+  "detail": "This operation is not implemented",
+  "instance": "/v1/routes/01JRTE-ABC/grpc-config",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "reason": "GRPC_ROUTING",
+    "domain": "cf.oagw",
+    "metadata": {},
+    "resource_type": "gts.cf.oagw.routes.route.v1"
+  }
+}
+```
+
+---
+
+## 11. internal
+
+**HTTP 500** | **Context**: `DebugInfo` | **GTS**: `gts.cf.core.errors.err.v1~cf.core.errors.internal.v1~`
+
+Unexpected server error — bugs, invariant violations, or library errors absorbed via `?`. In production, details are stripped.
+See [edge-cases.md](./edge-cases.md#production-vs-debug-mode) for the debug mode variant with stack traces.
+
+### Declaration
+
+```rust
+#[resource_error("gts.cf.core.users.user.v1")]
+struct UserResourceError;
+```
+
+### User Code
+
+```rust
+UserResourceError::internal(DebugInfo::new("An internal error occurred. Please retry later."))
+```
+
+> Library errors (sqlx, serde_json, etc.) also convert via the `?` operator using blanket `From` impls — see [edge-cases.md](./edge-cases.md#library-error-absorption). The `?` path
+> produces `CanonicalError::Internal` without `resource_type`.
+
+### Output
+
+```http
+HTTP/1.1 500 Internal Server Error
+Content-Type: application/problem+json
+
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.internal.v1~",
+  "title": "Internal",
+  "status": 500,
+  "detail": "An internal error occurred. Please retry later.",
+  "instance": "/v1/users/01JUSR-ABC",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "detail": "An internal error occurred. Please retry later.",
+    "stack_entries": [],
+    "resource_type": "gts.cf.core.users.user.v1"
+  }
+}
+```
+
+---
+
+## 12. unknown
+
+**HTTP 500** | **Context**: `DebugInfo` | **GTS**: `gts.cf.core.errors.err.v1~cf.core.errors.unknown.v1~`
+
+Error from an unknown source where the category cannot be determined. Differs from `internal` (server's own bugs) — `unknown` is for opaque external errors.
+
+### User Code
+
+```rust
+CanonicalError::unknown("Unexpected response from payment provider")
+```
+
+### Output
+
+```http
+HTTP/1.1 500 Internal Server Error
+Content-Type: application/problem+json
+
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.unknown.v1~",
+  "title": "Unknown",
+  "status": 500,
+  "detail": "Unexpected response from payment provider",
+  "instance": "/v1/integrations/payments/sync",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "detail": "Unexpected response from payment provider",
+    "stack_entries": []
+  }
+}
+```
+
+---
+
+## 13. service_unavailable
+
+**HTTP 503** | **Context**: `RetryInfo` | **GTS**: `gts.cf.core.errors.err.v1~cf.core.errors.service_unavailable.v1~`
+
+Service temporarily unavailable — client should retry. Not scoped to a resource.
+
+### User Code
+
+```rust
+CanonicalError::service_unavailable(RetryInfo::after_seconds(30))
+```
+
+### Output
+
+```http
+HTTP/1.1 503 Service Unavailable
+Content-Type: application/problem+json
+Retry-After: 30
+
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.service_unavailable.v1~",
+  "title": "Unavailable",
+  "status": 503,
+  "detail": "Service temporarily unavailable",
+  "instance": "/v1/users",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "retry_after_seconds": 30
+  }
+}
+```
+
+---
+
+## 14. deadline_exceeded
+
+**HTTP 504** | **Context**: `String` (message) | **GTS**: `gts.cf.core.errors.err.v1~cf.core.errors.deadline_exceeded.v1~`
+
+Operation did not complete within the allowed time.
+
+### Declaration
+
+```rust
+#[resource_error("gts.cf.core.reports.report.v1")]
+struct ReportResourceError;
+```
+
+### User Code
+
+```rust
+ReportResourceError::deadline_exceeded("Report generation exceeded 30s timeout")
+```
+
+### Output
+
+```http
+HTTP/1.1 504 Gateway Timeout
+Content-Type: application/problem+json
+
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.deadline_exceeded.v1~",
+  "title": "Deadline Exceeded",
+  "status": 504,
+  "detail": "Report generation exceeded 30s timeout",
+  "instance": "/v1/reports/generate",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "resource_type": "gts.cf.core.reports.report.v1"
+  }
+}
+```
+
+---
+
+## 15. cancelled
+
+**HTTP 499** | **Context**: `String` (message) | **GTS**: `gts.cf.core.errors.err.v1~cf.core.errors.cancelled.v1~`
+
+Operation cancelled by the caller (client disconnected).
+
+### Declaration
+
+```rust
+#[resource_error("gts.cf.core.reports.report.v1")]
+struct ReportResourceError;
+```
+
+### User Code
+
+```rust
+ReportResourceError::cancelled("Client disconnected during report generation")
+```
+
+### Output
+
+```http
+HTTP/1.1 499 Client Closed Request
+Content-Type: application/problem+json
+
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.cancelled.v1~",
+  "title": "Cancelled",
+  "status": 499,
+  "detail": "Client disconnected during report generation",
+  "instance": "/v1/reports/generate",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "resource_type": "gts.cf.core.reports.report.v1"
+  }
+}
+```
+
+---
+
+## 16. data_loss
+
+**HTTP 500** | **Context**: `ResourceInfo` | **GTS**: `gts.cf.core.errors.err.v1~cf.core.errors.data_loss.v1~`
+
+Unrecoverable data loss or corruption detected.
+
+### Declaration
+
+```rust
+#[resource_error("gts.cf.core.files.file.v1")]
+struct FileResourceError;
+```
+
+### User Code
+
+```rust
+FileResourceError::data_loss("01JFILE-ABC")
+```
+
+> The macro hardcodes `description` to `"Data loss detected"`. To customize the `detail` field in the Problem output, chain `.with_message("custom detail text")`.
+
+### Output
+
+```http
+HTTP/1.1 500 Internal Server Error
+Content-Type: application/problem+json
+
+{
+  "type": "gts.cf.core.errors.err.v1~cf.core.errors.data_loss.v1~",
+  "title": "Data Loss",
+  "status": 500,
+  "detail": "Data loss detected",
+  "instance": "/v1/files/01JFILE-ABC",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "context": {
+    "resource_type": "gts.cf.core.files.file.v1",
+    "resource_name": "01JFILE-ABC",
+    "description": "Data loss detected"
+  }
+}
+```
+
+---
+
+## Quick Reference
+
+All resource error types declared in these examples:
+
+```rust
+#[resource_error("gts.cf.core.users.user.v1")]
+struct UserResourceError;
+
+#[resource_error("gts.cf.core.tenants.tenant.v1")]
+struct TenantResourceError;
+
+#[resource_error("gts.cf.core.files.file.v1")]
+struct FileResourceError;
+
+#[resource_error("gts.cf.core.reports.report.v1")]
+struct ReportResourceError;
+
+#[resource_error("gts.cf.oagw.upstreams.upstream.v1")]
+struct UpstreamResourceError;
+
+#[resource_error("gts.cf.oagw.routes.route.v1")]
+struct RouteResourceError;
+```
+
+Summary of which categories use resource-scoped vs direct constructors:
+
+| Pattern                           | Categories                                                                                                                                                                                                                                               | Why                                                                              |
+|-----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
+| `XxxResourceError::category(...)` | `invalid_argument`, `not_found`, `already_exists`, `permission_denied`, `failed_precondition`, `aborted`, `out_of_range`, `unimplemented`, `internal`, `deadline_exceeded`, `cancelled`, `data_loss`, `unauthenticated`, `resource_exhausted`, `unknown` | Error may be about a specific resource                                           |
+| `CanonicalError::category(...)`   | `service_unavailable`                                                                                                                                                                                                                                    | System-level only; any category can also be used directly without resource scope |
+
+> Most categories can be used both ways: via the `XxxResourceError::category(...)` macro (which injects `resource_type` into the `context`) or via `CanonicalError::category(...)`
+> directly (no `resource_type`). Only `service_unavailable` is exclusively direct — it has no resource-scoped variant. Consumers route on `type` (GTS error category) and can
+> optionally use `resource_type` inside `context` to identify the affected resource.


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#739](https://github.com/cyberfabric/cyberware-rust/pull/739) | **Author:** striped-zebra-dev | **Opened:** 2026-02-25T10:38:17Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

Design proposal for a universal error architecture that replaces the current ad-hoc error system (`Problem::new()` / `ErrDef` / `declare_errors!` / `ErrorCode`) with a canonical 16-category error model inspired by Google's canonical error codes.

**This will change the modkit response API.** Every REST error response will migrate from the current `code` + `errors` fields to a structured `context` field with a category-specific schema. The `Problem` struct's public surface in `libs/modkit-errors` will change: `code` and `errors` fields are removed, replaced by `context` (typed per category) and `debug` (optional diagnostics).

## What's in scope

- **PRD** — requirements, functional drivers, NFRs
- **ADR** — decision record for typed-variant enum approach (supersedes PR #2077)
- **Technical Design** — 16 canonical categories, context types, GTS identifiers, `#[resource_error]` macro, `From<CanonicalError> for Problem` mapping, construction paths (resource-scoped vs direct), contract enforcement strategy (4-tier)
- **Migration Plan** — four-phase strategy with `cpt-` traceability:
  1. **Foundation** (non-breaking) — port PoC into `libs/modkit-errors`, additive only
  2. **Example migration** — migrate `users-info` to validate the pattern
  3. **System module migration** — migrate all modules (~40 files across 7+ modules)
  4. **Legacy removal** — remove `code`, `errors`, `ErrDef`, `declare_errors!`, `ErrorCode`
- **Examples** — REST responses, batch composition, contract-vs-variable fields, edge cases

## What's NOT in scope

- **No code changes** — this PR is documentation only
- gRPC mapping (`From<CanonicalError> for tonic::Status`) — future work
- W3C trace ID extraction — separate workstream
- Error middleware catch-all — depends on Phase 1, tracked separately

## Impact

- `libs/modkit-errors` public API will change (new types, eventually removed fields)
- Wire format of all REST error responses will change per-module during migration
- ~40 files across `oagw`, `nodes-registry`, `types-registry`, `simple-user-settings`, `api-gateway`, `file-parser`, and `users-info` will be migrated
- Handlers will migrate from `Result<T, Problem>` to `Result<T, CanonicalError>`

## Validated by

Standalone PoC: [canonical-errors](https://github.com/striped-zebra-dev/canonical-errors) — 54 tests covering all 16 categories, context types, `#[resource_error]` macro, `Problem::from_error()` / `Problem::from_error_debug()` mapping, and contract enforcement strategy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive design and PRD for a Universal Error Architecture with a 16-category canonical error vocabulary and RFC 9457–style mapping.
  * Added ADR describing the selected canonical-error approach, rationale, trade-offs, and verification guidance.
  * Added practical guides and examples: REST responses, batch composition, contract-vs-variable fields, and edge cases.
  * Added a phased migration plan and tasks for adopting the canonical error system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#739 -->