### PR TITLE
[PR #664] chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,96 @@ release-plz updates this file in the Release PR.
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-tr-plugin-v0.1.2...cf-static-tr-plugin-v0.1.3) - 2026-02-20
+
+### Other
+
+- migrate modules from ArcSwapOption to OnceLock (by @aviator5) - #660
+
+### Contributors
+
+* @aviator5
+
+## [0.1.1](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-authz-plugin-v0.1.0...cf-static-authz-plugin-v0.1.1) - 2026-02-20
+
+### Other
+
+- Merge pull request #660 from aviator5/module-oncelock-refactoring (by @MikeFalcon77) - #660
+- migrate modules from ArcSwapOption to OnceLock (by @aviator5) - #660
+
+### Contributors
+
+* @MikeFalcon77
+* @aviator5
+
+## [0.1.1](https://github.com/cyberfabric/cyberfabric-core/compare/cf-static-authn-plugin-v0.1.0...cf-static-authn-plugin-v0.1.1) - 2026-02-20
+
+### Other
+
+- Merge pull request #660 from aviator5/module-oncelock-refactoring (by @MikeFalcon77) - #660
+- migrate modules from ArcSwapOption to OnceLock (by @aviator5) - #660
+
+### Contributors
+
+* @MikeFalcon77
+* @aviator5
+
+## [0.1.3](https://github.com/cyberfabric/cyberfabric-core/compare/cf-single-tenant-tr-plugin-v0.1.2...cf-single-tenant-tr-plugin-v0.1.3) - 2026-02-20
+
+### Other
+
+- migrate modules from ArcSwapOption to OnceLock (by @aviator5) - #660
+
+### Contributors
+
+* @aviator5
+
+## [0.2.13](https://github.com/cyberfabric/cyberfabric-core/compare/cf-oagw-v0.2.12...cf-oagw-v0.2.13) - 2026-02-20
+
+### Other
+
+- OAGW SDK Extension (by @striped-zebra-dev) - #679
+- OAGW Unskip Failing Tests (by @striped-zebra-dev) - #675
+- OAGW Skip Failing Tests (by @striped-zebra-dev) - #673
+- OAGW Implementation (by @striped-zebra-dev) - #624
+- OAGW Implementation (by @striped-zebra-dev) - #624
+
+### Contributors
+
+* @striped-zebra-dev
+
+## [0.2.13](https://github.com/cyberfabric/cyberfabric-core/compare/cf-modkit-v0.2.12...cf-modkit-v0.2.13) - 2026-02-20
+
+### Fixed
+
+- upgrade gts to 0.8.0 and align schemars to 1.2 (by @Artifizer) - #687
+- fix merge conflicts (by @Bechma) - #670
+- fix nitpicks from the rabbit (by @Bechma) - #670
+
+### Other
+
+- Merge pull request #540 from KvizadSaderah/feature/500-list-modules-api (by @Artifizer) - #540
+- Merge branch 'main' into fix-oop-example (by @Bechma) - #670
+- - fix oop example (by @Bechma) - #670
+
+### Contributors
+
+* @Artifizer
+* @Bechma
+
+## [0.2.13](https://github.com/cyberfabric/cyberfabric-core/compare/cf-oagw-sdk-v0.2.12...cf-oagw-sdk-v0.2.13) - 2026-02-20
+
+### Other
+
+- OAGW SDK Extension (by @striped-zebra-dev) - #679
+- OAGW Implementation (by @striped-zebra-dev) - #624
+- OAGW Implementation (by @striped-zebra-dev) - #624
+- OAGW Design Changes #190 (by @striped-zebra-dev) - #527
+
+### Contributors
+
+* @striped-zebra-dev
+
 ## [0.2.12](https://github.com/cyberfabric/cyberfabric-core/compare/types-sdk-v0.2.11...types-sdk-v0.2.12) - 2026-02-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "cf-api-gateway"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "cf-authn-resolver"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "cf-authn-resolver-sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "cf-authz-resolver"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "cf-authz-resolver-sdk"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "cf-file-parser"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "cf-grpc-hub"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1079,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-auth"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "aliri_clock",
  "aliri_tokens",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db-macros"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-error2",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "axum",
  "http",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors-macro"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-http"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "bytes",
  "flate2",
@@ -1275,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-macros"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-macros-tests"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-node-info"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-odata"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "base64 0.22.1",
  "bigdecimal",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-odata-macros"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "cf-modkit-odata",
  "heck 0.5.0",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-sdk"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "cf-modkit-odata",
  "cf-modkit-odata-macros",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-security"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "postcard",
