### PR TITLE
fix(ci): make e2e-local and coverage work on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 CI := 1
 
+# Python interpreter used by helper scripts. Defaults to python3 (Linux/macOS);
+# on Windows, where `python3` is often absent, it falls back to `python`.
+# Override explicitly with `make <target> PYTHON=...` if needed.
+PYTHON ?= $(shell command -v python3 2>/dev/null || command -v python 2>/dev/null || echo python3)
+
 OPENAPI_URL ?= http://127.0.0.1:8087/cf/openapi.json
 OPENAPI_OUT ?= docs/api/api.json
 
@@ -114,7 +119,7 @@ endef
 
 # Show the help message with list of commands (default target)
 help:
-	@python3 tools/scripts/make_help.py Makefile
+	@$(PYTHON) tools/scripts/make_help.py Makefile
 
 
 # -------- Set up --------
@@ -139,8 +144,10 @@ setup: .setup-stamp
 	cargo install cargo-hack
 	cargo install gts-validator
 	@if echo "$$OS" | grep -iq windows || [ -n "$$COMSPEC" ]; then \
-		echo "WARNING: kani-verifier and cargo-llvm-cov installation skipped on Windows."; \
-		echo "These tools are not supported on Windows. Use WSL2 or Docker to install instead."; \
+		echo "NOTE: kani-verifier is not supported on Windows; skipping (use WSL2/Docker for Kani)."; \
+		echo "Installing cargo-llvm-cov (supported on Windows; needs llvm-tools-preview)..."; \
+		rustup component add llvm-tools-preview; \
+		cargo install cargo-llvm-cov; \
 		if ! command -v nasm >/dev/null 2>&1; then \
 			echo "Installing NASM (required by aws-lc-sys on Windows)..."; \
 			winget install NASM.NASM --accept-source-agreements --accept-package-agreements || \
@@ -170,7 +177,7 @@ fmt:
 
 ## Validate gear folder names follow kebab-case convention
 validate-gear-names:
-	@python3 tools/scripts/validate_gear_names.py
+	@$(PYTHON) tools/scripts/validate_gear_names.py
 
 # -------- Code safety checks --------
 #
@@ -388,12 +395,12 @@ openapi:
 	mkdir -p $$(dirname "$(OPENAPI_OUT)") && \
 	curl -fsS "$(OPENAPI_URL)" -o "$(OPENAPI_OUT)" && \
 	echo "Sorting OpenAPI JSON for deterministic ordering..." && \
-	python3 tools/scripts/sort_openapi_json.py "$(OPENAPI_OUT)" && \
+	$(PYTHON) tools/scripts/sort_openapi_json.py "$(OPENAPI_OUT)" && \
 	echo "OpenAPI spec saved to $(OPENAPI_OUT)"
 
 ## Generate Markdown files map
 md-fabric:
-	python3 ./tools/scripts/md-fabric.py --out docs/md-fabric/md-fabric.html
+	$(PYTHON) ./tools/scripts/md-fabric.py --out docs/md-fabric/md-fabric.html
 
 ## Build the slides with Marp
 slides:
@@ -555,25 +562,25 @@ e2e: e2e-docker
 
 ## Run E2E tests in Docker environment
 e2e-docker:
-	python3 tools/scripts/ci.py e2e-docker -- $(E2E_TARGET)
+	$(PYTHON) tools/scripts/ci.py e2e-docker -- $(E2E_TARGET)
 
 ## Run E2E smoke tests in Docker (only tests marked @pytest.mark.smoke)
 e2e-docker-smoke:
-	python3 tools/scripts/ci.py e2e-docker -- -m smoke $(E2E_TARGET)
+	$(PYTHON) tools/scripts/ci.py e2e-docker -- -m smoke $(E2E_TARGET)
 
 # Run E2E tests locally, use `make e2e-local E2E_TARGET=testing/e2e/gears/` to specify target
 e2e-local:
-	python3 tools/scripts/ci.py e2e-local -- $(E2E_TARGET)
+	$(PYTHON) tools/scripts/ci.py e2e-local -- $(E2E_TARGET)
 
 ## Run RG + AuthZ barrier E2E tests with tr-authz-plugin going through TR -> RG
 e2e-tr-authz:
