### PR TITLE
chore(deps): bump kreuzberg from 4.9.7 to 4.9.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "calamine"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ae05a4e39297eecf9a994210d27501318c37a9318201f8e11050add82bb6f0"
+checksum = "8822fe6253ca47aa5ad9a3be09f6fe7cd20c6a74e41b0aa42e8f4e3d523508df"
 dependencies = [
  "atoi_simd",
  "byteorder",
@@ -4419,9 +4419,9 @@ dependencies = [
 
 [[package]]
 name = "html-to-markdown-rs"
-version = "3.3.3"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9451a842dd9316c9762a1c2c1d496df9db4db29e702e22f7a3fca210636ed4f9"
+checksum = "42f856d5f5daa55ea8b81bd746f1e49170fe589eccd2f5020d9ea888417983ab"
 dependencies = [
  "ahash 0.8.12",
  "astral-tl",
@@ -4429,7 +4429,7 @@ dependencies = [
  "html-escape",
  "html5ever",
  "image",
- "lru 0.17.0",
+ "lru 0.18.0",
  "memchr",
  "once_cell",
  "regex",
@@ -5153,9 +5153,9 @@ dependencies = [
 
 [[package]]
 name = "kreuzberg"
-version = "4.9.7"
+version = "4.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b6e7118097d06f882f62427e6d8722eef31bc20bd0b2f434a8b8785d05c30c"
+checksum = "ef08d77d5b72b5c424acb86e297ea13fd9f3db9372d570dd4468011dfc8c3d53"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -5194,7 +5194,7 @@ dependencies = [
  "pastey 0.2.2",
  "pkg-config",
  "pulldown-cmark",
- "quick-xml 0.39.2",
+ "quick-xml 0.40.1",
  "rayon",
  "regex",
  "rmp-serde",
@@ -5330,9 +5330,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -5506,6 +5506,15 @@ name = "lru"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
+dependencies = [
+ "hashbrown 0.17.0",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
  "hashbrown 0.17.0",
 ]
@@ -6793,7 +6802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91bb5030596a3d442c0866ac68afe29c14ba558e77c726dcdf7016b0dbb359d9"
 dependencies = [
  "arrayvec",
- "hashbrown 0.17.0",
+ "hashbrown 0.12.3",
  "parking_lot",
  "rand 0.8.5",
 ]
@@ -7148,8 +7157,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -7170,7 +7179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7312,6 +7321,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "encoding_rs",
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+dependencies = [
  "memchr",
  "serde",
 ]
@@ -8470,7 +8488,7 @@ checksum = "546b4da4f679832602a8f8ab8ddc10b6b1d2e1a13b4f9dddcaee499436fa06ad"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "nohash-hasher",
@@ -8490,7 +8508,7 @@ checksum = "f83ad47c2f14654528a89495f8d0dbc64173176f8512c7c72386cbe81009f661"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "nohash-hasher",
@@ -8860,7 +8878,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9600,9 +9618,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -537,7 +537,7 @@ mime = "0.3"
 
 # Document parsing libraries
 docx-rust = "0.1.11"
-kreuzberg = { version = "=4.9.7", features = ["html", "excel", "office", "pdf", "bundled-pdfium"] }
+kreuzberg = { version = "=4.9.8", features = ["html", "excel", "office", "pdf", "bundled-pdfium"] }
 
 # Additional testing utilities
 temp-env = { version = "0.3", features = ["async_closure"] }

--- a/deny.toml
+++ b/deny.toml
@@ -78,10 +78,10 @@ exceptions = [
   #   2. CF/Gears's document parsing is incidental to the platform's core value
   #      proposition; it is NOT a product sold primarily as a document-parsing service
   #      competing with kreuzberg.
-  #   3. The pin `=4.9.4` prevents silent upgrades; any future version bump must be
-  #      reviewed for license changes.
+  #   3. The pin `=4.9.8` prevents silent upgrades; any future version bump must be
+  #      reviewed for license changes. 4.9.8 reviewed: still Elastic-2.0, no change.
   # Reviewer sign-off required before removing or modifying this exception.
-  { name = "kreuzberg", version = "=4.9.7", allow = ["Elastic-2.0"] },
+  { name = "kreuzberg", version = "=4.9.8", allow = ["Elastic-2.0"] },
   # aws-lc-fips-sys vendors AWS-LC-FIPS sources carrying an OpenSSL license term
   # as part of the upstream license expression. We do not allow OpenSSL globally,
   # so keep this exception pinned to the reviewed crate release only.


### PR DESCRIPTION
## What

Bumps `kreuzberg` 4.9.7 → 4.9.8 (patch; upstream bug fixes incl. RTF CP1251/Cyrillic decoding), and **pins `html-to-markdown-rs` to `3.4.1`** to keep the build green.

## Why the extra pin (and why the plain Dependabot bump #4096 is red)

kreuzberg 4.9.8 declares `html-to-markdown-rs = "3.4.1"` and its metadata mapper compiles against:

```rust
// html_to_markdown_rs::ImageMetadata
dimensions: Option<(u32, u32)>
```

But `html-to-markdown-rs` **3.6.x changed that field to `Option<ImageDimensions>` within the 3.x line** (an upstream semver break). Cargo's default resolution to the latest `3.6.x` therefore breaks kreuzberg's own compilation:

```
error[E0308]: mismatched types
  --> kreuzberg-4.9.8/src/types/metadata.rs:607
     expected `Option<(u32, u32)>`, found `Option<ImageDimensions>`
```

That is exactly why Dependabot PR #4096 lands with a fully red CI. Holding `html-to-markdown-rs` at `3.4.1` (the version kreuzberg declares) keeps the tuple API kreuzberg expects.

## Scope / blast radius

- `kreuzberg` is consumed only by `gears/file-parser`.
- No other workspace crate depends on `html-to-markdown-rs` directly (transitive only).
- Lockfile changes are the natural consequence of the kreuzberg patch: `calamine` 0.34→0.35, `html-to-markdown-rs` 3.3.3→**3.4.1**, `libc` 0.2.185→0.2.186, `tokio` 1.52.1→1.52.3, plus new `lru` 0.18 / `quick-xml` 0.40.1.

## Verification

- `cargo test --workspace` — green locally (0 failed).
- `cargo check -p cf-gears-file-parser` — green.

Supersedes #4096.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a core dependency to version 4.9.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->