### PR TITLE
[PR #336] 📝 Add docstrings to `fix/db_engine_ambiguity`

### DIFF
--- a/libs/modkit-db/tests/config_tests.rs
+++ b/libs/modkit-db/tests/config_tests.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 #[test]
 fn test_dbconnconfig_serialization() {
     let config = DbConnConfig {
+        engine: None,
         dsn: Some("postgresql://user:pass@localhost/db".to_owned()),
         host: Some("localhost".to_owned()),
         port: Some(5432),
@@ -45,9 +46,22 @@ fn test_dbconnconfig_serialization() {
     assert_eq!(deserialized.port, config.port);
 }
 
+/// Verifies that a newly created `DbConnConfig::default()` leaves all optional fields unset.
+///
+/// Asserts that `engine`, `dsn`, `host`, `port`, `user`, `password`, `dbname`,
+/// `params`, `file`, `path`, `pool`, and `server` are `None`.
+///
+/// # Examples
+///
+/// ```
+/// let cfg = DbConnConfig::default();
+/// assert!(cfg.engine.is_none());
+/// assert!(cfg.dsn.is_none());
+/// ```
 #[test]
 fn test_dbconnconfig_defaults() {
     let config = DbConnConfig::default();
+    assert!(config.engine.is_none());
     assert!(config.dsn.is_none());
     assert!(config.host.is_none());
     assert!(config.port.is_none());
@@ -165,6 +179,7 @@ fn test_deny_unknown_fields() {
 fn test_minimal_configs() {
     // Test minimal SQLite config
     let sqlite_config = DbConnConfig {
+        engine: Some(modkit_db::config::DbEngineCfg::Sqlite),
         file: Some("data.db".to_owned()),
         ..Default::default()
     };
@@ -174,6 +189,7 @@ fn test_minimal_configs() {
 
     // Test minimal server reference config
     let server_ref_config = DbConnConfig {
+        engine: Some(modkit_db::config::DbEngineCfg::Postgres),
         server: Some("main_db".to_owned()),
         dbname: Some("myapp".to_owned()),
         ..Default::default()

--- a/libs/modkit-db/tests/sqlite/options.rs
+++ b/libs/modkit-db/tests/sqlite/options.rs
@@ -5,20 +5,26 @@ use tempfile::TempDir;
 
 #[test]
 fn test_build_db_handle_env_expansion() {
-    temp_env::with_var("TEST_DB_PASSWORD", Some("secret123"), || {
+    temp_env::with_var("TEST_SQLITE_SYNC", Some("NORMAL"), || {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap();
         rt.block_on(async {
             let config = DbConnConfig {
+                engine: Some(modkit_db::config::DbEngineCfg::Sqlite),
                 dsn: Some("sqlite::memory:".to_owned()),
-                password: Some("${TEST_DB_PASSWORD}".to_owned()),
+                params: Some({
+                    let mut params = HashMap::new();
+                    // Exercise env expansion in params
+                    params.insert("synchronous".to_owned(), "${TEST_SQLITE_SYNC}".to_owned());
+                    params
+                }),
                 ..Default::default()
             };
 
             let result = build_db_handle(config, None).await;
-            assert!(result.is_ok());
+            assert!(result.is_ok(), "Expected Ok, got: {result:?}");
         });
     });
 }
@@ -26,6 +32,7 @@ fn test_build_db_handle_env_expansion() {
 #[tokio::test]
 async fn test_build_db_handle_sqlite_memory() {
     let config = DbConnConfig {
+        engine: Some(modkit_db::config::DbEngineCfg::Sqlite),
         dsn: Some("sqlite::memory:".to_owned()),
         params: Some({
             let mut params = HashMap::new();
@@ -42,12 +49,46 @@ async fn test_build_db_handle_sqlite_memory() {
     assert_eq!(handle.engine(), DbEngine::Sqlite);
 }
 
+/// Verifies that a file-backed SQLite database handle can be constructed with specified PRAGMA parameters.
+///
+/// This test creates a temporary database file, sets `journal_mode` and `synchronous` parameters,
+/// builds a database handle, and asserts the handle's engine is SQLite.
+///
+/// # Examples
+///
+/// ```
+/// # use std::collections::HashMap;
+/// # use tempfile::TempDir;
+/// # use modkit_db::config::DbEngineCfg;
+/// # use modkit_db::{DbConnConfig, DbEngine};
+/// # use crate::build_db_handle;
+/// let temp_dir = TempDir::new().unwrap();
+/// let db_path = temp_dir.path().join("test.db");
+///
+/// let config = DbConnConfig {
+///     engine: Some(DbEngineCfg::Sqlite),
+///     path: Some(db_path),
+///     params: Some({
+///         let mut params = HashMap::new();
+///         params.insert("journal_mode".to_owned(), "DELETE".to_owned());
+///         params.insert("synchronous".to_owned(), "NORMAL".to_owned());
+///         params
+///     }),
+///     ..Default::default()
+/// };
+///
+/// let result = tokio_test::block_on(async { build_db_handle(config, None).await });
+/// assert!(result.is_ok());
+/// let handle = result.unwrap();
+/// assert_eq!(handle.engine(), DbEngine::Sqlite);
+/// ```
 #[tokio::test]
 async fn test_build_db_handle_sqlite_file() {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("test.db");
 
     let config = DbConnConfig {
+        engine: Some(modkit_db::config::DbEngineCfg::Sqlite),
         path: Some(db_path),
         params: Some({
             let mut params = HashMap::new();
@@ -102,6 +143,7 @@ fn test_display_sqlite_relative_path() {
 #[tokio::test]
 async fn test_build_db_handle_invalid_env_var() {
     let config = DbConnConfig {
+        engine: Some(modkit_db::config::DbEngineCfg::Sqlite),
         dsn: Some("sqlite::memory:".to_owned()),
         password: Some("${NONEXISTENT_VAR}".to_owned()),
         ..Default::default()
@@ -114,10 +156,40 @@ async fn test_build_db_handle_invalid_env_var() {
     assert!(error.to_string().contains("environment variable not found"));
 }
 
+/// Verifies that building a SQLite database handle fails when provided with an invalid PRAGMA parameter.
+///
+/// Asserts that `build_db_handle` returns an error and that the error message contains the invalid parameter name.
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(feature = "sqlite")]
+/// # async fn _example() {
+/// use std::collections::HashMap;
+/// use modkit_db::config::DbEngineCfg;
+///
+/// let config = DbConnConfig {
+///     engine: Some(DbEngineCfg::Sqlite),
+///     dsn: Some("sqlite::memory:".to_owned()),
+///     params: Some({
+///         let mut params = HashMap::new();
+///         params.insert("invalid_pragma".to_owned(), "some_value".to_owned());
+///         params
+///     }),
+///     ..Default::default()
+/// };
+///
+/// let result = build_db_handle(config, None).await;
+/// assert!(result.is_err());
+/// let error = result.unwrap_err();
+/// assert!(error.to_string().contains("invalid_pragma"));
+/// # }
+/// ```
 #[cfg(feature = "sqlite")]
 #[tokio::test]
 async fn test_build_db_handle_invalid_sqlite_pragma() {
     let config = DbConnConfig {
+        engine: Some(modkit_db::config::DbEngineCfg::Sqlite),
         dsn: Some("sqlite::memory:".to_owned()),
         params: Some({
             let mut params = HashMap::new();
@@ -138,6 +210,7 @@ async fn test_build_db_handle_invalid_sqlite_pragma() {
 #[tokio::test]
 async fn test_build_db_handle_invalid_journal_mode() {
     let config = DbConnConfig {
+        engine: Some(modkit_db::config::DbEngineCfg::Sqlite),
         dsn: Some("sqlite::memory:".to_owned()),
         params: Some({
             let mut params = HashMap::new();
@@ -159,10 +232,40 @@ async fn test_build_db_handle_invalid_journal_mode() {
     );
 }
 
+/// Verifies that a SQLite database handle can be built with a custom connection pool configuration.
+///
+/// Builds a `DbConnConfig` specifying the SQLite engine, an in-memory DSN, and a `PoolCfg` with
+/// `max_conns` and `acquire_timeout`, then ensures `build_db_handle` succeeds and the resulting
+/// handle reports the `Sqlite` engine.
+///
+/// # Examples
+///
+/// ```
+/// # async fn run_example() -> Result<(), Box<dyn std::error::Error>> {
+/// use std::time::Duration;
+/// use modkit_db::config::{DbConnConfig, PoolCfg};
+/// use modkit_db::DbEngine;
+///
+/// let config = DbConnConfig {
+///     engine: Some(modkit_db::config::DbEngineCfg::Sqlite),
+///     dsn: Some("sqlite::memory:".to_owned()),
+///     pool: Some(PoolCfg {
+///         max_conns: Some(5),
+///         acquire_timeout: Some(Duration::from_secs(10)),
+///         ..Default::default()
+///     }),
+///     ..Default::default()
+/// };
+///
+/// let handle = crate::build_db_handle(config, None).await?;
+/// assert_eq!(handle.engine(), DbEngine::Sqlite);
+/// # Ok(()) }
+/// ```
 #[cfg(feature = "sqlite")]
 #[tokio::test]
 async fn test_build_db_handle_pool_config() {
     let config = DbConnConfig {
+        engine: Some(modkit_db::config::DbEngineCfg::Sqlite),
         dsn: Some("sqlite::memory:".to_owned()),
         pool: Some(PoolCfg {
             max_conns: Some(5),


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#336](https://github.com/cyberfabric/cyberware-rust/pull/336) | **Author:** coderabbitai[bot] | **Opened:** 2026-01-27T22:55:00Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

Docstrings generation was requested by &#2369;MikeFalcon77.

* https://github.com/hypernetix/hyperspot/pull/334#issuecomment-3807773834

The following files were modified:

* `libs/modkit-db/src/manager.rs`
* `libs/modkit-db/src/options.rs`
* `libs/modkit-db/tests/config_tests.rs`
* `libs/modkit-db/tests/precedence_tests.rs`
* `libs/modkit-db/tests/sqlite/concurrency_tests.rs`
* `libs/modkit-db/tests/sqlite/manager.rs`
* `libs/modkit-db/tests/sqlite/options.rs`
* `libs/modkit-db/tests/sqlite/sqlite_tests.rs`
* `libs/modkit/src/bootstrap/oop_tests.rs`

<details>
<summary>These files were kept as they were</summary>

* `libs/modkit-db/tests/manager_tests.rs`
* `libs/modkit-db/tests/sqlite/pooling_tests.rs`

</details>

<details>
<summary>These file types are not supported</summary>

* `config/e2e-local.yaml`
* `config/quickstart-windows.yaml`
* `config/quickstart.yaml`
* `config/static-tenants.yaml`

</details>

<details>
<summary>ℹ️ Note</summary><blockquote>

CodeRabbit cannot perform edits on its own pull requests yet.

</blockquote></details>

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#336 -->