-	python3 tools/scripts/ci.py e2e-local \
+	$(PYTHON) tools/scripts/ci.py e2e-local \
 		--config config/e2e-tr-authz.yaml \
 		-- -k "resource_group"
 
 ## Run E2E smoke tests locally (only tests marked @pytest.mark.smoke)
 e2e-local-smoke:
-	python3 tools/scripts/ci.py e2e-local --smoke
+	$(PYTHON) tools/scripts/ci.py e2e-local --smoke
 
 MINI_CHAT_FEATURES = mini-chat,static-authn,static-authz,single-tenant,static-credstore
 MINI_CHAT_K8S_FEATURES = $(MINI_CHAT_FEATURES),k8s
@@ -585,7 +592,7 @@ MINI_CHAT_TAG   ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo latest
 e2e-mini-chat:
 	cargo build --bin cf-gears-example-server --features=$(MINI_CHAT_FEATURES)
 	E2E_BINARY=target/debug/cf-gears-example-server \
-		python3 -m pytest testing/e2e/gears/mini_chat/ --mode offline -vv
+		$(PYTHON) -m pytest testing/e2e/gears/mini_chat/ --mode offline -vv
 
 # -------- Code coverage --------
 
@@ -594,21 +601,21 @@ e2e-mini-chat:
 # Generate code coverage report (unit + e2e-local tests)
 coverage:
 	$(call check_tool,cargo-llvm-cov)
-	python3 tools/scripts/coverage.py combined
+	$(PYTHON) tools/scripts/coverage.py combined
 
 # Generate code coverage report (unit tests only)
 coverage-unit:
 	$(call check_tool,cargo-llvm-cov)
-	python3 tools/scripts/coverage.py unit
+	$(PYTHON) tools/scripts/coverage.py unit
 
 ## Ensure needed packages and programs installed for local e2e testing
 check-prereq-e2e-local:
-	python3 tools/scripts/check_local_env.py --mode e2e-local
+	$(PYTHON) tools/scripts/check_local_env.py --mode e2e-local
 
 # Generate code coverage report (e2e-local tests only)
 coverage-e2e-local: check-prereq-e2e-local
 	$(call check_tool,cargo-llvm-cov)
-	python3 tools/scripts/coverage.py e2e-local
+	$(PYTHON) tools/scripts/coverage.py e2e-local
 
 # -------- Fuzzing --------
 

--- a/README.md
+++ b/README.md
@@ -230,13 +230,25 @@ make coverage-unit   # unit test code coverage
 make fuzz            # fuzz smoke tests (30 s per target)
 ```
 
-On **Windows** (no `make`), use the cross-platform CI script directly:
+On **Windows** (no `make`), use the cross-platform Python scripts directly
+(invoke them with `python`; `python3` is often absent on Windows):
 
 ```bash
 python tools/scripts/ci.py check          # full CI suite
 python tools/scripts/ci.py e2e-local      # end-to-end tests
 python tools/scripts/ci.py e2e-local -- testing/e2e/gears/file_parser/  # targeted end-to-end scope
 python tools/scripts/ci.py fuzz --seconds 60  # fuzz smoke run
+
+python tools/scripts/coverage.py unit      # unit-test code coverage
+python tools/scripts/coverage.py combined  # unit + e2e-local coverage
+```
+
+These scripts need a few prerequisites on Windows:
+
+```bash
+pip install -r testing/e2e/requirements.txt   # pytest + httpx (e2e tests)
+pip install -r testing/requirements.txt        # PyYAML + requests (coverage.py)
+cargo install cargo-llvm-cov                    # coverage backend (or run `make setup`)
 ```
 
 For the complete test strategy, coverage policy, CI pipeline details, and all

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -248,6 +248,26 @@ python scripts/ci.py fuzz --seconds 60  # fuzz smoke run
 python scripts/ci.py fuzz-run fuzz_odata_filter --seconds 300  # single target
 ```
 
