### PR TITLE
fix(account-management): derive effective realm + children-list filter parity

### DIFF
--- a/docs/api/api.json
+++ b/docs/api/api.json
@@ -5719,7 +5719,7 @@
             }
           },
           {
-            "description": "OData v4 filter expression\n- id: eq|ne|in\n- status: eq|ne|contains|startswith|endswith|in\n- tenant_type_uuid: eq|ne|in\n- self_managed: eq|ne\n- created_at: eq|ne|gt|ge|lt|le|in\n- updated_at: eq|ne|gt|ge|lt|le|in",
+            "description": "OData v4 filter expression\n- id: eq|ne|in\n- name: eq|ne|contains|startswith|endswith|in\n- status: eq|ne|contains|startswith|endswith|in\n- tenant_type_uuid: eq|ne|in\n- tenant_type: eq|ne|contains|startswith|endswith|in\n- self_managed: eq|ne\n- created_at: eq|ne|gt|ge|lt|le|in\n- updated_at: eq|ne|gt|ge|lt|le|in",
             "in": "query",
             "name": "$filter",
             "required": false,
@@ -5728,7 +5728,7 @@
             }
           },
           {
-            "description": "OData v4 orderby expression\n- id asc\n- id desc\n- status asc\n- status desc\n- tenant_type_uuid asc\n- tenant_type_uuid desc\n- self_managed asc\n- self_managed desc\n- created_at asc\n- created_at desc\n- updated_at asc\n- updated_at desc",
+            "description": "OData v4 orderby expression\n- id asc\n- id desc\n- name asc\n- name desc\n- status asc\n- status desc\n- tenant_type_uuid asc\n- tenant_type_uuid desc\n- tenant_type asc\n- tenant_type desc\n- self_managed asc\n- self_managed desc\n- created_at asc\n- created_at desc\n- updated_at asc\n- updated_at desc",
             "in": "query",
             "name": "$orderby",
             "required": false,
@@ -5854,11 +5854,27 @@
               "ne",
               "in"
             ],
