### PR TITLE
docs(spec-templates): drop non-existent "root PRD" from PRD guidance

### DIFF
--- a/docs/spec-templates/ISO_29148.md
+++ b/docs/spec-templates/ISO_29148.md
@@ -7,11 +7,11 @@ This document describes how the `spec` system fulfills ISO/IEC/IEEE 29148:2018 r
 - **Governance & stakeholders**: stakeholder needs are managed by a steering committee with vote/veto mechanics. The committee defines strategic direction and creates **tasks** that scope individual PRD/DESIGN/ADR documents. Stakeholder identification and needs analysis happen at the **project/task level**, not within individual module specs. Gear specs focus on **actors** (users, systems) that interact with the module, not organizational stakeholders.
 - **Repo model**: open-source, single modular mono-repo focused on **shared libraries**; downstream client systems handle final build/deployment/operations elsewhere.
 - **Gear integration**: all modules integrate via Rust native calls with automatically generated gRPC/REST API transport; integration patterns are standardized project-wide.
-- **Global guidelines**: project-wide standards exist for:
-  - Runtime, OS, CPU architecture compatibility (root PRD)
+- **Global guidelines**: project-wide standards live in the repository's foundational docs (the architecture manifest and `guidelines/`):
+  - Runtime, OS, CPU architecture compatibility (docs/ARCHITECTURE_MANIFEST.md)
   - Security policies and threat models (guidelines/SECURITY.md)
-  - Performance baselines and SLOs (root PRD § NFRs)
-  - Architecture patterns and tech stack (root DESIGN.md)
+  - Performance/observability guidance (docs/ARCHITECTURE_MANIFEST.md § 12)
+  - Architecture patterns and tech stack (docs/ARCHITECTURE_MANIFEST.md)
   - Testing strategy: 90%+ code coverage via unit/integration/e2e/security/performance tests
 - **Lifecycle management**: all modules committed to git are maintained; project-wide breaking changes policy (semver), deprecation (6-month notice), and support windows are enforced; gear-level deviations are exceptional.
 - **Git/PR record**: all changes flow through PRs with review, discussion, and an immutable merge/audit trail.
@@ -27,7 +27,7 @@ This document describes how the `spec` system fulfills ISO/IEC/IEEE 29148:2018 r
 
 ## System requirements
 
-**Fulfillment:** The PRD's functional and non-functional requirement sections provide system-level requirement statements with mandatory language, IDs, rationales, source, and actor linkage, aligning with 29148's well-formed requirement guidance. Global guidelines (root PRD, docs/guidelines/) establish project-wide baselines, and module PRDs document deviations/extensions, which effectively partitions requirements by scope. Verification methods are implicit (90% test coverage standard) unless exceptional. The layered approach (global + gear-specific) is stronger than per-gear duplication and aligns with modular mono-repo reality.
+**Fulfillment:** The PRD's functional and non-functional requirement sections provide system-level requirement statements with mandatory language, IDs, rationales, source, and actor linkage, aligning with 29148's well-formed requirement guidance. Foundational docs (docs/ARCHITECTURE_MANIFEST.md, guidelines/) establish project-wide baselines, and module PRDs document deviations/extensions, which effectively partitions requirements by scope. Verification methods are implicit (90% test coverage standard) unless exceptional. The layered approach (global + gear-specific) is stronger than per-gear duplication and aligns with modular mono-repo reality.
 
 **Deviations / possible future improvements:** enforce CI checks that every gear requirement explicitly declares if it's a deviation/extension of a global requirement, and add explicit system→module allocation tracing.
 
@@ -39,7 +39,7 @@ This document describes how the `spec` system fulfills ISO/IEC/IEEE 29148:2018 r
 
 ## Non-Functional Requirements
 
