### PR TITLE
ci: auto-add DCO signoff for docs/web-docs PRs

### DIFF
--- a/.github/forbidden-words.json
+++ b/.github/forbidden-words.json
@@ -1,0 +1,43 @@
+{
+  "excludePaths": [
+    "**/target/**",
+    "**/.git/**",
+    "**/node_modules/**",
+    ".github/forbidden-words.json"
+  ],
+  "rules": [
+    {
+      "pattern": "\\bTODO\\b",
+      "message": "Forgotten TODO in code",
+      "caseSensitive": false,
+      "excludePaths": ["CHANGELOG.md", "**/CHANGELOG.*"]
+    },
+    {
+      "pattern": "\\bFIXME\\b",
+      "message": "Forgotten FIXME in code",
+      "caseSensitive": false
+    },
+    {
+      "pattern": "\\bXXX\\b",
+      "message": "Temporary XXX marker left in code",
+      "caseSensitive": false
+    },
+    {
+      "pattern": "\\#\\[ignore\\]",
+      "message": "Ignored test left in code",
+      "caseSensitive": true,
+      "excludePaths": ["**/tests/**"]
+    },
+    {
+      "pattern": "\\#\\[cyberfabric\\]",
+      "message": "No Cyberfabric here",
+      "caseSensitive": true,
+      "excludePaths": ["**/tests/**"]
+    },
+    {
+      "pattern": "\\b(cyber\\s*fabric|cyber\\s*ware)\\b",
+      "message": "Forbidden term: cyberfabric / cyberware",
+      "caseSensitive": false
+    }
+  ]
+}

