### PR TITLE
[PR #412] chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,72 @@ release-plz updates this file in the Release PR.
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-tenant-resolver-gw-v0.1.1...cf-tenant-resolver-gw-v0.1.2) - 2026-02-05
+
+### Other
+
+- updated the following local packages: cf-modkit-security, cf-modkit-odata, cf-modkit, cf-types-registry-sdk, cf-tenant-resolver-sdk
+
+## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-static-tr-plugin-v0.1.1...cf-static-tr-plugin-v0.1.2) - 2026-02-05
+
+### Other
+
+- updated the following local packages: cf-modkit-security, cf-modkit-odata, cf-modkit, cf-types-registry-sdk, cf-tenant-resolver-sdk
+
+## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-single-tenant-tr-plugin-v0.1.1...cf-single-tenant-tr-plugin-v0.1.2) - 2026-02-05
+
+### Other
+
+- updated the following local packages: cf-modkit-security, cf-modkit-odata, cf-modkit, cf-types-registry-sdk, cf-tenant-resolver-sdk
+
+## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-tenant-resolver-sdk-v0.1.1...cf-tenant-resolver-sdk-v0.1.2) - 2026-02-05
+
+### Other
+
+- updated the following local packages: cf-modkit-security, cf-modkit-odata, cf-modkit
+
+## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-nodes-registry-v0.1.1...cf-nodes-registry-v0.1.2) - 2026-02-05
+
+### Other
+
+- updated the following local packages: cf-modkit-macros, cf-modkit, cf-modkit-node-info, cf-nodes-registry-sdk
+
+## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-nodes-registry-sdk-v0.1.1...cf-nodes-registry-sdk-v0.1.2) - 2026-02-05
+
+### Other
+
+- updated the following local packages: cf-modkit-node-info
+
+## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-module-orchestrator-v0.1.1...cf-module-orchestrator-v0.1.2) - 2026-02-05
+
+### Other
+
+- updated the following local packages: cf-modkit, cf-system-sdks
+
+## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-types-registry-sdk-v0.1.1...cf-types-registry-sdk-v0.1.2) - 2026-02-05
+
+### Other
+
+- updated the following local packages: cf-modkit-security
+
+## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-grpc-hub-v0.1.1...cf-grpc-hub-v0.1.2) - 2026-02-05
+
+### Other
+
+- updated the following local packages: cf-modkit-transport-grpc, cf-modkit, cf-system-sdks
+
+## [0.1.6](https://github.com/hypernetix/hyperspot/compare/cf-system-sdks-v0.1.5...cf-system-sdks-v0.1.6) - 2026-02-05
+
+### Other
+
+- updated the following local packages: cf-system-sdk-directory
+
+## [0.1.6](https://github.com/hypernetix/hyperspot/compare/cf-system-sdk-directory-v0.1.5...cf-system-sdk-directory-v0.1.6) - 2026-02-05
+
+### Other
+
+- updated the following local packages: cf-modkit-transport-grpc
+
 ## [0.1.5](https://github.com/hypernetix/hyperspot/compare/cf-system-sdks-v0.1.4...cf-system-sdks-v0.1.5) - 2026-02-02
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "cf-api-gateway"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "cf-file-parser"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "cf-grpc-hub"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-auth"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-error2",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "axum",
  "http",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors-macro"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-macros-tests"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-node-info"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-odata"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "bigdecimal",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-odata-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cf-modkit-odata",
  "heck 0.5.0",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-sdk"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cf-modkit-odata",
  "cf-modkit-odata-macros",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-security"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "postcard",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-transport-grpc"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "cf-modkit-security",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-utils"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "humantime",
  "serde",
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "cf-module-orchestrator"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "cf-nodes-registry"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "cf-nodes-registry-sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "cf-modkit-node-info",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "cf-single-tenant-tr-plugin"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "cf-static-tr-plugin"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1261,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "cf-system-sdk-directory"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1276,14 +1276,14 @@ dependencies = [
 
 [[package]]
 name = "cf-system-sdks"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "cf-system-sdk-directory",
 ]
 
 [[package]]
 name = "cf-tenant-resolver-gw"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "cf-tenant-resolver-sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "cf-types-registry"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "cf-types-registry-sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "cf-modkit-security",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "gts-docs-validator"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "hyperspot-server"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "calculator",
