### PR TITLE
docs: convert internal links to relative URLs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,38 @@ permissions:
   contents: read
 
 jobs:
+  # Gate: detect whether anything other than docs changed. Doc-only PRs skip the
+  # expensive CodeQL steps below but the analyze job still runs and reports green,
+  # so required status checks are never left pending.
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Filter changed paths
+        id: filter
+        shell: bash
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          if [ -z "$base" ]; then
+            # schedule / non-PR runs: always analyze
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed="$(git diff --name-only "$base"...HEAD)"
+          if printf '%s\n' "$changed" | grep -vE '(\.md$|^docs/)' | grep -q .; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
   analyze:
+    needs: changes
     name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
@@ -64,6 +95,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
+      if: needs.changes.outputs.code == 'true'
       uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
       with:
         languages: ${{ matrix.language }}
@@ -82,7 +114,7 @@ jobs:
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
     - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
+      if: needs.changes.outputs.code == 'true' && matrix.build-mode == 'manual'
       shell: bash
       run: |
         echo 'If you are using a "manual" build mode for one or more of the' \
@@ -93,6 +125,7 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
+      if: needs.changes.outputs.code == 'true'
       uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/gts-validation.yml
+++ b/.github/workflows/gts-validation.yml
@@ -35,12 +35,17 @@ jobs:
       - name: Cache Cargo/target
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
-          cache-bin: false
+          # cache-bin caches ${CARGO_HOME}/bin, so the gts-validator binary is
+          # restored across runs instead of being recompiled from source every
+          # time (doc-only PRs were paying a multi-minute build otherwise).
+          cache-bin: true
           cache-targets: false
-          shared-key: pr-Linux-stable-1.95
+          shared-key: gts-validator-0.10.1
 
       - name: Install gts-validator
-        run: cargo install gts-validator
+        # Pinned + --locked for reproducibility. On a cache hit the binary is
+        # already present, so cargo install detects it and skips the compile.
+        run: cargo install gts-validator --version 0.10.1 --locked
 
       - name: Validate GTS identifiers
         run: make gts-docs

--- a/Makefile
+++ b/Makefile
@@ -327,6 +327,7 @@ gts-docs:
 		--vendor cf,vendor,example,fabrikam \
 		--exclude "target/*" \
 		--exclude "docs/api/*" \
+		--exclude "docs/web-docs/*" \
 		--exclude "gears/chat-engine/*" \
 		--exclude "**/helm/*/templates/*" \
 		docs gears libs examples

--- a/docs/web-docs/architecture/index.md
+++ b/docs/web-docs/architecture/index.md
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 This is how a Gears system is organized end to end. It expands on the
-[core concepts](/concepts/) with the runtime lifecycle, the request path, and the
+[core concepts](../concepts/) with the runtime lifecycle, the request path, and the
 deployment model.
 
 ## Three tiers, one-way dependencies

--- a/docs/web-docs/concepts/gears-and-composition.mdx
+++ b/docs/web-docs/concepts/gears-and-composition.mdx
@@ -107,6 +107,6 @@ a plugin at runtime; the plugin registers a **scoped** client in `ClientHub`. A 
 simply one of the implementations behind a facade trait.
 
 <Aside type="tip">
-Build it yourself: the [first-gear walkthrough](/get-started/your-first-gear/) defines an SDK,
+Build it yourself: the [first-gear walkthrough](../../get-started/your-first-gear/) defines an SDK,
 a backend, and `ClientHub` registration against real code.
 </Aside>

--- a/docs/web-docs/concepts/index.md
+++ b/docs/web-docs/concepts/index.md
@@ -9,18 +9,18 @@ sidebar:
 These pages are the mental model you need before building. They are grouped into four
 areas; read them in order, or jump to what you need.
 
-- **[Gears & composition](/concepts/gears-and-composition/)** — what a gear is, the
+- **[Gears & composition](./gears-and-composition/)** — what a gear is, the
   three-tier hierarchy, the SDK facade+backend pattern, and how gears find each other
   through `ClientHub`.
