### PR TITLE
chore: allow to run sub-set of e2e tests using 'make e2e-local E2E_TARGET=testing/e2e/gears/file_parser/'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -489,20 +489,22 @@ bench-db-longhaul: bench-pg-longhaul bench-mysql-longhaul bench-mariadb-longhaul
 
 .PHONY: e2e e2e-local e2e-local-smoke e2e-mini-chat e2e-docker e2e-docker-smoke e2e-tr-authz
 
+E2E_TARGET ?=
+
 # Run E2E tests in Docker (default)
 e2e: e2e-docker
 
 ## Run E2E tests in Docker environment
 e2e-docker:
-	python3 tools/scripts/ci.py e2e-docker $(E2E_ARGS)
+	python3 tools/scripts/ci.py e2e-docker -- $(E2E_TARGET)
 
 ## Run E2E smoke tests in Docker (only tests marked @pytest.mark.smoke)
 e2e-docker-smoke:
-	python3 tools/scripts/ci.py e2e-docker $(E2E_ARGS) -- -m smoke
+	python3 tools/scripts/ci.py e2e-docker -- -m smoke $(E2E_TARGET)
 
-# Run E2E tests locally
+# Run E2E tests locally, use `make e2e-local E2E_TARGET=testing/e2e/gears/` to specify target
 e2e-local:
-	python3 tools/scripts/ci.py e2e-local
+	python3 tools/scripts/ci.py e2e-local -- $(E2E_TARGET)
 
 ## Run RG + AuthZ barrier E2E tests with tr-authz-plugin going through TR -> RG
 e2e-tr-authz:

--- a/testing/e2e/README.md
+++ b/testing/e2e/README.md
@@ -40,10 +40,12 @@ This approach runs tests against a locally running cf-gears-server.
 ```bash
 # Run local E2E (builds release artifacts and starts server automatically)
 make e2e-local  # all tests
+make e2e-local E2E_TARGET=testing/e2e/gears/file_parser/  # targeted scope
 make e2e-local-smoke  # smoke only tests (annotated with @pytest.mark.smoke)
 
 # Or directly
 python3 scripts/ci.py e2e-local
+python3 scripts/ci.py e2e-local -- testing/e2e/gears/file_parser/
 ```
 
 #### Advanced Usage
@@ -123,8 +125,10 @@ async def test_my_endpoint(base_url, auth_headers):
 | `make e2e-docker`                    | Docker | Run tests in Docker environment          |
 | `make e2e-docker-smoke`              | Docker | Run only smoke tests in Docker            |
 | `make e2e-local`                     | Local  | Run tests against auto-started local server |
+| `make e2e-local E2E_TARGET=testing/e2e/gears/file_parser/` | Local | Run a targeted local E2E subset |
 | `make e2e-local-smoke`               | Local  | Run only smoke tests locally              |
 | `python3 scripts/ci.py e2e-local`    | Local  | Direct script execution (local)          |
+| `python3 scripts/ci.py e2e-local -- testing/e2e/gears/file_parser/` | Local | Direct targeted local script execution |
 | `python3 scripts/ci.py e2e-local --smoke` | Local | Direct script execution (smoke only) |
 | `python3 scripts/ci.py e2e-docker`   | Docker | Direct script execution (Docker)         |
 

--- a/tools/scripts/ci.py
+++ b/tools/scripts/ci.py
@@ -272,7 +272,7 @@ def wait_for_health(
                 _print_log_file(output_log, "server stdout")
                 _print_log_file(error_log, "server stderr")
                 print("Fix the error above, rebuild with:")
-                print("  make build")
+                print("  make cargo-build")
                 print("Then re-run: make e2e-local")
                 sys.exit(1)
 
@@ -397,11 +397,11 @@ def cmd_e2e(args):
         server_process = None
         print("Starting cf-gears-server for local E2E...")
 
-        # Build all required gears and binaries using project build orchestration
-        step("Building release artifacts for local E2E")
-        run_cmd(["make", "build"])
+        # Build only the release binary required for local execution.
+        step("Building release binary for local E2E")
+        run_cmd(["make", "cargo-build"])
 
-        # Use the release binary produced by build
+        # Use the release binary produced by cargo-build
         release_bin = str(find_binary(
             Path(PROJECT_ROOT) / "target", "release", "cf-gears-example-server"
         ))
@@ -409,7 +409,7 @@ def cmd_e2e(args):
         if not os.path.isfile(release_bin):
             print(f"\nERROR: Release binary not found at: {release_bin}")
             print("Build it first with:")
-            print("  make build")
+            print("  make cargo-build")
             sys.exit(1)
 
         # Create logs directory if it doesn't exist
@@ -480,7 +480,7 @@ def cmd_e2e(args):
         env["E2E_DOCKER_MODE"] = "1"
         env.setdefault("E2E_MOCK_UPSTREAM_URL", "http://mock:8080")
 
-    pytest_cmd = [PYTHON, "-m", "pytest", "testing/e2e", "-vv"]
+    pytest_cmd = [PYTHON, "-m", "pytest", "-vv"]
     if args.smoke:
         pytest_cmd.extend(["-m", "smoke"])
     if args.pytest_args:
@@ -489,7 +489,13 @@ def cmd_e2e(args):
         extra_args = args.pytest_args
         if extra_args and extra_args[0] == "--":
             extra_args = extra_args[1:]
-        pytest_cmd.extend(extra_args)
+        if extra_args and not extra_args[0].startswith("-"):
+            pytest_cmd.extend(extra_args)
+        else:
+            pytest_cmd.append("testing/e2e")
+            pytest_cmd.extend(extra_args)
+    else:
+        pytest_cmd.append("testing/e2e")
 
     result = run_cmd_allow_fail(pytest_cmd, env=env)
     exit_code = result.returncode

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -90,16 +90,17 @@ fn split_debug(args: &[String]) -> ExitCode {
 
 fn split_dsym(bin: &Path) -> bool {
     let bin_s = bin.to_str().unwrap();
+    let bin_local = bin.file_name().and_then(|s| s.to_str()).unwrap_or(bin_s);
     let size_before = file_size(bin);
 
     eprintln!("extracting .dSYM bundle...");
-    if !run(&["dsymutil", bin_s], bin.parent().unwrap()) {
+    if !run(&["dsymutil", bin_local], bin.parent().unwrap()) {
         eprintln!("dsymutil failed — install Xcode command-line tools");
         return false;
     }
 
     eprintln!("stripping binary...");
-    if !run(&["strip", "-u", "-r", bin_s], bin.parent().unwrap()) {
+    if !run(&["strip", "-u", "-r", bin_local], bin.parent().unwrap()) {
         eprintln!("strip failed");
         return false;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced E2E test execution to support targeted subset runs via a new `E2E_TARGET` option, including updated `e2e-docker`, `e2e-docker-smoke`, and `e2e-local` commands.
* **Documentation**
  * Updated E2E testing docs to explain targeted local-mode execution and added matching command examples.
* **Bug Fixes**
  * Improved macOS symbol processing during `split_dsym` by using the local binary name for `dsymutil`/`strip` invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->