### PR TITLE
docs: FIPS 140-3 documentation improvements and README consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,95 +149,9 @@ See **[Security Overview](docs/security/SECURITY.md)** for the full breakdown, i
 
 ## FIPS 140-3 support
 
-Gears build with `--features fips` route every TLS data-path cryptographic operation through a **FIPS 140-3 validated cryptographic module**, on a single `rustls 0.23` state machine with one of three pluggable backends:
+Built with `--features fips`, Gears route every TLS data-path cryptographic operation through a **CMVP-validated cryptographic module** — AWS-LC FIPS (Linux), Apple corecrypto (macOS), or Microsoft Windows CNG (Windows) — behind a single `rustls 0.23` state machine. Gears are *consumers* of those validated modules, not a CMVP-listed module themselves.
 
-| Target | Validated module | Backend |
-|---|---|---|
-| macOS (any arch) | Apple `corecrypto` User-Space Gear (per-OS-version CMVP cert) | `cf-gears-rustls-corecrypto-provider` over Security.framework + CommonCrypto |
-| Windows (x86_64) | Microsoft Windows CNG (per-OS-version CMVP cert) | `rustls-cng-crypto`'s `fips_provider()` over `bcrypt.dll` + `ncrypt.dll` |
-
-All branches share the same `rustls 0.23` state machine — only the `CryptoProvider` swaps per OS.
-
-### What is enforced on the wire
-
-Built with `--features fips`, the toolkit-http client offers **only** FIPS-Approved algorithms in its `ClientHello`:
-
-| Category | Algorithms |
-|---|---|
-| TLS versions | TLS 1.2, TLS 1.3 (no TLS 1.0/1.1) |
-| TLS 1.3 cipher suites | `TLS_AES_128_GCM_SHA256`, `TLS_AES_256_GCM_SHA384` |
-| TLS 1.2 cipher suites | `ECDHE_{ECDSA,RSA}_WITH_AES_{128,256}_GCM_SHA{256,384}` (×4) |
-| Key exchange | NIST P-256, P-384 ECDHE |
-| Signatures (verify) | ECDSA P-256/P-384, RSA-PSS, RSA PKCS#1 v1.5 (SHA-256/384/512) |
-| Hash / HMAC / HKDF | SHA-256, SHA-384 |
-| TLS 1.2 Extended Master Secret (RFC 7627) | **required** (`require_ems = true`) per NIST SP 800-52 Rev. 2 §3.5 |
-
-Explicitly **excluded**: ChaCha20-Poly1305, x25519, X25519MLKEM768 / post-quantum hybrids, ED25519, MD5, SHA-1.
-
-### Build & runtime
-
-```sh
-cargo build -p cf-gears-example-server --features fips
-```
-
-This is *"uses FIPS-validated cryptography"* — Gears itself are not on the CMVP Validated Gears list; the validated modules belong to Apple, AWS Labs, and Microsoft.
-
-For the full per-OS detail (algorithm scope, build prerequisites, verification gates, runtime OE-validation, dep-graph policy, what is and is not covered) see **[Security Overview §9](docs/security/SECURITY.md#9-cryptographic-stack--fips-140-3)**. Architecture, ecosystem constraints, alternatives we rejected, and per-OS rationale live in the **[FIPS PRD](docs/security/fips/PRD.md)** and the ADRs in [`docs/security/fips/adrs/`](docs/security/fips/adrs/).
-
-### How to verify a build is FIPS-conformant
-
-```sh
-# Wire-level (offered ClientHello inspected by an external TLS server):
-cargo run -p cf-gears-fips-probe --features fips -- --url https://www.howsmyssl.com/a/check
-
-# Expected: given_cipher_suites contains only AES-GCM suites, given_named_groups
-# contains only secp256r1/secp384r1, post_quantum_key_agreement: false.
-# The probe heuristic prints `[OK] No ChaCha20 in ClientHello cipher_suites`.
-```
-
-```sh
-# Linkage on macOS+fips — should be Apple frameworks only, no aws-lc-fips dylib:
-otool -L target/debug/cf-gears-example-server | grep -E 'aws|crypto|ssl|ring'
-# (Expected: only /System/Library/Frameworks/Security.framework)
-
-# Runtime — corecrypto loaded:
-vmmap <cf-gears-example-server-pid> | grep -E 'corecrypto|Security\.framework'
-```
-
-See [`examples/cf-gears-fips-probe/README.md`](examples/cf-gears-fips-probe/README.md) for the full four-layer verification chain (linkage, runtime, wire-level, cert-validation).
-
-### Build prerequisites
-
-- **macOS + fips**: Xcode Command Line Tools + Rust toolchain. No `cmake` / `perl` / `go` (those used to be required when aws-lc-fips was linked on macOS; the per-target shim eliminates them).
-- **Linux + fips**: C toolchain + `cmake` + `perl` + `go` (required by `aws-lc-fips-sys` build script).
-- **Windows + fips**: MSVC toolchain + Windows SDK only for native Windows builds. No `cmake` / `perl` / `go` — `rustls-cng-crypto` is pure FFI to system DLLs (`bcrypt.dll`, `ncrypt.dll`) with no `build.rs`. Cross-compiling from a Linux/macOS host with `--target x86_64-pc-windows-msvc` needs no extra tooling beyond the standard MSVC sysroot bundled by `rustup target add` and `cargo-xwin` / `lld-link` if linking the binary; the `make check-windows-fips` target only `cargo check`s, so even that is unnecessary.
-
-### System FIPS-mode requirement (Windows)
-
-The Windows CNG FIPS provider only enforces its FIPS-Approved algorithm subset when the operating system itself is in FIPS mode. Gears bootstrap **fails closed** when this is not the case: `toolkit::bootstrap::init_crypto_provider` returns `CryptoProviderError::SystemFipsModeNotEnabled` and the binary refuses to start.
-
-Enable FIPS mode via Group Policy: *Computer Configuration → Windows Settings → Security Settings → Local Policies → Security Options → "System cryptography: Use FIPS compliant algorithms for encryption, hashing, and signing" → Enabled*. Or via the registry:
-
-```powershell
-reg add HKLM\System\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy /v Enabled /t REG_DWORD /d 1 /f
-```
-
-A reboot is required after either change. See <https://learn.microsoft.com/en-us/windows/security/threat-protection/fips-140-validation> for Microsoft's reference documentation on FIPS-mode posture.
-
-### What this does NOT claim
-
-- Gears itself is **not** on the CMVP Validated Gears list. CMVP-listed modules are Apple `corecrypto` (macOS), AWS-LC FIPS Provider (Linux), and Microsoft Windows CNG (Windows); Gears are *consumers*.
-- Neither `rustls-cng-crypto` nor `cf-gears-rustls-corecrypto-provider` is itself CMVP-listed — both are thin wrappers over the CMVP-listed system module they consume (CNG and corecrypto respectively). The chain-of-trust comes from the underlying validated module, not the wrapper crate.
-- The FIPS claim on macOS / Windows is valid only when the running OS version is covered by the Operational Environment of the current CMVP certificate for the system module (`corecrypto` / CNG). Verify per release against <https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search>.
-- `rustls-cng-crypto` is a young, single-maintainer crate (first release 2024-12). We pin to `0.1.x` and re-evaluate against `rustls-symcrypt` per release; the choice is documented in [`docs/security/fips/adrs/0003-windows-fips-via-rustls-cng-crypto.md`](docs/security/fips/adrs/0003-windows-fips-via-rustls-cng-crypto.md).
-- TLS protocol-level NIST recommendations (SP 800-52 Rev. 2) beyond EMS — minimum protocol version, certificate hygiene, etc. — are the deployment's responsibility.
-- Server-side TLS termination (inbound HTTPS) is delegated to the reverse proxy and is not part of this FIPS scope.
-
-### Architecture decisions
-
-- [`docs/adrs/toolkit/0004-macos-fips-via-corecrypto-provider.md`](docs/adrs/toolkit/0004-macos-fips-via-corecrypto-provider.md) — why we built a custom rustls `CryptoProvider` over Apple corecrypto rather than using `native-tls` or declaring FIPS Linux-only.
-- [`docs/adrs/toolkit/0005-fips-feature-target-conditional-shim.md`](docs/adrs/toolkit/0005-fips-feature-target-conditional-shim.md) — why a one-`fips`-feature design uses an empty shim crate to encode per-target activation.
-- [`docs/security/fips/adrs/0003-windows-fips-via-rustls-cng-crypto.md`](docs/security/fips/adrs/0003-windows-fips-via-rustls-cng-crypto.md) — why Windows+FIPS routes through `rustls-cng-crypto` today rather than waiting for Microsoft's `rustls-symcrypt` to obtain CMVP validation.
+See **[Security Overview §9 — Cryptographic Stack & FIPS-140-3](docs/security/SECURITY.md#9-cryptographic-stack--fips-140-3)** for algorithm scope, build prerequisites, runtime/verification gates, and the full "what this does and does not claim" breakdown.
 
 ## Configuration
 

--- a/docs/security/SECURITY.md
+++ b/docs/security/SECURITY.md
@@ -36,6 +36,11 @@ Gears take a **defense-in-depth** approach to security, combining Rust's compile
     - [Algorithm scope on the wire](#algorithm-scope-on-the-wire)
     - [Build-time dependency-graph policy](#build-time-dependency-graph-policy)
     - [Runtime Operational Environment validation](#runtime-operational-environment-validation)
+    - [Runtime failure modes](#runtime-failure-modes)
+    - [TLS configuration knobs](#tls-configuration-knobs)
+    - [Non-cryptographic `sha2` and `rand` usage](#non-cryptographic-sha2-and-rand-usage)
+    - [Approved-only deployment checklist](#approved-only-deployment-checklist)
+    - [Enabling OS FIPS mode (Windows)](#enabling-os-fips-mode-windows)
     - [How to verify a build is FIPS-conformant](#how-to-verify-a-build-is-fips-conformant)
     - [What this does NOT claim](#what-this-does-not-claim)
     - [Deep references](#deep-references)
@@ -459,6 +464,50 @@ A FIPS 140-3 claim is only valid when the running OS version lies inside the **O
 | Linux | Not yet implemented at runtime. | OE coverage verified manually per release (CMVP cert search for cert #4816). Tracked as **TODO-8** in [FIPS PRD §13](fips/PRD.md#13-open-questions). |
 | Windows | OS-level FIPS-mode flag check (via `rustls-cng-crypto`'s empty-provider gate). Build-number-vs-CMVP-OE check not yet implemented at runtime. | If `FipsAlgorithmPolicy = 0`: bootstrap refuses to install the provider. Build-number OE check tracked as **TODO-8**. |
 
+### Runtime failure modes
+
+What a `--features fips` process does when its environment cannot satisfy the FIPS claim. Each row is fail-closed — the gear never serves traffic under a degraded or non-validated provider.
+
+| OS (`--features fips`) | Failure mode | Process behaviour |
+|---|---|---|
+| macOS | OE mismatch — running macOS major ∉ [`SUPPORTED_OE_MACOS_MAJOR`](../../libs/rustls-corecrypto-provider/src/oe.rs), with `CF_GEARS_FIPS_OE_OVERRIDE` unset | Fail-closed **panic**. `oe::validate_oe()` returns `Err` ⇒ `fips_witness_ok()` caches `false` ⇒ every primitive's `fips()` returns `false` ⇒ `CryptoProvider::fips()` is `false` ⇒ the post-install `assert!(provider.fips())` in [`init_crypto_provider`](../../libs/toolkit/src/bootstrap/crypto.rs) panics. Defense-in-depth: even if that assert were bypassed, `tls::apply_fips_hardening` returns `Err(TlsConfigError::FipsHardeningFailed)`, so any TLS-config build also fails recoverably. CI on pre-release macOS sets `CF_GEARS_FIPS_OE_OVERRIDE=1`. |
+| Windows | OS FIPS-mode off (`FipsAlgorithmPolicy != 1`) | Bootstrap fails closed (no panic). `rustls_cng_crypto::fips_provider()` yields a provider with empty `cipher_suites`; `init_crypto_provider` detects the empty provider and returns `CryptoProviderError::SystemFipsModeNotEnabled`; the binary refuses to start. |
+| Linux | AWS-LC POST (power-on self-test) failure | Panic at provider construction. `rustls::crypto::default_fips_provider()` (AWS-LC FIPS module) aborts on a POST failure; `init_crypto_provider` returns `Err` for the install-conflict case it can observe, but an underlying POST failure propagates as a panic/abort. `main.rs` / `init_procedure` handle the `Err` path from `init_crypto_provider` but cannot catch the POST abort. |
+
+### TLS configuration knobs
+
+The HTTP client (`cf-gears-toolkit-http`) exposes the following transport knobs (see [`libs/toolkit-http/src/config.rs`](../../libs/toolkit-http/src/config.rs)). None of them relax FIPS hardening — under `--features fips`, `tls::apply_fips_hardening` still asserts `ClientConfig::fips()`, so any setting incompatible with the active FIPS provider surfaces as an error at build time.
+
+| Knob | Type | Effect |
+|---|---|---|
+| Transport security | `TransportSecurity` (`TlsOnly` \| `AllowInsecureHttp`); `HttpClientBuilder::deny_insecure_http()` | Whether cleartext `http://` is permitted. Defaults to `TlsOnly` under `--features fips`, `AllowInsecureHttp` otherwise. Selecting `AllowInsecureHttp` under FIPS makes `build()` return `HttpError::InsecureTransport`. |
+| Minimum TLS version | `TlsVersion` (`Tls12` \| `Tls13`) | `Tls12` advertises TLS 1.2 + 1.3 (rustls safe default); `Tls13` is TLS 1.3-only. Does not relax FIPS hardening. |
+| Mutual TLS identity | `ClientAuthConfig` | PEM cert-chain + private-key **file paths** (PKCS#8 / PKCS#1 / SEC1). Files are read lazily at build; no key bytes are held in the cloneable config. |
+| Trust roots | `TlsRootConfig` | Selects the certificate trust anchors (e.g. the native OS root store). |
+| Extended Master Secret | `require_ems` (set `true` by `apply_fips_hardening`) | Enforces RFC 7627 EMS under FIPS per NIST SP 800-52 Rev. 2 §3.5. |
+
+### Non-cryptographic `sha2` and `rand` usage
+
+Any residual `sha2` / `rand` usage in the tree is **non-cryptographic** and is **not part of the FIPS claim**. Non-cryptographic fingerprints use inline FNV-1a (OData pagination cursor consistency in `libs/toolkit-odata/src/pagination.rs`; the OIDC token-cache key in `oidc-authn-plugin`), and the `rand` ecosystem is pulled in transitively rather than used for key material on the TLS data plane. New `sha2`/`sha1`/`md5` imports are rejected at compile time by Dylint **DE0708** (`no_non_fips_hasher`) outside an explicit allow-list. See the [Non-FIPS hasher guard](#build-time-dependency-graph-policy) note above and [What this does NOT claim](#what-this-does-not-claim) below for the transitive-dependency posture.
+
+### Approved-only deployment checklist
+
+Before relying on the FIPS claim in a deployment:
+
+- **OS FIPS mode** — confirm the OS is in an approved state: Windows `HKLM\System\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy = 1`; macOS major version inside [`SUPPORTED_OE_MACOS_MAJOR`](../../libs/rustls-corecrypto-provider/src/oe.rs); Linux OE inside CMVP cert [#4816](https://csrc.nist.gov/projects/cryptographic-gear-validation-program/certificate/4816).
+- **Static-linkage check** — run the linkage smoke (`otool -L` on macOS, `dumpbin /imports` on Windows) and confirm only the OS-supplied / validated crypto module is loaded — see [How to verify a build is FIPS-conformant](#how-to-verify-a-build-is-fips-conformant).
+- **No-sccache FIPS build job** — build the FIPS provider in a dedicated CI job with `sccache` disabled, so AWS-LC FIPS integrity / self-test artifacts are produced fresh rather than served from a compilation cache.
+
+### Enabling OS FIPS mode (Windows)
+
+The Windows CNG FIPS provider only enforces its FIPS-Approved algorithm subset when the operating system itself is in FIPS mode; otherwise Gears bootstrap [fails closed](#runtime-failure-modes) with `CryptoProviderError::SystemFipsModeNotEnabled`. Enable system-wide FIPS mode via Group Policy: *Computer Configuration → Windows Settings → Security Settings → Local Policies → Security Options → "System cryptography: Use FIPS compliant algorithms for encryption, hashing, and signing" → Enabled*. Or via the registry:
+
+```powershell
+reg add HKLM\System\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy /v Enabled /t REG_DWORD /d 1 /f
+```
+
+A reboot is required after either change. See Microsoft's [FIPS 140 validation reference](https://learn.microsoft.com/en-us/windows/security/threat-protection/fips-140-validation) for the authoritative posture documentation.
+
 ### How to verify a build is FIPS-conformant
 
 ```sh
@@ -483,6 +532,7 @@ cargo tree --target x86_64-pc-windows-msvc -p cf-gears-example-server --features
 # 3. Linkage smoke — confirm only OS-supplied crypto framework is loaded:
 otool -L target/release/cf-gears-server | grep -E 'aws|crypto|ssl|ring'      # macOS — expect only Security.framework
 dumpbin /imports target\release\cf-gears-server.exe | findstr /i "bcrypt aws"  # Windows — expect only bcrypt.dll
+vmmap <cf-gears-server-pid> | grep -E 'corecrypto|Security\.framework'        # macOS runtime — confirm corecrypto is mapped into the live process
 
 # 4. Dep-graph policy regression (rejects non-FIPS crypto crates):
 make fips-policy
@@ -502,6 +552,8 @@ See [`examples/cf-gears-fips-probe/README.md`](../../examples/cf-gears-fips-prob
 - **JWT signature validation does not go through the FIPS path.** `jsonwebtoken` uses `ring` / non-FIPS `aws-lc-rs` for RSA / ECDSA verification on bearer tokens. Treat tokens as authentication context, not as data covered by the cryptographic claim. Out of scope today; tracked as **TODO-7** in [FIPS PRD §13](fips/PRD.md#13-open-questions). Cleanup is gated by `deny-fips.toml` Phase B promotion.
 - **Non-FIPS crypto crates remain in the final binary on macOS+fips.** `ring` is pulled in transitively by `pingora-rustls`, `pingora-pool`, and `ureq`; non-FIPS `aws-lc-rs` is pulled in by rustls's default feature set; `chacha20` is pulled in by the `rand` ecosystem. These are **not invoked** on the TLS data plane (the installed `CryptoProvider` routes every TLS primitive through the validated gear) but the symbols are linked into the binary. Linkage smoke (above) confirms no non-validated shared libraries appear at runtime.
 - **Server-side TLS keys load from PEM/DER bytes by default.** The bytes transit user-space memory before reaching `SecKeyCreateWithData` / `BCryptImportKeyPair` / `EVP_PKEY_new`. Strict-FIPS auditors operating under "no plaintext CSPs outside the boundary" require a Keychain / NCrypt / HSM flow; tracked as **TODO-1**.
+- **Server-side TLS termination (inbound HTTPS) is out of scope.** The FIPS scope here covers the toolkit's outbound TLS data path; inbound HTTPS termination is delegated to the reverse proxy in front of the gear and is the deployment's responsibility.
+- **The wrapper crates are not themselves CMVP-listed.** Neither `rustls-cng-crypto` nor `cf-gears-rustls-corecrypto-provider` is a CMVP-validated module — each is a thin wrapper over the validated system module it consumes (Windows CNG and Apple corecrypto respectively). The chain-of-trust comes from the underlying validated module, not the wrapper crate.
 
 ### Deep references
 

--- a/libs/toolkit-http/src/lib.rs
+++ b/libs/toolkit-http/src/lib.rs
@@ -4,7 +4,9 @@
 //! HTTP client infrastructure for `ToolKit`
 //!
 //! This crate provides a hyper-based HTTP client with:
-//! - Automatic TLS via rustls (HTTPS only by default)
+//! - Automatic TLS via rustls; transport security is configurable via
+//!   [`TransportSecurity`] — defaults to
+//!   `TlsOnly` (HTTPS-only) under `--features fips`, `AllowInsecureHttp` otherwise
 //! - Connection pooling
 //! - Configurable timeouts
 //! - Automatic retries with exponential backoff


### PR DESCRIPTION
L1+L2 from issue #1942: enhance SECURITY.md §9 with runtime behavior clarity and fix inaccurate toolkit-http docstring.

README.md:
- Collapse ~90-line "## FIPS 140-3 support" section to 6-line blurb (one paragraph + link to SECURITY.md §9)
- Rationale: FIPS is secondary topic; details belong in dedicated security guide; README was duplicating tables/commands already in SECURITY.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified FIPS 140-3 support documentation in README with high-level overview and reference to detailed security documentation.
  * Expanded security documentation with OS-specific runtime failure modes, TLS configuration details, deployment checklist, and Windows FIPS mode enablement instructions.
  * Added macOS runtime verification guidance.
  * Updated TLS client configuration documentation to clarify transport security behavior with and without FIPS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->