-- **[Runtime & lifecycle](/concepts/runtime-and-lifecycle/)** — capabilities, the ordered
+- **[Runtime & lifecycle](./runtime-and-lifecycle/)** — capabilities, the ordered
   lifecycle the runtime drives every gear through, async boundaries, and the (planned)
   cluster plane.
-- **[Security & multi-tenancy](/concepts/security-and-tenancy/)** — the secure-by-default
+- **[Security & multi-tenancy](./security-and-tenancy/)** — the secure-by-default
   data path: `SecurityContext`, PDP/PEP authorization, `AccessScope`, `SecureConn`, and the
   tenant tree.
-- **[Errors & the type system](/concepts/errors-and-types/)** — the canonical error model
+- **[Errors & the type system](./errors-and-types/)** — the canonical error model
   (RFC-9457) and the Global Type System (GTS).
 
-When you're ready to apply them, the [first-gear walkthrough](/get-started/your-first-gear/)
-ties everything together against real code, and the [Guides](/guides/) go deep on individual
+When you're ready to apply them, the [first-gear walkthrough](../get-started/your-first-gear/)
+ties everything together against real code, and the [Guides](../guides/) go deep on individual
 features.

--- a/docs/web-docs/concepts/security-and-tenancy.md
+++ b/docs/web-docs/concepts/security-and-tenancy.md
@@ -70,7 +70,7 @@ the workspace lints. Always go through `SecureConn` with a scope obtained from t
 `PolicyEnforcer`.
 :::
 
-The [authorization guide](/guides/authorization/) and [database guide](/guides/database/)
+The [authorization guide](../../guides/authorization/) and [database guide](../../guides/database/)
 show the full flow against real code.
 
 ## Multi-tenancy

--- a/docs/web-docs/contributing/contributor-guide.md
+++ b/docs/web-docs/contributing/contributor-guide.md
@@ -53,7 +53,7 @@ The dev server runs at `http://localhost:4321`.
 
 :::note
 Full-text search is disabled in `dev`. Run `pnpm build && pnpm preview` to exercise
-search and the production output (including the [/i18n/](/i18n/) dashboard).
+search and the production output (including the [/i18n/](../../i18n/) dashboard).
 :::
 
 ## Git workflow

--- a/docs/web-docs/contributing/translation-guide.md
+++ b/docs/web-docs/contributing/translation-guide.md
@@ -7,12 +7,12 @@ sidebar:
 ---
 
 The Gears docs are localizable. Translations live alongside the English source,
-and a [status dashboard](/i18n/) tracks what's done, outdated, or missing per
+and a [status dashboard](../../i18n/) tracks what's done, outdated, or missing per
 language.
 
 ## The translation dashboard
 
-Visit **[/i18n/](/i18n/)** to see overall progress for each language. Pages are
+Visit **[/i18n/](../../i18n/)** to see overall progress for each language. Pages are
 marked:
 
 - ✅ **Done** — translated and up to date.
@@ -36,8 +36,7 @@ Adding a language is two small edits plus a content directory:
    ```js
    locales: {
      root: { label: 'English', lang: 'en' },
-     ru: { label: 'Русский', lang: 'ru' },
-     de: { label: 'Deutsch', lang: 'de' }, // new
+     de: { label: 'Deutsch', lang: 'de' } // new
    }
    ```
 
@@ -73,14 +72,14 @@ them.
 
 ## Translating a page
 
-1. Open the [dashboard](/i18n/) and pick a **Missing** or **Outdated** page.
+1. Open the [dashboard](../../i18n/) and pick a **Missing** or **Outdated** page.
 2. Copy the English source to the matching path under your language directory.
 3. Translate the body. **Keep unchanged:**
    - frontmatter **keys** (translate only the `title`/`description` **values**),
    - code blocks and command output,
    - internal link targets (the path stays the same).
 4. Run `pnpm dev` and visit the localized URL (e.g. `/ru/concepts/runtime-and-lifecycle/`).
