### PR TITLE
chore: bump the Rust version to 1.96.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,7 +343,7 @@ jobs:
       contents: read
       id-token: write
     env:
-      RUSTUP_TOOLCHAIN: nightly-2026-01-22
+      RUSTUP_TOOLCHAIN: nightly-2026-04-16
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -393,7 +393,7 @@ jobs:
     name: Dylint Tests
     runs-on: ubuntu-latest
     env:
-      RUSTUP_TOOLCHAIN: nightly-2026-01-22
+      RUSTUP_TOOLCHAIN: nightly-2026-04-16
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/libs/rustls-fips-shim/Cargo.toml
+++ b/libs/rustls-fips-shim/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 description = "Workspace-feature-unification shim: pulls rustls + hyper-rustls with the `fips` feature on every target where the AWS-LC FIPS backend is the intended TLS provider (i.e. everywhere except macOS, where Apple corecrypto is used, and Windows, where CNG is used instead)."
 keywords = ["constructorfabric", "cf-gears"]
 publish = true
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "rustls_fips_shim"

--- a/libs/toolkit-db/tests/ui/fail/unscoped_query_execution.stderr
+++ b/libs/toolkit-db/tests/ui/fail/unscoped_query_execution.stderr
@@ -4,5 +4,4 @@ error[E0599]: no method named `all` found for struct `SecureSelect<test_entity::
 35 |     let _result = Entity::find().secure().all(conn).await;
    |                                           ^^^ method not found in `SecureSelect<test_entity::Entity, Unscoped>`
    |
-   = note: the method was found for
-           - `SecureSelect<E, Scoped>`
+   = note: the method was found for `SecureSelect<E, Scoped>`

--- a/libs/toolkit-odata-macros/tests/ui/fail/string_op_on_int_field.stderr
+++ b/libs/toolkit-odata-macros/tests/ui/fail/string_op_on_int_field.stderr
@@ -4,5 +4,4 @@ error[E0599]: no method named `contains` found for struct `FieldRef<UserSchema, 
 11 |     let _ = user::age().contains("test");
    |                         ^^^^^^^^ method not found in `FieldRef<UserSchema, i32>`
    |
-   = note: the method was found for
-           - `FieldRef<S, std::string::String>`
+   = note: the method was found for `FieldRef<S, std::string::String>`

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 ﻿[toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]

--- a/tools/dylint_lints/Cargo.lock
+++ b/tools/dylint_lints/Cargo.lock
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "cf-gears-system-sdk-directory"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -545,14 +545,14 @@ dependencies = [
 
 [[package]]
 name = "cf-gears-system-sdks"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "cf-gears-system-sdk-directory",
 ]
 
 [[package]]
 name = "cf-gears-toolkit"
-version = "0.6.10"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "cf-gears-toolkit-canonical-errors"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "axum 0.8.9",
  "cf-gears-toolkit-canonical-errors-macro",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "cf-gears-toolkit-db"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "cf-gears-toolkit-gts"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "cf-gears-toolkit-gts-macros",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "cf-gears-toolkit-gts-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "gts-macros",
  "proc-macro-crate",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "cf-gears-toolkit-odata"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "base64",
  "bigdecimal",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "cf-gears-toolkit-sdk"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "cf-gears-toolkit-odata",
  "cf-gears-toolkit-security",
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "cf-gears-toolkit-security"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "postcard",
@@ -787,8 +787,8 @@ dependencies = [
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.95"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=54482290b5f32e6c6b57cc9e0a17153f432b0036#54482290b5f32e6c6b57cc9e0a17153f432b0036"
+version = "0.1.97"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=f6d310692116e9a527ce6d0b3526c965d9c5d7b9#f6d310692116e9a527ce6d0b3526c965d9c5d7b9"
 dependencies = [
  "arrayvec",
  "itertools 0.12.1",
@@ -1413,9 +1413,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dylint"
-version = "5.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a937bab540c0c8cdcbd650a572e6899ef2b6ffbc277d61bd2ae8d17c0edce"
+checksum = "c738fb72ea7d248df2995a31b3698beb63d0f1f9ca5a5dc0188c4b64cd0e86e4"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -1431,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_internal"
-version = "5.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e11f358a59510be7fa5c4f412729fabbe31a3587a342e4241a6a72020a2a0c5"
+checksum = "9796d3441d7894cbaf4992640799efffc1661978f0cc1266ec788c32254fdfb3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -1441,10 +1441,8 @@ dependencies = [
  "cargo_metadata",
  "git2",
  "home",
- "if_chain",
  "log",
  "regex",
- "rustversion",
  "serde",
  "tar",
  "thiserror 2.0.18",
@@ -1453,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_linting"
-version = "5.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4588b33aafbd472a6468ad1521d74094faa2bbdb53d534c2d24320300ea94135"
+checksum = "c213635b3eaa84f43b9b497377f17d9a8d4feb413bab1d82e03ad1c73e4f6d8c"
 dependencies = [
  "cargo_metadata",
  "dylint_internal",
@@ -1468,9 +1466,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_testing"
-version = "5.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc27f344ddb5488eb16b6e0f8aec889a30fb7e4d135060d336cfa60d1fd671c"
+checksum = "4f5f50ee06be9ebfb5b9538ba0d7bb08adc33e8f31c901e7d398de2a9b1ae290"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -2303,12 +2301,6 @@ dependencies = [
  "icu_normalizer",
  "icu_properties",
 ]
-
-[[package]]
-name = "if_chain"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
 
 [[package]]
 name = "indexmap"
@@ -4725,26 +4717,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
+ "winnow",
 ]
 
 [[package]]
@@ -4763,9 +4746,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
@@ -4774,7 +4757,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
@@ -5558,12 +5541,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/tools/dylint_lints/Cargo.toml
+++ b/tools/dylint_lints/Cargo.toml
@@ -1,5 +1,3 @@
-# Updated: 2026-04-07 by Constructor Tech
-# Updated: 2026-03-13 by Constructor Tech
 [workspace]
 members = [
     "lint_utils",
@@ -53,9 +51,9 @@ unsafe_code = "forbid"
 unused_extern_crates = "warn"
 
 [workspace.dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "54482290b5f32e6c6b57cc9e0a17153f432b0036" }
-dylint_linting = "=5.0.0"
-dylint_testing = "=5.0.0"
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "f6d310692116e9a527ce6d0b3526c965d9c5d7b9" }
+dylint_linting = "6"
+dylint_testing = "6"
 lint_utils = { path = "lint_utils" }
 tokio = { version = "1.44", features = ["macros", "rt"] }
 # NOTE: Keep gts version in sync with /Cargo.toml workspace dependencies

--- a/tools/dylint_lints/de01_contract_layer/de0101_no_serde_in_contract/src/lib.rs
+++ b/tools/dylint_lints/de01_contract_layer/de0101_no_serde_in_contract/src/lib.rs
@@ -3,6 +3,7 @@
 
 extern crate rustc_ast;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::{Item, ItemKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
 
@@ -70,19 +71,29 @@ impl EarlyLintPass for De0101NoSerdeInContract {
             let is_deserialize = lint_utils::is_serde_trait(&segments, "Deserialize");
 
             if is_serialize {
-                cx.span_lint(DE0101_NO_SERDE_IN_CONTRACT, attr.span, |diag| {
-                    diag.primary_message("contract type should not derive `Serialize` (DE0101)");
-                    diag.help(
-                        "remove serde derives from contract models; use DTOs in the API layer",
-                    );
-                });
+                span_lint_and_then(
+                    cx,
+                    DE0101_NO_SERDE_IN_CONTRACT,
+                    attr.span,
+                    "contract type should not derive `Serialize` (DE0101)",
+                    |diag| {
+                        diag.help(
+                            "remove serde derives from contract models; use DTOs in the API layer",
+                        );
+                    },
+                );
             } else if is_deserialize {
-                cx.span_lint(DE0101_NO_SERDE_IN_CONTRACT, attr.span, |diag| {
-                    diag.primary_message("contract type should not derive `Deserialize` (DE0101)");
-                    diag.help(
-                        "remove serde derives from contract models; use DTOs in the API layer",
-                    );
-                });
+                span_lint_and_then(
+                    cx,
+                    DE0101_NO_SERDE_IN_CONTRACT,
+                    attr.span,
+                    "contract type should not derive `Deserialize` (DE0101)",
+                    |diag| {
+                        diag.help(
+                            "remove serde derives from contract models; use DTOs in the API layer",
+                        );
+                    },
+                );
             }
         });
     }

--- a/tools/dylint_lints/de01_contract_layer/de0102_no_toschema_in_contract/src/lib.rs
+++ b/tools/dylint_lints/de01_contract_layer/de0102_no_toschema_in_contract/src/lib.rs
@@ -3,6 +3,7 @@
 
 extern crate rustc_ast;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::{Item, ItemKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
 
@@ -68,10 +69,15 @@ impl EarlyLintPass for De0102NoToschemaInContract {
             // Check if this is a utoipa ToSchema
             // Handles: ToSchema, utoipa::ToSchema, ::utoipa::ToSchema
             if lint_utils::is_utoipa_trait(&segments, "ToSchema") {
-                cx.span_lint(DE0102_NO_TOSCHEMA_IN_CONTRACT, attr.span, |diag| {
-                    diag.primary_message("contract type should not derive `ToSchema` (DE0102)");
-                    diag.help("ToSchema is an OpenAPI concern; use DTOs in api/rest/ instead");
-                });
+                span_lint_and_then(
+                    cx,
+                    DE0102_NO_TOSCHEMA_IN_CONTRACT,
+                    attr.span,
+                    "contract type should not derive `ToSchema` (DE0102)",
+                    |diag| {
+                        diag.help("ToSchema is an OpenAPI concern; use DTOs in api/rest/ instead");
+                    },
+                );
             }
         });
     }

--- a/tools/dylint_lints/de01_contract_layer/de0103_no_http_types_in_contract/src/lib.rs
+++ b/tools/dylint_lints/de01_contract_layer/de0103_no_http_types_in_contract/src/lib.rs
@@ -3,8 +3,9 @@
 
 extern crate rustc_ast;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::{Item, ItemKind, UseTree, UseTreeKind};
-use rustc_lint::{EarlyLintPass, LintContext};
+use rustc_lint::EarlyLintPass;
 
 use lint_utils::is_in_contract_module_ast;
 