@@ -1383,7 +1383,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-transport-grpc"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "cf-modkit-security",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-utils"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "humantime",
  "serde",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "cf-module-orchestrator"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "cf-nodes-registry"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "cf-nodes-registry-sdk"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "cf-modkit-node-info",
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "cf-oagw"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "cf-oagw-sdk"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "async-trait",
  "axum",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "cf-single-tenant-tr-plugin"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1575,7 +1575,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-authn-plugin"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-authz-plugin"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-tr-plugin"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "cf-system-sdk-directory"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1649,14 +1649,14 @@ dependencies = [
 
 [[package]]
 name = "cf-system-sdks"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "cf-system-sdk-directory",
 ]
 
 [[package]]
 name = "cf-tenant-resolver"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "cf-tenant-resolver-sdk"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "cf-types-registry"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "cf-types-registry-sdk"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "gts",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "gts-docs-validator"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -3481,7 +3481,7 @@ dependencies = [
 
 [[package]]
 name = "hyperspot-server"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "calculator",
@@ -7414,7 +7414,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "types"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7430,7 +7430,7 @@ dependencies = [
 
 [[package]]
 name = "types-sdk"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "async-trait",
  "cf-modkit-odata",
@@ -7586,7 +7586,7 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "users-info"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7632,7 +7632,7 @@ dependencies = [
 
 [[package]]
 name = "users-info-sdk"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "async-trait",
  "cf-modkit-odata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.12"
+version = "0.2.13"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["Cyber Fabric"]
@@ -204,31 +204,31 @@ verbose_file_reads = "deny"
 
 [workspace.dependencies]
 # libs
-modkit = { package = "cf-modkit", version = "0.2.12", path = "libs/modkit" }
-modkit-http = { package = "cf-modkit-http", version = "0.2.12", path = "libs/modkit-http" }
-modkit-auth = { package = "cf-modkit-auth", version = "0.2.12", path = "libs/modkit-auth" }
-modkit-db = { package = "cf-modkit-db", version = "0.2.12", path = "libs/modkit-db" }
-modkit-db-macros = { package = "cf-modkit-db-macros", version = "0.2.12", path = "libs/modkit-db-macros" }
-modkit-errors = { package = "cf-modkit-errors", version = "0.2.12", path = "libs/modkit-errors" }
-modkit-errors-macro = { package = "cf-modkit-errors-macro", version = "0.2.12", path = "libs/modkit-errors-macro" }
-modkit-macros = { package = "cf-modkit-macros", version = "0.2.12", path = "libs/modkit-macros" }
-modkit-node-info = { package = "cf-modkit-node-info", version = "0.2.12", path = "libs/modkit-node-info" }
-modkit-odata = { package = "cf-modkit-odata", version = "0.2.12", path = "libs/modkit-odata" }
-modkit-odata-macros = { package = "cf-modkit-odata-macros", version = "0.2.12", path = "libs/modkit-odata-macros" }
-modkit-sdk = { package = "cf-modkit-sdk", version = "0.2.12", path = "libs/modkit-sdk" }
-modkit-security = { package = "cf-modkit-security", version = "0.2.12", path = "libs/modkit-security" }
-modkit-transport-grpc = { package = "cf-modkit-transport-grpc", version = "0.2.12", path = "libs/modkit-transport-grpc" }
-modkit-utils = { package = "cf-modkit-utils", version = "0.2.12", path = "libs/modkit-utils" }
+modkit = { package = "cf-modkit", version = "0.2.13", path = "libs/modkit" }
+modkit-http = { package = "cf-modkit-http", version = "0.2.13", path = "libs/modkit-http" }
+modkit-auth = { package = "cf-modkit-auth", version = "0.2.13", path = "libs/modkit-auth" }
+modkit-db = { package = "cf-modkit-db", version = "0.2.13", path = "libs/modkit-db" }
+modkit-db-macros = { package = "cf-modkit-db-macros", version = "0.2.13", path = "libs/modkit-db-macros" }
+modkit-errors = { package = "cf-modkit-errors", version = "0.2.13", path = "libs/modkit-errors" }
+modkit-errors-macro = { package = "cf-modkit-errors-macro", version = "0.2.13", path = "libs/modkit-errors-macro" }
+modkit-macros = { package = "cf-modkit-macros", version = "0.2.13", path = "libs/modkit-macros" }
+modkit-node-info = { package = "cf-modkit-node-info", version = "0.2.13", path = "libs/modkit-node-info" }
+modkit-odata = { package = "cf-modkit-odata", version = "0.2.13", path = "libs/modkit-odata" }
+modkit-odata-macros = { package = "cf-modkit-odata-macros", version = "0.2.13", path = "libs/modkit-odata-macros" }
+modkit-sdk = { package = "cf-modkit-sdk", version = "0.2.13", path = "libs/modkit-sdk" }
+modkit-security = { package = "cf-modkit-security", version = "0.2.13", path = "libs/modkit-security" }
+modkit-transport-grpc = { package = "cf-modkit-transport-grpc", version = "0.2.13", path = "libs/modkit-transport-grpc" }
+modkit-utils = { package = "cf-modkit-utils", version = "0.2.13", path = "libs/modkit-utils" }
 
-cf-system-sdks = { version = "0.1.13", path = "libs/system-sdks" }
-cf-system-sdk-directory = { version = "0.1.13", path = "libs/system-sdks/sdks/directory" }
+cf-system-sdks = { version = "0.1.14", path = "libs/system-sdks" }
+cf-system-sdk-directory = { version = "0.1.14", path = "libs/system-sdks/sdks/directory" }
 
 # system modules SDKs
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.3", path = "modules/system/types-registry/types-registry-sdk" }
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.1.4", path = "modules/system/tenant-resolver/tenant-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.4", path = "modules/system/types-registry/types-registry-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.1.5", path = "modules/system/tenant-resolver/tenant-resolver-sdk" }
 
 # system modules
-grpc_hub = { package = "cf-grpc-hub", version = "0.1.3", path = "modules/system/grpc-hub" }
+grpc_hub = { package = "cf-grpc-hub", version = "0.1.4", path = "modules/system/grpc-hub" }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/libs/system-sdks/Cargo.toml
+++ b/libs/system-sdks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-system-sdks"
-version = "0.1.13"
+version = "0.1.14"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/system-sdks/sdks/directory/Cargo.toml
+++ b/libs/system-sdks/sdks/directory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-system-sdk-directory"
-version = "0.1.13"
+version = "0.1.14"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/file-parser/Cargo.toml
+++ b/modules/file-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-file-parser"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/api-gateway/Cargo.toml
+++ b/modules/system/api-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-api-gateway"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ workspace = true
 modkit = { workspace = true }
 modkit-http = { workspace = true }
 modkit-security = { workspace = true }
-authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.1.1", path = "../authn-resolver/authn-resolver-sdk" }
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.1.2", path = "../authn-resolver/authn-resolver-sdk" }
 modkit-macros = { workspace = true }
 inventory = { workspace = true }
 anyhow = { workspace = true }

--- a/modules/system/authn-resolver/authn-resolver-sdk/Cargo.toml
+++ b/modules/system/authn-resolver/authn-resolver-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-authn-resolver-sdk"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/authn-resolver/authn-resolver/Cargo.toml
+++ b/modules/system/authn-resolver/authn-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-authn-resolver"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.1.1", path = "../authn-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.3", path = "../../types-registry/types-registry-sdk" }
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.1.2", path = "../authn-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.4", path = "../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/authn-resolver/plugins/static-authn-plugin/Cargo.toml
+++ b/modules/system/authn-resolver/plugins/static-authn-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-static-authn-plugin"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.1.1", path = "../../authn-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.3", path = "../../../types-registry/types-registry-sdk" }
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.1.2", path = "../../authn-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.4", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/authz-resolver/authz-resolver-sdk/Cargo.toml
+++ b/modules/system/authz-resolver/authz-resolver-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-authz-resolver-sdk"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/authz-resolver/authz-resolver/Cargo.toml
+++ b/modules/system/authz-resolver/authz-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-authz-resolver"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.1.0", path = "../authz-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.3", path = "../../types-registry/types-registry-sdk" }
+authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.1.1", path = "../authz-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.4", path = "../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/authz-resolver/plugins/static-authz-plugin/Cargo.toml
+++ b/modules/system/authz-resolver/plugins/static-authz-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-static-authz-plugin"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.1.0", path = "../../authz-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.3", path = "../../../types-registry/types-registry-sdk" }
+authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.1.1", path = "../../authz-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.4", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/grpc-hub/Cargo.toml
+++ b/modules/system/grpc-hub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-grpc-hub"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/module-orchestrator/Cargo.toml
+++ b/modules/system/module-orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-module-orchestrator"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/nodes-registry/nodes-registry-sdk/Cargo.toml
+++ b/modules/system/nodes-registry/nodes-registry-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-nodes-registry-sdk"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/nodes-registry/nodes-registry/Cargo.toml
+++ b/modules/system/nodes-registry/nodes-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-nodes-registry"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -31,4 +31,4 @@ thiserror = { workspace = true }
 modkit = { workspace = true }
 modkit-node-info = { workspace = true }
 modkit-macros = { workspace = true }
