### PR TITLE
fix(ci): revert to DOCS_DISPATCH_TOKEN for cross-repo dispatch

### DIFF
--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -20,4 +20,4 @@ jobs:
             -f event_type=docs-sync \
             -f "client_payload[sha]=$GITHUB_SHA"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DOCS_DISPATCH_TOKEN }}


### PR DESCRIPTION
GITHUB_TOKEN is scoped to the current repo and cannot trigger repository_dispatch events in other repos (403 from GitHub API).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation sync automation to use a dedicated token, improving reliability for docs-related updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->