-5. Open a pull request following the [contributor guide](/contributing/contributor-guide/).
+5. Open a pull request following the [contributor guide](../contributor-guide/).
 
 :::tip
 Prioritize quality over volume. A small set of accurate, well-reviewed pages is

--- a/docs/web-docs/get-started/index.md
+++ b/docs/web-docs/get-started/index.md
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 This page gets the example server running so you have something to explore and call.
-When you're ready to write code, continue to [Build your first gear](/get-started/your-first-gear/).
+When you're ready to write code, continue to [Build your first gear](./your-first-gear/).
 
 ## Prerequisites
 
@@ -83,6 +83,6 @@ pkill -f cf-gears-server
 
 ## Next
 
-- [Build your first gear](/get-started/your-first-gear/) — write an SDK, a domain service,
+- [Build your first gear](./your-first-gear/) — write an SDK, a domain service,
   and a REST endpoint, and wire it into the runtime.
-- [Core concepts](/concepts/) — the mental model behind what you just ran.
+- [Core concepts](../concepts/) — the mental model behind what you just ran.

--- a/docs/web-docs/get-started/your-first-gear.mdx
+++ b/docs/web-docs/get-started/your-first-gear.mdx
@@ -392,7 +392,7 @@ Inside the gear crate, layers are kept strictly separated (DDD-light): `domain/`
     }
     ```
 
-    Run it (see [Install & run](/get-started/)) and call your endpoint:
+    Run it (see [Install & run](../)) and call your endpoint:
 
     ```sh
     make example
@@ -417,10 +417,10 @@ decides whether `ClientHub` returns the local adapter or a gRPC client.
 ## Where to go next
 
 <CardGrid>
-  <LinkCard title="Authorization" href="/guides/authorization/" description="The PolicyEnforcer → AccessScope flow in depth." />
-  <LinkCard title="Database patterns" href="/guides/database/" description="SecureConn, Scopable, transactions, and migrations." />
-  <LinkCard title="Pagination & filtering" href="/guides/odata/" description="OData $filter / $orderby / $select and cursor pages." />
-  <LinkCard title="Out-of-process gears" href="/guides/out-of-process/" description="Expose the same SDK over gRPC, selected by config." />
+  <LinkCard title="Authorization" href="../../guides/authorization/" description="The PolicyEnforcer → AccessScope flow in depth." />
+  <LinkCard title="Database patterns" href="../../guides/database/" description="SecureConn, Scopable, transactions, and migrations." />
+  <LinkCard title="Pagination & filtering" href="../../guides/odata/" description="OData $filter / $orderby / $select and cursor pages." />
+  <LinkCard title="Out-of-process gears" href="../../guides/out-of-process/" description="Expose the same SDK over gRPC, selected by config." />
 </CardGrid>
 
 The full `users-info` example adds City and Address entities, streaming sub-clients, and

--- a/docs/web-docs/guides/authorization.md
+++ b/docs/web-docs/guides/authorization.md
@@ -125,6 +125,6 @@ DomainError::Forbidden =>
 
 ## See also
 
-- [Security & multi-tenancy](/concepts/security-and-tenancy/) — the model behind this flow.
-- [Database patterns](/guides/database/) — how the `AccessScope` becomes SQL.
+- [Security & multi-tenancy](../../concepts/security-and-tenancy/) — the model behind this flow.
+- [Database patterns](../database/) — how the `AccessScope` becomes SQL.
 - Full code: `examples/toolkit/users-info/users-info/src/domain/service/`.

--- a/docs/web-docs/guides/database.md
+++ b/docs/web-docs/guides/database.md
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 Gears never touch a raw database connection. All access flows through the secure ORM layer
-(`toolkit-db`), which applies an [`AccessScope`](/concepts/security-and-tenancy/) to every
+(`toolkit-db`), which applies an [`AccessScope`](../../concepts/security-and-tenancy/) to every
 query as automatic `WHERE` clauses. This guide shows the patterns you'll use day to day.
 
 ## Make an entity scopable
