### PR TITLE
fix(api-gateway): emit WWW-Authenticate challenge on rejected bearer …

### DIFF
--- a/gears/system/api-gateway/src/middleware/auth.rs
+++ b/gears/system/api-gateway/src/middleware/auth.rs
@@ -1,6 +1,5 @@
 use axum::http::Method;
 use axum::response::IntoResponse;
-use http::HeaderValue;
 use std::{collections::HashMap, sync::Arc};
 
 use crate::middleware::common;
@@ -200,13 +199,19 @@ pub async fn authn_middleware(
         }
         AuthRequirement::Required => {
             let Some(token) = extract_bearer_token(req.headers()) else {
-                let err = CanonicalError::unauthenticated()
-                    .with_reason("MISSING_BEARER")
-                    .create();
                 // `instance` / `trace_id` are filled by the canonical
                 // error middleware (`toolkit::api::canonical_error_middleware`)
                 // on the way out — this middleware sits inside its layer.
-                return err.into_response();
+                let mut response = CanonicalError::unauthenticated()
+                    .with_reason("MISSING_BEARER")
+                    .create()
+                    .into_response();
+                // No bearer credentials were presented (RFC 6750 §3).
+                common::append_bearer_challenge(
+                    &mut response,
+                    common::BearerChallenge::NoCredentials,
+                );
+                return response;
             };
 
             match state.authn_client.authenticate(token).await {
@@ -229,19 +234,12 @@ fn authn_error_to_response(err: &AuthNResolverError) -> axum::response::Response
     log_authn_error(err);
     match err {
         AuthNResolverError::Unauthorized(_) => {
-            // A token was presented but rejected. RFC 6750 §3 requires a
-            // rejected bearer request to carry a `WWW-Authenticate` challenge,
-            // with an `error` code when a token was supplied — here
-            // `invalid_token`. We deliberately omit `realm` and
-            // `error_description` so the challenge discloses no internal detail.
+            // A token was presented but rejected (RFC 6750 §3).
             let mut response = CanonicalError::unauthenticated()
                 .with_reason("AUTHN_FAILED")
                 .create()
                 .into_response();
-            response.headers_mut().append(
-                "WWW-Authenticate",
-                HeaderValue::from_static(r#"Bearer error="invalid_token""#),
-            );
+            common::append_bearer_challenge(&mut response, common::BearerChallenge::InvalidToken);
             response
         }
         AuthNResolverError::NoPluginAvailable | AuthNResolverError::ServiceUnavailable(_) => {

--- a/gears/system/api-gateway/src/middleware/auth.rs
+++ b/gears/system/api-gateway/src/middleware/auth.rs
@@ -1,5 +1,6 @@
 use axum::http::Method;
 use axum::response::IntoResponse;
+use http::HeaderValue;
 use std::{collections::HashMap, sync::Arc};
 
 use crate::middleware::common;
@@ -226,20 +227,35 @@ pub async fn authn_middleware(
 /// middleware sits inside its layer.
 fn authn_error_to_response(err: &AuthNResolverError) -> axum::response::Response {
     log_authn_error(err);
-    let canonical = match err {
-        AuthNResolverError::Unauthorized(_) => CanonicalError::unauthenticated()
-            .with_reason("AUTHN_FAILED")
-            .create(),
+    match err {
+        AuthNResolverError::Unauthorized(_) => {
+            // A token was presented but rejected. RFC 6750 §3 requires a
+            // rejected bearer request to carry a `WWW-Authenticate` challenge,
+            // with an `error` code when a token was supplied — here
+            // `invalid_token`. We deliberately omit `realm` and
+            // `error_description` so the challenge discloses no internal detail.
+            let mut response = CanonicalError::unauthenticated()
+                .with_reason("AUTHN_FAILED")
+                .create()
+                .into_response();
+            response.headers_mut().append(
+                "WWW-Authenticate",
+                HeaderValue::from_static(r#"Bearer error="invalid_token""#),
+            );
+            response
+        }
         AuthNResolverError::NoPluginAvailable | AuthNResolverError::ServiceUnavailable(_) => {
             CanonicalError::service_unavailable()
                 .with_retry_after_seconds(5)
                 .create()
+                .into_response()
         }
         AuthNResolverError::TokenAcquisitionFailed(_) | AuthNResolverError::Internal(_) => {
-            CanonicalError::internal("authentication infrastructure failure").create()
+            CanonicalError::internal("authentication infrastructure failure")
+                .create()
+                .into_response()
         }
-    };
-    canonical.into_response()
+    }
 }
 
 /// Log authentication errors at appropriate levels.

--- a/gears/system/api-gateway/src/middleware/common.rs
+++ b/gears/system/api-gateway/src/middleware/common.rs
@@ -1,4 +1,45 @@
 use axum::extract::Request;
+use axum::response::Response;
+use http::HeaderValue;
+use http::header::WWW_AUTHENTICATE;
+
+/// An RFC 6750 §3 `WWW-Authenticate: Bearer` challenge.
+///
+/// The `Bearer` scheme MUST be followed by at least one auth-param, so there is
+/// deliberately no bare-`Bearer` variant — each variant below carries exactly
+/// the params RFC 6750 prescribes for its situation.
+#[derive(Clone, Copy, Debug)]
+pub enum BearerChallenge {
+    /// A token was presented but rejected — RFC 6750 §3.1 `invalid_token`. Only
+    /// the `error` code is sent; `realm`/`error_description` are omitted so the
+    /// challenge discloses no internal detail.
+    InvalidToken,
+    /// A valid token lacked the required scope — RFC 6750 §3.1
+    /// `insufficient_scope`.
+    InsufficientScope,
+    /// No credentials were presented. §3 says the server SHOULD NOT disclose an
+    /// `error` code in that case, so `realm` is the sole auth-param — it meets
+    /// the "one or more" rule without leaking any detail.
+    NoCredentials,
+}
+
+impl BearerChallenge {
+    fn header_value(self) -> &'static str {
+        match self {
+            Self::InvalidToken => r#"Bearer error="invalid_token""#,
+            Self::InsufficientScope => r#"Bearer error="insufficient_scope""#,
+            Self::NoCredentials => r#"Bearer realm="api""#,
+        }
+    }
+}
+
+/// Append `challenge` to the response as a `WWW-Authenticate` header.
+pub fn append_bearer_challenge(response: &mut Response, challenge: BearerChallenge) {
+    response.headers_mut().append(
+        WWW_AUTHENTICATE,
+        HeaderValue::from_static(challenge.header_value()),
+    );
+}
 
 pub fn resolve_path(req: &Request, matched_path: &str) -> String {
     req.extensions()
@@ -29,6 +70,46 @@ fn strip_path_prefix(path: &str, prefix: &str) -> Option<String> {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
+    use axum::response::IntoResponse;
+
+    fn challenge_header(challenge: BearerChallenge) -> String {
+        let mut response = axum::http::StatusCode::UNAUTHORIZED.into_response();
+        append_bearer_challenge(&mut response, challenge);
+        response
+            .headers()
+            .get(WWW_AUTHENTICATE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_owned()
+    }
+
+    #[test]
+    fn error_challenges_carry_their_rfc_error_code() {
+        assert_eq!(
+            challenge_header(BearerChallenge::InvalidToken),
+            r#"Bearer error="invalid_token""#
+        );
+        assert_eq!(
+            challenge_header(BearerChallenge::InsufficientScope),
+            r#"Bearer error="insufficient_scope""#
+        );
+    }
+
+    #[test]
+    fn no_credentials_challenge_omits_error_code() {
+        let value = challenge_header(BearerChallenge::NoCredentials);
+        assert_eq!(value, r#"Bearer realm="api""#);
+        // RFC 6750 §3: when no token was supplied the challenge must not
+        // disclose an `error` code, but still needs an auth-param (`realm`).
+        assert!(
+            !value.contains("error="),
+            "no-credentials challenge leaked an error code"
+        );
+        assert!(
+            value.starts_with("Bearer "),
+            "challenge must carry an auth-param"
+        );
+    }
 
     #[test]
     fn exact_match_returns_root() {

--- a/gears/system/api-gateway/src/middleware/scope_enforcement.rs
+++ b/gears/system/api-gateway/src/middleware/scope_enforcement.rs
@@ -218,10 +218,13 @@ pub async fn scope_enforcement_middleware(
             // `instance` / `trace_id` are filled by the canonical error
             // middleware (`toolkit::api::canonical_error_middleware`) on the
             // way out — this middleware sits inside its layer.
-            return CanonicalError::unauthenticated()
+            let mut response = CanonicalError::unauthenticated()
                 .with_reason("AUTH_REQUIRED")
                 .create()
                 .into_response();
+            // No credentials reached this protected route (RFC 6750 §3).
+            common::append_bearer_challenge(&mut response, common::BearerChallenge::NoCredentials);
+            return response;
         }
         return next.run(req).await;
     };
@@ -234,7 +237,10 @@ pub async fn scope_enforcement_middleware(
         // `instance` / `trace_id` are filled by the canonical error
         // middleware (`toolkit::api::canonical_error_middleware`) on the
         // way out — this middleware sits inside its layer.
-        return canonical.into_response();
+        let mut response = canonical.into_response();
+        // A valid token reached here but lacked the required scope (RFC 6750 §3.1).
+        common::append_bearer_challenge(&mut response, common::BearerChallenge::InsufficientScope);
+        return response;
     }
 
     next.run(req).await

--- a/gears/system/api-gateway/tests/auth_middleware.rs
+++ b/gears/system/api-gateway/tests/auth_middleware.rs
@@ -38,6 +38,8 @@ const UNAUTHENTICATED_TYPE: &str =
 const SERVICE_UNAVAILABLE_TYPE: &str =
     "gts://gts.cf.core.errors.err.v1~cf.core.err.service_unavailable.v1~";
 const INTERNAL_TYPE: &str = "gts://gts.cf.core.errors.err.v1~cf.core.err.internal.v1~";
+const PERMISSION_DENIED_TYPE: &str =
+    "gts://gts.cf.core.errors.err.v1~cf.core.err.permission_denied.v1~";
 const PROBLEM_JSON: &str = "application/problem+json";
 
 async fn problem_from(response: Response) -> Problem {
@@ -51,6 +53,14 @@ fn content_type(response: &Response) -> &str {
     response
         .headers()
         .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+}
+
+fn www_authenticate(response: &Response) -> &str {
+    response
+        .headers()
+        .get(header::WWW_AUTHENTICATE)
         .and_then(|v| v.to_str().ok())
         .unwrap_or("")
 }
@@ -826,6 +836,56 @@ fn mock_returning_error(err_fn: fn() -> AuthNResolverError) -> MockAuthNResolver
     }
 }
 
+/// Build a mock that accepts a specific token and returns a `SecurityContext`
+/// carrying the given token scopes (for scope-enforcement tests).
+fn mock_accepting_token_with_scopes(
+    valid_token: &'static str,
+    scopes: Vec<String>,
+) -> MockAuthNResolverClient {
+    MockAuthNResolverClient {
+        handler: Arc::new(move |token| {
+            if token == valid_token {
+                Ok(AuthenticationResult {
+                    security_context: SecurityContext::builder()
+                        .subject_id(Uuid::new_v4())
+                        .subject_tenant_id(Uuid::new_v4())
+                        .token_scopes(scopes.clone())
+                        .build()
+                        .unwrap(),
+                })
+            } else {
+                Err(AuthNResolverError::Unauthorized("invalid token".to_owned()))
+            }
+        }),
+    }
+}
+
+/// Create a finalized router with auth **enabled** and route-policy scope
+/// enforcement covering `/tests/v1/api/**` with the given required scopes.
+async fn create_scope_enforced_router(
+    mock: MockAuthNResolverClient,
+    required_scopes: &[&str],
+) -> Router {
+    let config = json!({
+        "api-gateway": {
+            "config": {
+                "bind_addr": "0.0.0.0:8080",
+                // Scope enforcement requires auth to be enabled (gear rejects the
+                // combination otherwise); stated explicitly as test precondition.
+                "auth_disabled": false,
+                "route_policies": {
+                    "enabled": true,
+                    "rules": [
+                        { "path": "/tests/v1/api/**", "required_scopes": required_scopes }
+                    ]
+                }
+            }
+        }
+    });
+
+    create_router(config, mock).await
+}
+
 // --- Auth-enabled integration tests ---
 
 #[tokio::test]
@@ -878,6 +938,13 @@ async fn test_missing_token_returns_401() {
         "Missing token should yield 401"
     );
     assert_eq!(content_type(&response), PROBLEM_JSON);
+    // RFC 6750 §3: no credentials were presented, so the challenge carries a
+    // `realm` auth-param but no `error` code.
+    assert_eq!(
+        www_authenticate(&response),
+        r#"Bearer realm="api""#,
+        "Missing token should emit a WWW-Authenticate challenge"
+    );
     let problem = problem_from(response).await;
     assert_eq!(problem.problem_type, UNAUTHENTICATED_TYPE);
     assert_eq!(problem.context["reason"], "MISSING_BEARER");
@@ -905,6 +972,13 @@ async fn test_invalid_token_returns_401() {
         "Invalid token should yield 401"
     );
     assert_eq!(content_type(&response), PROBLEM_JSON);
+    // RFC 6750 §3.1: a token was presented but rejected, so the challenge
+    // carries the `invalid_token` error code.
+    assert_eq!(
+        www_authenticate(&response),
+        r#"Bearer error="invalid_token""#,
+        "Invalid token should emit a WWW-Authenticate challenge"
+    );
     let problem = problem_from(response).await;
     assert_eq!(problem.problem_type, UNAUTHENTICATED_TYPE);
     assert_eq!(problem.context["reason"], "AUTHN_FAILED");
@@ -932,6 +1006,9 @@ async fn test_no_plugin_available_returns_503() {
         "NoPluginAvailable should yield 503"
     );
     assert_eq!(content_type(&response), PROBLEM_JSON);
+    // A 503 is an infrastructure failure, not a credential rejection, so it
+    // must not carry a bearer challenge.
+    assert_eq!(www_authenticate(&response), "");
     let problem = problem_from(response).await;
     assert_eq!(problem.problem_type, SERVICE_UNAVAILABLE_TYPE);
     assert_eq!(problem.context["retry_after_seconds"], 5);
@@ -960,6 +1037,9 @@ async fn test_service_unavailable_returns_503() {
         "ServiceUnavailable should yield 503"
     );
     assert_eq!(content_type(&response), PROBLEM_JSON);
+    // A 503 is an infrastructure failure, not a credential rejection, so it
+    // must not carry a bearer challenge.
+    assert_eq!(www_authenticate(&response), "");
     let problem = problem_from(response).await;
     assert_eq!(problem.problem_type, SERVICE_UNAVAILABLE_TYPE);
     assert_eq!(problem.context["retry_after_seconds"], 5);
@@ -987,6 +1067,9 @@ async fn test_internal_error_returns_500() {
         "Internal error should yield 500"
     );
     assert_eq!(content_type(&response), PROBLEM_JSON);
+    // A 500 is an infrastructure failure, not a credential rejection, so it
+    // must not carry a bearer challenge.
+    assert_eq!(www_authenticate(&response), "");
     let problem = problem_from(response).await;
     assert_eq!(problem.problem_type, INTERNAL_TYPE);
 }
@@ -1113,4 +1196,65 @@ async fn test_cors_preflight_skips_auth() {
         StatusCode::FORBIDDEN,
         "CORS preflight must not be blocked by auth"
     );
+}
+
+#[tokio::test]
+async fn test_insufficient_scope_returns_403_with_challenge() {
+    // Valid token, but its scopes do not satisfy the route policy.
+    let mock = mock_accepting_token_with_scopes("valid-test-token", vec!["read:other".to_owned()]);
+    let router = create_scope_enforced_router(mock, &["admin"]).await;
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/tests/v1/api/protected")
+                .header(header::AUTHORIZATION, "Bearer valid-test-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "Insufficient scope should yield 403"
+    );
+    assert_eq!(content_type(&response), PROBLEM_JSON);
+    // RFC 6750 §3.1: a valid token lacked the required scope, so the challenge
+    // carries the `insufficient_scope` error code.
+    assert_eq!(
+        www_authenticate(&response),
+        r#"Bearer error="insufficient_scope""#,
+        "Insufficient scope should emit a WWW-Authenticate challenge"
+    );
+    let problem = problem_from(response).await;
+    assert_eq!(problem.problem_type, PERMISSION_DENIED_TYPE);
+    assert_eq!(problem.context["reason"], "INSUFFICIENT_SCOPES");
+}
+
+#[tokio::test]
+async fn test_wildcard_scope_passes_enforcement() {
+    // First-party apps carry the `["*"]` scope and bypass route-policy checks.
+    let mock = mock_accepting_token_with_scopes("valid-test-token", vec!["*".to_owned()]);
+    let router = create_scope_enforced_router(mock, &["admin"]).await;
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/tests/v1/api/protected")
+                .header(header::AUTHORIZATION, "Bearer valid-test-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Wildcard scope should satisfy any route policy"
+    );
+    // A successful response must not carry a bearer challenge.
+    assert_eq!(www_authenticate(&response), "");
 }

--- a/gears/system/api-gateway/tests/auth_middleware.rs
+++ b/gears/system/api-gateway/tests/auth_middleware.rs
@@ -57,12 +57,18 @@ fn content_type(response: &Response) -> &str {
         .unwrap_or("")
 }
 
-fn www_authenticate(response: &Response) -> &str {
+/// All `WWW-Authenticate` header values, in order. Empty if none.
+///
+/// Returning every value (rather than the first) lets assertions also catch a
+/// stacked/duplicate challenge, which RFC 7235 permits but the `Bearer` scheme
+/// makes ambiguous to parse.
+fn www_authenticate_all(response: &Response) -> Vec<&str> {
     response
         .headers()
-        .get(header::WWW_AUTHENTICATE)
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("")
+        .get_all(header::WWW_AUTHENTICATE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .collect()
 }
 
 /// Test configuration provider
@@ -939,11 +945,11 @@ async fn test_missing_token_returns_401() {
     );
     assert_eq!(content_type(&response), PROBLEM_JSON);
     // RFC 6750 §3: no credentials were presented, so the challenge carries a
-    // `realm` auth-param but no `error` code.
+    // `realm` auth-param but no `error` code. Exactly one challenge — no dup.
     assert_eq!(
-        www_authenticate(&response),
-        r#"Bearer realm="api""#,
-        "Missing token should emit a WWW-Authenticate challenge"
+        www_authenticate_all(&response),
+        [r#"Bearer realm="api""#],
+        "Missing token should emit a single WWW-Authenticate challenge"
     );
     let problem = problem_from(response).await;
     assert_eq!(problem.problem_type, UNAUTHENTICATED_TYPE);
@@ -973,11 +979,11 @@ async fn test_invalid_token_returns_401() {
     );
     assert_eq!(content_type(&response), PROBLEM_JSON);
     // RFC 6750 §3.1: a token was presented but rejected, so the challenge
-    // carries the `invalid_token` error code.
+    // carries the `invalid_token` error code. Exactly one challenge — no dup.
     assert_eq!(
-        www_authenticate(&response),
-        r#"Bearer error="invalid_token""#,
-        "Invalid token should emit a WWW-Authenticate challenge"
+        www_authenticate_all(&response),
+        [r#"Bearer error="invalid_token""#],
+        "Invalid token should emit a single WWW-Authenticate challenge"
     );
     let problem = problem_from(response).await;
     assert_eq!(problem.problem_type, UNAUTHENTICATED_TYPE);
@@ -1008,7 +1014,7 @@ async fn test_no_plugin_available_returns_503() {
     assert_eq!(content_type(&response), PROBLEM_JSON);
     // A 503 is an infrastructure failure, not a credential rejection, so it
     // must not carry a bearer challenge.
-    assert_eq!(www_authenticate(&response), "");
+    assert!(www_authenticate_all(&response).is_empty());
     let problem = problem_from(response).await;
     assert_eq!(problem.problem_type, SERVICE_UNAVAILABLE_TYPE);
     assert_eq!(problem.context["retry_after_seconds"], 5);
@@ -1039,7 +1045,7 @@ async fn test_service_unavailable_returns_503() {
     assert_eq!(content_type(&response), PROBLEM_JSON);
     // A 503 is an infrastructure failure, not a credential rejection, so it
     // must not carry a bearer challenge.
-    assert_eq!(www_authenticate(&response), "");
+    assert!(www_authenticate_all(&response).is_empty());
     let problem = problem_from(response).await;
     assert_eq!(problem.problem_type, SERVICE_UNAVAILABLE_TYPE);
     assert_eq!(problem.context["retry_after_seconds"], 5);
@@ -1069,7 +1075,7 @@ async fn test_internal_error_returns_500() {
     assert_eq!(content_type(&response), PROBLEM_JSON);
     // A 500 is an infrastructure failure, not a credential rejection, so it
     // must not carry a bearer challenge.
-    assert_eq!(www_authenticate(&response), "");
+    assert!(www_authenticate_all(&response).is_empty());
     let problem = problem_from(response).await;
     assert_eq!(problem.problem_type, INTERNAL_TYPE);
 }
@@ -1222,11 +1228,11 @@ async fn test_insufficient_scope_returns_403_with_challenge() {
     );
     assert_eq!(content_type(&response), PROBLEM_JSON);
     // RFC 6750 §3.1: a valid token lacked the required scope, so the challenge
-    // carries the `insufficient_scope` error code.
+    // carries the `insufficient_scope` error code. Exactly one challenge — no dup.
     assert_eq!(
-        www_authenticate(&response),
-        r#"Bearer error="insufficient_scope""#,
-        "Insufficient scope should emit a WWW-Authenticate challenge"
+        www_authenticate_all(&response),
+        [r#"Bearer error="insufficient_scope""#],
+        "Insufficient scope should emit a single WWW-Authenticate challenge"
     );
     let problem = problem_from(response).await;
     assert_eq!(problem.problem_type, PERMISSION_DENIED_TYPE);
@@ -1256,5 +1262,5 @@ async fn test_wildcard_scope_passes_enforcement() {
         "Wildcard scope should satisfy any route policy"
     );
     // A successful response must not carry a bearer challenge.
-    assert_eq!(www_authenticate(&response), "");
+    assert!(www_authenticate_all(&response).is_empty());
 }


### PR DESCRIPTION
…tokens

Per RFC 6750 §3, a rejected bearer request must carry a WWW-Authenticate challenge. On AuthNResolverError::Unauthorized, append `Bearer error="invalid_token"`; realm and error_description are omitted so the challenge discloses no internal detail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authentication and authorization failure responses to follow RFC 6750.
  * Unauthorized/invalid-token cases now include the correct `WWW-Authenticate: Bearer` challenge.
  * Missing credentials now return an unauthenticated response with `WWW-Authenticate: Bearer realm="api"`.
  * Insufficient-scope denials now include `WWW-Authenticate: Bearer error="insufficient_scope"`.
  * Infrastructure/authn resolver failures (e.g., 500/503) continue to return consistent responses without a bearer challenge (and still include `Retry-After` where applicable).
* **Tests**
  * Added/extended coverage for `WWW-Authenticate` behavior, including scope enforcement outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->