### PR TITLE
refactor(resource-group): adopt SDK canonical-projection pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,6 +1932,7 @@ version = "0.1.5"
 dependencies = [
  "async-trait",
  "cf-gears-toolkit",
+ "cf-gears-toolkit-canonical-errors",
  "cf-gears-toolkit-gts",
  "cf-gears-toolkit-odata",
  "cf-gears-toolkit-odata-macros",
@@ -1955,6 +1956,7 @@ dependencies = [
  "cf-gears-resource-group-sdk",
  "cf-gears-tenant-resolver-sdk",
  "cf-gears-toolkit",
+ "cf-gears-toolkit-canonical-errors",
  "cf-gears-toolkit-macros",
  "cf-gears-toolkit-odata",
  "cf-gears-toolkit-security",

--- a/gears/system/account-management/account-management/src/domain/user/service.rs
+++ b/gears/system/account-management/account-management/src/domain/user/service.rs
@@ -1008,12 +1008,16 @@ async fn cleanup_inner(
     let mut removed: usize = 0;
     let mut already_gone: usize = 0;
     for group_id in &groups {
-        match tokio::time::timeout(
+        // The trait boundary is `CanonicalError` (ADR 0005); project the
+        // inner result into the typed SDK view so the `NotFound`
+        // idempotent arm dispatches as before.
+        let outcome = tokio::time::timeout(
             RG_CLEANUP_TIMEOUT,
             rg.remove_membership(sys_ctx, *group_id, USER_RG_TYPE_CODE, &user_id_str),
         )
         .await
-        {
+        .map(|r| r.map_err(ResourceGroupError::from));
+        match outcome {
             Err(_elapsed) => {
                 emit_metric(
                     AM_DEPENDENCY_HEALTH,

--- a/gears/system/account-management/account-management/src/domain/user/service_tests.rs
+++ b/gears/system/account-management/account-management/src/domain/user/service_tests.rs
@@ -1149,26 +1149,40 @@ mod cleanup {
     use async_trait::async_trait;
     use resource_group_sdk::{
         CreateGroupRequest, CreateTypeRequest, GroupHierarchy, ResourceGroup, ResourceGroupClient,
-        ResourceGroupError, ResourceGroupMembership, ResourceGroupType, ResourceGroupWithDepth,
-        UpdateGroupRequest, UpdateTypeRequest,
+        ResourceGroupMembership, ResourceGroupType, ResourceGroupWithDepth, UpdateGroupRequest,
+        UpdateTypeRequest,
     };
     use std::sync::Mutex;
+    use toolkit_canonical_errors::{CanonicalError, resource_error};
     use toolkit_odata::{ODataQuery, Page, PageInfo};
     use toolkit_security::SecurityContext;
 
     use crate::domain::user::test_support::FakeUserOutcome;
 
+    // The RG trait boundary is `CanonicalError` (ADR 0005); synthesize the
+    // canonical `NotFound` the real RG ladder emits so the user-cleanup
+    // path's `.map_err(ResourceGroupError::from)` idempotent dispatch is
+    // exercised as in prod.
+    #[resource_error("gts.cf.core.resource_group.group.v1~")]
+    struct RgErr;
+
+    fn rg_not_found(code: &str) -> CanonicalError {
+        RgErr::not_found(format!("'{code}' not found"))
+            .with_resource(code)
+            .create()
+    }
+
     // -- minimal RG fake focused on list_groups + remove_membership --
 
     enum ListBehaviour {
         Pages(Vec<Page<ResourceGroup>>),
-        Error(ResourceGroupError),
+        Error(CanonicalError),
     }
 
     enum RemoveBehaviour {
         Ok,
         NotFound,
-        Error(ResourceGroupError),
+        Error(CanonicalError),
     }
 
     struct FakeMembershipRgClient {
@@ -1217,7 +1231,7 @@ mod cleanup {
             self
         }
 
-        fn with_list_error(error: ResourceGroupError) -> Self {
+        fn with_list_error(error: CanonicalError) -> Self {
             Self {
                 list_behaviour: Mutex::new(ListBehaviour::Error(error)),
                 remove_behaviour: RemoveBehaviour::Ok,
@@ -1241,7 +1255,7 @@ mod cleanup {
             &self,
             _ctx: &SecurityContext,
             _query: &ODataQuery,
-        ) -> Result<Page<ResourceGroup>, ResourceGroupError> {
+        ) -> Result<Page<ResourceGroup>, CanonicalError> {
             *self.list_calls.lock().expect("lock") += 1;
             let mut behaviour = self.list_behaviour.lock().expect("lock");
             match &mut *behaviour {
@@ -1261,7 +1275,7 @@ mod cleanup {
             group_id: Uuid,
             resource_type: &str,
             resource_id: &str,
-        ) -> Result<(), ResourceGroupError> {
+        ) -> Result<(), CanonicalError> {
             self.removed.lock().expect("lock").push((
                 group_id,
                 resource_type.to_owned(),
@@ -1269,7 +1283,7 @@ mod cleanup {
             ));
             match &self.remove_behaviour {
                 RemoveBehaviour::Ok => Ok(()),
-                RemoveBehaviour::NotFound => Err(ResourceGroupError::not_found("membership")),
+                RemoveBehaviour::NotFound => Err(rg_not_found("membership")),
                 RemoveBehaviour::Error(e) => Err(e.clone()),
             }
         }
@@ -1280,7 +1294,7 @@ mod cleanup {
             &self,
             _ctx: &SecurityContext,
             _query: &ODataQuery,
-        ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError> {
+        ) -> Result<Page<ResourceGroupMembership>, CanonicalError> {
             unreachable!(
                 "cleanup uses list_groups(tenant) + per-group remove, never list_memberships"
             )
@@ -1289,21 +1303,21 @@ mod cleanup {
             &self,
             _ctx: &SecurityContext,
             _request: CreateTypeRequest,
-        ) -> Result<ResourceGroupType, ResourceGroupError> {
+        ) -> Result<ResourceGroupType, CanonicalError> {
             unreachable!()
         }
         async fn get_type(
             &self,
             _ctx: &SecurityContext,
             _code: &str,
-        ) -> Result<ResourceGroupType, ResourceGroupError> {
+        ) -> Result<ResourceGroupType, CanonicalError> {
             unreachable!()
         }
         async fn list_types(
             &self,
             _ctx: &SecurityContext,
             _query: &ODataQuery,
-        ) -> Result<Page<ResourceGroupType>, ResourceGroupError> {
+        ) -> Result<Page<ResourceGroupType>, CanonicalError> {
             unreachable!()
         }
         async fn update_type(
@@ -1311,28 +1325,28 @@ mod cleanup {
             _ctx: &SecurityContext,
             _code: &str,
             _request: UpdateTypeRequest,
-        ) -> Result<ResourceGroupType, ResourceGroupError> {
+        ) -> Result<ResourceGroupType, CanonicalError> {
             unreachable!()
         }
         async fn delete_type(
             &self,
             _ctx: &SecurityContext,
             _code: &str,
-        ) -> Result<(), ResourceGroupError> {
+        ) -> Result<(), CanonicalError> {
             unreachable!()
         }
         async fn create_group(
             &self,
             _ctx: &SecurityContext,
             _request: CreateGroupRequest,
-        ) -> Result<ResourceGroup, ResourceGroupError> {
+        ) -> Result<ResourceGroup, CanonicalError> {
             unreachable!()
         }
         async fn get_group(
             &self,
             _ctx: &SecurityContext,
             _id: Uuid,
-        ) -> Result<ResourceGroup, ResourceGroupError> {
+        ) -> Result<ResourceGroup, CanonicalError> {
             unreachable!()
         }
         async fn update_group(
@@ -1340,14 +1354,14 @@ mod cleanup {
             _ctx: &SecurityContext,
             _id: Uuid,
             _request: UpdateGroupRequest,
-        ) -> Result<ResourceGroup, ResourceGroupError> {
+        ) -> Result<ResourceGroup, CanonicalError> {
             unreachable!()
         }
         async fn delete_group(
             &self,
             _ctx: &SecurityContext,
             _id: Uuid,
-        ) -> Result<(), ResourceGroupError> {
+        ) -> Result<(), CanonicalError> {
             unreachable!()
         }
         async fn get_group_descendants(
@@ -1355,7 +1369,7 @@ mod cleanup {
             _ctx: &SecurityContext,
             _group_id: Uuid,
             _query: &ODataQuery,
-        ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+        ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError> {
             unreachable!()
         }
         async fn get_group_ancestors(
@@ -1363,7 +1377,7 @@ mod cleanup {
             _ctx: &SecurityContext,
             _group_id: Uuid,
             _query: &ODataQuery,
-        ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+        ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError> {
             unreachable!()
         }
         async fn add_membership(
@@ -1372,7 +1386,7 @@ mod cleanup {
             _group_id: Uuid,
             _resource_type: &str,
             _resource_id: &str,
-        ) -> Result<ResourceGroupMembership, ResourceGroupError> {
+        ) -> Result<ResourceGroupMembership, CanonicalError> {
             unreachable!()
         }
     }
@@ -1506,9 +1520,7 @@ mod cleanup {
         let idp = Arc::new(FakeIdpUserProvisioner::new());
         idp.set_delete_outcome(FakeUserOutcome::Ok);
         let rg = Arc::new(FakeMembershipRgClient::with_list_error(
-            ResourceGroupError::ServiceUnavailable {
-                message: "connection refused".to_owned(),
-            },
+            CanonicalError::internal("connection refused").create(),
         ));
         let svc = make_service_with_cleanup(tenants, idp, Arc::clone(&rg));
 
@@ -1606,9 +1618,7 @@ mod cleanup {
         let rg = Arc::new(
             FakeMembershipRgClient::with_groups(vec![user_group(group_a, tenant_id)])
                 .with_remove_behaviour(RemoveBehaviour::Error(
-                    ResourceGroupError::ServiceUnavailable {
-                        message: "connection refused".to_owned(),
-                    },
+                    CanonicalError::internal("connection refused").create(),
                 )),
         );
         let svc = make_service_with_cleanup(tenants, idp, Arc::clone(&rg));

--- a/gears/system/account-management/account-management/src/domain/user_groups/cascade.rs
+++ b/gears/system/account-management/account-management/src/domain/user_groups/cascade.rs
@@ -186,7 +186,13 @@ async fn cascade_one(
     tenant_id: Uuid,
     group_id: Uuid,
 ) -> Result<bool, HookError> {
-    match tokio::time::timeout(CASCADE_TIMEOUT, client.delete_group_cascade(ctx, group_id)).await {
+    // The trait boundary is `CanonicalError` (ADR 0005); project the
+    // inner result into the typed SDK view so the `NotFound` idempotent
+    // arm below dispatches as before.
+    let outcome = tokio::time::timeout(CASCADE_TIMEOUT, client.delete_group_cascade(ctx, group_id))
+        .await
+        .map(|r| r.map_err(ResourceGroupError::from));
+    match outcome {
         Err(_elapsed) => {
             emit_metric(
                 AM_DEPENDENCY_HEALTH,

--- a/gears/system/account-management/account-management/src/domain/user_groups/cascade_tests.rs
+++ b/gears/system/account-management/account-management/src/domain/user_groups/cascade_tests.rs
@@ -26,9 +26,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use async_trait::async_trait;
 use resource_group_sdk::{
     CreateGroupRequest, CreateTypeRequest, GroupHierarchy, ResourceGroup, ResourceGroupClient,
-    ResourceGroupError, ResourceGroupMembership, ResourceGroupType, ResourceGroupWithDepth,
-    UpdateGroupRequest, UpdateTypeRequest,
+    ResourceGroupMembership, ResourceGroupType, ResourceGroupWithDepth, UpdateGroupRequest,
+    UpdateTypeRequest,
 };
+use toolkit_canonical_errors::{CanonicalError, resource_error};
 use toolkit_odata::page::PageInfo;
 use toolkit_odata::{ODataQuery, Page};
 use toolkit_security::SecurityContext;
@@ -38,10 +39,23 @@ use super::USER_GROUP_TYPE_CODE;
 use super::cascade::build_cascade_cleanup_hook;
 use crate::domain::tenant::hooks::HookError;
 
+// The RG trait boundary is `CanonicalError` (ADR 0005); synthesize the
+// canonical `NotFound` the real RG ladder emits so the cascade hook's
+// `.map_err(ResourceGroupError::from)` idempotent-NotFound dispatch is
+// exercised as in prod.
+#[resource_error("gts.cf.core.resource_group.group.v1~")]
+struct RgErr;
+
+fn rg_not_found(code: &str) -> CanonicalError {
+    RgErr::not_found(format!("'{code}' not found"))
+        .with_resource(code)
+        .create()
+}
+
 // ---- fake client ---------------------------------------------------
 
-type ListGroupsFn = Box<dyn Fn() -> Result<Page<ResourceGroup>, ResourceGroupError> + Send + Sync>;
-type DeleteCascadeFn = Box<dyn Fn(Uuid) -> Result<(), ResourceGroupError> + Send + Sync>;
+type ListGroupsFn = Box<dyn Fn() -> Result<Page<ResourceGroup>, CanonicalError> + Send + Sync>;
+type DeleteCascadeFn = Box<dyn Fn(Uuid) -> Result<(), CanonicalError> + Send + Sync>;
 
 struct FakeCascadeRgClient {
     list_groups_fn: ListGroupsFn,
@@ -65,7 +79,7 @@ impl ResourceGroupClient for FakeCascadeRgClient {
         &self,
         _ctx: &SecurityContext,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroup>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroup>, CanonicalError> {
         (self.list_groups_fn)()
     }
 
@@ -73,7 +87,7 @@ impl ResourceGroupClient for FakeCascadeRgClient {
         &self,
         _ctx: &SecurityContext,
         id: Uuid,
-    ) -> Result<(), ResourceGroupError> {
+    ) -> Result<(), CanonicalError> {
         self.cascade_calls.fetch_add(1, Ordering::SeqCst);
         (self.delete_cascade_fn)(id)
     }
@@ -84,7 +98,7 @@ impl ResourceGroupClient for FakeCascadeRgClient {
         &self,
         _ctx: &SecurityContext,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupMembership>, CanonicalError> {
         unreachable!("cascade hook no longer drains memberships -- RG cascade handles them")
     }
     async fn remove_membership(
@@ -93,35 +107,31 @@ impl ResourceGroupClient for FakeCascadeRgClient {
         _group_id: Uuid,
         _resource_type: &str,
         _resource_id: &str,
-    ) -> Result<(), ResourceGroupError> {
+    ) -> Result<(), CanonicalError> {
         unreachable!("cascade hook no longer removes memberships -- RG cascade handles them")
     }
-    async fn delete_group(
-        &self,
-        _ctx: &SecurityContext,
-        _id: Uuid,
-    ) -> Result<(), ResourceGroupError> {
+    async fn delete_group(&self, _ctx: &SecurityContext, _id: Uuid) -> Result<(), CanonicalError> {
         unreachable!("cascade hook only calls delete_group_cascade, not delete_group")
     }
     async fn create_type(
         &self,
         _ctx: &SecurityContext,
         _request: CreateTypeRequest,
-    ) -> Result<ResourceGroupType, ResourceGroupError> {
+    ) -> Result<ResourceGroupType, CanonicalError> {
         unreachable!()
     }
     async fn get_type(
         &self,
         _ctx: &SecurityContext,
         _code: &str,
-    ) -> Result<ResourceGroupType, ResourceGroupError> {
+    ) -> Result<ResourceGroupType, CanonicalError> {
         unreachable!()
     }
     async fn list_types(
         &self,
         _ctx: &SecurityContext,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupType>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupType>, CanonicalError> {
         unreachable!()
     }
     async fn update_type(
@@ -129,28 +139,24 @@ impl ResourceGroupClient for FakeCascadeRgClient {
         _ctx: &SecurityContext,
         _code: &str,
         _request: UpdateTypeRequest,
-    ) -> Result<ResourceGroupType, ResourceGroupError> {
+    ) -> Result<ResourceGroupType, CanonicalError> {
         unreachable!()
     }
-    async fn delete_type(
-        &self,
-        _ctx: &SecurityContext,
-        _code: &str,
-    ) -> Result<(), ResourceGroupError> {
+    async fn delete_type(&self, _ctx: &SecurityContext, _code: &str) -> Result<(), CanonicalError> {
         unreachable!()
     }
     async fn create_group(
         &self,
         _ctx: &SecurityContext,
         _request: CreateGroupRequest,
-    ) -> Result<ResourceGroup, ResourceGroupError> {
+    ) -> Result<ResourceGroup, CanonicalError> {
         unreachable!()
     }
     async fn get_group(
         &self,
         _ctx: &SecurityContext,
         _id: Uuid,
-    ) -> Result<ResourceGroup, ResourceGroupError> {
+    ) -> Result<ResourceGroup, CanonicalError> {
         unreachable!()
     }
     async fn update_group(
@@ -158,7 +164,7 @@ impl ResourceGroupClient for FakeCascadeRgClient {
         _ctx: &SecurityContext,
         _id: Uuid,
         _request: UpdateGroupRequest,
-    ) -> Result<ResourceGroup, ResourceGroupError> {
+    ) -> Result<ResourceGroup, CanonicalError> {
         unreachable!()
     }
     async fn get_group_descendants(
@@ -166,7 +172,7 @@ impl ResourceGroupClient for FakeCascadeRgClient {
         _ctx: &SecurityContext,
         _group_id: Uuid,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError> {
         unreachable!()
     }
     async fn get_group_ancestors(
@@ -174,7 +180,7 @@ impl ResourceGroupClient for FakeCascadeRgClient {
         _ctx: &SecurityContext,
         _group_id: Uuid,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError> {
         unreachable!()
     }
     async fn add_membership(
@@ -183,7 +189,7 @@ impl ResourceGroupClient for FakeCascadeRgClient {
         _group_id: Uuid,
         _resource_type: &str,
         _resource_id: &str,
-    ) -> Result<ResourceGroupMembership, ResourceGroupError> {
+    ) -> Result<ResourceGroupMembership, CanonicalError> {
         unreachable!()
     }
 }
@@ -319,7 +325,7 @@ async fn group_not_found_during_cascade_treated_as_already_deleted() {
             let g = g.clone();
             Box::new(move || Ok(groups_page(vec![g.clone()])))
         },
-        delete_cascade_fn: Box::new(|id| Err(ResourceGroupError::not_found(id.to_string()))),
+        delete_cascade_fn: Box::new(|id| Err(rg_not_found(&id.to_string()))),
         cascade_calls: AtomicUsize::new(0),
     };
     let client: Arc<dyn ResourceGroupClient + Send + Sync> = Arc::new(fake);
@@ -331,11 +337,7 @@ async fn group_not_found_during_cascade_treated_as_already_deleted() {
 #[tokio::test]
 async fn list_groups_unavailable_returns_retryable() {
     let fake = FakeCascadeRgClient {
-        list_groups_fn: Box::new(|| {
-            Err(ResourceGroupError::service_unavailable(
-                "connection refused",
-            ))
-        }),
+        list_groups_fn: Box::new(|| Err(CanonicalError::internal("connection refused").create())),
         delete_cascade_fn: Box::new(|_| Ok(())),
         cascade_calls: AtomicUsize::new(0),
     };
@@ -353,7 +355,9 @@ async fn cascade_error_returns_retryable() {
             let g = g.clone();
             Box::new(move || Ok(groups_page(vec![g.clone()])))
         },
-        delete_cascade_fn: Box::new(|_| Err(ResourceGroupError::internal())),
+        delete_cascade_fn: Box::new(
+            |_| Err(CanonicalError::internal("rg internal error").create()),
+        ),
         cascade_calls: AtomicUsize::new(0),
     };
     let client: Arc<dyn ResourceGroupClient + Send + Sync> = Arc::new(fake);

--- a/gears/system/account-management/account-management/src/domain/user_groups/registration.rs
+++ b/gears/system/account-management/account-management/src/domain/user_groups/registration.rs
@@ -173,7 +173,7 @@ impl TypeSpec {
 ///
 /// Each step runs the full idempotent algorithm independently
 /// ([`register_one`]): `get_type` → classify-or-create → on
-/// `TypeAlreadyExists` race re-read and classify. A step that lands
+/// `AlreadyExists` race re-read and classify. A step that lands
 /// on `DivergentSchema` aborts the pair; the caller (`gear init`)
 /// surfaces the error and does NOT signal ready.
 ///
@@ -247,7 +247,7 @@ pub async fn register_user_group_types(
 ///
 /// * `get_type` returns the row → classify it.
 /// * `get_type` returns `NotFound` → `create_type` → on success done,
-///   on `TypeAlreadyExists` re-read and classify the peer's row.
+///   on `AlreadyExists` re-read and classify the peer's row.
 /// * `get_type` / `create_type` returns transport failure →
 ///   `ServiceUnavailable`.
 #[allow(
@@ -259,8 +259,14 @@ async fn register_one(
     ctx: &SecurityContext,
     spec: &TypeSpec,
 ) -> Result<RegistrationOutcome, RegistrationError> {
-    // Step 1: query existing type definition.
-    let existing = match client.get_type(ctx, spec.code).await {
+    // Step 1: query existing type definition. The trait boundary is
+    // `CanonicalError` (ADR 0005); project into the typed SDK view to
+    // dispatch on `NotFound` vs. any transport failure.
+    let existing = match client
+        .get_type(ctx, spec.code)
+        .await
+        .map_err(ResourceGroupError::from)
+    {
         Ok(t) => Some(t),
         Err(ResourceGroupError::NotFound { .. }) => None,
         Err(e) => {
@@ -284,7 +290,11 @@ async fn register_one(
     }
 
     // Type is absent -- register it.
-    match client.create_type(ctx, spec.to_create_request()).await {
+    match client
+        .create_type(ctx, spec.to_create_request())
+        .await
+        .map_err(ResourceGroupError::from)
+    {
         Ok(_) => {
             emit_metric(
                 AM_DEPENDENCY_HEALTH,
@@ -311,7 +321,7 @@ async fn register_one(
         // surface that as `ServiceUnavailable` so the operator can
         // retry init; do NOT default to `AlreadyPresent` because the
         // traits-equivalence invariant is unverified.
-        Err(ResourceGroupError::TypeAlreadyExists { .. }) => {
+        Err(ResourceGroupError::AlreadyExists { .. }) => {
             match client.get_type(ctx, spec.code).await {
                 Ok(racy) => {
                     info!(
@@ -360,7 +370,7 @@ async fn register_one(
 
 /// Equivalence predicate: every trait `spec` declares MUST be honoured
 /// by `existing`. Shared by the step-1 "type already exists" path and
-/// the `TypeAlreadyExists` race-loser path so both honour the same
+/// the `AlreadyExists` race-loser path so both honour the same
 /// "AM MUST NOT auto-repair divergent traits" invariant.
 ///
 /// The check is **inclusive-equivalence**: RG is allowed to seed

--- a/gears/system/account-management/account-management/src/domain/user_groups/registration_tests.rs
+++ b/gears/system/account-management/account-management/src/domain/user_groups/registration_tests.rs
@@ -15,7 +15,7 @@
 //!   call (caller never proceeds past a failing step-1).
 //! * Container divergent / missing-membership-type surfaces with the
 //!   tightened `classify_existing` equivalence check.
-//! * `TypeAlreadyExists` race is re-read per-type via `get_type` and
+//! * `AlreadyExists` race is re-read per-type via `get_type` and
 //!   classified against the same spec (no silent swallow).
 //! * Transport errors from `get_type` / `create_type` collapse to
 //!   `ServiceUnavailable` on the first failing step.
@@ -34,10 +34,11 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use async_trait::async_trait;
 use resource_group_sdk::{
-    CreateGroupRequest, CreateTypeRequest, ResourceGroup, ResourceGroupClient, ResourceGroupError,
+    CreateGroupRequest, CreateTypeRequest, ResourceGroup, ResourceGroupClient,
     ResourceGroupMembership, ResourceGroupType, ResourceGroupWithDepth, UpdateGroupRequest,
     UpdateTypeRequest,
 };
+use toolkit_canonical_errors::{CanonicalError, resource_error};
 use toolkit_odata::{ODataQuery, Page};
 use toolkit_security::SecurityContext;
 use uuid::Uuid;
@@ -45,14 +46,33 @@ use uuid::Uuid;
 use super::registration::{RegistrationError, RegistrationOutcome, register_user_group_types};
 use super::{USER_GROUP_TYPE_CODE, USER_MEMBERSHIP_TYPE};
 
+// The RG trait boundary is `CanonicalError` (ADR 0005). These helpers
+// synthesize the canonical errors the real RG ladder emits, so the
+// production code's `.map_err(ResourceGroupError::from)` dispatch
+// (NotFound vs. transport failure) is exercised exactly as in prod.
+#[resource_error("gts.cf.core.resource_group.group.v1~")]
+struct RgErr;
+
+fn rg_not_found(code: &str) -> CanonicalError {
+    RgErr::not_found(format!("'{code}' not found"))
+        .with_resource(code)
+        .create()
+}
+
+fn rg_already_exists(code: &str) -> CanonicalError {
+    RgErr::already_exists(format!("'{code}' already exists"))
+        .with_resource(code)
+        .create()
+}
+
 // ---- fake client ---------------------------------------------------
 
 enum GetTypeBehaviour {
     Return(ResourceGroupType),
     NotFound,
-    Error(ResourceGroupError),
+    Error(CanonicalError),
     /// Sequence: every call advances; out-of-range calls reuse the
-    /// last entry. Used by the `TypeAlreadyExists` race-path tests
+    /// last entry. Used by the `AlreadyExists` race-path tests
     /// where the first `get_type` returns `NotFound` (we believe
     /// the type is absent) and a second call after a peer's race
     /// returns whatever the peer wrote (equivalent or divergent).
@@ -63,7 +83,7 @@ enum GetTypeBehaviour {
 enum CreateTypeBehaviour {
     Ok,
     AlreadyExists,
-    Error(ResourceGroupError),
+    Error(CanonicalError),
 }
 
 struct TypeState {
@@ -103,9 +123,9 @@ impl TypeState {
 
     fn get_type_unavailable() -> Self {
         Self {
-            get_type: GetTypeBehaviour::Error(ResourceGroupError::ServiceUnavailable {
-                message: "connection refused".to_owned(),
-            }),
+            get_type: GetTypeBehaviour::Error(
+                CanonicalError::internal("connection refused").create(),
+            ),
             create_type: CreateTypeBehaviour::Ok,
         }
     }
@@ -113,9 +133,9 @@ impl TypeState {
     fn create_type_unavailable() -> Self {
         Self {
             get_type: GetTypeBehaviour::NotFound,
-            create_type: CreateTypeBehaviour::Error(ResourceGroupError::ServiceUnavailable {
-                message: "connection refused".to_owned(),
-            }),
+            create_type: CreateTypeBehaviour::Error(
+                CanonicalError::internal("connection refused").create(),
+            ),
         }
     }
 }
@@ -224,11 +244,8 @@ impl ResourceGroupClient for FakeRgClient {
         &self,
         _ctx: &SecurityContext,
         code: &str,
-    ) -> Result<ResourceGroupType, ResourceGroupError> {
-        fn dispatch(
-            b: &GetTypeBehaviour,
-            code: &str,
-        ) -> Result<ResourceGroupType, ResourceGroupError> {
+    ) -> Result<ResourceGroupType, CanonicalError> {
+        fn dispatch(b: &GetTypeBehaviour, code: &str) -> Result<ResourceGroupType, CanonicalError> {
             match b {
                 GetTypeBehaviour::Return(t) => Ok(t.clone()),
                 GetTypeBehaviour::Error(e) => Err(e.clone()),
@@ -237,21 +254,18 @@ impl ResourceGroupClient for FakeRgClient {
                 // collapsing to `NotFound` keeps the fake observable
                 // rather than panicking inside a test fixture.
                 GetTypeBehaviour::NotFound | GetTypeBehaviour::Sequence(_, _) => {
-                    Err(ResourceGroupError::not_found(code))
+                    Err(rg_not_found(code))
                 }
             }
         }
-        let state = self
-            .states
-            .get(code)
-            .ok_or_else(|| ResourceGroupError::not_found(code))?;
+        let state = self.states.get(code).ok_or_else(|| rg_not_found(code))?;
         match &state.get_type {
             GetTypeBehaviour::Sequence(steps, idx) => {
                 let i = idx.fetch_add(1, Ordering::SeqCst);
                 let step = steps
                     .get(i)
                     .or_else(|| steps.last())
-                    .ok_or_else(|| ResourceGroupError::not_found(code))?;
+                    .ok_or_else(|| rg_not_found(code))?;
                 dispatch(step, code)
             }
             other => dispatch(other, code),
@@ -262,7 +276,7 @@ impl ResourceGroupClient for FakeRgClient {
         &self,
         _ctx: &SecurityContext,
         request: CreateTypeRequest,
-    ) -> Result<ResourceGroupType, ResourceGroupError> {
+    ) -> Result<ResourceGroupType, CanonicalError> {
         // Best-effort observability: out-of-band record the order of
         // `create_type` calls. Lock-poison failure aborts the test
         // with a clear cause rather than silently corrupting state.
@@ -273,7 +287,7 @@ impl ResourceGroupClient for FakeRgClient {
         let state = self
             .states
             .get(request.code.as_str())
-            .ok_or_else(|| ResourceGroupError::not_found(&request.code))?;
+            .ok_or_else(|| rg_not_found(&request.code))?;
         match &state.create_type {
             CreateTypeBehaviour::Ok => Ok(ResourceGroupType {
                 code: request.code,
@@ -282,9 +296,7 @@ impl ResourceGroupClient for FakeRgClient {
                 allowed_membership_types: request.allowed_membership_types,
                 metadata_schema: request.metadata_schema,
             }),
-            CreateTypeBehaviour::AlreadyExists => {
-                Err(ResourceGroupError::type_already_exists(&request.code))
-            }
+            CreateTypeBehaviour::AlreadyExists => Err(rg_already_exists(&request.code)),
             CreateTypeBehaviour::Error(e) => Err(e.clone()),
         }
     }
@@ -293,7 +305,7 @@ impl ResourceGroupClient for FakeRgClient {
         &self,
         _ctx: &SecurityContext,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupType>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupType>, CanonicalError> {
         unreachable!()
     }
     async fn update_type(
@@ -301,7 +313,7 @@ impl ResourceGroupClient for FakeRgClient {
         _ctx: &SecurityContext,
         code: &str,
         request: UpdateTypeRequest,
-    ) -> Result<ResourceGroupType, ResourceGroupError> {
+    ) -> Result<ResourceGroupType, CanonicalError> {
         self.update_calls
             .lock()
             .expect("update_calls lock not poisoned")
@@ -314,32 +326,28 @@ impl ResourceGroupClient for FakeRgClient {
             metadata_schema: request.metadata_schema,
         })
     }
-    async fn delete_type(
-        &self,
-        _ctx: &SecurityContext,
-        _code: &str,
-    ) -> Result<(), ResourceGroupError> {
+    async fn delete_type(&self, _ctx: &SecurityContext, _code: &str) -> Result<(), CanonicalError> {
         unreachable!()
     }
     async fn create_group(
         &self,
         _ctx: &SecurityContext,
         _request: CreateGroupRequest,
-    ) -> Result<ResourceGroup, ResourceGroupError> {
+    ) -> Result<ResourceGroup, CanonicalError> {
         unreachable!()
     }
     async fn get_group(
         &self,
         _ctx: &SecurityContext,
         _id: Uuid,
-    ) -> Result<ResourceGroup, ResourceGroupError> {
+    ) -> Result<ResourceGroup, CanonicalError> {
         unreachable!()
     }
     async fn list_groups(
         &self,
         _ctx: &SecurityContext,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroup>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroup>, CanonicalError> {
         unreachable!()
     }
     async fn update_group(
@@ -347,14 +355,10 @@ impl ResourceGroupClient for FakeRgClient {
         _ctx: &SecurityContext,
         _id: Uuid,
         _request: UpdateGroupRequest,
-    ) -> Result<ResourceGroup, ResourceGroupError> {
+    ) -> Result<ResourceGroup, CanonicalError> {
         unreachable!()
     }
-    async fn delete_group(
-        &self,
-        _ctx: &SecurityContext,
-        _id: Uuid,
-    ) -> Result<(), ResourceGroupError> {
+    async fn delete_group(&self, _ctx: &SecurityContext, _id: Uuid) -> Result<(), CanonicalError> {
         unreachable!()
     }
     async fn get_group_descendants(
@@ -362,7 +366,7 @@ impl ResourceGroupClient for FakeRgClient {
         _ctx: &SecurityContext,
         _group_id: Uuid,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError> {
         unreachable!()
     }
     async fn get_group_ancestors(
@@ -370,7 +374,7 @@ impl ResourceGroupClient for FakeRgClient {
         _ctx: &SecurityContext,
         _group_id: Uuid,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError> {
         unreachable!()
     }
     async fn add_membership(
@@ -379,7 +383,7 @@ impl ResourceGroupClient for FakeRgClient {
         _group_id: Uuid,
         _resource_type: &str,
         _resource_id: &str,
-    ) -> Result<ResourceGroupMembership, ResourceGroupError> {
+    ) -> Result<ResourceGroupMembership, CanonicalError> {
         unreachable!()
     }
     async fn remove_membership(
@@ -388,14 +392,14 @@ impl ResourceGroupClient for FakeRgClient {
         _group_id: Uuid,
         _resource_type: &str,
         _resource_id: &str,
-    ) -> Result<(), ResourceGroupError> {
+    ) -> Result<(), CanonicalError> {
         unreachable!()
     }
     async fn list_memberships(
         &self,
         _ctx: &SecurityContext,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupMembership>, CanonicalError> {
         unreachable!()
     }
 }
@@ -668,21 +672,21 @@ async fn container_update_type_transport_error_returns_service_unavailable() {
             &self,
             ctx: &SecurityContext,
             code: &str,
-        ) -> Result<ResourceGroupType, ResourceGroupError> {
+        ) -> Result<ResourceGroupType, CanonicalError> {
             self.delegate.get_type(ctx, code).await
         }
         async fn create_type(
             &self,
             ctx: &SecurityContext,
             request: CreateTypeRequest,
-        ) -> Result<ResourceGroupType, ResourceGroupError> {
+        ) -> Result<ResourceGroupType, CanonicalError> {
             self.delegate.create_type(ctx, request).await
         }
         async fn list_types(
             &self,
             ctx: &SecurityContext,
             query: &ODataQuery,
-        ) -> Result<Page<ResourceGroupType>, ResourceGroupError> {
+        ) -> Result<Page<ResourceGroupType>, CanonicalError> {
             self.delegate.list_types(ctx, query).await
         }
         async fn update_type(
@@ -690,37 +694,35 @@ async fn container_update_type_transport_error_returns_service_unavailable() {
             _ctx: &SecurityContext,
             _code: &str,
             _request: UpdateTypeRequest,
-        ) -> Result<ResourceGroupType, ResourceGroupError> {
-            Err(ResourceGroupError::ServiceUnavailable {
-                message: "connection refused".to_owned(),
-            })
+        ) -> Result<ResourceGroupType, CanonicalError> {
+            Err(CanonicalError::internal("connection refused").create())
         }
         async fn delete_type(
             &self,
             ctx: &SecurityContext,
             code: &str,
-        ) -> Result<(), ResourceGroupError> {
+        ) -> Result<(), CanonicalError> {
             self.delegate.delete_type(ctx, code).await
         }
         async fn create_group(
             &self,
             ctx: &SecurityContext,
             request: CreateGroupRequest,
-        ) -> Result<ResourceGroup, ResourceGroupError> {
+        ) -> Result<ResourceGroup, CanonicalError> {
             self.delegate.create_group(ctx, request).await
         }
         async fn get_group(
             &self,
             ctx: &SecurityContext,
             id: Uuid,
-        ) -> Result<ResourceGroup, ResourceGroupError> {
+        ) -> Result<ResourceGroup, CanonicalError> {
             self.delegate.get_group(ctx, id).await
         }
         async fn list_groups(
             &self,
             ctx: &SecurityContext,
             query: &ODataQuery,
-        ) -> Result<Page<ResourceGroup>, ResourceGroupError> {
+        ) -> Result<Page<ResourceGroup>, CanonicalError> {
             self.delegate.list_groups(ctx, query).await
         }
         async fn update_group(
@@ -728,14 +730,14 @@ async fn container_update_type_transport_error_returns_service_unavailable() {
             ctx: &SecurityContext,
             id: Uuid,
             request: UpdateGroupRequest,
-        ) -> Result<ResourceGroup, ResourceGroupError> {
+        ) -> Result<ResourceGroup, CanonicalError> {
             self.delegate.update_group(ctx, id, request).await
         }
         async fn delete_group(
             &self,
             ctx: &SecurityContext,
             id: Uuid,
-        ) -> Result<(), ResourceGroupError> {
+        ) -> Result<(), CanonicalError> {
             self.delegate.delete_group(ctx, id).await
         }
         async fn get_group_descendants(
@@ -743,7 +745,7 @@ async fn container_update_type_transport_error_returns_service_unavailable() {
             ctx: &SecurityContext,
             id: Uuid,
             query: &ODataQuery,
-        ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+        ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError> {
             self.delegate.get_group_descendants(ctx, id, query).await
         }
         async fn get_group_ancestors(
@@ -751,7 +753,7 @@ async fn container_update_type_transport_error_returns_service_unavailable() {
             ctx: &SecurityContext,
             id: Uuid,
             query: &ODataQuery,
-        ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+        ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError> {
             self.delegate.get_group_ancestors(ctx, id, query).await
         }
         async fn add_membership(
@@ -760,7 +762,7 @@ async fn container_update_type_transport_error_returns_service_unavailable() {
             id: Uuid,
             ty: &str,
             rid: &str,
-        ) -> Result<ResourceGroupMembership, ResourceGroupError> {
+        ) -> Result<ResourceGroupMembership, CanonicalError> {
             self.delegate.add_membership(ctx, id, ty, rid).await
         }
         async fn remove_membership(
@@ -769,14 +771,14 @@ async fn container_update_type_transport_error_returns_service_unavailable() {
             id: Uuid,
             ty: &str,
             rid: &str,
-        ) -> Result<(), ResourceGroupError> {
+        ) -> Result<(), CanonicalError> {
             self.delegate.remove_membership(ctx, id, ty, rid).await
         }
         async fn list_memberships(
             &self,
             ctx: &SecurityContext,
             query: &ODataQuery,
-        ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError> {
+        ) -> Result<Page<ResourceGroupMembership>, CanonicalError> {
             self.delegate.list_memberships(ctx, query).await
         }
     }

--- a/gears/system/account-management/account-management/src/infra/rg/checker_tests.rs
+++ b/gears/system/account-management/account-management/src/infra/rg/checker_tests.rs
@@ -8,11 +8,11 @@
 
 use super::*;
 use resource_group_sdk::{
-    CreateGroupRequest, CreateTypeRequest, GroupHierarchy, ResourceGroup, ResourceGroupError,
-    ResourceGroupMembership, ResourceGroupType, ResourceGroupWithDepth, UpdateGroupRequest,
-    UpdateTypeRequest,
+    CreateGroupRequest, CreateTypeRequest, GroupHierarchy, ResourceGroup, ResourceGroupMembership,
+    ResourceGroupType, ResourceGroupWithDepth, UpdateGroupRequest, UpdateTypeRequest,
 };
 use std::sync::Mutex;
+use toolkit_canonical_errors::CanonicalError;
 use toolkit_odata::Page;
 
 #[allow(
@@ -86,21 +86,21 @@ impl ResourceGroupClient for FakeRgClient {
         &self,
         _ctx: &SecurityContext,
         _request: CreateTypeRequest,
-    ) -> Result<ResourceGroupType, ResourceGroupError> {
+    ) -> Result<ResourceGroupType, CanonicalError> {
         unreachable!("not used by RgResourceOwnershipChecker")
     }
     async fn get_type(
         &self,
         _ctx: &SecurityContext,
         _code: &str,
-    ) -> Result<ResourceGroupType, ResourceGroupError> {
+    ) -> Result<ResourceGroupType, CanonicalError> {
         unreachable!()
     }
     async fn list_types(
         &self,
         _ctx: &SecurityContext,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupType>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupType>, CanonicalError> {
         unreachable!()
     }
     async fn update_type(
@@ -108,35 +108,31 @@ impl ResourceGroupClient for FakeRgClient {
         _ctx: &SecurityContext,
         _code: &str,
         _request: UpdateTypeRequest,
-    ) -> Result<ResourceGroupType, ResourceGroupError> {
+    ) -> Result<ResourceGroupType, CanonicalError> {
         unreachable!()
     }
-    async fn delete_type(
-        &self,
-        _ctx: &SecurityContext,
-        _code: &str,
-    ) -> Result<(), ResourceGroupError> {
+    async fn delete_type(&self, _ctx: &SecurityContext, _code: &str) -> Result<(), CanonicalError> {
         unreachable!()
     }
     async fn create_group(
         &self,
         _ctx: &SecurityContext,
         _request: CreateGroupRequest,
-    ) -> Result<ResourceGroup, ResourceGroupError> {
+    ) -> Result<ResourceGroup, CanonicalError> {
         unreachable!()
     }
     async fn get_group(
         &self,
         _ctx: &SecurityContext,
         _id: Uuid,
-    ) -> Result<ResourceGroup, ResourceGroupError> {
+    ) -> Result<ResourceGroup, CanonicalError> {
         unreachable!()
     }
     async fn list_groups(
         &self,
         _ctx: &SecurityContext,
         query: &ODataQuery,
-    ) -> Result<Page<ResourceGroup>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroup>, CanonicalError> {
         *self.list_calls.lock().expect("lock") += 1;
         *self.last_filter.lock().expect("lock") = query.filter().cloned();
         let behaviour = self.behaviour.lock().expect("lock").clone();
@@ -150,9 +146,7 @@ impl ResourceGroupClient for FakeRgClient {
                     limit: 1,
                 },
             )),
-            FakeBehaviour::ListErr => {
-                Err(ResourceGroupError::service_unavailable("rg backend down"))
-            }
+            FakeBehaviour::ListErr => Err(CanonicalError::internal("rg backend down").create()),
             FakeBehaviour::ListDelay(delay) => {
                 tokio::time::sleep(delay).await;
                 Ok(Page::empty(1))
@@ -164,14 +158,10 @@ impl ResourceGroupClient for FakeRgClient {
         _ctx: &SecurityContext,
         _id: Uuid,
         _request: UpdateGroupRequest,
-    ) -> Result<ResourceGroup, ResourceGroupError> {
+    ) -> Result<ResourceGroup, CanonicalError> {
         unreachable!()
     }
-    async fn delete_group(
-        &self,
-        _ctx: &SecurityContext,
-        _id: Uuid,
-    ) -> Result<(), ResourceGroupError> {
+    async fn delete_group(&self, _ctx: &SecurityContext, _id: Uuid) -> Result<(), CanonicalError> {
         unreachable!()
     }
     async fn get_group_descendants(
@@ -179,7 +169,7 @@ impl ResourceGroupClient for FakeRgClient {
         _ctx: &SecurityContext,
         _group_id: Uuid,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError> {
         unreachable!()
     }
     async fn get_group_ancestors(
@@ -187,7 +177,7 @@ impl ResourceGroupClient for FakeRgClient {
         _ctx: &SecurityContext,
         _group_id: Uuid,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError> {
         unreachable!()
     }
     async fn add_membership(
@@ -196,7 +186,7 @@ impl ResourceGroupClient for FakeRgClient {
         _group_id: Uuid,
         _resource_type: &str,
         _resource_id: &str,
-    ) -> Result<ResourceGroupMembership, ResourceGroupError> {
+    ) -> Result<ResourceGroupMembership, CanonicalError> {
         unreachable!()
     }
     async fn remove_membership(
@@ -205,14 +195,14 @@ impl ResourceGroupClient for FakeRgClient {
         _group_id: Uuid,
         _resource_type: &str,
         _resource_id: &str,
-    ) -> Result<(), ResourceGroupError> {
+    ) -> Result<(), CanonicalError> {
         unreachable!()
     }
     async fn list_memberships(
         &self,
         _ctx: &SecurityContext,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupMembership>, CanonicalError> {
         unreachable!("not used by RgResourceOwnershipChecker")
     }
 }

--- a/gears/system/account-management/account-management/src/infra/rg/test_helpers.rs
+++ b/gears/system/account-management/account-management/src/infra/rg/test_helpers.rs
@@ -14,10 +14,11 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use resource_group_sdk::{
-    CreateGroupRequest, CreateTypeRequest, ResourceGroup, ResourceGroupClient, ResourceGroupError,
+    CreateGroupRequest, CreateTypeRequest, ResourceGroup, ResourceGroupClient,
     ResourceGroupMembership, ResourceGroupType, ResourceGroupWithDepth, UpdateGroupRequest,
     UpdateTypeRequest,
 };
+use toolkit_canonical_errors::CanonicalError;
 use toolkit_odata::{ODataQuery, Page};
 use toolkit_security::SecurityContext;
 use uuid::Uuid;
@@ -44,21 +45,21 @@ impl ResourceGroupClient for SlowRgClient {
         &self,
         _ctx: &SecurityContext,
         _request: CreateTypeRequest,
-    ) -> Result<ResourceGroupType, ResourceGroupError> {
+    ) -> Result<ResourceGroupType, CanonicalError> {
         unreachable!()
     }
     async fn get_type(
         &self,
         _ctx: &SecurityContext,
         _code: &str,
-    ) -> Result<ResourceGroupType, ResourceGroupError> {
+    ) -> Result<ResourceGroupType, CanonicalError> {
         unreachable!()
     }
     async fn list_types(
         &self,
         _ctx: &SecurityContext,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupType>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupType>, CanonicalError> {
         unreachable!()
     }
     async fn update_type(
@@ -66,35 +67,31 @@ impl ResourceGroupClient for SlowRgClient {
         _ctx: &SecurityContext,
         _code: &str,
         _request: UpdateTypeRequest,
-    ) -> Result<ResourceGroupType, ResourceGroupError> {
+    ) -> Result<ResourceGroupType, CanonicalError> {
         unreachable!()
     }
-    async fn delete_type(
-        &self,
-        _ctx: &SecurityContext,
-        _code: &str,
-    ) -> Result<(), ResourceGroupError> {
+    async fn delete_type(&self, _ctx: &SecurityContext, _code: &str) -> Result<(), CanonicalError> {
         unreachable!()
     }
     async fn create_group(
         &self,
         _ctx: &SecurityContext,
         _request: CreateGroupRequest,
-    ) -> Result<ResourceGroup, ResourceGroupError> {
+    ) -> Result<ResourceGroup, CanonicalError> {
         unreachable!()
     }
     async fn get_group(
         &self,
         _ctx: &SecurityContext,
         _id: Uuid,
-    ) -> Result<ResourceGroup, ResourceGroupError> {
+    ) -> Result<ResourceGroup, CanonicalError> {
         unreachable!()
     }
     async fn list_groups(
         &self,
         _ctx: &SecurityContext,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroup>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroup>, CanonicalError> {
         tokio::time::sleep(self.delay).await;
         Ok(Page::empty(1))
     }
@@ -103,14 +100,10 @@ impl ResourceGroupClient for SlowRgClient {
         _ctx: &SecurityContext,
         _id: Uuid,
         _request: UpdateGroupRequest,
-    ) -> Result<ResourceGroup, ResourceGroupError> {
+    ) -> Result<ResourceGroup, CanonicalError> {
         unreachable!()
     }
-    async fn delete_group(
-        &self,
-        _ctx: &SecurityContext,
-        _id: Uuid,
-    ) -> Result<(), ResourceGroupError> {
+    async fn delete_group(&self, _ctx: &SecurityContext, _id: Uuid) -> Result<(), CanonicalError> {
         unreachable!()
     }
     async fn get_group_descendants(
@@ -118,7 +111,7 @@ impl ResourceGroupClient for SlowRgClient {
         _ctx: &SecurityContext,
         _group_id: Uuid,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError> {
         unreachable!()
     }
     async fn get_group_ancestors(
@@ -126,7 +119,7 @@ impl ResourceGroupClient for SlowRgClient {
         _ctx: &SecurityContext,
         _group_id: Uuid,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError> {
         unreachable!()
     }
     async fn add_membership(
@@ -135,7 +128,7 @@ impl ResourceGroupClient for SlowRgClient {
         _group_id: Uuid,
         _resource_type: &str,
         _resource_id: &str,
-    ) -> Result<ResourceGroupMembership, ResourceGroupError> {
+    ) -> Result<ResourceGroupMembership, CanonicalError> {
         unreachable!()
     }
     async fn remove_membership(
@@ -144,14 +137,14 @@ impl ResourceGroupClient for SlowRgClient {
         _group_id: Uuid,
         _resource_type: &str,
         _resource_id: &str,
-    ) -> Result<(), ResourceGroupError> {
+    ) -> Result<(), CanonicalError> {
         unreachable!()
     }
     async fn list_memberships(
         &self,
         _ctx: &SecurityContext,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupMembership>, CanonicalError> {
         unreachable!()
     }
 }

--- a/gears/system/resource-group/resource-group-sdk/Cargo.toml
+++ b/gears/system/resource-group/resource-group-sdk/Cargo.toml
@@ -23,6 +23,14 @@ odata = [
 ]
 
 [dependencies]
+# Per ADR 0005 the trait boundary is `CanonicalError`; the SDK ships
+# `ResourceGroupError` as an opt-in `From<CanonicalError>` projection
+# (see src/error.rs). The single AIP-193 ladder
+# (`From<DomainError> for CanonicalError`) lives in the impl crate's
+# `api::rest::error`; this SDK depends on the canonical-errors crate to
+# project that envelope into the typed view.
+toolkit-canonical-errors = { workspace = true }
+
 # Core dependencies for API trait
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/gears/system/resource-group/resource-group-sdk/src/api.rs
+++ b/gears/system/resource-group/resource-group-sdk/src/api.rs
@@ -8,7 +8,8 @@ use toolkit_security::SecurityContext;
 use toolkit_odata::{ODataQuery, Page};
 use uuid::Uuid;
 
-use crate::error::ResourceGroupError;
+use toolkit_canonical_errors::CanonicalError;
+
 use crate::models::{
     CreateGroupRequest, CreateTypeRequest, ResourceGroup, ResourceGroupMembership,
     ResourceGroupType, ResourceGroupWithDepth, UpdateGroupRequest, UpdateTypeRequest,
@@ -21,6 +22,19 @@ use crate::models::{
 /// let client = hub.get::<dyn ResourceGroupClient>()?;
 /// let rg_type = client.get_type(&ctx, "gts.cf.core.rg.type.v1~...").await?;
 /// ```
+///
+/// # Error envelope
+///
+/// Per [ADR 0005][adr] every fallible method returns
+/// `Result<_, CanonicalError>`. The single authoritative AIP-193 ladder
+/// (`From<DomainError> for CanonicalError`) lives in the impl crate's
+/// `api::rest::error`; this trait surfaces that envelope unchanged.
+/// Consumers may propagate it, or opt into the typed
+/// [`ResourceGroupError`](crate::ResourceGroupError) projection
+/// (`From<CanonicalError>`) for flat dispatch — see its gear docs for
+/// the dispatch table and the three integration patterns.
+///
+/// [adr]: https://github.com/constructorfabric/gears-rust/blob/main/docs/arch/errors/ADR/0005-cpt-cf-adr-sdk-canonical-projection.md
 #[async_trait]
 pub trait ResourceGroupClient: Send + Sync {
     // -- Type lifecycle --
@@ -30,21 +44,21 @@ pub trait ResourceGroupClient: Send + Sync {
         &self,
         ctx: &SecurityContext,
         request: CreateTypeRequest,
-    ) -> Result<ResourceGroupType, ResourceGroupError>;
+    ) -> Result<ResourceGroupType, CanonicalError>;
 
     /// Get a GTS type definition by its code (GTS type path).
     async fn get_type(
         &self,
         ctx: &SecurityContext,
         code: &str,
-    ) -> Result<ResourceGroupType, ResourceGroupError>;
+    ) -> Result<ResourceGroupType, CanonicalError>;
 
     /// List GTS type definitions with `OData` filtering and cursor-based pagination.
     async fn list_types(
         &self,
         ctx: &SecurityContext,
         query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupType>, ResourceGroupError>;
+    ) -> Result<Page<ResourceGroupType>, CanonicalError>;
 
     /// Update a GTS type definition (full replacement).
     async fn update_type(
@@ -52,14 +66,10 @@ pub trait ResourceGroupClient: Send + Sync {
         ctx: &SecurityContext,
         code: &str,
         request: UpdateTypeRequest,
-    ) -> Result<ResourceGroupType, ResourceGroupError>;
+    ) -> Result<ResourceGroupType, CanonicalError>;
 
     /// Delete a GTS type definition. Fails if groups of this type exist.
-    async fn delete_type(
-        &self,
-        ctx: &SecurityContext,
-        code: &str,
-    ) -> Result<(), ResourceGroupError>;
+    async fn delete_type(&self, ctx: &SecurityContext, code: &str) -> Result<(), CanonicalError>;
 
     // -- Group lifecycle --
 
@@ -68,21 +78,21 @@ pub trait ResourceGroupClient: Send + Sync {
         &self,
         ctx: &SecurityContext,
         request: CreateGroupRequest,
-    ) -> Result<ResourceGroup, ResourceGroupError>;
+    ) -> Result<ResourceGroup, CanonicalError>;
 
     /// Get a resource group by ID.
     async fn get_group(
         &self,
         ctx: &SecurityContext,
         id: Uuid,
-    ) -> Result<ResourceGroup, ResourceGroupError>;
+    ) -> Result<ResourceGroup, CanonicalError>;
 
     /// List resource groups with `OData` filtering and cursor-based pagination.
     async fn list_groups(
         &self,
         ctx: &SecurityContext,
         query: &ODataQuery,
-    ) -> Result<Page<ResourceGroup>, ResourceGroupError>;
+    ) -> Result<Page<ResourceGroup>, CanonicalError>;
 
     /// Update a resource group (full replacement).
     async fn update_group(
@@ -90,15 +100,15 @@ pub trait ResourceGroupClient: Send + Sync {
         ctx: &SecurityContext,
         id: Uuid,
         request: UpdateGroupRequest,
-    ) -> Result<ResourceGroup, ResourceGroupError>;
+    ) -> Result<ResourceGroup, CanonicalError>;
 
     /// Delete a resource group (non-cascade).
     ///
-    /// The call fails with `ConflictActiveReferences` if the group has child
+    /// The call fails with `FailedPrecondition` (`Subject::ActiveReferences`)
+    /// if the group has child
     /// groups or active memberships. For force-cascade behaviour use
     /// [`Self::delete_group_cascade`].
-    async fn delete_group(&self, ctx: &SecurityContext, id: Uuid)
-    -> Result<(), ResourceGroupError>;
+    async fn delete_group(&self, ctx: &SecurityContext, id: Uuid) -> Result<(), CanonicalError>;
 
     /// Force-delete a resource group, cascading into the entire subtree:
     /// every descendant group, every membership row for those groups, and
@@ -109,21 +119,21 @@ pub trait ResourceGroupClient: Send + Sync {
     /// tenant-hard-delete cascade hook that tears down all user-group
     /// state for a tenant before the `tenants` row is removed. Most
     /// consumers want [`Self::delete_group`] (the non-cascade variant)
-    /// and surface `ConflictActiveReferences` to the caller as 409.
+    /// and surface `FailedPrecondition` (`Subject::ActiveReferences`) to the caller as 409.
     ///
     /// Default impl delegates to the non-cascade variant so existing
     /// implementers (production `RgService`, test fakes) compile without
     /// breakage; implementations that genuinely support cascade SHOULD
     /// override this to call into their REST-side `force=true` path.
     /// Implementations that cannot cascade (e.g. inert test fakes) are
-    /// expected to return `ConflictActiveReferences` from the default
+    /// expected to return `FailedPrecondition` (`Subject::ActiveReferences`) from the default
     /// fallback when the group has children / memberships, mirroring the
     /// non-cascade contract.
     async fn delete_group_cascade(
         &self,
         ctx: &SecurityContext,
         id: Uuid,
-    ) -> Result<(), ResourceGroupError> {
+    ) -> Result<(), CanonicalError> {
         self.delete_group(ctx, id).await
     }
 
@@ -133,7 +143,7 @@ pub trait ResourceGroupClient: Send + Sync {
         ctx: &SecurityContext,
         group_id: Uuid,
         query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError>;
+    ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError>;
 
     /// Get ancestors of a reference group (depth <= 0).
     async fn get_group_ancestors(
@@ -141,7 +151,7 @@ pub trait ResourceGroupClient: Send + Sync {
         ctx: &SecurityContext,
         group_id: Uuid,
         query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError>;
+    ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError>;
 
     // -- Membership lifecycle --
 
@@ -152,7 +162,7 @@ pub trait ResourceGroupClient: Send + Sync {
         group_id: Uuid,
         resource_type: &str,
         resource_id: &str,
-    ) -> Result<ResourceGroupMembership, ResourceGroupError>;
+    ) -> Result<ResourceGroupMembership, CanonicalError>;
 
     /// Remove a membership link.
     async fn remove_membership(
@@ -161,14 +171,14 @@ pub trait ResourceGroupClient: Send + Sync {
         group_id: Uuid,
         resource_type: &str,
         resource_id: &str,
-    ) -> Result<(), ResourceGroupError>;
+    ) -> Result<(), CanonicalError>;
 
     /// List memberships with `OData` filtering and cursor-based pagination.
     async fn list_memberships(
         &self,
         ctx: &SecurityContext,
         query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError>;
+    ) -> Result<Page<ResourceGroupMembership>, CanonicalError>;
 }
 
 // @cpt-dod:cpt-cf-resource-group-dod-integration-auth-read-service:p1
@@ -193,6 +203,14 @@ pub trait ResourceGroupClient: Send + Sync {
 /// PDP and recurse. Implementations therefore resolve them unscoped (no tenant
 /// `AccessScope`); the caller supplies any subject/tenant `OData` filter and
 /// owns tenant scoping.
+///
+/// # Error envelope
+///
+/// Like [`ResourceGroupClient`], every fallible method returns
+/// `Result<_, CanonicalError>` per [ADR 0005]; consumers may project it
+/// into the typed [`ResourceGroupError`](crate::ResourceGroupError) view.
+///
+/// [ADR 0005]: https://github.com/constructorfabric/gears-rust/blob/main/docs/arch/errors/ADR/0005-cpt-cf-adr-sdk-canonical-projection.md
 #[async_trait]
 pub trait ResourceGroupReadHierarchy: Send + Sync {
     /// Get descendants of a reference group (depth >= 0).
@@ -201,7 +219,7 @@ pub trait ResourceGroupReadHierarchy: Send + Sync {
         ctx: &SecurityContext,
         group_id: Uuid,
         query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError>;
+    ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError>;
 
     /// Get ancestors of a reference group (depth <= 0).
     async fn get_group_ancestors(
@@ -209,7 +227,7 @@ pub trait ResourceGroupReadHierarchy: Send + Sync {
         ctx: &SecurityContext,
         group_id: Uuid,
         query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError>;
+    ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError>;
 
     /// List resource groups with `OData` filtering and cursor-based pagination.
     ///
@@ -221,7 +239,7 @@ pub trait ResourceGroupReadHierarchy: Send + Sync {
         &self,
         ctx: &SecurityContext,
         query: &ODataQuery,
-    ) -> Result<Page<ResourceGroup>, ResourceGroupError>;
+    ) -> Result<Page<ResourceGroup>, CanonicalError>;
 
     /// Get a single resource group by ID (existence + tenant-ownership check).
     ///
@@ -232,7 +250,7 @@ pub trait ResourceGroupReadHierarchy: Send + Sync {
         &self,
         ctx: &SecurityContext,
         id: Uuid,
-    ) -> Result<ResourceGroup, ResourceGroupError>;
+    ) -> Result<ResourceGroup, CanonicalError>;
 
     /// List memberships with `OData` filtering and cursor-based pagination.
     ///
@@ -243,5 +261,5 @@ pub trait ResourceGroupReadHierarchy: Send + Sync {
         &self,
         ctx: &SecurityContext,
         query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError>;
+    ) -> Result<Page<ResourceGroupMembership>, CanonicalError>;
 }

--- a/gears/system/resource-group/resource-group-sdk/src/error.rs
+++ b/gears/system/resource-group/resource-group-sdk/src/error.rs
@@ -1,158 +1,302 @@
 // Created: 2026-04-16 by Constructor Tech
 // @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-sdk-errors:p1
-//! Public error types for the resource-group gear.
+//! Resource Group SDK error surface — typed projection of
+//! [`CanonicalError`].
 //!
-//! These errors are safe to expose to other gears and consumers.
+//! # Opt-in convenience, not the contract
+//!
+//! Per [ADR 0005][adr] the [`ResourceGroupClient`] /
+//! [`ResourceGroupReadHierarchy`] trait boundaries are
+//! `Result<_, CanonicalError>`. [`ResourceGroupError`] is an **opt-in**
+//! typed view over that envelope, shipped for consumers that want flat
+//! dispatch on the categories resource-group emits. It is *not* part of
+//! the trait contract: adding a variant is non-breaking, and the single
+//! authoritative AIP-193 classification lives in the impl crate's one
+//! `From<DomainError> for CanonicalError` ladder (`api::rest::error`) —
+//! this projection only reads the finished `CanonicalError`.
+//!
+//! The conversion is infallible (`From<CanonicalError>`). Canonical
+//! categories resource-group does not emit fall through to
+//! [`ResourceGroupError::Other`], which preserves the full
+//! [`CanonicalError`] for inspection / forward-compatible dispatch on the
+//! inner variant.
+//!
+//! **Malformed envelopes also fall through to [`ResourceGroupError::Other`].**
+//! The in-process builder's type-state guarantees a well-formed envelope
+//! (a resource-scoped category always carries `resource_type`; a
+//! `FailedPrecondition` always carries ≥1 violation), but the documented
+//! wire path (`Problem JSON → CanonicalError`) does not re-validate. So a
+//! `NotFound`/`AlreadyExists` missing `resource_type`, or a
+//! `FailedPrecondition` with an empty violation list, projects to `Other`
+//! rather than to a typed variant with empty fields — a missing dispatch
+//! key surfaces as "unmodeled" instead of silently mis-dispatching.
+//!
+//! # What resource-group emits — consumer dispatch reference
+//!
+//! | Disposition | Match arm | HTTP |
+//! |---|---|---|
+//! | type / group / membership missing | [`ResourceGroupError::NotFound`] | 404 |
+//! | duplicate-on-create (type, membership, tenant root) | [`ResourceGroupError::AlreadyExists`] | 409 |
+//! | request-shape validation (inspect `reason` against [`field`]) | [`ResourceGroupError::InvalidArgument`] | 400 |
+//! | state precondition — inspect [`precondition::Subject`] | [`ResourceGroupError::FailedPrecondition`] | 400 |
+//! | generic concurrency / state conflict — inspect `reason` ([`reason::aborted`]) | [`ResourceGroupError::Aborted`] | 409 |
+//! | PDP denial — inspect `reason` ([`reason::permission`]) | [`ResourceGroupError::PermissionDenied`] | 403 |
+//! | internal error (DB / infra) | [`ResourceGroupError::Internal`] | 500 |
+//! | anything else (forward-compat) | [`ResourceGroupError::Other`] | — |
+//!
+//! Resource-scoped variants ([`ResourceGroupError::NotFound`] /
+//! [`ResourceGroupError::AlreadyExists`]) carry the raw `resource_type`;
+//! match it against [`crate::gts::GROUP_RESOURCE_TYPE`].
+//!
+//! [`FailedPrecondition`](ResourceGroupError::FailedPrecondition) flattens
+//! several domain families that share the canonical category; the
+//! discriminator is the typed [`precondition::Subject`] (e.g.
+//! `Subject::Hierarchy` ⇒ a detected cycle, `Subject::Limit` ⇒ a
+//! configured-limit violation), **not** the wire `type` (uniformly
+//! [`precondition::STATE_TYPE`]).
+//!
+//! # Consumer integration — three patterns
+//!
+//! **Pattern 1 — pure propagation (no projection):**
+//!
+//! ```ignore
+//! let group = rg_client.get_group(&ctx, id).await?; // ? propagates CanonicalError
+//! ```
+//!
+//! **Pattern 2 — explicit projection at the call site:**
+//!
+//! ```ignore
+//! use resource_group_sdk::{ResourceGroupError, precondition::Subject};
+//!
+//! let res = rg_client.create_group(&ctx, req).await
+//!     .map_err(ResourceGroupError::from);
+//! match res {
+//!     Err(ResourceGroupError::FailedPrecondition { subject: Subject::Hierarchy, .. }) =>
+//!         /* would create a cycle */,
+//!     Err(ResourceGroupError::NotFound { .. }) => /* parent gone */,
+//!     _ => /* … */,
+//! }
+//! ```
+//!
+//! **Pattern 3 — transparent chaining via `From<CanonicalError> for OwnError`:**
+//!
+//! ```ignore
+//! impl From<CanonicalError> for OwnConsumerError {
+//!     fn from(err: CanonicalError) -> Self {
+//!         ResourceGroupError::from(err).into() // route through the typed view
+//!     }
+//! }
+//! // then every call site stays plain `?`.
+//! ```
+//!
+//! Out-of-process consumers reconstruct the canonical error from the wire
+//! via `TryFrom<Problem> for CanonicalError` first, then project:
+//! `Problem JSON → Problem → CanonicalError → ResourceGroupError`.
+//!
+//! [`ResourceGroupClient`]: crate::ResourceGroupClient
+//! [`ResourceGroupReadHierarchy`]: crate::ResourceGroupReadHierarchy
+//! [adr]: https://github.com/constructorfabric/gears-rust/blob/main/docs/arch/errors/ADR/0005-cpt-cf-adr-sdk-canonical-projection.md
 
 use thiserror::Error;
+use toolkit_canonical_errors::{CanonicalError, InvalidArgument};
 
-/// Errors that can be returned by the `ResourceGroupClient`.
+use crate::precondition::Subject;
+
+/// Typed projection of [`CanonicalError`] for Resource Group consumers.
+///
+/// The impl crate's `From<DomainError> for CanonicalError` is the single
+/// authoritative AIP-193 mapping; this enum is a forward-compatible, flat
+/// view over the seven categories resource-group emits, plus the
+/// mandatory catch-all [`Self::Other`]. See the [gear docs](self) for
+/// the dispatch table and consumer patterns.
 #[derive(Error, Debug, Clone)]
 pub enum ResourceGroupError {
-    /// Resource with the specified identifier was not found.
-    #[error("Resource not found: {code}")]
-    NotFound { code: String },
+    /// Resource not found (type, group, or membership). `resource_type`
+    /// is the canonical GTS type — match it against
+    /// [`crate::gts::GROUP_RESOURCE_TYPE`]; `name` is the raw identifier
+    /// the caller supplied.
+    #[error("not found [{resource_type}]: {name}")]
+    NotFound {
+        resource_type: String,
+        name: String,
+        detail: String,
+    },
 
-    /// A resource with the specified code already exists.
-    #[error("Resource already exists: {code}")]
-    TypeAlreadyExists { code: String },
+    /// Duplicate-on-create conflict (type code clash, duplicate
+    /// membership, second tenant-type root).
+    #[error("already exists [{resource_type}]: {name}")]
+    AlreadyExists {
+        resource_type: String,
+        name: String,
+        detail: String,
+    },
 
-    /// Validation error with the provided data.
-    #[error("Validation error: {message}")]
-    Validation { message: String },
+    /// Request-shape validation failure. `reason` is the wire reason code
+    /// (match against [`field::INVALID_PARENT_TYPE`](crate::field::INVALID_PARENT_TYPE);
+    /// empty for the generic `Format` validation shape); `field` is the
+    /// attributed request field, if any.
+    #[error("invalid argument [{field}/{reason}]: {detail}")]
+    InvalidArgument {
+        field: String,
+        reason: String,
+        detail: String,
+    },
 
-    /// Removing allowed parents or disabling root placement would break
-    /// existing group hierarchy relationships.
-    #[error("Allowed parents violation: {message}")]
-    AllowedParentTypesViolation { message: String },
+    /// State precondition violation. `subject` is the typed
+    /// [`precondition::Subject`](crate::precondition::Subject) consumers
+    /// dispatch on (e.g. `Subject::Hierarchy` ⇒ cycle, `Subject::Limit` ⇒
+    /// limit-violation); `type_` is the uniform wire token
+    /// ([`precondition::STATE_TYPE`](crate::precondition::STATE_TYPE)).
+    #[error("failed precondition [{subject}/{type_}]: {detail}")]
+    FailedPrecondition {
+        subject: Subject,
+        type_: String,
+        detail: String,
+    },
 
-    /// Cannot delete a type because groups of this type still exist.
-    #[error("Active references exist: {message}")]
-    ConflictActiveReferences { message: String },
+    /// Generic concurrency / state conflict (HTTP 409). `reason` is the
+    /// [`reason::aborted::CONFLICT`](crate::reason::aborted::CONFLICT)
+    /// constant.
+    #[error("aborted [{reason}]: {detail}")]
+    Aborted { reason: String, detail: String },
 
-    /// A generic conflict (e.g. a concurrency or state conflict not related to references).
-    #[error("Conflict: {message}")]
-    Conflict { message: String },
+    /// Authorization denial (HTTP 403). `reason` is the
+    /// [`reason::permission::ACCESS_DENIED`](crate::reason::permission::ACCESS_DENIED)
+    /// constant.
+    #[error("permission denied [{reason}]: {detail}")]
+    PermissionDenied { reason: String, detail: String },
 
-    /// Parent type is not allowed by the type's `allowed_parent_types` configuration.
-    #[error("Invalid parent type: {message}")]
-    InvalidParentType { message: String },
+    /// Unclassified internal failure (HTTP 500). `detail` is already
+    /// redacted at the canonical boundary — it never carries the
+    /// server-side diagnostic.
+    #[error("internal error: {detail}")]
+    Internal { detail: String },
 
-    /// A cycle would be created in the group hierarchy.
-    #[error("Cycle detected: {message}")]
-    CycleDetected { message: String },
-
-    /// A configured limit (depth, width, etc.) would be exceeded.
-    #[error("Limit violation: {message}")]
-    LimitViolation { message: String },
-
-    /// Cross-tenant link would be created.
-    ///
-    /// Each resource (identified by the pair `(resource_type, resource_id)`)
-    /// belongs to groups in exactly one tenant. Returned by
-    /// `ResourceGroupClient::add_membership` when the target group's tenant
-    /// differs from the tenant of any existing membership for the same
-    /// resource. The resource continues to exist — only the cross-tenant link
-    /// is rejected.
-    #[error("Tenant incompatibility: {message}")]
-    TenantIncompatibility { message: String },
-
-    /// Service is temporarily unavailable.
-    #[error("Service unavailable: {message}")]
-    ServiceUnavailable { message: String },
-
-    /// Access was denied by the authorization policy (PDP denial).
-    #[error("Access denied")]
-    AccessDenied,
-
-    /// An internal error occurred.
-    #[error("Internal error")]
-    Internal,
+    /// Catch-all for canonical categories resource-group does not model —
+    /// preserves the full [`CanonicalError`] so consumers stay
+    /// forward-compatible if the impl crate ever emits a new category.
+    #[error("[{}] {}", canonical.gts_type(), canonical.detail())]
+    Other { canonical: CanonicalError },
 }
 
-impl ResourceGroupError {
-    /// Create a `NotFound` error.
-    pub fn not_found(code: impl Into<String>) -> Self {
-        Self::NotFound { code: code.into() }
-    }
+// ─────────────────────────────────────────────────────────────────────
+// CanonicalError → ResourceGroupError projection.
+//
+// The typed sub-enum (`precondition::Subject`) lives next to its
+// wire-string constants in `crate::precondition`; the single-valued
+// reasons stay plain consts in `crate::field` / `crate::reason`. This
+// file owns only the top-level enum and the dispatch from
+// `CanonicalError`.
+// ─────────────────────────────────────────────────────────────────────
 
-    /// Create a `TypeAlreadyExists` error.
-    pub fn type_already_exists(code: impl Into<String>) -> Self {
-        Self::TypeAlreadyExists { code: code.into() }
-    }
+impl From<CanonicalError> for ResourceGroupError {
+    fn from(err: CanonicalError) -> Self {
+        // Borrow the canonical detail before consuming `err`; the borrow
+        // ends here so each arm below can move its fields out (no clones).
+        let detail = err.detail().to_owned();
+        match err {
+            // A resource-scoped category MUST carry its `resource_type`
+            // (the dispatch key consumers match against
+            // `gts::GROUP_RESOURCE_TYPE`). Resource-group always sets it;
+            // a `None` here means a malformed / foreign envelope reached us
+            // via the wire path, so we let it fall through to `Other`
+            // rather than forge a `NotFound { resource_type: "" }` that
+            // would silently mis-dispatch.
+            CanonicalError::NotFound {
+                resource_type: Some(resource_type),
+                resource_name,
+                ..
+            } => Self::NotFound {
+                resource_type,
+                name: resource_name.unwrap_or_default(),
+                detail,
+            },
 
-    /// Create a `Validation` error.
-    pub fn validation(message: impl Into<String>) -> Self {
-        Self::Validation {
-            message: message.into(),
+            CanonicalError::AlreadyExists {
+                resource_type: Some(resource_type),
+                resource_name,
+                ..
+            } => Self::AlreadyExists {
+                resource_type,
+                name: resource_name.unwrap_or_default(),
+                detail,
+            },
+
+            CanonicalError::InvalidArgument { ctx, .. } => project_invalid_argument(ctx, detail),
+
+            // Resource-group emits exactly one PreconditionViolation per
+            // FailedPrecondition error; the meaningful message lives in
+            // the violation `description`, so surface it as `detail`. An
+            // empty violation list is a malformed / foreign envelope (the
+            // builder's type-state forbids it in-process) — the guard lets
+            // it fall through to `Other` rather than forge a
+            // `FailedPrecondition` with empty `subject`/`type_` that would
+            // look like a real domain precondition.
+            CanonicalError::FailedPrecondition { ctx, .. } if !ctx.violations.is_empty() => {
+                ctx.violations.into_iter().next().map_or_else(
+                    // Unreachable: the guard rejects empty violation lists.
+                    // Kept as a total, non-panicking fallback so the
+                    // conversion stays infallible.
+                    || Self::Internal { detail },
+                    |v| Self::FailedPrecondition {
+                        subject: Subject::from_wire(&v.subject),
+                        type_: v.type_,
+                        detail: v.description,
+                    },
+                )
+            }
+
+            CanonicalError::Aborted { ctx, .. } => Self::Aborted {
+                reason: ctx.reason,
+                detail,
+            },
+
+            CanonicalError::PermissionDenied { ctx, .. } => Self::PermissionDenied {
+                reason: ctx.reason,
+                detail,
+            },
+
+            CanonicalError::Internal { .. } => Self::Internal { detail },
+
+            other => Self::Other { canonical: other },
         }
-    }
-
-    /// Create an `AllowedParentTypesViolation` error.
-    pub fn allowed_parent_types_violation(message: impl Into<String>) -> Self {
-        Self::AllowedParentTypesViolation {
-            message: message.into(),
-        }
-    }
-
-    /// Create a `ConflictActiveReferences` error.
-    pub fn conflict_active_references(message: impl Into<String>) -> Self {
-        Self::ConflictActiveReferences {
-            message: message.into(),
-        }
-    }
-
-    /// Create a generic `Conflict` error.
-    pub fn conflict(message: impl Into<String>) -> Self {
-        Self::Conflict {
-            message: message.into(),
-        }
-    }
-
-    /// Create an `InvalidParentType` error.
-    pub fn invalid_parent_type(message: impl Into<String>) -> Self {
-        Self::InvalidParentType {
-            message: message.into(),
-        }
-    }
-
-    /// Create a `CycleDetected` error.
-    pub fn cycle_detected(message: impl Into<String>) -> Self {
-        Self::CycleDetected {
-            message: message.into(),
-        }
-    }
-
-    /// Create a `LimitViolation` error.
-    pub fn limit_violation(message: impl Into<String>) -> Self {
-        Self::LimitViolation {
-            message: message.into(),
-        }
-    }
-
-    /// Create a `TenantIncompatibility` error.
-    pub fn tenant_incompatibility(message: impl Into<String>) -> Self {
-        Self::TenantIncompatibility {
-            message: message.into(),
-        }
-    }
-
-    /// Create a `ServiceUnavailable` error.
-    pub fn service_unavailable(message: impl Into<String>) -> Self {
-        Self::ServiceUnavailable {
-            message: message.into(),
-        }
-    }
-
-    /// Create an `AccessDenied` error.
-    #[must_use]
-    pub fn access_denied() -> Self {
-        Self::AccessDenied
-    }
-
-    /// Create an `Internal` error.
-    #[must_use]
-    pub fn internal() -> Self {
-        Self::Internal
     }
 }
+
+fn project_invalid_argument(ctx: InvalidArgument, detail: String) -> ResourceGroupError {
+    // Resource-group emits two `InvalidArgument` shapes today: a single
+    // `FieldViolations` (parent-type rejects) and a `Format` (generic
+    // validation). `Constraint` carries a constraint identifier rather than
+    // a field, so it projects with an empty `field` and the constraint name
+    // in `reason`; the empty case falls back to the canonical detail.
+    match ctx {
+        InvalidArgument::FieldViolations { field_violations } => {
+            field_violations.into_iter().next().map_or_else(
+                || ResourceGroupError::InvalidArgument {
+                    field: String::new(),
+                    reason: String::new(),
+                    detail,
+                },
+                |v| ResourceGroupError::InvalidArgument {
+                    field: v.field,
+                    reason: v.reason,
+                    detail: v.description,
+                },
+            )
+        }
+        InvalidArgument::Constraint { constraint } => ResourceGroupError::InvalidArgument {
+            field: String::new(),
+            reason: constraint,
+            detail,
+        },
+        InvalidArgument::Format { .. } => ResourceGroupError::InvalidArgument {
+            field: String::new(),
+            reason: String::new(),
+            detail,
+        },
+    }
+}
+
+#[cfg(test)]
+#[path = "error_tests.rs"]
+mod error_tests;

--- a/gears/system/resource-group/resource-group-sdk/src/error_tests.rs
+++ b/gears/system/resource-group/resource-group-sdk/src/error_tests.rs
@@ -1,0 +1,411 @@
+//! Tests for the [`ResourceGroupError`] projection.
+//!
+//! Two suites:
+//!
+//! * `wire_vocabulary_round_trip` — pins every wire-string constant the
+//!   projection introduces ([`crate::field`], [`crate::precondition`],
+//!   [`crate::reason`], [`crate::gts`]) to its `Problem` JSON path. A
+//!   drift between an SDK constant and the wire trips here.
+//! * `projection_tests` — exercises `From<CanonicalError>`, verifying
+//!   each canonical category lands on the expected typed variant and that
+//!   unmodeled categories preserve the canonical in `Other`.
+
+use super::ResourceGroupError;
+
+// ─────────────────────────────────────────────────────────────────────
+// Wire-vocabulary round-trip
+// ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod wire_vocabulary_round_trip {
+    use crate::{field, gts, precondition, reason};
+    use toolkit_canonical_errors::{CanonicalError, Problem, resource_error};
+
+    // Test scope mirroring the impl crate's `#[resource_error]` marker.
+    // Its literal MUST equal `gts::GROUP_RESOURCE_TYPE` — the
+    // `gts_resource_type_round_trip` test asserts that equality (the
+    // proc-macro cannot reference the const directly).
+    #[resource_error("gts.cf.core.resource_group.group.v1~")]
+    struct RgScope;
+
+    fn problem(err: CanonicalError) -> serde_json::Value {
+        serde_json::to_value(Problem::from(err)).expect("Problem serializes")
+    }
+
+    #[test]
+    fn gts_resource_type_round_trips_to_context_resource_type() {
+        let err = RgScope::not_found("x").with_resource("x").create();
+        let json = problem(err);
+        assert_eq!(
+            json["context"]["resource_type"],
+            gts::GROUP_RESOURCE_TYPE,
+            "resource type must round-trip into context.resource_type",
+        );
+    }
+
+    #[test]
+    fn field_reason_constant_round_trips_to_field_violations() {
+        let err = RgScope::invalid_argument()
+            .with_field_violation(
+                field::PARENT_TYPE_FIELD,
+                "bad parent",
+                field::INVALID_PARENT_TYPE,
+            )
+            .create();
+        let json = problem(err);
+        assert_eq!(
+            json["context"]["field_violations"][0]["reason"],
+            field::INVALID_PARENT_TYPE,
+            "field reason must round-trip into field_violations[].reason",
+        );
+        assert_eq!(
+            json["context"]["field_violations"][0]["field"],
+            field::PARENT_TYPE_FIELD,
+            "field name must round-trip into field_violations[].field",
+        );
+    }
+
+    #[test]
+    fn precondition_subject_constants_round_trip_to_violations() {
+        for subject in [
+            precondition::ALLOWED_PARENTS_SUBJECT,
+            precondition::HIERARCHY_SUBJECT,
+            precondition::ACTIVE_REFERENCES_SUBJECT,
+            precondition::LIMIT_SUBJECT,
+            precondition::TENANT_SUBJECT,
+        ] {
+            let err = RgScope::failed_precondition()
+                .with_precondition_violation(subject, "test description", precondition::STATE_TYPE)
+                .create();
+            let json = problem(err);
+            assert_eq!(
+                json["context"]["violations"][0]["subject"], subject,
+                "subject {subject} must round-trip into violations[].subject",
+            );
+        }
+    }
+
+    #[test]
+    fn precondition_type_constant_round_trips_to_violations() {
+        let err = RgScope::failed_precondition()
+            .with_precondition_violation(
+                precondition::HIERARCHY_SUBJECT,
+                "test description",
+                precondition::STATE_TYPE,
+            )
+            .create();
+        let json = problem(err);
+        assert_eq!(
+            json["context"]["violations"][0]["type"],
+            precondition::STATE_TYPE,
+            "type must round-trip into violations[].type",
+        );
+    }
+
+    #[test]
+    fn aborted_reason_constant_round_trips_to_context_reason() {
+        let err = RgScope::aborted("conflict")
+            .with_reason(reason::aborted::CONFLICT)
+            .create();
+        let json = problem(err);
+        assert_eq!(json["context"]["reason"], reason::aborted::CONFLICT);
+    }
+
+    #[test]
+    fn permission_reason_constant_round_trips_to_context_reason() {
+        let err = RgScope::permission_denied()
+            .with_reason(reason::permission::ACCESS_DENIED)
+            .create();
+        let json = problem(err);
+        assert_eq!(json["context"]["reason"], reason::permission::ACCESS_DENIED);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Projection: From<CanonicalError> for ResourceGroupError
+// ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod projection_tests {
+    use super::ResourceGroupError;
+    use crate::precondition::Subject;
+    use crate::{field, gts, precondition, reason};
+    use toolkit_canonical_errors::{CanonicalError, Problem, resource_error};
+
+    #[resource_error("gts.cf.core.resource_group.group.v1~")]
+    struct RgScope;
+
+    #[test]
+    fn not_found_projects_resource_type_and_name() {
+        let canonical = RgScope::not_found("group 7 not found")
+            .with_resource("7")
+            .create();
+        match ResourceGroupError::from(canonical) {
+            ResourceGroupError::NotFound {
+                resource_type,
+                name,
+                ..
+            } => {
+                assert_eq!(resource_type, gts::GROUP_RESOURCE_TYPE);
+                assert_eq!(name, "7");
+            }
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn already_exists_projects_resource_type_and_name() {
+        let canonical = RgScope::already_exists("type exists")
+            .with_resource("my.code")
+            .create();
+        match ResourceGroupError::from(canonical) {
+            ResourceGroupError::AlreadyExists {
+                resource_type,
+                name,
+                ..
+            } => {
+                assert_eq!(resource_type, gts::GROUP_RESOURCE_TYPE);
+                assert_eq!(name, "my.code");
+            }
+            other => panic!("expected AlreadyExists, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn invalid_argument_field_violation_projects_field_and_reason() {
+        let canonical = RgScope::invalid_argument()
+            .with_field_violation(
+                field::PARENT_TYPE_FIELD,
+                "bad parent",
+                field::INVALID_PARENT_TYPE,
+            )
+            .create();
+        match ResourceGroupError::from(canonical) {
+            ResourceGroupError::InvalidArgument {
+                field,
+                reason,
+                detail,
+            } => {
+                assert_eq!(field, field::PARENT_TYPE_FIELD);
+                assert_eq!(reason, field::INVALID_PARENT_TYPE);
+                assert_eq!(detail, "bad parent");
+            }
+            other => panic!("expected InvalidArgument, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn invalid_argument_format_variant_projects_empty_field() {
+        let canonical = RgScope::invalid_argument()
+            .with_format("group name must be 1-63 chars")
+            .create();
+        match ResourceGroupError::from(canonical) {
+            ResourceGroupError::InvalidArgument { field, reason, .. } => {
+                assert!(field.is_empty());
+                assert!(reason.is_empty());
+            }
+            other => panic!("expected InvalidArgument, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn invalid_argument_constraint_variant_projects_constraint_into_reason() {
+        let canonical = RgScope::invalid_argument()
+            .with_constraint("parent_depth_limit")
+            .create();
+        match ResourceGroupError::from(canonical) {
+            ResourceGroupError::InvalidArgument {
+                field,
+                reason,
+                detail,
+            } => {
+                assert!(field.is_empty());
+                assert_eq!(reason, "parent_depth_limit");
+                assert!(!detail.is_empty());
+            }
+            other => panic!("expected InvalidArgument, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn failed_precondition_projects_typed_subject() {
+        let cases = [
+            (
+                precondition::ALLOWED_PARENTS_SUBJECT,
+                Subject::AllowedParents,
+            ),
+            (precondition::HIERARCHY_SUBJECT, Subject::Hierarchy),
+            (
+                precondition::ACTIVE_REFERENCES_SUBJECT,
+                Subject::ActiveReferences,
+            ),
+            (precondition::LIMIT_SUBJECT, Subject::Limit),
+            (precondition::TENANT_SUBJECT, Subject::Tenant),
+        ];
+        for (wire, expected) in cases {
+            let canonical = RgScope::failed_precondition()
+                .with_precondition_violation(wire, "guard message", precondition::STATE_TYPE)
+                .create();
+            match ResourceGroupError::from(canonical) {
+                ResourceGroupError::FailedPrecondition {
+                    subject,
+                    type_,
+                    detail,
+                } => {
+                    assert_eq!(subject, expected);
+                    assert_eq!(type_, precondition::STATE_TYPE);
+                    assert_eq!(detail, "guard message");
+                }
+                other => panic!("expected FailedPrecondition for {wire}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn aborted_projects_reason() {
+        let canonical = RgScope::aborted("write conflict")
+            .with_reason(reason::aborted::CONFLICT)
+            .create();
+        match ResourceGroupError::from(canonical) {
+            ResourceGroupError::Aborted { reason, detail } => {
+                assert_eq!(reason, reason::aborted::CONFLICT);
+                assert_eq!(detail, "write conflict");
+            }
+            other => panic!("expected Aborted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn permission_denied_projects_reason() {
+        let canonical = RgScope::permission_denied()
+            .with_reason(reason::permission::ACCESS_DENIED)
+            .create();
+        match ResourceGroupError::from(canonical) {
+            ResourceGroupError::PermissionDenied { reason, .. } => {
+                assert_eq!(reason, reason::permission::ACCESS_DENIED);
+            }
+            other => panic!("expected PermissionDenied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn internal_projects() {
+        let canonical = CanonicalError::internal("boom").create();
+        assert!(matches!(
+            ResourceGroupError::from(canonical),
+            ResourceGroupError::Internal { .. }
+        ));
+    }
+
+    #[test]
+    fn unmodeled_category_falls_through_to_other() {
+        // Resource-group never emits Unauthenticated; it must land in
+        // Other with the canonical preserved for inspection.
+        let canonical = CanonicalError::unauthenticated()
+            .with_reason("SOME_REASON")
+            .create();
+        match ResourceGroupError::from(canonical) {
+            ResourceGroupError::Other {
+                canonical: CanonicalError::Unauthenticated { .. },
+            } => {}
+            other => panic!("expected Other::Unauthenticated, got {other:?}"),
+        }
+    }
+
+    /// Reconstruct a `CanonicalError` from a `Problem` JSON after mutating
+    /// it, exercising the documented wire path the builder's type-state
+    /// cannot reach in-process.
+    fn canonical_from_mutated_problem(
+        canonical: CanonicalError,
+        mutate: impl FnOnce(&mut serde_json::Value),
+    ) -> CanonicalError {
+        let mut value = serde_json::to_value(Problem::from(canonical)).expect("Problem serializes");
+        mutate(&mut value);
+        let problem: Problem = serde_json::from_value(value).expect("Problem deserializes");
+        CanonicalError::try_from(problem).expect("reconstruct")
+    }
+
+    #[test]
+    fn not_found_without_resource_type_falls_through_to_other() {
+        // A malformed / foreign NotFound envelope (no resource_type) must
+        // NOT project to NotFound { resource_type: "" } — it would silently
+        // mis-dispatch consumers matching on gts::GROUP_RESOURCE_TYPE.
+        let canonical = RgScope::not_found("missing").with_resource("7").create();
+        let malformed = canonical_from_mutated_problem(canonical, |v| {
+            v["context"]
+                .as_object_mut()
+                .expect("context object")
+                .remove("resource_type");
+        });
+        match ResourceGroupError::from(malformed) {
+            ResourceGroupError::Other { .. } => {}
+            other => panic!("expected Other for resource_type-less NotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn already_exists_without_resource_type_falls_through_to_other() {
+        let canonical = RgScope::already_exists("dupe")
+            .with_resource("my.code")
+            .create();
+        let malformed = canonical_from_mutated_problem(canonical, |v| {
+            v["context"]
+                .as_object_mut()
+                .expect("context object")
+                .remove("resource_type");
+        });
+        match ResourceGroupError::from(malformed) {
+            ResourceGroupError::Other { .. } => {}
+            other => panic!("expected Other for resource_type-less AlreadyExists, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn failed_precondition_without_violations_falls_through_to_other() {
+        // An empty violation list is a malformed envelope; projecting it to
+        // FailedPrecondition with empty subject/type_ would masquerade as a
+        // real domain precondition.
+        let canonical = RgScope::failed_precondition()
+            .with_precondition_violation(
+                precondition::HIERARCHY_SUBJECT,
+                "would create a cycle",
+                precondition::STATE_TYPE,
+            )
+            .create();
+        let malformed = canonical_from_mutated_problem(canonical, |v| {
+            v["context"]["violations"] = serde_json::json!([]);
+        });
+        match ResourceGroupError::from(malformed) {
+            ResourceGroupError::Other { .. } => {}
+            other => panic!("expected Other for violation-less FailedPrecondition, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn projection_survives_full_problem_round_trip() {
+        // Out-of-process chain: canonical → Problem JSON → Problem →
+        // CanonicalError → ResourceGroupError. Pins that an HTTP consumer
+        // projecting from the wire gets the same typed variant as an
+        // in-process ClientHub caller — exercised on the cycle (hierarchy)
+        // dispatch the projection narrows.
+        let canonical = RgScope::failed_precondition()
+            .with_precondition_violation(
+                precondition::HIERARCHY_SUBJECT,
+                "would create a cycle",
+                precondition::STATE_TYPE,
+            )
+            .create();
+
+        let bytes = serde_json::to_vec(&Problem::from(canonical)).expect("serialize");
+        let restored: Problem = serde_json::from_slice(&bytes).expect("deserialize");
+        let restored_canonical = CanonicalError::try_from(restored).expect("reconstruct");
+
+        match ResourceGroupError::from(restored_canonical) {
+            ResourceGroupError::FailedPrecondition { subject, type_, .. } => {
+                assert_eq!(subject, Subject::Hierarchy);
+                assert_eq!(type_, precondition::STATE_TYPE);
+            }
+            other => panic!("expected FailedPrecondition after round-trip, got {other:?}"),
+        }
+    }
+}

--- a/gears/system/resource-group/resource-group-sdk/src/field.rs
+++ b/gears/system/resource-group/resource-group-sdk/src/field.rs
@@ -1,0 +1,38 @@
+//! Wire `field` / `reason` vocabulary for field violations under
+//! [`CanonicalError::InvalidArgument`].
+//!
+//! Resource-group emits exactly one field-violation `reason`
+//! ([`INVALID_PARENT_TYPE`]) on the [`crate::ResourceGroupError::InvalidArgument`]
+//! variant, attributed to the [`PARENT_TYPE_FIELD`] field. Because there
+//! is a single reason, it stays a **plain constant** with no typed
+//! sub-enum (ADR 0005: single-value reasons stay consts) — the
+//! projection surfaces `reason` as a raw `String` consumers match against
+//! this constant. The other `InvalidArgument` shape resource-group emits
+//! (generic `Validation`, mapped via `with_format`) carries no field
+//! attribution.
+//!
+//! The impl crate's single `From<DomainError> for CanonicalError` ladder
+//! references the same constants at construction time so the SDK
+//! vocabulary and the wire can never drift — the round-trip tests in
+//! [`crate::error`] pin every constant to its `Problem` JSON path.
+//!
+//! [`CanonicalError::InvalidArgument`]: toolkit_canonical_errors::CanonicalError::InvalidArgument
+
+// ---------------------------------------------------------------------------
+// `field_violations[].reason` code.
+// ---------------------------------------------------------------------------
+
+/// The requested parent type is not permitted by the type's
+/// `allowed_parent_types` configuration.
+pub const INVALID_PARENT_TYPE: &str = "INVALID_PARENT_TYPE";
+
+// ---------------------------------------------------------------------------
+// `field_violations[].field` attribution key.
+//
+// Identifies *which* request field failed. Extracted to a const
+// (ADR 0005 Rule 6) so the impl ladder and the SDK vocabulary cannot
+// drift; pinned by the round-trip tests.
+// ---------------------------------------------------------------------------
+
+/// `parent_type` reference field (carries [`INVALID_PARENT_TYPE`]).
+pub const PARENT_TYPE_FIELD: &str = "parent_type";

--- a/gears/system/resource-group/resource-group-sdk/src/gts.rs
+++ b/gears/system/resource-group/resource-group-sdk/src/gts.rs
@@ -51,6 +51,19 @@ pub struct ResourceGroupTypeV1 {
     pub allowed_membership_types: Vec<String>,
 }
 
+/// Canonical GTS resource type for a resource **group** as a resource.
+///
+/// Lands in `CanonicalError::{NotFound,AlreadyExists}.ctx.resource_type`
+/// for every group-attributable error and backs the impl crate's
+/// `#[resource_error("…")]` REST marker. The macro literal there cannot
+/// reference this const (proc-macros can't resolve consts), so the
+/// round-trip tests in [`crate::error`] assert the two stay equal.
+///
+/// Match it against the resource-scoped projection variants
+/// ([`crate::ResourceGroupError::NotFound`] /
+/// [`crate::ResourceGroupError::AlreadyExists`]).
+pub const GROUP_RESOURCE_TYPE: &str = "gts.cf.core.resource_group.group.v1~";
+
 /// GTS type path for the tenant resource-group type.
 ///
 /// Any RG type whose code **starts with** this path is considered a tenant

--- a/gears/system/resource-group/resource-group-sdk/src/lib.rs
+++ b/gears/system/resource-group/resource-group-sdk/src/lib.rs
@@ -3,18 +3,27 @@
 //! Resource Group SDK
 //!
 //! This crate provides the public API for the `resource-group` gear:
-//! - `ResourceGroupClient` trait
+//! - `ResourceGroupClient` / `ResourceGroupReadHierarchy` traits
+//!   (boundary returns [`toolkit_canonical_errors::CanonicalError`] per
+//!   [ADR 0005][adr])
 //! - Model types for GTS types, groups, memberships
-//! - Error type (`ResourceGroupError`)
+//! - [`ResourceGroupError`] — opt-in `From<CanonicalError>` projection
+//!   (see [`error`]) plus its co-located wire vocabulary ([`field`],
+//!   [`precondition`], [`reason`], [`gts`])
 //! - `OData` filter field definitions (behind `odata` feature)
+//!
+//! [adr]: https://github.com/constructorfabric/gears-rust/blob/main/docs/arch/errors/ADR/0005-cpt-cf-adr-sdk-canonical-projection.md
 
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
 
 pub mod api;
 pub mod error;
+pub mod field;
 pub mod gts;
 pub mod models;
+pub mod precondition;
+pub mod reason;
 
 // OData filter field definitions (feature-gated)
 #[cfg(feature = "odata")]
@@ -23,7 +32,7 @@ pub mod odata;
 // Re-export main types at crate root for convenience
 pub use api::{ResourceGroupClient, ResourceGroupReadHierarchy};
 pub use error::ResourceGroupError;
-pub use gts::TENANT_RG_TYPE_PATH;
+pub use gts::{GROUP_RESOURCE_TYPE, TENANT_RG_TYPE_PATH};
 pub use models::{
     CreateGroupRequest, CreateTypeRequest, GroupHierarchy, GroupHierarchyWithDepth, GtsTypePath,
     ResourceGroup, ResourceGroupMembership, ResourceGroupType, ResourceGroupWithDepth,

--- a/gears/system/resource-group/resource-group-sdk/src/precondition.rs
+++ b/gears/system/resource-group/resource-group-sdk/src/precondition.rs
@@ -1,0 +1,152 @@
+//! Wire `subject` / `type` vocabulary for precondition violations under
+//! [`CanonicalError::FailedPrecondition`].
+//!
+//! Each `*_SUBJECT` constant is the stable `subject` discriminator that
+//! lands in `CanonicalError::FailedPrecondition.ctx.violations[].subject`
+//! — the field consumers dispatch on. Resource-group emits several
+//! distinct precondition families that **all** share the
+//! `FailedPrecondition` category and the single `STATE` wire `type`
+//! ([`STATE_TYPE`]); the **subject** is therefore the discriminator, not
+//! the type. Two subjects carry domain meaning consumers care about:
+//!
+//! * [`Subject::Hierarchy`] (`"hierarchy"`) ⇒ the write would create a
+//!   **cycle** in the group hierarchy.
+//! * [`Subject::Limit`] (`"limit"`) ⇒ a configured **limit** (depth,
+//!   width, …) would be exceeded.
+//!
+//! The impl crate's single `From<DomainError> for CanonicalError` ladder
+//! references these constants; the round-trip tests in [`crate::error`]
+//! pin each to its `Problem` JSON path.
+//!
+//! [`CanonicalError::FailedPrecondition`]: toolkit_canonical_errors::CanonicalError::FailedPrecondition
+
+use core::fmt;
+
+// ---------------------------------------------------------------------------
+// `violations[].subject` discriminators.
+// ---------------------------------------------------------------------------
+
+/// Removing allowed parents / disabling root placement would break
+/// existing group-hierarchy relationships.
+pub const ALLOWED_PARENTS_SUBJECT: &str = "allowed_parents";
+
+/// The write would introduce a cycle in the group hierarchy
+/// (cycle-detected).
+pub const HIERARCHY_SUBJECT: &str = "hierarchy";
+
+/// A type still has groups of this type (active references) and cannot
+/// be deleted.
+pub const ACTIVE_REFERENCES_SUBJECT: &str = "active_references";
+
+/// A configured limit (depth, width, …) would be exceeded
+/// (limit-violation).
+pub const LIMIT_SUBJECT: &str = "limit";
+
+/// A cross-tenant link would be created — a resource may belong to
+/// groups of a single tenant only.
+pub const TENANT_SUBJECT: &str = "tenant";
+
+// ---------------------------------------------------------------------------
+// `violations[].type` token.
+//
+// Resource-group uses a single, uniform `type` across every precondition
+// family — the dispatch discriminator is the subject above, not the type.
+// Extracted to a const (ADR 0005 Rule 6) so the impl ladder and SDK
+// vocabulary cannot drift; pinned by the round-trip tests.
+// ---------------------------------------------------------------------------
+
+/// The uniform `violations[].type` token resource-group emits for every
+/// precondition family.
+pub const STATE_TYPE: &str = "STATE";
+
+// ---------------------------------------------------------------------------
+// Typed view of the `violations[].subject` discriminators.
+// ---------------------------------------------------------------------------
+
+/// Typed view of the resource-group `FailedPrecondition` `subject`
+/// strings declared above.
+///
+/// Carried by [`crate::ResourceGroupError::FailedPrecondition::subject`].
+/// `from_wire` returns `Self` (not `Option`) with an [`Self::Unknown`]
+/// catch-all because every `subject` resource-group emits under
+/// `FailedPrecondition` is one of the modeled values — the catch-all only
+/// fires for a future subject, keeping the projection forward-compatible.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Subject {
+    /// See [`ALLOWED_PARENTS_SUBJECT`].
+    AllowedParents,
+    /// See [`HIERARCHY_SUBJECT`] — denotes a detected cycle.
+    Hierarchy,
+    /// See [`ACTIVE_REFERENCES_SUBJECT`].
+    ActiveReferences,
+    /// See [`LIMIT_SUBJECT`] — denotes a configured-limit violation.
+    Limit,
+    /// See [`TENANT_SUBJECT`].
+    Tenant,
+    /// Unmodeled / future subject — preserves the raw wire string.
+    Unknown(String),
+}
+
+impl Subject {
+    /// Project a wire `violations[].subject` string into the typed
+    /// discriminator. Any unmodeled value is preserved in
+    /// [`Self::Unknown`].
+    #[must_use]
+    pub fn from_wire(s: &str) -> Self {
+        match s {
+            ALLOWED_PARENTS_SUBJECT => Self::AllowedParents,
+            HIERARCHY_SUBJECT => Self::Hierarchy,
+            ACTIVE_REFERENCES_SUBJECT => Self::ActiveReferences,
+            LIMIT_SUBJECT => Self::Limit,
+            TENANT_SUBJECT => Self::Tenant,
+            other => Self::Unknown(other.to_owned()),
+        }
+    }
+
+    /// Render the discriminator back to its wire `subject` string.
+    /// Inverse of [`Self::from_wire`] for the modeled variants.
+    #[must_use]
+    pub fn as_wire(&self) -> &str {
+        match self {
+            Self::AllowedParents => ALLOWED_PARENTS_SUBJECT,
+            Self::Hierarchy => HIERARCHY_SUBJECT,
+            Self::ActiveReferences => ACTIVE_REFERENCES_SUBJECT,
+            Self::Limit => LIMIT_SUBJECT,
+            Self::Tenant => TENANT_SUBJECT,
+            Self::Unknown(s) => s.as_str(),
+        }
+    }
+}
+
+impl fmt::Display for Subject {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_wire())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subject_round_trips_each_constant() {
+        for (wire, expected) in [
+            (ALLOWED_PARENTS_SUBJECT, Subject::AllowedParents),
+            (HIERARCHY_SUBJECT, Subject::Hierarchy),
+            (ACTIVE_REFERENCES_SUBJECT, Subject::ActiveReferences),
+            (LIMIT_SUBJECT, Subject::Limit),
+            (TENANT_SUBJECT, Subject::Tenant),
+        ] {
+            assert_eq!(Subject::from_wire(wire), expected);
+            assert_eq!(expected.as_wire(), wire);
+        }
+    }
+
+    #[test]
+    fn subject_preserves_unknown_wire_string() {
+        let raw = "future_subject";
+        let s = Subject::from_wire(raw);
+        assert_eq!(s, Subject::Unknown(raw.to_owned()));
+        assert_eq!(s.as_wire(), raw);
+    }
+}

--- a/gears/system/resource-group/resource-group-sdk/src/reason.rs
+++ b/gears/system/resource-group/resource-group-sdk/src/reason.rs
@@ -1,0 +1,37 @@
+//! Wire `reason` vocabulary for the single-valued resource-group
+//! canonical categories — [`CanonicalError::Aborted`] and
+//! [`CanonicalError::PermissionDenied`].
+//!
+//! These categories each carry a `ctx.reason` discriminator, but
+//! resource-group emits only a single value per category, so — unlike the
+//! multi-valued [`crate::precondition`] family — they stay **plain
+//! constants** with no typed sub-enum (ADR 0005: single-value reasons
+//! stay consts). Consumers match the projection's `reason: String` field
+//! against these constants.
+//!
+//! The impl crate's single `From<DomainError> for CanonicalError` ladder
+//! references the same constants; the round-trip tests in
+//! [`crate::error`] pin each to its `Problem` JSON path.
+//!
+//! [`CanonicalError::Aborted`]: toolkit_canonical_errors::CanonicalError::Aborted
+//! [`CanonicalError::PermissionDenied`]: toolkit_canonical_errors::CanonicalError::PermissionDenied
+
+/// Wire `reason` value for [`CanonicalError::Aborted`] (HTTP 409).
+///
+/// [`CanonicalError::Aborted`]: toolkit_canonical_errors::CanonicalError::Aborted
+pub mod aborted {
+    /// Generic concurrency / state conflict not tied to a structural
+    /// resource id (e.g. a write lost a race). The single abort reason
+    /// resource-group emits.
+    pub const CONFLICT: &str = "CONFLICT";
+}
+
+/// Wire `reason` value for [`CanonicalError::PermissionDenied`]
+/// (HTTP 403).
+///
+/// [`CanonicalError::PermissionDenied`]: toolkit_canonical_errors::CanonicalError::PermissionDenied
+pub mod permission {
+    /// The authorization policy (PDP) denied the operation. The single
+    /// denial reason resource-group emits.
+    pub const ACCESS_DENIED: &str = "ACCESS_DENIED";
+}

--- a/gears/system/resource-group/resource-group/src/api/rest/error.rs
+++ b/gears/system/resource-group/resource-group/src/api/rest/error.rs
@@ -8,11 +8,16 @@
 //! (`toolkit::api::canonical_error_middleware`) converts the `CanonicalError`
 //! to a wire `Problem` and fills `instance` / `trace_id` post-response.
 
+use resource_group_sdk::{field, precondition, reason};
 use toolkit_canonical_errors::{CanonicalError, resource_error};
 
 use crate::domain::error::DomainError;
 
 /// Errors attributable to a resource group as a resource.
+///
+/// The macro literal mirrors [`resource_group_sdk::gts::GROUP_RESOURCE_TYPE`]
+/// (proc-macros cannot resolve a const); the SDK round-trip tests pin the
+/// two equal.
 #[resource_error("gts.cf.core.resource_group.group.v1~")]
 pub struct RgError;
 
@@ -59,37 +64,61 @@ impl From<DomainError> for CanonicalError {
             // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2c
             // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2d
             DomainError::InvalidParentType { message } => RgError::invalid_argument()
-                .with_field_violation("parent_type", message, "INVALID_PARENT_TYPE")
+                .with_field_violation(
+                    field::PARENT_TYPE_FIELD,
+                    message,
+                    field::INVALID_PARENT_TYPE,
+                )
                 .create(),
             // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2d
             // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2e
             // ⚠ wire change accepted in the migration plan: 409 → 400.
             DomainError::AllowedParentTypesViolation { message } => RgError::failed_precondition()
-                .with_precondition_violation("allowed_parents", message, "STATE")
+                .with_precondition_violation(
+                    precondition::ALLOWED_PARENTS_SUBJECT,
+                    message,
+                    precondition::STATE_TYPE,
+                )
                 .create(),
             // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2e
             // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2f
             // ⚠ wire change accepted in the migration plan: 409 → 400.
             DomainError::CycleDetected { message } => RgError::failed_precondition()
-                .with_precondition_violation("hierarchy", message, "STATE")
+                .with_precondition_violation(
+                    precondition::HIERARCHY_SUBJECT,
+                    message,
+                    precondition::STATE_TYPE,
+                )
                 .create(),
             // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2f
             // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2g
             // ⚠ wire change accepted in the migration plan: 409 → 400.
             DomainError::ConflictActiveReferences { message } => RgError::failed_precondition()
-                .with_precondition_violation("active_references", message, "STATE")
+                .with_precondition_violation(
+                    precondition::ACTIVE_REFERENCES_SUBJECT,
+                    message,
+                    precondition::STATE_TYPE,
+                )
                 .create(),
             // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2g
             // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2h
             // ⚠ wire change accepted in the migration plan: 409 → 400.
             DomainError::LimitViolation { message } => RgError::failed_precondition()
-                .with_precondition_violation("limit", message, "STATE")
+                .with_precondition_violation(
+                    precondition::LIMIT_SUBJECT,
+                    message,
+                    precondition::STATE_TYPE,
+                )
                 .create(),
             // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2h
             // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2i
             // ⚠ wire change accepted in the migration plan: 409 → 400.
             DomainError::TenantIncompatibility { message } => RgError::failed_precondition()
-                .with_precondition_violation("tenant", message, "STATE")
+                .with_precondition_violation(
+                    precondition::TENANT_SUBJECT,
+                    message,
+                    precondition::STATE_TYPE,
+                )
                 .create(),
             // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2i
             // Duplicate-on-create variants route through `already_exists`
@@ -107,13 +136,13 @@ impl From<DomainError> for CanonicalError {
                 .create(),
             // Generic conflict carries no structural resource id — route
             // through `aborted` with a stable reason discriminator.
-            DomainError::Conflict { message } => {
-                RgError::aborted(message).with_reason("CONFLICT").create()
-            }
+            DomainError::Conflict { message } => RgError::aborted(message)
+                .with_reason(reason::aborted::CONFLICT)
+                .create(),
             DomainError::AccessDenied { message } => {
                 tracing::debug!(reason = %message, "resource-group access denied");
                 RgError::permission_denied()
-                    .with_reason("ACCESS_DENIED")
+                    .with_reason(reason::permission::ACCESS_DENIED)
                     .create()
             }
             // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2j

--- a/gears/system/resource-group/resource-group/src/domain/error.rs
+++ b/gears/system/resource-group/resource-group/src/domain/error.rs
@@ -4,7 +4,6 @@
 //! Domain error types for the resource-group gear.
 
 use authz_resolver_sdk::pep::EnforcerError;
-use resource_group_sdk::ResourceGroupError;
 use thiserror::Error;
 
 /// Domain-specific errors for the resource-group gear.
@@ -205,43 +204,12 @@ impl DomainError {
     }
 }
 
-/// Convert domain errors to SDK errors for public API consumption.
-impl From<DomainError> for ResourceGroupError {
-    fn from(e: DomainError) -> Self {
-        match e {
-            DomainError::TypeNotFound { code } => ResourceGroupError::not_found(code),
-            DomainError::TypeAlreadyExists { code } => {
-                ResourceGroupError::type_already_exists(code)
-            }
-            DomainError::Validation { message } => ResourceGroupError::validation(message),
-            DomainError::InvalidParentType { message } => {
-                ResourceGroupError::invalid_parent_type(message)
-            }
-            DomainError::CycleDetected { message } => ResourceGroupError::cycle_detected(message),
-            DomainError::LimitViolation { message } => ResourceGroupError::limit_violation(message),
-            DomainError::AllowedParentTypesViolation { message } => {
-                ResourceGroupError::allowed_parent_types_violation(message)
-            }
-            DomainError::ConflictActiveReferences { message } => {
-                ResourceGroupError::conflict_active_references(message)
-            }
-            DomainError::Conflict { message }
-            | DomainError::DuplicateMembership { message, .. } => {
-                ResourceGroupError::conflict(message)
-            }
-            DomainError::TenantRootAlreadyExists { detail, .. } => {
-                ResourceGroupError::conflict(detail)
-            }
-            DomainError::GroupNotFound { id } => ResourceGroupError::not_found(id.to_string()),
-            DomainError::MembershipNotFound { key } => ResourceGroupError::not_found(key),
-            DomainError::TenantIncompatibility { message } => {
-                ResourceGroupError::tenant_incompatibility(message)
-            }
-            DomainError::AccessDenied { .. } => ResourceGroupError::access_denied(),
-            DomainError::Database(_) | DomainError::InternalError => ResourceGroupError::internal(),
-        }
-    }
-}
+// The SDK-facing `From<DomainError> for ResourceGroupError` ladder was
+// removed per ADR 0005: the SDK trait boundary is now `CanonicalError`,
+// and `ResourceGroupError` is an opt-in `From<CanonicalError>` projection
+// in the SDK crate. The single authoritative AIP-193 classification is
+// the `From<DomainError> for CanonicalError` ladder in
+// `crate::api::rest::error`.
 
 impl From<sea_orm::DbErr> for DomainError {
     fn from(e: sea_orm::DbErr) -> Self {

--- a/gears/system/resource-group/resource-group/src/domain/read_service.rs
+++ b/gears/system/resource-group/resource-group/src/domain/read_service.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use resource_group_sdk::ResourceGroupReadHierarchy;
-use resource_group_sdk::error::ResourceGroupError;
 use resource_group_sdk::models::{ResourceGroup, ResourceGroupMembership, ResourceGroupWithDepth};
+use toolkit_canonical_errors::CanonicalError;
 use toolkit_odata::{ODataQuery, Page};
 use toolkit_security::SecurityContext;
 use uuid::Uuid;
@@ -94,7 +94,7 @@ impl<GR: GroupRepositoryTrait, TR: TypeRepositoryTrait, MR: MembershipRepository
         _ctx: &SecurityContext,
         group_id: Uuid,
         query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError> {
         // @cpt-begin:cpt-cf-resource-group-flow-integration-auth-plugin-routing:p1:inst-plugin-3a
         // @cpt-begin:cpt-cf-resource-group-flow-integration-auth-plugin-routing:p1:inst-plugin-5
         // @cpt-begin:cpt-cf-resource-group-flow-integration-auth-plugin-read:p1:inst-plugin-read-2
@@ -109,7 +109,7 @@ impl<GR: GroupRepositoryTrait, TR: TypeRepositoryTrait, MR: MembershipRepository
         self.group_service
             .get_group_descendants_unscoped(group_id, query)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
         // @cpt-end:cpt-cf-resource-group-flow-integration-auth-plugin-read:p1:inst-plugin-read-5
         // @cpt-end:cpt-cf-resource-group-flow-integration-auth-plugin-read:p1:inst-plugin-read-4
         // @cpt-end:cpt-cf-resource-group-flow-integration-auth-plugin-read:p1:inst-plugin-read-3
@@ -123,7 +123,7 @@ impl<GR: GroupRepositoryTrait, TR: TypeRepositoryTrait, MR: MembershipRepository
         _ctx: &SecurityContext,
         group_id: Uuid,
         query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError> {
         // Bypass AuthZ — use unscoped method (AccessScope::allow_all).
         // Tenant-resolver plugin needs full ancestor visibility regardless
         // of caller's tenant scope. Confirmed: TR plugins ignore SecurityContext
@@ -131,14 +131,14 @@ impl<GR: GroupRepositoryTrait, TR: TypeRepositoryTrait, MR: MembershipRepository
         self.group_service
             .get_group_ancestors_unscoped(group_id, query)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn list_groups(
         &self,
         _ctx: &SecurityContext,
         query: &ODataQuery,
-    ) -> Result<Page<ResourceGroup>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroup>, CanonicalError> {
         // Bypass AuthZ — same rationale as the hierarchy reads above.
         // Used by the tenant-resolver RG plugin's batch `get_tenants` path,
         // which queries `id in (…)` over tenant-typed groups regardless of
@@ -146,35 +146,35 @@ impl<GR: GroupRepositoryTrait, TR: TypeRepositoryTrait, MR: MembershipRepository
         self.group_service
             .list_groups_unscoped(query)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn get_group(
         &self,
         _ctx: &SecurityContext,
         id: Uuid,
-    ) -> Result<ResourceGroup, ResourceGroupError> {
+    ) -> Result<ResourceGroup, CanonicalError> {
         // Bypass AuthZ — an in-process PDP consumes this for scope-existence
         // checks while acting as the PDP, so it cannot re-enter the enforcer.
         // The consumer reads the group and compares `tenant_id` itself.
         self.group_service
             .get_group_unscoped(id)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn list_memberships(
         &self,
         _ctx: &SecurityContext,
         query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupMembership>, CanonicalError> {
         // Bypass AuthZ — an in-process PDP resolves a subject's group
         // memberships while acting as the PDP; re-entering the enforcer would
         // recurse. The caller supplies the subject/tenant OData filter.
         self.membership_service
             .list_memberships_unscoped(query)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
     }
 }
 // @cpt-end:cpt-cf-resource-group-dod-integration-auth-read-service:p1:inst-full

--- a/gears/system/resource-group/resource-group/src/domain/rg_service.rs
+++ b/gears/system/resource-group/resource-group/src/domain/rg_service.rs
@@ -9,11 +9,11 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use resource_group_sdk::ResourceGroupClient;
-use resource_group_sdk::error::ResourceGroupError;
 use resource_group_sdk::models::{
     CreateGroupRequest, CreateTypeRequest, ResourceGroup, ResourceGroupMembership,
     ResourceGroupType, ResourceGroupWithDepth, UpdateGroupRequest, UpdateTypeRequest,
 };
+use toolkit_canonical_errors::CanonicalError;
 use toolkit_odata::{ODataQuery, Page};
 use toolkit_security::SecurityContext;
 use uuid::Uuid;
@@ -64,33 +64,33 @@ impl<GR: GroupRepositoryTrait, TR: TypeRepositoryTrait, MR: MembershipRepository
         &self,
         _ctx: &SecurityContext,
         request: CreateTypeRequest,
-    ) -> Result<ResourceGroupType, ResourceGroupError> {
+    ) -> Result<ResourceGroupType, CanonicalError> {
         self.type_service
             .create_type(request)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn get_type(
         &self,
         _ctx: &SecurityContext,
         code: &str,
-    ) -> Result<ResourceGroupType, ResourceGroupError> {
+    ) -> Result<ResourceGroupType, CanonicalError> {
         self.type_service
             .get_type(code)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn list_types(
         &self,
         _ctx: &SecurityContext,
         query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupType>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupType>, CanonicalError> {
         self.type_service
             .list_types(query)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn update_type(
@@ -98,22 +98,18 @@ impl<GR: GroupRepositoryTrait, TR: TypeRepositoryTrait, MR: MembershipRepository
         _ctx: &SecurityContext,
         code: &str,
         request: UpdateTypeRequest,
-    ) -> Result<ResourceGroupType, ResourceGroupError> {
+    ) -> Result<ResourceGroupType, CanonicalError> {
         self.type_service
             .update_type(code, request)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
     }
 
-    async fn delete_type(
-        &self,
-        _ctx: &SecurityContext,
-        code: &str,
-    ) -> Result<(), ResourceGroupError> {
+    async fn delete_type(&self, _ctx: &SecurityContext, code: &str) -> Result<(), CanonicalError> {
         self.type_service
             .delete_type(code)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
     }
 
     // -- Group lifecycle --
@@ -122,34 +118,34 @@ impl<GR: GroupRepositoryTrait, TR: TypeRepositoryTrait, MR: MembershipRepository
         &self,
         ctx: &SecurityContext,
         request: CreateGroupRequest,
-    ) -> Result<ResourceGroup, ResourceGroupError> {
+    ) -> Result<ResourceGroup, CanonicalError> {
         let tenant_id = ctx.subject_tenant_id();
         self.group_service
             .create_group(ctx, request, tenant_id)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn get_group(
         &self,
         ctx: &SecurityContext,
         id: Uuid,
-    ) -> Result<ResourceGroup, ResourceGroupError> {
+    ) -> Result<ResourceGroup, CanonicalError> {
         self.group_service
             .get_group(ctx, id)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn list_groups(
         &self,
         ctx: &SecurityContext,
         query: &ODataQuery,
-    ) -> Result<Page<ResourceGroup>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroup>, CanonicalError> {
         self.group_service
             .list_groups(ctx, query)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn update_group(
@@ -157,31 +153,27 @@ impl<GR: GroupRepositoryTrait, TR: TypeRepositoryTrait, MR: MembershipRepository
         ctx: &SecurityContext,
         id: Uuid,
         request: UpdateGroupRequest,
-    ) -> Result<ResourceGroup, ResourceGroupError> {
+    ) -> Result<ResourceGroup, CanonicalError> {
         self.group_service
             .update_group(ctx, id, request)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
     }
 
-    async fn delete_group(
-        &self,
-        ctx: &SecurityContext,
-        id: Uuid,
-    ) -> Result<(), ResourceGroupError> {
+    async fn delete_group(&self, ctx: &SecurityContext, id: Uuid) -> Result<(), CanonicalError> {
         // Non-cascade variant: surface `ConflictActiveReferences` to the
         // caller; cascade goes through `delete_group_cascade` below.
         self.group_service
             .delete_group(ctx, id, false)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn delete_group_cascade(
         &self,
         ctx: &SecurityContext,
         id: Uuid,
-    ) -> Result<(), ResourceGroupError> {
+    ) -> Result<(), CanonicalError> {
         // Cascade variant: forwards to `delete_group_inner` with
         // `force=true`, which atomically removes the entire subtree,
         // membership rows, and closure rows under a SERIALIZABLE
@@ -189,7 +181,7 @@ impl<GR: GroupRepositoryTrait, TR: TypeRepositoryTrait, MR: MembershipRepository
         self.group_service
             .delete_group(ctx, id, true)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn get_group_descendants(
@@ -197,11 +189,11 @@ impl<GR: GroupRepositoryTrait, TR: TypeRepositoryTrait, MR: MembershipRepository
         ctx: &SecurityContext,
         group_id: Uuid,
         query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError> {
         self.group_service
             .get_group_descendants(ctx, group_id, query)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn get_group_ancestors(
@@ -209,11 +201,11 @@ impl<GR: GroupRepositoryTrait, TR: TypeRepositoryTrait, MR: MembershipRepository
         ctx: &SecurityContext,
         group_id: Uuid,
         query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError> {
         self.group_service
             .get_group_ancestors(ctx, group_id, query)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
     }
 
     // -- Membership lifecycle --
@@ -224,11 +216,11 @@ impl<GR: GroupRepositoryTrait, TR: TypeRepositoryTrait, MR: MembershipRepository
         group_id: Uuid,
         resource_type: &str,
         resource_id: &str,
-    ) -> Result<ResourceGroupMembership, ResourceGroupError> {
+    ) -> Result<ResourceGroupMembership, CanonicalError> {
         self.membership_service
             .add_membership(ctx, group_id, resource_type, resource_id)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn remove_membership(
@@ -237,21 +229,21 @@ impl<GR: GroupRepositoryTrait, TR: TypeRepositoryTrait, MR: MembershipRepository
         group_id: Uuid,
         resource_type: &str,
         resource_id: &str,
-    ) -> Result<(), ResourceGroupError> {
+    ) -> Result<(), CanonicalError> {
         self.membership_service
             .remove_membership(ctx, group_id, resource_type, resource_id)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
     }
 
     async fn list_memberships(
         &self,
         ctx: &SecurityContext,
         query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupMembership>, CanonicalError> {
         self.membership_service
             .list_memberships(ctx, query)
             .await
-            .map_err(ResourceGroupError::from)
+            .map_err(CanonicalError::from)
     }
 }

--- a/gears/system/resource-group/resource-group/tests/domain_unit_test.rs
+++ b/gears/system/resource-group/resource-group/tests/domain_unit_test.rs
@@ -575,64 +575,110 @@ fn is_serialization_failure_false_for_non_db_errors() {
     assert!(!err.is_serialization_failure());
 }
 
-// ── DomainError -> ResourceGroupError mapping ───────────────────────────
+// ── DomainError -> CanonicalError -> ResourceGroupError projection ──────
+//
+// The SDK trait boundary is `CanonicalError` (ADR 0005); `ResourceGroupError`
+// is the opt-in `From<CanonicalError>` projection. These tests exercise the
+// full domain → canonical → projection path a ClientHub consumer sees.
+
+/// Project a domain error the way a consumer would: through the single
+/// canonical ladder, then into the typed SDK view.
+fn project(err: DomainError) -> resource_group_sdk::ResourceGroupError {
+    resource_group_sdk::ResourceGroupError::from(CanonicalError::from(err))
+}
 
 #[test]
 fn domain_to_sdk_type_not_found() {
     use resource_group_sdk::ResourceGroupError;
-    let domain = DomainError::type_not_found("code");
-    let sdk: ResourceGroupError = domain.into();
-    assert!(sdk.to_string().contains("code"));
+    match project(DomainError::type_not_found("code")) {
+        ResourceGroupError::NotFound { name, .. } => assert_eq!(name, "code"),
+        other => panic!("expected NotFound, got {other:?}"),
+    }
 }
 
 #[test]
 fn domain_to_sdk_type_already_exists() {
     use resource_group_sdk::ResourceGroupError;
-    let domain = DomainError::type_already_exists("code");
-    let sdk: ResourceGroupError = domain.into();
-    assert!(sdk.to_string().contains("code"));
+    match project(DomainError::type_already_exists("code")) {
+        ResourceGroupError::AlreadyExists { name, .. } => assert_eq!(name, "code"),
+        other => panic!("expected AlreadyExists, got {other:?}"),
+    }
 }
 
 #[test]
 fn domain_to_sdk_validation() {
     use resource_group_sdk::ResourceGroupError;
-    let domain = DomainError::validation("msg");
-    let sdk: ResourceGroupError = domain.into();
-    assert!(sdk.to_string().contains("msg") || !sdk.to_string().is_empty());
+    // Generic validation maps to a `Format` InvalidArgument — no field
+    // attribution, message preserved in `detail`.
+    match project(DomainError::validation("msg")) {
+        ResourceGroupError::InvalidArgument { detail, .. } => assert!(detail.contains("msg")),
+        other => panic!("expected InvalidArgument, got {other:?}"),
+    }
+}
+
+#[test]
+fn domain_to_sdk_invalid_parent_type() {
+    use resource_group_sdk::{ResourceGroupError, field};
+    match project(DomainError::invalid_parent_type("bad parent")) {
+        ResourceGroupError::InvalidArgument { field, reason, .. } => {
+            assert_eq!(field, field::PARENT_TYPE_FIELD);
+            assert_eq!(reason, field::INVALID_PARENT_TYPE);
+        }
+        other => panic!("expected InvalidArgument, got {other:?}"),
+    }
 }
 
 #[test]
 fn domain_to_sdk_group_not_found() {
     use resource_group_sdk::ResourceGroupError;
     let id = uuid::Uuid::now_v7();
-    let domain = DomainError::group_not_found(id);
-    let sdk: ResourceGroupError = domain.into();
-    assert!(sdk.to_string().contains(&id.to_string()));
+    match project(DomainError::group_not_found(id)) {
+        ResourceGroupError::NotFound { name, .. } => assert_eq!(name, id.to_string()),
+        other => panic!("expected NotFound, got {other:?}"),
+    }
 }
 
 #[test]
 fn domain_to_sdk_cycle_detected() {
-    use resource_group_sdk::ResourceGroupError;
-    let domain = DomainError::cycle_detected("cycle");
-    let sdk: ResourceGroupError = domain.into();
-    assert!(!sdk.to_string().is_empty());
+    use resource_group_sdk::{ResourceGroupError, precondition::Subject};
+    // Cycle flattens to FailedPrecondition; the `hierarchy` subject is the
+    // discriminator.
+    match project(DomainError::cycle_detected("cycle")) {
+        ResourceGroupError::FailedPrecondition { subject, .. } => {
+            assert_eq!(subject, Subject::Hierarchy);
+        }
+        other => panic!("expected FailedPrecondition, got {other:?}"),
+    }
+}
+
+#[test]
+fn domain_to_sdk_limit_violation() {
+    use resource_group_sdk::{ResourceGroupError, precondition::Subject};
+    match project(DomainError::limit_violation("limit")) {
+        ResourceGroupError::FailedPrecondition { subject, .. } => {
+            assert_eq!(subject, Subject::Limit);
+        }
+        other => panic!("expected FailedPrecondition, got {other:?}"),
+    }
 }
 
 #[test]
 fn domain_to_sdk_database_maps_to_internal() {
     use resource_group_sdk::ResourceGroupError;
-    let domain = DomainError::database("db error");
-    let sdk: ResourceGroupError = domain.into();
-    // Database errors map to internal (no sensitive info leaked)
-    assert!(sdk.to_string().to_lowercase().contains("internal"));
+    // Database errors map to internal (no sensitive info leaked).
+    assert!(matches!(
+        project(DomainError::database("db error")),
+        ResourceGroupError::Internal { .. }
+    ));
 }
 
 #[test]
 fn domain_to_sdk_membership_not_found() {
     use resource_group_sdk::ResourceGroupError;
-    let domain = DomainError::membership_not_found("key");
-    let sdk: ResourceGroupError = domain.into();
-    assert!(sdk.to_string().contains("key"));
+    match project(DomainError::membership_not_found("key")) {
+        ResourceGroupError::NotFound { name, .. } => assert_eq!(name, "key"),
+        other => panic!("expected NotFound, got {other:?}"),
+    }
 }
 
 #[test]
@@ -646,13 +692,17 @@ fn domain_to_problem_membership_not_found_is_404() {
 }
 
 #[test]
-fn domain_to_sdk_access_denied_maps_to_internal() {
-    use resource_group_sdk::ResourceGroupError;
+fn domain_to_sdk_access_denied_maps_to_permission_denied() {
+    use resource_group_sdk::{ResourceGroupError, reason};
     let domain = DomainError::AccessDenied {
         message: "denied".to_owned(),
     };
-    let sdk: ResourceGroupError = domain.into();
-    assert!(sdk.to_string().to_lowercase().contains("denied"));
+    match project(domain) {
+        ResourceGroupError::PermissionDenied { reason, .. } => {
+            assert_eq!(reason, reason::permission::ACCESS_DENIED);
+        }
+        other => panic!("expected PermissionDenied, got {other:?}"),
+    }
 }
 
 // ── DomainError -> Problem (RFC 9457) mapping ───────────────────────────

--- a/gears/system/tenant-resolver/plugins/rg-tr-plugin/Cargo.toml
+++ b/gears/system/tenant-resolver/plugins/rg-tr-plugin/Cargo.toml
@@ -51,3 +51,7 @@ inventory = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }
+# Test fakes synthesize the `CanonicalError` envelope the RG trait now
+# returns (ADR 0005). Production code only projects it via the SDK's
+# `ResourceGroupError::from`, so this is dev-only.
+toolkit-canonical-errors = { workspace = true }

--- a/gears/system/tenant-resolver/plugins/rg-tr-plugin/src/domain/service.rs
+++ b/gears/system/tenant-resolver/plugins/rg-tr-plugin/src/domain/service.rs
@@ -297,7 +297,13 @@ impl Service {
                     self.rg.get_group_descendants(ctx, group_id, &query).await
                 }
             }
-            .map_err(|e| match e {
+            // Project the raw canonical error through `ResourceGroupError`
+            // so we can match on semantic variants at the error boundary:
+            // a missing group (`NotFound`) becomes `TenantNotFound`, while
+            // every other variant collapses to `Internal`. We match on the
+            // projected `ResourceGroupError` rather than the raw error
+            // because the projection preserves the semantic classification.
+            .map_err(|e| match ResourceGroupError::from(e) {
                 ResourceGroupError::NotFound { .. } => TenantResolverError::TenantNotFound {
                     tenant_id: TenantId(group_id),
                 },

--- a/gears/system/tenant-resolver/plugins/rg-tr-plugin/src/domain/service_tests.rs
+++ b/gears/system/tenant-resolver/plugins/rg-tr-plugin/src/domain/service_tests.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use resource_group_sdk::TENANT_RG_TYPE_PATH;
 use resource_group_sdk::api::ResourceGroupReadHierarchy;
-use resource_group_sdk::error::ResourceGroupError;
 use resource_group_sdk::models::{
     GroupHierarchy, GroupHierarchyWithDepth, ResourceGroup, ResourceGroupMembership,
     ResourceGroupWithDepth,
@@ -15,6 +14,7 @@ use tenant_resolver_sdk::{
     BarrierMode, GetAncestorsOptions, GetDescendantsOptions, GetTenantsOptions, IsAncestorOptions,
     TenantId, TenantResolverError, TenantResolverPluginClient, TenantStatus,
 };
+use toolkit_canonical_errors::CanonicalError;
 use toolkit_odata::ast::{CompareOperator, Expr, Value};
 use toolkit_odata::{ODataQuery, Page, PageInfo};
 use toolkit_security::SecurityContext;
@@ -76,7 +76,7 @@ impl ResourceGroupReadHierarchy for MockRgHierarchy {
         _ctx: &SecurityContext,
         group_id: Uuid,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError> {
         // Precedence: if per-id dispatch is configured, honor it strictly —
         // unknown ids return an empty page (simulates "group not found").
         // Otherwise fall back to the flat list. Real RG returns the subtree
@@ -104,7 +104,7 @@ impl ResourceGroupReadHierarchy for MockRgHierarchy {
         _ctx: &SecurityContext,
         group_id: Uuid,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError> {
         // See `get_group_descendants` for precedence rules.
         let items = if self.ancestors_by_id.is_empty() {
             self.ancestors.clone()
@@ -128,7 +128,7 @@ impl ResourceGroupReadHierarchy for MockRgHierarchy {
         &self,
         _ctx: &SecurityContext,
         query: &ODataQuery,
-    ) -> Result<Page<ResourceGroup>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroup>, CanonicalError> {
         // Flatten every `ResourceGroupWithDepth` known to the mock (ancestors
         // + descendants + per-id dispatches) into `ResourceGroup` entries,
         // deduplicated by id, then apply the `OData $filter` predicate so
@@ -180,7 +180,7 @@ impl ResourceGroupReadHierarchy for MockRgHierarchy {
         &self,
         _ctx: &SecurityContext,
         _id: Uuid,
-    ) -> Result<ResourceGroup, ResourceGroupError> {
+    ) -> Result<ResourceGroup, CanonicalError> {
         unimplemented!("MockRgHierarchy models hierarchy reads only")
     }
 
@@ -188,7 +188,7 @@ impl ResourceGroupReadHierarchy for MockRgHierarchy {
         &self,
         _ctx: &SecurityContext,
         _query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError> {
+    ) -> Result<Page<ResourceGroupMembership>, CanonicalError> {
         unimplemented!("MockRgHierarchy models hierarchy reads only")
     }
 }
@@ -774,8 +774,8 @@ async fn rg_error_propagates() {
             _ctx: &SecurityContext,
             _group_id: Uuid,
             _query: &ODataQuery,
-        ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
-            Err(ResourceGroupError::internal())
+        ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError> {
+            Err(CanonicalError::internal("rg backend error").create())
         }
 
         async fn get_group_ancestors(
@@ -783,32 +783,32 @@ async fn rg_error_propagates() {
             _ctx: &SecurityContext,
             _group_id: Uuid,
             _query: &ODataQuery,
-        ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
-            Err(ResourceGroupError::internal())
+        ) -> Result<Page<ResourceGroupWithDepth>, CanonicalError> {
+            Err(CanonicalError::internal("rg backend error").create())
         }
 
         async fn list_groups(
             &self,
             _ctx: &SecurityContext,
             _query: &ODataQuery,
-        ) -> Result<Page<ResourceGroup>, ResourceGroupError> {
-            Err(ResourceGroupError::internal())
+        ) -> Result<Page<ResourceGroup>, CanonicalError> {
+            Err(CanonicalError::internal("rg backend error").create())
         }
 
         async fn get_group(
             &self,
             _ctx: &SecurityContext,
             _id: Uuid,
-        ) -> Result<ResourceGroup, ResourceGroupError> {
-            Err(ResourceGroupError::internal())
+        ) -> Result<ResourceGroup, CanonicalError> {
+            Err(CanonicalError::internal("rg backend error").create())
         }
 
         async fn list_memberships(
             &self,
             _ctx: &SecurityContext,
             _query: &ODataQuery,
-        ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError> {
-            Err(ResourceGroupError::internal())
+        ) -> Result<Page<ResourceGroupMembership>, CanonicalError> {
+            Err(CanonicalError::internal("rg backend error").create())
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized error handling across resource-group features to a unified canonical error model, producing more consistent, typed error responses for type, group, and membership operations.
  * Improved error context (validation fields, precondition subjects, reason tokens) for clearer, machine- and human-readable failures.
* **Documentation**
  * Expanded crate-level docs and exported vocab constants to describe the canonical error vocabulary and mappings.
* **Tests**
  * Added and expanded tests to validate canonical error projection, round-trip wire mappings, and idempotent/error-handling behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->