-nodes_registry-sdk = { package = "cf-nodes-registry-sdk", version = "0.1.3", path = "../nodes-registry-sdk" }
+nodes_registry-sdk = { package = "cf-nodes-registry-sdk", version = "0.1.4", path = "../nodes-registry-sdk" }

--- a/modules/system/tenant-resolver/plugins/single-tenant-tr-plugin/Cargo.toml
+++ b/modules/system/tenant-resolver/plugins/single-tenant-tr-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-single-tenant-tr-plugin"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.1.4", path = "../../tenant-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.3", path = "../../../types-registry/types-registry-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.1.5", path = "../../tenant-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.4", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/tenant-resolver/plugins/static-tr-plugin/Cargo.toml
+++ b/modules/system/tenant-resolver/plugins/static-tr-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-static-tr-plugin"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.1.4", path = "../../tenant-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.3", path = "../../../types-registry/types-registry-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.1.5", path = "../../tenant-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.4", path = "../../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/tenant-resolver/tenant-resolver-sdk/Cargo.toml
+++ b/modules/system/tenant-resolver/tenant-resolver-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-tenant-resolver-sdk"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/tenant-resolver/tenant-resolver/Cargo.toml
+++ b/modules/system/tenant-resolver/tenant-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-tenant-resolver"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.1.4", path = "../tenant-resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.3", path = "../../types-registry/types-registry-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.1.5", path = "../tenant-resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.4", path = "../../types-registry/types-registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/types-registry/types-registry-sdk/Cargo.toml
+++ b/modules/system/types-registry/types-registry-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-types-registry-sdk"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/types-registry/types-registry/Cargo.toml
+++ b/modules/system/types-registry/types-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-types-registry"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -19,7 +19,7 @@ doctest = false
 
 [dependencies]
 # SDK - public API, models, and errors
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.3", path = "../types-registry-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.4", path = "../types-registry-sdk" }
 
 # GTS types (from git dependency)
 gts = { workspace = true }


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#664](https://github.com/cyberfabric/cyberware-rust/pull/664) | **Author:** github-actions[bot] | **Opened:** 2026-02-18T16:02:43Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---




