### PR TITLE
feat(security): add two-plane auth primitives and HTTP/gRPC middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2454,6 +2454,7 @@ dependencies = [
  "bytes",
  "cf-gears-rustls-corecrypto-provider",
  "cf-gears-rustls-fips-shim",
+ "cf-gears-toolkit-security",
  "flate2",
  "http",
  "http-body",
@@ -2472,6 +2473,7 @@ dependencies = [
  "rustls-cng-crypto",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
+ "secrecy",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2483,7 +2485,23 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "url",
+ "uuid",
  "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "cf-gears-toolkit-http-middleware"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "cf-gears-toolkit-canonical-errors",
+ "cf-gears-toolkit-security",
+ "http",
+ "secrecy",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tracing",
 ]
 
 [[package]]
@@ -2581,6 +2599,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "trybuild",
  "uuid",
 ]
 
@@ -2591,6 +2610,7 @@ dependencies = [
  "anyhow",
  "cf-gears-toolkit-security",
  "rand 0.10.1",
+ "secrecy",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "libs/toolkit-gts",
     "libs/toolkit-gts-macros",
     "libs/toolkit-http",
+    "libs/toolkit-http-middleware",
     "libs/toolkit-sdk",
     "libs/toolkit-odata-macros",
     "libs/toolkit-security",

--- a/docs/arch/toolkit-oop/ADR/0006-cpt-cf-adr-platform-plane-auth.md
+++ b/docs/arch/toolkit-oop/ADR/0006-cpt-cf-adr-platform-plane-auth.md
@@ -61,7 +61,7 @@ Sequencing:
 
 1. **First phase — K8s ServiceAccount tokens (steady state, not just enrollment).** A gear attaches its projected SA
    token as `X-ToolKit-Internal-Token`; the receiver validates it via the k8s TokenReview API (cached TTL) and builds a
-   `PlatformIdentity::ServiceAccount`. Zero new infrastructure, K8s-native, auto-rotated. This ships the first OoP gear
+   `PlatformIdentity::KubernetesServiceAccount`. Zero new infrastructure, K8s-native, auto-rotated. This ships the first OoP gear
    without any PKI. Profile 2 single-node uses a bootstrap token (or plain UDS when all gears share a uid).
 2. **Next phase — mTLS + SPIFFE.** cert-manager (K8s) / an embedded CA (on-prem) mints a workload certificate
    (`SAN URI = spiffe://<trust_domain>/gear/<gear>/<version>`). The TLS handshake establishes peer identity *before* any
@@ -110,9 +110,9 @@ pub enum InternalCredential {
 #[non_exhaustive]
 pub enum PlatformIdentity {
     /// First phase: from a validated projected SA token (TokenReview).
-    ServiceAccount { namespace: String, service_account: String, pod: Option<String> },
+    KubernetesServiceAccount { namespace: String, service_account: String, pod: Option<String> },
     /// Next phase: mTLS + SPIFFE, parsed from the X.509 SAN.
-    Spiffe { trust_domain: String, gear: String, version: String },
+    Spiffe { trust_domain: String, name: String, version: String },
 }
 ```
 
@@ -135,8 +135,8 @@ platform-plane call to `Authorization`.
 ### Consequences
 
 * **Phase 1 validates a per-request token.** Each inbound system call carries `X-ToolKit-Internal-Token` (SA token),
-  validated via TokenReview (cached). `InternalAuthMiddleware` builds `PlatformIdentity::ServiceAccount` and sets
-  `PeerAuthenticated { gear }` for workload-policy decisions only.
+  validated via TokenReview (cached). `InternalAuthMiddleware` builds `PlatformIdentity::KubernetesServiceAccount` and sets
+  `PeerAuthenticated { name }` for workload-policy decisions only.
 * **The end state removes the per-request token from the hot path.** Once mTLS lands, peer identity is established by
   the TLS handshake (the cert-derived `PlatformIdentity::Spiffe`), and `InternalAuthMiddleware` becomes a thin
   shim asserting the connection-level identity — there is no per-request token to validate.
@@ -148,7 +148,7 @@ platform-plane call to `Authorization`.
   rotated certs from a well-known path (Profile 2: file watched by `notify`; Profile 3: projected volume).
 * Flight Control validates inbound `RegisterInstance` / `DeregisterInstance` / `Heartbeat` by the validated
   `PlatformIdentity` (the `ServiceAccount` variant in phase 1; the `Spiffe` variant from mTLS next), not by a bespoke token scheme.
-* `InternalAuthMiddleware` inserts two values from the validated credential: `PeerAuthenticated { gear }` — a
+* `InternalAuthMiddleware` inserts two values from the validated credential: `PeerAuthenticated { name }` — a
   lightweight marker for **workload-policy** checks — and `PlatformSecurityContext { identity }` — the identity object
   that AuthZ-exempt platform handlers consume. Neither is ever passed to the tenant `PolicyEnforcer`, and neither
   substitutes for tenant-plane JWT validation.

--- a/docs/arch/toolkit-oop/ADR/0008-cpt-cf-adr-two-plane-auth.md
+++ b/docs/arch/toolkit-oop/ADR/0008-cpt-cf-adr-two-plane-auth.md
@@ -99,6 +99,35 @@ genuinely non-tenant (platform-level) work is on the platform plane.
   [ADR-0006 (Platform-Plane Authentication)](0006-cpt-cf-adr-platform-plane-auth.md).**
 * Ideally served on a **separate listener** from business endpoints.
 
+### Extensibility — how each plane is customized (vendor-agnostic)
+
+Both planes keep the **authentication mechanism behind a trait**, so the transport and middleware never change
+when the mechanism does. *How that implementation is selected* differs by plane — and the difference is forced by
+**layering**, not preference:
+
+* **Tenant plane → GTS-discovered AuthN Resolver plugin.** The transport and middleware depend only on the
+  `BearerAuthenticator` trait (`toolkit-security`); the concrete adapter wraps `AuthNResolverClient`, which
+  dispatches to whatever `AuthNResolverPluginClient` a vendor registers and the Types Registry discovers at
+  runtime. The tenant plane sits *above* the discovery machinery, so GTS-based plugin discovery is available to
+  it. Customizing tenant authentication means bringing your own AuthN Resolver plugin — no change to the
+  transport, middleware, or this model.
+* **Platform plane → bootstrap-selected `InternalAuthenticator`.** The middleware depends only on the
+  `InternalAuthenticator` trait — the structural twin of `BearerAuthenticator` — but its implementation is
+  **selected at bootstrap by deployment profile/config and linked in locally, *not* discovered via GTS.** The
+  platform plane sits *below* the discovery machinery it secures: platform auth protects DirectoryService
+  registration, heartbeats, and global GTS registration — the calls a gear makes *before* its ClientHub/plugin
+  chain exists. With a shared Types Registry, discovering the platform validator over the network would itself
+  be a platform-plane call to authenticate the platform plane — a bootstrapping cycle. It is therefore wired
+  in-process at startup, and its validation backend is an **external trust anchor** (K8s SA `TokenReview`,
+  mTLS+SPIFFE next), never a call routed back through the platform plane.
+
+The platform plane is **still vendor-extensible** — a vendor can supply its own `InternalAuthenticator`
+implementation (e.g. a bespoke workload-identity validator) — but selection is bootstrap/config-driven and
+compiled in, not GTS-discovered. `InternalCredential` and `PlatformIdentity` stay framework-owned,
+method-agnostic, and `#[non_exhaustive]`, so new methods never change the shape of `PlatformSecurityContext`.
+Mechanism details for the built-in platform validators are owned by
+[ADR-0006](0006-cpt-cf-adr-platform-plane-auth.md).
+
 ### Plane selection by call type
 
 A request carries exactly one plane. Note that *system-initiated* does not imply *platform plane* — tenant-scoped

--- a/docs/arch/toolkit-oop/DESIGN.md
+++ b/docs/arch/toolkit-oop/DESIGN.md
@@ -57,7 +57,7 @@ OoP gear lifecycle, discovery coordination, and gateway registration. The archit
 | `cpt-cf-fr-client-transparency`    | ClientHub returns in-process impl or generated `RestXxxClient` based on DirectoryService resolution. Callers use the same SDK trait.                                                     |
 | `cpt-cf-fr-rest-primary`           | Each OoP gear runs Axum with full ToolKit middleware. No gRPC bridge or transcoding layer.                                                                                              |
 | `cpt-cf-fr-direct-communication`   | Generated REST clients resolve target endpoints via DirectoryService (or k8s DNS) and call directly. Gateway is not in the inter-gear path.                                            |
-| `cpt-cf-fr-secctx-propagation`     | `toolkit-http` forwards `Authorization: Bearer <jwt>`; OoP `secctx_middleware` re-validates it via AuthN Resolver and reconstructs SecurityContext (ADR-0008). No `x-secctx-bin` over HTTP.                                                          |
+| `cpt-cf-fr-secctx-propagation`     | `toolkit-http` forwards `Authorization: Bearer <jwt>`; OoP `security_context_middleware` re-validates it via AuthN Resolver and reconstructs SecurityContext (ADR-0008). No `x-secctx-bin` over HTTP.                                                          |
 | `cpt-cf-fr-gateway-registration`   | OoP bootstrap calls `GatewayProvider::register_routes()` after HTTP server starts.                                                                                                       |
 | `cpt-cf-fr-gateway-abstraction`    | `GatewayProvider` trait with `ToolKitGatewayProvider` as first implementation.                                                                                                            |
 | `cpt-cf-fr-rest-client-gen`        | Trait-first codegen: `#[toolkit::rest_contract]` emits `RestXxxClient` from the SDK trait (`openapi.json` is a published output, not a codegen input).                                     |
@@ -68,7 +68,7 @@ OoP gear lifecycle, discovery coordination, and gateway registration. The archit
 | NFR ID                            | NFR Summary                  | Allocated To                                               | Design Response                                                                           | Verification Approach                                            |
 |-----------------------------------|------------------------------|------------------------------------------------------------|-------------------------------------------------------------------------------------------|------------------------------------------------------------------|
 | `cpt-cf-nfr-oop-latency`          | OoP call overhead < 5 ms p95 (localhost; 10 ms k8s) | `toolkit-http`, OoP HTTP server                             | Connection pooling in `toolkit-http`; Axum's zero-copy routing; UDS transport on same-host | Automated benchmark: 1000 echo requests, measure p95             |
-| `cpt-cf-nfr-per-hop-revalidation`  | One JWT verify per hop (~0.5 ms) | `api-gateway` authn + OoP `secctx_middleware` | Each hop re-validates via `authn-resolver` with cached JWKS (ADR-0008); single IdP trust root | Latency benchmark + forged-signature rejection test |
+| `cpt-cf-nfr-per-hop-revalidation`  | One JWT verify per hop (~0.5 ms) | `api-gateway` authn + OoP `security_context_middleware` | Each hop re-validates via `authn-resolver` with cached JWKS (ADR-0008); single IdP trust root | Latency benchmark + forged-signature rejection test |
 | `cpt-cf-nfr-graceful-degradation` | Unavailable OoP → 503        | Generated REST client, `toolkit-http`                       | `toolkit-http` timeout + connection error → mapped to 503 Problem response                 | Integration test: stop target, assert 503                        |
 
 #### Key ADRs
@@ -343,7 +343,7 @@ What is **missing** and needs to be added:
   attach to all system-level outgoing calls automatically.
 - **Install `InternalAuthMiddleware`** (platform plane) to validate incoming system calls — SA token in the first
   phase; sets `PeerAuthenticated` for workload policy (ADR-0006).
-- Attach `secctx_middleware` (tenant plane) that re-validates the forwarded JWT via AuthN Resolver and reconstructs
+- Attach `security_context_middleware` (tenant plane) that re-validates the forwarded JWT via AuthN Resolver and reconstructs
   SecurityContext.
 - Send heartbeats to DirectoryService (already implemented).
 - Deregister from DirectoryService on graceful shutdown.
@@ -671,7 +671,7 @@ rebuilds the full context (including the bearer token) from it.
   forwarded as-is across hops.
 - Provide `attach_bearer_http(request, secctx)` — sets `Authorization: Bearer <jwt>` from `secctx.bearer_token()` on an
   outgoing request. No binary encoding.
-- Provide Axum middleware (`secctx_middleware`) that extracts the bearer token and **re-validates it** via
+- Provide Axum middleware (`security_context_middleware`) that extracts the bearer token and **re-validates it** via
   `AuthNResolverClient::authenticate()`, then inserts the reconstructed `SecurityContext` into request extensions. One
   code path; no `x-secctx-bin` decode.
 - `encode_bin` / `decode_bin` remain for in-process gRPC metadata only (Profile 1).
@@ -748,25 +748,25 @@ plane (user JWT) or the platform plane (gear identity), not both. The two planes
 
 ###### Middleware order
 
-When both middlewares are installed, `InternalAuthMiddleware` (platform plane) runs before `secctx_middleware` (tenant
-plane). On a system call it sets `PeerAuthenticated { gear }` for workload-policy decisions; on a user-propagated call
-`secctx_middleware` **re-validates** the JWT via `AuthNResolverClient` and reconstructs `SecurityContext`.
+When both middlewares are installed, `InternalAuthMiddleware` (platform plane) runs before `security_context_middleware` (tenant
+plane). On a system call it sets `PeerAuthenticated { name }` for workload-policy decisions; on a user-propagated call
+`security_context_middleware` **re-validates** the JWT via `AuthNResolverClient` and reconstructs `SecurityContext`.
 
 Note: `PeerAuthenticated` is **not** a prerequisite for trusting the user context — the JWT is self-authenticating, so
-`secctx_middleware` re-validates it regardless of peer trust. There is no unsigned envelope to gate behind peer
+`security_context_middleware` re-validates it regardless of peer trust. There is no unsigned envelope to gate behind peer
 authentication.
 
 ###### `PeerAuthenticated` vs `PlatformSecurityContext`
 
 From one validated credential, `InternalAuthMiddleware` inserts **two** values into the request's extensions (the same
-way `secctx_middleware` inserts `SecurityContext` on the tenant plane):
+way `security_context_middleware` inserts `SecurityContext` on the tenant plane):
 
