### PR TITLE
test(dylint): isolate DE1201 fixture target dirs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,10 +354,13 @@ jobs:
       - name: Set Rust nightly for Dylint temp builds
         run: rustup override set ${{ env.RUSTUP_TOOLCHAIN }} --path /tmp
 
-      - name: Install dylint-link and nextest
+      - name: Install nextest
         uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3
         with:
-          tool: cargo-dylint,dylint-link, nextest
+          tool: nextest
+
+      - name: Install cargo-dylint and dylint-link from source
+        run: cargo install --locked cargo-dylint dylint-link
 
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0

--- a/tools/dylint_lints/de12_documentation/de1201_docs_rs_all_features/tests/cargo_fixtures.rs
+++ b/tools/dylint_lints/de12_documentation/de1201_docs_rs_all_features/tests/cargo_fixtures.rs
@@ -37,6 +37,7 @@ fn run_fixture_with_env(name: &str, extra_env: &[(&str, &str)]) -> Output {
     let fixture = fixtures_dir().join(name);
     let manifest_path = fixture.join("Cargo.toml");
     let lint_parent_dir = lint_parent_dir();
+    let target_dir = fixture.join("target").join(target_dir_name(name, extra_env));
 
     let mut command = Command::new("cargo");
     command
@@ -48,7 +49,7 @@ fn run_fixture_with_env(name: &str, extra_env: &[(&str, &str)]) -> Output {
         .arg("--manifest-path")
         .arg(&manifest_path)
         .arg("--no-deps")
-        .env_remove("CARGO_TARGET_DIR")
+        .env("CARGO_TARGET_DIR", target_dir)
         .env_remove(ENV_EXCLUDED_CRATES)
         .env_remove("DYLINT_RUSTFLAGS")
         .env_remove("DYLINT_TOML")
@@ -89,6 +90,20 @@ fn remove_fixture_lockfile(fixture: &Path) {
             fixture.display()
         ),
     }
+}
+
+fn target_dir_name(name: &str, extra_env: &[(&str, &str)]) -> String {
+    if extra_env.is_empty() {
+        return format!("dylint-fixture-{name}");
+    }
+
+    let env_suffix = extra_env
+        .iter()
+        .map(|(key, value)| format!("{key}-{value}"))
+        .collect::<Vec<_>>()
+        .join("-");
+
+    format!("dylint-fixture-{name}-{env_suffix}")
 }
 
 fn assert_success(name: &str, output: &Output) {

--- a/tools/dylint_lints/de12_documentation/de1201_docs_rs_all_features/tests/cargo_fixtures.rs
+++ b/tools/dylint_lints/de12_documentation/de1201_docs_rs_all_features/tests/cargo_fixtures.rs
@@ -37,7 +37,9 @@ fn run_fixture_with_env(name: &str, extra_env: &[(&str, &str)]) -> Output {
     let fixture = fixtures_dir().join(name);
     let manifest_path = fixture.join("Cargo.toml");
     let lint_parent_dir = lint_parent_dir();
-    let target_dir = fixture.join("target").join(target_dir_name(name, extra_env));
+    let target_dir = fixture
+        .join("target")
+        .join(target_dir_name(name, extra_env));
 
     let mut command = Command::new("cargo");
     command

--- a/tools/dylint_lints/de12_documentation/de1201_docs_rs_all_features/tests/cargo_fixtures.rs
+++ b/tools/dylint_lints/de12_documentation/de1201_docs_rs_all_features/tests/cargo_fixtures.rs
@@ -37,9 +37,6 @@ fn run_fixture_with_env(name: &str, extra_env: &[(&str, &str)]) -> Output {
     let fixture = fixtures_dir().join(name);
     let manifest_path = fixture.join("Cargo.toml");
     let lint_parent_dir = lint_parent_dir();
-    let target_dir = fixture
-        .join("target")
-        .join(target_dir_name(name, extra_env));
 
     let mut command = Command::new("cargo");
     command
@@ -51,7 +48,7 @@ fn run_fixture_with_env(name: &str, extra_env: &[(&str, &str)]) -> Output {
         .arg("--manifest-path")
         .arg(&manifest_path)
         .arg("--no-deps")
-        .env("CARGO_TARGET_DIR", target_dir)
+        .env_remove("CARGO_TARGET_DIR")
         .env_remove(ENV_EXCLUDED_CRATES)
         .env_remove("DYLINT_RUSTFLAGS")
         .env_remove("DYLINT_TOML")
@@ -92,20 +89,6 @@ fn remove_fixture_lockfile(fixture: &Path) {
             fixture.display()
         ),
     }
-}
-
-fn target_dir_name(name: &str, extra_env: &[(&str, &str)]) -> String {
-    if extra_env.is_empty() {
-        return format!("dylint-fixture-{name}");
-    }
-
-    let env_suffix = extra_env
-        .iter()
-        .map(|(key, value)| format!("{key}-{value}"))
-        .collect::<Vec<_>>()
-        .join("-");
-
-    format!("dylint-fixture-{name}-{env_suffix}")
 }
 
 fn assert_success(name: &str, output: &Output) {


### PR DESCRIPTION
Use fixture- and env-specific Cargo target directories when running DE1201 cargo fixtures. This prevents Dylint from reusing a compiled lint library built with different exclusion env state, fixing order/cache dependent CI failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD build tooling installation process for improved efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->