+> The helper scripts live under `tools/scripts/` (e.g.
+> `python tools/scripts/ci.py ...`). On Windows invoke them with `python`
+> (the `python3` alias is frequently absent).
+
+Code coverage is produced by a separate script, `coverage.py`:
+
+```bash
+python tools/scripts/coverage.py unit       # unit-test coverage
+python tools/scripts/coverage.py e2e-local  # e2e-local coverage
+python tools/scripts/coverage.py combined   # unit + e2e-local (== make coverage)
+```
+
+Prerequisites (install once; `make setup` handles these on supported hosts):
+
+```bash
+pip install -r testing/e2e/requirements.txt   # pytest + httpx (e2e tests)
+pip install -r testing/requirements.txt        # PyYAML + requests (coverage.py)
+cargo install cargo-llvm-cov                    # coverage backend (works on Windows too)
+```
+
 ### 7.2 Makefile shortcuts (Unix / Linux / macOS)
 
 The `Makefile` wraps the same operations for convenience:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -53,7 +53,7 @@ make all                   # full pipeline (build + check + test-sqlite + e2e-lo
 ### 2.1 Threshold
 
 The project-wide **line-coverage threshold is 80 %**.  The threshold is enforced in
-`scripts/coverage.py` (`COVERAGE_THRESHOLD`) and printed as a warning when any gear
+`tools/scripts/coverage.py` (`COVERAGE_THRESHOLD`) and printed as a warning when any gear
 or library falls below it.
 
 ### 2.2 Coverage modes
@@ -224,33 +224,32 @@ See [`fuzz/README.md`](../tools/fuzz/README.md) for corpus management and crash 
 
 ## 7. CI / Development Commands
 
-Gears uses a unified, cross-platform Python CI script (`scripts/ci.py`).
+Gears uses a unified, cross-platform Python CI script (`tools/scripts/ci.py`).
 This is the **primary entry point on Windows** where `make` is not available.
 Requires Python 3.9+.
 
-### 7.1 Cross-platform commands (`scripts/ci.py`)
+### 7.1 Cross-platform commands (`tools/scripts/ci.py`)
 
 ```bash
-python scripts/ci.py all            # build + full check suite + e2e
-python scripts/ci.py check          # fmt, clippy, test, audit, deny
-python scripts/ci.py fmt            # check formatting
-python scripts/ci.py fmt --fix      # auto-format code
-python scripts/ci.py clippy         # run linter
-python scripts/ci.py clippy --fix   # attempt to fix warnings
-python scripts/ci.py dylint         # custom project compliance lints
-python scripts/ci.py audit          # security audit
-python scripts/ci.py deny           # license & dependency checks
-python scripts/ci.py e2e-local      # build server + run E2E tests locally
-python scripts/ci.py e2e-local --smoke  # E2E smoke subset only
-python scripts/ci.py e2e-docker     # E2E in Docker
-python scripts/ci.py fuzz-build     # build fuzz targets
-python scripts/ci.py fuzz --seconds 60  # fuzz smoke run
-python scripts/ci.py fuzz-run fuzz_odata_filter --seconds 300  # single target
+python tools/scripts/ci.py all            # build + full check suite + e2e
+python tools/scripts/ci.py check          # fmt, clippy, test, audit, deny
+python tools/scripts/ci.py fmt            # check formatting
+python tools/scripts/ci.py fmt --fix      # auto-format code
+python tools/scripts/ci.py clippy         # run linter
+python tools/scripts/ci.py clippy --fix   # attempt to fix warnings
+python tools/scripts/ci.py dylint         # custom project compliance lints
+python tools/scripts/ci.py audit          # security audit
+python tools/scripts/ci.py deny           # license & dependency checks
+python tools/scripts/ci.py e2e-local      # build server + run E2E tests locally
+python tools/scripts/ci.py e2e-local --smoke  # E2E smoke subset only
+python tools/scripts/ci.py e2e-docker     # E2E in Docker
+python tools/scripts/ci.py fuzz-build     # build fuzz targets
+python tools/scripts/ci.py fuzz --seconds 60  # fuzz smoke run
+python tools/scripts/ci.py fuzz-run fuzz_odata_filter --seconds 300  # single target
 ```
 