-- **`PeerAuthenticated { gear }`** — a lightweight marker that *some* gear authenticated as a peer, distilled to the
-  caller's gear name. Consumed only by **workload-policy** checks (e.g. "only `flight-control` may call
+- **`PeerAuthenticated { name }`** — a lightweight marker that *some* gear authenticated as a peer, distilled to the
+  caller's name. Consumed only by **workload-policy** checks (e.g. "only `flight-control` may call
   `DeregisterInstance`").
 - **`PlatformSecurityContext { identity }`** — the full platform-plane **identity object** that AuthZ-exempt platform
   handlers consume in place of a tenant `SecurityContext` (see the surfaces table below). Its `identity` is the richer,
-  mechanism-typed form of the same caller (`PlatformIdentity::ServiceAccount` / `Spiffe`).
+  mechanism-typed form of the same caller (`PlatformIdentity::KubernetesServiceAccount` / `Spiffe`).
 
 Neither is ever passed to the tenant `PolicyEnforcer`, and neither substitutes for tenant-plane JWT validation.
 
@@ -794,10 +794,10 @@ pub struct PlatformSecurityContext {
 #[non_exhaustive]
 pub enum PlatformIdentity {
     /// First phase: K8s ServiceAccount (from a validated projected SA token / TokenReview).
-    ServiceAccount { namespace: String, service_account: String, pod: Option<String> },
+    KubernetesServiceAccount { namespace: String, service_account: String, pod: Option<String> },
     /// Next phase: mTLS + SPIFFE workload identity, parsed from the X.509 SAN.
     /// SPIFFE ID format: `spiffe://<trust_domain>/gear/<gear>/<version>` (per platform-authn).
-    Spiffe { trust_domain: String, gear: String, version: String },
+    Spiffe { trust_domain: String, name: String, version: String },
 }
 ```
 
@@ -1761,19 +1761,19 @@ use toolkit_security::SecurityContext;
 async fn secctx_from_request(
     headers: &HeaderMap,
     authn: &AuthNResolverClient,
-) -> Result<SecurityContext, SecCtxHttpError> {
+) -> Result<SecurityContext, SecurityContextHttpError> {
     let token = headers
         .get("authorization")
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.strip_prefix("Bearer "))
-        .ok_or(SecCtxHttpError::MissingAuth)?;
+        .ok_or(SecurityContextHttpError::MissingAuth)?;
 
     // Signature + claims check, JWKS-cached (~0.5 ms on hit). Returns a fully
     // populated SecurityContext, so no post-deserialization bearer-token merge.
     authn
         .authenticate(token)
         .await
-        .map_err(|_| SecCtxHttpError::Unauthorized)
+        .map_err(|_| SecurityContextHttpError::Unauthorized)
 }
 
 fn attach_bearer_http(request: &mut Request, secctx: &SecurityContext) -> Result<()> {

--- a/docs/arch/toolkit-oop/PRD.md
+++ b/docs/arch/toolkit-oop/PRD.md
@@ -342,10 +342,10 @@ of `PlatformSecurityContext` — it is only another way to populate it, dispatch
 
 - **First phase (K8s)**: projected K8s ServiceAccount tokens (audience: `toolkit-internal`), validated via the
   TokenReview API. Builds the `PlatformSecurityContext` from the validated SA identity and sets
-  `PeerAuthenticated { gear }` for workload-policy decisions only.
+  `PeerAuthenticated { name }` for workload-policy decisions only.
 - **Next phase**: mTLS + SPIFFE issued by cert-manager (embedded CA / boot-token on-prem), populating the same
   `PlatformSecurityContext` with the SPIFFE variant of the tenant-less, method-agnostic `PlatformIdentity` enum
-  (`ServiceAccount` from phase 1, `Spiffe { trust_domain, gear, version }` added here from the X.509 SAN
+  (`ServiceAccount` from phase 1, `Spiffe { trust_domain, name, version }` added here from the X.509 SAN
   `spiffe://<trust_domain>/gear/<gear>/<version>`; `#[non_exhaustive]` for future methods).
 - **Profile 2 (single-node)**: ephemeral bootstrap token, or plain UDS when all gears share one uid.
 

--- a/libs/toolkit-http-middleware/Cargo.toml
+++ b/libs/toolkit-http-middleware/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "cf-gears-toolkit-http-middleware"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "ToolKit server-side HTTP middleware (two-plane auth) and request extractors"
+readme = "README.md"
+keywords = ["constructorfabric", "cf-gears", "cf-gears-toolkit"]
+categories = ["web-programming"]
+metadata.docs.rs.all-features = true
+
+[lib]
+name = "toolkit_http_middleware"
+
+[lints]
+workspace = true
+
+[dependencies]
+# SecurityContext + authenticator traits (transport-agnostic). Owns
+# `SecurityContext`, the `BearerAuthenticator` / `InternalAuthenticator` traits,
+# and the shared `INTERNAL_TOKEN_HEADER` constant.
+toolkit-security = { workspace = true }
+# Canonical (AIP-193 / RFC 9457) error rendering for middleware rejections.
+# `axum` feature provides `IntoResponse for CanonicalError` (problem+json).
+toolkit-canonical-errors = { workspace = true, features = ["axum"] }
+
+axum = { workspace = true }
+http = { workspace = true }
+secrecy = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+tower = { workspace = true, features = ["util"] }

--- a/libs/toolkit-http-middleware/README.md
+++ b/libs/toolkit-http-middleware/README.md
@@ -1,0 +1,45 @@
+# cf-gears-toolkit-http-middleware
+
+Server-side HTTP middleware for ToolKit, built on axum and tower.
+
+This crate is the shared home for all of ToolKit's server-side HTTP middleware,
+so gears install the same inbound layers from one place rather than each
+maintaining their own.
+
+## What it does
+
+- **Two-plane authentication** as axum layers:
+  - `security_context_middleware` (tenant plane) — always re-validates the bearer token via
+    an injected `BearerAuthenticator` and inserts a `SecurityContext`
+  - `internal_auth_middleware` (platform plane) — validates the
+    `X-ToolKit-Internal-Token` via an injected `InternalAuthenticator` and inserts
+    a `PlatformSecurityContext` plus `PeerAuthenticated`
+- Header extractors for `Authorization: Bearer` and `X-ToolKit-Internal-Token`
+- `PublicRoute` marker so routes that carry no JWT pass through without `401`
+- Renders rejections as canonical RFC 9457 `application/problem+json`
+
+## What it does NOT do
+
+- Run an HTTP server — consumers own the server and router
+- Provide the concrete authenticators — they are injected via axum state at the
+  gear/bootstrap layer
+- Outbound HTTP requests — that is `cf-gears-toolkit-http` (the client crate)
+
+## Usage
+
+```rust
+use std::sync::Arc;
+use axum::{Router, middleware::from_fn_with_state, routing::get};
+use toolkit_http_middleware::{internal_auth_middleware, security_context_middleware};
+
+// `bearer` and `internal` are your concrete `BearerAuthenticator` /
+// `InternalAuthenticator` adapters, supplied at the bootstrap layer.
+let router = Router::new()
+    .route("/widgets", get(list_widgets))
+    .route_layer(from_fn_with_state(bearer, security_context_middleware::<MyBearerAuth>))
+    .route_layer(from_fn_with_state(internal, internal_auth_middleware::<MyInternalAuth>));
+```
+
+## License
+
+Apache-2.0

--- a/libs/toolkit-http-middleware/src/auth.rs
+++ b/libs/toolkit-http-middleware/src/auth.rs
@@ -1,0 +1,262 @@
+//! Axum middleware for two-plane authentication.
+//!
+//! Two complementary middlewares:
+//!
+//! - [`security_context_middleware`] (**tenant plane**) extracts the bearer token from
+//!   the incoming `Authorization` header and **always** re-validates it via an
+//!   injected [`BearerAuthenticator`] — there is no trusted-peer fast path
+//!   (zero-trust). On success the reconstructed [`SecurityContext`](toolkit_security::SecurityContext)
+//!   is inserted into the request extensions for downstream handlers and the
+//!   `AuthZ` resolver.
+//! - [`internal_auth_middleware`] (**platform plane**) extracts the
+//!   `X-ToolKit-Internal-Token` header and, if present, validates it via an
+//!   injected [`InternalAuthenticator`], inserting [`PeerAuthenticated`] and a
+//!   [`PlatformSecurityContext`] for workload-policy / platform handlers.
+//!
+//! **Middleware order:** when both are installed, [`internal_auth_middleware`]
+//! runs **before** [`security_context_middleware`] (DESIGN § 3.2). The two middlewares are
+//! independent: each handles its own plane and the planes are mutually exclusive
+//! per request — system calls carry `X-ToolKit-Internal-Token` (no JWT); user
+//! calls carry `Authorization: Bearer` (no internal token). [`PeerAuthenticated`]
+//! is never a prerequisite for JWT validation; [`security_context_middleware`] does not
+//! consult it.
+//!
+//! Routes that carry no tenant JWT (probes, platform-plane-only handlers) are
+//! marked with the [`PublicRoute`] request extension by the gear/bootstrap layer;
+//! note this is distinct from `OperationSpec.is_public`, which controls gateway
+//! registration. The concrete authenticator adapters are injected via Axum state
+//! at the same layer.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Request, State},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use toolkit_canonical_errors::CanonicalError;
+use toolkit_security::{
+    AuthNError, BearerAuthenticator, InternalAuthNError, InternalAuthenticator, PeerAuthenticated,
+    PlatformSecurityContext,
+};
+
+use crate::security::{
+    InternalTokenHttpError, SecurityContextHttpError, extract_bearer_http,
+    extract_internal_token_http,
+};
+use secrecy::ExposeSecret;
+
+/// Retry hint (seconds) advertised when the authentication backend is
+/// temporarily unavailable, mirroring `api-gateway`'s authn middleware.
+const AUTH_RETRY_AFTER_SECONDS: u64 = 5;
+
+/// Public detail for an unexpected authentication-infrastructure failure,
+/// mirroring `api-gateway`'s authn middleware. Carries no diagnostic specifics.
+const AUTH_INFRA_FAILURE_DETAIL: &str = "authentication infrastructure failure";
+
+/// Per-route marker indicating the route carries **no tenant JWT** and must not
+/// require a [`SecurityContext`](toolkit_security::SecurityContext).
+///
+/// Inserted by the gear/bootstrap layer for routes that never carry an
+/// `Authorization: Bearer` header — framework probe endpoints (`/healthz`,
+/// `/readyz`), and platform-plane-only handlers that authenticate via
+/// `X-ToolKit-Internal-Token` instead. When present, [`security_context_middleware`] lets
+/// a request without an `Authorization` header pass through instead of
+/// returning `401`.
+///
+/// **Not the same as `OperationSpec.is_public`.** `is_public` controls whether
+/// a route is registered in the gateway for external access; this marker
+/// controls whether [`security_context_middleware`] requires a JWT. The two are
+/// independent: most gateway-exposed routes DO carry a JWT and do NOT need this
+/// marker; most probe routes are NOT gateway-exposed but DO need it.
+#[derive(Clone, Copy, Debug)]
+pub struct PublicRoute;
+
+/// Tenant-plane `SecurityContext` middleware.
+///
+/// Behaviour:
+/// - A bearer token, if present, is **always** re-validated via the injected
+///   [`BearerAuthenticator`]; on success the [`SecurityContext`](toolkit_security::SecurityContext) is inserted
+///   into request extensions.
+/// - A protected route (no [`PublicRoute`] marker) with a missing or invalid
+///   `Authorization` header is rejected with `401`.
+/// - A public / system-only route (carrying the [`PublicRoute`] marker) with no
+///   `Authorization` header passes through.
+/// - A rejected token is `401`; an unreachable backend is `503`; any other
+///   unexpected authentication failure is `500`.
+///
+/// Rejections are rendered as canonical RFC 9457 `application/problem+json`
+/// responses (via [`CanonicalError`]) so they match the platform-wide error
+/// contract; `instance` / `trace_id` enrichment is left to the outer canonical
+/// error middleware installed at the gear/bootstrap layer.
+///
+/// The handler is generic over `A`; the concrete authenticator is supplied via
+/// Axum state as `Arc<A>` at the gear/bootstrap layer.
+///
+/// TODO: Rework to align with the gateway's `authn_middleware`
+/// (`gears/system/api-gateway/src/middleware/auth.rs`), the more mature
+/// implementation: route-policy-driven auth requirements (vs. the binary
+/// `PublicRoute` marker), CORS-preflight handling, anonymous-`SecurityContext`
+/// insertion for public routes, and RFC 6750 `WWW-Authenticate` Bearer
+/// challenges. Part of consolidating all gateway middlewares into this crate.
+pub async fn security_context_middleware<A>(
+    State(authenticator): State<Arc<A>>,
+    mut request: Request,
+    next: Next,
+) -> Response
+where
+    A: BearerAuthenticator + 'static,
+{
+    let is_public = request.extensions().get::<PublicRoute>().is_some();
+
+    match extract_bearer_http(request.headers()) {
+        Ok(token) => match authenticator.authenticate(token.expose_secret()).await {
+            Ok(secctx) => {
+                request.extensions_mut().insert(secctx);
+                next.run(request).await
+            }
+            Err(err) => authn_error_to_response(&err),
+        },
+        // No credential presented: allow through only for public/system-only
+        // routes; protected routes require a user context.
+        Err(SecurityContextHttpError::MissingAuthHeader) if is_public => next.run(request).await,
+        Err(SecurityContextHttpError::MissingAuthHeader) => unauthenticated("MISSING_BEARER"),
+        Err(SecurityContextHttpError::InvalidAuthHeader | SecurityContextHttpError::EmptyToken) => {
+            unauthenticated("INVALID_BEARER")
+        }
+    }
+}
+
+/// Map a neutral [`AuthNError`] to a canonical `problem+json` response.
+///
+/// The token and any provider-specific detail are never surfaced on the wire.
+fn authn_error_to_response(err: &AuthNError) -> Response {
+    match err {
+        // A reachable backend that rejected the token: the caller's credential
+        // is bad (401).
+        AuthNError::InvalidToken => {
+            tracing::warn!("bearer token rejected: invalid or expired");
+            unauthenticated("AUTHN_FAILED")
+        }
+        // The backend could not be reached: surface 503 with a retry hint so
+        // callers can distinguish "try later" from "your token is bad".
+        AuthNError::Unavailable => {
+            tracing::warn!("bearer token validation: authentication backend unavailable");
+            CanonicalError::service_unavailable()
+                .with_retry_after_seconds(AUTH_RETRY_AFTER_SECONDS)
+                .create()
+                .into_response()
+        }
+        // `Other` (and, defensively, any future neutral variant) is an
+        // unexpected authentication-infrastructure failure, not a bad
+        // credential — surface 500 rather than blaming the caller. The
+        // diagnostic detail is redacted on the wire by `CanonicalError`.
+        // `AuthNError` is `#[non_exhaustive]`, so the wildcard is required.
+        _ => {
+            tracing::error!("bearer token validation: unexpected infrastructure failure");
+            CanonicalError::internal(AUTH_INFRA_FAILURE_DETAIL)
+                .create()
+                .into_response()
+        }
+    }
+}
+
+/// Build a canonical `Unauthenticated` (`401`) `problem+json` response with the
+/// given machine-readable reason.
+fn unauthenticated(reason: &str) -> Response {
+    CanonicalError::unauthenticated()
+        .with_reason(reason)
+        .create()
+        .into_response()
+}
+
+/// Platform-plane internal-auth middleware.
+///
+/// Behaviour:
+/// - When an `X-ToolKit-Internal-Token` header is present, it is validated via
+///   the injected [`InternalAuthenticator`]; on success [`PeerAuthenticated`]
+///   and a [`PlatformSecurityContext`] are inserted into request extensions.
+/// - When the header is **absent**, the request passes through unchanged
+///   (permissive): user-only endpoints do not require a system credential, and
+///   the tenant plane is enforced independently by [`security_context_middleware`].
+/// - When the header is present but **invalid/empty**, or validation fails, the
+///   request is **rejected** — so an invalid SA token is turned away before
+///   [`security_context_middleware`] (and any handler) runs.
+///
+/// This sets workload-policy state only; it **never** skips or substitutes for
+/// tenant-plane JWT validation. Install this layer so it runs **before**
+/// [`security_context_middleware`] (DESIGN § 3.2).
+///
+/// Rejections are rendered as canonical RFC 9457 `application/problem+json`:
+/// an invalid credential is `401`, an unreachable validation backend is `503`,
+/// and any other unexpected failure is `500`.
+///
+/// The handler is generic over `A`; the concrete validator (K8s `TokenReview`
+/// in the first phase) is supplied via Axum state as `Arc<A>` at the
+/// gear/bootstrap layer.
+pub async fn internal_auth_middleware<A>(
+    State(authenticator): State<Arc<A>>,
+    mut request: Request,
+    next: Next,
+) -> Response
+where
+    A: InternalAuthenticator + 'static,
+{
+    match extract_internal_token_http(request.headers()) {
+        Ok(token) => match authenticator.authenticate(token.expose_secret()).await {
+            Ok(identity) => {
+                request.extensions_mut().insert(PeerAuthenticated {
+                    name: identity.peer_name().to_owned(),
+                });
+                request
+                    .extensions_mut()
+                    .insert(PlatformSecurityContext::new(identity));
+                next.run(request).await
+            }
+            Err(err) => internal_authn_error_to_response(&err),
+        },
+        // No system credential presented: permissive — user-only endpoints do
+        // not require one, and the tenant plane is enforced separately.
+        Err(InternalTokenHttpError::MissingHeader) => next.run(request).await,
+        // A credential was presented but is malformed: reject before the
+        // tenant plane runs.
+        Err(InternalTokenHttpError::InvalidHeader | InternalTokenHttpError::EmptyToken) => {
+            unauthenticated("INVALID_INTERNAL_TOKEN")
+        }
+    }
+}
+
+/// Map a neutral [`InternalAuthNError`] to a canonical `problem+json` response.
+///
+/// The token and any provider-specific detail are never surfaced on the wire.
+fn internal_authn_error_to_response(err: &InternalAuthNError) -> Response {
+    match err {
+        // A reachable backend that rejected the credential: it is bad (401).
+        InternalAuthNError::InvalidToken => {
+            tracing::warn!("internal token rejected: invalid or expired credential");
+            unauthenticated("INTERNAL_AUTH_FAILED")
+        }
+        // The validation backend (e.g. K8s TokenReview) was unreachable: 503.
+        InternalAuthNError::Unavailable => {
+            tracing::warn!("internal token validation: authentication backend unavailable");
+            CanonicalError::service_unavailable()
+                .with_retry_after_seconds(AUTH_RETRY_AFTER_SECONDS)
+                .create()
+                .into_response()
+        }
+        // `Other` (and, defensively, any future neutral variant) is an
+        // unexpected infrastructure failure — surface 500. `InternalAuthNError`
+        // is `#[non_exhaustive]`, so the wildcard is required.
+        _ => {
+            tracing::error!("internal token validation: unexpected infrastructure failure");
+            CanonicalError::internal(AUTH_INFRA_FAILURE_DETAIL)
+                .create()
+                .into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "auth_tests.rs"]
+mod tests;

--- a/libs/toolkit-http-middleware/src/auth_tests.rs
+++ b/libs/toolkit-http-middleware/src/auth_tests.rs
@@ -1,0 +1,337 @@
+use super::*;
+
+use axum::{
+    Extension, Router,
+    body::{Body, to_bytes},
+    routing::get,
+};
+use http::{Request as HttpRequest, StatusCode, header};
+use toolkit_security::{
+    InternalAuthNError, InternalAuthenticator, PlatformIdentity, SecurityContext,
+};
+use tower::ServiceExt;
+
+const GOOD_TOKEN: &str = "valid-token";
+const UNAVAILABLE_TOKEN: &str = "unavailable-token";
+const INTERNAL_TOKEN: &str = "internal-failure-token";
+const INTERNAL_HEADER: &str = "x-toolkit-internal-token";
+const SA_GOOD: &str = "good-sa-token";
+const SA_UNAVAILABLE: &str = "unavailable-sa-token";
+const SA_INTERNAL: &str = "internal-failure-sa-token";
+const PROBLEM_JSON: &str = "application/problem+json";
+
+/// Authenticator stand-in: accepts `GOOD_TOKEN`, signals a transient
+/// backend outage for `UNAVAILABLE_TOKEN`, an unexpected infrastructure
+/// failure for `INTERNAL_TOKEN`, and rejects everything else (a forged or
+/// expired JWT).
+struct StubAuthenticator;
+
+impl BearerAuthenticator for StubAuthenticator {
+    async fn authenticate(&self, token: &str) -> Result<SecurityContext, AuthNError> {
+        match token {
+            GOOD_TOKEN => Ok(SecurityContext::anonymous()),
+            UNAVAILABLE_TOKEN => Err(AuthNError::Unavailable),
+            INTERNAL_TOKEN => Err(AuthNError::Other("boom".to_owned())),
+            _ => Err(AuthNError::InvalidToken),
+        }
+    }
+}
+
+fn app(is_public: bool) -> Router {
+    let authenticator = Arc::new(StubAuthenticator);
+
+    // `security_context_middleware` runs as a `route_layer` (after routing); the
+    // `PublicRoute` marker is added as an outer router `layer` so it is
+    // present in the request extensions by the time the middleware reads it
+    // (this mirrors how the bootstrap layer surfaces `OperationSpec.is_public` per-route).
+    let secctx = axum::middleware::from_fn_with_state(
+        authenticator,
+        security_context_middleware::<StubAuthenticator>,
+    );
+
+    let router = Router::new()
+        .route("/", get(|| async { StatusCode::OK }))
+        .route_layer(secctx);
+
+    if is_public {
+        router.layer(axum::Extension(PublicRoute))
+    } else {
+        router
+    }
+}
+
+/// Drive a request through `router` and return `(status, content_type)`.
+async fn send(router: Router, auth: Option<&str>) -> (StatusCode, Option<String>) {
+    let mut builder = HttpRequest::builder().uri("/");
+    if let Some(value) = auth {
+        builder = builder.header(header::AUTHORIZATION, value);
+    }
+    let request = builder.body(Body::empty()).unwrap();
+    let response = router.oneshot(request).await.unwrap();
+    let content_type = response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+    (response.status(), content_type)
+}
+
+/// Internal-auth stand-in: accepts `SA_GOOD` (as `flight-control`), signals
+/// outage for `SA_UNAVAILABLE`, an unexpected failure for `SA_INTERNAL`, and
+/// rejects everything else.
+struct StubInternalAuthenticator;
+
+impl InternalAuthenticator for StubInternalAuthenticator {
+    async fn authenticate(&self, token: &str) -> Result<PlatformIdentity, InternalAuthNError> {
+        match token {
+            SA_GOOD => Ok(PlatformIdentity::KubernetesServiceAccount {
+                namespace: "toolkit".to_owned(),
+                service_account: "flight-control".to_owned(),
+                pod: None,
+            }),
+            SA_UNAVAILABLE => Err(InternalAuthNError::Unavailable),
+            SA_INTERNAL => Err(InternalAuthNError::Other("boom".to_owned())),
+            _ => Err(InternalAuthNError::InvalidToken),
+        }
+    }
+}
+
+/// Handler that echoes the authenticated peer gear, but only when **both**
+/// the [`PeerAuthenticated`] marker and the [`PlatformSecurityContext`] are
+/// present in the request extensions (otherwise `"none"`).
+async fn peer_echo(
+    peer: Option<Extension<PeerAuthenticated>>,
+    platform: Option<Extension<PlatformSecurityContext>>,
+) -> String {
+    match (peer, platform) {
+        (Some(Extension(peer)), Some(_)) => peer.name,
+        _ => "none".to_owned(),
+    }
+}
+
+fn platform_app() -> Router {
+    let authenticator = Arc::new(StubInternalAuthenticator);
+    let layer = axum::middleware::from_fn_with_state(
+        authenticator,
+        internal_auth_middleware::<StubInternalAuthenticator>,
+    );
+    Router::new().route("/", get(peer_echo)).route_layer(layer)
+}
+
+/// Stacked app: `internal_auth_middleware` (outermost, runs first) then
+/// `security_context_middleware`, mirroring the DESIGN § 3.2 middleware order.
+fn stacked_app() -> Router {
+    let bearer = Arc::new(StubAuthenticator);
+    let internal = Arc::new(StubInternalAuthenticator);
+    let secctx = axum::middleware::from_fn_with_state(
+        bearer,
+        security_context_middleware::<StubAuthenticator>,
+    );
+    let internal_layer = axum::middleware::from_fn_with_state(
+        internal,
+        internal_auth_middleware::<StubInternalAuthenticator>,
+    );
+    Router::new()
+        .route("/", get(|| async { StatusCode::OK }))
+        .route_layer(secctx)
+        .route_layer(internal_layer)
+}
+
+fn stacked_public_app() -> Router {
+    let bearer = Arc::new(StubAuthenticator);
+    let internal = Arc::new(StubInternalAuthenticator);
+    let secctx = axum::middleware::from_fn_with_state(
+        bearer,
+        security_context_middleware::<StubAuthenticator>,
+    );
+    let internal_layer = axum::middleware::from_fn_with_state(
+        internal,
+        internal_auth_middleware::<StubInternalAuthenticator>,
+    );
+    Router::new()
+        .route("/", get(|| async { StatusCode::OK }))
+        .route_layer(secctx)
+        .route_layer(internal_layer)
+        .layer(axum::Extension(PublicRoute))
+}
+
+/// Drive a request with arbitrary headers through `router`, returning
+/// `(status, content_type, body)`.
+async fn send_headers(
+    router: Router,
+    headers: &[(&str, &str)],
+) -> (StatusCode, Option<String>, String) {
+    let mut builder = HttpRequest::builder().uri("/");
+    for (name, value) in headers {
+        builder = builder.header(*name, *value);
+    }
+    let request = builder.body(Body::empty()).unwrap();
+    let response = router.oneshot(request).await.unwrap();
+    let status = response.status();
+    let content_type = response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    (
+        status,
+        content_type,
+        String::from_utf8_lossy(&bytes).into_owned(),
+    )
+}
+
+#[tokio::test]
+async fn protected_route_without_auth_is_401_problem() {
+    let (status, content_type) = send(app(false), None).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(content_type.as_deref(), Some(PROBLEM_JSON));
+}
+
+#[tokio::test]
+async fn protected_route_with_valid_token_passes() {
+    let (status, _) = send(app(false), Some("Bearer valid-token")).await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn forged_token_is_rejected_as_401_problem() {
+    let (status, content_type) = send(app(false), Some("Bearer forged-token")).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(content_type.as_deref(), Some(PROBLEM_JSON));
+}
+
+#[tokio::test]
+async fn invalid_auth_header_is_401_problem() {
+    let (status, content_type) = send(app(false), Some("Basic dXNlcjpwYXNz")).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(content_type.as_deref(), Some(PROBLEM_JSON));
+}
+
+#[tokio::test]
+async fn backend_unavailable_is_503_problem() {
+    let (status, content_type) = send(app(false), Some("Bearer unavailable-token")).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(content_type.as_deref(), Some(PROBLEM_JSON));
+}
+
+#[tokio::test]
+async fn unexpected_authn_failure_is_500_problem() {
+    let (status, content_type) = send(app(false), Some("Bearer internal-failure-token")).await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(content_type.as_deref(), Some(PROBLEM_JSON));
+}
+
+#[tokio::test]
+async fn public_route_without_auth_passes_through() {
+    let (status, _) = send(app(true), None).await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn public_route_revalidates_present_token() {
+    let (status, _) = send(app(true), Some("Bearer forged-token")).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn internal_no_header_passes_through_permissive() {
+    let (status, _, body) = send_headers(platform_app(), &[]).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, "none");
+}
+
+#[tokio::test]
+async fn internal_valid_token_sets_peer_and_platform_context() {
+    let (status, _, body) = send_headers(platform_app(), &[(INTERNAL_HEADER, SA_GOOD)]).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, "flight-control");
+}
+
+#[tokio::test]
+async fn internal_invalid_token_is_401_problem() {
+    let (status, content_type, _) =
+        send_headers(platform_app(), &[(INTERNAL_HEADER, "forged")]).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(content_type.as_deref(), Some(PROBLEM_JSON));
+}
+
+#[tokio::test]
+async fn internal_backend_unavailable_is_503_problem() {
+    let (status, content_type, _) =
+        send_headers(platform_app(), &[(INTERNAL_HEADER, SA_UNAVAILABLE)]).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(content_type.as_deref(), Some(PROBLEM_JSON));
+}
+
+#[tokio::test]
+async fn internal_unexpected_failure_is_500_problem() {
+    let (status, content_type, _) =
+        send_headers(platform_app(), &[(INTERNAL_HEADER, SA_INTERNAL)]).await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(content_type.as_deref(), Some(PROBLEM_JSON));
+}
+
+#[tokio::test]
+async fn internal_empty_header_is_401_problem() {
+    let (status, content_type, _) = send_headers(platform_app(), &[(INTERNAL_HEADER, "   ")]).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(content_type.as_deref(), Some(PROBLEM_JSON));
+}
+
+#[tokio::test]
+async fn peer_authenticated_does_not_skip_jwt_validation() {
+    // Valid SA token (peer authenticated) but a forged user JWT: the tenant
+    // plane must still reject — peer trust is not a JWT fast path.
+    let (status, _, _) = send_headers(
+        stacked_app(),
+        &[
+            (INTERNAL_HEADER, SA_GOOD),
+            (header::AUTHORIZATION.as_str(), "Bearer forged-token"),
+        ],
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn valid_peer_and_valid_jwt_passes() {
+    let (status, _, _) = send_headers(
+        stacked_app(),
+        &[
+            (INTERNAL_HEADER, SA_GOOD),
+            (header::AUTHORIZATION.as_str(), "Bearer valid-token"),
+        ],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn invalid_internal_token_rejected_before_tenant_plane() {
+    // A bad SA token must be turned away by internal_auth_middleware before
+    // security_context_middleware runs — even though the user JWT here is valid.
+    let (status, _, _) = send_headers(
+        stacked_app(),
+        &[
+            (INTERNAL_HEADER, "forged"),
+            (header::AUTHORIZATION.as_str(), "Bearer valid-token"),
+        ],
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn system_call_to_public_endpoint_passes() {
+    // Valid SA token, no JWT, route is PublicRoute — the normal probe/platform path.
+    let (status, _, _) = send_headers(stacked_public_app(), &[(INTERNAL_HEADER, SA_GOOD)]).await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn public_endpoint_with_no_credentials_passes() {
+    // No SA token and no JWT on a PublicRoute: passes (health probe).
+    let (status, _, _) = send_headers(stacked_public_app(), &[]).await;
+    assert_eq!(status, StatusCode::OK);
+}

--- a/libs/toolkit-http-middleware/src/lib.rs
+++ b/libs/toolkit-http-middleware/src/lib.rs
@@ -1,0 +1,31 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![warn(warnings)]
+
+//! Server-side HTTP middleware for `ToolKit`.
+//!
+//! This crate provides the inbound request-handling layers a gear's HTTP server
+//! installs at its edge. It does **not** run an HTTP server itself — the server
+//! is owned by the `OoP` bootstrap (`toolkit::bootstrap::oop`) and by the
+//! `api-gateway` gear's `rest_host`, which install these layers onto their
+//! router.
+//!
+//! - [`auth`] — Axum middleware for two-plane authentication. It turns
+//!   inbound credentials into a [`toolkit_security::SecurityContext`] (tenant
+//!   plane) or a [`toolkit_security::PlatformSecurityContext`] (platform plane),
+//!   rejecting invalid credentials with canonical RFC 9457 `problem+json`
+//!   responses.
+//! - [`security`] — the supporting extractors that pull the tenant-plane bearer
+//!   token and the platform-plane internal token out of inbound request headers.
+//!
+//! Keeping these out of `toolkit-http` (the outbound HTTP client) keeps the
+//! client crate free of `axum` and the canonical-error stack, and gives every
+//! gear a single place to depend on for the server-side auth planes.
+
+pub mod auth;
+pub mod security;
+
+pub use auth::{PublicRoute, internal_auth_middleware, security_context_middleware};
+pub use security::{
+    InternalTokenHttpError, SecurityContextHttpError, extract_bearer_http,
+    extract_internal_token_http,
+};

--- a/libs/toolkit-http-middleware/src/security.rs
+++ b/libs/toolkit-http-middleware/src/security.rs
@@ -1,0 +1,143 @@
+//! Inbound HTTP security extractors.
+//!
+//! `SecurityContext` propagation over HTTP uses a single header,
+//! `Authorization: Bearer <jwt>`, carrying the original tenant-plane JWT. The
+//! token is forwarded as-is across hops and **re-validated at every hop** —
+//! there is no trusted-peer fast path (zero-trust). The platform plane uses a
+//! dedicated `X-ToolKit-Internal-Token` header so system credentials never
+//! collide with the tenant-plane user JWT.
+//!
+//! These extractors are the receiving (server) half; the matching `attach_*`
+//! helpers that set the headers on outgoing requests live in `toolkit-http`
+//! (the HTTP client).
+
+use http::{
+    HeaderMap, HeaderValue,
+    header::{AUTHORIZATION, AsHeaderName},
+};
+use secrecy::SecretString;
+use toolkit_security::constants::INTERNAL_TOKEN_HEADER;
+
+/// Errors raised while extracting a bearer token from HTTP request headers.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SecurityContextHttpError {
+    /// No `Authorization` header was present on the request.
+    #[error("missing Authorization header")]
+    MissingAuthHeader,
+    /// The `Authorization` header was present but not a valid `Bearer` token
+    /// (non-ASCII bytes, wrong scheme, or no scheme/token separator).
+    #[error("invalid Authorization header format")]
+    InvalidAuthHeader,
+    /// The `Authorization` header used the `Bearer` scheme but the token was
+    /// empty after trimming surrounding whitespace.
+    #[error("empty bearer token")]
+    EmptyToken,
+}
+
+/// Extract the raw bearer token from the `Authorization` header.
+///
+/// The `Bearer` scheme is matched case-insensitively, surrounding whitespace is
+/// trimmed, and an empty token is rejected.
+///
+/// # Errors
+///
+/// Returns [`SecurityContextHttpError`] when the header is absent, not a valid
+/// `Bearer` credential, or carries an empty token.
+pub fn extract_bearer_http(headers: &HeaderMap) -> Result<SecretString, SecurityContextHttpError> {
+    let header = single_header_value(headers, AUTHORIZATION)
+        .map_err(|()| SecurityContextHttpError::InvalidAuthHeader)?
+        .ok_or(SecurityContextHttpError::MissingAuthHeader)?;
+    let raw = header
+        .to_str()
+        .map_err(|_| SecurityContextHttpError::InvalidAuthHeader)?;
+
+    let (scheme, token) = raw
+        .trim_start()
+        .split_once(char::is_whitespace)
+        .ok_or(SecurityContextHttpError::InvalidAuthHeader)?;
+
+    if !scheme.eq_ignore_ascii_case("Bearer") {
+        return Err(SecurityContextHttpError::InvalidAuthHeader);
+    }
+
+    let token = token.trim();
+    if token.is_empty() {
+        return Err(SecurityContextHttpError::EmptyToken);
+    }
+    if token.contains(char::is_whitespace) {
+        return Err(SecurityContextHttpError::InvalidAuthHeader);
+    }
+
+    Ok(SecretString::from(token))
+}
+
+/// Errors raised while extracting the platform-plane internal token from HTTP
+/// request headers.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum InternalTokenHttpError {
+    /// No `X-ToolKit-Internal-Token` header was present on the request.
+    #[error("missing X-ToolKit-Internal-Token header")]
+    MissingHeader,
+    /// The header was present but its value was not valid (non-ASCII bytes).
+    #[error("invalid X-ToolKit-Internal-Token header value")]
+    InvalidHeader,
+    /// The header was present but empty after trimming surrounding whitespace.
+    #[error("empty internal token")]
+    EmptyToken,
+}
+
+/// Extract the raw platform-plane internal token from the
+/// `X-ToolKit-Internal-Token` header.
+///
+/// Surrounding whitespace is trimmed and an empty token is rejected. The token
+/// is opaque to the transport — its shape (JWT vs. opaque) is classified, and
+/// it is validated, by the receiving `InternalAuthenticator`.
+///
+/// # Errors
+///
+/// Returns [`InternalTokenHttpError`] when the header is absent, not valid
+/// ASCII, or carries an empty token.
+pub fn extract_internal_token_http(
+    headers: &HeaderMap,
+) -> Result<SecretString, InternalTokenHttpError> {
+    let header = single_header_value(headers, INTERNAL_TOKEN_HEADER)
+        .map_err(|()| InternalTokenHttpError::InvalidHeader)?
+        .ok_or(InternalTokenHttpError::MissingHeader)?;
+    let raw = header
+        .to_str()
+        .map_err(|_| InternalTokenHttpError::InvalidHeader)?;
+
+    let token = raw.trim();
+    if token.is_empty() {
+        return Err(InternalTokenHttpError::EmptyToken);
+    }
+
+    Ok(SecretString::from(token))
+}
+
+/// Look up a credential header that may appear at most once.
+///
+/// Returns `Ok(None)` when the header is absent and `Ok(Some(value))` for
+/// exactly one value. Returns `Err(())` when the header appears more than once:
+/// duplicate credential headers are rejected as invalid input to avoid
+/// request-smuggling ambiguity between a proxy and the application. Callers map
+/// the `Err(())` and `None` cases onto their own invalid / missing error
+/// variants so both extractors behave consistently.
+fn single_header_value<K: AsHeaderName>(
+    headers: &HeaderMap,
+    name: K,
+) -> Result<Option<&HeaderValue>, ()> {
+    let mut values = headers.get_all(name).iter();
+    let first = values.next();
+    if values.next().is_some() {
+        return Err(());
+    }
+    Ok(first)
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "security_tests.rs"]
+mod tests;

--- a/libs/toolkit-http-middleware/src/security_tests.rs
+++ b/libs/toolkit-http-middleware/src/security_tests.rs
@@ -1,0 +1,148 @@
+use super::*;
+use secrecy::ExposeSecret;
+
+#[test]
+fn extract_missing_header() {
+    let headers = HeaderMap::new();
+    assert_eq!(
+        extract_bearer_http(&headers).unwrap_err(),
+        SecurityContextHttpError::MissingAuthHeader
+    );
+}
+
+#[test]
+fn extract_case_insensitive_scheme() {
+    let mut headers = HeaderMap::new();
+    headers.insert(AUTHORIZATION, HeaderValue::from_static("bEaReR my-token"));
+    assert_eq!(
+        extract_bearer_http(&headers).unwrap().expose_secret(),
+        "my-token"
+    );
+}
+
+#[test]
+fn extract_trims_surrounding_whitespace() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_static("  Bearer   my-token  "),
+    );
+    assert_eq!(
+        extract_bearer_http(&headers).unwrap().expose_secret(),
+        "my-token"
+    );
+}
+
+#[test]
+fn extract_wrong_scheme() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_static("Basic dXNlcjpwYXNz"),
+    );
+    assert_eq!(
+        extract_bearer_http(&headers).unwrap_err(),
+        SecurityContextHttpError::InvalidAuthHeader
+    );
+}
+
+#[test]
+fn extract_no_separator() {
+    let mut headers = HeaderMap::new();
+    headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer"));
+    assert_eq!(
+        extract_bearer_http(&headers).unwrap_err(),
+        SecurityContextHttpError::InvalidAuthHeader
+    );
+}
+
+#[test]
+fn extract_empty_token() {
+    let mut headers = HeaderMap::new();
+    headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer    "));
+    assert_eq!(
+        extract_bearer_http(&headers).unwrap_err(),
+        SecurityContextHttpError::EmptyToken
+    );
+}
+
+#[test]
+fn extract_bearer_extracts_token() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_static("Bearer header.payload.signature"),
+    );
+    assert_eq!(
+        extract_bearer_http(&headers).unwrap().expose_secret(),
+        "header.payload.signature"
+    );
+}
+
+#[test]
+fn extract_rejects_duplicate_authorization() {
+    let mut headers = HeaderMap::new();
+    headers.append(AUTHORIZATION, HeaderValue::from_static("Bearer token-a"));
+    headers.append(AUTHORIZATION, HeaderValue::from_static("Bearer token-b"));
+    assert_eq!(
+        extract_bearer_http(&headers).unwrap_err(),
+        SecurityContextHttpError::InvalidAuthHeader
+    );
+}
+
+#[test]
+fn extract_internal_token_extracts_token() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        INTERNAL_TOKEN_HEADER,
+        HeaderValue::from_static("sa.jwt.token"),
+    );
+    assert_eq!(
+        extract_internal_token_http(&headers)
+            .unwrap()
+            .expose_secret(),
+        "sa.jwt.token"
+    );
+}
+
+#[test]
+fn extract_internal_token_missing_header() {
+    let headers = HeaderMap::new();
+    assert_eq!(
+        extract_internal_token_http(&headers).unwrap_err(),
+        InternalTokenHttpError::MissingHeader
+    );
+}
+
+#[test]
+fn extract_internal_token_trims_whitespace() {
+    let mut headers = HeaderMap::new();
+    headers.insert(INTERNAL_TOKEN_HEADER, HeaderValue::from_static("  tok  "));
+    assert_eq!(
+        extract_internal_token_http(&headers)
+            .unwrap()
+            .expose_secret(),
+        "tok"
+    );
+}
+
+#[test]
+fn extract_internal_token_empty() {
+    let mut headers = HeaderMap::new();
+    headers.insert(INTERNAL_TOKEN_HEADER, HeaderValue::from_static("   "));
+    assert_eq!(
+        extract_internal_token_http(&headers).unwrap_err(),
+        InternalTokenHttpError::EmptyToken
+    );
+}
+
+#[test]
+fn extract_internal_token_rejects_duplicates() {
+    let mut headers = HeaderMap::new();
+    headers.append(INTERNAL_TOKEN_HEADER, HeaderValue::from_static("tok-a"));
+    headers.append(INTERNAL_TOKEN_HEADER, HeaderValue::from_static("tok-b"));
+    assert_eq!(
+        extract_internal_token_http(&headers).unwrap_err(),
+        InternalTokenHttpError::InvalidHeader
+    );
+}

--- a/libs/toolkit-http/Cargo.toml
+++ b/libs/toolkit-http/Cargo.toml
@@ -55,6 +55,15 @@ tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
+# SecurityContext propagation. `toolkit-security` is transport-agnostic and owns
+# both `SecurityContext` and the `BearerAuthenticator` trait, so it can be the
+# only auth dependency here. Do NOT add authn-resolver-sdk: it would pull the
+# whole ToolKit framework into this transport crate and invert the layering —
+# the concrete AuthNResolverClient is adapted to BearerAuthenticator at the
+# gear/bootstrap layer instead.
+toolkit-security = { workspace = true }
+secrecy = { workspace = true }
+
 # HTTP stack
 hyper = { workspace = true, features = ["client", "http1", "http2"] }
 hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "http2", "tokio"] }
