### PR TITLE
docs(security): fix FIPS 140-3 doc

### DIFF
--- a/docs/security/SECURITY.md
+++ b/docs/security/SECURITY.md
@@ -400,13 +400,13 @@ The project uses `aws-lc-rs` (via `rustls`) as its primary TLS cryptographic bac
 
 ### FIPS-140-3 build (`--features fips`)
 
-Gears applications can be built with FIPS 140-3 validated cryptography by enabling the `fips` feature flag on `cf-gears-toolkit`, `cf-gears-toolkit-http`, and any binary that ships TLS. A single feature flag selects a per-target CMVP-validated backend behind one shared `rustls 0.23` TLS state machine:
+Gears applications can be built with FIPS-validated cryptography by enabling the `fips` feature flag on `cf-gears-toolkit`, `cf-gears-toolkit-http`, and any binary that ships TLS. A single feature flag selects a per-target CMVP-validated backend behind one shared `rustls 0.23` TLS state machine. The TLS data plane routes through a **FIPS 140-3** validated module on Linux and macOS; on Windows it is currently **FIPS 140-2** (140-3 in CMVP processing — see the per-target table and [What this does NOT claim](#what-this-does-not-claim)):
 
-| Target | Validated gear | How it routes |
+| Target | Validated module | How it routes |
 |---|---|---|
-| Linux (x86_64, aarch64) | **AWS-LC FIPS Provider v2** — CMVP cert [#4816](https://csrc.nist.gov/projects/cryptographic-gear-validation-program/certificate/4816) | `rustls/fips` + `aws-lc-fips-sys`; activated via target-gated shim `cf-gears-rustls-fips-shim` |
-| macOS (any arch) | **Apple corecrypto User-Space Gear** — per-macOS-major CMVP cert (search by *"Apple corecrypto Gear"* on the [CMVP database](https://csrc.nist.gov/projects/cryptographic-gear-validation-program/validated-gears/search)) | In-tree `cf-gears-rustls-corecrypto-provider` over `Security.framework` + `CommonCrypto` |
-| Windows (x86_64) | **Microsoft Windows CNG** (`bcrypt.dll`) — per-Windows-build CMVP cert | Community `rustls-cng-crypto` (caret-pinned `0.1.x`); requires OS-level FIPS-mode via `HKLM\System\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy = 1` |
+| Linux (x86_64, aarch64) | **AWS-LC FIPS Provider v2** — CMVP cert [#4816](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4816) (FIPS 140-3) | `rustls/fips` + `aws-lc-fips-sys`; activated via target-gated shim `cf-gears-rustls-fips-shim` |
+| macOS (any arch) | **Apple corecrypto User-Space Module** — per-macOS-major CMVP cert (search by *"Apple corecrypto Module"* on the [CMVP database](https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search)) | In-tree `cf-gears-rustls-corecrypto-provider` over `Security.framework` + `CommonCrypto` |
+| Windows (x86_64) | **Microsoft Windows CNG** — Cryptographic Primitives Library (`bcryptprimitives.dll`, loaded via `bcrypt.dll`); per-Windows-build CMVP cert, currently **FIPS 140-2** validated (**FIPS 140-3 in CMVP processing** — see [What this does NOT claim](#what-this-does-not-claim)) | Community `rustls-cng-crypto` (caret-pinned `0.1.x`); requires OS-level FIPS-mode via `HKLM\System\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy = 1` |
 
 ```sh
 cargo build -p cf-gears-server --features fips
@@ -418,7 +418,7 @@ cargo build -p cf-gears-server --features fips
 
 | Target | Toolchain |
 |---|---|
-| Linux + `fips` | C toolchain, `cmake`, `perl`, `go` (required by `aws-lc-fips-sys` build script — gear integrity checks) |
+| Linux + `fips` | C toolchain, `cmake`, `perl`, `go` (required by `aws-lc-fips-sys` build script — module integrity checks) |
 | macOS + `fips` | Xcode Command Line Tools + Rust toolchain. No `cmake` / `perl` / `go`. The per-target shim excludes `aws-lc-fips-sys` from the macOS build graph entirely. |
 | Windows + `fips` (native) | MSVC + Windows SDK. No `cmake` / `perl` / `go`. CNG is loaded at runtime from `bcrypt.dll`. |
 | Windows + `fips` (cross-compile from Linux/macOS) | `cargo install cargo-xwin` plus `ninja`. See `make check-windows-fips`. |
@@ -434,7 +434,7 @@ Under `--features fips`, the `ClientHello` and `ServerHello` offer **only** FIPS
 | TLS 1.2 cipher suites | `ECDHE_{ECDSA,RSA}_WITH_AES_{128,256}_GCM_SHA{256,384}` (×4 — Linux + Windows only) |
 | Key exchange | NIST P-256, P-384 ECDHE |
 | Signature verify | ECDSA P-256/P-384/P-521, RSA-PSS, RSA PKCS#1 v1.5 (SHA-256/384/512) |
-| Signature sign (server-side / mTLS) | Same scope as verify; routed through the validated gear (`SecKeyCreateSignature` on macOS, `BCryptSignHash` on Windows, `EVP_PKEY_sign` on Linux) |
+| Signature sign (server-side / mTLS) | Same scope as verify; routed through the validated module (`SecKeyCreateSignature` on macOS, `BCryptSignHash` on Windows, `EVP_PKEY_sign` on Linux) |
 | Hash / HMAC / HKDF | SHA-256, SHA-384 (HKDF is an Approved KDF per NIST SP 800-56C) |
 | TLS 1.2 Extended Master Secret (RFC 7627) | **required** (`require_ems = true`) per NIST SP 800-52 Rev. 2 §3.5 |
 | RSA modulus floor | ≥ 2048 bits (NIST FIPS 186-5 §5.1) — enforced at server-side key load on macOS |
@@ -494,7 +494,7 @@ Any residual `sha2` / `rand` usage in the tree is **non-cryptographic** and is *
 
 Before relying on the FIPS claim in a deployment:
 
-- **OS FIPS mode** — confirm the OS is in an approved state: Windows `HKLM\System\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy = 1`; macOS major version inside [`SUPPORTED_OE_MACOS_MAJOR`](../../libs/rustls-corecrypto-provider/src/oe.rs); Linux OE inside CMVP cert [#4816](https://csrc.nist.gov/projects/cryptographic-gear-validation-program/certificate/4816).
+- **OS FIPS mode** — confirm the OS is in an approved state: Windows `HKLM\System\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy = 1`; macOS major version inside [`SUPPORTED_OE_MACOS_MAJOR`](../../libs/rustls-corecrypto-provider/src/oe.rs); Linux OE inside CMVP cert [#4816](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4816).
 - **Static-linkage check** — run the linkage smoke (`otool -L` on macOS, `dumpbin /imports` on Windows) and confirm only the OS-supplied / validated crypto module is loaded — see [How to verify a build is FIPS-conformant](#how-to-verify-a-build-is-fips-conformant).
 - **No-sccache FIPS build job** — build the FIPS provider in a dedicated CI job with `sccache` disabled, so AWS-LC FIPS integrity / self-test artifacts are produced fresh rather than served from a compilation cache.
 
@@ -506,7 +506,7 @@ The Windows CNG FIPS provider only enforces its FIPS-Approved algorithm subset w
 reg add HKLM\System\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy /v Enabled /t REG_DWORD /d 1 /f
 ```
 
-A reboot is required after either change. See Microsoft's [FIPS 140 validation reference](https://learn.microsoft.com/en-us/windows/security/threat-protection/fips-140-validation) for the authoritative posture documentation.
+A reboot is required after either change. See Microsoft's [FIPS 140 validation reference](https://learn.microsoft.com/en-us/windows/security/security-foundations/certification/fips-140-validation) for the authoritative posture documentation.
 
 ### How to verify a build is FIPS-conformant
 
@@ -545,12 +545,13 @@ See [`examples/cf-gears-fips-probe/README.md`](../../examples/cf-gears-fips-prob
 
 ### What this does NOT claim
 
-- **Gears list itself is not on the CMVP Validated Gears list.** The validated gears are Apple corecrypto, AWS-LC FIPS Provider, and Microsoft Windows CNG. Gears are *consumers* of those gears.
+- **Gears itself is not on the CMVP Validated Modules list.** The validated modules are Apple corecrypto, AWS-LC FIPS Provider, and Microsoft Windows CNG. Gears are *consumers* of those modules.
+- **The Windows path is FIPS 140-2 today, not 140-3.** The Windows CNG module that Gears routes through — the Cryptographic Primitives Library (`bcryptprimitives.dll`) — holds a CMVP **FIPS 140-2** certificate per Windows build; Microsoft's FIPS 140-3 validation of the Windows cryptographic modules is still in CMVP processing. A `--features fips` Windows binary therefore carries a **140-2** claim on the TLS data plane until the 140-3 certificate is issued. Linux (AWS-LC, cert [#4816](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4816)) and macOS (Apple corecrypto) carry **140-3** claims.
 - **CMVP OE-coverage is the deployment's responsibility.** A FIPS claim is void if the running OS version is not inside the cert's OE. The macOS runtime gate is fail-closed; Linux + Windows OE coverage is verified manually per release.
 - **`CryptoProvider::fips() = true` is a runtime witness, not just design intent.** On macOS it reflects the OE check (`oe::fips_witness_ok`); on Windows, the OS FIPS-mode flag. On Linux, runtime OE-validation is not yet implemented; OE coverage is verified manually per release via the §release-checklist CMVP-cert search.
 - **TLS 1.2 PRF on macOS is not CAVS-listed.** Apple corecrypto exposes generic HMAC primitives but not a CAVS-listed dedicated TLS PRF (unlike `aws-lc-fips`'s `tls_prf::Algorithm`). Consequence: `fips_provider()` on macOS is TLS-1.3-only; customers requiring TLS 1.2 on macOS+FIPS must accept that those connections do not carry a FIPS claim.
 - **JWT signature validation does not go through the FIPS path.** `jsonwebtoken` uses `ring` / non-FIPS `aws-lc-rs` for RSA / ECDSA verification on bearer tokens. Treat tokens as authentication context, not as data covered by the cryptographic claim. Out of scope today; tracked as **TODO-7** in [FIPS PRD §13](fips/PRD.md#13-open-questions). Cleanup is gated by `deny-fips.toml` Phase B promotion.
-- **Non-FIPS crypto crates remain in the final binary on macOS+fips.** `ring` is pulled in transitively by `pingora-rustls`, `pingora-pool`, and `ureq`; non-FIPS `aws-lc-rs` is pulled in by rustls's default feature set; `chacha20` is pulled in by the `rand` ecosystem. These are **not invoked** on the TLS data plane (the installed `CryptoProvider` routes every TLS primitive through the validated gear) but the symbols are linked into the binary. Linkage smoke (above) confirms no non-validated shared libraries appear at runtime.
+- **Non-FIPS crypto crates remain in the final binary on macOS+fips.** `ring` is pulled in transitively by `pingora-rustls`, `pingora-pool`, and `ureq`; non-FIPS `aws-lc-rs` is pulled in by rustls's default feature set; `chacha20` is pulled in by the `rand` ecosystem. These are **not invoked** on the TLS data plane (the installed `CryptoProvider` routes every TLS primitive through the validated module) but the symbols are linked into the binary. Linkage smoke (above) confirms no non-validated shared libraries appear at runtime.
 - **Server-side TLS keys load from PEM/DER bytes by default.** The bytes transit user-space memory before reaching `SecKeyCreateWithData` / `BCryptImportKeyPair` / `EVP_PKEY_new`. Strict-FIPS auditors operating under "no plaintext CSPs outside the boundary" require a Keychain / NCrypt / HSM flow; tracked as **TODO-1**.
 - **Server-side TLS termination (inbound HTTPS) is out of scope.** The FIPS scope here covers the toolkit's outbound TLS data path; inbound HTTPS termination is delegated to the reverse proxy in front of the gear and is the deployment's responsibility.
 - **The wrapper crates are not themselves CMVP-listed.** Neither `rustls-cng-crypto` nor `cf-gears-rustls-corecrypto-provider` is a CMVP-validated module — each is a thin wrapper over the validated system module it consumes (Windows CNG and Apple corecrypto respectively). The chain-of-trust comes from the underlying validated module, not the wrapper crate.
@@ -649,7 +650,7 @@ This ensures every new service or gear repository starts with the same defense-i
 
 The following areas have been identified for future hardening:
 
-1. **FIPS-140-3 — non-TLS crypto cleanup** — the `--features fips` build routes the **TLS data plane** through a CMVP-validated gear on Linux, macOS, and Windows (see §9). Open items, tracked in the [FIPS PRD §13](fips/PRD.md#13-open-questions):
+1. **FIPS-140-3 — non-TLS crypto cleanup** — the `--features fips` build routes the **TLS data plane** through a CMVP-validated module on Linux, macOS, and Windows (see §9). Open items, tracked in the [FIPS PRD §13](fips/PRD.md#13-open-questions):
    - **TODO-7** — JWT signature validation (`jsonwebtoken`) currently uses `ring` / non-FIPS `aws-lc-rs`. Audit the surface and either replace upstream, fork, or restrict JWT to symmetric HMAC. Build-time floor enforced via [`deny-fips.toml`](../../deny-fips.toml) Phase B promotion.
    - **TODO-8** — Runtime Operational Environment validation on Linux + Windows (macOS already has a sysctl-based fail-closed gate). Today OE coverage on Linux + Windows is verified manually per release via CMVP cert search.
    - **TODO-1** — Keychain / NCrypt / HSM-stored private keys for server-side TLS (today's PEM/DER load is acceptable for development and most production deployments where filesystem permissions guard the key).

--- a/docs/security/fips/PRD.md
+++ b/docs/security/fips/PRD.md
@@ -49,7 +49,7 @@ the ADRs in [`adrs/`](adrs/).
 
 | Term        | Definition                                                                                                                                                            |
 |-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| CMVP        | Cryptographic Gear Validation Program (NIST) — the validation regime that produces FIPS 140-3 certificates.                                                         |
+| CMVP        | Cryptographic Module Validation Program (NIST) — the validation regime that produces FIPS 140-3 certificates.                                                         |
 | OE          | Operational Environment — the specific OS version + hardware combination listed on a CMVP certificate. A binary running outside the OE has no valid FIPS claim.       |
 | CAVS        | Cryptographic Algorithm Validation System — NIST's per-algorithm test program. CAVS validation is one prerequisite for the composite CMVP module certification.       |
 | corecrypto  | Apple's user-space cryptographic module, CMVP-validated per macOS release. Accessed via `Security.framework` / `CommonCrypto`.                                        |
@@ -93,7 +93,7 @@ the ADRs in [`adrs/`](adrs/).
 
 ### 2.2 System Actors
 
-#### CMVP Gear (Apple corecrypto / AWS-LC FIPS / Windows CNG)
+#### CMVP Module (Apple corecrypto / AWS-LC FIPS / Windows CNG)
 
 **ID**: `cpt-toolkit-fips-actor-cmvp-module`
 
@@ -150,7 +150,7 @@ engineering.
 
 ### 4.2 Out of Scope
 
-- **Gears themselves on the CMVP Validated Gears list.** Gears are consumers of validated modules; the validated
+- **Gears themselves on the CMVP Validated Modules list.** Gears are consumers of validated modules; the validated
   modules are Apple corecrypto, AWS-LC FIPS Provider, and Microsoft Windows CNG.
 - **Non-TLS crypto in the binary.** JWT signature validation (`jsonwebtoken`) uses `ring` / non-FIPS
   `aws-lc-rs`. `ring`, non-FIPS `aws-lc-rs`, and `chacha20` are linked into the macOS+fips binary via transitive deps
@@ -400,12 +400,12 @@ TLS state machine. Only the crypto-primitive backend behind a `cfg` branch MUST 
 
 #### CMVP-validated module ABI
 
-- [ ] `p1` - **ID**: `cpt-toolkit-fips-contract-cmvp-gear-abi`
+- [ ] `p1` - **ID**: `cpt-toolkit-fips-contract-cmvp-module-abi`
 
 - **Direction**: required from external system.
 - **Protocol/Format**: Apple `Security.framework` / `CommonCrypto` (macOS), `bcrypt.dll` / `ncrypt.dll` (Windows),
   AWS-LC C ABI (Linux).
-- **Compatibility**: Each gear's ABI is stable per OS major version; Apple, Microsoft, and AWS Labs publish a new CMVP
+- **Compatibility**: Each module's ABI is stable per OS major version; Apple, Microsoft, and AWS Labs publish a new CMVP
   cert per OS major release. The Gears code adapts via the per-target `CryptoProvider` integration; binary
   compatibility is maintained by re-linking against the OS-supplied module at run time.
 
@@ -549,7 +549,7 @@ TLS state machine. Only the crypto-primitive backend behind a `cfg` branch MUST 
 | `rustls-cng-crypto` is a single-maintainer young crate; upstream may stagnate                | Windows FIPS posture loses upstream maintenance                                                              | Caret-pin to `0.1.x`; migration path to `rustls-symcrypt` documented in [ADR 0003](adrs/0003-windows-fips-via-rustls-cng-crypto.md) as a trigger-based switch |
 | Apple SDK silently changes RSA-PSS salt-length default                                       | TLS 1.3 interop breaks with RFC-compliant peers; FIPS-claim becomes ambiguous                                | Cross-impl regression test `rsa_pss_apple_salt_length_matches_rfc8017` runs on every CI build                                                                 |
 | Transitive dep pulls a banned Phase A crate into a future PR                                 | Build-time FIPS regression                                                                                   | `make fips-policy` is a required CI gate via `make security`; pre-merge `cargo-deny` rejection                                                                |
-| Non-TLS crypto paths (JWT, password hashing) drift further from the validated gear surface | Audit finding: "FIPS claim is not what it says on the tin"                                                   | Phase B of `deny-fips.toml` tracks each non-validated crypto crate currently in graph; TODO-7 tracks the broader audit                                        |
+| Non-TLS crypto paths (JWT, password hashing) drift further from the validated module surface | Audit finding: "FIPS claim is not what it says on the tin"                                                   | Phase B of `deny-fips.toml` tracks each non-validated crypto crate currently in graph; TODO-7 tracks the broader audit                                        |
 | OE-validation cert table goes stale                                                          | Production deployments accept an OS version that has dropped out of the cert's OE                            | Release-checklist explicitly searches the CMVP database per release; TODO-6 tracks automation                                                                 |
 
 ## 13. Open Questions

--- a/docs/security/fips/adrs/0003-windows-fips-via-rustls-cng-crypto.md
+++ b/docs/security/fips/adrs/0003-windows-fips-via-rustls-cng-crypto.md
@@ -33,7 +33,7 @@ Key reasons:
 
 * **Only crate with a CMVP chain-of-trust today.** Thin FFI wrapper over Windows CNG, which Microsoft itself validates per OS release. Chain-of-trust terminates at CNG, the same posture as `cf-gears-rustls-corecrypto-provider` over Apple corecrypto.
 * **Pure FFI, no `build.rs` toolchain.** Links directly against `bcrypt.dll` via `windows-sys`. Cross-compile from Linux/macOS works with `rustup target add x86_64-pc-windows-msvc` (plus `cargo-xwin` on non-Windows hosts for the MSVC sysroot).
-* **Option B (`rustls-symcrypt`) is rejected today** because SymCrypt is not on the CMVP Validated Gears list as of 2026-05. Using it would create the same failure mode we eliminated for macOS in ADR 0001 — a FIPS-mode-flagged binary routing through a non-CMVP-validated module. If/when SymCrypt obtains a CMVP cert, swap is two files (`crypto.rs` + `tls.rs`) plus a workspace dep alias.
+* **Option B (`rustls-symcrypt`) is rejected today** because SymCrypt is not on the CMVP Validated Modules list as of 2026-05. Using it would create the same failure mode we eliminated for macOS in ADR 0001 — a FIPS-mode-flagged binary routing through a non-CMVP-validated module. If/when SymCrypt obtains a CMVP cert, swap is two files (`crypto.rs` + `tls.rs`) plus a workspace dep alias.
 * **Option C is rejected** because cross-OS FIPS is a stated product requirement (PRD §2 F-1, F-4).
 * **Option D is rejected on cost/benefit**: ~1500 LOC of CNG FFI work duplicates what `rustls-cng-crypto` already does, with no audit-trail advantage — CNG itself is the CMVP-validated artifact, the FFI wrapper is reviewable in isolation either way. Reserve for emergency use if upstream is abandoned.
 
@@ -61,7 +61,7 @@ Following the verification gates in [PRD §9](../PRD.md#9-acceptance-criteria):
 * Good: pure FFI (`windows-sys`), no `build.rs` C toolchain on Windows.
 * Good: `fips_provider()` is feature-gated and idiomatically fail-closed (empty provider when FIPS-mode off).
 * Bad: young crate, single maintainer — upstream-stagnation risk, not correctness risk.
-* Bad: not itself on the CMVP Validated Gears list. (Neither is our corecrypto provider; both rely on the OS-native module.)
+* Bad: not itself on the CMVP Validated Modules list. (Neither is our corecrypto provider; both rely on the OS-native module.)
 
 ### Option B — `rustls-symcrypt`
 
@@ -86,7 +86,7 @@ Following the verification gates in [PRD §9](../PRD.md#9-acceptance-criteria):
 ## More Information
 
 * Crate: <https://crates.io/crates/rustls-cng-crypto> / <https://github.com/tofay/rustls-cng-crypto>
-* Microsoft FIPS-mode reference: <https://learn.microsoft.com/en-us/windows/security/threat-protection/fips-140-validation>
+* Microsoft FIPS-mode reference: <https://learn.microsoft.com/en-us/windows/security/security-foundations/certification/fips-140-validation>
 * Wire-level smoke runbook: [`examples/cf-gears-fips-probe/README.md`](../../../../examples/cf-gears-fips-probe/README.md) — "Verify on Windows".
 
 ## Traceability

--- a/docs/security/fips/adrs/0004-macos-server-side-tls-via-corecrypto.md
+++ b/docs/security/fips/adrs/0004-macos-server-side-tls-via-corecrypto.md
@@ -14,7 +14,7 @@ decision-makers: Constructor Fabric Steering Committee
 
 ## Background
 
-This ADR **extends** the macOS provider scope decided in [ADR 0001](0001-macos-fips-via-corecrypto-provider.md). The provider was deliberately client-side-only; this ADR adds server-side `KeyProvider` so a `rustls::ServerConfig` works on macOS+FIPS, and brings the algorithm scope into parity with the Windows path. Cross-OS architecture and the dual `default_provider()` / `fips_provider()` factory pattern are documented in the [FIPS PRD](../PRD.md) (see §3 gear-specific environment constraints and §7 public library interfaces).
+This ADR **extends** the macOS provider scope decided in [ADR 0001](0001-macos-fips-via-corecrypto-provider.md). The provider was deliberately client-side-only; this ADR adds server-side `KeyProvider` so a `rustls::ServerConfig` works on macOS+FIPS, and brings the algorithm scope into parity with the Windows path. Cross-OS architecture and the dual `default_provider()` / `fips_provider()` factory pattern are documented in the [FIPS PRD](../PRD.md) (see §3 module-specific environment constraints and §7 public library interfaces).
 
 ## Context and Problem Statement
 


### PR DESCRIPTION
- Documentation
  - Corrected broken NIST CMVP links in the FIPS 140-3 security documentation and refreshed an outdated Microsoft FIPS validation reference.
  - Restored accurate "Cryptographic Module Validation Program" terminology throughout the FIPS docs, fixing mislabeled references (e.g., "Apple corecrypto Module") while preserving the "Gears" product name.
  - Clarified the Windows cryptographic backend status, identifying the validated module as the Cryptographic Primitives Library (bcryptprimitives.dll) and noting its current FIPS 140-2 validation with FIPS 140-3 in CMVP processing.
  - Added a per-operating-system FIPS validation breakdown to the section introduction and a new caveat clarifying that the Windows TLS path currently carries a FIPS 140-2 claim, while Linux and macOS carry FIPS 140-3 claims.
  - Propagated the same terminology and accuracy fixes across the FIPS PRD and the Windows FIPS architecture decision record.

Closes issue https://github.com/cyberfabric/cyberware-rust/issues/2023