-**Fulfillment:** The layered NFR approach (global baselines in root PRD + gear-specific deviations/extensions) aligns well with 29148's quality attribute requirements and is stronger than per-gear duplication. Gear PRDs include explicit NFR categories with measurable thresholds, source, rationale, and architecture allocation (via DESIGN.md NFR Allocation table). Verification methods are implicit (automated benchmarks, security scans, monitoring) unless exceptional. The approach is pragmatic and ISO-aligned for a modular library mono-repo.
+**Fulfillment:** The layered NFR approach (global baselines in the foundational docs — architecture manifest + guidelines/ — plus gear-specific deviations/extensions) aligns well with 29148's quality attribute requirements and is stronger than per-gear duplication. Gear PRDs include explicit NFR categories with measurable thresholds, source, rationale, and architecture allocation (via DESIGN.md NFR Allocation table). Verification methods are implicit (automated benchmarks, security scans, monitoring) unless exceptional. The approach is pragmatic and ISO-aligned for a modular library mono-repo.
 
 **Deviations / possible future improvements:** add CI enforcement that module NFRs explicitly reference which global baseline they deviate from (if any), and require quantitative evidence (benchmark results, scan reports) for all critical NFRs before merge.
 
@@ -87,7 +87,7 @@ This document describes how the `spec` system fulfills ISO/IEC/IEEE 29148:2018 r
 
 ## Lifecycle Coverage
 
-**Fulfillment:** Project-wide lifecycle policies (semver, breaking changes with 6-month deprecation notice, support windows, migration tooling) are documented in root PRD and enforced across all modules committed to git. Gear PRDs document only lifecycle deviations (exceptional cases). This approach covers library lifecycle (release, upgrade/migration, deprecation, maintenance) appropriate for a shared-library mono-repo. **Library mono-repo disclaimer**: "operations" happen in client deployments; this repo focuses on library lifecycle and API stability.
+**Fulfillment:** Project-wide lifecycle policies (semver, breaking changes with 6-month deprecation notice, support windows, migration tooling) are documented in the project's foundational docs and enforced across all modules committed to git. Gear PRDs document only lifecycle deviations (exceptional cases). This approach covers library lifecycle (release, upgrade/migration, deprecation, maintenance) appropriate for a shared-library mono-repo. **Library mono-repo disclaimer**: "operations" happen in client deployments; this repo focuses on library lifecycle and API stability.
 
 **Deviations / possible future improvements:** add CI enforcement that breaking changes are flagged and require ADR + migration guide, and maintain a project-wide lifecycle roadmap linking module releases to compatibility/deprecation timelines.
 
@@ -99,7 +99,7 @@ This document describes how the `spec` system fulfills ISO/IEC/IEEE 29148:2018 r
 
 ## Operational Concept & Environment
 
-**Fulfillment:** Project-wide operational environment (supported runtime, OS, CPU architectures, toolchain versions, compatibility targets) is documented in root PRD, aligning with 29148's foundational context requirements. Standardized module integration patterns (Rust native + auto-generated gRPC/REST transport) establish consistent usage modes. Gear PRDs document only environment-specific constraints or deviations. This layered approach is appropriate for a library mono-repo. **Library mono-repo disclaimer**: final deployment environments are owned by downstream clients; this repo specifies library compatibility and integration constraints.
+**Fulfillment:** Project-wide operational environment (supported runtime, OS, CPU architectures, toolchain versions, compatibility targets) is documented in docs/ARCHITECTURE_MANIFEST.md, aligning with 29148's foundational context requirements. Standardized module integration patterns (Rust native + auto-generated gRPC/REST transport) establish consistent usage modes. Gear PRDs document only environment-specific constraints or deviations. This layered approach is appropriate for a library mono-repo. **Library mono-repo disclaimer**: final deployment environments are owned by downstream clients; this repo specifies library compatibility and integration constraints.
 
 **Deviations / possible future improvements:** add CI validation that gear-specific environment constraints are compatible with project-wide baselines, and maintain a compatibility matrix linking supported environments to tested module combinations.
 
@@ -156,9 +156,9 @@ This document describes how the `spec` system fulfills ISO/IEC/IEEE 29148:2018 r
 | **Architecture Decisions** | Context, drivers, options, consequences, confirmation, requirement traceability, status |
 | **Traceability** | Cypilot ID system across all artifacts; bidirectional links |
 | **Verification/Validation** | Acceptance criteria; implicit testing standard; ADR confirmation |
-| **Lifecycle Coverage** | Project-wide semver + deprecation policy; documented in root PRD |
+| **Lifecycle Coverage** | Project-wide semver + deprecation policy; documented in foundational docs |
 | **Change Management** | Git/PR audit trail; ADR status/dates; governance vote/veto |