@@ -107,3 +116,4 @@ tempfile = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 flate2 = { workspace = true }
 url = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }

--- a/libs/toolkit-http/src/lib.rs
+++ b/libs/toolkit-http/src/lib.rs
@@ -72,4 +72,5 @@ pub use layers::{
 };
 pub use request::{RequestBuilder, RequestType};
 pub use response::{HttpResponse, LimitedBody, ResponseBody};
+pub use security::{attach_bearer_http, attach_internal_token_http};
 pub use tls::TlsConfigError;

--- a/libs/toolkit-http/src/security.rs
+++ b/libs/toolkit-http/src/security.rs
@@ -1,4 +1,15 @@
 //! HTTP security utilities.
+//!
+//! `SecurityContext` propagation over HTTP uses a single header,
+//! `Authorization: Bearer <jwt>`, carrying the original tenant-plane JWT. The
+//! token is forwarded as-is across hops and **re-validated at every hop** —
+//! there is no trusted-peer fast path (zero-trust). No binary
+//! `x-secctx-bin` encoding is used over HTTP.
+
+use http::{HeaderValue, header::AUTHORIZATION};
+use secrecy::{ExposeSecret, SecretString};
+use toolkit_security::SecurityContext;
+use toolkit_security::constants::INTERNAL_TOKEN_HEADER;
 
 /// Maximum body preview size for error messages (8KB).
 ///