@@ -74,7 +75,7 @@ const HTTP_TYPE_PATTERNS: &[&str] = &[
 
 fn use_tree_to_string(tree: &UseTree) -> String {
     match &tree.kind {
-        UseTreeKind::Simple(..) | UseTreeKind::Glob => tree
+        UseTreeKind::Simple(..) | UseTreeKind::Glob(_) => tree
             .prefix
             .segments
             .iter()
@@ -109,12 +110,17 @@ fn check_use_in_contract(cx: &rustc_lint::EarlyContext<'_>, item: &Item) {
     let path_str = use_tree_to_string(use_tree);
     for pattern in HTTP_TYPE_PATTERNS {
         if path_str.contains(pattern) {
-            cx.span_lint(DE0103_NO_HTTP_TYPES_IN_CONTRACT, item.span, |diag| {
-                diag.primary_message("contract module imports HTTP type (DE0103)");
-                diag.help(
-                    "contract gears should be transport-agnostic; move HTTP types to api/rest/",
-                );
-            });
+            span_lint_and_then(
+                cx,
+                DE0103_NO_HTTP_TYPES_IN_CONTRACT,
+                item.span,
+                "contract module imports HTTP type (DE0103)",
+                |diag| {
+                    diag.help(
+                        "contract gears should be transport-agnostic; move HTTP types to api/rest/",
+                    );
+                },
+            );
             break;
         }
     }

--- a/tools/dylint_lints/de01_contract_layer/de0104_no_api_dto_in_contract/src/lib.rs
+++ b/tools/dylint_lints/de01_contract_layer/de0104_no_api_dto_in_contract/src/lib.rs
@@ -3,8 +3,9 @@
 
 extern crate rustc_ast;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::{Item, ItemKind};
-use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
+use rustc_lint::{EarlyContext, EarlyLintPass};
 
 use lint_utils::is_in_contract_module_ast;
 
@@ -77,10 +78,15 @@ impl EarlyLintPass for De0104NoApiDtoInContract {
                 );
 
                 if is_api_dto {
-                    cx.span_lint(DE0104_NO_API_DTO_IN_CONTRACT, attr.span, |diag| {
-                        diag.primary_message("contract type should not use `api_dto` macro (DE0104)");
-                        diag.help("api_dto is for API DTOs; use plain structs in contract/ and create DTOs in api/rest/");
-                    });
+                    span_lint_and_then(
+                        cx,
+                        DE0104_NO_API_DTO_IN_CONTRACT,
+                        attr.span,
+                        "contract type should not use `api_dto` macro (DE0104)",
+                        |diag| {
+                            diag.help("api_dto is for API DTOs; use plain structs in contract/ and create DTOs in api/rest/");
+                        },
+                    );
                 }
             }
         }

--- a/tools/dylint_lints/de01_contract_layer/de0110_no_schema_for_on_gts_structs/src/lib.rs
+++ b/tools/dylint_lints/de01_contract_layer/de0110_no_schema_for_on_gts_structs/src/lib.rs
@@ -5,6 +5,7 @@ extern crate rustc_hir;
 extern crate rustc_middle;
 extern crate rustc_span;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_hir::{Expr, ExprKind, GenericArg};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::ty::{self, Ty};
@@ -113,20 +114,21 @@ impl<'tcx> LateLintPass<'tcx> for De0110NoSchemaForOnGtsStructs {
                             && is_gts_type(cx, ty)
                         {
                             let type_name = get_type_name(ty);
-                            cx.span_lint(
-                                        DE0110_NO_SCHEMA_FOR_ON_GTS_STRUCTS,
-                                        callsite_span,
-                                        |diag| {
-                                            diag.primary_message(format!(
-                                                "do not use `schema_for!({})` on GTS-wrapped struct (DE0110)",
-                                                type_name
-                                            ));
-                                            diag.help(format!(
-                                                "use `{}::gts_json_schema_with_refs()` instead for proper `$id` and `$ref` handling",
-                                                type_name
-                                            ));
-                                        },
-                                    );
+                            span_lint_and_then(
+                                cx,
+                                DE0110_NO_SCHEMA_FOR_ON_GTS_STRUCTS,
+                                callsite_span,
+                                format!(
+                                    "do not use `schema_for!({})` on GTS-wrapped struct (DE0110)",
+                                    type_name
+                                ),
+                                |diag| {
+                                    diag.help(format!(
+                                        "use `{}::gts_json_schema_with_refs()` instead for proper `$id` and `$ref` handling",
+                                        type_name
+                                    ));
+                                },
+                            );
                             return;
                         }
                     }

--- a/tools/dylint_lints/de02_api_layer/de0201_dtos_only_in_api_rest/src/lib.rs
+++ b/tools/dylint_lints/de02_api_layer/de0201_dtos_only_in_api_rest/src/lib.rs
@@ -3,6 +3,7 @@
 
 extern crate rustc_ast;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::ItemKind;
 use rustc_lint::{EarlyLintPass, LintContext};
 
@@ -41,13 +42,18 @@ impl EarlyLintPass for De0201DtosOnlyInApiRest {
 
         // Check if the file is in api/rest folder (supports simulated_dir for tests)
         if !lint_utils::is_in_api_rest_folder(cx.sess().source_map(), item.span) {
-            cx.span_lint(DE0201_DTOS_ONLY_IN_API_REST, span, |diag| {
-                diag.primary_message(format!(
+            span_lint_and_then(
+                cx,
+                DE0201_DTOS_ONLY_IN_API_REST,
+                span,
+                format!(
                     "DTO type `{}` is defined outside of api/rest folder (DE0201)",
                     item_name
-                ));
-                diag.help("move DTO types to src/api/rest/dto.rs");
-            });
+                ),
+                |diag| {
+                    diag.help("move DTO types to src/api/rest/dto.rs");
+                },
+            );
         }
     }
 }

--- a/tools/dylint_lints/de02_api_layer/de0202_dtos_not_referenced_outside_api/src/lib.rs
+++ b/tools/dylint_lints/de02_api_layer/de0202_dtos_not_referenced_outside_api/src/lib.rs
@@ -3,6 +3,7 @@
 
 extern crate rustc_hir;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_hir::{Item, ItemKind};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 
@@ -59,15 +60,20 @@ impl<'tcx> LateLintPass<'tcx> for De0202DtosNotReferencedOutsideApi {
                     "infra"
                 };
 
-                cx.span_lint(DE0202_DTOS_NOT_REFERENCED_OUTSIDE_API, item.span, |diag| {
-                    diag.primary_message(format!(
+                span_lint_and_then(
+                    cx,
+                    DE0202_DTOS_NOT_REFERENCED_OUTSIDE_API,
+                    item.span,
+                    format!(
                         "{} module imports DTO type `{}` from api layer (DE0202)",
                         module_type, last
-                    ));
-                    diag.help(
-                        "DTOs are API layer details; use contract models or domain types instead",
-                    );
-                });
+                    ),
+                    |diag| {
+                        diag.help(
+                            "DTOs are API layer details; use contract models or domain types instead",
+                        );
+                    },
+                );
             }
         }
     }

--- a/tools/dylint_lints/de02_api_layer/de0203_dtos_must_use_api_dto/src/lib.rs
+++ b/tools/dylint_lints/de02_api_layer/de0203_dtos_must_use_api_dto/src/lib.rs
@@ -3,6 +3,7 @@
 
 extern crate rustc_ast;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::{Item, ItemKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
 
@@ -73,10 +74,15 @@ fn check_dto_uses_api_dto(cx: &EarlyContext<'_>, item: &Item) {
     }
 
     // Report missing api_dto macro
-    cx.span_lint(DE0203_DTOS_MUST_USE_API_DTO, item.span, |diag| {
-        diag.primary_message("api/rest DTO type must use the api_dto macro (DE0203)");
-        diag.help("Use #[toolkit_macros::api_dto(request)] for request DTOs, #[toolkit_macros::api_dto(response)] for response DTOs, or #[toolkit_macros::api_dto(request, response)] for both");
-    });
+    span_lint_and_then(
+        cx,
+        DE0203_DTOS_MUST_USE_API_DTO,
+        item.span,
+        "api/rest DTO type must use the api_dto macro (DE0203)",
+        |diag| {
+            diag.help("Use #[toolkit_macros::api_dto(request)] for request DTOs, #[toolkit_macros::api_dto(response)] for response DTOs, or #[toolkit_macros::api_dto(request, response)] for both");
+        },
+    );
 }
 
 #[cfg(test)]

--- a/tools/dylint_lints/de02_api_layer/de0204_dtos_must_have_toschema_derive/src/lib.rs
+++ b/tools/dylint_lints/de02_api_layer/de0204_dtos_must_have_toschema_derive/src/lib.rs
@@ -3,8 +3,9 @@
 
 extern crate rustc_ast;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::{Item, ItemKind};
