### PR TITLE
refactor(nodes-registry): adopt SDK canonical-projection pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,7 +1759,9 @@ name = "cf-gears-nodes-registry-sdk"
 version = "0.1.21"
 dependencies = [
  "async-trait",
+ "cf-gears-toolkit-canonical-errors",
  "cf-gears-toolkit-node-info",
+ "serde_json",
  "thiserror 2.0.18",
  "uuid",
 ]

--- a/gears/system/nodes-registry/nodes-registry-sdk/Cargo.toml
+++ b/gears/system/nodes-registry/nodes-registry-sdk/Cargo.toml
@@ -23,4 +23,8 @@ async-trait = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 
+toolkit-canonical-errors = { workspace = true }
 toolkit-node-info = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/gears/system/nodes-registry/nodes-registry-sdk/src/api.rs
+++ b/gears/system/nodes-registry/nodes-registry-sdk/src/api.rs
@@ -1,21 +1,29 @@
-use crate::error::NodesRegistryError;
+use toolkit_canonical_errors::CanonicalError;
+
 use crate::{Node, NodeSysCap, NodeSysInfo};
 
-/// Client trait for accessing nodes registry functionality
+/// Client trait for accessing nodes registry functionality.
+///
+/// Per [ADR 0005][adr] every fallible method returns
+/// `Result<_, CanonicalError>` — the canonical error envelope is the
+/// contract at this in-process boundary. Consumers that prefer flat
+/// dispatch over the categories nodes-registry emits may project the
+/// envelope into the opt-in [`crate::NodesRegistryError`] view via
+/// `.map_err(NodesRegistryError::from)`; see its gear docs for the
+/// dispatch table and consumer patterns.
+///
+/// [adr]: https://github.com/constructorfabric/gears-rust/blob/main/docs/arch/errors/ADR/0005-cpt-cf-adr-sdk-canonical-projection.md
 #[async_trait::async_trait]
 pub trait NodesRegistryClient: Send + Sync {
     /// Get a node by ID
-    async fn get_node(&self, id: uuid::Uuid) -> Result<Node, NodesRegistryError>;
+    async fn get_node(&self, id: uuid::Uuid) -> Result<Node, CanonicalError>;
 
     /// List all nodes
-    async fn list_nodes(&self) -> Result<Vec<Node>, NodesRegistryError>;
+    async fn list_nodes(&self) -> Result<Vec<Node>, CanonicalError>;
 
     /// Get system information for a node
-    async fn get_node_sysinfo(
-        &self,
-        node_id: uuid::Uuid,
-    ) -> Result<NodeSysInfo, NodesRegistryError>;
+    async fn get_node_sysinfo(&self, node_id: uuid::Uuid) -> Result<NodeSysInfo, CanonicalError>;
 
     /// Get system capabilities for a node
-    async fn get_node_syscap(&self, node_id: uuid::Uuid) -> Result<NodeSysCap, NodesRegistryError>;
+    async fn get_node_syscap(&self, node_id: uuid::Uuid) -> Result<NodeSysCap, CanonicalError>;
 }