@@ -6,3 +17,111 @@
 /// in the error message for debugging. This constant limits how much of the body
 /// is read to prevent memory issues with large error responses.
 pub const ERROR_BODY_PREVIEW_LIMIT: usize = 8 * 1024;
+
+/// Attach the tenant-plane JWT from `secctx` to an outgoing request as
+/// `Authorization: Bearer <jwt>`.
+///
+/// The secret is exposed only at this transport boundary and the resulting
+/// header value is marked sensitive so it is never logged. If `secctx` carries
+/// no bearer token, or the token cannot be represented as a header value, the
+/// request is left unchanged.
+pub fn attach_bearer_http<B>(request: &mut http::Request<B>, secctx: &SecurityContext) {
+    let Some(token) = secctx.bearer_token() else {
+        return;
+    };
+    // Expose the secret only here, at the transport boundary, and never log it.
+    let Ok(mut value) = HeaderValue::from_str(&format!("Bearer {}", token.expose_secret())) else {
+        tracing::warn!(
+            "bearer token contains invalid HTTP header characters; outgoing request sent without Authorization header"
+        );
+        return;
+    };
+    value.set_sensitive(true);
+    request.headers_mut().insert(AUTHORIZATION, value);
+}
+
+/// Attach a platform-plane internal `token` to an outgoing request as the
+/// `X-ToolKit-Internal-Token` header.
+///
+/// The token is carried raw (no `Bearer` scheme) and **never** on
+/// `Authorization`, to avoid colliding with the tenant-plane user JWT.
+/// The secret is exposed only at this transport boundary
+/// and the resulting header value is marked sensitive so it is never logged. If
+/// the token cannot be represented as a header value, the request is left
+/// unchanged.
+pub fn attach_internal_token_http<B>(request: &mut http::Request<B>, token: &SecretString) {
+    // Expose the secret only here, at the transport boundary, and never log it.
+    let Ok(mut value) = HeaderValue::from_str(token.expose_secret()) else {
+        tracing::warn!(
+            "internal token contains invalid HTTP header characters; outgoing request sent without X-ToolKit-Internal-Token header"
+        );
+        return;
+    };
+    value.set_sensitive(true);
+    request.headers_mut().insert(INTERNAL_TOKEN_HEADER, value);
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    fn secctx_with_token(token: &str) -> SecurityContext {
+        SecurityContext::builder()
+            .subject_id(uuid::Uuid::nil())
+            .subject_tenant_id(uuid::Uuid::nil())
+            .bearer_token(token.to_owned())
+            .build()
+            .expect("valid security context")
+    }
+
+    #[test]
+    fn attach_sets_bearer_header() {
+        let secctx = secctx_with_token("header.payload.signature");
+        let mut request = http::Request::new(());
+        attach_bearer_http(&mut request, &secctx);
+
+        let value = request.headers().get(AUTHORIZATION).expect("header set");
+        assert_eq!(value.to_str().unwrap(), "Bearer header.payload.signature");
+    }
+
+    #[test]
+    fn attach_marks_header_sensitive() {
+        let secctx = secctx_with_token("abc.def.ghi");
+        let mut request = http::Request::new(());
+        attach_bearer_http(&mut request, &secctx);
+
+        let value = request.headers().get(AUTHORIZATION).expect("header set");
+        assert!(value.is_sensitive());
+    }
+
+    #[test]
+    fn attach_noop_when_no_token() {
+        let secctx = SecurityContext::anonymous();
+        let mut request = http::Request::new(());
+        attach_bearer_http(&mut request, &secctx);
+
+        assert!(request.headers().get(AUTHORIZATION).is_none());
+    }
+
+    #[test]
+    fn internal_token_uses_dedicated_header_not_authorization() {
+        let mut request = http::Request::new(());
+        attach_internal_token_http(&mut request, &SecretString::from("sa.jwt.token"));
+
+        assert!(request.headers().get(INTERNAL_TOKEN_HEADER).is_some());
+        assert!(request.headers().get(AUTHORIZATION).is_none());
+    }
+
+    #[test]
+    fn internal_token_header_is_sensitive() {
+        let mut request = http::Request::new(());
+        attach_internal_token_http(&mut request, &SecretString::from("sa.jwt.token"));
+
+        let value = request
+            .headers()
+            .get(INTERNAL_TOKEN_HEADER)
+            .expect("header set");
+        assert!(value.is_sensitive());
+    }
+}

