### PR TITLE
fix(resource-group): add explicit `[lib] name` to follow gear naming convention

### DIFF
--- a/gears/system/resource-group/resource-group/Cargo.toml
+++ b/gears/system/resource-group/resource-group/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["constructorfabric", "cf-gears", "resource-group"]
 categories = ["web-programming"]
 metadata.docs.rs.all-features = true
 
+[lib]
+name = "resource_group"
+
 [lints]
 workspace = true
 

--- a/gears/system/resource-group/resource-group/tests/api_rest_test.rs
+++ b/gears/system/resource-group/resource-group/tests/api_rest_test.rs
@@ -31,13 +31,13 @@ use toolkit_db::{
 };
 use toolkit_security::{SecurityContext, pep_properties};
 
-use cf_gears_resource_group::domain::group_service::{GroupService, QueryProfile};
-use cf_gears_resource_group::domain::membership_service::MembershipService;
-use cf_gears_resource_group::domain::type_service::TypeService;
-use cf_gears_resource_group::infra::storage::group_repo::GroupRepository;
-use cf_gears_resource_group::infra::storage::membership_repo::MembershipRepository;
-use cf_gears_resource_group::infra::storage::migrations::Migrator;
-use cf_gears_resource_group::infra::storage::type_repo::TypeRepository;
+use resource_group::domain::group_service::{GroupService, QueryProfile};
+use resource_group::domain::membership_service::MembershipService;
+use resource_group::domain::type_service::TypeService;
+use resource_group::infra::storage::group_repo::GroupRepository;
+use resource_group::infra::storage::membership_repo::MembershipRepository;
+use resource_group::infra::storage::migrations::Migrator;
+use resource_group::infra::storage::type_repo::TypeRepository;
 
 // ── Noop OpenAPI Registry for tests ─────────────────────────────────────
 
@@ -149,7 +149,7 @@ async fn build_test_router() -> (Router, Arc<TypeService<TypeRepository>>) {
     ));
 
     let openapi = NoopOpenApiRegistry;