## 🤖 New release

* `cf-modkit-security`: 0.2.12 -> 0.2.13
* `cf-oagw-sdk`: 0.2.12 -> 0.2.13
* `cf-modkit-transport-grpc`: 0.2.12 -> 0.2.13
* `cf-modkit-db-macros`: 0.2.12 -> 0.2.13
* `cf-modkit-errors`: 0.2.12 -> 0.2.13
* `cf-modkit-errors-macro`: 0.2.12 -> 0.2.13
* `cf-modkit-odata`: 0.2.12 -> 0.2.13
* `cf-modkit-utils`: 0.2.12 -> 0.2.13
* `cf-modkit-db`: 0.2.12 -> 0.2.13
* `cf-modkit-macros`: 0.2.12 -> 0.2.13
* `cf-modkit-odata-macros`: 0.2.12 -> 0.2.13
* `cf-modkit-sdk`: 0.2.12 -> 0.2.13
* `cf-modkit`: 0.2.12 -> 0.2.13
* `cf-types-registry-sdk`: 0.1.3 -> 0.1.4
* `cf-oagw`: 0.2.12 -> 0.2.13
* `cf-authn-resolver-sdk`: 0.1.1 -> 0.1.2
* `cf-modkit-http`: 0.2.12 -> 0.2.13
* `cf-authn-resolver`: 0.1.1 -> 0.1.2
* `cf-authz-resolver-sdk`: 0.1.0 -> 0.1.1
* `cf-authz-resolver`: 0.1.0 -> 0.1.1
* `cf-file-parser`: 0.1.3 -> 0.1.4
* `cf-module-orchestrator`: 0.1.3 -> 0.1.4
* `cf-modkit-node-info`: 0.2.12 -> 0.2.13
* `cf-nodes-registry`: 0.1.3 -> 0.1.4
* `cf-tenant-resolver-sdk`: 0.1.4 -> 0.1.5
* `cf-single-tenant-tr-plugin`: 0.1.2 -> 0.1.3
* `cf-static-authn-plugin`: 0.1.0 -> 0.1.1
* `cf-static-authz-plugin`: 0.1.0 -> 0.1.1
* `cf-static-tr-plugin`: 0.1.2 -> 0.1.3
* `cf-tenant-resolver`: 0.1.3 -> 0.1.4
* `types-sdk`: 0.2.12 -> 0.2.13
* `cf-types-registry`: 0.1.3 -> 0.1.4
* `cf-modkit-auth`: 0.2.12 -> 0.2.13
* `cf-system-sdk-directory`: 0.1.13 -> 0.1.14
* `cf-system-sdks`: 0.1.13 -> 0.1.14
* `cf-api-gateway`: 0.1.4 -> 0.1.5
* `cf-grpc-hub`: 0.1.3 -> 0.1.4
* `cf-nodes-registry-sdk`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>