-| **Operational Concept & Environment** | Root PRD defines runtime/OS/arch; module PRDs for deviations |
+| **Operational Concept & Environment** | Architecture manifest defines runtime/OS/arch; module PRDs for deviations |
 | **Constraints & Assumptions** | PRD assumptions + DESIGN constraints; spread but present |
 | **Requirement Language & Quality** | Explicit rules (MUST/SHALL; no fluff); implicit testing standard |
 | **Requirement Attributes & Allocation** | Source, rationale, actors; DESIGN drivers + NFR allocation; FEATURE "Implements/Touches" |

--- a/docs/spec-templates/README.md
+++ b/docs/spec-templates/README.md
@@ -21,7 +21,7 @@ Templates work standalone or can be enhanced with Cypilot annotations (`cpt-id`)
 
 **Governance**: Steering committee with vote/veto authority on major requirements and architecture decisions. Escalation paths documented separately.
 
-**Global Guidelines**: Project-wide standards defined in root PRD, DESIGN, and [guidelines/](../../guidelines/) covering architecture, security, performance, operations, runtime environments, testing strategy.
+**Global Guidelines**: Project-wide standards (architecture, security, performance, operations, runtime environments, testing strategy) live in the repository's foundational documents — for this repo, the [architecture manifest](../ARCHITECTURE_MANIFEST.md) and [guidelines/](../../guidelines/). A project may also have a parent/root PRD or DESIGN; link whichever foundational sources actually exist rather than assuming a fixed set.
 
 **Gear-level specs**: Document only **deviations** or **extensions** from global standards. Avoid duplicating project-wide requirements.
 

--- a/docs/spec-templates/examples/todo-app/PRD.md
+++ b/docs/spec-templates/examples/todo-app/PRD.md
@@ -84,7 +84,7 @@ The application is designed for individual use with cross-device synchronization
 
 ## 3. Operational Concept & Environment
 
-> **Note**: Project-wide runtime, OS, architecture, lifecycle policy, and gear integration patterns (Rust native + auto-generated gRPC/REST) are defined in root [PRD.md](../../PRD.md). Only document gear-specific deviations or additional constraints here. **If this gear has no special environment constraints, delete this entire section.**
+> **Note**: Runtime, OS, architecture, lifecycle policy, and gear integration patterns (Rust native + auto-generated gRPC/REST) are defined in this repository's foundational documents — the [architecture manifest](../../../ARCHITECTURE_MANIFEST.md) and [guidelines/](../../../../guidelines/) — not in a gear PRD. This section captures only this gear's deviations.
 
 ### 3.1 Gear-Specific Environment Constraints
 
