### PR TITLE
[PR #539] chore: enable `docs.rs.all-features` for published crates

### DIFF
--- a/libs/modkit-auth/Cargo.toml
+++ b/libs/modkit-auth/Cargo.toml
@@ -10,6 +10,7 @@ description = "ModKit authentication library"
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-modkit"]
 categories = ["development-tools"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "modkit_auth"

--- a/libs/modkit-db-macros/Cargo.toml
+++ b/libs/modkit-db-macros/Cargo.toml
@@ -10,6 +10,7 @@ description = "Proc-macro derives for modkit-db secure ORM layer"
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-modkit"]
 categories = ["development-tools::procedural-macro-helpers"]
+metadata.docs.rs.all-features = true
 
 [lib]
 proc-macro = true

--- a/libs/modkit-db/Cargo.toml
+++ b/libs/modkit-db/Cargo.toml
@@ -10,6 +10,7 @@ description = "ModKit database library"
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-modkit"]
 categories = ["development-tools"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "modkit_db"

--- a/libs/modkit-errors-macro/Cargo.toml
+++ b/libs/modkit-errors-macro/Cargo.toml
@@ -10,6 +10,7 @@ description = "ModKit errors macro"
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-modkit"]
 categories = ["development-tools::procedural-macro-helpers"]
+metadata.docs.rs.all-features = true
 
 [lib]
 proc-macro = true

--- a/libs/modkit-errors/Cargo.toml
+++ b/libs/modkit-errors/Cargo.toml
@@ -10,6 +10,7 @@ description = "ModKit errors library"
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-modkit"]
 categories = ["web-programming"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "modkit_errors"

--- a/libs/modkit-http/Cargo.toml
+++ b/libs/modkit-http/Cargo.toml
@@ -10,6 +10,7 @@ description = "ModKit HTTP client library"
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-modkit"]
 categories = ["web-programming"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "modkit_http"

--- a/libs/modkit-macros/Cargo.toml
+++ b/libs/modkit-macros/Cargo.toml
@@ -10,6 +10,7 @@ description = "ModKit macros"
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-modkit"]
 categories = ["development-tools::procedural-macro-helpers"]
+metadata.docs.rs.all-features = true
 
 [lib]
 proc-macro = true

--- a/libs/modkit-node-info/Cargo.toml
+++ b/libs/modkit-node-info/Cargo.toml
@@ -10,6 +10,7 @@ description = "ModKit node info library"
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-modkit"]
 categories = ["development-tools"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "modkit_node_info"

--- a/libs/modkit-odata-macros/Cargo.toml
+++ b/libs/modkit-odata-macros/Cargo.toml
@@ -10,6 +10,7 @@ description = "Proc-macro derives for OData protocol (FilterField, Schema, etc)"
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-modkit"]
 categories = ["development-tools::procedural-macro-helpers"]
+metadata.docs.rs.all-features = true
 
 [lib]
 proc-macro = true

--- a/libs/modkit-odata/Cargo.toml
+++ b/libs/modkit-odata/Cargo.toml
@@ -10,6 +10,7 @@ description = "ModKit OData library"
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-modkit"]
 categories = ["web-programming"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "modkit_odata"

--- a/libs/modkit-sdk/Cargo.toml
+++ b/libs/modkit-sdk/Cargo.toml
@@ -10,6 +10,7 @@ description = "ModKit SDK"
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-modkit"]
 categories = ["development-tools"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "modkit_sdk"

--- a/libs/modkit-security/Cargo.toml
+++ b/libs/modkit-security/Cargo.toml
@@ -10,6 +10,7 @@ description = "ModKit security library"
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-modkit"]
 categories = ["authentication"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "modkit_security"

--- a/libs/modkit-transport-grpc/Cargo.toml
+++ b/libs/modkit-transport-grpc/Cargo.toml
@@ -10,6 +10,7 @@ description = "ModKit gRPC transport library"
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-modkit"]
 categories = ["network-programming"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "modkit_transport_grpc"

--- a/libs/modkit-utils/Cargo.toml
+++ b/libs/modkit-utils/Cargo.toml
@@ -10,6 +10,7 @@ description = "ModKit utils library"
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-modkit"]
 categories = ["development-tools"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "modkit_utils"

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -10,6 +10,7 @@ description = "Core ModKit library"
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-modkit"]
 categories = ["development-tools"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "modkit"

--- a/libs/system-sdks/Cargo.toml
+++ b/libs/system-sdks/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 rust-version.workspace = true
 keywords = ["cyberfabric", "cyberfabric-system"]
 categories = ["development-tools"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "cf_system_sdks"
@@ -24,4 +25,3 @@ directory_grpc = ["directory", "cf-system-sdk-directory?/grpc"]
 
 [dependencies]
 cf-system-sdk-directory = { workspace = true, optional = true }
-

--- a/libs/system-sdks/sdks/directory/Cargo.toml
+++ b/libs/system-sdks/sdks/directory/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["cyberfabric", "cyberfabric-system"]
 categories = ["web-programming"]
 build = "build.rs"
 include = ["proto/", "src/", "build.rs", "Cargo.toml"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "cf_system_sdk_directory"

--- a/modules/file_parser/Cargo.toml
+++ b/modules/file_parser/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-system"]
 categories = ["parsing"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "file_parser"

--- a/modules/system/api_gateway/Cargo.toml
+++ b/modules/system/api_gateway/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-system"]
 categories = ["web-programming"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "api_gateway"

--- a/modules/system/grpc_hub/Cargo.toml
+++ b/modules/system/grpc_hub/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-system"]
 categories = ["network-programming"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "grpc_hub"

--- a/modules/system/module_orchestrator/Cargo.toml
+++ b/modules/system/module_orchestrator/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-system"]
 categories = ["development-tools"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "module_orchestrator"

--- a/modules/system/nodes_registry/nodes_registry-sdk/Cargo.toml
+++ b/modules/system/nodes_registry/nodes_registry-sdk/Cargo.toml
@@ -10,6 +10,7 @@ description = "SDK for nodes_registry module: API trait, node models, and error 
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-system"]
 categories = ["development-tools"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "nodes_registry_sdk"

--- a/modules/system/nodes_registry/nodes_registry/Cargo.toml
+++ b/modules/system/nodes_registry/nodes_registry/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-system"]
 categories = ["development-tools"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "nodes_registry"

--- a/modules/system/tenant_resolver/plugins/single_tenant_tr_plugin/Cargo.toml
+++ b/modules/system/tenant_resolver/plugins/single_tenant_tr_plugin/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-system"]
 categories = ["web-programming"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "single_tenant_tr_plugin"

--- a/modules/system/tenant_resolver/plugins/static_tr_plugin/Cargo.toml
+++ b/modules/system/tenant_resolver/plugins/static_tr_plugin/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-system"]
 categories = ["web-programming"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "static_tr_plugin"

--- a/modules/system/tenant_resolver/tenant_resolver-gw/Cargo.toml
+++ b/modules/system/tenant_resolver/tenant_resolver-gw/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-system"]
 categories = ["web-programming"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "tenant_resolver_gw"

--- a/modules/system/tenant_resolver/tenant_resolver-sdk/Cargo.toml
+++ b/modules/system/tenant_resolver/tenant_resolver-sdk/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-system"]
 categories = ["web-programming"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "tenant_resolver_sdk"

--- a/modules/system/types-sdk/Cargo.toml
+++ b/modules/system/types-sdk/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 description = "SDK for types module: API trait, domain models and error definitions"
+metadata.docs.rs.all-features = true
 
 [lints]
 workspace = true

--- a/modules/system/types_registry/types_registry-sdk/Cargo.toml
+++ b/modules/system/types_registry/types_registry-sdk/Cargo.toml
@@ -10,6 +10,7 @@ description = "SDK for types-registry module: API trait, GTS entity types, and e
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-system"]
 categories = ["development-tools"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "types_registry_sdk"

--- a/modules/system/types_registry/types_registry/Cargo.toml
+++ b/modules/system/types_registry/types_registry/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 readme = "README.md"
 keywords = ["cyberfabric", "cyberfabric-system"]
 categories = ["development-tools"]
+metadata.docs.rs.all-features = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#539](https://github.com/cyberfabric/cyberware-rust/pull/539) | **Author:** fluiderson | **Opened:** 2026-02-10T10:20:02Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

According to https://docs.rs/about/metadata, this is disabled by default. Hence, for example, [`modkit::bootstrap` is inaccessible](https://docs.rs/cf-modkit/0.2.1/modkit/bootstrap/index.html).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation build configuration across all packages to enable building with all feature flags on docs.rs, ensuring comprehensive documentation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#539 -->