-    let router = cf_gears_resource_group::api::rest::routes::register_routes(
+    let router = resource_group::api::rest::routes::register_routes(
         Router::new(),
         &openapi,
         type_svc.clone(),
@@ -717,7 +717,7 @@ async fn build_shared_router() -> (
         Arc::new(TypeRepository),
         Arc::new(MembershipRepository),
     ));
-    let router = cf_gears_resource_group::api::rest::routes::register_routes(
+    let router = resource_group::api::rest::routes::register_routes(
         Router::new(),
         &NoopOpenApiRegistry,
         type_svc.clone(),

--- a/gears/system/resource-group/resource-group/tests/authz_integration_test.rs
+++ b/gears/system/resource-group/resource-group/tests/authz_integration_test.rs
@@ -341,7 +341,7 @@ async fn enforcer_works_for_all_crud_actions() {
 // Scenario: L2-AuthZ-08 - Full chain list_groups calls enforcer with correct params
 #[tokio::test]
 async fn full_chain_list_groups_calls_enforcer_with_correct_params() {
-    use cf_gears_resource_group::domain::group_service::RG_GROUP_RESOURCE;
+    use resource_group::domain::group_service::RG_GROUP_RESOURCE;
     use std::sync::Mutex;
 
     /// Mock that captures requests and returns tenant-scoped allow.
@@ -431,7 +431,7 @@ async fn full_chain_list_groups_calls_enforcer_with_correct_params() {
 // Scenario: L2-AuthZ-09 - Full chain deny-all blocks list_groups
 #[tokio::test]
 async fn full_chain_deny_all_blocks_list_groups() {
-    use cf_gears_resource_group::domain::group_service::RG_GROUP_RESOURCE;
+    use resource_group::domain::group_service::RG_GROUP_RESOURCE;
 
     let authz: Arc<dyn AuthZResolverClient> = Arc::new(DenyAllAuthZ);
     let enforcer = PolicyEnforcer::new(authz);

--- a/gears/system/resource-group/resource-group/tests/common/mod.rs
+++ b/gears/system/resource-group/resource-group/tests/common/mod.rs
@@ -23,13 +23,13 @@ use toolkit_db::{
 };
 use toolkit_security::{SecurityContext, pep_properties};
 
-use cf_gears_resource_group::domain::group_service::{GroupService, QueryProfile};
-use cf_gears_resource_group::domain::membership_service::MembershipService;
-use cf_gears_resource_group::domain::type_service::TypeService;
-use cf_gears_resource_group::infra::storage::group_repo::GroupRepository;
-use cf_gears_resource_group::infra::storage::membership_repo::MembershipRepository;
-use cf_gears_resource_group::infra::storage::migrations::Migrator;
-use cf_gears_resource_group::infra::storage::type_repo::TypeRepository;
+use resource_group::domain::group_service::{GroupService, QueryProfile};
+use resource_group::domain::membership_service::MembershipService;
+use resource_group::domain::type_service::TypeService;
+use resource_group::infra::storage::group_repo::GroupRepository;
+use resource_group::infra::storage::membership_repo::MembershipRepository;
+use resource_group::infra::storage::migrations::Migrator;
+use resource_group::infra::storage::type_repo::TypeRepository;
 use resource_group_sdk::{
     CreateGroupRequest, CreateTypeRequest, ResourceGroup as ResourceGroupModel, ResourceGroupType,
 };
@@ -394,7 +394,7 @@ pub async fn assert_closure_rows(
     descendant_id: Uuid,
     expected: &[(Uuid, i32)],
 ) {
-    use cf_gears_resource_group::infra::storage::entity::resource_group_closure::{
+    use resource_group::infra::storage::entity::resource_group_closure::{
         Column, Entity as ClosureEntity,
     };
     use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
@@ -429,7 +429,7 @@ pub async fn assert_closure_count(
     group_ids: &[Uuid],
     expected_total: usize,
 ) {
-    use cf_gears_resource_group::infra::storage::entity::resource_group_closure::{
+    use resource_group::infra::storage::entity::resource_group_closure::{
         Column, Entity as ClosureEntity,
     };
     use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};

--- a/gears/system/resource-group/resource-group/tests/domain_unit_test.rs
+++ b/gears/system/resource-group/resource-group/tests/domain_unit_test.rs
@@ -7,8 +7,8 @@
 //! Full domain service tests with mock repositories are deferred to
 //! TODO-16 (repository trait abstraction).
 
-use cf_gears_resource_group::domain::error::DomainError;
-use cf_gears_resource_group::domain::validation::{self, RG_TYPE_PREFIX};
+use resource_group::domain::error::DomainError;
+use resource_group::domain::validation::{self, RG_TYPE_PREFIX};
 use toolkit_canonical_errors::{CanonicalError, Problem};
 
 /// Build the wire `Problem` the canonical error middleware would emit
@@ -1039,7 +1039,7 @@ fn toolkit_db_error_maps_to_database() {
 
 #[test]
 fn query_profile_defaults_are_sensible() {
-    use cf_gears_resource_group::domain::group_service::QueryProfile;
+    use resource_group::domain::group_service::QueryProfile;
 
     let profile = QueryProfile::default();
     assert_eq!(profile.max_depth, Some(10));

--- a/gears/system/resource-group/resource-group/tests/group_service_test.rs
+++ b/gears/system/resource-group/resource-group/tests/group_service_test.rs
@@ -16,20 +16,20 @@ use std::sync::Arc;
 use serde_json::json;
 use uuid::Uuid;
 
-use cf_gears_resource_group::domain::error::DomainError;
-use cf_gears_resource_group::domain::group_service::{GroupService, QueryProfile};
-use cf_gears_resource_group::domain::type_service::TypeService;
-use cf_gears_resource_group::infra::storage::entity::gts_type::{
+use resource_group::domain::error::DomainError;
+use resource_group::domain::group_service::{GroupService, QueryProfile};
+use resource_group::domain::type_service::TypeService;
+use resource_group::infra::storage::entity::gts_type::{
     Column as GtsTypeColumn, Entity as GtsTypeEntity,
 };
-use cf_gears_resource_group::infra::storage::entity::resource_group::{
+use resource_group::infra::storage::entity::resource_group::{
     Column as RgColumn, Entity as RgEntity,
 };
-use cf_gears_resource_group::infra::storage::entity::resource_group_membership::{
+use resource_group::infra::storage::entity::resource_group_membership::{
     self as membership_entity, Entity as MembershipEntity,
 };
-use cf_gears_resource_group::infra::storage::group_repo::GroupRepository;
-use cf_gears_resource_group::infra::storage::type_repo::TypeRepository;
+use resource_group::infra::storage::group_repo::GroupRepository;
+use resource_group::infra::storage::type_repo::TypeRepository;
 use resource_group_sdk::{CreateGroupRequest, CreateTypeRequest, UpdateGroupRequest};
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set};
 use toolkit_db::secure::{SecureEntityExt, secure_insert};
@@ -1917,7 +1917,7 @@ async fn group_metadata_in_hierarchy_response() {
 /// Helper: build the ADR-001 type ecosystem.
 /// Returns (tenant_type, dept_type, branch_type, user_type, course_type).
 async fn create_adr_types(
-    type_svc: &cf_gears_resource_group::domain::type_service::TypeService<TypeRepository>,
+    type_svc: &resource_group::domain::type_service::TypeService<TypeRepository>,
 ) -> (
     resource_group_sdk::ResourceGroupType,
     resource_group_sdk::ResourceGroupType,
@@ -1982,7 +1982,7 @@ async fn create_adr_types(
 #[tokio::test]
 async fn adr_full_hierarchy_reproduction() {
     let db = common::test_db().await;
-    let type_svc = cf_gears_resource_group::domain::type_service::TypeService::new(
+    let type_svc = resource_group::domain::type_service::TypeService::new(
         db.clone(),
         Arc::new(TypeRepository),
     );
@@ -2058,7 +2058,7 @@ async fn adr_full_hierarchy_reproduction() {
 #[tokio::test]
 async fn adr_tenant_self_nesting() {
     let db = common::test_db().await;
-    let type_svc = cf_gears_resource_group::domain::type_service::TypeService::new(
+    let type_svc = resource_group::domain::type_service::TypeService::new(
         db.clone(),
         Arc::new(TypeRepository),
     );
@@ -2079,7 +2079,7 @@ async fn adr_tenant_self_nesting() {
 #[tokio::test]
 async fn adr_department_cannot_be_root() {
     let db = common::test_db().await;
-    let type_svc = cf_gears_resource_group::domain::type_service::TypeService::new(
+    let type_svc = resource_group::domain::type_service::TypeService::new(
         db.clone(),
         Arc::new(TypeRepository),
     );
@@ -2114,7 +2114,7 @@ async fn adr_department_cannot_be_root() {
 #[tokio::test]
 async fn adr_branch_only_under_department() {
     let db = common::test_db().await;
-    let type_svc = cf_gears_resource_group::domain::type_service::TypeService::new(
+    let type_svc = resource_group::domain::type_service::TypeService::new(
         db.clone(),
         Arc::new(TypeRepository),
     );
@@ -2154,7 +2154,7 @@ async fn adr_branch_only_under_department() {
 #[tokio::test]
 async fn adr_branch_allows_users_and_courses() {
     let db = common::test_db().await;
-    let type_svc = cf_gears_resource_group::domain::type_service::TypeService::new(
+    let type_svc = resource_group::domain::type_service::TypeService::new(
         db.clone(),
         Arc::new(TypeRepository),
     );
@@ -2188,7 +2188,7 @@ async fn adr_branch_allows_users_and_courses() {
 #[tokio::test]
 async fn adr_tenant_rejects_course_membership() {
     let db = common::test_db().await;
-    let type_svc = cf_gears_resource_group::domain::type_service::TypeService::new(
+    let type_svc = resource_group::domain::type_service::TypeService::new(
         db.clone(),
         Arc::new(TypeRepository),
     );
@@ -2219,7 +2219,7 @@ async fn adr_tenant_rejects_course_membership() {
 #[tokio::test]
 async fn adr_same_user_in_multiple_groups() {
     let db = common::test_db().await;
-    let type_svc = cf_gears_resource_group::domain::type_service::TypeService::new(
+    let type_svc = resource_group::domain::type_service::TypeService::new(
         db.clone(),
         Arc::new(TypeRepository),
     );
@@ -2252,7 +2252,7 @@ async fn adr_same_user_in_multiple_groups() {
 #[tokio::test]
 async fn adr_same_resource_different_types() {
     let db = common::test_db().await;
-    let type_svc = cf_gears_resource_group::domain::type_service::TypeService::new(
+    let type_svc = resource_group::domain::type_service::TypeService::new(
         db.clone(),
         Arc::new(TypeRepository),
     );
@@ -2291,7 +2291,7 @@ async fn adr_same_resource_different_types() {
 #[tokio::test]
 async fn security_group_metadata_sql_injection() {
     let db = common::test_db().await;
-    let type_svc = cf_gears_resource_group::domain::type_service::TypeService::new(
+    let type_svc = resource_group::domain::type_service::TypeService::new(
         db.clone(),
         Arc::new(TypeRepository),
     );
@@ -2342,7 +2342,7 @@ async fn security_group_metadata_sql_injection() {
 #[tokio::test]
 async fn security_group_metadata_large_payload() {
     let db = common::test_db().await;
-    let type_svc = cf_gears_resource_group::domain::type_service::TypeService::new(
+    let type_svc = resource_group::domain::type_service::TypeService::new(
         db.clone(),
         Arc::new(TypeRepository),
     );
@@ -2688,7 +2688,7 @@ async fn tenant_root_self_update_allowed() {
 #[tokio::test]
 async fn get_group_unscoped_returns_group_without_ctx() {
     let db = common::test_db().await;
-    let type_svc = cf_gears_resource_group::domain::type_service::TypeService::new(
+    let type_svc = resource_group::domain::type_service::TypeService::new(
         db.clone(),
         Arc::new(TypeRepository),
     );

--- a/gears/system/resource-group/resource-group/tests/membership_service_test.rs
+++ b/gears/system/resource-group/resource-group/tests/membership_service_test.rs
@@ -14,12 +14,12 @@ use common::{create_root_type, make_ctx, make_group_service, make_membership_ser
 use toolkit_odata::ODataQuery;
 use uuid::Uuid;
 
-use cf_gears_resource_group::domain::error::DomainError;
-use cf_gears_resource_group::domain::type_service::TypeService;
-use cf_gears_resource_group::infra::storage::entity::resource_group_membership::{
+use resource_group::domain::error::DomainError;
+use resource_group::domain::type_service::TypeService;
+use resource_group::infra::storage::entity::resource_group_membership::{
     Column as MbrColumn, Entity as MbrEntity,
 };
-use cf_gears_resource_group::infra::storage::type_repo::TypeRepository;
+use resource_group::infra::storage::type_repo::TypeRepository;
 use resource_group_sdk::CreateTypeRequest;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use toolkit_db::secure::SecureEntityExt;

--- a/gears/system/resource-group/resource-group/tests/read_service_test.rs
+++ b/gears/system/resource-group/resource-group/tests/read_service_test.rs
@@ -18,9 +18,9 @@ use std::sync::Arc;
 use toolkit_odata::ODataQuery;
 use uuid::Uuid;
 
-use cf_gears_resource_group::domain::read_service::RgReadService;
-use cf_gears_resource_group::domain::type_service::TypeService;
-use cf_gears_resource_group::infra::storage::type_repo::TypeRepository;
+use resource_group::domain::read_service::RgReadService;
+use resource_group::domain::type_service::TypeService;
+use resource_group::infra::storage::type_repo::TypeRepository;
 use resource_group_sdk::{CreateTypeRequest, ResourceGroupReadHierarchy, ResourceGroupType};
 
 /// Root type (`can_be_root = true`) that accepts the given membership types.

--- a/gears/system/resource-group/resource-group/tests/seeding_test.rs
+++ b/gears/system/resource-group/resource-group/tests/seeding_test.rs
@@ -16,18 +16,18 @@ use std::sync::Arc;
 use common::{make_ctx, make_group_service, make_membership_service, test_db};
 use uuid::Uuid;
 
-use cf_gears_resource_group::domain::seeding::{
+use resource_group::domain::seeding::{
     GroupSeedDef, MembershipSeedDef, seed_groups, seed_memberships, seed_types,
 };
-use cf_gears_resource_group::domain::type_service::TypeService;
-use cf_gears_resource_group::infra::storage::entity::gts_type::{
+use resource_group::domain::type_service::TypeService;
+use resource_group::infra::storage::entity::gts_type::{
     Column as TypeColumn, Entity as TypeEntity,
 };
-use cf_gears_resource_group::infra::storage::entity::resource_group::Entity as GroupEntity;
-use cf_gears_resource_group::infra::storage::entity::resource_group_membership::{
+use resource_group::infra::storage::entity::resource_group::Entity as GroupEntity;
+use resource_group::infra::storage::entity::resource_group_membership::{
     Column as MbrColumn, Entity as MbrEntity,
 };
-use cf_gears_resource_group::infra::storage::type_repo::TypeRepository;
+use resource_group::infra::storage::type_repo::TypeRepository;
 use resource_group_sdk::CreateTypeRequest;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use toolkit_db::secure::SecureEntityExt;

--- a/gears/system/resource-group/resource-group/tests/tenant_filtering_db_test.rs
+++ b/gears/system/resource-group/resource-group/tests/tenant_filtering_db_test.rs
@@ -25,11 +25,11 @@ use toolkit_db::{DBProvider, DbError};
 use toolkit_odata::ODataQuery;
 use toolkit_security::pep_properties;
 
-use cf_gears_resource_group::domain::group_service::{GroupService, QueryProfile};
-use cf_gears_resource_group::domain::type_service::TypeService;
-use cf_gears_resource_group::infra::storage::group_repo::GroupRepository;
-use cf_gears_resource_group::infra::storage::membership_repo::MembershipRepository;
-use cf_gears_resource_group::infra::storage::type_repo::TypeRepository;
+use resource_group::domain::group_service::{GroupService, QueryProfile};
+use resource_group::domain::type_service::TypeService;
+use resource_group::infra::storage::group_repo::GroupRepository;
+use resource_group::infra::storage::membership_repo::MembershipRepository;
+use resource_group::infra::storage::type_repo::TypeRepository;
 
 use common::{make_ctx, test_db};
 
@@ -446,7 +446,7 @@ async fn group_based_in_group_predicate_produces_combined_scope() {
     let scope = enforcer
         .access_scope(
             &ctx,
-            &cf_gears_resource_group::domain::group_service::RG_GROUP_RESOURCE,
+            &resource_group::domain::group_service::RG_GROUP_RESOURCE,
             "list",
             None,
         )
@@ -555,14 +555,13 @@ async fn group_based_membership_data_correctly_stored() {
     // Add memberships via MembershipService (with PolicyEnforcer)
     let authz: Arc<dyn AuthZResolverClient> = Arc::new(TenantScopingAuthZ);
     let enforcer = PolicyEnforcer::new(authz);
-    let membership_svc =
-        cf_gears_resource_group::domain::membership_service::MembershipService::new(
-            db.clone(),
-            enforcer,
-            Arc::new(GroupRepository),
-            Arc::new(TypeRepository),
-            Arc::new(MembershipRepository),
-        );
+    let membership_svc = resource_group::domain::membership_service::MembershipService::new(
+        db.clone(),
+        enforcer,
+        Arc::new(GroupRepository),
+        Arc::new(TypeRepository),
+        Arc::new(MembershipRepository),
+    );
 
     // task-001, task-002 → ProjectA
     membership_svc

--- a/gears/system/resource-group/resource-group/tests/type_service_test.rs
+++ b/gears/system/resource-group/resource-group/tests/type_service_test.rs
@@ -14,15 +14,15 @@ use std::sync::Arc;
 use serde_json::json;
 use uuid::Uuid;
 
-use cf_gears_resource_group::domain::error::DomainError;
-use cf_gears_resource_group::domain::repo::TypeRepositoryTrait;
-use cf_gears_resource_group::domain::type_service::TypeService;
-use cf_gears_resource_group::infra::storage::entity::{
+use resource_group::domain::error::DomainError;
+use resource_group::domain::repo::TypeRepositoryTrait;
+use resource_group::domain::type_service::TypeService;
+use resource_group::infra::storage::entity::{
     gts_type::{self, Entity as GtsTypeEntity},
     gts_type_allowed_membership::{self, Entity as AllowedMembershipEntity},
     gts_type_allowed_parent::{self, Entity as AllowedParentEntity},
 };
-use cf_gears_resource_group::infra::storage::type_repo::TypeRepository;
+use resource_group::infra::storage::type_repo::TypeRepository;
 use resource_group_sdk::{CreateTypeRequest, UpdateTypeRequest};
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set};
 use toolkit_db::secure::{SecureEntityExt, secure_insert};


### PR DESCRIPTION
## Problem

Every gear crate in the repo follows a consistent naming convention:

| Gear name | Package name | Lib name |
|---|---|---|
| `api-gateway` | `cf-gears-api-gateway` | `api_gateway` |
| `types-registry` | `cf-gears-types-registry` | `types_registry` |
| `authn-resolver` | `cf-gears-authn-resolver` | `authn_resolver` |

The `resource-group` crate is the only exception: it has no explicit `[lib]`
section in its `Cargo.toml`, so Cargo defaults the lib name to
`cf_gears_resource_group` (derived from the package name) instead of
`resource_group` (derived from the gear name).

This breaks the bidirectional `gear-name <-> lib-name` mapping.
If this mapping is maintained (or even enforced, at some point), it can serve
as a basis for avoiding explicit / hard-coded mappings from gear and lib
names to and from package names.

## Fix

- Added `[lib] name = "resource_group"` to
  `gears/system/resource-group/resource-group/Cargo.toml`
- Renamed all 68 `cf_gears_resource_group` references to `resource_group`
  across 10 test files

## Verification

- `cargo build`: Full workspace compiles cleanly.
- `cargo test -p cf-gears-resource-group`: All tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Explicitly defined the resource-group library crate name for consistent project integration.
  * Updated resource-group test modules to use the standardized crate namespace.

* **Tests**
  * Preserved existing test behavior and assertions while aligning imports with the updated library name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->