-> The helper scripts live under `tools/scripts/` (e.g.
-> `python tools/scripts/ci.py ...`). On Windows invoke them with `python`
-> (the `python3` alias is frequently absent).
+> On Windows, invoke these helpers with `python` (the `python3` alias is
+> frequently absent).
 
 Code coverage is produced by a separate script, `coverage.py`:
 

--- a/tools/scripts/ci.py
+++ b/tools/scripts/ci.py
@@ -359,10 +359,23 @@ def cmd_e2e(args):
         print("Starting cf-gears-server for local E2E...")
 
         # Build only the release binary required for local execution.
+        # Invoke cargo directly (mirrors the Makefile `cargo-build` target)
+        # instead of shelling out to `make`, which is unavailable on Windows
+        # where this script is the documented entry point.
         step("Building release binary for local E2E")
-        run_cmd(["make", "cargo-build"])
+        build_cmd = [
+            "cargo",
+            "build",
+            "--release",
+            "--bin",
+            "cf-gears-example-server",
+        ]
+        e2e_features = read_e2e_features(Path(PROJECT_ROOT))
+        if e2e_features:
+            build_cmd.extend(["--features", e2e_features])
+        run_cmd(build_cmd)
 
-        # Use the release binary produced by cargo-build
+        # Use the release binary produced by the cargo build above
         release_bin = str(find_binary(
             Path(PROJECT_ROOT) / "target", "release", "cf-gears-example-server"
         ))

