### PR TITLE
[PR #501] Add SSRF and path traversal protection to file parser

### DIFF
--- a/config/server.yaml
+++ b/config/server.yaml
@@ -259,7 +259,7 @@ modules:
       ssh_python_default:
         code_executor_path: "/usr/local/bin/python3.11"
         host: "localhost"
-        password: "password"
+        password: "${SSH_PASSWORD}"
         port: 22
         private_key: "~/.ssh/id_rsa"
         timeout_sec: 30

--- a/modules/file_parser/src/config.rs
+++ b/modules/file_parser/src/config.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use serde::{Deserialize, Serialize};
 
 /// Configuration for the `file_parser` module
@@ -8,6 +10,12 @@ pub struct FileParserConfig {
     pub max_file_size_mb: u64,
     #[serde(default = "default_download_timeout_secs")]
     pub download_timeout_secs: u64,
+    /// Base directory for local file parsing. When set, only files within this
+    /// directory (and its subdirectories) can be read via the `parse_local`
+    /// endpoints. This prevents path traversal attacks. If not set, path
+    /// traversal components (`..`) are still rejected.
+    #[serde(default)]
+    pub allowed_local_base_dir: Option<PathBuf>,
 }
 
 impl Default for FileParserConfig {
@@ -15,6 +23,7 @@ impl Default for FileParserConfig {
         Self {
             max_file_size_mb: default_max_file_size_mb(),
             download_timeout_secs: default_download_timeout_secs(),
+            allowed_local_base_dir: None,
         }
     }
 }

--- a/modules/file_parser/src/module.rs
+++ b/modules/file_parser/src/module.rs
@@ -72,6 +72,7 @@ impl Module for FileParserModule {
             max_file_size_bytes: usize::try_from(cfg.max_file_size_mb * BYTES_IN_MB)
                 .unwrap_or(usize::MAX),
             download_timeout_secs: cfg.download_timeout_secs,
+            allowed_local_base_dir: cfg.allowed_local_base_dir,
         };
 
         // Create file parser service

--- a/modules/system/api_gateway/src/config.rs
+++ b/modules/system/api_gateway/src/config.rs
@@ -109,7 +109,12 @@ pub struct CorsConfig {
 impl Default for CorsConfig {
     fn default() -> Self {
         Self {
-            allowed_origins: vec!["*".to_owned()],
+            // Default to localhost origins only. Production deployments should
+            // explicitly configure their allowed origins in the YAML config.
+            allowed_origins: vec![
+                "http://localhost".to_owned(),
+                "http://127.0.0.1".to_owned(),
+            ],
             allowed_methods: vec![
                 "GET".to_owned(),
                 "POST".to_owned(),


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#501](https://github.com/cyberfabric/cyberware-rust/pull/501) | **Author:** Artifizer | **Opened:** 2026-02-07T19:27:29Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary
This PR adds security protections to the file parser module to prevent Server-Side Request Forgery (SSRF) and path traversal attacks.

## Key Changes

- **SSRF Protection**: Added `validate_url_for_ssrf()` method that:
  - Restricts URL schemes to HTTP(S) only
  - Blocks requests to loopback addresses (127.0.0.0/8, ::1)
  - Blocks requests to private network ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
  - Blocks requests to link-local addresses (169.254.0.0/16, including cloud metadata endpoints)
  - Blocks well-known internal hostnames (localhost, *.internal, metadata.google.internal)
  - Validates both IP literals in URLs and DNS-resolved addresses

- **Path Traversal Protection**: Added `validate_local_path()` method that:
  - Rejects paths containing `..` components before canonicalization
  - Canonicalizes paths to resolve symlinks and normalize components
  - Enforces optional `allowed_local_base_dir` configuration to restrict file access to a specific directory tree

- **Configuration**: Added `allowed_local_base_dir` option to both `FileParserConfig` and `ServiceConfig` to allow operators to restrict local file parsing to a specific base directory

- **Integration**: Updated `parse_local()` and `parse_url()` methods to call the new validation functions

## Implementation Details

- Helper methods `is_private_ipv4()` and `is_private_ipv6()` encapsulate IP range checks
- Comprehensive logging with `warn!()` for rejected requests to aid security monitoring
- Path validation happens before file operations to fail fast
- DNS resolution is performed to catch hostname-based SSRF attempts
- All validation errors return appropriate `DomainError` variants with descriptive messages

https://claude.ai/code/session_01WeiS3AXLugkdKQVp9cZ1w9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional base-directory constraint for local file reads to prevent path traversal.
  * SSRF protections for URL parsing (reject non-HTTP(S), loopback/private addresses, internal hosts).

* **Bug Fixes**
  * Safe fallback for disabled auth: returns an internal error instead of causing a server crash.

* **Chores**
  * CORS defaults narrowed to local origins and added runtime warnings for wildcard origins; wildcard cannot be combined with credentialed requests.
* **Config**
  * SSH password moved to environment-variable reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#501 -->