### PR TITLE
[PR #318] chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,100 @@ release-plz updates this file in the Release PR.
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-types-registry-v0.1.1) - 2026-01-26
+
+### Other
+
+- release
+- Normalize modules (types registry and simple user settings) paths to snake_case
+
+## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-tenant-resolver-gw-v0.1.1) - 2026-01-26
+
+### Other
+
+- release
+- Normalize modules (types registry and simple user settings) paths to snake_case
+
+## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-static-tr-plugin-v0.1.1) - 2026-01-26
+
+### Other
+
+- release
+- Normalize modules (types registry and simple user settings) paths to snake_case
+
+## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-single-tenant-tr-plugin-v0.1.1) - 2026-01-26
+
+### Other
+
+- release
+- Normalize modules (types registry and simple user settings) paths to snake_case
+
+## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-tenant-resolver-sdk-v0.1.1) - 2026-01-26
+
+### Other
+
+- release
+
+## [0.1.0](https://github.com/hypernetix/hyperspot/releases/tag/cf-simple-user-settings-v0.1.0) - 2026-01-26
+
+### Other
+
+- Normalize modules (types registry and simple user settings) paths to snake_case
+
+## [0.1.0](https://github.com/hypernetix/hyperspot/releases/tag/cf-simple-user-settings-sdk-v0.1.0) - 2026-01-26
+
+### Other
+
+- Normalize modules (types registry and simple user settings) paths to snake_case
+
+## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-nodes-registry-v0.1.1) - 2026-01-26
+
+### Other
+
+- release
+
+## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-nodes-registry-sdk-v0.1.1) - 2026-01-26
+
+### Other
+
+- release
+
+## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-module-orchestrator-v0.1.1) - 2026-01-26
+
+### Other
+
+- release
+
+## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-file-parser-v0.1.1) - 2026-01-26
+
+### Other
+
+- release
+
+## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-types-registry-sdk-v0.1.1) - 2026-01-26
+
+### Other
+
+- release
+
+## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-grpc-hub-v0.1.1) - 2026-01-26
+
+### Other
+
+- release
+
+## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-api-gateway-v0.1.1) - 2026-01-26
+
+### Other
+
+- release
+
+## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-modkit-db-v0.1.1...cf-modkit-db-v0.1.2) - 2026-01-26
+
+### Other
+
+- chore(tests):
+
 ## [0.1.1](https://github.com/hypernetix/hyperspot/compare/cf-system-sdk-directory-v0.1.0...cf-system-sdk-directory-v0.1.1) - 2026-01-26
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-auth"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db-macros"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-error2",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "axum",
  "http",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors-macro"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-macros"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-node-info"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-odata"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64 0.22.1",
  "bigdecimal",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-odata-macros"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cf-modkit-odata",
  "heck 0.5.0",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cf-modkit-odata",
  "cf-modkit-odata-macros",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-security"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "postcard",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-transport-grpc"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "cf-modkit-security",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-utils"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "humantime",
  "serde",