+            "name": [
+              "eq",
+              "ne",
+              "contains",
+              "startswith",
+              "endswith",
+              "in"
+            ],
             "self_managed": [
               "eq",
               "ne"
             ],
             "status": [
+              "eq",
+              "ne",
+              "contains",
+              "startswith",
+              "endswith",
+              "in"
+            ],
+            "tenant_type": [
               "eq",
               "ne",
               "contains",
@@ -5886,10 +5902,14 @@
           "allowedFields": [
             "id asc",
             "id desc",
+            "name asc",
+            "name desc",
             "status asc",
             "status desc",
             "tenant_type_uuid asc",
             "tenant_type_uuid desc",
+            "tenant_type asc",
+            "tenant_type desc",
             "self_managed asc",
             "self_managed desc",
             "created_at asc",

--- a/gears/system/account-management/account-management-sdk/src/idp.rs
+++ b/gears/system/account-management/account-management-sdk/src/idp.rs
@@ -139,6 +139,11 @@ pub struct IdpProvisionTenantRequest {
     pub tenant_type: GtsTypeId,
     /// Opaque provider-specific metadata from `TenantCreateRequest.provisioning_metadata`.
     pub metadata: Option<Value>,
+    /// The parent tenant's resolved snapshot, replayed so the plugin can
+    /// derive the effective realm from the parent's opaque `metadata`.
+    /// `None` for the root-bootstrap path. AM remains the sole echo-proxy;
+    /// the plugin remains the sole interpreter of the blob.
+    pub parent_context: Option<IdpTenantContext>,
 }
 
 impl IdpProvisionTenantRequest {
@@ -153,6 +158,7 @@ impl IdpProvisionTenantRequest {
             name: name.into(),
             tenant_type,
             metadata: None,
+            parent_context: None,
         }
     }
 
@@ -173,6 +179,7 @@ impl IdpProvisionTenantRequest {
             name: name.into(),
             tenant_type,
             metadata: None,
+            parent_context: None,
         }
     }
 
@@ -180,6 +187,13 @@ impl IdpProvisionTenantRequest {
     #[must_use]
     pub fn with_metadata(mut self, metadata: Value) -> Self {
         self.metadata = Some(metadata);
+        self
+    }
+
+    /// Builder-style setter for [`Self::parent_context`].
+    #[must_use]
+    pub fn with_parent_context(mut self, ctx: IdpTenantContext) -> Self {
+        self.parent_context = Some(ctx);
         self
     }
 }

--- a/gears/system/account-management/account-management-sdk/src/idp_tests.rs
+++ b/gears/system/account-management/account-management-sdk/src/idp_tests.rs
@@ -107,6 +107,28 @@ async fn list_users_default_impl_returns_unsupported_operation() {
 }
 
 #[test]
+fn parent_context_defaults_none_and_builder_sets_it() {
+    let tt = gts::GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~");
+    let req = IdpProvisionTenantRequest::new(Uuid::nil(), Uuid::nil(), "t", tt.clone());
+    assert!(
+        req.parent_context.is_none(),
+        "new() must default parent_context to None"
+    );
+
+    let pctx = IdpTenantContext::new(
+        Uuid::nil(),
+        "parent",
+        tt,
+        Some(serde_json::json!({"k":"v"})),
+    );
+    let req2 = req.with_parent_context(pctx);
+    assert!(
+        req2.parent_context.is_some(),
+        "with_parent_context must set the field"
+    );
+}
+
+#[test]
 fn provision_failure_metric_labels_are_stable() {
     assert_eq!(
         IdpProvisionFailure::CleanFailure {

--- a/gears/system/account-management/account-management-sdk/src/tenant.rs
+++ b/gears/system/account-management/account-management-sdk/src/tenant.rs
@@ -218,6 +218,13 @@ pub struct TenantInfoQuery {
     /// path for exact-id reads.
     #[odata(filter(kind = "Uuid"))]
     pub id: Uuid,
+    /// `tenants.name` — the human label returned in every list item.
+    /// Filterable (`$filter=name eq '...'`) and orderable
+    /// (`$orderby=name`) so operator UIs can search and sort children by
+    /// name. `name` is in the response projection, so it must be in the
+    /// filter/order allow-list too (projection-vs-filter parity).
+    #[odata(filter(kind = "String"))]
+    pub name: String,
     /// `tenants.status` projected as the public [`TenantStatus`]
     /// lifecycle string: `"active"`, `"suspended"`, or `"deleted"`
     /// (the serde rename on the SDK enum). The `OData` parser only
@@ -227,14 +234,24 @@ pub struct TenantInfoQuery {
     #[odata(filter(kind = "String"))]
     pub status: String,
     /// Deterministic `UUIDv5` of the registered tenant-type schema id.
-    /// Filtering on the UUID rather than the chained `gts.*` string
-    /// keeps the wire path simple — callers building a UI dropdown
-    /// over tenant types already hold the UUID (the resolver registry
-    /// returns it on type lookups), and the SDK does not need a
-    /// server-side `derive_schema_uuid` rewrite step. Exact-type
-    /// listings go through `$filter=tenant_type_uuid eq <uuid>`.
+    /// The raw-UUID filter remains for callers that already hold the
+    /// UUID (the resolver registry returns it on type lookups):
+    /// `$filter=tenant_type_uuid eq <uuid>`. Most callers should prefer
+    /// the chained-string [`tenant_type`](Self::tenant_type) filter
+    /// below, which matches the value returned in the projection.
     #[odata(filter(kind = "Uuid"))]
     pub tenant_type_uuid: Uuid,
+    /// Chained `gts.*` tenant-type string, exactly as returned in the
+    /// projection (`TenantDto.tenant_type`). Filterable
+    /// (`$filter=tenant_type eq 'gts.cf.core.am.tenant_type.v1~…~'`,
+    /// plus `ne` / `in`) so operator UIs can filter by the value they
+    /// already display — projection-vs-filter parity. The
+    /// string is mapped server-side to its deterministic `UUIDv5` and
+    /// compared against `tenant_type_uuid`; ordered operators and
+    /// `$orderby` are rejected (sorting by a derived UUID is
+    /// meaningless), mirroring `status`.
+    #[odata(filter(kind = "String"))]
+    pub tenant_type: String,
     /// `tenants.self_managed` flag. Useful to surface "boundary"
     /// child tenants vs ordinary ones in operator UIs.
     #[odata(filter(kind = "Bool"))]

--- a/gears/system/account-management/account-management-sdk/src/tenant_tests.rs
+++ b/gears/system/account-management/account-management-sdk/src/tenant_tests.rs
@@ -46,8 +46,10 @@ fn tenant_filter_fields_are_pinned() {
         names,
         vec![
             "id",
+            "name",
             "status",
             "tenant_type_uuid",
+            "tenant_type",
             "self_managed",
             "created_at",
             "updated_at",

--- a/gears/system/account-management/account-management/src/domain/tenant/service/mod.rs
+++ b/gears/system/account-management/account-management/src/domain/tenant/service/mod.rs
@@ -802,12 +802,14 @@ impl<R: TenantRepo> TenantService<R> {
 
         // Saga step 2 — invoke IdP provider outside any TX.
         // @cpt-begin:cpt-cf-account-management-dod-tenant-hierarchy-management-idp-tenant-provision:p1:inst-dod-idp-provision-call
+        let parent_ctx = self.load_tenant_context(parent.id).await?;
         let mut req = IdpProvisionTenantRequest::new(
             provisioning_row.id,
             parent.id,
             input.name.clone(),
             input.tenant_type.clone(),
-        );
+        )
+        .with_parent_context((&parent_ctx).into());
         if let Some(meta) = input.provisioning_metadata.clone() {
             req = req.with_metadata(meta);
         }

--- a/gears/system/account-management/account-management/src/domain/tenant/service/service_tests.rs
+++ b/gears/system/account-management/account-management/src/domain/tenant/service/service_tests.rs
@@ -368,6 +368,40 @@ async fn create_tenant_happy_path_writes_self_row_and_one_ancestor_row() {
 }
 
 #[tokio::test]
+async fn create_child_forwards_parent_context() {
+    let root = Uuid::from_u128(0x100);
+    let child = Uuid::from_u128(0x200);
+    let repo = Arc::new(FakeTenantRepo::with_root(root));
+    let idp = Arc::new(FakeIdpProvisioner::new(FakeOutcome::Ok));
+    let svc = TenantService::new(
+        repo.clone(),
+        idp.clone(),
+        Arc::new(InertResourceOwnershipChecker),
+        crate::domain::tenant_type::inert_tenant_type_checker(),
+        mock_enforcer(),
+        AccountManagementConfig::default(),
+    )
+    .with_types_registry(::std::sync::Arc::new(ConstantTypesRegistry));
+
+    svc.create_tenant(&ctx_for(root), child_input(child, root))
+        .await
+        .expect("create ok");
+
+    // The saga MUST replay the parent's resolved snapshot so the plugin
+    // can derive the effective realm from the parent's opaque metadata.
+    let req = idp
+        .last_provision_request()
+        .expect("provision_tenant was called");
+    let parent_ctx = req
+        .parent_context
+        .expect("child provision must carry parent_context");
+    assert_eq!(
+        parent_ctx.tenant_id, root,
+        "parent_context must snapshot the parent tenant"
+    );
+}
+
+#[tokio::test]
 async fn create_tenant_clean_failure_compensates_and_writes_no_closure_rows() {
     let root = Uuid::from_u128(0x100);
     let child = Uuid::from_u128(0x201);
@@ -3721,7 +3755,8 @@ async fn get_tenant_outside_caller_subtree_returns_not_found() {
         crate::domain::tenant_type::inert_tenant_type_checker(),
         mock_enforcer(),
         AccountManagementConfig::default(),
-    );
+    )
+    .with_types_registry(Arc::new(ConstantTypesRegistry));
     setup_svc
         .create_tenant(&ctx_for(root), child_input(child, root))
         .await
@@ -3763,7 +3798,8 @@ async fn make_cross_subtree_svc(
         crate::domain::tenant_type::inert_tenant_type_checker(),
         mock_enforcer(),
         AccountManagementConfig::default(),
-    );
+    )
+    .with_types_registry(Arc::new(ConstantTypesRegistry));
     setup_svc
         .create_tenant(&ctx_for(root), child_input(child, root))
         .await

--- a/gears/system/account-management/account-management/src/domain/tenant/test_support/idp.rs
+++ b/gears/system/account-management/account-management/src/domain/tenant/test_support/idp.rs
@@ -71,6 +71,11 @@ pub struct FakeIdpProvisioner {
     /// [`account_management_sdk::IdpTenantContext::metadata`].
     pub metadata: Mutex<Option<Value>>,
     pub calls: Mutex<Vec<Uuid>>,
+    /// Last [`IdpProvisionTenantRequest`] observed by `provision_tenant`,
+    /// captured verbatim so tests can assert request-shaping the saga
+    /// performs (e.g. `parent_context` replay) rather than only the
+    /// `tenant_id`.
+    pub last_provision_request: Mutex<Option<IdpProvisionTenantRequest>>,
     pub deprovision_calls: Mutex<Vec<Uuid>>,
     /// Notified once `provision_tenant` is entered (BEFORE the
     /// per-outcome dispatch). Tests using `FakeOutcome::Hang` await
@@ -87,6 +92,7 @@ impl FakeIdpProvisioner {
             deprovision_outcome: Mutex::new(FakeDeprovisionOutcome::Ok),
             metadata: Mutex::new(None),
             calls: Mutex::new(Vec::new()),
+            last_provision_request: Mutex::new(None),
             deprovision_calls: Mutex::new(Vec::new()),
             provision_entered: Arc::new(Notify::new()),
         }
@@ -117,6 +123,12 @@ impl FakeIdpProvisioner {
     pub fn provision_call_count(&self) -> usize {
         self.calls.lock().expect("lock").len()
     }
+
+    /// The last provision request the fake captured, cloned out for
+    /// assertions. `None` until `provision_tenant` has been called.
+    pub fn last_provision_request(&self) -> Option<IdpProvisionTenantRequest> {
+        self.last_provision_request.lock().expect("lock").clone()
+    }
 }
 
 #[async_trait]
@@ -127,6 +139,7 @@ impl IdpPluginClient for FakeIdpProvisioner {
         req: &IdpProvisionTenantRequest,
     ) -> Result<IdpProvisionResult, IdpProvisionFailure> {
         self.calls.lock().expect("lock").push(req.tenant_id);
+        *self.last_provision_request.lock().expect("lock") = Some(req.clone());
         // Signal that the saga has reached `provision_tenant`
         // BEFORE the per-outcome dispatch so a test using
         // `FakeOutcome::Hang` can synchronize against entry rather

--- a/gears/system/account-management/account-management/src/infra/storage/repo_impl/reads.rs
+++ b/gears/system/account-management/account-management/src/infra/storage/repo_impl/reads.rs
@@ -7,6 +7,7 @@
 
 use account_management_sdk::TenantInfoFilterField;
 use bigdecimal::BigDecimal;
+use gts::GtsID;
 use sea_orm::{ColumnTrait, Condition, EntityTrait, Order};
 use serde_json::Value;
 use toolkit_db::odata::sea_orm_filter::{
@@ -38,8 +39,14 @@ impl FieldToColumn<TenantInfoFilterField> for TenantODataMapper {
     fn map_field(field: TenantInfoFilterField) -> tenants::Column {
         match field {
             TenantInfoFilterField::Id => tenants::Column::Id,
+            TenantInfoFilterField::Name => tenants::Column::Name,
             TenantInfoFilterField::Status => tenants::Column::Status,
-            TenantInfoFilterField::TenantTypeUuid => tenants::Column::TenantTypeUuid,
+            // Both the raw-UUID filter and the chained-string filter target
+            // the same storage column; the string form is mapped to its
+            // UUIDv5 in `map_value` below.
+            TenantInfoFilterField::TenantTypeUuid | TenantInfoFilterField::TenantType => {
+                tenants::Column::TenantTypeUuid
+            }
             TenantInfoFilterField::SelfManaged => tenants::Column::SelfManaged,
             TenantInfoFilterField::CreatedAt => tenants::Column::CreatedAt,
             TenantInfoFilterField::UpdatedAt => tenants::Column::UpdatedAt,
@@ -97,6 +104,31 @@ impl FieldToColumn<TenantInfoFilterField> for TenantODataMapper {
                 };
                 Ok(ODataValue::Number(BigDecimal::from(i64::from(code))))
             }
+            // Chained `gts.*` tenant-type string → its deterministic UUIDv5,
+            // compared against the `tenant_type_uuid` column. Same derivation
+            // as `uuid_for_registered_schema` (`GtsID::new(s).to_uuid()`), so a
+            // value taken from the projection round-trips to the stored UUID.
+            // Only membership operators are admissible — an ordered comparison
+            // on a derived UUID has no honest meaning (mirrors `status`).
+            (TenantInfoFilterField::TenantType, ODataValue::String(s)) => {
+                match op {
+                    FilterOp::Eq | FilterOp::Ne | FilterOp::In => {}
+                    other => {
+                        return Err(format!(
+                            "operator {other:?} is not supported on `tenant_type`; \
+                             use `eq`, `ne`, or `in` — ordered comparisons on a \
+                             derived UUIDv5 have no meaningful order"
+                        ));
+                    }
+                }
+                let uuid = GtsID::new(s).map(|g| g.to_uuid()).map_err(|e| {
+                    format!(
+                        "invalid `tenant_type` value '{s}'; expected a chained GTS \
+                         type id (e.g. 'gts.cf.core.am.tenant_type.v1~…~'): {e}"
+                    )
+                })?;
+                Ok(ODataValue::Uuid(uuid))
+            }
             _ => Ok(value.clone()),
         }
     }
@@ -110,7 +142,14 @@ impl FieldToColumn<TenantInfoFilterField> for TenantODataMapper {
     /// `InvalidOrderByField` before composing the effective order, so
     /// the cursor codec never sees a translated-shape value.
     fn is_orderable(field: TenantInfoFilterField) -> bool {
-        !matches!(field, TenantInfoFilterField::Status)
+        // `status` and `tenant_type` are exposed as strings on the wire but
+        // compared via a translated storage shape (SMALLINT / derived
+        // UUIDv5); neither has a consistent wire-vs-storage order, so
+        // `$orderby` on them is rejected before the effective order composes.
+        !matches!(
+            field,
+            TenantInfoFilterField::Status | TenantInfoFilterField::TenantType
+        )
     }
 }
 
@@ -123,8 +162,14 @@ impl ODataFieldMapping<TenantInfoFilterField> for TenantODataMapper {
     ) -> sea_orm::Value {
         match field {
             TenantInfoFilterField::Id => sea_orm::Value::Uuid(Some(Box::new(model.id))),
+            TenantInfoFilterField::Name => {
+                sea_orm::Value::String(Some(Box::new(model.name.clone())))
+            }
             TenantInfoFilterField::Status => sea_orm::Value::SmallInt(Some(model.status)),
-            TenantInfoFilterField::TenantTypeUuid => {
+            // `TenantType` is filter-only (not orderable), so it never reaches
+            // the cursor path; map it identically to the raw-UUID field for
+            // exhaustiveness.
+            TenantInfoFilterField::TenantTypeUuid | TenantInfoFilterField::TenantType => {
                 sea_orm::Value::Uuid(Some(Box::new(model.tenant_type_uuid)))
             }
             TenantInfoFilterField::SelfManaged => sea_orm::Value::Bool(Some(model.self_managed)),
@@ -476,4 +521,65 @@ pub(super) async fn is_descendant(
         .await
         .map_err(map_scope_err)?;
     Ok(count > 0)
+}
+
+#[cfg(test)]
+mod tenant_type_filter_tests {
+    use super::*;
+
+    // A valid `cf`-vendor chained tenant-type id (the one `service_tests`
+    // uses). de0901 validates GTS string literals via `GtsOps::parse_id`; a
+    // valid `cf` id is accepted, so no lint suppression is needed.
+    const SAMPLE_TENANT_TYPE_GTS: &str = "gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~";
+
+    type Mapper = TenantODataMapper;
+    type Field = TenantInfoFilterField;
+
+    /// `$filter=tenant_type eq '<gts>'` maps the chained string to the same
+    /// deterministic `UUIDv5` the storage column holds, so a value
+    /// taken from the projection round-trips. Pins the derivation against
+    /// `GtsID::to_uuid` so a future codec change is caught.
+    #[test]
+    fn tenant_type_string_maps_to_derived_uuidv5() {
+        let expected = GtsID::new(SAMPLE_TENANT_TYPE_GTS).expect("gts").to_uuid();
+        let out = <Mapper as FieldToColumn<Field>>::map_value(
+            Field::TenantType,
+            FilterOp::Eq,
+            &ODataValue::String(SAMPLE_TENANT_TYPE_GTS.to_owned()),
+        )
+        .expect("derive ok");
+        match out {
+            ODataValue::Uuid(u) => assert_eq!(u, expected, "string must map to its UUIDv5"),
+            other => panic!("expected ODataValue::Uuid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tenant_type_rejects_ordered_operator() {
+        let err = <Mapper as FieldToColumn<Field>>::map_value(
+            Field::TenantType,
+            FilterOp::Lt,
+            &ODataValue::String(SAMPLE_TENANT_TYPE_GTS.to_owned()),
+        )
+        .expect_err("ordered op must be rejected");
+        assert!(err.contains("tenant_type"), "got {err}");
+    }
+
+    #[test]
+    fn tenant_type_invalid_string_errors() {
+        let err = <Mapper as FieldToColumn<Field>>::map_value(
+            Field::TenantType,
+            FilterOp::Eq,
+            &ODataValue::String("not-a-gts-id".to_owned()),
+        )
+        .expect_err("invalid gts must error");
+        assert!(err.contains("invalid `tenant_type`"), "got {err}");
+    }
+
+    #[test]
+    fn tenant_type_is_not_orderable() {
+        assert!(!<Mapper as FieldToColumn<Field>>::is_orderable(
+            Field::TenantType
+        ));
+    }
 }

--- a/gears/system/account-management/account-management/tests/common/mod.rs
+++ b/gears/system/account-management/account-management/tests/common/mod.rs
@@ -946,16 +946,6 @@ pub fn inert_resource_checker()
     Arc::new(InertResourceOwnershipChecker)
 }
 
-/// Empty `MockTypesRegistryClient` from the SDK's `test-util` feature.
-/// Every `get_*` returns `gts_type_schema_not_found`; reads that
-/// expect a populated registry (e.g. the `tenant_type` lift in
-/// `TenantDto::from_sdk_tenant`) collapse to `None` rather than
-/// failing the whole HTTP call.
-#[must_use]
-pub fn inert_types_registry() -> Arc<dyn types_registry_sdk::TypesRegistryClient> {
-    Arc::new(types_registry_sdk::testing::MockTypesRegistryClient::new())
-}
-
 /// Canonical chained `tenant_type` id used by every E2E tenant fixture.
 /// Mirrors the in-source `domain::user::service_tests::TEST_TENANT_TYPE_ID`
 /// so the harness lines up byte-for-byte with the canonical AM unit-test
@@ -1073,14 +1063,17 @@ pub fn build_services(harness: &Harness) -> TestServices {
 /// Same as [`build_services`] but parameterised on the `IdP` plugin
 /// and the metadata-schema registry — used by tests that need a
 /// pre-seeded schema or a non-default IdP behaviour. Uses
-/// [`inert_types_registry`] for the types-registry side.
+/// [`types_registry_for_users`] so the types-registry resolves the
+/// harness tenant-type chain: `create_tenant` now loads the parent's
+/// context (`load_tenant_context`), which reverse-resolves the
+/// parent's `tenant_type_uuid` — an inert registry would 503 it.
 #[must_use]
 pub fn build_services_with(
     harness: &Harness,
     idp: Arc<dyn IdpPluginClient>,
     metadata_registry: Arc<dyn MetadataSchemaRegistry>,
 ) -> TestServices {
-    build_services_full(harness, idp, metadata_registry, inert_types_registry())
+    build_services_full(harness, idp, metadata_registry, types_registry_for_users())
 }
 
 /// Full variant of [`build_services_with`] that also takes the

--- a/gears/system/account-management/account-management/tests/list_children_integration.rs
+++ b/gears/system/account-management/account-management/tests/list_children_integration.rs
@@ -97,6 +97,41 @@ async fn seed_root(h: &Harness, root_id: Uuid) {
         .expect("root self-row");
 }
 
+/// Seed an active, non-barrier child with an explicit `name` so the
+/// name-filter / name-orderby tests can assert on a controlled label
+/// (the generic `seed_tenant_at` derives `name` from the id, which is
+/// not lexicographically controllable).
+async fn seed_tenant_named(
+    h: &Harness,
+    id: Uuid,
+    parent_id: Uuid,
+    name: &str,
+    tenant_type_uuid: Uuid,
+    created_at: OffsetDateTime,
+) {
+    use toolkit_db::secure::secure_insert;
+    let conn = h.provider.conn().expect("conn");
+    let am = tenants::ActiveModel {
+        id: ActiveValue::Set(id),
+        parent_id: ActiveValue::Set(Some(parent_id)),
+        name: ActiveValue::Set(name.to_owned()),
+        status: ActiveValue::Set(ACTIVE),
+        self_managed: ActiveValue::Set(false),
+        tenant_type_uuid: ActiveValue::Set(tenant_type_uuid),
+        depth: ActiveValue::Set(1),
+        created_at: ActiveValue::Set(created_at),
+        updated_at: ActiveValue::Set(created_at),
+        deleted_at: ActiveValue::Set(None),
+        retention_window_secs: ActiveValue::Set(None),
+        claimed_by: ActiveValue::Set(None),
+        claimed_at: ActiveValue::Set(None),
+        terminal_failure_at: ActiveValue::Set(None),
+    };
+    secure_insert::<tenants::Entity>(am, &allow_all(), &conn)
+        .await
+        .expect("seed named child");
+}
+
 /// Build `$filter=<field> eq <i16>` for a numeric column. Used by
 /// non-status numeric columns in these tests (none currently — kept
 /// as scaffold for future numeric filters).
@@ -156,8 +191,10 @@ fn tenant_filter_fields_are_stable() {
         names,
         vec![
             "id",
+            "name",
             "status",
             "tenant_type_uuid",
+            "tenant_type",
             "self_managed",
             "created_at",
             "updated_at",
@@ -383,6 +420,68 @@ async fn list_children_filter_self_managed_isolates_barrier_children() {
         ids_of(&page.items),
         vec![boundary],
         "`$filter=self_managed eq true` MUST return only the barrier child"
+    );
+}
+
+// ---- name filter / orderby ------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_children_filter_by_name_returns_only_match() {
+    let h = setup_sqlite().await.expect("harness");
+    let root = Uuid::from_u128(ROOT_ID);
+    seed_root(&h, root).await;
+
+    let type_a = Uuid::from_u128(0xAA);
+    let alpha = Uuid::from_u128(0x501);
+    let beta = Uuid::from_u128(0x502);
+    seed_tenant_named(&h, alpha, root, "alpha", type_a, ts_at(1)).await;
+    seed_tenant_named(&h, beta, root, "beta", type_a, ts_at(2)).await;
+
+    let query = ODataQuery::default().with_filter(filter_field_eq_string("name", "alpha"));
+    let page = h
+        .repo
+        .list_children(&allow_all(), root, &query)
+        .await
+        .expect("list");
+
+    assert_eq!(
+        ids_of(&page.items),
+        vec![alpha],
+        "`$filter=name eq 'alpha'` MUST return only the exactly-named child"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_children_orderby_name_sorts_lexicographically() {
+    let h = setup_sqlite().await.expect("harness");
+    let root = Uuid::from_u128(ROOT_ID);
+    seed_root(&h, root).await;
+
+    let type_a = Uuid::from_u128(0xAA);
+    let charlie = Uuid::from_u128(0x601);
+    let alpha = Uuid::from_u128(0x602);
+    let bravo = Uuid::from_u128(0x603);
+    // Insertion (created_at) order is charlie, alpha, bravo — deliberately
+    // NOT the lexicographic name order, so a passing assertion proves the
+    // sort honoured `name`, not the default `created_at`.
+    seed_tenant_named(&h, charlie, root, "charlie", type_a, ts_at(1)).await;
+    seed_tenant_named(&h, alpha, root, "alpha", type_a, ts_at(2)).await;
+    seed_tenant_named(&h, bravo, root, "bravo", type_a, ts_at(3)).await;
+
+    let query = ODataQuery::default().with_order(ODataOrderBy(vec![OrderKey {
+        field: "name".to_owned(),
+        dir: SortDir::Asc,
+    }]));
+    let page = h
+        .repo
+        .list_children(&allow_all(), root, &query)
+        .await
+        .expect("list");
+
+    assert_eq!(
+        ids_of(&page.items),
+        vec![alpha, bravo, charlie],
+        "`$orderby=name asc` MUST sort children lexicographically by name"
     );
 }
 


### PR DESCRIPTION
## Summary

Two account-management changes (one commit).

### Replay parent context for IdP provisioning
- **SDK**: add `IdpProvisionTenantRequest.parent_context: Option<IdpTenantContext>` + a `with_parent_context` builder (additive; the struct is `#[non_exhaustive]`, constructors default the field to `None`).
- **AM create saga**: before `provision_tenant`, load the parent's resolved snapshot via `load_tenant_context(parent.id)` and attach it. This lets an IdP plugin derive a child's *effective realm* from the parent's opaque metadata instead of requiring the caller to send a realm on every create. AM stays the echo-proxy; the plugin remains the sole interpreter of the blob (same replay pattern already used for user-ops / deprovision). A parent Types-Registry outage surfaces as `ServiceUnavailable` here — before any IdP-side state is written.

### Children-list OData projection-vs-filter parity
`GET /tenants/{id}/children` returned `name` and `tenant_type` in every item, but neither was in the OData filter/order allow-list. Restored parity:
- **`name`** → filterable (`eq`/`ne`/`in`) and orderable (`$orderby=name`).
- **`tenant_type`** (the chained `gts.*` string, exactly as projected) → filterable (`eq`/`ne`/`in`). Mapped server-side to its deterministic `UUIDv5` (`GtsID::to_uuid` — the same pure derivation as `uuid_for_registered_schema`) and compared against `tenant_type_uuid`, so a value taken from the projection round-trips. Not orderable (ordering a derived UUID has no honest meaning — mirrors `status`). The raw `tenant_type_uuid` filter is retained for back-compat.

## Tests
- **SDK**: `parent_context` default/builder; filter-field pinning updated (`name`, `tenant_type`).
- **AM**: saga replays `parent_context`; `reads.rs` unit tests for the `tenant_type` string→UUIDv5 derivation + operator guard + invalid-string + not-orderable; `list_children_integration` name filter/orderby + field-pinning. The integration harness (`build_services`) now wires a resolving types-registry, since `create_tenant` resolves the parent's type.
- `docs/api/api.json` regenerated (`make openapi`).
- `cargo fmt` + workspace `clippy` + `dylint` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced `GET /account-management/v1/tenants/{tenant_id}/children` OData support to allow `$filter` and `$orderby` by `name` and `tenant_type`.
* **Bug Fixes**
  * Improved child-tenant IdP provisioning to correctly apply parent tenant context when creating non-root tenants.
* **Documentation**
  * Updated the API/OpenAPI docs to reflect the new `$filter` and `$orderby` capabilities for tenant listing queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->