### PR TITLE
feat(docs): preview full site with cargo-gears CLI section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -366,3 +366,6 @@ testing/e2e/logs/
 
 # Cached checkout of the web docs site for `make docs-preview`
 .web-docs-preview/
+
+# Cached checkout of sibling docs sources (e.g. cargo-gears) for `make docs-preview`
+.web-docs-sources/

--- a/tools/scripts/docs-preview.sh
+++ b/tools/scripts/docs-preview.sh
@@ -14,6 +14,9 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 CACHE_DIR="${GEARS_DOCS_CACHE:-$REPO_ROOT/.web-docs-preview}"
 DOCS_REPO="${GEARS_DOCS_REPO:-https://github.com/constructorfabric/gears-rust-web-docs.git}"
+# Site branch to preview against. Override to test an unmerged site PR, e.g.
+# GEARS_DOCS_REF=fix/asto-config-new-section make docs-preview
+DOCS_REF="${GEARS_DOCS_REF:-main}"
 
 # --- Prerequisite: Node >= 22.13 (required by Astro / the docs site) ---
 if ! command -v node >/dev/null 2>&1; then
@@ -37,14 +40,40 @@ if [ "$node_major" -lt 22 ] || { [ "$node_major" -eq 22 ] && [ "$node_minor" -lt
   fi
 fi
 
-# --- Clone or update the docs site into the cache dir ---
+# --- Clone or update the docs site into the cache dir (on $DOCS_REF) ---
+# The cache is disposable: hard-reset to the fetched ref so a stale checkout or
+# locally-modified tracked files (e.g. .sync-lock.json) can't leave it behind.
 if [ -d "$CACHE_DIR/.git" ]; then
-  echo "==> Updating cached docs site in $CACHE_DIR"
-  git -C "$CACHE_DIR" pull --ff-only || echo "WARNING: could not fast-forward cached docs site; using existing checkout." >&2
+  echo "==> Updating cached docs site in $CACHE_DIR ($DOCS_REF)"
+  git -C "$CACHE_DIR" fetch --depth 1 origin "$DOCS_REF"
+  git -C "$CACHE_DIR" reset --hard FETCH_HEAD
 else
-  echo "==> Cloning docs site into $CACHE_DIR"
-  git clone --depth 1 "$DOCS_REPO" "$CACHE_DIR"
+  echo "==> Cloning docs site into $CACHE_DIR ($DOCS_REF)"
+  git clone --depth 1 --branch "$DOCS_REF" "$DOCS_REPO" "$CACHE_DIR"
 fi
+
+# --- Resolve the cargo-gears docs source so the CLI section appears too ---
+# The site syncs from two repos. Prefer a sibling checkout (picks up your local,
+# uncommitted edits); otherwise shallow-clone into a gitignored cache. Override
+# with CARGO_GEARS_PATH to point at an arbitrary checkout.
+CARGO_GEARS_REPO="${CARGO_GEARS_REPO:-https://github.com/constructorfabric/cargo-gears.git}"
+if [ -z "${CARGO_GEARS_PATH:-}" ]; then
+  if [ -d "$REPO_ROOT/../cargo-gears/docs/web-docs" ]; then
+    CARGO_GEARS_PATH="$(cd "$REPO_ROOT/../cargo-gears" && pwd)"
+  else
+    CG="${GEARS_DOCS_SOURCES:-$REPO_ROOT/.web-docs-sources}/cargo-gears"
+    if [ -d "$CG/.git" ]; then
+      echo "==> Updating cached cargo-gears source in $CG"
+      git -C "$CG" pull --ff-only || echo "WARNING: could not fast-forward cached cargo-gears; using existing checkout." >&2
+    else
+      echo "==> Cloning cargo-gears source into $CG"
+      git clone --depth 1 "$CARGO_GEARS_REPO" "$CG"
+    fi
+    CARGO_GEARS_PATH="$CG"
+  fi
+fi
+export CARGO_GEARS_PATH
+echo "==> cargo-gears docs source: $CARGO_GEARS_PATH"
 
 cd "$CACHE_DIR"
 
@@ -52,9 +81,9 @@ cd "$CACHE_DIR"
 if command -v pnpm >/dev/null 2>&1; then
   pnpm install
   echo "==> Starting docs site at http://localhost:4321 (content from $REPO_ROOT/docs/web-docs)"
-  GEARS_RUST_PATH="$REPO_ROOT" BASE=/ pnpm dev
+  GEARS_RUST_PATH="$REPO_ROOT" CARGO_GEARS_PATH="$CARGO_GEARS_PATH" BASE=/ pnpm dev
 else
   npm install
   echo "==> Starting docs site at http://localhost:4321 (content from $REPO_ROOT/docs/web-docs)"
-  GEARS_RUST_PATH="$REPO_ROOT" BASE=/ npm run dev
+  GEARS_RUST_PATH="$REPO_ROOT" CARGO_GEARS_PATH="$CARGO_GEARS_PATH" BASE=/ npm run dev
 fi


### PR DESCRIPTION
The docs site now syncs from two repos (gears-rust + cargo-gears). Resolve the cargo-gears source for 'make docs-preview' — prefer a sibling checkout (picks up local edits), else shallow-clone into a gitignored cache — and pass CARGO_GEARS_PATH to the dev server so the CLI section renders locally.