@@ -2405,7 +2405,7 @@ dependencies = [
 
 [[package]]
 name = "gts-docs-validator"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "hyperspot-server"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "calculator",
@@ -5892,7 +5892,7 @@ dependencies = [
 
 [[package]]
 name = "tenant-resolver-sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "cf-modkit",
@@ -6630,7 +6630,7 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "user_info-sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "cf-modkit-odata",
@@ -6647,7 +6647,7 @@ dependencies = [
 
 [[package]]
 name = "users_info"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["Hypernetix"]
@@ -194,20 +194,20 @@ verbose_file_reads = "deny"
 
 [workspace.dependencies]
 # libs
-modkit = { package = "cf-modkit", version = "0.1.1", path = "libs/modkit" }
-modkit-auth = { package = "cf-modkit-auth", version = "0.1.1", path = "libs/modkit-auth" }
-modkit-db = { package = "cf-modkit-db", version = "0.1.1", path = "libs/modkit-db" }
-modkit-db-macros = { package = "cf-modkit-db-macros", version = "0.1.1", path = "libs/modkit-db-macros" }
-modkit-errors = { package = "cf-modkit-errors", version = "0.1.1", path = "libs/modkit-errors" }
-modkit-errors-macro = { package = "cf-modkit-errors-macro", version = "0.1.1", path = "libs/modkit-errors-macro" }
-modkit-macros = { package = "cf-modkit-macros", version = "0.1.1", path = "libs/modkit-macros" }
-modkit-node-info = { package = "cf-modkit-node-info", version = "0.1.1", path = "libs/modkit-node-info" }
-modkit-odata = { package = "cf-modkit-odata", version = "0.1.1", path = "libs/modkit-odata" }
-modkit-odata-macros = { package = "cf-modkit-odata-macros", version = "0.1.1", path = "libs/modkit-odata-macros" }
-modkit-sdk = { package = "cf-modkit-sdk", version = "0.1.1", path = "libs/modkit-sdk" }
-modkit-security = { package = "cf-modkit-security", version = "0.1.1", path = "libs/modkit-security" }
-modkit-transport-grpc = { package = "cf-modkit-transport-grpc", version = "0.1.1", path = "libs/modkit-transport-grpc" }
-modkit-utils = { package = "cf-modkit-utils", version = "0.1.1", path = "libs/modkit-utils" }
+modkit = { package = "cf-modkit", version = "0.1.2", path = "libs/modkit" }
+modkit-auth = { package = "cf-modkit-auth", version = "0.1.2", path = "libs/modkit-auth" }
+modkit-db = { package = "cf-modkit-db", version = "0.1.2", path = "libs/modkit-db" }
+modkit-db-macros = { package = "cf-modkit-db-macros", version = "0.1.2", path = "libs/modkit-db-macros" }
+modkit-errors = { package = "cf-modkit-errors", version = "0.1.2", path = "libs/modkit-errors" }
+modkit-errors-macro = { package = "cf-modkit-errors-macro", version = "0.1.2", path = "libs/modkit-errors-macro" }
+modkit-macros = { package = "cf-modkit-macros", version = "0.1.2", path = "libs/modkit-macros" }
+modkit-node-info = { package = "cf-modkit-node-info", version = "0.1.2", path = "libs/modkit-node-info" }
+modkit-odata = { package = "cf-modkit-odata", version = "0.1.2", path = "libs/modkit-odata" }
+modkit-odata-macros = { package = "cf-modkit-odata-macros", version = "0.1.2", path = "libs/modkit-odata-macros" }
+modkit-sdk = { package = "cf-modkit-sdk", version = "0.1.2", path = "libs/modkit-sdk" }
+modkit-security = { package = "cf-modkit-security", version = "0.1.2", path = "libs/modkit-security" }
+modkit-transport-grpc = { package = "cf-modkit-transport-grpc", version = "0.1.2", path = "libs/modkit-transport-grpc" }
+modkit-utils = { package = "cf-modkit-utils", version = "0.1.2", path = "libs/modkit-utils" }
 
 cf-system-sdks = { version = "0.1.1", path = "libs/system-sdks" }
 cf-system-sdk-directory = { version = "0.1.1", path = "libs/system-sdks/sdks/directory" }


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyberware-rust#318](https://github.com/cyberfabric/cyberware-rust/pull/318) | **Author:** github-actions[bot] | **Opened:** 2026-01-26T21:43:16Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---




## 🤖 New release

* `cf-modkit-security`: 0.1.1 -> 0.1.2
* `cf-modkit-transport-grpc`: 0.1.1 -> 0.1.2
* `cf-system-sdk-directory`: 0.1.1
* `cf-system-sdks`: 0.1.1
* `cf-modkit-db-macros`: 0.1.1 -> 0.1.2
* `cf-modkit-errors`: 0.1.1 -> 0.1.2
* `cf-modkit-errors-macro`: 0.1.1 -> 0.1.2
* `cf-modkit-odata`: 0.1.1 -> 0.1.2
* `cf-modkit-utils`: 0.1.1 -> 0.1.2
* `cf-modkit-db`: 0.1.1 -> 0.1.2
* `cf-modkit-macros`: 0.1.1 -> 0.1.2
* `cf-modkit-odata-macros`: 0.1.1 -> 0.1.2
* `cf-modkit-sdk`: 0.1.1 -> 0.1.2
* `cf-modkit`: 0.1.1 -> 0.1.2
* `cf-modkit-auth`: 0.1.1 -> 0.1.2
* `cf-api-gateway`: 0.1.1
* `cf-grpc-hub`: 0.1.1
* `cf-types-registry-sdk`: 0.1.1
* `cf-file-parser`: 0.1.1
* `cf-module-orchestrator`: 0.1.1
* `cf-modkit-node-info`: 0.1.1 -> 0.1.2
* `cf-nodes-registry-sdk`: 0.1.1
* `cf-nodes-registry`: 0.1.1
* `cf-simple-user-settings-sdk`: 0.1.0
* `cf-simple-user-settings`: 0.1.0
* `cf-tenant-resolver-sdk`: 0.1.1
* `cf-single-tenant-tr-plugin`: 0.1.1
* `cf-static-tr-plugin`: 0.1.1
* `cf-tenant-resolver-gw`: 0.1.1
* `cf-types-registry`: 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `cf-modkit-security`

<blockquote>

## [0.1.1](https://github.com/hypernetix/hyperspot/compare/cf-system-sdk-directory-v0.1.0...cf-system-sdk-directory-v0.1.1) - 2026-01-26

### Other

- updated the following local packages: cf-modkit-transport-grpc

### Added

### Changed

### Fixed
</blockquote>

## `cf-modkit-transport-grpc`

<blockquote>

## [0.1.1](https://github.com/hypernetix/hyperspot/compare/cf-system-sdk-directory-v0.1.0...cf-system-sdk-directory-v0.1.1) - 2026-01-26

### Other

- updated the following local packages: cf-modkit-transport-grpc

### Added

### Changed

### Fixed
</blockquote>

## `cf-system-sdk-directory`

<blockquote>

## [0.1.1](https://github.com/hypernetix/hyperspot/compare/cf-system-sdk-directory-v0.1.0...cf-system-sdk-directory-v0.1.1) - 2026-01-26

### Other

- updated the following local packages: cf-modkit-transport-grpc

### Added

### Changed

### Fixed
</blockquote>

## `cf-system-sdks`

<blockquote>

## [0.1.1](https://github.com/hypernetix/hyperspot/compare/cf-system-sdk-directory-v0.1.0...cf-system-sdk-directory-v0.1.1) - 2026-01-26

### Other

- updated the following local packages: cf-modkit-transport-grpc

### Added

### Changed

### Fixed
</blockquote>

## `cf-modkit-db-macros`

<blockquote>

## [0.1.1](https://github.com/hypernetix/hyperspot/compare/cf-system-sdk-directory-v0.1.0...cf-system-sdk-directory-v0.1.1) - 2026-01-26

### Other

- updated the following local packages: cf-modkit-transport-grpc

### Added

### Changed

### Fixed
</blockquote>

## `cf-modkit-errors`

<blockquote>

## [0.1.1](https://github.com/hypernetix/hyperspot/compare/cf-system-sdk-directory-v0.1.0...cf-system-sdk-directory-v0.1.1) - 2026-01-26

### Other

- updated the following local packages: cf-modkit-transport-grpc

### Added

### Changed

### Fixed
</blockquote>

## `cf-modkit-errors-macro`

<blockquote>

## [0.1.1](https://github.com/hypernetix/hyperspot/compare/cf-system-sdk-directory-v0.1.0...cf-system-sdk-directory-v0.1.1) - 2026-01-26

### Other

- updated the following local packages: cf-modkit-transport-grpc

### Added

### Changed

### Fixed
</blockquote>

## `cf-modkit-odata`

<blockquote>

## [0.1.1](https://github.com/hypernetix/hyperspot/compare/cf-system-sdk-directory-v0.1.0...cf-system-sdk-directory-v0.1.1) - 2026-01-26

### Other

- updated the following local packages: cf-modkit-transport-grpc

### Added

### Changed

### Fixed
</blockquote>

## `cf-modkit-utils`

<blockquote>

## [0.1.1](https://github.com/hypernetix/hyperspot/compare/cf-system-sdk-directory-v0.1.0...cf-system-sdk-directory-v0.1.1) - 2026-01-26

### Other

- updated the following local packages: cf-modkit-transport-grpc

### Added

### Changed

### Fixed
</blockquote>

## `cf-modkit-db`

<blockquote>

## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-modkit-db-v0.1.1...cf-modkit-db-v0.1.2) - 2026-01-26

### Other

- chore(tests):
</blockquote>

## `cf-modkit-macros`

<blockquote>

## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-modkit-db-v0.1.1...cf-modkit-db-v0.1.2) - 2026-01-26

### Other

- chore(tests):
</blockquote>

## `cf-modkit-odata-macros`

<blockquote>

## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-modkit-db-v0.1.1...cf-modkit-db-v0.1.2) - 2026-01-26

### Other

- chore(tests):
</blockquote>

## `cf-modkit-sdk`

<blockquote>

## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-modkit-db-v0.1.1...cf-modkit-db-v0.1.2) - 2026-01-26

### Other

- chore(tests):
</blockquote>

## `cf-modkit`

<blockquote>

## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-modkit-db-v0.1.1...cf-modkit-db-v0.1.2) - 2026-01-26

### Other

- chore(tests):
</blockquote>

## `cf-modkit-auth`

<blockquote>

## [0.1.2](https://github.com/hypernetix/hyperspot/compare/cf-modkit-db-v0.1.1...cf-modkit-db-v0.1.2) - 2026-01-26

### Other

- chore(tests):
</blockquote>

## `cf-api-gateway`

<blockquote>


## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-api-gateway-v0.1.1) - 2026-01-26

### Other

- release
</blockquote>

## `cf-grpc-hub`

<blockquote>


## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-grpc-hub-v0.1.1) - 2026-01-26

### Other

- release
</blockquote>

## `cf-types-registry-sdk`

<blockquote>


## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-types-registry-sdk-v0.1.1) - 2026-01-26

### Other

- release
</blockquote>

## `cf-file-parser`

<blockquote>


## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-file-parser-v0.1.1) - 2026-01-26

### Other

- release
</blockquote>

## `cf-module-orchestrator`

<blockquote>


## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-module-orchestrator-v0.1.1) - 2026-01-26

### Other

- release
</blockquote>


## `cf-nodes-registry-sdk`

<blockquote>


## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-nodes-registry-sdk-v0.1.1) - 2026-01-26

### Other

- release
</blockquote>

## `cf-nodes-registry`

<blockquote>


## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-nodes-registry-v0.1.1) - 2026-01-26

### Other

- release
</blockquote>

## `cf-simple-user-settings-sdk`

<blockquote>


## [0.1.0](https://github.com/hypernetix/hyperspot/releases/tag/cf-simple-user-settings-sdk-v0.1.0) - 2026-01-26

### Other

- Normalize modules (types registry and simple user settings) paths to snake_case
</blockquote>

## `cf-simple-user-settings`

<blockquote>


## [0.1.0](https://github.com/hypernetix/hyperspot/releases/tag/cf-simple-user-settings-v0.1.0) - 2026-01-26

### Other

- Normalize modules (types registry and simple user settings) paths to snake_case
</blockquote>

## `cf-tenant-resolver-sdk`

<blockquote>


## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-tenant-resolver-sdk-v0.1.1) - 2026-01-26

### Other

- release
</blockquote>

## `cf-single-tenant-tr-plugin`

<blockquote>


## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-single-tenant-tr-plugin-v0.1.1) - 2026-01-26

### Other

- release
- Normalize modules (types registry and simple user settings) paths to snake_case
</blockquote>

## `cf-static-tr-plugin`

<blockquote>


## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-static-tr-plugin-v0.1.1) - 2026-01-26

### Other

- release
- Normalize modules (types registry and simple user settings) paths to snake_case
</blockquote>

## `cf-tenant-resolver-gw`

<blockquote>


## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-tenant-resolver-gw-v0.1.1) - 2026-01-26

### Other

- release
- Normalize modules (types registry and simple user settings) paths to snake_case
</blockquote>

## `cf-types-registry`

<blockquote>


## [0.1.1](https://github.com/hypernetix/hyperspot/releases/tag/cf-types-registry-v0.1.1) - 2026-01-26

### Other

- release
- Normalize modules (types registry and simple user settings) paths to snake_case
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

---
<!-- cf-mirror-pr: cyberfabric/cyberware-rust#318 -->