### PR TITLE
refactor(account-management): adopt SDK canonical-projection pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,6 +1352,7 @@ dependencies = [
  "async-trait",
  "cf-gears-tenant-resolver-sdk",
  "cf-gears-toolkit",
+ "cf-gears-toolkit-canonical-errors",
  "cf-gears-toolkit-gts",
  "cf-gears-toolkit-odata",
  "cf-gears-toolkit-odata-macros",

--- a/gears/system/account-management/account-management-sdk/Cargo.toml
+++ b/gears/system/account-management/account-management-sdk/Cargo.toml
@@ -17,12 +17,13 @@ name = "account_management_sdk"
 workspace = true
 
 [dependencies]
-# AM's public inter-module error surface is `AccountManagementError`
-# (see src/error.rs) — a flat thiserror enum mirroring the AIP-193
-# categories. The impl crate maps `DomainError → AccountManagementError`
-# at the trait boundary and lifts further to
-# `toolkit_canonical_errors::CanonicalError` at the REST boundary; the
-# SDK itself stays decoupled from the canonical-errors crate.
+# Per ADR 0005 the trait boundary is `CanonicalError`; the SDK ships
+# `AccountManagementError` as an opt-in `From<CanonicalError>`
+# projection (see src/error.rs). The single AIP-193 ladder
+# (`From<DomainError> for CanonicalError`) lives in the impl crate's
+# `infra::sdk_error_mapping`; this SDK depends on the canonical-errors
+# crate to project that envelope into the typed view.
+toolkit-canonical-errors = { workspace = true }
 thiserror = { workspace = true }
 
 # IdP provisioner contract (trait + DTO) consumed by AM and implemented

--- a/gears/system/account-management/account-management-sdk/src/client.rs
+++ b/gears/system/account-management/account-management-sdk/src/client.rs
@@ -58,7 +58,8 @@ use toolkit_odata::{ODataQuery, Page};
 use toolkit_security::SecurityContext;
 use uuid::Uuid;
 
-use crate::error::AccountManagementError;
+use toolkit_canonical_errors::CanonicalError;
+
 use crate::idp_user::{IdpNewUser, IdpUser, ListUsersQuery};
 use crate::metadata::{MetadataEntry, UpsertMetadataRequest};
 use crate::tenant::{CreateTenantRequest, Tenant, UpdateTenantRequest};
@@ -70,15 +71,16 @@ use crate::tenant::{CreateTenantRequest, Tenant, UpdateTenantRequest};
 ///
 /// # Error envelope
 ///
-/// All methods return [`AccountManagementError`] — a flat enum
-/// mirroring the AIP-193 categories AM raises. AM's impl crate maps
-/// `DomainError → AccountManagementError` at this boundary
-/// (`infra::sdk_error_mapping::From<DomainError> for AccountManagementError`);
-/// the REST handler (when it lands) lifts to
-/// `toolkit_canonical_errors::CanonicalError` via the
-/// `account_management_error_to_canonical` helper in the same gear.
-/// Consumers match on [`AccountManagementError`] variants directly
-/// and never depend on `toolkit-canonical-errors`.
+/// Per [ADR 0005][adr] every fallible method returns
+/// `Result<_, CanonicalError>`. The single authoritative AIP-193 ladder
+/// (`From<DomainError> for CanonicalError`) lives in the impl crate's
+/// `infra::sdk_error_mapping`; this trait surfaces that envelope
+/// unchanged. Consumers may propagate it, or opt into the typed
+/// [`AccountManagementError`](crate::AccountManagementError) projection
+/// (`From<CanonicalError>`) for flat dispatch — see its gear docs for
+/// the dispatch table and the three integration patterns.
+///
+/// [adr]: https://github.com/constructorfabric/gears-rust/blob/main/docs/arch/errors/ADR/0005-cpt-cf-adr-sdk-canonical-projection.md
 #[async_trait]
 pub trait AccountManagementClient: Send + Sync + 'static {
     // -----------------------------------------------------------------
@@ -104,7 +106,7 @@ pub trait AccountManagementClient: Send + Sync + 'static {
         &self,
         ctx: &SecurityContext,
         input: CreateTenantRequest,
-    ) -> Result<Tenant, AccountManagementError>;
+    ) -> Result<Tenant, CanonicalError>;
 
     /// Read a tenant by id. Returns the live tenant row projected to
     /// [`Tenant`]. AM-internal `Provisioning` rows surface as
@@ -121,11 +123,7 @@ pub trait AccountManagementClient: Send + Sync + 'static {
     /// * `NotFound` (HTTP 404) -- tenant does not exist, is
     ///   `Provisioning`, or sits outside the caller's PDP-compiled
     ///   subtree.
-    async fn get_tenant(
-        &self,
-        ctx: &SecurityContext,
-        id: Uuid,
-    ) -> Result<Tenant, AccountManagementError>;
+    async fn get_tenant(&self, ctx: &SecurityContext, id: Uuid) -> Result<Tenant, CanonicalError>;
 
     /// List direct children of `parent_id`. The listing is
     /// **direct-only** (`WHERE tenants.parent_id = :parent_id`) — full
@@ -163,7 +161,7 @@ pub trait AccountManagementClient: Send + Sync + 'static {
         ctx: &SecurityContext,
         parent_id: Uuid,
         query: &ODataQuery,
-    ) -> Result<Page<Tenant>, AccountManagementError>;
+    ) -> Result<Page<Tenant>, CanonicalError>;
 
     /// PATCH-style update on the mutable tenant fields. An empty
     /// patch is rejected as `InvalidArgument`.
@@ -187,7 +185,7 @@ pub trait AccountManagementClient: Send + Sync + 'static {
         ctx: &SecurityContext,
         id: Uuid,
         patch: UpdateTenantRequest,
-    ) -> Result<Tenant, AccountManagementError>;
+    ) -> Result<Tenant, CanonicalError>;
 
     /// Transition `id` from `Active` to `Suspended`. Calling on an
     /// already-`Suspended` tenant is an idempotent no-op and returns
@@ -203,7 +201,7 @@ pub trait AccountManagementClient: Send + Sync + 'static {
         &self,
         ctx: &SecurityContext,
         id: Uuid,
-    ) -> Result<Tenant, AccountManagementError>;
+    ) -> Result<Tenant, CanonicalError>;
 
     /// Transition `id` from `Suspended` back to `Active`. Calling on
     /// an already-`Active` tenant is an idempotent no-op. `Deleted`
@@ -218,7 +216,7 @@ pub trait AccountManagementClient: Send + Sync + 'static {
         &self,
         ctx: &SecurityContext,
         id: Uuid,
-    ) -> Result<Tenant, AccountManagementError>;
+    ) -> Result<Tenant, CanonicalError>;
 
     /// Schedule a soft-delete of `tenant_id`. The tenant transitions
     /// to `Deleted` with `deleted_at` stamped to the current wall-clock
@@ -244,7 +242,7 @@ pub trait AccountManagementClient: Send + Sync + 'static {
         &self,
         ctx: &SecurityContext,
         tenant_id: Uuid,
-    ) -> Result<Tenant, AccountManagementError>;
+    ) -> Result<Tenant, CanonicalError>;
 
     // -----------------------------------------------------------------
     // IdpUser CRUD — PEP-gated inside the impl by `UserService::authorize`
@@ -275,7 +273,7 @@ pub trait AccountManagementClient: Send + Sync + 'static {
         ctx: &SecurityContext,
         tenant_id: Uuid,
         payload: IdpNewUser,
-    ) -> Result<IdpUser, AccountManagementError>;
+    ) -> Result<IdpUser, CanonicalError>;
 
     /// Fetch a single user by id from `tenant_id` via the configured
     /// `IdP` plugin. Thin wrapper over [`Self::list_users`] with the
@@ -301,7 +299,7 @@ pub trait AccountManagementClient: Send + Sync + 'static {
         ctx: &SecurityContext,
         tenant_id: Uuid,
         user_id: Uuid,
-    ) -> Result<IdpUser, AccountManagementError>;
+    ) -> Result<IdpUser, CanonicalError>;
 
     /// List users in `tenant_id` via the configured `IdP` plugin.
     /// `$filter = id eq <uuid>` (via [`crate::ListUsersQuery::with_id`])
@@ -327,7 +325,7 @@ pub trait AccountManagementClient: Send + Sync + 'static {
         ctx: &SecurityContext,
         tenant_id: Uuid,
         query: ListUsersQuery,
-    ) -> Result<Page<IdpUser>, AccountManagementError>;
+    ) -> Result<Page<IdpUser>, CanonicalError>;
 
     /// Deprovision a user from `tenant_id` via the configured `IdP`
     /// plugin. AM's deprovision saga additionally cleans up
@@ -349,7 +347,7 @@ pub trait AccountManagementClient: Send + Sync + 'static {
         ctx: &SecurityContext,
         tenant_id: Uuid,
         user_id: Uuid,
-    ) -> Result<(), AccountManagementError>;
+    ) -> Result<(), CanonicalError>;
 
     // -----------------------------------------------------------------
     // Tenant metadata — PEP-gated inside the impl by `MetadataService::authorize`
@@ -377,7 +375,7 @@ pub trait AccountManagementClient: Send + Sync + 'static {
         ctx: &SecurityContext,
         tenant_id: Uuid,
         type_id: GtsTypeId,
-    ) -> Result<MetadataEntry, AccountManagementError>;
+    ) -> Result<MetadataEntry, CanonicalError>;
 
     /// Resolve the **effective** metadata for `tenant_id` at
     /// `type_id`, walking up the ancestor chain per the FEATURE
@@ -405,7 +403,7 @@ pub trait AccountManagementClient: Send + Sync + 'static {
         ctx: &SecurityContext,
         tenant_id: Uuid,
         type_id: GtsTypeId,
-    ) -> Result<Option<MetadataEntry>, AccountManagementError>;
+    ) -> Result<Option<MetadataEntry>, CanonicalError>;
 
     /// List metadata entries attached directly to `tenant_id`,
     /// filtered + paginated via the supplied [`ODataQuery`]. The
@@ -427,7 +425,7 @@ pub trait AccountManagementClient: Send + Sync + 'static {
         ctx: &SecurityContext,
         tenant_id: Uuid,
         query: &ODataQuery,
-    ) -> Result<Page<MetadataEntry>, AccountManagementError>;
+    ) -> Result<Page<MetadataEntry>, CanonicalError>;
 
     /// Upsert the metadata row at `(tenant_id, input.type_id)`.
     /// Returns the post-write [`MetadataEntry`] — REST handlers
@@ -457,7 +455,7 @@ pub trait AccountManagementClient: Send + Sync + 'static {
         ctx: &SecurityContext,
         tenant_id: Uuid,
         input: UpsertMetadataRequest,
-    ) -> Result<MetadataEntry, AccountManagementError>;
+    ) -> Result<MetadataEntry, CanonicalError>;
 
     /// Delete the metadata row attached **directly** to `tenant_id`
     /// for `type_id`. Inherited entries (resolved through an
@@ -483,5 +481,5 @@ pub trait AccountManagementClient: Send + Sync + 'static {
         ctx: &SecurityContext,
         tenant_id: Uuid,
         type_id: GtsTypeId,
-    ) -> Result<(), AccountManagementError>;
+    ) -> Result<(), CanonicalError>;
 }

--- a/gears/system/account-management/account-management-sdk/src/error.rs
+++ b/gears/system/account-management/account-management-sdk/src/error.rs
@@ -1,350 +1,301 @@
-//! Account Management SDK public error type.
+//! Account Management SDK error surface — typed projection of
+//! [`CanonicalError`].
 //!
-//! Variant-per-failure shape: each enum case identifies what went wrong
-//! semantically (mirrors the `mini-chat::DomainError` convention).
-//! SDK consumers pattern-match on variants directly; AIP-193 / HTTP
-//! mapping is performed at the canonical boundary in the impl crate
-//! (`account-management::infra::sdk_error_mapping`).
+//! # Opt-in convenience, not the contract
 //!
-//! # Group-membership helpers
+//! Per [ADR 0005][adr] the [`AccountManagementClient`] trait boundary is
+//! `Result<_, CanonicalError>`. [`AccountManagementError`] is an
+//! **opt-in** typed view over that envelope, shipped for consumers that
+//! want flat dispatch on the categories AM emits. It is *not* part of
+//! the trait contract: adding a variant is non-breaking, and the single
+//! authoritative AIP-193 classification lives in the impl crate's one
+//! `From<DomainError> for CanonicalError` ladder — this projection only
+//! reads the finished `CanonicalError`.
 //!
-//! Per-variant matching is precise but category-level handling (retry
-//! on transient outages, surface as 404 regardless of which resource
-//! was missing) is a recurring need. The `is_*` helpers below collapse
-//! related variants into a single predicate so consumers do not need
-//! to enumerate every variant — adding a new transient variant means
-//! extending `is_unavailable()` in one place, not patching every
-//! call site.
+//! The conversion is infallible (`From<CanonicalError>`). Canonical
+//! categories AM does not emit fall through to [`AccountManagementError::Other`],
+//! which preserves the full [`CanonicalError`] for inspection /
+//! forward-compatible dispatch on the inner variant.
+//!
+//! # What AM emits — consumer dispatch reference
+//!
+//! | Disposition | Match arm | HTTP |
+//! |---|---|---|
+//! | resource missing (tenant / user / conversion / metadata) | [`AccountManagementError::NotFound`] | 404 |
+//! | duplicate-on-create | [`AccountManagementError::AlreadyExists`] | 409 |
+//! | request-shape validation — inspect [`field::ValidationReason`] | [`AccountManagementError::InvalidArgument`] | 400 |
+//! | state precondition — inspect [`precondition::Subject`] | [`AccountManagementError::FailedPrecondition`] | 400 |
+//! | concurrency / version conflict — inspect `reason` ([`reason::aborted`]) | [`AccountManagementError::Aborted`] | 409 |
+//! | cross-tenant denied — inspect `reason` ([`reason::permission`]) | [`AccountManagementError::PermissionDenied`] | 403 |
+//! | `IdP` operation unsupported | [`AccountManagementError::Unimplemented`] | 501 |
+//! | transient outage (infra / `IdP` transport), retry hint | [`AccountManagementError::Unavailable`] | 503 |
+//! | integrity-check single-flight gate held — inspect `subject` ([`quota`]) | [`AccountManagementError::ResourceExhausted`] | 429 |
+//! | internal error | [`AccountManagementError::Internal`] | 500 |
+//! | anything else (forward-compat) | [`AccountManagementError::Other`] | — |
+//!
+//! Resource-scoped variants ([`AccountManagementError::NotFound`] /
+//! [`AccountManagementError::AlreadyExists`]) carry the raw
+//! `resource_type`; match it against the [`gts`] constants
+//! (`gts.cf.core.am.{tenant|user|tenant_metadata|conversion_request}.v1~`).
+//!
+//! # Consumer integration — three patterns
+//!
+//! **Pattern 1 — pure propagation (no projection):**
+//!
+//! ```ignore
+//! let tenant = am_client.get_tenant(&ctx, id).await?; // ? propagates CanonicalError
+//! ```
+//!
+//! **Pattern 2 — explicit projection at the call site:**
+//!
+//! ```ignore
+//! use account_management_sdk::{AccountManagementError, precondition::Subject};
+//!
+//! let res = am_client.delete_tenant(&ctx, id).await
+//!     .map_err(AccountManagementError::from);
+//! match res {
+//!     Err(AccountManagementError::FailedPrecondition { subject: Subject::Tenant, .. }) =>
+//!         /* has children / owns resources — surface a conflict to the user */,
+//!     Err(AccountManagementError::NotFound { .. }) => /* already gone */,
+//!     _ => /* … */,
+//! }
+//! ```
+//!
+//! **Pattern 3 — transparent chaining via `From<CanonicalError> for OwnError`:**
+//!
+//! ```ignore
+//! impl From<CanonicalError> for OwnConsumerError {
+//!     fn from(err: CanonicalError) -> Self {
+//!         AccountManagementError::from(err).into() // route through the typed view
+//!     }
+//! }
+//! // then every call site stays plain `?`.
+//! ```
+//!
+//! Out-of-process consumers reconstruct the canonical error from the
+//! wire via `TryFrom<Problem> for CanonicalError` first, then project:
+//! `Problem JSON → Problem → CanonicalError → AccountManagementError`.
+//!
+//! [`AccountManagementClient`]: crate::AccountManagementClient
+//! [adr]: https://github.com/constructorfabric/gears-rust/blob/main/docs/arch/errors/ADR/0005-cpt-cf-adr-sdk-canonical-projection.md
 
 use thiserror::Error;
+use toolkit_canonical_errors::{CanonicalError, InvalidArgument};
 
