### PR TITLE
fix(dylint): use opt_span_lint for forward compatibility with newer rustc

### DIFF
--- a/tools/dylint_lints/de01_contract_layer/de0101_no_serde_in_contract/src/lib.rs
+++ b/tools/dylint_lints/de01_contract_layer/de0101_no_serde_in_contract/src/lib.rs
@@ -70,14 +70,14 @@ impl EarlyLintPass for De0101NoSerdeInContract {
             let is_deserialize = lint_utils::is_serde_trait(&segments, "Deserialize");
 
             if is_serialize {
-                cx.span_lint(DE0101_NO_SERDE_IN_CONTRACT, attr.span, |diag| {
+                cx.opt_span_lint(DE0101_NO_SERDE_IN_CONTRACT, Some(attr.span), |diag| {
                     diag.primary_message("contract type should not derive `Serialize` (DE0101)");
                     diag.help(
                         "remove serde derives from contract models; use DTOs in the API layer",
                     );
                 });
             } else if is_deserialize {
-                cx.span_lint(DE0101_NO_SERDE_IN_CONTRACT, attr.span, |diag| {
+                cx.opt_span_lint(DE0101_NO_SERDE_IN_CONTRACT, Some(attr.span), |diag| {
                     diag.primary_message("contract type should not derive `Deserialize` (DE0101)");
                     diag.help(
                         "remove serde derives from contract models; use DTOs in the API layer",

--- a/tools/dylint_lints/de01_contract_layer/de0102_no_toschema_in_contract/src/lib.rs
+++ b/tools/dylint_lints/de01_contract_layer/de0102_no_toschema_in_contract/src/lib.rs
@@ -68,7 +68,7 @@ impl EarlyLintPass for De0102NoToschemaInContract {
             // Check if this is a utoipa ToSchema
             // Handles: ToSchema, utoipa::ToSchema, ::utoipa::ToSchema
             if lint_utils::is_utoipa_trait(&segments, "ToSchema") {
-                cx.span_lint(DE0102_NO_TOSCHEMA_IN_CONTRACT, attr.span, |diag| {
+                cx.opt_span_lint(DE0102_NO_TOSCHEMA_IN_CONTRACT, Some(attr.span), |diag| {
                     diag.primary_message("contract type should not derive `ToSchema` (DE0102)");
                     diag.help("ToSchema is an OpenAPI concern; use DTOs in api/rest/ instead");
                 });

--- a/tools/dylint_lints/de01_contract_layer/de0103_no_http_types_in_contract/src/lib.rs
+++ b/tools/dylint_lints/de01_contract_layer/de0103_no_http_types_in_contract/src/lib.rs
@@ -109,7 +109,7 @@ fn check_use_in_contract(cx: &rustc_lint::EarlyContext<'_>, item: &Item) {
     let path_str = use_tree_to_string(use_tree);
     for pattern in HTTP_TYPE_PATTERNS {
         if path_str.contains(pattern) {
-            cx.span_lint(DE0103_NO_HTTP_TYPES_IN_CONTRACT, item.span, |diag| {
+            cx.opt_span_lint(DE0103_NO_HTTP_TYPES_IN_CONTRACT, Some(item.span), |diag| {
                 diag.primary_message("contract module imports HTTP type (DE0103)");
                 diag.help(
                     "contract gears should be transport-agnostic; move HTTP types to api/rest/",

--- a/tools/dylint_lints/de01_contract_layer/de0104_no_api_dto_in_contract/src/lib.rs
+++ b/tools/dylint_lints/de01_contract_layer/de0104_no_api_dto_in_contract/src/lib.rs
@@ -77,7 +77,7 @@ impl EarlyLintPass for De0104NoApiDtoInContract {
                 );
 
                 if is_api_dto {
-                    cx.span_lint(DE0104_NO_API_DTO_IN_CONTRACT, attr.span, |diag| {
+                    cx.opt_span_lint(DE0104_NO_API_DTO_IN_CONTRACT, Some(attr.span), |diag| {
                         diag.primary_message("contract type should not use `api_dto` macro (DE0104)");
                         diag.help("api_dto is for API DTOs; use plain structs in contract/ and create DTOs in api/rest/");
                     });

--- a/tools/dylint_lints/de01_contract_layer/de0110_no_schema_for_on_gts_structs/src/lib.rs
+++ b/tools/dylint_lints/de01_contract_layer/de0110_no_schema_for_on_gts_structs/src/lib.rs
@@ -113,9 +113,9 @@ impl<'tcx> LateLintPass<'tcx> for De0110NoSchemaForOnGtsStructs {
                             && is_gts_type(cx, ty)
                         {
                             let type_name = get_type_name(ty);
-                            cx.span_lint(
+                            cx.opt_span_lint(
                                         DE0110_NO_SCHEMA_FOR_ON_GTS_STRUCTS,
-                                        callsite_span,
+                                        Some(callsite_span),
                                         |diag| {
                                             diag.primary_message(format!(
                                                 "do not use `schema_for!({})` on GTS-wrapped struct (DE0110)",

--- a/tools/dylint_lints/de02_api_layer/de0201_dtos_only_in_api_rest/src/lib.rs
+++ b/tools/dylint_lints/de02_api_layer/de0201_dtos_only_in_api_rest/src/lib.rs
@@ -41,7 +41,7 @@ impl EarlyLintPass for De0201DtosOnlyInApiRest {
 
         // Check if the file is in api/rest folder (supports simulated_dir for tests)
         if !lint_utils::is_in_api_rest_folder(cx.sess().source_map(), item.span) {
-            cx.span_lint(DE0201_DTOS_ONLY_IN_API_REST, span, |diag| {
+            cx.opt_span_lint(DE0201_DTOS_ONLY_IN_API_REST, Some(span), |diag| {
                 diag.primary_message(format!(
                     "DTO type `{}` is defined outside of api/rest folder (DE0201)",
                     item_name

--- a/tools/dylint_lints/de02_api_layer/de0202_dtos_not_referenced_outside_api/src/lib.rs
+++ b/tools/dylint_lints/de02_api_layer/de0202_dtos_not_referenced_outside_api/src/lib.rs
@@ -59,15 +59,19 @@ impl<'tcx> LateLintPass<'tcx> for De0202DtosNotReferencedOutsideApi {
                     "infra"
                 };
 
-                cx.span_lint(DE0202_DTOS_NOT_REFERENCED_OUTSIDE_API, item.span, |diag| {
-                    diag.primary_message(format!(
-                        "{} module imports DTO type `{}` from api layer (DE0202)",
-                        module_type, last
-                    ));
-                    diag.help(
+                cx.opt_span_lint(
+                    DE0202_DTOS_NOT_REFERENCED_OUTSIDE_API,
+                    Some(item.span),
+                    |diag| {
+                        diag.primary_message(format!(
+                            "{} module imports DTO type `{}` from api layer (DE0202)",
+                            module_type, last
+                        ));
+                        diag.help(
                         "DTOs are API layer details; use contract models or domain types instead",
                     );
-                });
+                    },
+                );
             }
         }
     }

--- a/tools/dylint_lints/de02_api_layer/de0203_dtos_must_use_api_dto/src/lib.rs
+++ b/tools/dylint_lints/de02_api_layer/de0203_dtos_must_use_api_dto/src/lib.rs
@@ -73,7 +73,7 @@ fn check_dto_uses_api_dto(cx: &EarlyContext<'_>, item: &Item) {
     }
 
     // Report missing api_dto macro
-    cx.span_lint(DE0203_DTOS_MUST_USE_API_DTO, item.span, |diag| {
+    cx.opt_span_lint(DE0203_DTOS_MUST_USE_API_DTO, Some(item.span), |diag| {
         diag.primary_message("api/rest DTO type must use the api_dto macro (DE0203)");
         diag.help("Use #[toolkit_macros::api_dto(request)] for request DTOs, #[toolkit_macros::api_dto(response)] for response DTOs, or #[toolkit_macros::api_dto(request, response)] for both");
     });

--- a/tools/dylint_lints/de02_api_layer/de0204_dtos_must_have_toschema_derive/src/lib.rs
+++ b/tools/dylint_lints/de02_api_layer/de0204_dtos_must_have_toschema_derive/src/lib.rs
@@ -81,10 +81,14 @@ fn check_dto_toschema_derive(cx: &EarlyContext<'_>, item: &Item) {
 
     // Report missing derive
     if !has_toschema {
-        cx.span_lint(DE0204_DTOS_MUST_HAVE_TOSCHEMA_DERIVE, item.span, |diag| {
-            diag.primary_message("api/rest type is missing required ToSchema derive (DE0204)");
-            diag.help("DTOs in api/rest must derive ToSchema for OpenAPI documentation");
-        });
+        cx.opt_span_lint(
+            DE0204_DTOS_MUST_HAVE_TOSCHEMA_DERIVE,
+            Some(item.span),
+            |diag| {
+                diag.primary_message("api/rest type is missing required ToSchema derive (DE0204)");
+                diag.help("DTOs in api/rest must derive ToSchema for OpenAPI documentation");
+            },
+        );
     }
 }
 

--- a/tools/dylint_lints/de02_api_layer/de0205_operation_builder/src/lib.rs
+++ b/tools/dylint_lints/de02_api_layer/de0205_operation_builder/src/lib.rs
@@ -71,14 +71,14 @@ impl<'tcx> LateLintPass<'tcx> for De0205OperationBuilder {
                     if let Some(tag_arg) = args.first() {
                         if let Some(tag_string) = extract_tag_value(cx, tag_arg) {
                             if !is_valid_tag_format(&tag_string) {
-                                cx.span_lint(DE0205_OPERATION_BUILDER, tag_arg.span, |diag| {
+                                cx.opt_span_lint(DE0205_OPERATION_BUILDER, Some(tag_arg.span), |diag| {
                                         diag.primary_message("tag format is invalid");
                                         diag.help("tags must contain whitespace-separated words, each starting with a capital letter");
                                         diag.note("example: \"User Management\", \"Simple Resource Registry\"");
                                     });
                             }
                         } else {
-                            cx.span_lint(DE0205_OPERATION_BUILDER, tag_arg.span, |diag| {
+                            cx.opt_span_lint(DE0205_OPERATION_BUILDER, Some(tag_arg.span), |diag| {
                                     diag.primary_message("tag must be a string literal or const string");
                                     diag.help("use a string literal like `.tag(\"Your Tag\")` or a const string");
                                 });
@@ -89,13 +89,17 @@ impl<'tcx> LateLintPass<'tcx> for De0205OperationBuilder {
                     if let Some(summary_arg) = args.first() {
                         if let Some(summary_string) = extract_tag_value(cx, summary_arg) {
                             if summary_string.trim().is_empty() {
-                                cx.span_lint(DE0205_OPERATION_BUILDER, summary_arg.span, |diag| {
-                                    diag.primary_message("summary cannot be empty");
-                                    diag.help("provide a meaningful summary for the operation");
-                                });
+                                cx.opt_span_lint(
+                                    DE0205_OPERATION_BUILDER,
+                                    Some(summary_arg.span),
+                                    |diag| {
+                                        diag.primary_message("summary cannot be empty");
+                                        diag.help("provide a meaningful summary for the operation");
+                                    },
+                                );
                             }
                         } else {
-                            cx.span_lint(DE0205_OPERATION_BUILDER, summary_arg.span, |diag| {
+                            cx.opt_span_lint(DE0205_OPERATION_BUILDER, Some(summary_arg.span), |diag| {
                                     diag.primary_message("summary must be a string literal or const string");
                                     diag.help("use a string literal like `.summary(\"Your summary\")` or a const string");
                                 });
@@ -120,7 +124,7 @@ fn check_complete_builder_chain(cx: &LateContext<'_>, expr: &rustc_hir::Expr<'_>
         // Report missing calls
         let builder_span = get_builder_constructor_span(expr);
         if !has_tag || !has_summary {
-            cx.span_lint(DE0205_OPERATION_BUILDER, builder_span, |diag| {
+            cx.opt_span_lint(DE0205_OPERATION_BUILDER, Some(builder_span), |diag| {
                 match (has_tag, has_summary) {
                     (false, false) => {
                         diag.primary_message("operation builder missing .tag() and .summary() calls");

--- a/tools/dylint_lints/de03_domain_layer/de0301_no_infra_in_domain/src/lib.rs
+++ b/tools/dylint_lints/de03_domain_layer/de0301_no_infra_in_domain/src/lib.rs
@@ -101,7 +101,7 @@ fn check_use_in_domain(cx: &rustc_lint::EarlyContext<'_>, item: &Item) {
 
     for path_str in use_tree_to_strings(use_tree) {
         if let Some(pattern) = matches_infra_pattern(&path_str) {
-            cx.span_lint(DE0301_NO_INFRA_IN_DOMAIN, item.span, |diag| {
+            cx.opt_span_lint(DE0301_NO_INFRA_IN_DOMAIN, Some(item.span), |diag| {
                 diag.primary_message(format!(
                     "domain module imports infrastructure dependency `{pattern}` (DE0301)"
                 ));
@@ -126,7 +126,7 @@ fn check_type_in_domain(cx: &rustc_lint::EarlyContext<'_>, ty: &Ty) {
                 .join("::");
 
             if matches_infra_pattern(&path_str).is_some() {
-                cx.span_lint(DE0301_NO_INFRA_IN_DOMAIN, ty.span, |diag| {
+                cx.opt_span_lint(DE0301_NO_INFRA_IN_DOMAIN, Some(ty.span), |diag| {
                     diag.primary_message(format!(
                         "domain module uses infrastructure type `{path_str}` (DE0301)"
                     ));
@@ -189,7 +189,7 @@ fn check_type_in_domain(cx: &rustc_lint::EarlyContext<'_>, ty: &Ty) {
                         .join("::");
 
                     if matches_infra_pattern(&path_str).is_some() {
-                        cx.span_lint(DE0301_NO_INFRA_IN_DOMAIN, ty.span, |diag| {
+                        cx.opt_span_lint(DE0301_NO_INFRA_IN_DOMAIN, Some(ty.span), |diag| {
                             diag.primary_message(format!(
                                 "domain module uses infrastructure trait `{path_str}` (DE0301)"
                             ));
@@ -216,7 +216,7 @@ fn check_type_in_domain(cx: &rustc_lint::EarlyContext<'_>, ty: &Ty) {
                         .join("::");
 
                     if matches_infra_pattern(&path_str).is_some() {
-                        cx.span_lint(DE0301_NO_INFRA_IN_DOMAIN, ty.span, |diag| {
+                        cx.opt_span_lint(DE0301_NO_INFRA_IN_DOMAIN, Some(ty.span), |diag| {
                             diag.primary_message(format!(
                                 "domain module uses infrastructure trait `{path_str}` (DE0301)"
                             ));

--- a/tools/dylint_lints/de03_domain_layer/de0308_no_http_in_domain/src/lib.rs
+++ b/tools/dylint_lints/de03_domain_layer/de0308_no_http_in_domain/src/lib.rs
@@ -67,7 +67,7 @@ fn matches_http_pattern(path: &str) -> Option<&'static str> {
 fn check_use_item(cx: &EarlyContext<'_>, item: &Item, tree: &rustc_ast::UseTree) {
     for path_str in use_tree_to_strings(tree) {
         if let Some(pattern) = matches_http_pattern(&path_str) {
-            cx.span_lint(DE0308_NO_HTTP_IN_DOMAIN, item.span, |diag| {
+            cx.opt_span_lint(DE0308_NO_HTTP_IN_DOMAIN, Some(item.span), |diag| {
                 diag.primary_message(format!(
                     "domain module imports HTTP type `{pattern}` (DE0308)"
                 ));
@@ -90,7 +90,7 @@ fn check_type_in_domain(cx: &rustc_lint::EarlyContext<'_>, ty: &Ty) {
                 .join("::");
 
             if matches_http_pattern(&path_str).is_some() {
-                cx.span_lint(DE0308_NO_HTTP_IN_DOMAIN, ty.span, |diag| {
+                cx.opt_span_lint(DE0308_NO_HTTP_IN_DOMAIN, Some(ty.span), |diag| {
                     diag.primary_message(format!(
                         "domain module uses HTTP type `{}` (DE0308)",
                         path_str
@@ -152,7 +152,7 @@ fn check_type_in_domain(cx: &rustc_lint::EarlyContext<'_>, ty: &Ty) {
                         .join("::");
 
                     if matches_http_pattern(&path_str).is_some() {
-                        cx.span_lint(DE0308_NO_HTTP_IN_DOMAIN, ty.span, |diag| {
+                        cx.opt_span_lint(DE0308_NO_HTTP_IN_DOMAIN, Some(ty.span), |diag| {
                             diag.primary_message(format!(
                                 "domain module uses HTTP trait `{}` (DE0308)",
                                 path_str
@@ -180,7 +180,7 @@ fn check_type_in_domain(cx: &rustc_lint::EarlyContext<'_>, ty: &Ty) {
                         .join("::");
 
                     if matches_http_pattern(&path_str).is_some() {
-                        cx.span_lint(DE0308_NO_HTTP_IN_DOMAIN, ty.span, |diag| {
+                        cx.opt_span_lint(DE0308_NO_HTTP_IN_DOMAIN, Some(ty.span), |diag| {
                             diag.primary_message(format!(
                                 "domain module uses HTTP trait `{}` (DE0308)",
                                 path_str

--- a/tools/dylint_lints/de03_domain_layer/de0309_must_have_domain_model/src/lib.rs
+++ b/tools/dylint_lints/de03_domain_layer/de0309_must_have_domain_model/src/lib.rs
@@ -76,7 +76,7 @@ fn check_domain_model_attribute(cx: &EarlyContext<'_>, item: &Item) {
         _ => return,
     };
 
-    cx.span_lint(DE0309_MUST_HAVE_DOMAIN_MODEL, item.span, |diag| {
+    cx.opt_span_lint(DE0309_MUST_HAVE_DOMAIN_MODEL, Some(item.span), |diag| {
         diag.primary_message(format!(
             "domain type `{item_name}` is missing required #[domain_model] attribute (DE0309)"
         ));

--- a/tools/dylint_lints/de05_client_layer/de0503_plugin_client_suffix/src/lib.rs
+++ b/tools/dylint_lints/de05_client_layer/de0503_plugin_client_suffix/src/lib.rs
@@ -116,7 +116,7 @@ fn emit_lint(
         format!("{trait_name}Client")
     };
 
-    cx.span_lint(DE0503_PLUGIN_CLIENT_SUFFIX, span, |diag| {
+    cx.opt_span_lint(DE0503_PLUGIN_CLIENT_SUFFIX, Some(span), |diag| {
         diag.primary_message(format!(
             "plugin client trait `{trait_name}` should use `*{suggested_suffix}` suffix, not `*{wrong_suffix}` (DE0503)"
         ));

--- a/tools/dylint_lints/de05_client_layer/de0504_client_versioning/src/lib.rs
+++ b/tools/dylint_lints/de05_client_layer/de0504_client_versioning/src/lib.rs
@@ -116,7 +116,7 @@ fn emit_lint(
             format!("{}V1", version.base)
         };
 
-    cx.span_lint(DE0504_CLIENT_VERSIONING, span, |diag| {
+    cx.opt_span_lint(DE0504_CLIENT_VERSIONING, Some(span), |diag| {
         diag.primary_message(format!(
             "Client trait `{trait_name}` in non-system gear must have a version suffix (DE0504)"
         ));

--- a/tools/dylint_lints/de07_security/de0706_no_direct_sqlx/src/lib.rs
+++ b/tools/dylint_lints/de07_security/de0706_no_direct_sqlx/src/lib.rs
@@ -79,7 +79,7 @@ fn check_type_for_sqlx(cx: &rustc_lint::EarlyContext<'_>, ty: &Ty) {
                 .join("::");
 
             if is_sqlx_path(&path_str) {
-                cx.span_lint(DE0706_NO_DIRECT_SQLX, ty.span, |diag| {
+                cx.opt_span_lint(DE0706_NO_DIRECT_SQLX, Some(ty.span), |diag| {
                     diag.primary_message(format!(
                         "direct sqlx type usage detected: `{path_str}` (DE0706)"
                     ));
@@ -131,7 +131,7 @@ fn check_type_for_sqlx(cx: &rustc_lint::EarlyContext<'_>, ty: &Ty) {
                         .join("::");
 
                     if is_sqlx_path(&path_str) {
-                        cx.span_lint(DE0706_NO_DIRECT_SQLX, ty.span, |diag| {
+                        cx.opt_span_lint(DE0706_NO_DIRECT_SQLX, Some(ty.span), |diag| {
                             diag.primary_message(format!(
                                 "direct sqlx trait usage detected: `{path_str}` (DE0706)"
                             ));
@@ -155,7 +155,7 @@ fn check_use_for_sqlx(cx: &rustc_lint::EarlyContext<'_>, item: &Item) {
     };
 
     if let Some(path_str) = find_sqlx_path(use_tree) {
-        cx.span_lint(DE0706_NO_DIRECT_SQLX, item.span, |diag| {
+        cx.opt_span_lint(DE0706_NO_DIRECT_SQLX, Some(item.span), |diag| {
             diag.primary_message(format!(
                 "direct sqlx import detected: `{}` (DE0706)",
                 path_str
@@ -197,7 +197,7 @@ impl EarlyLintPass for De0706NoDirectSqlx {
                 };
 
                 if is_sqlx {
-                    cx.span_lint(DE0706_NO_DIRECT_SQLX, item.span, |diag| {
+                    cx.opt_span_lint(DE0706_NO_DIRECT_SQLX, Some(item.span), |diag| {
                         diag.primary_message("extern crate sqlx is prohibited (DE0706)");
                         diag.help("use Sea-ORM EntityTrait or SecORM abstractions instead");
                         diag.note("sqlx bypasses security enforcement and architectural patterns");

--- a/tools/dylint_lints/de07_security/de0707_drop_zeroize/src/lib.rs
+++ b/tools/dylint_lints/de07_security/de0707_drop_zeroize/src/lib.rs
@@ -158,7 +158,7 @@ impl<'tcx> hir::intravisit::Visitor<'tcx> for ZeroingVisitor<'tcx, '_> {
                 {
                     let inner_ty = self.typeck.expr_ty(inner);
                     if is_u8_ptr_or_ref(inner_ty) {
-                        self.cx.span_lint(DE0707_DROP_ZEROIZE, expr.span, |diag| {
+                        self.cx.opt_span_lint(DE0707_DROP_ZEROIZE, Some(expr.span), |diag| {
                                 diag.primary_message(
                                     "manual byte-zeroing in `Drop::drop` may be eliminated by the optimizer (DE0707)",
                                 );
@@ -190,7 +190,7 @@ impl<'tcx> hir::intravisit::Visitor<'tcx> for ZeroingVisitor<'tcx, '_> {
                     // Use adjusted type so Vec<u8> auto-derefs to [u8]
                     let recv_ty = self.typeck.expr_ty_adjusted(recv);
                     if method_in_std && has_u8_element(recv_ty) {
-                        self.cx.span_lint(DE0707_DROP_ZEROIZE, expr.span, |diag| {
+                        self.cx.opt_span_lint(DE0707_DROP_ZEROIZE, Some(expr.span), |diag| {
                                     diag.primary_message(
                                         "manual byte-zeroing in `Drop::drop` may be eliminated by the optimizer (DE0707)",
                                     );
@@ -215,9 +215,9 @@ impl<'tcx> hir::intravisit::Visitor<'tcx> for ZeroingVisitor<'tcx, '_> {
                     && let Some(def_id) = self.cx.qpath_res(qpath, func.hir_id).opt_def_id()
                     && is_ptr_write_bytes(self.cx, def_id)
                 {
-                    self.cx.span_lint(
+                    self.cx.opt_span_lint(
                                             DE0707_DROP_ZEROIZE,
-                                            expr.span,
+                                            Some(expr.span),
                                             |diag| {
                                                 diag.primary_message(
                                                     "manual byte-zeroing in `Drop::drop` may be eliminated by the optimizer (DE0707)",

--- a/tools/dylint_lints/de07_security/de0708_no_non_fips_hasher/src/lib.rs
+++ b/tools/dylint_lints/de07_security/de0708_no_non_fips_hasher/src/lib.rs
@@ -70,7 +70,7 @@ impl EarlyLintPass for De0708NoNonFipsHasher {
         };
 
         if let Some(path_str) = find_banned_path(use_tree) {
-            cx.span_lint(DE0708_NO_NON_FIPS_HASHER, item.span, |diag| {
+            cx.opt_span_lint(DE0708_NO_NON_FIPS_HASHER, Some(item.span), |diag| {
                 diag.primary_message(format!(
                     "non-FIPS-validated hasher import detected: `{}` (DE0708)",
                     path_str

--- a/tools/dylint_lints/de08_rest_api_conventions/de0801_api_endpoint_version/src/lib.rs
+++ b/tools/dylint_lints/de08_rest_api_conventions/de0801_api_endpoint_version/src/lib.rs
@@ -273,7 +273,7 @@ fn check_path_argument<'tcx>(cx: &LateContext<'tcx>, path_arg: &'tcx Expr<'tcx>)
                 ),
             };
 
-            cx.span_lint(DE0801_API_ENDPOINT_VERSION, path_arg.span, |diag| {
+            cx.opt_span_lint(DE0801_API_ENDPOINT_VERSION, Some(path_arg.span), |diag| {
                 diag.primary_message(message);
                 diag.help(help);
                 diag.note(note);

--- a/tools/dylint_lints/de08_rest_api_conventions/de0802_use_odata_ext/src/lib.rs
+++ b/tools/dylint_lints/de08_rest_api_conventions/de0802_use_odata_ext/src/lib.rs
@@ -133,7 +133,7 @@ fn check_odata_param<'tcx>(cx: &LateContext<'tcx>, arg: &'tcx Expr<'tcx>, method
         if ODATA_PARAMS.contains(&param_name) {
             let recommended = get_recommended_method(param_name);
 
-            cx.span_lint(DE0802_USE_ODATA_EXT, arg.span, |diag| {
+            cx.opt_span_lint(DE0802_USE_ODATA_EXT, Some(arg.span), |diag| {
                 diag.primary_message(format!(
                     "use OperationBuilderODataExt instead of .{}() for OData parameter `{}` (DE0802)",
                     method_name, param_name

--- a/tools/dylint_lints/de08_rest_api_conventions/de0803_api_snake_case/src/lib.rs
+++ b/tools/dylint_lints/de08_rest_api_conventions/de0803_api_snake_case/src/lib.rs
@@ -104,7 +104,7 @@ fn find_serde_attribute_value(
 fn check_type_rename_all(cx: &EarlyContext<'_>, attrs: &[Attribute]) {
     for (span, value) in find_serde_attribute_value(attrs, "rename_all") {
         if value != "snake_case" {
-            cx.span_lint(DE0803_API_SNAKE_CASE, span, |diag| {
+            cx.opt_span_lint(DE0803_API_SNAKE_CASE, Some(span), |diag| {
                 diag.primary_message(
                     "DTOs must not use non-snake_case in serde rename_all (DE0803)",
                 );
@@ -120,7 +120,7 @@ fn check_type_rename_all(cx: &EarlyContext<'_>, attrs: &[Attribute]) {
 fn check_variant_rename(cx: &EarlyContext<'_>, attrs: &[Attribute]) {
     for (span, value) in find_serde_attribute_value(attrs, "rename") {
         if !is_snake_case(&value) {
-            cx.span_lint(DE0803_API_SNAKE_CASE, span, |diag| {
+            cx.opt_span_lint(DE0803_API_SNAKE_CASE, Some(span), |diag| {
                 diag.primary_message(
                     "Enum variants must not use non-snake_case in serde rename (DE0803)",
                 );
@@ -157,9 +157,9 @@ fn check_field_snake_case(cx: &EarlyContext<'_>, field: &FieldDef) {
     if rename_values.is_empty() {
         // No field-level serde rename - field name must be snake_case
         if !is_snake_case(&field_name) {
-            cx.span_lint(
+            cx.opt_span_lint(
                 DE0803_API_SNAKE_CASE,
-                field.ident.unwrap().span,
+                Some(field.ident.unwrap().span),
                 |diag| {
                     diag.primary_message(
                         "DTO field name must be snake_case or have a serde rename to snake_case (DE0803)"
@@ -175,7 +175,7 @@ fn check_field_snake_case(cx: &EarlyContext<'_>, field: &FieldDef) {
         // Has field-level serde rename - the rename value must be snake_case
         for (span, value) in rename_values {
             if !is_snake_case(&value) {
-                cx.span_lint(DE0803_API_SNAKE_CASE, span, |diag| {
+                cx.opt_span_lint(DE0803_API_SNAKE_CASE, Some(span), |diag| {
                     diag.primary_message(
                         "DTO fields must not use non-snake_case in serde rename (DE0803)",
                     );

--- a/tools/dylint_lints/de09_gts_layer/de0901_gts_string_pattern/src/lib.rs
+++ b/tools/dylint_lints/de09_gts_layer/de0901_gts_string_pattern/src/lib.rs
@@ -91,7 +91,7 @@ impl EarlyLintPass for De0901GtsStringPattern {
         // Validate the wildcard GTS pattern itself before skip-listing.
         let result = GtsOps::parse_id(s);
         if !result.ok {
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, item.span, |diag| {
+            cx.opt_span_lint(DE0901_GTS_STRING_PATTERN, Some(item.span), |diag| {
                 diag.primary_message(format!(
                     "invalid GTS wildcard pattern in `{item_name}`: '{s}' (DE0901)"
                 ));
@@ -108,7 +108,7 @@ impl EarlyLintPass for De0901GtsStringPattern {
         self.check_vendors_in_parse_result(cx, item.span, s, &result);
 
         if !item_name.ends_with("_WILDCARD") {
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, item.span, |diag| {
+            cx.opt_span_lint(DE0901_GTS_STRING_PATTERN, Some(item.span), |diag| {
                 diag.primary_message(format!(
                     "GTS wildcard string in `const`/`static` `{item_name}` must have a name ending with `_WILDCARD` (DE0901)"
                 ));
@@ -503,7 +503,7 @@ impl De0901GtsStringPattern {
 
         // Wildcards are NOT allowed in schema_id
         if s.contains('*') {
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
+            cx.opt_span_lint(DE0901_GTS_STRING_PATTERN, Some(span), |diag| {
                 diag.primary_message(format!("wildcards are not allowed in schema_id: '{}' (DE0901)", s));
                 diag.note("Wildcards (*) are only allowed in permission strings, not in schema_id attributes");
                 diag.help("Use concrete type names in schema_id");
@@ -515,7 +515,7 @@ impl De0901GtsStringPattern {
         let result = GtsOps::parse_id(s);
 
         if !result.ok {
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
+            cx.opt_span_lint(DE0901_GTS_STRING_PATTERN, Some(span), |diag| {
                 diag.primary_message(format!("invalid GTS schema_id: '{}' (DE0901)", s));
                 diag.note(result.error);
                 diag.help("Example: gts.cf.core.events.type.v1~");
@@ -525,7 +525,7 @@ impl De0901GtsStringPattern {
 
         // Ensure it's actually a schema (type), not an instance
         if result.is_type != Some(true) {
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
+            cx.opt_span_lint(DE0901_GTS_STRING_PATTERN, Some(span), |diag| {
                 diag.primary_message(format!(
                     "schema_id must be a type schema, not an instance: '{}' (DE0901)",
                     s
@@ -546,7 +546,7 @@ impl De0901GtsStringPattern {
         // If the input contains delimiters for chained ids / permission strings,
         // it is not a single segment.
         if s.contains('~') || s.contains(':') {
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
+            cx.opt_span_lint(DE0901_GTS_STRING_PATTERN, Some(span), |diag| {
                 diag.primary_message(format!(
                     "gts_make_instance_id expects a single GTS segment, got: '{}' (DE0901)",
                     s
@@ -557,7 +557,7 @@ impl De0901GtsStringPattern {
         }
 
         if s.contains('*') {
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
+            cx.opt_span_lint(DE0901_GTS_STRING_PATTERN, Some(span), |diag| {
                 diag.primary_message(format!(
                     "wildcards are not allowed in instance id segments: '{}' (DE0901)",
                     s
@@ -569,14 +569,14 @@ impl De0901GtsStringPattern {
 
         match GtsIdSegment::new(0, 0, s) {
             Err(e) => {
-                cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
+                cx.opt_span_lint(DE0901_GTS_STRING_PATTERN, Some(span), |diag| {
                     diag.primary_message(format!("invalid GTS segment: '{}' (DE0901)", s));
                     diag.note(e.to_string());
                     diag.help("Example: vendor.package.sku.abc.v1");
                 });
             }
             Ok(seg) if !allowed_vendors(cx, span).contains(&seg.vendor.as_str()) => {
-                cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
+                cx.opt_span_lint(DE0901_GTS_STRING_PATTERN, Some(span), |diag| {
                     diag.primary_message(format!(
                         "invalid GTS vendor in segment: '{}' (DE0901)",
                         s
@@ -604,7 +604,7 @@ impl De0901GtsStringPattern {
             {
                 continue;
             }
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
+            cx.opt_span_lint(DE0901_GTS_STRING_PATTERN, Some(span), |diag| {
                 diag.primary_message(format!(
                     "invalid GTS vendor in segment #{idx}: '{}' (DE0901)",
                     s
@@ -623,7 +623,7 @@ impl De0901GtsStringPattern {
 
         // Wildcards are NOT allowed in regular GTS strings (only in permission strings)
         if s.contains('*') {
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
+            cx.opt_span_lint(DE0901_GTS_STRING_PATTERN, Some(span), |diag| {
                 diag.primary_message(format!("invalid GTS string (wildcards not allowed): '{}' (DE0901)", s));
                 diag.note("Wildcards (*) are only allowed in permission strings, not in regular GTS identifiers");
                 diag.help("Use concrete type names");
@@ -634,7 +634,7 @@ impl De0901GtsStringPattern {
         let result = GtsOps::parse_id(s);
 
         if !result.ok {
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
+            cx.opt_span_lint(DE0901_GTS_STRING_PATTERN, Some(span), |diag| {
                 diag.primary_message(format!("invalid GTS string: '{}' (DE0901)", s));
                 diag.note(result.error);
             });
@@ -655,7 +655,7 @@ impl De0901GtsStringPattern {
         let result = GtsOps::parse_id(s);
 
         if !result.ok {
-            cx.span_lint(DE0901_GTS_STRING_PATTERN, span, |diag| {
+            cx.opt_span_lint(DE0901_GTS_STRING_PATTERN, Some(span), |diag| {
                 diag.primary_message(format!("invalid GTS string: '{}' (DE0901)", s));
                 diag.note(result.error);
             });

--- a/tools/dylint_lints/de09_gts_layer/de0902_no_schema_for_on_gts_structs/src/lib.rs
+++ b/tools/dylint_lints/de09_gts_layer/de0902_no_schema_for_on_gts_structs/src/lib.rs
@@ -113,9 +113,9 @@ impl<'tcx> LateLintPass<'tcx> for De0902NoSchemaForOnGtsStructs {
                             && is_gts_type(cx, ty)
                         {
                             let type_name = get_type_name(ty);
-                            cx.span_lint(
+                            cx.opt_span_lint(
                                         DE0902_NO_SCHEMA_FOR_ON_GTS_STRUCTS,
-                                        callsite_span,
+                                        Some(callsite_span),
                                         |diag| {
                                             diag.primary_message(format!(
                                                 "do not use `schema_for!({})` on GTS-wrapped struct (DE0902)",

--- a/tools/dylint_lints/de11_testing/de1101_tests_in_separate_files/src/lib.rs
+++ b/tools/dylint_lints/de11_testing/de1101_tests_in_separate_files/src/lib.rs
@@ -159,7 +159,7 @@ impl EarlyLintPass for De1101TestsInSeparateFiles {
         for violation in violations {
             match violation {
                 TestViolation::InlineTestCode => {
-                    cx.span_lint(DE1101_TESTS_IN_SEPARATE_FILES, item.span, |diag| {
+                    cx.opt_span_lint(DE1101_TESTS_IN_SEPARATE_FILES, Some(item.span), |diag| {
                         diag.primary_message(
                             "test code must be moved to a separate test file (DE1101)",
                         );
@@ -170,7 +170,7 @@ impl EarlyLintPass for De1101TestsInSeparateFiles {
                     });
                 }
                 TestViolation::InlineTestCodeWithCompanion => {
-                    cx.span_lint(DE1101_TESTS_IN_SEPARATE_FILES, item.span, |diag| {
+                    cx.opt_span_lint(DE1101_TESTS_IN_SEPARATE_FILES, Some(item.span), |diag| {
                         diag.primary_message(
                             "test code must not be added back to a file that already has a companion test file (DE1101)",
                         );
@@ -180,7 +180,7 @@ impl EarlyLintPass for De1101TestsInSeparateFiles {
                     });
                 }
                 TestViolation::WrongPathAttr { expected, actual } => {
-                    cx.span_lint(DE1101_TESTS_IN_SEPARATE_FILES, item.span, |diag| {
+                    cx.opt_span_lint(DE1101_TESTS_IN_SEPARATE_FILES, Some(item.span), |diag| {
                         diag.primary_message(format!(
                             "test module path `{actual}.rs` must reference `{expected}.rs` to match the source file (DE1101)",
                         ));

--- a/tools/dylint_lints/de12_documentation/de1201_docs_rs_all_features/src/lib.rs
+++ b/tools/dylint_lints/de12_documentation/de1201_docs_rs_all_features/src/lib.rs
@@ -75,7 +75,7 @@ impl LateLintPass<'_> for De1201DocsRsAllFeatures {
         {
             Ok(metadata) => metadata,
             Err(error) => {
-                cx.span_lint(DE1201_DOCS_RS_ALL_FEATURES, DUMMY_SP, |diag| {
+                cx.opt_span_lint(DE1201_DOCS_RS_ALL_FEATURES, Some(DUMMY_SP), |diag| {
                     diag.primary_message(format!(
                         "could not read Cargo metadata for docs.rs configuration check: {error}"
                     ));
@@ -85,7 +85,7 @@ impl LateLintPass<'_> for De1201DocsRsAllFeatures {
         };
 
         let Some(package) = find_current_package(&metadata, &manifest_path) else {
-            cx.span_lint(DE1201_DOCS_RS_ALL_FEATURES, DUMMY_SP, |diag| {
+            cx.opt_span_lint(DE1201_DOCS_RS_ALL_FEATURES, Some(DUMMY_SP), |diag| {
                 diag.primary_message(format!(
                     "could not find current package in Cargo metadata for `{}`",
                     manifest_path.display()
@@ -103,7 +103,7 @@ impl LateLintPass<'_> for De1201DocsRsAllFeatures {
             return;
         };
 
-        cx.span_lint(DE1201_DOCS_RS_ALL_FEATURES, DUMMY_SP, |diag| {
+        cx.opt_span_lint(DE1201_DOCS_RS_ALL_FEATURES, Some(DUMMY_SP), |diag| {
             diag.primary_message(format!(
                 "publishable crate `{}` must set `package.metadata.docs.rs.all-features = true` (DE1201)",
                 package.name

--- a/tools/dylint_lints/de13_common_patterns/de1301_no_print_macros/src/lib.rs
+++ b/tools/dylint_lints/de13_common_patterns/de1301_no_print_macros/src/lib.rs
@@ -133,7 +133,7 @@ impl<'a, 'cx> ForbiddenMacroVisitor<'a, 'cx> {
         }
 
         self.cx
-            .span_lint(DE1301_NO_PRINT_MACROS, mac_call.span(), |diag| {
+            .opt_span_lint(DE1301_NO_PRINT_MACROS, Some(mac_call.span()), |diag| {
                 diag.primary_message(format!(
                     "macro `{name}!` is forbidden in production code (DE1301)"
                 ));

--- a/tools/dylint_lints/de13_common_patterns/de1302_error_from_to_string/src/lib.rs
+++ b/tools/dylint_lints/de13_common_patterns/de1302_error_from_to_string/src/lib.rs
@@ -114,7 +114,7 @@ struct ToStringVisitor<'tcx, 'cx> {
 impl<'tcx> ToStringVisitor<'tcx, '_> {
     /// Emit the DE1302 diagnostic at `span`.
     fn emit(&self, span: rustc_span::Span) {
-        self.cx.span_lint(DE1302_ERROR_FROM_TO_STRING, span, |diag| {
+        self.cx.opt_span_lint(DE1302_ERROR_FROM_TO_STRING, Some(span), |diag| {
             diag.primary_message(
                 "`.to_string()` in `From`/`TryFrom` impl destroys the error chain (DE1302)",
             );

--- a/tools/dylint_lints/de13_common_patterns/de1303_no_primitive_type_alias/src/lib.rs
+++ b/tools/dylint_lints/de13_common_patterns/de1303_no_primitive_type_alias/src/lib.rs
@@ -103,7 +103,7 @@ impl EarlyLintPass for De1303NoPrimitiveTypeAlias {
             return;
         }
 
-        cx.span_lint(DE1303_NO_PRIMITIVE_TYPE_ALIAS, item.span, |diag| {
+        cx.opt_span_lint(DE1303_NO_PRIMITIVE_TYPE_ALIAS, Some(item.span), |diag| {
             diag.primary_message(format!(
                 "`pub type {name} = {backing}` is a transparent alias with no type safety (DE1303)"
             ));


### PR DESCRIPTION
## Summary

The `Dylint Tests` CI job fails to compile the lint crates with:

```
error[E0599]: no method named `span_lint` found for reference `&EarlyContext<'_>`
  --> de07_security/de0708_no_non_fips_hasher/src/lib.rs:73
   |  cx.span_lint(...)   help: there is a method `opt_span_lint`
```

`LintContext::span_lint` was removed in newer rustc nightlies in favour of `opt_span_lint(lint, Option<Span>, decorate)`. This PR switches every lint call site from `cx.span_lint(LINT, span, ..)` to `cx.opt_span_lint(LINT, Some(span), ..)`, which exists on both the pinned `nightly-2026-01-22` and newer toolchains — so the lints build regardless of which rustc the runner resolves.

## Validation

Built and tested the whole `tools/dylint_lints` workspace on the pinned `nightly-2026-01-22`:

- `cargo build` — clean
- `cargo test` — all lint UI/unit tests pass

No lint behaviour changes; this is a pure API-compatibility rename (`span_lint` → `opt_span_lint` + wrap the span in `Some(..)`).