### PR TITLE
fix(toolkit-config): allow k8s env override of gear config via underscore gear names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2246,6 +2246,7 @@ dependencies = [
  "serde",
  "serde-saphyr 0.0.22",
  "serde_json",
+ "serial_test",
  "supports-color",
  "temp-env",
  "tempfile",
@@ -4278,10 +4279,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash 0.8.12",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -6805,7 +6802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91bb5030596a3d442c0866ac68afe29c14ba558e77c726dcdf7016b0dbb359d9"
 dependencies = [
  "arrayvec",
- "hashbrown 0.14.5",
+ "hashbrown 0.17.0",
  "parking_lot",
  "rand 0.8.5",
 ]
@@ -7160,7 +7157,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -8704,6 +8701,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "sfv"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8881,7 +8903,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -514,6 +514,7 @@ proc-macro-error2 = "2.0"
 
 # Testing utilities
 trybuild = "1"
+serial_test = "3"
 criterion = { version = "0.8", default-features = false }
 testcontainers = { version = "0.27", default-features = false, features = ["aws-lc-rs"] }
 testcontainers-modules = { version = "0.15", default-features = false, features = ["aws-lc-rs", "postgres", "mysql"] }

--- a/deny.toml
+++ b/deny.toml
@@ -38,6 +38,7 @@ ignore = [
   "RUSTSEC-2024-0437", # protobuf 2.28 stack overflow — transitive via pingora-core→prometheus 0.13; we never parse untrusted protobuf (prometheus metrics endpoint is unused)
   "RUSTSEC-2023-0071", # Marvin Attack timing sidechannel in rsa 0.9 — dev-only dep of rustls-corecrypto-provider; used solely for RSA-PSS *verification* (public-key op, no private key involved) in rsa_pss_apple_salt_length_matches_rfc8017 test; no safe upgrade available; advisory itself permits "local use on a non-compromised computer"
   "RUSTSEC-2026-0173", # proc-macro-error2 unmaintained — direct dep of our proc-macro crate cf-gears-toolkit-db-macros (compile-time only, never in any runtime artifact); no advisory of a vulnerability, only maintenance status. Tracked for migration to std syn::Error -> compile_error! emission.
+  "RUSTSEC-2026-0187", # lopdf <0.42 unbounded-recursion DoS on crafted PDFs — transitive via kreuzberg→cf-gears-file-parser→cf-gears-example-server (example app only, never parses untrusted PDFs). No usable fix: kreuzberg 4.9.x pins lopdf "^0.41" (<0.42) and the fix landed in 0.42.0; 5.x drops the bundled-pdfium feature we use. Remove once kreuzberg ships a release allowing lopdf >=0.42.
 ]
 
 # Note:

--- a/libs/toolkit-db/src/odata/sea_orm_filter.rs
+++ b/libs/toolkit-db/src/odata/sea_orm_filter.rs
@@ -399,7 +399,7 @@ pub fn encode_cursor_value(value: &sea_orm::Value, kind: FieldKind) -> Result<St
             Ok(dt.to_rfc3339_opts(SecondsFormat::Nanos, true))
         }
         (FieldKind::DateTimeUtc, V::TimeDateTimeWithTimeZone(Some(dt))) => {
-            let fmt = time::format_description::parse(
+            let fmt = time::format_description::parse_borrowed::<2>(
                 "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:9]Z",
             )
             .map_err(|_| "invalid datetime format".to_owned())?;

--- a/libs/toolkit/Cargo.toml
+++ b/libs/toolkit/Cargo.toml
@@ -174,6 +174,7 @@ tower = { workspace = true }
 trybuild = { workspace = true }
 tempfile = { workspace = true }
 temp-env = { workspace = true }
+serial_test = { workspace = true }
 toolkit-db = { workspace = true, features = ["sqlite"] }
 tracing-subscriber = { workspace = true }
 tracing-test = { workspace = true, features = ["no-env-filter"] }

--- a/libs/toolkit/src/bootstrap/config/mod.rs
+++ b/libs/toolkit/src/bootstrap/config/mod.rs
@@ -303,6 +303,29 @@ pub fn default_logging_config() -> LoggingConfig {
     logging
 }
 
+/// Remap a split, `APP__`-prefixed environment key into a figment config path.
+///
+/// k8s env var names must be `C_IDENTIFIERs` (no dashes), but gear names are
+/// kebab-case. Under the `gears` branch we therefore remap `_` -> `-` in the
+/// gear-name segment only (the one right after `gears`). Nested field names
+/// (e.g. `max_age_days`) and other branches (e.g. `vendor`) are left alone; the
+/// dash form is unaffected since remapping `-` is a no-op.
+///
+/// Safe because gear names are guaranteed kebab-case by `validate_kebab_case`
+/// (`#[toolkit::gear]` macro + `make validate-gear-names`).
+pub(crate) fn remap_gear_env_key(key: &str) -> String {
+    // Lowercase so the match is independent of figment's own (later) lowercasing.
+    let lower = key.to_ascii_lowercase();
+    let mut parts: Vec<&str> = lower.split('.').collect();
+    if parts.first() == Some(&"gears") && parts.len() >= 2 {
+        let gear = parts[1].replace('_', "-");
+        parts[1] = gear.as_str();
+        parts.join(".")
+    } else {
+        lower
+    }
+}
+
 impl AppConfig {
     /// Load configuration with layered loading: defaults → YAML file → environment variables.
     /// Also normalizes `server.home_dir` into an absolute path and creates the directory.
@@ -321,8 +344,12 @@ impl AppConfig {
         let figment = Figment::new()
             .merge(Serialized::defaults(AppConfig::default()))
             .merge(StrictYaml::file(config_path))
-            // Example: APP__SERVER__PORT=8087 maps to server.port
-            .merge(Env::prefixed("APP__").split("__"));
+            // Example: APP__SERVER__PORT=8087 maps to server.port.
+            .merge(
+                Env::prefixed("APP__")
+                    .split("__")
+                    .map(|key| remap_gear_env_key(key.as_str()).into()),
+            );
 
         let mut config: AppConfig = figment
             .extract()
@@ -1304,6 +1331,7 @@ pub fn gear_home(app: &AppConfig, gear_name: &str) -> PathBuf {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::fs;
     use temp_env::with_var;
     use tempfile::tempdir;
@@ -1316,6 +1344,39 @@ mod tests {
     /// Helper: platform default subdirectory name.
     fn default_subdir() -> &'static str {
         ".cf-gears"
+    }
+
+    #[test]
+    fn test_remap_gear_env_key() {
+        // (input, expected) — input keys are the dot-joined segments figment
+        // produces after `split("__")`, before its own lowercasing.
+        let cases = [
+            // Gear-name segment: underscores -> dashes.
+            ("gears.my_gear.port", "gears.my-gear.port"),
+            // Only the gear-name segment is remapped; nested fields keep '_'.
+            ("gears.my_gear.max_age_days", "gears.my-gear.max_age_days"),
+            // Multiple underscores in the gear name are all remapped.
+            ("gears.a_b_c.field", "gears.a-b-c.field"),
+            // Already-kebab gear name is unaffected (remapping '-' is a no-op).
+            ("gears.my-gear.port", "gears.my-gear.port"),
+            // Non-gears branches are left alone.
+            ("vendor.my_vendor.key", "vendor.my_vendor.key"),
+            ("server.home_dir", "server.home_dir"),
+            // `gears` with no gear-name segment is left as-is.
+            ("gears", "gears"),
+            // Uppercase input is lowercased.
+            ("GEARS.MY_GEAR.PORT", "gears.my-gear.port"),
+            // Bare key without dots.
+            ("server", "server"),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(
+                remap_gear_env_key(input),
+                expected,
+                "remap_gear_env_key({input:?})"
+            );
+        }
     }
 
     #[test]
@@ -1337,7 +1398,10 @@ mod tests {
         assert!(config.gears.is_empty());
     }
 
+    // `#[serial]`: calls load_layered, which reads the APP__ env layer; serialize
+    // against the env-override tests that mutate process-global APP__* vars.
     #[test]
+    #[serial]
     fn test_load_layered_normalizes_home_dir() {
         let tmp = tempdir().unwrap();
         let cfg_path = tmp.path().join("cfg.yaml");
@@ -1395,7 +1459,10 @@ logging:
         });
     }
 
+    // `#[serial]`: load_layered reads the APP__ env layer, so `gears.is_empty()`
+    // would race with the (also `#[serial]`) env-override tests that set APP__GEARS__*.
     #[test]
+    #[serial]
     fn test_minimal_yaml_config() {
         let tmp = tempdir().unwrap();
         let cfg_path = tmp.path().join("cfg.yaml");
@@ -1467,7 +1534,10 @@ server:
         }
     }
 
+    // `#[serial]`: calls load_layered (reads APP__ env layer) and asserts on the
+    // gears map, which the env-override tests mutate via APP__GEARS__*.
     #[test]
+    #[serial]
     fn test_layered_config_loading_with_gears_dir() {
         let tmp = tempdir().unwrap();
         let cfg_path = tmp.path().join("gears_dir.yaml");
@@ -1515,7 +1585,10 @@ gears:
         assert_eq!(test_gear["setting2"], 42);
     }
 
+    // `#[serial]`: calls load_layered, which reads the APP__ env layer; serialize
+    // against the env-override tests that mutate process-global APP__* vars.
     #[test]
+    #[serial]
     fn test_load_and_init_logging_smoke() {
         // Just verifies structure is acceptable for logging init path.
         let tmp = tempdir().unwrap();
@@ -2869,6 +2942,7 @@ vendor:
     }
 
     #[test]
+    #[serial]
     fn test_vendor_config_env_override() {
         let tmp = tempdir().unwrap();
         let cfg_path = tmp.path().join("cfg.yaml");
@@ -2888,6 +2962,130 @@ vendor:
                 let config = AppConfig::load_layered(&cfg_path).unwrap();
                 let v: TestVendorConfig = config.vendor_config("env_test_vendor").unwrap();
                 assert_eq!(v.api_token, "from_env");
+            },
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_gear_config_env_override_underscore_gear_name() {
+        // k8s-friendly form: gear name uses underscores in the env var name,
+        // which should be remapped to the kebab-case gear key.
+        let tmp = tempdir().unwrap();
+        let cfg_path = tmp.path().join("cfg.yaml");
+        let yaml = r#"
+server:
+  home_dir: "~/.test_gear_env_underscore"
+gears:
+  static-authz-plugin:
+    config:
+      vendor: "from_yaml"
+"#;
+        fs::write(&cfg_path, yaml).unwrap();
+
+        with_var(
+            "APP__GEARS__STATIC_AUTHZ_PLUGIN__CONFIG__VENDOR",
+            Some("acme"),
+            || {
+                let config = AppConfig::load_layered(&cfg_path).unwrap();
+                let gear = config.gears.get("static-authz-plugin").unwrap();
+                assert_eq!(gear["config"]["vendor"], serde_json::json!("acme"));
+            },
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_gear_config_env_override_dash_gear_name_backcompat() {
+        // Back-compat: the existing dash form must still work.
+        let tmp = tempdir().unwrap();
+        let cfg_path = tmp.path().join("cfg.yaml");
+        let yaml = r#"
+server:
+  home_dir: "~/.test_gear_env_dash"
+gears:
+  static-authz-plugin:
+    config:
+      vendor: "from_yaml"
+"#;
+        fs::write(&cfg_path, yaml).unwrap();
+
+        with_var(
+            "APP__GEARS__static-authz-plugin__CONFIG__VENDOR",
+            Some("acme"),
+            || {
+                let config = AppConfig::load_layered(&cfg_path).unwrap();
+                let gear = config.gears.get("static-authz-plugin").unwrap();
+                assert_eq!(gear["config"]["vendor"], serde_json::json!("acme"));
+            },
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_gear_config_env_override_preserves_field_underscores() {
+        // Underscores in nested config field names must NOT be remapped.
+        let tmp = tempdir().unwrap();
+        let cfg_path = tmp.path().join("cfg.yaml");
+        let yaml = r#"
+server:
+  home_dir: "~/.test_gear_env_field"
+gears:
+  static-authz-plugin:
+    config:
+      some_field: "from_yaml"
+"#;
+        fs::write(&cfg_path, yaml).unwrap();
+
+        with_var(
+            "APP__GEARS__STATIC_AUTHZ_PLUGIN__CONFIG__SOME_FIELD",
+            Some("from_env"),
+            || {
+                let config = AppConfig::load_layered(&cfg_path).unwrap();
+                let gear = config.gears.get("static-authz-plugin").unwrap();
+                assert_eq!(gear["config"]["some_field"], serde_json::json!("from_env"));
+            },
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_vendor_config_env_override_unaffected_by_gear_remap() {
+        // Isolation invariant: the gear-name `_`->`-` remap must NOT touch the
+        // `vendor` branch. The underscore vendor name is the canary — if the
+        // remap leaked, the env override would land under a dashed
+        // `env-test-vendor` key and the underscore lookup would miss it.
+        let tmp = tempdir().unwrap();
+        let cfg_path = tmp.path().join("cfg.yaml");
+        let yaml = r#"
+server:
+  home_dir: "~/.test_vendor_unaffected"
+vendor:
+  env_test_vendor:
+    api_token: "from_yaml"
+"#;
+        fs::write(&cfg_path, yaml).unwrap();
+
+        with_var(
+            "APP__VENDOR__ENV_TEST_VENDOR__API_TOKEN",
+            Some("from_env"),
+            || {
+                let config = AppConfig::load_layered(&cfg_path).unwrap();
+
+                // The override applied to the underscore key, not a remapped one.
+                let v: TestVendorConfig = config.vendor_config("env_test_vendor").unwrap();
+                assert_eq!(v.api_token, "from_env");
+
+                // Distinguishing assertion vs. test_vendor_config_env_override:
+                // no dashed key was synthesized in the vendor branch.
+                assert!(
+                    config.vendor.contains_key("env_test_vendor"),
+                    "underscore vendor key must be preserved"
+                );
+                assert!(
+                    !config.vendor.contains_key("env-test-vendor"),
+                    "gear remap leaked into the vendor branch"
+                );
             },
         );
     }


### PR DESCRIPTION
Closes https://github.com/constructorfabric/gears-rust/issues/4115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment-based configuration parsing so gear names provided with underscores correctly map to kebab-case keys.
  * Preserved underscores in nested configuration field names during env-var ingestion.
  * Ensured `vendor` environment overrides remain unaffected by gear-name remapping.
  * Updated OData cursor datetime formatting for `DateTimeUtc` to use a more reliable RFC3339 format description.
* **Tests**
  * Reduced flakiness by running env-dependent configuration tests serially.
  * Added/expanded coverage for underscore-form gear names and nested field override behavior.
* **Chores**
  * Added `serial_test` as a shared development test utility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->