-/// AM public error envelope.
-#[derive(Error, Debug, Clone)]
+use crate::field::ValidationReason;
+use crate::precondition::Subject;
+
+/// Typed projection of [`CanonicalError`] for Account Management
+/// consumers.
+///
+/// The impl crate's `From<DomainError> for CanonicalError` is the single
+/// authoritative AIP-193 mapping; this enum is a forward-compatible,
+/// flat view over the ten categories AM emits, plus the mandatory
+/// catch-all [`Self::Other`]. See the [gear docs](self) for the
+/// dispatch table and consumer patterns.
+#[derive(Debug, Clone, Error)]
 #[non_exhaustive]
 pub enum AccountManagementError {
-    // ===================================================================
-    // Tenant CRUD
-    // ===================================================================
-    /// Tenant with `tenant_id` does not exist (or is soft-deleted /
-    /// provisioning — both surface as `NotFound` per AM contract).
-    #[error("tenant {tenant_id} not found: {detail}")]
-    TenantNotFound { tenant_id: String, detail: String },
-
-    /// `IdP` user not found within the requested tenant scope. The
-    /// `tenant_id` carried here is informational (the lookup scope);
-    /// the discriminator for "the missing thing" is `user_id`.
-    #[error("user {user_id} not found: {detail}")]
-    UserNotFound { user_id: String, detail: String },
-
-    /// Conversion request with `request_id` does not exist (or has
-    /// been soft-deleted, or the caller's scope cannot reach it —
-    /// existence-leak protection collapses all three into `NotFound`).
-    #[error("conversion request {request_id} not found: {detail}")]
-    ConversionRequestNotFound { request_id: String, detail: String },
-
-    /// Unique-constraint violation when creating a tenant.
-    #[error("tenant already exists: {detail}")]
-    TenantAlreadyExists { detail: String },
-
-    /// `tenant_type` reference is malformed or unknown.
-    #[error("invalid tenant type: {detail}")]
-    InvalidTenantType { detail: String },
-
-    /// `tenant_type` is registered but not permitted for the requested
-    /// placement (parent / depth / root constraint).
-    #[error("tenant type not allowed for this placement: {detail}")]
-    TenantTypeNotAllowed { detail: String },
-
-    /// Hierarchy depth budget exceeded.
-    #[error("tenant depth exceeded: {detail}")]
-    TenantDepthExceeded { detail: String },
-
-    /// Tenant still has child tenants; cannot be deleted/converted.
-    #[error("tenant has child tenants")]
-    TenantHasChildren,
-
-    /// Tenant still owns active RG memberships; cannot be deleted.
-    #[error("tenant still owns resources")]
-    TenantHasResources,
-
-    /// Root tenant cannot be deleted (delete operation refused).
-    #[error("root tenant cannot be deleted")]
-    RootTenantCannotDelete,
-
-    /// Root tenant cannot be converted (conversion operation refused).
-    #[error("root tenant cannot be converted")]
-    RootTenantCannotConvert,
-
-    /// Root tenant status is immutable — `suspend` / `unsuspend` refused.
-    /// Symmetric with [`Self::RootTenantCannotDelete`]: the platform
-    /// root is a singleton whose lifecycle state must not flip from
-    /// the public API. Downstream gears that branch on
-    /// `root.status` may take unexpected paths (read-only mode,
-    /// refuse provisioning, etc.) without a documented recovery
-    /// runbook.
-    #[error("root tenant status cannot be changed")]
-    RootTenantCannotChangeStatus,
-
-    /// `IdP` plugin rejected the provisioning request shape BEFORE
-    /// making any external call. Permanent client error — the
-    /// `provisioning` row was compensated by the saga; nothing on
-    /// the provider side to undo. Distinct from
-    /// [`Self::InvalidRequest`] so the canonical envelope can carry
-    /// the dotted-path `field` (e.g. `provisioning_metadata.realm_name`)
-    /// the plugin localised the violation to, surfaced as
-    /// `field_violations[0].field` with reason `IDP_INVALID_INPUT`.
-    /// `field` is `None` when the plugin couldn't localise to a
-    /// specific key; the canonical mapping then uses
-    /// `"provisioning_metadata"` as the field key (the surface
-    /// every `IdP` plugin shares).
-    #[error("IdP provider rejected request shape: {detail}")]
-    IdpInvalidInput {
+    /// Resource not found (tenant, user, conversion request, or metadata
+    /// entry). `resource_type` is the canonical GTS type — match it
+    /// against the [`crate::gts`] constants; `name` is the raw
+    /// identifier the caller supplied.
+    #[error("not found [{resource_type}]: {name}")]
+    NotFound {
+        resource_type: String,
+        name: String,
         detail: String,
-        field: Option<String>,
     },
 
-    // ===================================================================
-    // Conversion request
-    // ===================================================================
-    /// Another conversion request for the same tenant is still pending.
-    #[error("a pending conversion request already exists: {request_id}")]
-    PendingConversionExists { request_id: String },
-
-    /// Approver/rejecter side does not match the conversion's target
-    /// transition.
-    #[error(
-        "invalid actor for conversion transition: attempted={attempted_status} caller_side={caller_side}"
-    )]
-    InvalidActorForConversionTransition {
-        attempted_status: String,
-        caller_side: String,
+    /// Duplicate-on-create conflict (tenant slug clash, pending
+    /// conversion already exists).
+    #[error("already exists [{resource_type}]: {name}")]
+    AlreadyExists {
+        resource_type: String,
+        name: String,
+        detail: String,
     },
 
-    /// Conversion request is already in a terminal state (approved or
-    /// rejected); cannot be transitioned again.
-    #[error("conversion request already resolved")]
-    ConversionAlreadyResolved,
-
-    // ===================================================================
-    // Tenant Metadata
-    // ===================================================================
-    /// Metadata entry not found. Surfaces uniformly for both
-    /// "`type_id` is unknown to the types-registry" and "schema is
-    /// registered but no row exists at `(tenant_id, schema_uuid)`" —
-    /// AM intentionally does not distinguish the two on the wire so
-    /// clients see a single `not_found` shape for every metadata
-    /// lookup miss. `entry` carries the chained `type_id` string
-    /// the caller supplied (or, on rare orphan-row paths, the bare
-    /// `schema_uuid`).
-    #[error("metadata entry {entry} not found: {detail}")]
-    MetadataEntryNotFound { entry: String, detail: String },
-
-    /// Optimistic-lock precondition on
-    /// [`crate::UpsertMetadataRequest::expected_version`] did not
-    /// match the stored row's [`crate::MetadataEntry::version`]. The
-    /// caller MUST re-read the entry, decide how to merge with the
-    /// concurrent change, and re-issue the upsert with the updated
-    /// `expected_version`. HTTP 409 (AIP-193 `Aborted`).
-    #[error("metadata version mismatch for {entry}: expected v{expected}, stored v{current}")]
-    MetadataVersionMismatch {
-        entry: String,
-        expected: i64,
-        current: i64,
+    /// Request-shape validation failure. `reason` is the typed
+    /// [`field::ValidationReason`](crate::field::ValidationReason);
+    /// `field` is the attributed request field.
+    #[error("invalid argument [{field}/{reason}]: {detail}")]
+    InvalidArgument {
+        field: String,
+        reason: ValidationReason,
+        detail: String,
     },
 
-    // ===================================================================
-    // Generic validation / precondition (fallbacks)
-    // ===================================================================
-    /// Request shape rejected by validator (no typed variant).
-    #[error("invalid request: {detail}")]
-    InvalidRequest { detail: String },
+    /// State precondition violation. `subject` is the typed
+    /// [`precondition::Subject`](crate::precondition::Subject) consumers
+    /// dispatch on (e.g. `Subject::Tenant` ⇒ has children / owns
+    /// resources); `type_` is the finer wire token.
+    #[error("failed precondition [{subject}/{type_}]: {detail}")]
+    FailedPrecondition {
+        subject: Subject,
+        type_: String,
+        detail: String,
+    },
 
-    /// Metadata-payload validation rejected. Distinct from
-    /// [`Self::InvalidRequest`] so the canonical envelope can route
-    /// to `gts.cf.core.am.tenant_metadata.v1~` instead of the tenant
-    /// default — both still map to AIP-193 `InvalidArgument` (HTTP
-    /// 400). Producers raise this when the metadata payload itself or
-    /// its `type_id` is malformed (chain-shape, null body, GTS body
-    /// validation), keeping [`Self::InvalidRequest`] for tenant-state
-    /// guards.
-    #[error("metadata validation failed: {detail}")]
-    MetadataInvalidRequest { detail: String },
+    /// Concurrency / version conflict (HTTP 409). `reason` is one of the
+    /// [`reason::aborted`](crate::reason::aborted) constants
+    /// (`METADATA_VERSION_MISMATCH`, `SERIALIZATION_CONFLICT`).
+    #[error("aborted [{reason}]: {detail}")]
+    Aborted { reason: String, detail: String },
 
-    /// State precondition violation not covered by a more specific
-    /// variant (tenant deleted, type immutable, etc.).
-    #[error("precondition failed: {detail}")]
-    PreconditionFailed { detail: String },
+    /// Authorization denial (HTTP 403). `reason` is one of the
+    /// [`reason::permission`](crate::reason::permission) constants
+    /// (`CROSS_TENANT_DENIED`).
+    #[error("permission denied [{reason}]: {detail}")]
+    PermissionDenied { reason: String, detail: String },
 
-    /// Deployment-level feature gate refused the operation. Distinct
-    /// from [`Self::UnsupportedOperation`] (`IdP` capability gap) so
-    /// callers can distinguish a configuration switch from a vendor
-    /// gap without string matching.
-    #[error("feature disabled: {detail}")]
-    FeatureDisabled { detail: String },
+    /// The configured `IdP` plugin declared the operation unsupported in
+    /// its current profile (HTTP 501).
+    #[error("unimplemented: {detail}")]
+    Unimplemented { detail: String },
 
-    // ===================================================================
-    // Authorization
-    // ===================================================================
-    /// PEP denied cross-tenant access (or AM-side ancestry walk
-    /// rejected the call). HTTP 403.
-    #[error("cross-tenant access denied")]
-    CrossTenantDenied,
-
-    // ===================================================================
-    // Transactional
-    // ===================================================================
-    /// Storage retry budget exhausted for a serializable transaction.
-    /// Treated as 409 per AIP-193 `Aborted`.
-    #[error("serialization conflict: {detail}")]
-    SerializationConflict { detail: String },
-
-    // ===================================================================
-    // IdP plugin contract
-    // ===================================================================
-    /// `IdP` plugin transport / availability failure. Surfaces as 503;
-    /// distinct from generic [`Self::ServiceUnavailable`] so the
-    /// bootstrap saga retry loop can pattern-match this specifically
-    /// without losing the AIP-193 status mapping.
-    #[error("IdP plugin unavailable")]
-    IdpUnavailable,
-
-    /// `IdP` plugin declared the operation unsupported in its current
-    /// profile. HTTP 501.
-    #[error("operation not supported by IdP provider")]
-    UnsupportedOperation,
-
-    // ===================================================================
-    // Generic infra / fallback
-    // ===================================================================
-    /// Non-IdP transient infrastructure failure (DB transport, PDP
-    /// evaluation, types-registry). HTTP 503 with optional
-    /// `retry_after_seconds` hint.
+    /// Transient infrastructure / `IdP` transport outage (HTTP 503).
+    /// `retry_after_seconds` carries the backoff hint when one is
+    /// available.
     #[error("service unavailable: {detail}")]
-    ServiceUnavailable {
+    Unavailable {
+        retry_after_seconds: Option<u64>,
         detail: String,
-        retry_after_seconds: Option<u32>,
     },
 
-    /// Unclassified internal failure. `detail` MUST be redacted at the
-    /// construction site — the impl crate's classifier produces only
-    /// DSN-free strings.
+    /// A bounded resource is exhausted (HTTP 429) — today only the
+    /// hierarchy-integrity single-flight gate. `subject` is one of the
+    /// [`quota`](crate::quota) constants (`integrity_check`).
+    #[error("resource exhausted [{subject}]: {detail}")]
+    ResourceExhausted { subject: String, detail: String },
+
+    /// Unclassified internal failure (HTTP 500). `detail` is already
+    /// redacted at the canonical boundary — it never carries the
+    /// server-side diagnostic.
     #[error("internal error: {detail}")]
     Internal { detail: String },
+
+    /// Catch-all for canonical categories AM does not model — preserves
+    /// the full [`CanonicalError`] so consumers stay forward-compatible
+    /// if the impl crate ever emits a new category. Reaching `Other`
+    /// indicates a category outside AM's documented emission set.
+    #[error("[{}] {}", canonical.gts_type(), canonical.detail())]
+    Other { canonical: CanonicalError },
 }
 
-impl AccountManagementError {
-    // -------------------------------------------------------------------
-    // Group-membership helpers
-    //
-    // These collapse related variants into a single predicate so
-    // callers do not have to enumerate every variant for
-    // category-level handling (backoff, retry, surface-as-404). Adding
-    // a new variant to one of these categories means extending the
-    // helper here in one place — call sites stay untouched.
-    // -------------------------------------------------------------------
+// ─────────────────────────────────────────────────────────────────────
+// CanonicalError → AccountManagementError projection.
+//
+// The typed sub-enums (`field::ValidationReason`, `precondition::Subject`)
+// live next to their wire-string constants in `crate::field` /
+// `crate::precondition`; the single-valued reasons stay plain consts in
+// `crate::reason` / `crate::quota`. This file owns only the top-level
+// enum and the dispatch from `CanonicalError`.
+// ─────────────────────────────────────────────────────────────────────
 
-    /// `true` for any not-found shape (tenant, user, conversion
-    /// request, metadata entry, metadata schema, …). Use when the
-    /// caller wants to treat any missing resource uniformly (cache
-    /// invalidation, "go back to list").
-    #[must_use]
-    pub fn is_not_found(&self) -> bool {
-        matches!(
-            self,
-            Self::TenantNotFound { .. }
-                | Self::UserNotFound { .. }
-                | Self::ConversionRequestNotFound { .. }
-                | Self::MetadataEntryNotFound { .. }
-        )
-    }
-
-    /// `true` for any transient infrastructure outage where retry is
-    /// the appropriate response. Covers `ServiceUnavailable` (generic
-    /// infra) and `IdpUnavailable` (vendor plugin transport).
-    #[must_use]
-    pub fn is_unavailable(&self) -> bool {
-        matches!(self, Self::ServiceUnavailable { .. } | Self::IdpUnavailable)
-    }
-
-    /// `true` if the operation MAY succeed on a future retry: any
-    /// transient outage plus serializable-retry exhaustion.
-    /// `IntegrityCheckInProgress` is NOT included — caller is expected
-    /// to back off until the in-flight check completes, not retry
-    /// immediately.
-    #[must_use]
-    pub fn is_retryable(&self) -> bool {
-        self.is_unavailable() || matches!(self, Self::SerializationConflict { .. })
-    }
-
-    /// `true` for request-shape rejections (HTTP 400 `InvalidArgument`).
-    #[must_use]
-    pub fn is_validation_error(&self) -> bool {
-        matches!(
-            self,
-            Self::InvalidTenantType { .. }
-                | Self::InvalidRequest { .. }
-                | Self::MetadataInvalidRequest { .. }
-                | Self::RootTenantCannotDelete
-                | Self::RootTenantCannotConvert
-                | Self::RootTenantCannotChangeStatus
-                | Self::IdpInvalidInput { .. }
-        )
-    }
-
-    /// `true` for state-precondition failures (HTTP 400
-    /// `FailedPrecondition` per AIP-193).
-    #[must_use]
-    pub fn is_precondition_failed(&self) -> bool {
-        matches!(
-            self,
-            Self::TenantTypeNotAllowed { .. }
-                | Self::TenantDepthExceeded { .. }
-                | Self::TenantHasChildren
-                | Self::TenantHasResources
-                | Self::InvalidActorForConversionTransition { .. }
-                | Self::ConversionAlreadyResolved
-                | Self::PreconditionFailed { .. }
-                | Self::FeatureDisabled { .. }
-        )
-    }
-
-    /// `true` for duplicate-on-create failures (HTTP 409
-    /// `AlreadyExists` per AIP-193). Distinct from
-    /// [`Self::is_precondition_failed`] because the duplicate-resource
-    /// category carries the existing resource id as part of its
-    /// envelope and is retryable only after the caller resolves the
-    /// existing row.
-    #[must_use]
-    pub fn is_already_exists(&self) -> bool {
-        matches!(
-            self,
-            Self::TenantAlreadyExists { .. } | Self::PendingConversionExists { .. }
-        )
-    }
-
-    /// `true` for authorization denials (HTTP 403).
-    #[must_use]
-    pub fn is_permission_denied(&self) -> bool {
-        matches!(self, Self::CrossTenantDenied)
-    }
-
-    // -------------------------------------------------------------------
-    // Field accessors
-    // -------------------------------------------------------------------
-
-    /// Retry-after hint (seconds) for transient outages that carry
-    /// one. Currently only [`Self::ServiceUnavailable`] populates it;
-    /// other variants return `None`.
-    #[must_use]
-    pub fn retry_after_seconds(&self) -> Option<u32> {
-        match self {
-            Self::ServiceUnavailable {
-                retry_after_seconds,
+impl From<CanonicalError> for AccountManagementError {
+    fn from(err: CanonicalError) -> Self {
+        // Borrow the canonical detail before consuming `err`; the borrow
+        // ends here so each arm below can move its fields out (no clones).
+        let detail = err.detail().to_owned();
+        match err {
+            CanonicalError::NotFound {
+                resource_type,
+                resource_name,
                 ..
-            } => *retry_after_seconds,
-            _ => None,
+            } => Self::NotFound {
+                resource_type: resource_type.unwrap_or_default(),
+                name: resource_name.unwrap_or_default(),
+                detail,
+            },
+
+            CanonicalError::AlreadyExists {
+                resource_type,
+                resource_name,
+                ..
+            } => Self::AlreadyExists {
+                resource_type: resource_type.unwrap_or_default(),
+                name: resource_name.unwrap_or_default(),
+                detail,
+            },
+
+            CanonicalError::InvalidArgument { ctx, .. } => project_invalid_argument(ctx, detail),
+
+            // AM emits exactly one PreconditionViolation per
+            // FailedPrecondition error; the meaningful message lives in
+            // the violation `description`, so surface it as `detail`.
+            CanonicalError::FailedPrecondition { ctx, .. } => {
+                ctx.violations.into_iter().next().map_or_else(
+                    || Self::FailedPrecondition {
+                        subject: Subject::Unknown(String::new()),
+                        type_: String::new(),
+                        detail,
+                    },
+                    |v| Self::FailedPrecondition {
+                        subject: Subject::from_wire(&v.subject),
+                        type_: v.type_,
+                        detail: v.description,
+                    },
+                )
+            }
+
+            CanonicalError::Aborted { ctx, .. } => Self::Aborted {
+                reason: ctx.reason,
+                detail,
+            },
+
+            CanonicalError::PermissionDenied { ctx, .. } => Self::PermissionDenied {
+                reason: ctx.reason,
+                detail,
+            },
+
+            CanonicalError::Unimplemented { .. } => Self::Unimplemented { detail },
+
+            CanonicalError::ServiceUnavailable { ctx, .. } => Self::Unavailable {
+                retry_after_seconds: ctx.retry_after_seconds,
+                detail,
+            },
+
+            CanonicalError::ResourceExhausted { ctx, .. } => Self::ResourceExhausted {
+                subject: ctx
+                    .violations
+                    .into_iter()
+                    .next()
+                    .map(|v| v.subject)
+                    .unwrap_or_default(),
+                detail,
+            },
+
+            CanonicalError::Internal { .. } => Self::Internal { detail },
+
+            other => Self::Other { canonical: other },
         }
     }
+}
+
+fn project_invalid_argument(ctx: InvalidArgument, detail: String) -> AccountManagementError {
+    // AM only ever emits the `FieldViolations` shape with a single
+    // violation; the `Format` / `Constraint` shapes and the empty case
+    // fall back to the canonical detail with an unknown reason.
+    let first_violation = match ctx {
+        InvalidArgument::FieldViolations { field_violations } => {
+            field_violations.into_iter().next()
+        }
+        InvalidArgument::Format { .. } | InvalidArgument::Constraint { .. } => None,
+    };
+
+    first_violation.map_or(
+        AccountManagementError::InvalidArgument {
+            field: String::new(),
+            reason: ValidationReason::Unknown(String::new()),
+            detail,
+        },
+        |v| AccountManagementError::InvalidArgument {
+            field: v.field,
+            reason: ValidationReason::from_wire(&v.reason),
+            detail: v.description,
+        },
+    )
 }
 
 #[cfg(test)]

--- a/gears/system/account-management/account-management-sdk/src/error_tests.rs
+++ b/gears/system/account-management/account-management-sdk/src/error_tests.rs
@@ -1,107 +1,455 @@
-//! Display / accessor / group-helper unit tests for `AccountManagementError`.
+//! Tests for the [`AccountManagementError`] projection.
+//!
+//! Two suites:
+//!
+//! * `wire_vocabulary_round_trip` — pins every wire-string constant the
+//!   projection introduces ([`crate::field`], [`crate::precondition`],
+//!   [`crate::reason`], [`crate::quota`], [`crate::gts`]) to its
+//!   `Problem` JSON path. A drift between an SDK constant and the wire
+//!   trips here.
+//! * `projection_tests` — exercises `From<CanonicalError>`, verifying
+//!   each canonical category lands on the expected typed variant and
+//!   that unmodeled categories preserve the canonical in `Other`.
 
 use super::AccountManagementError;
 
-#[test]
-fn tenant_not_found_is_recognised_as_not_found() {
-    let err = AccountManagementError::TenantNotFound {
-        tenant_id: "abc".to_owned(),
-        detail: "tenant not found: abc".to_owned(),
-    };
-    assert!(err.is_not_found());
-    assert!(!err.is_retryable());
-    assert_eq!(
-        format!("{err}"),
-        "tenant abc not found: tenant not found: abc"
-    );
+// ─────────────────────────────────────────────────────────────────────
+// Wire-vocabulary round-trip
+// ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod wire_vocabulary_round_trip {
+    use crate::{field, gts, precondition, quota, reason};
+    use toolkit_canonical_errors::{CanonicalError, Problem, resource_error};
+
+    // Test scopes mirroring the impl crate's `#[resource_error]` markers.
+    // Their literals MUST equal the `gts::*` constants — the
+    // `gts_resource_types_round_trip` test asserts that equality.
+    #[resource_error("gts.cf.core.am.tenant.v1~")]
+    struct TenantScope;
+
+    #[resource_error("gts.cf.core.am.user.v1~")]
+    struct UserScope;
+
+    #[resource_error("gts.cf.core.am.tenant_metadata.v1~")]
+    struct MetadataScope;
+
+    #[resource_error("gts.cf.core.am.conversion_request.v1~")]
+    struct ConversionScope;
+
+    fn problem(err: CanonicalError) -> serde_json::Value {
+        serde_json::to_value(Problem::from(err)).expect("Problem serializes")
+    }
+
+    #[test]
+    fn gts_resource_types_round_trip_to_context_resource_type() {
+        let cases = [
+            (
+                TenantScope::not_found("x").with_resource("x").create(),
+                gts::TENANT_RESOURCE_TYPE,
+            ),
+            (
+                UserScope::not_found("x").with_resource("x").create(),
+                gts::USER_RESOURCE_TYPE,
+            ),
+            (
+                MetadataScope::not_found("x").with_resource("x").create(),
+                gts::TENANT_METADATA_RESOURCE_TYPE,
+            ),
+            (
+                ConversionScope::not_found("x").with_resource("x").create(),
+                gts::CONVERSION_REQUEST_RESOURCE_TYPE,
+            ),
+        ];
+        for (err, expected) in cases {
+            let json = problem(err);
+            assert_eq!(
+                json["context"]["resource_type"], expected,
+                "resource type {expected} must round-trip into context.resource_type",
+            );
+        }
+    }
+
+    #[test]
+    fn field_reason_constants_round_trip_to_field_violations() {
+        for code in [
+            field::INVALID_TENANT_TYPE,
+            field::VALIDATION,
+            field::ROOT_TENANT_CANNOT_DELETE,
+            field::ROOT_TENANT_CANNOT_CONVERT,
+            field::ROOT_TENANT_CANNOT_CHANGE_STATUS,
+            field::IDP_INVALID_INPUT,
+        ] {
+            let err = TenantScope::invalid_argument()
+                .with_field_violation("test_field", "test description", code)
+                .create();
+            let json = problem(err);
+            assert_eq!(
+                json["context"]["field_violations"][0]["reason"], code,
+                "field reason {code} must round-trip into field_violations[].reason",
+            );
+        }
+    }
+
+    #[test]
+    fn field_name_constants_round_trip_to_field_violations() {
+        for name in [
+            field::TENANT_TYPE_FIELD,
+            field::REQUEST_FIELD,
+            field::METADATA_FIELD,
+            field::TENANT_ID_FIELD,
+            field::PROVISIONING_METADATA_FIELD,
+        ] {
+            let err = TenantScope::invalid_argument()
+                .with_field_violation(name, "test description", field::VALIDATION)
+                .create();
+            let json = problem(err);
+            assert_eq!(
+                json["context"]["field_violations"][0]["field"], name,
+                "field name {name} must round-trip into field_violations[].field",
+            );
+        }
+    }
+
+    #[test]
+    fn precondition_subject_constants_round_trip_to_violations() {
+        for subject in [
+            precondition::TENANT_TYPE_SUBJECT,
+            precondition::DEPTH_SUBJECT,
+            precondition::TENANT_SUBJECT,
+            precondition::REQUEST_SUBJECT,
+            precondition::CONFIGURATION_SUBJECT,
+            precondition::CONVERSION_REQUEST_SUBJECT,
+        ] {
+            let err = TenantScope::failed_precondition()
+                .with_precondition_violation(subject, "test description", "TEST_TYPE")
+                .create();
+            let json = problem(err);
+            assert_eq!(
+                json["context"]["violations"][0]["subject"], subject,
+                "subject {subject} must round-trip into violations[].subject",
+            );
+        }
+    }
+
+    #[test]
+    fn precondition_type_constants_round_trip_to_violations() {
+        for type_ in [
+            precondition::TYPE_NOT_ALLOWED_TYPE,
+            precondition::TENANT_DEPTH_EXCEEDED_TYPE,
+            precondition::TENANT_HAS_CHILDREN_TYPE,
+            precondition::TENANT_HAS_RESOURCES_TYPE,
+            precondition::PRECONDITION_FAILED_TYPE,
+            precondition::FEATURE_DISABLED_TYPE,
+            precondition::INVALID_ACTOR_FOR_TRANSITION_TYPE,
+            precondition::ALREADY_RESOLVED_TYPE,
+        ] {
+            let err = TenantScope::failed_precondition()
+                .with_precondition_violation("test_subject", "test description", type_)
+                .create();
+            let json = problem(err);
+            assert_eq!(
+                json["context"]["violations"][0]["type"], type_,
+                "type {type_} must round-trip into violations[].type",
+            );
+        }
+    }
+
+    #[test]
+    fn aborted_reason_constants_round_trip_to_context_reason() {
+        for r in [
+            reason::aborted::METADATA_VERSION_MISMATCH,
+            reason::aborted::SERIALIZATION_CONFLICT,
+        ] {
+            let err = TenantScope::aborted("conflict").with_reason(r).create();
+            let json = problem(err);
+            assert_eq!(
+                json["context"]["reason"], r,
+                "aborted reason {r} must round-trip into context.reason",
+            );
+        }
+    }
+
+    #[test]
+    fn permission_reason_constant_round_trips_to_context_reason() {
+        let r = reason::permission::CROSS_TENANT_DENIED;
+        let err = TenantScope::permission_denied().with_reason(r).create();
+        let json = problem(err);
+        assert_eq!(json["context"]["reason"], r);
+    }
+
+    #[test]
+    fn quota_subject_constant_round_trips_to_violations() {
+        let err = TenantScope::resource_exhausted("integrity check already in progress")
+            .with_quota_violation(quota::INTEGRITY_CHECK, "another check is in progress")
+            .create();
+        let json = problem(err);
+        assert_eq!(
+            json["context"]["violations"][0]["subject"],
+            quota::INTEGRITY_CHECK,
+        );
+    }
 }
 
-#[test]
-fn metadata_entry_not_found_is_not_found() {
-    // Unified metadata 404: both "schema unknown to registry" and
-    // "entry missing for tenant" surface as `MetadataEntryNotFound`
-    // — `entry` carries the chained `type_id` (or, on orphan
-    // paths, the bare `schema_uuid`).
-    let err = AccountManagementError::MetadataEntryNotFound {
-        entry: "gts.cf.core.am.tenant_metadata.v1~cf.core.billing.usage.v1~".to_owned(),
-        detail: "entry missing".to_owned(),
-    };
-    assert!(err.is_not_found());
-}
+// ─────────────────────────────────────────────────────────────────────
+// Projection: From<CanonicalError> for AccountManagementError
+// ─────────────────────────────────────────────────────────────────────
 
-#[test]
-fn invalid_tenant_type_is_validation() {
-    let err = AccountManagementError::InvalidTenantType {
-        detail: "bad type".to_owned(),
-    };
-    assert!(err.is_validation_error());
-    assert!(!err.is_precondition_failed());
-}
+#[cfg(test)]
+mod projection_tests {
+    use super::AccountManagementError;
+    use crate::field::ValidationReason;
+    use crate::precondition::Subject;
+    use crate::{field, gts, precondition, quota, reason};
+    use toolkit_canonical_errors::{CanonicalError, Problem, resource_error};
 
-#[test]
-fn tenant_has_children_is_precondition() {
-    let err = AccountManagementError::TenantHasChildren;
-    assert!(err.is_precondition_failed());
-    assert!(!err.is_validation_error());
-}
+    #[resource_error("gts.cf.core.am.tenant.v1~")]
+    struct TenantScope;
 
-#[test]
-fn cross_tenant_denied_is_permission_denied() {
-    let err = AccountManagementError::CrossTenantDenied;
-    assert!(err.is_permission_denied());
-}
+    #[resource_error("gts.cf.core.am.tenant_metadata.v1~")]
+    struct MetadataScope;
 
-#[test]
-fn service_unavailable_carries_retry_hint_and_is_retryable() {
-    let err = AccountManagementError::ServiceUnavailable {
-        detail: "idp transport failed".to_owned(),
-        retry_after_seconds: Some(30),
-    };
-    assert_eq!(err.retry_after_seconds(), Some(30));
-    assert!(err.is_unavailable());
-    assert!(err.is_retryable());
-}
+    #[test]
+    fn not_found_projects_resource_type_and_name() {
+        let canonical = TenantScope::not_found("tenant 7 not found")
+            .with_resource("7")
+            .create();
+        match AccountManagementError::from(canonical) {
+            AccountManagementError::NotFound {
+                resource_type,
+                name,
+                ..
+            } => {
+                assert_eq!(resource_type, gts::TENANT_RESOURCE_TYPE);
+                assert_eq!(name, "7");
+            }
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
 
-#[test]
-fn idp_unavailable_is_unavailable_and_retryable() {
-    let err = AccountManagementError::IdpUnavailable;
-    assert!(err.is_unavailable());
-    assert!(err.is_retryable());
-    // No retry hint surface on this variant — group-helper is the seam.
-    assert!(err.retry_after_seconds().is_none());
-}
+    #[test]
+    fn already_exists_projects_resource_type_and_name() {
+        let canonical = TenantScope::already_exists("tenant exists")
+            .with_resource("tenant")
+            .create();
+        match AccountManagementError::from(canonical) {
+            AccountManagementError::AlreadyExists {
+                resource_type,
+                name,
+                ..
+            } => {
+                assert_eq!(resource_type, gts::TENANT_RESOURCE_TYPE);
+                assert_eq!(name, "tenant");
+            }
+            other => panic!("expected AlreadyExists, got {other:?}"),
+        }
+    }
 
-#[test]
-fn unsupported_operation_is_not_retryable() {
-    let err = AccountManagementError::UnsupportedOperation;
-    assert!(!err.is_unavailable());
-    assert!(!err.is_retryable());
-}
+    #[test]
+    fn invalid_argument_projects_typed_reason() {
+        let cases = [
+            (
+                field::INVALID_TENANT_TYPE,
+                ValidationReason::InvalidTenantType,
+            ),
+            (field::VALIDATION, ValidationReason::Validation),
+            (
+                field::ROOT_TENANT_CANNOT_DELETE,
+                ValidationReason::RootTenantCannotDelete,
+            ),
+            (field::IDP_INVALID_INPUT, ValidationReason::IdpInvalidInput),
+        ];
+        for (wire, expected) in cases {
+            let canonical = TenantScope::invalid_argument()
+                .with_field_violation(field::TENANT_TYPE_FIELD, "bad", wire)
+                .create();
+            match AccountManagementError::from(canonical) {
+                AccountManagementError::InvalidArgument {
+                    field,
+                    reason,
+                    detail,
+                } => {
+                    assert_eq!(field, field::TENANT_TYPE_FIELD);
+                    assert_eq!(reason, expected);
+                    assert_eq!(detail, "bad");
+                }
+                other => panic!("expected InvalidArgument for {wire}, got {other:?}"),
+            }
+        }
+    }
 
-#[test]
-fn serialization_conflict_is_retryable_but_not_unavailable() {
-    let err = AccountManagementError::SerializationConflict {
-        detail: "retry budget exhausted".to_owned(),
-    };
-    assert!(err.is_retryable());
-    // Distinct shape from transient outages.
-    assert!(!err.is_unavailable());
-}
+    #[test]
+    fn invalid_argument_unknown_reason_preserved() {
+        let canonical = TenantScope::invalid_argument()
+            .with_field_violation("f", "d", "FUTURE_CODE")
+            .create();
+        match AccountManagementError::from(canonical) {
+            AccountManagementError::InvalidArgument { reason, .. } => {
+                assert_eq!(reason, ValidationReason::Unknown("FUTURE_CODE".to_owned()));
+            }
+            other => panic!("expected InvalidArgument::Unknown, got {other:?}"),
+        }
+    }
 
-#[test]
-fn tenant_already_exists_is_not_retryable() {
-    let err = AccountManagementError::TenantAlreadyExists {
-        detail: "tenant slug already exists".to_owned(),
-    };
-    assert!(!err.is_retryable());
-}
+    #[test]
+    fn invalid_argument_format_variant_projects_empty_field() {
+        let canonical = TenantScope::invalid_argument()
+            .with_format("alias must be 1-63 chars")
+            .create();
+        match AccountManagementError::from(canonical) {
+            AccountManagementError::InvalidArgument { field, reason, .. } => {
+                assert!(field.is_empty());
+                assert_eq!(reason, ValidationReason::Unknown(String::new()));
+            }
+            other => panic!("expected InvalidArgument, got {other:?}"),
+        }
+    }
 
-#[test]
-fn internal_does_not_leak_diagnostic_through_display() {
-    let err = AccountManagementError::Internal {
-        detail: "internal error".to_owned(),
-    };
-    // Public Display MUST NOT leak the diagnostic — verified at Display level
-    // because the impl crate populates `detail` with a redacted summary.
-    assert_eq!(format!("{err}"), "internal error: internal error");
+    #[test]
+    fn failed_precondition_projects_typed_subject() {
+        let cases = [
+            (precondition::TENANT_TYPE_SUBJECT, Subject::TenantType),
+            (precondition::DEPTH_SUBJECT, Subject::Depth),
+            (precondition::TENANT_SUBJECT, Subject::Tenant),
+            (
+                precondition::CONVERSION_REQUEST_SUBJECT,
+                Subject::ConversionRequest,
+            ),
+        ];
+        for (wire, expected) in cases {
+            let canonical = TenantScope::failed_precondition()
+                .with_precondition_violation(
+                    wire,
+                    "guard message",
+                    precondition::TENANT_HAS_CHILDREN_TYPE,
+                )
+                .create();
+            match AccountManagementError::from(canonical) {
+                AccountManagementError::FailedPrecondition {
+                    subject,
+                    type_,
+                    detail,
+                } => {
+                    assert_eq!(subject, expected);
+                    assert_eq!(type_, precondition::TENANT_HAS_CHILDREN_TYPE);
+                    assert_eq!(detail, "guard message");
+                }
+                other => panic!("expected FailedPrecondition for {wire}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn aborted_projects_reason() {
+        let canonical = MetadataScope::aborted("version mismatch")
+            .with_reason(reason::aborted::METADATA_VERSION_MISMATCH)
+            .create();
+        match AccountManagementError::from(canonical) {
+            AccountManagementError::Aborted { reason, detail } => {
+                assert_eq!(reason, reason::aborted::METADATA_VERSION_MISMATCH);
+                assert_eq!(detail, "version mismatch");
+            }
+            other => panic!("expected Aborted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn permission_denied_projects_reason() {
+        let canonical = TenantScope::permission_denied()
+            .with_reason(reason::permission::CROSS_TENANT_DENIED)
+            .create();
+        match AccountManagementError::from(canonical) {
+            AccountManagementError::PermissionDenied { reason, .. } => {
+                assert_eq!(reason, reason::permission::CROSS_TENANT_DENIED);
+            }
+            other => panic!("expected PermissionDenied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unimplemented_projects() {
+        let canonical = TenantScope::unimplemented("not supported").create();
+        assert!(matches!(
+            AccountManagementError::from(canonical),
+            AccountManagementError::Unimplemented { .. }
+        ));
+    }
+
+    #[test]
+    fn service_unavailable_projects_with_retry_after() {
+        let canonical = CanonicalError::service_unavailable()
+            .with_retry_after_seconds(30)
+            .create();
+        match AccountManagementError::from(canonical) {
+            AccountManagementError::Unavailable {
+                retry_after_seconds: Some(30),
+                ..
+            } => {}
+            other => panic!("expected Unavailable with retry=30, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resource_exhausted_projects_subject() {
+        let canonical = TenantScope::resource_exhausted("integrity check in progress")
+            .with_quota_violation(quota::INTEGRITY_CHECK, "another check is in progress")
+            .create();
+        match AccountManagementError::from(canonical) {
+            AccountManagementError::ResourceExhausted { subject, .. } => {
+                assert_eq!(subject, quota::INTEGRITY_CHECK);
+            }
+            other => panic!("expected ResourceExhausted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn internal_projects() {
+        let canonical = CanonicalError::internal("boom").create();
+        assert!(matches!(
+            AccountManagementError::from(canonical),
+            AccountManagementError::Internal { .. }
+        ));
+    }
+
+    #[test]
+    fn unmodeled_category_falls_through_to_other() {
+        // AM never emits Unauthenticated; it must land in Other with the
+        // canonical preserved for inspection.
+        let canonical = CanonicalError::unauthenticated()
+            .with_reason("SOME_REASON")
+            .create();
+        match AccountManagementError::from(canonical) {
+            AccountManagementError::Other {
+                canonical: CanonicalError::Unauthenticated { .. },
+            } => {}
+            other => panic!("expected Other::Unauthenticated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn projection_survives_full_problem_round_trip() {
+        // Out-of-process chain: canonical → Problem JSON → Problem →
+        // CanonicalError → AccountManagementError. Pins that an HTTP
+        // consumer projecting from the wire gets the same typed variant
+        // as an in-process ClientHub caller.
+        let canonical = TenantScope::failed_precondition()
+            .with_precondition_violation(
+                precondition::TENANT_SUBJECT,
+                "tenant has child tenants",
+                precondition::TENANT_HAS_CHILDREN_TYPE,
+            )
+            .create();
+
+        let bytes = serde_json::to_vec(&Problem::from(canonical)).expect("serialize");
+        let restored: Problem = serde_json::from_slice(&bytes).expect("deserialize");
+        let restored_canonical = CanonicalError::try_from(restored).expect("reconstruct");
+
+        match AccountManagementError::from(restored_canonical) {
+            AccountManagementError::FailedPrecondition { subject, type_, .. } => {
+                assert_eq!(subject, Subject::Tenant);
+                assert_eq!(type_, precondition::TENANT_HAS_CHILDREN_TYPE);
+            }
+            other => panic!("expected FailedPrecondition after round-trip, got {other:?}"),
+        }
+    }
 }

--- a/gears/system/account-management/account-management-sdk/src/field.rs
+++ b/gears/system/account-management/account-management-sdk/src/field.rs
@@ -1,0 +1,181 @@
+//! Wire `field` / `reason` vocabulary for field violations under
+//! [`CanonicalError::InvalidArgument`].
+//!
+//! Each `reason` constant is a stable machine-readable code that lands
+//! in `CanonicalError::InvalidArgument.ctx.field_violations[].reason`
+//! when Account Management rejects a request field; each `*_FIELD`
+//! constant is the corresponding `field_violations[].field` attribution.
+//!
+//! Consumers dispatch on these to disposition validation errors without
+//! string-typing literals. The impl crate's single
+//! `From<DomainError> for CanonicalError` ladder references the same
+//! constants at construction time so the SDK vocabulary and the wire can
+//! never drift — the round-trip tests in [`crate::error`] pin every
+//! constant to its `Problem` JSON path.
+//!
+//! [`CanonicalError::InvalidArgument`]: toolkit_canonical_errors::CanonicalError::InvalidArgument
+
+use core::fmt;
+
+// ---------------------------------------------------------------------------
+// `field_violations[].reason` codes (the dispatch discriminator).
+// ---------------------------------------------------------------------------
+
+/// `tenant_type` reference is malformed or unknown.
+pub const INVALID_TENANT_TYPE: &str = "INVALID_TENANT_TYPE";
+
+/// Generic request-shape validation failure (tenant-state guards,
+/// metadata-payload rejects). The catch-all reason when no more
+/// specific code applies.
+pub const VALIDATION: &str = "VALIDATION";
+
+/// Delete refused: the platform root tenant cannot be deleted.
+pub const ROOT_TENANT_CANNOT_DELETE: &str = "ROOT_TENANT_CANNOT_DELETE";
+
+/// Conversion refused: the platform root tenant cannot be converted.
+pub const ROOT_TENANT_CANNOT_CONVERT: &str = "ROOT_TENANT_CANNOT_CONVERT";
+
+/// Suspend / unsuspend refused: the platform root tenant's lifecycle
+/// status is immutable from the public API.
+pub const ROOT_TENANT_CANNOT_CHANGE_STATUS: &str = "ROOT_TENANT_CANNOT_CHANGE_STATUS";
+
+/// The configured `IdP` plugin rejected the provisioning request shape
+/// before any external call. The accompanying `field` carries the
+/// dotted-path the plugin localised the violation to (e.g.
+/// `provisioning_metadata.realm_name`) — see [`PROVISIONING_METADATA_FIELD`].
+pub const IDP_INVALID_INPUT: &str = "IDP_INVALID_INPUT";
+
+// ---------------------------------------------------------------------------
+// `field_violations[].field` attribution keys.
+//
+// Not a dispatch discriminator — these identify *which* request field
+// failed. Extracted to consts (ADR 0005 Rule 6) so the impl ladder and
+// the SDK vocabulary cannot drift; pinned by the round-trip tests.
+// ---------------------------------------------------------------------------
+
+/// `tenant_type` reference field (carries [`INVALID_TENANT_TYPE`]).
+pub const TENANT_TYPE_FIELD: &str = "tenant_type";
+
+/// Whole-request field for generic tenant-state validation rejects
+/// (carries [`VALIDATION`]).
+pub const REQUEST_FIELD: &str = "request";
+
+/// Metadata-payload field for metadata-content validation rejects
+/// (carries [`VALIDATION`], routed to the metadata resource type).
+pub const METADATA_FIELD: &str = "metadata";
+
+/// `tenant_id` field for the root-tenant protection rejects
+/// ([`ROOT_TENANT_CANNOT_DELETE`] / [`ROOT_TENANT_CANNOT_CONVERT`] /
+/// [`ROOT_TENANT_CANNOT_CHANGE_STATUS`]).
+pub const TENANT_ID_FIELD: &str = "tenant_id";
+
+/// Shared fallback field for [`IDP_INVALID_INPUT`] when the `IdP`
+/// plugin cannot localise the violation to a specific sub-key — the
+/// public surface every `IdP` plugin shares.
+pub const PROVISIONING_METADATA_FIELD: &str = "provisioning_metadata";
+
+// ---------------------------------------------------------------------------
+// Typed view of the `field_violations[].reason` codes.
+// ---------------------------------------------------------------------------
+
+/// Typed view of the AM `InvalidArgument` field-violation `reason`
+/// strings declared above.
+///
+/// Carried by [`crate::AccountManagementError::InvalidArgument::reason`].
+/// `from_wire` returns `Self` (not `Option`) with an [`Self::Unknown`]
+/// catch-all because every `reason` AM emits under `InvalidArgument` is
+/// one of the modeled codes — the catch-all only fires for a future code
+/// added after this SDK version, keeping the projection forward-compatible.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidationReason {
+    /// See [`INVALID_TENANT_TYPE`].
+    InvalidTenantType,
+    /// See [`VALIDATION`].
+    Validation,
+    /// See [`ROOT_TENANT_CANNOT_DELETE`].
+    RootTenantCannotDelete,
+    /// See [`ROOT_TENANT_CANNOT_CONVERT`].
+    RootTenantCannotConvert,
+    /// See [`ROOT_TENANT_CANNOT_CHANGE_STATUS`].
+    RootTenantCannotChangeStatus,
+    /// See [`IDP_INVALID_INPUT`].
+    IdpInvalidInput,
+    /// Unmodeled / future reason — preserves the raw wire string.
+    Unknown(String),
+}
+
+impl ValidationReason {
+    /// Project a wire `field_violations[].reason` string into the typed
+    /// discriminator. Any unmodeled value is preserved in
+    /// [`Self::Unknown`].
+    #[must_use]
+    pub fn from_wire(s: &str) -> Self {
+        match s {
+            INVALID_TENANT_TYPE => Self::InvalidTenantType,
+            VALIDATION => Self::Validation,
+            ROOT_TENANT_CANNOT_DELETE => Self::RootTenantCannotDelete,
+            ROOT_TENANT_CANNOT_CONVERT => Self::RootTenantCannotConvert,
+            ROOT_TENANT_CANNOT_CHANGE_STATUS => Self::RootTenantCannotChangeStatus,
+            IDP_INVALID_INPUT => Self::IdpInvalidInput,
+            other => Self::Unknown(other.to_owned()),
+        }
+    }
+
+    /// Render the discriminator back to its wire `reason` string.
+    /// Inverse of [`Self::from_wire`] for the modeled variants.
+    #[must_use]
+    pub fn as_wire(&self) -> &str {
+        match self {
+            Self::InvalidTenantType => INVALID_TENANT_TYPE,
+            Self::Validation => VALIDATION,
+            Self::RootTenantCannotDelete => ROOT_TENANT_CANNOT_DELETE,
+            Self::RootTenantCannotConvert => ROOT_TENANT_CANNOT_CONVERT,
+            Self::RootTenantCannotChangeStatus => ROOT_TENANT_CANNOT_CHANGE_STATUS,
+            Self::IdpInvalidInput => IDP_INVALID_INPUT,
+            Self::Unknown(s) => s.as_str(),
+        }
+    }
+}
+
+impl fmt::Display for ValidationReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_wire())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validation_reason_round_trips_each_constant() {
+        for (wire, expected) in [
+            (INVALID_TENANT_TYPE, ValidationReason::InvalidTenantType),
+            (VALIDATION, ValidationReason::Validation),
+            (
+                ROOT_TENANT_CANNOT_DELETE,
+                ValidationReason::RootTenantCannotDelete,
+            ),
+            (
+                ROOT_TENANT_CANNOT_CONVERT,
+                ValidationReason::RootTenantCannotConvert,
+            ),
+            (
+                ROOT_TENANT_CANNOT_CHANGE_STATUS,
+                ValidationReason::RootTenantCannotChangeStatus,
+            ),
+            (IDP_INVALID_INPUT, ValidationReason::IdpInvalidInput),
+        ] {
+            assert_eq!(ValidationReason::from_wire(wire), expected);
+            assert_eq!(expected.as_wire(), wire);
+        }
+    }
+
+    #[test]
+    fn validation_reason_preserves_unknown_wire_string() {
+        let raw = "FUTURE_VALIDATION_CODE";
+        let r = ValidationReason::from_wire(raw);
+        assert_eq!(r, ValidationReason::Unknown(raw.to_owned()));
+        assert_eq!(r.as_wire(), raw);
+    }
+}

--- a/gears/system/account-management/account-management-sdk/src/idp.rs
+++ b/gears/system/account-management/account-management-sdk/src/idp.rs
@@ -236,10 +236,11 @@ pub enum IdpProvisionFailure {
     ///
     /// `field` carries the dotted-path reference (e.g.
     /// `"provisioning_metadata.realm_name"`) describing where in the
-    /// request body the violation lives. The AM-side boundary lifts
-    /// this into `AccountManagementError::IdpInvalidInput { field }`
-    /// and the canonical envelope surfaces it as
-    /// `field_violations[0].field` with `reason = "IDP_INVALID_INPUT"`.
+    /// request body the violation lives. The AM-side boundary maps
+    /// this to `CanonicalError::InvalidArgument` and the canonical
+    /// envelope surfaces it as `field_violations[0].field` with
+    /// `reason = "IDP_INVALID_INPUT"` (the SDK projection's
+    /// `AccountManagementError::InvalidArgument`).
     /// `None` means the plugin couldn't localise the violation to a
     /// specific key — the canonical mapping then falls back to the
     /// shared `"provisioning_metadata"` field key.

--- a/gears/system/account-management/account-management-sdk/src/lib.rs
+++ b/gears/system/account-management/account-management-sdk/src/lib.rs
@@ -1,14 +1,15 @@
 //! Account Management SDK — public contract surface.
 //!
 //! This crate publishes the inter-gear client trait
-//! ([`AccountManagementClient`]) and its data types. The public error
-//! envelope is [`AccountManagementError`] — a flat enum mirroring the
-//! AIP-193 categories AM raises; this SDK does **not** depend on
-//! `toolkit-canonical-errors`. The impl crate
-//! (`cf-gears-account-management`) owns the mapping between AM's
-//! internal `DomainError` vocabulary and [`AccountManagementError`]
-//! at this boundary, and the further lift to
-//! `toolkit_canonical_errors::CanonicalError` at the REST boundary.
+//! ([`AccountManagementClient`]) and its data types. Per
+//! [ADR 0005][adr] the trait boundary is
+//! [`toolkit_canonical_errors::CanonicalError`]; the SDK additionally
+//! ships [`AccountManagementError`] as an **opt-in** typed projection
+//! (`From<CanonicalError>`) for consumers that want flat dispatch on
+//! AM's emission set. The single authoritative AIP-193 ladder
+//! (`From<DomainError> for CanonicalError`) lives in the impl crate
+//! (`cf-gears-account-management`); this SDK never re-derives that
+//! classification — it only projects the finished `CanonicalError`.
 //!
 //! External consumers — plugin authors, dashboards, integration tests,
 //! sibling gears calling AM via `ClientHub` — depend on **this**
@@ -16,44 +17,34 @@
 //! migrations, axum wiring, tokio runtime) does not propagate as a
 //! contract break.
 //!
-//! # Mapping summary (AIP-193)
+//! # Error surface
 //!
-//! Every AM domain failure surfaces in one of the
-//! [`AccountManagementError`] variants below; the HTTP status column
-//! is the AIP-193 mapping the REST handler applies through the
-//! impl-side `account_management_error_to_canonical` lift.
+//! Trait methods return `Result<_, CanonicalError>`. Consumers may
+//! propagate the canonical error, or project it into the typed
+//! [`AccountManagementError`] view via
+//! `.map_err(AccountManagementError::from)` (or a
+//! `From<CanonicalError> for OwnError` chain). The projection models
+//! the ten canonical categories AM emits, plus a catch-all
+//! `Other { canonical }`; see [`error`] for the full dispatch table,
+//! the three consumer integration patterns, and the co-located wire
+//! vocabulary ([`field`], [`precondition`], [`reason`], [`quota`],
+//! [`gts`]).
 //!
-//! | Variant | AIP-193 category | HTTP |
-//! |---------|-----------------|------|
-//! | `Validation` | `InvalidArgument` | 400 |
-//! | `NotFound` | `NotFound` | 404 |
-//! | `AlreadyExists` | `AlreadyExists` | 409 |
-//! | `FailedPrecondition` | `FailedPrecondition` | 400 |
-//! | `Aborted` | `Aborted` | 409 |
-//! | `CrossTenantDenied` | `PermissionDenied` | 403 |
-//! | `IntegrityCheckInProgress` | `ResourceExhausted` | 429 |
-//! | `UnsupportedOperation` | `Unimplemented` | 501 |
-//! | `ServiceUnavailable` | `ServiceUnavailable` | 503 |
-//! | `Internal` | `Internal` | 500 |
-//!
-//! `ServiceUnavailable` carries `retry_after_seconds`; `Aborted`
-//! carries `reason = "SERIALIZATION_CONFLICT"` for retry-exhausted
-//! serializable conflicts; resource-scoped variants (`NotFound`,
-//! `FailedPrecondition`) carry the GTS resource type from [`gts`] —
-//! e.g. `gts.cf.core.am.{tenant|tenant_metadata|conversion_request}.v1~`.
-//! Those strings live in [`gts`] as `pub const` so consumers can
-//! match on them by typed reference instead of stringly-typed
-//! comparison.
+//! [adr]: https://github.com/constructorfabric/gears-rust/blob/main/docs/arch/errors/ADR/0005-cpt-cf-adr-sdk-canonical-projection.md
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
 
 pub mod client;
 pub mod error;
+pub mod field;
 pub mod gts;
 pub mod idp;
 pub mod idp_user;
 pub mod metadata;
+pub mod precondition;
+pub mod quota;
+pub mod reason;
 pub mod tenant;
 
 pub use client::AccountManagementClient;

--- a/gears/system/account-management/account-management-sdk/src/metadata.rs
+++ b/gears/system/account-management/account-management-sdk/src/metadata.rs
@@ -4,7 +4,7 @@
 //! [`crate::AccountManagementClient`] trait boundary; validation of
 //! the chained `type_id` string (root-segment check, schema-shape
 //! check, GTS-syntax validation) lives **inside** the AM impl crate
-//! and surfaces as [`AccountManagementError::InvalidRequest`](crate::AccountManagementError::InvalidRequest) at the boundary.
+//! and surfaces as [`AccountManagementError::InvalidArgument`](crate::AccountManagementError::InvalidArgument) at the boundary.
 //! The SDK does not expose a wrapper newtype, the deterministic
 //! `UUIDv5` derivation, or the per-schema validation error vocabulary —
 //! those are AM internal concerns hidden behind the trait surface.
@@ -111,14 +111,14 @@ impl MetadataEntry {
 /// The SDK side does **no** validation: `type_id` chain-shape is
 /// checked by AM impl on entry, and `value` non-null + GTS-schema
 /// validation runs there too. Failures surface as
-/// [`AccountManagementError::InvalidRequest`](crate::AccountManagementError::InvalidRequest).
+/// [`AccountManagementError::InvalidArgument`](crate::AccountManagementError::InvalidArgument).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct UpsertMetadataRequest {
     /// Chained `gts.cf.core.am.tenant_metadata.v1~vendor.app.foo.v1~`
     /// id. Typed via [`GtsTypeId`] (platform-standard marker); the
     /// chain-shape / namespace-root validation runs server-side and
-    /// surfaces as [`AccountManagementError::InvalidRequest`](crate::AccountManagementError::InvalidRequest) on failure. The
+    /// surfaces as [`AccountManagementError::InvalidArgument`](crate::AccountManagementError::InvalidArgument) on failure. The
     /// JSON wire shape stays a plain string.
     pub type_id: GtsTypeId,
     /// Payload to upsert. Must be non-null and conform to the
@@ -127,9 +127,9 @@ pub struct UpsertMetadataRequest {
     /// Optimistic-lock precondition. **Opt-in** — `None` retains the
     /// last-write-wins behaviour; `Some(v)` requires the
     /// stored row's [`MetadataEntry::version`] to equal `v`, and
-    /// surfaces [`AccountManagementError::MetadataVersionMismatch`](crate::AccountManagementError::MetadataVersionMismatch)
-    /// (HTTP 409) when the stored version drifted between the
-    /// caller's read and write.
+    /// surfaces [`AccountManagementError::Aborted`](crate::AccountManagementError::Aborted)
+    /// (HTTP 409, `reason = "METADATA_VERSION_MISMATCH"`) when the
+    /// stored version drifted between the caller's read and write.
     ///
     /// Convention for a new entry: the row doesn't exist yet, so the
     /// "current version" is conceptually `0` — passing
@@ -156,7 +156,8 @@ impl UpsertMetadataRequest {
     /// Builder: attach an optimistic-lock precondition. The write
     /// succeeds only if the stored row's `version` equals `v`; a
     /// drift surfaces as
-    /// [`AccountManagementError::MetadataVersionMismatch`](crate::AccountManagementError::MetadataVersionMismatch).
+    /// [`AccountManagementError::Aborted`](crate::AccountManagementError::Aborted)
+    /// (`reason = "METADATA_VERSION_MISMATCH"`).
     #[must_use]
     pub const fn with_expected_version(mut self, v: i64) -> Self {
         self.expected_version = Some(v);

--- a/gears/system/account-management/account-management-sdk/src/metadata_tests.rs
+++ b/gears/system/account-management/account-management-sdk/src/metadata_tests.rs
@@ -104,7 +104,7 @@ fn upsert_metadata_request_rejects_missing_value() {
 
 /// Sanity: a non-null `value` is accepted at the SDK boundary. The
 /// AM impl-side validation rejects `Value::Null` and surfaces it as
-/// `AccountManagementError::InvalidRequest` — the SDK type itself is
+/// `AccountManagementError::InvalidArgument` — the SDK type itself is
 /// content-agnostic.
 #[test]
 fn upsert_metadata_request_accepts_any_non_missing_value() {

--- a/gears/system/account-management/account-management-sdk/src/precondition.rs
+++ b/gears/system/account-management/account-management-sdk/src/precondition.rs
@@ -1,0 +1,170 @@
+//! Wire `subject` / `type` vocabulary for precondition violations under
+//! [`CanonicalError::FailedPrecondition`].
+//!
+//! Each `*_SUBJECT` constant is the stable `subject` discriminator that
+//! lands in `CanonicalError::FailedPrecondition.ctx.violations[].subject`
+//! — the field consumers dispatch on. Each `*_TYPE` constant is the
+//! accompanying `violations[].type` token.
+//!
+//! AM emits several distinct precondition families that all share the
+//! `FailedPrecondition` category; the **subject** is the discriminator
+//! (`tenant`, `depth`, `conversion_request`, …), mirroring the
+//! `resource-group-sdk` `precondition::Subject` convention. The impl
+//! crate's single `From<DomainError> for CanonicalError` ladder
+//! references these constants; the round-trip tests in [`crate::error`]
+//! pin each to its `Problem` JSON path.
+//!
+//! [`CanonicalError::FailedPrecondition`]: toolkit_canonical_errors::CanonicalError::FailedPrecondition
+
+use core::fmt;
+
+// ---------------------------------------------------------------------------
+// `violations[].subject` discriminators.
+// ---------------------------------------------------------------------------
+
+/// Tenant-type placement rejected for the requested parent / depth.
+pub const TENANT_TYPE_SUBJECT: &str = "tenant_type";
+
+/// Hierarchy depth budget exceeded.
+pub const DEPTH_SUBJECT: &str = "depth";
+
+/// Tenant-lifecycle guard (still has children / still owns resources).
+pub const TENANT_SUBJECT: &str = "tenant";
+
+/// Generic request-state guard (tenant deleted, type immutable, …).
+pub const REQUEST_SUBJECT: &str = "request";
+
+/// Deployment-level feature-gate guard.
+pub const CONFIGURATION_SUBJECT: &str = "configuration";
+
+/// Conversion-request lifecycle guard (invalid actor / already resolved).
+pub const CONVERSION_REQUEST_SUBJECT: &str = "conversion_request";
+
+// ---------------------------------------------------------------------------
+// `violations[].type` tokens.
+//
+// Not the dispatch discriminator (that is the subject) but a finer code
+// per emission site. Extracted to consts (ADR 0005 Rule 6) so the impl
+// ladder and SDK vocabulary cannot drift; pinned by the round-trip tests.
+// ---------------------------------------------------------------------------
+
+/// `tenant_type` subject — type not allowed for placement.
+pub const TYPE_NOT_ALLOWED_TYPE: &str = "TYPE_NOT_ALLOWED";
+
+/// `depth` subject — hierarchy depth exceeded.
+pub const TENANT_DEPTH_EXCEEDED_TYPE: &str = "TENANT_DEPTH_EXCEEDED";
+
+/// `tenant` subject — tenant still has child tenants.
+pub const TENANT_HAS_CHILDREN_TYPE: &str = "TENANT_HAS_CHILDREN";
+
+/// `tenant` subject — tenant still owns active resource references.
+pub const TENANT_HAS_RESOURCES_TYPE: &str = "TENANT_HAS_RESOURCES";
+
+/// `request` subject — generic precondition failure.
+pub const PRECONDITION_FAILED_TYPE: &str = "PRECONDITION_FAILED";
+
+/// `configuration` subject — feature gate disabled.
+pub const FEATURE_DISABLED_TYPE: &str = "FEATURE_DISABLED";
+
+/// `conversion_request` subject — approver/rejecter side mismatch.
+pub const INVALID_ACTOR_FOR_TRANSITION_TYPE: &str = "INVALID_ACTOR_FOR_TRANSITION";
+
+/// `conversion_request` subject — request already in a terminal state.
+pub const ALREADY_RESOLVED_TYPE: &str = "ALREADY_RESOLVED";
+
+// ---------------------------------------------------------------------------
+// Typed view of the `violations[].subject` discriminators.
+// ---------------------------------------------------------------------------
+
+/// Typed view of the AM `FailedPrecondition` `subject` strings declared
+/// above.
+///
+/// Carried by [`crate::AccountManagementError::FailedPrecondition::subject`].
+/// `from_wire` returns `Self` (not `Option`) with an [`Self::Unknown`]
+/// catch-all because every `subject` AM emits under `FailedPrecondition`
+/// is one of the modeled values — the catch-all only fires for a future
+/// subject, keeping the projection forward-compatible.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Subject {
+    /// See [`TENANT_TYPE_SUBJECT`].
+    TenantType,
+    /// See [`DEPTH_SUBJECT`].
+    Depth,
+    /// See [`TENANT_SUBJECT`].
+    Tenant,
+    /// See [`REQUEST_SUBJECT`].
+    Request,
+    /// See [`CONFIGURATION_SUBJECT`].
+    Configuration,
+    /// See [`CONVERSION_REQUEST_SUBJECT`].
+    ConversionRequest,
+    /// Unmodeled / future subject — preserves the raw wire string.
+    Unknown(String),
+}
+
+impl Subject {
+    /// Project a wire `violations[].subject` string into the typed
+    /// discriminator. Any unmodeled value is preserved in
+    /// [`Self::Unknown`].
+    #[must_use]
+    pub fn from_wire(s: &str) -> Self {
+        match s {
+            TENANT_TYPE_SUBJECT => Self::TenantType,
+            DEPTH_SUBJECT => Self::Depth,
+            TENANT_SUBJECT => Self::Tenant,
+            REQUEST_SUBJECT => Self::Request,
+            CONFIGURATION_SUBJECT => Self::Configuration,
+            CONVERSION_REQUEST_SUBJECT => Self::ConversionRequest,
+            other => Self::Unknown(other.to_owned()),
+        }
+    }
+
+    /// Render the discriminator back to its wire `subject` string.
+    /// Inverse of [`Self::from_wire`] for the modeled variants.
+    #[must_use]
+    pub fn as_wire(&self) -> &str {
+        match self {
+            Self::TenantType => TENANT_TYPE_SUBJECT,
+            Self::Depth => DEPTH_SUBJECT,
+            Self::Tenant => TENANT_SUBJECT,
+            Self::Request => REQUEST_SUBJECT,
+            Self::Configuration => CONFIGURATION_SUBJECT,
+            Self::ConversionRequest => CONVERSION_REQUEST_SUBJECT,
+            Self::Unknown(s) => s.as_str(),
+        }
+    }
+}
+
+impl fmt::Display for Subject {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_wire())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subject_round_trips_each_constant() {
+        for (wire, expected) in [
+            (TENANT_TYPE_SUBJECT, Subject::TenantType),
+            (DEPTH_SUBJECT, Subject::Depth),
+            (TENANT_SUBJECT, Subject::Tenant),
+            (REQUEST_SUBJECT, Subject::Request),
+            (CONFIGURATION_SUBJECT, Subject::Configuration),
+            (CONVERSION_REQUEST_SUBJECT, Subject::ConversionRequest),
+        ] {
+            assert_eq!(Subject::from_wire(wire), expected);
+            assert_eq!(expected.as_wire(), wire);
+        }
+    }
+
+    #[test]
+    fn subject_preserves_unknown_wire_string() {
+        let raw = "future_subject";
+        let s = Subject::from_wire(raw);
+        assert_eq!(s, Subject::Unknown(raw.to_owned()));
+        assert_eq!(s.as_wire(), raw);
+    }
+}

--- a/gears/system/account-management/account-management-sdk/src/quota.rs
+++ b/gears/system/account-management/account-management-sdk/src/quota.rs
@@ -1,0 +1,15 @@
+//! Wire `subject` vocabulary for quota violations under
+//! [`CanonicalError::ResourceExhausted`].
+//!
+//! AM emits exactly one `ResourceExhausted` subject today (the
+//! hierarchy-integrity single-flight gate), so this is a single plain
+//! constant with no typed sub-enum. The impl crate's single
+//! `From<DomainError> for CanonicalError` ladder references it; the
+//! round-trip test in [`crate::error`] pins it to its `Problem` JSON
+//! path (`context.violations[].subject`).
+//!
+//! [`CanonicalError::ResourceExhausted`]: toolkit_canonical_errors::CanonicalError::ResourceExhausted
+
+/// `violations[].subject` for the hierarchy-integrity check: a check is
+/// already in progress and the single-flight gate is held (HTTP 429).
+pub const INTEGRITY_CHECK: &str = "integrity_check";

--- a/gears/system/account-management/account-management-sdk/src/reason.rs
+++ b/gears/system/account-management/account-management-sdk/src/reason.rs
@@ -1,0 +1,41 @@
+//! Wire `reason` vocabulary for the single-valued AM canonical
+//! categories — [`CanonicalError::Aborted`] and
+//! [`CanonicalError::PermissionDenied`].
+//!
+//! These categories each carry a `ctx.reason` discriminator, but AM
+//! emits only a fixed handful of values per category, so — unlike the
+//! multi-valued [`crate::field`] / [`crate::precondition`] families —
+//! they stay **plain constants** with no typed sub-enum (ADR 0005:
+//! single-value reasons stay consts). Consumers match the projection's
+//! `reason: String` field against these constants.
+//!
+//! The impl crate's single `From<DomainError> for CanonicalError` ladder
+//! references the same constants; the round-trip tests in
+//! [`crate::error`] pin each to its `Problem` JSON path.
+//!
+//! [`CanonicalError::Aborted`]: toolkit_canonical_errors::CanonicalError::Aborted
+//! [`CanonicalError::PermissionDenied`]: toolkit_canonical_errors::CanonicalError::PermissionDenied
+
+/// Wire `reason` values for [`CanonicalError::Aborted`] (HTTP 409).
+///
+/// [`CanonicalError::Aborted`]: toolkit_canonical_errors::CanonicalError::Aborted
+pub mod aborted {
+    /// `upsert_metadata` optimistic-lock precondition (the supplied
+    /// `expected_version` did not match the stored row). The caller
+    /// must re-read and re-issue with the updated `expected_version`.
+    pub const METADATA_VERSION_MISMATCH: &str = "METADATA_VERSION_MISMATCH";
+
+    /// Storage serializable-transaction retry budget was exhausted; the
+    /// operation may succeed on a fresh retry.
+    pub const SERIALIZATION_CONFLICT: &str = "SERIALIZATION_CONFLICT";
+}
+
+/// Wire `reason` values for [`CanonicalError::PermissionDenied`]
+/// (HTTP 403).
+///
+/// [`CanonicalError::PermissionDenied`]: toolkit_canonical_errors::CanonicalError::PermissionDenied
+pub mod permission {
+    /// PEP denied cross-tenant access (or the AM-side ancestry walk
+    /// rejected the call). The single denial reason AM emits.
+    pub const CROSS_TENANT_DENIED: &str = "CROSS_TENANT_DENIED";
+}

--- a/gears/system/account-management/account-management/src/client.rs
+++ b/gears/system/account-management/account-management/src/client.rs
@@ -11,12 +11,14 @@
 //! The adapter is a **thin shim**:
 //!
 //! * Forwards every call 1:1 to the underlying service.
-//! * Maps every internal `DomainError` to `AccountManagementError` via the
-//!   `From<DomainError> for AccountManagementError` impl in
-//!   `infra::sdk_error_mapping`. The REST handler (when it lands)
-//!   lifts further to `toolkit_canonical_errors::CanonicalError` via
-//!   the `account_management_error_to_canonical` helper in the same
-//!   gear. No new error vocabulary is introduced at this boundary.
+//! * Maps every internal `DomainError` to
+//!   `toolkit_canonical_errors::CanonicalError` via the single
+//!   `From<DomainError> for CanonicalError` ladder in
+//!   `infra::sdk_error_mapping` (the same ladder the REST boundary
+//!   uses), per ADR 0005. Consumers may project the canonical envelope
+//!   into the typed `account_management_sdk::AccountManagementError`
+//!   view at their call site; no new error vocabulary is introduced at
+//!   this boundary.
 //! * Does NOT add any extra authorization / validation — those live
 //!   in the service layer where they belong (PEP for tenants, plugin
 //!   guards for users).
@@ -29,13 +31,13 @@
 
 use std::sync::Arc;
 
-use account_management_sdk::AccountManagementError;
 use account_management_sdk::client::AccountManagementClient;
 use account_management_sdk::idp_user::{IdpNewUser, IdpUser, ListUsersQuery};
 use account_management_sdk::metadata::{MetadataEntry, UpsertMetadataRequest};
 use account_management_sdk::tenant::{CreateTenantRequest, Tenant, UpdateTenantRequest};
 use async_trait::async_trait;
 use gts::GtsTypeId;
+use toolkit_canonical_errors::CanonicalError;
 use toolkit_odata::{ODataQuery, Page};
 use toolkit_security::SecurityContext;
 use uuid::Uuid;
@@ -93,22 +95,18 @@ where
         &self,
         ctx: &SecurityContext,
         input: CreateTenantRequest,
-    ) -> Result<Tenant, AccountManagementError> {
+    ) -> Result<Tenant, CanonicalError> {
         self.tenant_service
             .create_tenant(ctx, input)
             .await
-            .map_err(AccountManagementError::from)
+            .map_err(CanonicalError::from)
     }
 
-    async fn get_tenant(
-        &self,
-        ctx: &SecurityContext,
-        id: Uuid,
-    ) -> Result<Tenant, AccountManagementError> {
+    async fn get_tenant(&self, ctx: &SecurityContext, id: Uuid) -> Result<Tenant, CanonicalError> {
         self.tenant_service
             .get_tenant(ctx, id)
             .await
-            .map_err(AccountManagementError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn list_children(
@@ -116,11 +114,11 @@ where
         ctx: &SecurityContext,
         parent_id: Uuid,
         query: &ODataQuery,
-    ) -> Result<Page<Tenant>, AccountManagementError> {
+    ) -> Result<Page<Tenant>, CanonicalError> {
         self.tenant_service
             .list_children(ctx, parent_id, query)
             .await
-            .map_err(AccountManagementError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn update_tenant(
@@ -128,44 +126,44 @@ where
         ctx: &SecurityContext,
         id: Uuid,
         patch: UpdateTenantRequest,
-    ) -> Result<Tenant, AccountManagementError> {
+    ) -> Result<Tenant, CanonicalError> {
         self.tenant_service
             .update_tenant(ctx, id, patch)
             .await
-            .map_err(AccountManagementError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn suspend_tenant(
         &self,
         ctx: &SecurityContext,
         id: Uuid,
-    ) -> Result<Tenant, AccountManagementError> {
+    ) -> Result<Tenant, CanonicalError> {
         self.tenant_service
             .suspend_tenant(ctx, id)
             .await
-            .map_err(AccountManagementError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn unsuspend_tenant(
         &self,
         ctx: &SecurityContext,
         id: Uuid,
-    ) -> Result<Tenant, AccountManagementError> {
+    ) -> Result<Tenant, CanonicalError> {
         self.tenant_service
             .unsuspend_tenant(ctx, id)
             .await
-            .map_err(AccountManagementError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn delete_tenant(
         &self,
         ctx: &SecurityContext,
         tenant_id: Uuid,
-    ) -> Result<Tenant, AccountManagementError> {
+    ) -> Result<Tenant, CanonicalError> {
         self.tenant_service
             .delete_tenant(ctx, tenant_id)
             .await
-            .map_err(AccountManagementError::from)
+            .map_err(CanonicalError::from)
     }
 
     // -----------------------------------------------------------------
@@ -177,11 +175,11 @@ where
         ctx: &SecurityContext,
         tenant_id: Uuid,
         payload: IdpNewUser,
-    ) -> Result<IdpUser, AccountManagementError> {
+    ) -> Result<IdpUser, CanonicalError> {
         self.user_service
             .create_user(ctx, tenant_id, payload)
             .await
-            .map_err(AccountManagementError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn get_user(
@@ -189,11 +187,11 @@ where
         ctx: &SecurityContext,
         tenant_id: Uuid,
         user_id: Uuid,
-    ) -> Result<IdpUser, AccountManagementError> {
+    ) -> Result<IdpUser, CanonicalError> {
         self.user_service
             .get_user(ctx, tenant_id, user_id)
             .await
-            .map_err(AccountManagementError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn list_users(
@@ -201,11 +199,11 @@ where
         ctx: &SecurityContext,
         tenant_id: Uuid,
         query: ListUsersQuery,
-    ) -> Result<Page<IdpUser>, AccountManagementError> {
+    ) -> Result<Page<IdpUser>, CanonicalError> {
         self.user_service
             .list_users(ctx, tenant_id, query)
             .await
-            .map_err(AccountManagementError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn delete_user(
@@ -213,11 +211,11 @@ where
         ctx: &SecurityContext,
         tenant_id: Uuid,
         user_id: Uuid,
-    ) -> Result<(), AccountManagementError> {
+    ) -> Result<(), CanonicalError> {
         self.user_service
             .delete_user(ctx, tenant_id, user_id)
             .await
-            .map_err(AccountManagementError::from)
+            .map_err(CanonicalError::from)
     }
 
     // -----------------------------------------------------------------
@@ -229,11 +227,11 @@ where
         ctx: &SecurityContext,
         tenant_id: Uuid,
         type_id: GtsTypeId,
-    ) -> Result<MetadataEntry, AccountManagementError> {
+    ) -> Result<MetadataEntry, CanonicalError> {
         self.metadata_service
             .get_metadata(ctx, tenant_id, type_id)
             .await
-            .map_err(AccountManagementError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn resolve_metadata(
@@ -241,11 +239,11 @@ where
         ctx: &SecurityContext,
         tenant_id: Uuid,
         type_id: GtsTypeId,
-    ) -> Result<Option<MetadataEntry>, AccountManagementError> {
+    ) -> Result<Option<MetadataEntry>, CanonicalError> {
         self.metadata_service
             .resolve_metadata(ctx, tenant_id, type_id)
             .await
-            .map_err(AccountManagementError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn list_metadata(
@@ -253,11 +251,11 @@ where
         ctx: &SecurityContext,
         tenant_id: Uuid,
         query: &ODataQuery,
-    ) -> Result<Page<MetadataEntry>, AccountManagementError> {
+    ) -> Result<Page<MetadataEntry>, CanonicalError> {
         self.metadata_service
             .list_metadata(ctx, tenant_id, query)
             .await
-            .map_err(AccountManagementError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn upsert_metadata(
@@ -265,11 +263,11 @@ where
         ctx: &SecurityContext,
         tenant_id: Uuid,
         input: UpsertMetadataRequest,
-    ) -> Result<MetadataEntry, AccountManagementError> {
+    ) -> Result<MetadataEntry, CanonicalError> {
         self.metadata_service
             .upsert_metadata(ctx, tenant_id, input)
             .await
-            .map_err(AccountManagementError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn delete_metadata(
@@ -277,10 +275,10 @@ where
         ctx: &SecurityContext,
         tenant_id: Uuid,
         type_id: GtsTypeId,
-    ) -> Result<(), AccountManagementError> {
+    ) -> Result<(), CanonicalError> {
         self.metadata_service
             .delete_metadata(ctx, tenant_id, type_id)
             .await
-            .map_err(AccountManagementError::from)
+            .map_err(CanonicalError::from)
     }
 }

--- a/gears/system/account-management/account-management/src/domain/error_tests.rs
+++ b/gears/system/account-management/account-management/src/domain/error_tests.rs
@@ -1,27 +1,27 @@
-//! Tests for the [`DomainError`] → [`AccountManagementError`] boundary mapping.
+//! Tests for the [`DomainError`] → [`CanonicalError`] boundary and the
+//! [`AccountManagementError`] projection over it.
 //!
-//! Validates the AIP-193 category, HTTP status code, and key context
-//! fields (`resource_type`, `resource`, `retry_after_seconds`, `reason`)
-//! produced by `From<DomainError> for AccountManagementError`. Renaming
-//! any of these mappings is a public-contract break — the tests below
-//! are the regression line for the SDK enum shape.
-//!
-//! Boundary mapping lives in [`crate::infra::sdk_error_mapping`] (kept
-//! out of `domain/` so the DB-aware classification ladder can reach
-//! `sea_orm`/`toolkit_db` without violating Dylint domain-layer rules).
-//! The tests still live alongside `domain/error` because they pin the
-//! shape of the public contract.
-//!
-//! The companion `infra::sdk_error_mapping_tests` exercise the second
-//! hop (`AccountManagementError → CanonicalError`) and the full
-//! composition end-to-end; this file covers the SDK enum shape that
-//! consumers pattern-match on directly.
+//! Per ADR 0005 the single ladder is `From<DomainError> for CanonicalError`
+//! in [`crate::infra::sdk_error_mapping`]; the SDK's typed
+//! [`AccountManagementError`] is a `From<CanonicalError>` view. These
+//! tests pin the projected shape consumers pattern-match on (variant,
+//! carried identifiers, retry hint). The companion
+//! `infra::sdk_error_mapping_tests` pin the full `CanonicalError`
+//! envelope (category, status, resource type, context tokens).
 
 use std::time::Duration;
 
 use account_management_sdk::error::AccountManagementError;
+use toolkit_canonical_errors::CanonicalError;
 
 use super::DomainError;
+
+/// Drive a `DomainError` through the production path consumers see:
+/// the single canonical ladder, then the opt-in SDK projection.
+#[allow(clippy::needless_pass_by_value)]
+fn project(d: DomainError) -> AccountManagementError {
+    AccountManagementError::from(CanonicalError::from(d))
+}
 
 /// Convenience: read the test-only `DomainError::http_status()`
 /// helper. Pinned to the canonical AIP-193 table — the production
@@ -125,16 +125,17 @@ fn already_exists_maps_to_409() {
 
 #[test]
 fn aborted_maps_to_409_with_reason() {
-    let ame: AccountManagementError = DomainError::Aborted {
+    let ame = project(DomainError::Aborted {
         reason: "SERIALIZATION_CONFLICT".into(),
         detail: "serialization conflict; retry budget exhausted".into(),
-    }
-    .into();
-    assert!(matches!(
-        ame,
-        AccountManagementError::SerializationConflict { .. }
-    ));
-    assert!(ame.is_retryable());
+    });
+    let AccountManagementError::Aborted { reason, .. } = ame else {
+        panic!("expected Aborted projection, got {ame:?}");
+    };
+    assert_eq!(
+        reason,
+        account_management_sdk::reason::aborted::SERIALIZATION_CONFLICT
+    );
 }
 
 #[test]
@@ -197,36 +198,50 @@ fn internal_maps_to_500() {
 
 #[test]
 fn not_found_carries_resource_id() {
-    let ame: AccountManagementError = DomainError::NotFound {
+    let ame = project(DomainError::NotFound {
         detail: "tenant 7 not found".into(),
         resource: "7".into(),
-    }
-    .into();
-    let AccountManagementError::TenantNotFound { tenant_id, .. } = &ame else {
-        panic!("expected TenantNotFound variant");
+    });
+    let AccountManagementError::NotFound {
+        resource_type,
+        name,
+        ..
+    } = &ame
+    else {
+        panic!("expected NotFound projection, got {ame:?}");
     };
-    assert_eq!(tenant_id, "7");
-    assert!(ame.is_not_found());
+    assert_eq!(name, "7");
+    assert_eq!(
+        resource_type,
+        account_management_sdk::gts::TENANT_RESOURCE_TYPE
+    );
 }
 
 #[test]
 fn metadata_entry_not_found_carries_chained_type_id() {
-    // `MetadataEntryNotFound` carries the chained `type_id` the
-    // caller supplied so the canonical envelope surfaces it as
-    // `resource_name`.
-    let ame: AccountManagementError = DomainError::MetadataEntryNotFound {
+    // The chained `type_id` the caller supplied surfaces as the
+    // canonical `resource_name`, projected onto `NotFound.name`, under
+    // the metadata resource type.
+    let ame = project(DomainError::MetadataEntryNotFound {
         detail: "schema billing.v1 missing".into(),
         entry: "gts.cf.core.am.tenant_metadata.v1~cf.core.billing.usage.v1~".into(),
-    }
-    .into();
-    let AccountManagementError::MetadataEntryNotFound { entry, .. } = &ame else {
-        panic!("expected MetadataEntryNotFound variant");
+    });
+    let AccountManagementError::NotFound {
+        resource_type,
+        name,
+        ..
+    } = &ame
+    else {
+        panic!("expected NotFound projection, got {ame:?}");
     };
     assert_eq!(
-        entry,
+        name,
         "gts.cf.core.am.tenant_metadata.v1~cf.core.billing.usage.v1~"
     );
-    assert!(ame.is_not_found());
+    assert_eq!(
+        resource_type,
+        account_management_sdk::gts::TENANT_METADATA_RESOURCE_TYPE
+    );
 }
 
 // Drift between `#[resource_error("...")]` macro literals in
@@ -240,19 +255,32 @@ fn metadata_entry_not_found_carries_chained_type_id() {
 
 #[test]
 fn service_unavailable_propagates_retry_after_seconds() {
-    let ame: AccountManagementError = DomainError::ServiceUnavailable {
+    let ame = project(DomainError::ServiceUnavailable {
         detail: "idp warming up".into(),
         retry_after: Some(Duration::from_secs(15)),
         cause: None,
-    }
-    .into();
-    assert_eq!(ame.retry_after_seconds(), Some(15));
+    });
+    let AccountManagementError::Unavailable {
+        retry_after_seconds,
+        ..
+    } = ame
+    else {
+        panic!("expected Unavailable projection, got {ame:?}");
+    };
+    assert_eq!(retry_after_seconds, Some(15));
 }
 
 #[test]
 fn service_unavailable_without_hint_omits_retry_after() {
-    let ame: AccountManagementError = DomainError::service_unavailable("db down").into();
-    assert!(ame.retry_after_seconds().is_none());
+    let ame = project(DomainError::service_unavailable("db down"));
+    let AccountManagementError::Unavailable {
+        retry_after_seconds,
+        ..
+    } = ame
+    else {
+        panic!("expected Unavailable projection, got {ame:?}");
+    };
+    assert!(retry_after_seconds.is_none());
 }
 
 // ---------------------------------------------------------------------------

--- a/gears/system/account-management/account-management/src/infra/canonical_mapping.rs
+++ b/gears/system/account-management/account-management/src/infra/canonical_mapping.rs
@@ -8,10 +8,11 @@
 //! imports, `#[domain_model]` enforced) while still routing DB
 //! failures onto the AIP-193 canonical categories.
 //!
-//! The boundary mapping between [`DomainError`] and the public
-//! [`AccountManagementError`](account_management_sdk::error::AccountManagementError)
-//! / [`CanonicalError`](toolkit_canonical_errors::CanonicalError) wire
-//! envelope lives in [`crate::infra::sdk_error_mapping`]. This gear
+//! The single boundary mapping from [`DomainError`] to the
+//! [`CanonicalError`](toolkit_canonical_errors::CanonicalError) wire
+//! envelope lives in [`crate::infra::sdk_error_mapping`] (ADR 0005); the
+//! SDK's [`AccountManagementError`](account_management_sdk::error::AccountManagementError)
+//! is an opt-in `From<CanonicalError>` projection over it. This gear
 //! is classifier-only.
 //!
 //! # Lift vs classify

--- a/gears/system/account-management/account-management/src/infra/canonical_mapping_tests.rs
+++ b/gears/system/account-management/account-management/src/infra/canonical_mapping_tests.rs
@@ -11,15 +11,12 @@ use toolkit_canonical_errors::{CanonicalError, Problem};
 
 use super::classify_db_err_to_domain;
 use crate::domain::error::DomainError;
-use crate::infra::sdk_error_mapping::account_management_error_to_canonical;
 
-/// Route a `DomainError` through the two-hop pipeline
-/// (`DomainError → AccountManagementError → CanonicalError`). The
-/// temporary `From<DomainError> for CanonicalError` bridge has been
-/// retired; tests that pin the wire-envelope shape must drive both
-/// hops explicitly.
+/// Route a `DomainError` through the single canonical ladder
+/// (`From<DomainError> for CanonicalError`, ADR 0005) to pin the
+/// wire-envelope shape these classifier outputs produce.
 fn canonical_of(domain: DomainError) -> CanonicalError {
-    account_management_error_to_canonical(domain.into())
+    CanonicalError::from(domain)
 }
 
 #[test]

--- a/gears/system/account-management/account-management/src/infra/sdk_error_mapping.rs
+++ b/gears/system/account-management/account-management/src/infra/sdk_error_mapping.rs
@@ -1,35 +1,47 @@
-//! Boundary mapping between AM's internal [`DomainError`] and the two
-//! public error envelopes AM emits:
+//! Boundary mapping from AM's internal [`DomainError`] to the AIP-193
+//! [`toolkit_canonical_errors::CanonicalError`] envelope.
 //!
-//! * [`AccountManagementError`] (`account-management-sdk`) — the
-//!   typed error surface inter-gear Rust callers see through
-//!   [`account_management_sdk::AccountManagementClient`] (resolved
-//!   via `ClientHub`). Variant-per-failure shape (mirrors `mini-chat`
-//!   convention) — each enum case names the failure semantically.
-//! * [`toolkit_canonical_errors::CanonicalError`] — the AIP-193
-//!   envelope REST handlers convert to RFC-9457 `Problem` responses.
+//! Per [ADR 0005] this is the **single** authoritative classification
+//! ladder for Account Management. Both surfaces consume it:
 //!
-//! Both targets share the same upstream `DomainError`; the SDK lift
-//! happens through the `From<DomainError> for AccountManagementError`
-//! impl below and the REST lift through
-//! [`account_management_error_to_canonical`] (free fn — both types
-//! foreign to this crate, orphan rule blocks an impl block). The
-//! `From<DomainError> for CanonicalError` at the bottom composes the
-//! two hops so REST handlers can write `service.foo().await?`.
+//! * REST handlers convert `DomainError` to `CanonicalError` via `?`
+//!   (and then to an RFC-9457 `Problem` via the platform-wide
+//!   `From<CanonicalError> for Problem`).
+//! * The in-process [`account_management_sdk::AccountManagementClient`]
+//!   facade calls `.map_err(CanonicalError::from)`; consumers may opt
+//!   into the typed `AccountManagementError` projection
+//!   (`From<CanonicalError>`) at their call site.
+//!
+//! There is no parallel `From<DomainError> for AccountManagementError`
+//! ladder — the projection is driven from `CanonicalError`, so this file
+//! is the only place a domain variant is assigned a canonical category.
+//!
+//! # Wire vocabulary
+//!
+//! Every wire-string discriminator this ladder emits
+//! (`field_violations[].field`/`.reason`, `violations[].subject`/`.type`,
+//! `Aborted`/`PermissionDenied` `reason`, the quota `subject`) is
+//! referenced from the SDK constant gears
+//! ([`account_management_sdk::field`], [`account_management_sdk::precondition`],
+//! [`account_management_sdk::reason`], [`account_management_sdk::quota`])
+//! so the impl and the SDK projection cannot drift; the SDK's round-trip
+//! `Problem` tests pin each constant to its JSON path. The
+//! `#[resource_error("…")]` literals below are the one exception (proc
+//! macros cannot resolve constants) and stay literals, pinned by the
+//! `sdk_error_mapping_tests` canonical-envelope assertions.
 //!
 //! # Resource markers
 //!
-//! [`TenantResource`], [`TenantMetadataResource`], and
+//! [`TenantResource`], [`UserResource`], [`TenantMetadataResource`], and
 //! [`ConversionRequestResource`] are unit structs whose
 //! `#[resource_error]`-generated impls produce
 //! [`toolkit_canonical_errors::ResourceErrorBuilder`]s tagged with the
 //! AM GTS resource types. The literal strings below MUST match the
-//! corresponding constants in `account_management_sdk::gts`; the
-//! `domain::error_tests::resource_error_strings_match_sdk_constants`
-//! test asserts equality at test time so a divergence trips there, not
-//! in production.
+//! corresponding `account_management_sdk::gts` constants.
+//!
+//! [ADR 0005]: ../../../../../../docs/arch/errors/ADR/0005-cpt-cf-adr-sdk-canonical-projection.md
 
-use account_management_sdk::error::AccountManagementError;
+use account_management_sdk::{field, precondition, quota, reason};
 use toolkit_canonical_errors::{CanonicalError, resource_error};
 use tracing::warn;
 
@@ -37,8 +49,7 @@ use crate::domain::error::DomainError;
 use crate::domain::metrics::{AM_CROSS_TENANT_DENIAL, MetricKind, emit_metric};
 
 // ---------------------------------------------------------------------------
-// Resource markers — kept in sync with account_management_sdk::gts via
-// `domain::error_tests::resource_error_strings_match_sdk_constants`.
+// Resource markers — kept in sync with account_management_sdk::gts.
 // ---------------------------------------------------------------------------
 
 #[resource_error("gts.cf.core.am.tenant.v1~")]
@@ -50,9 +61,9 @@ pub(crate) struct UserResource;
 // `TenantMetadataResource` carries the unified 404 for the metadata
 // surface — both "schema unknown to the registry" and "entry missing
 // for this tenant" resolve to this `resource_type`. The chained
-// `type_id` the caller supplied is surfaced through
-// `resource_name`, so consumers still see *which* schema was
-// involved without a separate type-level discriminator.
+// `type_id` the caller supplied is surfaced through `resource_name`,
+// so consumers still see *which* schema was involved without a separate
+// type-level discriminator.
 #[resource_error("gts.cf.core.am.tenant_metadata.v1~")]
 pub(crate) struct TenantMetadataResource;
 
@@ -60,119 +71,243 @@ pub(crate) struct TenantMetadataResource;
 pub(crate) struct ConversionRequestResource;
 
 // ---------------------------------------------------------------------------
-// DomainError → AccountManagementError (SDK boundary).
+// DomainError → CanonicalError (the single AIP-193 ladder).
 // ---------------------------------------------------------------------------
 //
-// Direct semantic mapping — each `DomainError` variant lifts to a
-// uniquely-named `AccountManagementError` variant. The provider-detail
-// redaction for `IdpUnavailable` / `UnsupportedOperation` happens here
-// so the public detail that reaches the SDK never carries vendor SDK
-// text; raw detail is logged via the `am.domain` `tracing` target with
-// a digest + length only (mirrors
+// One arm per `DomainError` variant, each assigned exactly one of the
+// 16 canonical categories. Provider-detail redaction for `IdpUnavailable`
+// / `UnsupportedOperation` happens here so the public envelope never
+// carries vendor SDK text; the raw detail is logged via the `am.domain`
+// `tracing` target with a digest + length only (mirrors
 // [`crate::domain::idp::redact_provider_detail`]).
 
-// @cpt-begin:cpt-cf-account-management-algo-errors-observability-error-to-problem-mapping:p1:inst-algo-etp-domain-to-sdk
-impl From<DomainError> for AccountManagementError {
+// @cpt-begin:cpt-cf-account-management-algo-errors-observability-error-to-problem-mapping:p1:inst-algo-etp-domain-to-canonical
+impl From<DomainError> for CanonicalError {
+    #[allow(
+        clippy::too_many_lines,
+        reason = "flat one-arm-per-variant AIP-193 ladder; splitting it would obscure the 1:1 mapping reviewers eyeball-check against the DomainError enum"
+    )]
     fn from(err: DomainError) -> Self {
         match err {
-            // ---- Tenant CRUD ----
-            DomainError::InvalidTenantType { detail } => Self::InvalidTenantType { detail },
-            DomainError::Validation { detail } => Self::InvalidRequest { detail },
+            // ---- InvalidArgument (HTTP 400) ----
+            DomainError::InvalidTenantType { detail } => TenantResource::invalid_argument()
+                .with_field_violation(field::TENANT_TYPE_FIELD, detail, field::INVALID_TENANT_TYPE)
+                .create(),
+            DomainError::Validation { detail } => TenantResource::invalid_argument()
+                .with_field_violation(field::REQUEST_FIELD, detail, field::VALIDATION)
+                .create(),
             // Metadata-payload validation rejects (malformed chained
-            // schema id, GTS body validation failure, etc.) route to
-            // the dedicated `MetadataInvalidRequest` so the canonical
-            // envelope can carry `TENANT_METADATA_RESOURCE_TYPE`
-            // instead of the tenant default. Both map to HTTP 400
-            // `invalid_argument` at the AIP-193 layer.
-            DomainError::MetadataValidation { detail } => Self::MetadataInvalidRequest { detail },
-            DomainError::RootTenantCannotDelete => Self::RootTenantCannotDelete,
-            DomainError::RootTenantCannotConvert => Self::RootTenantCannotConvert,
-            DomainError::RootTenantCannotChangeStatus => Self::RootTenantCannotChangeStatus,
-            DomainError::IdpInvalidInput { detail, field } => {
-                Self::IdpInvalidInput { detail, field }
+            // schema id, GTS body validation failure, etc.) carry the
+            // metadata resource type instead of the tenant default; both
+            // are HTTP 400 `invalid_argument`.
+            DomainError::MetadataValidation { detail } => {
+                TenantMetadataResource::invalid_argument()
+                    .with_field_violation(field::METADATA_FIELD, detail, field::VALIDATION)
+                    .create()
             }
-
-            DomainError::NotFound { detail, resource } => Self::TenantNotFound {
-                tenant_id: resource,
-                detail,
-            },
-            DomainError::UserNotFound { detail, resource } => Self::UserNotFound {
-                user_id: resource,
-                detail,
-            },
-            DomainError::ConversionRequestNotFound { detail, resource } => {
-                Self::ConversionRequestNotFound {
-                    request_id: resource,
+            DomainError::RootTenantCannotDelete => TenantResource::invalid_argument()
+                .with_field_violation(
+                    field::TENANT_ID_FIELD,
+                    "root tenant cannot be deleted",
+                    field::ROOT_TENANT_CANNOT_DELETE,
+                )
+                .create(),
+            DomainError::RootTenantCannotConvert => TenantResource::invalid_argument()
+                .with_field_violation(
+                    field::TENANT_ID_FIELD,
+                    "root tenant cannot be converted",
+                    field::ROOT_TENANT_CANNOT_CONVERT,
+                )
+                .create(),
+            DomainError::RootTenantCannotChangeStatus => TenantResource::invalid_argument()
+                .with_field_violation(
+                    field::TENANT_ID_FIELD,
+                    "root tenant status cannot be changed",
+                    field::ROOT_TENANT_CANNOT_CHANGE_STATUS,
+                )
+                .create(),
+            // `field` is the dotted-path the IdP plugin localised the
+            // violation to (e.g. `provisioning_metadata.realm_name`).
+            // When the plugin can't localise (`None`) we fall back to the
+            // shared `provisioning_metadata` field key — the public
+            // surface every IdP plugin shares. Stays on `TenantResource`
+            // (the operation being rejected is tenant provisioning).
+            DomainError::IdpInvalidInput { detail, field } => TenantResource::invalid_argument()
+                .with_field_violation(
+                    field.unwrap_or_else(|| {
+                        account_management_sdk::field::PROVISIONING_METADATA_FIELD.to_owned()
+                    }),
                     detail,
-                }
+                    account_management_sdk::field::IDP_INVALID_INPUT,
+                )
+                .create(),
+
+            // ---- NotFound (HTTP 404) — one resource per variant ----
+            DomainError::NotFound { detail, resource } => TenantResource::not_found(detail)
+                .with_resource(resource)
+                .create(),
+            DomainError::UserNotFound { detail, resource } => UserResource::not_found(detail)
+                .with_resource(resource)
+                .create(),
+            DomainError::ConversionRequestNotFound { detail, resource } => {
+                ConversionRequestResource::not_found(detail)
+                    .with_resource(resource)
+                    .create()
             }
-
-            DomainError::AlreadyExists { detail } => Self::TenantAlreadyExists { detail },
-
-            DomainError::TypeNotAllowed { detail } => Self::TenantTypeNotAllowed { detail },
-            DomainError::TenantDepthExceeded { detail } => Self::TenantDepthExceeded { detail },
-            DomainError::TenantHasChildren => Self::TenantHasChildren,
-            DomainError::TenantHasResources => Self::TenantHasResources,
-
-            // ---- Conversion request ----
-            DomainError::PendingExists { request_id } => {
-                Self::PendingConversionExists { request_id }
-            }
-            DomainError::InvalidActorForTransition {
-                attempted_status,
-                caller_side,
-            } => Self::InvalidActorForConversionTransition {
-                attempted_status,
-                caller_side,
-            },
-            DomainError::AlreadyResolved => Self::ConversionAlreadyResolved,
-
-            // ---- Tenant metadata ----
+            // Both "schema unknown to registry" and "entry missing for
+            // tenant" resolve to the same `TenantMetadataResource` 404;
+            // `entry` carries the chained `schema_id` the caller supplied.
             DomainError::MetadataEntryNotFound { detail, entry } => {
-                Self::MetadataEntryNotFound { entry, detail }
+                TenantMetadataResource::not_found(detail)
+                    .with_resource(entry)
+                    .create()
             }
+
+            // ---- Aborted (HTTP 409 with reason) ----
             DomainError::MetadataVersionMismatch {
                 entry,
                 expected,
                 current,
-            } => Self::MetadataVersionMismatch {
-                entry,
-                expected,
-                current,
-            },
+            } => TenantMetadataResource::aborted(format!(
+                "metadata version mismatch for {entry}: expected v{expected}, stored v{current}"
+            ))
+            .with_resource(entry)
+            .with_reason(reason::aborted::METADATA_VERSION_MISMATCH)
+            .create(),
+            // The domain `reason` is curated upstream but the wire token
+            // is the fixed `SERIALIZATION_CONFLICT` discriminator.
+            DomainError::Aborted { reason: _, detail } => TenantResource::aborted(detail)
+                .with_reason(reason::aborted::SERIALIZATION_CONFLICT)
+                .create(),
 
-            // ---- Generic precondition fallbacks ----
-            DomainError::Conflict { detail } => Self::PreconditionFailed { detail },
-            DomainError::FeatureDisabled { detail } => Self::FeatureDisabled { detail },
+            // ---- AlreadyExists (HTTP 409) ----
+            DomainError::AlreadyExists { detail } => TenantResource::already_exists(detail)
+                .with_resource("tenant")
+                .create(),
+            // Duplicate-on-create per AIP-193: the at-most-one-pending
+            // invariant surfaces as HTTP 409 with the existing
+            // `request_id` as the structural resource identifier.
+            DomainError::PendingExists { request_id } => ConversionRequestResource::already_exists(
+                format!("a pending conversion request already exists: {request_id}"),
+            )
+            .with_resource(request_id)
+            .create(),
 
-            // ---- Authorization ----
-            // Single funnel for every cross-tenant denial (PDP enforcer + storage
-            // scope-clamp); also reached on the REST path via the composed
-            // From<DomainError> for CanonicalError. The metadata visibility probe
-            // that swallows this into Ok(false) bypasses this mapping, so it is
-            // correctly not counted.
+            // ---- FailedPrecondition (HTTP 400) ----
+            DomainError::TypeNotAllowed { detail } => TenantResource::failed_precondition()
+                .with_precondition_violation(
+                    precondition::TENANT_TYPE_SUBJECT,
+                    detail,
+                    precondition::TYPE_NOT_ALLOWED_TYPE,
+                )
+                .create(),
+            DomainError::TenantDepthExceeded { detail } => TenantResource::failed_precondition()
+                .with_precondition_violation(
+                    precondition::DEPTH_SUBJECT,
+                    detail,
+                    precondition::TENANT_DEPTH_EXCEEDED_TYPE,
+                )
+                .create(),
+            DomainError::TenantHasChildren => TenantResource::failed_precondition()
+                .with_precondition_violation(
+                    precondition::TENANT_SUBJECT,
+                    "tenant has child tenants",
+                    precondition::TENANT_HAS_CHILDREN_TYPE,
+                )
+                .create(),
+            DomainError::TenantHasResources => TenantResource::failed_precondition()
+                .with_precondition_violation(
+                    precondition::TENANT_SUBJECT,
+                    "tenant still owns resources",
+                    precondition::TENANT_HAS_RESOURCES_TYPE,
+                )
+                .create(),
+            DomainError::InvalidActorForTransition {
+                attempted_status,
+                caller_side,
+            } => ConversionRequestResource::failed_precondition()
+                .with_precondition_violation(
+                    precondition::CONVERSION_REQUEST_SUBJECT,
+                    format!(
+                        "invalid actor for conversion transition: \
+                         attempted={attempted_status} caller_side={caller_side}"
+                    ),
+                    precondition::INVALID_ACTOR_FOR_TRANSITION_TYPE,
+                )
+                .create(),
+            DomainError::AlreadyResolved => ConversionRequestResource::failed_precondition()
+                .with_precondition_violation(
+                    precondition::CONVERSION_REQUEST_SUBJECT,
+                    "conversion request already resolved",
+                    precondition::ALREADY_RESOLVED_TYPE,
+                )
+                .create(),
+            DomainError::Conflict { detail } => TenantResource::failed_precondition()
+                .with_precondition_violation(
+                    precondition::REQUEST_SUBJECT,
+                    detail,
+                    precondition::PRECONDITION_FAILED_TYPE,
+                )
+                .create(),
+            DomainError::FeatureDisabled { detail } => TenantResource::failed_precondition()
+                .with_precondition_violation(
+                    precondition::CONFIGURATION_SUBJECT,
+                    detail,
+                    precondition::FEATURE_DISABLED_TYPE,
+                )
+                .create(),
+
+            // ---- PermissionDenied (HTTP 403) ----
+            //
+            // Single funnel for every cross-tenant denial (PDP enforcer +
+            // storage scope-clamp). The metadata visibility probe that
+            // swallows this into `Ok(false)` bypasses this mapping, so it
+            // is correctly not counted. Macro-supplied default detail
+            // ("You do not have permission to perform this operation")
+            // matches the pre-migration wire shape.
             DomainError::CrossTenantDenied { cause: _ } => {
                 emit_metric(AM_CROSS_TENANT_DENIAL, MetricKind::Counter, &[]);
-                Self::CrossTenantDenied
+                TenantResource::permission_denied()
+                    .with_reason(reason::permission::CROSS_TENANT_DENIED)
+                    .create()
             }
 
-            // ---- Transactional ----
-            DomainError::Aborted { reason: _, detail } => Self::SerializationConflict { detail },
-
-            // Not reachable via REST (canonical impl short-circuits to 429);
-            // defensive fallback on `Internal` for tooling that lifts
-            // `DomainError` directly.
-            DomainError::IntegrityCheckInProgress => Self::Internal {
-                detail: "integrity check already in progress".to_owned(),
-            },
-
-            // ---- IdP plugin (with detail redaction) ----
+            // ---- ResourceExhausted (HTTP 429) ----
             //
-            // `IdpUnavailable` reuses the AIP-193 `ServiceUnavailable`
-            // envelope at the canonical layer. Provider-supplied
-            // `detail` can carry vendor SDK strings / endpoint names:
-            // log a digest through `am.domain` and emit the variant
-            // with no public detail string.
+            // Not part of the inter-gear SDK contract (no
+            // `AccountManagementClient` method surfaces it); routed
+            // directly to the canonical 429 quota envelope.
+            DomainError::IntegrityCheckInProgress => {
+                TenantResource::resource_exhausted("integrity check already in progress")
+                    .with_quota_violation(
+                        quota::INTEGRITY_CHECK,
+                        "another integrity check is already in progress",
+                    )
+                    .create()
+            }
+            // `IntegrityCheckLeaseLost` shares the public retry contract
+            // with `IntegrityCheckInProgress` — both surface as the same
+            // canonical 429 envelope. The metric-label split
+            // (`AbortedLeaseLost` vs `SkippedInProgress`) is observed at
+            // the loop-driver layer, not the REST boundary, so collapsing
+            // them here keeps the public contract stable.
+            DomainError::IntegrityCheckLeaseLost => {
+                TenantResource::resource_exhausted("integrity repair aborted: lease lost to a peer")
+                    .with_quota_violation(
+                        quota::INTEGRITY_CHECK,
+                        "integrity repair aborted; another worker took the lease",
+                    )
+                    .create()
+            }
+
+            // ---- ServiceUnavailable (HTTP 503) ----
+            //
+            // `IdpUnavailable` collapses to the same 503 shape as generic
+            // `ServiceUnavailable` (no `retry_after_seconds` — IdP retry
+            // budgets are governed by the bootstrap saga, not the wire
+            // hint). Provider `detail` can carry vendor SDK strings:
+            // log a digest through `am.domain` and emit a fixed envelope
+            // detail.
             DomainError::IdpUnavailable { detail } => {
                 let (digest, len) = crate::domain::idp::redact_provider_detail(&detail);
                 warn!(
@@ -181,8 +316,27 @@ impl From<DomainError> for AccountManagementError {
                     detail_len_chars = len,
                     "IdpUnavailable surfaced; provider detail redacted for log/envelope safety"
                 );
-                Self::IdpUnavailable
+                CanonicalError::service_unavailable()
+                    .with_detail("IdP plugin unavailable")
+                    .create()
             }
+            // `detail` is curated upstream by the adapter that produced
+            // the variant (DB classifier redaction, PDP wrapper, …) and
+            // is forwarded so callers see the specific outage cause.
+            DomainError::ServiceUnavailable {
+                detail,
+                retry_after,
+                cause: _,
+            } => {
+                let mut builder = CanonicalError::service_unavailable().with_detail(detail);
+                if let Some(after) = retry_after {
+                    let secs = u32::try_from(after.as_secs()).unwrap_or(u32::MAX);
+                    builder = builder.with_retry_after_seconds(u64::from(secs));
+                }
+                builder.create()
+            }
+
+            // ---- Unimplemented (HTTP 501) ----
             DomainError::UnsupportedOperation { detail } => {
                 let (digest, len) = crate::domain::idp::redact_provider_detail(&detail);
                 warn!(
@@ -191,302 +345,15 @@ impl From<DomainError> for AccountManagementError {
                     detail_len_chars = len,
                     "UnsupportedOperation surfaced; provider detail redacted for log/envelope safety"
                 );
-                Self::UnsupportedOperation
+                TenantResource::unimplemented("operation not supported by the IdP provider")
+                    .create()
             }
 
-            // ---- Generic infra ----
-            //
-            // `detail` is curated upstream by the adapter that
-            // produced the variant — `From<EnforcerError::EvaluationFailed>`
-            // emits `"authorization evaluation failed"`, the DB
-            // classifier runs `redacted_db_diagnostic`, etc. Forward
-            // it through so callers see the specific outage cause.
-            DomainError::ServiceUnavailable {
-                detail,
-                retry_after,
-                cause: _,
-            } => Self::ServiceUnavailable {
-                detail,
-                retry_after_seconds: retry_after
-                    .map(|d| u32::try_from(d.as_secs()).unwrap_or(u32::MAX)),
-            },
-
-            // Not reachable via REST (canonical impl short-circuits to 429);
-            // mirrors `IntegrityCheckInProgress` — both bypass through
-            // `From<DomainError> for CanonicalError` below and only
-            // hit this arm via tooling that lifts `DomainError`
-            // directly.
-            DomainError::IntegrityCheckLeaseLost => Self::Internal {
-                detail: "integrity repair aborted: lease lost to a peer".to_owned(),
-            },
-
-            // ---- Internal ----
+            // ---- Internal (HTTP 500) ----
             DomainError::Internal {
                 diagnostic,
                 cause: _,
-            } => Self::Internal { detail: diagnostic },
-        }
-    }
-}
-// @cpt-end:cpt-cf-account-management-algo-errors-observability-error-to-problem-mapping:p1:inst-algo-etp-domain-to-sdk
-
-// ---------------------------------------------------------------------------
-// AccountManagementError → CanonicalError (REST boundary).
-// ---------------------------------------------------------------------------
-//
-// Hosted as a free `pub(crate) fn` because both `AccountManagementError`
-// and `CanonicalError` are foreign to this crate — an `impl` block
-// here would violate the orphan rule. Callers go through the
-// `From<DomainError> for CanonicalError` impl below (REST `?`
-// shorthand); direct callers (e.g. SDK clients bubbling typed errors
-// to a REST adapter) call this function.
-
-// @cpt-begin:cpt-cf-account-management-algo-errors-observability-error-to-problem-mapping:p1:inst-algo-etp-sdk-to-canonical
-/// Lift the public SDK error envelope onto the AIP-193 canonical
-/// shape — same category, status, resource type, field-violation /
-/// precondition-violation / reason context.
-#[must_use]
-pub(crate) fn account_management_error_to_canonical(err: AccountManagementError) -> CanonicalError {
-    use AccountManagementError as A;
-    match err {
-        // ---- NotFound — one resource per variant ----
-        A::TenantNotFound { tenant_id, detail } => TenantResource::not_found(detail)
-            .with_resource(tenant_id)
-            .create(),
-        A::UserNotFound { user_id, detail } => UserResource::not_found(detail)
-            .with_resource(user_id)
-            .create(),
-        A::ConversionRequestNotFound { request_id, detail } => {
-            ConversionRequestResource::not_found(detail)
-                .with_resource(request_id)
-                .create()
-        }
-        // Both "schema unknown to registry" and "entry missing for
-        // tenant" resolve to the same `TenantMetadataResource` 404 —
-        // AM no longer distinguishes them on the wire. `entry`
-        // carries the chained `type_id` the caller supplied (or a
-        // bare `schema_uuid` on the rare orphan-row paths handled
-        // via `Internal` rather than this 404).
-        A::MetadataEntryNotFound { entry, detail } => TenantMetadataResource::not_found(detail)
-            .with_resource(entry)
-            .create(),
-        A::MetadataVersionMismatch {
-            entry,
-            expected,
-            current,
-        } => TenantMetadataResource::aborted(format!(
-            "metadata version mismatch for {entry}: expected v{expected}, stored v{current}"
-        ))
-        .with_resource(entry)
-        .with_reason("METADATA_VERSION_MISMATCH")
-        .create(),
-
-        // ---- InvalidArgument ----
-        A::InvalidTenantType { detail } => TenantResource::invalid_argument()
-            .with_field_violation("tenant_type", detail, "INVALID_TENANT_TYPE")
-            .create(),
-        A::InvalidRequest { detail } => TenantResource::invalid_argument()
-            .with_field_violation("request", detail, "VALIDATION")
-            .create(),
-        A::MetadataInvalidRequest { detail } => TenantMetadataResource::invalid_argument()
-            .with_field_violation("metadata", detail, "VALIDATION")
-            .create(),
-        A::RootTenantCannotDelete => TenantResource::invalid_argument()
-            .with_field_violation(
-                "tenant_id",
-                "root tenant cannot be deleted",
-                "ROOT_TENANT_CANNOT_DELETE",
-            )
-            .create(),
-        A::RootTenantCannotConvert => TenantResource::invalid_argument()
-            .with_field_violation(
-                "tenant_id",
-                "root tenant cannot be converted",
-                "ROOT_TENANT_CANNOT_CONVERT",
-            )
-            .create(),
-        A::RootTenantCannotChangeStatus => TenantResource::invalid_argument()
-            .with_field_violation(
-                "tenant_id",
-                "root tenant status cannot be changed",
-                "ROOT_TENANT_CANNOT_CHANGE_STATUS",
-            )
-            .create(),
-        // `field` is the dotted-path the IdP plugin localised the
-        // violation to (e.g. `provisioning_metadata.realm_name`). When
-        // the plugin can't localise (`None`) we fall back to the
-        // shared `"provisioning_metadata"` field key — the public
-        // surface every IdP plugin shares — so callers see a
-        // consistent attribution shape rather than a missing field.
-        // Stays on `TenantResource` (the operation being rejected is
-        // tenant provisioning).
-        A::IdpInvalidInput { detail, field } => TenantResource::invalid_argument()
-            .with_field_violation(
-                field.unwrap_or_else(|| "provisioning_metadata".to_owned()),
-                detail,
-                "IDP_INVALID_INPUT",
-            )
-            .create(),
-
-        // ---- AlreadyExists ----
-        A::TenantAlreadyExists { detail } => TenantResource::already_exists(detail)
-            .with_resource("tenant")
-            .create(),
-
-        // ---- FailedPrecondition (tenant) ----
-        A::TenantTypeNotAllowed { detail } => TenantResource::failed_precondition()
-            .with_precondition_violation("tenant_type", detail, "TYPE_NOT_ALLOWED")
-            .create(),
-        A::TenantDepthExceeded { detail } => TenantResource::failed_precondition()
-            .with_precondition_violation("depth", detail, "TENANT_DEPTH_EXCEEDED")
-            .create(),
-        A::TenantHasChildren => TenantResource::failed_precondition()
-            .with_precondition_violation(
-                "tenant",
-                "tenant has child tenants",
-                "TENANT_HAS_CHILDREN",
-            )
-            .create(),
-        A::TenantHasResources => TenantResource::failed_precondition()
-            .with_precondition_violation(
-                "tenant",
-                "tenant still owns resources",
-                "TENANT_HAS_RESOURCES",
-            )
-            .create(),
-        A::PreconditionFailed { detail } => TenantResource::failed_precondition()
-            .with_precondition_violation("request", detail, "PRECONDITION_FAILED")
-            .create(),
-        A::FeatureDisabled { detail } => TenantResource::failed_precondition()
-            .with_precondition_violation("configuration", detail, "FEATURE_DISABLED")
-            .create(),
-
-        // ---- AlreadyExists (conversion request) ----
-        // Duplicate-on-create per AIP-193: at-most-one-pending invariant
-        // surfaces as `code=pending_exists` (HTTP 409). The OpenAPI
-        // contract (`docs/account-management-v1.yaml`) and the handler
-        // docstrings document the 409 wire shape; the existing
-        // `request_id` is the structural resource identifier so the
-        // canonical `with_resource(...)` carries it.
-        A::PendingConversionExists { request_id } => ConversionRequestResource::already_exists(
-            format!("a pending conversion request already exists: {request_id}"),
-        )
-        .with_resource(request_id)
-        .create(),
-
-        // ---- FailedPrecondition (conversion request) ----
-        A::InvalidActorForConversionTransition {
-            attempted_status,
-            caller_side,
-        } => ConversionRequestResource::failed_precondition()
-            .with_precondition_violation(
-                "conversion_request",
-                format!(
-                    "invalid actor for conversion transition: \
-                     attempted={attempted_status} caller_side={caller_side}"
-                ),
-                "INVALID_ACTOR_FOR_TRANSITION",
-            )
-            .create(),
-        A::ConversionAlreadyResolved => ConversionRequestResource::failed_precondition()
-            .with_precondition_violation(
-                "conversion_request",
-                "conversion request already resolved",
-                "ALREADY_RESOLVED",
-            )
-            .create(),
-
-        // ---- Aborted (HTTP 409 with reason) ----
-        A::SerializationConflict { detail } => TenantResource::aborted(detail)
-            .with_reason("SERIALIZATION_CONFLICT")
-            .create(),
-
-        // ---- PermissionDenied ----
-        //
-        // Macro-supplied default detail: "You do not have permission
-        // to perform this operation". Match the pre-migration wire
-        // shape — no caller-supplied detail override.
-        A::CrossTenantDenied => TenantResource::permission_denied()
-            .with_reason("CROSS_TENANT_DENIED")
-            .create(),
-
-        // ---- Unimplemented ----
-        A::UnsupportedOperation => {
-            TenantResource::unimplemented("operation not supported by the IdP provider").create()
-        }
-
-        // ---- ServiceUnavailable ----
-        //
-        // `IdpUnavailable` is a tagged subset of canonical
-        // `ServiceUnavailable` — the SDK enum distinguishes it for
-        // typed retry logic, but the wire envelope collapses to the
-        // same 503 shape (no `retry_after_seconds` because IdP retry
-        // budgets are governed by the bootstrap saga, not the wire
-        // hint).
-        A::IdpUnavailable => CanonicalError::service_unavailable()
-            .with_detail("IdP plugin unavailable")
-            .create(),
-        A::ServiceUnavailable {
-            detail,
-            retry_after_seconds,
-        } => {
-            let mut builder = CanonicalError::service_unavailable().with_detail(detail);
-            if let Some(after) = retry_after_seconds {
-                builder = builder.with_retry_after_seconds(u64::from(after));
-            }
-            builder.create()
-        }
-
-        // ---- Internal ----
-        A::Internal { detail } => CanonicalError::internal(detail).create(),
-
-        // `AccountManagementError` is `#[non_exhaustive]`; this
-        // fallback maps any unmapped variant to a 500 with a generic
-        // diagnostic.
-        #[allow(unreachable_patterns)]
-        _ => CanonicalError::internal("unmapped AccountManagementError variant").create(),
-    }
-}
-// @cpt-end:cpt-cf-account-management-algo-errors-observability-error-to-problem-mapping:p1:inst-algo-etp-sdk-to-canonical
-
-// ---------------------------------------------------------------------------
-// DomainError → CanonicalError (REST `?` shorthand).
-// ---------------------------------------------------------------------------
-
-// @cpt-begin:cpt-cf-account-management-algo-errors-observability-error-to-problem-mapping:p1:inst-algo-etp-domain-to-canonical
-impl From<DomainError> for CanonicalError {
-    fn from(err: DomainError) -> Self {
-        match err {
-            // Bypass: `IntegrityCheckInProgress` is not exposed via
-            // the public SDK contract (no `AccountManagementClient`
-            // method surfaces it) — route directly to the canonical
-            // 429 envelope without instantiating an
-            // `AccountManagementError`. Wire-shape identical to the
-            // pre-migration two-hop output.
-            DomainError::IntegrityCheckInProgress => {
-                TenantResource::resource_exhausted("integrity check already in progress")
-                    .with_quota_violation(
-                        "integrity_check",
-                        "another integrity check is already in progress",
-                    )
-                    .create()
-            }
-            // `IntegrityCheckLeaseLost` shares the public retry
-            // contract with `IntegrityCheckInProgress` — both surface
-            // as the same canonical 429 envelope. The metric-label
-            // split (`AbortedLeaseLost` vs `SkippedInProgress`) is
-            // observed at the loop-driver layer, not at the REST
-            // boundary, so collapsing them here keeps the public
-            // contract stable.
-            DomainError::IntegrityCheckLeaseLost => {
-                TenantResource::resource_exhausted("integrity repair aborted: lease lost to a peer")
-                    .with_quota_violation(
-                        "integrity_check",
-                        "integrity repair aborted; another worker took the lease",
-                    )
-                    .create()
-            }
-            other => account_management_error_to_canonical(AccountManagementError::from(other)),
+            } => CanonicalError::internal(diagnostic).create(),
         }
     }
 }

--- a/gears/system/account-management/account-management/src/infra/sdk_error_mapping_tests.rs
+++ b/gears/system/account-management/account-management/src/infra/sdk_error_mapping_tests.rs
@@ -1,41 +1,22 @@
-//! Composition tests: `DomainError → AccountManagementError → CanonicalError`
-//! preserves the pre-migration AIP-193 envelope shape variant-by-variant.
+//! Regression tests for the single `From<DomainError> for CanonicalError`
+//! ladder in [`super::sdk_error_mapping`].
 //!
-//! The pre-migration regression line lived in `domain/error_tests.rs`
-//! and asserted directly on `From<DomainError> for CanonicalError`.
-//! That single-hop boundary is now replaced by the two-step pipeline
-//! [`From<DomainError> for AccountManagementError`] +
-//! [`From<AccountManagementError> for CanonicalError`] in
-//! [`super::sdk_error_mapping`]. These tests assert that the
-//! composition still produces the exact same `CanonicalError` envelope
-//! shape — same AIP-193 category, HTTP status, resource type, and key
-//! context fields — for every `DomainError` variant.
+//! Per ADR 0005 there is one classification ladder; these tests pin the
+//! exact `CanonicalError` envelope it produces — AIP-193 category, HTTP
+//! status, resource type, and key context fields (`field_violations`,
+//! `violations`, `reason`) — for every `DomainError` variant. They are
+//! the unit-level wire-invariant guard; the HTTP-level sweep lives in
+//! `tests/api_status_mapping_test.rs`.
 
 use std::time::Duration;
 
-use account_management_sdk::error::AccountManagementError;
 use toolkit_canonical_errors::{CanonicalError, InvalidArgument};
 
 use crate::domain::error::DomainError;
-use crate::infra::sdk_error_mapping::account_management_error_to_canonical;
 
-/// Run a `DomainError` through the production pipeline. For variants
-/// that travel via the SDK boundary this is the two-step
-/// `DomainError → AccountManagementError → CanonicalError`; for the
-/// `IntegrityCheckInProgress` bypass (not part of the inter-gear
-/// SDK contract) the `From<DomainError> for CanonicalError` impl
-/// short-circuits directly to the canonical envelope.
+/// Run a `DomainError` through the single canonical ladder.
 fn round_trip(d: DomainError) -> CanonicalError {
     CanonicalError::from(d)
-}
-
-/// Variants of [`round_trip`] for tests that want to pin the SDK shape
-/// before the canonical conversion. Unsuitable for
-/// `IntegrityCheckInProgress` (it bypasses the SDK boundary).
-#[allow(dead_code)]
-fn round_trip_via_sdk(d: DomainError) -> CanonicalError {
-    let sdk: AccountManagementError = d.into();
-    account_management_error_to_canonical(sdk)
 }
 
 // ---------------------------------------------------------------------------
@@ -568,26 +549,6 @@ fn integrity_check_in_progress_maps_to_429_with_quota_violation() {
     };
     assert_eq!(ctx.violations.len(), 1);
     assert_eq!(ctx.violations[0].subject, "integrity_check");
-}
-
-#[test]
-fn integrity_check_in_progress_via_sdk_boundary_does_not_panic() {
-    // Defensive coverage for the pre-fix `unreachable!()` on
-    // `From<DomainError> for AccountManagementError`. The canonical
-    // path short-circuits `IntegrityCheckInProgress` before the SDK
-    // hop, but a direct caller (tooling that bubbles typed SDK
-    // errors) used to crash the process. The mapping now produces
-    // an `Internal` SDK variant, and the SDK→canonical hop renders
-    // it as a generic 500 — distinct from the 429 quota envelope on
-    // the canonical bypass above, by design (the SDK boundary is
-    // not where `IntegrityCheckInProgress` is supposed to surface).
-    let sdk: AccountManagementError = DomainError::IntegrityCheckInProgress.into();
-    assert!(
-        matches!(sdk, AccountManagementError::Internal { .. }),
-        "SDK boundary must map IntegrityCheckInProgress defensively, got {sdk:?}",
-    );
-    let canonical = account_management_error_to_canonical(sdk);
-    assert_eq!(canonical.status_code(), 500);
 }
 
 // ---------------------------------------------------------------------------

--- a/gears/system/account-management/account-management/src/infra/storage/repo_impl/helpers_tests.rs
+++ b/gears/system/account-management/account-management/src/infra/storage/repo_impl/helpers_tests.rs
@@ -4,6 +4,7 @@
 use super::*;
 use account_management_sdk::error::AccountManagementError;
 use time::OffsetDateTime;
+use toolkit_canonical_errors::CanonicalError;
 
 #[test]
 fn entity_to_model_rejects_unknown_status() {
@@ -80,8 +81,11 @@ fn map_scope_err_preserves_tenant_not_in_scope_routing() {
     };
     let err = map_scope_err(scope_err);
     assert!(matches!(err, DomainError::CrossTenantDenied { .. }));
-    let ame: AccountManagementError = err.into();
-    assert!(ame.is_permission_denied());
+    let ame = AccountManagementError::from(CanonicalError::from(err));
+    assert!(matches!(
+        ame,
+        AccountManagementError::PermissionDenied { .. }
+    ));
 }
 
 #[test]

--- a/gears/system/account-management/account-management/tests/api_tenants_test.rs
+++ b/gears/system/account-management/account-management/tests/api_tenants_test.rs
@@ -473,9 +473,8 @@ async fn suspend_tenant_is_idempotent_on_suspended_tenant() {
 
 #[tokio::test]
 async fn suspend_tenant_rejects_deleted_tenant_with_400() {
-    // `DomainError::Conflict` (target is `Deleted`) lifts to
-    // `AccountManagementError::PreconditionFailed` and the canonical
-    // mapping renders `failed_precondition` as HTTP 400 (see
+    // `DomainError::Conflict` (target is `Deleted`) maps to
+    // `CanonicalError::FailedPrecondition`, rendered as HTTP 400 (see
     // `infra::sdk_error_mapping` -- the only `409` paths on the AM
     // surface are `AlreadyExists` and `Aborted`/serialization-conflict).
     // The task brief named this "_409" but the wire reality matches the


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  - Account Management SDK now returns standardized canonical error types instead of custom error types. SDK provides conversion utilities to optionally project canonical errors into typed error categories.

* **Refactor**
  - Simplified error classification with AIP-193 aligned canonical error format across all Account Management operations.
  - Removed legacy error helper methods in favor of new vocabulary modules for field validation, preconditions, and quota management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->