-use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
+use rustc_lint::{EarlyContext, EarlyLintPass};
 
 dylint_linting::declare_pre_expansion_lint! {
     /// DE0204: DTOs Must Have ToSchema Derive
@@ -81,10 +82,15 @@ fn check_dto_toschema_derive(cx: &EarlyContext<'_>, item: &Item) {
 
     // Report missing derive
     if !has_toschema {
-        cx.span_lint(DE0204_DTOS_MUST_HAVE_TOSCHEMA_DERIVE, item.span, |diag| {
-            diag.primary_message("api/rest type is missing required ToSchema derive (DE0204)");
-            diag.help("DTOs in api/rest must derive ToSchema for OpenAPI documentation");
-        });
+        span_lint_and_then(
+            cx,
+            DE0204_DTOS_MUST_HAVE_TOSCHEMA_DERIVE,
+            item.span,
+            "api/rest type is missing required ToSchema derive (DE0204)",
+            |diag| {
+                diag.help("DTOs in api/rest must derive ToSchema for OpenAPI documentation");
+            },
+        );
     }
 }
 

--- a/tools/dylint_lints/de02_api_layer/de0205_operation_builder/src/lib.rs
+++ b/tools/dylint_lints/de02_api_layer/de0205_operation_builder/src/lib.rs
@@ -6,7 +6,8 @@ extern crate rustc_hir;
 extern crate rustc_span;
 
 use clippy_utils::consts::{ConstEvalCtxt, Constant};
-use rustc_lint::{LateContext, LateLintPass, LintContext};
+use clippy_utils::diagnostics::span_lint_and_then;
+use rustc_lint::{LateContext, LateLintPass};
 use rustc_span::Span;
 
 dylint_linting::declare_late_lint! {
@@ -71,17 +72,27 @@ impl<'tcx> LateLintPass<'tcx> for De0205OperationBuilder {
                     if let Some(tag_arg) = args.first() {
                         if let Some(tag_string) = extract_tag_value(cx, tag_arg) {
                             if !is_valid_tag_format(&tag_string) {
-                                cx.span_lint(DE0205_OPERATION_BUILDER, tag_arg.span, |diag| {
-                                        diag.primary_message("tag format is invalid");
+                                span_lint_and_then(
+                                    cx,
+                                    DE0205_OPERATION_BUILDER,
+                                    tag_arg.span,
+                                    "tag format is invalid",
+                                    |diag| {
                                         diag.help("tags must contain whitespace-separated words, each starting with a capital letter");
                                         diag.note("example: \"User Management\", \"Simple Resource Registry\"");
-                                    });
+                                    },
+                                );
                             }
                         } else {
-                            cx.span_lint(DE0205_OPERATION_BUILDER, tag_arg.span, |diag| {
-                                    diag.primary_message("tag must be a string literal or const string");
+                            span_lint_and_then(
+                                cx,
+                                DE0205_OPERATION_BUILDER,
+                                tag_arg.span,
+                                "tag must be a string literal or const string",
+                                |diag| {
                                     diag.help("use a string literal like `.tag(\"Your Tag\")` or a const string");
-                                });
+                                },
+                            );
                         }
                     }
                 }
@@ -89,16 +100,26 @@ impl<'tcx> LateLintPass<'tcx> for De0205OperationBuilder {
                     if let Some(summary_arg) = args.first() {
                         if let Some(summary_string) = extract_tag_value(cx, summary_arg) {
                             if summary_string.trim().is_empty() {
-                                cx.span_lint(DE0205_OPERATION_BUILDER, summary_arg.span, |diag| {
-                                    diag.primary_message("summary cannot be empty");
-                                    diag.help("provide a meaningful summary for the operation");
-                                });
+                                span_lint_and_then(
+                                    cx,
+                                    DE0205_OPERATION_BUILDER,
+                                    summary_arg.span,
+                                    "summary cannot be empty",
+                                    |diag| {
+                                        diag.help("provide a meaningful summary for the operation");
+                                    },
+                                );
                             }
                         } else {
-                            cx.span_lint(DE0205_OPERATION_BUILDER, summary_arg.span, |diag| {
-                                    diag.primary_message("summary must be a string literal or const string");
+                            span_lint_and_then(
+                                cx,
+                                DE0205_OPERATION_BUILDER,
+                                summary_arg.span,
+                                "summary must be a string literal or const string",
+                                |diag| {
                                     diag.help("use a string literal like `.summary(\"Your summary\")` or a const string");
-                                });
+                                },
+                            );
                         }
                     }
                 }
@@ -120,26 +141,33 @@ fn check_complete_builder_chain(cx: &LateContext<'_>, expr: &rustc_hir::Expr<'_>
         // Report missing calls
         let builder_span = get_builder_constructor_span(expr);
         if !has_tag || !has_summary {
-            cx.span_lint(DE0205_OPERATION_BUILDER, builder_span, |diag| {
-                match (has_tag, has_summary) {
+            let msg = match (has_tag, has_summary) {
+                (false, false) => "operation builder missing .tag() and .summary() calls",
+                (false, true) => "operation builder missing .tag() call",
+                (true, false) => "operation builder missing .summary() call",
+                (true, true) => "",
+            };
+            span_lint_and_then(
+                cx,
+                DE0205_OPERATION_BUILDER,
+                builder_span,
+                msg,
+                |diag| match (has_tag, has_summary) {
                     (false, false) => {
-                        diag.primary_message("operation builder missing .tag() and .summary() calls");
                         diag.help("add .tag(\"Your Tag\") with properly formatted tag");
                         diag.note("tags must contain whitespace-separated words, each starting with a capital letter");
                         diag.help("add .summary(\"Your summary\") with a meaningful description");
                     }
                     (false, true) => {
-                        diag.primary_message("operation builder missing .tag() call");
                         diag.help("add .tag(\"Your Tag\") with properly formatted tag");
                         diag.note("tags must contain whitespace-separated words, each starting with a capital letter");
                     }
                     (true, false) => {
-                        diag.primary_message("operation builder missing .summary() call");
                         diag.help("add .summary(\"Your summary\") with a meaningful description");
                     }
                     (true, true) => {}
-                }
-            });
+                },
+            );
         }
     }
 }

--- a/tools/dylint_lints/de03_domain_layer/de0301_no_infra_in_domain/src/lib.rs
+++ b/tools/dylint_lints/de03_domain_layer/de0301_no_infra_in_domain/src/lib.rs
@@ -3,6 +3,7 @@
 
 extern crate rustc_ast;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use lint_utils::{is_in_contract_module_ast, is_in_domain_path, use_tree_to_strings};
 use rustc_ast::{Item, ItemKind, Ty, TyKind};
 use rustc_lint::{EarlyLintPass, LintContext};
@@ -101,14 +102,17 @@ fn check_use_in_domain(cx: &rustc_lint::EarlyContext<'_>, item: &Item) {
 
     for path_str in use_tree_to_strings(use_tree) {
         if let Some(pattern) = matches_infra_pattern(&path_str) {
-            cx.span_lint(DE0301_NO_INFRA_IN_DOMAIN, item.span, |diag| {
-                diag.primary_message(format!(
-                    "domain module imports infrastructure dependency `{pattern}` (DE0301)"
-                ));
-                diag.help(
-                    "domain should depend only on abstractions; move infrastructure code to infra/ layer",
-                );
-            });
+            span_lint_and_then(
+                cx,
+                DE0301_NO_INFRA_IN_DOMAIN,
+                item.span,
+                format!("domain module imports infrastructure dependency `{pattern}` (DE0301)"),
+                |diag| {
+                    diag.help(
+                        "domain should depend only on abstractions; move infrastructure code to infra/ layer",
+                    );
+                },
+            );
             return;
         }
     }
@@ -126,14 +130,17 @@ fn check_type_in_domain(cx: &rustc_lint::EarlyContext<'_>, ty: &Ty) {
                 .join("::");
 
             if matches_infra_pattern(&path_str).is_some() {
-                cx.span_lint(DE0301_NO_INFRA_IN_DOMAIN, ty.span, |diag| {
-                    diag.primary_message(format!(
-                        "domain module uses infrastructure type `{path_str}` (DE0301)"
-                    ));
-                    diag.help(
-                        "domain should depend only on abstractions; move infrastructure code to infra/ layer",
-                    );
-                });
+                span_lint_and_then(
+                    cx,
+                    DE0301_NO_INFRA_IN_DOMAIN,
+                    ty.span,
+                    format!("domain module uses infrastructure type `{path_str}` (DE0301)"),
+                    |diag| {
+                        diag.help(
+                            "domain should depend only on abstractions; move infrastructure code to infra/ layer",
+                        );
+                    },
+                );
                 return;
             }
 
@@ -189,14 +196,19 @@ fn check_type_in_domain(cx: &rustc_lint::EarlyContext<'_>, ty: &Ty) {
                         .join("::");
 
                     if matches_infra_pattern(&path_str).is_some() {
-                        cx.span_lint(DE0301_NO_INFRA_IN_DOMAIN, ty.span, |diag| {
-                            diag.primary_message(format!(
+                        span_lint_and_then(
+                            cx,
+                            DE0301_NO_INFRA_IN_DOMAIN,
+                            ty.span,
+                            format!(
                                 "domain module uses infrastructure trait `{path_str}` (DE0301)"
-                            ));
-                            diag.help(
-                                "domain should depend only on abstractions; move infrastructure code to infra/ layer",
-                            );
-                        });
+                            ),
+                            |diag| {
+                                diag.help(
+                                    "domain should depend only on abstractions; move infrastructure code to infra/ layer",
+                                );
+                            },
+                        );
                         return;
                     }
                 }
@@ -216,14 +228,19 @@ fn check_type_in_domain(cx: &rustc_lint::EarlyContext<'_>, ty: &Ty) {
                         .join("::");
 
                     if matches_infra_pattern(&path_str).is_some() {
-                        cx.span_lint(DE0301_NO_INFRA_IN_DOMAIN, ty.span, |diag| {
-                            diag.primary_message(format!(
+                        span_lint_and_then(
+                            cx,
+                            DE0301_NO_INFRA_IN_DOMAIN,
+                            ty.span,
+                            format!(
                                 "domain module uses infrastructure trait `{path_str}` (DE0301)"
-                            ));
-                            diag.help(
-                                "domain should depend only on abstractions; move infrastructure code to infra/ layer",
-                            );
-                        });
+                            ),
+                            |diag| {
+                                diag.help(
+                                    "domain should depend only on abstractions; move infrastructure code to infra/ layer",
+                                );
+                            },
+                        );
                         return;
                     }
                 }

--- a/tools/dylint_lints/de03_domain_layer/de0308_no_http_in_domain/src/lib.rs
+++ b/tools/dylint_lints/de03_domain_layer/de0308_no_http_in_domain/src/lib.rs
@@ -3,6 +3,7 @@
 
 extern crate rustc_ast;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use lint_utils::{is_in_contract_module_ast, is_in_domain_path, use_tree_to_strings};
 use rustc_ast::{Item, ItemKind, Ty, TyKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
@@ -67,12 +68,15 @@ fn matches_http_pattern(path: &str) -> Option<&'static str> {
 fn check_use_item(cx: &EarlyContext<'_>, item: &Item, tree: &rustc_ast::UseTree) {
     for path_str in use_tree_to_strings(tree) {
         if let Some(pattern) = matches_http_pattern(&path_str) {
-            cx.span_lint(DE0308_NO_HTTP_IN_DOMAIN, item.span, |diag| {
-                diag.primary_message(format!(
-                    "domain module imports HTTP type `{pattern}` (DE0308)"
-                ));
-                diag.help("domain should be transport-agnostic; handle HTTP in api/ layer");
-            });
+            span_lint_and_then(
+                cx,
+                DE0308_NO_HTTP_IN_DOMAIN,
+                item.span,
+                format!("domain module imports HTTP type `{pattern}` (DE0308)"),
+                |diag| {
+                    diag.help("domain should be transport-agnostic; handle HTTP in api/ layer");
+                },
+            );
             return;
         }
     }
@@ -90,13 +94,15 @@ fn check_type_in_domain(cx: &rustc_lint::EarlyContext<'_>, ty: &Ty) {
                 .join("::");
 
             if matches_http_pattern(&path_str).is_some() {
-                cx.span_lint(DE0308_NO_HTTP_IN_DOMAIN, ty.span, |diag| {
-                    diag.primary_message(format!(
-                        "domain module uses HTTP type `{}` (DE0308)",
-                        path_str
-                    ));
-                    diag.help("domain should be transport-agnostic; handle HTTP in api/ layer");
-                });
+                span_lint_and_then(
+                    cx,
+                    DE0308_NO_HTTP_IN_DOMAIN,
+                    ty.span,
+                    format!("domain module uses HTTP type `{}` (DE0308)", path_str),
+                    |diag| {
+                        diag.help("domain should be transport-agnostic; handle HTTP in api/ layer");
+                    },
+                );
                 return;
             }
 
@@ -152,15 +158,17 @@ fn check_type_in_domain(cx: &rustc_lint::EarlyContext<'_>, ty: &Ty) {
                         .join("::");
 
                     if matches_http_pattern(&path_str).is_some() {
-                        cx.span_lint(DE0308_NO_HTTP_IN_DOMAIN, ty.span, |diag| {
-                            diag.primary_message(format!(
-                                "domain module uses HTTP trait `{}` (DE0308)",
-                                path_str
-                            ));
-                            diag.help(
-                                "domain should be transport-agnostic; handle HTTP in api/ layer",
-                            );
-                        });
+                        span_lint_and_then(
+                            cx,
+                            DE0308_NO_HTTP_IN_DOMAIN,
+                            ty.span,
+                            format!("domain module uses HTTP trait `{}` (DE0308)", path_str),
+                            |diag| {
+                                diag.help(
+                                    "domain should be transport-agnostic; handle HTTP in api/ layer",
+                                );
+                            },
+                        );
                         return;
                     }
                 }
@@ -180,15 +188,17 @@ fn check_type_in_domain(cx: &rustc_lint::EarlyContext<'_>, ty: &Ty) {
                         .join("::");
 
                     if matches_http_pattern(&path_str).is_some() {
-                        cx.span_lint(DE0308_NO_HTTP_IN_DOMAIN, ty.span, |diag| {
-                            diag.primary_message(format!(
-                                "domain module uses HTTP trait `{}` (DE0308)",
-                                path_str
-                            ));
-                            diag.help(
-                                "domain should be transport-agnostic; handle HTTP in api/ layer",
-                            );
-                        });
+                        span_lint_and_then(
+                            cx,
+                            DE0308_NO_HTTP_IN_DOMAIN,
+                            ty.span,
+                            format!("domain module uses HTTP trait `{}` (DE0308)", path_str),
+                            |diag| {
+                                diag.help(
+                                    "domain should be transport-agnostic; handle HTTP in api/ layer",
+                                );
+                            },
+                        );
                         return;
                     }
                 }

--- a/tools/dylint_lints/de03_domain_layer/de0309_must_have_domain_model/src/lib.rs
+++ b/tools/dylint_lints/de03_domain_layer/de0309_must_have_domain_model/src/lib.rs
@@ -3,6 +3,7 @@
 
 extern crate rustc_ast;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use lint_utils::is_in_domain_path;
 use rustc_ast::{Item, ItemKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
@@ -76,15 +77,18 @@ fn check_domain_model_attribute(cx: &EarlyContext<'_>, item: &Item) {
         _ => return,
     };
 
-    cx.span_lint(DE0309_MUST_HAVE_DOMAIN_MODEL, item.span, |diag| {
-        diag.primary_message(format!(
-            "domain type `{item_name}` is missing required #[domain_model] attribute (DE0309)"
-        ));
-        diag.help(format!(
-            "add #[domain_model] attribute to enforce DDD boundaries at compile time: \
-             use toolkit_macros::domain_model; #[domain_model] pub {item_keyword} ..."
-        ));
-    });
+    span_lint_and_then(
+        cx,
+        DE0309_MUST_HAVE_DOMAIN_MODEL,
+        item.span,
+        format!("domain type `{item_name}` is missing required #[domain_model] attribute (DE0309)"),
+        |diag| {
+            diag.help(format!(
+                "add #[domain_model] attribute to enforce DDD boundaries at compile time: \
+                 use toolkit_macros::domain_model; #[domain_model] pub {item_keyword} ..."
+            ));
+        },
+    );
 }
 
 /// Check if an item has the `#[domain_model]` or `#[toolkit::domain_model]` attribute.

--- a/tools/dylint_lints/de05_client_layer/de0503_plugin_client_suffix/src/lib.rs
+++ b/tools/dylint_lints/de05_client_layer/de0503_plugin_client_suffix/src/lib.rs
@@ -4,8 +4,9 @@
 extern crate rustc_ast;
 extern crate rustc_span;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::{Item, ItemKind};
-use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
+use rustc_lint::{EarlyContext, EarlyLintPass};
 use rustc_span::Span;
 
 dylint_linting::declare_early_lint! {
@@ -116,14 +117,19 @@ fn emit_lint(
         format!("{trait_name}Client")
     };
 
-    cx.span_lint(DE0503_PLUGIN_CLIENT_SUFFIX, span, |diag| {
-        diag.primary_message(format!(
+    span_lint_and_then(
+        cx,
+        DE0503_PLUGIN_CLIENT_SUFFIX,
+        span,
+        format!(
             "plugin client trait `{trait_name}` should use `*{suggested_suffix}` suffix, not `*{wrong_suffix}` (DE0503)"
-        ));
-        diag.help(format!(
-            "rename trait to `{suggestion}` to follow plugin client naming conventions"
-        ));
-    });
+        ),
+        |diag| {
+            diag.help(format!(
+                "rename trait to `{suggestion}` to follow plugin client naming conventions"
+            ));
+        },
+    );
 }
 
 #[cfg(test)]

--- a/tools/dylint_lints/de05_client_layer/de0504_client_versioning/src/lib.rs
+++ b/tools/dylint_lints/de05_client_layer/de0504_client_versioning/src/lib.rs
@@ -4,6 +4,7 @@
 extern crate rustc_ast;
 extern crate rustc_span;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::{Item, ItemKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
 use rustc_span::Span;
@@ -116,14 +117,19 @@ fn emit_lint(
             format!("{}V1", version.base)
         };
 
-    cx.span_lint(DE0504_CLIENT_VERSIONING, span, |diag| {
-        diag.primary_message(format!(
+    span_lint_and_then(
+        cx,
+        DE0504_CLIENT_VERSIONING,
+        span,
+        format!(
             "Client trait `{trait_name}` in non-system gear must have a version suffix (DE0504)"
-        ));
-        diag.help(format!(
-            "rename trait to `{suggestion}` to indicate API version"
-        ));
-    });
+        ),
+        |diag| {
+            diag.help(format!(
+                "rename trait to `{suggestion}` to indicate API version"
+            ));
+        },
+    );
 }
 
 #[cfg(test)]

--- a/tools/dylint_lints/de07_security/de0706_no_direct_sqlx/src/lib.rs
+++ b/tools/dylint_lints/de07_security/de0706_no_direct_sqlx/src/lib.rs
@@ -3,6 +3,7 @@
 
 extern crate rustc_ast;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use lint_utils::{
     is_in_cf_gears_server_path, is_in_contract_module_ast, is_in_toolkit_db_path,
     use_tree_to_strings,
@@ -79,13 +80,16 @@ fn check_type_for_sqlx(cx: &rustc_lint::EarlyContext<'_>, ty: &Ty) {
                 .join("::");
 
             if is_sqlx_path(&path_str) {
-                cx.span_lint(DE0706_NO_DIRECT_SQLX, ty.span, |diag| {
-                    diag.primary_message(format!(
-                        "direct sqlx type usage detected: `{path_str}` (DE0706)"
-                    ));
-                    diag.help("use Sea-ORM EntityTrait or SecORM abstractions instead");
-                    diag.note("sqlx bypasses security enforcement and architectural patterns");
-                });
+                span_lint_and_then(
+                    cx,
+                    DE0706_NO_DIRECT_SQLX,
+                    ty.span,
+                    format!("direct sqlx type usage detected: `{path_str}` (DE0706)"),
+                    |diag| {
+                        diag.help("use Sea-ORM EntityTrait or SecORM abstractions instead");
+                        diag.note("sqlx bypasses security enforcement and architectural patterns");
+                    },
+                );
                 return;
             }
 
@@ -131,15 +135,18 @@ fn check_type_for_sqlx(cx: &rustc_lint::EarlyContext<'_>, ty: &Ty) {
                         .join("::");
 
                     if is_sqlx_path(&path_str) {
-                        cx.span_lint(DE0706_NO_DIRECT_SQLX, ty.span, |diag| {
-                            diag.primary_message(format!(
-                                "direct sqlx trait usage detected: `{path_str}` (DE0706)"
-                            ));
-                            diag.help("use Sea-ORM EntityTrait or SecORM abstractions instead");
-                            diag.note(
-                                "sqlx bypasses security enforcement and architectural patterns",
-                            );
-                        });
+                        span_lint_and_then(
+                            cx,
+                            DE0706_NO_DIRECT_SQLX,
+                            ty.span,
+                            format!("direct sqlx trait usage detected: `{path_str}` (DE0706)"),
+                            |diag| {
+                                diag.help("use Sea-ORM EntityTrait or SecORM abstractions instead");
+                                diag.note(
+                                    "sqlx bypasses security enforcement and architectural patterns",
+                                );
+                            },
+                        );
                         return;
                     }
                 }
@@ -155,14 +162,16 @@ fn check_use_for_sqlx(cx: &rustc_lint::EarlyContext<'_>, item: &Item) {
     };
 
     if let Some(path_str) = find_sqlx_path(use_tree) {
-        cx.span_lint(DE0706_NO_DIRECT_SQLX, item.span, |diag| {
-            diag.primary_message(format!(
-                "direct sqlx import detected: `{}` (DE0706)",
-                path_str
-            ));
-            diag.help("use Sea-ORM EntityTrait or SecORM abstractions instead");
-            diag.note("sqlx bypasses security enforcement and architectural patterns");
-        });
+        span_lint_and_then(
+            cx,
+            DE0706_NO_DIRECT_SQLX,
+            item.span,
+            format!("direct sqlx import detected: `{}` (DE0706)", path_str),
+            |diag| {
+                diag.help("use Sea-ORM EntityTrait or SecORM abstractions instead");
+                diag.note("sqlx bypasses security enforcement and architectural patterns");
+            },
+        );
     }
 }
 
@@ -197,11 +206,18 @@ impl EarlyLintPass for De0706NoDirectSqlx {
                 };
 
                 if is_sqlx {
-                    cx.span_lint(DE0706_NO_DIRECT_SQLX, item.span, |diag| {
-                        diag.primary_message("extern crate sqlx is prohibited (DE0706)");
-                        diag.help("use Sea-ORM EntityTrait or SecORM abstractions instead");
-                        diag.note("sqlx bypasses security enforcement and architectural patterns");
-                    });
+                    span_lint_and_then(
+                        cx,
+                        DE0706_NO_DIRECT_SQLX,
+                        item.span,
+                        "extern crate sqlx is prohibited (DE0706)",
+                        |diag| {
+                            diag.help("use Sea-ORM EntityTrait or SecORM abstractions instead");
+                            diag.note(
+                                "sqlx bypasses security enforcement and architectural patterns",
+                            );
+                        },
+                    );
                 }
             }
             // Check struct fields for sqlx types

--- a/tools/dylint_lints/de07_security/de0707_drop_zeroize/src/lib.rs
+++ b/tools/dylint_lints/de07_security/de0707_drop_zeroize/src/lib.rs
@@ -8,9 +8,10 @@ extern crate rustc_hir;
 extern crate rustc_middle;
 extern crate rustc_span;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_hir::def_id::DefId;
 use rustc_hir::{self as hir, Expr, ExprKind, ImplItemKind, ItemKind};
-use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{Ty, TypeckResults};
 use rustc_span::symbol::Symbol;
 
@@ -158,17 +159,20 @@ impl<'tcx> hir::intravisit::Visitor<'tcx> for ZeroingVisitor<'tcx, '_> {
                 {
                     let inner_ty = self.typeck.expr_ty(inner);
                     if is_u8_ptr_or_ref(inner_ty) {
-                        self.cx.span_lint(DE0707_DROP_ZEROIZE, expr.span, |diag| {
-                                diag.primary_message(
-                                    "manual byte-zeroing in `Drop::drop` may be eliminated by the optimizer (DE0707)",
-                                );
+                        span_lint_and_then(
+                            self.cx,
+                            DE0707_DROP_ZEROIZE,
+                            expr.span,
+                            "manual byte-zeroing in `Drop::drop` may be eliminated by the optimizer (DE0707)",
+                            |diag| {
                                 diag.help(
                                     "use `secrecy::SecretBox` or `zeroize`: `.zeroize()` / `#[derive(ZeroizeOnDrop)]`",
                                 );
                                 diag.note(
                                     "LLVM dead-store elimination can legally remove writes that are never read; `zeroize` uses a compiler fence to prevent this",
                                 );
-                            });
+                            },
+                        );
                     }
                 }
             }
@@ -190,17 +194,20 @@ impl<'tcx> hir::intravisit::Visitor<'tcx> for ZeroingVisitor<'tcx, '_> {
                     // Use adjusted type so Vec<u8> auto-derefs to [u8]
                     let recv_ty = self.typeck.expr_ty_adjusted(recv);
                     if method_in_std && has_u8_element(recv_ty) {
-                        self.cx.span_lint(DE0707_DROP_ZEROIZE, expr.span, |diag| {
-                                    diag.primary_message(
-                                        "manual byte-zeroing in `Drop::drop` may be eliminated by the optimizer (DE0707)",
-                                    );
-                                    diag.help(
-                                        "use `secrecy::SecretBox` or `zeroize`: `.zeroize()` / `#[derive(ZeroizeOnDrop)]`",
-                                    );
-                                    diag.note(
-                                        "LLVM dead-store elimination can legally remove writes that are never read; `zeroize` uses a compiler fence to prevent this",
-                                    );
-                                });
+                        span_lint_and_then(
+                            self.cx,
+                            DE0707_DROP_ZEROIZE,
+                            expr.span,
+                            "manual byte-zeroing in `Drop::drop` may be eliminated by the optimizer (DE0707)",
+                            |diag| {
+                                diag.help(
+                                    "use `secrecy::SecretBox` or `zeroize`: `.zeroize()` / `#[derive(ZeroizeOnDrop)]`",
+                                );
+                                diag.note(
+                                    "LLVM dead-store elimination can legally remove writes that are never read; `zeroize` uses a compiler fence to prevent this",
+                                );
+                            },
+                        );
                     }
                 }
             }
@@ -215,21 +222,20 @@ impl<'tcx> hir::intravisit::Visitor<'tcx> for ZeroingVisitor<'tcx, '_> {
                     && let Some(def_id) = self.cx.qpath_res(qpath, func.hir_id).opt_def_id()
                     && is_ptr_write_bytes(self.cx, def_id)
                 {
-                    self.cx.span_lint(
-                                            DE0707_DROP_ZEROIZE,
-                                            expr.span,
-                                            |diag| {
-                                                diag.primary_message(
-                                                    "manual byte-zeroing in `Drop::drop` may be eliminated by the optimizer (DE0707)",
-                                                );
-                                                diag.help(
-                                                    "use `secrecy::SecretBox` or `zeroize`: `.zeroize()` / `#[derive(ZeroizeOnDrop)]`",
-                                                );
-                                                diag.note(
-                                                    "LLVM dead-store elimination can legally remove writes that are never read; `zeroize` uses a compiler fence to prevent this",
-                                                );
-                                            },
-                                        );
+                    span_lint_and_then(
+                        self.cx,
+                        DE0707_DROP_ZEROIZE,
+                        expr.span,
+                        "manual byte-zeroing in `Drop::drop` may be eliminated by the optimizer (DE0707)",
+                        |diag| {
+                            diag.help(
+                                "use `secrecy::SecretBox` or `zeroize`: `.zeroize()` / `#[derive(ZeroizeOnDrop)]`",
+                            );
+                            diag.note(
+                                "LLVM dead-store elimination can legally remove writes that are never read; `zeroize` uses a compiler fence to prevent this",
+                            );
+                        },
+                    );
                 }
             }
             _ => {}

--- a/tools/dylint_lints/de08_rest_api_conventions/de0801_api_endpoint_version/src/lib.rs
+++ b/tools/dylint_lints/de08_rest_api_conventions/de0801_api_endpoint_version/src/lib.rs
@@ -4,8 +4,9 @@
 extern crate rustc_ast;
 extern crate rustc_hir;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_hir::{Expr, ExprKind};
-use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_lint::{LateContext, LateLintPass};
 
 dylint_linting::declare_late_lint! {
     /// ### What it does
@@ -273,11 +274,16 @@ fn check_path_argument<'tcx>(cx: &LateContext<'tcx>, path_arg: &'tcx Expr<'tcx>)
                 ),
             };
 
-            cx.span_lint(DE0801_API_ENDPOINT_VERSION, path_arg.span, |diag| {
-                diag.primary_message(message);
-                diag.help(help);
-                diag.note(note);
-            });
+            span_lint_and_then(
+                cx,
+                DE0801_API_ENDPOINT_VERSION,
+                path_arg.span,
+                message,
+                |diag| {
+                    diag.help(help);
+                    diag.note(note);
+                },
+            );
         }
     }
 }

