### PR TITLE
[PR #553] 460: WIP Added Prefix for service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CI := 1
 
-OPENAPI_URL ?= http://127.0.0.1:8087/openapi.json
+OPENAPI_URL ?= http://127.0.0.1:8087/chat/openapi.json
 OPENAPI_OUT ?= docs/api/api.json
 
 # E2E Docker args

--- a/libs/modkit/src/contracts.rs
+++ b/libs/modkit/src/contracts.rs
@@ -90,6 +90,9 @@ pub trait ApiGatewayCapability: Send + Sync + 'static {
 
     // Return OpenAPI registry of the module, e.g., to register endpoints
     fn as_registry(&self) -> &dyn OpenApiRegistry;
+
+    /// Return the URL prefix for nesting REST routes (e.g. "/chat").
+    fn prefix(&self) -> String;
 }
 
 #[async_trait]

--- a/libs/modkit/src/registry.rs
+++ b/libs/modkit/src/registry.rs
@@ -1027,5 +1027,8 @@ mod tests {
         fn as_registry(&self) -> &dyn crate::contracts::OpenApiRegistry {
             panic!("DummyRestHost::as_registry should not be called in tests")
         }
+        fn prefix(&self) -> String {
+            "/chat".to_owned()
+        }
     }
 }

--- a/libs/modkit/src/runtime/host_runtime.rs
+++ b/libs/modkit/src/runtime/host_runtime.rs
@@ -413,6 +413,8 @@ impl HostRuntime {
                     source,
                 })?;
 
+        let mut base_router = Router::new();
+
         // 2) Register all REST providers (in the current discovery order)
         for e in self.registry.modules() {
             if let Some(rest) = e.caps.query::<RestApiCap>() {
@@ -422,22 +424,24 @@ impl HostRuntime {
                         source: err,
                     }
                 })?;
-                router = rest
-                    .register_rest(&ctx, router, registry)
-                    .map_err(|source| RegistryError::RestRegister {
-                        module: e.name,
-                        source,
-                    })?;
+                base_router =
+                    rest.register_rest(&ctx, base_router, registry)
+                        .map_err(|source| RegistryError::RestRegister {
+                            module: e.name,
+                            source,
+                        })?;
             }
         }
 
         // 3) Host finalize: attach /openapi.json and /docs, persist Router if needed (no server start)
-        router = host.rest_finalize(&host_ctx, router).map_err(|source| {
-            RegistryError::RestFinalize {
+        base_router = host
+            .rest_finalize(&host_ctx, base_router)
+            .map_err(|source| RegistryError::RestFinalize {
                 module: host_entry.name,
                 source,
-            }
-        })?;
+            })?;
+
+        router = router.merge(base_router);
 
         Ok(router)
     }

--- a/libs/modkit/tests/macro_tests.rs
+++ b/libs/modkit/tests/macro_tests.rs
@@ -203,6 +203,10 @@ impl ApiGatewayCapability for TestApiGatewayModule {
     fn as_registry(&self) -> &dyn OpenApiRegistry {
         &self.registry
     }
+
+    fn prefix(&self) -> String {
+        "/chat".to_owned()
+    }
 }
 
 #[derive(Default)]

--- a/modules/system/api-gateway/src/config.rs
+++ b/modules/system/api-gateway/src/config.rs
@@ -8,6 +8,10 @@ fn default_body_limit_bytes() -> usize {
     16 * 1024 * 1024
 }
 