--- a/tools/scripts/ci.py
+++ b/tools/scripts/ci.py
@@ -13,6 +13,7 @@ from urllib.error import URLError, HTTPError
 sys.path.insert(0, os.path.dirname(__file__))
 
 from lib.platform import (
+    e2e_env_overrides,
     find_binary,
     kill_port_holder,
     popen_new_group,
@@ -206,7 +207,10 @@ def _print_log_file(path, label):
     try:
         if "../" in path or "..\\" in path:
             raise Exception("Invalid file path")
-        with open(path) as f:
+        # Logs may contain non-ASCII bytes; force UTF-8 and never let a
+        # decode error mask the server output we are trying to surface
+        # (Python defaults to cp1252 on Windows, which raises on such bytes).
+        with open(path, encoding="utf-8", errors="replace") as f:
             content = f.read()
             if content:
                 print(content, end="" if content.endswith("\n") else "\n")
@@ -410,6 +414,11 @@ def cmd_e2e(args):
             # Set RUST_LOG to enable debug logging for types_registry module
             server_env = os.environ.copy()
             server_env["RUST_LOG"] = "types_registry=debug,info"
+            # Apply per-OS server config overrides (e.g. grpc-hub TCP on
+            # Windows, where the config's UDS address is unsupported).
+            # setdefault keeps any explicit user-provided override.
+            for key, value in e2e_env_overrides().items():
+                server_env.setdefault(key, value)
             try:
                 server_process = popen_new_group(
                     server_cmd,

--- a/tools/scripts/coverage.py
+++ b/tools/scripts/coverage.py
@@ -696,6 +696,11 @@ def check_port_available(port):
 
 
 def get_llvm_cov_env():
+    # `show-env --sh` emits POSIX `export KEY='value'` lines. Values are
+    # single-quoted, so parsing with shlex(posix=True) preserves Windows
+    # backslash paths verbatim (single quotes are literal in POSIX) -- this
+    # parser is therefore cross-platform; do not switch to a backslash-aware
+    # mode that would corrupt these paths.
     result = run_cmd_capture(
         ["cargo", "llvm-cov", "show-env", "--sh"],
         cwd=PROJECT_ROOT,

--- a/tools/scripts/coverage.py
+++ b/tools/scripts/coverage.py
@@ -22,6 +22,7 @@ import yaml
 # Import prereq gear for environment validation
 from lib.prereq import check_environment_ready
 from lib.platform import (
+    e2e_env_overrides,
     find_binary,
     popen_new_group,
     read_e2e_features,
@@ -783,6 +784,12 @@ def start_instrumented_server(config_file, output_dir, port=None):
     target_dir = PROJECT_ROOT / "target" / "llvm-cov-target"
     env2["CARGO_TARGET_DIR"] = str(target_dir)
     env2["LLVM_PROFILE_FILE"] = str(target_dir / "cf-gears-%p-%m.profraw")
+
+    # Apply per-OS server config overrides (e.g. grpc-hub TCP on Windows,
+    # where the config's UDS address is unsupported). setdefault keeps any
+    # explicit user-provided override.
+    for key, value in e2e_env_overrides().items():
+        env2.setdefault(key, value)
 
     build_instrumented_server(env2, target_dir)
 

--- a/tools/scripts/lib/platform.py
+++ b/tools/scripts/lib/platform.py
@@ -8,6 +8,7 @@ import os
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -33,6 +34,40 @@ def read_e2e_features(project_root: Path) -> str:
         )
         sys.exit(1)
     return p.read_text(encoding="utf-8").strip()
+
+
+# ---------------------------------------------------------------------------
+# E2E server environment overrides
+# ---------------------------------------------------------------------------
+
+def e2e_env_overrides() -> dict:
+    """Environment overrides required to launch the e2e server on this OS.
+
+    The committed e2e configs (``config/e2e-local.yaml`` etc.) bake in two
+    Unix-only values that the gears reject at startup on Windows:
+
+    * grpc-hub listens on a Unix Domain Socket (``uds:///tmp/...``).
+    * file-parser sandboxes local reads under ``/tmp``.
+
+    Rather than fork the YAML (and change Linux/macOS behaviour, where these
+    values are intentional), we override just those two values via the app's
+    figment env layer (``APP__<SECTION>__<KEY>...``):
+
+    * grpc-hub → ephemeral loopback TCP, which works on every platform; gear
+      clients resolve the bound address in-process through the directory.
+    * file-parser → the OS temp directory, which exists and is writable.
+
+    Returns an empty mapping on non-Windows hosts so Unix runs are untouched.
+    """
+    if not IS_WINDOWS:
+        return {}
+    # Forward slashes: accepted by std::path on Windows and avoid any
+    # backslash-escaping ambiguity when the value flows through config layers.
+    temp_dir = tempfile.gettempdir().replace("\\", "/")
+    return {
+        "APP__GEARS__GRPC-HUB__CONFIG__LISTEN_ADDR": "127.0.0.1:0",
+        "APP__GEARS__FILE-PARSER__CONFIG__ALLOWED_LOCAL_BASE_DIR": temp_dir,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tools/scripts/lib/prereq.py
+++ b/tools/scripts/lib/prereq.py
@@ -414,7 +414,7 @@ class PrereqCargo(Prereq):
 class PrereqPython(Prereq):
     def __init__(self):
         super().__init__(
-            name="python3 is installed",
+            name="python3/python is installed",
             remediation=(
                 "Install Python 3 from https://python.org/ "
                 "or using a package manager like Homebrew: "
@@ -423,24 +423,22 @@ class PrereqPython(Prereq):
         )
 
     def check(self):
-        # Check if python3 is installed
-        try:
-            subprocess.check_output(
-                ["python3", "--version"], stderr=subprocess.DEVNULL
-            )
-            return PRECHECK_OK
-        except subprocess.CalledProcessError:
-            logging.error(
-                "python3 is not installed or not working properly"
-            )
-            logging.error(f"Possible remediation: {self.remediation}")
-            return PRECHECK_ERROR
-        except FileNotFoundError:
-            logging.error(
-                "'python3' command not found"
-            )
-            logging.error(f"Possible remediation: {self.remediation}")
-            return PRECHECK_ERROR
+        # `python3` is the canonical name on Linux/macOS, but Windows ships
+        # only `python`. Accept either so the e2e/coverage scripts (which
+        # auto-detect the interpreter) pass this check on Windows too.
+        for exe in ("python3", "python"):
+            try:
+                subprocess.check_output(
+                    [exe, "--version"], stderr=subprocess.DEVNULL
+                )
+                return PRECHECK_OK
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                continue
+        logging.error(
+            "no working 'python3' or 'python' interpreter found"
+        )
+        logging.error(f"Possible remediation: {self.remediation}")
+        return PRECHECK_ERROR
 
 
 class PrereqPytest(Prereq):


### PR DESCRIPTION
## What

Make the two test entry points from #2730 — `make e2e-local` and `make coverage` — actually work on Windows. The repo had no `make` on Windows, and the documented Python entry points (`tools/scripts/ci.py`, `tools/scripts/coverage.py`) were broken in several Windows-specific ways. This branch fixes them end-to-end and was verified by really running the flows on Windows 11.

## Changes

**Build / entry points (commit `d6e95d7`)**
- `ci.py e2e-local` built the release binary directly with `cargo` instead of shelling out to `make cargo-build` (absent on Windows).
- `Makefile`: `PYTHON` variable auto-detects `python3`/`python` so targets work where only `python` exists.
- `make setup` now installs `cargo-llvm-cov` on Windows (it is supported; needs `llvm-tools-preview`); only Kani stays skipped.
- README / `docs/TESTING.md`: documented the Windows invocation and Python prerequisites.

**Server startup / runtime (commit `bf3eab2`)**
The build and entry points then worked, but the e2e server still failed to start on Windows because `config/e2e-local.yaml` bakes in two Unix-only values the gears reject at startup:
- grpc-hub listens on a Unix Domain Socket (`uds:///tmp/...`) — explicitly rejected on Windows.
- file-parser sandboxes local reads under `/tmp` — does not exist on Windows (canonicalization fails, `os error 2`).

Rather than fork the committed YAML (UDS is intentional on Linux/macOS), these two values are overridden **only on Windows** via the app's figment env layer (`APP__GEARS__...`): grpc-hub → ephemeral loopback TCP (`127.0.0.1:0`; gear clients resolve the bound address in-process via the directory), file-parser → the OS temp dir. Implemented as `e2e_env_overrides()` in `lib/platform.py` (returns `{}` on non-Windows, so Linux/macOS behaviour is untouched) and applied in `ci.py` and `coverage.py`.

Plus two Windows-only paper cuts found while verifying:
- `ci.py _print_log_file` read server logs with the locale default codec (cp1252 on Windows) and crashed with `UnicodeDecodeError`, masking the real server error → now UTF-8 with `errors="replace"`.
- The coverage env precheck (`lib/prereq.py`) hard-required `python3`, which Windows does not ship → now accepts `python` too.

## Verification (Windows 11, native, no WSL)

| Flow | Result |
|------|--------|
| `python tools/scripts/ci.py e2e-local` | ✅ 248 passed, 393 skipped, exit 0 |
| `python tools/scripts/coverage.py e2e-local` | ✅ HTML/LCOV/JSON/text reports generated, exit 0 |
| `python tools/scripts/coverage.py combined` (== `make coverage`) | ✅ unit coverage + e2e (248 passed) + reports, exit 0 |

Prerequisites used on Windows: Rust stable, Python 3.12, `protoc`, NASM + CMake (for `aws-lc-rs`), `cargo-llvm-cov` (+ `llvm-tools-preview`).

## Note

`testing/e2e/gears/oagw/test_websocket.py::test_websocket_rapid_small_message_burst` is an occasional flake on Windows (~1 in 10 here): the Python test client and the hand-rolled raw-asyncio mock upstream run on Windows' Proactor event loop, which intermittently raises `WinError 64` (connection reset) under the 150-frame burst. The Rust OAGW relay itself is correct and platform-agnostic — this is pre-existing test-infrastructure flakiness on Windows, not introduced by this PR, and is left out of scope here.

Closes #2730


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Python interpreter detection to work with either `python3` or `python` across helper scripts and CI tasks.
  * Enhanced cross-platform behavior for E2E and coverage runs on Windows, including safer environment handling and more reliable log output.
  * Updated the Windows `make setup` flow to use the appropriate `cargo-llvm-cov` installation approach.

* **Documentation**
  * Refreshed Windows testing instructions with clearer command blocks and added coverage/e2e prerequisites guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->