--- a/tools/dylint_lints/de08_rest_api_conventions/de0802_use_odata_ext/src/lib.rs
+++ b/tools/dylint_lints/de08_rest_api_conventions/de0802_use_odata_ext/src/lib.rs
@@ -4,8 +4,9 @@
 extern crate rustc_ast;
 extern crate rustc_hir;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_hir::{Expr, ExprKind};
-use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_lint::{LateContext, LateLintPass};
 
 dylint_linting::declare_late_lint! {
     /// ### What it does
@@ -133,16 +134,21 @@ fn check_odata_param<'tcx>(cx: &LateContext<'tcx>, arg: &'tcx Expr<'tcx>, method
         if ODATA_PARAMS.contains(&param_name) {
             let recommended = get_recommended_method(param_name);
 
-            cx.span_lint(DE0802_USE_ODATA_EXT, arg.span, |diag| {
-                diag.primary_message(format!(
+            span_lint_and_then(
+                cx,
+                DE0802_USE_ODATA_EXT,
+                arg.span,
+                format!(
                     "use OperationBuilderODataExt instead of .{}() for OData parameter `{}` (DE0802)",
                     method_name, param_name
-                ));
-                diag.help(format!("use {} instead", recommended));
-                diag.note(
-                    "type-safe OData methods provide compile-time validation and automatic OpenAPI schema generation",
-                );
-            });
+                ),
+                |diag| {
+                    diag.help(format!("use {} instead", recommended));
+                    diag.note(
+                        "type-safe OData methods provide compile-time validation and automatic OpenAPI schema generation",
+                    );
+                },
+            );
         }
     }
 }

