### PR TITLE
docs(bff): add reusable BFF gear PRD, DESIGN, and ADRs

### DIFF
--- a/gears/system/bff/docs/ADR/0001-cpt-cf-bff-adr-session-store-plugin.md
+++ b/gears/system/bff/docs/ADR/0001-cpt-cf-bff-adr-session-store-plugin.md
@@ -1,0 +1,113 @@
+---
+status: accepted
+date: 2026-06-26
+decision-makers: BFF gear authors
+---
+
+# Session storage as a swappable plugin, not a gear dependency
+
+
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [`SessionStore` SDK trait implemented by plugins](#sessionstore-sdk-trait-implemented-by-plugins)
+  - [Depend on Redis directly inside the gear crate](#depend-on-redis-directly-inside-the-gear-crate)
+  - [Store as a generic type parameter on the gear](#store-as-a-generic-type-parameter-on-the-gear)
+- [More Information](#more-information)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
+**ID**: `cpt-cf-bff-adr-session-store`
+## Context and Problem Statement
+
+The BFF gear must persist server-side session state with low-latency lookups,
+atomic refresh-rotation, per-user indexing, and TTL expiry. The gear is intended to
+be **reusable across products** (`cpt-cf-bff-fr-pluggable-store`). How should the gear
+obtain its storage backend so that different consumers can run different backends
+(or supply their own) without changing gear code?
+
+## Decision Drivers
+
+* Reusability: consumers must choose a backend (or write one) without forking the gear.
+* Testability: tests and local dev must run with no external infrastructure.
+* Consistency: a backend-selection mechanism already exists in the workspace, and
+  `credstore` is a direct precedent — a *storage* gear whose backend is a plugin
+  (`CredStoreClientV1` consumer + `CredStorePluginClientV1` plugin, via types-registry
+  + `ClientHub`). No session/KV/state-store trait exists today, so this is greenfield.
+* Fail-closed and stateless requirements (`cpt-cf-bff-nfr-fail-closed`,
+  `cpt-cf-bff-nfr-stateless`) — the backend is authoritative; the gear holds no session
+  state in memory.
+
+## Considered Options
+
+* Define a `SessionStore` SDK trait, implemented by plugins selected at composition time
+* Depend on Redis directly inside the gear crate
+* Make the store a generic type parameter on the gear
+
+## Decision Outcome
+
+Chosen option: **`SessionStore` SDK trait implemented by plugins**, because it is the
+only option that makes the gear backend-agnostic at composition time using the
+workspace's established plugin mechanism, while keeping the gear crate free of any
+concrete backend dependency.
+
+### Consequences
+
+* `bff-sdk` must define the `SessionStore` plugin trait, its models, and a
+  `SessionStoreSpecV1` GTS schema; plugins register a `PluginV1<SessionStoreSpecV1>`
+  in types-registry and a scoped `ClientHub` client (same mechanics as `credstore` /
+  `oidc-authn-plugin`).
+* The gear resolves the store via `ClientHub` in `init`; if none is present it must
+  refuse to start (fail-closed).
+* The project must ship at least two plugins: `redis-session-store-plugin`
+  (production) and `inmem-session-store-plugin` (dev/test).
+* Atomicity guarantees for refresh-rotation (§3.6 DESIGN) become part of the trait
+  contract, so every plugin must honor them.
+* **New external dependency:** the workspace has no Redis client today (no
+  `redis`/`fred`/`deadpool` in any `Cargo.toml`). `redis-session-store-plugin` adds the
+  first one, so it needs dependency sign-off per `guidelines/DEPENDENCIES.md`. Isolating
+  it in the plugin crate (not the gear or SDK) keeps the new dependency opt-in: consumers
+  that pick `inmem` or another backend never compile Redis.
+
+### Confirmation
+
+Design/code review confirms the gear crate has no Redis/backend dependency in
+`Cargo.toml`; an integration test runs the gear against both shipped plugins
+unchanged (`cpt-cf-bff-fr-pluggable-store` acceptance).
+
+## Pros and Cons of the Options
+
+### `SessionStore` SDK trait implemented by plugins
+
+* Good: backend-agnostic; matches existing plugin convention; trivial dev/test via in-memory plugin.
+* Good: consumers can supply proprietary backends.
+* Bad: one indirection layer; atomic operations must be expressed in the trait, constraining its shape.
+
+### Depend on Redis directly inside the gear crate
+
+* Good: simplest to implement; direct access to Redis primitives.
+* Bad: every consumer must run Redis; cannot swap backends; tests need a Redis or a mock; least reusable.
+
+### Store as a generic type parameter on the gear
+
+* Good: zero-cost abstraction, compile-time backend selection.
+* Bad: generics fight the `inventory`/`ClientHub` dynamic gear registration model; awkward composition; no runtime selection by config.
+
+## More Information
+
+Closest precedent: `gears/credstore` — a storage gear with a plugin backend
+(`gears/credstore/plugins/static-credstore-plugin`). Plugin mechanics also mirror
+`gears/system/authn-resolver/plugins/oidc-authn-plugin`. No pre-existing
+session/KV/state-store trait or Redis client exists in the workspace.
+
+## Traceability
+
+* PRD: `cpt-cf-bff-fr-pluggable-store`, `cpt-cf-bff-nfr-fail-closed`, `cpt-cf-bff-nfr-stateless`
+* DESIGN: [DESIGN.md](../DESIGN.md) §3.4

--- a/gears/system/bff/docs/ADR/0002-cpt-cf-bff-adr-opaque-sessions-no-jwt.md
+++ b/gears/system/bff/docs/ADR/0002-cpt-cf-bff-adr-opaque-sessions-no-jwt.md
@@ -1,0 +1,104 @@
+---
+status: accepted
+date: 2026-06-26
+decision-makers: BFF gear authors
+---
+
+# Opaque server-side sessions; no JWT minting in v1
+
+
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [Opaque server-side session; no JWT in v1](#opaque-server-side-session-no-jwt-in-v1)
+  - [JWT-in-cookie](#jwt-in-cookie)
+  - [Opaque cookie + mint downstream JWT now](#opaque-cookie--mint-downstream-jwt-now)
+- [More Information](#more-information)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
+**ID**: `cpt-cf-bff-adr-opaque-sessions-no-jwt`
+## Context and Problem Statement
+
+The browser needs a credential to reference its authenticated session. Two shapes are
+common: a self-contained signed token (JWT) in the cookie, or an opaque reference to
+server-side state. Separately, the upstream Insight design has a "Router" that mints
+an EdDSA gateway-JWT for downstream services. What should the browser hold, and does
+the BFF mint any JWT in v1?
+
+## Decision Drivers
+
+* Instant revocability (`cpt-cf-bff-fr-session-revoke`) and short stolen-cookie lifetime.
+* No identity material readable by the browser (`cpt-cf-bff-fr-cookie`, `cpt-cf-bff-nfr-secret-confidentiality`).
+* v1 scope excludes the Router / downstream-JWT role (PRD §4.2).
+* Workspace crypto posture is FIPS-oriented; EdDSA is acceptable but not mandated, and
+  introducing signing now would force an algorithm/FIPS decision for no v1 benefit.
+
+## Considered Options
+
+* Opaque server-side session reference; no JWT minted in v1
+* JWT-in-cookie (self-contained signed session)
+* Opaque cookie **and** mint a downstream gateway-JWT in the BFF now
+
+## Decision Outcome
+
+Chosen option: **opaque server-side session reference, no JWT minted in v1**, because
+it gives instant revocation, keeps all identity server-side, and — since the Router
+role is out of scope — removes any signing-algorithm/FIPS decision from v1 entirely.
+
+### Consequences
+
+* The cookie carries only an opaque `SessionId`; identity is resolved server-side via
+  `SessionResolver` (DESIGN §3.3). Downstream consumers use the in-process
+  `SecurityContext`, not a token.
+* The gear has no JWT-signing dependency and serves no JWKS in v1.
+* If/when the downstream-JWT (Router) role is adopted, it will consume
+  `SessionResolver` and add signing; the EdDSA-vs-ES256/FIPS trade-off is decided in a
+  dedicated ADR **at that time**, not now.
+* Revocation is a store delete; it takes effect on the next resolve.
+* The mandatory per-request lookup is also the substrate for **device/session
+  inventory**: the session record carries `user_agent`, `ip`, `created_at`, and a
+  `last_used_at` updated (coalesced, no TTL slide) on the same pipelined round-trip,
+  powering `/auth/sessions` and future anomaly detection (new device/IP) — capabilities
+  JWT cannot offer without its own liveness store.
+
+### Confirmation
+
+Code review confirms no signing crate / JWKS endpoint in v1; a revocation test shows a
+revoked session is rejected on the next request.
+
+## Pros and Cons of the Options
+
+### Opaque server-side session; no JWT in v1
+
+* Good: instant revocation; nothing sensitive in the browser; no crypto/FIPS decision now; smallest v1.
+* Good: the per-request store lookup enables device/session inventory, `last_used_at`, and an anomaly-detection substrate — for free on a lookup that is mandatory anyway.
+* Bad: every request needs a store lookup (one round-trip, `cpt-cf-bff-nfr-latency`) plus a coalesced `last_used_at` write — unavoidable given revocation + device-management requirements, so not a real disadvantage versus JWT here.
+
+### JWT-in-cookie
+
+* Good: stateless validation, no per-request store lookup.
+* Bad: cannot revoke before expiry; identity readable if decoded; reintroduces signing/FIPS decision; conflicts with `cpt-cf-bff-fr-session-revoke`.
+* Bad: statelessness is illusory once revocation or device/session management is required — those force a per-request liveness/denylist check anyway, erasing the round-trip saving while still lacking a server-side record to attach device/last-used/IP to.
+
+### Opaque cookie + mint downstream JWT now
+
+* Good: ready for downstream propagation immediately.
+* Bad: pulls the out-of-scope Router role into v1; forces the EdDSA/FIPS decision prematurely; larger surface.
+
+## More Information
+
+Aligns with Insight DD-BFF-01 (opaque session) and DD-BFF-05 (EdDSA) — the latter
+deferred here because v1 mints no token.
+
+## Traceability
+
+* PRD: `cpt-cf-bff-fr-cookie`, `cpt-cf-bff-fr-session-revoke`, `cpt-cf-bff-nfr-secret-confidentiality`; Open Question on signing posture
+* DESIGN: [DESIGN.md](../DESIGN.md) §1.1, §3.3

--- a/gears/system/bff/docs/DESIGN.md
+++ b/gears/system/bff/docs/DESIGN.md
@@ -1,0 +1,409 @@
+# DESIGN — BFF (Backend-for-Frontend) Gear
+
+<!-- toc -->
+
+- [1. Architecture Overview](#1-architecture-overview)
+  - [1.1 Architectural Vision](#11-architectural-vision)
+  - [1.2 Architecture Drivers](#12-architecture-drivers)
+  - [1.3 Architecture Layers](#13-architecture-layers)
+- [2. Principles & Constraints](#2-principles--constraints)
+  - [2.1 Design Principles](#21-design-principles)
+  - [2.2 Constraints](#22-constraints)
+- [3. Technical Architecture](#3-technical-architecture)
+  - [3.1 Domain Model](#31-domain-model)
+  - [3.2 Component Model](#32-component-model)
+  - [3.3 API Contracts](#33-api-contracts)
+  - [3.4 Internal Dependencies](#34-internal-dependencies)
+  - [3.5 External Dependencies](#35-external-dependencies)
+  - [3.6 Interactions & Sequences](#36-interactions--sequences)
+  - [3.7 Database schemas & tables](#37-database-schemas--tables)
+  - [3.8 Deployment Topology](#38-deployment-topology)
+- [4. Additional context](#4-additional-context)
+- [5. Traceability](#5-traceability)
+
+<!-- /toc -->
+
+<!--
+Technical Design (IEEE 1016 / 42010). Defines HOW the BFF gear realizes the PRD.
+Decisions with meaningful trade-offs are captured as ADRs under ./ADR and linked here.
+Traces to gears/system/bff/docs/PRD.md.
+-->
+
+## 1. Architecture Overview
+
+### 1.1 Architectural Vision
+
+The BFF gear is a **stateless, reusable authentication-session layer** for browser
+SPAs, packaged as a CF/Gears gear. It runs the OIDC Authorization Code + PKCE flow
+server-side, persists session state in a **swappable session-store plugin**, and
+hands the browser only an opaque, hardened cookie (`__Host-sid`). It exposes an HTTP
+`/auth/*` surface for the SPA and an in-process `SessionResolver` trait (via
+`ClientHub`) so a co-hosted gateway (`api-gateway`) can turn a session cookie into a
+`SecurityContext`. It reuses `authn-resolver` for ID-token validation and
+`tenant-resolver` for tenant association, and depends on no relational database.
+
+Sessions are **opaque server-side records**; the gear mints **no JWT** in v1.
+Minting/serving downstream gateway-JWTs (the "Router" role) is out of scope per
+PRD §4.2, which removes any signing-algorithm/FIPS decision from v1.
+
+### 1.2 Architecture Drivers
+
+#### Functional Drivers
+
+| Requirement | Design Response |
+|-------------|-----------------|
+| `cpt-cf-bff-fr-login` / `cpt-cf-bff-fr-callback` | `OidcLoginService`: PKCE start + state/nonce in `LoginState`; code exchange; ID-token validation via `authn-resolver`; session creation |
+| `cpt-cf-bff-fr-cookie` | single cookie constructor enforcing `__Host-`/`HttpOnly`/`Secure`/`SameSite=Strict`/`Path=/`, no Domain |
+| `cpt-cf-bff-fr-resolve` | `SessionResolver` trait in `ClientHub`; one read-only store lookup, no IdP I/O |
+| `cpt-cf-bff-fr-refresh` / `cpt-cf-bff-fr-refresh-timing` | rotate-with-grace algorithm (§3.6); server-supplied jittered `refresh_at` |
+| `cpt-cf-bff-fr-logout` / `cpt-cf-bff-fr-backchannel-logout` | `LogoutService`: local revoke + RP redirect; back-channel receiver with `(iss,jti)` replay guard |
+| `cpt-cf-bff-fr-session-list` / `cpt-cf-bff-fr-session-revoke` | per-user index in `SessionStore`; revoke deletes record + index entry |
+| `cpt-cf-bff-fr-csrf` | double-submit token bound to session + Origin allowlist (§3.2) |
+| `cpt-cf-bff-fr-housekeeping` | background janitor, single runner via store lock |
+| `cpt-cf-bff-fr-pluggable-store` | `SessionStore` plugin trait + types-registry discovery (§3.3) |
+| `cpt-cf-bff-fr-pluggable-idp` | delegation to `authn-resolver` (§3.4) |
+| `cpt-cf-bff-fr-audit` | lifecycle events emitted to the audit sink (§3.5) |
+
+#### NFR Allocation
+
+| NFR ID | NFR Summary | Allocated To | Design Response | Verification Approach |
+|--------|-------------|--------------|-----------------|-----------------------|
+| `cpt-cf-bff-nfr-latency` | ≤15 ms p95 added | `SessionResolver` | single store round-trip, no IdP I/O on resolve | benchmark |
+| `cpt-cf-bff-nfr-cookie-attrs` | hardened cookie 100% | cookie constructor | one builder, no other Set-Cookie path | snapshot unit test |
+| `cpt-cf-bff-nfr-fail-closed` | deny on store outage | gear init + resolve | no in-process authority; store error → 401/503; readiness gated on `ping` | integration test |
+| `cpt-cf-bff-nfr-stateless` | survive replica loss | whole gear | all state in store plugin | e2e kill-a-replica |
+| `cpt-cf-bff-nfr-session-ttl` | bounded TTL + cap | `SessionService` | configurable TTL + absolute cap; short defaults | unit test |
+| `cpt-cf-bff-nfr-secret-confidentiality` | no secret leakage | logging + DTOs | tokens/sid/csrf never logged or returned client-readable | unit + review |
+| `cpt-cf-bff-nfr-rate-limit` | abuse resistance | `api-gateway` middleware | per-client limit on `/auth/*` + concurrent-login cap | integration test |
+
+#### Key ADRs
+
+| ADR ID | Decision Summary |
+|--------|------------------|
+| `cpt-cf-bff-adr-session-store` | Session storage is a swappable plugin, not a gear dependency. See [ADR/0001](./ADR/0001-cpt-cf-bff-adr-session-store-plugin.md). |
+| `cpt-cf-bff-adr-opaque-sessions-no-jwt` | Opaque server-side sessions; no JWT minted in v1. See [ADR/0002](./ADR/0002-cpt-cf-bff-adr-opaque-sessions-no-jwt.md). |
+
+### 1.3 Architecture Layers
+
+| Layer | Responsibility | Technology |
+|-------|----------------|------------|
+| Presentation | `/auth/*` REST handlers + DTOs | `axum` (via api-gateway host), `OperationBuilder` |
+| Application | `SessionService`, `OidcLoginService`, `CsrfService`, `LogoutService`, janitor | Rust, store-agnostic |
+| Domain | session/identity model, refresh-rotation rules | Rust, `#[domain_model]` |
+| Infrastructure | cookie builder, OIDC code-exchange client, `ClientHub` dep wiring | `axum-extra`, reused `oidc-authn-plugin` infra |
+
+Dependency direction: `api → domain → infra`; `domain` depends only on the SDK
+`SessionStore` trait, never on a concrete backend. The `bff-sdk` crate publishes the
+`SessionResolver` (consumer) and `SessionStore` (plugin) contracts.
+
+## 2. Principles & Constraints
+
+### 2.1 Design Principles
+
+#### Opaque sessions, server-side tokens
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-principle-opaque-sessions`
+
+The browser never receives an IdP token or client-readable identity — only an opaque
+session reference.
+
+**ADRs**: `cpt-cf-bff-adr-opaque-sessions-no-jwt`
+
+#### Storage is a plugin
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-principle-store-plugin`
+
+The gear is backend-agnostic; Redis is a reference plugin, not a dependency of the
+gear crate.
+
+**ADRs**: `cpt-cf-bff-adr-session-store`
+
+#### Fail closed
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-principle-fail-closed`
+
+No degraded read-only auth path; the store is the single source of truth.
+
+#### Reuse, don't reimplement
+
+- [ ] `p2` - **ID**: `cpt-cf-bff-principle-reuse`
+
+IdP validation via `authn-resolver`; tenant via `tenant-resolver`;
+rate-limit/CORS/error-mapping via `api-gateway` middleware.
+
+### 2.2 Constraints
+
+#### No relational storage
+
+- [ ] `p2` - **ID**: `cpt-cf-bff-constraint-no-relational`
+
+Session state is ephemeral and lives in the `SessionStore` plugin; `DatabaseCapability`
+is not implemented.
+
+#### Store and TLS required
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-constraint-store-tls`
+
+The gear refuses to start without a `SessionStore` plugin (fail-closed); hardened
+cookies require TLS at the browser edge and a same-site SPA/gateway deployment
+(`SameSite=Strict`).
+
+## 3. Technical Architecture
+
+### 3.1 Domain Model
+
+**Technology**: Rust structs in `bff-sdk` (`#[domain_model]` where applicable), shared
+by consumers and plugins.
+
+**Core Entities**:
+
+| Entity | Description | Schema |
+|--------|-------------|--------|
+| `SessionId` | opaque 256-bit CSPRNG value (base64url); the cookie value; never logged | `bff-sdk` |
+| `Session` | `user_id`, `tenant_id`, `idp_iss`, `idp_sub`, `idp_sid?`, `id_token`, `created_at`, `expires_at`, `absolute_expires_at`, `last_used_at`, `csrf_token`, `user_agent?`, `ip?` | `bff-sdk`; `user_agent`/`ip`/`last_used_at` power device inventory |
+| `LoginState` | `pkce_verifier`, `nonce`, `return_to`, `created_at` (one-shot, short TTL) | `bff-sdk` |
+| `IdentitySnapshot` | `user_id`, `tenant_id`, `expires_at`, `refresh_at` (resolver + `/auth/me` output) | `bff-sdk` |
+| `RefreshOutcome` | `new_session_id`, `expires_at`, `refresh_at` | `bff-sdk` |
+
+**Relationships**:
+- `Session` → `SessionId`: referenced by the cookie value.
+- `Session` → user index: a user has many sessions (per-user index in the store).
+
+### 3.2 Component Model
+
+```mermaid
+graph LR
+    SPA -->|/auth/*| API[BFF REST api]
+    API --> DOM[domain services]
+    DOM --> STORE[(SessionStore plugin)]
+    DOM --> AUTHN[authn-resolver]
+    DOM --> TENANT[tenant-resolver]
+    GW[api-gateway] -->|SessionResolver| DOM
+```
+
+- **`BffGear`** (`gear.rs`) — `#[toolkit::gear(name="bff", deps=["authn-resolver","tenant-resolver","types-registry"], capabilities=[system], lifecycle(entry="janitor", await_ready))]`. On `init`: load config; resolve `SessionStore` (scoped client) + `AuthNResolverClient` + `TenantResolverClient` from `ClientHub`; build services; register `SessionResolver` in `ClientHub`.
+- **`OidcLoginService`** — builds the authorization URL (PKCE challenge, state, nonce), stores `LoginState`; on callback validates state, exchanges code, validates the ID token via `authn-resolver`, resolves tenant, creates the `Session`.
+- **`SessionService`** — create / resolve / refresh(rotate) / revoke / list against the `SessionStore` trait.
+- **`CsrfService`** — issues a token stored on the `Session`, mirrored to a readable `__Host-csrf` cookie; verifies the `X-CSRF-Token` header (double-submit) plus an `Origin` allowlist on state-changing calls.
+- **`LogoutService`** — local revoke + RP-initiated redirect URL; back-channel `logout_token` validation + `(iss,jti)` replay guard.
+- **Janitor** — `lifecycle` task trimming expired index entries; single active runner via a store lock.
+
+Component IDs:
+
+- [ ] `p2` - **ID**: `cpt-cf-bff-component-gear`
+- [ ] `p2` - **ID**: `cpt-cf-bff-component-oidc-login`
+- [ ] `p2` - **ID**: `cpt-cf-bff-component-session`
+- [ ] `p2` - **ID**: `cpt-cf-bff-component-csrf`
+- [ ] `p2` - **ID**: `cpt-cf-bff-component-logout`
+- [ ] `p2` - **ID**: `cpt-cf-bff-component-janitor`
+
+**Cookie handling**: a single constructor emits `__Host-sid` with `HttpOnly`,
+`Secure`, `SameSite=Strict`, `Path=/`, no `Domain`; logout sets `Max-Age=0`. No other
+code path sets the session cookie (guarantees `cpt-cf-bff-nfr-cookie-attrs`).
+
+### 3.3 API Contracts
+
+Two published contracts in `bff-sdk` plus the `/auth/*` HTTP surface.
+
+`SessionResolver` (consumer trait — one store round-trip; on success it pipelines a
+**coalesced** `last_used_at` touch (at most once per configurable interval, **never**
+sliding the TTL — explicit-refresh-only stands); satisfies `cpt-cf-bff-fr-resolve`):
+
+```rust
+#[async_trait]
+pub trait SessionResolver: Send + Sync {
+    /// Ok(None) for absent/expired/revoked sessions (never errors on "not found").
+    async fn resolve(&self, session_id: &SessionId) -> Result<Option<IdentitySnapshot>, BffError>;
+}
+```
+
+`SessionStore` (plugin trait — the reusability boundary; plugins register a
+`PluginV1<SessionStoreSpecV1>` in types-registry + a scoped `ClientHub` client, same
+mechanics as `credstore` / `oidc-authn-plugin`; satisfies `cpt-cf-bff-fr-pluggable-store`).
+No session/KV/state-store trait exists in the workspace today, so this trait is new:
+
+```rust
+#[async_trait]
+pub trait SessionStore: Send + Sync {
+    async fn put_login_state(&self, state: &str, v: &LoginState, ttl: Duration) -> Result<(), StoreError>;
+    async fn take_login_state(&self, state: &str) -> Result<Option<LoginState>, StoreError>; // one-shot
+
+    async fn create_session(&self, id: &SessionId, s: &Session) -> Result<(), StoreError>;
+    async fn get_session(&self, id: &SessionId) -> Result<Option<Session>, StoreError>;
+
+    /// Atomic rotate: rename old->new, update expiry/index, write swap(old->new, grace_ttl).
+    async fn rotate_session(&self, old: &SessionId, new: &SessionId, s: &Session, grace: Duration) -> Result<(), StoreError>;
+    async fn resolve_swap(&self, old: &SessionId) -> Result<Option<SessionId>, StoreError>;
+
+    async fn revoke_session(&self, id: &SessionId) -> Result<(), StoreError>;
+    async fn revoke_all_for_user(&self, user_id: &UserId) -> Result<u64, StoreError>;
+    async fn list_for_user(&self, user_id: &UserId) -> Result<Vec<SessionSummary>, StoreError>;
+
+    async fn sessions_by_idp_sid(&self, iss: &str, sid: &str) -> Result<Vec<SessionId>, StoreError>;
+    async fn mark_logout_jti(&self, iss: &str, jti: &str, ttl: Duration) -> Result<bool, StoreError>; // false = replay
+
+    async fn janitor_sweep(&self, now: i64) -> Result<u64, StoreError>;
+    async fn try_lock(&self, key: &str, ttl: Duration) -> Result<bool, StoreError>;
+    async fn ping(&self) -> Result<(), StoreError>; // readiness
+}
+```
+
+**Endpoints Overview** (`cpt-cf-bff-interface-auth-api`):
+
+| Method | Path | Description | Stability |
+|--------|------|-------------|-----------|
+| `GET` | `/auth/login` | start code+PKCE, 302 to IdP | stable |
+| `GET` | `/auth/callback` | finish flow, create session, set cookie | stable |
+| `GET` | `/auth/me` | current identity + refresh timing | stable |
+| `POST` | `/auth/refresh` | rotate + extend (CSRF) | stable |
+| `POST` | `/auth/logout` | revoke + RP-logout URL (CSRF) | stable |
+| `GET` | `/auth/sessions` | list user sessions | stable |
+| `DELETE` | `/auth/sessions/{id}` | revoke one (CSRF) | stable |
+| `DELETE` | `/auth/sessions` | revoke all (CSRF) | stable |
+| `GET` | `/auth/csrf` | issue CSRF token | stable |
+| `POST` | `/auth/oidc/back-channel-logout` | IdP-driven revoke (auth via `logout_token`) | stable |
+
+Errors use RFC 9457 problem+json via `toolkit-canonical-errors`, namespace `gts.cf.bff.*`.
+
+### 3.4 Internal Dependencies
+
+| Dependency Gear | Interface Used | Purpose |
+|-----------------|----------------|---------|
+| `authn-resolver` | SDK client | validate IdP ID token → identity (`SecurityContext`) |
+| `tenant-resolver` | SDK client | resolve/validate the session tenant |
+| `types-registry` | SDK client | discover the selected `SessionStore` plugin instance |
+| session-store plugin | `SessionStore` plugin trait (scoped client) | persist/expire/index sessions |
+| `oidc-authn-plugin` | reused infra (`infra/oidc.rs`, `infra/token_client.rs`) | OIDC discovery + token-endpoint exchange |
+
+**Dependency Rules**: no circular deps; inter-gear calls via SDK/plugin contracts
+only; `SecurityContext` propagated across in-process calls.
+
+### 3.5 External Dependencies
+
+#### OIDC Identity Provider
+
+OpenID Connect: discovery, Authorization Code + PKCE, RP-initiated logout, and
+Back-Channel Logout (where enabled). Reached through `authn-resolver` / reused OIDC infra.
+
+#### Session-store backend
+
+Whatever the chosen plugin wraps (Redis for the reference plugin; none for in-memory).
+The gear talks to it only through the `SessionStore` trait. The in-memory plugin is
+**process-local** — fine for dev/test/single-instance, but it does **not** satisfy
+`cpt-cf-bff-nfr-stateless`; multi-replica production needs a shared/distributed plugin. The workspace has no Redis
+client today (no `redis`/`fred`/`deadpool` in any `Cargo.toml`), so
+`redis-session-store-plugin` introduces the first one — confined to that plugin crate,
+gated by dependency sign-off (`guidelines/DEPENDENCIES.md`), and never compiled by
+consumers that pick another backend. See [ADR/0001](./ADR/0001-cpt-cf-bff-adr-session-store-plugin.md).
+
+#### CredStore (optional) and Audit sink
+
+`credstore` custody of the OIDC client secret; audit sink receives login / logout /
+refresh / revoke / back-channel events.
+
+### 3.6 Interactions & Sequences
+
+#### Login (code + PKCE)
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-seq-login`
+
+```mermaid
+sequenceDiagram
+  participant SPA
+  participant BFF
+  participant IdP
+  participant Store
+  participant AuthN as authn-resolver
+  SPA->>BFF: GET /auth/login
+  BFF->>Store: put_login_state(state,{pkce,nonce,return_to})
+  BFF-->>SPA: 302 IdP authorize(code_challenge,state,nonce)
+  SPA->>IdP: authenticate
+  IdP-->>SPA: 302 /auth/callback?code&state
+  SPA->>BFF: GET /auth/callback?code&state
+  BFF->>Store: take_login_state(state)
+  BFF->>IdP: token exchange(code,pkce_verifier)
+  BFF->>AuthN: authenticate(id_token)
+  AuthN-->>BFF: SecurityContext(user,tenant)
+  BFF->>Store: create_session(sid,Session)
+  BFF-->>SPA: Set-Cookie __Host-sid; 302 return_to
+```
+
+#### Refresh-rotation with grace (key algorithm)
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-seq-refresh`
+
+```
+POST /auth/refresh (cookie=old_sid, X-CSRF-Token):
+  s = store.get_session(old_sid)            ; if None: 401 + clear cookie
+  verify_csrf(s, header)                     ; if bad: 403
+  new_sid = csprng()
+  new_exp = min(now + ttl, s.absolute_expires_at)
+  store.rotate_session(old_sid, new_sid, s{expires_at=new_exp}, grace)  ; atomic
+  Set-Cookie(new_sid); return {expires_at:new_exp, refresh_at: new_exp - margin ± jitter}
+
+Stale old_sid within grace: resolve_swap(old_sid) -> new_sid ⇒ treat as valid.
+Past grace: 401 + clear cookie ⇒ SPA redirects to /auth/login.
+```
+
+`rotate_session` is atomic in the plugin (Redis: `MULTI/EXEC` rename + index update +
+`SET swap PX grace`). Defaults: TTL 120 s, absolute cap 8 h, grace 250 ms, margin 30 s,
+jitter ±5 s — all configurable.
+
+### 3.7 Database schemas & tables
+
+No relational schema. The Redis reference plugin uses these keys (abstracted behind
+`SessionStore`; other plugins may differ):
+
+| Key | Type | Contents | TTL |
+|-----|------|----------|-----|
+| `bff:session:{sid}` | HASH | `Session` fields | = expires_at |
+| `bff:user_sessions:{user_id}` | ZSET | member=sid, score=expires_at | — |
+| `bff:sid_index:{iss}:{idp_sid}` | SET | sids (back-channel lookup) | — |
+| `bff:login_state:{state}` | HASH | `LoginState` | 5 min |
+| `bff:swap:{old_sid}` | STRING | new_sid (refresh grace) | grace (250 ms) |
+| `bff:logout_jti:{iss}:{jti}` | STRING | replay guard | iat+skew+grace |
+| `bff:lock:janitor` | STRING | single-runner lock | janitor interval |
+
+ZSET (not SET) for the user index → `ZREMRANGEBYSCORE 0 now` janitor sweep.
+
+### 3.8 Deployment Topology
+
+The gear is linked into the gateway app binary (single process, single pod); the
+session store is the only external stateful dependency. Stack: `axum` (via
+api-gateway host), `axum-extra` cookies, `getrandom`/`rand` for session ids,
+`oauth2`/`openidconnect` (or reused `oidc-authn-plugin` infra) for the code flow;
+Redis plugin uses `fred`. No JWT-signing crate in v1.
+
+Configuration (under `gears.bff.config`):
+
+```yaml
+oidc:    { issuer, client_id, client_secret_ref, scopes, redirect_uri }
+session: { ttl: 120s, absolute_cap: 8h, refresh_grace: 250ms,
+           refresh_margin: 30s, refresh_jitter: 5s }
+csrf:    { origin_allowlist: [...] }
+janitor: { interval: 30s }
+store:   { vendor: redis }   # selects the SessionStore plugin instance
+```
+
+## 4. Additional context
+
+- **Dev/local**: compose the in-memory session-store plugin + a dev/fake IdP from
+  test infra; the real BFF code path runs unchanged (no `/auth/login` short-circuit).
+- **Testing**: isolated rotate/grace tests against the in-memory store before wiring;
+  e2e against Redis + fake IdP; cookie-attribute and fail-closed assertions per NFR.
+- **Migration path to Router**: if downstream-JWT mint is later adopted, it consumes
+  `SessionResolver` and adds signing — the algorithm/FIPS ADR is written then, not now.
+- **Open questions (design-level)**:
+  - OQ-1: make the OIDC code↔token exchange a shared helper extracted from
+    `oidc-authn-plugin`, or a small BFF-local client reusing its discovery cache?
+  - OQ-2: does `authn-resolver.authenticate` accept an OIDC ID token as-is, or does
+    the code-flow need a small extension vs. its current bearer-validation path?
+  - OQ-3: back-channel `logout_token` validation — reuse `authn-resolver` JWKS
+    validation (preferred) or validate in the BFF?
+
+## 5. Traceability
+
+- **PRD**: [PRD.md](./PRD.md)
+- **ADRs**: [ADR/0001 — session-store as plugin](./ADR/0001-cpt-cf-bff-adr-session-store-plugin.md) (`cpt-cf-bff-adr-session-store`), [ADR/0002 — opaque sessions, no JWT in v1](./ADR/0002-cpt-cf-bff-adr-opaque-sessions-no-jwt.md) (`cpt-cf-bff-adr-opaque-sessions-no-jwt`)
+- **Upstream inputs**: Insight `api-gateway/bff` PRD & DESIGN (DD-BFF-01..10), `BFF.md`.
+- **Reused code**: `oidc-authn-plugin` (`infra/oidc.rs`, `infra/token_client.rs`), `authn-resolver`, `tenant-resolver`.

--- a/gears/system/bff/docs/PRD.md
+++ b/gears/system/bff/docs/PRD.md
@@ -1,0 +1,694 @@
+# PRD — BFF (Backend-for-Frontend) Gear
+
+
+<!-- toc -->
+
+- [1. Overview](#1-overview)
+  - [1.1 Purpose](#11-purpose)
+  - [1.2 Background / Problem Statement](#12-background--problem-statement)
+  - [1.3 Goals (Business Outcomes)](#13-goals-business-outcomes)
+  - [1.4 Glossary](#14-glossary)
+- [2. Actors](#2-actors)
+  - [2.1 Human Actors](#21-human-actors)
+  - [2.2 System Actors](#22-system-actors)
+- [3. Operational Concept & Environment](#3-operational-concept--environment)
+  - [3.1 Gear-Specific Environment Constraints](#31-gear-specific-environment-constraints)
+- [4. Scope](#4-scope)
+  - [4.1 In Scope](#41-in-scope)
+  - [4.2 Out of Scope](#42-out-of-scope)
+- [5. Functional Requirements](#5-functional-requirements)
+  - [5.1 Authentication & Login](#51-authentication--login)
+  - [5.2 Session & Cookie](#52-session--cookie)
+  - [5.3 Logout & Revocation](#53-logout--revocation)
+  - [5.4 Protection & Integrity](#54-protection--integrity)
+  - [5.5 Extensibility & Reuse](#55-extensibility--reuse)
+- [6. Non-Functional Requirements](#6-non-functional-requirements)
+  - [6.1 Gear-Specific NFRs](#61-gear-specific-nfrs)
+  - [6.2 NFR Exclusions](#62-nfr-exclusions)
+- [7. Public Library Interfaces](#7-public-library-interfaces)
+  - [7.1 Public API Surface](#71-public-api-surface)
+  - [7.2 External Integration Contracts](#72-external-integration-contracts)
+- [8. Use Cases](#8-use-cases)
+- [9. Acceptance Criteria](#9-acceptance-criteria)
+- [10. Dependencies](#10-dependencies)
+- [11. Assumptions](#11-assumptions)
+- [12. Risks](#12-risks)
+- [13. Open Questions](#13-open-questions)
+- [14. Traceability](#14-traceability)
+
+<!-- /toc -->
+
+<!--
+Product Requirements Document. Defines WHAT the BFF gear must do and WHY.
+Implementation, architecture, and technology choices live in DESIGN.md / ADR/.
+Requirement language: MUST/SHALL = mandatory; use priority p2/p3 instead of SHOULD/MAY.
+-->
+## 1. Overview
+
+### 1.1 Purpose
+
+The **BFF (Backend-for-Frontend) gear** provides browser-facing authentication and
+session management for single-page applications (SPAs). It runs the OIDC
+Authorization Code + PKCE flow as a confidential client on the server side, holds
+all identity-provider (IdP) tokens server-side, and exposes the browser only an
+opaque, hardened session cookie. It offers an `/auth/*` API for login, logout,
+refresh, session listing/revocation, and CSRF, and a programmatic interface that
+lets a co-hosted gateway turn a session cookie into an authenticated identity.
+
+The gear is **product-agnostic and reusable**: the session storage backend is a
+swappable plugin (e.g. Redis for production, in-memory for development), and the
+IdP integration reuses the existing `authn-resolver` gear. Any consumer can link
+the gear, choose a session-store plugin, and obtain a working cookie-based auth
+layer for their SPA.
+
+### 1.2 Background / Problem Statement
+
+SPAs that store IdP tokens in the browser (sessionStorage / in-memory) and send
+them as `Authorization: Bearer` headers expose those tokens to XSS, cannot revoke
+a leaked token before expiry, and force the frontend to decode JWTs to derive
+user identity. This is the pattern in use today across consuming products and it
+is a recurring security and maintenance liability.
+
+The BFF pattern removes tokens from the browser entirely: the server performs the
+OIDC handshake, stores tokens and session state server-side, and the browser holds
+only an opaque session reference in a `__Host-`-prefixed, `HttpOnly`, `Secure`,
+`SameSite=Strict` cookie. Sessions become individually revocable, refresh is
+explicit and server-controlled, and the frontend stops handling tokens.
+
+Today the gears-rust workspace has an `api-gateway` gear (routing, middleware,
+Bearer validation via `authn-resolver`) but **no cookie/session/OIDC-login layer**.
+This gear fills that gap as a standalone, reusable unit rather than as
+product-specific code.
+
+### 1.3 Goals (Business Outcomes)
+
+- Eliminate browser-held IdP tokens for consuming SPAs (zero tokens in
+  `localStorage`/`sessionStorage`).
+- Provide individually revocable sessions: a single session, or all sessions for a
+  user, can be terminated and take effect within the session TTL.
+- Ship a reusable gear adoptable by any product with two-line composition plus a
+  session-store plugin choice — no auth logic re-implementation per product.
+- Keep added authentication-path overhead within the gateway's latency budget so
+  the BFF is viable in the request hot path.
+
+### 1.4 Glossary
+
+| Term | Definition |
+|------|------------|
+| BFF | Backend-for-Frontend: server-side component that mediates auth between a browser SPA and IdPs/APIs. |
+| SPA | Single-Page Application (browser frontend). |
+| OIDC | OpenID Connect, the identity layer over OAuth 2.0. |
+| PKCE | Proof Key for Code Exchange (RFC 7636) — protects the authorization code flow. |
+| Session | Server-side record of an authenticated user, referenced by an opaque session ID held in a cookie. |
+| Session store | Pluggable backend persisting session records (e.g. Redis, in-memory). |
+| RP-initiated logout | Relying-Party-initiated OIDC logout: BFF redirects the browser to the IdP `end_session_endpoint`. |
+| Back-channel logout | IdP-initiated logout delivered server-to-server (OIDC Back-Channel Logout). |
+| CSRF | Cross-Site Request Forgery. |
+| Refresh rotation | Replacing the session identifier on each explicit refresh to bound the value of a stolen cookie. |
+
+## 2. Actors
+
+### 2.1 Human Actors
+
+#### End User
+
+**ID**: `cpt-cf-bff-actor-end-user`
+
+- **Role**: A person using a consuming SPA in a browser who authenticates via the
+  organization's IdP and holds an active session.
+- **Needs**: Sign in once via the IdP; remain signed in across page reloads and
+  multiple tabs without re-entering credentials; sign out reliably; see and revoke
+  their active sessions.
+
+### 2.2 System Actors
+
+#### SPA / Browser Client
+
+**ID**: `cpt-cf-bff-actor-spa`
+
+- **Role**: The consuming frontend. Initiates login by navigation, sends the
+  session cookie on subsequent requests, primes a refresh timer from
+  server-supplied values, and coordinates refresh across tabs.
+
+#### Identity Provider (OIDC)
+
+**ID**: `cpt-cf-bff-actor-idp`
+
+- **Role**: External OIDC provider. Authenticates the user, issues tokens via the
+  code exchange, supports RP-initiated logout, and may emit back-channel logout
+  notifications.
+
+#### Session Store Plugin
+
+**ID**: `cpt-cf-bff-actor-session-store`
+
+- **Role**: Pluggable backend that persists and expires session records and
+  supporting indexes on behalf of the gear. Selected at composition time.
+
+#### Co-hosted Gateway
+
+**ID**: `cpt-cf-bff-actor-gateway`
+
+- **Role**: The `api-gateway` (or equivalent) that serves `/api/*`. It consumes the
+  BFF's session-resolution interface to convert a session cookie into an
+  authenticated identity for downstream request handling.
+
+#### Audit Sink
+
+**ID**: `cpt-cf-bff-actor-audit`
+
+- **Role**: External service receiving authentication lifecycle events (login,
+  logout, refresh, revoke, back-channel logout).
+
+## 3. Operational Concept & Environment
+
+> Project-wide runtime, security, and lifecycle baselines are defined in
+> [`docs/ARCHITECTURE_MANIFEST.md`](../../../../docs/ARCHITECTURE_MANIFEST.md) and
+> [`guidelines/`](../../../../guidelines). This gear has no parent/root PRD. Only
+> gear-specific deviations are listed below.
+
+### 3.1 Gear-Specific Environment Constraints
+
+- Requires a session-store plugin to be present at composition time; with no store
+  configured the gear MUST refuse to start (fail-closed, see `cpt-cf-bff-nfr-fail-closed`).
+- Requires HTTPS at the browser edge: the hardened cookie attributes
+  (`__Host-` prefix, `Secure`) are only valid over TLS. TLS termination is provided
+  by the deployment environment, not this gear.
+- Requires a reachable OIDC IdP exposing standard discovery and code-flow endpoints.
+- Assumes the SPA and the gateway are served same-site so the session cookie is
+  first-party (a `SameSite=Strict` constraint, see `cpt-cf-bff-fr-cookie`).
+
+## 4. Scope
+
+### 4.1 In Scope
+
+- Server-side OIDC Authorization Code + PKCE login as a confidential client.
+- Server-side session lifecycle: create, validate, explicit refresh with rotation,
+  expire, and revoke.
+- Hardened, opaque session cookie issuance and clearing.
+- `/auth/*` API: login, callback, refresh, logout, current-identity, session list,
+  session revoke (one and all), CSRF token, back-channel logout receiver.
+- A programmatic session-resolution interface consumed by a co-hosted gateway.
+- Pluggable session storage (plugin contract + at least one production-grade and one
+  development-grade plugin).
+- Pluggable IdP integration by reuse of the `authn-resolver` gear for ID-token
+  validation and identity extraction.
+- Tenant association of sessions via the `tenant-resolver` gear.
+- Emission of authentication lifecycle audit events.
+- A defined SPA integration contract (cookie behavior, refresh timing semantics,
+  CSRF, multi-tab coordination expectations).
+
+### 4.2 Out of Scope
+
+- Reverse proxying of `/api/*` and request routing — owned by the `api-gateway` gear.
+- Minting and serving downstream/internal service JWTs (the "Router"/gateway-JWT
+  role) and JWKS publication — a separable concern, not part of this gear's first
+  release (tracked in Open Questions).
+- The IdP itself and IdP administration.
+- A development/fake IdP for local stands — a testing enabler that belongs to test
+  infrastructure, not a product capability of this gear (see Assumptions).
+- Suspicious-activity / anomaly **detection**, alerting, and step-up re-auth. v1
+  *captures* device context (last-used, IP, user agent) and lists sessions, but acting
+  on it (new-device detection, impossible-travel, notifications, step-up) is deferred to
+  a later feature or a separate gear.
+- The consuming SPA's own UI and routing.
+- Authorization / policy decisions beyond producing an authenticated identity
+  (owned by `authz-resolver`).
+
+## 5. Functional Requirements
+
+> All requirements verified via automated tests (unit, integration, e2e) at 90%+
+> coverage unless a non-standard verification method is noted.
+
+### 5.1 Authentication & Login
+
+#### OIDC login initiation
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-fr-login`
+
+The system **MUST** start an OIDC Authorization Code flow with PKCE as a
+confidential client, redirecting the browser to the IdP, and **MUST** carry
+protection against CSRF and replay on the authorization request (per-attempt
+state and nonce) and preserve a caller-supplied post-login return location.
+
+- **Rationale**: Code + PKCE is the secure browser login flow; tokens never reach
+  the browser.
+- **Actors**: `cpt-cf-bff-actor-spa`, `cpt-cf-bff-actor-idp`
+
+#### Login completion and session establishment
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-fr-callback`
+
+The system **MUST** complete the OIDC flow on the IdP redirect: validate the
+returned state/nonce, exchange the authorization code for tokens server-side,
+validate the ID token, resolve the authenticated identity and its tenant, create a
+server-side session holding the IdP tokens, and establish the session cookie.
+
+- **Rationale**: Turns a successful IdP handshake into a durable, server-held session.
+- **Actors**: `cpt-cf-bff-actor-idp`, `cpt-cf-bff-actor-session-store`
+
+### 5.2 Session & Cookie
+
+#### Hardened session cookie
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-fr-cookie`
+
+The system **MUST** convey the session to the browser only as an opaque,
+unguessable reference in a cookie carrying the `__Host-` prefix, `HttpOnly`,
+`Secure`, `SameSite=Strict`, and `Path=/`, with no `Domain` attribute. The browser
+**MUST NOT** receive any IdP token or any user identity claim in client-readable form.
+
+- **Rationale**: Removes token exposure to XSS and confines the cookie to first-party use.
+- **Actors**: `cpt-cf-bff-actor-spa`
+
+#### Session resolution
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-fr-resolve`
+
+The system **MUST** provide a means to resolve a presented session reference into
+the current authenticated identity (user, tenant, and session validity/expiry),
+returning an unauthenticated result when the session is absent, expired, or revoked.
+
+- **Rationale**: This is how the co-hosted gateway and the `/auth/me` endpoint learn
+  who the caller is without the browser holding identity.
+- **Actors**: `cpt-cf-bff-actor-gateway`, `cpt-cf-bff-actor-spa`
+
+#### Explicit session refresh with rotation
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-fr-refresh`
+
+The system **MUST** extend a session's lifetime only by an explicit refresh
+request (no sliding/passive extension), **MUST** rotate the session reference on
+each refresh, **MUST** bound total session lifetime by a configurable absolute cap,
+and **MUST** tolerate benign concurrent/duplicate refreshes (e.g. multiple tabs,
+page reloads, retries) within a short grace window without forcing re-login.
+
+- **Rationale**: Short TTL plus rotation bounds the value of a stolen cookie; the
+  grace window prevents multi-tab races from logging users out.
+- **Actors**: `cpt-cf-bff-actor-spa`, `cpt-cf-bff-actor-session-store`
+
+#### Refresh timing contract
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-fr-refresh-timing`
+
+On session establishment and on refresh, the system **MUST** return a
+server-supplied next-refresh deadline and absolute expiry, and the deadline
+**MUST** be jittered so that refreshes across clients do not align to a predictable
+instant. Clients use the server-supplied deadline rather than computing their own.
+
+- **Rationale**: Server-controlled, jittered timing prevents thundering-herd and
+  timing-aligned attacks; keeps refresh logic out of the frontend.
+- **Actors**: `cpt-cf-bff-actor-spa`
+
+### 5.3 Logout & Revocation
+
+#### Logout
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-fr-logout`
+
+The system **MUST** support local logout (revoke the current session and clear the
+cookie) and RP-initiated logout (provide the IdP end-session redirect so the IdP
+session is also terminated).
+
+- **Rationale**: A user signing out must end both the local session and the IdP session.
+- **Actors**: `cpt-cf-bff-actor-spa`, `cpt-cf-bff-actor-idp`
+
+#### Back-channel logout
+
+- [ ] `p2` - **ID**: `cpt-cf-bff-fr-backchannel-logout`
+
+The system **MUST** accept IdP-initiated back-channel logout notifications,
+validate them, protect against replay, and revoke the matching session(s).
+
+- **Rationale**: Lets the IdP terminate sessions (e.g. admin action, credential
+  compromise) without a browser round-trip.
+- **Actors**: `cpt-cf-bff-actor-idp`
+
+#### Session listing
+
+- [ ] `p2` - **ID**: `cpt-cf-bff-fr-session-list`
+
+The system **MUST** let an authenticated user enumerate their active sessions with
+enough context to recognize each device (creation time, expiry, last-used time, source
+IP, a device/browser label derived from the user agent, and which one is current).
+
+- **Rationale**: Transparency, device inventory, and a prerequisite for selective
+  revocation and anomaly detection — a capability the opaque-session model provides on
+  the per-request lookup that authentication already requires.
+- **Actors**: `cpt-cf-bff-actor-end-user`
+
+#### Session revocation
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-fr-session-revoke`
+
+The system **MUST** let an authenticated user revoke a specific session by
+reference and revoke all of their sessions ("sign out everywhere"); revocation
+**MUST** take effect for subsequent requests.
+
+- **Rationale**: Core security control for lost devices or suspected compromise.
+- **Actors**: `cpt-cf-bff-actor-end-user`
+
+### 5.4 Protection & Integrity
+
+#### CSRF protection
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-fr-csrf`
+
+The system **MUST** protect state-changing `/auth/*` operations against CSRF using
+a token bound to the session in addition to the cookie's `SameSite=Strict` posture,
+and **MUST** provide a way for the SPA to obtain the current token.
+
+- **Rationale**: Defense-in-depth for state-changing auth operations.
+- **Actors**: `cpt-cf-bff-actor-spa`
+
+#### Expired-session housekeeping
+
+- [ ] `p2` - **ID**: `cpt-cf-bff-fr-housekeeping`
+
+The system **MUST** reclaim references to expired sessions from supporting indexes
+so that listings and per-user indexes do not accumulate stale entries, coordinating
+so that the work is not duplicated across replicas.
+
+- **Rationale**: Keeps the per-user session index accurate and bounded over time.
+- **Actors**: `cpt-cf-bff-actor-session-store`
+
+### 5.5 Extensibility & Reuse
+
+#### Pluggable session store
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-fr-pluggable-store`
+
+The system **MUST** define the session-store backend as a plugin selected at
+composition time, **MUST** function with any conformant plugin without code
+changes, and **MUST** ship at least one production-grade plugin and one
+development-grade plugin.
+
+- **Rationale**: The core reuse mechanism — consumers choose or supply a backend.
+- **Actors**: `cpt-cf-bff-actor-session-store`
+
+#### Pluggable IdP integration
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-fr-pluggable-idp`
+
+The system **MUST** obtain ID-token validation and identity extraction through the
+`authn-resolver` gear rather than embedding IdP-specific validation, so that the
+set of supported IdPs is governed by `authn-resolver` plugins.
+
+- **Rationale**: Reuses existing, plugin-based IdP support; avoids duplicating
+  JWKS/validation logic per product.
+- **Actors**: `cpt-cf-bff-actor-idp`
+
+#### Audit of authentication events
+
+- [ ] `p2` - **ID**: `cpt-cf-bff-fr-audit`
+
+The system **MUST** emit an audit event for each authentication lifecycle action:
+login, logout, refresh, revoke (single and all), and back-channel logout.
+
+- **Rationale**: Security accountability and incident forensics.
+- **Actors**: `cpt-cf-bff-actor-audit`
+
+## 6. Non-Functional Requirements
+
+> Project-wide NFRs (baseline security, observability, tenancy isolation) are
+> inherited from [`docs/ARCHITECTURE_MANIFEST.md`](../../../../docs/ARCHITECTURE_MANIFEST.md)
+> and [`guidelines/`](../../../../guidelines). Only gear-specific NFRs are listed.
+
+### 6.1 Gear-Specific NFRs
+
+#### Authentication-path latency
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-nfr-latency`
+
+Session resolution on the request hot path **MUST** add no more than 15 ms at p95
+under nominal load, exclusive of session-store round-trip time.
+
+- **Threshold**: ≤ 15 ms p95 added latency, nominal load.
+- **Rationale**: The BFF sits in front of every authenticated request; it must not
+  dominate latency.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation.
+
+#### Cookie hardening
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-nfr-cookie-attrs`
+
+100% of session-cookie responses **MUST** carry the `__Host-` prefix, `HttpOnly`,
+`Secure`, `SameSite=Strict`, and `Path=/`, with no `Domain` attribute.
+
+- **Threshold**: 100% of set-cookie responses conform.
+- **Rationale**: Any non-conforming cookie reintroduces the exposure the gear exists
+  to remove.
+
+#### Fail-closed
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-nfr-fail-closed`
+
+If the session store is unreachable or no store/IdP configuration is present, the
+system **MUST** deny authentication (reject auth mutations and report not-ready)
+rather than serve any degraded or cached-auth path. No per-user session state is
+held in process memory as an authority.
+
+- **Threshold**: Zero authenticated outcomes produced while the store is unreachable.
+- **Rationale**: Auth must never silently weaken under partial failure.
+
+#### Stateless horizontal scale
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-nfr-stateless`
+
+The system **MUST** hold no authoritative per-user session state in process memory;
+terminating any single replica **MUST NOT** sign any user out.
+
+- **Threshold**: Session survives replica loss; any replica can serve any session.
+- **Rationale**: Horizontal scalability and zero-downtime deploys.
+- **Note**: This is satisfied only by a **shared/distributed** session-store plugin
+  (e.g. Redis). The in-memory plugin is process-local and does **not** satisfy it — it
+  is for development, tests, and single-instance use only.
+
+#### Session lifetime bounds
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-nfr-session-ttl`
+
+Session TTL and absolute lifetime cap **MUST** be configurable within bounded
+ranges with safe short defaults; a stolen cookie's usable lifetime is limited to the
+TTL plus the refresh grace window.
+
+- **Threshold**: TTL and absolute cap configurable; defaults short (sub-hour TTL).
+- **Rationale**: Bounds exposure from a leaked cookie.
+
+#### Token & secret confidentiality
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-nfr-secret-confidentiality`
+
+IdP tokens, session references, and CSRF tokens **MUST NOT** appear in logs, error
+responses, or any browser-readable surface.
+
+- **Threshold**: No secret material in logs or client-visible output.
+- **Rationale**: Server-side token custody is the gear's reason to exist.
+
+#### Abuse resistance on `/auth/*`
+
+- [ ] `p2` - **ID**: `cpt-cf-bff-nfr-rate-limit`
+
+The `/auth/*` surface **MUST** be protected against abuse by per-client rate
+limiting and a bound on concurrent in-flight login attempts, such that sustained
+request floods do not exhaust the session store or CPU.
+
+- **Threshold**: Configurable per-client limit and concurrent-login cap; sustained
+  flood does not degrade healthy traffic.
+- **Rationale**: Login endpoints are a common DoS and credential-stuffing target.
+
+### 6.2 NFR Exclusions
+
+- **Persistent relational storage / migrations**: Not applicable — session state is
+  ephemeral and lives in the session-store plugin, not a relational database.
+
+## 7. Public Library Interfaces
+
+### 7.1 Public API Surface
+
+#### Session-resolution interface
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-interface-session-resolver`
+
+- **Type**: Rust gear/trait (SDK), registered via ClientHub.
+- **Stability**: stable.
+- **Description**: Resolves a presented session reference into an authenticated
+  identity (user, tenant, validity). Consumed in-process by the co-hosted gateway
+  and by the gear's own `/auth/me` handler. Satisfies `cpt-cf-bff-fr-resolve`.
+- **Breaking Change Policy**: Major version bump required.
+
+#### Session-store plugin interface
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-interface-session-store`
+
+- **Type**: Rust plugin trait (SDK) discovered via the registry, implemented by
+  session-store plugins.
+- **Stability**: stable.
+- **Description**: The contract a backend must implement to persist, look up,
+  rotate, expire, index, and revoke sessions. Satisfies `cpt-cf-bff-fr-pluggable-store`.
+- **Breaking Change Policy**: Major version bump required.
+
+#### `/auth/*` HTTP API
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-interface-auth-api`
+
+- **Type**: REST API (registered through the host gateway, documented via OpenAPI).
+- **Stability**: stable.
+- **Description**: Browser-facing endpoints covering login, callback, refresh,
+  logout, current identity, session list, session revoke (one/all), CSRF token, and
+  back-channel logout receiver. Concrete paths, methods, and payloads are specified
+  in DESIGN.md, not here.
+- **Breaking Change Policy**: Additive changes only within a major version.
+
+### 7.2 External Integration Contracts
+
+#### SPA integration contract
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-contract-spa`
+
+- **Direction**: provided by library (to consuming SPAs).
+- **Protocol/Format**: HTTP + cookie; server-supplied refresh timing.
+- **Compatibility**: The SPA navigates to login, sends the cookie with credentials,
+  primes its refresh timer from server-supplied values, echoes the CSRF token on
+  state-changing requests, and coordinates refresh across tabs (single refresher per
+  browser). Stable within a major version.
+
+#### OIDC provider contract
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-contract-oidc`
+
+- **Direction**: required from environment.
+- **Protocol/Format**: OpenID Connect (discovery, Authorization Code + PKCE,
+  RP-initiated logout; Back-Channel Logout where `cpt-cf-bff-fr-backchannel-logout` is enabled).
+- **Compatibility**: Standards-conformant OIDC providers.
+
+## 8. Use Cases
+
+#### First-time sign-in
+
+- [ ] `p1` - **ID**: `cpt-cf-bff-usecase-signin`
+
+**Actor**: `cpt-cf-bff-actor-end-user`
+
+**Preconditions**: User is unauthenticated; IdP reachable; session store available.
+
+**Main Flow**:
+1. SPA detects no session and navigates the browser to the login initiation endpoint.
+2. BFF redirects to the IdP with a code+PKCE authorization request.
+3. User authenticates at the IdP; IdP redirects back to the BFF callback.
+4. BFF validates the response, exchanges the code, validates the ID token, resolves
+   identity and tenant, creates a session, and sets the session cookie.
+5. SPA loads its authenticated state from the current-identity endpoint.
+
+**Postconditions**: A server-side session exists; the browser holds only the cookie.
+
+**Alternative Flows**:
+- **IdP denies / state mismatch**: BFF rejects the callback and returns the user to
+  an unauthenticated state without creating a session.
+
+#### Staying signed in across tabs
+
+- [ ] `p2` - **ID**: `cpt-cf-bff-usecase-refresh`
+
+**Actor**: `cpt-cf-bff-actor-spa`
+
+**Preconditions**: An active session exists.
+
+**Main Flow**:
+1. SPA primes a timer from the server-supplied next-refresh deadline.
+2. At the deadline, a single tab issues a refresh; the session reference rotates and
+   a new deadline is returned.
+3. Other tabs consume the rotation result rather than each refreshing.
+
+**Postconditions**: Session lifetime extended within the absolute cap; cookie rotated.
+
+**Alternative Flows**:
+- **Concurrent refresh within grace**: A near-simultaneous refresh from another tab
+  resolves to the rotated session without forcing re-login.
+- **Refresh after expiry**: Session is gone; user is sent back to sign-in.
+
+#### Sign out everywhere
+
+- [ ] `p2` - **ID**: `cpt-cf-bff-usecase-revoke-all`
+
+**Actor**: `cpt-cf-bff-actor-end-user`
+
+**Preconditions**: User has one or more active sessions.
+
+**Main Flow**:
+1. User requests revocation of all sessions.
+2. BFF revokes every session for the user and clears the current cookie.
+
+**Postconditions**: All of the user's sessions are invalid for subsequent requests.
+
+## 9. Acceptance Criteria
+
+- [ ] A consuming SPA completes IdP sign-in and obtains an authenticated session
+      with zero IdP tokens stored in the browser.
+- [ ] Every session-cookie response conforms to the hardened-cookie attribute set.
+- [ ] A revoked session (single or "all") is rejected on the next request.
+- [ ] An explicit refresh rotates the session reference and returns a new
+      server-supplied deadline; concurrent refreshes within the grace window do not
+      log the user out.
+- [ ] With the session store unreachable, no request is served as authenticated and
+      readiness reports not-ready.
+- [ ] The gear runs against at least two session-store plugins (production and
+      development) with no change to gear code.
+- [ ] All listed authentication lifecycle actions produce audit events.
+
+## 10. Dependencies
+
+| Dependency | Description | Criticality |
+|------------|-------------|-------------|
+| `authn-resolver` gear | ID-token validation and identity extraction (IdP plugin host) | p1 |
+| `tenant-resolver` gear | Resolves/validates the tenant associated with a session | p1 |
+| Session-store plugin | Persists and expires session state | p1 |
+| `api-gateway` gear | Hosts `/auth/*` routes and consumes session resolution for `/api/*` | p1 |
+| `types-registry` gear | Plugin discovery/selection mechanism | p1 |
+| `credstore` gear | Custody of OIDC client secret / any signing material | p2 |
+| OIDC IdP | External authentication authority | p1 |
+| Audit sink | Receives authentication lifecycle events | p2 |
+
+## 11. Assumptions
+
+- TLS is terminated at the deployment edge; the gear is reached over HTTPS so
+  `__Host-`/`Secure` cookies are valid.
+- The SPA and gateway are served same-site, satisfying `SameSite=Strict`.
+- `authn-resolver` with a suitable IdP plugin is composed into the same binary.
+- Exactly one logical session store is available per deployment.
+- Local development uses a development session-store plugin and a development/fake
+  IdP supplied by test infrastructure (outside this gear) so the real code path runs
+  without external IdP infrastructure.
+
+## 12. Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Session store is a hard auth dependency | Store outage = no logins/refresh | Fail-closed by design (`cpt-cf-bff-nfr-fail-closed`); rely on store HA at deployment. |
+| Refresh-rotation race correctness | Spurious logouts or accepted stale cookies | Grace window + atomic rotation; isolated tests of the rotation path before wiring (detailed in DESIGN). |
+| `SameSite=Strict` breaks cross-site deep links | Inbound links from external sites land unauthenticated | Accepted for v1; revisit a separate cookie class later (DESIGN/ADR). |
+| OIDC provider behavior varies | Edge-case login failures per IdP | Delegate validation to `authn-resolver` plugins; conformance-test against target IdPs. |
+| Gateway-JWT / downstream identity propagation deferred | Downstream services still need a trusted identity assertion | Tracked in Open Questions; current consumers use in-process `SecurityContext` from session resolution. |
+
+## 13. Open Questions
+
+- Where does the IdP-subject → internal-user mapping live: entirely within
+  `authn-resolver` identity extraction, or via a separate identity service? Affects
+  the shape of `cpt-cf-bff-fr-callback` and `cpt-cf-bff-fr-resolve`.
+- Is the downstream/internal-service JWT mint + JWKS publication (the "Router"
+  role) a future extension of this gear, an extension of `api-gateway`, or a
+  separate gear? Out of scope for v1 but needs an owner.
+- Is back-channel logout (`cpt-cf-bff-fr-backchannel-logout`) required for the first
+  adopter, or can it follow? Drives p1/p2 sequencing.
+- Default values for session TTL, absolute cap, refresh grace window, and jitter —
+  to be fixed in DESIGN with rationale.
+- Signing-algorithm posture for any gear-issued assertion: EdDSA is acceptable but
+  not mandatory; the choice (and any FIPS implications) is deferred to an ADR.
+
+## 14. Traceability
+
+- **Design**: [DESIGN.md](./DESIGN.md)
+- **ADRs**: [ADR/](./ADR/)
+- **Features**: [features/](./features/)
+- **Upstream spec inputs**: Insight api-gateway/bff PRD & DESIGN (product-specific
+  origin of this reusable gear), and `BFF.md` (cookie-auth handoff).


### PR DESCRIPTION
Specify gears/system/bff: a reusable cookie-based OIDC session layer for browser SPAs, with a swappable SessionStore plugin (Redis + in-memory), opaque server-side sessions, and no JWT minted in v1.

Includes PRD, DESIGN, ADR 0001 (session store as a plugin) and ADR 0002 (opaque sessions, no JWT in v1). All artifacts pass cfs validate.