--- a/gears/system/nodes-registry/nodes-registry-sdk/src/error.rs
+++ b/gears/system/nodes-registry/nodes-registry-sdk/src/error.rs
@@ -1,18 +1,167 @@
-/// Errors for the nodes registry gear
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+//! Nodes Registry SDK error surface — typed projection of
+//! [`CanonicalError`].
+//!
+//! # Opt-in convenience, not the contract
+//!
+//! Per [ADR 0005][adr] the [`NodesRegistryClient`] trait boundary is
+//! `Result<_, CanonicalError>`. [`NodesRegistryError`] is an **opt-in**
+//! typed view over that envelope, shipped for consumers that want flat
+//! dispatch on the categories nodes-registry emits. It is *not* part of
+//! the trait contract: adding a variant is non-breaking, and the single
+//! authoritative AIP-193 classification lives in the impl crate's one
+//! `From<DomainError> for CanonicalError` ladder — this projection only
+//! reads the finished `CanonicalError`.
+//!
+//! The conversion is infallible (`From<CanonicalError>`). Canonical
+//! categories nodes-registry does not emit fall through to
+//! [`NodesRegistryError::Other`], which preserves the full
+//! [`CanonicalError`] for inspection / forward-compatible dispatch.
+//!
+//! # What nodes-registry emits — consumer dispatch reference
+//!
+//! | Disposition | Match arm | HTTP |
+//! |---|---|---|
+//! | node id does not resolve | [`NodesRegistryError::NotFound`] | 404 |
+//! | request-input validation (e.g. bad capability key) | [`NodesRegistryError::InvalidArgument`] | 400 |
+//! | sysinfo/syscap collection failure, internal error | [`NodesRegistryError::Internal`] | 500 |
+//! | anything else (forward-compat) | [`NodesRegistryError::Other`] | — |
+//!
+//! [`NodesRegistryError::NotFound`] carries the raw `resource_type`;
+//! match it against [`crate::gts::NODE_RESOURCE_TYPE`].
+//! [`NodesRegistryError::InvalidArgument`] carries the wire `reason`
+//! (currently only [`crate::field::VALIDATION_ERROR`]) and `field`.
+//!
+//! # Consumer integration — three patterns
+//!
+//! **Pattern 1 — pure propagation (no projection):**
+//!
+//! ```ignore
+//! let node = nodes_client.get_node(id).await?; // ? propagates CanonicalError
+//! ```
+//!
+//! **Pattern 2 — explicit projection at the call site:**
+//!
+//! ```ignore
+//! use nodes_registry_sdk::NodesRegistryError;
+//!
+//! match nodes_client.get_node(id).await.map_err(NodesRegistryError::from) {
+//!     Err(NodesRegistryError::NotFound { .. }) => /* unknown node */,
+//!     Err(NodesRegistryError::InvalidArgument { field, .. }) => /* bad input */,
+//!     _ => /* … */,
+//! }
+//! ```
+//!
+//! **Pattern 3 — transparent chaining via `From<CanonicalError> for OwnError`:**
+//!
+//! ```ignore
+//! impl From<CanonicalError> for OwnConsumerError {
+//!     fn from(err: CanonicalError) -> Self {
+//!         NodesRegistryError::from(err).into() // route through the typed view
+//!     }
+//! }
+//! // then every call site stays plain `?`.
+//! ```
+//!
+//! Out-of-process consumers reconstruct the canonical error from the
+//! wire via `TryFrom<Problem> for CanonicalError` first, then project:
+//! `Problem JSON → Problem → CanonicalError → NodesRegistryError`.
+//!
+//! [`NodesRegistryClient`]: crate::NodesRegistryClient
+//! [adr]: https://github.com/constructorfabric/gears-rust/blob/main/docs/arch/errors/ADR/0005-cpt-cf-adr-sdk-canonical-projection.md
+
+use thiserror::Error;
+use toolkit_canonical_errors::{CanonicalError, InvalidArgument};
+
+/// Typed projection of [`CanonicalError`] for nodes-registry consumers.
+///
+/// The impl crate's `From<DomainError> for CanonicalError` is the single
+/// authoritative AIP-193 mapping; this enum is a forward-compatible,
+/// flat view over the three categories nodes-registry emits, plus the
+/// mandatory catch-all [`Self::Other`]. See the [gear docs](self) for
+/// the dispatch table and consumer patterns.
+#[derive(Debug, Clone, Error)]
+#[non_exhaustive]
 pub enum NodesRegistryError {
-    #[error("Node not found with ID: {0}")]
-    NodeNotFound(uuid::Uuid),
+    /// Node not found. `resource_type` is the canonical GTS type — match
+    /// it against [`crate::gts::NODE_RESOURCE_TYPE`]; `name` is the raw
+    /// node id the caller supplied.
+    #[error("not found [{resource_type}]: {name}")]
+    NotFound {
+        resource_type: String,
+        name: String,
+        detail: String,
+    },
 
-    #[error("Failed to collect system information: {0}")]
-    SysInfoCollectionFailed(String),
+    /// Request-input validation failure. `reason` is the wire code
+    /// (currently only [`crate::field::VALIDATION_ERROR`]); `field` is
+    /// the attributed request input.
+    #[error("invalid argument [{field}/{reason}]: {detail}")]
+    InvalidArgument {
+        field: String,
+        reason: String,
+        detail: String,
+    },
 
-    #[error("Failed to collect system capabilities: {0}")]
-    SysCapCollectionFailed(String),
+    /// Internal failure — sysinfo/syscap collection failure or an
+    /// internal error (HTTP 500). Detail is intentionally opaque.
+    #[error("internal error: {detail}")]
+    Internal { detail: String },
 
-    #[error("Invalid input: {0}")]
-    Validation(String),
-
-    #[error("An internal error occurred")]
-    Internal,
+    /// Forward-compatibility catch-all for any canonical category
+    /// nodes-registry does not model above. Preserves the full
+    /// [`CanonicalError`] for inspection.
+    #[error("{canonical}")]
+    Other { canonical: CanonicalError },
 }