--- a/tools/dylint_lints/de08_rest_api_conventions/de0803_api_snake_case/src/lib.rs
+++ b/tools/dylint_lints/de08_rest_api_conventions/de0803_api_snake_case/src/lib.rs
@@ -4,6 +4,7 @@
 extern crate rustc_ast;
 extern crate rustc_span;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::{Attribute, FieldDef, Item, ItemKind, VariantData};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
 
@@ -104,14 +105,17 @@ fn find_serde_attribute_value(
 fn check_type_rename_all(cx: &EarlyContext<'_>, attrs: &[Attribute]) {
     for (span, value) in find_serde_attribute_value(attrs, "rename_all") {
         if value != "snake_case" {
-            cx.span_lint(DE0803_API_SNAKE_CASE, span, |diag| {
-                diag.primary_message(
-                    "DTOs must not use non-snake_case in serde rename_all (DE0803)",
-                );
-                diag.help(
-                    "DTOs in api/rest must use snake_case (or default) to match API standards",
-                );
-            });
+            span_lint_and_then(
+                cx,
+                DE0803_API_SNAKE_CASE,
+                span,
+                "DTOs must not use non-snake_case in serde rename_all (DE0803)",
+                |diag| {
+                    diag.help(
+                        "DTOs in api/rest must use snake_case (or default) to match API standards",
+                    );
+                },
+            );
         }
     }
 }
@@ -120,12 +124,17 @@ fn check_type_rename_all(cx: &EarlyContext<'_>, attrs: &[Attribute]) {
 fn check_variant_rename(cx: &EarlyContext<'_>, attrs: &[Attribute]) {
     for (span, value) in find_serde_attribute_value(attrs, "rename") {
         if !is_snake_case(&value) {
-            cx.span_lint(DE0803_API_SNAKE_CASE, span, |diag| {
-                diag.primary_message(
-                    "Enum variants must not use non-snake_case in serde rename (DE0803)",
-                );
-                diag.help("Enum variants in api/rest must use snake_case to match API standards");
-            });
+            span_lint_and_then(
+                cx,
+                DE0803_API_SNAKE_CASE,
+                span,
+                "Enum variants must not use non-snake_case in serde rename (DE0803)",
+                |diag| {
+                    diag.help(
+                        "Enum variants in api/rest must use snake_case to match API standards",
+                    );
+                },
+            );
         }
     }
 }
@@ -157,13 +166,12 @@ fn check_field_snake_case(cx: &EarlyContext<'_>, field: &FieldDef) {
     if rename_values.is_empty() {
         // No field-level serde rename - field name must be snake_case
         if !is_snake_case(&field_name) {
-            cx.span_lint(
+            span_lint_and_then(
+                cx,
                 DE0803_API_SNAKE_CASE,
                 field.ident.unwrap().span,
+                "DTO field name must be snake_case or have a serde rename to snake_case (DE0803)",
                 |diag| {
-                    diag.primary_message(
-                        "DTO field name must be snake_case or have a serde rename to snake_case (DE0803)"
-                    );
                     diag.help(format!(
                         "rename field to snake_case or add #[serde(rename = \"{}\")]",
                         to_snake_case(&field_name)
@@ -175,12 +183,17 @@ fn check_field_snake_case(cx: &EarlyContext<'_>, field: &FieldDef) {
         // Has field-level serde rename - the rename value must be snake_case
         for (span, value) in rename_values {
             if !is_snake_case(&value) {
-                cx.span_lint(DE0803_API_SNAKE_CASE, span, |diag| {
-                    diag.primary_message(
-                        "DTO fields must not use non-snake_case in serde rename (DE0803)",
-                    );
-                    diag.help("DTO fields in api/rest must use snake_case to match API standards");
-                });
+                span_lint_and_then(
+                    cx,
+                    DE0803_API_SNAKE_CASE,
+                    span,
+                    "DTO fields must not use non-snake_case in serde rename (DE0803)",
+                    |diag| {
+                        diag.help(
+                            "DTO fields in api/rest must use snake_case to match API standards",
+                        );
+                    },
+                );
             }
         }
     }

--- a/tools/dylint_lints/de09_gts_layer/de0901_gts_string_pattern/src/lib.rs
+++ b/tools/dylint_lints/de09_gts_layer/de0901_gts_string_pattern/src/lib.rs
@@ -4,6 +4,7 @@
 extern crate rustc_ast;
 extern crate rustc_span;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use gts::{GtsIdSegment, GtsOps};
 use lint_utils::{filename_str, is_temp_path};
 use rustc_ast::token::LitKind;
@@ -71,10 +72,7 @@ impl EarlyLintPass for De0901GtsStringPattern {
         // Extract both the item name and the initializer expression from const/static items.
         // Note: `Item` has no top-level `ident`; it lives inside `ConstItem` / `StaticItem`.
         let (item_name, init_expr): (&str, Option<&Expr>) = match &item.kind {
-            ItemKind::Const(ci) => (
-                ci.ident.name.as_str(),
-                ci.rhs.as_ref().map(|rhs| rhs.expr()),
-            ),
+            ItemKind::Const(ci) => (ci.ident.name.as_str(), ci.rhs_kind.expr()),
             ItemKind::Static(si) => (si.ident.name.as_str(), si.expr.as_deref()),
             _ => return,
         };
@@ -91,13 +89,16 @@ impl EarlyLintPass for De0901GtsStringPattern {
         // Validate the wildcard GTS pattern itself before skip-listing.
         let result = GtsOps::parse_id(s);
         if !result.ok {
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, item.span, |diag| {
-                diag.primary_message(format!(
-                    "invalid GTS wildcard pattern in `{item_name}`: '{s}' (DE0901)"
-                ));
-                diag.note(result.error);
-                diag.help("Example: gts.cf.core.srr.resource.v1~*");
-            });
+            span_lint_and_then(
+                cx,
+                DE0901_GTS_STRING_PATTERN,
+                item.span,
+                format!("invalid GTS wildcard pattern in `{item_name}`: '{s}' (DE0901)"),
+                |diag| {
+                    diag.note(result.error);
+                    diag.help("Example: gts.cf.core.srr.resource.v1~*");
+                },
+            );
             // Still skip-list so check_expr doesn't double-report the literal.
             SKIP_SPANS.with(|spans| {
                 collect_nested_spans(init, &mut spans.borrow_mut());
@@ -108,17 +109,22 @@ impl EarlyLintPass for De0901GtsStringPattern {
         self.check_vendors_in_parse_result(cx, item.span, s, &result);
 
         if !item_name.ends_with("_WILDCARD") {
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, item.span, |diag| {
-                diag.primary_message(format!(
+            span_lint_and_then(
+                cx,
+                DE0901_GTS_STRING_PATTERN,
+                item.span,
+                format!(
                     "GTS wildcard string in `const`/`static` `{item_name}` must have a name ending with `_WILDCARD` (DE0901)"
-                ));
-                diag.note(format!(
-                    "found wildcard GTS pattern `{s}` stored in `{item_name}`"
-                ));
-                diag.help(format!(
-                    "rename to `{item_name}_WILDCARD` or use a non-wildcard value"
-                ));
-            });
+                ),
+                |diag| {
+                    diag.note(format!(
+                        "found wildcard GTS pattern `{s}` stored in `{item_name}`"
+                    ));
+                    diag.help(format!(
+                        "rename to `{item_name}_WILDCARD` or use a non-wildcard value"
+                    ));
+                },
+            );
         }
 
         // Skip-list the span so check_expr doesn't re-flag (or double-report) the literal.
@@ -503,11 +509,16 @@ impl De0901GtsStringPattern {
 
         // Wildcards are NOT allowed in schema_id
         if s.contains('*') {
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
-                diag.primary_message(format!("wildcards are not allowed in schema_id: '{}' (DE0901)", s));
-                diag.note("Wildcards (*) are only allowed in permission strings, not in schema_id attributes");
-                diag.help("Use concrete type names in schema_id");
-            });
+            span_lint_and_then(
+                cx,
+                DE0901_GTS_STRING_PATTERN,
+                span,
+                format!("wildcards are not allowed in schema_id: '{}' (DE0901)", s),
+                |diag| {
+                    diag.note("Wildcards (*) are only allowed in permission strings, not in schema_id attributes");
+                    diag.help("Use concrete type names in schema_id");
+                },
+            );
             return;
         }
 
@@ -515,24 +526,34 @@ impl De0901GtsStringPattern {
         let result = GtsOps::parse_id(s);
 
         if !result.ok {
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
-                diag.primary_message(format!("invalid GTS schema_id: '{}' (DE0901)", s));
-                diag.note(result.error);
-                diag.help("Example: gts.cf.core.events.type.v1~");
-            });
+            span_lint_and_then(
+                cx,
+                DE0901_GTS_STRING_PATTERN,
+                span,
+                format!("invalid GTS schema_id: '{}' (DE0901)", s),
+                |diag| {
+                    diag.note(result.error);
+                    diag.help("Example: gts.cf.core.events.type.v1~");
+                },
+            );
             return;
         }
 
         // Ensure it's actually a schema (type), not an instance
         if result.is_type != Some(true) {
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
-                diag.primary_message(format!(
+            span_lint_and_then(
+                cx,
+                DE0901_GTS_STRING_PATTERN,
+                span,
+                format!(
                     "schema_id must be a type schema, not an instance: '{}' (DE0901)",
                     s
-                ));
-                diag.note("schema_id must end with '~' to indicate it's a type schema");
-                diag.help("Example: gts.cf.core.events.type.v1~");
-            });
+                ),
+                |diag| {
+                    diag.note("schema_id must end with '~' to indicate it's a type schema");
+                    diag.help("Example: gts.cf.core.events.type.v1~");
+                },
+            );
         } else {
             self.check_vendors_in_parse_result(cx, span, s, &result);
         }
@@ -546,46 +567,63 @@ impl De0901GtsStringPattern {
         // If the input contains delimiters for chained ids / permission strings,
         // it is not a single segment.
         if s.contains('~') || s.contains(':') {
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
-                diag.primary_message(format!(
+            span_lint_and_then(
+                cx,
+                DE0901_GTS_STRING_PATTERN,
+                span,
+                format!(
                     "gts_make_instance_id expects a single GTS segment, got: '{}' (DE0901)",
                     s
-                ));
-                diag.help("Example: vendor.package.sku.abc.v1");
-            });
+                ),
+                |diag| {
+                    diag.help("Example: vendor.package.sku.abc.v1");
+                },
+            );
             return;
         }
 
         if s.contains('*') {
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
-                diag.primary_message(format!(
+            span_lint_and_then(
+                cx,
+                DE0901_GTS_STRING_PATTERN,
+                span,
+                format!(
                     "wildcards are not allowed in instance id segments: '{}' (DE0901)",
                     s
-                ));
-                diag.help("Example: vendor.package.sku.abc.v1");
-            });
+                ),
+                |diag| {
+                    diag.help("Example: vendor.package.sku.abc.v1");
+                },
+            );
             return;
         }
 
         match GtsIdSegment::new(0, 0, s) {
             Err(e) => {
-                cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
-                    diag.primary_message(format!("invalid GTS segment: '{}' (DE0901)", s));
-                    diag.note(e.to_string());
-                    diag.help("Example: vendor.package.sku.abc.v1");
-                });
+                span_lint_and_then(
+                    cx,
+                    DE0901_GTS_STRING_PATTERN,
+                    span,
+                    format!("invalid GTS segment: '{}' (DE0901)", s),
+                    |diag| {
+                        diag.note(e.to_string());
+                        diag.help("Example: vendor.package.sku.abc.v1");
+                    },
+                );
             }
             Ok(seg) if !allowed_vendors(cx, span).contains(&seg.vendor.as_str()) => {
-                cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
-                    diag.primary_message(format!(
-                        "invalid GTS vendor in segment: '{}' (DE0901)",
-                        s
-                    ));
-                    diag.note(format!(
-                        "found vendor '{}', allowed vendors are 'cf' and 'example'",
-                        seg.vendor
-                    ));
-                });
+                span_lint_and_then(
+                    cx,
+                    DE0901_GTS_STRING_PATTERN,
+                    span,
+                    format!("invalid GTS vendor in segment: '{}' (DE0901)", s),
+                    |diag| {
+                        diag.note(format!(
+                            "found vendor '{}', allowed vendors are 'cf' and 'example'",
+                            seg.vendor
+                        ));
+                    },
+                );
             }
             Ok(_) => {}
         }
@@ -604,16 +642,18 @@ impl De0901GtsStringPattern {
             {
                 continue;
             }
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
-                diag.primary_message(format!(
-                    "invalid GTS vendor in segment #{idx}: '{}' (DE0901)",
-                    s
-                ));
-                diag.note(format!(
-                    "found vendor '{}', allowed vendors are 'cf' and 'example'",
-                    seg.vendor
-                ));
-            });
+            span_lint_and_then(
+                cx,
+                DE0901_GTS_STRING_PATTERN,
+                span,
+                format!("invalid GTS vendor in segment #{idx}: '{}' (DE0901)", s),
+                |diag| {
+                    diag.note(format!(
+                        "found vendor '{}', allowed vendors are 'cf' and 'example'",
+                        seg.vendor
+                    ));
+                },
+            );
             break;
         }
     }
