### PR TITLE
[PR #413] CI: Add cargo audit to workflow and document RUSTSEC-2023-0071 ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,16 @@ jobs:
       - name: cargo deny check
         run: cargo deny check
 
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+
+      # RUSTSEC-2023-0071 (rsa crate Marvin Attack) is ignored because:
+      # - The vulnerability is in the rsa crate, used only as a transitive dependency via sqlx-mysql (through sea-orm)
+      # - No fixed upgrade is available
+      # - The project does not use rsa directly, and the risk is considered acceptable until upstream dependencies are updated
+      - name: Run cargo audit
+        run: cargo audit --ignore RUSTSEC-2023-0071
+
   coverage:
     name: Code Coverage (cargo-llvm-cov)
     runs-on: ubuntu-latest


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#413](https://github.com/cyberfabric/cyberware-rust/pull/413) | **Author:** maxcherey | **Opened:** 2026-02-02T19:54:18Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

- Integrated cargo audit into the security job of the CI workflow to automatically check for vulnerable dependencies on every commit/PR.
- Configured the audit step to ignore RUSTSEC-2023-0071 (rsa Marvin Attack) because:
  - The vulnerability is in the rsa crate, which is only used as a transitive dependency via sqlx-mysql (through sea-orm).
  - No fixed upgrade is available at this time.
  - The project does not use rsa directly, and the risk is considered acceptable until upstream dependencies are updated.
- Added comments in the workflow to document the rationale for this ignore.

Partially addresses https://github.com/hypernetix/hyperspot/issues/268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security scanning in the continuous integration pipeline with additional vulnerability detection capabilities and targeted exclusions for specific advisories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#413 -->