@@ -6232,7 +6232,7 @@ dependencies = [
 
 [[package]]
 name = "tenant-resolver-sdk"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -6860,7 +6860,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "types"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6875,7 +6875,7 @@ dependencies = [
 
 [[package]]
 name = "types-sdk"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "cf-modkit-odata",
@@ -7010,7 +7010,7 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "user_info-sdk"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "cf-modkit-odata",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "users_info"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["Hypernetix"]
@@ -198,29 +198,29 @@ verbose_file_reads = "deny"
 
 [workspace.dependencies]
 # libs
-modkit = { package = "cf-modkit", version = "0.2.0", path = "libs/modkit" }
-modkit-auth = { package = "cf-modkit-auth", version = "0.2.0", path = "libs/modkit-auth" }
-modkit-db = { package = "cf-modkit-db", version = "0.2.0", path = "libs/modkit-db" }
-modkit-db-macros = { package = "cf-modkit-db-macros", version = "0.2.0", path = "libs/modkit-db-macros" }
-modkit-errors = { package = "cf-modkit-errors", version = "0.2.0", path = "libs/modkit-errors" }
-modkit-errors-macro = { package = "cf-modkit-errors-macro", version = "0.2.0", path = "libs/modkit-errors-macro" }
-modkit-macros = { package = "cf-modkit-macros", version = "0.2.0", path = "libs/modkit-macros" }
-modkit-node-info = { package = "cf-modkit-node-info", version = "0.2.0", path = "libs/modkit-node-info" }
-modkit-odata = { package = "cf-modkit-odata", version = "0.2.0", path = "libs/modkit-odata" }
-modkit-odata-macros = { package = "cf-modkit-odata-macros", version = "0.2.0", path = "libs/modkit-odata-macros" }
-modkit-sdk = { package = "cf-modkit-sdk", version = "0.2.0", path = "libs/modkit-sdk" }
-modkit-security = { package = "cf-modkit-security", version = "0.2.0", path = "libs/modkit-security" }
-modkit-transport-grpc = { package = "cf-modkit-transport-grpc", version = "0.2.0", path = "libs/modkit-transport-grpc" }
-modkit-utils = { package = "cf-modkit-utils", version = "0.2.0", path = "libs/modkit-utils" }
+modkit = { package = "cf-modkit", version = "0.2.1", path = "libs/modkit" }
+modkit-auth = { package = "cf-modkit-auth", version = "0.2.1", path = "libs/modkit-auth" }
+modkit-db = { package = "cf-modkit-db", version = "0.2.1", path = "libs/modkit-db" }
+modkit-db-macros = { package = "cf-modkit-db-macros", version = "0.2.1", path = "libs/modkit-db-macros" }
+modkit-errors = { package = "cf-modkit-errors", version = "0.2.1", path = "libs/modkit-errors" }
+modkit-errors-macro = { package = "cf-modkit-errors-macro", version = "0.2.1", path = "libs/modkit-errors-macro" }
+modkit-macros = { package = "cf-modkit-macros", version = "0.2.1", path = "libs/modkit-macros" }
+modkit-node-info = { package = "cf-modkit-node-info", version = "0.2.1", path = "libs/modkit-node-info" }
+modkit-odata = { package = "cf-modkit-odata", version = "0.2.1", path = "libs/modkit-odata" }
+modkit-odata-macros = { package = "cf-modkit-odata-macros", version = "0.2.1", path = "libs/modkit-odata-macros" }
+modkit-sdk = { package = "cf-modkit-sdk", version = "0.2.1", path = "libs/modkit-sdk" }
+modkit-security = { package = "cf-modkit-security", version = "0.2.1", path = "libs/modkit-security" }
+modkit-transport-grpc = { package = "cf-modkit-transport-grpc", version = "0.2.1", path = "libs/modkit-transport-grpc" }
+modkit-utils = { package = "cf-modkit-utils", version = "0.2.1", path = "libs/modkit-utils" }
 
-cf-system-sdks = { version = "0.1.5", path = "libs/system-sdks" }
-cf-system-sdk-directory = { version = "0.1.5", path = "libs/system-sdks/sdks/directory" }
+cf-system-sdks = { version = "0.1.6", path = "libs/system-sdks" }
+cf-system-sdk-directory = { version = "0.1.6", path = "libs/system-sdks/sdks/directory" }
 
 # system modules SDKs
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.1", path = "modules/system/types_registry/types_registry-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.2", path = "modules/system/types_registry/types_registry-sdk" }
 
 # system modules
-grpc_hub = { package = "cf-grpc-hub", version = "0.1.1", path = "modules/system/grpc_hub" }
+grpc_hub = { package = "cf-grpc-hub", version = "0.1.2", path = "modules/system/grpc_hub" }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/libs/system-sdks/Cargo.toml
+++ b/libs/system-sdks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-system-sdks"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/system-sdks/sdks/directory/Cargo.toml
+++ b/libs/system-sdks/sdks/directory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-system-sdk-directory"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/file_parser/Cargo.toml
+++ b/modules/file_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-file-parser"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/api_gateway/Cargo.toml
+++ b/modules/system/api_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-api-gateway"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -53,7 +53,7 @@ rust-embed = { workspace = true }
 [dev-dependencies]
 futures-core = { workspace = true }
 uuid = { workspace = true }
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.1.1", path = "../tenant_resolver/tenant_resolver-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.1.2", path = "../tenant_resolver/tenant_resolver-sdk" }
 
 [features]
 grpc = []

--- a/modules/system/grpc_hub/Cargo.toml
+++ b/modules/system/grpc_hub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-grpc-hub"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/module_orchestrator/Cargo.toml
+++ b/modules/system/module_orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-module-orchestrator"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/nodes_registry/nodes_registry-sdk/Cargo.toml
+++ b/modules/system/nodes_registry/nodes_registry-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-nodes-registry-sdk"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/nodes_registry/nodes_registry/Cargo.toml
+++ b/modules/system/nodes_registry/nodes_registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-nodes-registry"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -32,4 +32,4 @@ thiserror = { workspace = true }
 modkit = { workspace = true }
 modkit-node-info = { workspace = true }
 modkit-macros = { workspace = true }
-nodes_registry-sdk = { package = "cf-nodes-registry-sdk", version = "0.1.1", path = "../nodes_registry-sdk" }
+nodes_registry-sdk = { package = "cf-nodes-registry-sdk", version = "0.1.2", path = "../nodes_registry-sdk" }

--- a/modules/system/tenant_resolver/plugins/single_tenant_tr_plugin/Cargo.toml
+++ b/modules/system/tenant_resolver/plugins/single_tenant_tr_plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-single-tenant-tr-plugin"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.1.1", path = "../../tenant_resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.1", path = "../../../types_registry/types_registry-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.1.2", path = "../../tenant_resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.2", path = "../../../types_registry/types_registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/tenant_resolver/plugins/static_tr_plugin/Cargo.toml
+++ b/modules/system/tenant_resolver/plugins/static_tr_plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-static-tr-plugin"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.1.1", path = "../../tenant_resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.1", path = "../../../types_registry/types_registry-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.1.2", path = "../../tenant_resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.2", path = "../../../types_registry/types_registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/tenant_resolver/tenant_resolver-gw/Cargo.toml
+++ b/modules/system/tenant_resolver/tenant_resolver-gw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-tenant-resolver-gw"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 # Local dependencies
-tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.1.1", path = "../tenant_resolver-sdk" }
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.1", path = "../../types_registry/types_registry-sdk" }
+tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.1.2", path = "../tenant_resolver-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.2", path = "../../types_registry/types_registry-sdk" }
 
 # ModKit dependencies
 modkit = { workspace = true }

--- a/modules/system/tenant_resolver/tenant_resolver-sdk/Cargo.toml
+++ b/modules/system/tenant_resolver/tenant_resolver-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-tenant-resolver-sdk"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/types_registry/types_registry-sdk/Cargo.toml
+++ b/modules/system/types_registry/types_registry-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-types-registry-sdk"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/types_registry/types_registry/Cargo.toml
+++ b/modules/system/types_registry/types_registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-types-registry"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -19,7 +19,7 @@ doctest = false
 
 [dependencies]
 # SDK - public API, models, and errors
-types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.1", path = "../types_registry-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.2", path = "../types_registry-sdk" }
 
 # GTS types (from git dependency)
 gts = { workspace = true }
@@ -48,5 +48,5 @@ modkit-macros = { workspace = true }
 
 [dev-dependencies]
 tower = { workspace = true, features = ["util"] }
-api_gateway = { package = "cf-api-gateway", version = "0.1.1", path = "../../api_gateway" }
+api_gateway = { package = "cf-api-gateway", version = "0.1.2", path = "../../api_gateway" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#412](https://github.com/cyberfabric/cyberware-rust/pull/412) | **Author:** github-actions[bot] | **Opened:** 2026-02-02T19:21:35Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---




## 🤖 New release

* `cf-modkit-security`: 0.2.0 -> 0.2.1
* `cf-modkit-transport-grpc`: 0.2.0 -> 0.2.1
* `cf-modkit-db-macros`: 0.2.0 -> 0.2.1
* `cf-modkit-errors`: 0.2.0 -> 0.2.1
* `cf-modkit-errors-macro`: 0.2.0 -> 0.2.1
* `cf-modkit-odata`: 0.2.0 -> 0.2.1
* `cf-modkit-utils`: 0.2.0 -> 0.2.1
* `cf-modkit-db`: 0.2.0 -> 0.2.1
* `cf-modkit-macros`: 0.2.0 -> 0.2.1
* `cf-modkit-odata-macros`: 0.2.0 -> 0.2.1
* `cf-modkit-sdk`: 0.2.0 -> 0.2.1
* `cf-modkit`: 0.2.0 -> 0.2.1
* `cf-modkit-auth`: 0.2.0 -> 0.2.1
* `cf-api-gateway`: 0.1.1 -> 0.1.2
* `types-sdk`: 0.2.0 -> 0.2.1
* `cf-file-parser`: 0.1.1 -> 0.1.2
* `cf-modkit-node-info`: 0.2.0 -> 0.2.1
* `cf-types-registry`: 0.1.1 -> 0.1.2
* `cf-system-sdk-directory`: 0.1.5 -> 0.1.6
* `cf-system-sdks`: 0.1.5 -> 0.1.6
* `cf-grpc-hub`: 0.1.1 -> 0.1.2
* `cf-types-registry-sdk`: 0.1.1 -> 0.1.2
* `cf-module-orchestrator`: 0.1.1 -> 0.1.2
* `cf-nodes-registry-sdk`: 0.1.1 -> 0.1.2
* `cf-nodes-registry`: 0.1.1 -> 0.1.2
* `cf-tenant-resolver-sdk`: 0.1.1 -> 0.1.2
* `cf-single-tenant-tr-plugin`: 0.1.1 -> 0.1.2
* `cf-static-tr-plugin`: 0.1.1 -> 0.1.2
* `cf-tenant-resolver-gw`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>












## `cf-modkit`

<blockquote>


## [0.2.1](https://github.com/hypernetix/hyperspot/compare/cf-modkit-v0.2.0...cf-modkit-v0.2.1) - 2026-02-05

### Added

- *(modkit-macros)* add #[domain_model] proc-macro for DDD boundary enforcement (by &#2369;KvizadSaderah)

### Other

- Merge pull request #3948 from KvizadSaderah/feature/domain-macro (by &#2369;MikeFalcon77) - #3948

### Contributors

* &#2369;MikeFalcon77
* &#2369;KvizadSaderah
</blockquote>


## `cf-api-gateway`

<blockquote>


## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-api-gateway-v0.1.1...cf-api-gateway-v0.1.2) - 2026-02-05

### Other

- reduce cognitive complexity threshold to 20 for modules
</blockquote>


## `cf-file-parser`

<blockquote>


## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-file-parser-v0.1.1...cf-file-parser-v0.1.2) - 2026-02-05

### Other

- Merge pull request #2103 from yoskini/feat/Quick_start_guide (by &#2369;Artifizer) - #2103

### Contributors

* &#2369;Artifizer
</blockquote>


## `cf-types-registry`

<blockquote>


## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-types-registry-v0.1.1...cf-types-registry-v0.1.2) - 2026-02-05

### Other

- reduce cognitive complexity threshold to 20 for modules
</blockquote>

## `cf-system-sdk-directory`

<blockquote>


## [0.1.6](https://github.com/hypernetix/hyperspot/compare/cf-system-sdk-directory-v0.1.5...cf-system-sdk-directory-v0.1.6) - 2026-02-05

### Other

- updated the following local packages: cf-modkit-transport-grpc
</blockquote>

## `cf-system-sdks`

<blockquote>


## [0.1.6](https://github.com/hypernetix/hyperspot/compare/cf-system-sdks-v0.1.5...cf-system-sdks-v0.1.6) - 2026-02-05

### Other

- updated the following local packages: cf-system-sdk-directory
</blockquote>

## `cf-grpc-hub`

<blockquote>


## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-grpc-hub-v0.1.1...cf-grpc-hub-v0.1.2) - 2026-02-05

### Other

- updated the following local packages: cf-modkit-transport-grpc, cf-modkit, cf-system-sdks
</blockquote>

## `cf-types-registry-sdk`

<blockquote>


## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-types-registry-sdk-v0.1.1...cf-types-registry-sdk-v0.1.2) - 2026-02-05

### Other

- updated the following local packages: cf-modkit-security
</blockquote>

## `cf-module-orchestrator`

<blockquote>


## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-module-orchestrator-v0.1.1...cf-module-orchestrator-v0.1.2) - 2026-02-05

### Other

- updated the following local packages: cf-modkit, cf-system-sdks
</blockquote>

## `cf-nodes-registry-sdk`

<blockquote>


## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-nodes-registry-sdk-v0.1.1...cf-nodes-registry-sdk-v0.1.2) - 2026-02-05

### Other

- updated the following local packages: cf-modkit-node-info
</blockquote>

## `cf-nodes-registry`

<blockquote>


## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-nodes-registry-v0.1.1...cf-nodes-registry-v0.1.2) - 2026-02-05

### Other

- updated the following local packages: cf-modkit-macros, cf-modkit, cf-modkit-node-info, cf-nodes-registry-sdk
</blockquote>

## `cf-tenant-resolver-sdk`

<blockquote>


## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-tenant-resolver-sdk-v0.1.1...cf-tenant-resolver-sdk-v0.1.2) - 2026-02-05

### Other

- updated the following local packages: cf-modkit-security, cf-modkit-odata, cf-modkit
</blockquote>

## `cf-single-tenant-tr-plugin`

<blockquote>


## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-single-tenant-tr-plugin-v0.1.1...cf-single-tenant-tr-plugin-v0.1.2) - 2026-02-05

### Other

- updated the following local packages: cf-modkit-security, cf-modkit-odata, cf-modkit, cf-types-registry-sdk, cf-tenant-resolver-sdk
</blockquote>

## `cf-static-tr-plugin`

<blockquote>


## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-static-tr-plugin-v0.1.1...cf-static-tr-plugin-v0.1.2) - 2026-02-05

### Other

- updated the following local packages: cf-modkit-security, cf-modkit-odata, cf-modkit, cf-types-registry-sdk, cf-tenant-resolver-sdk
</blockquote>

## `cf-tenant-resolver-gw`

<blockquote>


## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-tenant-resolver-gw-v0.1.1...cf-tenant-resolver-gw-v0.1.2) - 2026-02-05

### Other

- updated the following local packages: cf-modkit-security, cf-modkit-odata, cf-modkit, cf-types-registry-sdk, cf-tenant-resolver-sdk
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#412 -->