### PR TITLE
docs(license-resolver): prepare design documents

### DIFF
--- a/gears/system/license-resolver/docs/ADR/0001-cpt-cf-license-resolver-adr-gts-resource-identity.md
+++ b/gears/system/license-resolver/docs/ADR/0001-cpt-cf-license-resolver-adr-gts-resource-identity.md
@@ -1,9 +1,9 @@
 ---
 status: accepted
-date: 2026-06-08
+date: 2026-06-11
 ---
 
-# ADR-0001: Resource Identity as a Single GTS Instance ID
+# ADR-0001: Subject and Resource Identity as GTS Type plus Optional Instance ID
 
 <!-- toc -->
 
@@ -14,8 +14,8 @@ date: 2026-06-08
   - [Consequences](#consequences)
   - [Confirmation](#confirmation)
 - [Pros and Cons of the Options](#pros-and-cons-of-the-options)
-  - [(a) Single `GtsInstanceId`](#a-single-gtsinstanceid)
-  - [(b) Split `ResourceRef`](#b-split-resourceref)
+  - [(a) GTS type (required) + optional instance id](#a-gts-type-required--optional-instance-id)
+  - [(b) Single `GtsInstanceId`](#b-single-gtsinstanceid)
   - [(c) Free-form / opaque string](#c-free-form--opaque-string)
 - [More Information](#more-information)
 - [Traceability](#traceability)
@@ -27,98 +27,88 @@ date: 2026-06-08
 ## Context and Problem Statement
 
 License resolver answers "is THIS resource granted to THIS subject?", so every check must carry a stable, unambiguous
-identity for the resource being licensed. A licensable resource comes in two kinds: a **named** resource — a stable,
-human-meaningful instance such as a specific feature — and an **opaque** resource — a runtime instance addressed by a
-UUID, for example a content item. Resources are heterogeneous and externally owned (a feature type is owned by the
-feature module, a content type by the content module, etc.). The contract must represent "resource type + id" so that
-both kinds are expressible. The Global Type System (GTS) already provides exactly this shape: an **instance identifier**
-joins a type chain and an instance segment with `~`, and supports both well-known/named instances (§2.3) and anonymous
-instances addressed by UUID (§2.4, combined notation). How should the cross-module contract represent resource identity?
+identity for both sides. Checks come in two kinds. A **specific-instance** check targets one concrete object — a
+**named** instance (a stable, human-meaningful name such as a specific feature) or an **opaque** instance (addressed by
+a UUID, e.g. a content item). A **whole-type** check targets an entire class before any instance id exists — e.g.
+gating a `POST` that creates a new resource of that type, where the id is not yet known. Subject and resource domain
+types are heterogeneous and externally owned (a feature type is owned by the feature module, a user type by its
+identity module, etc.). Within the licensing contract objects (`cpt-cf-license-resolver-adr-typed-licensing-contracts`),
+how should the Subject and Resource identity fields represent the domain type and id so that both check kinds are
+expressible?
 
 ## Decision Drivers
 
-* A GTS **instance identifier** already combines a type chain and an instance segment — i.e. it is exactly "resource
-  type + id" expressed as a single value — and both resource kinds (named, opaque) map onto it directly.
-* Both forms must be expressible: named/well-known (§2.3) and opaque/anonymous-by-UUID (§2.4 combined notation).
-* This is a contract consumed by other modules, so the identity should be **constrained to a valid GTS instance
-  identifier**, not an arbitrary string.
-* The `resource_type` must stay referenceable and derivable from the identity, so the backend can validate it and the
-  resolver can reference it.
-* Which resources can be licensed — the catalog of licensable resource types and the rules for validating them — is
-  determined by the backend licensing service (a license enforcement/management service) that implements the resolver
-  plugin, not by the resolver core, which only references resource types by GTS type path and never defines or validates
-  them.
-* There is no listing/enumeration in scope, so a separate discrete `resource_type` field (useful for wildcard list
-  filtering) is not needed.
+* Both check kinds must be expressible: a specific instance (named or UUID-addressed) and a whole type (no instance id
+  exists yet, e.g. on `POST`).
+* The domain type must always be present and referenceable — for both subject and resource — so telemetry can be
+  dimensioned by it and rules can target it.
+* This is a contract consumed by other modules, so identity components should be constrained to valid GTS concepts, not
+  arbitrary strings.
+* What a backend *answers* for an id-less (whole-type) check is the backend's policy, not the contract's: the engine
+  validates shape, the plugin decides the outcome.
+* There is no listing/enumeration in scope, so no wildcard/set expressions are needed in the identity.
 
 ## Considered Options
 
-* (a) A single `GtsInstanceId` resource identity (well-known/named §2.3, or UUID-based anonymous §2.4)
-* (b) A split `ResourceRef { resource_type: GtsTypeId, resource_id }` carrying type and id as separate fields
+* (a) **GTS type (required) + optional instance id** for both Subject and Resource: `type` is a GTS type id; `id` is an
+  optional stable well-known name or UUID
+* (b) A single GTS **instance** identifier (`GtsInstanceId`) always carrying type + id combined via `~`
 * (c) A free-form / opaque string with no GTS structure
 
 ## Decision Outcome
 
-Chosen option: **(a) a single `GtsInstanceId`** as the resource identity. The check contract identifies a resource by
-one GTS instance identifier whose instance segment is either a well-known name (§2.3, e.g.
-`…feature.v1~cf.<vendor>._.somename.v1`) or a UUID (§2.4 combined notation, e.g. `…content.v1~<uuid>`). This covers both
-resource kinds — named and opaque — in a single value, and constrains the contract to a valid GTS instance identifier
-rather than an arbitrary string. The resolver core does not validate the type or own the licensable-type catalog: the
-full instance id is propagated to the selected backend plugin (the licensing service), which owns those, validates the
-resource, and answers the check.
+Chosen option: **(a) GTS type (required) + optional instance id**. Inside the licensing Subject and Resource contract
+objects, identity is carried as two fields: `type` — the domain GTS type (e.g. `gts.cf.<pkg>.content.v1~`), always
+present — and an optional `id` — a stable well-known name (e.g. a named feature) or a UUID (e.g. a content item).
+Without the `id` the check asks about the whole type; with it, about a specific instance. The engine validates the
+shape (type present, id well-formed when present); how an id-less check is answered is the backend plugin's policy.
 
-Option (b) was rejected: once listing/enumeration is out of scope, a discrete `resource_type` field carries no advantage
-for a *concrete-instance* check and just splits one identity across two fields (the type is derivable from the instance
-id anyway). Note `authz-resolver` splits because its `resource_type` is a *set/wildcard expression* for permissions, not
-a concrete instance — a different problem. Option (c) was rejected because dropping GTS structure loses the typed
-identity (nothing can validate the type) and lets callers pass ambiguous identifiers across a shared contract.
+Option (b) was rejected because an instance identifier denotes exactly one concrete instance by definition (GTS rule:
+types end with `~`, instances never do) — it cannot express a whole-type entitlement, which the `POST`-style use case
+requires. Option (c) was rejected because dropping GTS structure loses the typed identity (nothing can validate the
+type) and lets callers pass ambiguous identifiers across a shared contract.
 
 ### Consequences
 
-* The SDK identifies a resource by a `GtsInstanceId` (named §2.3 or UUID-based §2.4). A helper may build one from a
-  separate type + id and parse one back.
-* The resolver core never declares, owns, or validates resource types; it forwards the resource identity
-  (`GtsInstanceId`) to the backend unchanged.
-* The backend licensing service (the plugin) determines which resource types are licensable and validates the resource;
-  the full `GtsInstanceId` is propagated to it unchanged and it answers the check.
-* Telemetry is dimensioned by the **derived type** (bounded cardinality); the full instance id is never used as a label.
-* For opaque resources, the `type~<uuid>` form is the GTS §2.4 *combined* notation (the spec's optional form, not the
-  storage-canonical split); this is an accepted trade-off for a single-value contract identifier.
+* The licensing base types carry identity as two fields — required `type`, optional `id` — for both Subject and
+  Resource. Code MAY provide helpers converting to/from a combined GTS instance identifier where convenient; that is an
+  implementation detail, not part of the contract.
+* The resolver references externally-owned domain types only; it validates their *presence and form* (per
+  `cpt-cf-license-resolver-adr-typed-licensing-contracts`), while which types are licensable — and how an id-less check
+  is answered — is owned by the backend licensing service.
+* Telemetry is dimensioned by the domain type and the contract type (bounded cardinality); the instance id is never
+  used as a label.
 
 ### Confirmation
 
-Confirmed by design and code review of the SDK contract (the resource identity is a `GtsInstanceId`; a helper
-builds/parses it), plus unit tests asserting that named (§2.3) and UUID (§2.4) forms both round-trip and that the full
-instance id is forwarded to the backend unchanged. (Resource-type licensability and validation are the backend's
-concern, tested there — not in the resolver core.)
+Confirmed by design and code review of the licensing base types (identity is a required GTS `type` plus an optional
+`id` on both Subject and Resource), plus unit tests asserting that the id-absent and id-present forms both pass
+validation and are forwarded to the backend unchanged, and that a missing `type` is rejected as a validation error.
 
 ## Pros and Cons of the Options
 
-### (a) Single `GtsInstanceId`
+### (a) GTS type (required) + optional instance id
 
-One GTS instance identifier carries type and id via `~`.
+Two contract fields: the domain GTS type, and an optional instance name/UUID.
 
-* Good, because it is the literal GTS expression of "resource type + id" and represents both named and opaque resources
-  in one value.
-* Good, because it constrains the contract to a valid GTS instance identifier — appropriate for a cross-module contract.
-* Good, because both named (§2.3) and UUID (§2.4) forms are expressible in one type, while the `resource_type` stays
-  derivable from it and its licensability and validation stay with the backend licensing service.
-* Neutral, because callers holding a separate type + id compose them into the instance id (a helper covers this).
-* Bad, because for opaque resources it uses the §2.4 *combined* notation rather than the storage-canonical
-  `{type, UUID}` split.
+* Good, because both check kinds are expressible — whole-type (id absent) and specific instance (id present) — without
+  sentinel values or flags.
+* Good, because the contract states intent directly: the type is always there to validate and dimension by; the id is
+  present exactly when a concrete instance is meant.
+* Good, because the type stays GTS-typed and registry-validatable, externally-owned types are referenced in a
+  structured way, and the id stays a simple natural key (name or UUID).
+* Neutral, because callers holding a combined GTS instance identifier split it into the two fields (a trivial helper).
+* Bad, because a caller could omit the id where a specific instance was intended; the backend must decide what an
+  id-less check means for it.
 
-### (b) Split `ResourceRef`
+### (b) Single `GtsInstanceId`
 
-Type and id as separate fields.
+One GTS instance identifier always carrying type and id via `~`.
 
-* Good, because the type is a discrete field, trivially validatable and usable as a telemetry dimension.
-* Good, because for opaque/UUID resources it is GTS's canonical shape (§2.4 keeps type and UUID separate), so it carries
-  no combined-notation trade-off.
-* Good, because it mirrors `authz-resolver`'s `Resource { resource_type, id }`, so it is familiar to callers and easy to
-  reuse.
-* Bad, because a concrete-instance check needs one identity, not two fields; the discrete type adds value mainly for
-  wildcard *list* filtering, which is out of scope.
-* Bad, because it diverges from the natural single-value `type~id` GTS instance-identifier notation.
+* Good, because one value carries the whole identity for concrete-instance checks.
+* Bad, because an instance identifier denotes one concrete instance by definition — a whole-type entitlement (id not
+  yet known, e.g. on `POST`) is not expressible without overloading the notation with sentinels or flags.
+* Bad, because callers and backends must parse the combined string to recover the type for validation and telemetry.
 
 ### (c) Free-form / opaque string
 
@@ -131,10 +121,10 @@ An unstructured string with no GTS typing.
 
 ## More Information
 
-GTS guidelines `guidelines/GTS.md` §2.3 (well-known instances) and §2.4 (anonymous instances, with optional combined
-`type~uuid` notation). Both a named resource and an opaque (UUID-addressed) resource are single GTS instance
-identifiers. The resolver references externally-owned resource types only; any types it owns (e.g. its plugin spec) live
-under `gts.cf.bss.licensing.*`.
+GTS guidelines `guidelines/GTS.md`: §2.1/§2.2 define the type identifiers (ending with `~`) used in the `type` field;
+§2.3/§2.4 describe GTS instance identifiers — the combined notation considered and rejected as option (b). The
+contract objects these fields live in are decided by
+`cpt-cf-license-resolver-adr-typed-licensing-contracts`; the resolver's own types live under `gts.cf.core.lic.*`.
 
 ## Traceability
 
@@ -143,9 +133,10 @@ under `gts.cf.bss.licensing.*`.
 
 This decision directly addresses the following requirements or design elements:
 
-* `cpt-cf-license-resolver-fr-resource-identity` — defines resource identity as a single `GtsInstanceId` (named or
-  UUID-based), which this ADR records as canonical.
-* `cpt-cf-license-resolver-fr-subject-identity` — the subject + resource pair of a check relies on this resource shape.
+* `cpt-cf-license-resolver-fr-resource-identity` — defines resource identity as the domain GTS type (required) plus an
+  optional instance id, which this ADR records as canonical.
+* `cpt-cf-license-resolver-fr-subject-identity` — subject identity follows the same shape inside the Subject contract
+  object.
 * `cpt-cf-license-resolver-principle-gts-typed-resource-identity` — this ADR is the rationale for that DESIGN principle.
-* `cpt-cf-license-resolver-constraint-gts-via-types-registry` — the type derived from the instance id is what gets
-  validated against the registry.
+* `cpt-cf-license-resolver-constraint-gts-via-types-registry` — the domain type is what gets validated against the
+  registry.

--- a/gears/system/license-resolver/docs/ADR/0001-cpt-cf-license-resolver-adr-gts-resource-identity.md
+++ b/gears/system/license-resolver/docs/ADR/0001-cpt-cf-license-resolver-adr-gts-resource-identity.md
@@ -1,0 +1,151 @@
+---
+status: accepted
+date: 2026-06-08
+---
+
+# ADR-0001: Resource Identity as a Single GTS Instance ID
+
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [(a) Single `GtsInstanceId`](#a-single-gtsinstanceid)
+  - [(b) Split `ResourceRef { resource_type, resource_id }`](#b-split-resourceref--resource_type-resource_id)
+  - [(c) Free-form / opaque string](#c-free-form--opaque-string)
+- [More Information](#more-information)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
+**ID**: `cpt-cf-license-resolver-adr-gts-resource-identity`
+
+## Context and Problem Statement
+
+License resolver answers "is THIS resource granted to THIS subject?", so every check must carry a stable, unambiguous
+identity for the resource being licensed. A licensable resource comes in two kinds: a **named** resource — a stable,
+human-meaningful instance such as a specific feature — and an **opaque** resource — a runtime instance addressed by a
+UUID, for example a content item. Resources are heterogeneous and externally owned (a feature type is owned by the
+feature module, a content type by the content module, etc.). The contract must represent "resource type + id" so that
+both kinds are expressible. The Global Type System (GTS) already provides exactly this shape: an **instance identifier**
+joins a type chain and an instance segment with `~`, and supports both well-known/named instances (§2.3) and anonymous
+instances addressed by UUID (§2.4, combined notation). How should the cross-module contract represent resource identity?
+
+## Decision Drivers
+
+* A GTS **instance identifier** already combines a type chain and an instance segment — i.e. it is exactly "resource
+  type + id" expressed as a single value — and both resource kinds (named, opaque) map onto it directly.
+* Both forms must be expressible: named/well-known (§2.3) and opaque/anonymous-by-UUID (§2.4 combined notation).
+* This is a contract consumed by other modules, so the identity should be **constrained to a valid GTS instance
+  identifier**, not an arbitrary string.
+* The `resource_type` must stay referenceable and derivable from the identity, so the backend can validate it and the
+  resolver can reference it.
+* Which resources can be licensed — the catalog of licensable resource types and the rules for validating them — is
+  determined by the backend licensing service (a license enforcement/management service) that implements the resolver
+  plugin, not by the resolver core, which only references resource types by GTS type path and never defines or validates
+  them.
+* There is no listing/enumeration in scope, so a separate discrete `resource_type` field (useful for wildcard list
+  filtering) is not needed.
+
+## Considered Options
+
+* (a) A single `GtsInstanceId` resource identity (well-known/named §2.3, or UUID-based anonymous §2.4)
+* (b) A split `ResourceRef { resource_type: GtsTypeId, resource_id }` carrying type and id as separate fields
+* (c) A free-form / opaque string with no GTS structure
+
+## Decision Outcome
+
+Chosen option: **(a) a single `GtsInstanceId`** as the resource identity. The check contract identifies a resource by
+one GTS instance identifier whose instance segment is either a well-known name (§2.3, e.g.
+`…feature.v1~cf.<vendor>._.somename.v1`) or a UUID (§2.4 combined notation, e.g. `…content.v1~<uuid>`). This covers both
+resource kinds — named and opaque — in a single value, and constrains the contract to a valid GTS instance identifier
+rather than an arbitrary string. The resolver core does not validate the type or own the licensable-type catalog: the
+full instance id is propagated to the selected backend plugin (the licensing service), which owns those, validates the
+resource, and answers the check.
+
+Option (b) was rejected: once listing/enumeration is out of scope, a discrete `resource_type` field carries no advantage
+for a *concrete-instance* check and just splits one identity across two fields (the type is derivable from the instance
+id anyway). Note `authz-resolver` splits because its `resource_type` is a *set/wildcard expression* for permissions, not
+a concrete instance — a different problem. Option (c) was rejected because dropping GTS structure loses the typed
+identity (nothing can validate the type) and lets callers pass ambiguous identifiers across a shared contract.
+
+### Consequences
+
+* The SDK identifies a resource by a `GtsInstanceId` (named §2.3 or UUID-based §2.4). A helper may build one from a
+  separate type + id and parse one back.
+* The resolver core never declares, owns, or validates resource types; it forwards the resource identity
+  (`GtsInstanceId`) to the backend unchanged.
+* The backend licensing service (the plugin) determines which resource types are licensable and validates the resource;
+  the full `GtsInstanceId` is propagated to it unchanged and it answers the check.
+* Telemetry is dimensioned by the **derived type** (bounded cardinality); the full instance id is never used as a label.
+* For opaque resources, the `type~<uuid>` form is the GTS §2.4 *combined* notation (the spec's optional form, not the
+  storage-canonical split); this is an accepted trade-off for a single-value contract identifier.
+
+### Confirmation
+
+Confirmed by design and code review of the SDK contract (the resource identity is a `GtsInstanceId`; a helper
+builds/parses it), plus unit tests asserting that named (§2.3) and UUID (§2.4) forms both round-trip and that the full
+instance id is forwarded to the backend unchanged. (Resource-type licensability and validation are the backend's
+concern, tested there — not in the resolver core.)
+
+## Pros and Cons of the Options
+
+### (a) Single `GtsInstanceId`
+
+One GTS instance identifier carries type and id via `~`.
+
+* Good, because it is the literal GTS expression of "resource type + id" and represents both named and opaque resources
+  in one value.
+* Good, because it constrains the contract to a valid GTS instance identifier — appropriate for a cross-module contract.
+* Good, because both named (§2.3) and UUID (§2.4) forms are expressible in one type, while the `resource_type` stays
+  derivable from it and its licensability and validation stay with the backend licensing service.
+* Neutral, because callers holding a separate type + id compose them into the instance id (a helper covers this).
+* Bad, because for opaque resources it uses the §2.4 *combined* notation rather than the storage-canonical
+  `{type, UUID}` split.
+
+### (b) Split `ResourceRef { resource_type, resource_id }`
+
+Type and id as separate fields.
+
+* Good, because the type is a discrete field, trivially validatable and usable as a telemetry dimension.
+* Good, because for opaque/UUID resources it is GTS's canonical shape (§2.4 keeps type and UUID separate), so it carries
+  no combined-notation trade-off.
+* Good, because it mirrors `authz-resolver`'s `Resource { resource_type, id }`, so it is familiar to callers and easy to
+  reuse.
+* Bad, because a concrete-instance check needs one identity, not two fields; the discrete type adds value mainly for
+  wildcard *list* filtering, which is out of scope.
+* Bad, because it diverges from the natural single-value `type~id` GTS instance-identifier notation.
+
+### (c) Free-form / opaque string
+
+An unstructured string with no GTS typing.
+
+* Good, because it imposes no schema.
+* Bad, because it loses GTS validation entirely, so the registry cannot validate the type and externally-owned types are
+  no longer referenced in a structured way.
+* Bad, because ambiguity across a shared contract undermines correct routing and auditing.
+
+## More Information
+
+GTS guidelines `guidelines/GTS.md` §2.3 (well-known instances) and §2.4 (anonymous instances, with optional combined
+`type~uuid` notation). Both a named resource and an opaque (UUID-addressed) resource are single GTS instance
+identifiers. The resolver references externally-owned resource types only; any types it owns (e.g. its plugin spec) live
+under `gts.cf.bss.licensing.*`.
+
+## Traceability
+
+- **PRD**: [PRD.md](../PRD.md)
+- **DESIGN**: [DESIGN.md](../DESIGN.md)
+
+This decision directly addresses the following requirements or design elements:
+
+* `cpt-cf-license-resolver-fr-resource-identity` — defines resource identity as a single `GtsInstanceId` (named or
+  UUID-based), which this ADR records as canonical.
+* `cpt-cf-license-resolver-fr-subject-identity` — the subject + resource pair of a check relies on this resource shape.
+* `cpt-cf-license-resolver-principle-gts-typed-resource-identity` — this ADR is the rationale for that DESIGN principle.
+* `cpt-cf-license-resolver-constraint-gts-via-types-registry` — the type derived from the instance id is what gets
+  validated against the registry.

--- a/gears/system/license-resolver/docs/ADR/0001-cpt-cf-license-resolver-adr-gts-resource-identity.md
+++ b/gears/system/license-resolver/docs/ADR/0001-cpt-cf-license-resolver-adr-gts-resource-identity.md
@@ -15,7 +15,7 @@ date: 2026-06-08
   - [Confirmation](#confirmation)
 - [Pros and Cons of the Options](#pros-and-cons-of-the-options)
   - [(a) Single `GtsInstanceId`](#a-single-gtsinstanceid)
-  - [(b) Split `ResourceRef { resource_type, resource_id }`](#b-split-resourceref--resource_type-resource_id)
+  - [(b) Split `ResourceRef`](#b-split-resourceref)
   - [(c) Free-form / opaque string](#c-free-form--opaque-string)
 - [More Information](#more-information)
 - [Traceability](#traceability)
@@ -107,7 +107,7 @@ One GTS instance identifier carries type and id via `~`.
 * Bad, because for opaque resources it uses the §2.4 *combined* notation rather than the storage-canonical
   `{type, UUID}` split.
 
-### (b) Split `ResourceRef { resource_type, resource_id }`
+### (b) Split `ResourceRef`
 
 Type and id as separate fields.
 

--- a/gears/system/license-resolver/docs/ADR/0002-cpt-cf-license-resolver-adr-plugin-delegation.md
+++ b/gears/system/license-resolver/docs/ADR/0002-cpt-cf-license-resolver-adr-plugin-delegation.md
@@ -115,7 +115,7 @@ plugins).
 
 Mirrors `tenant-resolver` (`TenantResolverPluginSpecV1`) and `authz-resolver` (`AuthZResolverPluginSpecV1`) discovery
 and selection. The plugin spec `LicenseResolverPluginSpecV1` is registered under the toolkit plugin base /
-`gts.cf.bss.licensing.*`. See `guidelines/GTS.md` for the types-registry and plugin-spec model.
+`gts.cf.core.lic.*`. See `guidelines/GTS.md` for the types-registry and plugin-spec model.
 
 ## Traceability
 

--- a/gears/system/license-resolver/docs/ADR/0002-cpt-cf-license-resolver-adr-plugin-delegation.md
+++ b/gears/system/license-resolver/docs/ADR/0002-cpt-cf-license-resolver-adr-plugin-delegation.md
@@ -1,0 +1,137 @@
+---
+status: accepted
+date: 2026-06-08
+---
+
+# ADR-0002: Pure Plugin-Delegating Gateway with No Grant Store
+
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [(a) Plugin-delegating gateway, no own store](#a-plugin-delegating-gateway-no-own-store)
+  - [(b) Resolver-owned grant store](#b-resolver-owned-grant-store)
+  - [(c) Hybrid built-in store + plugins](#c-hybrid-built-in-store--plugins)
+- [More Information](#more-information)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
+**ID**: `cpt-cf-license-resolver-adr-plugin-delegation`
+
+## Context and Problem Statement
+
+License resolver must answer `is_licensed(request)` for grants that physically live in many heterogeneous,
+vendor-specific backends (entitlement services, SaaS licensing APIs, on-prem stores). Where should grant facts live, and
+how should the resolver reach them — should the module own a grant store, delegate to pluggable backends, or do both?
+The Global Type System (GTS) types registry already provides versioned plugin discovery and vendor/priority selection
+used by sibling resolvers.
+
+## Decision Drivers
+
+* Grant data is owned by external authorities and varies per vendor; the resolver is a read-only evaluator, not a system
+  of record.
+* New backends must be addable or swappable without changing callers or the public contract.
+* Behavior must fail closed: when no backend can be reached, the resolver must never grant by default.
+* Consistency with `tenant-resolver` / `authz-resolver`, which already discover and select plugins via the types
+  registry by vendor + priority.
+* Avoid duplicating or caching authoritative grant state that the resolver does not own.
+
+## Considered Options
+
+* (a) Pure plugin-delegating gateway with no resolver-owned grant store; backends discovered via the types registry (
+  `LicenseResolverPluginSpecV1`) and selected by vendor + priority
+* (b) A resolver-owned grant store as the **sole** source: the resolver persists grant records and answers from its own
+  store, with **no** plugin delegation
+* (c) A **hybrid**: the resolver keeps its own store **and** delegates to plugins, so a check may be answered from either
+  — **two** sources of truth
+
+## Decision Outcome
+
+Chosen option: (a) pure plugin-delegating gateway with no grant store, because grant facts are externally owned and
+heterogeneous, delegation keeps the resolver read-only and authoritative-by-reference, and reusing the types-registry
+discovery + vendor/priority selection already proven in `tenant-resolver` / `authz-resolver` lets backends evolve
+independently of callers while making fail-closed behavior natural when no plugin matches.
+
+### Consequences
+
+* The main module is a gateway/selector only: it discovers plugins via the types registry (GTS spec
+  `LicenseResolverPluginSpecV1`), selects by vendor + priority, delegates the check, and maps plugin errors to
+  `LicenseResolverError`.
+* No persistence, schema, or migrations are owned by this module; there is no grant table to back up or reconcile.
+* When no plugin matches, the gateway returns `NoPluginAvailable`; when a selected backend is unreachable, it returns
+  `ServiceUnavailable` — neither path can yield a granted decision.
+* Plugins implement an identical check signature (`LicenseResolverPluginClient`), so adding a vendor backend requires
+  registering its plugin spec, with no caller or contract change.
+
+### Confirmation
+
+Confirmed by design and code review (no persistence layer in the main module; discovery/selection routed through the
+types registry) and by tests asserting that vendor/priority selection picks the expected plugin and that no-plugin and
+unreachable-backend conditions produce zero grant-by-default outcomes.
+
+## Pros and Cons of the Options
+
+### (a) Plugin-delegating gateway, no own store
+
+The module discovers and delegates to backend plugins; it stores nothing.
+
+* Good, because authoritative grant data stays with its owners and is never duplicated.
+* Good, because backends are added/swapped via plugin registration with no caller change.
+* Good, because it reuses the proven `tenant-resolver` / `authz-resolver` registry discovery + vendor/priority
+  selection.
+* Good, because fail-closed is natural: no plugin or unreachable backend cannot produce a grant.
+* Neutral, because per-check latency depends on the selected backend rather than a local store.
+* Bad, because availability of a check is bounded by the backend's availability (no local fallback).
+
+### (b) Resolver-owned grant store
+
+The resolver is the **single** source of truth: it persists grant records and answers checks from its own store, with no
+delegation to backends.
+
+* Good, because checks can be served with low, predictable local latency.
+* Bad, because it makes the resolver a system of record for data it does not own, requiring ingestion, reconciliation,
+  and migrations.
+* Bad, because heterogeneous vendor models do not fit one schema, and stale local copies risk incorrect grant/deny
+  decisions.
+* Bad, because it contradicts the read-only / delegate-don't-store design intent.
+
+### (c) Hybrid built-in store + plugins
+
+The resolver keeps its own store **and** also delegates to plugins — a check may be answered from the local store or
+from a backend, so there are **two** sources of truth (unlike (b), which has only the store, and (a), which has only
+plugins).
+
+* Good, because it could offer a local fast path alongside delegation.
+* Bad, because it carries the store's ownership and staleness costs plus the delegation machinery — the worst of both.
+* Bad, because dual sources of truth complicate fail-closed guarantees and auditing of which source decided a check.
+
+## More Information
+
+Mirrors `tenant-resolver` (`TenantResolverPluginSpecV1`) and `authz-resolver` (`AuthZResolverPluginSpecV1`) discovery
+and selection. The plugin spec `LicenseResolverPluginSpecV1` is registered under the toolkit plugin base /
+`gts.cf.bss.licensing.*`. See `guidelines/GTS.md` for the types-registry and plugin-spec model.
+
+## Traceability
+
+- **PRD**: [PRD.md](../PRD.md)
+- **DESIGN**: [DESIGN.md](../DESIGN.md)
+
+This decision directly addresses the following requirements or design elements:
+
+* `cpt-cf-license-resolver-fr-plugin-delegation` — defines the discover-and-delegate gateway behavior this ADR records.
+* `cpt-cf-license-resolver-fr-read-only` — no store and no write paths follow directly from this decision.
+* `cpt-cf-license-resolver-fr-is-licensed-check` — the single check operation is served by delegating to the selected
+  plugin.
+* `cpt-cf-license-resolver-nfr-fail-closed` — no-plugin / unreachable-backend paths yield no grant by default.
+* `cpt-cf-license-resolver-nfr-read-latency` — per-check latency is bounded by the delegated backend, not a local store.
+* `cpt-cf-license-resolver-principle-delegate-dont-store` — this ADR is the rationale for that DESIGN principle.
+* `cpt-cf-license-resolver-principle-fail-closed-no-plugin` — fail-closed behavior is a direct consequence of pure
+  delegation.
+* `cpt-cf-license-resolver-constraint-gts-via-types-registry` — discovery/selection go exclusively through the GTS types
+  registry.

--- a/gears/system/license-resolver/docs/ADR/0003-cpt-cf-license-resolver-adr-typed-licensing-contracts.md
+++ b/gears/system/license-resolver/docs/ADR/0003-cpt-cf-license-resolver-adr-typed-licensing-contracts.md
@@ -1,0 +1,151 @@
+---
+status: accepted
+date: 2026-06-11
+---
+
+# ADR-0003: Typed, Registry-Observable Licensing Contracts Validated by the Engine
+
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [(a) Opaque metadata, backend-owned validation](#a-opaque-metadata-backend-owned-validation)
+  - [(b) Typed derived GTS contracts validated by the engine](#b-typed-derived-gts-contracts-validated-by-the-engine)
+  - [(c) Registered schemas, documentation only](#c-registered-schemas-documentation-only)
+- [More Information](#more-information)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
+**ID**: `cpt-cf-license-resolver-adr-typed-licensing-contracts`
+
+## Context and Problem Statement
+
+License enforcement and license decision happen at different levels. The Gear calling `is_licensed` knows *where* a
+check belongs, but only the platform vendor — who composes a concrete platform out of Gears and a licensing backend —
+knows *what* must be licensed, and different platform vendors apply different licensing models to the same Gear (one
+licenses every LLM model individually, another does not care about models at all). This raises the question: who
+defines which Subject/Resource pairs and which of their properties are passed into a license check?
+
+With an opaque `metadata` bag, the check is *callable* but not *governable*: the keys a plugin can rely on exist only
+in Gear source code, a platform vendor has no inventory of checks, no schema of available properties, and no
+change-control point when a Gear silently adds, renames, or removes a key. How should the check payload represent
+Subject, Resource, and their properties so that platform vendors can discover, review, and rely on what Gears pass into
+licensing?
+
+## Decision Drivers
+
+* Platform vendors must be able to enumerate the platform's licensing surface (checks, Subject/Resource pairs,
+  available properties) from the types registry alone, without reading Gear source code.
+* Licensing contracts need their own review and version lifecycle, decoupled from Gear domain types.
+* The plugin must be able to trust the shape of what it receives; validation must be uniform, not re-implemented (or
+  skipped) per backend.
+* Gears must stay free to expose arbitrary, Gear-specific properties, and platform vendors must be free to ignore what
+  they do not need.
+* Fail-closed semantics: a malformed check must be an error, never a silent evaluation.
+
+## Considered Options
+
+* (a) **Opaque metadata, backend-owned validation**: Subject/Resource as plain identity fields, `metadata` as an
+  uninterpreted JSON bag forwarded to the plugin, which owns all validation
+* (b) **Typed derived GTS contracts validated by the engine**: licensing base types
+  `gts.cf.core.lic.subj.v1~` / `gts.cf.core.lic.res.v1~`; Gears derive concrete Subject/Resource types with
+  metadata schemas and an admitted-subjects trait; the engine validates every request against the registered contracts
+  before delegation
+* (c) **Registered schemas for documentation only**: the request shape of (a), plus registered metadata schemas for
+  discoverability — without engine validation
+
+## Decision Outcome
+
+Chosen option: **(b)**. Every Subject and Resource shape used in a check is a registered, versioned GTS type derived
+from the licensing base types — the Gear's published licensing contract. The engine validates each request against the
+registered contracts before delegating to the plugin and rejects non-conforming requests as fail-closed errors,
+distinct from a not-granted decision.
+
+Only (b) makes the licensing surface a real contract: discoverable through the registry (query everything derived from
+the base types), reviewable in isolation from other registered types, versioned independently of domain types, and
+*enforced*. Option (a) was rejected because it makes the check callable but not governable: every backend validates (or
+doesn't) differently, and a Gear can silently change the payload with no review point. Option (c) was rejected because
+unvalidated contracts are not contracts — the registered schema and actual behavior drift apart, buying (b)'s
+documentation upside while keeping (a)'s integrity downside. Schema-validation performance is not a differentiator:
+schemas are resolved from the registry and cached, negligible against the check-latency budget.
+
+### Consequences
+
+* The licensing Gear owns the base types under `gts.cf.core.lic.*`; every licensing-aware Gear registers derived
+  Subject/Resource types — its published licensing contract — before it can check.
+* Gears pay a projection cost: licensing-relevant fields are copied from domain objects into the licensing types. This
+  is the same deliberate boundary cost as DTO and persistence mappings, and it is what decouples domain evolution from
+  contract evolution.
+* The gateway gains a validation pipeline (structural + subject-compatibility) ahead of plugin delegation; validation
+  failures are errors, never not-granted decisions. The engine validates *shape and compatibility* only — what the
+  properties mean and what is licensable remain the backend's concern.
+* `metadata` stays semantically opaque to the engine but becomes schematized: new properties arrive as optional,
+  non-breaking schema fields rather than undocumented keys.
+* Compatibility rule: adding an optional property is non-breaking (consumers ignore unknown fields); removing or
+  renaming a property, changing its type, or narrowing the admitted subjects requires a new contract version.
+* The admitted-subjects constraint is expressed as a GTS trait (`x-gts-traits`) on the derived Resource type — the
+  mechanism already used by resource-group's `allowed_parent_types`.
+
+### Confirmation
+
+Confirmed by design and code review (base + derived licensing types registered in the types registry; validation
+pipeline in the gateway ahead of delegation) and by tests asserting that non-conforming requests — schema mismatch or
+inadmissible subject type — produce validation errors (never `granted: true`, never a plain not-granted decision), and
+that conforming requests reach the plugin unchanged.
+
+## Pros and Cons of the Options
+
+### (a) Opaque metadata, backend-owned validation
+
+* Good, because zero coupling and zero engine-side work; maximal short-term flexibility.
+* Bad, because the licensing surface is invisible to platform vendors — no inventory, no schema, no change control.
+* Bad, because every backend re-implements validation differently, or skips it.
+
+### (b) Typed derived GTS contracts validated by the engine
+
+* Good, because the full licensing surface is enumerable from the registry, reviewable in isolation from other types,
+  and versioned.
+* Good, because validation is uniform and fail-closed; plugins receive only conforming requests.
+* Good, because subject/resource compatibility (admitted subjects) is expressible and checked.
+* Good, because metadata stays flexible: Gears expose what they need, platform vendors ignore the rest.
+* Bad, because of projection boilerplate, registry governance overhead, and registry schema resolution on the check
+  path (mitigated by caching).
+
+### (c) Registered schemas, documentation only
+
+* Good, because cheap: discoverability without engine changes.
+* Bad, because nothing keeps schema and behavior in sync — the contract can lie, which is worse than no contract.
+
+## More Information
+
+The admitted-subjects prerequisite is already satisfied by GTS traits (`guidelines/GTS.md` §10): `x-gts-traits-schema`
+/ `x-gts-traits` on type schemas, inherited along the derivation chain — resource-group's `allowed_parent_types` is a
+working precedent of the same pattern. Base and derived licensing types live under `gts.cf.core.lic.*`.
+`cpt-cf-license-resolver-adr-gts-resource-identity` records the identity fields *inside* the contract objects;
+`cpt-cf-license-resolver-adr-plugin-delegation` (delegation, no grant store, fail-closed) is untouched and fully
+compatible.
+
+## Traceability
+
+- **PRD**: [PRD.md](../PRD.md)
+- **DESIGN**: [DESIGN.md](../DESIGN.md)
+
+This decision directly addresses the following requirements or design elements:
+
+* `cpt-cf-license-resolver-fr-contract-registration` — Subject/Resource shapes as registered, versioned derived types.
+* `cpt-cf-license-resolver-fr-contract-discoverability` — the licensing surface is enumerable from the registry, in
+  isolation from other types.
+* `cpt-cf-license-resolver-fr-request-validation` — engine-side validation ahead of delegation, fail-closed, distinct
+  from not-granted.
+* `cpt-cf-license-resolver-fr-contract-compatibility` — additive-optional is non-breaking; everything else is a new
+  contract version.
+* `cpt-cf-license-resolver-fr-evaluation-metadata` — metadata becomes schematized while staying semantically opaque to
+  the engine.
+* `cpt-cf-license-resolver-principle-validated-contracts` — this ADR is the rationale for that DESIGN principle.
+* `cpt-cf-license-resolver-actor-platform-vendor` — the actor this decision serves.

--- a/gears/system/license-resolver/docs/DESIGN.md
+++ b/gears/system/license-resolver/docs/DESIGN.md
@@ -1,0 +1,436 @@
+<!-- cpt:
+version: 1.0.0
+status: draft
+module: license-resolver
+system: cf
+-->
+
+# Technical Design — License Resolver
+
+<!-- toc -->
+
+- [1. Architecture Overview](#1-architecture-overview)
+    - [1.1 Architectural Vision](#11-architectural-vision)
+    - [1.2 Architecture Drivers](#12-architecture-drivers)
+    - [1.3 Architecture Layers](#13-architecture-layers)
+- [2. Principles & Constraints](#2-principles--constraints)
+    - [2.1 Design Principles](#21-design-principles)
+    - [2.2 Constraints](#22-constraints)
+- [3. Technical Architecture](#3-technical-architecture)
+    - [3.1 Domain Model](#31-domain-model)
+    - [3.2 Component Model](#32-component-model)
+    - [3.3 API Contracts](#33-api-contracts)
+    - [3.4 Internal Dependencies](#34-internal-dependencies)
+    - [3.5 External Dependencies](#35-external-dependencies)
+    - [3.6 Interactions & Sequences](#36-interactions--sequences)
+    - [3.7 Database schemas & tables](#37-database-schemas--tables)
+    - [3.8 Deployment Topology](#38-deployment-topology)
+- [4. Additional context](#4-additional-context)
+- [5. Traceability](#5-traceability)
+
+<!-- /toc -->
+
+- [ ] `p3` - **ID**: `cpt-cf-license-resolver-design-overview`
+
+## 1. Architecture Overview
+
+### 1.1 Architectural Vision
+
+License Resolver is a thin, read-only, plugin-delegating system module. It answers exactly one question — *is this
+resource licensed to this subject right now?* — through a single `is_licensed(request)` check, where the
+`LicenseCheckRequest` bundles subject, resource, optional evaluation `metadata`, and the tenant context, and returns a
+yes/no decision plus a structured, non-authoritative `diagnostics` map (debug info about how the decision was reached).
+It owns no grant store: grant facts live in heterogeneous, vendor-owned backends, so the main module discovers and
+selects a backend plugin at runtime via the GTS types registry (by vendor + priority) and delegates the lookup. This
+mirrors the proven `authz-resolver` / `tenant-resolver` delegation model and keeps issuance, billing, storage, and
+catalog/listing concerns out of the resolver.
+
+The architecture is deliberately minimal: a three-crate triad (SDK contract, main-module gateway/selector, backend
+plugin) over the ToolKit framework. Resource identity is a single GTS instance id (`GtsInstanceId`) — named (§2.3) or
+UUID-based (§2.4) — that encodes resource type + id and references externally-owned resource types (a `feature`, a
+`content` item, a capability) without ever defining or validating them — which resource types are licensable and how
+they are validated is owned by the backend licensing service. Because the resolver performs no writes and holds no
+state, it is stateless and side-effect-free;
+the only behavioral guarantees that shape the design are tenant scoping via the request's tenant context (derived from
+the caller's `SecurityContext`) and fail-closed semantics when no plugin or backend is reachable.
+
+### 1.2 Architecture Drivers
+
+Requirements from PRD that significantly influence architecture decisions.
+
+#### Functional Drivers
+
+| Requirement                                      | Design Response                                                                                                                                                                                                                                                                  |
+|--------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `cpt-cf-license-resolver-fr-is-licensed-check`   | A single `is_licensed` method on the public `LicenseResolverClient` contract (`cpt-cf-license-resolver-component-sdk-contract`); the main-module gateway (`cpt-cf-license-resolver-component-main-gateway`) realizes it by delegating to the selected plugin.                    |
+| `cpt-cf-license-resolver-fr-subject-identity`    | `Subject` domain entity (subject type + id); carried into the check and propagated to the plugin.                                                                                                                                                                                |
+| `cpt-cf-license-resolver-fr-resource-identity`   | Single `GtsInstanceId` resource identity (§3.1; named §2.3 or UUID §2.4); principle `cpt-cf-license-resolver-principle-gts-typed-resource-identity`; the type is derived from the instance id.                                                                                   |
+| `cpt-cf-license-resolver-fr-evaluation-metadata` | An opaque `metadata` map (`string`→JSON) on the check input (§3.1, §3.3); the gateway forwards it unchanged to the plugin, which MAY evaluate attribute constraints (region, country, …). The resolver neither interprets nor requires any key — the contract's extension point. |
+| `cpt-cf-license-resolver-fr-plugin-delegation`   | Gateway/selector component discovers plugins via the types registry and routes by vendor + priority; principle `cpt-cf-license-resolver-principle-delegate-dont-store`.                                                                                                          |
+| `cpt-cf-license-resolver-fr-read-only`           | No write paths, no store, no list method anywhere in the contract; principles `cpt-cf-license-resolver-principle-read-only` and `cpt-cf-license-resolver-principle-check-only-no-listing`.                                                                                       |
+
+#### NFR Allocation
+
+| NFR ID                                       | NFR Summary                                                 | Allocated To                                                        | Design Response                                                                                                                                                                                                                                                                                                                                                                  | Verification Approach                                                                      |
+|----------------------------------------------|-------------------------------------------------------------|---------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
+| `cpt-cf-license-resolver-nfr-read-latency`   | `is_licensed` ≤ 50ms p95 at the resolver boundary           | Gateway/selector (`cpt-cf-license-resolver-component-main-gateway`) | Plugin instance selection is memoized after first resolution so the hot path is a scoped ClientHub lookup plus one delegated call; boundary excludes plugin compute.                                                                                                                                                                                                             | Boundary latency benchmark at p95 excluding plugin processing.                             |
+| `cpt-cf-license-resolver-nfr-fail-closed`    | Never grant by default when no plugin / backend unreachable | Gateway/selector + `LicenseResolverError` mapping                   | No matching plugin yields `NoPluginAvailable`; an unreachable backend yields `ServiceUnavailable`; neither path can produce a granted decision (principle `cpt-cf-license-resolver-principle-fail-closed-no-plugin`).                                                                                                                                                            | Tests asserting 0 grant-by-default outcomes across all no-plugin / unavailable conditions. |
+| `cpt-cf-license-resolver-nfr-tenant-scoping` | Every resolution scoped to the request's tenant context     | All components                                                      | Current model: every license is tenant-bounded — regardless of subject type the subject belongs to a tenant. The `LicenseCheckRequest` carries a tenant context (built by the caller from its `SecurityContext`); the gateway scopes by it and forwards the request unchanged to the plugin; tenant scope is derived solely from `request.context` (no cross-tenant resolution). | Tests asserting 0 cross-tenant resolutions.                                                |
+
+#### Key ADRs
+
+| ADR ID                                              | Decision Summary                                                                                                                                                                            |
+|-----------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `cpt-cf-license-resolver-adr-gts-resource-identity` | Resource identity is a single `GtsInstanceId` (named §2.3 or UUID §2.4); the resolver references the type — licensable-type catalog and validation belong to the backend licensing service. |
+| `cpt-cf-license-resolver-adr-plugin-delegation`     | No resolver-owned store; backend discovered via types-registry and selected by vendor + priority, failing closed when none matches.                                                         |
+
+### 1.3 Architecture Layers
+
+```text
++-----------------------------------------------------------+
+|  Consuming module (caller)                                |
+| builds LicenseCheckRequest(subject, resource, metadata, ctx)|
++----------------------------+------------------------------+
+                             | LicenseResolverClient.is_licensed
+                             v
++-----------------------------------------------------------+
+|  SDK contract crate  (LicenseResolverClient,              |
+|    LicenseResolverPluginClient, DTOs, error enum, GTS)    |
++----------------------------+------------------------------+
+                             v
++-----------------------------------------------------------+
+|  Main module (gateway / selector)                         |
+|    discovers + selects plugin, delegates, maps errors     |
++------------------+----------------------+-----------------+
+                   | types-registry (GTS) | scoped ClientHub
+                   v                      v
++---------------------------+   +---------------------------+
+|  types-registry (GTS)     |   |  Backend plugin           |
+|    plugin discovery       |   |    validates + holds      |
+|    (vendor + priority)    |   |    grants, answers check  |
++---------------------------+   +---------------------------+
+```
+
+- [ ] `p3` - **ID**: `cpt-cf-license-resolver-tech-layers`
+
+| Layer                     | Responsibility                                                            | Technology               |
+|---------------------------|---------------------------------------------------------------------------|--------------------------|
+| Contract (SDK)            | Public + plugin traits, DTOs, error enum, plugin GTS spec                 | Rust, ToolKit SDK, GTS   |
+| Application (main module) | Plugin discovery/selection, delegation, error mapping, tenant propagation | Rust, ToolKit, ClientHub |
+| Domain                    | `Subject`, resource `GtsInstanceId`, `LicenseDecision` value types        | Rust, GTS                |
+| Integration               | Plugin discovery / selection (vendor + priority)                          | types-registry (GTS)     |
+
+## 2. Principles & Constraints
+
+### 2.1 Design Principles
+
+#### Read-Only / No Issuance
+
+- [ ] `p2` - **ID**: `cpt-cf-license-resolver-principle-read-only`
+
+The resolver only evaluates a check. It never issues, revokes, bills, manages, or stores grants, and its public contract
+exposes no such operation. This is a property of the resolver only — a backend plugin behind the delegation boundary may
+itself be backed by mutable systems (issuance, billing); how it sources or maintains grants is its own concern. Write
+and lifecycle concerns stay out of the resolver, keeping the contract narrow and authoritative.
+
+**ADRs**: `cpt-cf-license-resolver-adr-plugin-delegation`
+
+#### Check-Only / No Listing
+
+- [ ] `p2` - **ID**: `cpt-cf-license-resolver-principle-check-only-no-listing`
+
+The resolver answers a point-in-time question about ONE concrete resource and subject. Enumerating "everything licensed
+to a subject" is a catalog/query concern, so there is no list operation and no pagination — there is exactly one
+`is_licensed` method.
+
+**ADRs**: `cpt-cf-license-resolver-adr-plugin-delegation`
+
+#### GTS-Typed Resource Identity
+
+- [ ] `p2` - **ID**: `cpt-cf-license-resolver-principle-gts-typed-resource-identity`
+
+Resource identity is a single GTS instance id (`GtsInstanceId`) encoding resource type + id via `~`: a well-known name (
+§2.3) or a UUID (§2.4 combined notation). The resolver references externally-owned resource types and never defines or
+validates them; which resource types are licensable, and their validation, are owned by the backend licensing service.
+The full instance id is passed to that backend, which interprets it.
+
+**ADRs**: `cpt-cf-license-resolver-adr-gts-resource-identity`
+
+#### Delegate, Don't Store
+
+- [ ] `p2` - **ID**: `cpt-cf-license-resolver-principle-delegate-dont-store`
+
+Grant facts live in heterogeneous vendor backends. The main module discovers a backend plugin via the types registry and
+delegates the lookup; it holds no grant store of its own, so backends can be added or swapped without caller changes.
+
+**ADRs**: `cpt-cf-license-resolver-adr-plugin-delegation`
+
+#### Fail Closed on No Plugin
+
+- [ ] `p2` - **ID**: `cpt-cf-license-resolver-principle-fail-closed-no-plugin`
+
+When no matching plugin is available or the backend is unreachable, the resolver fails closed: it returns a not-granted
+decision or an error and never grants by default. Granting when the authority cannot be reached would be a
+license/security violation.
+
+**ADRs**: `cpt-cf-license-resolver-adr-plugin-delegation`
+
+### 2.2 Constraints
+
+#### ToolKit Framework
+
+- [ ] `p2` - **ID**: `cpt-cf-license-resolver-constraint-toolkit-framework`
+
+The module is built on the ToolKit framework and follows the SDK / main-module / plugin triad. Inter-module
+communication uses SDK clients and the ClientHub; plugins are consumed only through the main module's public contract,
+never directly.
+
+**ADRs**: `cpt-cf-license-resolver-adr-plugin-delegation`
+
+#### GTS via Types Registry
+
+- [ ] `p2` - **ID**: `cpt-cf-license-resolver-constraint-gts-via-types-registry`
+
+Plugin discovery goes exclusively through the GTS types registry: plugins are described by a versioned GTS plugin spec
+and selected by vendor + priority. Resource types are referenced by GTS type path; which types are licensable and how
+they are validated is owned by the backend licensing service, not the resolver core.
+
+**ADRs**: `cpt-cf-license-resolver-adr-gts-resource-identity`
+
+## 3. Technical Architecture
+
+### 3.1 Domain Model
+
+**Technology**: GTS-typed Rust value types (transport-agnostic SDK models).
+
+**Core Entities**:
+
+| Entity                   | Description                                                                                                                                                                                                                                                                                                                                    |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `LicenseCheckRequest`    | The single input to a check — bundles `subject`, `resource` (`GtsInstanceId`), optional `metadata`, and `context`; the contract's growth surface (new inputs are added as fields, not new parameters).                                                                                                                                         |
+| `Subject`                | The "someone" a license is checked for: a subject type plus an id, consistent with the authz-resolver subject model. Polymorphic — a tenant, a user, or any future subject type; not restricted to tenants.                                                                                                                                    |
+| resource `GtsInstanceId` | The resource identity: a single GTS instance id encoding type + id via `~`, either a well-known name (§2.3, e.g. `…feature.v1~cf.<vendor>._.somename.v1`) or a UUID (§2.4 combined notation, e.g. `…content.v1~<uuid>`). The full id is passed to the backend plugin, which interprets it.                                                     |
+| `Metadata`               | Optional caller-supplied evaluation attributes: a `string`→JSON map, opaque to the core, forwarded unchanged to the plugin for attribute/constraint-based licensing (region, country, environment, …). The contract's extension point; mirrors quota-enforcement request metadata.                                                             |
+| `LicenseCheckContext`    | The request's tenant context — the tenant isolation scope, which the caller derives from its `SecurityContext`. Minimal today (tenant scope); reserved for future contextual inputs.                                                                                                                                                           |
+| `LicenseDecision`        | The check result: a `granted` boolean plus a `diagnostics` map (string → JSON) of non-authoritative debug info about how the decision was reached (e.g. backend id, matched grant, denial cause). Carrying minimal grant metadata (e.g. status) is a possible future enrichment (PRD §13 open question, §4), not part of the current decision. |
+
+**Resource identity forms** — a single `GtsInstanceId`:
+
+- Named resource (GTS §2.3 well-known instance): the instance segment is a well-known name, e.g.
+  `gts.cf.<pkg>.feature.v1~cf.<vendor>._.somename.v1` (the `feature~somename` shorthand).
+- Opaque resource (GTS §2.4 anonymous instance): the instance segment is a UUID via the combined notation, e.g.
+  `gts.cf.<pkg>.content.v1~<uuid>` (the `content~<uuid>` shorthand).
+
+Both are one `GtsInstanceId`; the backend plugin interprets the concrete instance to answer the check.
+
+**Relationships**:
+
+- `LicenseCheckRequest` is the single input to a check — it bundles `Subject`, the resource `GtsInstanceId`, optional
+  `Metadata`, and the `LicenseCheckContext` (tenant scope); `LicenseDecision` is its output.
+- The `resource_type` (`GtsTypeId`) derived from the resource instance id is owned by an external module; the resolver
+  references it but neither defines nor validates it — the backend licensing service owns the licensable-type catalog
+  and its validation.
+- There is intentionally NO `Page<T>` and NO `LicensedResource` entity — the resolver does not list or enumerate.
+
+### 3.2 Component Model
+
+```text
+            LicenseResolverClient.is_licensed
+   caller ------------------------------------> [Main module: gateway/selector]
+                                                   |  discovers via types-registry (GTS)
+                                                   |  selects by vendor + priority
+                                                   v
+                              get_scoped::<LicenseResolverPluginClient>
+                                                   |
+                                                   v
+                                          [Backend plugin]
+                                            holds grant facts
+   (SDK contract crate defines both traits, DTOs, error enum, and the plugin GTS spec)
+```
+
+#### SDK Contract
+
+- [ ] `p2` - **ID**: `cpt-cf-license-resolver-component-sdk-contract`
+
+- **Why**: Provides the stable, transport-agnostic contract shared by callers and plugins so neither depends on the
+  other's internals.
+- **Responsibility scope**: Defines the public `LicenseResolverClient` trait and the `LicenseResolverPluginClient`
+  trait (both with the single `is_licensed` method incl. the `metadata` input), the domain DTOs (`Subject`, resource
+  `GtsInstanceId`, `Metadata`, `LicenseDecision`), the `LicenseResolverError` enum, the `GtsInstanceId`/`GtsTypeId`
+  helpers, and the GTS plugin spec used for discovery.
+- **Responsibility boundaries**: Holds no logic, no state, and no plugin selection; defines no resource types (
+  externally owned); exposes no listing/enumeration method.
+- **Related components**: `cpt-cf-license-resolver-component-main-gateway` — implemented-by (gateway implements the
+  public trait); `cpt-cf-license-resolver-component-plugin` — implemented-by (plugin implements the plugin trait).
+
+#### Main-Module Gateway / Selector
+
+- [ ] `p2` - **ID**: `cpt-cf-license-resolver-component-main-gateway`
+
+- **Why**: Realizes the public contract while keeping callers decoupled from any specific backend, centralizing plugin
+  discovery, selection, delegation, and fail-closed error mapping.
+- **Responsibility scope**: Implements `LicenseResolverClient`; receives a `LicenseCheckRequest`, scopes by its
+  `context` (tenant), discovers plugin instances via the plugin GTS spec, selects one by vendor + priority (memoizing
+  the selection), resolves the scoped plugin client via ClientHub, propagates the `LicenseCheckRequest` unchanged,
+  delegates the `is_licensed` check, and maps plugin/registry failures to the canonical `LicenseResolverError`.
+- **Responsibility boundaries**: Owns no grant store and makes no licensing decision itself — it routes; beyond reading
+  the tenant scope from `request.context`, does not interpret or validate request fields (the resource instance id and
+  `metadata` are passed through to the plugin, which owns resource-type licensability and validation); never grants by
+  default (a missing plugin or unreachable backend maps to a non-granting error); performs no listing.
+- **Related components**: `cpt-cf-license-resolver-component-sdk-contract` — depends on (implements its public trait);
+  `cpt-cf-license-resolver-component-plugin` — calls (delegates the check via the scoped plugin client).
+
+#### Backend Plugin
+
+- [ ] `p2` - **ID**: `cpt-cf-license-resolver-component-plugin`
+
+- **Why**: A license enforcement/management service that encapsulates a vendor-specific source of grant facts behind the
+  shared plugin trait so backends are swappable without caller changes.
+- **Responsibility scope**: Registers its GTS instance (vendor + priority metadata) and a scoped client; owns the
+  catalog of licensable resource types and validates the resource (interpreting the request's resource `GtsInstanceId`,
+  named or UUID-based); MAY evaluate the forwarded `metadata` to apply attribute/constraint-based licensing (region,
+  country, …); holds/queries grant facts; and answers the delegated `is_licensed` check for the given subject (whatever
+  its subject type) within the tenant isolation scope carried in `request.context`.
+- **Responsibility boundaries**: Never consumed directly by other modules — only through the main module's public
+  contract; does not define the GTS resource types themselves (those are owned by the resources' modules); exposes no
+  listing method.
+- **Related components**: `cpt-cf-license-resolver-component-sdk-contract` — depends on (implements its plugin trait);
+  `cpt-cf-license-resolver-component-main-gateway` — called-by (receives delegated checks).
+
+### 3.3 API Contracts
+
+The module exposes one public client trait and requires one plugin trait, described in prose only (no code).
+
+- **Public interface (PRD)**: `cpt-cf-license-resolver-interface-client`
+- **Plugin contract (PRD)**: `cpt-cf-license-resolver-contract-plugin`
+- **Technology**: Rust traits over the ToolKit ClientHub (in-process); transport-agnostic SDK models.
+
+**Public client — `LicenseResolverClient`** (realizes PRD `cpt-cf-license-resolver-interface-client`): exposes the
+SINGLE method `is_licensed(request: LicenseCheckRequest) -> LicenseDecision`. `LicenseCheckRequest` bundles `subject` (a
+`Subject`), `resource` (a `GtsInstanceId`), `metadata` (opaque `string`→JSON evaluation attributes, forwarded to the
+plugin), and `context` (a `LicenseCheckContext` carrying the tenant scope). The caller builds `context` from its
+`SecurityContext`, exactly as authz-resolver's `PolicyEnforcer` builds an `EvaluationRequest` — the resolver method
+itself takes no separate `SecurityContext`. There is no listing or enumeration method.
+
+**Plugin client — `LicenseResolverPluginClient`** (realizes PRD `cpt-cf-license-resolver-contract-plugin`): mirrors the
+public signature with the same single `is_licensed` method, discovered via the GTS types-registry plugin spec and
+resolved as a scoped client. It tracks the public contract's major version.
+
+**Operation summary**:
+
+| Operation     | Inputs                                                                                | Output                                        | Stability |
+|---------------|---------------------------------------------------------------------------------------|-----------------------------------------------|-----------|
+| `is_licensed` | `LicenseCheckRequest` (subject, resource `GtsInstanceId`, `metadata`, tenant context) | `LicenseDecision` (granted + diagnostics map) | stable    |
+
+**Error model — `LicenseResolverError`**: the SDK returns this enum; each variant maps to a canonical RFC-9457 error
+(`Problem`), so callers get canonical errors directly. Canonical categories and their GTS error type ids come from the
+platform error catalog (`toolkit-canonical-errors`).
+
+| Variant                      | Meaning                                              | Canonical error — GTS error type id                                                    |
+|------------------------------|------------------------------------------------------|----------------------------------------------------------------------------------------|
+| `Unauthorized`               | Caller/subject not permitted to perform the check    | `PermissionDenied` — `gts.cf.core.errors.err.v1~cf.core.err.permission_denied.v1~`     |
+| `NoPluginAvailable`          | No backend plugin matches the resource type / vendor | `Internal` — `gts.cf.core.errors.err.v1~cf.core.err.internal.v1~`                      |
+| `ServiceUnavailable(reason)` | Selected backend unreachable or erroring             | `ServiceUnavailable` — `gts.cf.core.errors.err.v1~cf.core.err.service_unavailable.v1~` |
+| `Internal(reason)`           | Unexpected internal failure                          | `Internal` — `gts.cf.core.errors.err.v1~cf.core.err.internal.v1~`                      |
+
+A negative result is **not** an error — it is `LicenseDecision { granted: false }`. The error enum covers only
+"cannot-determine" conditions; on any of them the caller fails closed (treats the outcome as not-granted). Being
+read-only, there are no mutation / "not found" write errors.
+
+### 3.4 Internal Dependencies
+
+| Dependency Module   | Interface Used                        | Purpose                                                                             |
+|---------------------|---------------------------------------|-------------------------------------------------------------------------------------|
+| `types-registry`    | SDK client (`TypesRegistryClient`)    | Discover and select backend plugin instances by GTS plugin spec (vendor + priority) |
+| ToolKit `ClientHub` | scoped client registration/resolution | Resolve the selected plugin as a scoped `LicenseResolverPluginClient`               |
+
+**Dependency Rules** (per project conventions):
+
+- No circular dependencies; the main module depends on `types-registry` but not on any plugin crate.
+- Always use SDK clients / scoped ClientHub for inter-module communication.
+- Plugins are consumed only through the main module's public contract.
+- The `LicenseCheckRequest` (including its tenant context) is propagated unchanged across all in-process calls.
+
+### 3.5 External Dependencies
+
+The resolver integrates with no external systems, databases, or third-party services directly. Backend grant sources are
+reached only via the discovered plugin component, which is responsible for any external integration it requires. There
+is no resolver-owned external dependency.
+
+### 3.6 Interactions & Sequences
+
+#### License Check (is_licensed)
+
+**ID**: `cpt-cf-license-resolver-seq-is-licensed`
+
+**Use cases**: `cpt-cf-license-resolver-usecase-gate-access`
+
+**Actors**: `cpt-cf-license-resolver-actor-consuming-module`, `cpt-cf-license-resolver-actor-backend-plugin`
+
+```mermaid
+sequenceDiagram
+    participant C as Consuming Module
+    participant G as Main Module (Gateway/Selector)
+    participant R as types-registry (GTS)
+    participant P as Backend Plugin
+    C ->> G: is_licensed(request)
+    alt plugin selection not yet memoized
+        G ->> R: list plugin instances by GTS spec
+        R -->> G: instances (vendor, priority)
+        G ->> G: choose by vendor + priority (memoize)
+        Note over G: no matching plugin -> NoPluginAvailable (fail closed)
+    end
+    G ->> P: is_licensed(request) [scoped by request.context, forwarded unchanged]
+    alt backend unreachable
+        P -->> G: error -> ServiceUnavailable (fail closed)
+    else backend answers
+        P -->> G: LicenseDecision(granted, diagnostics)
+    end
+    G -->> C: LicenseDecision | LicenseResolverError
+```
+
+**Description**: The gateway resolves and memoizes the backend plugin via the types registry (selecting by vendor +
+priority), then delegates the single `is_licensed` check, forwarding the `LicenseCheckRequest` unchanged (tenant scope
+comes from `request.context`). A missing plugin or unreachable backend fails closed to a non-granting error. No listing
+or enumeration sequence exists.
+
+### 3.7 Database schemas & tables
+
+Not applicable because the resolver is read-only and stateless: it owns no grant store and persists nothing. All grant
+data lives in the backend plugin.
+
+### 3.8 Deployment Topology
+
+Not applicable because the resolver is read-only and stateless: it is an in-process library module with no dedicated
+infrastructure, datastore, or network topology of its own.
+
+## 4. Additional context
+
+**Telemetry**: The resolver's own telemetry surface is minimal — a check counter and a boundary latency histogram.
+Dimension them only by bounded labels (the derived resource type, selected vendor, decision outcome); never label by the
+full resource instance id or by `metadata` values (unbounded cardinality). Boundary latency excludes plugin compute to
+support NFR `cpt-cf-license-resolver-nfr-read-latency`. (Backend plugins' own telemetry is their concern.)
+
+**Future considerations**: The opaque `metadata` map (`cpt-cf-license-resolver-fr-evaluation-metadata`) is the
+contract's primary extension point — future attribute/constraint dimensions (region, country, environment, …) are
+expressed as new keys interpreted by backends, with no signature change; a conventional key vocabulary MAY be
+standardized later, and per-key GTS schema validation is a candidate future addition. Likewise a conventional
+`diagnostics` key vocabulary and optional grant metadata (status/expiry) on `LicenseDecision` may be enriched without
+changing the single-operation shape. Any such change follows the breaking-change policy on the public contract.
+
+## 5. Traceability
+
+- **PRD**: [PRD.md](./PRD.md)
+- **ADRs**: [ADR/](./ADR/)
+
+| PRD ID                                           | Type | DESIGN Section(s)          | Backing ADR                                         |
+|--------------------------------------------------|------|----------------------------|-----------------------------------------------------|
+| `cpt-cf-license-resolver-fr-is-licensed-check`   | FR   | §1.2, §3.3, §3.6           | `cpt-cf-license-resolver-adr-plugin-delegation`     |
+| `cpt-cf-license-resolver-fr-subject-identity`    | FR   | §1.2, §3.1                 | `cpt-cf-license-resolver-adr-gts-resource-identity` |
+| `cpt-cf-license-resolver-fr-resource-identity`   | FR   | §1.2, §3.1                 | `cpt-cf-license-resolver-adr-gts-resource-identity` |
+| `cpt-cf-license-resolver-fr-evaluation-metadata` | FR   | §1.2, §3.1, §3.3, §3.6, §4 | —                                                   |
+| `cpt-cf-license-resolver-fr-plugin-delegation`   | FR   | §1.2, §3.2, §3.4, §3.6     | `cpt-cf-license-resolver-adr-plugin-delegation`     |
+| `cpt-cf-license-resolver-fr-read-only`           | FR   | §1.2, §2.1, §3.7           | `cpt-cf-license-resolver-adr-plugin-delegation`     |
+| `cpt-cf-license-resolver-nfr-read-latency`       | NFR  | §1.2, §3.2, §4             | `cpt-cf-license-resolver-adr-plugin-delegation`     |
+| `cpt-cf-license-resolver-nfr-fail-closed`        | NFR  | §1.2, §2.1, §3.3           | `cpt-cf-license-resolver-adr-plugin-delegation`     |
+| `cpt-cf-license-resolver-nfr-tenant-scoping`     | NFR  | §1.2, §3.2, §3.6           | —                                                   |

--- a/gears/system/license-resolver/docs/DESIGN.md
+++ b/gears/system/license-resolver/docs/DESIGN.md
@@ -10,21 +10,21 @@ system: cf
 <!-- toc -->
 
 - [1. Architecture Overview](#1-architecture-overview)
-    - [1.1 Architectural Vision](#11-architectural-vision)
-    - [1.2 Architecture Drivers](#12-architecture-drivers)
-    - [1.3 Architecture Layers](#13-architecture-layers)
+  - [1.1 Architectural Vision](#11-architectural-vision)
+  - [1.2 Architecture Drivers](#12-architecture-drivers)
+  - [1.3 Architecture Layers](#13-architecture-layers)
 - [2. Principles & Constraints](#2-principles--constraints)
-    - [2.1 Design Principles](#21-design-principles)
-    - [2.2 Constraints](#22-constraints)
+  - [2.1 Design Principles](#21-design-principles)
+  - [2.2 Constraints](#22-constraints)
 - [3. Technical Architecture](#3-technical-architecture)
-    - [3.1 Domain Model](#31-domain-model)
-    - [3.2 Component Model](#32-component-model)
-    - [3.3 API Contracts](#33-api-contracts)
-    - [3.4 Internal Dependencies](#34-internal-dependencies)
-    - [3.5 External Dependencies](#35-external-dependencies)
-    - [3.6 Interactions & Sequences](#36-interactions--sequences)
-    - [3.7 Database schemas & tables](#37-database-schemas--tables)
-    - [3.8 Deployment Topology](#38-deployment-topology)
+  - [3.1 Domain Model](#31-domain-model)
+  - [3.2 Component Model](#32-component-model)
+  - [3.3 API Contracts](#33-api-contracts)
+  - [3.4 Internal Dependencies](#34-internal-dependencies)
+  - [3.5 External Dependencies](#35-external-dependencies)
+  - [3.6 Interactions & Sequences](#36-interactions--sequences)
+  - [3.7 Database schemas & tables](#37-database-schemas--tables)
+  - [3.8 Deployment Topology](#38-deployment-topology)
 - [4. Additional context](#4-additional-context)
 - [5. Traceability](#5-traceability)
 
@@ -38,21 +38,27 @@ system: cf
 
 License Resolver is a thin, read-only, plugin-delegating system module. It answers exactly one question — *is this
 resource licensed to this subject right now?* — through a single `is_licensed(request)` check, where the
-`LicenseCheckRequest` bundles subject, resource, optional evaluation `metadata`, and the tenant context, and returns a
-yes/no decision plus a structured, non-authoritative `diagnostics` map (debug info about how the decision was reached).
-It owns no grant store: grant facts live in heterogeneous, vendor-owned backends, so the main module discovers and
-selects a backend plugin at runtime via the GTS types registry (by vendor + priority) and delegates the lookup. This
-mirrors the proven `authz-resolver` / `tenant-resolver` delegation model and keeps issuance, billing, storage, and
-catalog/listing concerns out of the resolver.
+`LicenseCheckRequest` bundles the subject and resource contract objects (each with schematized `metadata`) and the
+tenant context, and returns a yes/no decision plus a structured, non-authoritative `diagnostics` map (debug info about
+how the decision was reached). It owns no grant store: grant facts live in heterogeneous, vendor-owned backends, so the
+main module discovers and selects a backend plugin at runtime via the GTS types registry (by vendor + priority) and
+delegates the lookup. This mirrors the proven `authz-resolver` / `tenant-resolver` delegation model and keeps issuance,
+billing, storage, and catalog/listing concerns out of the resolver.
 
 The architecture is deliberately minimal: a three-crate triad (SDK contract, main-module gateway/selector, backend
-plugin) over the ToolKit framework. Resource identity is a single GTS instance id (`GtsInstanceId`) — named (§2.3) or
-UUID-based (§2.4) — that encodes resource type + id and references externally-owned resource types (a `feature`, a
-`content` item, a capability) without ever defining or validating them — which resource types are licensable and how
-they are validated is owned by the backend licensing service. Because the resolver performs no writes and holds no
-state, it is stateless and side-effect-free;
-the only behavioral guarantees that shape the design are tenant scoping via the request's tenant context (derived from
-the caller's `SecurityContext`) and fail-closed semantics when no plugin or backend is reachable.
+plugin) over the ToolKit framework. The check payload is a **typed licensing contract**: the Subject and Resource in a
+request are instances of registered GTS types derived from the licensing base types
+(`gts.cf.core.lic.subj.v1~` / `…res.v1~`) — a module that wants license enforcement registers its derived Subject and
+Resource types (its published licensing surface) and *projects* the licensing-relevant slice of its domain objects
+into them; this module owns only the base types and MAY provide helpers for registering the well-known
+`SecurityContext` subjects (`user`, `tenant`). Inside the contract objects,
+identity is the domain GTS type (always present) plus an optional instance id — a well-known name or a UUID; without
+the id the check targets the whole resource type (e.g. on a `POST`, before any instance exists). The gateway validates
+every request against the registered contracts (schemas + admitted subject types) before delegating; what the
+properties *mean* and what is *licensable* remain the backend licensing service's concern. Because the resolver
+performs no writes and holds no state, it is stateless and side-effect-free; the behavioral guarantees that shape the
+design are tenant scoping via the request's tenant context (derived from the caller's `SecurityContext`), fail-closed
+semantics when no plugin or backend is reachable, and fail-closed rejection of non-conforming requests.
 
 ### 1.2 Architecture Drivers
 
@@ -60,29 +66,34 @@ Requirements from PRD that significantly influence architecture decisions.
 
 #### Functional Drivers
 
-| Requirement                                      | Design Response                                                                                                                                                                                                                                                                  |
-|--------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `cpt-cf-license-resolver-fr-is-licensed-check`   | A single `is_licensed` method on the public `LicenseResolverClient` contract (`cpt-cf-license-resolver-component-sdk-contract`); the main-module gateway (`cpt-cf-license-resolver-component-main-gateway`) realizes it by delegating to the selected plugin.                    |
-| `cpt-cf-license-resolver-fr-subject-identity`    | `Subject` domain entity (subject type + id); carried into the check and propagated to the plugin.                                                                                                                                                                                |
-| `cpt-cf-license-resolver-fr-resource-identity`   | Single `GtsInstanceId` resource identity (§3.1; named §2.3 or UUID §2.4); principle `cpt-cf-license-resolver-principle-gts-typed-resource-identity`; the type is derived from the instance id.                                                                                   |
-| `cpt-cf-license-resolver-fr-evaluation-metadata` | An opaque `metadata` map (`string`→JSON) on the check input (§3.1, §3.3); the gateway forwards it unchanged to the plugin, which MAY evaluate attribute constraints (region, country, …). The resolver neither interprets nor requires any key — the contract's extension point. |
-| `cpt-cf-license-resolver-fr-plugin-delegation`   | Gateway/selector component discovers plugins via the types registry and routes by vendor + priority; principle `cpt-cf-license-resolver-principle-delegate-dont-store`.                                                                                                          |
-| `cpt-cf-license-resolver-fr-read-only`           | No write paths, no store, no list method anywhere in the contract; principles `cpt-cf-license-resolver-principle-read-only` and `cpt-cf-license-resolver-principle-check-only-no-listing`.                                                                                       |
+| Requirement                                           | Design Response                                                                                                                                                                                                                                                                                                                                                                                                               |
+|-------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `cpt-cf-license-resolver-fr-is-licensed-check`        | A single `is_licensed` method on the public `LicenseResolverClient` contract (`cpt-cf-license-resolver-component-sdk-contract`); the main-module gateway (`cpt-cf-license-resolver-component-main-gateway`) realizes it by delegating to the selected plugin.                                                                                                                                                                 |
+| `cpt-cf-license-resolver-fr-subject-identity`         | The Subject is an instance of a derived Subject contract type (§3.1): domain GTS type (required) + optional id + schematized `metadata`; carried into the check and propagated to the plugin.                                                                                                                                                                                                                                 |
+| `cpt-cf-license-resolver-fr-resource-identity`        | The Resource is an instance of a derived Resource contract type (§3.1): domain GTS type (required) + optional instance id + schematized `metadata`; without the id the check targets the whole type, with it a specific resource; principle `cpt-cf-license-resolver-principle-gts-typed-resource-identity`.                                                                                                                  |
+| `cpt-cf-license-resolver-fr-contract-registration`    | Licensing base types owned by this module, defined in its SDK contract crate (§3.1, §3.2); a module that wants license enforcement registers its derived Subject and Resource types in the types registry — its published licensing surface; this module MAY provide helpers for registering the well-known `SecurityContext` subjects (`user`, `tenant`); principle `cpt-cf-license-resolver-principle-validated-contracts`. |
+| `cpt-cf-license-resolver-fr-contract-discoverability` | Derived contract types are enumerable from the types registry by derivation from the base types (§3.1); no resolver API is involved — discoverability is registry-native.                                                                                                                                                                                                                                                     |
+| `cpt-cf-license-resolver-fr-request-validation`       | Gateway validation pipeline (§3.2, §3.6): structural (contract schemas, identity invariants) + compatibility (`admitted_subjects` trait) ahead of delegation; failures map to `InvalidRequest` (§3.3), never to a not-granted decision.                                                                                                                                                                                       |
+| `cpt-cf-license-resolver-fr-contract-compatibility`   | Additive optional properties are non-breaking (consumers ignore unknown fields); removals/renames/type changes/narrowing of admitted subjects require a new contract version (§3.1, §3.3 breaking-change policy).                                                                                                                                                                                                             |
+| `cpt-cf-license-resolver-fr-evaluation-metadata`      | `metadata` lives on the Subject/Resource contract objects (§3.1, §3.3); shape-validated against the registered contract schema, semantically uninterpreted by the gateway, forwarded unchanged to the plugin, which MAY evaluate attribute constraints (region, model, …).                                                                                                                                                    |
+| `cpt-cf-license-resolver-fr-plugin-delegation`        | Gateway/selector component discovers plugins via the types registry and routes by vendor + priority; principle `cpt-cf-license-resolver-principle-delegate-dont-store`.                                                                                                                                                                                                                                                       |
+| `cpt-cf-license-resolver-fr-read-only`                | No write paths, no store, no list method anywhere in the contract; principles `cpt-cf-license-resolver-principle-read-only` and `cpt-cf-license-resolver-principle-check-only-no-listing`.                                                                                                                                                                                                                                    |
 
 #### NFR Allocation
 
 | NFR ID                                       | NFR Summary                                                 | Allocated To                                                        | Design Response                                                                                                                                                                                                                                                                                                                                                                  | Verification Approach                                                                      |
 |----------------------------------------------|-------------------------------------------------------------|---------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
-| `cpt-cf-license-resolver-nfr-read-latency`   | `is_licensed` ≤ 50ms p95 at the resolver boundary           | Gateway/selector (`cpt-cf-license-resolver-component-main-gateway`) | Plugin instance selection is memoized after first resolution so the hot path is a scoped ClientHub lookup plus one delegated call; boundary excludes plugin compute.                                                                                                                                                                                                             | Boundary latency benchmark at p95 excluding plugin processing.                             |
+| `cpt-cf-license-resolver-nfr-read-latency`   | `is_licensed` ≤ 50ms p95 at the resolver boundary           | Gateway/selector (`cpt-cf-license-resolver-component-main-gateway`) | Plugin instance selection is memoized after first resolution and contract schemas are resolved from the registry once and cached, so the hot path is a cached-schema validation, a scoped ClientHub lookup, and one delegated call; boundary excludes plugin compute.                                                                                                            | Boundary latency benchmark at p95 excluding plugin processing.                             |
 | `cpt-cf-license-resolver-nfr-fail-closed`    | Never grant by default when no plugin / backend unreachable | Gateway/selector + `LicenseResolverError` mapping                   | No matching plugin yields `NoPluginAvailable`; an unreachable backend yields `ServiceUnavailable`; neither path can produce a granted decision (principle `cpt-cf-license-resolver-principle-fail-closed-no-plugin`).                                                                                                                                                            | Tests asserting 0 grant-by-default outcomes across all no-plugin / unavailable conditions. |
 | `cpt-cf-license-resolver-nfr-tenant-scoping` | Every resolution scoped to the request's tenant context     | All components                                                      | Current model: every license is tenant-bounded — regardless of subject type the subject belongs to a tenant. The `LicenseCheckRequest` carries a tenant context (built by the caller from its `SecurityContext`); the gateway scopes by it and forwards the request unchanged to the plugin; tenant scope is derived solely from `request.context` (no cross-tenant resolution). | Tests asserting 0 cross-tenant resolutions.                                                |
 
 #### Key ADRs
 
-| ADR ID                                              | Decision Summary                                                                                                                                                                            |
-|-----------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `cpt-cf-license-resolver-adr-gts-resource-identity` | Resource identity is a single `GtsInstanceId` (named §2.3 or UUID §2.4); the resolver references the type — licensable-type catalog and validation belong to the backend licensing service. |
-| `cpt-cf-license-resolver-adr-plugin-delegation`     | No resolver-owned store; backend discovered via types-registry and selected by vendor + priority, failing closed when none matches.                                                         |
+| ADR ID                                                  | Decision Summary                                                                                                                                                                                                                                                          |
+|---------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `cpt-cf-license-resolver-adr-gts-resource-identity`     | Inside the contract objects, subject/resource identity is the domain GTS type (required) plus an optional instance id (name or UUID) — without the id the check targets a whole resource type (e.g. on `POST`); how an id-less check is answered is the backend's policy. |
+| `cpt-cf-license-resolver-adr-typed-licensing-contracts` | Subject/Resource shapes are registered, versioned GTS types derived from the licensing base types; the gateway validates every request against the registered contracts (fail-closed) before delegation; metadata is schematized but semantically opaque to the engine.   |
+| `cpt-cf-license-resolver-adr-plugin-delegation`         | No resolver-owned store; backend discovered via types-registry and selected by vendor + priority, failing closed when none matches.                                                                                                                                       |
 
 ### 1.3 Architecture Layers
 
@@ -113,12 +124,12 @@ Requirements from PRD that significantly influence architecture decisions.
 
 - [ ] `p3` - **ID**: `cpt-cf-license-resolver-tech-layers`
 
-| Layer                     | Responsibility                                                            | Technology               |
-|---------------------------|---------------------------------------------------------------------------|--------------------------|
-| Contract (SDK)            | Public + plugin traits, DTOs, error enum, plugin GTS spec                 | Rust, ToolKit SDK, GTS   |
-| Application (main module) | Plugin discovery/selection, delegation, error mapping, tenant propagation | Rust, ToolKit, ClientHub |
-| Domain                    | `Subject`, resource `GtsInstanceId`, `LicenseDecision` value types        | Rust, GTS                |
-| Integration               | Plugin discovery / selection (vendor + priority)                          | types-registry (GTS)     |
+| Layer                     | Responsibility                                                                                         | Technology               |
+|---------------------------|--------------------------------------------------------------------------------------------------------|--------------------------|
+| Contract (SDK)            | Public + plugin traits, DTOs, error enum, plugin GTS spec                                              | Rust, ToolKit SDK, GTS   |
+| Application (main module) | Contract validation, plugin discovery/selection, delegation, error mapping, tenant propagation         | Rust, ToolKit, ClientHub |
+| Domain                    | Licensing base + derived contract types, `Subject`/`Resource` contract objects, `LicenseDecision`      | Rust, GTS                |
+| Integration               | Plugin discovery / selection (vendor + priority); contract registration and schema resolution (cached) | types-registry (GTS)     |
 
 ## 2. Principles & Constraints
 
@@ -145,16 +156,30 @@ to a subject" is a catalog/query concern, so there is no list operation and no p
 
 **ADRs**: `cpt-cf-license-resolver-adr-plugin-delegation`
 
-#### GTS-Typed Resource Identity
+#### GTS-Typed Identity
 
 - [ ] `p2` - **ID**: `cpt-cf-license-resolver-principle-gts-typed-resource-identity`
 
-Resource identity is a single GTS instance id (`GtsInstanceId`) encoding resource type + id via `~`: a well-known name (
-§2.3) or a UUID (§2.4 combined notation). The resolver references externally-owned resource types and never defines or
-validates them; which resource types are licensable, and their validation, are owned by the backend licensing service.
-The full instance id is passed to that backend, which interprets it.
+Inside the Subject/Resource contract objects, identity is the domain GTS type (`GtsTypeId`, `…type.v1~`, always
+present) plus an optional instance id — a stable well-known name or a UUID. Without the id the check targets
+the whole resource type; with it, a specific instance. The domain types are externally owned: the resolver references
+them and validates their presence/form, while which types are licensable — and how an id-less check is answered — is
+the backend licensing service's policy.
 
 **ADRs**: `cpt-cf-license-resolver-adr-gts-resource-identity`
+
+#### Typed, Validated Licensing Contracts
+
+- [ ] `p2` - **ID**: `cpt-cf-license-resolver-principle-validated-contracts`
+
+Every Subject/Resource shape in a check is a registered, versioned GTS type derived from the licensing base types —
+never an ad-hoc payload. The gateway validates each request against the registered contracts (schemas + admitted
+subject types) before delegation and rejects non-conforming requests fail-closed, distinct from a not-granted decision.
+The engine validates *shape and compatibility* only; it never interprets what properties mean or decides
+licensability — semantics stay with the backend. This is what makes the licensing surface observable and governable by
+platform vendors.
+
+**ADRs**: `cpt-cf-license-resolver-adr-typed-licensing-contracts`
 
 #### Delegate, Don't Store
 
@@ -191,45 +216,86 @@ never directly.
 
 - [ ] `p2` - **ID**: `cpt-cf-license-resolver-constraint-gts-via-types-registry`
 
-Plugin discovery goes exclusively through the GTS types registry: plugins are described by a versioned GTS plugin spec
-and selected by vendor + priority. Resource types are referenced by GTS type path; which types are licensable and how
-they are validated is owned by the backend licensing service, not the resolver core.
+Plugin discovery and licensing contracts go exclusively through the GTS types registry: plugins are described by a
+versioned GTS plugin spec and selected by vendor + priority; licensing contract types (base + derived) are registered
+there and their schemas resolved (and cached) from there. The `admitted_subjects` constraint is expressed as a GTS
+trait (`x-gts-traits`) on derived Resource types. Domain types are referenced by GTS type path; which types are
+licensable is owned by the backend licensing service, not the resolver core.
 
-**ADRs**: `cpt-cf-license-resolver-adr-gts-resource-identity`
+**ADRs**: `cpt-cf-license-resolver-adr-gts-resource-identity`, `cpt-cf-license-resolver-adr-typed-licensing-contracts`
 
 ## 3. Technical Architecture
 
 ### 3.1 Domain Model
 
-**Technology**: GTS-typed Rust value types (transport-agnostic SDK models).
+**Technology**: a registry-resident GTS **contract type** (the durable domain entity), instantiated by transport-agnostic
+Rust **value objects** (the SDK models passed in and out of a check).
 
 **Core Entities**:
 
-| Entity                   | Description                                                                                                                                                                                                                                                                                                                                    |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `LicenseCheckRequest`    | The single input to a check — bundles `subject`, `resource` (`GtsInstanceId`), optional `metadata`, and `context`; the contract's growth surface (new inputs are added as fields, not new parameters).                                                                                                                                         |
-| `Subject`                | The "someone" a license is checked for: a subject type plus an id, consistent with the authz-resolver subject model. Polymorphic — a tenant, a user, or any future subject type; not restricted to tenants.                                                                                                                                    |
-| resource `GtsInstanceId` | The resource identity: a single GTS instance id encoding type + id via `~`, either a well-known name (§2.3, e.g. `…feature.v1~cf.<vendor>._.somename.v1`) or a UUID (§2.4 combined notation, e.g. `…content.v1~<uuid>`). The full id is passed to the backend plugin, which interprets it.                                                     |
-| `Metadata`               | Optional caller-supplied evaluation attributes: a `string`→JSON map, opaque to the core, forwarded unchanged to the plugin for attribute/constraint-based licensing (region, country, environment, …). The contract's extension point; mirrors quota-enforcement request metadata.                                                             |
-| `LicenseCheckContext`    | The request's tenant context — the tenant isolation scope, which the caller derives from its `SecurityContext`. Minimal today (tenant scope); reserved for future contextual inputs.                                                                                                                                                           |
-| `LicenseDecision`        | The check result: a `granted` boolean plus a `diagnostics` map (string → JSON) of non-authoritative debug info about how the decision was reached (e.g. backend id, matched grant, denial cause). Carrying minimal grant metadata (e.g. status) is a possible future enrichment (PRD §13 open question, §4), not part of the current decision. |
+| Entity                | Description                                                                                                                                                                                                                                                                                                                                           |
+|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Licensing Contract    | The durable domain entity: a registered, versioned GTS type derived from a licensing base type, with identity (its GTS type id) and its own version + compatibility lifecycle. Defines a Subject or Resource shape — required domain `type`, optional `id`, a `metadata` schema; a Resource contract also declares its `admitted_subjects`. Lives in the types registry; the value objects below are its instances (base/derived schemas detailed under *Licensing base types* / *Derived types*). |
+| `LicenseCheckRequest` | The single input to a check — bundles the `subject` and `resource` contract objects and `context`; the contract's growth surface (new inputs are added as fields, not new parameters).                                                                                                                                                                |
+| `Subject`             | An instance of a derived Subject contract type (base `gts.cf.core.lic.subj.v1~`): domain GTS type (required), optional id, `metadata` conforming to the contract schema. Polymorphic — a tenant, a user, or any future subject type; not restricted to tenants.                                                                                       |
+| `Resource`            | An instance of a derived Resource contract type (base `gts.cf.core.lic.res.v1~`): domain GTS type (required), optional instance id, `metadata` conforming to the contract schema. Without the id the check targets the whole resource type; with it, a specific resource. Passed to the backend plugin unchanged.                                     |
+| `LicenseCheckContext` | The request's tenant context — the tenant isolation scope, which the caller derives from its `SecurityContext` (as authz-resolver does). Minimal today (tenant scope); the extension point for future contextual evaluation semantics (e.g. whether hierarchy traversal is allowed), mirroring how authz models such cases.                           |
+| `LicenseDecision`     | The check result: a `granted` boolean plus a `diagnostics` map (string → JSON) of non-authoritative debug info about how the decision was reached (e.g. backend id, matched grant, denial cause). Carrying minimal grant metadata (e.g. status) is a possible future enrichment (PRD §13 open question; DESIGN §4), not part of the current decision. |
 
-**Resource identity forms** — a single `GtsInstanceId`:
+**Licensing base types** (owned by this module, under `gts.cf.core.lic.*`):
 
-- Named resource (GTS §2.3 well-known instance): the instance segment is a well-known name, e.g.
-  `gts.cf.<pkg>.feature.v1~cf.<vendor>._.somename.v1` (the `feature~somename` shorthand).
-- Opaque resource (GTS §2.4 anonymous instance): the instance segment is a UUID via the combined notation, e.g.
-  `gts.cf.<pkg>.content.v1~<uuid>` (the `content~<uuid>` shorthand).
+`gts.cf.core.lic.subj.v1~` — base Subject type:
 
-Both are one `GtsInstanceId`; the backend plugin interprets the concrete instance to answer the check.
+| Field      | Type                               | Notes                                                       |
+|------------|------------------------------------|-------------------------------------------------------------|
+| `type`     | GTS type id, **required**          | The subject's domain type (e.g. a user type)                |
+| `id`       | optional — UUID or well-known name | Absent for type-level subjects                              |
+| `metadata` | object                             | Subject properties, conforming to the derived type's schema |
+
+`gts.cf.core.lic.res.v1~` — base Resource type:
+
+| Field                       | Type                               | Notes                                                                                       |
+|-----------------------------|------------------------------------|---------------------------------------------------------------------------------------------|
+| `type`                      | GTS type id, **required**          | The resource's domain type                                                                  |
+| `id`                        | optional — UUID or well-known name | Absent = whole-type check (e.g. on `POST`); how it is answered is the backend's policy      |
+| `metadata`                  | object                             | Resource properties, conforming to the derived type's schema                                |
+| *trait* `admitted_subjects` | set of Subject contract types      | The `gts.cf.core.lic.subj.v1~*` types this Resource may be checked against (`x-gts-traits`) |
+
+**Derived types — a Gear's licensing surface** (example, LLM gateway):
+
+- Subject `gts.cf.core.lic.subj.v1~cf.genai.llm_gateway.user.v1~` — `metadata: { category: string }`
+- Resource `gts.cf.core.lic.res.v1~cf.genai.llm_gateway.model_usage.v1~` —
+  `metadata: { model_vendor: string, model_name: string }`,
+  `admitted_subjects: [gts.cf.core.lic.subj.v1~cf.genai.llm_gateway.user.v1~*]`
+
+Because all contracts derive from the base types, querying the registry for everything under
+`gts.cf.core.lic.subj.v1~` / `…res.v1~` yields the complete licensing surface of a platform — every check, every
+Subject/Resource pair, every property available for rules — with no surrounding type noise. A platform vendor that
+licenses per-model writes rules over `model_vendor`/`model_name`; one that does not, ignores those fields. Same Gear,
+same contract, different licensing models.
+
+**Identity forms inside a contract object** — the domain GTS type is always present; the instance id is optional:
+
+- Whole resource type (no instance id): type only, e.g. `gts.cf.<pkg>.content.v1~` — asks whether the subject is
+  entitled to resources of this type as a class; typically gating creation (e.g. a `POST`), where the resource does not
+  exist yet so there is no id to pass. What a type-level grant means is the backend's definition; a caller that needs a
+  pre-creation check distinguished from other type-level checks signals it via a `metadata` property of its contract
+  schema.
+- Named instance: type plus a stable well-known name (e.g. a named feature).
+- Opaque instance: type plus a UUID (e.g. a content item).
+
+Both fields are forwarded to the backend plugin unchanged; it interprets them to answer the check — see
+`cpt-cf-license-resolver-adr-gts-resource-identity`.
 
 **Relationships**:
 
-- `LicenseCheckRequest` is the single input to a check — it bundles `Subject`, the resource `GtsInstanceId`, optional
-  `Metadata`, and the `LicenseCheckContext` (tenant scope); `LicenseDecision` is its output.
-- The `resource_type` (`GtsTypeId`) derived from the resource instance id is owned by an external module; the resolver
-  references it but neither defines nor validates it — the backend licensing service owns the licensable-type catalog
-  and its validation.
+- `LicenseCheckRequest` is the single input to a check — it bundles the `Subject` and `Resource` contract objects and
+  the `LicenseCheckContext` (tenant scope); `LicenseDecision` is its output.
+- Base types are owned by this module's SDK; the derived Subject and Resource contract types are registered by the
+  module that wants license enforcement (this module MAY provide helpers for registering the well-known
+  `SecurityContext` subjects, `user`/`tenant`); the domain types
+  referenced inside (`type` fields) are owned by external modules — the resolver validates contract conformance but
+  never defines domain types or decides licensability (the backend licensing service does).
 - There is intentionally NO `Page<T>` and NO `LicensedResource` entity — the resolver does not list or enumerate.
 
 ### 3.2 Component Model
@@ -237,15 +303,19 @@ Both are one `GtsInstanceId`; the backend plugin interprets the concrete instanc
 ```text
             LicenseResolverClient.is_licensed
    caller ------------------------------------> [Main module: gateway/selector]
-                                                   |  discovers via types-registry (GTS)
-                                                   |  selects by vendor + priority
+                                                   |  1. validates request vs registered
+                                                   |     contracts (schemas + admitted
+                                                   |     subjects; cached from registry)
+                                                   |  2. discovers via types-registry (GTS)
+                                                   |     and selects by vendor + priority
                                                    v
                               get_scoped::<LicenseResolverPluginClient>
                                                    |
                                                    v
                                           [Backend plugin]
                                             holds grant facts
-   (SDK contract crate defines both traits, DTOs, error enum, and the plugin GTS spec)
+   (SDK contract crate defines both traits, the licensing base types, DTOs,
+    error enum, and the plugin GTS spec)
 ```
 
 #### SDK Contract
@@ -255,11 +325,14 @@ Both are one `GtsInstanceId`; the backend plugin interprets the concrete instanc
 - **Why**: Provides the stable, transport-agnostic contract shared by callers and plugins so neither depends on the
   other's internals.
 - **Responsibility scope**: Defines the public `LicenseResolverClient` trait and the `LicenseResolverPluginClient`
-  trait (both with the single `is_licensed` method incl. the `metadata` input), the domain DTOs (`Subject`, resource
-  `GtsInstanceId`, `Metadata`, `LicenseDecision`), the `LicenseResolverError` enum, the `GtsInstanceId`/`GtsTypeId`
-  helpers, and the GTS plugin spec used for discovery.
-- **Responsibility boundaries**: Holds no logic, no state, and no plugin selection; defines no resource types (
-  externally owned); exposes no listing/enumeration method.
+  trait (both with the single `is_licensed` method), the licensing base types
+  (`gts.cf.core.lic.subj.v1~` / `…res.v1~`, incl. the `admitted_subjects` trait schema), optionally helpers that other
+  modules use to register the well-known `SecurityContext`-derived Subject types (`user`, `tenant`), the DTOs
+  (`Subject` / `Resource` contract objects, `LicenseCheckContext`, `LicenseDecision`), the `LicenseResolverError` enum,
+  and the GTS plugin spec used for discovery.
+- **Responsibility boundaries**: Holds no logic, no state, and no plugin selection; defines no domain types (externally
+  owned) and registers no derived contract types itself (those are registered by the modules that want license
+  enforcement); exposes no listing/enumeration method.
 - **Related components**: `cpt-cf-license-resolver-component-main-gateway` — implemented-by (gateway implements the
   public trait); `cpt-cf-license-resolver-component-plugin` — implemented-by (plugin implements the plugin trait).
 
@@ -270,12 +343,17 @@ Both are one `GtsInstanceId`; the backend plugin interprets the concrete instanc
 - **Why**: Realizes the public contract while keeping callers decoupled from any specific backend, centralizing plugin
   discovery, selection, delegation, and fail-closed error mapping.
 - **Responsibility scope**: Implements `LicenseResolverClient`; receives a `LicenseCheckRequest`, scopes by its
-  `context` (tenant), discovers plugin instances via the plugin GTS spec, selects one by vendor + priority (memoizing
-  the selection), resolves the scoped plugin client via ClientHub, propagates the `LicenseCheckRequest` unchanged,
-  delegates the `is_licensed` check, and maps plugin/registry failures to the canonical `LicenseResolverError`.
-- **Responsibility boundaries**: Owns no grant store and makes no licensing decision itself — it routes; beyond reading
-  the tenant scope from `request.context`, does not interpret or validate request fields (the resource instance id and
-  `metadata` are passed through to the plugin, which owns resource-type licensability and validation); never grants by
+  `context` (tenant), **validates the request against the registered contracts** — structural (contract schemas,
+  domain-type presence) and compatibility (`admitted_subjects` trait), with schemas resolved from the types registry
+  and cached — then discovers plugin instances via the plugin GTS spec, selects one by vendor + priority (memoizing the
+  selection), resolves the scoped plugin client via ClientHub, propagates the `LicenseCheckRequest` unchanged,
+  delegates the `is_licensed` check, and maps validation and plugin/registry failures to the canonical
+  `LicenseResolverError`.
+- **Responsibility boundaries**: Owns no grant store and makes no licensing decision itself — it validates shape and
+  routes; it never interprets what contract properties *mean* and never decides licensability (`metadata` and identity
+  fields are shape-validated, then passed through unchanged to the plugin, which owns the licensable-type catalog and
+  grant semantics); a
+  non-conforming request maps to a validation error (fail-closed), never to a not-granted decision; never grants by
   default (a missing plugin or unreachable backend maps to a non-granting error); performs no listing.
 - **Related components**: `cpt-cf-license-resolver-component-sdk-contract` — depends on (implements its public trait);
   `cpt-cf-license-resolver-component-plugin` — calls (delegates the check via the scoped plugin client).
@@ -286,14 +364,16 @@ Both are one `GtsInstanceId`; the backend plugin interprets the concrete instanc
 
 - **Why**: A license enforcement/management service that encapsulates a vendor-specific source of grant facts behind the
   shared plugin trait so backends are swappable without caller changes.
-- **Responsibility scope**: Registers its GTS instance (vendor + priority metadata) and a scoped client; owns the
-  catalog of licensable resource types and validates the resource (interpreting the request's resource `GtsInstanceId`,
-  named or UUID-based); MAY evaluate the forwarded `metadata` to apply attribute/constraint-based licensing (region,
-  country, …); holds/queries grant facts; and answers the delegated `is_licensed` check for the given subject (whatever
-  its subject type) within the tenant isolation scope carried in `request.context`.
+- **Responsibility scope**: Registers its GTS instance (vendor + priority metadata) and a scoped client; receives only
+  requests that conform to a registered contract; owns the catalog of licensable resource types and grant semantics
+  (interpreting the contract objects' domain type and optional id — without the id, a whole-type check whose answer is
+  the backend's policy; with the id, a specific resource); MAY evaluate the forwarded contract `metadata` to apply
+  attribute/constraint-based licensing (region, model, …); holds/queries grant facts; and answers the delegated
+  `is_licensed` check for the given subject within the tenant isolation scope carried in `request.context`.
 - **Responsibility boundaries**: Never consumed directly by other modules — only through the main module's public
-  contract; does not define the GTS resource types themselves (those are owned by the resources' modules); exposes no
-  listing method.
+  contract; does not define the domain types (owned by their modules) or the derived contract types (registered by the
+  consuming Gears); MUST ignore contract properties it does not use (additive compatibility); exposes no listing
+  method.
 - **Related components**: `cpt-cf-license-resolver-component-sdk-contract` — depends on (implements its plugin trait);
   `cpt-cf-license-resolver-component-main-gateway` — called-by (receives delegated checks).
 
@@ -306,9 +386,10 @@ The module exposes one public client trait and requires one plugin trait, descri
 - **Technology**: Rust traits over the ToolKit ClientHub (in-process); transport-agnostic SDK models.
 
 **Public client — `LicenseResolverClient`** (realizes PRD `cpt-cf-license-resolver-interface-client`): exposes the
-SINGLE method `is_licensed(request: LicenseCheckRequest) -> LicenseDecision`. `LicenseCheckRequest` bundles `subject` (a
-`Subject`), `resource` (a `GtsInstanceId`), `metadata` (opaque `string`→JSON evaluation attributes, forwarded to the
-plugin), and `context` (a `LicenseCheckContext` carrying the tenant scope). The caller builds `context` from its
+single method `is_licensed(request: LicenseCheckRequest) -> LicenseDecision`. `LicenseCheckRequest` bundles `subject`
+and `resource` — instances of registered derived licensing contract types, each carrying the domain GTS type
+(required), an optional id, and schematized `metadata` (shape-validated, semantically uninterpreted, forwarded to the
+plugin) — and `context` (a `LicenseCheckContext` carrying the tenant scope). The caller builds `context` from its
 `SecurityContext`, exactly as authz-resolver's `PolicyEnforcer` builds an `EvaluationRequest` — the resolver method
 itself takes no separate `SecurityContext`. There is no listing or enumeration method.
 
@@ -318,31 +399,37 @@ resolved as a scoped client. It tracks the public contract's major version.
 
 **Operation summary**:
 
-| Operation     | Inputs                                                                                | Output                                        | Stability |
-|---------------|---------------------------------------------------------------------------------------|-----------------------------------------------|-----------|
-| `is_licensed` | `LicenseCheckRequest` (subject, resource `GtsInstanceId`, `metadata`, tenant context) | `LicenseDecision` (granted + diagnostics map) | stable    |
+| Operation     | Inputs                                                                      | Output                                        | Stability |
+|---------------|-----------------------------------------------------------------------------|-----------------------------------------------|-----------|
+| `is_licensed` | `LicenseCheckRequest` (subject + resource contract objects, tenant context) | `LicenseDecision` (granted + diagnostics map) | stable    |
 
-**Error model — `LicenseResolverError`**: the SDK returns this enum; each variant maps to a canonical RFC-9457 error
-(`Problem`), so callers get canonical errors directly. Canonical categories and their GTS error type ids come from the
-platform error catalog (`toolkit-canonical-errors`).
+**Error model — `LicenseResolverError`**: the SDK returns this typed enum. It also provides a **default mapping** of
+each variant to a canonical RFC-9457 error (`Problem`) — the table below — but whether to apply that mapping is the
+**caller's** responsibility: a caller may surface the canonical `Problem` as-is, or match on the typed variant and
+handle it its own way. Canonical categories and their GTS error type ids come from the platform error catalog
+(`toolkit-canonical-errors`).
 
-| Variant                      | Meaning                                              | Canonical error — GTS error type id                                                    |
-|------------------------------|------------------------------------------------------|----------------------------------------------------------------------------------------|
-| `Unauthorized`               | Caller/subject not permitted to perform the check    | `PermissionDenied` — `gts.cf.core.errors.err.v1~cf.core.err.permission_denied.v1~`     |
-| `NoPluginAvailable`          | No backend plugin matches the resource type / vendor | `Internal` — `gts.cf.core.errors.err.v1~cf.core.err.internal.v1~`                      |
-| `ServiceUnavailable(reason)` | Selected backend unreachable or erroring             | `ServiceUnavailable` — `gts.cf.core.errors.err.v1~cf.core.err.service_unavailable.v1~` |
-| `Internal(reason)`           | Unexpected internal failure                          | `Internal` — `gts.cf.core.errors.err.v1~cf.core.err.internal.v1~`                      |
+| Variant                      | Meaning                                                                                                                | Default canonical error — GTS error type id                                            |
+|------------------------------|------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| `Unauthorized`               | Caller/subject not permitted to perform the check                                                                      | `PermissionDenied` — `gts.cf.core.errors.err.v1~cf.core.err.permission_denied.v1~`     |
+| `InvalidRequest(violations)` | Request does not conform to its registered contracts (schema mismatch, missing domain type, subject type not admitted) | `InvalidArgument` — `gts.cf.core.errors.err.v1~cf.core.err.invalid_argument.v1~`       |
+| `NoPluginAvailable`          | No backend plugin matches the resource type / vendor                                                                   | `Internal` — `gts.cf.core.errors.err.v1~cf.core.err.internal.v1~`                      |
+| `ServiceUnavailable(reason)` | Selected backend unreachable or erroring                                                                               | `ServiceUnavailable` — `gts.cf.core.errors.err.v1~cf.core.err.service_unavailable.v1~` |
+| `Internal(reason)`           | Unexpected internal failure                                                                                            | `Internal` — `gts.cf.core.errors.err.v1~cf.core.err.internal.v1~`                      |
 
 A negative result is **not** an error — it is `LicenseDecision { granted: false }`. The error enum covers only
-"cannot-determine" conditions; on any of them the caller fails closed (treats the outcome as not-granted). Being
+"cannot-determine" conditions; on any of them the caller fails closed (treats the outcome as not-granted). A contract
+violation is an `InvalidRequest` error, never a not-granted decision — an invalid check silently evaluated would be an
+unauditable check. A request declaring a contract type that is **not registered** is likewise `InvalidRequest`; the
+registry being **unreachable** with no cached schema is `ServiceUnavailable` (cannot-determine, fail closed). Being
 read-only, there are no mutation / "not found" write errors.
 
 ### 3.4 Internal Dependencies
 
-| Dependency Module   | Interface Used                        | Purpose                                                                             |
-|---------------------|---------------------------------------|-------------------------------------------------------------------------------------|
-| `types-registry`    | SDK client (`TypesRegistryClient`)    | Discover and select backend plugin instances by GTS plugin spec (vendor + priority) |
-| ToolKit `ClientHub` | scoped client registration/resolution | Resolve the selected plugin as a scoped `LicenseResolverPluginClient`               |
+| Dependency Module   | Interface Used                        | Purpose                                                                                                                                                         |
+|---------------------|---------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `types-registry`    | SDK client (`TypesRegistryClient`)    | Discover and select backend plugin instances by GTS plugin spec (vendor + priority); resolve licensing contract schemas and `admitted_subjects` traits (cached) |
+| ToolKit `ClientHub` | scoped client registration/resolution | Resolve the selected plugin as a scoped `LicenseResolverPluginClient`                                                                                           |
 
 **Dependency Rules** (per project conventions):
 
@@ -373,7 +460,14 @@ sequenceDiagram
     participant G as Main Module (Gateway/Selector)
     participant R as types-registry (GTS)
     participant P as Backend Plugin
+    C ->> C: project domain objects into contract types
     C ->> G: is_licensed(request)
+    alt contract schemas not yet cached
+        G ->> R: resolve contract schemas + admitted_subjects traits
+        R -->> G: schemas (cache)
+    end
+    G ->> G: validate request vs registered contracts
+    Note over G: non-conforming -> InvalidRequest (fail closed, never evaluated)
     alt plugin selection not yet memoized
         G ->> R: list plugin instances by GTS spec
         R -->> G: instances (vendor, priority)
@@ -389,10 +483,14 @@ sequenceDiagram
     G -->> C: LicenseDecision | LicenseResolverError
 ```
 
-**Description**: The gateway resolves and memoizes the backend plugin via the types registry (selecting by vendor +
-priority), then delegates the single `is_licensed` check, forwarding the `LicenseCheckRequest` unchanged (tenant scope
-comes from `request.context`). A missing plugin or unreachable backend fails closed to a non-granting error. No listing
-or enumeration sequence exists.
+**Description**: The consuming module projects its domain objects into instances of the registered contract types and
+calls the check. The gateway validates the request against the registered contracts (schemas resolved from the types
+registry and
+cached; structural conformance plus `admitted_subjects` compatibility) — a non-conforming request is rejected as
+`InvalidRequest` without ever reaching a plugin. It then resolves and memoizes the backend plugin via the types
+registry (selecting by vendor + priority) and delegates the single `is_licensed` check, forwarding the
+`LicenseCheckRequest` unchanged (tenant scope comes from `request.context`). A missing plugin or unreachable backend
+fails closed to a non-granting error. No listing or enumeration sequence exists.
 
 ### 3.7 Database schemas & tables
 
@@ -406,31 +504,38 @@ infrastructure, datastore, or network topology of its own.
 
 ## 4. Additional context
 
-**Telemetry**: The resolver's own telemetry surface is minimal — a check counter and a boundary latency histogram.
-Dimension them only by bounded labels (the derived resource type, selected vendor, decision outcome); never label by the
-full resource instance id or by `metadata` values (unbounded cardinality). Boundary latency excludes plugin compute to
-support NFR `cpt-cf-license-resolver-nfr-read-latency`. (Backend plugins' own telemetry is their concern.)
+**Telemetry**: The resolver's own telemetry surface is minimal — a check counter, a boundary latency histogram, and a
+validation-failure counter. Dimension them only by bounded labels (the contract type, the domain type, selected vendor,
+decision outcome, violation kind); never label by instance ids or `metadata` values (unbounded cardinality). Boundary
+latency excludes plugin compute to support NFR `cpt-cf-license-resolver-nfr-read-latency`. (Backend plugins' own
+telemetry is their concern.)
 
-**Future considerations**: The opaque `metadata` map (`cpt-cf-license-resolver-fr-evaluation-metadata`) is the
-contract's primary extension point — future attribute/constraint dimensions (region, country, environment, …) are
-expressed as new keys interpreted by backends, with no signature change; a conventional key vocabulary MAY be
-standardized later, and per-key GTS schema validation is a candidate future addition. Likewise a conventional
-`diagnostics` key vocabulary and optional grant metadata (status/expiry) on `LicenseDecision` may be enriched without
-changing the single-operation shape. Any such change follows the breaking-change policy on the public contract.
+**Future considerations**: Contract `metadata` (`cpt-cf-license-resolver-fr-evaluation-metadata`) is the contract's
+primary extension point — future attribute/constraint dimensions (region, country, environment, …) arrive as new
+optional schema fields on derived contract types, non-breaking per
+`cpt-cf-license-resolver-fr-contract-compatibility`, with no signature change. Deployment-wide evaluation attributes
+sourced from configuration (rather than per-call code) are a candidate SDK-level convenience, provided merged
+properties conform to the registered contract schema. Likewise a conventional `diagnostics` key vocabulary and optional
+grant metadata (status/expiry) on `LicenseDecision` may be enriched without changing the single-operation shape. Any
+such change follows the breaking-change policy on the public contract.
 
 ## 5. Traceability
 
 - **PRD**: [PRD.md](./PRD.md)
 - **ADRs**: [ADR/](./ADR/)
 
-| PRD ID                                           | Type | DESIGN Section(s)          | Backing ADR                                         |
-|--------------------------------------------------|------|----------------------------|-----------------------------------------------------|
-| `cpt-cf-license-resolver-fr-is-licensed-check`   | FR   | §1.2, §3.3, §3.6           | `cpt-cf-license-resolver-adr-plugin-delegation`     |
-| `cpt-cf-license-resolver-fr-subject-identity`    | FR   | §1.2, §3.1                 | `cpt-cf-license-resolver-adr-gts-resource-identity` |
-| `cpt-cf-license-resolver-fr-resource-identity`   | FR   | §1.2, §3.1                 | `cpt-cf-license-resolver-adr-gts-resource-identity` |
-| `cpt-cf-license-resolver-fr-evaluation-metadata` | FR   | §1.2, §3.1, §3.3, §3.6, §4 | —                                                   |
-| `cpt-cf-license-resolver-fr-plugin-delegation`   | FR   | §1.2, §3.2, §3.4, §3.6     | `cpt-cf-license-resolver-adr-plugin-delegation`     |
-| `cpt-cf-license-resolver-fr-read-only`           | FR   | §1.2, §2.1, §3.7           | `cpt-cf-license-resolver-adr-plugin-delegation`     |
-| `cpt-cf-license-resolver-nfr-read-latency`       | NFR  | §1.2, §3.2, §4             | `cpt-cf-license-resolver-adr-plugin-delegation`     |
-| `cpt-cf-license-resolver-nfr-fail-closed`        | NFR  | §1.2, §2.1, §3.3           | `cpt-cf-license-resolver-adr-plugin-delegation`     |
-| `cpt-cf-license-resolver-nfr-tenant-scoping`     | NFR  | §1.2, §3.2, §3.6           | —                                                   |
+| PRD ID                                                | Type | DESIGN Section(s)            | Backing ADR                                             |
+|-------------------------------------------------------|------|------------------------------|---------------------------------------------------------|
+| `cpt-cf-license-resolver-fr-is-licensed-check`        | FR   | §1.2, §3.3, §3.6             | `cpt-cf-license-resolver-adr-plugin-delegation`         |
+| `cpt-cf-license-resolver-fr-subject-identity`         | FR   | §1.2, §3.1                   | `cpt-cf-license-resolver-adr-gts-resource-identity`     |
+| `cpt-cf-license-resolver-fr-resource-identity`        | FR   | §1.2, §3.1                   | `cpt-cf-license-resolver-adr-gts-resource-identity`     |
+| `cpt-cf-license-resolver-fr-contract-registration`    | FR   | §1.2, §2.1, §3.1, §3.2       | `cpt-cf-license-resolver-adr-typed-licensing-contracts` |
+| `cpt-cf-license-resolver-fr-contract-discoverability` | FR   | §1.2, §3.1                   | `cpt-cf-license-resolver-adr-typed-licensing-contracts` |
+| `cpt-cf-license-resolver-fr-request-validation`       | FR   | §1.2, §2.1, §3.2, §3.3, §3.6 | `cpt-cf-license-resolver-adr-typed-licensing-contracts` |
+| `cpt-cf-license-resolver-fr-contract-compatibility`   | FR   | §1.2, §3.1, §4               | `cpt-cf-license-resolver-adr-typed-licensing-contracts` |
+| `cpt-cf-license-resolver-fr-evaluation-metadata`      | FR   | §1.2, §3.1, §3.3, §3.6, §4   | `cpt-cf-license-resolver-adr-typed-licensing-contracts` |
+| `cpt-cf-license-resolver-fr-plugin-delegation`        | FR   | §1.2, §3.2, §3.4, §3.6       | `cpt-cf-license-resolver-adr-plugin-delegation`         |
+| `cpt-cf-license-resolver-fr-read-only`                | FR   | §1.2, §2.1, §3.7             | `cpt-cf-license-resolver-adr-plugin-delegation`         |
+| `cpt-cf-license-resolver-nfr-read-latency`            | NFR  | §1.2, §3.2, §4               | `cpt-cf-license-resolver-adr-plugin-delegation`         |
+| `cpt-cf-license-resolver-nfr-fail-closed`             | NFR  | §1.2, §2.1, §3.3             | `cpt-cf-license-resolver-adr-plugin-delegation`         |
+| `cpt-cf-license-resolver-nfr-tenant-scoping`          | NFR  | §1.2, §3.2, §3.6             | —                                                       |

--- a/gears/system/license-resolver/docs/PRD.md
+++ b/gears/system/license-resolver/docs/PRD.md
@@ -1,0 +1,391 @@
+<!-- cpt:
+version: 1.0.0
+status: draft
+module: license-resolver
+system: cf
+-->
+
+# PRD — License Resolver
+
+<!-- toc -->
+
+- [1. Overview](#1-overview)
+  - [1.1 Purpose](#11-purpose)
+  - [1.2 Background / Problem Statement](#12-background--problem-statement)
+  - [1.3 Goals (Business Outcomes)](#13-goals-business-outcomes)
+  - [1.4 Glossary](#14-glossary)
+- [2. Actors](#2-actors)
+  - [2.1 Human Actors](#21-human-actors)
+  - [2.2 System Actors](#22-system-actors)
+- [3. Operational Concept & Environment](#3-operational-concept--environment)
+- [4. Scope](#4-scope)
+  - [4.1 In Scope](#41-in-scope)
+  - [4.2 Out of Scope](#42-out-of-scope)
+- [5. Functional Requirements](#5-functional-requirements)
+  - [5.1 License Resolution](#51-license-resolution)
+- [6. Non-Functional Requirements](#6-non-functional-requirements)
+  - [6.1 Module-Specific NFRs](#61-module-specific-nfrs)
+  - [6.2 NFR Exclusions](#62-nfr-exclusions)
+- [7. Public Library Interfaces](#7-public-library-interfaces)
+  - [7.1 Public API Surface](#71-public-api-surface)
+  - [7.2 External Integration Contracts](#72-external-integration-contracts)
+- [8. Use Cases](#8-use-cases)
+- [9. Acceptance Criteria](#9-acceptance-criteria)
+- [10. Dependencies](#10-dependencies)
+- [11. Assumptions](#11-assumptions)
+- [12. Risks](#12-risks)
+- [13. Open Questions](#13-open-questions)
+- [14. Traceability](#14-traceability)
+
+<!-- /toc -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+License Resolver is a read-only CF/Gears system module that answers a single question: *is a specific resource
+licensed (granted) to a specific subject right now?* Callers ask `is_licensed(request)` — a single `LicenseCheckRequest`
+carrying the subject, the resource, optional evaluation `metadata`, and the tenant context — and receive a yes/no
+decision plus structured, non-authoritative diagnostics (debug information about how the decision was reached). It is
+the authoritative point-in-time license check used by other modules to gate access.
+
+License Resolver owns no grant data; it delegates the lookup to a pluggable backend selected at runtime, mirroring
+authz-resolver and tenant-resolver. This keeps licensing storage, issuance, and billing concerns out of the resolver and
+behind a stable contract.
+
+### 1.2 Background / Problem Statement
+
+Multiple CF modules need to check whether a subject may use a licensable resource (a feature, a content item, a
+capability) before granting access. The subject is whoever the license is granted to — a tenant, a user, or any future
+subject type — identified by subject type + id, exactly as the authz-resolver and quota-enforcement subject models do.
+Today no such check exists: CF modules simply do not contain license-resolution logic, so there is no shared contract
+for it, no common GTS-typed resource identity, and no fail-closed guarantee to rely on when gating access.
+
+A dedicated resolver consolidates the check behind one contract keyed by subject (subject type + id) with consistent
+resource identity (GTS-typed) and consistent deny semantics. Because grant facts live in heterogeneous backends owned by
+different vendors, the resolver must delegate the lookup rather than own a store — matching the proven authz-resolver /
+tenant-resolver delegation model. (Tenancy enters only as the isolation scope, carried in the request context that the
+caller derives from its `SecurityContext`.)
+
+### 1.3 Goals (Business Outcomes)
+
+- Single check contract: one `is_licensed` operation reused by all callers, giving modules a license check they do not
+  have today and preventing future per-module divergence.
+- Fail-closed guarantee: a license is never granted by default when the backend is unavailable; deny is the safe outcome
+  in 100% of unavailable-backend cases.
+- Backend independence: licensing backends can be swapped or added via plugin discovery with zero caller code changes.
+
+### 1.4 Glossary
+
+| Term                  | Definition                                                                                                                                                                            |
+|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `LicenseCheckRequest` | A single object bundling the inputs of one check: subject, resource, optional `metadata`, and tenant context. The contract's growth surface (new inputs are added as request fields). |
+| Subject               | The "someone" a license is checked for, identified by subject type + id. Polymorphic — e.g. a tenant, a user, or any future subject type (the licensee is not restricted to tenants). |
+| Resource              | The licensable thing, identified by a single GTS instance id (`GtsInstanceId`) — named (§2.3) or UUID-based (§2.4).                                                                   |
+| Grant                 | A backend fact that a resource is licensed to a subject.                                                                                                                              |
+| Plugin                | A backend implementation discovered via the GTS types registry that answers the check.                                                                                                |
+| Metadata              | Caller-supplied JSON on a check, opaque to the resolver core and forwarded to the backend; the extension point for attribute/constraint-based licensing (region, country, …).         |
+
+## 2. Actors
+
+> **Note**: Stakeholder needs are managed at project/task level by steering committee. Document **actors** (users,
+> systems) that interact with this module.
+
+### 2.1 Human Actors
+
+This module exposes no direct human interface; all actors are systems.
+
+### 2.2 System Actors
+
+#### Consuming Module
+
+**ID**: `cpt-cf-license-resolver-actor-consuming-module`
+
+- **Role**: Any CF/Gears module that must gate access to a licensable resource. Calls
+  `is_licensed(request)` and enforces the returned decision.
+
+#### License Backend Plugin
+
+**ID**: `cpt-cf-license-resolver-actor-backend-plugin`
+
+- **Role**: A vendor-supplied backend implementation that holds grant facts and answers the delegated check. Discovered
+  and selected at runtime via the GTS types registry by vendor + priority.
+
+## 3. Operational Concept & Environment
+
+This module introduces no environment constraints beyond project defaults. Runtime, OS, lifecycle, and integration
+patterns are inherited from the root PRD.
+
+## 4. Scope
+
+### 4.1 In Scope
+
+- Point-in-time check of whether a single resource is licensed to a single subject.
+- Tenant-scoped resolution via the request's tenant context (derived from the caller's `SecurityContext`).
+- GTS-typed resource identity (named/well-known and opaque resources), referencing externally-owned resource types.
+- Plugin-delegated backend selection via the GTS types registry.
+
+### 4.2 Out of Scope
+
+- **Listing / enumeration of granted resources** — answering "everything licensed to a subject" is a catalog/query
+  concern, not a resolver concern; no list operation and no pagination.
+- License issuance and revocation — grant lifecycle is owned by issuing/management modules.
+- Billing and usage metering — owned by the billing/usage domain.
+- Grant storage and management — the resolver owns no grant store; backends do.
+- Defining resource types — resource types are owned by their respective modules and only referenced here by GTS type
+  path.
+
+## 5. Functional Requirements
+
+> **Testing strategy**: All requirements verified via automated tests (unit, integration, e2e) targeting 90%+ code
+> coverage unless otherwise specified.
+
+### 5.1 License Resolution
+
+#### License Check
+
+- [ ] `p1` - **ID**: `cpt-cf-license-resolver-fr-is-licensed-check`
+
+The system **MUST** provide a single check operation `is_licensed(request)` taking a `LicenseCheckRequest` — which
+bundles the subject (whom), the resource (what), optional evaluation `metadata`, and the tenant context (the caller
+derives it from its `SecurityContext`) — and returning a decision indicating whether the resource is licensed to the
+subject at the time of the call, together with structured, non-authoritative **diagnostics** (a string-keyed map of
+debug information about how the decision was reached — e.g. which backend answered, matched grant, denial cause).
+Diagnostics are advisory only and **MUST NOT** be required for the caller to interpret the boolean outcome. The single
+request object is the contract's growth surface — new inputs are added as request fields, not as new parameters or
+method-signature changes. (See `cpt-cf-license-resolver-fr-evaluation-metadata` for the `metadata` field.)
+
+- **Rationale**: A single shared check is the module's reason to exist: it provides license-resolution logic that no
+  module has today, and gives one consistent contract instead of each module growing its own.
+- **Actors**: `cpt-cf-license-resolver-actor-consuming-module`
+
+#### Subject Identity
+
+- [ ] `p1` - **ID**: `cpt-cf-license-resolver-fr-subject-identity`
+
+The system **MUST** identify the subject of a check by a subject type plus an id, consistent with the authz-resolver
+subject model. The subject type **MUST** be open-ended — a license may be granted to a tenant, a user, or any future
+subject type — and the resolver **MUST NOT** assume the subject is a tenant.
+
+- **Rationale**: Consistent, polymorphic subject identity lets callers reuse existing subject references (as
+  authz-resolver and quota-enforcement do), supports licensing any subject kind, and aligns deny semantics across
+  resolvers.
+- **Actors**: `cpt-cf-license-resolver-actor-consuming-module`
+
+#### Resource Identity
+
+- [ ] `p1` - **ID**: `cpt-cf-license-resolver-fr-resource-identity`
+
+The system **MUST** identify the resource of a check by a single **GTS instance identifier** (`GtsInstanceId`) that
+encodes resource type + id via the `~` notation. The instance segment **MUST** be either a well-known name (GTS §2.3,
+e.g. `…feature.v1~cf.<vendor>._.somename.v1`) or a UUID (GTS §2.4 combined notation, e.g. `…content.v1~<uuid>`). The
+resolver **MUST** reference externally-owned resource types only, never defining them. Which resource types are
+licensable, and their validation, are owned by the backend licensing service that answers the check.
+
+- **Rationale**: A GTS instance identifier already encodes type + id and expresses both resource kinds — named
+  (`feature~somename`, §2.3) and opaque (`content~<uuid>`, §2.4) — so a single `GtsInstanceId` is the natural identity
+  and constrains the contract to a valid GTS identifier, appropriate for a cross-module contract. A discrete type field
+  would only help wildcard list filtering, which is out of scope.
+- **Actors**: `cpt-cf-license-resolver-actor-consuming-module`
+
+#### Evaluation Metadata
+
+- [ ] `p2` - **ID**: `cpt-cf-license-resolver-fr-evaluation-metadata`
+
+The check **MAY** carry caller-supplied `metadata` (JSON) describing the evaluation context (e.g. region, country,
+environment). The resolver core **MUST** treat `metadata` as opaque — it **MUST NOT** interpret or require any key — and
+**MUST** forward it unchanged to the selected backend plugin, which **MAY** use it to express attribute/constraint-based
+licensing (e.g. "is this resource licensed to this subject in region X?"). `metadata` is the contract's extension point:
+future constraint dimensions are expressed as new keys rather than new parameters or signature changes.
+
+- **Rationale**: Whether a resource is licensed can depend on contextual attributes (region, country, environment, …),
+  and which attributes matter is backend-specific and expected to grow. Carrying them as an opaque, forwarded bag lets
+  backends gate grants on that context, lets new constraint dimensions be added without changing the check signature,
+  and keeps the resolver core free of any business rules about what the attributes mean.
+- **Actors**: `cpt-cf-license-resolver-actor-consuming-module`, `cpt-cf-license-resolver-actor-backend-plugin`
+
+#### Plugin-Delegated Backend
+
+- [ ] `p1` - **ID**: `cpt-cf-license-resolver-fr-plugin-delegation`
+
+The system **MUST** delegate the grant lookup to a backend plugin discovered via the GTS types registry and selected by
+vendor + priority; the resolver **MUST NOT** hold its own grant store.
+
+- **Rationale**: Grant facts live in heterogeneous vendor backends; delegation keeps storage out of the resolver and
+  allows backends to be added or swapped without caller changes.
+- **Actors**: `cpt-cf-license-resolver-actor-backend-plugin`, `cpt-cf-license-resolver-actor-consuming-module`
+
+#### Read-Only Contract
+
+- [ ] `p1` - **ID**: `cpt-cf-license-resolver-fr-read-only`
+
+The resolver and its public contract **MUST** be read-only: the contract **MUST** expose only the `is_licensed` check
+and **MUST NOT** offer any operation to issue, revoke, bill, manage, or list/enumerate grants, and the resolver itself
+**MUST NOT** hold a grant store. This constrains the resolver only — backend plugins **MAY** be backed by read-write
+systems (e.g. issuance or billing); how a backend sources or maintains grants is outside the resolver's scope.
+
+- **Rationale**: A read-only resolver contract keeps the module simple and authoritative as a check point and prevents
+  scope creep into the issuance, billing, and catalog domains, while still allowing backends to be backed by mutable
+  systems behind the delegation boundary.
+- **Actors**: `cpt-cf-license-resolver-actor-consuming-module`
+
+## 6. Non-Functional Requirements
+
+> **Global baselines**: Project-wide NFRs defined in root PRD and guidelines. Document only module-specific NFRs here.
+
+### 6.1 Module-Specific NFRs
+
+#### Read Latency
+
+- [ ] `p1` - **ID**: `cpt-cf-license-resolver-nfr-read-latency`
+
+The `is_licensed` check **MUST** complete within 50ms at p95, measured at the resolver boundary excluding backend plugin
+processing time, under normal load.
+
+- **Threshold**: 50ms p95 at the resolver boundary (excludes plugin compute), normal load.
+- **Rationale**: The check sits on the access-granting path of consuming modules, so added latency directly impacts
+  every gated request.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation for how this is realized.
+
+#### Fail-Closed on No Plugin
+
+- [ ] `p1` - **ID**: `cpt-cf-license-resolver-nfr-fail-closed`
+
+When no backend plugin is available or the backend is unreachable, the resolver **MUST** fail closed — return a
+non-granted decision or an error, and **MUST NOT** grant by default — in 100% of such cases.
+
+- **Threshold**: 0 grant-by-default outcomes across all no-plugin / backend-unavailable conditions.
+- **Rationale**: Granting access when the authority cannot be reached would be a license/security violation.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation for how this is realized.
+
+#### Tenant Scoping
+
+- [ ] `p1` - **ID**: `cpt-cf-license-resolver-nfr-tenant-scoping`
+
+Every resolution **MUST** be scoped to the tenant carried by the request context (which the caller derives from its
+`SecurityContext`), with 0 cross-tenant grant leaks tolerated. Regardless of subject type, the subject is treated as
+bounded within that tenant (the current tenant-bounded model — see §11).
+
+- **Threshold**: 0 cross-tenant resolutions; tenant scope derived solely from the request context.
+- **Rationale**: Under the current model every license is tenant-bounded (a user belongs to a tenant), so the resolver
+  enforces tenant isolation like other CF modules; a cross-tenant grant would expose another tenant's entitlements.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation for how this is realized.
+
+### 6.2 NFR Exclusions
+
+- Horizontal write-scalability NFRs: N/A — the module performs no writes.
+
+## 7. Public Library Interfaces
+
+### 7.1 Public API Surface
+
+#### License Resolver Client
+
+- [ ] `p1` - **ID**: `cpt-cf-license-resolver-interface-client`
+
+- **Type**: Rust trait (`LicenseResolverClient`)
+- **Stability**: stable
+- **Description**: The public client contract exposing the **single** method
+  `is_licensed(request: LicenseCheckRequest) -> LicenseDecision` — the point-in-time check of whether a resource is
+  licensed to a subject. `LicenseCheckRequest` bundles the subject, the resource, opaque forwarded `metadata` (JSON) for
+  attribute-based constraints, and the tenant context (caller-derived from `SecurityContext`). There is no listing or
+  enumeration method.
+- **Breaking Change Policy**: Major version bump required to change the `LicenseCheckRequest`/`LicenseDecision` shape (a
+  backward-compatible new optional request field is not breaking), the `GtsInstanceId` resource
+  identity, or the decision/error semantics.
+
+### 7.2 External Integration Contracts
+
+#### Backend Plugin Contract
+
+- [ ] `p2` - **ID**: `cpt-cf-license-resolver-contract-plugin`
+
+- **Direction**: required from backend plugin
+- **Protocol/Format**: Plugin trait (`LicenseResolverPluginClient`) mirroring the `is_licensed` signature, discovered
+  via the GTS types registry plugin spec.
+- **Compatibility**: Plugin spec is GTS-versioned; the plugin contract tracks the public client contract's major
+  version.
+
+## 8. Use Cases
+
+#### Gate Access to a Licensable Resource
+
+- [ ] `p2` - **ID**: `cpt-cf-license-resolver-usecase-gate-access`
+
+**Actor**: `cpt-cf-license-resolver-actor-consuming-module`
+
+**Preconditions**:
+
+- A `SecurityContext` with a tenant is available.
+- The resource type is a registered GTS type referenced by the caller.
+
+**Main Flow**:
+
+1. Consuming module assembles a `LicenseCheckRequest`: the resource's `GtsInstanceId` (named or UUID-based), the
+   subject,
+   any evaluation `metadata`, and the tenant context derived from its `SecurityContext`.
+2. Module calls `is_licensed(request)`.
+3. Resolver selects the backend plugin via the GTS registry and delegates the check, forwarding the request unchanged.
+4. Resolver returns a decision (granted true/false plus diagnostics).
+5. Module enforces the decision.
+
+**Postconditions**:
+
+- The caller has an authoritative, tenant-scoped grant decision; no state was changed.
+
+**Alternative Flows**:
+
+- **No plugin available / backend unreachable**: Resolver fails closed — returns not-granted or an error; the module
+  denies access.
+
+## 9. Acceptance Criteria
+
+- [ ] `is_licensed(request)` returns a correct granted/not-granted decision for both named and opaque resources.
+- [ ] No listing or enumeration capability exists in the public contract.
+- [ ] When no backend plugin is available, the resolver never grants by default.
+- [ ] All resolutions are tenant-scoped via the request context (derived from `SecurityContext`) with no cross-tenant
+  leakage.
+- [ ] Backend selection is performed by GTS registry discovery (vendor + priority) with no resolver-owned grant store.
+
+## 10. Dependencies
+
+| Dependency                            | Description                                                  | Criticality |
+|---------------------------------------|--------------------------------------------------------------|-------------|
+| GTS types registry (`types-registry`) | Backend plugin discovery (by GTS plugin spec)                | p1          |
+| `SecurityContext`                     | Source of the request's tenant context (built by the caller) | p1          |
+| Backend license plugin                | Holds grant facts and answers the delegated check            | p1          |
+
+## 11. Assumptions
+
+- Resource types consumed in checks are owned and registered by their respective modules; the resolver only references
+  them by GTS type path.
+- At least one backend plugin is registered in environments where license checks are expected to grant.
+- Subject identity provided by callers follows the authz-resolver subject model.
+- **Tenant-bounded grants (current model)**: at this stage, every license is assumed to be bounded within a single
+  tenant — regardless of subject type, the subject (e.g. a user) belongs to a tenant — and the resolver enforces tenant
+  isolation via the request's tenant context (derived from `SecurityContext`) as other CF modules do. Cross-tenant or
+  tenant-independent licensing is not
+  modeled yet; lifting this assumption would be a future, explicitly-versioned contract change.
+
+## 12. Risks
+
+| Risk                                           | Impact                                         | Mitigation                                                                                                                            |
+|------------------------------------------------|------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| No backend plugin registered in an environment | All checks deny, blocking legitimate access    | Fail-closed by design; surface a clear `NoPluginAvailable` signal for operability.                                                    |
+| Backend latency degrades the check             | Slows every gated request in consuming modules | Boundary p95 NFR; consuming modules may apply their own timeouts/fallbacks.                                                           |
+| Misreferenced resource type path               | Check resolves against the wrong type          | GTS instance identifier is format-validated; the backend licensing service validates the type/licensability and denies unknown types. |
+
+## 13. Open Questions
+
+- Should `LicenseDecision` carry minimal grant metadata (e.g. status/expiry) beyond the boolean? — Owner:
+  license-resolver maintainers; target: DESIGN phase (2026-06-30).
+- What diagnostics keys/conventions do consuming modules need (denial cause, matched grant, backend id, etc.)? — Owner:
+  license-resolver maintainers; target: DESIGN phase (2026-06-30).
+
+## 14. Traceability
+
+Links to related specification artifacts.
+
+- **Design**: [DESIGN.md](./DESIGN.md)
+- **ADRs**: [ADR/](./ADR/)
+- **Features**: [features/](./features/)

--- a/gears/system/license-resolver/docs/PRD.md
+++ b/gears/system/license-resolver/docs/PRD.md
@@ -46,9 +46,9 @@ system: cf
 
 License Resolver is a read-only CF/Gears system module that answers a single question: *is a specific resource
 licensed (granted) to a specific subject right now?* Callers ask `is_licensed(request)` — a single `LicenseCheckRequest`
-carrying the subject, the resource, optional evaluation `metadata`, and the tenant context — and receive a yes/no
-decision plus structured, non-authoritative diagnostics (debug information about how the decision was reached). It is
-the authoritative point-in-time license check used by other modules to gate access.
+carrying the subject and resource contract objects (each with schematized `metadata`) and the tenant context — and
+receive a yes/no decision plus structured, non-authoritative diagnostics (debug information about how the decision was
+reached). It is the authoritative point-in-time license check used by other modules to gate access.
 
 License Resolver owns no grant data; it delegates the lookup to a pluggable backend selected at runtime, mirroring
 authz-resolver and tenant-resolver. This keeps licensing storage, issuance, and billing concerns out of the resolver and
@@ -58,15 +58,22 @@ behind a stable contract.
 
 Multiple CF modules need to check whether a subject may use a licensable resource (a feature, a content item, a
 capability) before granting access. The subject is whoever the license is granted to — a tenant, a user, or any future
-subject type — identified by subject type + id, exactly as the authz-resolver and quota-enforcement subject models do.
+subject type — identified by its domain GTS type plus an optional id.
 Today no such check exists: CF modules simply do not contain license-resolution logic, so there is no shared contract
-for it, no common GTS-typed resource identity, and no fail-closed guarantee to rely on when gating access.
+for it, no common GTS-typed identity, and no fail-closed guarantee to rely on when gating access.
 
-A dedicated resolver consolidates the check behind one contract keyed by subject (subject type + id) with consistent
-resource identity (GTS-typed) and consistent deny semantics. Because grant facts live in heterogeneous backends owned by
+A dedicated resolver consolidates the check behind one contract with consistent GTS-typed subject and resource
+identity and consistent deny semantics. Because grant facts live in heterogeneous backends owned by
 different vendors, the resolver must delegate the lookup rather than own a store — matching the proven authz-resolver /
 tenant-resolver delegation model. (Tenancy enters only as the isolation scope, carried in the request context that the
 caller derives from its `SecurityContext`.)
+
+Licensing is also split across levels: the Gear performing enforcement knows *where* a check belongs, while only the
+platform vendor — who composes a concrete platform out of Gears and a licensing backend — knows *what* must be
+licensed, and different platform vendors apply different licensing models to the same Gear (one licenses every LLM
+model individually, another does not distinguish models at all). The check payload must therefore be a stable,
+observable contract, not an ad-hoc payload that exists only in Gear source code: platform vendors need to see which
+checks exist, which Subject/Resource pairs they involve, and which properties are available to author rules against.
 
 ### 1.3 Goals (Business Outcomes)
 
@@ -75,17 +82,22 @@ caller derives from its `SecurityContext`.)
 - Fail-closed guarantee: a license is never granted by default when the backend is unavailable; deny is the safe outcome
   in 100% of unavailable-backend cases.
 - Backend independence: licensing backends can be swapped or added via plugin discovery with zero caller code changes.
+- Governable licensing surface: every check payload is a registered, versioned licensing contract that platform vendors
+  can enumerate, review, and author rules against — without reading Gear source code.
 
 ### 1.4 Glossary
 
-| Term                  | Definition                                                                                                                                                                            |
-|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `LicenseCheckRequest` | A single object bundling the inputs of one check: subject, resource, optional `metadata`, and tenant context. The contract's growth surface (new inputs are added as request fields). |
-| Subject               | The "someone" a license is checked for, identified by subject type + id. Polymorphic — e.g. a tenant, a user, or any future subject type (the licensee is not restricted to tenants). |
-| Resource              | The licensable thing, identified by a single GTS instance id (`GtsInstanceId`) — named (§2.3) or UUID-based (§2.4).                                                                   |
-| Grant                 | A backend fact that a resource is licensed to a subject.                                                                                                                              |
-| Plugin                | A backend implementation discovered via the GTS types registry that answers the check.                                                                                                |
-| Metadata              | Caller-supplied JSON on a check, opaque to the resolver core and forwarded to the backend; the extension point for attribute/constraint-based licensing (region, country, …).         |
+| Term                  | Definition                                                                                                                                                                                                                                                                                                                                           |
+|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `LicenseCheckRequest` | A single object bundling the inputs of one check: the subject and resource contract objects and the tenant context. The contract's growth surface (new inputs are added as request fields).                                                                                                                                                          |
+| Licensing Contract    | A registered, versioned GTS type derived from the licensing base types, describing a Subject or Resource shape: identity fields plus the schema of its `metadata`; a Resource contract also declares which Subject types it admits. The set of a Gear's derived contract types is its published licensing surface.                                   |
+| Subject               | The "someone" a license is checked for — an instance of a derived Subject contract type, carrying the subject's domain GTS type (required), an optional id (well-known name or UUID), and `metadata` conforming to the contract schema. Polymorphic — e.g. a tenant, a user, or any future subject type (the licensee is not restricted to tenants). |
+| Resource              | The licensable thing — an instance of a derived Resource contract type, carrying the resource's domain GTS type (required), an optional instance id (well-known name or UUID), and `metadata` conforming to the contract schema. Without the id the check targets the whole resource type; with it, a specific resource.                             |
+| Licensing Projection  | Copying the licensing-relevant slice of a Gear's domain objects into its licensing contract types when assembling a check. Domain types evolve freely; the projection changes only deliberately, under contract review.                                                                                                                              |
+| Platform Vendor       | The party that composes a concrete platform out of Gears and a licensing backend and defines the licensing rules; reviews, approves, and authors rules against the licensing contracts Gears expose.                                                                                                                                                 |
+| Grant                 | A backend fact that a resource is licensed to a subject.                                                                                                                                                                                                                                                                                             |
+| Plugin                | A backend implementation discovered via the GTS types registry that answers the check.                                                                                                                                                                                                                                                               |
+| Metadata              | Licensing-relevant properties on the Subject/Resource contract objects (e.g. region, model name, user category). Validated against the registered contract schema, semantically uninterpreted by the resolver, forwarded unchanged to the backend; the extension point for attribute/constraint-based licensing.                                     |
 
 ## 2. Actors
 
@@ -94,7 +106,13 @@ caller derives from its `SecurityContext`.)
 
 ### 2.1 Human Actors
 
-This module exposes no direct human interface; all actors are systems.
+#### Platform Vendor
+
+**ID**: `cpt-cf-license-resolver-actor-platform-vendor`
+
+- **Role**: Composes a concrete platform out of Gears and a licensing backend, and defines the licensing rules. Does
+  not call the check; reviews, approves, and authors rules against the licensing contracts that Gears expose,
+  enumerating them via the types registry — without reading Gear source code.
 
 ### 2.2 System Actors
 
@@ -102,8 +120,9 @@ This module exposes no direct human interface; all actors are systems.
 
 **ID**: `cpt-cf-license-resolver-actor-consuming-module`
 
-- **Role**: Any CF/Gears module that must gate access to a licensable resource. Calls
-  `is_licensed(request)` and enforces the returned decision.
+- **Role**: Any CF/Gears module that must gate access to a licensable resource. Registers its derived licensing
+  contract types in the types registry, projects its domain objects into them, calls `is_licensed(request)`, and
+  enforces the returned decision.
 
 #### License Backend Plugin
 
@@ -115,26 +134,32 @@ This module exposes no direct human interface; all actors are systems.
 ## 3. Operational Concept & Environment
 
 This module introduces no environment constraints beyond project defaults. Runtime, OS, lifecycle, and integration
-patterns are inherited from the root PRD.
+patterns are inherited from the project-wide architecture in
+[docs/ARCHITECTURE_MANIFEST.md](../../../../docs/ARCHITECTURE_MANIFEST.md) and [guidelines/](../../../../guidelines/).
 
 ## 4. Scope
 
 ### 4.1 In Scope
 
-- Point-in-time check of whether a single resource is licensed to a single subject.
+- Point-in-time check of whether a resource — a specific instance or a whole resource type — is licensed to a single
+  subject.
 - Tenant-scoped resolution via the request's tenant context (derived from the caller's `SecurityContext`).
-- GTS-typed resource identity (named/well-known and opaque resources), referencing externally-owned resource types.
+- Typed licensing contracts: base Subject/Resource GTS types owned by this module, derived contract types registered by
+  consuming Gears, and validation of every check request against the registered contracts before delegation.
+- GTS-typed identity inside the contracts (whole-type, named/well-known, and opaque), referencing externally-owned
+  domain types.
 - Plugin-delegated backend selection via the GTS types registry.
 
 ### 4.2 Out of Scope
 
 - **Listing / enumeration of granted resources** — answering "everything licensed to a subject" is a catalog/query
-  concern, not a resolver concern; no list operation and no pagination.
+  concern, not a resolver concern; no list operation and no pagination. Enumeration of licensing *contract types* is a
+  different, in-scope concern served natively by the types registry — it requires no resolver API.
 - License issuance and revocation — grant lifecycle is owned by issuing/management modules.
 - Billing and usage metering — owned by the billing/usage domain.
 - Grant storage and management — the resolver owns no grant store; backends do.
-- Defining resource types — resource types are owned by their respective modules and only referenced here by GTS type
-  path.
+- Defining domain types — the subject/resource domain types referenced inside licensing contracts are owned by their
+  respective modules and only referenced here by GTS type path.
 
 ## 5. Functional Requirements
 
@@ -148,10 +173,11 @@ patterns are inherited from the root PRD.
 - [ ] `p1` - **ID**: `cpt-cf-license-resolver-fr-is-licensed-check`
 
 The system **MUST** provide a single check operation `is_licensed(request)` taking a `LicenseCheckRequest` — which
-bundles the subject (whom), the resource (what), optional evaluation `metadata`, and the tenant context (the caller
-derives it from its `SecurityContext`) — and returning a decision indicating whether the resource is licensed to the
-subject at the time of the call, together with structured, non-authoritative **diagnostics** (a string-keyed map of
-debug information about how the decision was reached — e.g. which backend answered, matched grant, denial cause).
+bundles the subject (whom) and resource (what) contract objects — each carrying its schematized `metadata` — and the
+tenant context (the caller derives it from its `SecurityContext`) — and returning a decision indicating whether the
+resource is licensed to the subject at the time of the call, together with structured, non-authoritative
+**diagnostics** (a string-keyed map of debug information about how the decision was reached — e.g. which backend
+answered, matched grant, denial cause).
 Diagnostics are advisory only and **MUST NOT** be required for the caller to interpret the boolean outcome. The single
 request object is the contract's growth surface — new inputs are added as request fields, not as new parameters or
 method-signature changes. (See `cpt-cf-license-resolver-fr-evaluation-metadata` for the `metadata` field.)
@@ -160,49 +186,131 @@ method-signature changes. (See `cpt-cf-license-resolver-fr-evaluation-metadata` 
   module has today, and gives one consistent contract instead of each module growing its own.
 - **Actors**: `cpt-cf-license-resolver-actor-consuming-module`
 
+#### Licensing Contract Registration
+
+- [ ] `p1` - **ID**: `cpt-cf-license-resolver-fr-contract-registration`
+
+Every Subject and Resource shape used in a license check **MUST** be a registered, versioned GTS type derived from the
+licensing base types owned by this module (under `gts.cf.core.lic.*`) — never an ad-hoc payload assembled at the call
+site. A module that wants license enforcement **MUST** register, before the check, both the Subject and Resource
+contract types it checks — as derivatives of the base types — together with the exact schema of the properties it
+supplies with each; a derived Resource type **MUST** declare which Subject types it admits. This module **MAY** provide
+helpers other modules use to register the reusable, well-known Subject types sourced from the `SecurityContext` (e.g.
+`user`, `tenant`).
+
+- **Rationale**: Platform vendors author licensing rules against contracts, not against source code. A contract that
+  exists only in a Gear's internals cannot be reviewed, approved, or relied upon.
+- **Actors**: `cpt-cf-license-resolver-actor-consuming-module`, `cpt-cf-license-resolver-actor-platform-vendor`
+
 #### Subject Identity
 
 - [ ] `p1` - **ID**: `cpt-cf-license-resolver-fr-subject-identity`
 
-The system **MUST** identify the subject of a check by a subject type plus an id, consistent with the authz-resolver
-subject model. The subject type **MUST** be open-ended — a license may be granted to a tenant, a user, or any future
-subject type — and the resolver **MUST NOT** assume the subject is a tenant.
+The system **MUST** identify the subject of a check as an instance of a registered Subject licensing contract type
+(see `cpt-cf-license-resolver-fr-contract-registration`). Within the contract object, the subject **MUST** carry its
+domain **GTS type** (always present) and **MAY** carry an **id** — a well-known instance name or a UUID — plus
+`metadata` conforming to the contract schema. The subject's domain type **MUST** be open-ended — a license may be
+granted to a tenant, a user, or any future subject type — and the resolver **MUST NOT** assume the subject is a tenant.
+This module owns the base Subject type. A module that wants license enforcement registers its derived Subject contract
+type — alongside its Resource contract type (see `cpt-cf-license-resolver-fr-contract-registration`) — as a derivative
+of the base type, projecting an externally-owned domain subject type. To ease reuse of the common subjects sourced from
+the `SecurityContext` (e.g. `user`, `tenant`), this module **MAY** provide helpers other modules use to register those
+well-known Subject types. The domain types themselves are owned by their modules and only referenced, never defined.
 
-- **Rationale**: Consistent, polymorphic subject identity lets callers reuse existing subject references (as
-  authz-resolver and quota-enforcement do), supports licensing any subject kind, and aligns deny semantics across
-  resolvers.
+- **Rationale**: A GTS-typed, contract-carried subject identity is polymorphic and type-safe, supports licensing any
+  subject kind, and makes the subject side of every check observable to platform vendors via the registered contract —
+  while domain-type ownership stays with the modules that define those types.
 - **Actors**: `cpt-cf-license-resolver-actor-consuming-module`
 
 #### Resource Identity
 
 - [ ] `p1` - **ID**: `cpt-cf-license-resolver-fr-resource-identity`
 
-The system **MUST** identify the resource of a check by a single **GTS instance identifier** (`GtsInstanceId`) that
-encodes resource type + id via the `~` notation. The instance segment **MUST** be either a well-known name (GTS §2.3,
-e.g. `…feature.v1~cf.<vendor>._.somename.v1`) or a UUID (GTS §2.4 combined notation, e.g. `…content.v1~<uuid>`). The
-resolver **MUST** reference externally-owned resource types only, never defining them. Which resource types are
-licensable, and their validation, are owned by the backend licensing service that answers the check.
+The system **MUST** identify the resource of a check as an instance of a registered Resource licensing contract type
+(see `cpt-cf-license-resolver-fr-contract-registration`). Within the contract object, the resource **MUST** carry its
+domain **GTS type** (always present) and **MAY** carry an **instance id**, plus `metadata` conforming to the contract
+schema:
 
-- **Rationale**: A GTS instance identifier already encodes type + id and expresses both resource kinds — named
-  (`feature~somename`, §2.3) and opaque (`content~<uuid>`, §2.4) — so a single `GtsInstanceId` is the natural identity
-  and constrains the contract to a valid GTS identifier, appropriate for a cross-module contract. A discrete type field
-  would only help wildcard list filtering, which is out of scope.
+- **Whole resource type** (no instance id) — the check asks whether the subject is entitled to resources of this type
+  *as a class*, not to one concrete instance. The typical case is gating creation (e.g. a `POST`): the resource does
+  not exist yet, so there is no instance id to pass. The contract only carries this type-level question; what a
+  type-level grant means — and therefore how such a check is answered — is defined by the backend licensing service,
+  not by the resolver.
+- **Specific resource** (instance id present) — the instance id identifies one concrete resource: a stable well-known
+  name (e.g. a named feature) or a UUID (e.g. a content item).
+
+This module owns the base Resource type; the concrete (derived) Resource contract types — each projecting an
+externally-owned domain resource type (e.g. a feature or content type) — are registered by the module performing
+license enforcement for that resource. The domain types themselves are owned by their modules and only referenced
+here, never defined. Which resource types are licensable, and what a grant means for them, are owned by the backend
+licensing service that answers the check.
+
+- **Rationale**: A required domain GTS type plus an optional instance id covers both check kinds — whole-class
+  entitlement (e.g. on `POST`, before an id is known) and a specific resource — without sentinel values or flags. Both
+  components are GTS concepts (a GTS type id; a well-known instance name or UUID), so the identity stays GTS-typed and
+  validatable, appropriate for a cross-module contract.
 - **Actors**: `cpt-cf-license-resolver-actor-consuming-module`
+
+#### Contract Discoverability
+
+- [ ] `p2` - **ID**: `cpt-cf-license-resolver-fr-contract-discoverability`
+
+Platform vendors **MUST** be able to enumerate, for a given environment: which licensing contracts (Subject/Resource
+type pairs) exist; which Subject types each Resource type admits; and the exact, versioned property schema of each
+Subject and Resource type. This enumeration **MUST** be possible through the types registry alone, independently of
+Gear source code, and licensing contracts **MUST** be identifiable as such (by derivation from the licensing base
+types), so they can be reviewed in isolation from all other registered types.
+
+- **Rationale**: Discoverability is what turns "the Gear sends some fields" into "the platform exposes a licensing
+  surface" that can be controlled, reviewed, and approved.
+- **Actors**: `cpt-cf-license-resolver-actor-platform-vendor`
+
+#### Request Validation Against Registered Contracts
+
+- [ ] `p1` - **ID**: `cpt-cf-license-resolver-fr-request-validation`
+
+The system **MUST** validate every check request against the registered contracts *before* delegating to the backend
+plugin, and **MUST** reject non-conforming requests with a validation error — fail-closed and distinct from a
+not-granted decision. At minimum: Subject or Resource `metadata` not matching the registered schema of its declared
+contract type → error; a missing domain type → error; a Subject contract type not admitted by the Resource contract
+type → error. The resolver validates *shape and compatibility* only; it **MUST NOT** interpret what the properties mean
+or decide licensability — those remain the backend's concern.
+
+- **Rationale**: An invalid check silently evaluated is an unauditable check. Validation in the engine gives every
+  plugin vendor the same guarantee — a request that reaches the plugin conforms to a published contract — instead of
+  each backend re-implementing (or skipping) validation differently.
+- **Actors**: `cpt-cf-license-resolver-actor-consuming-module`, `cpt-cf-license-resolver-actor-backend-plugin`
+
+#### Contract Stability and Compatibility
+
+- [ ] `p2` - **ID**: `cpt-cf-license-resolver-fr-contract-compatibility`
+
+Licensing contracts **MUST** follow explicit compatibility rules: adding an **optional** property to a Subject/Resource
+schema is non-breaking — plugins and platform vendors **MUST** ignore properties they do not use; removing or renaming
+a property, changing its type, or narrowing the admitted Subject types is breaking and **MUST** be published as a new
+contract version.
+
+- **Rationale**: "Stable contract" must be a property, not an aspiration. The ignore-unknown-fields rule is also what
+  keeps contracts flexible: a Gear may expose rich metadata, and each platform vendor consumes only the slice relevant
+  to its licensing model.
+- **Actors**: `cpt-cf-license-resolver-actor-consuming-module`, `cpt-cf-license-resolver-actor-platform-vendor`
 
 #### Evaluation Metadata
 
 - [ ] `p2` - **ID**: `cpt-cf-license-resolver-fr-evaluation-metadata`
 
-The check **MAY** carry caller-supplied `metadata` (JSON) describing the evaluation context (e.g. region, country,
-environment). The resolver core **MUST** treat `metadata` as opaque — it **MUST NOT** interpret or require any key — and
-**MUST** forward it unchanged to the selected backend plugin, which **MAY** use it to express attribute/constraint-based
-licensing (e.g. "is this resource licensed to this subject in region X?"). `metadata` is the contract's extension point:
-future constraint dimensions are expressed as new keys rather than new parameters or signature changes.
+The Subject and Resource contract objects **MAY** carry `metadata` — licensing-relevant properties (e.g. region, model
+name, user category) conforming to the registered schema of their contract type. The resolver **MUST** treat `metadata`
+as semantically opaque — it **MUST NOT** interpret what any property means or require any particular property — but
+**MUST** validate its shape against the registered contract schema (per
+`cpt-cf-license-resolver-fr-request-validation`) and forward it unchanged to the selected backend plugin, which **MAY**
+use it to express attribute/constraint-based licensing (e.g. "is this resource licensed to this subject in region
+X?"). `metadata` is the contract's extension point: new properties arrive as new optional schema fields (non-breaking
+per `cpt-cf-license-resolver-fr-contract-compatibility`) rather than undocumented keys.
 
-- **Rationale**: Whether a resource is licensed can depend on contextual attributes (region, country, environment, …),
-  and which attributes matter is backend-specific and expected to grow. Carrying them as an opaque, forwarded bag lets
-  backends gate grants on that context, lets new constraint dimensions be added without changing the check signature,
-  and keeps the resolver core free of any business rules about what the attributes mean.
+- **Rationale**: Whether a resource is licensed can depend on contextual attributes, and which attributes matter is
+  backend-specific and expected to grow. Schematizing them keeps the licensing surface observable and validatable while
+  the resolver stays free of any business rules about what the attributes mean.
 - **Actors**: `cpt-cf-license-resolver-actor-consuming-module`, `cpt-cf-license-resolver-actor-backend-plugin`
 
 #### Plugin-Delegated Backend
@@ -232,7 +340,9 @@ systems (e.g. issuance or billing); how a backend sources or maintains grants is
 
 ## 6. Non-Functional Requirements
 
-> **Global baselines**: Project-wide NFRs defined in root PRD and guidelines. Document only module-specific NFRs here.
+> **Global baselines**: Project-wide NFRs defined
+> in [docs/ARCHITECTURE_MANIFEST.md](../../../../docs/ARCHITECTURE_MANIFEST.md)
+> and [guidelines/](../../../../guidelines/). Document only module-specific NFRs here.
 
 ### 6.1 Module-Specific NFRs
 
@@ -288,12 +398,14 @@ bounded within that tenant (the current tenant-bounded model — see §11).
 - **Stability**: stable
 - **Description**: The public client contract exposing the **single** method
   `is_licensed(request: LicenseCheckRequest) -> LicenseDecision` — the point-in-time check of whether a resource is
-  licensed to a subject. `LicenseCheckRequest` bundles the subject, the resource, opaque forwarded `metadata` (JSON) for
-  attribute-based constraints, and the tenant context (caller-derived from `SecurityContext`). There is no listing or
-  enumeration method.
+  licensed to a subject. `LicenseCheckRequest` bundles the Subject and Resource contract objects (instances of
+  registered derived licensing types, each carrying domain type + optional id + schematized `metadata`) and the tenant
+  context (caller-derived from `SecurityContext`). A request that does not conform to its registered contracts is
+  rejected with a validation error, distinct from a not-granted decision. There is no listing or enumeration method.
 - **Breaking Change Policy**: Major version bump required to change the `LicenseCheckRequest`/`LicenseDecision` shape (a
-  backward-compatible new optional request field is not breaking), the `GtsInstanceId` resource
-  identity, or the decision/error semantics.
+  backward-compatible new optional request field is not breaking), the identity model (domain GTS type + optional
+  instance id), or the decision/error semantics. Individual licensing contracts evolve under
+  `cpt-cf-license-resolver-fr-contract-compatibility` (additive optional properties are non-breaking).
 
 ### 7.2 External Integration Contracts
 
@@ -318,17 +430,20 @@ bounded within that tenant (the current tenant-bounded model — see §11).
 **Preconditions**:
 
 - A `SecurityContext` with a tenant is available.
-- The resource type is a registered GTS type referenced by the caller.
+- The Gear's derived Subject/Resource licensing contract types are registered in the types registry.
 
 **Main Flow**:
 
-1. Consuming module assembles a `LicenseCheckRequest`: the resource's `GtsInstanceId` (named or UUID-based), the
-   subject,
-   any evaluation `metadata`, and the tenant context derived from its `SecurityContext`.
-2. Module calls `is_licensed(request)`.
-3. Resolver selects the backend plugin via the GTS registry and delegates the check, forwarding the request unchanged.
-4. Resolver returns a decision (granted true/false plus diagnostics).
-5. Module enforces the decision.
+1. Consuming module builds the Subject and Resource contract objects as instances of the registered contract types,
+   projecting the licensing-relevant fields from the data it has at hand (e.g. the resource from its domain objects,
+   the subject from `SecurityContext`): each carries the domain GTS type (required), an optional id (a well-known
+   name or UUID; omitted to check a whole resource type), and `metadata` conforming to the contract schema.
+2. Module assembles a `LicenseCheckRequest` with the two contract objects and the tenant context derived from its
+   `SecurityContext`, and calls `is_licensed(request)`.
+3. Resolver validates the request against the registered contracts (schemas + admitted subject types).
+4. Resolver selects the backend plugin via the GTS registry and delegates the check, forwarding the request unchanged.
+5. Resolver returns a decision (granted true/false plus diagnostics).
+6. Module enforces the decision.
 
 **Postconditions**:
 
@@ -336,12 +451,20 @@ bounded within that tenant (the current tenant-bounded model — see §11).
 
 **Alternative Flows**:
 
+- **Request does not conform to its registered contracts** (schema mismatch, missing domain type, subject type not
+  admitted): Resolver rejects with a validation error before delegation — fail-closed, never evaluated; the module
+  denies access.
 - **No plugin available / backend unreachable**: Resolver fails closed — returns not-granted or an error; the module
   denies access.
 
 ## 9. Acceptance Criteria
 
-- [ ] `is_licensed(request)` returns a correct granted/not-granted decision for both named and opaque resources.
+- [ ] `is_licensed(request)` returns a correct granted/not-granted decision for whole-type, named, and opaque
+  resources.
+- [ ] Non-conforming requests (schema mismatch, missing domain type, inadmissible subject type) are rejected with a
+  validation error before delegation — never silently evaluated, never granted.
+- [ ] The platform's licensing surface is enumerable from the types registry alone (all types derived from the
+  licensing base types), with per-contract property schemas and admitted subject types.
 - [ ] No listing or enumeration capability exists in the public contract.
 - [ ] When no backend plugin is available, the resolver never grants by default.
 - [ ] All resolutions are tenant-scoped via the request context (derived from `SecurityContext`) with no cross-tenant
@@ -350,18 +473,24 @@ bounded within that tenant (the current tenant-bounded model — see §11).
 
 ## 10. Dependencies
 
-| Dependency                            | Description                                                  | Criticality |
-|---------------------------------------|--------------------------------------------------------------|-------------|
-| GTS types registry (`types-registry`) | Backend plugin discovery (by GTS plugin spec)                | p1          |
-| `SecurityContext`                     | Source of the request's tenant context (built by the caller) | p1          |
-| Backend license plugin                | Holds grant facts and answers the delegated check            | p1          |
+| Dependency                            | Description                                                                                              | Criticality |
+|---------------------------------------|----------------------------------------------------------------------------------------------------------|-------------|
+| GTS types registry (`types-registry`) | Backend plugin discovery (by GTS plugin spec); registration and schema resolution of licensing contracts | p1          |
+| `SecurityContext`                     | Source of the request's tenant context (built by the caller)                                             | p1          |
+| Backend license plugin                | Holds grant facts and answers the delegated check                                                        | p1          |
 
 ## 11. Assumptions
 
-- Resource types consumed in checks are owned and registered by their respective modules; the resolver only references
-  them by GTS type path.
+- Domain types referenced inside licensing contracts (subject and resource) are owned and registered by their
+  respective modules; the resolver only references them by GTS type path.
+- The licensing base types are owned by this module under `gts.cf.core.lic.*`; a module that wants license enforcement
+  registers its derived Subject and Resource contract types before checks are made.
+- This module **MAY**, at some stage, provide a set of helpers that other modules use to register the reusable,
+  well-known Subject contract types sourced from the `SecurityContext` (e.g. `user`, `tenant`), so common subjects need
+  not be re-declared by each module.
 - At least one backend plugin is registered in environments where license checks are expected to grant.
-- Subject identity provided by callers follows the authz-resolver subject model.
+- Contract schemas are resolvable from the types registry and cacheable; the registry is available at bootstrap and its
+  schema reads are not on the per-check hot path (cached).
 - **Tenant-bounded grants (current model)**: at this stage, every license is assumed to be bounded within a single
   tenant — regardless of subject type, the subject (e.g. a user) belongs to a tenant — and the resolver enforces tenant
   isolation via the request's tenant context (derived from `SecurityContext`) as other CF modules do. Cross-tenant or
@@ -370,11 +499,13 @@ bounded within that tenant (the current tenant-bounded model — see §11).
 
 ## 12. Risks
 
-| Risk                                           | Impact                                         | Mitigation                                                                                                                            |
-|------------------------------------------------|------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| No backend plugin registered in an environment | All checks deny, blocking legitimate access    | Fail-closed by design; surface a clear `NoPluginAvailable` signal for operability.                                                    |
-| Backend latency degrades the check             | Slows every gated request in consuming modules | Boundary p95 NFR; consuming modules may apply their own timeouts/fallbacks.                                                           |
-| Misreferenced resource type path               | Check resolves against the wrong type          | GTS instance identifier is format-validated; the backend licensing service validates the type/licensability and denies unknown types. |
+| Risk                                            | Impact                                                  | Mitigation                                                                                                                                    |
+|-------------------------------------------------|---------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| No backend plugin registered in an environment  | All checks deny, blocking legitimate access             | Fail-closed by design; surface a clear `NoPluginAvailable` signal for operability.                                                            |
+| Backend latency degrades the check              | Slows every gated request in consuming modules          | Boundary p95 NFR; consuming modules may apply their own timeouts/fallbacks.                                                                   |
+| Misreferenced domain type path                  | Check resolves against the wrong type                   | Engine validates the request against the registered contract; the backend licensing service validates licensability and denies unknown types. |
+| Contract drift (Gear code vs registered schema) | Checks start failing validation after a Gear change     | Engine-side validation surfaces drift immediately and fail-closed; additive-optional evolution is non-breaking by rule.                       |
+| Contract governance overhead                    | New licensable surfaces require registration and review | The review point is the feature; per-Gear contract count is small and bounded by its distinct licensable surfaces.                            |
 
 ## 13. Open Questions
 
@@ -382,6 +513,10 @@ bounded within that tenant (the current tenant-bounded model — see §11).
   license-resolver maintainers; target: DESIGN phase (2026-06-30).
 - What diagnostics keys/conventions do consuming modules need (denial cause, matched grant, backend id, etc.)? — Owner:
   license-resolver maintainers; target: DESIGN phase (2026-06-30).
+- How do callers source deployment-wide contract `metadata` properties (e.g. region, environment) that are fixed per
+  deployment rather than known per call? Candidate: an SDK-level wrapper merging configuration-sourced properties into
+  the contract objects (conforming to the registered schema) before delegation; merge precedence (caller-provided vs
+  configuration-sourced) to be settled. — Owner: license-resolver maintainers; target: DESIGN phase (2026-06-30).
 
 ## 14. Traceability
 

--- a/gears/system/license-resolver/docs/PRD.md
+++ b/gears/system/license-resolver/docs/PRD.md
@@ -30,6 +30,7 @@ system: cf
   - [7.1 Public API Surface](#71-public-api-surface)
   - [7.2 External Integration Contracts](#72-external-integration-contracts)
 - [8. Use Cases](#8-use-cases)
+  - [Gate Access to a Licensable Resource](#gate-access-to-a-licensable-resource)
 - [9. Acceptance Criteria](#9-acceptance-criteria)
 - [10. Dependencies](#10-dependencies)
 - [11. Assumptions](#11-assumptions)
@@ -308,7 +309,7 @@ bounded within that tenant (the current tenant-bounded model — see §11).
 
 ## 8. Use Cases
 
-#### Gate Access to a Licensable Resource
+### Gate Access to a Licensable Resource
 
 - [ ] `p2` - **ID**: `cpt-cf-license-resolver-usecase-gate-access`
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added PRD and full technical design for a read-only, plugin-delegating License Resolver exposing is_licensed(request).
  * Added ADR-0001: subject/resource identity uses required domain type + optional instance id (rejects combined/free-form ids); telemetry by domain type.
  * Added ADR-0002: resolver delegates to plugins, owns no grant store, and is fail-closed when no plugin/backends are available.
  * Added ADR-0003: typed, registry-derived licensing contracts with engine-side validation and versioning guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->