--- a/.github/scripts/check-forbidden-words.sh
+++ b/.github/scripts/check-forbidden-words.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Scans the lines added by a pull request for forbidden words/phrases.
+#
+# Only newly added lines (those prefixed with '+' in the diff) are checked.
+# Rules are defined in .github/forbidden-words.json.
+#
+# Usage:
+#   check-forbidden-words.sh <base_sha> <head_sha>
+
+set -euo pipefail
+
+BASE_SHA="${1:?base SHA required}"
+HEAD_SHA="${2:?head SHA required}"
+MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")" || { echo "::error::Unable to compute merge-base"; exit 2; }
+CONFIG_FILE=".github/forbidden-words.json"
+
+[[ -f "$CONFIG_FILE" ]] || { echo "::notice::No forbidden-words.json; skipping check"; exit 0; }
+command -v jq >/dev/null 2>&1 || { echo "::error::jq is required"; exit 2; }
+
+rule_count=$(jq '(.rules // []) | length' "$CONFIG_FILE")
+[[ "$rule_count" -gt 0 ]] || { echo "No rules defined; nothing to check."; exit 0; }
+
+mapfile -t GLOBAL_EXCLUDES < <(jq -r '.excludePaths // [] | .[]' "$CONFIG_FILE")
+
+matches_any_glob() {
+  local path="$1"; shift
+  local glob
+  for glob in "$@"; do
+    [[ -z "$glob" ]] && continue
+    if [[ "$path" == $glob ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+violations=0
+
+mapfile -t CHANGED_FILES < <(git diff --name-only --diff-filter=ACMR "$MERGE_BASE" "$HEAD_SHA")
+
+for file in "${CHANGED_FILES[@]}"; do
+  [[ -z "$file" ]] && continue
+  matches_any_glob "$file" "${GLOBAL_EXCLUDES[@]}" && continue
+
+  diff_output=$(git diff --unified=0 "$MERGE_BASE" "$HEAD_SHA" -- "$file") || true
+  [[ -z "$diff_output" ]] && continue
+
+  added_lines=$(awk '
+    /^@@/ {
+      for (i = 1; i <= NF; i++) {
+        if (substr($i, 1, 1) == "+") {
+          s = substr($i, 2)
+          split(s, parts, ",")
+          line = parts[1] + 0
+          break
+        }
+      }
+      next
+    }
+    /^\+\+\+/ { next }
+    /^\+/ {
+      content = substr($0, 2)
+      printf "%d:%s\n", line, content
+      line++
+    }
+  ' <<< "$diff_output")
+
+  [[ -z "$added_lines" ]] && continue
+
+  for ((r = 0; r < rule_count; r++)); do
+    pattern=$(jq -r ".rules[$r].pattern" "$CONFIG_FILE")
+    message=$(jq -r ".rules[$r].message // \"\"" "$CONFIG_FILE")
+    case_sensitive=$(jq -r ".rules[$r].caseSensitive // false" "$CONFIG_FILE")
+
+    mapfile -t RULE_EXCLUDES < <(jq -r ".rules[$r].excludePaths // [] | .[]" "$CONFIG_FILE")
+    if ((${#RULE_EXCLUDES[@]} > 0)) && matches_any_glob "$file" "${RULE_EXCLUDES[@]}"; then
+      continue
+    fi
+
+    grep_opts=(-P)
+    [[ "$case_sensitive" != "true" ]] && grep_opts+=(-i)
+
+    while IFS= read -r entry; do
+      [[ -z "$entry" ]] && continue
+      lineno="${entry%%:*}"
+      content="${entry#*:}"
+      if printf '%s' "$content" | grep -q "${grep_opts[@]}" -- "$pattern" 2>/dev/null; then
+        printf '::error file=%s,line=%s::Forbidden phrase: %s\n' "$file" "$lineno" "$message"
+        violations=$((violations + 1))
+      fi
+    done <<< "$added_lines"
+  done
+done
+
+echo
+if [[ "$violations" -gt 0 ]]; then
+  echo "❌ Found $violations forbidden phrase occurrence(s) in added lines."
+  echo "   Update the wording or adjust .github/forbidden-words.json if a rule is wrong."
+  exit 1
+fi
+
+echo "✅ No forbidden phrases found in added lines."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
-# Cancel previous runs for the same ref to save CI minutes.
+# Concurrency strategy:
+# - On pull_request: group by PR number. New commits cancel the in-flight run.
+# - On push (main/develop): include run_id so pushes never cancel each other,
+#   preventing required CI from silently being dropped.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/dco-signoff.yml
+++ b/.github/workflows/dco-signoff.yml
@@ -1,0 +1,52 @@
+name: Auto DCO Signoff for Docs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'docs/web-docs/**'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dco:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Fetch base repository
+        run: |
+          git remote add base https://github.com/${{ github.event.pull_request.base.repo.full_name }}.git
+          git fetch base ${{ github.base_ref }}
+
+      - name: Add DCO signoff to docs commits
+        env:
+          BASE_BRANCH: ${{ github.base_ref }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          NEEDS_SIGNOFF=false
+
+          while IFS= read -r commit; do
+            if ! git log -1 --format=%B "$commit" | grep -q "^Signed-off-by:"; then
+              NEEDS_SIGNOFF=true
+              echo "Adding signoff to $commit"
+            fi
+          done < <(git rev-list base/$BASE_BRANCH..HEAD)
+
+          if [ "$NEEDS_SIGNOFF" = true ]; then
+            GIT_COMMITTER_NAME="github-actions[bot]" \
+            GIT_COMMITTER_EMAIL="github-actions[bot]@users.noreply.github.com" \
+            git rebase --signoff base/$BASE_BRANCH
+            git push --force-with-lease
+            echo "✅ Added DCO signoff"
+          else
+            echo "✅ Already signed"
+          fi

--- a/.github/workflows/forbidden-words.yml
+++ b/.github/workflows/forbidden-words.yml
@@ -1,0 +1,62 @@
+name: Forbidden Words
+
+on:
+  pull_request:
+    paths:
+      - 'docs/web-docs/**'
+  workflow_dispatch:
+    inputs:
+      base_sha:
+        description: 'Base SHA to diff from (defaults to origin/main)'
+        required: false
+      head_sha:
+        description: 'Head SHA to diff to (defaults to HEAD)'
+        required: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  forbidden-words:
+    name: Check forbidden words
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve base and head SHAs
+        id: shas
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          INPUT_BASE_SHA: ${{ github.event.inputs.base_sha }}
+          INPUT_HEAD_SHA: ${{ github.event.inputs.head_sha }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            base="$PR_BASE_SHA"
+            head="$PR_HEAD_SHA"
+          else
+            base="$INPUT_BASE_SHA"
+            head="${INPUT_HEAD_SHA:-$(git rev-parse HEAD)}"
+            if [[ -z "$base" ]]; then
+              git fetch origin main || true
+              base="$(git rev-parse origin/main 2>/dev/null || git rev-parse HEAD~1)"
+            fi
+          fi
+          echo "base=$base" >> "$GITHUB_OUTPUT"
+          echo "head=$head" >> "$GITHUB_OUTPUT"
+
+      - name: Scan added lines for forbidden words
+        shell: bash
+        run: |
+          .github/scripts/check-forbidden-words.sh \
+            "${{ steps.shas.outputs.base }}" \
+            "${{ steps.shas.outputs.head }}"


### PR DESCRIPTION
- Add workflow that automatically adds 'Signed-off-by' trailer to commits editing docs/web-docs/ if signoff is missing. This solves the UX issue where GitHub's edit-in-browser UI doesn't add DCO signoff.
- add forbidden-words check
- improve concurrency strategy to:
  - Group PR runs by PR number, allowing new commits to cancel in-flight runs
  - Group push runs by unique run_id, preventing pushes from canceling each other (prevents required CI from being silently dropped when multiple commits land)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks to flag forbidden words and debug markers in pull requests, with support for manual runs.
  * Added automatic DCO signoff handling for documentation-related pull requests.

* **Improvements**
  * Updated CI concurrency so non-PR runs no longer cancel each other, while pull request runs still avoid overlap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->