### PR TITLE
[PR #677] Integrate tokio-console under feature flag

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     env:
-      RUSTFLAGS: "-C debuginfo=0"
+      RUSTFLAGS: "-C debuginfo=0 --cfg tokio_unstable"
     steps:
       - name: Force LF in working tree (w/a for Windows)
         if: runner.os == 'Windows'
@@ -93,7 +93,7 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: "-C debuginfo=0"
+      RUSTFLAGS: "-C debuginfo=0 --cfg tokio_unstable"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -202,7 +202,7 @@ jobs:
       # Generate lcov.info for upload. Customize flags/features as needed.
       - name: Coverage (lcov)
         env:
-          RUSTFLAGS: "-C debuginfo=0 --cfg coverage_nightly"
+          RUSTFLAGS: "-C debuginfo=0 --cfg coverage_nightly --cfg tokio_unstable"
           CARGO_LLVM_COV_TARGET_DIR: llvm-cov-target
           CARGO_LLVM_COV_BUILD_DIR: llvm-cov-build
         run: |
@@ -245,7 +245,7 @@ jobs:
       - name: Run dylint tests
         working-directory: dylint_lints
         env:
-          RUSTFLAGS: "-C debuginfo=0"
+          RUSTFLAGS: "-C debuginfo=0 --cfg tokio_unstable"
         run: cargo test
 
       - name: Run dylint on all crates

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,11 +431,38 @@ dependencies = [
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "axum-macros",
  "base64 0.22.1",
  "bytes",
@@ -461,10 +488,30 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -641,7 +688,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic",
+ "tonic 0.14.4",
  "tower-service",
  "url",
  "winapi",
@@ -653,9 +700,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
 dependencies = [
- "prost",
- "prost-types",
- "tonic",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "tonic 0.14.4",
  "tonic-prost",
  "ureq 3.2.0",
 ]
@@ -670,7 +717,7 @@ dependencies = [
  "bollard-buildkit-proto",
  "bytes",
  "chrono",
- "prost",
+ "prost 0.14.3",
  "serde",
  "serde_json",
  "serde_repr",
@@ -827,7 +874,7 @@ dependencies = [
  "clap",
  "inventory",
  "tokio",
- "tonic",
+ "tonic 0.14.4",
  "tracing",
 ]
 
@@ -837,7 +884,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
+ "axum 0.8.8",
  "calculator-sdk",
  "cf-modkit",
  "cf-modkit-macros",
@@ -862,10 +909,10 @@ dependencies = [
  "cf-modkit-security",
  "cf-modkit-transport-grpc",
  "cf-system-sdks",
- "prost",
+ "prost 0.14.3",
  "thiserror 2.0.18",
  "tokio",
- "tonic",
+ "tonic 0.14.4",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
@@ -912,7 +959,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "async-trait",
- "axum",
+ "axum 0.8.8",
  "cf-authn-resolver-sdk",
  "cf-modkit",
  "cf-modkit-http",
@@ -933,7 +980,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
  "ureq 2.12.1",
@@ -1022,7 +1069,7 @@ version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
+ "axum 0.8.8",
  "base64 0.22.1",
  "bytes",
  "calamine",
@@ -1065,8 +1112,8 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic",
- "tower",
+ "tonic 0.14.4",
+ "tower 0.5.3",
  "tracing",
  "uuid",
 ]
@@ -1078,7 +1125,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "async-trait",
- "axum",
+ "axum 0.8.8",
  "cf-modkit-db",
  "cf-modkit-errors",
  "cf-modkit-macros",
@@ -1086,6 +1133,7 @@ dependencies = [
  "cf-modkit-sdk",
  "cf-system-sdks",
  "chrono",
+ "console-subscriber",
  "dashmap",
  "dsn",
  "enable-ansi-support",
@@ -1116,8 +1164,8 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic",
- "tower",
+ "tonic 0.14.4",
+ "tower 0.5.3",
  "tracing",
  "tracing-appender",
  "tracing-log",
@@ -1154,7 +1202,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "url",
  "uuid",
@@ -1215,7 +1263,7 @@ dependencies = [
 name = "cf-modkit-errors"
 version = "0.2.12"
 dependencies = [
- "axum",
+ "axum 0.8.8",
  "http",
  "serde",
  "serde_json",
@@ -1260,7 +1308,7 @@ dependencies = [
  "serde_urlencoded",
  "thiserror 2.0.18",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
  "tracing-opentelemetry",
@@ -1291,7 +1339,7 @@ dependencies = [
  "inventory",
  "tokio",
  "tokio-util",
- "tonic",
+ "tonic 0.14.4",
  "trybuild",
 ]
 
@@ -1384,7 +1432,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic",
+ "tonic 0.14.4",
  "tracing",
 ]
 
@@ -1404,7 +1452,7 @@ version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
+ "axum 0.8.8",
  "cf-api-gateway",
  "cf-modkit",
  "cf-modkit-macros",
@@ -1414,8 +1462,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tonic",
- "tower",
+ "tonic 0.14.4",
+ "tower 0.5.3",
  "tracing",
  "utoipa",
  "uuid",
@@ -1427,7 +1475,7 @@ version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
+ "axum 0.8.8",
  "cf-modkit",
  "cf-modkit-macros",
  "cf-modkit-node-info",
@@ -1459,7 +1507,7 @@ dependencies = [
  "arc-swap",
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.8.8",
  "bytes",
  "cf-modkit",
  "cf-modkit-macros",
@@ -1480,7 +1528,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "utoipa",
  "uuid",
@@ -1507,7 +1555,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
+ "axum 0.8.8",
  "cf-authz-resolver-sdk",
  "cf-modkit",
  "cf-modkit-db",
@@ -1524,7 +1572,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "utoipa",
  "uuid",
@@ -1629,9 +1677,9 @@ dependencies = [
  "anyhow",
  "async-trait",
  "cf-modkit-transport-grpc",
- "prost",
+ "prost 0.14.3",
  "tokio",
- "tonic",
+ "tonic 0.14.4",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
@@ -1688,7 +1736,7 @@ version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
+ "axum 0.8.8",
  "cf-modkit",
  "cf-modkit-macros",
  "cf-types-registry-sdk",
@@ -1892,6 +1940,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console-api"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857"
+dependencies = [
+ "futures-core",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "tonic 0.12.3",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6539aa9c6a4cd31f4b1c040f860a1eac9aa80e7df6b05d506a6e7179936d6a01"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "hyper-util",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.12.3",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3137,6 +3224,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "flate2",
+ "nom 7.1.3",
+ "num-traits",
+]
+
+[[package]]
 name = "headers"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3417,7 +3517,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3723,7 +3823,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
 dependencies = [
- "nom",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -3965,7 +4065,7 @@ dependencies = [
  "itoa",
  "log",
  "md-5",
- "nom",
+ "nom 8.0.0",
  "nom_locate",
  "rand 0.9.2",
  "rangemap",
@@ -4028,6 +4128,12 @@ dependencies = [
 
 [[package]]
 name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -4068,6 +4174,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -4200,6 +4312,16 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
@@ -4215,7 +4337,7 @@ checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
 dependencies = [
  "bytecount",
  "memchr",
- "nom",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -4503,11 +4625,11 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.14.3",
  "reqwest",
  "thiserror 2.0.18",
  "tokio",
- "tonic",
+ "tonic 0.14.4",
  "tracing",
 ]
 
@@ -4519,8 +4641,8 @@ checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
- "tonic",
+ "prost 0.14.3",
+ "tonic 0.14.4",
  "tonic-prost",
 ]
 
@@ -5055,12 +5177,22 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.3",
 ]
 
 [[package]]
@@ -5075,13 +5207,26 @@ dependencies = [
  "multimap",
  "petgraph",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.115",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -5099,11 +5244,20 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost 0.13.5",
+]
+
+[[package]]
+name = "prost-types"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost",
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -5416,7 +5570,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -6252,6 +6406,16 @@ checksum = "ef784004ca8777809dcdad6ac37629f0a97caee4c685fcea805278d81dd8b857"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -6894,8 +7058,9 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -7041,12 +7206,13 @@ checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
-version = "0.14.4"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f32a6f80051a4111560201420c7885d0082ba9efe2ab61875c587bb6b18b9a0"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
+ "async-stream",
  "async-trait",
- "axum",
+ "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
  "h2",
@@ -7058,11 +7224,40 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2",
+ "prost 0.13.5",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f32a6f80051a4111560201420c7885d0082ba9efe2ab61875c587bb6b18b9a0"
+dependencies = [
+ "async-trait",
+ "axum 0.8.8",
+ "base64 0.22.1",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2 0.6.2",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -7087,8 +7282,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f86539c0089bfd09b1f8c0ab0239d80392af74c21bc9e0f15e1b4aca4c1647f"
 dependencies = [
  "bytes",
- "prost",
- "tonic",
+ "prost 0.14.3",
+ "tonic 0.14.4",
 ]
 
 [[package]]
@@ -7100,11 +7295,31 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
- "prost-types",
+ "prost-types 0.14.3",
  "quote",
  "syn 2.0.115",
  "tempfile",
  "tonic-build",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -7144,7 +7359,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -7519,7 +7734,7 @@ version = "0.2.12"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
+ "axum 0.8.8",
  "cf-api-gateway",
  "cf-authz-resolver-sdk",
  "cf-modkit",
@@ -7549,7 +7764,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
  "tracing-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,6 +246,7 @@ thiserror = "2.0"
 tokio = { version = "1.47", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 tokio-stream = { version = "0.1", features = ["sync", "net"] }
+console-subscriber = "0.4"
 futures = "0.3"
 async-trait = "0.1"
 

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ geiger:
 
 ## Check there are no compile time warnings
 lint:
-	RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --all-features
+	RUSTFLAGS="-D warnings --cfg tokio_unstable" cargo check --workspace --all-targets --all-features
 
 ## Validate GTS identifiers in .md and .json files (DE0903)
 # Uses gts-docs-validator from apps/gts-docs-validator

--- a/apps/hyperspot-server/Cargo.toml
+++ b/apps/hyperspot-server/Cargo.toml
@@ -18,6 +18,7 @@ static-tenants = ["dep:static-tr-plugin"]
 static-authn = ["dep:static-authn-plugin"]
 static-authz = ["dep:static-authz-plugin"]
 otel = ["modkit/otel"]
+tokio-console = ["modkit/tokio-console"]
 
 [dependencies]
 mimalloc = { version = "0.1" }

--- a/apps/hyperspot-server/src/main.rs
+++ b/apps/hyperspot-server/src/main.rs
@@ -5,7 +5,8 @@ use clap::{Parser, Subcommand};
 use mimalloc::MiMalloc;
 use modkit::bootstrap::{
     AppConfig, dump_effective_modules_config_json, dump_effective_modules_config_yaml,
-    host::init_logging_unified, list_module_names, run_migrate, run_server,
+    host::{build_console_layer, init_logging_unified},
+    list_module_names, run_migrate, run_server,
 };
 
 use std::path::PathBuf;
@@ -91,8 +92,16 @@ async fn main() -> Result<()> {
     #[cfg(not(feature = "otel"))]
     let otel_layer = None;
 
-    // Initialize logging + otel in one Registry
-    init_logging_unified(&config.logging, &config.server.home_dir, otel_layer);
+    // Build tokio-console layer before logging (when feature is enabled)
+    let console_layer = build_console_layer(config.tokio_console.as_ref());
+
+    // Initialize logging + otel + tokio-console in one Registry
+    init_logging_unified(
+        &config.logging,
+        &config.server.home_dir,
+        otel_layer,
+        console_layer,
+    );
 
     // One-time connectivity probe
     #[cfg(feature = "otel")]

--- a/docs/TOKIO_CONSOLE.md
+++ b/docs/TOKIO_CONSOLE.md
@@ -1,0 +1,72 @@
+# tokio-console Integration
+
+[tokio-console](https://github.com/tokio-rs/console) provides deep async runtime inspection for debugging and profiling tokio-based applications.
+
+The integration is **feature-gated** behind the `tokio-console` Cargo feature and is **disabled by default** in production builds.
+
+## Building with tokio-console
+
+```bash
+cargo build -p hyperspot-server --features tokio-console
+```
+
+For a release build with console support (e.g. preprod):
+
+```bash
+cargo build -p hyperspot-server --release --features tokio-console
+```
+
+## Configuration
+
+Add a `tokio_console` section to your YAML config file:
+
+```yaml
+tokio_console:
+  server_addr: "127.0.0.1:6669"   # default
+```
+
+The `server_addr` field controls the bind address for the console-subscriber gRPC server.
+Default is `127.0.0.1:6669` (localhost only).
+
+Configuration can also be set via environment variables:
+
+```bash
+APP__TOKIO_CONSOLE__SERVER_ADDR=127.0.0.1:6669
+```
+
+### Enabling at runtime
+
+The console layer is only activated when **both** conditions are met:
+
+1. The binary was built with `--features tokio-console`.
+2. The `tokio_console` section is present in the config file.
+
+If the feature is compiled in but no `tokio_console` config section exists, the layer is not started.
+
+## Connecting with tokio-console
+
+### Local development
+
+```bash
+tokio-console http://localhost:6669
+```
+
+### Kubernetes (via port-forward)
+
+```bash
+kubectl port-forward pod/<pod-name> 6669:6669
+tokio-console http://localhost:6669
+```
+
+The default `127.0.0.1` binding is compatible with `kubectl port-forward` — no `0.0.0.0` binding is needed.
+
+## Disabling
+
+- **Build time**: omit `--features tokio-console` (the default). The `console-subscriber` crate is not compiled at all.
+- **Runtime**: remove or omit the `tokio_console` section from the config file.
+
+## Security considerations
+
+- Never expose the console gRPC port to untrusted networks.
+- The default localhost binding ensures the port is only reachable via port-forward or local access.
+- Do not enable this feature in production builds unless actively debugging.

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -34,6 +34,9 @@ otel = [
     "dep:opentelemetry-otlp",
     "dep:tonic",
 ]
+# tokio-console support for async runtime inspection (debug/preprod only)
+tokio-console = ["dep:console-subscriber", "tokio/tracing"]
+
 bootstrap = [
     "db",
     "dep:serde-saphyr",
@@ -114,6 +117,9 @@ opentelemetry-otlp = { workspace = true, optional = true }
 
 # gRPC support only for otel (optional)
 tonic = { workspace = true, optional = true }
+
+# tokio-console support (optional)
+console-subscriber = { workspace = true, optional = true }
 
 # Unix-specific dependencies for graceful process termination
 [target.'cfg(unix)'.dependencies]

--- a/libs/modkit/src/bootstrap/config/mod.rs
+++ b/libs/modkit/src/bootstrap/config/mod.rs
@@ -73,6 +73,19 @@ pub enum RuntimeKind {
     Oop,
 }
 
+/// Configuration for tokio-console async runtime inspector.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TokioConsoleConfig {
+    /// Bind address for the console-subscriber gRPC server.
+    /// Default: `"127.0.0.1:6669"`.
+    #[serde(default = "default_console_server_addr")]
+    pub server_addr: String,
+}
+
+fn default_console_server_addr() -> String {
+    "127.0.0.1:6669".to_owned()
+}
+
 /// Main application configuration with strongly-typed global sections
 /// and a flexible per-module configuration bag.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -87,6 +100,9 @@ pub struct AppConfig {
     pub logging: LoggingConfig,
     /// Tracing configuration (optional, disabled if None).
     pub tracing: Option<TracingConfig>,
+    /// tokio-console configuration (optional).
+    #[serde(default)]
+    pub tokio_console: Option<TokioConsoleConfig>,
     /// Directory containing per-module YAML files (optional).
     #[serde(default)]
     pub modules_dir: Option<String>,
@@ -102,7 +118,8 @@ impl Default for AppConfig {
             server,
             database: None,
             logging: default_logging_config(),
-            tracing: None, // Disabled by default
+            tracing: None,
+            tokio_console: None,
             modules_dir: None,
             modules: HashMap::new(),
         }

--- a/libs/modkit/src/bootstrap/host/mod.rs
+++ b/libs/modkit/src/bootstrap/host/mod.rs
@@ -6,9 +6,11 @@
 //! Configuration types are now in the top-level `config` module.
 
 pub mod logging;
+pub mod observability;
 pub mod paths;
 pub mod signals;
 
 pub use logging::*;
+pub use observability::*;
 pub use paths::{HomeDirError, expand_tilde, normalize_path};
 pub use signals::*;

--- a/libs/modkit/src/bootstrap/host/observability.rs
+++ b/libs/modkit/src/bootstrap/host/observability.rs
@@ -1,0 +1,94 @@
+//! tokio-console observability support (feature-gated behind `tokio-console`).
+//!
+//! Provides async runtime inspection via [`console-subscriber`](https://docs.rs/console-subscriber).
+//! The layer is only built when the `tokio-console` Cargo feature is enabled
+//! **and** a `tokio_console` section is present in the application config.
+
+use super::super::config::TokioConsoleConfig;
+
+// ========== tokio-console-agnostic layer type (compiles with/without the feature) ==========
+#[cfg(feature = "tokio-console")]
+pub type TokioConsoleLayer = console_subscriber::ConsoleLayer;
+#[cfg(not(feature = "tokio-console"))]
+pub type TokioConsoleLayer = ();
+
+/// Build a [`TokioConsoleLayer`] from configuration.
+///
+/// Returns `Some(layer)` when the `tokio-console` feature is compiled in and
+/// `config` is `Some`; returns `None` otherwise.
+///
+/// Uses [`Builder::build`] to obtain a nameable [`ConsoleLayer`] and spawns the
+/// gRPC [`Server`] on a dedicated background thread (same strategy as
+/// [`Builder::spawn`], but avoids the opaque `impl Layer<S>` return type).
+#[cfg(feature = "tokio-console")]
+#[must_use]
+pub fn build_console_layer(config: Option<&TokioConsoleConfig>) -> Option<TokioConsoleLayer> {
+    let Some(tokio_config) = config else {
+        tracing::warn!(
+            "tokio_console config must not be None when `tokio-console` feature is enabled"
+        );
+        return None;
+    };
+
+    let addr = match tokio_config.server_addr.parse::<std::net::SocketAddr>() {
+        Ok(addr) => addr,
+        Err(err) => {
+            tracing::error!(
+                server_addr = %tokio_config.server_addr,
+                error = %err,
+                "invalid tokio_console.server_addr, tokio-console layer disabled"
+            );
+            return None;
+        }
+    };
+
+    let (layer, server) = console_subscriber::ConsoleLayer::builder()
+        .server_addr(addr)
+        .build();
+
+    if let Err(err) = std::thread::Builder::new()
+        .name("console_subscriber".into())
+        .spawn(move || {
+            let runtime = match tokio::runtime::Builder::new_current_thread()
+                .enable_io()
+                .enable_time()
+                .build()
+            {
+                Ok(rt) => rt,
+                Err(err) => {
+                    eprintln!("console subscriber runtime initialization failed: {err}");
+                    return;
+                }
+            };
+            runtime.block_on(async move {
+                if let Err(err) = server.serve().await {
+                    eprintln!("console subscriber server failed: {err}");
+                }
+            });
+        })
+    {
+        tracing::error!(
+            error = %err,
+            "console subscriber could not spawn thread, tokio-console layer disabled"
+        );
+        return None;
+    }
+
+    Some(layer)
+}
+
+/// No-op fallback when the `tokio-console` feature is disabled.
+#[cfg(not(feature = "tokio-console"))]
+#[must_use]
+pub fn build_console_layer(config: Option<&TokioConsoleConfig>) -> Option<TokioConsoleLayer> {
+    if config.is_some() {
+        tracing::warn!(
+            "tokio_console section present in config but the `tokio-console` feature is disabled"
+        );
+    }
+    None
+}
+
+#[cfg(test)]
+#[path = "observability_tests.rs"]
+mod tests;

--- a/libs/modkit/src/bootstrap/host/observability_tests.rs
+++ b/libs/modkit/src/bootstrap/host/observability_tests.rs
@@ -1,0 +1,61 @@
+use super::*;
+
+fn valid_config() -> TokioConsoleConfig {
+    TokioConsoleConfig {
+        server_addr: "127.0.0.1:6669".to_owned(),
+    }
+}
+
+fn invalid_config() -> TokioConsoleConfig {
+    TokioConsoleConfig {
+        server_addr: "not-a-socket-addr".to_owned(),
+    }
+}
+
+// ----- tests for the `tokio-console` feature enabled branch -----
+
+#[cfg(feature = "tokio-console")]
+mod with_feature {
+    use super::*;
+
+    #[test]
+    fn none_config_returns_none() {
+        assert!(build_console_layer(None).is_none());
+    }
+
+    #[test]
+    fn valid_addr_returns_some() {
+        let cfg = valid_config();
+        assert!(build_console_layer(Some(&cfg)).is_some());
+    }
+
+    #[test]
+    fn invalid_addr_returns_none() {
+        let cfg = invalid_config();
+        assert!(build_console_layer(Some(&cfg)).is_none());
+    }
+}
+
+// ----- tests for the no-op fallback (feature disabled) -----
+
+#[cfg(not(feature = "tokio-console"))]
+mod without_feature {
+    use super::*;
+
+    #[test]
+    fn none_config_returns_none() {
+        assert!(build_console_layer(None).is_none());
+    }
+
+    #[test]
+    fn valid_addr_returns_none_when_feature_disabled() {
+        let cfg = valid_config();
+        assert!(build_console_layer(Some(&cfg)).is_none());
+    }
+
+    #[test]
+    fn invalid_addr_returns_none_when_feature_disabled() {
+        let cfg = invalid_config();
+        assert!(build_console_layer(Some(&cfg)).is_none());
+    }
+}

--- a/libs/modkit/src/bootstrap/oop.rs
+++ b/libs/modkit/src/bootstrap/oop.rs
@@ -470,8 +470,17 @@ pub async fn run_oop_with_options(opts: OopRunOptions) -> Result<()> {
     #[cfg(not(feature = "otel"))]
     let otel_layer = None;
 
+    // Build tokio-console layer for OoP module (when feature is enabled)
+    let console_layer =
+        super::host::observability::build_console_layer(config.tokio_console.as_ref());
+
     // Initialize logging with MERGED config (master base + local override)
-    init_logging_unified(&merged_logging, &config.server.home_dir, otel_layer);
+    init_logging_unified(
+        &merged_logging,
+        &config.server.home_dir,
+        otel_layer,
+        console_layer,
+    );
 
     // Now we can log - report what we received from master
     if let Some(ref rc) = rendered_config {

--- a/libs/modkit/src/bootstrap/oop_tests.rs
+++ b/libs/modkit/src/bootstrap/oop_tests.rs
@@ -24,6 +24,7 @@ fn minimal_app_config() -> AppConfig {
         database: None,
         logging: default_logging_config(),
         tracing: None,
+        tokio_console: None,
         modules_dir: None,
         modules: HashMap::new(),
     }


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#677](https://github.com/cyberfabric/cyberware-rust/pull/677) | **Author:** genericaccount-de | **Opened:** 2026-02-19T15:29:18Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

Integrate tokio-console under feature flag.

Partly REAL-163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional tokio-console runtime inspector support (disabled by default) with configurable server address (default 127.0.0.1:6669).

* **Documentation**
  * Added comprehensive guide: build/enable instructions, YAML/env configuration, runtime activation steps, local and Kubernetes usage, and security notes.

* **Chores**
  * Build and CI updated to allow the tokio-console build-time flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#677 -->