### PR TITLE
[PR #733] OAGW Pingora-based proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +277,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +546,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +646,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,7 +701,7 @@ dependencies = [
  "pin-project-lite",
  "rand 0.9.2",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -708,13 +780,34 @@ dependencies = [
 
 [[package]]
 name = "brotli"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor 2.5.1",
+]
+
+[[package]]
+name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor",
+ "brotli-decompressor 5.0.0",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -725,6 +818,17 @@ checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -1297,7 +1401,7 @@ dependencies = [
  "pin-project-lite",
  "rand 0.9.2",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1517,9 +1621,14 @@ dependencies = [
  "futures-util",
  "gts",
  "http",
+ "httparse",
  "hyper",
  "inventory",
- "reqwest",
+ "pingora-core",
+ "pingora-http",
+ "pingora-load-balancing",
+ "pingora-proxy",
+ "rustls",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1547,6 +1656,34 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "cf-rustracing"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f85c3824e4191621dec0551e3cef3d511f329da9a8990bf3e450a85651d97e"
+dependencies = [
+ "backtrace",
+ "rand 0.8.5",
+ "tokio",
+ "trackable",
+]
+
+[[package]]
+name = "cf-rustracing-jaeger"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a5f80d44c257c3300a7f45ada676c211e64bbbac591bbec19344a8f61fbcab"
+dependencies = [
+ "cf-rustracing",
+ "hostname",
+ "local-ip-address",
+ "percent-encoding",
+ "rand 0.9.2",
+ "thrift_codec",
+ "tokio",
+ "trackable",
 ]
 
 [[package]]
@@ -1921,7 +2058,7 @@ version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00828ba6fd27b45a448e57dbfe84f1029d4c9f26b368157e9a448a5f49a2ec2a"
 dependencies = [
- "brotli",
+ "brotli 8.0.2",
  "compression-core",
  "flate2",
  "memchr",
@@ -2124,6 +2261,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "daemonize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2237,6 +2383,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,6 +2404,17 @@ checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2738,6 +2909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
+ "libz-ng-sys",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -2781,21 +2953,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -3004,6 +3161,12 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -3440,7 +3603,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -3462,22 +3625,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3495,11 +3642,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -3543,6 +3688,7 @@ dependencies = [
  "cf-types-registry",
  "clap",
  "mimalloc",
+ "rustls",
  "serde-saphyr 0.0.16",
  "serde_json",
  "tempfile",
@@ -3977,6 +4123,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-ng-sys"
+version = "1.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bf914b7dd154ca9193afec311d8e39345c1bd93b48b3faa77329f0db8f553c0"
+dependencies = [
+ "cmake",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4031,7 +4187,7 @@ dependencies = [
  "itoa",
  "log",
  "md-5",
- "nom",
+ "nom 8.0.0",
  "nom_locate",
  "rand 0.9.2",
  "rangemap",
@@ -4040,6 +4196,15 @@ dependencies = [
  "thiserror 2.0.18",
  "ttf-parser",
  "weezl",
+]
+
+[[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -4121,6 +4286,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mimalloc"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4134,6 +4308,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -4189,23 +4369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5d26952a508f321b4d3d2e80e78fc2603eaefcdf0c30783867f19586518bdc"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "neli"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4236,6 +4399,18 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
@@ -4259,10 +4434,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "no_debug"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f23a60c850e1144fc1dd9435152e0cfdc7dd18725350b4243584118013a52a4"
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nom"
@@ -4281,7 +4472,7 @@ checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
 dependencies = [
  "bytecount",
  "memchr",
- "nom",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -4462,6 +4653,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "odata-params"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4473,6 +4673,15 @@ dependencies = [
  "peg",
  "thiserror 1.0.69",
  "uuid",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -4488,48 +4697,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.75"
+name = "openssl-probe"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.115",
-]
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -4932,6 +5109,252 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pingora-cache"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcea698ba4fef0863caf2feaf0f699ee29d82c19f9c54bc55c8f29e8609c773c"
+dependencies = [
+ "ahash 0.8.12",
+ "async-trait",
+ "blake2",
+ "bstr",
+ "bytes",
+ "cf-rustracing",
+ "cf-rustracing-jaeger",
+ "hex",
+ "http",
+ "httparse",
+ "httpdate",
+ "indexmap 1.9.3",
+ "log",
+ "lru",
+ "once_cell",
+ "parking_lot",
+ "pingora-core",
+ "pingora-error",
+ "pingora-header-serde",
+ "pingora-http",
+ "pingora-lru",
+ "pingora-timeout",
+ "rand 0.8.5",
+ "regex",
+ "rmp",
+ "rmp-serde",
+ "serde",
+ "strum",
+ "tokio",
+]
+
+[[package]]
+name = "pingora-core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aced35d346b7c6559234b5ec493d638471d3234b0152f18c59390bbdafac2a7"
+dependencies = [
+ "ahash 0.8.12",
+ "async-trait",
+ "brotli 3.5.0",
+ "bstr",
+ "bytes",
+ "chrono",
+ "clap",
+ "daemonize",
+ "derivative",
+ "flate2",
+ "futures",
+ "h2",
+ "http",
+ "httparse",
+ "httpdate",
+ "libc",
+ "log",
+ "nix 0.24.3",
+ "once_cell",
+ "openssl-probe 0.1.6",
+ "ouroboros",
+ "parking_lot",
+ "percent-encoding",
+ "pingora-error",
+ "pingora-http",
+ "pingora-pool",
+ "pingora-runtime",
+ "pingora-rustls",
+ "pingora-timeout",
+ "prometheus",
+ "rand 0.8.5",
+ "regex",
+ "serde",
+ "serde_yaml",
+ "sfv",
+ "socket2",
+ "strum",
+ "strum_macros",
+ "tokio",
+ "tokio-stream",
+ "tokio-test",
+ "unicase",
+ "windows-sys 0.59.0",
+ "x509-parser",
+ "zstd",
+]
+
+[[package]]
+name = "pingora-error"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b761e30ae329162ddddbbb41d2bf8a3e48d52c70a0d5ff51ccb964acf0bd505"
+
+[[package]]
+name = "pingora-header-serde"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640aa945c00ad51c7d06a434c41dbad560bf51dbf6f00e5d614102e7794aae67"
+dependencies = [
+ "bytes",
+ "http",
+ "httparse",
+ "pingora-error",
+ "pingora-http",
+ "thread_local",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "pingora-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf2ce52fefeb2ed795a3d5fa4b556cfa33a7592691677e8837c6a58d0358215"
+dependencies = [
+ "bytes",
+ "http",
+ "pingora-error",
+]
+
+[[package]]
+name = "pingora-ketama"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5566ee2f3ca3ba478792d765d6b28aaf1ebae4a7f302c7eb814c83f4d793c1f1"
+dependencies = [
+ "crc32fast",
+]
+
+[[package]]
+name = "pingora-load-balancing"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e7ff0d87ab5924c1af03fc1b766aef398e75cfe0273019f68b7c2978002ca97"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "derivative",
+ "fnv",
+ "futures",
+ "http",
+ "log",
+ "pingora-core",
+ "pingora-error",
+ "pingora-http",
+ "pingora-ketama",
+ "pingora-runtime",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
+name = "pingora-lru"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aa964c4e12e6328388b7059c93aac37b052be7962bbb70dd239b515532be4bf"
+dependencies = [
+ "arrayvec",
+ "hashbrown 0.16.1",
+ "parking_lot",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "pingora-pool"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a89f8d8d48caadb7f711227e0754bac6495dd2d4ee03137cc2c6d46c3b0a9d"
+dependencies = [
+ "crossbeam-queue",
+ "log",
+ "lru",
+ "parking_lot",
+ "pingora-timeout",
+ "thread_local",
+ "tokio",
+]
+
+[[package]]
+name = "pingora-proxy"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0884d6158a828f53f4069861493a4225ed2a26c8d739a875350fa0c97109edf"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "clap",
+ "futures",
+ "h2",
+ "http",
+ "log",
+ "once_cell",
+ "pingora-cache",
+ "pingora-core",
+ "pingora-error",
+ "pingora-http",
+ "rand 0.8.5",
+ "regex",
+ "tokio",
+]
+
+[[package]]
+name = "pingora-runtime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c107d6eaf57c98285b91c487a1972bcb08405f39f9e73a5c28525620f7010956"
+dependencies = [
+ "once_cell",
+ "rand 0.8.5",
+ "thread_local",
+ "tokio",
+]
+
+[[package]]
+name = "pingora-rustls"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46dd230b3c4545f02be082e6409169a57982a1f3d97468e70f1fb21c6dd170c0"
+dependencies = [
+ "log",
+ "no_debug",
+ "pingora-error",
+ "ring",
+ "rustls",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio-rustls",
+]
+
+[[package]]
+name = "pingora-timeout"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64451dc4613770411814209b8c1659945682f0258305bae51c1e44cb9b887d30"
+dependencies = [
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "thread_local",
+ "tokio",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5126,6 +5549,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5177,6 +5615,12 @@ checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "ptr_meta"
@@ -5477,39 +5921,29 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
- "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
 ]
 
@@ -5564,6 +5998,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
 ]
 
 [[package]]
@@ -5643,6 +6096,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5655,6 +6114,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -5688,14 +6156,27 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.6.0",
 ]
 
 [[package]]
@@ -6008,6 +6489,19 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
@@ -6223,6 +6717,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sfv"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fa1f336066b758b7c9df34ed049c0e693a426afe2b27ff7d5b14f410ab1a132"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap 2.13.0",
+ "rust_decimal",
 ]
 
 [[package]]
@@ -6678,6 +7183,22 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.115",
+]
 
 [[package]]
 name = "subtle"
@@ -6748,27 +7269,6 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "windows",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -6912,6 +7412,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift_codec"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d957f535b242b91aa9f47bde08080f9a6fef276477e55b0079979d002759d5"
+dependencies = [
+ "byteorder",
+ "trackable",
+]
+
+[[package]]
 name = "tiff"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7012,16 +7522,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.115",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -7390,6 +7890,25 @@ checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
  "syn 2.0.115",
+]
+
+[[package]]
+name = "trackable"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15bd114abb99ef8cee977e517c8f37aee63f184f2d08e3e6ceca092373369ae"
+dependencies = [
+ "trackable_derive",
+]
+
+[[package]]
+name = "trackable_derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebeb235c5847e2f82cfe0f07eb971d1e5f6804b18dac2ae16349cc604380f82f"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7906,19 +8425,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8156,6 +8662,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -8537,6 +9052,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
 ]
 
 [[package]]

--- a/apps/hyperspot-server/Cargo.toml
+++ b/apps/hyperspot-server/Cargo.toml
@@ -54,6 +54,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 clap = { workspace = true }
 serde_json = { workspace = true }
+rustls = { workspace = true }
 
 # Optional example module
 users-info = { path = "../../examples/modkit/users-info/users-info", optional = true }

--- a/apps/hyperspot-server/src/main.rs
+++ b/apps/hyperspot-server/src/main.rs
@@ -65,6 +65,13 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Install the default TLS crypto provider (aws-lc-rs) before any module
+    // touches rustls. Required because both aws-lc-rs (via sqlx) and ring
+    // (via pingora-rustls) are in the dep tree, preventing auto-detection.
+    if rustls::crypto::CryptoProvider::get_default().is_none() {
+        drop(rustls::crypto::aws_lc_rs::default_provider().install_default());
+    }
+
     let cli = Cli::parse();
 
     // Layered config:

--- a/deny.toml
+++ b/deny.toml
@@ -36,6 +36,7 @@ yanked = "warn"
 ignore = [
   # "RUSTSEC-0000-0000",
   "RUSTSEC-2023-0071", # we cannot replace rsa 0.9 as it's used by sqlx-mysql AND jsonwebtoken
+  "RUSTSEC-2024-0437", # protobuf 2.28 stack overflow — transitive via pingora-core→prometheus 0.13; we never parse untrusted protobuf (prometheus metrics endpoint is unused)
 ]
 
 # Note:

--- a/modules/system/oagw/oagw-sdk/src/api.rs
+++ b/modules/system/oagw/oagw-sdk/src/api.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use modkit_security::SecurityContext;
 use uuid::Uuid;
 
@@ -42,7 +43,7 @@ impl ErrorSource {
 /// ```ignore
 /// let gw = hub.get::<dyn ServiceGatewayClientV1>()?;
 /// ```
-#[async_trait::async_trait]
+#[async_trait]
 pub trait ServiceGatewayClientV1: Send + Sync {
     // -- Upstream CRUD --
 

--- a/modules/system/oagw/oagw-sdk/tests/usage.rs
+++ b/modules/system/oagw/oagw-sdk/tests/usage.rs
@@ -11,6 +11,7 @@
 
 use std::sync::Mutex;
 
+use async_trait::async_trait;
 use bytes::Bytes;
 use futures_util::{SinkExt, StreamExt};
 use modkit_security::SecurityContext;
@@ -61,7 +62,7 @@ impl MockGateway {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl ServiceGatewayClientV1 for MockGateway {
     async fn create_upstream(
         &self,

--- a/modules/system/oagw/oagw/Cargo.toml
+++ b/modules/system/oagw/oagw/Cargo.toml
@@ -9,7 +9,7 @@ name = "oagw"
 path = "src/lib.rs"
 
 [features]
-test-utils = ["axum/ws", "dep:async-stream", "dep:futures", "dep:tower", "tokio/net", "tokio/sync", "tokio/rt"]
+test-utils = ["axum/ws", "dep:async-stream", "dep:futures", "dep:tower", "dep:rustls", "tokio/net", "tokio/sync", "tokio/rt"]
 
 [dependencies]
 cf-oagw-sdk = { path = "../oagw-sdk", features = ["axum"] }
@@ -35,13 +35,19 @@ dashmap = "6.1"
 thiserror = "2.0"
 # DP deps
 form_urlencoded = "1"
-reqwest = { version = "0.12", features = ["stream"] }
 futures-util = "0.3"
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["time", "io-util"] }
+# Pingora proxy engine
+pingora-proxy = { version = "0.7", features = ["rustls"] }
+pingora-core = { version = "0.7", features = ["rustls"] }
+pingora-load-balancing = { version = "0.7", features = ["rustls"] }
+pingora-http = { version = "0.7" }
+httparse = "1"
 # test-utils optional deps
 async-stream = { version = "0.3", optional = true }
 futures = { version = "0.3", optional = true }
 tower = { version = "0.5", features = ["util"], optional = true }
+rustls = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/modules/system/oagw/oagw/src/api/rest/handlers/upstream.rs
+++ b/modules/system/oagw/oagw/src/api/rest/handlers/upstream.rs
@@ -38,6 +38,7 @@ pub async fn create_upstream(
         .create_upstream(&ctx, req.into())
         .await
         .map_err(|e| domain_error_to_problem(e, "/oagw/v1/upstreams"))?;
+    state.backend_selector.invalidate(upstream.id);
     Ok((StatusCode::CREATED, Json(to_response(upstream))))
 }
 
@@ -84,6 +85,7 @@ pub async fn update_upstream(
         .update_upstream(&ctx, uuid, req.into())
         .await
         .map_err(|e| domain_error_to_problem(e, &instance))?;
+    state.backend_selector.invalidate(upstream.id);
     Ok(Json(to_response(upstream)))
 }
 
@@ -99,5 +101,6 @@ pub async fn delete_upstream(
         .delete_upstream(&ctx, uuid)
         .await
         .map_err(|e| domain_error_to_problem(e, &instance))?;
+    state.backend_selector.invalidate(uuid);
     Ok(StatusCode::NO_CONTENT)
 }

--- a/modules/system/oagw/oagw/src/domain/credential.rs
+++ b/modules/system/oagw/oagw/src/domain/credential.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use modkit_macros::domain_model;
 
 /// The resolved secret material.
@@ -66,7 +67,7 @@ pub(crate) enum CredentialError {
 }
 
 /// Trait for resolving secret references to their actual values.
-#[async_trait::async_trait]
+#[async_trait]
 pub(crate) trait CredentialResolver: Send + Sync {
     /// Resolve a secret reference (e.g. `cred://openai-key`) to its value.
     ///

--- a/modules/system/oagw/oagw/src/domain/plugin/mod.rs
+++ b/modules/system/oagw/oagw/src/domain/plugin/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use async_trait::async_trait;
 use modkit_macros::domain_model;
 
 // ---------------------------------------------------------------------------
@@ -31,7 +32,7 @@ pub struct AuthContext {
     pub config: HashMap<String, String>,
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 pub trait AuthPlugin: Send + Sync {
     async fn authenticate(&self, ctx: &mut AuthContext) -> Result<(), PluginError>;
 }

--- a/modules/system/oagw/oagw/src/domain/repo.rs
+++ b/modules/system/oagw/oagw/src/domain/repo.rs
@@ -1,4 +1,5 @@
 use crate::domain::model::{ListQuery, Route, Upstream};
+use async_trait::async_trait;
 use modkit_macros::domain_model;
 use uuid::Uuid;
 
@@ -24,7 +25,7 @@ pub enum RepositoryError {
 // ---------------------------------------------------------------------------
 
 /// Repository trait for upstream persistence.
-#[async_trait::async_trait]
+#[async_trait]
 pub trait UpstreamRepository: Send + Sync {
     /// Insert a new upstream. Returns Conflict if alias is taken for the tenant.
     async fn create(&self, upstream: Upstream) -> Result<Upstream, RepositoryError>;
@@ -51,7 +52,7 @@ pub trait UpstreamRepository: Send + Sync {
 }
 
 /// Repository trait for route persistence.
-#[async_trait::async_trait]
+#[async_trait]
 pub trait RouteRepository: Send + Sync {
     /// Insert a new route.
     async fn create(&self, route: Route) -> Result<Route, RepositoryError>;

--- a/modules/system/oagw/oagw/src/domain/services/client.rs
+++ b/modules/system/oagw/oagw/src/domain/services/client.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use modkit_macros::domain_model;
 use modkit_security::SecurityContext;
 use oagw_sdk::api::ServiceGatewayClientV1;
@@ -25,7 +26,7 @@ impl ServiceGatewayClientV1Facade {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl ServiceGatewayClientV1 for ServiceGatewayClientV1Facade {
     async fn create_upstream(
         &self,

--- a/modules/system/oagw/oagw/src/domain/services/management.rs
+++ b/modules/system/oagw/oagw/src/domain/services/management.rs
@@ -7,6 +7,8 @@ use crate::domain::model::{
     UpdateUpstreamRequest, Upstream,
 };
 use crate::domain::repo::{RouteRepository, UpstreamRepository};
+
+use async_trait::async_trait;
 use modkit_macros::domain_model;
 use modkit_security::SecurityContext;
 use uuid::Uuid;
@@ -63,7 +65,7 @@ fn generate_alias(upstream: &Upstream) -> String {
     endpoints[0].alias_contribution()
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl ControlPlaneService for ControlPlaneServiceImpl {
     // -- Upstream CRUD --
 

--- a/modules/system/oagw/oagw/src/domain/services/mod.rs
+++ b/modules/system/oagw/oagw/src/domain/services/mod.rs
@@ -4,18 +4,19 @@ pub(crate) mod management;
 pub(crate) use client::ServiceGatewayClientV1Facade;
 pub(crate) use management::ControlPlaneServiceImpl;
 
+use async_trait::async_trait;
 use modkit_security::SecurityContext;
 use oagw_sdk::Body;
 use uuid::Uuid;
 
 use crate::domain::error::DomainError;
 use crate::domain::model::{
-    CreateRouteRequest, CreateUpstreamRequest, ListQuery, Route, UpdateRouteRequest,
+    CreateRouteRequest, CreateUpstreamRequest, Endpoint, ListQuery, Route, UpdateRouteRequest,
     UpdateUpstreamRequest, Upstream,
 };
 
 /// Internal Control Plane service trait — configuration management and resolution.
-#[async_trait::async_trait]
+#[async_trait]
 pub(crate) trait ControlPlaneService: Send + Sync {
     // -- Upstream CRUD --
 
@@ -86,11 +87,24 @@ pub(crate) trait ControlPlaneService: Send + Sync {
 }
 
 /// Internal Data Plane service trait — proxy orchestration and plugin execution.
-#[async_trait::async_trait]
+#[async_trait]
 pub(crate) trait DataPlaneService: Send + Sync {
     async fn proxy_request(
         &self,
         ctx: SecurityContext,
         req: http::Request<Body>,
     ) -> Result<http::Response<Body>, DomainError>;
+}
+
+/// Endpoint selection abstraction for multi-endpoint load balancing.
+///
+/// Implementations select the next healthy endpoint for a given upstream.
+#[async_trait]
+pub(crate) trait EndpointSelector: Send + Sync {
+    /// Select the next healthy endpoint for the given upstream.
+    /// Returns `None` if all backends are unhealthy or the endpoint list is empty.
+    async fn select(&self, upstream_id: Uuid, endpoints: &[Endpoint]) -> Option<Endpoint>;
+
+    /// Invalidate cached state for the given upstream (called on CRUD).
+    fn invalidate(&self, upstream_id: Uuid);
 }

--- a/modules/system/oagw/oagw/src/domain/test_support.rs
+++ b/modules/system/oagw/oagw/src/domain/test_support.rs
@@ -8,7 +8,8 @@ use modkit::client_hub::ClientHub;
 use oagw_sdk::api::ServiceGatewayClientV1;
 
 use crate::domain::services::{
-    ControlPlaneService, ControlPlaneServiceImpl, DataPlaneService, ServiceGatewayClientV1Facade,
+    ControlPlaneService, ControlPlaneServiceImpl, DataPlaneService, EndpointSelector,
+    ServiceGatewayClientV1Facade,
 };
 use crate::infra::proxy::DataPlaneServiceImpl;
 use crate::infra::storage::{InMemoryCredentialResolver, InMemoryRouteRepo, InMemoryUpstreamRepo};
@@ -97,8 +98,21 @@ impl TestDpBuilder {
             .get::<dyn CredentialResolver>()
             .expect("CredentialResolver must be registered before building DP");
 
-        let mut svc = DataPlaneServiceImpl::new(cp, cred_resolver)
-            .expect("failed to build DataPlaneServiceImpl in test");
+        let server_conf =
+            std::sync::Arc::new(pingora_core::server::configuration::ServerConf::default());
+        let pingora_proxy = crate::infra::proxy::pingora_proxy::PingoraProxy::new(
+            std::time::Duration::from_secs(10),
+            std::time::Duration::from_secs(30),
+        );
+        let proxy = std::sync::Arc::new(crate::infra::proxy::pingora_proxy::new_http_proxy(
+            &server_conf,
+            pingora_proxy,
+        ));
+
+        let backend_selector: Arc<dyn EndpointSelector> =
+            Arc::new(crate::infra::proxy::pingora_proxy::PingoraEndpointSelector::new());
+
+        let mut svc = DataPlaneServiceImpl::new(cp, cred_resolver, backend_selector, proxy);
         if let Some(timeout) = self.request_timeout {
             svc = svc.with_request_timeout(timeout);
         }
@@ -132,6 +146,8 @@ pub fn build_test_app_state(
 ) -> TestAppState {
     let cp = cp_builder.build_and_register(hub);
     let dp = dp_builder.build_and_register(hub, cp.clone());
+    let backend_selector: Arc<dyn EndpointSelector> =
+        Arc::new(crate::infra::proxy::pingora_proxy::PingoraEndpointSelector::new());
     let facade: Arc<dyn ServiceGatewayClientV1> =
         Arc::new(ServiceGatewayClientV1Facade::new(cp.clone(), dp.clone()));
     hub.register::<dyn ServiceGatewayClientV1>(facade.clone());
@@ -139,6 +155,7 @@ pub fn build_test_app_state(
         state: crate::module::AppState {
             cp,
             dp,
+            backend_selector,
             config: crate::config::RuntimeConfig {
                 max_body_size_bytes: 100 * 1024 * 1024, // 100 MB default for tests
             },

--- a/modules/system/oagw/oagw/src/infra/plugin/apikey_auth.rs
+++ b/modules/system/oagw/oagw/src/infra/plugin/apikey_auth.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::domain::credential::CredentialResolver;
 use crate::domain::plugin::{AuthContext, AuthPlugin, PluginError};
+use async_trait::async_trait;
 use serde::Deserialize;
 
 /// Configuration for the API key auth plugin.
@@ -30,7 +31,7 @@ impl ApiKeyAuthPlugin {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl AuthPlugin for ApiKeyAuthPlugin {
     async fn authenticate(&self, ctx: &mut AuthContext) -> Result<(), PluginError> {
         let config: ApiKeyConfig = serde_json::from_value(

--- a/modules/system/oagw/oagw/src/infra/plugin/noop_auth.rs
+++ b/modules/system/oagw/oagw/src/infra/plugin/noop_auth.rs
@@ -1,9 +1,10 @@
 use crate::domain::plugin::{AuthContext, AuthPlugin, PluginError};
+use async_trait::async_trait;
 
 /// Auth plugin that does nothing — used for upstreams requiring no authentication.
 pub struct NoopAuthPlugin;
 
-#[async_trait::async_trait]
+#[async_trait]
 impl AuthPlugin for NoopAuthPlugin {
     async fn authenticate(&self, _ctx: &mut AuthContext) -> Result<(), PluginError> {
         Ok(())

--- a/modules/system/oagw/oagw/src/infra/proxy/mod.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/mod.rs
@@ -1,5 +1,7 @@
 pub(crate) mod headers;
+pub(crate) mod pingora_proxy;
 pub(crate) mod request_builder;
 pub(crate) mod service;
+pub(crate) mod session_bridge;
 
 pub(crate) use service::DataPlaneServiceImpl;

--- a/modules/system/oagw/oagw/src/infra/proxy/pingora_proxy.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/pingora_proxy.rs
@@ -1,0 +1,571 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use dashmap::DashMap;
+use pingora_core::protocols::Digest;
+use pingora_core::upstreams::peer::HttpPeer;
+use pingora_http::ResponseHeader;
+use pingora_load_balancing::LoadBalancer;
+use pingora_load_balancing::health_check::TcpHealthCheck;
+use pingora_load_balancing::selection::RoundRobin;
+use pingora_proxy::{HttpProxy, ProxyHttp, Session, http_proxy};
+use tokio::sync::watch;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use crate::domain::model::{Endpoint, Scheme};
+use crate::domain::services::EndpointSelector;
+
+// ---------------------------------------------------------------------------
+// Internal header names (D9)
+// ---------------------------------------------------------------------------
+
+const INTERNAL_PREFIX: &str = "x-oagw-internal-";
+
+pub(crate) const H_UPSTREAM_ID: &str = "x-oagw-internal-upstream-id";
+pub(crate) const H_ENDPOINT_HOST: &str = "x-oagw-internal-endpoint-host";
+pub(crate) const H_ENDPOINT_PORT: &str = "x-oagw-internal-endpoint-port";
+pub(crate) const H_ENDPOINT_SCHEME: &str = "x-oagw-internal-endpoint-scheme";
+pub(crate) const H_INSTANCE_URI: &str = "x-oagw-internal-instance-uri";
+
+/// Hop-by-hop headers that must not be forwarded in responses (mirrors headers.rs).
+const HOP_BY_HOP: &[&str] = &[
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+];
+
+// ---------------------------------------------------------------------------
+// PingoraProxy — ProxyHttp implementation (D3)
+// ---------------------------------------------------------------------------
+
+pub struct PingoraProxy {
+    connect_timeout: Duration,
+    read_timeout: Duration,
+}
+
+impl PingoraProxy {
+    pub fn new(connect_timeout: Duration, read_timeout: Duration) -> Self {
+        Self {
+            connect_timeout,
+            read_timeout,
+        }
+    }
+}
+
+/// Construct an `HttpProxy` from a `ServerConf` and `PingoraProxy`.
+pub fn new_http_proxy(
+    conf: &Arc<pingora_core::server::configuration::ServerConf>,
+    inner: PingoraProxy,
+) -> HttpProxy<PingoraProxy> {
+    http_proxy(conf, inner)
+}
+
+// ---------------------------------------------------------------------------
+// PingoraBackendSelector — default in-process BackendSelector (D2, D3)
+// ---------------------------------------------------------------------------
+
+/// Cache entry: load balancer + addr-to-endpoint mapping + shutdown handle.
+struct LbEntry {
+    lb: Arc<LoadBalancer<RoundRobin>>,
+    /// Maps `"host:port"` → `Endpoint` for reverse lookup after `select()`.
+    endpoints_by_addr: HashMap<String, Endpoint>,
+    /// Dropping this sender signals the health-check background task to stop.
+    _shutdown_tx: watch::Sender<bool>,
+}
+
+/// Default in-process `BackendSelector` backed by Pingora's `LoadBalancer<RoundRobin>`.
+///
+/// Lazily constructs a `LoadBalancer` per upstream on first `select()` call,
+/// caches it in a `DashMap`, and attaches a `TcpHealthCheck` with 10s interval.
+/// Dropping the cache entry (via `invalidate()`) stops the health-check task.
+pub struct PingoraEndpointSelector {
+    cache: DashMap<Uuid, LbEntry>,
+}
+
+impl PingoraEndpointSelector {
+    pub fn new() -> Self {
+        Self {
+            cache: DashMap::new(),
+        }
+    }
+
+    /// Build a `LoadBalancer<RoundRobin>` from domain endpoints, attach TCP
+    /// health check, spawn background health-check task, return cache entry.
+    fn build_entry(&self, endpoints: &[Endpoint]) -> Option<LbEntry> {
+        let addrs: Vec<String> = endpoints
+            .iter()
+            .map(|ep| format!("{}:{}", ep.host, ep.port))
+            .collect();
+
+        // try_from_iter resolves addresses, builds the selector, and calls
+        // update() internally, so backends are ready for select() immediately.
+        let mut lb = LoadBalancer::<RoundRobin>::try_from_iter(addrs.iter().map(|s| s.as_str()))
+            .map_err(|e| warn!("Failed to create LoadBalancer: {e}"))
+            .ok()?;
+
+        let hc = TcpHealthCheck::new();
+        lb.set_health_check(hc);
+        lb.health_check_frequency = Some(Duration::from_secs(10));
+
+        let lb = Arc::new(lb);
+
+        // Build "host:port" → Endpoint mapping for reverse lookup after select().
+        let mut endpoints_by_addr = HashMap::with_capacity(endpoints.len());
+        for (ep, addr_str) in endpoints.iter().zip(addrs.iter()) {
+            endpoints_by_addr.insert(addr_str.clone(), ep.clone());
+        }
+
+        // Spawn background health-check loop; drops when _shutdown_tx is dropped.
+        let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+        let lb_bg = lb.clone();
+        tokio::spawn(async move {
+            loop {
+                // update() refreshes backends from discovery (no-op for static)
+                // and is required before health checks can report status.
+                let _ = lb_bg.update().await;
+
+                tokio::select! {
+                    _ = tokio::time::sleep(Duration::from_secs(10)) => {}
+                    _ = shutdown_rx.changed() => { break; }
+                }
+            }
+        });
+
+        Some(LbEntry {
+            lb,
+            endpoints_by_addr,
+            _shutdown_tx: shutdown_tx,
+        })
+    }
+}
+
+#[async_trait]
+impl EndpointSelector for PingoraEndpointSelector {
+    async fn select(&self, upstream_id: Uuid, endpoints: &[Endpoint]) -> Option<Endpoint> {
+        // Fast path: LB already cached.
+        if let Some(entry) = self.cache.get(&upstream_id) {
+            let backend = entry.lb.select(b"", 256)?;
+            let addr_key = backend.addr.to_string();
+            return entry.endpoints_by_addr.get(&addr_key).cloned();
+        }
+
+        // Slow path: build and cache.
+        let entry = self.build_entry(endpoints)?;
+        let backend = entry.lb.select(b"", 256)?;
+        let addr_key = backend.addr.to_string();
+        let result = entry.endpoints_by_addr.get(&addr_key).cloned();
+        self.cache.insert(upstream_id, entry);
+        result
+    }
+
+    fn invalidate(&self, upstream_id: Uuid) {
+        // Removing the entry drops LbEntry, which drops _shutdown_tx,
+        // which signals the health-check background task to stop.
+        self.cache.remove(&upstream_id);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-request context (D3)
+// ---------------------------------------------------------------------------
+
+pub struct ProxyCtx {
+    endpoint: Endpoint,
+    instance_uri: String,
+    retries: u32,
+}
+
+impl Default for ProxyCtx {
+    fn default() -> Self {
+        Self {
+            endpoint: Endpoint {
+                scheme: Scheme::Https,
+                host: String::new(),
+                port: 443,
+            },
+            instance_uri: String::new(),
+            retries: 0,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ProxyHttp trait implementation
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl ProxyHttp for PingoraProxy {
+    type CTX = ProxyCtx;
+
+    fn new_ctx(&self) -> Self::CTX {
+        ProxyCtx::default()
+    }
+
+    /// Extract internal context headers, populate `ProxyCtx`, strip them. (D9)
+    async fn request_filter(
+        &self,
+        session: &mut Session,
+        ctx: &mut Self::CTX,
+    ) -> pingora_core::Result<bool> {
+        // Read context from internal headers.
+        let req = session.req_header();
+        if let Some(v) = req
+            .headers
+            .get(H_ENDPOINT_HOST)
+            .and_then(|v| v.to_str().ok())
+        {
+            ctx.endpoint.host = v.to_string();
+        }
+        if let Some(v) = req
+            .headers
+            .get(H_ENDPOINT_PORT)
+            .and_then(|v| v.to_str().ok())
+            && let Ok(port) = v.parse()
+        {
+            ctx.endpoint.port = port;
+        }
+        if let Some(v) = req
+            .headers
+            .get(H_ENDPOINT_SCHEME)
+            .and_then(|v| v.to_str().ok())
+        {
+            ctx.endpoint.scheme = match v {
+                "http" => Scheme::Http,
+                "https" => Scheme::Https,
+                "wss" => Scheme::Wss,
+                "wt" => Scheme::Wt,
+                _ => Scheme::Https,
+            };
+        }
+        if let Some(v) = req
+            .headers
+            .get(H_INSTANCE_URI)
+            .and_then(|v| v.to_str().ok())
+        {
+            ctx.instance_uri = v.to_string();
+        }
+
+        // Strip all internal headers before forwarding.
+        let to_remove: Vec<http::HeaderName> = session
+            .req_header()
+            .headers
+            .keys()
+            .filter(|k| k.as_str().starts_with(INTERNAL_PREFIX))
+            .cloned()
+            .collect();
+        let req_mut = session.req_header_mut();
+        for name in &to_remove {
+            req_mut.remove_header(name);
+        }
+
+        Ok(false) // continue processing
+    }
+
+    /// Build `HttpPeer` from the resolved endpoint. (D3, D4, D7)
+    async fn upstream_peer(
+        &self,
+        _session: &mut Session,
+        ctx: &mut Self::CTX,
+    ) -> pingora_core::Result<Box<HttpPeer>> {
+        let ep = &ctx.endpoint;
+        let tls = matches!(ep.scheme, Scheme::Https | Scheme::Wss | Scheme::Wt);
+
+        let mut peer = HttpPeer::new(format!("{}:{}", ep.host, ep.port), tls, ep.host.clone());
+
+        peer.options.connection_timeout = Some(self.connect_timeout);
+        peer.options.read_timeout = Some(self.read_timeout);
+        peer.options.idle_timeout = Some(Duration::from_secs(90));
+
+        // ALPN: H2H1 for HTTPS, H1 for WebSocket and cleartext.
+        peer.options.alpn = if tls && !matches!(ep.scheme, Scheme::Wss) {
+            pingora_core::protocols::tls::ALPN::H2H1
+        } else {
+            pingora_core::protocols::tls::ALPN::H1
+        };
+
+        Ok(Box::new(peer))
+    }
+
+    /// No-op — headers are already prepared by proxy_request() stages 4-6. (D3)
+    async fn upstream_request_filter(
+        &self,
+        _session: &mut Session,
+        _upstream_request: &mut pingora_http::RequestHeader,
+        _ctx: &mut Self::CTX,
+    ) -> pingora_core::Result<()> {
+        Ok(())
+    }
+
+    /// Sanitize response headers: strip hop-by-hop and x-oagw-* headers. (D3)
+    async fn upstream_response_filter(
+        &self,
+        _session: &mut Session,
+        upstream_response: &mut ResponseHeader,
+        _ctx: &mut Self::CTX,
+    ) -> pingora_core::Result<()> {
+        // Strip hop-by-hop headers.
+        for name in HOP_BY_HOP {
+            upstream_response.remove_header(*name);
+        }
+
+        // Strip x-oagw-* internal headers.
+        let to_remove: Vec<http::HeaderName> = upstream_response
+            .headers
+            .keys()
+            .filter(|k| k.as_str().starts_with("x-oagw-"))
+            .cloned()
+            .collect();
+        for name in &to_remove {
+            upstream_response.remove_header(name);
+        }
+
+        Ok(())
+    }
+
+    /// Retry on connection failure, up to 2 retries (3 total attempts). (D6)
+    fn fail_to_connect(
+        &self,
+        _session: &mut Session,
+        _peer: &HttpPeer,
+        ctx: &mut Self::CTX,
+        mut e: Box<pingora_core::Error>,
+    ) -> Box<pingora_core::Error> {
+        ctx.retries += 1;
+        if ctx.retries <= 2 {
+            e.set_retry(true);
+        }
+        e
+    }
+
+    /// Retry on stale pooled connection errors. (D6)
+    fn error_while_proxy(
+        &self,
+        _peer: &HttpPeer,
+        _session: &mut Session,
+        mut e: Box<pingora_core::Error>,
+        _ctx: &mut Self::CTX,
+        client_reused: bool,
+    ) -> Box<pingora_core::Error> {
+        if client_reused {
+            e.retry.decide_reuse(true);
+        }
+        e
+    }
+
+    /// Map Pingora error types to HTTP status codes and write RFC 9457 response. (D6)
+    async fn fail_to_proxy(
+        &self,
+        session: &mut Session,
+        e: &pingora_core::Error,
+        ctx: &mut Self::CTX,
+    ) -> pingora_proxy::FailToProxy {
+        let (status, detail) = match &e.etype {
+            pingora_core::ErrorType::ConnectTimedout => (502, "upstream connection timed out"),
+            pingora_core::ErrorType::ConnectRefused => (502, "upstream connection refused"),
+            pingora_core::ErrorType::TLSHandshakeFailure
+            | pingora_core::ErrorType::TLSHandshakeTimedout => {
+                (502, "upstream TLS handshake failed")
+            }
+            pingora_core::ErrorType::InvalidCert => (502, "upstream certificate invalid"),
+            pingora_core::ErrorType::ReadTimedout => (504, "upstream read timed out"),
+            pingora_core::ErrorType::WriteTimedout => (504, "upstream write timed out"),
+            pingora_core::ErrorType::ConnectionClosed => (502, "upstream connection closed"),
+            pingora_core::ErrorType::H2Error | pingora_core::ErrorType::H2Downgrade => {
+                (502, "upstream HTTP/2 error")
+            }
+            _ => (502, "upstream error"),
+        };
+
+        // RFC 9457 Problem Details JSON.
+        let body = serde_json::json!({
+            "type": "about:blank",
+            "title": http::StatusCode::from_u16(status)
+                .ok()
+                .and_then(|s| s.canonical_reason())
+                .unwrap_or("Error"),
+            "status": status,
+            "detail": detail,
+            "instance": ctx.instance_uri,
+        });
+
+        let body_bytes = Bytes::from(serde_json::to_vec(&body).unwrap_or_default());
+
+        // Write the error response with correct content-type.
+        if let Ok(mut resp) = ResponseHeader::build(status, Some(body_bytes.len())) {
+            let _ = resp.insert_header("content-type", "application/problem+json");
+            let _ = session.write_response_header(Box::new(resp), false).await;
+            let _ = session.write_response_body(Some(body_bytes), true).await;
+        } else {
+            let _ = session.respond_error(status).await;
+        }
+
+        pingora_proxy::FailToProxy {
+            error_code: 0,
+            can_reuse_downstream: false,
+        }
+    }
+
+    /// Log upstream connection info. (D3)
+    async fn connected_to_upstream(
+        &self,
+        _session: &mut Session,
+        reused: bool,
+        peer: &HttpPeer,
+        #[cfg(unix)] _fd: std::os::unix::io::RawFd,
+        #[cfg(windows)] _sock: std::os::windows::io::RawSocket,
+        _digest: Option<&Digest>,
+        ctx: &mut Self::CTX,
+    ) -> pingora_core::Result<()> {
+        info!(
+            reused,
+            peer = %peer,
+            instance = %ctx.instance_uri,
+            "Connected to upstream"
+        );
+        Ok(())
+    }
+
+    /// Log request summary with timing. (D3)
+    async fn logging(
+        &self,
+        session: &mut Session,
+        e: Option<&pingora_core::Error>,
+        _ctx: &mut Self::CTX,
+    ) {
+        let status = session
+            .as_downstream()
+            .response_written()
+            .map(|r| r.status.as_u16())
+            .unwrap_or(0);
+        let method = session.req_header().method.as_str();
+        let path = session.req_header().uri.path();
+
+        if let Some(err) = e {
+            warn!(method, path, status, error = %err, "Proxy request failed");
+        } else {
+            info!(method, path, status, "Proxy request completed");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::model::{Endpoint, Scheme};
+
+    fn init_crypto() {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    }
+
+    fn ep(host: &str, port: u16, scheme: Scheme) -> Endpoint {
+        Endpoint {
+            scheme,
+            host: host.to_string(),
+            port,
+        }
+    }
+
+    // Note: PingoraBackendSelector uses Pingora's LoadBalancer which resolves
+    // addresses via ToSocketAddrs during construction. Tests must use real IP
+    // addresses (e.g. 127.0.0.1) with distinct ports to differentiate endpoints.
+
+    #[tokio::test]
+    async fn select_round_robin_distribution() {
+        init_crypto();
+        let selector = PingoraEndpointSelector::new();
+        let id = Uuid::new_v4();
+        let endpoints = vec![
+            ep("127.0.0.1", 10001, Scheme::Https),
+            ep("127.0.0.1", 10002, Scheme::Https),
+        ];
+
+        let mut port_a = 0u32;
+        let mut port_b = 0u32;
+        for _ in 0..4 {
+            let selected = selector.select(id, &endpoints).await.unwrap();
+            match selected.port {
+                10001 => port_a += 1,
+                10002 => port_b += 1,
+                other => panic!("unexpected port: {other}"),
+            }
+        }
+        assert!(port_a > 0, "port 10001 should be selected at least once");
+        assert!(port_b > 0, "port 10002 should be selected at least once");
+    }
+
+    #[tokio::test]
+    async fn invalidate_causes_rebuild() {
+        init_crypto();
+        let selector = PingoraEndpointSelector::new();
+        let id = Uuid::new_v4();
+
+        let v1 = vec![ep("127.0.0.1", 20001, Scheme::Https)];
+        let selected = selector.select(id, &v1).await.unwrap();
+        assert_eq!(selected.port, 20001);
+
+        selector.invalidate(id);
+
+        let v2 = vec![ep("127.0.0.1", 20002, Scheme::Https)];
+        let selected = selector.select(id, &v2).await.unwrap();
+        assert_eq!(selected.port, 20002);
+    }
+
+    #[tokio::test]
+    async fn select_single_endpoint() {
+        init_crypto();
+        let selector = PingoraEndpointSelector::new();
+        let id = Uuid::new_v4();
+        let endpoints = vec![ep("127.0.0.1", 30001, Scheme::Http)];
+
+        let selected = selector.select(id, &endpoints).await.unwrap();
+        assert_eq!(selected.host, "127.0.0.1");
+        assert_eq!(selected.port, 30001);
+        assert_eq!(selected.scheme, Scheme::Http);
+    }
+
+    /// Endpoints in an upstream share scheme/port (by design).
+    /// Verify the scheme survives the Pingora Backend round-trip.
+    #[tokio::test]
+    async fn select_preserves_scheme() {
+        init_crypto();
+        let selector = PingoraEndpointSelector::new();
+        let id = Uuid::new_v4();
+        // All endpoints share the same scheme (upstream-level invariant).
+        // Use different ports to distinguish endpoints.
+        let endpoints = vec![
+            ep("127.0.0.1", 40001, Scheme::Https),
+            ep("127.0.0.1", 40002, Scheme::Https),
+        ];
+
+        let mut found_1 = false;
+        let mut found_2 = false;
+        for _ in 0..20 {
+            let selected = selector.select(id, &endpoints).await.unwrap();
+            assert_eq!(selected.scheme, Scheme::Https, "scheme must be preserved");
+            assert_eq!(selected.host, "127.0.0.1", "host must be preserved");
+            match selected.port {
+                40001 => found_1 = true,
+                40002 => found_2 = true,
+                other => panic!("unexpected port: {other}"),
+            }
+            if found_1 && found_2 {
+                break;
+            }
+        }
+        assert!(found_1, "should have selected port 40001");
+        assert!(found_2, "should have selected port 40002");
+    }
+}

--- a/modules/system/oagw/oagw/src/infra/proxy/service.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/service.rs
@@ -2,62 +2,71 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::domain::credential::CredentialResolver;
-use crate::domain::error::DomainError;
-use crate::domain::model::{PassthroughMode, PathSuffixMode};
-use crate::domain::plugin::AuthContext;
+use async_trait::async_trait;
+use bytes::Bytes;
 use futures_util::StreamExt;
 use http::{HeaderMap, HeaderName, HeaderValue};
 use modkit_security::SecurityContext;
 use oagw_sdk::api::ErrorSource;
-use oagw_sdk::body::{Body, BodyStream, BoxError};
+use oagw_sdk::body::{Body, BodyStream};
+use pingora_core::apps::HttpServerApp;
+use pingora_proxy::HttpProxy;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::watch;
 
-use crate::domain::services::{ControlPlaneService, DataPlaneService};
-
+use crate::domain::credential::CredentialResolver;
+use crate::domain::error::DomainError;
+use crate::domain::model::{Endpoint, Upstream};
+use crate::domain::model::{PassthroughMode, PathSuffixMode, Scheme};
+use crate::domain::plugin::AuthContext;
 use crate::domain::rate_limit::RateLimiter;
+use crate::domain::services::{ControlPlaneService, DataPlaneService, EndpointSelector};
 use crate::infra::plugin::AuthPluginRegistry;
 
 use super::headers;
+use super::pingora_proxy::{
+    H_ENDPOINT_HOST, H_ENDPOINT_PORT, H_ENDPOINT_SCHEME, H_INSTANCE_URI, H_UPSTREAM_ID,
+    PingoraProxy,
+};
 use super::request_builder;
+use super::session_bridge;
 
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Data Plane service implementation: proxy orchestration and plugin execution.
 pub struct DataPlaneServiceImpl {
     cp: Arc<dyn ControlPlaneService>,
-    http_client: reqwest::Client,
+    backend_selector: Arc<dyn EndpointSelector>,
+    proxy: Arc<HttpProxy<PingoraProxy>>,
+    /// Sender kept alive so receivers see `false` (not shutting down) until drop.
+    _shutdown_tx: watch::Sender<bool>,
+    shutdown_rx: watch::Receiver<bool>,
     auth_registry: AuthPluginRegistry,
     rate_limiter: RateLimiter,
     request_timeout: Duration,
 }
 
 impl DataPlaneServiceImpl {
-    /// # Errors
-    ///
-    /// Returns an error if the HTTP client cannot be built.
     pub fn new(
         cp: Arc<dyn ControlPlaneService>,
         credential_resolver: Arc<dyn CredentialResolver>,
-    ) -> anyhow::Result<Self> {
-        let http_client = reqwest::Client::builder()
-            .connect_timeout(CONNECT_TIMEOUT)
-            // Never follow redirects — upstream could redirect to internal/metadata IPs.
-            .redirect(reqwest::redirect::Policy::none())
-            // No overall timeout — SSE streams run indefinitely.
-            // Request-header timeout is applied via tokio::time::timeout below.
-            .build()?;
-
+        backend_selector: Arc<dyn EndpointSelector>,
+        proxy: Arc<HttpProxy<PingoraProxy>>,
+    ) -> Self {
         let auth_registry = AuthPluginRegistry::with_builtins(credential_resolver);
         let rate_limiter = RateLimiter::new();
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
-        Ok(Self {
+        Self {
             cp,
-            http_client,
+            backend_selector,
+            proxy,
+            _shutdown_tx: shutdown_tx,
+            shutdown_rx,
             auth_registry,
             rate_limiter,
             request_timeout: REQUEST_TIMEOUT,
-        })
+        }
     }
 
     /// Override the request timeout.
@@ -66,9 +75,79 @@ impl DataPlaneServiceImpl {
         self.request_timeout = timeout;
         self
     }
+
+    /// Two-tier endpoint selection (D1):
+    /// 1. `X-OAGW-Target-Host` header → validate against endpoint list
+    /// 2. Round-robin via `BackendSelector` for multi-endpoint, direct for single
+    async fn select_endpoint(
+        &self,
+        upstream: &Upstream,
+        req_headers: &http::HeaderMap,
+        instance_uri: &str,
+    ) -> Result<Endpoint, DomainError> {
+        let endpoints = &upstream.server.endpoints;
+
+        if endpoints.is_empty() {
+            return Err(DomainError::DownstreamError {
+                detail: "upstream has no endpoints".into(),
+                instance: instance_uri.to_string(),
+            });
+        }
+
+        // Tier 1: Explicit selection via X-OAGW-Target-Host header.
+        if let Some(target_host) = req_headers
+            .get("x-oagw-target-host")
+            .and_then(|v| v.to_str().ok())
+        {
+            // Validate format: must be a hostname or IP, no port/path/special chars.
+            if target_host.is_empty()
+                || target_host.contains('/')
+                || target_host.contains(':')
+                || target_host.contains('?')
+                || target_host.contains('#')
+                || target_host.contains(' ')
+            {
+                return Err(DomainError::InvalidTargetHost {
+                    instance: instance_uri.to_string(),
+                });
+            }
+
+            // Find matching endpoint by host.
+            return endpoints
+                .iter()
+                .find(|ep| ep.host == target_host)
+                .cloned()
+                .ok_or_else(|| {
+                    let valid_hosts: Vec<&str> =
+                        endpoints.iter().map(|ep| ep.host.as_str()).collect();
+                    DomainError::UnknownTargetHost {
+                        detail: format!(
+                            "X-OAGW-Target-Host '{}' does not match any configured endpoint. Valid hosts: {:?}",
+                            target_host, valid_hosts
+                        ),
+                        instance: instance_uri.to_string(),
+                    }
+                });
+        }
+
+        // Tier 2: Automatic selection.
+        if endpoints.len() == 1 {
+            // Single-endpoint: use directly, no LB overhead.
+            return Ok(endpoints[0].clone());
+        }
+
+        // Multi-endpoint: round-robin via BackendSelector.
+        self.backend_selector
+            .select(upstream.id, endpoints)
+            .await
+            .ok_or_else(|| DomainError::DownstreamError {
+                detail: "all backends are unhealthy".into(),
+                instance: instance_uri.to_string(),
+            })
+    }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl DataPlaneService for DataPlaneServiceImpl {
     async fn proxy_request(
         &self,
@@ -99,18 +178,17 @@ impl DataPlaneService for DataPlaneServiceImpl {
             })
             .unwrap_or_default();
 
+        // Decompose request into parts. Keep body as-is for conditional handling.
         let (parts, body) = req.into_parts();
         let method = parts.method;
         let req_headers = parts.headers;
 
-        // Convert Body to Bytes for the outbound HTTP request.
-        let body_bytes = body
-            .into_bytes()
-            .await
-            .map_err(|e| DomainError::Validation {
-                detail: format!("failed to read request body: {e}"),
-                instance: instance_uri.clone(),
-            })?;
+        // Stage 3: conditional body conversion — keep streams for bidirectional bridge.
+        let (body_bytes, body_stream): (Bytes, Option<BodyStream>) = match body {
+            Body::Empty => (Bytes::new(), None),
+            Body::Bytes(b) => (b, None),
+            Body::Stream(s) => (Bytes::new(), Some(s)),
+        };
 
         // 1. Resolve upstream by alias.
         let upstream = self.cp.resolve_upstream(&ctx, &alias).await?;
@@ -231,15 +309,11 @@ impl DataPlaneService for DataPlaneServiceImpl {
         {
             headers::apply_header_rules(&mut outbound_headers, rules);
         }
-        let endpoint =
-            upstream
-                .server
-                .endpoints
-                .first()
-                .ok_or_else(|| DomainError::DownstreamError {
-                    detail: "upstream has no endpoints".into(),
-                    instance: instance_uri.clone(),
-                })?;
+
+        // 5b. Endpoint selection (D1 — two-tier).
+        let endpoint = self
+            .select_endpoint(&upstream, &req_headers, &instance_uri)
+            .await?;
         headers::set_host_header(&mut outbound_headers, &endpoint.host, endpoint.port);
 
         // 6. Check rate limit (upstream then route).
@@ -262,64 +336,149 @@ impl DataPlaneService for DataPlaneServiceImpl {
             .map_or("/", |h| h.path.as_str());
         let remaining_suffix = path_suffix.strip_prefix(route_path).unwrap_or("");
         let url = request_builder::build_upstream_url(
-            endpoint,
+            &endpoint,
             route_path,
             remaining_suffix,
             &query_params,
         )?;
 
-        // 8. Forward request with timeout on response headers.
-        let send_future = self
-            .http_client
-            .request(method, &url)
-            .headers(outbound_headers)
-            .body(body_bytes)
-            .send();
+        // 7.5. Inject internal context headers for PingoraProxy (D9).
+        let scheme_str = match endpoint.scheme {
+            Scheme::Http => "http",
+            Scheme::Https => "https",
+            Scheme::Wss => "wss",
+            Scheme::Wt => "wt",
+            Scheme::Grpc => "grpc",
+        };
+        if let Ok(v) = HeaderValue::from_str(&upstream.id.to_string()) {
+            outbound_headers.insert(H_UPSTREAM_ID, v);
+        }
+        if let Ok(v) = HeaderValue::from_str(&endpoint.host) {
+            outbound_headers.insert(H_ENDPOINT_HOST, v);
+        }
+        if let Ok(v) = HeaderValue::from_str(&endpoint.port.to_string()) {
+            outbound_headers.insert(H_ENDPOINT_PORT, v);
+        }
+        outbound_headers.insert(H_ENDPOINT_SCHEME, HeaderValue::from_static(scheme_str));
+        if let Ok(v) = HeaderValue::from_str(&instance_uri) {
+            outbound_headers.insert(H_INSTANCE_URI, v);
+        }
 
+        // 8. Bridge request into Pingora via in-memory DuplexStream.
+        let (client_io, server_io) = tokio::io::duplex(65_536);
+
+        // Create Pingora H1 session from the server side of the DuplexStream.
+        // Pingora implements all IO traits for DuplexStream (in ext_io_impl).
+        let session = pingora_core::protocols::http::ServerSession::new_http1(Box::new(server_io));
+
+        // Spawn Pingora proxy processing in background.
+        let proxy = self.proxy.clone();
+        let shutdown = self.shutdown_rx.clone();
+        tokio::spawn(async move {
+            proxy.process_new_http(session, &shutdown).await;
+        });
+
+        // Write the request and read the response from the client side.
         let timeout = self.request_timeout;
-        let response = tokio::time::timeout(timeout, send_future)
-            .await
-            .map_err(|_| DomainError::RequestTimeout {
-                detail: format!("request to {url} timed out after {timeout:?}"),
-                instance: instance_uri.clone(),
-            })?
-            .map_err(|e| {
-                if e.is_connect() {
-                    DomainError::ConnectionTimeout {
-                        detail: e.to_string(),
-                        instance: instance_uri.clone(),
-                    }
-                } else {
-                    DomainError::DownstreamError {
-                        detail: e.to_string(),
-                        instance: instance_uri.clone(),
-                    }
+
+        if let Some(mut body_stream) = body_stream {
+            // Streaming path: write headers, then forward body chunks concurrently.
+            let (client_read, mut client_write) = tokio::io::split(client_io);
+
+            let header_bytes =
+                session_bridge::serialize_request_headers(&method, &url, &outbound_headers);
+            client_write.write_all(&header_bytes).await.map_err(|e| {
+                DomainError::DownstreamError {
+                    detail: format!("failed to write to proxy bridge: {e}"),
+                    instance: instance_uri.clone(),
                 }
             })?;
 
-        // 9. Build streaming response.
-        let status = response.status();
-        let mut resp_headers = response.headers().clone();
-        headers::sanitize_response_headers(&mut resp_headers);
+            // Spawn task to forward body stream chunks, then shutdown.
+            tokio::spawn(async move {
+                while let Some(chunk) = body_stream.next().await {
+                    match chunk {
+                        Ok(bytes) => {
+                            if client_write.write_all(&bytes).await.is_err() {
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            tracing::debug!(error = %e, "body stream chunk error");
+                            break;
+                        }
+                    }
+                }
+                let _ = client_write.shutdown().await;
+            });
 
-        let body_stream: BodyStream = Box::pin(
-            response
-                .bytes_stream()
-                .map(|r| r.map_err(|e| Box::new(e) as BoxError)),
-        );
+            // 9. Parse response from the read half.
+            let (status, mut resp_headers, resp_body_stream) =
+                tokio::time::timeout(timeout, session_bridge::parse_response_stream(client_read))
+                    .await
+                    .map_err(|_| DomainError::RequestTimeout {
+                        detail: format!("request to {url} timed out after {timeout:?}"),
+                        instance: instance_uri.clone(),
+                    })?
+                    .map_err(|e| DomainError::DownstreamError {
+                        detail: format!("proxy bridge error: {e}"),
+                        instance: instance_uri.clone(),
+                    })?;
 
-        let mut resp = http::Response::builder()
-            .status(status)
-            .body(Body::Stream(body_stream))
-            .map_err(|e| DomainError::DownstreamError {
-                detail: format!("failed to build response: {e}"),
-                instance: instance_uri,
-            })?;
+            headers::sanitize_response_headers(&mut resp_headers);
 
-        *resp.headers_mut() = resp_headers;
-        resp.extensions_mut().insert(ErrorSource::Upstream);
+            let mut resp = http::Response::builder()
+                .status(status)
+                .body(Body::Stream(resp_body_stream))
+                .map_err(|e| DomainError::DownstreamError {
+                    detail: format!("failed to build response: {e}"),
+                    instance: instance_uri,
+                })?;
+            *resp.headers_mut() = resp_headers;
+            resp.extensions_mut().insert(ErrorSource::Upstream);
+            Ok(resp)
+        } else {
+            // Buffered path: write full request, shutdown write side, then read response.
+            let wire =
+                session_bridge::serialize_request(&method, &url, &outbound_headers, &body_bytes);
+            let mut client_io = client_io;
+            client_io
+                .write_all(&wire)
+                .await
+                .map_err(|e| DomainError::DownstreamError {
+                    detail: format!("failed to write to proxy bridge: {e}"),
+                    instance: instance_uri.clone(),
+                })?;
+            // Do NOT shutdown the write side — Pingora uses Content-Length to
+            // determine the request boundary, and an early write-close is
+            // misinterpreted as "downstream dropped the connection".
 
-        Ok(resp)
+            // 9. Parse response.
+            let (status, mut resp_headers, resp_body_stream) =
+                tokio::time::timeout(timeout, session_bridge::parse_response_stream(client_io))
+                    .await
+                    .map_err(|_| DomainError::RequestTimeout {
+                        detail: format!("request to {url} timed out after {timeout:?}"),
+                        instance: instance_uri.clone(),
+                    })?
+                    .map_err(|e| DomainError::DownstreamError {
+                        detail: format!("proxy bridge error: {e}"),
+                        instance: instance_uri.clone(),
+                    })?;
+
+            headers::sanitize_response_headers(&mut resp_headers);
+
+            let mut resp = http::Response::builder()
+                .status(status)
+                .body(Body::Stream(resp_body_stream))
+                .map_err(|e| DomainError::DownstreamError {
+                    detail: format!("failed to build response: {e}"),
+                    instance: instance_uri,
+                })?;
+            *resp.headers_mut() = resp_headers;
+            resp.extensions_mut().insert(ErrorSource::Upstream);
+            Ok(resp)
+        }
     }
 }
 
@@ -346,7 +505,11 @@ fn normalize_path(path: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_path;
+    use super::*;
+    use crate::domain::model::{Endpoint, Scheme, Server, Upstream};
+    use crate::domain::services::EndpointSelector;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use uuid::Uuid;
 
     #[test]
     fn normalize_collapses_double_slashes() {
@@ -371,5 +534,330 @@ mod tests {
     #[test]
     fn normalize_preserves_clean_path() {
         assert_eq!(normalize_path("/alias/v1/chat"), "/alias/v1/chat");
+    }
+
+    // -----------------------------------------------------------------------
+    // select_endpoint() unit tests
+    // -----------------------------------------------------------------------
+
+    fn ep(host: &str, port: u16) -> Endpoint {
+        Endpoint {
+            scheme: Scheme::Https,
+            host: host.to_string(),
+            port,
+        }
+    }
+
+    fn upstream_with(endpoints: Vec<Endpoint>) -> Upstream {
+        Upstream {
+            id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            alias: "test".to_string(),
+            server: Server { endpoints },
+            protocol: "http".to_string(),
+            enabled: true,
+            auth: None,
+            headers: None,
+            plugins: None,
+            rate_limit: None,
+            tags: vec![],
+        }
+    }
+
+    /// Mock BackendSelector that returns endpoints[call_count % endpoints.len()].
+    struct MockSelector {
+        call_count: AtomicUsize,
+    }
+
+    impl MockSelector {
+        fn new() -> Self {
+            Self {
+                call_count: AtomicUsize::new(0),
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.call_count.load(Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait]
+    impl EndpointSelector for MockSelector {
+        async fn select(&self, _upstream_id: Uuid, endpoints: &[Endpoint]) -> Option<Endpoint> {
+            let idx = self.call_count.fetch_add(1, Ordering::Relaxed) % endpoints.len();
+            Some(endpoints[idx].clone())
+        }
+
+        fn invalidate(&self, _upstream_id: Uuid) {}
+    }
+
+    /// Build a minimal `DataPlaneServiceImpl` with the given `BackendSelector`.
+    fn build_svc(selector: Arc<dyn EndpointSelector>) -> DataPlaneServiceImpl {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        use crate::domain::credential::{CredentialError, CredentialResolver, SecretValue};
+
+        struct NoopCred;
+        #[async_trait]
+        impl CredentialResolver for NoopCred {
+            async fn resolve(&self, _: &str) -> Result<SecretValue, CredentialError> {
+                unimplemented!()
+            }
+        }
+
+        let cred: Arc<dyn CredentialResolver> = Arc::new(NoopCred);
+
+        // Minimal CP — never called by select_endpoint().
+        use crate::domain::error::DomainError;
+        use crate::domain::model::*;
+        use crate::domain::services::ControlPlaneService;
+        use modkit_security::SecurityContext;
+
+        struct NoopCp;
+        #[async_trait]
+        impl ControlPlaneService for NoopCp {
+            async fn create_upstream(
+                &self,
+                _: &SecurityContext,
+                _: CreateUpstreamRequest,
+            ) -> Result<Upstream, DomainError> {
+                unimplemented!()
+            }
+            async fn get_upstream(
+                &self,
+                _: &SecurityContext,
+                _: Uuid,
+            ) -> Result<Upstream, DomainError> {
+                unimplemented!()
+            }
+            async fn list_upstreams(
+                &self,
+                _: &SecurityContext,
+                _: &ListQuery,
+            ) -> Result<Vec<Upstream>, DomainError> {
+                unimplemented!()
+            }
+            async fn update_upstream(
+                &self,
+                _: &SecurityContext,
+                _: Uuid,
+                _: UpdateUpstreamRequest,
+            ) -> Result<Upstream, DomainError> {
+                unimplemented!()
+            }
+            async fn delete_upstream(
+                &self,
+                _: &SecurityContext,
+                _: Uuid,
+            ) -> Result<(), DomainError> {
+                unimplemented!()
+            }
+            async fn create_route(
+                &self,
+                _: &SecurityContext,
+                _: CreateRouteRequest,
+            ) -> Result<Route, DomainError> {
+                unimplemented!()
+            }
+            async fn get_route(&self, _: &SecurityContext, _: Uuid) -> Result<Route, DomainError> {
+                unimplemented!()
+            }
+            async fn list_routes(
+                &self,
+                _: &SecurityContext,
+                _: Uuid,
+                _: &ListQuery,
+            ) -> Result<Vec<Route>, DomainError> {
+                unimplemented!()
+            }
+            async fn update_route(
+                &self,
+                _: &SecurityContext,
+                _: Uuid,
+                _: UpdateRouteRequest,
+            ) -> Result<Route, DomainError> {
+                unimplemented!()
+            }
+            async fn delete_route(&self, _: &SecurityContext, _: Uuid) -> Result<(), DomainError> {
+                unimplemented!()
+            }
+            async fn resolve_upstream(
+                &self,
+                _: &SecurityContext,
+                _: &str,
+            ) -> Result<Upstream, DomainError> {
+                unimplemented!()
+            }
+            async fn resolve_route(
+                &self,
+                _: &SecurityContext,
+                _: Uuid,
+                _: &str,
+                _: &str,
+            ) -> Result<Route, DomainError> {
+                unimplemented!()
+            }
+        }
+
+        let cp: Arc<dyn ControlPlaneService> = Arc::new(NoopCp);
+        let server_conf = Arc::new(pingora_core::server::configuration::ServerConf::default());
+        let pingora = crate::infra::proxy::pingora_proxy::PingoraProxy::new(
+            Duration::from_secs(10),
+            Duration::from_secs(30),
+        );
+        let proxy = Arc::new(crate::infra::proxy::pingora_proxy::new_http_proxy(
+            &server_conf,
+            pingora,
+        ));
+
+        DataPlaneServiceImpl::new(cp, cred, selector, proxy)
+    }
+
+    // positive-2.2 (custom-header-routing): X-OAGW-Target-Host matches an endpoint.
+    #[tokio::test]
+    async fn select_endpoint_target_host_matches() {
+        let selector = Arc::new(MockSelector::new());
+        let svc = build_svc(selector.clone());
+        let upstream = upstream_with(vec![ep("a.com", 443), ep("b.com", 443)]);
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-oagw-target-host", "a.com".parse().unwrap());
+
+        let result = svc
+            .select_endpoint(&upstream, &headers, "/test")
+            .await
+            .unwrap();
+        assert_eq!(result.host, "a.com");
+        assert_eq!(selector.calls(), 0, "BackendSelector should not be called");
+    }
+
+    // negative-2.1 (custom-header-routing): X-OAGW-Target-Host does not match any endpoint.
+    #[tokio::test]
+    async fn select_endpoint_target_host_unknown() {
+        let svc = build_svc(Arc::new(MockSelector::new()));
+        let upstream = upstream_with(vec![ep("a.com", 443), ep("b.com", 443)]);
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-oagw-target-host", "evil.com".parse().unwrap());
+
+        let err = svc
+            .select_endpoint(&upstream, &headers, "/test")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, DomainError::UnknownTargetHost { .. }),
+            "expected UnknownTargetHost, got: {err:?}"
+        );
+    }
+
+    // negative-1.2..1.4 (custom-header-routing): X-OAGW-Target-Host with invalid format.
+    #[tokio::test]
+    async fn select_endpoint_target_host_invalid_format() {
+        let svc = build_svc(Arc::new(MockSelector::new()));
+        let upstream = upstream_with(vec![ep("a.com", 443)]);
+
+        for bad_value in ["a.com:443", "a.com/path", "a.com?q=1", "a b"] {
+            let mut headers = HeaderMap::new();
+            headers.insert("x-oagw-target-host", bad_value.parse().unwrap());
+            let err = svc
+                .select_endpoint(&upstream, &headers, "/test")
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    DomainError::InvalidTargetHost { .. }
+                        | DomainError::UnknownTargetHost { .. }
+                ),
+                "expected InvalidTargetHost or UnknownTargetHost for '{bad_value}', got: {err:?}"
+            );
+        }
+
+        // Empty header value: test separately since HeaderValue::from_static
+        // allows empty strings while .parse() does not.
+        let mut headers = HeaderMap::new();
+        headers.insert("x-oagw-target-host", HeaderValue::from_static(""));
+        let err = svc
+            .select_endpoint(&upstream, &headers, "/test")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, DomainError::InvalidTargetHost { .. }),
+            "expected InvalidTargetHost for empty header, got: {err:?}"
+        );
+    }
+
+    // positive-2.1 (custom-header-routing): Round-robin fallback for multi-endpoint (no header).
+    #[tokio::test]
+    async fn select_endpoint_round_robin_fallback() {
+        let selector = Arc::new(MockSelector::new());
+        let svc = build_svc(selector.clone());
+        let upstream = upstream_with(vec![ep("a.com", 443), ep("b.com", 443)]);
+        let headers = HeaderMap::new();
+
+        let ep1 = svc
+            .select_endpoint(&upstream, &headers, "/test")
+            .await
+            .unwrap();
+        let ep2 = svc
+            .select_endpoint(&upstream, &headers, "/test")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            selector.calls(),
+            2,
+            "BackendSelector should be called for multi-endpoint"
+        );
+        // MockSelector returns endpoints in order: [0], [1], [0], ...
+        assert_eq!(ep1.host, "a.com");
+        assert_eq!(ep2.host, "b.com");
+    }
+
+    // positive-1.1 (custom-header-routing): Single-endpoint bypass (no header, no BackendSelector call).
+    #[tokio::test]
+    async fn select_endpoint_single_endpoint_bypass() {
+        let selector = Arc::new(MockSelector::new());
+        let svc = build_svc(selector.clone());
+        let upstream = upstream_with(vec![ep("only.com", 443)]);
+        let headers = HeaderMap::new();
+
+        let result = svc
+            .select_endpoint(&upstream, &headers, "/test")
+            .await
+            .unwrap();
+        assert_eq!(result.host, "only.com");
+        assert_eq!(
+            selector.calls(),
+            0,
+            "BackendSelector should NOT be called for single endpoint"
+        );
+    }
+
+    // positive-1.2 (custom-header-routing): Single-endpoint upstream validates header if present.
+    #[tokio::test]
+    async fn select_endpoint_single_endpoint_validates_header() {
+        let svc = build_svc(Arc::new(MockSelector::new()));
+        let upstream = upstream_with(vec![ep("a.com", 443)]);
+
+        // Valid header matching the single endpoint → OK.
+        let mut headers = HeaderMap::new();
+        headers.insert("x-oagw-target-host", "a.com".parse().unwrap());
+        let result = svc
+            .select_endpoint(&upstream, &headers, "/test")
+            .await
+            .unwrap();
+        assert_eq!(result.host, "a.com");
+
+        // Invalid header not matching → UnknownTargetHost.
+        let mut headers = HeaderMap::new();
+        headers.insert("x-oagw-target-host", "b.com".parse().unwrap());
+        let err = svc
+            .select_endpoint(&upstream, &headers, "/test")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, DomainError::UnknownTargetHost { .. }),
+            "expected UnknownTargetHost for mismatched header on single-endpoint upstream"
+        );
     }
 }

--- a/modules/system/oagw/oagw/src/infra/proxy/session_bridge.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/session_bridge.rs
@@ -1,0 +1,510 @@
+use std::io::Write as _;
+
+use anyhow::Context;
+use bytes::{Buf, Bytes, BytesMut};
+use futures_util::stream::unfold;
+use http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
+use oagw_sdk::body::{BodyStream, BoxError};
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+// ---------------------------------------------------------------------------
+// Request serialization
+// ---------------------------------------------------------------------------
+
+/// Extract path and query from a full URL.
+/// e.g. `"https://api.example.com/v1/chat?k=v"` → `"/v1/chat?k=v"`
+fn url_path_and_query(url: &str) -> &str {
+    if let Some(scheme_end) = url.find("://") {
+        let after_scheme = &url[scheme_end + 3..];
+        if let Some(path_start) = after_scheme.find('/') {
+            return &after_scheme[path_start..];
+        }
+        return "/";
+    }
+    url
+}
+
+/// Serialize an HTTP/1.1 request with a buffered body to wire format.
+///
+/// Produces: request-line, headers, Content-Length (if body non-empty),
+/// blank line, body bytes.
+pub(crate) fn serialize_request(
+    method: &Method,
+    url: &str,
+    headers: &HeaderMap,
+    body: &Bytes,
+) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(512 + body.len());
+    let _ = write!(buf, "{} {} HTTP/1.1\r\n", method, url_path_and_query(url));
+    for (name, value) in headers {
+        buf.extend_from_slice(name.as_str().as_bytes());
+        buf.extend_from_slice(b": ");
+        buf.extend_from_slice(value.as_bytes());
+        buf.extend_from_slice(b"\r\n");
+    }
+    // Always include Content-Length so Pingora knows the body boundary.
+    let _ = write!(buf, "Content-Length: {}\r\n", body.len());
+    // Single-shot bridge — no keep-alive on the in-memory session.
+    buf.extend_from_slice(b"Connection: close\r\n");
+    buf.extend_from_slice(b"\r\n");
+    buf.extend_from_slice(body);
+    buf
+}
+
+/// Serialize HTTP/1.1 request headers only (no Content-Length, no body).
+///
+/// Used for the `Body::Stream` (WebSocket) bridge path where the body is
+/// forwarded as raw stream chunks after the headers.
+pub(crate) fn serialize_request_headers(
+    method: &Method,
+    url: &str,
+    headers: &HeaderMap,
+) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(512);
+    let _ = write!(buf, "{} {} HTTP/1.1\r\n", method, url_path_and_query(url));
+    for (name, value) in headers {
+        buf.extend_from_slice(name.as_str().as_bytes());
+        buf.extend_from_slice(b": ");
+        buf.extend_from_slice(value.as_bytes());
+        buf.extend_from_slice(b"\r\n");
+    }
+    // Single-shot bridge — no keep-alive on the in-memory session.
+    buf.extend_from_slice(b"Connection: close\r\n");
+    buf.extend_from_slice(b"\r\n");
+    buf
+}
+
+// ---------------------------------------------------------------------------
+// Response parsing
+// ---------------------------------------------------------------------------
+
+/// Read an HTTP/1.1 response from the client side of a DuplexStream.
+///
+/// Parses the status line and headers via `httparse`, then returns a
+/// streaming body whose framing strategy depends on the response:
+///
+/// - **101 Switching Protocols** → raw unbounded byte stream (WebSocket)
+/// - **Content-Length** → exactly N bytes
+/// - **Transfer-Encoding: chunked** → decoded chunks
+/// - **Otherwise** → read until EOF
+pub(crate) async fn parse_response_stream(
+    mut io: impl AsyncRead + Unpin + Send + 'static,
+) -> anyhow::Result<(StatusCode, HeaderMap, BodyStream)> {
+    // Phase 1: accumulate bytes until httparse can parse a complete header.
+    let mut buf = BytesMut::with_capacity(4096);
+    let (status, headers, body_offset) = loop {
+        let mut tmp = [0u8; 4096];
+        let n = io
+            .read(&mut tmp)
+            .await
+            .context("failed to read response from proxy")?;
+        if n == 0 {
+            anyhow::bail!("proxy closed connection before sending response headers");
+        }
+        buf.extend_from_slice(&tmp[..n]);
+
+        let mut parsed_headers = [httparse::EMPTY_HEADER; 64];
+        let mut resp = httparse::Response::new(&mut parsed_headers);
+        match resp.parse(&buf)? {
+            httparse::Status::Complete(offset) => {
+                let status = StatusCode::from_u16(resp.code.unwrap_or(502))?;
+                let mut headers = HeaderMap::new();
+                for h in resp.headers.iter() {
+                    if let (Ok(name), Ok(value)) = (
+                        HeaderName::from_bytes(h.name.as_bytes()),
+                        HeaderValue::from_bytes(h.value),
+                    ) {
+                        headers.append(name, value);
+                    }
+                }
+                break (status, headers, offset);
+            }
+            httparse::Status::Partial => continue,
+        }
+    };
+
+    // Leftover body bytes that were read together with the headers.
+    let _ = buf.split_to(body_offset);
+    let remaining = buf.freeze();
+
+    // Phase 2: select body-reading strategy.
+    let body_stream = if status == StatusCode::SWITCHING_PROTOCOLS {
+        raw_body_stream(remaining, io)
+    } else if let Some(len) = content_length_value(&headers) {
+        content_length_body_stream(remaining, io, len)
+    } else if is_chunked_encoding(&headers) {
+        chunked_body_stream(remaining, io)
+    } else {
+        raw_body_stream(remaining, io)
+    };
+
+    Ok((status, headers, body_stream))
+}
+
+fn content_length_value(headers: &HeaderMap) -> Option<usize> {
+    headers
+        .get(http::header::CONTENT_LENGTH)?
+        .to_str()
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
+
+fn is_chunked_encoding(headers: &HeaderMap) -> bool {
+    headers
+        .get(http::header::TRANSFER_ENCODING)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.to_ascii_lowercase().contains("chunked"))
+}
+
+// ---------------------------------------------------------------------------
+// Body stream builders
+// ---------------------------------------------------------------------------
+
+/// Read raw bytes until EOF (used for 101 Upgrade and connection-close).
+fn raw_body_stream<R: AsyncRead + Unpin + Send + 'static>(initial: Bytes, io: R) -> BodyStream {
+    struct State<R> {
+        io: R,
+        initial: Option<Bytes>,
+    }
+
+    Box::pin(unfold(
+        State {
+            io,
+            initial: if initial.is_empty() {
+                None
+            } else {
+                Some(initial)
+            },
+        },
+        |mut state| async move {
+            if let Some(initial) = state.initial.take() {
+                return Some((Ok(initial), state));
+            }
+            let mut buf = vec![0u8; 8192];
+            match state.io.read(&mut buf).await {
+                Ok(0) => None,
+                Ok(n) => {
+                    buf.truncate(n);
+                    Some((Ok(Bytes::from(buf)), state))
+                }
+                Err(e) => Some((Err(Box::new(e) as BoxError), state)),
+            }
+        },
+    ))
+}
+
+/// Read exactly `total` body bytes (Content-Length delimited).
+fn content_length_body_stream<R: AsyncRead + Unpin + Send + 'static>(
+    initial: Bytes,
+    io: R,
+    total: usize,
+) -> BodyStream {
+    struct State<R> {
+        io: R,
+        remaining: usize,
+        initial: Option<Bytes>,
+    }
+
+    Box::pin(unfold(
+        State {
+            io,
+            remaining: total,
+            initial: if initial.is_empty() {
+                None
+            } else {
+                Some(initial)
+            },
+        },
+        |mut state| async move {
+            if state.remaining == 0 {
+                return None;
+            }
+            if let Some(initial) = state.initial.take() {
+                let to_take = initial.len().min(state.remaining);
+                state.remaining -= to_take;
+                return Some((Ok(initial.slice(..to_take)), state));
+            }
+            let to_read = state.remaining.min(8192);
+            let mut buf = vec![0u8; to_read];
+            match state.io.read(&mut buf).await {
+                Ok(0) => None,
+                Ok(n) => {
+                    buf.truncate(n);
+                    state.remaining -= n;
+                    Some((Ok(Bytes::from(buf)), state))
+                }
+                Err(e) => Some((Err(Box::new(e) as BoxError), state)),
+            }
+        },
+    ))
+}
+
+/// Decode chunked transfer encoding into plain body chunks.
+fn chunked_body_stream<R: AsyncRead + Unpin + Send + 'static>(initial: Bytes, io: R) -> BodyStream {
+    struct State<R> {
+        io: R,
+        buf: BytesMut,
+    }
+
+    Box::pin(unfold(
+        State {
+            io,
+            buf: BytesMut::from(initial.as_ref()),
+        },
+        |mut state| async move {
+            loop {
+                // Look for the chunk-size line terminator.
+                if let Some(pos) = find_crlf(&state.buf) {
+                    let size_hex = std::str::from_utf8(&state.buf[..pos])
+                        .ok()?
+                        .split(';')
+                        .next()?
+                        .trim();
+                    let chunk_size = usize::from_str_radix(size_hex, 16).ok()?;
+
+                    // Advance past the size line.
+                    state.buf.advance(pos + 2);
+
+                    if chunk_size == 0 {
+                        return None;
+                    }
+
+                    // Ensure we have chunk_size + trailing CRLF bytes.
+                    while state.buf.len() < chunk_size + 2 {
+                        if fill_buf(&mut state.io, &mut state.buf).await.is_err() {
+                            return None;
+                        }
+                    }
+
+                    let chunk = state.buf.split_to(chunk_size).freeze();
+                    state.buf.advance(2); // trailing \r\n
+                    return Some((Ok(chunk), state));
+                }
+
+                // Need more data from the stream.
+                if fill_buf(&mut state.io, &mut state.buf).await.is_err() {
+                    return None;
+                }
+            }
+        },
+    ))
+}
+
+fn find_crlf(buf: &[u8]) -> Option<usize> {
+    buf.windows(2).position(|w| w == b"\r\n")
+}
+
+async fn fill_buf<R: AsyncRead + Unpin>(
+    io: &mut R,
+    buf: &mut BytesMut,
+) -> Result<usize, std::io::Error> {
+    let mut tmp = [0u8; 8192];
+    let n = io.read(&mut tmp).await?;
+    if n == 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "unexpected EOF in chunked body",
+        ));
+    }
+    buf.extend_from_slice(&tmp[..n]);
+    Ok(n)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::StreamExt;
+    use tokio::io::DuplexStream;
+    // Use fully-qualified `AsyncWriteExt` to avoid ambiguity with
+    // pingora_core::protocols::Shutdown (also implemented for DuplexStream).
+    use tokio::io::AsyncWriteExt as _;
+
+    /// Shutdown the write side of a DuplexStream (disambiguated).
+    async fn shut(w: &mut DuplexStream) {
+        tokio::io::AsyncWriteExt::shutdown(w).await.unwrap();
+    }
+
+    // -- serialize_request tests (task 2.4) --
+
+    #[test]
+    fn serialize_request_line_format() {
+        let headers = HeaderMap::new();
+        let body = Bytes::new();
+        let wire = serialize_request(&Method::GET, "https://example.com/v1/chat", &headers, &body);
+        let text = String::from_utf8_lossy(&wire);
+        assert!(text.starts_with("GET /v1/chat HTTP/1.1\r\n"));
+    }
+
+    #[test]
+    fn serialize_request_includes_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert("host", HeaderValue::from_static("example.com"));
+        headers.insert("x-api-key", HeaderValue::from_static("secret"));
+        let body = Bytes::new();
+        let wire = serialize_request(&Method::POST, "https://example.com/api", &headers, &body);
+        let text = String::from_utf8_lossy(&wire);
+        assert!(text.contains("host: example.com\r\n"));
+        assert!(text.contains("x-api-key: secret\r\n"));
+    }
+
+    #[test]
+    fn serialize_request_content_length_with_body() {
+        let headers = HeaderMap::new();
+        let body = Bytes::from_static(b"hello world");
+        let wire = serialize_request(&Method::POST, "https://example.com/api", &headers, &body);
+        let text = String::from_utf8_lossy(&wire);
+        assert!(text.contains("Content-Length: 11\r\n"));
+        assert!(wire.ends_with(b"hello world"));
+    }
+
+    #[test]
+    fn serialize_request_content_length_zero_for_empty_body() {
+        let headers = HeaderMap::new();
+        let body = Bytes::new();
+        let wire = serialize_request(&Method::GET, "https://example.com/api", &headers, &body);
+        let text = String::from_utf8_lossy(&wire);
+        assert!(text.contains("Content-Length: 0\r\n"));
+        assert!(text.contains("Connection: close\r\n"));
+    }
+
+    #[test]
+    fn serialize_request_url_without_scheme() {
+        let wire = serialize_request(
+            &Method::GET,
+            "/plain/path",
+            &HeaderMap::new(),
+            &Bytes::new(),
+        );
+        let text = String::from_utf8_lossy(&wire);
+        assert!(text.starts_with("GET /plain/path HTTP/1.1\r\n"));
+    }
+
+    // -- serialize_request_headers tests (task 2.5) --
+
+    #[test]
+    fn serialize_headers_only_no_content_length() {
+        let mut headers = HeaderMap::new();
+        headers.insert("upgrade", HeaderValue::from_static("websocket"));
+        let wire = serialize_request_headers(&Method::GET, "wss://example.com/ws", &headers);
+        let text = String::from_utf8_lossy(&wire);
+        assert!(!text.contains("Content-Length"));
+        assert!(text.contains("upgrade: websocket\r\n"));
+        assert!(text.contains("Connection: close\r\n"));
+        assert!(wire.ends_with(b"\r\n\r\n"));
+    }
+
+    #[test]
+    fn serialize_headers_only_no_body_bytes() {
+        let wire =
+            serialize_request_headers(&Method::GET, "https://example.com/api", &HeaderMap::new());
+        // After the final \r\n\r\n there must be nothing.
+        let text = String::from_utf8_lossy(&wire);
+        assert!(text.ends_with("\r\n\r\n"));
+        let parts: Vec<&str> = text.splitn(2, "\r\n\r\n").collect();
+        assert_eq!(parts.len(), 2);
+        assert!(parts[1].is_empty());
+    }
+
+    // -- parse_response_stream tests (task 2.6) --
+
+    #[tokio::test]
+    async fn parse_response_content_length() {
+        let (mut writer, reader) = tokio::io::duplex(4096);
+        let body = b"hello world";
+        let resp = format!("HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n", body.len());
+        tokio::spawn(async move {
+            writer.write_all(resp.as_bytes()).await.unwrap();
+            writer.write_all(body).await.unwrap();
+            shut(&mut writer).await;
+        });
+
+        let (status, headers, body_stream) = parse_response_stream(reader).await.unwrap();
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            headers.get("content-length").unwrap().to_str().unwrap(),
+            "11"
+        );
+
+        let chunks: Vec<Bytes> = body_stream.map(|r| r.unwrap()).collect().await;
+        let all: Vec<u8> = chunks.iter().flat_map(|c| c.iter().copied()).collect();
+        assert_eq!(all, b"hello world");
+    }
+
+    #[tokio::test]
+    async fn parse_response_chunked() {
+        let (mut writer, reader) = tokio::io::duplex(4096);
+        tokio::spawn(async move {
+            writer
+                .write_all(b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n")
+                .await
+                .unwrap();
+            writer.write_all(b"5\r\nhello\r\n").await.unwrap();
+            writer.write_all(b"6\r\n world\r\n").await.unwrap();
+            writer.write_all(b"0\r\n\r\n").await.unwrap();
+            shut(&mut writer).await;
+        });
+
+        let (status, _headers, body_stream) = parse_response_stream(reader).await.unwrap();
+        assert_eq!(status, StatusCode::OK);
+
+        let chunks: Vec<Bytes> = body_stream.map(|r| r.unwrap()).collect().await;
+        let all: Vec<u8> = chunks.iter().flat_map(|c| c.iter().copied()).collect();
+        assert_eq!(all, b"hello world");
+    }
+
+    #[tokio::test]
+    async fn parse_response_101_upgrade() {
+        let (mut writer, reader) = tokio::io::duplex(4096);
+        tokio::spawn(async move {
+            writer
+                .write_all(
+                    b"HTTP/1.1 101 Switching Protocols\r\n\
+                      Upgrade: websocket\r\n\
+                      Connection: Upgrade\r\n\r\n\
+                      raw ws frames here",
+                )
+                .await
+                .unwrap();
+            shut(&mut writer).await;
+        });
+
+        let (status, headers, body_stream) = parse_response_stream(reader).await.unwrap();
+        assert_eq!(status, StatusCode::SWITCHING_PROTOCOLS);
+        assert_eq!(
+            headers.get("upgrade").unwrap().to_str().unwrap(),
+            "websocket"
+        );
+
+        let chunks: Vec<Bytes> = body_stream.map(|r| r.unwrap()).collect().await;
+        let all: Vec<u8> = chunks.iter().flat_map(|c| c.iter().copied()).collect();
+        assert_eq!(all, b"raw ws frames here");
+    }
+
+    #[tokio::test]
+    async fn parse_response_error_502() {
+        let (mut writer, reader) = tokio::io::duplex(4096);
+        let body = br#"{"status":502,"detail":"upstream error"}"#;
+        let resp = format!(
+            "HTTP/1.1 502 Bad Gateway\r\nContent-Length: {}\r\n\r\n",
+            body.len()
+        );
+        tokio::spawn(async move {
+            writer.write_all(resp.as_bytes()).await.unwrap();
+            writer.write_all(body).await.unwrap();
+            shut(&mut writer).await;
+        });
+
+        let (status, _headers, body_stream) = parse_response_stream(reader).await.unwrap();
+        assert_eq!(status, StatusCode::BAD_GATEWAY);
+
+        let chunks: Vec<Bytes> = body_stream.map(|r| r.unwrap()).collect().await;
+        let all: Vec<u8> = chunks.iter().flat_map(|c| c.iter().copied()).collect();
+        assert_eq!(all, body.as_slice());
+    }
+}

--- a/modules/system/oagw/oagw/src/infra/storage/credential_repo.rs
+++ b/modules/system/oagw/oagw/src/infra/storage/credential_repo.rs
@@ -1,4 +1,5 @@
 use crate::domain::credential::{CredentialError, CredentialResolver, SecretValue};
+use async_trait::async_trait;
 use dashmap::DashMap;
 use modkit_macros::domain_model;
 
@@ -39,7 +40,7 @@ impl Default for InMemoryCredentialResolver {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl CredentialResolver for InMemoryCredentialResolver {
     async fn resolve(&self, secret_ref: &str) -> Result<SecretValue, CredentialError> {
         self.store

--- a/modules/system/oagw/oagw/src/infra/storage/route_repo.rs
+++ b/modules/system/oagw/oagw/src/infra/storage/route_repo.rs
@@ -1,5 +1,6 @@
 use crate::domain::model::{HttpMethod, ListQuery, Route};
 use crate::domain::repo::{RepositoryError, RouteRepository};
+use async_trait::async_trait;
 use dashmap::DashMap;
 use modkit_macros::domain_model;
 use uuid::Uuid;
@@ -29,7 +30,7 @@ impl Default for InMemoryRouteRepo {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl RouteRepository for InMemoryRouteRepo {
     async fn create(&self, route: Route) -> Result<Route, RepositoryError> {
         let route_id = route.id;

--- a/modules/system/oagw/oagw/src/infra/storage/upstream_repo.rs
+++ b/modules/system/oagw/oagw/src/infra/storage/upstream_repo.rs
@@ -1,5 +1,6 @@
 use crate::domain::model::{ListQuery, Upstream};
 use crate::domain::repo::{RepositoryError, UpstreamRepository};
+use async_trait::async_trait;
 use dashmap::DashMap;
 use modkit_macros::domain_model;
 use uuid::Uuid;
@@ -29,7 +30,7 @@ impl Default for InMemoryUpstreamRepo {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl UpstreamRepository for InMemoryUpstreamRepo {
     async fn create(&self, upstream: Upstream) -> Result<Upstream, RepositoryError> {
         let alias_key = (upstream.tenant_id, upstream.alias.clone());

--- a/modules/system/oagw/oagw/src/module.rs
+++ b/modules/system/oagw/oagw/src/module.rs
@@ -17,7 +17,8 @@ use types_registry_sdk::{RegisterResult, RegisterSummary, TypesRegistryClient};
 
 use crate::api::rest::routes;
 use crate::domain::services::{
-    ControlPlaneService, ControlPlaneServiceImpl, DataPlaneService, ServiceGatewayClientV1Facade,
+    ControlPlaneService, ControlPlaneServiceImpl, DataPlaneService, EndpointSelector,
+    ServiceGatewayClientV1Facade,
 };
 use crate::infra::proxy::DataPlaneServiceImpl;
 use crate::infra::storage::{InMemoryCredentialResolver, InMemoryRouteRepo, InMemoryUpstreamRepo};
@@ -27,6 +28,7 @@ use crate::infra::storage::{InMemoryCredentialResolver, InMemoryRouteRepo, InMem
 pub struct AppState {
     pub(crate) cp: Arc<dyn ControlPlaneService>,
     pub(crate) dp: Arc<dyn DataPlaneService>,
+    pub(crate) backend_selector: Arc<dyn EndpointSelector>,
     pub(crate) config: crate::config::RuntimeConfig,
 }
 
@@ -76,9 +78,24 @@ impl Module for OutboundApiGatewayModule {
         ctx.client_hub()
             .register::<dyn CredentialResolver>(cred_resolver.clone());
 
-        // -- Data Plane init --
+        // -- Data Plane init (Pingora proxy engine) --
+        let server_conf = Arc::new(pingora_core::server::configuration::ServerConf {
+            upstream_keepalive_pool_size: 128,
+            ..Default::default()
+        });
+        let connect_timeout = Duration::from_secs(10);
+        let read_timeout = Duration::from_secs(cfg.proxy_timeout_secs);
+        let pingora_proxy =
+            crate::infra::proxy::pingora_proxy::PingoraProxy::new(connect_timeout, read_timeout);
+        let proxy = Arc::new(crate::infra::proxy::pingora_proxy::new_http_proxy(
+            &server_conf,
+            pingora_proxy,
+        ));
+        let backend_selector: Arc<dyn EndpointSelector> =
+            Arc::new(crate::infra::proxy::pingora_proxy::PingoraEndpointSelector::new());
+
         let dp: Arc<dyn DataPlaneService> = Arc::new(
-            DataPlaneServiceImpl::new(cp.clone(), cred_resolver)?
+            DataPlaneServiceImpl::new(cp.clone(), cred_resolver, backend_selector.clone(), proxy)
                 .with_request_timeout(Duration::from_secs(cfg.proxy_timeout_secs)),
         );
 
@@ -123,6 +140,7 @@ impl Module for OutboundApiGatewayModule {
         let app_state = AppState {
             cp,
             dp,
+            backend_selector,
             config: (&cfg).into(),
         };
 

--- a/modules/system/oagw/oagw/src/test_support/harness.rs
+++ b/modules/system/oagw/oagw/src/test_support/harness.rs
@@ -67,6 +67,13 @@ impl AppHarnessBuilder {
     }
 
     pub async fn build(self) -> AppHarness {
+        // When `cargo test --workspace` unifies features, rustls may end up
+        // with both `aws-lc-rs` and `ring` enabled, preventing auto-detection.
+        // Explicitly install the provider once (skip if already set).
+        if rustls::crypto::CryptoProvider::get_default().is_none() {
+            drop(rustls::crypto::aws_lc_rs::default_provider().install_default());
+        }
+
         let hub = ClientHub::new();
 
         let mut cp_builder = TestCpBuilder::new();

--- a/modules/system/oagw/oagw/tests/proxy_integration.rs
+++ b/modules/system/oagw/oagw/tests/proxy_integration.rs
@@ -1,6 +1,7 @@
 use http::{Method, StatusCode};
 use oagw::test_support::{
-    APIKEY_AUTH_PLUGIN_ID, AppHarness, MockBody, MockGuard, MockResponse, parse_resource_gts,
+    APIKEY_AUTH_PLUGIN_ID, AppHarness, MockBody, MockGuard, MockResponse, MockUpstream,
+    parse_resource_gts,
 };
 use oagw_sdk::Body;
 use oagw_sdk::api::ErrorSource;
@@ -950,6 +951,395 @@ async fn proxy_path_suffix_disabled_rejects_extra_path() {
         )),
         Ok(_) => panic!("expected validation error for disabled path_suffix_mode"),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Multi-endpoint load balancing integration tests
+// ---------------------------------------------------------------------------
+
+// positive-2.1 (custom-header-routing), positive-2.10 (upstreams): Round-robin distribution across 2 endpoints.
+#[tokio::test]
+async fn proxy_multi_endpoint_round_robin() {
+    // Start two independent mock servers.
+    let mock_a = MockUpstream::start().await;
+    let mock_b = MockUpstream::start().await;
+
+    let h = AppHarness::builder().build().await;
+    let ctx = h.security_context().clone();
+
+    let upstream = h
+        .facade()
+        .create_upstream(
+            ctx.clone(),
+            CreateUpstreamRequest::builder(
+                Server {
+                    endpoints: vec![
+                        Endpoint {
+                            scheme: Scheme::Http,
+                            host: "127.0.0.1".into(),
+                            port: mock_a.addr().port(),
+                        },
+                        Endpoint {
+                            scheme: Scheme::Http,
+                            host: "127.0.0.1".into(),
+                            port: mock_b.addr().port(),
+                        },
+                    ],
+                },
+                "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            )
+            .alias("rr-test")
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Get],
+                        path: "/v1/models".into(),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Append,
+                    }),
+                    grpc: None,
+                },
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    // Send 4 requests — round-robin should distribute across both backends.
+    for _ in 0..4 {
+        let req = http::Request::builder()
+            .method(Method::GET)
+            .uri("/rr-test/v1/models")
+            .body(Body::Empty)
+            .unwrap();
+        let response = h.facade().proxy_request(ctx.clone(), req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    let a_count = mock_a.recorded_requests().await.len();
+    let b_count = mock_b.recorded_requests().await.len();
+    assert!(
+        a_count > 0,
+        "mock_a should have received at least 1 request, got {a_count}"
+    );
+    assert!(
+        b_count > 0,
+        "mock_b should have received at least 1 request, got {b_count}"
+    );
+    assert_eq!(a_count + b_count, 4, "total requests should be 4");
+}
+
+// positive-2.2 (custom-header-routing): X-OAGW-Target-Host explicit selection.
+#[tokio::test]
+async fn proxy_target_host_header_selects_endpoint() {
+    let mock_a = MockUpstream::start().await;
+    let mock_b = MockUpstream::start().await;
+
+    let h = AppHarness::builder().build().await;
+    let ctx = h.security_context().clone();
+
+    let port_a = mock_a.addr().port();
+    let port_b = mock_b.addr().port();
+
+    // Create upstream with 2 endpoints, different ports as distinguishing factor.
+    // Use distinct "hosts" for the X-OAGW-Target-Host selection.
+    // Both resolve to 127.0.0.1 since they're IP addresses.
+    let upstream = h
+        .facade()
+        .create_upstream(
+            ctx.clone(),
+            CreateUpstreamRequest::builder(
+                Server {
+                    endpoints: vec![
+                        Endpoint {
+                            scheme: Scheme::Http,
+                            host: "127.0.0.1".into(),
+                            port: port_a,
+                        },
+                        Endpoint {
+                            scheme: Scheme::Http,
+                            host: "127.0.0.1".into(),
+                            port: port_b,
+                        },
+                    ],
+                },
+                "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            )
+            .alias("target-host-test")
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Get],
+                        path: "/v1/models".into(),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Append,
+                    }),
+                    grpc: None,
+                },
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    // Send request with X-OAGW-Target-Host header selecting endpoint host.
+    let req = http::Request::builder()
+        .method(Method::GET)
+        .uri("/target-host-test/v1/models")
+        .header("x-oagw-target-host", "127.0.0.1")
+        .body(Body::Empty)
+        .unwrap();
+    let response = h.facade().proxy_request(ctx.clone(), req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+// negative-2.1 (custom-header-routing): X-OAGW-Target-Host validation — unknown host returns error.
+#[tokio::test]
+async fn proxy_target_host_unknown_returns_error() {
+    let h = AppHarness::builder().build().await;
+    let ctx = h.security_context().clone();
+
+    let upstream = h
+        .facade()
+        .create_upstream(
+            ctx.clone(),
+            CreateUpstreamRequest::builder(
+                Server {
+                    endpoints: vec![Endpoint {
+                        scheme: Scheme::Http,
+                        host: "127.0.0.1".into(),
+                        port: h.mock_port(),
+                    }],
+                },
+                "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            )
+            .alias("target-host-unknown")
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Get],
+                        path: "/v1/models".into(),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Append,
+                    }),
+                    grpc: None,
+                },
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    let req = http::Request::builder()
+        .method(Method::GET)
+        .uri("/target-host-unknown/v1/models")
+        .header("x-oagw-target-host", "unknown.com")
+        .body(Body::Empty)
+        .unwrap();
+
+    match h.facade().proxy_request(ctx.clone(), req).await {
+        Err(err) => assert!(
+            matches!(
+                err,
+                oagw_sdk::error::ServiceGatewayError::UnknownTargetHost { .. }
+            ),
+            "expected UnknownTargetHost, got: {err:?}"
+        ),
+        Ok(_) => panic!("expected error for unknown target host"),
+    }
+}
+
+// negative-2.10 (upstreams): All backends unreachable returns connection error (502).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn proxy_all_backends_unreachable() {
+    let h = AppHarness::builder()
+        .with_request_timeout(std::time::Duration::from_secs(5))
+        .build()
+        .await;
+    let ctx = h.security_context().clone();
+
+    // Ports 19991/19992 are unlikely to be listening.
+    let upstream = h
+        .facade()
+        .create_upstream(
+            ctx.clone(),
+            CreateUpstreamRequest::builder(
+                Server {
+                    endpoints: vec![Endpoint {
+                        scheme: Scheme::Http,
+                        host: "127.0.0.1".into(),
+                        port: 19991,
+                    }],
+                },
+                "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            )
+            .alias("unreachable-test")
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Get],
+                        path: "/v1/models".into(),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Append,
+                    }),
+                    grpc: None,
+                },
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    let req = http::Request::builder()
+        .method(Method::GET)
+        .uri("/unreachable-test/v1/models")
+        .body(Body::Empty)
+        .unwrap();
+
+    match h.facade().proxy_request(ctx.clone(), req).await {
+        Err(err) => assert!(
+            matches!(
+                err,
+                oagw_sdk::error::ServiceGatewayError::DownstreamError { .. }
+            ),
+            "expected DownstreamError for unreachable backend, got: {err:?}"
+        ),
+        Ok(resp) => {
+            // Pingora may return a 502 response directly via fail_to_proxy.
+            assert!(
+                resp.status() == StatusCode::BAD_GATEWAY
+                    || resp.status() == StatusCode::GATEWAY_TIMEOUT,
+                "expected 502 or 504, got: {}",
+                resp.status()
+            );
+        }
+    }
+}
+
+// positive-2.13 (upstreams): CRUD invalidation — update upstream endpoints, verify new endpoint used.
+#[tokio::test]
+async fn proxy_crud_invalidation_after_update() {
+    let mock_a = MockUpstream::start().await;
+    let mock_b = MockUpstream::start().await;
+    let port_a = mock_a.addr().port();
+    let port_b = mock_b.addr().port();
+
+    let h = AppHarness::builder().build().await;
+    let ctx = h.security_context().clone();
+
+    // Create upstream pointing to mock_a only.
+    let resp = h
+        .api_v1()
+        .post_upstream()
+        .with_body(json!({
+            "server": {
+                "endpoints": [{"host": "127.0.0.1", "port": port_a, "scheme": "http"}]
+            },
+            "protocol": "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            "alias": "crud-invalidation",
+            "enabled": true,
+            "tags": []
+        }))
+        .expect_status(201)
+        .await;
+    let upstream_id = resp.json()["id"].as_str().unwrap().to_string();
+    let (_, upstream_uuid) = parse_resource_gts(&upstream_id).unwrap();
+
+    h.api_v1()
+        .post_route()
+        .with_body(json!({
+            "upstream_id": upstream_uuid,
+            "match": {
+                "http": {
+                    "methods": ["GET"],
+                    "path": "/v1/models"
+                }
+            },
+            "enabled": true,
+            "tags": [],
+            "priority": 0
+        }))
+        .expect_status(201)
+        .await;
+
+    // Proxy to mock_a.
+    let req = http::Request::builder()
+        .method(Method::GET)
+        .uri("/crud-invalidation/v1/models")
+        .body(Body::Empty)
+        .unwrap();
+    let response = h.facade().proxy_request(ctx.clone(), req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        mock_a.recorded_requests().await.len(),
+        1,
+        "mock_a should have received 1 request"
+    );
+    assert_eq!(
+        mock_b.recorded_requests().await.len(),
+        0,
+        "mock_b should have received 0 requests"
+    );
+
+    // Update upstream to point to mock_b via REST API (triggers invalidation).
+    h.api_v1()
+        .patch_upstream(&upstream_id)
+        .with_body(json!({
+            "server": {
+                "endpoints": [{"host": "127.0.0.1", "port": port_b, "scheme": "http"}]
+            }
+        }))
+        .expect_status(200)
+        .await;
+
+    // Proxy again — should now go to mock_b (cache was invalidated).
+    let req = http::Request::builder()
+        .method(Method::GET)
+        .uri("/crud-invalidation/v1/models")
+        .body(Body::Empty)
+        .unwrap();
+    let response = h.facade().proxy_request(ctx.clone(), req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        !mock_b.recorded_requests().await.is_empty(),
+        "mock_b should have received at least 1 request after update"
+    );
 }
 
 // Demonstrate MockGuard pattern for custom per-test responses

--- a/modules/system/oagw/scenarios/INDEX.md
+++ b/modules/system/oagw/scenarios/INDEX.md
@@ -108,6 +108,10 @@ Call your external service through OAGW's proxy endpoint: `{METHOD} /api/oagw/v1
 - **Scenario**: [positive-2.12-list-upstreams-includes-disabled-resources.md](management-api/upstreams/positive-2.12-list-upstreams-includes-disabled-resources.md)
 - **Mechanism**: `GET /upstreams` returns both enabled and disabled upstreams with `enabled` field. Optional `$filter=enabled eq true` for active only.
 
+#### CRUD endpoint update invalidates load balancer
+- **Scenario**: [positive-2.13-crud-endpoint-update-invalidates-load-balancer.md](management-api/upstreams/positive-2.13-crud-endpoint-update-invalidates-load-balancer.md)
+- **Mechanism**: `PUT /upstreams/{id}` with new endpoints invalidates cached LoadBalancer. Next proxy request lazily rebuilds with updated endpoints.
+
 ---
 
 ### Route configuration
@@ -575,6 +579,10 @@ Full integration walkthroughs — each demonstrates the complete journey (upstre
 #### Alias uniqueness enforced per tenant → conflict
 - **Scenario**: [negative-2.8-alias-uniqueness-enforced-per-tenant.md](management-api/upstreams/negative-2.8-alias-uniqueness-enforced-per-tenant.md)
 - **What happens**: Two upstreams with same alias in same tenant rejected (conflict). Same alias in different tenants succeeds.
+
+#### All backends unreachable → 502
+- **Scenario**: [negative-2.10-all-backends-unreachable-returns-502.md](management-api/upstreams/negative-2.10-all-backends-unreachable-returns-502.md)
+- **What happens**: Multi-endpoint upstream with all endpoints unreachable returns `502 Bad Gateway` or `504 Gateway Timeout`. Retry mechanism exhausts all attempts.
 
 #### Enforced ancestor limits still apply when alias shadowed
 - **Scenario**: [negative-6.2-enforced-ancestor-limits-still-apply-alias-shadowed.md](proxy-api/alias-resolution/negative-6.2-enforced-ancestor-limits-still-apply-alias-shadowed.md)

--- a/modules/system/oagw/scenarios/management-api/upstreams/negative-2.10-all-backends-unreachable-returns-502.md
+++ b/modules/system/oagw/scenarios/management-api/upstreams/negative-2.10-all-backends-unreachable-returns-502.md
@@ -1,0 +1,46 @@
+# All backends unreachable returns 502
+
+## Setup
+
+- Upstream `my-service` with multiple endpoints, all pointing to unreachable addresses:
+  - `endpoints`: `[{"scheme": "https", "host": "10.0.0.1", "port": 19999}, {"scheme": "https", "host": "10.0.0.2", "port": 19999}]`
+  - `alias`: `my-service`
+- Route: `POST /v1/chat`
+
+## Request
+
+```http
+POST /api/oagw/v1/proxy/my-service/v1/chat HTTP/1.1
+Host: oagw.example.com
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{"prompt": "hello"}
+```
+
+## Expected behavior
+
+- All connection attempts fail (connection refused or timeout)
+- Response: `502 Bad Gateway` or `504 Gateway Timeout`
+- Error source: `X-OAGW-Error-Source: gateway`
+- Body: RFC 9457 Problem Details
+
+```http
+HTTP/1.1 502 Bad Gateway
+X-OAGW-Error-Source: gateway
+Content-Type: application/problem+json
+
+{
+  "type": "gts.x.core.errors.err.v1~x.oagw.proxy.downstream_error.v1",
+  "title": "Downstream Error",
+  "status": 502,
+  "detail": "Connection refused or timed out to all configured endpoints",
+  "instance": "/api/oagw/v1/proxy/my-service/v1/chat"
+}
+```
+
+## Validation
+
+- Multi-endpoint upstream with all endpoints unreachable returns gateway error
+- Retry mechanism exhausts attempts across configured retries
+- No partial or hanging response — client receives a clear error

--- a/modules/system/oagw/scenarios/management-api/upstreams/positive-2.13-crud-endpoint-update-invalidates-load-balancer.md
+++ b/modules/system/oagw/scenarios/management-api/upstreams/positive-2.13-crud-endpoint-update-invalidates-load-balancer.md
@@ -1,0 +1,71 @@
+# CRUD endpoint update invalidates load balancer
+
+## Setup
+
+- Upstream `my-service` with one endpoint:
+  - `endpoints`: `[{"scheme": "http", "host": "server-a.example.com", "port": 8080}]`
+  - `alias`: `my-service`
+- Route: `POST /v1/chat`
+
+## Step 1: Proxy request to original endpoint
+
+```http
+POST /api/oagw/v1/proxy/my-service/v1/chat HTTP/1.1
+Host: oagw.example.com
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{"prompt": "hello"}
+```
+
+- Response: `200 OK` from `server-a.example.com`
+- LoadBalancer is lazily constructed and cached for this upstream
+
+## Step 2: Update upstream endpoints via management API
+
+```http
+PUT /api/oagw/v1/upstreams/{id} HTTP/1.1
+Host: oagw.example.com
+Authorization: Bearer <admin-token>
+Content-Type: application/json
+
+{
+  "server": {
+    "endpoints": [
+      { "scheme": "http", "host": "server-b.example.com", "port": 8080 }
+    ]
+  },
+  "protocol": "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+  "alias": "my-service"
+}
+```
+
+- Response: `200 OK`
+- LoadBalancer cache entry for this upstream is invalidated
+
+## Step 3: Proxy request after update
+
+```http
+POST /api/oagw/v1/proxy/my-service/v1/chat HTTP/1.1
+Host: oagw.example.com
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{"prompt": "hello again"}
+```
+
+- Response: `200 OK` from `server-b.example.com` (not `server-a`)
+- A new LoadBalancer is lazily constructed with the updated endpoint list
+
+## Expected behavior
+
+- After `PUT /upstreams/{id}`, the cached LoadBalancer is invalidated
+- Next proxy request uses the updated endpoint configuration
+- Old endpoint (`server-a`) receives no further traffic after the update
+- New endpoint (`server-b`) receives all subsequent traffic
+
+## Validation
+
+- CRUD operations on upstreams trigger LoadBalancer cache invalidation
+- Invalidation is immediate — no stale routing to old endpoints
+- Same behavior applies to `POST` (create) and `DELETE` operations

--- a/testing/e2e/modules/oagw/test_proxy_round_trip.py
+++ b/testing/e2e/modules/oagw/test_proxy_round_trip.py
@@ -70,7 +70,12 @@ async def test_get_proxy_returns_upstream_response(
 async def test_hop_by_hop_headers_stripped(
     oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
 ):
-    """Hop-by-hop headers are not forwarded to the upstream."""
+    """Hop-by-hop headers from the client are not forwarded to the upstream.
+
+    The proxy itself may set its own Connection header (e.g. ``close`` on
+    HTTP/1.1) — that is acceptable.  What matters is that the *client's*
+    hop-by-hop values are stripped.
+    """
     _ = mock_upstream
     alias = unique_alias("proxy-hop")
     async with httpx.AsyncClient(timeout=10.0) as client:
@@ -94,12 +99,20 @@ async def test_hop_by_hop_headers_stripped(
         assert resp.status_code == 200
         echoed_headers = resp.json().get("headers", {})
 
-        hop_by_hop = [
-            "connection", "keep-alive", "proxy-authorization",
+        # These hop-by-hop headers must never reach the upstream.
+        must_strip = [
+            "keep-alive", "proxy-authorization",
             "te", "trailer", "transfer-encoding", "upgrade",
         ]
-        for h in hop_by_hop:
+        for h in must_strip:
             assert h not in echoed_headers, f"Hop-by-hop header '{h}' was forwarded to upstream"
+
+        # The proxy may set its own Connection header (e.g. "close" on
+        # HTTP/1.1), but the client's value ("keep-alive") must not appear.
+        conn = echoed_headers.get("connection", "")
+        assert "keep-alive" not in conn.lower(), (
+            f"Client's 'Connection: keep-alive' was forwarded; got '{conn}'"
+        )
 
         await delete_upstream(client, oagw_base_url, oagw_headers, uid)
 


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#733](https://github.com/cyberfabric/cyberware-rust/pull/733) | **Author:** striped-zebra-dev | **Opened:** 2026-02-24T11:21:29Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-process HTTP proxy backend with streaming request/response bridging and per-upstream endpoint selection.

* **Improvements**
  * Multi-endpoint round-robin, explicit target-host routing, health checks, and immediate cache invalidation after upstream create/update/delete.
  * Standardized error responses to RFC 9457 and stricter hop-by-hop header stripping.

* **Tests**
  * New integration and unit tests for proxy routing, selection, invalidation, and body framing.

* **Documentation**
  * New scenario docs for upstream invalidation and unreachable-backends behavior.

* **Chores**
  * TLS/provider initialization and dependency/feature updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#733 -->