--- a/libs/toolkit-security/Cargo.toml
+++ b/libs/toolkit-security/Cargo.toml
@@ -27,3 +27,4 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+trybuild = { workspace = true }

--- a/libs/toolkit-security/src/authenticator.rs
+++ b/libs/toolkit-security/src/authenticator.rs
@@ -1,0 +1,61 @@
+//! Transport-agnostic bearer-token authentication abstraction.
+//!
+//! [`BearerAuthenticator`] decouples the HTTP/gRPC transport layers from the
+//! concrete `AuthN` Resolver client. The transport only needs to hand a raw
+//! bearer token to an implementation and receive a reconstructed
+//! [`SecurityContext`] back. The concrete `AuthNResolverClient` adapter is
+//! injected at the gear/bootstrap layer so neither `toolkit-http` nor
+//! `toolkit-transport-grpc` need to depend on the full `ToolKit` framework.
+//!
+//! This lives in `toolkit-security` (not `toolkit-http`) so it stays
+//! transport-agnostic and reusable by the gRPC path — it returns
+//! [`SecurityContext`], which `toolkit-security` already owns, and
+//! `toolkit-security` has no dependency on any transport crate.
+
+use std::future::Future;
+
+use crate::context::SecurityContext;
+
+/// Neutral authentication error returned by a [`BearerAuthenticator`].
+///
+/// Intentionally coarse-grained and transport-agnostic: it never carries the
+/// token or any provider-specific detail so it is safe to surface at a trust
+/// boundary. Concrete adapters map their own error types into these variants.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum AuthNError {
+    /// The token was syntactically present but failed validation
+    /// (invalid signature, expired, malformed claims, etc.).
+    #[error("invalid or expired token")]
+    InvalidToken,
+    /// The authentication backend could not be reached or returned a
+    /// transient failure. Callers may choose to retry or surface a 503.
+    #[error("authentication backend unavailable")]
+    Unavailable,
+    /// Any other authentication failure. The message must not contain the
+    /// token or other sensitive material.
+    #[error("authentication failed: {0}")]
+    Other(String),
+}
+
+/// Re-validates a raw bearer token and reconstructs a [`SecurityContext`].
+///
+/// Implementations perform a full validation on every call — there is no
+/// trusted-peer fast path (zero-trust; see `cpt-cf-adr-two-plane-auth`). The transport layer
+/// stays generic over this trait; the concrete `AuthNResolverClient` adapter
+/// is supplied at the gear/bootstrap layer.
+///
+/// The returned future is `Send` so the trait can be used from Axum/Tower
+/// middleware running on a multi-threaded runtime.
+pub trait BearerAuthenticator: Send + Sync {
+    /// Validate `token` and reconstruct the corresponding [`SecurityContext`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthNError`] if the token is invalid, the backend is
+    /// unavailable, or authentication otherwise fails.
+    fn authenticate(
+        &self,
+        token: &str,
+    ) -> impl Future<Output = Result<SecurityContext, AuthNError>> + Send;
+}