@@ -70,7 +70,7 @@ async fn delete<C: DBRunner>(&self, conn: &C, scope: &AccessScope, id: Uuid)
 ```
 
 The scope is obtained from the `PolicyEnforcer` in the domain service and passed down — see
-[Authorization](/guides/authorization/). An empty scope matches **no rows**
+[Authorization](../authorization/). An empty scope matches **no rows**
 (deny-by-default), and `tenant_id` is immutable on update.
 
 ## Acquire a connection
@@ -134,7 +134,7 @@ backend-aware SQL via `manager.get_connection().execute_unprepared(...)`).
 
 ## See also
 
-- [Security & multi-tenancy](/concepts/security-and-tenancy/) — where the scope comes from.
-- [Authorization](/guides/authorization/) — obtaining an `AccessScope`.
-- [Pagination & filtering](/guides/odata/) — `paginate_odata` over a scoped query.
+- [Security & multi-tenancy](../../concepts/security-and-tenancy/) — where the scope comes from.
+- [Authorization](../authorization/) — obtaining an `AccessScope`.
+- [Pagination & filtering](../odata/) — `paginate_odata` over a scoped query.
 - Full code: `examples/toolkit/users-info/users-info/src/infra/storage/`.

--- a/docs/web-docs/guides/index.md
+++ b/docs/web-docs/guides/index.md
@@ -10,16 +10,16 @@ Task-oriented guides for the things you do while building a gear. Each is ground
 real framework source and the `users-info` / `calculator` examples; where the source is thin,
 the guide says so and links to the example.
 
-- **[Database patterns](/guides/database/)** — secure, tenant-scoped persistence with
+- **[Database patterns](./database/)** — secure, tenant-scoped persistence with
   `SecureConn`, `#[derive(Scopable)]`, transactions, and migrations.
-- **[Authorization](/guides/authorization/)** — the PDP/PEP flow: `PolicyEnforcer`,
+- **[Authorization](./authorization/)** — the PDP/PEP flow: `PolicyEnforcer`,
   `AccessScope`, constraint predicates, and route-level auth.
-- **[Pagination & filtering](/guides/odata/)** — OData `$filter` / `$orderby` / `$select`
+- **[Pagination & filtering](./odata/)** — OData `$filter` / `$orderby` / `$select`
   and cursor-based pages.
-- **[Out-of-process gears](/guides/out-of-process/)** — run a gear as a separate gRPC
+- **[Out-of-process gears](./out-of-process/)** — run a gear as a separate gRPC
   service behind the same SDK, selected by configuration.
-- **[Observability](/guides/observability/)** — OpenTelemetry tracing, request IDs, health
+- **[Observability](./observability/)** — OpenTelemetry tracing, request IDs, health
   endpoints, and instrumented HTTP clients.
 
-New here? Start with the [first-gear walkthrough](/get-started/your-first-gear/), which uses
+New here? Start with the [first-gear walkthrough](../get-started/your-first-gear/), which uses
 all of these together.

--- a/docs/web-docs/guides/observability.md
+++ b/docs/web-docs/guides/observability.md
@@ -91,6 +91,6 @@ full; the exact init entry point is part of the bootstrap, not something gears c
 
 ## See also
 
-- [Runtime & lifecycle](/concepts/runtime-and-lifecycle/) — where background work and
+- [Runtime & lifecycle](../../concepts/runtime-and-lifecycle/) — where background work and
   cancellation fit.
 - Full reference: `docs/TRACING_SETUP.md` in the framework repository.

--- a/docs/web-docs/guides/odata.md
+++ b/docs/web-docs/guides/odata.md
@@ -101,5 +101,5 @@ then projected. Keep that in mind for very wide rows.
 
 ## See also
 
-- [Database patterns](/guides/database/) — the scoped base query `paginate_odata` runs over.
+- [Database patterns](../database/) — the scoped base query `paginate_odata` runs over.
 - Full code: the `odata/` module in `users-info-sdk` and `odata_mapper.rs` in the gear.