@@ -623,21 +663,34 @@ impl De0901GtsStringPattern {
 
         // Wildcards are NOT allowed in regular GTS strings (only in permission strings)
         if s.contains('*') {
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
-                diag.primary_message(format!("invalid GTS string (wildcards not allowed): '{}' (DE0901)", s));
-                diag.note("Wildcards (*) are only allowed in permission strings, not in regular GTS identifiers");
-                diag.help("Use concrete type names");
-            });
+            span_lint_and_then(
+                cx,
+                DE0901_GTS_STRING_PATTERN,
+                span,
+                format!(
+                    "invalid GTS string (wildcards not allowed): '{}' (DE0901)",
+                    s
+                ),
+                |diag| {
+                    diag.note("Wildcards (*) are only allowed in permission strings, not in regular GTS identifiers");
+                    diag.help("Use concrete type names");
+                },
+            );
             return;
         }
 
         let result = GtsOps::parse_id(s);
 
         if !result.ok {
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
-                diag.primary_message(format!("invalid GTS string: '{}' (DE0901)", s));
-                diag.note(result.error);
-            });
+            span_lint_and_then(
+                cx,
+                DE0901_GTS_STRING_PATTERN,
+                span,
+                format!("invalid GTS string: '{}' (DE0901)", s),
+                |diag| {
+                    diag.note(result.error);
+                },
+            );
         } else {
             self.check_vendors_in_parse_result(cx, span, s, &result);
         }
