### PR TITLE
[PR #499] chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ release-plz updates this file in the Release PR.
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/cyberfabric/cyberfabric-core/compare/cf-system-sdks-v0.1.7...cf-system-sdks-v0.1.8) - 2026-02-10
+
+### Other
+
+- updated the following local packages: cf-system-sdk-directory
+
+## [0.1.8](https://github.com/cyberfabric/cyberfabric-core/compare/cf-system-sdk-directory-v0.1.7...cf-system-sdk-directory-v0.1.8) - 2026-02-10
+
+### Other
+
+- updated the following local packages: cf-modkit-transport-grpc
+
 ## [0.1.3](https://github.com/cyberfabric/cyberfabric-core/compare/cf-tenant-resolver-sdk-v0.1.2...cf-tenant-resolver-sdk-v0.1.3) - 2026-02-07
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-auth"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db-macros"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-error2",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "axum",
  "http",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors-macro"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1079,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-http"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bytes",
  "flate2",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-macros"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-macros-tests"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-node-info"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-odata"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "base64 0.22.1",
  "bigdecimal",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-odata-macros"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "cf-modkit-odata",
  "heck 0.5.0",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-sdk"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "cf-modkit-odata",
  "cf-modkit-odata-macros",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-security"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "postcard",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-transport-grpc"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "cf-modkit-security",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-utils"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "humantime",
  "serde",
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "cf-system-sdk-directory"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "cf-system-sdks"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "cf-system-sdk-directory",
 ]
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "gts-docs-validator"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3168,7 +3168,7 @@ dependencies = [
 
 [[package]]
 name = "hyperspot-server"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "calculator",
@@ -6313,7 +6313,7 @@ dependencies = [
 
 [[package]]
 name = "tenant-resolver-sdk"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -6944,7 +6944,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "types"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6960,7 +6960,7 @@ dependencies = [
 
 [[package]]
 name = "types-sdk"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "cf-modkit-odata",
@@ -7111,7 +7111,7 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "user_info-sdk"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "cf-modkit-odata",
@@ -7128,7 +7128,7 @@ dependencies = [
 
 [[package]]
 name = "users_info"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["Cyber Fabric"]
@@ -199,24 +199,24 @@ verbose_file_reads = "deny"
 
 [workspace.dependencies]
 # libs
-modkit = { package = "cf-modkit", version = "0.2.2", path = "libs/modkit" }
-modkit-http = { package = "cf-modkit-http",  version = "0.2.2", path = "libs/modkit-http" }
-modkit-auth = { package = "cf-modkit-auth", version = "0.2.2", path = "libs/modkit-auth" }
-modkit-db = { package = "cf-modkit-db", version = "0.2.2", path = "libs/modkit-db" }
-modkit-db-macros = { package = "cf-modkit-db-macros", version = "0.2.2", path = "libs/modkit-db-macros" }
-modkit-errors = { package = "cf-modkit-errors", version = "0.2.2", path = "libs/modkit-errors" }
-modkit-errors-macro = { package = "cf-modkit-errors-macro", version = "0.2.2", path = "libs/modkit-errors-macro" }
-modkit-macros = { package = "cf-modkit-macros", version = "0.2.2", path = "libs/modkit-macros" }
-modkit-node-info = { package = "cf-modkit-node-info", version = "0.2.2", path = "libs/modkit-node-info" }
-modkit-odata = { package = "cf-modkit-odata", version = "0.2.2", path = "libs/modkit-odata" }
-modkit-odata-macros = { package = "cf-modkit-odata-macros", version = "0.2.2", path = "libs/modkit-odata-macros" }
-modkit-sdk = { package = "cf-modkit-sdk", version = "0.2.2", path = "libs/modkit-sdk" }
-modkit-security = { package = "cf-modkit-security", version = "0.2.2", path = "libs/modkit-security" }
-modkit-transport-grpc = { package = "cf-modkit-transport-grpc", version = "0.2.2", path = "libs/modkit-transport-grpc" }
-modkit-utils = { package = "cf-modkit-utils", version = "0.2.2", path = "libs/modkit-utils" }
+modkit = { package = "cf-modkit", version = "0.2.3", path = "libs/modkit" }
+modkit-http = { package = "cf-modkit-http", version = "0.2.3", path = "libs/modkit-http" }
+modkit-auth = { package = "cf-modkit-auth", version = "0.2.3", path = "libs/modkit-auth" }
+modkit-db = { package = "cf-modkit-db", version = "0.2.3", path = "libs/modkit-db" }
+modkit-db-macros = { package = "cf-modkit-db-macros", version = "0.2.3", path = "libs/modkit-db-macros" }
+modkit-errors = { package = "cf-modkit-errors", version = "0.2.3", path = "libs/modkit-errors" }
+modkit-errors-macro = { package = "cf-modkit-errors-macro", version = "0.2.3", path = "libs/modkit-errors-macro" }
+modkit-macros = { package = "cf-modkit-macros", version = "0.2.3", path = "libs/modkit-macros" }
+modkit-node-info = { package = "cf-modkit-node-info", version = "0.2.3", path = "libs/modkit-node-info" }
+modkit-odata = { package = "cf-modkit-odata", version = "0.2.3", path = "libs/modkit-odata" }
+modkit-odata-macros = { package = "cf-modkit-odata-macros", version = "0.2.3", path = "libs/modkit-odata-macros" }
+modkit-sdk = { package = "cf-modkit-sdk", version = "0.2.3", path = "libs/modkit-sdk" }
+modkit-security = { package = "cf-modkit-security", version = "0.2.3", path = "libs/modkit-security" }
+modkit-transport-grpc = { package = "cf-modkit-transport-grpc", version = "0.2.3", path = "libs/modkit-transport-grpc" }
+modkit-utils = { package = "cf-modkit-utils", version = "0.2.3", path = "libs/modkit-utils" }
 
-cf-system-sdks = { version = "0.1.7", path = "libs/system-sdks" }
-cf-system-sdk-directory = { version = "0.1.7", path = "libs/system-sdks/sdks/directory" }
+cf-system-sdks = { version = "0.1.8", path = "libs/system-sdks" }
+cf-system-sdk-directory = { version = "0.1.8", path = "libs/system-sdks/sdks/directory" }
 
 # system modules SDKs
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.2", path = "modules/system/types_registry/types_registry-sdk" }

--- a/libs/system-sdks/Cargo.toml
+++ b/libs/system-sdks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-system-sdks"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/system-sdks/sdks/directory/Cargo.toml
+++ b/libs/system-sdks/sdks/directory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-system-sdk-directory"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#499](https://github.com/cyberfabric/cyberware-rust/pull/499) | **Author:** github-actions[bot] | **Opened:** 2026-02-07T16:16:21Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---




## 🤖 New release

* `cf-modkit-security`: 0.2.2 -> 0.2.3
* `cf-modkit-transport-grpc`: 0.2.2 -> 0.2.3
* `cf-modkit-db-macros`: 0.2.2 -> 0.2.3
* `cf-modkit-errors`: 0.2.2 -> 0.2.3
* `cf-modkit-errors-macro`: 0.2.2 -> 0.2.3
* `cf-modkit-odata`: 0.2.2 -> 0.2.3
* `cf-modkit-utils`: 0.2.2 -> 0.2.3
* `cf-modkit-db`: 0.2.2 -> 0.2.3
* `cf-modkit-macros`: 0.2.2 -> 0.2.3
* `cf-modkit-odata-macros`: 0.2.2 -> 0.2.3
* `cf-modkit-sdk`: 0.2.2 -> 0.2.3
* `cf-modkit`: 0.2.2 -> 0.2.3
* `cf-modkit-http`: 0.2.2 -> 0.2.3
* `cf-modkit-auth`: 0.2.2 -> 0.2.3
* `cf-api-gateway`: 0.1.2
* `cf-grpc-hub`: 0.1.2
* `cf-types-registry-sdk`: 0.1.2
* `types-sdk`: 0.2.2 -> 0.2.3
* `cf-file-parser`: 0.1.2
* `cf-module-orchestrator`: 0.1.2
* `cf-modkit-node-info`: 0.2.2 -> 0.2.3
* `cf-nodes-registry-sdk`: 0.1.2
* `cf-nodes-registry`: 0.1.2
* `cf-tenant-resolver-sdk`: 0.1.3
* `cf-single-tenant-tr-plugin`: 0.1.2
* `cf-static-tr-plugin`: 0.1.2
* `cf-tenant-resolver-gw`: 0.1.2
* `cf-types-registry`: 0.1.2
* `cf-system-sdk-directory`: 0.1.7 -> 0.1.8
* `cf-system-sdks`: 0.1.7 -> 0.1.8

<details><summary><i><b>Changelog</b></i></summary><p>












## `cf-modkit`

<blockquote>


## [0.2.3](https://github.com/constructorfabric/cyberfabric-core/compare/cf-modkit-v0.2.2...cf-modkit-v0.2.3) - 2026-02-10

### Added

- *(modkit-http)* introduce HttpClient (hyper+tower), replace reqwest and harden JWKS handling (by &#2369;MikeFalcon77)

### Fixed

- *(dylint/de1301)* allow proc-macro impl methods via visit_assoc_item (by &#2369;Artifizer)

### Other

- Merge branch 'main' into shutdown-nl (by &#2369;Artifizer) - #3929
- Merge branch 'main' into rescue-docs-standards (by &#2369;Artifizer) - #3928

### Contributors

* &#2369;MikeFalcon77
* &#2369;Artifizer
</blockquote>

## `cf-modkit-http`

<blockquote>


## [0.2.3](https://github.com/constructorfabric/cyberfabric-core/compare/cf-modkit-http-v0.2.2...cf-modkit-http-v0.2.3) - 2026-02-10

### Added

- *(modkit-http)* introduce HttpClient (hyper+tower), replace reqwest and harden JWKS handling (by &#2369;MikeFalcon77)

### Contributors

* &#2369;MikeFalcon77
</blockquote>


## `cf-api-gateway`

<blockquote>


## [0.1.2](https://github.com/constructorfabric/cyberfabric-core/releases/tag/cf-api-gateway-v0.1.2) - 2026-02-10

### Added

- replace access-based Tenant Resolver with hierarchy-based implementation (by &#2369;aviator5) - #3924
- *(modkit-http)* introduce HttpClient (hyper+tower), replace reqwest and harden JWKS handling (by &#2369;MikeFalcon77)

### Other

- consolidate Tenant Resolver SDK parameters into per-method options structs (by &#2369;aviator5) - #3924
- release (by &#2369;github-actions[bot]) - #3922
- release (by &#2369;github-actions[bot]) - #3940
- CI: add oasdiff to compare openapi.spec on PR (by &#2369;dominic1988-lgtm) - #3923
- reduce cognitive complexity threshold to 20 for modules

### Contributors

* &#2369;aviator5
* &#2369;MikeFalcon77
* &#2369;github-actions[bot]
* &#2369;dominic1988-lgtm
</blockquote>

## `cf-grpc-hub`

<blockquote>


## [0.1.2](https://github.com/constructorfabric/cyberfabric-core/releases/tag/cf-grpc-hub-v0.1.2) - 2026-02-10

### Other

- release (by &#2369;github-actions[bot]) - #3940

### Contributors

* &#2369;github-actions[bot]
</blockquote>

## `cf-types-registry-sdk`

<blockquote>


## [0.1.2](https://github.com/constructorfabric/cyberfabric-core/releases/tag/cf-types-registry-sdk-v0.1.2) - 2026-02-10

### Other

- release (by &#2369;github-actions[bot]) - #3940

### Contributors

* &#2369;github-actions[bot]
</blockquote>

## `types-sdk`

<blockquote>


## [0.2.3](https://github.com/constructorfabric/cyberfabric-core/compare/types-sdk-v0.2.2...types-sdk-v0.2.3) - 2026-02-10

### Other

- update Cargo.toml dependencies
</blockquote>

## `cf-file-parser`

<blockquote>


## [0.1.2](https://github.com/constructorfabric/cyberfabric-core/releases/tag/cf-file-parser-v0.1.2) - 2026-02-10

### Added

- *(dylint)* add DE0309 must_have_domain_model lint (by &#2369;KvizadSaderah)
- *(modkit-http)* introduce HttpClient (hyper+tower), replace reqwest and harden JWKS handling (by &#2369;MikeFalcon77)

### Other

- release (by &#2369;github-actions[bot]) - #3940
- CI: add oasdiff to compare openapi.spec on PR (by &#2369;dominic1988-lgtm) - #3923
- Merge pull request #2103 from yoskini/feat/Quick_start_guide (by &#2369;Artifizer) - #2103

### Contributors

* &#2369;KvizadSaderah
* &#2369;MikeFalcon77
* &#2369;github-actions[bot]
* &#2369;dominic1988-lgtm
* &#2369;Artifizer
</blockquote>

## `cf-module-orchestrator`

<blockquote>


## [0.1.2](https://github.com/constructorfabric/cyberfabric-core/releases/tag/cf-module-orchestrator-v0.1.2) - 2026-02-10

### Other

- release (by &#2369;github-actions[bot]) - #3940

### Contributors

* &#2369;github-actions[bot]
</blockquote>


## `cf-nodes-registry-sdk`

<blockquote>


## [0.1.2](https://github.com/constructorfabric/cyberfabric-core/releases/tag/cf-nodes-registry-sdk-v0.1.2) - 2026-02-10

### Other

- release (by &#2369;github-actions[bot]) - #3940

### Contributors

* &#2369;github-actions[bot]
</blockquote>

## `cf-nodes-registry`

<blockquote>


## [0.1.2](https://github.com/constructorfabric/cyberfabric-core/releases/tag/cf-nodes-registry-v0.1.2) - 2026-02-10

### Added

- *(dylint)* add DE0309 must_have_domain_model lint (by &#2369;KvizadSaderah)

### Other

- release (by &#2369;github-actions[bot]) - #3940

### Contributors

* &#2369;KvizadSaderah
* &#2369;github-actions[bot]
</blockquote>

## `cf-tenant-resolver-sdk`

<blockquote>


## [0.1.3](https://github.com/constructorfabric/cyberfabric-core/releases/tag/cf-tenant-resolver-sdk-v0.1.3) - 2026-02-10

### Added

- replace access-based Tenant Resolver with hierarchy-based implementation (by &#2369;aviator5) - #3924

### Other

- consolidate Tenant Resolver SDK parameters into per-method options structs (by &#2369;aviator5) - #3924
- release (by &#2369;github-actions[bot]) - #3922

### Contributors

* &#2369;aviator5
* &#2369;github-actions[bot]
</blockquote>

## `cf-single-tenant-tr-plugin`

<blockquote>


## [0.1.2](https://github.com/constructorfabric/cyberfabric-core/releases/tag/cf-single-tenant-tr-plugin-v0.1.2) - 2026-02-10

### Added

- *(dylint)* add DE0309 must_have_domain_model lint (by &#2369;KvizadSaderah)
- replace access-based Tenant Resolver with hierarchy-based implementation (by &#2369;aviator5) - #3924

### Other

- consolidate Tenant Resolver SDK parameters into per-method options structs (by &#2369;aviator5) - #3924
- release (by &#2369;github-actions[bot]) - #3922
- release (by &#2369;github-actions[bot]) - #3940

### Contributors

* &#2369;KvizadSaderah
* &#2369;aviator5
* &#2369;github-actions[bot]
</blockquote>

## `cf-static-tr-plugin`

<blockquote>


## [0.1.2](https://github.com/constructorfabric/cyberfabric-core/releases/tag/cf-static-tr-plugin-v0.1.2) - 2026-02-10

### Added

- *(dylint)* add DE0309 must_have_domain_model lint (by &#2369;KvizadSaderah)
- replace access-based Tenant Resolver with hierarchy-based implementation (by &#2369;aviator5) - #3924

### Other

- consolidate Tenant Resolver SDK parameters into per-method options structs (by &#2369;aviator5) - #3924
- release (by &#2369;github-actions[bot]) - #3922
- release (by &#2369;github-actions[bot]) - #3940

### Contributors

* &#2369;KvizadSaderah
* &#2369;aviator5
* &#2369;github-actions[bot]
</blockquote>

## `cf-tenant-resolver-gw`

<blockquote>


## [0.1.2](https://github.com/constructorfabric/cyberfabric-core/releases/tag/cf-tenant-resolver-gw-v0.1.2) - 2026-02-10

### Added

- *(dylint)* add DE0309 must_have_domain_model lint (by &#2369;KvizadSaderah)
- replace access-based Tenant Resolver with hierarchy-based implementation (by &#2369;aviator5) - #3924

### Other

- consolidate Tenant Resolver SDK parameters into per-method options structs (by &#2369;aviator5) - #3924
- release (by &#2369;github-actions[bot]) - #3922
- release (by &#2369;github-actions[bot]) - #3940

### Contributors

* &#2369;KvizadSaderah
* &#2369;aviator5
* &#2369;github-actions[bot]
</blockquote>

## `cf-types-registry`

<blockquote>


## [0.1.2](https://github.com/constructorfabric/cyberfabric-core/releases/tag/cf-types-registry-v0.1.2) - 2026-02-10

### Added

- *(dylint)* add DE0309 must_have_domain_model lint (by &#2369;KvizadSaderah)

### Other

- release (by &#2369;github-actions[bot]) - #3940
- reduce cognitive complexity threshold to 20 for modules

### Contributors

* &#2369;KvizadSaderah
* &#2369;github-actions[bot]
</blockquote>

## `cf-system-sdk-directory`

<blockquote>


## [0.1.8](https://github.com/constructorfabric/cyberfabric-core/compare/cf-system-sdk-directory-v0.1.7...cf-system-sdk-directory-v0.1.8) - 2026-02-10

### Other

- updated the following local packages: cf-modkit-transport-grpc
</blockquote>

## `cf-system-sdks`

<blockquote>


## [0.1.8](https://github.com/constructorfabric/cyberfabric-core/compare/cf-system-sdks-v0.1.7...cf-system-sdks-v0.1.8) - 2026-02-10

### Other

- updated the following local packages: cf-system-sdk-directory
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#499 -->