--- a/libs/toolkit-security/src/constants.rs
+++ b/libs/toolkit-security/src/constants.rs
@@ -22,3 +22,11 @@ pub const DEFAULT_SUBJECT_ID: Uuid = uuid!("11111111-6a88-4768-9dfc-6bcd5187d9ed
 
 /// Default GTS type ID placeholder.
 pub const GTS_DEFAULT_TYPE_ID: Uuid = uuid!("22222222-0000-0000-0000-000000000001");
+
+/// Header (HTTP) / metadata (gRPC) key carrying the platform-plane internal
+/// credential. Always lower-case (canonical for both HTTP/2 and gRPC metadata).
+///
+/// Platform-plane (system) calls use this key — **never** `Authorization`, to
+/// avoid colliding with the tenant-plane user JWT
+/// (`cpt-cf-adr-platform-plane-auth` / `cpt-cf-adr-two-plane-auth`).
+pub const INTERNAL_TOKEN_HEADER: &str = "x-toolkit-internal-token";

--- a/libs/toolkit-security/src/internal_auth.rs
+++ b/libs/toolkit-security/src/internal_auth.rs
@@ -1,0 +1,264 @@
+//! Platform-plane (workload) authentication primitives.
+//!
+//! The platform plane authenticates *which gear* is making a system-initiated
+//! call that carries **no user context** (`DirectoryService` registration,
+//! heartbeats, global GTS registration). It is deliberately separate from the
+//! tenant plane (`Authorization: Bearer <jwt>` + [`SecurityContext`]): platform
+//! calls carry an [`InternalCredential`] over the `X-ToolKit-Internal-Token`
+//! header (never `Authorization`, to avoid colliding with the user JWT) and
+//! resolve to a [`PlatformSecurityContext`] — a type **distinct** from the
+//! tenant [`SecurityContext`] that is never evaluated by the tenant
+//! `PolicyEnforcer`.
+//!
+//! This module owns only the transport-agnostic, dependency-light pieces: the
+//! credential/identity types, a neutral error, and the [`InternalAuthenticator`]
+//! authentication trait. The Axum middleware, the tonic interceptor, and the
+//! concrete K8s `TokenReview` validator live in the transport / bootstrap
+//! layers so this foundational crate stays free of `axum`, `tonic`, and `kube`.
+//!
+//! [`SecurityContext`]: crate::context::SecurityContext
+
+use std::future::Future;
+use std::path::PathBuf;
+
+use secrecy::SecretString;
+
+/// The credential a gear attaches to its system (platform-plane) calls.
+///
+/// Selected by deployment profile at the bootstrap layer. The variant set is
+/// **frozen now** to keep the API stable across phases, but only
+/// [`InternalCredential::None`] (Profile 1) and
+/// [`InternalCredential::KubeServiceAccountToken`] (Profile 3) are wired in the
+/// first phase. [`InternalCredential::BootstrapToken`] (Profile 2) and
+/// [`InternalCredential::MtlsIdentity`] (mTLS end state) are struct-only —
+/// their validation/wiring is deferred to a later phase.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum InternalCredential {
+    /// Profile 1 (in-process): no credential — the process boundary is the
+    /// trust root, so no header/metadata is attached.
+    None,
+    /// Profile 2 (single-node): an ephemeral bootstrap token minted by the
+    /// Platform Host. Struct-only in the first phase; validation deferred to P2.
+    BootstrapToken(SecretString),
+    /// Profile 3 (K8s): a projected `ServiceAccount` JWT (auto-mounted,
+    /// auto-rotated). `token_path` is the projected-volume path; `audience` is
+    /// the expected token audience (e.g. `toolkit-internal`).
+    KubeServiceAccountToken {
+        /// Path to the projected SA token file.
+        token_path: PathBuf,
+        /// Expected audience the token must be scoped to.
+        audience: String,
+    },
+    /// End state (and Profile 2 multi-node): an mTLS client identity. Struct-only
+    /// here; mTLS validation/wiring is deferred to a later phase.
+    MtlsIdentity {
+        /// Client certificate path.
+        cert: PathBuf,
+        /// Client private-key path.
+        key: PathBuf,
+        /// Trust-anchor (CA bundle) path.
+        ca: PathBuf,
+    },
+}
+
+/// Method-agnostic platform identity produced by validating an
+/// [`InternalCredential`].
+///
+/// The variant reflects *which credential* authenticated the caller; platform
+/// handlers consume a [`PlatformSecurityContext`] without branching on it. New
+/// authentication methods add a variant — hence `#[non_exhaustive]` — without
+/// changing [`PlatformSecurityContext`]'s shape.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
+#[serde(tag = "type")]
+pub enum PlatformIdentity {
+    /// First phase: a validated K8s `ServiceAccount` (from a projected SA token
+    /// verified via the `TokenReview` API).
+    KubernetesServiceAccount {
+        /// Namespace the `ServiceAccount` belongs to.
+        namespace: String,
+        /// `ServiceAccount` name.
+        service_account: String,
+        /// Originating pod name, when the token review reports it.
+        pod: Option<String>,
+    },
+    /// Next phase: an mTLS + SPIFFE workload identity parsed from the X.509 SAN
+    /// (`spiffe://<trust_domain>/gear/<name>/<version>`). Reserved — not
+    /// populated in the first phase.
+    Spiffe {
+        /// SPIFFE trust domain.
+        trust_domain: String,
+        /// Workload name component of the SPIFFE ID (the gear segment of
+        /// `spiffe://<trust_domain>/gear/<name>/<version>`).
+        name: String,
+        /// Version component of the SPIFFE ID.
+        version: String,
+    },
+    /// Catch-all for variants introduced in a newer library version.
+    ///
+    /// Produced only by `serde::Deserialize` when the `"type"` field holds an
+    /// unrecognised value. Never constructed directly; `peer_name` returns
+    /// `"<unknown>"` for this variant.
+    #[serde(other)]
+    Unknown,
+}
+
+impl PlatformIdentity {
+    /// The caller's name, distilled for workload-policy decisions.
+    ///
+    /// For a [`PlatformIdentity::KubernetesServiceAccount`] this is the `ServiceAccount`
+    /// name; for [`PlatformIdentity::Spiffe`] it is the workload (gear) component
+    /// of the SPIFFE ID.
+    #[must_use]
+    pub fn peer_name(&self) -> &str {
+        match self {
+            Self::KubernetesServiceAccount {
+                service_account, ..
+            } => service_account,
+            Self::Spiffe { name, .. } => name,
+            Self::Unknown => "<unknown>",
+        }
+    }
+}
+
+/// Identity for non-tenant, platform-scoped operations.
+///
+/// **Never** carries a tenant subject and is **never** passed to the tenant
+/// `PolicyEnforcer`. This is a separate type from the tenant
+/// [`SecurityContext`] by design (separation of mechanisms): "this call has no
+/// tenant" is unrepresentable-as-a-tenant rather than encoded as a nil tenant
+/// id. The wrapper is stable across authentication phases; only its
+/// [`PlatformIdentity`] changes.
+///
+/// [`SecurityContext`]: crate::context::SecurityContext
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct PlatformSecurityContext {
+    identity: PlatformIdentity,
+}
+
+impl PlatformSecurityContext {
+    /// Wrap a validated [`PlatformIdentity`].
+    #[must_use]
+    pub fn new(identity: PlatformIdentity) -> Self {
+        Self { identity }
+    }
+
+    /// The validated platform identity backing this context.
+    #[must_use]
+    pub fn identity(&self) -> &PlatformIdentity {
+        &self.identity
+    }
+
+    /// Consume the context, returning the owned [`PlatformIdentity`].
+    #[must_use]
+    pub fn into_identity(self) -> PlatformIdentity {
+        self.identity
+    }
+}
+
+/// Lightweight marker that *some* gear authenticated as a peer.
+///
+/// Distilled to the caller's name and consumed **only** by workload-policy
+/// checks (e.g. "only `flight-control` may call `DeregisterInstance`"). It is
+/// **not** a prerequisite for trusting a user context: the tenant JWT is
+/// self-authenticating and is always re-validated regardless of peer trust.
+/// It never substitutes for tenant-plane validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerAuthenticated {
+    /// The authenticated caller's name.
+    pub name: String,
+}
+
+/// Neutral platform-plane authentication error.
+///
+/// Intentionally coarse-grained and transport-agnostic: it never carries the
+/// token or provider-specific detail, so it is safe to surface at a trust
+/// boundary. Concrete validators map their own errors into these variants.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum InternalAuthNError {
+    /// The credential was present but failed validation (bad signature, wrong
+    /// audience, expired, not authenticated by the backend, etc.).
+    #[error("invalid internal credential")]
+    InvalidToken,
+    /// The validation backend (e.g. the K8s `TokenReview` API) could not be
+    /// reached or returned a transient failure. Callers may retry or surface 503.
+    #[error("internal-auth backend unavailable")]
+    Unavailable,
+    /// Any other validation failure. The message must not contain the token or
+    /// other sensitive material.
+    #[error("internal authentication failed: {0}")]
+    Other(String),
+}
+
+/// Authenticates a raw platform-plane credential and resolves the caller's
+/// [`PlatformIdentity`].
+///
+/// The transport layer (Axum middleware / tonic interceptor) stays generic over
+/// this trait; the concrete validator (K8s `TokenReview` in the first phase) is
+/// supplied at the gear/bootstrap layer so neither `toolkit-http` nor
+/// `toolkit-transport-grpc` depend on `kube`.
+///
+/// The returned future is `Send` so the trait can be used from Axum/Tower
+/// middleware on a multi-threaded runtime.
+pub trait InternalAuthenticator: Send + Sync {
+    /// Authenticate the raw `X-ToolKit-Internal-Token` value and resolve the
+    /// caller's [`PlatformIdentity`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InternalAuthNError`] if the credential is invalid, the backend
+    /// is unavailable, or authentication otherwise fails.
+    fn authenticate(
+        &self,
+        token: &str,
+    ) -> impl Future<Output = Result<PlatformIdentity, InternalAuthNError>> + Send;
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn platform_identity_peer_name() {
+        let sa = PlatformIdentity::KubernetesServiceAccount {
+            namespace: "toolkit".to_owned(),
+            service_account: "flight-control".to_owned(),
+            pod: Some("flight-control-0".to_owned()),
+        };
+        assert_eq!(sa.peer_name(), "flight-control");
+
+        let spiffe = PlatformIdentity::Spiffe {
+            trust_domain: "example.org".to_owned(),
+            name: "mini-chat".to_owned(),
+            version: "1.0.0".to_owned(),
+        };
+        assert_eq!(spiffe.peer_name(), "mini-chat");
+    }
+
+    #[test]
+    fn platform_security_context_wraps_identity() {
+        let identity = PlatformIdentity::KubernetesServiceAccount {
+            namespace: "toolkit".to_owned(),
+            service_account: "directory-service".to_owned(),
+            pod: None,
+        };
+        let ctx = PlatformSecurityContext::new(identity.clone());
+        assert_eq!(ctx.identity(), &identity);
+        assert_eq!(ctx.into_identity(), identity);
+    }
+
+    #[test]
+    fn platform_security_context_roundtrips_serde() {
+        let ctx = PlatformSecurityContext::new(PlatformIdentity::KubernetesServiceAccount {
+            namespace: "toolkit".to_owned(),
+            service_account: "directory-service".to_owned(),
+            pod: None,
+        });
+        let json = serde_json::to_string(&ctx).unwrap();
+        let back: PlatformSecurityContext = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, ctx);
+    }
+}