@@ -655,10 +708,15 @@ impl De0901GtsStringPattern {
         let result = GtsOps::parse_id(s);
 
         if !result.ok {
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
-                diag.primary_message(format!("invalid GTS string: '{}' (DE0901)", s));
-                diag.note(result.error);
-            });
+            span_lint_and_then(
+                cx,
+                DE0901_GTS_STRING_PATTERN,
+                span,
+                format!("invalid GTS string: '{}' (DE0901)", s),
+                |diag| {
+                    diag.note(result.error);
+                },
+            );
         } else {
             self.check_vendors_in_parse_result(cx, span, s, &result);
         }

--- a/tools/dylint_lints/de09_gts_layer/de0902_no_schema_for_on_gts_structs/src/lib.rs
+++ b/tools/dylint_lints/de09_gts_layer/de0902_no_schema_for_on_gts_structs/src/lib.rs
@@ -5,6 +5,7 @@ extern crate rustc_hir;
 extern crate rustc_middle;
 extern crate rustc_span;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_hir::{Expr, ExprKind, GenericArg};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::ty::{self, Ty};
@@ -113,20 +114,21 @@ impl<'tcx> LateLintPass<'tcx> for De0902NoSchemaForOnGtsStructs {
                             && is_gts_type(cx, ty)
                         {
                             let type_name = get_type_name(ty);
-                            cx.span_lint(
-                                        DE0902_NO_SCHEMA_FOR_ON_GTS_STRUCTS,
-                                        callsite_span,
-                                        |diag| {
-                                            diag.primary_message(format!(
-                                                "do not use `schema_for!({})` on GTS-wrapped struct (DE0902)",
-                                                type_name
-                                            ));
-                                            diag.help(format!(
-                                                "use `{}::gts_schema_with_refs_as_string()` instead for proper `$id` and `$ref` handling",
-                                                type_name
-                                            ));
-                                        },
-                                    );
+                            span_lint_and_then(
+                                cx,
+                                DE0902_NO_SCHEMA_FOR_ON_GTS_STRUCTS,
+                                callsite_span,
+                                format!(
+                                    "do not use `schema_for!({})` on GTS-wrapped struct (DE0902)",
+                                    type_name
+                                ),
+                                |diag| {
+                                    diag.help(format!(
+                                        "use `{}::gts_schema_with_refs_as_string()` instead for proper `$id` and `$ref` handling",
+                                        type_name
+                                    ));
+                                },
+                            );
                             return;
                         }
                     }

--- a/tools/dylint_lints/de11_testing/de1101_tests_in_separate_files/src/lib.rs
+++ b/tools/dylint_lints/de11_testing/de1101_tests_in_separate_files/src/lib.rs
@@ -5,6 +5,7 @@
 
 extern crate rustc_ast;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::Item;
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
 use std::cell::RefCell;
@@ -159,35 +160,46 @@ impl EarlyLintPass for De1101TestsInSeparateFiles {
         for violation in violations {
             match violation {
                 TestViolation::InlineTestCode => {
-                    cx.span_lint(DE1101_TESTS_IN_SEPARATE_FILES, item.span, |diag| {
-                        diag.primary_message(
-                            "test code must be moved to a separate test file (DE1101)",
-                        );
-                        diag.help(format!(
-                            "move the test into `tests/*.rs` or an out-of-line `*_tests.rs` module (inline test block exceeds {} lines)",
-                            self.max_inline_test_lines,
-                        ));
-                    });
+                    span_lint_and_then(
+                        cx,
+                        DE1101_TESTS_IN_SEPARATE_FILES,
+                        item.span,
+                        "test code must be moved to a separate test file (DE1101)",
+                        |diag| {
+                            diag.help(format!(
+                                "move the test into `tests/*.rs` or an out-of-line `*_tests.rs` module (inline test block exceeds {} lines)",
+                                self.max_inline_test_lines,
+                            ));
+                        },
+                    );
                 }
                 TestViolation::InlineTestCodeWithCompanion => {
-                    cx.span_lint(DE1101_TESTS_IN_SEPARATE_FILES, item.span, |diag| {
-                        diag.primary_message(
-                            "test code must not be added back to a file that already has a companion test file (DE1101)",
-                        );
-                        diag.help(
-                            "a `*_tests.rs` companion file already exists; add tests there instead",
-                        );
-                    });
+                    span_lint_and_then(
+                        cx,
+                        DE1101_TESTS_IN_SEPARATE_FILES,
+                        item.span,
+                        "test code must not be added back to a file that already has a companion test file (DE1101)",
+                        |diag| {
+                            diag.help(
+                                "a `*_tests.rs` companion file already exists; add tests there instead",
+                            );
+                        },
+                    );
                 }
                 TestViolation::WrongPathAttr { expected, actual } => {
-                    cx.span_lint(DE1101_TESTS_IN_SEPARATE_FILES, item.span, |diag| {
-                        diag.primary_message(format!(
+                    span_lint_and_then(
+                        cx,
+                        DE1101_TESTS_IN_SEPARATE_FILES,
+                        item.span,
+                        format!(
                             "test module path `{actual}.rs` must reference `{expected}.rs` to match the source file (DE1101)",
-                        ));
-                        diag.help(format!(
-                            "use `#[path = \"{expected}.rs\"]` or remove `#[path]`"
-                        ));
-                    });
+                        ),
+                        |diag| {
+                            diag.help(format!(
+                                "use `#[path = \"{expected}.rs\"]` or remove `#[path]`"
+                            ));
+                        },
+                    );
                 }
             }
         }

--- a/tools/dylint_lints/de12_documentation/de1201_docs_rs_all_features/src/lib.rs
+++ b/tools/dylint_lints/de12_documentation/de1201_docs_rs_all_features/src/lib.rs
@@ -1,9 +1,11 @@
 #![feature(rustc_private)]
 #![warn(unused_extern_crates)]
 
+extern crate rustc_errors;
 extern crate rustc_span;
 
 use cargo_metadata::{Metadata, MetadataCommand, Package};
+use rustc_errors::DiagDecorator;
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_span::DUMMY_SP;
 use serde_json::Value;
@@ -75,22 +77,30 @@ impl LateLintPass<'_> for De1201DocsRsAllFeatures {
         {
             Ok(metadata) => metadata,
             Err(error) => {
-                cx.span_lint(DE1201_DOCS_RS_ALL_FEATURES, DUMMY_SP, |diag| {
-                    diag.primary_message(format!(
-                        "could not read Cargo metadata for docs.rs configuration check: {error}"
-                    ));
-                });
+                cx.emit_span_lint(
+                    DE1201_DOCS_RS_ALL_FEATURES,
+                    DUMMY_SP,
+                    DiagDecorator(|diag| {
+                        diag.primary_message(format!(
+                            "could not read Cargo metadata for docs.rs configuration check: {error}"
+                        ));
+                    }),
+                );
                 return;
             }
         };
 
         let Some(package) = find_current_package(&metadata, &manifest_path) else {
-            cx.span_lint(DE1201_DOCS_RS_ALL_FEATURES, DUMMY_SP, |diag| {
-                diag.primary_message(format!(
-                    "could not find current package in Cargo metadata for `{}`",
-                    manifest_path.display()
-                ));
-            });
+            cx.emit_span_lint(
+                DE1201_DOCS_RS_ALL_FEATURES,
+                DUMMY_SP,
+                DiagDecorator(|diag| {
+                    diag.primary_message(format!(
+                        "could not find current package in Cargo metadata for `{}`",
+                        manifest_path.display()
+                    ));
+                }),
+            );
             return;
         };
 
@@ -103,7 +113,10 @@ impl LateLintPass<'_> for De1201DocsRsAllFeatures {
             return;
         };
 