--- a/docs/web-docs/guides/out-of-process.md
+++ b/docs/web-docs/guides/out-of-process.md
@@ -131,5 +131,5 @@ orchestrator; custom discovery backends are an advanced topic the example doesn'
 
 ## See also
 
-- [Gears & composition](/concepts/gears-and-composition/) — in-process vs out-of-process.
+- [Gears & composition](../../concepts/gears-and-composition/) — in-process vs out-of-process.
 - Full code: `examples/oop-gears/calculator/`.

--- a/docs/web-docs/index.mdx
+++ b/docs/web-docs/index.mdx
@@ -41,11 +41,11 @@ hero:
       </svg>
   actions:
     - text: Get started
-      link: /get-started/
+      link: ./get-started/
       icon: right-arrow
       variant: primary
     - text: Core concepts
-      link: /concepts/
+      link: ./concepts/
       icon: open-book
       variant: minimal
 ---
@@ -55,18 +55,18 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 <CardGrid>
   <Card title="Build a gear" icon="puzzle">
     Define an SDK, implement a domain service, and wire it into the runtime.
-    See [Getting Started](/get-started/).
+    See [Getting Started](./get-started/).
   </Card>
   <Card title="Runtime model" icon="setting">
     Ordered lifecycle phases, explicit dependencies, one runtime across many
-    deployment shapes. See [Concepts](/concepts/).
+    deployment shapes. See [Concepts](./concepts/).
   </Card>
   <Card title="Architecture" icon="seti:default">
     The three-tier gear hierarchy, gateway, and safety contracts.
-    See [Architecture](/architecture/).
+    See [Architecture](./architecture/).
   </Card>
   <Card title="Reference" icon="open-book">
     Crates, gears, traits, configuration, and the canonical error model.
-    See [Reference](/reference/).
+    See [Reference](./reference/).
   </Card>
 </CardGrid>

--- a/docs/web-docs/introduction/index.md
+++ b/docs/web-docs/introduction/index.md
@@ -48,7 +48,7 @@ Gears ships a substantial substrate so you build features, not plumbing:
 - **Out-of-process gears** over gRPC, selected by configuration — no code changes.
 - **FIPS 140-3-ready** crypto on Linux, macOS, and Windows.
 
-See [Components & features](/reference/) for the full catalog of toolkit libraries
+See [Components & features](../reference/) for the full catalog of toolkit libraries
 and ready-made system gears.
 
 ## One codebase, three deployment shapes
@@ -76,10 +76,10 @@ over quick-start minimalism. From the framework's own non-goals:
 
 A typical path from reading to a running application:
 
-1. [Install the toolchain and run the example server](/get-started/).
-2. [Build your first gear](/get-started/your-first-gear/) — an SDK, a domain service,
+1. [Install the toolchain and run the example server](../get-started/).
+2. [Build your first gear](../get-started/your-first-gear/) — an SDK, a domain service,
    a REST endpoint, wired into the runtime.
-3. Learn the [core concepts](/concepts/) — gears, the SDK pattern, `ClientHub`, the
+3. Learn the [core concepts](../concepts/) — gears, the SDK pattern, `ClientHub`, the
    security model.
-4. Reach for [ready-made components & features](/reference/) as you need them.
-5. Understand [how the system is organized](/architecture/) when you scale up.
+4. Reach for [ready-made components & features](../reference/) as you need them.
+5. Understand [how the system is organized](../architecture/) when you scale up.


### PR DESCRIPTION
Convert all internal links across all doc files from root-absolute (/get-started/, /guides/authorization/) to relative (./get-started/, ../../guides/authorization/) so content renders correctly both on GitHub Pages subpath (/gears-rust-web-docs/) and future root custom domain.

Covers markdown body links, frontmatter splash-page actions, and MDX component hrefs. Links now route-independent and deployment-agnostic.