@@ -163,7 +163,7 @@ The system **MUST** allow users to filter tasks by status (all, active, complete
 
 ## 6. Non-Functional Requirements
 
-> **Default guidelines**: Project-wide NFR baselines (performance, security, reliability, scalability) are defined in root [PRD.md](../../PRD.md) and [docs/guidelines/](../../guidelines/). Only document gear-specific NFRs here — either **exclusions** from defaults or **standalone** requirements unique to this gear.
+> **Default guidelines**: Project-wide NFR baselines (performance, security, reliability, scalability) are defined in this repository's foundational documents — the [architecture manifest](../../../ARCHITECTURE_MANIFEST.md) and [guidelines/](../../../../guidelines/). This section captures only this gear's NFR deviations and extensions.
 >
 > **Testing strategy**: NFRs are verified via automated benchmarks, security scans, and monitoring unless otherwise specified.
 

--- a/docs/spec-templates/gears-sdlc/PRD/examples/example.md
+++ b/docs/spec-templates/gears-sdlc/PRD/examples/example.md
@@ -84,7 +84,7 @@ The application is designed for individual use with cross-device synchronization
 
 ## 3. Operational Concept & Environment
 
-> **Note**: Project-wide runtime, OS, architecture, lifecycle policy, and gear integration patterns (Rust native + auto-generated gRPC/REST) are defined in root [PRD.md](../../PRD.md). Only document gear-specific deviations or additional constraints here. **If this gear has no special environment constraints, delete this entire section.**
+> **Note**: Runtime, OS, architecture, lifecycle policy, and gear integration patterns (Rust native + auto-generated gRPC/REST) are defined in this repository's foundational documents — the [architecture manifest](../../../../ARCHITECTURE_MANIFEST.md) and [guidelines/](../../../../../guidelines/) — not in a gear PRD. This section captures only this gear's deviations.
 
 ### 3.1 Gear-Specific Environment Constraints
 
@@ -153,7 +153,7 @@ The system **MUST** allow users to filter tasks by status (all, active, complete
 
 ## 6. Non-Functional Requirements
 
-> **Default guidelines**: Project-wide NFR baselines (performance, security, reliability, scalability) are defined in root [PRD.md](../../PRD.md) and [docs/guidelines/](../../guidelines/). Only document gear-specific NFRs here — either **exclusions** from defaults or **standalone** requirements unique to this gear.
+> **Default guidelines**: Project-wide NFR baselines (performance, security, reliability, scalability) are defined in this repository's foundational documents — the [architecture manifest](../../../../ARCHITECTURE_MANIFEST.md) and [guidelines/](../../../../../guidelines/). This section captures only this gear's NFR deviations and extensions.
 >
 > **Testing strategy**: NFRs are verified via automated benchmarks, security scans, and monitoring unless otherwise specified.
 

--- a/docs/spec-templates/gears-sdlc/PRD/template.md
+++ b/docs/spec-templates/gears-sdlc/PRD/template.md
@@ -80,7 +80,7 @@ REQUIREMENT LANGUAGE:
 
 ## 3. Operational Concept & Environment
 
-> **Note**: Project-wide runtime, OS, architecture, lifecycle policy, and integration patterns defined in root PRD. Document only gear-specific deviations here. **Delete this section if no special constraints.**
+> **Note**: Runtime, OS, architecture, lifecycle policy, and integration patterns are defined once at the project/foundational level, not per gear. **Before writing this section, identify and link the foundational documents that actually exist in this repository** — these are typically repository-level: an architecture manifest (e.g. `docs/ARCHITECTURE_MANIFEST.md`) and the foundational `guidelines/`. Additionally, if this gear sits beneath a parent system/gear that has its own PRD, link that parent/root PRD too. Link only the sources that actually exist; don't invent a root PRD if this gear has no parent one. Document only gear-specific deviations here. **Delete this section if no special constraints.**
 
 ### 3.1 Gear-Specific Environment Constraints
 
@@ -124,7 +124,7 @@ The system **MUST** {do something specific and verifiable}.
 
 ## 6. Non-Functional Requirements
 
-> **Global baselines**: Project-wide NFRs (performance, security, reliability, scalability) defined in root PRD and [guidelines/](../guidelines/). Document only gear-specific NFRs here: **exclusions** from defaults or **standalone** requirements.
+> **Global baselines**: Project-wide NFRs (performance, security, reliability, scalability) are defined once at the project/foundational level. **Before writing this section, identify and link the baseline sources that actually exist in this repository** — these are typically repository-level — an architecture manifest (e.g. `docs/ARCHITECTURE_MANIFEST.md`) and the foundational `guidelines/`. Additionally, if this gear sits beneath a parent system/gear that has its own PRD, link that parent/root PRD too. Link only the sources that actually exist; don't invent a root PRD if this gear has no parent one. Document only gear-specific NFRs here: **exclusions** from defaults or **standalone** requirements.
 >
 > **Testing strategy**: NFRs verified via automated benchmarks, security scans, and monitoring unless otherwise specified.
 


### PR DESCRIPTION
The PRD template and examples hardcoded a "root PRD" as the source of project-wide baselines. No such document exists in this repo — baselines live in docs/ARCHITECTURE_MANIFEST.md + guidelines/ — which confused reviewers.
- template: direct authors to identify and link the foundational docs that actually exist (repo-level architecture manifest + guidelines/), and a parent/root PRD only when the module sits beneath a parent one
- examples (example.md, todo-app/PRD.md): replace the dead ../../PRD.md link with working links to the real foundational docs
- README + ISO_29148.md: align on the same model (no "root PRD/DESIGN")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated ISO/IEEE 29148 alignment and specification templates to point to repository foundational architecture and guideline documents as the primary baselines.
  * Clarified that module/gear PRDs should document only deviations or extensions from those repository-wide baselines (runtime, NFRs, lifecycle, operations).
  * Added change-management, lifecycle, and operational-concept framing to the fulfillment summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->