--- a/libs/toolkit-security/src/lib.rs
+++ b/libs/toolkit-security/src/lib.rs
@@ -1,8 +1,10 @@
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 pub mod access_scope;
+pub mod authenticator;
 pub mod bin_codec;
 pub mod constants;
 pub mod context;
+pub mod internal_auth;
 pub mod prelude;
 
 pub use access_scope::{
@@ -10,7 +12,12 @@ pub use access_scope::{
     InTenantSubtreeScopeFilter, ScopeConstraint, ScopeFilter, ScopeValue, pep_properties,
     rg_tables, tenant_tables,
 };
+pub use authenticator::{AuthNError, BearerAuthenticator};
 pub use context::{SecurityContext, SecurityContextBuildError};
+pub use internal_auth::{
+    InternalAuthNError, InternalAuthenticator, InternalCredential, PeerAuthenticated,
+    PlatformIdentity, PlatformSecurityContext,
+};
 
 pub use bin_codec::{
     SECCTX_BIN_VERSION, SecCtxDecodeError, SecCtxEncodeError, decode_bin, encode_bin,

--- a/libs/toolkit-security/tests/ui.rs
+++ b/libs/toolkit-security/tests/ui.rs
@@ -1,0 +1,5 @@
+#[test]
+fn ui_compile_fail() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/libs/toolkit-security/tests/ui/platform_context_is_not_tenant_context.rs
+++ b/libs/toolkit-security/tests/ui/platform_context_is_not_tenant_context.rs
@@ -1,0 +1,19 @@
+extern crate toolkit_security;
+
+use toolkit_security::{PlatformIdentity, PlatformSecurityContext, SecurityContext};
+
+// A tenant-plane consumer (stand-in for the tenant PolicyEnforcer / handlers)
+// that only accepts the tenant SecurityContext.
+fn takes_tenant_context(_ctx: &SecurityContext) {}
+
+fn main() {
+    let platform = PlatformSecurityContext::new(PlatformIdentity::KubernetesServiceAccount {
+        namespace: "toolkit".to_owned(),
+        service_account: "flight-control".to_owned(),
+        pod: None,
+    });
+
+    // Must NOT compile: a platform context is a distinct type and can never be
+    // passed where a tenant SecurityContext is expected (cpt-cf-adr-two-plane-auth).
+    takes_tenant_context(&platform);
+}

--- a/libs/toolkit-security/tests/ui/platform_context_is_not_tenant_context.stderr
+++ b/libs/toolkit-security/tests/ui/platform_context_is_not_tenant_context.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+  --> tests/ui/platform_context_is_not_tenant_context.rs:18:26
+   |
+18 |     takes_tenant_context(&platform);
+   |     -------------------- ^^^^^^^^^ expected `&SecurityContext`, found `&PlatformSecurityContext`
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: expected reference `&SecurityContext`
+              found reference `&PlatformSecurityContext`
+note: function defined here
+  --> tests/ui/platform_context_is_not_tenant_context.rs:7:4
+   |
+ 7 | fn takes_tenant_context(_ctx: &SecurityContext) {}
+   |    ^^^^^^^^^^^^^^^^^^^^ ----------------------

--- a/libs/toolkit-transport-grpc/Cargo.toml
+++ b/libs/toolkit-transport-grpc/Cargo.toml
@@ -27,3 +27,4 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 tokio-stream = { workspace = true }
 rand = { workspace = true }
+secrecy = { workspace = true }

--- a/libs/toolkit-transport-grpc/src/internal_auth.rs
+++ b/libs/toolkit-transport-grpc/src/internal_auth.rs
@@ -1,0 +1,217 @@
+//! Platform-plane (workload) authentication over gRPC.
+//!
+//! System-initiated calls (e.g. a gear registering with `DirectoryService`)
+//! carry the platform-plane credential in the `x-toolkit-internal-token`
+//! metadata key — **never** in `authorization`, to avoid colliding with the
+//! tenant-plane user JWT.
+//!
+//! This module provides the **outbound** path used by gears calling system
+//! services:
+//! - [`attach_internal_token_grpc`] / [`extract_internal_token_grpc`] — the
+//!   metadata helpers (symmetric with `attach_secctx` / `extract_secctx`).
+//! - [`InternalAuthInterceptor`] — a tonic **client** interceptor that attaches
+//!   the gear's current internal credential to every outgoing request.
+//!
+//! Inbound server-side validation (e.g. protecting `DirectoryService`
+//! register/resolve RPCs) is **async** — it cannot use tonic's synchronous
+//! `Interceptor` trait — and its enforcement is installed at the bootstrap /
+//! orchestrator wiring layer, reusing
+//! [`extract_internal_token_grpc`] together with the
+//! `toolkit_security::InternalAuthenticator` trait.
+
+use std::sync::Arc;
+
+use secrecy::{ExposeSecret, SecretString};
+use tonic::metadata::{MetadataMap, MetadataValue};
+use tonic::service::Interceptor;
+use tonic::{Request, Status};
+use toolkit_security::constants::INTERNAL_TOKEN_HEADER;
+
+/// Attach a platform-plane internal `token` to outgoing gRPC metadata under the
+/// `x-toolkit-internal-token` key.
+///
+/// # Errors
+///
+/// Returns `Status::internal` if the token cannot be represented as an ASCII
+/// metadata value.
+pub fn attach_internal_token_grpc(
+    meta: &mut MetadataMap,
+    token: &SecretString,
+) -> Result<(), Status> {
+    // Expose the secret only here, at the transport boundary, and never log it.
+    let value = MetadataValue::try_from(token.expose_secret())
+        .map_err(|_| Status::internal("invalid internal token metadata value"))?;
+    meta.insert(INTERNAL_TOKEN_HEADER, value);
+    Ok(())
+}
+
+/// Extract the raw platform-plane internal token from gRPC metadata.
+///
+/// Surrounding whitespace is trimmed and an empty token is rejected. The token
+/// is opaque to the transport — it is validated by the receiving
+/// `InternalAuthenticator`.
+///
+/// # Errors
+///
+/// Returns `Status::unauthenticated` if the metadata is absent, not valid
+/// ASCII, or carries an empty token.
+pub fn extract_internal_token_grpc(meta: &MetadataMap) -> Result<SecretString, Status> {
+    let value = meta
+        .get(INTERNAL_TOKEN_HEADER)
+        .ok_or_else(|| Status::unauthenticated("missing internal token metadata"))?;
+    let raw = value
+        .to_str()
+        .map_err(|_| Status::unauthenticated("invalid internal token metadata"))?;
+
+    let token = raw.trim();
+    if token.is_empty() {
+        return Err(Status::unauthenticated("empty internal token"));
+    }
+
+    Ok(SecretString::from(token))
+}
+
+/// Source of the current platform-plane credential.
+///
+/// Invoked on every outgoing request so the interceptor always attaches the
+/// *current* token across rotation (a projected K8s SA token is re-read by the
+/// reader at the bootstrap layer). Returning `None` attaches no header — used
+/// for Profile 1 (`InternalCredential::None`).
+type TokenProvider = Arc<dyn Fn() -> Option<SecretString> + Send + Sync>;
+
+/// tonic **client** interceptor that attaches the gear's platform-plane
+/// credential to outgoing system calls.
+///
+/// Use via the generated client's `with_interceptor`, e.g.
+/// `DirectoryServiceClient::with_interceptor(channel, interceptor)`.
+#[derive(Clone)]
+pub struct InternalAuthInterceptor {
+    token_provider: TokenProvider,
+}
+
+impl InternalAuthInterceptor {
+    /// Build an interceptor whose credential is resolved by `provider` on each
+    /// call (supports rotation; `None` attaches no header).
+    #[must_use]
+    pub fn new(provider: impl Fn() -> Option<SecretString> + Send + Sync + 'static) -> Self {
+        Self {
+            token_provider: Arc::new(provider),
+        }
+    }
+
+    /// Build an interceptor that always attaches the given static `token`.
+    ///
+    /// Suitable for a non-rotating credential (e.g. a Profile 2 bootstrap
+    /// token); prefer [`InternalAuthInterceptor::new`] for rotating SA tokens.
+    #[must_use]
+    pub fn from_token(token: SecretString) -> Self {
+        Self::new(move || Some(token.clone()))
+    }
+
+    /// Build an interceptor that attaches nothing (Profile 1 /
+    /// `InternalCredential::None`).
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self::new(|| None)
+    }
+}
+
+impl Interceptor for InternalAuthInterceptor {
+    fn call(&mut self, mut request: Request<()>) -> Result<Request<()>, Status> {
+        if let Some(token) = (self.token_provider)() {
+            attach_internal_token_grpc(request.metadata_mut(), &token)?;
+        }
+        Ok(request)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn attach_extract_round_trip() {
+        let mut meta = MetadataMap::new();
+        attach_internal_token_grpc(&mut meta, &SecretString::from("sa.jwt.token"))
+            .expect("attach succeeds");
+
+        let token = extract_internal_token_grpc(&meta).expect("token extracted");
+        assert_eq!(token.expose_secret(), "sa.jwt.token");
+    }
+
+    #[test]
+    fn attach_uses_dedicated_key_not_authorization() {
+        let mut meta = MetadataMap::new();
+        attach_internal_token_grpc(&mut meta, &SecretString::from("sa.jwt.token"))
+            .expect("attach succeeds");
+
+        assert!(meta.get(INTERNAL_TOKEN_HEADER).is_some());
+        assert!(meta.get("authorization").is_none());
+    }
+
+    #[test]
+    fn extract_missing_metadata() {
+        let meta = MetadataMap::new();
+        let err = extract_internal_token_grpc(&meta).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[test]
+    fn extract_empty_token() {
+        let mut meta = MetadataMap::new();
+        meta.insert(INTERNAL_TOKEN_HEADER, MetadataValue::from_static("   "));
+        let err = extract_internal_token_grpc(&meta).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[test]
+    fn interceptor_attaches_provided_token() {
+        let mut interceptor = InternalAuthInterceptor::from_token(SecretString::from("sa.tok"));
+        let request = interceptor
+            .call(Request::new(()))
+            .expect("interceptor succeeds");
+        assert_eq!(
+            extract_internal_token_grpc(request.metadata())
+                .unwrap()
+                .expose_secret(),
+            "sa.tok"
+        );
+    }
+
+    #[test]
+    fn interceptor_disabled_attaches_nothing() {
+        let mut interceptor = InternalAuthInterceptor::disabled();
+        let request = interceptor
+            .call(Request::new(()))
+            .expect("interceptor succeeds");
+        assert!(request.metadata().get(INTERNAL_TOKEN_HEADER).is_none());
+    }
+
+    #[test]
+    fn interceptor_provider_reads_current_token() {
+        // Provider returns a different token each call (rotation simulation).
+        let counter = std::sync::atomic::AtomicU32::new(0);
+        let counter = Arc::new(counter);
+        let provider_counter = Arc::clone(&counter);
+        let mut interceptor = InternalAuthInterceptor::new(move || {
+            let n = provider_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Some(SecretString::from(format!("token-{n}")))
+        });
+
+        let first = interceptor.call(Request::new(())).unwrap();
+        let second = interceptor.call(Request::new(())).unwrap();
+        assert_eq!(
+            extract_internal_token_grpc(first.metadata())
+                .unwrap()
+                .expose_secret(),
+            "token-0"
+        );
+        assert_eq!(
+            extract_internal_token_grpc(second.metadata())
+                .unwrap()
+                .expose_secret(),
+            "token-1"
+        );
+    }
+}

--- a/libs/toolkit-transport-grpc/src/lib.rs
+++ b/libs/toolkit-transport-grpc/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 mod backoff;
 pub mod client;
+pub mod internal_auth;
 pub mod rpc_retry;
 
 #[cfg(windows)]
@@ -8,6 +9,10 @@ pub mod windows_named_pipe;
 
 #[cfg(windows)]
 pub use windows_named_pipe::{NamedPipeConnection, NamedPipeIncoming, create_named_pipe_incoming};
+
+pub use internal_auth::{
+    InternalAuthInterceptor, attach_internal_token_grpc, extract_internal_token_grpc,
+};
 
 pub const SECCTX_METADATA_KEY: &str = "x-secctx-bin";
 


### PR DESCRIPTION
Closes https://github.com/constructorfabric/gears-rust/issues/4103
Closes https://github.com/constructorfabric/gears-rust/issues/4104

Implements the library-layer foundation for both authentication planes defined
in the two-plane auth model. Nothing is wired to a running gear yet - that comes
later (OoP-4), along with the concrete K8s `TokenReview` validator and the SA
token file-watcher.
 
Adds a new crate, **`toolkit-http-middleware`**, as the shared home for
server-side inbound auth layers - kept separate from the outbound HTTP client.
Rejections render as canonical RFC 9457 `application/problem+json`.
 
## OoP-1 - Tenant-plane JWT re-validation
 
The user's JWT is **always** re-validated at every hop via an injected
authenticator - there is no trusted-peer fast path (zero-trust). Outbound calls
forward the user's token from the security context; inbound middleware
re-validates it and makes the reconstructed security context available to
handlers. Routes that carry no JWT (health probes, platform-only handlers) can
be marked so they pass through instead of returning `401`.
 
## OoP-2 - Platform-plane authentication primitives
 
System-initiated calls carry a dedicated internal-token header, never
`Authorization`, so they never collide with the tenant JWT - the two planes are
mutually exclusive per request. This adds the platform credential, identity, and
security-context types, a neutral validation error, and the validator trait the
transport layers depend on. The credential set is frozen up front; only the
first-phase variants are validated, with the bootstrap-token and mTLS variants
present but deferred.
 
Inbound HTTP middleware validates the internal token and exposes the platform
identity (plus a peer-authenticated marker) to handlers - permissive when the
header is absent, `401` when it is present but invalid. The gRPC path gets
matching attach/extract helpers and a rotation-aware client interceptor
(rotating, static, or disabled credential modes).
 
A compile-fail test enforces that a platform security context can never be passed
where a tenant security context is expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two-plane authentication support for HTTP and gRPC requests.
  * Introduced middleware and helpers for handling bearer and internal tokens, plus public-route bypass support.
  * Added support for authenticated platform/internal requests and request-level identity propagation.

* **Bug Fixes**
  * Improved token handling by trimming whitespace, rejecting invalid formats, and avoiding accidental exposure in logs.
  * Added clearer error responses for missing, invalid, or unavailable authentication services.

* **Documentation**
  * Added architecture and crate documentation for the new authentication flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->