## `cf-oagw-sdk`

<blockquote>


## [0.2.13](https://github.com/constructorfabric/cyberfabric-core/compare/cf-oagw-sdk-v0.2.12...cf-oagw-sdk-v0.2.13) - 2026-02-20

### Other

- OAGW SDK Extension (by &#2369;striped-zebra-dev) - #3842
- OAGW Implementation (by &#2369;striped-zebra-dev) - #3865
- OAGW Implementation (by &#2369;striped-zebra-dev) - #3865
- OAGW Design Changes #2427 (by &#2369;striped-zebra-dev) - #3909

### Contributors

* &#2369;striped-zebra-dev
</blockquote>











## `cf-modkit`

<blockquote>


## [0.2.13](https://github.com/constructorfabric/cyberfabric-core/compare/cf-modkit-v0.2.12...cf-modkit-v0.2.13) - 2026-02-20

### Fixed

- upgrade gts to 0.8.0 and align schemars to 1.2 (by &#2369;Artifizer) - #3837
- fix merge conflicts (by &#2369;Bechma) - #3846
- fix nitpicks from the rabbit (by &#2369;Bechma) - #3846

### Other

- Merge pull request #3903 from KvizadSaderah/feature/500-list-modules-api (by &#2369;Artifizer) - #3903
- Merge branch 'main' into fix-oop-example (by &#2369;Bechma) - #3846
- - fix oop example (by &#2369;Bechma) - #3846

### Contributors

* &#2369;Artifizer
* &#2369;Bechma
</blockquote>


## `cf-oagw`

<blockquote>


## [0.2.13](https://github.com/constructorfabric/cyberfabric-core/compare/cf-oagw-v0.2.12...cf-oagw-v0.2.13) - 2026-02-20

### Other

- OAGW SDK Extension (by &#2369;striped-zebra-dev) - #3842
- OAGW Unskip Failing Tests (by &#2369;striped-zebra-dev) - #3844
- OAGW Skip Failing Tests (by &#2369;striped-zebra-dev) - #3845
- OAGW Implementation (by &#2369;striped-zebra-dev) - #3865
- OAGW Implementation (by &#2369;striped-zebra-dev) - #3865

### Contributors

* &#2369;striped-zebra-dev
</blockquote>











## `cf-single-tenant-tr-plugin`

<blockquote>


## [0.1.3](https://github.com/constructorfabric/cyberfabric-core/compare/cf-single-tenant-tr-plugin-v0.1.2...cf-single-tenant-tr-plugin-v0.1.3) - 2026-02-20

### Other

- migrate modules from ArcSwapOption to OnceLock (by &#2369;aviator5) - #3849

### Contributors

* &#2369;aviator5
</blockquote>

## `cf-static-authn-plugin`

<blockquote>


## [0.1.1](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-authn-plugin-v0.1.0...cf-static-authn-plugin-v0.1.1) - 2026-02-20

### Other

- Merge pull request #3849 from aviator5/module-oncelock-refactoring (by &#2369;MikeFalcon77) - #3849
- migrate modules from ArcSwapOption to OnceLock (by &#2369;aviator5) - #3849

### Contributors

* &#2369;MikeFalcon77
* &#2369;aviator5
</blockquote>

## `cf-static-authz-plugin`

<blockquote>


## [0.1.1](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-authz-plugin-v0.1.0...cf-static-authz-plugin-v0.1.1) - 2026-02-20

### Other

- Merge pull request #3849 from aviator5/module-oncelock-refactoring (by &#2369;MikeFalcon77) - #3849
- migrate modules from ArcSwapOption to OnceLock (by &#2369;aviator5) - #3849

### Contributors

* &#2369;MikeFalcon77
* &#2369;aviator5
</blockquote>

## `cf-static-tr-plugin`

<blockquote>


## [0.1.3](https://github.com/constructorfabric/cyberfabric-core/compare/cf-static-tr-plugin-v0.1.2...cf-static-tr-plugin-v0.1.3) - 2026-02-20

### Other

- migrate modules from ArcSwapOption to OnceLock (by &#2369;aviator5) - #3849

### Contributors

* &#2369;aviator5
</blockquote>











</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#664 -->