+
+impl From<CanonicalError> for NodesRegistryError {
+    fn from(err: CanonicalError) -> Self {
+        let detail = err.detail().to_owned();
+        match err {
+            CanonicalError::NotFound {
+                resource_type,
+                resource_name,
+                ..
+            } => Self::NotFound {
+                resource_type: resource_type.unwrap_or_default(),
+                name: resource_name.unwrap_or_default(),
+                detail,
+            },
+
+            CanonicalError::InvalidArgument { ctx, .. } => project_invalid_argument(ctx, detail),
+
+            CanonicalError::Internal { .. } => Self::Internal { detail },
+
+            other => Self::Other { canonical: other },
+        }
+    }
+}
+
+fn project_invalid_argument(ctx: InvalidArgument, detail: String) -> NodesRegistryError {
+    // nodes-registry only ever emits the `FieldViolations` shape with a
+    // single violation; the `Format` / `Constraint` shapes and the empty
+    // case fall back to the canonical detail with an empty field/reason.
+    let first_violation = match ctx {
+        InvalidArgument::FieldViolations { field_violations } => {
+            field_violations.into_iter().next()
+        }
+        InvalidArgument::Format { .. } | InvalidArgument::Constraint { .. } => None,
+    };
+
+    first_violation.map_or(
+        NodesRegistryError::InvalidArgument {
+            field: String::new(),
+            reason: String::new(),
+            detail,
+        },
+        |v| NodesRegistryError::InvalidArgument {
+            field: v.field,
+            reason: v.reason,
+            detail: v.description,
+        },
+    )
+}
+
+#[cfg(test)]
+#[path = "error_tests.rs"]
+mod error_tests;

