### PR TITLE
chore: make rustls-fips-shim crate publishable

### DIFF
--- a/libs/rustls-fips-shim/Cargo.toml
+++ b/libs/rustls-fips-shim/Cargo.toml
@@ -7,7 +7,7 @@ authors.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 description = "Workspace-feature-unification shim: pulls rustls + hyper-rustls with the `fips` feature on every target where the AWS-LC FIPS backend is the intended TLS provider (i.e. everywhere except macOS, where Apple corecrypto is used, and Windows, where CNG is used instead)."
-publish = false
+publish = true
 
 [lib]
 name = "rustls_fips_shim"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled public distribution of the rustls-fips-shim library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->