-        cx.span_lint(DE1201_DOCS_RS_ALL_FEATURES, DUMMY_SP, |diag| {
+        cx.emit_span_lint(
+            DE1201_DOCS_RS_ALL_FEATURES,
+            DUMMY_SP,
+            DiagDecorator(|diag| {
             diag.primary_message(format!(
                 "publishable crate `{}` must set `package.metadata.docs.rs.all-features = true` (DE1201)",
                 package.name
@@ -114,7 +127,8 @@ impl LateLintPass<'_> for De1201DocsRsAllFeatures {
                 package.manifest_path,
                 package.name,
             ));
-        });
+            }),
+        );
     }
 }
 

--- a/tools/dylint_lints/de13_common_patterns/de1301_no_print_macros/src/lib.rs
+++ b/tools/dylint_lints/de13_common_patterns/de1301_no_print_macros/src/lib.rs
@@ -4,6 +4,7 @@
 extern crate rustc_ast;
 extern crate rustc_span;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::{
     AttrKind, Attribute, ExprKind, Item, ItemKind, MacCall, VisibilityKind, visit, visit::Visitor,
 };
@@ -132,15 +133,17 @@ impl<'a, 'cx> ForbiddenMacroVisitor<'a, 'cx> {
             return;
         }
 
-        self.cx
-            .span_lint(DE1301_NO_PRINT_MACROS, mac_call.span(), |diag| {
-                diag.primary_message(format!(
-                    "macro `{name}!` is forbidden in production code (DE1301)"
-                ));
+        span_lint_and_then(
+            self.cx,
+            DE1301_NO_PRINT_MACROS,
+            mac_call.span(),
+            format!("macro `{name}!` is forbidden in production code (DE1301)"),
+            |diag| {
                 diag.help(
                     "use `tracing`/`log` for observability, or return the value and handle it at the boundary",
                 );
-            });
+            },
+        );
     }
 }
 

--- a/tools/dylint_lints/de13_common_patterns/de1302_error_from_to_string/src/lib.rs
+++ b/tools/dylint_lints/de13_common_patterns/de1302_error_from_to_string/src/lib.rs
@@ -7,11 +7,12 @@ extern crate rustc_hir;
 extern crate rustc_middle;
 extern crate rustc_span;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::ty::implements_trait;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::{self as hir, Expr, ExprKind, ImplItemKind, ItemKind, QPath};
-use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{Ty, TypeckResults};
 use rustc_span::hygiene::{ExpnKind, MacroKind};
 
@@ -88,7 +89,7 @@ dylint_linting::declare_late_lint! {
 /// Uses the `rustc_diagnostic_item = "Error"` marker and `clippy_utils::ty::implements_trait`
 /// for proper trait resolution. Handles ADTs, type aliases, and generic params with bounds.
 fn implements_error<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
-    let Some(error_did) = cx.tcx.get_diagnostic_item(rustc_span::sym::Error) else {
+    let Some(error_did) = cx.tcx.get_diagnostic_item(clippy_utils::sym::Error) else {
         return false;
     };
     implements_trait(cx, ty, error_did, &[])
@@ -114,17 +115,20 @@ struct ToStringVisitor<'tcx, 'cx> {
 impl<'tcx> ToStringVisitor<'tcx, '_> {
     /// Emit the DE1302 diagnostic at `span`.
     fn emit(&self, span: rustc_span::Span) {
-        self.cx.span_lint(DE1302_ERROR_FROM_TO_STRING, span, |diag| {
-            diag.primary_message(
-                "`.to_string()` in `From`/`TryFrom` impl destroys the error chain (DE1302)",
-            );
-            diag.help(
-                "store the source error directly, use an enum variant, or use `#[from]` with thiserror",
-            );
-            diag.note(
-                "`.to_string()` discards the original error type: `.source()` returns None and the error cannot be downcast",
-            );
-        });
+        span_lint_and_then(
+            self.cx,
+            DE1302_ERROR_FROM_TO_STRING,
+            span,
+            "`.to_string()` in `From`/`TryFrom` impl destroys the error chain (DE1302)",
+            |diag| {
+                diag.help(
+                    "store the source error directly, use an enum variant, or use `#[from]` with thiserror",
+                );
+                diag.note(
+                    "`.to_string()` discards the original error type: `.source()` returns None and the error cannot be downcast",
+                );
+            },
+        );
     }
 
     /// Returns true if `ty` (after peeling references) is a type whose
@@ -166,7 +170,7 @@ impl<'tcx> ToStringVisitor<'tcx, '_> {
 /// both paths verify they're actually hitting the trait method, not a bare
 /// inherent method named `to_string`.
 fn is_to_string_def<'tcx>(cx: &LateContext<'tcx>, def_id: DefId) -> bool {
-    let Some(to_string_trait) = cx.tcx.get_diagnostic_item(rustc_span::sym::ToString) else {
+    let Some(to_string_trait) = cx.tcx.get_diagnostic_item(clippy_utils::sym::ToString) else {
         return false;
     };
     cx.tcx.trait_of_assoc(def_id) == Some(to_string_trait)
@@ -209,12 +213,10 @@ impl<'tcx> hir::intravisit::Visitor<'tcx> for ToStringVisitor<'tcx, '_> {
                 }
             }
             // UFCS form: `ToString::to_string(&e)` or `<E as ToString>::to_string(&e)`.
-            ExprKind::Call(callee, [arg]) if !hidden => {
-                if is_to_string_path(self.cx, callee) {
-                    let arg_ty = self.typeck.expr_ty(arg);
-                    if self.is_relevant_receiver(arg_ty) {
-                        self.emit(expr.span);
-                    }
+            ExprKind::Call(callee, [arg]) if !hidden && is_to_string_path(self.cx, callee) => {
+                let arg_ty = self.typeck.expr_ty(arg);
+                if self.is_relevant_receiver(arg_ty) {
+                    self.emit(expr.span);
                 }
             }
             // Closures have their own typeck tables; delegate to a helper

--- a/tools/dylint_lints/de13_common_patterns/de1303_no_primitive_type_alias/src/lib.rs
+++ b/tools/dylint_lints/de13_common_patterns/de1303_no_primitive_type_alias/src/lib.rs
@@ -5,9 +5,10 @@
 
 extern crate rustc_ast;
 
+use clippy_utils::diagnostics::span_lint_and_then;
 use lint_utils::is_in_contract_module_ast;
 use rustc_ast::{Item, ItemKind, TyKind, VisibilityKind};
-use rustc_lint::{EarlyLintPass, LintContext};
+use rustc_lint::EarlyLintPass;
 
 dylint_linting::declare_early_lint! {
     /// ### What it does
@@ -103,15 +104,20 @@ impl EarlyLintPass for De1303NoPrimitiveTypeAlias {
             return;
         }
 
-        cx.span_lint(DE1303_NO_PRIMITIVE_TYPE_ALIAS, item.span, |diag| {
-            diag.primary_message(format!(
+        span_lint_and_then(
+            cx,
+            DE1303_NO_PRIMITIVE_TYPE_ALIAS,
+            item.span,
+            format!(
                 "`pub type {name} = {backing}` is a transparent alias with no type safety (DE1303)"
-            ));
-            diag.help(format!(
-                "wrap {backing} in a newtype: `pub struct {name}(pub {backing});` or `pub struct {name}({backing});`"
-            ));
-            diag.note("transparent aliases provide no compile-time separation; use a newtype for distinct semantic types");
-        });
+            ),
+            |diag| {
+                diag.help(format!(
+                    "wrap {backing} in a newtype: `pub struct {name}(pub {backing});` or `pub struct {name}({backing});`"
+                ));
+                diag.note("transparent aliases provide no compile-time separation; use a newtype for distinct semantic types");
+            },
+        );
     }
 }
 

--- a/tools/dylint_lints/lint_utils/Cargo.toml
+++ b/tools/dylint_lints/lint_utils/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 test = false
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "54482290b5f32e6c6b57cc9e0a17153f432b0036" }
+clippy_utils.workspace = true
 dylint_linting.workspace = true
 
 [package.metadata.rust-analyzer]

--- a/tools/dylint_lints/lint_utils/src/lib.rs
+++ b/tools/dylint_lints/lint_utils/src/lib.rs
@@ -465,7 +465,7 @@ pub fn is_utoipa_trait(segments: &[&str], trait_name: &str) -> bool {
 /// - `use foo::*` -> `["foo"]`
 pub fn use_tree_to_strings(tree: &UseTree) -> Vec<String> {
     match &tree.kind {
-        UseTreeKind::Simple(..) | UseTreeKind::Glob => {
+        UseTreeKind::Simple(..) | UseTreeKind::Glob(_) => {
             vec![
                 tree.prefix
                     .segments

--- a/tools/dylint_lints/rust-toolchain.toml
+++ b/tools/dylint_lints/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2026-01-22"
+channel = "nightly-2026-04-16"
 components = ["llvm-tools-preview", "rustc-dev"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Rust toolchain from 1.95.0 to 1.96.0 and aligned CI/nightly toolchain pins
  * Enabled docs.rs builds with all features for a crate
  * Improved linting infrastructure to produce clearer diagnostics

* **Tests**
  * Adjusted test expectations to match updated compiler/diagnostic output
<!-- end of auto-generated comment: release notes by coderabbit.ai -->