+fn default_prefix() -> String {
+    "/chat".to_owned()
+}
+
 /// API gateway configuration - reused from `api_gateway` module
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(deny_unknown_fields)]
@@ -18,6 +22,8 @@ pub struct ApiGatewayConfig {
     pub enable_docs: bool,
     #[serde(default)]
     pub cors_enabled: bool,
+    #[serde(default = "default_prefix")]
+    pub prefix: String,
     /// Optional detailed CORS configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cors: Option<CorsConfig>,

--- a/modules/system/api-gateway/src/middleware/license_validation.rs
+++ b/modules/system/api-gateway/src/middleware/license_validation.rs
@@ -49,10 +49,11 @@ pub async fn license_validation_middleware(
     next: Next,
 ) -> Response {
     let method = req.method().clone();
-    let path = req
-        .extensions()
-        .get::<axum::extract::MatchedPath>()
-        .map_or_else(|| req.uri().path().to_owned(), |p| p.as_str().to_owned());
+    // Use req.uri().path() rather than MatchedPath because MatchedPath includes
+    // the nest prefix (e.g. "/chat"), while the specs store un-prefixed paths.
+    // Since this middleware is applied before nesting, req.uri().path() is already
+    // prefix-stripped by Axum.
+    let path = req.uri().path().to_owned();
 
     let Some(required) = map.get(&method, &path) else {
         return next.run(req).await;

--- a/modules/system/api-gateway/src/middleware/mime_validation.rs
+++ b/modules/system/api-gateway/src/middleware/mime_validation.rs
@@ -90,10 +90,7 @@ pub async fn mime_validation_middleware(
 ) -> Response {
     let method = req.method().clone();
     // Use MatchedPath extension (set by Axum router) for accurate route matching
-    let path = req
-        .extensions()
-        .get::<axum::extract::MatchedPath>()
-        .map_or_else(|| req.uri().path().to_owned(), |p| p.as_str().to_owned());
+    let path = req.uri().path().to_owned();
 
     // Check if this operation has MIME validation configured
     let Some(allowed_types) = validation_map.get(&(method.clone(), path.clone())) else {

--- a/modules/system/api-gateway/src/middleware/rate_limit.rs
+++ b/modules/system/api-gateway/src/middleware/rate_limit.rs
@@ -87,10 +87,7 @@ impl RateLimiterMap {
 pub async fn rate_limit_middleware(map: RateLimiterMap, mut req: Request, next: Next) -> Response {
     let method = req.method().clone();
     // Use MatchedPath extension (set by Axum router) for accurate route matching
-    let path = req
-        .extensions()
-        .get::<axum::extract::MatchedPath>()
-        .map_or_else(|| req.uri().path().to_owned(), |p| p.as_str().to_owned());
+    let path = req.uri().path().to_owned();
     let key = (method, path);
 
     if let Some(bucker_map_entry) = map.buckets.get(&key) {

--- a/modules/system/api-gateway/tests/auth_middleware.rs
+++ b/modules/system/api-gateway/tests/auth_middleware.rs
@@ -229,7 +229,7 @@ async fn test_auth_disabled_mode() {
         .clone()
         .oneshot(
             Request::builder()
-                .uri("/tests/v1/api/protected")
+                .uri("/chat/tests/v1/api/protected")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -246,7 +246,7 @@ async fn test_auth_disabled_mode() {
     let response = router
         .oneshot(
             Request::builder()
-                .uri("/tests/v1/api/public")
+                .uri("/chat/tests/v1/api/public")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -281,21 +281,25 @@ async fn test_public_routes_accessible() {
     api_gateway.init(&api_ctx).await.expect("Failed to init");
 
     // First call rest_prepare to add built-in routes
-    let router = Router::new();
-    let router = api_gateway
+    let mut router = Router::new();
+    router = api_gateway
         .rest_prepare(&api_ctx, router)
         .expect("Failed to prepare");
 
+    let mut base_router = Router::new();
+
     // Then register test module routes
     let test_module = TestAuthModule;
-    let router = test_module
-        .register_rest(&test_ctx, router, &api_gateway)
+    base_router = test_module
+        .register_rest(&test_ctx, base_router, &api_gateway)
         .expect("Failed to register routes");
 
     // Finally finalize
-    let router = api_gateway
-        .rest_finalize(&api_ctx, router)
+    base_router = api_gateway
+        .rest_finalize(&api_ctx, base_router)
         .expect("Failed to finalize");
+
+    router = router.merge(base_router);
 
     // Test built-in health endpoints
     let response = router
@@ -319,7 +323,7 @@ async fn test_public_routes_accessible() {
     let response = router
         .oneshot(
             Request::builder()
-                .uri("/openapi.json")
+                .uri("/chat/openapi.json")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -367,7 +371,7 @@ async fn test_middleware_always_inserts_security_ctx() {
     let response = router
         .oneshot(
             Request::builder()
-                .uri("/tests/v1/api/protected")
+                .uri("/chat/tests/v1/api/protected")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -479,7 +483,7 @@ async fn test_route_pattern_matching_with_path_params() {
         .clone()
         .oneshot(
             Request::builder()
-                .uri("/tests/v1/api/users/123")
+                .uri("/chat/tests/v1/api/users/123")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -496,7 +500,7 @@ async fn test_route_pattern_matching_with_path_params() {
     let response = router
         .oneshot(
             Request::builder()
-                .uri("/tests/v1/api/users/abc-def-456")
+                .uri("/chat/tests/v1/api/users/abc-def-456")
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/modules/system/api-gateway/tests/license_middleware.rs
+++ b/modules/system/api-gateway/tests/license_middleware.rs
@@ -192,7 +192,7 @@ async fn rejects_non_base_feature_requirement() {
     let response = router
         .oneshot(
             Request::builder()
-                .uri("/tests/v1/license/bad")
+                .uri("/chat/tests/v1/license/bad")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -234,7 +234,7 @@ async fn allows_base_feature_requirement() {
     let response = router
         .oneshot(
             Request::builder()
-                .uri("/tests/v1/license/good")
+                .uri("/chat/tests/v1/license/good")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -276,7 +276,7 @@ async fn allows_no_license_requirement() {
     let response = router
         .oneshot(
             Request::builder()
-                .uri("/tests/v1/license/none")
+                .uri("/chat/tests/v1/license/none")
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/modules/system/api-gateway/tests/middleware_order.rs
+++ b/modules/system/api-gateway/tests/middleware_order.rs
@@ -102,7 +102,7 @@ async fn real_middlewares_observe_documented_order() -> Result<()> {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/tests/v1/middleware-order")
+                .uri("/chat/tests/v1/middleware-order")
                 .header("origin", "https://example.com")
                 .header("x-request-id", "fixed-req-1")
                 .header("content-type", "text/plain")
@@ -130,7 +130,7 @@ async fn real_middlewares_observe_documented_order() -> Result<()> {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/tests/v1/middleware-order")
+                .uri("/chat/tests/v1/middleware-order")
                 .header("origin", "https://example.com")
                 .header("content-type", "application/json")
                 .body(Body::from(r#"{"ok":true}"#))?,
@@ -159,7 +159,7 @@ async fn real_middlewares_observe_documented_order() -> Result<()> {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/tests/v1/middleware-order")
+                .uri("/chat/tests/v1/middleware-order")
                 .header("origin", "https://example.com")
                 .header("content-type", "application/json")
                 .body(Body::from(r#"{"ok":true}"#))?,

--- a/testing/e2e/conftest.py
+++ b/testing/e2e/conftest.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(Path(__file__).parent / "helpers"))
 @pytest.fixture
 def base_url():
     """Provide base URL for the API from E2E_BASE_URL env var."""
-    return os.getenv("E2E_BASE_URL", "http://localhost:8086")
+    return os.getenv("E2E_BASE_URL", "http://localhost:8086/chat")
 
 
 @pytest.fixture


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#553](https://github.com/cyberfabric/cyberware-rust/pull/553) | **Author:** dominic1988-lgtm | **Opened:** 2026-02-11T04:04:24Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API routes can be nested under a configurable prefix (defaults to "/chat"); endpoints and OpenAPI now reflect the base path.

* **Configuration**
  * Added a prefix option for the API Gateway with default "/chat".
  * Default OpenAPI URL updated to use the prefixed path.

* **Chores**
  * End-to-end and integration tests updated to target the new prefixed routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#553 -->