--- a/gears/system/nodes-registry/nodes-registry-sdk/src/error_tests.rs
+++ b/gears/system/nodes-registry/nodes-registry-sdk/src/error_tests.rs
@@ -1,0 +1,165 @@
+//! Tests for the [`NodesRegistryError`](super::NodesRegistryError) projection.
+//!
+//! Two suites:
+//!
+//! * `wire_vocabulary_round_trip` — pins every wire-string constant the
+//!   projection introduces ([`crate::field`], [`crate::gts`]) to its
+//!   `Problem` JSON path. A drift between an SDK constant and the wire
+//!   trips here.
+//! * `projection_tests` — exercises `From<CanonicalError>`, verifying
+//!   each canonical category nodes-registry emits lands on the expected
+//!   typed variant and that unmodeled categories preserve the canonical
+//!   in `Other`.
+
+use super::NodesRegistryError;
+
+// ─────────────────────────────────────────────────────────────────────
+// Wire-vocabulary round-trip
+// ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod wire_vocabulary_round_trip {
+    use crate::{field, gts};
+    use toolkit_canonical_errors::{CanonicalError, Problem, resource_error};
+
+    // Test scope mirroring the impl crate's `#[resource_error]` marker.
+    // Its literal MUST equal `gts::NODE_RESOURCE_TYPE` — the
+    // `node_resource_type_round_trip` test asserts that equality.
+    #[resource_error("gts.cf.nodes_registry.registry.node.v1~")]
+    struct NodeScope;
+
+    fn problem(err: CanonicalError) -> serde_json::Value {
+        serde_json::to_value(Problem::from(err)).expect("Problem serializes")
+    }
+
+    #[test]
+    fn node_resource_type_round_trips_to_context_resource_type() {
+        let err = NodeScope::not_found("missing").with_resource("x").create();
+        let json = problem(err);
+        assert_eq!(
+            json["context"]["resource_type"],
+            gts::NODE_RESOURCE_TYPE,
+            "NODE_RESOURCE_TYPE must round-trip into context.resource_type",
+        );
+    }
+
+    #[test]
+    fn field_vocabulary_round_trips_to_field_violations() {
+        let err = NodeScope::invalid_argument()
+            .with_field_violation(
+                field::INPUT_FIELD,
+                "bad capability key",
+                field::VALIDATION_ERROR,
+            )
+            .create();
+        let json = problem(err);
+        assert_eq!(
+            json["context"]["field_violations"][0]["field"],
+            field::INPUT_FIELD,
+            "INPUT_FIELD must round-trip into field_violations[].field",
+        );
+        assert_eq!(
+            json["context"]["field_violations"][0]["reason"],
+            field::VALIDATION_ERROR,
+            "VALIDATION_ERROR must round-trip into field_violations[].reason",
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Projection — From<CanonicalError>
+// ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod projection_tests {
+    use super::NodesRegistryError;
+    use crate::{field, gts};
+    use toolkit_canonical_errors::{CanonicalError, resource_error};
+
+    #[resource_error("gts.cf.nodes_registry.registry.node.v1~")]
+    struct NodeScope;
+
+    #[test]
+    fn not_found_projects_to_not_found_with_resource_type_and_name() {
+        let err = NodeScope::not_found("no node with id abc")
+            .with_resource("abc")
+            .create();
+        match NodesRegistryError::from(err) {
+            NodesRegistryError::NotFound {
+                resource_type,
+                name,
+                ..
+            } => {
+                assert_eq!(resource_type, gts::NODE_RESOURCE_TYPE);
+                assert_eq!(name, "abc");
+            }
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn invalid_argument_projects_field_reason_and_description() {
+        let err = NodeScope::invalid_argument()
+            .with_field_violation(
+                field::INPUT_FIELD,
+                "bad capability key",
+                field::VALIDATION_ERROR,
+            )
+            .create();
+        match NodesRegistryError::from(err) {
+            NodesRegistryError::InvalidArgument {
+                field: field_name,
+                reason,
+                detail,
+            } => {
+                assert_eq!(field_name, field::INPUT_FIELD);
+                assert_eq!(reason, field::VALIDATION_ERROR);
+                assert_eq!(detail, "bad capability key");
+            }
+            other => panic!("expected InvalidArgument, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn invalid_argument_without_field_violation_falls_back_to_empty_field_reason() {
+        // nodes-registry never emits the `Format` / `Constraint` / empty
+        // shapes, but the projection must still handle them: field/reason
+        // go empty and `detail` falls back to the canonical detail (the
+        // format message, here).
+        let err = NodeScope::invalid_argument()
+            .with_format("malformed request shape")
+            .create();
+        match NodesRegistryError::from(err) {
+            NodesRegistryError::InvalidArgument {
+                field,
+                reason,
+                detail,
+            } => {
+                assert!(field.is_empty(), "field should be empty, got {field:?}");
+                assert!(reason.is_empty(), "reason should be empty, got {reason:?}");
+                assert_eq!(detail, "malformed request shape");
+            }
+            other => panic!("expected InvalidArgument, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn internal_projects_to_internal() {
+        let err = CanonicalError::internal("collection failed").create();
+        assert!(matches!(
+            NodesRegistryError::from(err),
+            NodesRegistryError::Internal { .. }
+        ));
+    }
+
+    #[test]
+    fn unmodeled_category_falls_through_to_other() {
+        // nodes-registry never emits ServiceUnavailable — it must be
+        // preserved verbatim in the `Other` catch-all.
+        let err = CanonicalError::service_unavailable().create();
+        assert!(matches!(
+            NodesRegistryError::from(err),
+            NodesRegistryError::Other { .. }
+        ));
+    }
+}

--- a/gears/system/nodes-registry/nodes-registry-sdk/src/field.rs
+++ b/gears/system/nodes-registry/nodes-registry-sdk/src/field.rs
@@ -1,0 +1,30 @@
+//! Wire `field` / `reason` vocabulary for field violations under
+//! [`CanonicalError::InvalidArgument`].
+//!
+//! The reason constant is a stable machine-readable code that lands in
+//! `CanonicalError::InvalidArgument.ctx.field_violations[].reason` when
+//! the nodes registry rejects request input; the field constant is the
+//! corresponding `field_violations[].field` attribution.
+//!
+//! nodes-registry emits exactly one reason (`VALIDATION_ERROR`), so the
+//! projected [`crate::NodesRegistryError::InvalidArgument`] carries the
+//! `reason` as a plain `String` rather than a typed sub-enum — there is
+//! no second disposition to `match` on. A typed `ValidationReason` view
+//! can be introduced later if the emission set grows; this gear is the
+//! seam for that. The impl crate's single
+//! `From<DomainError> for CanonicalError` ladder references the same
+//! constants at construction time so the SDK vocabulary and the wire can
+//! never drift — the round-trip tests in [`crate::error`] pin every
+//! constant to its `Problem` JSON path.
+//!
+//! [`CanonicalError::InvalidArgument`]: toolkit_canonical_errors::CanonicalError::InvalidArgument
+
+/// Generic request-input validation failure (e.g. malformed capability
+/// key). The only `field_violations[].reason` nodes-registry emits.
+pub const VALIDATION_ERROR: &str = "VALIDATION_ERROR";
+
+/// `field_violations[].field` attribution for [`VALIDATION_ERROR`] — the
+/// rejected request input. Not a dispatch discriminator; extracted to a
+/// const (ADR 0005 Rule 6) so the impl ladder and the SDK vocabulary
+/// cannot drift, pinned by the round-trip tests.
+pub const INPUT_FIELD: &str = "input";

--- a/gears/system/nodes-registry/nodes-registry-sdk/src/gts.rs
+++ b/gears/system/nodes-registry/nodes-registry-sdk/src/gts.rs
@@ -1,0 +1,23 @@
+//! GTS resource type identifiers for the nodes registry.
+//!
+//! Single source of truth for the nodes-registry resource-type string
+//! used as the `resource_type` field on the canonical envelope (and the
+//! projected [`crate::NodesRegistryError::NotFound`] variant) when a node
+//! lookup misses.
+//!
+//! The string follows the gear's GTS namespace convention,
+//! `gts.cf.nodes_registry.registry.node.v1~`. The trailing `~` is the
+//! GTS terminator and is part of the identifier.
+//!
+//! # Note on `#[resource_error]` macro arguments
+//!
+//! The `toolkit_canonical_errors::resource_error` proc-macro takes a
+//! literal string at expansion time and cannot resolve constants — the
+//! impl-crate site (`api/rest/error.rs`) therefore duplicates this
+//! literal. The round-trip tests in [`crate::error`] assert the wire
+//! `resource_type` equals this constant, so a divergence trips at test
+//! time, not in production.
+
+/// Nodes-registry node resource. Surfaces as the `resource_type` on the
+/// canonical `NotFound` raised when a node id does not resolve (404).
+pub const NODE_RESOURCE_TYPE: &str = "gts.cf.nodes_registry.registry.node.v1~";

--- a/gears/system/nodes-registry/nodes-registry-sdk/src/lib.rs
+++ b/gears/system/nodes-registry/nodes-registry-sdk/src/lib.rs
@@ -1,11 +1,41 @@
+//! Nodes Registry SDK — public contract surface.
+//!
+//! This crate publishes the inter-gear client trait
+//! ([`NodesRegistryClient`]) and its node data types. Per
+//! [ADR 0005][adr] the trait boundary is
+//! [`toolkit_canonical_errors::CanonicalError`]; the SDK additionally
+//! ships [`NodesRegistryError`] as an **opt-in** typed projection
+//! (`From<CanonicalError>`) for consumers that want flat dispatch on
+//! the categories nodes-registry emits. The single authoritative
+//! AIP-193 ladder (`From<DomainError> for CanonicalError`) lives in the
+//! impl crate (`cf-gears-nodes-registry`); this SDK never re-derives
+//! that classification — it only projects the finished `CanonicalError`.
+//!
+//! # Error surface
+//!
+//! Trait methods return `Result<_, CanonicalError>`. Consumers may
+//! propagate the canonical error, or project it into the typed
+//! [`NodesRegistryError`] view via
+//! `.map_err(NodesRegistryError::from)` (or a
+//! `From<CanonicalError> for OwnError` chain). The projection models the
+//! three canonical categories nodes-registry emits (`NotFound`,
+//! `InvalidArgument`, `Internal`), plus a catch-all `Other { canonical }`;
+//! see [`error`] for the full dispatch table, the three consumer
+//! integration patterns, and the co-located wire vocabulary ([`field`],
+//! [`gts`]).
+//!
+//! [adr]: https://github.com/constructorfabric/gears-rust/blob/main/docs/arch/errors/ADR/0005-cpt-cf-adr-sdk-canonical-projection.md
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
 
 pub mod api;
 pub mod error;
+pub mod field;
+pub mod gts;
 
 pub use api::NodesRegistryClient;
 pub use error::NodesRegistryError;
+pub use gts::NODE_RESOURCE_TYPE;
 
 pub use toolkit_node_info::{
     BatteryInfo, CpuInfo, GpuInfo, HostInfo, MemoryInfo, Node, NodeSysCap, NodeSysInfo, OsInfo,

--- a/gears/system/nodes-registry/nodes-registry/src/api/rest/error.rs
+++ b/gears/system/nodes-registry/nodes-registry/src/api/rest/error.rs
@@ -39,7 +39,11 @@ impl From<DomainError> for CanonicalError {
                 CanonicalError::internal(msg).create()
             }
             DomainError::InvalidInput(msg) => NodeError::invalid_argument()
-                .with_field_violation("input", msg, "VALIDATION_ERROR")
+                .with_field_violation(
+                    nodes_registry_sdk::field::INPUT_FIELD,
+                    msg,
+                    nodes_registry_sdk::field::VALIDATION_ERROR,
+                )
                 .create(),
         }
     }

--- a/gears/system/nodes-registry/nodes-registry/src/domain/error.rs
+++ b/gears/system/nodes-registry/nodes-registry/src/domain/error.rs
@@ -43,15 +43,3 @@ impl From<toolkit_node_info::NodeInfoError> for DomainError {
         }
     }
 }
-
-impl From<DomainError> for nodes_registry_sdk::NodesRegistryError {
-    fn from(e: DomainError) -> Self {
-        match e {
-            DomainError::NodeNotFound(id) => Self::NodeNotFound(id),
-            DomainError::SysInfoCollectionFailed(msg) => Self::SysInfoCollectionFailed(msg),
-            DomainError::SysCapCollectionFailed(msg) => Self::SysCapCollectionFailed(msg),
-            DomainError::InvalidInput(msg) => Self::Validation(msg),
-            DomainError::Internal(_) => Self::Internal,
-        }
-    }
-}

--- a/gears/system/nodes-registry/nodes-registry/src/domain/local_client.rs
+++ b/gears/system/nodes-registry/nodes-registry/src/domain/local_client.rs
@@ -1,6 +1,7 @@
 use crate::domain::service::Service;
-use nodes_registry_sdk::{Node, NodeSysCap, NodeSysInfo, NodesRegistryClient, NodesRegistryError};
+use nodes_registry_sdk::{Node, NodeSysCap, NodeSysInfo, NodesRegistryClient};
 use std::sync::Arc;
+use toolkit_canonical_errors::CanonicalError;
 use toolkit_macros::domain_model;
 
 /// Local client implementation for the nodes registry
@@ -18,24 +19,23 @@ impl NodesRegistryLocalClient {
 
 #[async_trait::async_trait]
 impl NodesRegistryClient for NodesRegistryLocalClient {
-    async fn get_node(&self, id: uuid::Uuid) -> Result<Node, NodesRegistryError> {
-        self.service.get_node(id).map_err(Into::into)
+    async fn get_node(&self, id: uuid::Uuid) -> Result<Node, CanonicalError> {
+        self.service.get_node(id).map_err(CanonicalError::from)
     }
 
-    async fn list_nodes(&self) -> Result<Vec<Node>, NodesRegistryError> {
+    async fn list_nodes(&self) -> Result<Vec<Node>, CanonicalError> {
         Ok(self.service.list_nodes())
     }
 
-    async fn get_node_sysinfo(
-        &self,
-        node_id: uuid::Uuid,
-    ) -> Result<NodeSysInfo, NodesRegistryError> {
-        self.service.get_node_sysinfo(node_id).map_err(Into::into)
+    async fn get_node_sysinfo(&self, node_id: uuid::Uuid) -> Result<NodeSysInfo, CanonicalError> {
+        self.service
+            .get_node_sysinfo(node_id)
+            .map_err(CanonicalError::from)
     }
 
-    async fn get_node_syscap(&self, node_id: uuid::Uuid) -> Result<NodeSysCap, NodesRegistryError> {
+    async fn get_node_syscap(&self, node_id: uuid::Uuid) -> Result<NodeSysCap, CanonicalError> {
         self.service
             .get_node_syscap(node_id, false)
-            .map_err(Into::into)
+            .map_err(CanonicalError::from)
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Standardized error handling across the Nodes Registry SDK to use a consistent canonical error format, improving error categorization and consistency.

* **Chores**
  * Updated internal dependencies and refactored error handling mechanisms to align with system-wide error standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->