### PR TITLE
feat(toolkit-db): support configurable outbox table prefixes

### DIFF
--- a/libs/toolkit-db/Cargo.toml
+++ b/libs/toolkit-db/Cargo.toml
@@ -103,6 +103,10 @@ required-features = ["sqlite", "preview-outbox"]
 name = "outbox_batch_multi_queue"
 required-features = ["sqlite", "preview-outbox"]
 
+[[example]]
+name = "outbox_custom_prefix"
+required-features = ["sqlite", "preview-outbox"]
+
 [[bench]]
 name = "outbox_throughput"
 harness = false

--- a/libs/toolkit-db/benches/outbox_throughput.rs
+++ b/libs/toolkit-db/benches/outbox_throughput.rs
@@ -35,6 +35,8 @@
 //! (DB seq must be strictly monotonic) and completeness (no lost messages).
 //! Multi-instance profiles verify that competing outbox instances correctly
 //! share partitions via DB-level leases without duplication.
+//! Profiles with `table_prefixes` run independent outbox instances in the same
+//! database. Those measure isolated table families, not lease competition.
 //!
 //! **Run examples:**
 //!   ```sh
@@ -57,7 +59,7 @@ use tokio::sync::Notify;
 
 use toolkit_db::outbox::{
     Batch, EnqueueMessage, HandlerResult, LeasedHandler, Outbox, OutboxHandle, OutboxProfile,
-    Partitions, outbox_migrations,
+    Partitions, outbox_migrations, outbox_migrations_with_prefix,
 };
 use toolkit_db::{ConnectOpts, Db, connect_db, migration_runner::run_migrations_for_testing};
 
@@ -101,6 +103,11 @@ struct BenchProfile {
     /// claimed via DB-level leases, so instances compete for work.
     #[serde(default = "default_one")]
     num_instances: usize,
+    /// Optional per-instance table prefixes. Empty means all instances use the
+    /// default shared table family and compete for DB leases. When set, each
+    /// instance uses its matching prefix and runs independently in the same DB.
+    #[serde(default)]
+    table_prefixes: Vec<String>,
 
     // -- Workload --
     /// Target message count. Automatically rounded up to be evenly divisible
@@ -234,9 +241,18 @@ impl BenchProfile {
         self.num_queues * self.partitions_per_queue as usize
     }
 
-    /// Round message_count up to be evenly divisible by total_partitions.
+    fn verification_partitions(&self) -> usize {
+        let total_parts = self.total_partitions();
+        if self.independent_table_families() {
+            total_parts * self.num_instances
+        } else {
+            total_parts
+        }
+    }
+
+    /// Round message_count up to be evenly divisible by the verified partition space.
     fn aligned_message_count(&self) -> usize {
-        let tp = self.total_partitions();
+        let tp = self.verification_partitions();
         let remainder = self.message_count % tp;
         if remainder == 0 {
             self.message_count
@@ -267,6 +283,23 @@ impl BenchProfile {
             ProducerMode::SmallBatch(n) => n,
             ProducerMode::FullBatch => BATCH_SIZE,
         }
+    }
+
+    fn independent_table_families(&self) -> bool {
+        !self.table_prefixes.is_empty()
+    }
+
+    fn validate_table_prefixes(&self) {
+        assert!(
+            self.table_prefixes.is_empty() || self.table_prefixes.len() == self.num_instances,
+            "table_prefixes must be empty or contain one prefix per outbox instance"
+        );
+        let unique: HashSet<&str> = self.table_prefixes.iter().map(String::as_str).collect();
+        assert_eq!(
+            unique.len(),
+            self.table_prefixes.len(),
+            "table_prefixes must be distinct for independent outbox instances"
+        );
     }
 }
 
@@ -301,6 +334,7 @@ fn validation_profiles() -> Vec<BenchProfile> {
             partitions_per_queue: 64,
             message_count: 10_000,
             num_instances: 1,
+            table_prefixes: Vec::new(),
             load_distribution: LoadDistribution::Uniform,
             pool_size: None,
             criterion,
@@ -316,6 +350,7 @@ fn validation_profiles() -> Vec<BenchProfile> {
             partitions_per_queue: 64,
             message_count: 100_000,
             num_instances: 1,
+            table_prefixes: Vec::new(),
             load_distribution: LoadDistribution::Uniform,
             pool_size: None,
             criterion,
@@ -331,6 +366,7 @@ fn validation_profiles() -> Vec<BenchProfile> {
             partitions_per_queue: 64,
             message_count: 100_000,
             num_instances: 1,
+            table_prefixes: Vec::new(),
             load_distribution: LoadDistribution::Uniform,
             pool_size: None,
             criterion,
@@ -346,6 +382,7 @@ fn validation_profiles() -> Vec<BenchProfile> {
             partitions_per_queue: 64,
             message_count: 100_000,
             num_instances: 1,
+            table_prefixes: Vec::new(),
             load_distribution: LoadDistribution::Uniform,
             pool_size: None,
             criterion,
@@ -361,6 +398,7 @@ fn validation_profiles() -> Vec<BenchProfile> {
             partitions_per_queue: 64,
             message_count: 100_000,
             num_instances: 1,
+            table_prefixes: Vec::new(),
             load_distribution: LoadDistribution::Uniform,
             pool_size: None,
             criterion,
@@ -382,6 +420,7 @@ fn longhaul_profiles() -> Vec<BenchProfile> {
             partitions_per_queue: 64,
             message_count: 1_000_000,
             num_instances: 1,
+            table_prefixes: Vec::new(),
             load_distribution: LoadDistribution::Uniform,
             pool_size: None,
             criterion,
@@ -397,6 +436,7 @@ fn longhaul_profiles() -> Vec<BenchProfile> {
             partitions_per_queue: 64,
             message_count: 1_000_000,
             num_instances: 1,
+            table_prefixes: Vec::new(),
             load_distribution: LoadDistribution::Uniform,
             pool_size: None,
             criterion,
@@ -419,6 +459,7 @@ fn stress_profiles() -> Vec<BenchProfile> {
             partitions_per_queue: 64,
             message_count: 1_000_000,
             num_instances: 1,
+            table_prefixes: Vec::new(),
             load_distribution: LoadDistribution::Uniform,
             pool_size: None,
             criterion,
@@ -434,6 +475,7 @@ fn stress_profiles() -> Vec<BenchProfile> {
             partitions_per_queue: 64,
             message_count: 1_000_000,
             num_instances: 1,
+            table_prefixes: Vec::new(),
             load_distribution: LoadDistribution::Uniform,
             pool_size: None,
             criterion,
@@ -452,6 +494,7 @@ fn stress_profiles() -> Vec<BenchProfile> {
             partitions_per_queue: 64,
             message_count: 1_000_000,
             num_instances: 1,
+            table_prefixes: Vec::new(),
             load_distribution: LoadDistribution::Uniform,
             pool_size: None,
             criterion,
@@ -470,6 +513,7 @@ fn stress_profiles() -> Vec<BenchProfile> {
             partitions_per_queue: 64,
             message_count: 1_000_000,
             num_instances: 1,
+            table_prefixes: Vec::new(),
             load_distribution: LoadDistribution::Uniform,
             pool_size: None,
             criterion,
@@ -488,6 +532,7 @@ fn stress_profiles() -> Vec<BenchProfile> {
             partitions_per_queue: 64,
             message_count: 1_000_000,
             num_instances: 1,
+            table_prefixes: Vec::new(),
             load_distribution: LoadDistribution::Realistic { hot_queues: 8 },
             pool_size: None,
             criterion,
@@ -504,6 +549,7 @@ fn stress_profiles() -> Vec<BenchProfile> {
             partitions_per_queue: 64,
             message_count: 100_000,
             num_instances: 2,
+            table_prefixes: Vec::new(),
             load_distribution: LoadDistribution::Uniform,
             pool_size: None,
             criterion: validation,
@@ -519,6 +565,7 @@ fn stress_profiles() -> Vec<BenchProfile> {
             partitions_per_queue: 64,
             message_count: 100_000,
             num_instances: 2,
+            table_prefixes: Vec::new(),
             load_distribution: LoadDistribution::Uniform,
             pool_size: None,
             criterion: validation,
@@ -534,6 +581,7 @@ fn stress_profiles() -> Vec<BenchProfile> {
             partitions_per_queue: 64,
             message_count: 100_000,
             num_instances: 2,
+            table_prefixes: Vec::new(),
             load_distribution: LoadDistribution::Uniform,
             pool_size: None,
             criterion: validation,
@@ -549,6 +597,7 @@ fn stress_profiles() -> Vec<BenchProfile> {
             partitions_per_queue: 64,
             message_count: 1_000_000,
             num_instances: 2,
+            table_prefixes: Vec::new(),
             load_distribution: LoadDistribution::Uniform,
             pool_size: None,
             criterion,
@@ -564,9 +613,26 @@ fn stress_profiles() -> Vec<BenchProfile> {
             partitions_per_queue: 64,
             message_count: 1_000_000,
             num_instances: 2,
+            table_prefixes: Vec::new(),
             load_distribution: LoadDistribution::Uniform,
             pool_size: None,
             criterion,
+        },
+        BenchProfile {
+            name: "2i_independent_prefix_batch".into(),
+            tier: Tier::Stress,
+            producer_mode: ProducerMode::FullBatch,
+            num_producers: 16,
+            num_processors: 8,
+            maintenance: MaintenanceConfig::default(),
+            num_queues: 1,
+            partitions_per_queue: 64,
+            message_count: 100_000,
+            num_instances: 2,
+            table_prefixes: vec!["bench_outbox_a".into(), "bench_outbox_b".into()],
+            load_distribution: LoadDistribution::Uniform,
+            pool_size: None,
+            criterion: validation,
         },
     ]
 }
@@ -636,6 +702,7 @@ struct BenchHandler {
     counter: Arc<AtomicUsize>,
     notify: Arc<Notify>,
     expected_total: usize,
+    partition_key_offset: i64,
 }
 
 #[async_trait::async_trait]
@@ -646,11 +713,9 @@ impl LeasedHandler for BenchHandler {
             let (_, seq_str) = payload.split_once(':').unwrap();
             let seq: u64 = seq_str.parse().unwrap();
 
-            self.consumed.entry(msg.partition_id).or_default().push(seq);
-            self.db_seqs
-                .entry(msg.partition_id)
-                .or_default()
-                .push(msg.seq);
+            let partition_key = self.partition_key_offset + msg.partition_id;
+            self.consumed.entry(partition_key).or_default().push(seq);
+            self.db_seqs.entry(partition_key).or_default().push(msg.seq);
 
             batch.ack();
 
@@ -663,13 +728,14 @@ impl LeasedHandler for BenchHandler {
     }
 }
 
-fn make_handler(state: &BenchState) -> BenchHandler {
+fn make_handler(state: &BenchState, partition_key_offset: i64) -> BenchHandler {
     BenchHandler {
         consumed: Arc::clone(&state.consumed),
         db_seqs: Arc::clone(&state.db_seqs),
         counter: Arc::clone(&state.counter),
         notify: Arc::clone(&state.notify),
         expected_total: state.expected_total,
+        partition_key_offset,
     }
 }
 
@@ -704,7 +770,7 @@ async fn wait_for_completion(state: &BenchState, timeout: Duration) {
 /// For realistic distributions, checks total count and per-partition ordering only.
 fn verify_results(state: &BenchState, profile: &BenchProfile) {
     let msg_count = profile.aligned_message_count();
-    let total_parts = profile.total_partitions();
+    let verification_parts = profile.verification_partitions();
 
     // DB-seq ordering: must be strictly monotonically increasing per partition
     for entry in state.db_seqs.iter() {
@@ -724,12 +790,12 @@ fn verify_results(state: &BenchState, profile: &BenchProfile) {
 
     match profile.load_distribution {
         LoadDistribution::Uniform => {
-            let msgs_per_partition = msg_count / total_parts;
+            let msgs_per_partition = msg_count / verification_parts;
 
             assert_eq!(
                 state.consumed.len(),
-                total_parts,
-                "expected {total_parts} partitions, got {}",
+                verification_parts,
+                "expected {verification_parts} partitions, got {}",
                 state.consumed.len()
             );
 
@@ -1010,6 +1076,8 @@ async fn start_instance(
     profile: &BenchProfile,
     queue_prefix: &str,
     state: &BenchState,
+    table_prefix: Option<&str>,
+    partition_key_offset: i64,
 ) -> OutboxHandle {
     let mut builder = Outbox::builder(db.clone())
         .profile(OutboxProfile::high_throughput())
@@ -1017,10 +1085,14 @@ async fn start_instance(
         .maintenance(profile.maintenance.guaranteed, profile.maintenance.shared)
         .stats_interval(Duration::from_secs(10));
 
+    if let Some(prefix) = table_prefix {
+        builder = builder.table_prefix(prefix).unwrap();
+    }
+
     for name in queue_names(queue_prefix, profile) {
         builder = builder
             .queue(&name, Partitions::of(profile.partitions_per_queue))
-            .leased(make_handler(state))
+            .leased(make_handler(state, partition_key_offset))
             .done();
     }
 
@@ -1038,6 +1110,7 @@ async fn setup_pipeline(
     profile: &BenchProfile,
     queue_prefix: &str,
 ) -> (Db, Vec<OutboxHandle>, Arc<BenchState>) {
+    profile.validate_table_prefixes();
     let is_sqlite = db_url.starts_with("sqlite");
     let max_conns = profile.effective_pool_size(is_sqlite);
     let msg_count = profile.aligned_message_count();
@@ -1054,40 +1127,93 @@ async fn setup_pipeline(
 
     let state = Arc::new(BenchState::new(msg_count));
 
+    if profile.independent_table_families() {
+        for prefix in &profile.table_prefixes {
+            run_migrations_for_testing(&db, outbox_migrations_with_prefix(prefix).unwrap())
+                .await
+                .unwrap();
+        }
+    }
+
     let mut handles = Vec::with_capacity(profile.num_instances);
-    for _ in 0..profile.num_instances {
-        handles.push(start_instance(&db, profile, queue_prefix, &state).await);
+    for instance_idx in 0..profile.num_instances {
+        let table_prefix = profile.table_prefixes.get(instance_idx).map(String::as_str);
+        let partition_key_offset = if profile.independent_table_families() {
+            i64::try_from(instance_idx).unwrap() * 1_000_000_000
+        } else {
+            0
+        };
+        handles.push(
+            start_instance(
+                &db,
+                profile,
+                queue_prefix,
+                &state,
+                table_prefix,
+                partition_key_offset,
+            )
+            .await,
+        );
     }
 
     (db, handles, state)
 }
 
-/// Delete all data from outbox tables after each iteration.
-async fn cleanup_outbox_tables(db_url: &str) {
-    use sea_orm::{ConnectionTrait, Database, Statement};
+fn cleanup_prefixes(profile: &BenchProfile) -> Vec<&str> {
+    if profile.independent_table_families() {
+        profile.table_prefixes.iter().map(String::as_str).collect()
+    } else {
+        vec!["toolkit_outbox"]
+    }
+}
 
-    const TABLES: &[&str] = &[
-        "toolkit_outbox_dead_letters",
-        "toolkit_outbox_outgoing",
-        "toolkit_outbox_incoming",
-        "toolkit_outbox_vacuum_counter",
-        "toolkit_outbox_processor",
-        "toolkit_outbox_body",
-        "toolkit_outbox_partitions",
-    ];
+fn table_family(prefix: &str) -> [String; 7] {
+    [
+        format!("{prefix}_dead_letters"),
+        format!("{prefix}_outgoing"),
+        format!("{prefix}_incoming"),
+        format!("{prefix}_vacuum_counter"),
+        format!("{prefix}_processor"),
+        format!("{prefix}_body"),
+        format!("{prefix}_partitions"),
+    ]
+}
+
+fn sequence_tables(prefix: &str) -> [String; 2] {
+    [
+        format!("{prefix}_body_id_sequence"),
+        format!("{prefix}_incoming_id_sequence"),
+    ]
+}
+
+/// Delete all data from the configured outbox table families after each iteration.
+async fn cleanup_outbox_tables(db_url: &str, profile: &BenchProfile) {
+    use sea_orm::{ConnectionTrait, Database, Statement};
 
     let db = Database::connect(db_url).await.unwrap();
     let backend = db.get_database_backend();
-    for table in TABLES {
-        let sql = match backend {
-            sea_orm::DbBackend::Postgres => format!("TRUNCATE TABLE {table} CASCADE"),
-            sea_orm::DbBackend::Sqlite | sea_orm::DbBackend::MySql => {
-                format!("DELETE FROM {table}")
+    for prefix in cleanup_prefixes(profile) {
+        for table in table_family(prefix) {
+            let sql = match backend {
+                sea_orm::DbBackend::Postgres => format!("TRUNCATE TABLE {table} CASCADE"),
+                sea_orm::DbBackend::Sqlite | sea_orm::DbBackend::MySql => {
+                    format!("DELETE FROM {table}")
+                }
+            };
+            db.execute(Statement::from_string(backend, sql))
+                .await
+                .unwrap();
+        }
+        if backend == sea_orm::DbBackend::MySql {
+            for table in sequence_tables(prefix) {
+                db.execute(Statement::from_string(
+                    backend,
+                    format!("UPDATE {table} SET next_id = 1 WHERE slot = 1"),
+                ))
+                .await
+                .unwrap();
             }
-        };
-        db.execute(Statement::from_string(backend, sql))
-            .await
-            .unwrap();
+        }
     }
 }
 
@@ -1144,7 +1270,7 @@ fn run_profile(
                         h.stop().await;
                     }
                     drop(db);
-                    cleanup_outbox_tables(&db_url).await;
+                    cleanup_outbox_tables(&db_url, &profile).await;
                     tokio::time::sleep(Duration::from_millis(100)).await;
                 }
                 total

--- a/libs/toolkit-db/examples/outbox_custom_prefix.rs
+++ b/libs/toolkit-db/examples/outbox_custom_prefix.rs
@@ -1,0 +1,86 @@
+//! Custom table-prefix outbox example.
+//!
+//! Run:
+//!   cargo run -p cf-gears-toolkit-db --example `outbox_custom_prefix` --features sqlite,preview-outbox
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+
+use toolkit_db::outbox::{
+    LeasedMessageHandler, MessageResult, Outbox, OutboxMessage, Partitions, WorkerTuning,
+    outbox_migrations_with_prefix,
+};
+use toolkit_db::{ConnectOpts, connect_db, migration_runner::run_migrations_for_testing};
+
+struct PrintHandler {
+    processed: Arc<AtomicU32>,
+}
+
+#[async_trait::async_trait]
+impl LeasedMessageHandler for PrintHandler {
+    async fn handle(&self, msg: &OutboxMessage) -> MessageResult {
+        println!(
+            "processed partition={} seq={} payload={}",
+            msg.partition_id,
+            msg.seq,
+            String::from_utf8_lossy(&msg.payload)
+        );
+        self.processed.fetch_add(1, Ordering::Relaxed);
+        MessageResult::Ok
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let prefix = "mini_chat_outbox";
+    let db = connect_db(
+        "sqlite:file:outbox_custom_prefix?mode=memory&cache=shared",
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    run_migrations_for_testing(&db, outbox_migrations_with_prefix(prefix)?).await?;
+
+    let processed = Arc::new(AtomicU32::new(0));
+    let handle = Outbox::builder(db.clone())
+        .table_prefix(prefix)?
+        .processor_tuning(
+            WorkerTuning::processor_default().idle_interval(Duration::from_millis(50)),
+        )
+        .sequencer_tuning(
+            WorkerTuning::sequencer_default().idle_interval(Duration::from_millis(50)),
+        )
+        .queue("messages", Partitions::of(1))
+        .leased(PrintHandler {
+            processed: Arc::clone(&processed),
+        })
+        .start()
+        .await?;
+
+    handle
+        .outbox()
+        .enqueue(
+            &db.conn()?,
+            "messages",
+            0,
+            b"hello from a prefixed outbox".to_vec(),
+            "text/plain",
+        )
+        .await?;
+    handle.outbox().flush();
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while processed.load(Ordering::Relaxed) == 0 {
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!("message was not processed before timeout");
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    handle.stop().await;
+    Ok(())
+}

--- a/libs/toolkit-db/src/contention.rs
+++ b/libs/toolkit-db/src/contention.rs
@@ -6,7 +6,9 @@
 //!
 //! # Covered engines
 //!
-//! * **`MySQL` / `MariaDB`** — `InnoDB` deadlock (SQLSTATE `40001`).
+//! * **`MySQL` / `MariaDB` / Percona `XtraDB` Cluster** — `InnoDB` deadlock
+//!   (SQLSTATE `40001`) and Galera/wsrep certification conflicts that abort
+//!   the transaction and require a full retry.
 //!   `InnoDB` detects deadlocks instantly and rolls back one transaction.
 //!
 //!   > "Always be prepared to re-issue a transaction if it fails due to
@@ -39,6 +41,14 @@ use sea_orm::{DbBackend, DbErr};
 
 /// `MySQL` deadlock SQLSTATE code.
 const MYSQL_DEADLOCK_SQLSTATE: &str = "40001";
+const MYSQL_DEADLOCK_MSG: &str = "deadlock";
+const MYSQL_WSREP_DEADLOCK_MSG: &str = "wsrep detected deadlock/conflict";
+const MYSQL_WSREP_CERTIFICATION_ERROR_MSG: &str = "transaction failed due to certification error";
+const MYSQL_WSREP_CANNOT_CERTIFY_MSG: &str = "transaction cannot be certified";
+const MYSQL_WSREP_WRITE_SET_CONFLICT_MSG: &str = "write-set conflict";
+const MYSQL_WSREP_CERTIFICATION_FAILURE_MSG: &str =
+    "transaction rolled back due to certification failure";
+const MYSQL_RESTART_MSG: &str = "try restarting transaction";
 
 /// `PostgreSQL` retryable SQLSTATE codes.
 const PG_SERIALIZATION_FAILURE: &str = "40001";
@@ -88,7 +98,15 @@ pub fn is_retryable_contention(backend: DbBackend, err: &DbErr) -> bool {
 }
 
 fn is_mysql_deadlock(msg: &str) -> bool {
+    let msg = msg.to_ascii_lowercase();
     msg.contains(MYSQL_DEADLOCK_SQLSTATE)
+        || msg.contains(MYSQL_DEADLOCK_MSG)
+        || msg.contains(MYSQL_WSREP_DEADLOCK_MSG)
+        || msg.contains(MYSQL_WSREP_CERTIFICATION_ERROR_MSG)
+        || msg.contains(MYSQL_WSREP_CANNOT_CERTIFY_MSG)
+        || msg.contains(MYSQL_WSREP_WRITE_SET_CONFLICT_MSG)
+        || msg.contains(MYSQL_WSREP_CERTIFICATION_FAILURE_MSG)
+        || msg.contains(MYSQL_RESTART_MSG)
 }
 
 fn is_pg_contention(msg: &str) -> bool {
@@ -122,6 +140,33 @@ mod tests {
     #[test]
     fn mysql_deadlock_detected() {
         let err = exec_err("MySqlError { ... SQLSTATE 40001: Deadlock found ... }");
+        assert!(is_retryable_contention(DbBackend::MySql, &err));
+    }
+
+    #[test]
+    fn mysql_wsrep_certification_conflict_detected() {
+        let err =
+            exec_err("MySqlError: WSREP detected deadlock/conflict and aborted the transaction");
+        assert!(is_retryable_contention(DbBackend::MySql, &err));
+    }
+
+    #[test]
+    fn mysql_wsrep_write_set_conflict_detected() {
+        let err = exec_err("MySqlError: WSREP: Transaction failed due to write-set conflict");
+        assert!(is_retryable_contention(DbBackend::MySql, &err));
+    }
+
+    #[test]
+    fn unrelated_mysql_wsrep_message_not_retryable() {
+        let err = exec_err(
+            "MySqlError: WSREP provider failed certification metadata validation permanently",
+        );
+        assert!(!is_retryable_contention(DbBackend::MySql, &err));
+    }
+
+    #[test]
+    fn mysql_restart_transaction_detected() {
+        let err = exec_err("MySqlError: Lock wait timeout exceeded; try restarting transaction");
         assert!(is_retryable_contention(DbBackend::MySql, &err));
     }
 

--- a/libs/toolkit-db/src/outbox/README.md
+++ b/libs/toolkit-db/src/outbox/README.md
@@ -11,6 +11,62 @@ cancellation).
 
 ## Usage
 
+Default usage keeps the existing `toolkit_outbox_*` tables:
+
+```rust
+run_migrations_for_testing(&db, outbox_migrations()).await?;
+
+let handle = Outbox::builder(db)
+    .queue("orders", Partitions::of(4))
+    .leased(OrderHandler { client })
+    .start().await?;
+```
+
+### Custom table prefix
+
+Use the same prefix for migrations and the runtime builder. The prefix creates
+a complete independent table family by appending fixed suffixes such as
+`_body`, `_partitions`, `_incoming`, `_outgoing`, and `_dead_letters`.
+
+```rust
+run_migrations_for_testing(
+    &db,
+    outbox_migrations_with_prefix("mini_chat_outbox")?,
+).await?;
+
+let handle = Outbox::builder(db)
+    .table_prefix("mini_chat_outbox")?
+    .queue("orders", Partitions::of(4))
+    .leased(OrderHandler { client })
+    .start().await?;
+```
+
+Changing the prefix points the outbox at a different table family. It does not
+rename tables or move existing rows. To move data between prefixes, drain or
+migrate the rows explicitly.
+
+Prefixes are validated before SQL is generated: they must be non-empty ASCII
+identifiers, start with a letter, contain only letters, digits, and underscores,
+and stay short enough that derived table and index names fit common backend
+identifier limits. Schema-qualified input such as `public.outbox`, quoting,
+spaces, semicolons, and other punctuation are rejected. Table and index names
+are SQL identifiers, so they cannot be bound as query parameters; only validated
+identifiers are interpolated, while queue names, payloads, partition IDs, lease
+IDs, limits, and filters remain SQL parameters.
+
+At runtime, the validated table names and detected backend are compiled once
+into an internal `OutboxStatements` catalog. Fixed-shape SQL is reused from that
+catalog instead of being rebuilt through default table-name replacement on every
+operation. Dynamic SQL is still built for runtime-cardinality cases such as
+multi-row inserts and `IN (...)` lists.
+
+For MySQL, migrations also create `<prefix>_body_id_sequence` and
+`<prefix>_incoming_id_sequence`. Batch enqueue reserves body IDs first and
+incoming IDs second by locking the singleton row with `SELECT ... FOR UPDATE`,
+advancing `next_id`, then inserting rows with explicit IDs. On MySQL-compatible
+clusters such as Percona XtraDB Cluster/Galera, retry the whole transaction on
+deadlock, serialization, or certification-conflict errors.
+
 ### Single-message handler (leased)
 
 ```rust

--- a/libs/toolkit-db/src/outbox/builder.rs
+++ b/libs/toolkit-db/src/outbox/builder.rs
@@ -48,7 +48,13 @@ fn build_processor_worker<S: super::strategy::ProcessingStrategy + 'static>(
     ctx: &SpawnContext,
     strategy: S,
 ) -> (String, Pin<Box<dyn Future<Output = ()> + Send>>) {
-    let processor = PartitionProcessor::new(strategy, ctx.pid, ctx.tuning.clone(), ctx.db.clone());
+    let processor = PartitionProcessor::new(
+        strategy,
+        ctx.pid,
+        ctx.tuning.clone(),
+        ctx.db.clone(),
+        ctx.outbox.statements_arc(),
+    );
     let name = format!("processor-{}", ctx.pid);
     let (poker_notify, _poker_handle) =
         super::taskward::poker(ctx.tuning.idle_interval, ctx.cancel.clone());

--- a/libs/toolkit-db/src/outbox/core.rs
+++ b/libs/toolkit-db/src/outbox/core.rs
@@ -2,12 +2,15 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use dashmap::DashMap;
-use sea_orm::{ConnectionTrait, DbBackend, FromQueryResult, Statement, TransactionTrait};
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DbBackend, FromQueryResult, Statement, TransactionTrait,
+};
 use tokio::sync::{Notify, RwLock};
 
-use super::dialect::Dialect;
 use super::manager::OutboxBuilder;
 use super::prioritizer::SharedPrioritizer;
+use super::statements::OutboxStatements;
+use super::store::OutboxStore;
 use super::types::{EnqueueMessage, OutboxConfig, OutboxError, OutboxMessageId};
 use crate::Db;
 use crate::secure::SeaOrmRunner;
@@ -24,6 +27,7 @@ const BATCH_CHUNK_SIZE: usize = 100;
 /// Core outbox handle. Holds partition cache and notification channels.
 pub struct Outbox {
     config: OutboxConfig,
+    statements: Arc<OutboxStatements>,
     /// Cached partition lookup: `partitions[queue_name][partition_number] = partitions.id` (PK).
     partitions: DashMap<String, Vec<i64>>,
     /// Reverse map: `partition_id → queue_name`. Populated during `register_queue`.
@@ -54,9 +58,17 @@ impl Outbox {
 
     /// Create a new outbox. Construction goes through [`OutboxBuilder::start()`].
     #[must_use]
+    #[allow(dead_code)]
     pub(crate) fn new(config: OutboxConfig) -> Self {
+        Self::new_with_backend(config, DbBackend::Sqlite)
+    }
+
+    #[must_use]
+    pub(crate) fn new_with_backend(config: OutboxConfig, backend: DbBackend) -> Self {
+        let statements = Arc::new(OutboxStatements::new(backend, &config.tables));
         Self {
             config,
+            statements,
             partitions: DashMap::new(),
             partition_to_queue: DashMap::new(),
             all_partition_ids: RwLock::new(Vec::new()),
@@ -91,13 +103,11 @@ impl Outbox {
         super::validation::validate_queue_name(queue)?;
         let conn = db.sea_internal();
         let txn = conn.begin().await?;
-        let backend = txn.get_database_backend();
-        let dialect = Dialect::from(backend);
+        let store = OutboxStore::new(self.statements());
 
-        let ids =
-            Self::ensure_partition_rows(&txn, backend, &dialect, queue, num_partitions).await?;
-        Self::ensure_processor_rows(&txn, backend, &dialect, &ids).await?;
-        Self::ensure_vacuum_counter_rows(&txn, backend, &dialect, &ids).await?;
+        let ids = Self::ensure_partition_rows(&txn, &store, queue, num_partitions).await?;
+        Self::ensure_processor_rows(&txn, &store, &ids).await?;
+        Self::ensure_vacuum_counter_rows(&txn, &store, &ids).await?;
 
         txn.commit().await?;
 
@@ -111,14 +121,13 @@ impl Outbox {
     /// already present or freshly inserted.
     async fn ensure_partition_rows<C: ConnectionTrait>(
         conn: &C,
-        backend: DbBackend,
-        dialect: &Dialect,
+        store: &OutboxStore<'_>,
         queue: &str,
         num_partitions: u16,
     ) -> Result<Vec<i64>, OutboxError> {
         let existing = PartitionRow::find_by_statement(Statement::from_sql_and_values(
-            backend,
-            dialect.register_queue_select(),
+            store.backend(),
+            store.register_queue_select(),
             [queue.into()],
         ))
         .all(conn)
@@ -138,8 +147,8 @@ impl Outbox {
         // First registration — insert partition rows
         for p in 0..num_partitions {
             conn.execute(Statement::from_sql_and_values(
-                backend,
-                dialect.register_queue_insert(),
+                store.backend(),
+                store.register_queue_insert(),
                 #[allow(clippy::cast_possible_wrap)]
                 [queue.into(), (p as i16).into()],
             ))
@@ -148,8 +157,8 @@ impl Outbox {
 
         // Read back inserted rows to get their PKs
         let rows = PartitionRow::find_by_statement(Statement::from_sql_and_values(
-            backend,
-            dialect.register_queue_select(),
+            store.backend(),
+            store.register_queue_select(),
             [queue.into()],
         ))
         .all(conn)
@@ -162,14 +171,13 @@ impl Outbox {
     /// `ON CONFLICT DO NOTHING`).
     async fn ensure_processor_rows<C: ConnectionTrait>(
         conn: &C,
-        backend: DbBackend,
-        dialect: &Dialect,
+        store: &OutboxStore<'_>,
         ids: &[i64],
     ) -> Result<(), OutboxError> {
         for &id in ids {
             conn.execute(Statement::from_sql_and_values(
-                backend,
-                dialect.insert_processor_row(),
+                store.backend(),
+                store.insert_processor_row(),
                 [id.into()],
             ))
             .await?;
@@ -181,14 +189,13 @@ impl Outbox {
     /// `ON CONFLICT DO NOTHING`).
     async fn ensure_vacuum_counter_rows<C: ConnectionTrait>(
         conn: &C,
-        backend: DbBackend,
-        dialect: &Dialect,
+        store: &OutboxStore<'_>,
         ids: &[i64],
     ) -> Result<(), OutboxError> {
         for &id in ids {
             conn.execute(Statement::from_sql_and_values(
-                backend,
-                dialect.insert_vacuum_counter_row(),
+                store.backend(),
+                store.insert_vacuum_counter_row(),
                 [id.into()],
             ))
             .await?;
@@ -253,8 +260,14 @@ impl Outbox {
         let partition_id = self.resolve_partition(queue, partition)?;
 
         let runner = db.as_seaorm();
-        let incoming_id =
-            Self::insert_body_and_incoming(&runner, partition_id, payload, payload_type).await?;
+        let incoming_id = Self::insert_body_and_incoming(
+            &runner,
+            self.statements(),
+            partition_id,
+            payload,
+            payload_type,
+        )
+        .await?;
 
         self.push_dirty(partition_id);
 
@@ -285,7 +298,7 @@ impl Outbox {
         }
 
         let runner = db.as_seaorm();
-        let ids = Self::insert_batch(&runner, &resolved, items).await?;
+        let ids = Self::insert_batch(&runner, self.statements(), &resolved, items).await?;
 
         // Push dirty for each distinct partition_id in the batch
         for &pid in &resolved {
@@ -298,14 +311,34 @@ impl Outbox {
     /// Insert a batch of body + incoming rows using multi-row INSERTs.
     async fn insert_batch(
         runner: &SeaOrmRunner<'_>,
+        statements: &OutboxStatements,
         partition_ids: &[i64],
         items: &[EnqueueMessage<'_>],
     ) -> Result<Vec<OutboxMessageId>, OutboxError> {
-        let (conn, backend): (&dyn ConnectionTrait, DbBackend) = match runner {
-            SeaOrmRunner::Conn(c) => (*c, c.get_database_backend()),
-            SeaOrmRunner::Tx(t) => (*t, t.get_database_backend()),
+        let backend = Self::runner_backend(runner);
+        debug_assert_eq!(backend, statements.backend());
+
+        if let Some(c) = Self::conn_requiring_composite_write_tx(runner) {
+            let txn = c.begin().await?;
+            let ids = Self::insert_batch_on_conn(&txn, statements, partition_ids, items).await?;
+            txn.commit().await?;
+            return Ok(ids);
+        }
+
+        let conn: &dyn ConnectionTrait = match runner {
+            SeaOrmRunner::Conn(c) => *c,
+            SeaOrmRunner::Tx(t) => *t,
         };
-        let dialect = Dialect::from(backend);
+        Self::insert_batch_on_conn(conn, statements, partition_ids, items).await
+    }
+
+    async fn insert_batch_on_conn(
+        conn: &dyn ConnectionTrait,
+        statements: &OutboxStatements,
+        partition_ids: &[i64],
+        items: &[EnqueueMessage<'_>],
+    ) -> Result<Vec<OutboxMessageId>, OutboxError> {
+        let store = OutboxStore::new(statements);
 
         if items.is_empty() {
             return Ok(Vec::new());
@@ -319,9 +352,7 @@ impl Outbox {
                 .iter()
                 .map(|item| (item.payload.as_slice(), item.payload_type))
                 .collect();
-            let chunk_ids = dialect
-                .exec_insert_body_batch(conn, backend, &payloads)
-                .await?;
+            let chunk_ids = store.exec_insert_body_batch(conn, &payloads).await?;
             all_body_ids.extend(chunk_ids);
         }
 
@@ -333,9 +364,7 @@ impl Outbox {
             let entries: Vec<(i64, i64)> = (chunk_start..chunk_end)
                 .map(|i| (partition_ids[i], all_body_ids[i]))
                 .collect();
-            let chunk_ids = dialect
-                .exec_insert_incoming_batch(conn, backend, &entries)
-                .await?;
+            let chunk_ids = store.exec_insert_incoming_batch(conn, &entries).await?;
             all_incoming_ids.extend(chunk_ids.into_iter().map(OutboxMessageId));
         }
 
@@ -345,21 +374,50 @@ impl Outbox {
     /// Insert body + incoming rows, returning the `incoming_id`.
     async fn insert_body_and_incoming(
         runner: &SeaOrmRunner<'_>,
+        statements: &OutboxStatements,
         partition_id: i64,
         payload: Vec<u8>,
         payload_type: &str,
     ) -> Result<i64, OutboxError> {
-        let (conn, backend): (&dyn ConnectionTrait, DbBackend) = match runner {
-            SeaOrmRunner::Conn(c) => (*c, c.get_database_backend()),
-            SeaOrmRunner::Tx(t) => (*t, t.get_database_backend()),
-        };
-        let dialect = Dialect::from(backend);
+        let backend = Self::runner_backend(runner);
+        debug_assert_eq!(backend, statements.backend());
 
-        let incoming_id = dialect
-            .exec_insert_body_and_incoming(conn, backend, partition_id, payload, payload_type)
+        if let Some(c) = Self::conn_requiring_composite_write_tx(runner) {
+            let txn = c.begin().await?;
+            let store = OutboxStore::new(statements);
+            let incoming_id = store
+                .exec_insert_body_and_incoming(&txn, partition_id, payload, payload_type)
+                .await?;
+            txn.commit().await?;
+            return Ok(incoming_id);
+        }
+
+        let conn: &dyn ConnectionTrait = match runner {
+            SeaOrmRunner::Conn(c) => *c,
+            SeaOrmRunner::Tx(t) => *t,
+        };
+        let store = OutboxStore::new(statements);
+        let incoming_id = store
+            .exec_insert_body_and_incoming(conn, partition_id, payload, payload_type)
             .await?;
 
         Ok(incoming_id)
+    }
+
+    fn runner_backend(runner: &SeaOrmRunner<'_>) -> DbBackend {
+        match runner {
+            SeaOrmRunner::Conn(c) => c.get_database_backend(),
+            SeaOrmRunner::Tx(t) => t.get_database_backend(),
+        }
+    }
+
+    fn conn_requiring_composite_write_tx<'a>(
+        runner: &'a SeaOrmRunner<'_>,
+    ) -> Option<&'a DatabaseConnection> {
+        match runner {
+            SeaOrmRunner::Conn(c) if c.get_database_backend() == DbBackend::MySql => Some(*c),
+            SeaOrmRunner::Conn(_) | SeaOrmRunner::Tx(_) => None,
+        }
     }
 
     /// List dead-lettered messages with optional filtering.
@@ -376,7 +434,7 @@ impl Outbox {
         db: &(impl crate::secure::DBRunner + Sync),
         filter: &super::dead_letter::DeadLetterFilter,
     ) -> Result<Vec<super::dead_letter::DeadLetterMessage>, OutboxError> {
-        super::dead_letter::dead_letter_list(db.as_seaorm(), filter).await
+        super::dead_letter::dead_letter_list(db.as_seaorm(), self.statements(), filter).await
     }
 
     /// Count dead-lettered messages matching the filter.
@@ -388,7 +446,7 @@ impl Outbox {
         db: &(impl crate::secure::DBRunner + Sync),
         filter: &super::dead_letter::DeadLetterFilter,
     ) -> Result<u64, OutboxError> {
-        super::dead_letter::dead_letter_count(db.as_seaorm(), filter).await
+        super::dead_letter::dead_letter_count(db.as_seaorm(), self.statements(), filter).await
     }
 
     /// Claim dead letters for reprocessing. Returns the claimed messages.
@@ -404,7 +462,8 @@ impl Outbox {
         scope: &super::dead_letter::DeadLetterScope,
         timeout: std::time::Duration,
     ) -> Result<Vec<super::dead_letter::DeadLetterMessage>, OutboxError> {
-        super::dead_letter::dead_letter_replay(db.as_seaorm(), scope, timeout).await
+        super::dead_letter::dead_letter_replay(db.as_seaorm(), self.statements(), scope, timeout)
+            .await
     }
 
     /// Transition claimed dead letters to `resolved`.
@@ -416,7 +475,7 @@ impl Outbox {
         db: &(impl crate::secure::DBRunner + Sync),
         ids: &[i64],
     ) -> Result<u64, OutboxError> {
-        super::dead_letter::dead_letter_resolve(db.as_seaorm(), ids).await
+        super::dead_letter::dead_letter_resolve(db.as_seaorm(), self.statements(), ids).await
     }
 
     /// Transition claimed dead letters back to `pending` with attempts++.
@@ -429,7 +488,7 @@ impl Outbox {
         ids: &[i64],
         reason: &str,
     ) -> Result<u64, OutboxError> {
-        super::dead_letter::dead_letter_reject(db.as_seaorm(), ids, reason).await
+        super::dead_letter::dead_letter_reject(db.as_seaorm(), self.statements(), ids, reason).await
     }
 
     /// Discard pending dead letters — transitions to `discarded`.
@@ -441,7 +500,7 @@ impl Outbox {
         db: &(impl crate::secure::DBRunner + Sync),
         scope: &super::dead_letter::DeadLetterScope,
     ) -> Result<u64, OutboxError> {
-        super::dead_letter::dead_letter_discard(db.as_seaorm(), scope).await
+        super::dead_letter::dead_letter_discard(db.as_seaorm(), self.statements(), scope).await
     }
 
     /// Delete terminal-state dead letters (`resolved` + `discarded`).
@@ -453,7 +512,7 @@ impl Outbox {
         db: &(impl crate::secure::DBRunner + Sync),
         scope: &super::dead_letter::DeadLetterScope,
     ) -> Result<u64, OutboxError> {
-        super::dead_letter::dead_letter_cleanup(db.as_seaorm(), scope).await
+        super::dead_letter::dead_letter_cleanup(db.as_seaorm(), self.statements(), scope).await
     }
 
     /// Install the shared prioritizer. Called once during `start()`.
@@ -543,6 +602,16 @@ impl Outbox {
     #[must_use]
     pub fn config(&self) -> &OutboxConfig {
         &self.config
+    }
+
+    #[must_use]
+    pub(super) fn statements(&self) -> &OutboxStatements {
+        &self.statements
+    }
+
+    #[must_use]
+    pub(super) fn statements_arc(&self) -> Arc<OutboxStatements> {
+        Arc::clone(&self.statements)
     }
 
     /// Returns the partition IDs for a specific queue, in order.

--- a/libs/toolkit-db/src/outbox/dead_letter.rs
+++ b/libs/toolkit-db/src/outbox/dead_letter.rs
@@ -40,6 +40,10 @@ use sea_orm::{
     TryGetable,
 };
 
+use super::statements::OutboxStatements;
+use super::store::OutboxStore;
+#[cfg(test)]
+use super::tables::OutboxTables;
 use super::types::OutboxError;
 use crate::secure::SeaOrmRunner;
 
@@ -221,11 +225,13 @@ impl Default for DeadLetterFilter {
 /// List dead-lettered messages with optional filtering.
 pub(super) async fn dead_letter_list(
     runner: SeaOrmRunner<'_>,
+    statements: &OutboxStatements,
     filter: &DeadLetterFilter,
 ) -> Result<Vec<DeadLetterMessage>, OutboxError> {
-    let backend = runner_backend(&runner);
-    let (sql, values) = build_select_query(backend, filter);
-    let stmt = Statement::from_sql_and_values(backend, &sql, values);
+    debug_assert_eq!(runner_backend(&runner), statements.backend());
+    let store = OutboxStore::new(statements);
+    let (sql, values) = build_select_query(&store, filter);
+    let stmt = Statement::from_sql_and_values(store.backend(), &sql, values);
 
     let rows = match &runner {
         SeaOrmRunner::Conn(c) => DeadLetterMessage::find_by_statement(stmt).all(*c).await?,
@@ -237,6 +243,7 @@ pub(super) async fn dead_letter_list(
 /// Count dead-lettered messages matching the filter.
 pub(super) async fn dead_letter_count(
     runner: SeaOrmRunner<'_>,
+    statements: &OutboxStatements,
     filter: &DeadLetterFilter,
 ) -> Result<u64, OutboxError> {
     #[derive(Debug, FromQueryResult)]
@@ -244,9 +251,10 @@ pub(super) async fn dead_letter_count(
         cnt: i64,
     }
 
-    let backend = runner_backend(&runner);
-    let (sql, values) = build_count_query(backend, filter);
-    let stmt = Statement::from_sql_and_values(backend, &sql, values);
+    debug_assert_eq!(runner_backend(&runner), statements.backend());
+    let store = OutboxStore::new(statements);
+    let (sql, values) = build_count_query(&store, filter);
+    let stmt = Statement::from_sql_and_values(store.backend(), &sql, values);
 
     let row = match &runner {
         SeaOrmRunner::Conn(c) => Count::find_by_statement(stmt).one(*c).await?,
@@ -268,21 +276,26 @@ pub(super) async fn dead_letter_count(
 /// callers from claiming the same rows.
 pub(super) async fn dead_letter_replay(
     runner: SeaOrmRunner<'_>,
+    statements: &OutboxStatements,
     scope: &DeadLetterScope,
     timeout: Duration,
 ) -> Result<Vec<DeadLetterMessage>, OutboxError> {
-    let backend = runner_backend(&runner);
+    debug_assert_eq!(runner_backend(&runner), statements.backend());
+    let store = OutboxStore::new(statements);
 
     let txn = match &runner {
         SeaOrmRunner::Conn(c) => c.begin().await?,
         SeaOrmRunner::Tx(t) => t.begin().await?,
     };
 
-    let (sql, values) = build_replay_select(backend, scope);
-    let rows =
-        DeadLetterMessage::find_by_statement(Statement::from_sql_and_values(backend, &sql, values))
-            .all(&txn)
-            .await?;
+    let (sql, values) = build_replay_select(&store, scope);
+    let rows = DeadLetterMessage::find_by_statement(Statement::from_sql_and_values(
+        store.backend(),
+        &sql,
+        values,
+    ))
+    .all(&txn)
+    .await?;
 
     if rows.is_empty() {
         txn.commit().await?;
@@ -290,7 +303,7 @@ pub(super) async fn dead_letter_replay(
     }
 
     let dl_ids: Vec<i64> = rows.iter().map(|r| r.id).collect();
-    let claim_sql = build_batch_claim(backend, dl_ids.len());
+    let claim_sql = build_batch_claim(&store, dl_ids.len());
     let mut claim_values: Vec<sea_orm::Value> = Vec::with_capacity(1 + dl_ids.len());
     #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
     claim_values.push((timeout.as_secs() as i64).into());
@@ -298,7 +311,7 @@ pub(super) async fn dead_letter_replay(
         claim_values.push(id.into());
     }
     txn.execute(Statement::from_sql_and_values(
-        backend,
+        store.backend(),
         &claim_sql,
         claim_values,
     ))
@@ -315,15 +328,17 @@ pub(super) async fn dead_letter_replay(
 /// skipped (returns 0 for those).
 pub(super) async fn dead_letter_resolve(
     runner: SeaOrmRunner<'_>,
+    statements: &OutboxStatements,
     ids: &[i64],
 ) -> Result<u64, OutboxError> {
     if ids.is_empty() {
         return Ok(0);
     }
-    let backend = runner_backend(&runner);
-    let sql = build_batch_resolve(backend, ids.len());
+    debug_assert_eq!(runner_backend(&runner), statements.backend());
+    let store = OutboxStore::new(statements);
+    let sql = build_batch_resolve(&store, ids.len());
     let values: Vec<sea_orm::Value> = ids.iter().map(|&id| id.into()).collect();
-    let stmt = Statement::from_sql_and_values(backend, &sql, values);
+    let stmt = Statement::from_sql_and_values(store.backend(), &sql, values);
     let result = match &runner {
         SeaOrmRunner::Conn(c) => c.execute(stmt).await?,
         SeaOrmRunner::Tx(t) => t.execute(stmt).await?,
@@ -337,20 +352,22 @@ pub(super) async fn dead_letter_resolve(
 /// Returns count of rejected rows.
 pub(super) async fn dead_letter_reject(
     runner: SeaOrmRunner<'_>,
+    statements: &OutboxStatements,
     ids: &[i64],
     reason: &str,
 ) -> Result<u64, OutboxError> {
     if ids.is_empty() {
         return Ok(0);
     }
-    let backend = runner_backend(&runner);
-    let sql = build_batch_reject(backend, ids.len());
+    debug_assert_eq!(runner_backend(&runner), statements.backend());
+    let store = OutboxStore::new(statements);
+    let sql = build_batch_reject(&store, ids.len());
     let mut values: Vec<sea_orm::Value> = Vec::with_capacity(1 + ids.len());
     values.push(reason.to_owned().into());
     for &id in ids {
         values.push(id.into());
     }
-    let stmt = Statement::from_sql_and_values(backend, &sql, values);
+    let stmt = Statement::from_sql_and_values(store.backend(), &sql, values);
     let result = match &runner {
         SeaOrmRunner::Conn(c) => c.execute(stmt).await?,
         SeaOrmRunner::Tx(t) => t.execute(stmt).await?,
@@ -363,6 +380,7 @@ pub(super) async fn dead_letter_reject(
 /// Uses `FOR UPDATE SKIP LOCKED` for concurrent safety.
 pub(super) async fn dead_letter_discard(
     runner: SeaOrmRunner<'_>,
+    statements: &OutboxStatements,
     scope: &DeadLetterScope,
 ) -> Result<u64, OutboxError> {
     #[derive(Debug, FromQueryResult)]
@@ -370,18 +388,23 @@ pub(super) async fn dead_letter_discard(
         id: i64,
     }
 
-    let backend = runner_backend(&runner);
+    debug_assert_eq!(runner_backend(&runner), statements.backend());
+    let store = OutboxStore::new(statements);
 
     let txn = match &runner {
         SeaOrmRunner::Conn(c) => c.begin().await?,
         SeaOrmRunner::Tx(t) => t.begin().await?,
     };
 
-    let (sql, values) = build_discard_select(backend, scope);
+    let (sql, values) = build_discard_select(&store, scope);
 
-    let rows = Id::find_by_statement(Statement::from_sql_and_values(backend, &sql, values))
-        .all(&txn)
-        .await?;
+    let rows = Id::find_by_statement(Statement::from_sql_and_values(
+        store.backend(),
+        &sql,
+        values,
+    ))
+    .all(&txn)
+    .await?;
 
     if rows.is_empty() {
         txn.commit().await?;
@@ -389,10 +412,10 @@ pub(super) async fn dead_letter_discard(
     }
 
     let ids: Vec<i64> = rows.iter().map(|r| r.id).collect();
-    let update_sql = build_batch_discard(backend, ids.len());
+    let update_sql = build_batch_discard(&store, ids.len());
     let update_values: Vec<sea_orm::Value> = ids.iter().map(|&id| id.into()).collect();
     txn.execute(Statement::from_sql_and_values(
-        backend,
+        store.backend(),
         &update_sql,
         update_values,
     ))
@@ -409,11 +432,13 @@ pub(super) async fn dead_letter_discard(
 /// `pending` and `reprocessing` rows are always preserved.
 pub(super) async fn dead_letter_cleanup(
     runner: SeaOrmRunner<'_>,
+    statements: &OutboxStatements,
     scope: &DeadLetterScope,
 ) -> Result<u64, OutboxError> {
-    let backend = runner_backend(&runner);
-    let (sql, values) = build_delete_query(backend, scope);
-    let stmt = Statement::from_sql_and_values(backend, &sql, values);
+    debug_assert_eq!(runner_backend(&runner), statements.backend());
+    let store = OutboxStore::new(statements);
+    let (sql, values) = build_delete_query(&store, scope);
+    let stmt = Statement::from_sql_and_values(store.backend(), &sql, values);
     let result = match &runner {
         SeaOrmRunner::Conn(c) => c.execute(stmt).await?,
         SeaOrmRunner::Tx(t) => t.execute(stmt).await?,
@@ -500,7 +525,7 @@ impl QueryBuilder {
     }
 }
 
-fn apply_scope(qb: &mut QueryBuilder, scope: &DeadLetterScope) {
+fn apply_scope(qb: &mut QueryBuilder, store: &OutboxStore<'_>, scope: &DeadLetterScope) {
     if let Some(pid) = scope.partition_id {
         let idx = qb.param_idx;
         qb.add_condition(&format!("d.partition_id = ${idx}"), pid.into());
@@ -509,7 +534,8 @@ fn apply_scope(qb: &mut QueryBuilder, scope: &DeadLetterScope) {
         let idx = qb.param_idx;
         qb.add_condition(
             &format!(
-                "d.partition_id IN (SELECT id FROM toolkit_outbox_partitions WHERE queue = ${idx})"
+                "d.partition_id IN (SELECT id FROM {} WHERE queue = ${idx})",
+                store.tables().partitions()
             ),
             queue.clone().into(),
         );
@@ -523,60 +549,56 @@ fn apply_scope(qb: &mut QueryBuilder, scope: &DeadLetterScope) {
     }
 }
 
-fn apply_filter(qb: &mut QueryBuilder, filter: &DeadLetterFilter) {
-    apply_scope(qb, &filter.scope);
+fn apply_filter(qb: &mut QueryBuilder, store: &OutboxStore<'_>, filter: &DeadLetterFilter) {
+    apply_scope(qb, store, &filter.scope);
     if let Some(status) = filter.status {
         let idx = qb.param_idx;
         qb.add_condition(&format!("d.status = ${idx}"), status.to_string().into());
     }
 }
 
-const SELECT_COLUMNS: &str = "SELECT d.id, d.partition_id, d.seq, d.payload, d.payload_type, \
-     d.created_at, d.failed_at, d.last_error, d.attempts, d.status, d.completed_at, d.deadline \
-     FROM toolkit_outbox_dead_letters d";
-
 fn build_select_query(
-    backend: DbBackend,
+    store: &OutboxStore<'_>,
     filter: &DeadLetterFilter,
 ) -> (String, Vec<sea_orm::Value>) {
-    let mut qb = QueryBuilder::new(SELECT_COLUMNS, backend);
-    apply_filter(&mut qb, filter);
+    let mut qb = QueryBuilder::new(store.dead_letter_select_columns(), store.backend());
+    apply_filter(&mut qb, store, filter);
     qb.finish(filter.scope.limit.or(Some(DEFAULT_DEAD_LETTER_LIMIT)))
 }
 
 fn build_count_query(
-    backend: DbBackend,
+    store: &OutboxStore<'_>,
     filter: &DeadLetterFilter,
 ) -> (String, Vec<sea_orm::Value>) {
-    let mut qb = QueryBuilder::new(
-        "SELECT COUNT(*) AS cnt FROM toolkit_outbox_dead_letters d",
-        backend,
-    );
-    apply_filter(&mut qb, filter);
+    let mut qb = QueryBuilder::new(store.dead_letter_count_base(), store.backend());
+    apply_filter(&mut qb, store, filter);
     qb.finish_no_order(None)
 }
 
 /// Build a DELETE query for cleanup — only terminal states.
 fn build_delete_query(
-    backend: DbBackend,
+    store: &OutboxStore<'_>,
     scope: &DeadLetterScope,
 ) -> (String, Vec<sea_orm::Value>) {
-    let mut inner_qb = QueryBuilder::new("SELECT d.id FROM toolkit_outbox_dead_letters d", backend);
-    apply_scope(&mut inner_qb, scope);
+    let mut inner_qb = QueryBuilder::new(store.dead_letter_id_select_base(), store.backend());
+    apply_scope(&mut inner_qb, store, scope);
     inner_qb.add_raw_condition("d.status IN ('resolved', 'discarded')");
     let (inner_sql, values) = inner_qb.finish_locking_no_order(scope.limit, true);
-    let sql = format!("DELETE FROM toolkit_outbox_dead_letters WHERE id IN ({inner_sql})");
+    let sql = format!(
+        "DELETE FROM {} WHERE id IN ({inner_sql})",
+        store.tables().dead_letters()
+    );
     (sql, values)
 }
 
 /// Build the replay SELECT with orphan recovery: pending rows + expired reprocessing rows.
 fn build_replay_select(
-    backend: DbBackend,
+    store: &OutboxStore<'_>,
     scope: &DeadLetterScope,
 ) -> (String, Vec<sea_orm::Value>) {
-    let mut qb = QueryBuilder::new(SELECT_COLUMNS, backend);
-    apply_scope(&mut qb, scope);
-    let now_fn = db_now(backend);
+    let mut qb = QueryBuilder::new(store.dead_letter_select_columns(), store.backend());
+    apply_scope(&mut qb, store, scope);
+    let now_fn = db_now(store.backend());
     qb.add_raw_condition(&format!(
         "(d.status = 'pending' OR (d.status = 'reprocessing' AND d.deadline < {now_fn}))"
     ));
@@ -601,11 +623,14 @@ fn build_replay_select(
 }
 
 /// Build `UPDATE ... SET status = 'reprocessing', deadline = now() + timeout WHERE id IN (...)`.
-fn build_batch_claim(backend: DbBackend, count: usize) -> String {
+fn build_batch_claim(store: &OutboxStore<'_>, count: usize) -> String {
+    let backend = store.backend();
     let is_mysql = backend == DbBackend::MySql;
     let now_fn = db_now(backend);
-    let mut sql =
-        String::from("UPDATE toolkit_outbox_dead_letters SET status = 'reprocessing', deadline = ");
+    let mut sql = format!(
+        "UPDATE {} SET status = 'reprocessing', deadline = ",
+        store.tables().dead_letters()
+    );
     match backend {
         DbBackend::Postgres => {
             #[allow(clippy::let_underscore_must_use)]
@@ -636,11 +661,13 @@ fn build_batch_claim(backend: DbBackend, count: usize) -> String {
 }
 
 /// Build `UPDATE ... SET status = 'resolved', completed_at = now(), deadline = NULL WHERE id IN (...) AND status = 'reprocessing'`.
-fn build_batch_resolve(backend: DbBackend, count: usize) -> String {
+fn build_batch_resolve(store: &OutboxStore<'_>, count: usize) -> String {
+    let backend = store.backend();
     let is_mysql = backend == DbBackend::MySql;
     let now_fn = db_now(backend);
     let mut sql = format!(
-        "UPDATE toolkit_outbox_dead_letters SET status = 'resolved', completed_at = {now_fn}, deadline = NULL WHERE id IN ("
+        "UPDATE {} SET status = 'resolved', completed_at = {now_fn}, deadline = NULL WHERE id IN (",
+        store.tables().dead_letters()
     );
     for i in 0..count {
         if i > 0 {
@@ -658,13 +685,15 @@ fn build_batch_resolve(backend: DbBackend, count: usize) -> String {
 }
 
 /// Build `UPDATE ... SET status = 'pending', attempts = attempts + 1, last_error = $reason, failed_at = now(), deadline = NULL WHERE id IN (...) AND status = 'reprocessing'`.
-fn build_batch_reject(backend: DbBackend, count: usize) -> String {
+fn build_batch_reject(store: &OutboxStore<'_>, count: usize) -> String {
+    let backend = store.backend();
     let is_mysql = backend == DbBackend::MySql;
     let now_fn = db_now(backend);
     // First param is the reason string, then IDs
     let mut sql = format!(
-        "UPDATE toolkit_outbox_dead_letters SET status = 'pending', attempts = attempts + 1, \
+        "UPDATE {} SET status = 'pending', attempts = attempts + 1, \
          last_error = {reason}, failed_at = {now_fn}, deadline = NULL WHERE id IN (",
+        store.tables().dead_letters(),
         reason = if is_mysql { "?" } else { "$1" },
     );
     for i in 0..count {
@@ -684,21 +713,23 @@ fn build_batch_reject(backend: DbBackend, count: usize) -> String {
 
 /// Build discard SELECT: pending rows only, with FOR UPDATE SKIP LOCKED.
 fn build_discard_select(
-    backend: DbBackend,
+    store: &OutboxStore<'_>,
     scope: &DeadLetterScope,
 ) -> (String, Vec<sea_orm::Value>) {
-    let mut qb = QueryBuilder::new("SELECT d.id FROM toolkit_outbox_dead_letters d", backend);
-    apply_scope(&mut qb, scope);
+    let mut qb = QueryBuilder::new(store.dead_letter_id_select_base(), store.backend());
+    apply_scope(&mut qb, store, scope);
     qb.add_raw_condition("d.status = 'pending'");
     qb.finish_locking_no_order(scope.limit, true)
 }
 
 /// Build `UPDATE ... SET status = 'discarded', completed_at = now() WHERE id IN (...)`.
-fn build_batch_discard(backend: DbBackend, count: usize) -> String {
+fn build_batch_discard(store: &OutboxStore<'_>, count: usize) -> String {
+    let backend = store.backend();
     let is_mysql = backend == DbBackend::MySql;
     let now_fn = db_now(backend);
     let mut sql = format!(
-        "UPDATE toolkit_outbox_dead_letters SET status = 'discarded', completed_at = {now_fn} WHERE id IN ("
+        "UPDATE {} SET status = 'discarded', completed_at = {now_fn} WHERE id IN (",
+        store.tables().dead_letters()
     );
     for i in 0..count {
         if i > 0 {
@@ -727,6 +758,88 @@ fn db_now(backend: DbBackend) -> &'static str {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
+
+    fn default_tables() -> OutboxTables {
+        OutboxTables::default()
+    }
+
+    fn build_select_query(
+        backend: DbBackend,
+        filter: &DeadLetterFilter,
+    ) -> (String, Vec<sea_orm::Value>) {
+        let tables = default_tables();
+        let statements = OutboxStatements::new(backend, &tables);
+        let store = OutboxStore::new(&statements);
+        super::build_select_query(&store, filter)
+    }
+
+    fn build_count_query(
+        backend: DbBackend,
+        filter: &DeadLetterFilter,
+    ) -> (String, Vec<sea_orm::Value>) {
+        let tables = default_tables();
+        let statements = OutboxStatements::new(backend, &tables);
+        let store = OutboxStore::new(&statements);
+        super::build_count_query(&store, filter)
+    }
+
+    fn build_delete_query(
+        backend: DbBackend,
+        scope: &DeadLetterScope,
+    ) -> (String, Vec<sea_orm::Value>) {
+        let tables = default_tables();
+        let statements = OutboxStatements::new(backend, &tables);
+        let store = OutboxStore::new(&statements);
+        super::build_delete_query(&store, scope)
+    }
+
+    fn build_replay_select(
+        backend: DbBackend,
+        scope: &DeadLetterScope,
+    ) -> (String, Vec<sea_orm::Value>) {
+        let tables = default_tables();
+        let statements = OutboxStatements::new(backend, &tables);
+        let store = OutboxStore::new(&statements);
+        super::build_replay_select(&store, scope)
+    }
+
+    fn build_batch_claim(backend: DbBackend, count: usize) -> String {
+        let tables = default_tables();
+        let statements = OutboxStatements::new(backend, &tables);
+        let store = OutboxStore::new(&statements);
+        super::build_batch_claim(&store, count)
+    }
+
+    fn build_batch_resolve(backend: DbBackend, count: usize) -> String {
+        let tables = default_tables();
+        let statements = OutboxStatements::new(backend, &tables);
+        let store = OutboxStore::new(&statements);
+        super::build_batch_resolve(&store, count)
+    }
+
+    fn build_batch_reject(backend: DbBackend, count: usize) -> String {
+        let tables = default_tables();
+        let statements = OutboxStatements::new(backend, &tables);
+        let store = OutboxStore::new(&statements);
+        super::build_batch_reject(&store, count)
+    }
+
+    fn build_discard_select(
+        backend: DbBackend,
+        scope: &DeadLetterScope,
+    ) -> (String, Vec<sea_orm::Value>) {
+        let tables = default_tables();
+        let statements = OutboxStatements::new(backend, &tables);
+        let store = OutboxStore::new(&statements);
+        super::build_discard_select(&store, scope)
+    }
+
+    fn apply_scope(qb: &mut QueryBuilder, scope: &DeadLetterScope) {
+        let tables = default_tables();
+        let statements = OutboxStatements::new(DbBackend::Postgres, &tables);
+        let store = OutboxStore::new(&statements);
+        super::apply_scope(qb, &store, scope);
+    }
 
     // --- Filter / scope tests ---
 

--- a/libs/toolkit-db/src/outbox/dialect.rs
+++ b/libs/toolkit-db/src/outbox/dialect.rs
@@ -1,6 +1,10 @@
+#![allow(dead_code)]
+
 use std::fmt::Write as _;
 
-use sea_orm::{ConnectionTrait, DbBackend, DbErr, Statement};
+use sea_orm::DbBackend;
+
+use super::tables::OutboxTables;
 
 /// Backend-specific SQL dialect for the outbox gear.
 ///
@@ -37,7 +41,7 @@ impl From<DbBackend> for Dialect {
 pub struct VacuumSql {
     /// SELECT id, `body_id` with LIMIT for bounded chunk deletion.
     /// Parameters: `partition_id`, `processed_seq`, limit.
-    pub select_outgoing_chunk: &'static str,
+    pub select_outgoing_chunk: String,
 }
 
 /// SQL for the sequencer's claim-incoming operation.
@@ -54,44 +58,42 @@ pub struct ClaimSql {
 /// SQL for the sequencer's sequence-allocation operation.
 pub enum AllocSql {
     /// `Pg`/`SQLite`: single `UPDATE ... RETURNING` statement.
-    UpdateReturning(&'static str),
+    UpdateReturning(String),
     /// `MySQL`: `UPDATE` then `SELECT` as two separate statements.
-    UpdateThenSelect {
-        update: &'static str,
-        select: &'static str,
-    },
+    UpdateThenSelect { update: String, select: String },
 }
 
 // -- Registration queries --
 
 impl Dialect {
-    pub fn register_queue_select(self) -> &'static str {
+    pub fn register_queue_select(self, tables: &OutboxTables) -> String {
         match self {
-            Self::Postgres | Self::Sqlite => {
-                "SELECT id FROM toolkit_outbox_partitions \
-                 WHERE queue = $1 ORDER BY partition ASC"
-            }
-            Self::MySql => {
-                "SELECT id FROM toolkit_outbox_partitions \
-                 WHERE queue = ? ORDER BY `partition` ASC"
-            }
+            Self::Postgres | Self::Sqlite => format!(
+                "SELECT id FROM {} WHERE queue = $1 ORDER BY partition ASC",
+                tables.partitions()
+            ),
+            Self::MySql => format!(
+                "SELECT id FROM {} WHERE queue = ? ORDER BY `partition` ASC",
+                tables.partitions()
+            ),
         }
     }
 
-    pub fn register_queue_insert(self) -> &'static str {
+    pub fn register_queue_insert(self, tables: &OutboxTables) -> String {
         match self {
-            Self::Postgres => {
-                "INSERT INTO toolkit_outbox_partitions (queue, partition) \
-                 VALUES ($1, $2) ON CONFLICT (queue, partition) DO NOTHING"
-            }
-            Self::Sqlite => {
-                "INSERT OR IGNORE INTO toolkit_outbox_partitions (queue, partition) \
-                 VALUES ($1, $2)"
-            }
-            Self::MySql => {
-                "INSERT IGNORE INTO toolkit_outbox_partitions (queue, `partition`) \
-                 VALUES (?, ?)"
-            }
+            Self::Postgres => format!(
+                "INSERT INTO {} (queue, partition) \
+                 VALUES ($1, $2) ON CONFLICT (queue, partition) DO NOTHING",
+                tables.partitions()
+            ),
+            Self::Sqlite => format!(
+                "INSERT OR IGNORE INTO {} (queue, partition) VALUES ($1, $2)",
+                tables.partitions()
+            ),
+            Self::MySql => format!(
+                "INSERT IGNORE INTO {} (queue, `partition`) VALUES (?, ?)",
+                tables.partitions()
+            ),
         }
     }
 }
@@ -101,49 +103,51 @@ impl Dialect {
 impl Dialect {
     /// Combined CTE: insert body + incoming in a single round-trip.
     /// Returns the incoming row id. Only for backends that support RETURNING.
-    pub fn insert_body_and_incoming_cte(self) -> Option<&'static str> {
+    pub fn insert_body_and_incoming_cte(self, tables: &OutboxTables) -> Option<String> {
         match self {
-            Self::Postgres => Some(
+            Self::Postgres => Some(format!(
                 "WITH b AS (\
-                   INSERT INTO toolkit_outbox_body (payload, payload_type) \
+                   INSERT INTO {} (payload, payload_type) \
                    VALUES ($1, $2) RETURNING id\
                  ) \
-                 INSERT INTO toolkit_outbox_incoming (partition_id, body_id) \
+                 INSERT INTO {} (partition_id, body_id) \
                  SELECT $3, id FROM b RETURNING id",
-            ),
+                tables.body(),
+                tables.incoming()
+            )),
             // SQLite: writable CTEs require 3.35+; the bundled libsqlite3
             // version may be older, so fall back to two separate INSERTs.
             Self::Sqlite | Self::MySql => None,
         }
     }
 
-    pub fn insert_body(self) -> &'static str {
+    pub fn insert_body(self, tables: &OutboxTables) -> String {
         match self {
-            Self::Postgres | Self::Sqlite => {
-                "INSERT INTO toolkit_outbox_body (payload, payload_type) \
-                 VALUES ($1, $2) RETURNING id"
-            }
-            Self::MySql => {
-                "INSERT INTO toolkit_outbox_body (payload, payload_type) \
-                 VALUES (?, ?)"
-            }
+            Self::Postgres | Self::Sqlite => format!(
+                "INSERT INTO {} (payload, payload_type) VALUES ($1, $2) RETURNING id",
+                tables.body()
+            ),
+            Self::MySql => format!(
+                "INSERT INTO {} (payload, payload_type) VALUES (?, ?)",
+                tables.body()
+            ),
         }
     }
 
-    pub fn insert_incoming(self) -> &'static str {
+    pub fn insert_incoming(self, tables: &OutboxTables) -> String {
         match self {
-            Self::Postgres | Self::Sqlite => {
-                "INSERT INTO toolkit_outbox_incoming (partition_id, body_id) \
-                 VALUES ($1, $2) RETURNING id"
-            }
-            Self::MySql => {
-                "INSERT INTO toolkit_outbox_incoming (partition_id, body_id) \
-                 VALUES (?, ?)"
-            }
+            Self::Postgres | Self::Sqlite => format!(
+                "INSERT INTO {} (partition_id, body_id) VALUES ($1, $2) RETURNING id",
+                tables.incoming()
+            ),
+            Self::MySql => format!(
+                "INSERT INTO {} (partition_id, body_id) VALUES (?, ?)",
+                tables.incoming()
+            ),
         }
     }
 
-    fn supports_returning(self) -> bool {
+    pub(super) fn supports_returning(self) -> bool {
         match self {
             Self::Postgres | Self::Sqlite => true,
             Self::MySql => false,
@@ -151,7 +155,7 @@ impl Dialect {
     }
 
     /// Returns the `MySQL` query to retrieve the last auto-generated ID.
-    fn last_insert_id() -> &'static str {
+    pub(super) fn last_insert_id() -> &'static str {
         "SELECT CAST(LAST_INSERT_ID() AS SIGNED) AS id"
     }
 }
@@ -163,9 +167,11 @@ impl Dialect {
     ///
     /// `MySQL` note: consecutive auto-increment IDs are guaranteed by `InnoDB`
     /// for a single multi-row INSERT when `innodb_autoinc_lock_mode` is 0 or 1.
-    pub fn build_insert_body_batch(self, count: usize) -> String {
-        let mut sql =
-            String::from("INSERT INTO toolkit_outbox_body (payload, payload_type) VALUES ");
+    pub fn build_insert_body_batch(self, tables: &OutboxTables, count: usize) -> String {
+        let mut sql = format!(
+            "INSERT INTO {} (payload, payload_type) VALUES ",
+            tables.body()
+        );
         self.append_value_tuples(&mut sql, count, 2);
         if self.supports_returning() {
             sql.push_str(" RETURNING id");
@@ -173,9 +179,11 @@ impl Dialect {
         sql
     }
 
-    pub fn build_insert_incoming_batch(self, count: usize) -> String {
-        let mut sql =
-            String::from("INSERT INTO toolkit_outbox_incoming (partition_id, body_id) VALUES ");
+    pub fn build_insert_incoming_batch(self, tables: &OutboxTables, count: usize) -> String {
+        let mut sql = format!(
+            "INSERT INTO {} (partition_id, body_id) VALUES ",
+            tables.incoming()
+        );
         self.append_value_tuples(&mut sql, count, 2);
         if self.supports_returning() {
             sql.push_str(" RETURNING id");
@@ -184,9 +192,10 @@ impl Dialect {
     }
 
     /// Build `SELECT id, payload, payload_type, created_at FROM toolkit_outbox_body WHERE id IN (...)`.
-    pub fn build_read_body_batch(self, count: usize) -> String {
-        let mut sql = String::from(
-            "SELECT id, payload, payload_type, created_at FROM toolkit_outbox_body WHERE id IN (",
+    pub fn build_read_body_batch(self, tables: &OutboxTables, count: usize) -> String {
+        let mut sql = format!(
+            "SELECT id, payload, payload_type, created_at FROM {} WHERE id IN (",
+            tables.body()
         );
         self.append_in_placeholders(&mut sql, count);
         sql.push(')');
@@ -239,287 +248,30 @@ impl Dialect {
     }
 }
 
-// -- Insert execution helpers --
-//
-// Encapsulate the RETURNING vs LAST_INSERT_ID branching so callers
-// never need to check `supports_returning()`.
-
-impl Dialect {
-    /// Execute a multi-row body INSERT and return generated IDs.
-    pub async fn exec_insert_body_batch(
-        self,
-        conn: &dyn ConnectionTrait,
-        backend: DbBackend,
-        payloads: &[(&[u8], &str)],
-    ) -> Result<Vec<i64>, DbErr> {
-        if payloads.is_empty() {
-            return Ok(Vec::new());
-        }
-        let sql = self.build_insert_body_batch(payloads.len());
-        let mut values: Vec<sea_orm::Value> = Vec::with_capacity(payloads.len() * 2);
-        for &(payload, payload_type) in payloads {
-            values.push(payload.to_vec().into());
-            values.push(payload_type.into());
-        }
-
-        if self.supports_returning() {
-            let rows = conn
-                .query_all(Statement::from_sql_and_values(backend, &sql, values))
-                .await?;
-            rows.iter()
-                .map(|r| {
-                    r.try_get_by_index(0)
-                        .map_err(|e| DbErr::Custom(format!("body id column: {e}")))
-                })
-                .collect()
-        } else {
-            conn.execute(Statement::from_sql_and_values(backend, &sql, values))
-                .await?;
-            let row = conn
-                .query_one(Statement::from_string(backend, Self::last_insert_id()))
-                .await?
-                .ok_or_else(|| {
-                    DbErr::Custom("LAST_INSERT_ID() returned no row for body batch".to_owned())
-                })?;
-            let first_id: i64 = row
-                .try_get_by_index(0)
-                .map_err(|e| DbErr::Custom(format!("body first_id column: {e}")))?;
-            #[allow(clippy::cast_possible_wrap)]
-            Ok((0..payloads.len() as i64).map(|i| first_id + i).collect())
-        }
-    }
-
-    /// Execute a multi-row incoming INSERT and return generated IDs.
-    pub async fn exec_insert_incoming_batch(
-        self,
-        conn: &dyn ConnectionTrait,
-        backend: DbBackend,
-        entries: &[(i64, i64)],
-    ) -> Result<Vec<i64>, DbErr> {
-        if entries.is_empty() {
-            return Ok(Vec::new());
-        }
-        let sql = self.build_insert_incoming_batch(entries.len());
-        let mut values: Vec<sea_orm::Value> = Vec::with_capacity(entries.len() * 2);
-        for &(partition_id, body_id) in entries {
-            values.push(partition_id.into());
-            values.push(body_id.into());
-        }
-
-        if self.supports_returning() {
-            let rows = conn
-                .query_all(Statement::from_sql_and_values(backend, &sql, values))
-                .await?;
-            rows.iter()
-                .map(|r| {
-                    r.try_get_by_index(0)
-                        .map_err(|e| DbErr::Custom(format!("incoming id column: {e}")))
-                })
-                .collect()
-        } else {
-            conn.execute(Statement::from_sql_and_values(backend, &sql, values))
-                .await?;
-            let row = conn
-                .query_one(Statement::from_string(backend, Self::last_insert_id()))
-                .await?
-                .ok_or_else(|| {
-                    DbErr::Custom("LAST_INSERT_ID() returned no row for incoming batch".to_owned())
-                })?;
-            let first_id: i64 = row
-                .try_get_by_index(0)
-                .map_err(|e| DbErr::Custom(format!("incoming first_id column: {e}")))?;
-            #[allow(clippy::cast_possible_wrap)]
-            Ok((0..entries.len() as i64).map(|i| first_id + i).collect())
-        }
-    }
-
-    /// Execute an INSERT and return the generated `id` column.
-    ///
-    /// Encapsulates RETURNING (Postgres/SQLite) vs `LAST_INSERT_ID` (`MySQL`).
-    async fn exec_insert_returning_id(
-        self,
-        conn: &dyn ConnectionTrait,
-        backend: DbBackend,
-        sql: &str,
-        params: Vec<sea_orm::Value>,
-        context: &str,
-    ) -> Result<i64, DbErr> {
-        if self.supports_returning() {
-            let row = conn
-                .query_one(Statement::from_sql_and_values(backend, sql, params))
-                .await?
-                .ok_or_else(|| {
-                    DbErr::Custom(format!("INSERT RETURNING returned no row for {context}"))
-                })?;
-            row.try_get_by_index(0)
-                .map_err(|e| DbErr::Custom(format!("{context} id column: {e}")))
-        } else {
-            conn.execute(Statement::from_sql_and_values(backend, sql, params))
-                .await?;
-            let row = conn
-                .query_one(Statement::from_string(backend, Self::last_insert_id()))
-                .await?
-                .ok_or_else(|| {
-                    DbErr::Custom(format!("LAST_INSERT_ID() returned no row for {context}"))
-                })?;
-            row.try_get_by_index(0)
-                .map_err(|e| DbErr::Custom(format!("{context} id column: {e}")))
-        }
-    }
-
-    /// Execute a single body INSERT and return the generated ID.
-    pub async fn exec_insert_body(
-        self,
-        conn: &dyn ConnectionTrait,
-        backend: DbBackend,
-        payload: Vec<u8>,
-        payload_type: &str,
-    ) -> Result<i64, DbErr> {
-        self.exec_insert_returning_id(
-            conn,
-            backend,
-            self.insert_body(),
-            vec![payload.into(), payload_type.into()],
-            "body",
-        )
-        .await
-    }
-
-    /// Execute a single incoming INSERT and return the generated ID.
-    pub async fn exec_insert_incoming(
-        self,
-        conn: &dyn ConnectionTrait,
-        backend: DbBackend,
-        partition_id: i64,
-        body_id: i64,
-    ) -> Result<i64, DbErr> {
-        self.exec_insert_returning_id(
-            conn,
-            backend,
-            self.insert_incoming(),
-            vec![partition_id.into(), body_id.into()],
-            "incoming",
-        )
-        .await
-    }
-
-    /// Execute combined CTE: insert body + incoming in one round-trip.
-    /// Falls back to two separate inserts on `MySQL`.
-    pub async fn exec_insert_body_and_incoming(
-        self,
-        conn: &dyn ConnectionTrait,
-        backend: DbBackend,
-        partition_id: i64,
-        payload: Vec<u8>,
-        payload_type: &str,
-    ) -> Result<i64, DbErr> {
-        if let Some(cte) = self.insert_body_and_incoming_cte() {
-            self.exec_insert_returning_id(
-                conn,
-                backend,
-                cte,
-                vec![payload.into(), payload_type.into(), partition_id.into()],
-                "incoming",
-            )
-            .await
-        } else {
-            // MySQL: two separate round-trips (no CTE INSERT support)
-            let body_id = self
-                .exec_insert_body(conn, backend, payload, payload_type)
-                .await?;
-            self.exec_insert_incoming(conn, backend, partition_id, body_id)
-                .await
-        }
-    }
-
-    /// Execute the lease-acquire UPDATE and return `(processed_seq, attempts)` if
-    /// the lease was obtained.
-    ///
-    /// Encapsulates the `RETURNING` vs UPDATE-then-SELECT branching for `MySQL`.
-    pub async fn exec_lease_acquire(
-        self,
-        conn: &dyn ConnectionTrait,
-        backend: DbBackend,
-        lease_id: &str,
-        lease_secs: i64,
-        partition_id: i64,
-    ) -> Result<Option<(i64, i16)>, DbErr> {
-        if self.supports_returning() {
-            let row = conn
-                .query_one(Statement::from_sql_and_values(
-                    backend,
-                    self.lease_acquire(),
-                    [lease_id.into(), lease_secs.into(), partition_id.into()],
-                ))
-                .await?;
-            match row {
-                Some(r) => {
-                    let processed_seq: i64 = r
-                        .try_get_by_index(0)
-                        .map_err(|e| DbErr::Custom(format!("processed_seq column: {e}")))?;
-                    let attempts: i16 = r
-                        .try_get_by_index(1)
-                        .map_err(|e| DbErr::Custom(format!("attempts column: {e}")))?;
-                    Ok(Some((processed_seq, attempts)))
-                }
-                None => Ok(None),
-            }
-        } else {
-            let result = conn
-                .execute(Statement::from_sql_and_values(
-                    backend,
-                    self.lease_acquire(),
-                    [lease_id.into(), lease_secs.into(), partition_id.into()],
-                ))
-                .await?;
-            if result.rows_affected() == 0 {
-                return Ok(None);
-            }
-            let row = conn
-                .query_one(Statement::from_sql_and_values(
-                    backend,
-                    self.read_processor(),
-                    [partition_id.into()],
-                ))
-                .await?;
-            match row {
-                Some(r) => {
-                    let processed_seq: i64 = r
-                        .try_get_by_index(0)
-                        .map_err(|e| DbErr::Custom(format!("processed_seq column: {e}")))?;
-                    let attempts: i16 = r
-                        .try_get_by_index(1)
-                        .map_err(|e| DbErr::Custom(format!("attempts column: {e}")))?;
-                    Ok(Some((processed_seq, attempts)))
-                }
-                None => Ok(None),
-            }
-        }
-    }
-}
-
 // -- Sequencer queries --
 
 impl Dialect {
-    pub fn claim_incoming(self, batch_size: u32) -> ClaimSql {
+    pub fn claim_incoming(self, tables: &OutboxTables, batch_size: u32) -> ClaimSql {
         match self {
             Self::Postgres => ClaimSql {
                 select: format!(
                     "SELECT id, body_id \
-                     FROM toolkit_outbox_incoming \
+                     FROM {} \
                      WHERE partition_id = $1 \
                      ORDER BY id \
                      LIMIT {batch_size} \
-                     FOR UPDATE SKIP LOCKED"
+                     FOR UPDATE SKIP LOCKED",
+                    tables.incoming()
                 ),
             },
             Self::Sqlite => ClaimSql {
                 select: format!(
                     "SELECT id, body_id \
-                     FROM toolkit_outbox_incoming \
+                     FROM {} \
                      WHERE partition_id = $1 \
                      ORDER BY id \
-                     LIMIT {batch_size}"
+                     LIMIT {batch_size}",
+                    tables.incoming()
                 ),
             },
             // SKIP LOCKED prevents InnoDB gap-lock deadlocks when
@@ -527,19 +279,20 @@ impl Dialect {
             Self::MySql => ClaimSql {
                 select: format!(
                     "SELECT id, body_id \
-                     FROM toolkit_outbox_incoming \
+                     FROM {} \
                      WHERE partition_id = ? \
                      ORDER BY id \
                      LIMIT {batch_size} \
-                     FOR UPDATE SKIP LOCKED"
+                     FOR UPDATE SKIP LOCKED",
+                    tables.incoming()
                 ),
             },
         }
     }
 
     /// Build `DELETE FROM toolkit_outbox_incoming WHERE id IN ($1, $2, ...)`.
-    pub fn delete_incoming_batch(self, count: usize) -> String {
-        let mut sql = String::from("DELETE FROM toolkit_outbox_incoming WHERE id IN (");
+    pub fn delete_incoming_batch(self, tables: &OutboxTables, count: usize) -> String {
+        let mut sql = format!("DELETE FROM {} WHERE id IN (", tables.incoming());
         for i in 0..count {
             if i > 0 {
                 sql.push_str(", ");
@@ -559,41 +312,47 @@ impl Dialect {
         sql
     }
 
-    pub fn allocate_sequences(self) -> AllocSql {
+    pub fn allocate_sequences(self, tables: &OutboxTables) -> AllocSql {
         match self {
-            Self::Postgres | Self::Sqlite => AllocSql::UpdateReturning(
-                "UPDATE toolkit_outbox_partitions \
+            Self::Postgres | Self::Sqlite => AllocSql::UpdateReturning(format!(
+                "UPDATE {} \
                  SET sequence = sequence + $2 \
                  WHERE id = $1 \
                  RETURNING sequence - $2 AS start_seq",
-            ),
+                tables.partitions()
+            )),
             Self::MySql => AllocSql::UpdateThenSelect {
-                update: "UPDATE toolkit_outbox_partitions \
-                         SET sequence = sequence + ? WHERE id = ?",
-                select: "SELECT sequence - ? AS start_seq \
-                         FROM toolkit_outbox_partitions WHERE id = ?",
+                update: format!(
+                    "UPDATE {} SET sequence = sequence + ? WHERE id = ?",
+                    tables.partitions()
+                ),
+                select: format!(
+                    "SELECT sequence - ? AS start_seq FROM {} WHERE id = ?",
+                    tables.partitions()
+                ),
             },
         }
     }
 
-    pub fn build_insert_outgoing_batch(self, count: usize) -> String {
-        let mut sql = String::from(
-            "INSERT INTO toolkit_outbox_outgoing (partition_id, body_id, seq) VALUES ",
+    pub fn build_insert_outgoing_batch(self, tables: &OutboxTables, count: usize) -> String {
+        let mut sql = format!(
+            "INSERT INTO {} (partition_id, body_id, seq) VALUES ",
+            tables.outgoing()
         );
         self.append_value_tuples(&mut sql, count, 3);
         sql
     }
 
-    pub fn lock_partition(self) -> Option<&'static str> {
+    pub fn lock_partition(self, tables: &OutboxTables) -> Option<String> {
         match self {
-            Self::Postgres => Some(
-                "SELECT id FROM toolkit_outbox_partitions \
-                 WHERE id = $1 FOR UPDATE SKIP LOCKED",
-            ),
-            Self::MySql => Some(
-                "SELECT id FROM toolkit_outbox_partitions \
-                 WHERE id = ? FOR UPDATE SKIP LOCKED",
-            ),
+            Self::Postgres => Some(format!(
+                "SELECT id FROM {} WHERE id = $1 FOR UPDATE SKIP LOCKED",
+                tables.partitions()
+            )),
+            Self::MySql => Some(format!(
+                "SELECT id FROM {} WHERE id = ? FOR UPDATE SKIP LOCKED",
+                tables.partitions()
+            )),
             Self::Sqlite => None,
         }
     }
@@ -601,11 +360,11 @@ impl Dialect {
     /// Cold-path discovery: find all partition IDs with pending incoming rows.
     /// Uses the existing `(partition_id, id)` index for an index-only skip scan.
     /// Same SQL for all backends — `DISTINCT` on the leading index column is portable.
-    pub fn discover_dirty_partitions(self) -> &'static str {
+    pub fn discover_dirty_partitions(self, tables: &OutboxTables) -> String {
         // Same SQL for all backends — DISTINCT on leading index column is portable.
         match self {
             Self::Postgres | Self::Sqlite | Self::MySql => {
-                "SELECT DISTINCT partition_id FROM toolkit_outbox_incoming"
+                format!("SELECT DISTINCT partition_id FROM {}", tables.incoming())
             }
         }
     }
@@ -614,100 +373,109 @@ impl Dialect {
 // -- Processor queries --
 
 impl Dialect {
-    pub fn insert_processor_row(self) -> &'static str {
+    pub fn insert_processor_row(self, tables: &OutboxTables) -> String {
         match self {
-            Self::Postgres => {
-                "INSERT INTO toolkit_outbox_processor (partition_id) \
-                 VALUES ($1) ON CONFLICT (partition_id) DO NOTHING"
-            }
-            Self::Sqlite => {
-                "INSERT OR IGNORE INTO toolkit_outbox_processor (partition_id) \
-                 VALUES ($1)"
-            }
-            Self::MySql => {
-                "INSERT IGNORE INTO toolkit_outbox_processor (partition_id) \
-                 VALUES (?)"
-            }
+            Self::Postgres => format!(
+                "INSERT INTO {} (partition_id) \
+                 VALUES ($1) ON CONFLICT (partition_id) DO NOTHING",
+                tables.processor()
+            ),
+            Self::Sqlite => format!(
+                "INSERT OR IGNORE INTO {} (partition_id) VALUES ($1)",
+                tables.processor()
+            ),
+            Self::MySql => format!(
+                "INSERT IGNORE INTO {} (partition_id) VALUES (?)",
+                tables.processor()
+            ),
         }
     }
 
-    pub fn lock_processor(self) -> Option<&'static str> {
+    pub fn lock_processor(self, tables: &OutboxTables) -> Option<String> {
         match self {
-            Self::Postgres => Some(
+            Self::Postgres => Some(format!(
                 "SELECT partition_id, processed_seq, attempts \
-                 FROM toolkit_outbox_processor \
-                 WHERE partition_id = $1 FOR UPDATE SKIP LOCKED",
-            ),
-            Self::MySql => Some(
+                 FROM {} WHERE partition_id = $1 FOR UPDATE SKIP LOCKED",
+                tables.processor()
+            )),
+            Self::MySql => Some(format!(
                 "SELECT partition_id, processed_seq, attempts \
-                 FROM toolkit_outbox_processor \
-                 WHERE partition_id = ? FOR UPDATE SKIP LOCKED",
-            ),
+                 FROM {} WHERE partition_id = ? FOR UPDATE SKIP LOCKED",
+                tables.processor()
+            )),
             Self::Sqlite => None,
         }
     }
 
-    pub fn read_outgoing_batch(self, batch_size: u32) -> String {
+    pub fn read_outgoing_batch(self, tables: &OutboxTables, batch_size: u32) -> String {
         match self {
             Self::Postgres | Self::Sqlite => format!(
                 "SELECT id, body_id, seq \
-                 FROM toolkit_outbox_outgoing \
+                 FROM {} \
                  WHERE partition_id = $1 AND seq > $2 \
                  ORDER BY seq \
-                 LIMIT {batch_size}"
+                 LIMIT {batch_size}",
+                tables.outgoing()
             ),
             Self::MySql => format!(
                 "SELECT id, body_id, seq \
-                 FROM toolkit_outbox_outgoing \
+                 FROM {} \
                  WHERE partition_id = ? AND seq > ? \
                  ORDER BY seq \
-                 LIMIT {batch_size}"
+                 LIMIT {batch_size}",
+                tables.outgoing()
             ),
         }
     }
 
-    pub fn advance_processed_seq(self) -> &'static str {
+    pub fn advance_processed_seq(self, tables: &OutboxTables) -> String {
         match self {
-            Self::Postgres | Self::Sqlite => {
-                "UPDATE toolkit_outbox_processor \
+            Self::Postgres | Self::Sqlite => format!(
+                "UPDATE {} \
                  SET processed_seq = $1, attempts = 0, last_error = NULL \
-                 WHERE partition_id = $2"
-            }
-            Self::MySql => {
-                "UPDATE toolkit_outbox_processor \
+                 WHERE partition_id = $2",
+                tables.processor()
+            ),
+            Self::MySql => format!(
+                "UPDATE {} \
                  SET processed_seq = ?, attempts = 0, last_error = NULL \
-                 WHERE partition_id = ?"
-            }
+                 WHERE partition_id = ?",
+                tables.processor()
+            ),
         }
     }
 
-    pub fn record_retry(self) -> &'static str {
+    pub fn record_retry(self, tables: &OutboxTables) -> String {
         match self {
-            Self::Postgres | Self::Sqlite => {
-                "UPDATE toolkit_outbox_processor \
+            Self::Postgres | Self::Sqlite => format!(
+                "UPDATE {} \
                  SET attempts = attempts + 1, last_error = $1 \
-                 WHERE partition_id = $2"
-            }
-            Self::MySql => {
-                "UPDATE toolkit_outbox_processor \
+                 WHERE partition_id = $2",
+                tables.processor()
+            ),
+            Self::MySql => format!(
+                "UPDATE {} \
                  SET attempts = attempts + 1, last_error = ? \
-                 WHERE partition_id = ?"
-            }
+                 WHERE partition_id = ?",
+                tables.processor()
+            ),
         }
     }
 
-    pub fn insert_dead_letter(self) -> &'static str {
+    pub fn insert_dead_letter(self, tables: &OutboxTables) -> String {
         match self {
-            Self::Postgres | Self::Sqlite => {
-                "INSERT INTO toolkit_outbox_dead_letters \
+            Self::Postgres | Self::Sqlite => format!(
+                "INSERT INTO {} \
                  (partition_id, seq, payload, payload_type, created_at, last_error, attempts) \
-                 VALUES ($1, $2, $3, $4, $5, $6, $7)"
-            }
-            Self::MySql => {
-                "INSERT INTO toolkit_outbox_dead_letters \
+                 VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                tables.dead_letters()
+            ),
+            Self::MySql => format!(
+                "INSERT INTO {} \
                  (partition_id, seq, payload, payload_type, created_at, last_error, attempts) \
-                 VALUES (?, ?, ?, ?, ?, ?, ?)"
-            }
+                 VALUES (?, ?, ?, ?, ?, ?, ?)",
+                tables.dead_letters()
+            ),
         }
     }
 
@@ -719,49 +487,54 @@ impl Dialect {
     ///
     /// Returns `processed_seq` and `attempts` (post-increment).
     /// Callers subtract 1 to recover the pre-increment value for the handler.
-    pub fn lease_acquire(self) -> &'static str {
+    pub fn lease_acquire(self, tables: &OutboxTables) -> String {
         match self {
-            Self::Postgres => {
-                "UPDATE toolkit_outbox_processor \
+            Self::Postgres => format!(
+                "UPDATE {} \
                  SET locked_by = $1, locked_until = NOW() + $2 * INTERVAL '1 second', \
                      attempts = attempts + 1 \
                  WHERE partition_id = $3 \
                    AND (locked_by IS NULL OR locked_until < NOW()) \
-                 RETURNING processed_seq, attempts"
-            }
-            Self::Sqlite => {
-                "UPDATE toolkit_outbox_processor \
+                 RETURNING processed_seq, attempts",
+                tables.processor()
+            ),
+            Self::Sqlite => format!(
+                "UPDATE {} \
                  SET locked_by = $1, locked_until = datetime('now', '+' || $2 || ' seconds'), \
                      attempts = attempts + 1 \
                  WHERE partition_id = $3 \
                    AND (locked_by IS NULL OR locked_until < datetime('now')) \
-                 RETURNING processed_seq, attempts"
-            }
-            Self::MySql => {
-                "UPDATE toolkit_outbox_processor \
+                 RETURNING processed_seq, attempts",
+                tables.processor()
+            ),
+            Self::MySql => format!(
+                "UPDATE {} \
                  SET locked_by = ?, locked_until = DATE_ADD(NOW(6), INTERVAL ? SECOND), \
                      attempts = attempts + 1 \
                  WHERE partition_id = ? \
-                   AND (locked_by IS NULL OR locked_until < NOW(6))"
-            }
+                   AND (locked_by IS NULL OR locked_until < NOW(6))",
+                tables.processor()
+            ),
         }
     }
 
     /// Ack with lease guard: advance `processed_seq` only if we still own the lease.
-    pub fn lease_ack_advance(self) -> &'static str {
+    pub fn lease_ack_advance(self, tables: &OutboxTables) -> String {
         match self {
-            Self::Postgres | Self::Sqlite => {
-                "UPDATE toolkit_outbox_processor \
+            Self::Postgres | Self::Sqlite => format!(
+                "UPDATE {} \
                  SET processed_seq = $1, attempts = 0, last_error = NULL, \
                      locked_by = NULL, locked_until = NULL \
-                 WHERE partition_id = $2 AND locked_by = $3"
-            }
-            Self::MySql => {
-                "UPDATE toolkit_outbox_processor \
+                 WHERE partition_id = $2 AND locked_by = $3",
+                tables.processor()
+            ),
+            Self::MySql => format!(
+                "UPDATE {} \
                  SET processed_seq = ?, attempts = 0, last_error = NULL, \
                      locked_by = NULL, locked_until = NULL \
-                 WHERE partition_id = ? AND locked_by = ?"
-            }
+                 WHERE partition_id = ? AND locked_by = ?",
+                tables.processor()
+            ),
         }
     }
 
@@ -770,36 +543,38 @@ impl Dialect {
     /// Does NOT increment `attempts` — already incremented during
     /// [`lease_acquire`](Self::lease_acquire). Just records the error
     /// and releases the lease.
-    pub fn lease_record_retry(self) -> &'static str {
+    pub fn lease_record_retry(self, tables: &OutboxTables) -> String {
         match self {
-            Self::Postgres | Self::Sqlite => {
-                "UPDATE toolkit_outbox_processor \
-                 SET last_error = $1, \
-                     locked_by = NULL, locked_until = NULL \
-                 WHERE partition_id = $2 AND locked_by = $3"
-            }
-            Self::MySql => {
-                "UPDATE toolkit_outbox_processor \
-                 SET last_error = ?, \
-                     locked_by = NULL, locked_until = NULL \
-                 WHERE partition_id = ? AND locked_by = ?"
-            }
+            Self::Postgres | Self::Sqlite => format!(
+                "UPDATE {} \
+                 SET last_error = $1, locked_by = NULL, locked_until = NULL \
+                 WHERE partition_id = $2 AND locked_by = $3",
+                tables.processor()
+            ),
+            Self::MySql => format!(
+                "UPDATE {} \
+                 SET last_error = ?, locked_by = NULL, locked_until = NULL \
+                 WHERE partition_id = ? AND locked_by = ?",
+                tables.processor()
+            ),
         }
     }
 
     /// Release a lease without changing state (e.g. on empty partition).
-    pub fn lease_release(self) -> &'static str {
+    pub fn lease_release(self, tables: &OutboxTables) -> String {
         match self {
-            Self::Postgres | Self::Sqlite => {
-                "UPDATE toolkit_outbox_processor \
+            Self::Postgres | Self::Sqlite => format!(
+                "UPDATE {} \
                  SET attempts = 0, locked_by = NULL, locked_until = NULL \
-                 WHERE partition_id = $1 AND locked_by = $2"
-            }
-            Self::MySql => {
-                "UPDATE toolkit_outbox_processor \
+                 WHERE partition_id = $1 AND locked_by = $2",
+                tables.processor()
+            ),
+            Self::MySql => format!(
+                "UPDATE {} \
                  SET attempts = 0, locked_by = NULL, locked_until = NULL \
-                 WHERE partition_id = ? AND locked_by = ?"
-            }
+                 WHERE partition_id = ? AND locked_by = ?",
+                tables.processor()
+            ),
         }
     }
 
@@ -808,47 +583,53 @@ impl Dialect {
     /// Returns SQL to SELECT a bounded chunk of (id, `body_id`) from outgoing.
     /// The caller deletes those rows by ID, then loops while
     /// `deleted == batch_size`.
-    pub fn vacuum_cleanup(self) -> VacuumSql {
+    pub fn vacuum_cleanup(self, tables: &OutboxTables) -> VacuumSql {
         match self {
             Self::Postgres | Self::Sqlite => VacuumSql {
-                select_outgoing_chunk: "SELECT id, body_id FROM toolkit_outbox_outgoing \
-                                        WHERE partition_id = $1 AND seq <= $2 \
-                                        ORDER BY seq LIMIT $3",
+                select_outgoing_chunk: format!(
+                    "SELECT id, body_id FROM {} \
+                     WHERE partition_id = $1 AND seq <= $2 \
+                     ORDER BY seq LIMIT $3",
+                    tables.outgoing()
+                ),
             },
             Self::MySql => VacuumSql {
-                select_outgoing_chunk: "SELECT id, body_id FROM toolkit_outbox_outgoing \
-                                        WHERE partition_id = ? AND seq <= ? \
-                                        ORDER BY seq LIMIT ?",
+                select_outgoing_chunk: format!(
+                    "SELECT id, body_id FROM {} \
+                     WHERE partition_id = ? AND seq <= ? \
+                     ORDER BY seq LIMIT ?",
+                    tables.outgoing()
+                ),
             },
         }
     }
 
     /// Build `DELETE FROM toolkit_outbox_outgoing WHERE id IN ($1, $2, ...)`.
-    pub fn build_delete_outgoing_batch(self, count: usize) -> String {
-        let mut sql = String::from("DELETE FROM toolkit_outbox_outgoing WHERE id IN (");
+    pub fn build_delete_outgoing_batch(self, tables: &OutboxTables, count: usize) -> String {
+        let mut sql = format!("DELETE FROM {} WHERE id IN (", tables.outgoing());
         self.append_in_placeholders(&mut sql, count);
         sql.push(')');
         sql
     }
 
     /// Build `DELETE FROM toolkit_outbox_body WHERE id IN (...)`.
-    pub fn build_delete_body_batch(self, count: usize) -> String {
-        let mut sql = String::from("DELETE FROM toolkit_outbox_body WHERE id IN (");
+    pub fn build_delete_body_batch(self, tables: &OutboxTables, count: usize) -> String {
+        let mut sql = format!("DELETE FROM {} WHERE id IN (", tables.body());
         self.append_in_placeholders(&mut sql, count);
         sql.push(')');
         sql
     }
 
-    pub fn read_processor(self) -> &'static str {
+    pub fn read_processor(self, tables: &OutboxTables) -> String {
         match self {
-            Self::Postgres | Self::Sqlite => {
-                "SELECT processed_seq, attempts \
-                 FROM toolkit_outbox_processor WHERE partition_id = $1"
-            }
-            Self::MySql => {
-                "SELECT processed_seq, attempts \
-                 FROM toolkit_outbox_processor WHERE partition_id = ?"
-            }
+            Self::Postgres | Self::Sqlite => format!(
+                "SELECT processed_seq, attempts FROM {} WHERE partition_id = $1",
+                tables.processor()
+            ),
+            Self::MySql => format!(
+                "SELECT processed_seq, attempts FROM {} WHERE partition_id = ?",
+                tables.processor()
+            ),
         }
     }
 }
@@ -857,89 +638,95 @@ impl Dialect {
 
 impl Dialect {
     /// Bump the vacuum counter for a partition (called by processor on ack).
-    pub fn bump_vacuum_counter(self) -> &'static str {
+    pub fn bump_vacuum_counter(self, tables: &OutboxTables) -> String {
         match self {
-            Self::Postgres | Self::Sqlite => {
-                "UPDATE toolkit_outbox_vacuum_counter \
-                 SET counter = counter + 1 WHERE partition_id = $1"
-            }
-            Self::MySql => {
-                "UPDATE toolkit_outbox_vacuum_counter \
-                 SET counter = counter + 1 WHERE partition_id = ?"
-            }
+            Self::Postgres | Self::Sqlite => format!(
+                "UPDATE {} SET counter = counter + 1 WHERE partition_id = $1",
+                tables.vacuum_counter()
+            ),
+            Self::MySql => format!(
+                "UPDATE {} SET counter = counter + 1 WHERE partition_id = ?",
+                tables.vacuum_counter()
+            ),
         }
     }
 
     /// Fetch dirty partitions paginated by `partition_id` cursor.
     /// Returns `(partition_id, counter)` for partitions with `counter > 0`.
-    pub fn fetch_dirty_partitions(self) -> &'static str {
+    pub fn fetch_dirty_partitions(self, tables: &OutboxTables) -> String {
         match self {
-            Self::Postgres | Self::Sqlite => {
+            Self::Postgres | Self::Sqlite => format!(
                 "SELECT partition_id, counter \
-                 FROM toolkit_outbox_vacuum_counter \
+                 FROM {} \
                  WHERE counter > 0 AND partition_id > $1 \
-                 ORDER BY partition_id LIMIT $2"
-            }
-            Self::MySql => {
+                 ORDER BY partition_id LIMIT $2",
+                tables.vacuum_counter()
+            ),
+            Self::MySql => format!(
                 "SELECT partition_id, counter \
-                 FROM toolkit_outbox_vacuum_counter \
+                 FROM {} \
                  WHERE counter > 0 AND partition_id > ? \
-                 ORDER BY partition_id LIMIT ?"
-            }
+                 ORDER BY partition_id LIMIT ?",
+                tables.vacuum_counter()
+            ),
         }
     }
 
     /// Decrement vacuum counter by snapshot value, floored at 0.
-    pub fn decrement_vacuum_counter(self) -> &'static str {
+    pub fn decrement_vacuum_counter(self, tables: &OutboxTables) -> String {
         match self {
-            Self::Postgres => {
-                "UPDATE toolkit_outbox_vacuum_counter \
+            Self::Postgres => format!(
+                "UPDATE {} \
                  SET counter = GREATEST(counter - $1, 0) \
-                 WHERE partition_id = $2"
-            }
-            Self::Sqlite => {
-                "UPDATE toolkit_outbox_vacuum_counter \
+                 WHERE partition_id = $2",
+                tables.vacuum_counter()
+            ),
+            Self::Sqlite => format!(
+                "UPDATE {} \
                  SET counter = MAX(counter - $1, 0) \
-                 WHERE partition_id = $2"
-            }
-            Self::MySql => {
-                "UPDATE toolkit_outbox_vacuum_counter \
+                 WHERE partition_id = $2",
+                tables.vacuum_counter()
+            ),
+            Self::MySql => format!(
+                "UPDATE {} \
                  SET counter = GREATEST(counter - ?, 0) \
-                 WHERE partition_id = ?"
-            }
+                 WHERE partition_id = ?",
+                tables.vacuum_counter()
+            ),
         }
     }
 
     /// Reset vacuum counter to 0. Used by integration tests for state cleanup.
     #[cfg(test)]
-    pub fn reset_vacuum_counter(self) -> &'static str {
+    pub fn reset_vacuum_counter(self, tables: &OutboxTables) -> String {
         match self {
-            Self::Postgres | Self::Sqlite => {
-                "UPDATE toolkit_outbox_vacuum_counter \
-                 SET counter = 0 WHERE partition_id = $1"
-            }
-            Self::MySql => {
-                "UPDATE toolkit_outbox_vacuum_counter \
-                 SET counter = 0 WHERE partition_id = ?"
-            }
+            Self::Postgres | Self::Sqlite => format!(
+                "UPDATE {} SET counter = 0 WHERE partition_id = $1",
+                tables.vacuum_counter()
+            ),
+            Self::MySql => format!(
+                "UPDATE {} SET counter = 0 WHERE partition_id = ?",
+                tables.vacuum_counter()
+            ),
         }
     }
 
     /// Insert a vacuum counter row (idempotent, for `register_queue`).
-    pub fn insert_vacuum_counter_row(self) -> &'static str {
+    pub fn insert_vacuum_counter_row(self, tables: &OutboxTables) -> String {
         match self {
-            Self::Postgres => {
-                "INSERT INTO toolkit_outbox_vacuum_counter (partition_id) \
-                 VALUES ($1) ON CONFLICT (partition_id) DO NOTHING"
-            }
-            Self::Sqlite => {
-                "INSERT OR IGNORE INTO toolkit_outbox_vacuum_counter (partition_id) \
-                 VALUES ($1)"
-            }
-            Self::MySql => {
-                "INSERT IGNORE INTO toolkit_outbox_vacuum_counter (partition_id) \
-                 VALUES (?)"
-            }
+            Self::Postgres => format!(
+                "INSERT INTO {} (partition_id) \
+                 VALUES ($1) ON CONFLICT (partition_id) DO NOTHING",
+                tables.vacuum_counter()
+            ),
+            Self::Sqlite => format!(
+                "INSERT OR IGNORE INTO {} (partition_id) VALUES ($1)",
+                tables.vacuum_counter()
+            ),
+            Self::MySql => format!(
+                "INSERT IGNORE INTO {} (partition_id) VALUES (?)",
+                tables.vacuum_counter()
+            ),
         }
     }
 }
@@ -948,6 +735,10 @@ impl Dialect {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
+
+    fn tables() -> OutboxTables {
+        OutboxTables::default()
+    }
 
     #[test]
     fn dialect_from_dbbackend() {
@@ -959,17 +750,17 @@ mod tests {
     #[test]
     fn postgres_uses_dollar_placeholders() {
         let d = Dialect::Postgres;
-        assert!(d.insert_body().contains("$1"));
-        assert!(d.insert_body().contains("$2"));
-        assert!(d.insert_body().contains("RETURNING"));
+        assert!(d.insert_body(&tables()).contains("$1"));
+        assert!(d.insert_body(&tables()).contains("$2"));
+        assert!(d.insert_body(&tables()).contains("RETURNING"));
     }
 
     #[test]
     fn mysql_uses_question_placeholders() {
         let d = Dialect::MySql;
-        assert!(d.insert_body().contains('?'));
-        assert!(!d.insert_body().contains('$'));
-        assert!(!d.insert_body().contains("RETURNING"));
+        assert!(d.insert_body(&tables()).contains('?'));
+        assert!(!d.insert_body(&tables()).contains('$'));
+        assert!(!d.insert_body(&tables()).contains("RETURNING"));
     }
 
     #[test]
@@ -981,28 +772,28 @@ mod tests {
 
     #[test]
     fn lock_partition_correct() {
-        assert!(Dialect::Postgres.lock_partition().is_some());
-        assert!(Dialect::MySql.lock_partition().is_some());
-        assert!(Dialect::Sqlite.lock_partition().is_none());
+        assert!(Dialect::Postgres.lock_partition(&tables()).is_some());
+        assert!(Dialect::MySql.lock_partition(&tables()).is_some());
+        assert!(Dialect::Sqlite.lock_partition(&tables()).is_none());
     }
 
     #[test]
     fn batch_body_pg_placeholder_format() {
-        let sql = Dialect::Postgres.build_insert_body_batch(3);
+        let sql = Dialect::Postgres.build_insert_body_batch(&tables(), 3);
         assert!(sql.contains("($1, $2), ($3, $4), ($5, $6)"));
         assert!(sql.ends_with("RETURNING id"));
     }
 
     #[test]
     fn batch_body_mysql_placeholder_format() {
-        let sql = Dialect::MySql.build_insert_body_batch(3);
+        let sql = Dialect::MySql.build_insert_body_batch(&tables(), 3);
         assert!(sql.contains("(?, ?), (?, ?), (?, ?)"));
         assert!(!sql.contains("RETURNING"));
     }
 
     #[test]
     fn claim_pg_select_ordered_with_for_update() {
-        let claim = Dialect::Postgres.claim_incoming(100);
+        let claim = Dialect::Postgres.claim_incoming(&tables(), 100);
         assert!(claim.select.contains("ORDER BY id"));
         assert!(claim.select.contains("FOR UPDATE SKIP LOCKED"));
         assert!(claim.select.contains("$1"));
@@ -1010,14 +801,14 @@ mod tests {
 
     #[test]
     fn claim_sqlite_select_ordered_no_lock() {
-        let claim = Dialect::Sqlite.claim_incoming(100);
+        let claim = Dialect::Sqlite.claim_incoming(&tables(), 100);
         assert!(claim.select.contains("ORDER BY id"));
         assert!(!claim.select.contains("FOR UPDATE"));
     }
 
     #[test]
     fn claim_mysql_select_ordered_with_for_update() {
-        let claim = Dialect::MySql.claim_incoming(100);
+        let claim = Dialect::MySql.claim_incoming(&tables(), 100);
         assert!(claim.select.contains("ORDER BY id"));
         assert!(claim.select.contains("FOR UPDATE SKIP LOCKED"));
         assert!(claim.select.contains('?'));
@@ -1025,52 +816,52 @@ mod tests {
 
     #[test]
     fn delete_incoming_batch_placeholders() {
-        let pg = Dialect::Postgres.delete_incoming_batch(3);
+        let pg = Dialect::Postgres.delete_incoming_batch(&tables(), 3);
         assert!(pg.contains("$1, $2, $3"));
         assert!(pg.contains("DELETE FROM toolkit_outbox_incoming"));
 
-        let mysql = Dialect::MySql.delete_incoming_batch(3);
+        let mysql = Dialect::MySql.delete_incoming_batch(&tables(), 3);
         assert!(mysql.contains("?, ?, ?"));
     }
 
     #[test]
     fn alloc_pg_is_update_returning() {
-        let alloc = Dialect::Postgres.allocate_sequences();
+        let alloc = Dialect::Postgres.allocate_sequences(&tables());
         assert!(matches!(alloc, AllocSql::UpdateReturning(_)));
     }
 
     #[test]
     fn alloc_mysql_is_update_then_select() {
-        let alloc = Dialect::MySql.allocate_sequences();
+        let alloc = Dialect::MySql.allocate_sequences(&tables());
         assert!(matches!(alloc, AllocSql::UpdateThenSelect { .. }));
     }
 
     #[test]
     fn mysql_register_queue_backtick_partition() {
         let d = Dialect::MySql;
-        assert!(d.register_queue_select().contains("`partition`"));
-        assert!(d.register_queue_insert().contains("`partition`"));
+        assert!(d.register_queue_select(&tables()).contains("`partition`"));
+        assert!(d.register_queue_insert(&tables()).contains("`partition`"));
     }
 
     // -- Processor dialect tests --
 
     #[test]
     fn insert_processor_row_pg_uses_on_conflict() {
-        let sql = Dialect::Postgres.insert_processor_row();
+        let sql = Dialect::Postgres.insert_processor_row(&tables());
         assert!(sql.contains("$1"));
         assert!(sql.contains("ON CONFLICT"));
     }
 
     #[test]
     fn insert_processor_row_sqlite_uses_or_ignore() {
-        let sql = Dialect::Sqlite.insert_processor_row();
+        let sql = Dialect::Sqlite.insert_processor_row(&tables());
         assert!(sql.contains("INSERT OR IGNORE"));
         assert!(sql.contains("$1"));
     }
 
     #[test]
     fn insert_processor_row_mysql_uses_insert_ignore() {
-        let sql = Dialect::MySql.insert_processor_row();
+        let sql = Dialect::MySql.insert_processor_row(&tables());
         assert!(sql.contains("INSERT IGNORE"));
         assert!(sql.contains('?'));
         assert!(!sql.contains('$'));
@@ -1078,22 +869,22 @@ mod tests {
 
     #[test]
     fn lock_processor_correct() {
-        assert!(Dialect::Postgres.lock_processor().is_some());
-        assert!(Dialect::MySql.lock_processor().is_some());
-        assert!(Dialect::Sqlite.lock_processor().is_none());
+        assert!(Dialect::Postgres.lock_processor(&tables()).is_some());
+        assert!(Dialect::MySql.lock_processor(&tables()).is_some());
+        assert!(Dialect::Sqlite.lock_processor(&tables()).is_none());
 
-        let pg = Dialect::Postgres.lock_processor().unwrap();
+        let pg = Dialect::Postgres.lock_processor(&tables()).unwrap();
         assert!(pg.contains("FOR UPDATE SKIP LOCKED"));
         assert!(pg.contains("$1"));
 
-        let mysql = Dialect::MySql.lock_processor().unwrap();
+        let mysql = Dialect::MySql.lock_processor(&tables()).unwrap();
         assert!(mysql.contains("FOR UPDATE SKIP LOCKED"));
         assert!(mysql.contains('?'));
     }
 
     #[test]
     fn read_outgoing_batch_uses_limit() {
-        let pg = Dialect::Postgres.read_outgoing_batch(50);
+        let pg = Dialect::Postgres.read_outgoing_batch(&tables(), 50);
         assert!(pg.contains("$1"));
         assert!(pg.contains("$2"));
         assert!(!pg.contains("$3"));
@@ -1101,7 +892,7 @@ mod tests {
         assert!(pg.contains("ORDER BY seq"));
         assert!(pg.contains("LIMIT 50"));
 
-        let mysql = Dialect::MySql.read_outgoing_batch(50);
+        let mysql = Dialect::MySql.read_outgoing_batch(&tables(), 50);
         assert!(mysql.contains('?'));
         assert!(!mysql.contains('$'));
         assert!(mysql.contains("seq > ?"));
@@ -1110,57 +901,57 @@ mod tests {
 
     #[test]
     fn build_read_body_batch_placeholders() {
-        let pg = Dialect::Postgres.build_read_body_batch(3);
+        let pg = Dialect::Postgres.build_read_body_batch(&tables(), 3);
         assert!(pg.contains("$1, $2, $3"));
         assert!(pg.contains("SELECT id, payload, payload_type, created_at"));
 
-        let mysql = Dialect::MySql.build_read_body_batch(3);
+        let mysql = Dialect::MySql.build_read_body_batch(&tables(), 3);
         assert!(mysql.contains("?, ?, ?"));
         assert!(!mysql.contains('$'));
     }
 
     #[test]
     fn build_delete_body_batch_placeholders() {
-        let pg = Dialect::Postgres.build_delete_body_batch(3);
+        let pg = Dialect::Postgres.build_delete_body_batch(&tables(), 3);
         assert!(pg.contains("$1, $2, $3"));
         assert!(pg.contains("DELETE FROM toolkit_outbox_body"));
 
-        let mysql = Dialect::MySql.build_delete_body_batch(3);
+        let mysql = Dialect::MySql.build_delete_body_batch(&tables(), 3);
         assert!(mysql.contains("?, ?, ?"));
     }
 
     #[test]
     fn advance_processed_seq_placeholders() {
-        let pg = Dialect::Postgres.advance_processed_seq();
+        let pg = Dialect::Postgres.advance_processed_seq(&tables());
         assert!(pg.contains("$1"));
         assert!(pg.contains("$2"));
         assert!(pg.contains("attempts = 0"));
 
-        let mysql = Dialect::MySql.advance_processed_seq();
+        let mysql = Dialect::MySql.advance_processed_seq(&tables());
         assert!(mysql.contains('?'));
         assert!(!mysql.contains('$'));
     }
 
     #[test]
     fn record_retry_placeholders() {
-        let pg = Dialect::Postgres.record_retry();
+        let pg = Dialect::Postgres.record_retry(&tables());
         assert!(pg.contains("attempts + 1"));
         assert!(pg.contains("$1"));
         assert!(pg.contains("$2"));
 
-        let mysql = Dialect::MySql.record_retry();
+        let mysql = Dialect::MySql.record_retry(&tables());
         assert!(mysql.contains('?'));
     }
 
     #[test]
     fn insert_dead_letter_placeholders() {
-        let pg = Dialect::Postgres.insert_dead_letter();
+        let pg = Dialect::Postgres.insert_dead_letter(&tables());
         assert!(pg.contains("$1"));
         assert!(pg.contains("$7"));
         assert!(pg.contains("payload"));
         assert!(pg.contains("payload_type"));
 
-        let mysql = Dialect::MySql.insert_dead_letter();
+        let mysql = Dialect::MySql.insert_dead_letter(&tables());
         assert!(mysql.contains('?'));
         assert!(!mysql.contains('$'));
     }
@@ -1169,77 +960,77 @@ mod tests {
 
     #[test]
     fn bump_vacuum_counter_placeholders() {
-        let pg = Dialect::Postgres.bump_vacuum_counter();
+        let pg = Dialect::Postgres.bump_vacuum_counter(&tables());
         assert!(pg.contains("$1"));
         assert!(pg.contains("toolkit_outbox_vacuum_counter"));
         assert!(pg.contains("counter + 1"));
 
-        let mysql = Dialect::MySql.bump_vacuum_counter();
+        let mysql = Dialect::MySql.bump_vacuum_counter(&tables());
         assert!(mysql.contains('?'));
         assert!(!mysql.contains('$'));
     }
 
     #[test]
     fn fetch_dirty_partitions_placeholders() {
-        let pg = Dialect::Postgres.fetch_dirty_partitions();
+        let pg = Dialect::Postgres.fetch_dirty_partitions(&tables());
         assert!(pg.contains("$1"));
         assert!(pg.contains("$2"));
         assert!(pg.contains("counter > 0"));
         assert!(pg.contains("ORDER BY partition_id"));
 
-        let mysql = Dialect::MySql.fetch_dirty_partitions();
+        let mysql = Dialect::MySql.fetch_dirty_partitions(&tables());
         assert!(mysql.contains('?'));
         assert!(!mysql.contains('$'));
     }
 
     #[test]
     fn decrement_vacuum_counter_placeholders() {
-        let pg = Dialect::Postgres.decrement_vacuum_counter();
+        let pg = Dialect::Postgres.decrement_vacuum_counter(&tables());
         assert!(pg.contains("GREATEST"));
         assert!(pg.contains("$1"));
         assert!(pg.contains("$2"));
 
-        let sqlite = Dialect::Sqlite.decrement_vacuum_counter();
+        let sqlite = Dialect::Sqlite.decrement_vacuum_counter(&tables());
         assert!(sqlite.contains("MAX"));
         assert!(sqlite.contains("$1"));
 
-        let mysql = Dialect::MySql.decrement_vacuum_counter();
+        let mysql = Dialect::MySql.decrement_vacuum_counter(&tables());
         assert!(mysql.contains("GREATEST"));
         assert!(mysql.contains('?'));
     }
 
     #[test]
     fn reset_vacuum_counter_placeholders() {
-        let pg = Dialect::Postgres.reset_vacuum_counter();
+        let pg = Dialect::Postgres.reset_vacuum_counter(&tables());
         assert!(pg.contains("counter = 0"));
         assert!(pg.contains("$1"));
 
-        let mysql = Dialect::MySql.reset_vacuum_counter();
+        let mysql = Dialect::MySql.reset_vacuum_counter(&tables());
         assert!(mysql.contains('?'));
     }
 
     #[test]
     fn insert_vacuum_counter_row_placeholders() {
-        let pg = Dialect::Postgres.insert_vacuum_counter_row();
+        let pg = Dialect::Postgres.insert_vacuum_counter_row(&tables());
         assert!(pg.contains("$1"));
         assert!(pg.contains("ON CONFLICT"));
 
-        let sqlite = Dialect::Sqlite.insert_vacuum_counter_row();
+        let sqlite = Dialect::Sqlite.insert_vacuum_counter_row(&tables());
         assert!(sqlite.contains("INSERT OR IGNORE"));
 
-        let mysql = Dialect::MySql.insert_vacuum_counter_row();
+        let mysql = Dialect::MySql.insert_vacuum_counter_row(&tables());
         assert!(mysql.contains("INSERT IGNORE"));
         assert!(mysql.contains('?'));
     }
 
     #[test]
     fn vacuum_cleanup_placeholders() {
-        let pg = Dialect::Postgres.vacuum_cleanup();
+        let pg = Dialect::Postgres.vacuum_cleanup(&tables());
         assert!(pg.select_outgoing_chunk.contains("$1"));
         assert!(pg.select_outgoing_chunk.contains("$2"));
         assert!(pg.select_outgoing_chunk.contains("$3"));
 
-        let mysql = Dialect::MySql.vacuum_cleanup();
+        let mysql = Dialect::MySql.vacuum_cleanup(&tables());
         assert!(mysql.select_outgoing_chunk.contains('?'));
     }
 }

--- a/libs/toolkit-db/src/outbox/integration_tests.rs
+++ b/libs/toolkit-db/src/outbox/integration_tests.rs
@@ -17,6 +17,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use sea_orm::{ConnectionTrait, DbBackend, FromQueryResult, Statement};
+use sea_orm_migration::prelude::MigrationTrait;
 use tokio_util::sync::CancellationToken;
 
 use super::batch::Batch;
@@ -27,7 +28,9 @@ use super::handler::{
     PerMessageAdapter, TransactionalHandler, TransactionalMessageHandler,
 };
 use super::prioritizer::SharedPrioritizer;
+use super::store::OutboxStore;
 use super::strategy::{LeasedStrategy, ProcessContext, ProcessingStrategy, TransactionalStrategy};
+use super::tables::OutboxTables;
 use super::taskward::{Directive, WorkerAction};
 use super::types::{EnqueueMessage, LeaseConfig, OutboxConfig, SequencerConfig, WorkerTuning};
 use super::workers::sequencer::Sequencer;
@@ -81,16 +84,24 @@ struct DeadLetterSnapshot {
 // ======================================================================
 
 async fn setup_db(name: &str) -> Db {
+    setup_db_with_migrations(name, super::outbox_migrations()).await
+}
+
+async fn setup_db_with_migrations(name: &str, migrations: Vec<Box<dyn MigrationTrait>>) -> Db {
+    let db = setup_empty_db(name).await;
+    run_migrations_for_testing(&db, migrations)
+        .await
+        .expect("migrations");
+    db
+}
+
+async fn setup_empty_db(name: &str) -> Db {
     let url = format!("sqlite:file:{name}?mode=memory&cache=shared");
     let opts = ConnectOpts {
         max_conns: Some(1),
         ..Default::default()
     };
-    let db = connect_db(&url, opts).await.expect("connect");
-    run_migrations_for_testing(&db, super::outbox_migrations())
-        .await
-        .expect("migrations");
-    db
+    connect_db(&url, opts).await.expect("connect")
 }
 
 // Must be async: `prioritizer` is a tokio::sync::RwLock and `blocking_write()`
@@ -179,14 +190,26 @@ async fn enqueue_and_sequence(
 }
 
 async fn simulate_crash(db: &Db, partition_id: i64, lease_secs: i64) {
+    simulate_crash_for_tables(db, &OutboxTables::default(), partition_id, lease_secs).await;
+}
+
+async fn simulate_crash_for_tables(
+    db: &Db,
+    tables: &OutboxTables,
+    partition_id: i64,
+    lease_secs: i64,
+) {
     let conn = db.sea_internal();
     conn.execute(Statement::from_sql_and_values(
         DbBackend::Sqlite,
-        "UPDATE toolkit_outbox_processor \
+        format!(
+            "UPDATE {} \
          SET locked_by = $1, \
              locked_until = datetime('now', '+' || $2 || ' seconds'), \
              attempts = attempts + 1 \
          WHERE partition_id = $3",
+            tables.processor()
+        ),
         ["crashed-pod".into(), lease_secs.into(), partition_id.into()],
     ))
     .await
@@ -194,12 +217,19 @@ async fn simulate_crash(db: &Db, partition_id: i64, lease_secs: i64) {
 }
 
 async fn expire_lease(db: &Db, partition_id: i64) {
+    expire_lease_for_tables(db, &OutboxTables::default(), partition_id).await;
+}
+
+async fn expire_lease_for_tables(db: &Db, tables: &OutboxTables, partition_id: i64) {
     let conn = db.sea_internal();
     conn.execute(Statement::from_sql_and_values(
         DbBackend::Sqlite,
-        "UPDATE toolkit_outbox_processor \
+        format!(
+            "UPDATE {} \
          SET locked_until = datetime('now', '-1 seconds') \
          WHERE partition_id = $1",
+            tables.processor()
+        ),
         [partition_id.into()],
     ))
     .await
@@ -227,7 +257,39 @@ async fn count_rows(db: &Db, table: &str) -> i64 {
     .cnt
 }
 
+async fn table_exists(db: &Db, table: &str) -> bool {
+    #[derive(Debug, FromQueryResult)]
+    struct Exists {
+        cnt: i64,
+    }
+    let conn = db.sea_internal();
+    Exists::find_by_statement(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        "SELECT COUNT(*) AS cnt FROM sqlite_master WHERE type = 'table' AND name = $1",
+        [table.into()],
+    ))
+    .one(&conn)
+    .await
+    .expect("table-exists query")
+    .expect("table-exists row")
+    .cnt == 1
+}
+
+async fn assert_table_family_exists(db: &Db, tables: &OutboxTables) {
+    for table in tables.table_names() {
+        assert!(table_exists(db, table).await, "expected table {table}");
+    }
+}
+
 async fn read_processor_state(db: &Db, partition_id: i64) -> ProcessorSnapshot {
+    read_processor_state_for_tables(db, &OutboxTables::default(), partition_id).await
+}
+
+async fn read_processor_state_for_tables(
+    db: &Db,
+    tables: &OutboxTables,
+    partition_id: i64,
+) -> ProcessorSnapshot {
     #[derive(Debug, FromQueryResult)]
     struct Row {
         processed_seq: i64,
@@ -239,9 +301,12 @@ async fn read_processor_state(db: &Db, partition_id: i64) -> ProcessorSnapshot {
     let conn = db.sea_internal();
     let row = Row::find_by_statement(Statement::from_sql_and_values(
         DbBackend::Sqlite,
-        "SELECT processed_seq, attempts, last_error, locked_by, \
+        format!(
+            "SELECT processed_seq, attempts, last_error, locked_by, \
          CAST(locked_until AS TEXT) AS locked_until \
-         FROM toolkit_outbox_processor WHERE partition_id = $1",
+         FROM {} WHERE partition_id = $1",
+            tables.processor()
+        ),
         [partition_id.into()],
     ))
     .one(&conn)
@@ -258,6 +323,14 @@ async fn read_processor_state(db: &Db, partition_id: i64) -> ProcessorSnapshot {
 }
 
 async fn read_outgoing(db: &Db, partition_id: i64) -> Vec<OutgoingSnapshot> {
+    read_outgoing_for_tables(db, &OutboxTables::default(), partition_id).await
+}
+
+async fn read_outgoing_for_tables(
+    db: &Db,
+    tables: &OutboxTables,
+    partition_id: i64,
+) -> Vec<OutgoingSnapshot> {
     #[derive(Debug, FromQueryResult)]
     struct Row {
         id: i64,
@@ -268,8 +341,11 @@ async fn read_outgoing(db: &Db, partition_id: i64) -> Vec<OutgoingSnapshot> {
     let conn = db.sea_internal();
     Row::find_by_statement(Statement::from_sql_and_values(
         DbBackend::Sqlite,
-        "SELECT id, partition_id, body_id, seq \
-         FROM toolkit_outbox_outgoing WHERE partition_id = $1 ORDER BY seq",
+        format!(
+            "SELECT id, partition_id, body_id, seq \
+         FROM {} WHERE partition_id = $1 ORDER BY seq",
+            tables.outgoing()
+        ),
         [partition_id.into()],
     ))
     .all(&conn)
@@ -286,6 +362,10 @@ async fn read_outgoing(db: &Db, partition_id: i64) -> Vec<OutgoingSnapshot> {
 }
 
 async fn read_dead_letters(db: &Db) -> Vec<DeadLetterSnapshot> {
+    read_dead_letters_for_tables(db, &OutboxTables::default()).await
+}
+
+async fn read_dead_letters_for_tables(db: &Db, tables: &OutboxTables) -> Vec<DeadLetterSnapshot> {
     #[derive(Debug, FromQueryResult)]
     struct Row {
         id: i64,
@@ -302,10 +382,13 @@ async fn read_dead_letters(db: &Db) -> Vec<DeadLetterSnapshot> {
     let conn = db.sea_internal();
     Row::find_by_statement(Statement::from_string(
         DbBackend::Sqlite,
-        "SELECT id, partition_id, seq, payload, payload_type, last_error, \
+        format!(
+            "SELECT id, partition_id, seq, payload, payload_type, last_error, \
          attempts, status, CAST(completed_at AS TEXT) AS completed_at, \
          CAST(deadline AS TEXT) AS deadline \
-         FROM toolkit_outbox_dead_letters ORDER BY seq",
+         FROM {} ORDER BY seq",
+            tables.dead_letters()
+        ),
     ))
     .all(&conn)
     .await
@@ -327,6 +410,14 @@ async fn read_dead_letters(db: &Db) -> Vec<DeadLetterSnapshot> {
 }
 
 async fn read_partition_sequence(db: &Db, partition_id: i64) -> i64 {
+    read_partition_sequence_for_tables(db, &OutboxTables::default(), partition_id).await
+}
+
+async fn read_partition_sequence_for_tables(
+    db: &Db,
+    tables: &OutboxTables,
+    partition_id: i64,
+) -> i64 {
     #[derive(Debug, FromQueryResult)]
     struct Row {
         sequence: i64,
@@ -334,7 +425,7 @@ async fn read_partition_sequence(db: &Db, partition_id: i64) -> i64 {
     let conn = db.sea_internal();
     Row::find_by_statement(Statement::from_sql_and_values(
         DbBackend::Sqlite,
-        "SELECT sequence FROM toolkit_outbox_partitions WHERE id = $1",
+        format!("SELECT sequence FROM {} WHERE id = $1", tables.partitions()),
         [partition_id.into()],
     ))
     .one(&conn)
@@ -472,6 +563,40 @@ impl LeasedMessageHandler for PoisonMessageHandler {
             MessageResult::Ok
         }
     }
+}
+
+// ======================================================================
+// Chapter 0: Migrations
+// ======================================================================
+
+#[tokio::test]
+async fn migrations_create_default_table_family() {
+    let db = setup_db("ch0_default_tables").await;
+
+    assert_table_family_exists(&db, &OutboxTables::default()).await;
+}
+
+#[tokio::test]
+async fn migrations_create_custom_table_family() {
+    let tables = OutboxTables::new("mini_chat_outbox").unwrap();
+    let db = setup_db_with_migrations(
+        "ch0_custom_tables",
+        super::outbox_migrations_with_prefix(tables.prefix()).unwrap(),
+    )
+    .await;
+
+    assert_table_family_exists(&db, &tables).await;
+}
+
+#[tokio::test]
+async fn migrations_create_default_and_custom_table_families_together() {
+    let custom_tables = OutboxTables::new("mini_chat_outbox").unwrap();
+    let mut migrations = super::outbox_migrations();
+    migrations.extend(super::outbox_migrations_with_prefix(custom_tables.prefix()).unwrap());
+    let db = setup_db_with_migrations("ch0_default_and_custom_tables", migrations).await;
+
+    assert_table_family_exists(&db, &OutboxTables::default()).await;
+    assert_table_family_exists(&db, &custom_tables).await;
 }
 
 // ======================================================================
@@ -1099,14 +1224,14 @@ async fn run_transactional(
 ) -> Option<super::strategy::ProcessResult> {
     let conn = db.sea_internal();
     let backend = conn.get_database_backend();
-    let dialect = Dialect::from(backend);
     drop(conn);
 
     let strategy = TransactionalStrategy::new(Box::new(handler));
+    let tables = OutboxTables::default();
+    let statements = super::statements::OutboxStatements::new(backend, &tables);
     let ctx = ProcessContext {
         db,
-        backend,
-        dialect,
+        store: OutboxStore::new(&statements),
         partition_id,
     };
     strategy.process(&ctx, msg_batch_size).await.unwrap()
@@ -1219,7 +1344,6 @@ async fn run_leased(
 ) -> Option<super::strategy::ProcessResult> {
     let conn = db.sea_internal();
     let backend = conn.get_database_backend();
-    let dialect = Dialect::from(backend);
     drop(conn);
 
     let strategy = LeasedStrategy::new(
@@ -1230,10 +1354,11 @@ async fn run_leased(
             headroom: Duration::from_secs(2),
         },
     );
+    let tables = OutboxTables::default();
+    let statements = super::statements::OutboxStatements::new(backend, &tables);
     let ctx = ProcessContext {
         db,
-        backend,
-        dialect,
+        store: OutboxStore::new(&statements),
         partition_id,
     };
     strategy.process(&ctx, msg_batch_size).await.unwrap()
@@ -1630,6 +1755,10 @@ async fn adaptive_batch_isolates_poison_message() {
 /// Run the vacuum for a single partition: read `processed_seq`, delete
 /// outgoing + body rows in batches, then reset the vacuum counter.
 async fn run_vacuum(db: &Db, partition_id: i64) {
+    run_vacuum_for_tables(db, &OutboxTables::default(), partition_id).await;
+}
+
+async fn run_vacuum_for_tables(db: &Db, tables: &OutboxTables, partition_id: i64) {
     #[derive(Debug, FromQueryResult)]
     struct ProcRow {
         processed_seq: i64,
@@ -1637,11 +1766,15 @@ async fn run_vacuum(db: &Db, partition_id: i64) {
 
     let conn = db.sea_internal();
     let backend = conn.get_database_backend();
-    let dialect = Dialect::from(backend);
+    let statements = super::statements::OutboxStatements::new(backend, tables);
+    let store = OutboxStore::new(&statements);
 
     let proc_row = ProcRow::find_by_statement(Statement::from_sql_and_values(
-        backend,
-        "SELECT processed_seq FROM toolkit_outbox_processor WHERE partition_id = $1",
+        store.backend(),
+        format!(
+            "SELECT processed_seq FROM {} WHERE partition_id = $1",
+            tables.processor()
+        ),
         [partition_id.into()],
     ))
     .one(&conn)
@@ -1653,14 +1786,14 @@ async fn run_vacuum(db: &Db, partition_id: i64) {
         return;
     }
 
-    let vacuum_sql = dialect.vacuum_cleanup();
+    let vacuum_sql = store.vacuum_cleanup();
 
     // Fetch outgoing rows in bounded chunks.
     loop {
         let rows = conn
             .query_all(Statement::from_sql_and_values(
-                backend,
-                vacuum_sql.select_outgoing_chunk,
+                store.backend(),
+                &vacuum_sql.select_outgoing_chunk,
                 [
                     partition_id.into(),
                     proc_row.processed_seq.into(),
@@ -1674,32 +1807,42 @@ async fn run_vacuum(db: &Db, partition_id: i64) {
         }
         let outgoing_ids: Vec<i64> = rows
             .iter()
-            .filter_map(|r| r.try_get_by_index::<i64>(0).ok())
-            .collect();
+            .map(|r| r.try_get_by_index::<i64>(0))
+            .collect::<Result<_, _>>()
+            .expect("outgoing id column");
         let body_ids: Vec<i64> = rows
             .iter()
-            .filter_map(|r| r.try_get_by_index::<i64>(1).ok())
-            .collect();
+            .map(|r| r.try_get_by_index::<i64>(1))
+            .collect::<Result<_, _>>()
+            .expect("body id column");
         // Delete outgoing by ID
-        let del_out = dialect.build_delete_outgoing_batch(outgoing_ids.len());
+        let del_out = store.build_delete_outgoing_batch(outgoing_ids.len());
         let values: Vec<sea_orm::Value> = outgoing_ids.iter().map(|&id| id.into()).collect();
-        conn.execute(Statement::from_sql_and_values(backend, &del_out, values))
-            .await
-            .unwrap();
+        conn.execute(Statement::from_sql_and_values(
+            store.backend(),
+            &del_out,
+            values,
+        ))
+        .await
+        .unwrap();
         // Delete body by ID
         if !body_ids.is_empty() {
-            let del_body = dialect.build_delete_body_batch(body_ids.len());
+            let del_body = store.build_delete_body_batch(body_ids.len());
             let values: Vec<sea_orm::Value> = body_ids.iter().map(|&id| id.into()).collect();
-            conn.execute(Statement::from_sql_and_values(backend, &del_body, values))
-                .await
-                .unwrap();
+            conn.execute(Statement::from_sql_and_values(
+                store.backend(),
+                &del_body,
+                values,
+            ))
+            .await
+            .unwrap();
         }
     }
 
     // Reset vacuum counter after cleanup.
     conn.execute(Statement::from_sql_and_values(
-        backend,
-        dialect.reset_vacuum_counter(),
+        store.backend(),
+        store.reset_vacuum_counter(),
         [partition_id.into()],
     ))
     .await
@@ -1798,6 +1941,10 @@ async fn vacuum_preserves_unprocessed_rows() {
 
 /// Read the vacuum counter for a partition.
 async fn read_vacuum_counter(db: &Db, partition_id: i64) -> i64 {
+    read_vacuum_counter_for_tables(db, &OutboxTables::default(), partition_id).await
+}
+
+async fn read_vacuum_counter_for_tables(db: &Db, tables: &OutboxTables, partition_id: i64) -> i64 {
     #[derive(Debug, FromQueryResult)]
     struct Row {
         counter: i64,
@@ -1805,7 +1952,10 @@ async fn read_vacuum_counter(db: &Db, partition_id: i64) -> i64 {
     let conn = db.sea_internal();
     Row::find_by_statement(Statement::from_sql_and_values(
         DbBackend::Sqlite,
-        "SELECT counter FROM toolkit_outbox_vacuum_counter WHERE partition_id = $1",
+        format!(
+            "SELECT counter FROM {} WHERE partition_id = $1",
+            tables.vacuum_counter()
+        ),
         [partition_id.into()],
     ))
     .one(&conn)
@@ -1817,10 +1967,22 @@ async fn read_vacuum_counter(db: &Db, partition_id: i64) -> i64 {
 
 /// Set the vacuum counter to an arbitrary value (test helper).
 async fn set_vacuum_counter(db: &Db, partition_id: i64, value: i64) {
+    set_vacuum_counter_for_tables(db, &OutboxTables::default(), partition_id, value).await;
+}
+
+async fn set_vacuum_counter_for_tables(
+    db: &Db,
+    tables: &OutboxTables,
+    partition_id: i64,
+    value: i64,
+) {
     let conn = db.sea_internal();
     conn.execute(Statement::from_sql_and_values(
         DbBackend::Sqlite,
-        "UPDATE toolkit_outbox_vacuum_counter SET counter = $1 WHERE partition_id = $2",
+        format!(
+            "UPDATE {} SET counter = $1 WHERE partition_id = $2",
+            tables.vacuum_counter()
+        ),
         [value.into(), partition_id.into()],
     ))
     .await
@@ -2345,6 +2507,379 @@ async fn builder_partitions_of_all_valid_values() {
         let p = Partitions::of(n);
         assert_eq!(p.count(), n);
     }
+}
+
+#[tokio::test]
+async fn default_prefix_builder_enqueue_uses_default_tables() {
+    let db = setup_db("ch10_default_prefix_builder").await;
+    let t = make_default_test_outbox().await;
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    t.outbox
+        .enqueue(
+            &db.conn().unwrap(),
+            "q",
+            0,
+            b"default".to_vec(),
+            "text/plain",
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(count_rows(&db, "toolkit_outbox_body").await, 1);
+    assert_eq!(count_rows(&db, "toolkit_outbox_incoming").await, 1);
+}
+
+#[tokio::test]
+async fn custom_prefix_builder_registers_queue() {
+    let tables = OutboxTables::new("mini_chat_outbox").unwrap();
+    let db = setup_db_with_migrations(
+        "ch10_custom_prefix_register",
+        super::outbox_migrations_with_prefix(tables.prefix()).unwrap(),
+    )
+    .await;
+
+    let handle = Outbox::builder(db.clone())
+        .table_prefix(tables.prefix())
+        .unwrap()
+        .queue("q", Partitions::of(1))
+        .leased(CountingMessageHandler {
+            count: Arc::new(AtomicU32::new(0)),
+        })
+        .start()
+        .await
+        .unwrap();
+
+    assert_eq!(count_rows(&db, tables.partitions()).await, 1);
+    assert_eq!(count_rows(&db, tables.processor()).await, 1);
+    assert!(!table_exists(&db, "toolkit_outbox_partitions").await);
+
+    handle.stop().await;
+}
+
+#[tokio::test]
+async fn custom_prefix_containing_default_body_token_registers_and_enqueues() {
+    let tables = OutboxTables::new("toolkit_outbox_body").unwrap();
+    let db = setup_db_with_migrations(
+        "ch10_custom_prefix_body_token",
+        super::outbox_migrations_with_prefix(tables.prefix()).unwrap(),
+    )
+    .await;
+
+    let handle = Outbox::builder(db.clone())
+        .table_prefix(tables.prefix())
+        .unwrap()
+        .queue("q", Partitions::of(1))
+        .leased(CountingMessageHandler {
+            count: Arc::new(AtomicU32::new(0)),
+        })
+        .start()
+        .await
+        .unwrap();
+
+    let message_id = handle
+        .outbox()
+        .enqueue(
+            &db.conn().unwrap(),
+            "q",
+            0,
+            b"nasty-prefix".to_vec(),
+            "text/plain",
+        )
+        .await
+        .unwrap();
+
+    assert!(message_id.0 > 0);
+    assert_eq!(count_rows(&db, tables.body()).await, 1);
+    assert!(!table_exists(&db, "toolkit_outbox_body").await);
+    assert!(!table_exists(&db, "toolkit_outbox_body_body_dead_letters").await);
+
+    handle.stop().await;
+}
+
+#[tokio::test]
+async fn custom_prefix_processes_message_without_default_tables() {
+    let tables = OutboxTables::new("mini_chat_outbox").unwrap();
+    let db = setup_db_with_migrations(
+        "ch10_custom_prefix_process",
+        super::outbox_migrations_with_prefix(tables.prefix()).unwrap(),
+    )
+    .await;
+    let processed = Arc::new(AtomicU32::new(0));
+
+    let handle = Outbox::builder(db.clone())
+        .table_prefix(tables.prefix())
+        .unwrap()
+        .processor_tuning(
+            WorkerTuning::processor_default().idle_interval(Duration::from_millis(20)),
+        )
+        .sequencer_tuning(
+            WorkerTuning::sequencer_default().idle_interval(Duration::from_millis(20)),
+        )
+        .queue("q", Partitions::of(1))
+        .leased(CountingMessageHandler {
+            count: processed.clone(),
+        })
+        .start()
+        .await
+        .unwrap();
+
+    let outbox = handle.outbox();
+    outbox
+        .enqueue(
+            &db.conn().unwrap(),
+            "q",
+            0,
+            b"custom".to_vec(),
+            "text/plain",
+        )
+        .await
+        .unwrap();
+    outbox.flush();
+
+    poll_until(
+        || {
+            let processed = processed.load(Ordering::Relaxed);
+            async move { processed >= 1 }
+        },
+        5000,
+    )
+    .await;
+
+    assert_eq!(count_rows(&db, tables.body()).await, 1);
+    assert_eq!(count_rows(&db, tables.outgoing()).await, 1);
+    assert!(!table_exists(&db, "toolkit_outbox_body").await);
+
+    handle.stop().await;
+}
+
+#[tokio::test]
+async fn custom_prefix_dead_letter_uses_custom_table() {
+    let tables = OutboxTables::new("mini_chat_outbox").unwrap();
+    let db = setup_db_with_migrations(
+        "ch10_custom_prefix_dead_letter",
+        super::outbox_migrations_with_prefix(tables.prefix()).unwrap(),
+    )
+    .await;
+
+    let handle = Outbox::builder(db.clone())
+        .table_prefix(tables.prefix())
+        .unwrap()
+        .processor_tuning(
+            WorkerTuning::processor_default().idle_interval(Duration::from_millis(20)),
+        )
+        .sequencer_tuning(
+            WorkerTuning::sequencer_default().idle_interval(Duration::from_millis(20)),
+        )
+        .queue("q", Partitions::of(1))
+        .leased(AlwaysRejectHandler)
+        .start()
+        .await
+        .unwrap();
+
+    let outbox = handle.outbox();
+    outbox
+        .enqueue(
+            &db.conn().unwrap(),
+            "q",
+            0,
+            b"reject".to_vec(),
+            "text/plain",
+        )
+        .await
+        .unwrap();
+    outbox.flush();
+
+    poll_until(
+        || {
+            let db = db.clone();
+            let table = tables.dead_letters().to_owned();
+            async move { count_rows(&db, &table).await >= 1 }
+        },
+        5000,
+    )
+    .await;
+
+    assert_eq!(count_rows(&db, tables.dead_letters()).await, 1);
+    assert!(!table_exists(&db, "toolkit_outbox_dead_letters").await);
+
+    handle.stop().await;
+}
+
+#[tokio::test]
+async fn custom_prefix_vacuum_cleans_custom_tables() {
+    use super::workers::vacuum::VacuumTask;
+
+    let tables = OutboxTables::new("mini_chat_outbox").unwrap();
+    let db = setup_db_with_migrations(
+        "ch10_custom_prefix_vacuum",
+        super::outbox_migrations_with_prefix(tables.prefix()).unwrap(),
+    )
+    .await;
+    let processed = Arc::new(AtomicU32::new(0));
+
+    let handle = Outbox::builder(db.clone())
+        .table_prefix(tables.prefix())
+        .unwrap()
+        .processor_tuning(
+            WorkerTuning::processor_default().idle_interval(Duration::from_millis(20)),
+        )
+        .sequencer_tuning(
+            WorkerTuning::sequencer_default().idle_interval(Duration::from_millis(20)),
+        )
+        .queue("q", Partitions::of(1))
+        .leased(CountingMessageHandler {
+            count: processed.clone(),
+        })
+        .start()
+        .await
+        .unwrap();
+
+    let outbox = handle.outbox();
+    outbox
+        .enqueue(
+            &db.conn().unwrap(),
+            "q",
+            0,
+            b"vacuum".to_vec(),
+            "text/plain",
+        )
+        .await
+        .unwrap();
+    outbox.flush();
+
+    poll_until(
+        || {
+            let processed = processed.load(Ordering::Relaxed);
+            async move { processed >= 1 }
+        },
+        5000,
+    )
+    .await;
+
+    handle.stop().await;
+
+    assert_eq!(count_rows(&db, tables.outgoing()).await, 1);
+    assert_eq!(count_rows(&db, tables.body()).await, 1);
+
+    let cancel = CancellationToken::new();
+    let statements = Arc::new(super::statements::OutboxStatements::new(
+        db.sea_internal().get_database_backend(),
+        &tables,
+    ));
+    let mut vacuum = VacuumTask::new(db.clone(), statements, 10_000);
+    vacuum.execute(&cancel).await.unwrap();
+
+    assert_eq!(count_rows(&db, tables.outgoing()).await, 0);
+    assert_eq!(count_rows(&db, tables.body()).await, 0);
+    assert!(!table_exists(&db, "toolkit_outbox_outgoing").await);
+}
+
+#[tokio::test]
+async fn default_and_custom_prefix_instances_coexist() {
+    let custom_tables = OutboxTables::new("mini_chat_outbox").unwrap();
+    let mut migrations = super::outbox_migrations();
+    migrations.extend(super::outbox_migrations_with_prefix(custom_tables.prefix()).unwrap());
+    let db = setup_db_with_migrations("ch10_prefix_instances_coexist", migrations).await;
+
+    let default_count = Arc::new(AtomicU32::new(0));
+    let custom_count = Arc::new(AtomicU32::new(0));
+
+    let default_handle = Outbox::builder(db.clone())
+        .processor_tuning(
+            WorkerTuning::processor_default().idle_interval(Duration::from_millis(20)),
+        )
+        .sequencer_tuning(
+            WorkerTuning::sequencer_default().idle_interval(Duration::from_millis(20)),
+        )
+        .queue("q", Partitions::of(1))
+        .leased(CountingMessageHandler {
+            count: default_count.clone(),
+        })
+        .start()
+        .await
+        .unwrap();
+
+    let custom_handle = Outbox::builder(db.clone())
+        .table_prefix(custom_tables.prefix())
+        .unwrap()
+        .processor_tuning(
+            WorkerTuning::processor_default().idle_interval(Duration::from_millis(20)),
+        )
+        .sequencer_tuning(
+            WorkerTuning::sequencer_default().idle_interval(Duration::from_millis(20)),
+        )
+        .queue("q", Partitions::of(1))
+        .leased(CountingMessageHandler {
+            count: custom_count.clone(),
+        })
+        .start()
+        .await
+        .unwrap();
+
+    default_handle
+        .outbox()
+        .enqueue(
+            &db.conn().unwrap(),
+            "q",
+            0,
+            b"default".to_vec(),
+            "text/plain",
+        )
+        .await
+        .unwrap();
+    custom_handle
+        .outbox()
+        .enqueue(
+            &db.conn().unwrap(),
+            "q",
+            0,
+            b"custom".to_vec(),
+            "text/plain",
+        )
+        .await
+        .unwrap();
+    default_handle.outbox().flush();
+    custom_handle.outbox().flush();
+
+    poll_until(
+        || {
+            let default_count = default_count.load(Ordering::Relaxed);
+            let custom_count = custom_count.load(Ordering::Relaxed);
+            async move { default_count >= 1 && custom_count >= 1 }
+        },
+        5000,
+    )
+    .await;
+
+    assert_eq!(count_rows(&db, "toolkit_outbox_body").await, 1);
+    assert_eq!(count_rows(&db, custom_tables.body()).await, 1);
+
+    default_handle.stop().await;
+    custom_handle.stop().await;
+}
+
+#[tokio::test]
+async fn custom_prefix_without_matching_migration_fails_startup() {
+    let db = setup_empty_db("ch10_custom_prefix_missing_migration").await;
+    let result = Outbox::builder(db)
+        .table_prefix("mini_chat_outbox")
+        .unwrap()
+        .queue("q", Partitions::of(1))
+        .leased(CountingMessageHandler {
+            count: Arc::new(AtomicU32::new(0)),
+        })
+        .start()
+        .await;
+    let err = match result {
+        Ok(handle) => {
+            handle.stop().await;
+            panic!("expected startup to fail without matching migrations");
+        }
+        Err(err) => err,
+    };
+
+    assert!(matches!(err, OutboxError::Database(_)));
 }
 
 #[tokio::test]
@@ -2938,13 +3473,25 @@ async fn processed_count_exceeds_batch_is_clamped() {
 
 /// Helper: insert raw incoming rows bypassing enqueue (no dirty flag set).
 async fn insert_raw_incoming(db: &Db, partition_id: i64, count: usize) {
+    insert_raw_incoming_for_tables(db, &OutboxTables::default(), partition_id, count).await;
+}
+
+async fn insert_raw_incoming_for_tables(
+    db: &Db,
+    tables: &OutboxTables,
+    partition_id: i64,
+    count: usize,
+) {
     let conn = db.sea_internal();
     for _ in 0..count {
         // Insert a body row first
         let body_id = conn
             .query_one(Statement::from_string(
                 DbBackend::Sqlite,
-                "INSERT INTO toolkit_outbox_body (payload, payload_type) VALUES (X'AA', 'raw') RETURNING id",
+                format!(
+                    "INSERT INTO {} (payload, payload_type) VALUES (X'AA', 'raw') RETURNING id",
+                    tables.body()
+                ),
             ))
             .await
             .expect("insert body")
@@ -2954,7 +3501,10 @@ async fn insert_raw_incoming(db: &Db, partition_id: i64, count: usize) {
 
         conn.execute(Statement::from_sql_and_values(
             DbBackend::Sqlite,
-            "INSERT INTO toolkit_outbox_incoming (partition_id, body_id) VALUES ($1, $2)",
+            format!(
+                "INSERT INTO {} (partition_id, body_id) VALUES ($1, $2)",
+                tables.incoming()
+            ),
             [partition_id.into(), body_id.into()],
         ))
         .await
@@ -3378,9 +3928,10 @@ async fn vacuum_counter_decrement_is_idempotent() {
     // First decrement: 5 - 5 = 0
     let conn = db.sea_internal();
     let dialect = Dialect::from(conn.get_database_backend());
+    let tables = OutboxTables::default();
     conn.execute(Statement::from_sql_and_values(
         conn.get_database_backend(),
-        dialect.decrement_vacuum_counter(),
+        dialect.decrement_vacuum_counter(&tables),
         [5i64.into(), pid.into()],
     ))
     .await
@@ -3390,7 +3941,7 @@ async fn vacuum_counter_decrement_is_idempotent() {
     // Second decrement (stale snapshot): GREATEST(0 - 5, 0) = 0
     conn.execute(Statement::from_sql_and_values(
         conn.get_database_backend(),
-        dialect.decrement_vacuum_counter(),
+        dialect.decrement_vacuum_counter(&tables),
         [5i64.into(), pid.into()],
     ))
     .await
@@ -3426,8 +3977,13 @@ async fn vacuum_concurrent_workers_safe() {
 
     // Run two vacuum workers sequentially (SQLite single connection)
     let cancel = CancellationToken::new();
-    let mut vac1 = VacuumTask::new(db.clone(), 10_000);
-    let mut vac2 = VacuumTask::new(db.clone(), 10_000);
+    let tables = OutboxTables::default();
+    let statements = Arc::new(super::statements::OutboxStatements::new(
+        db.sea_internal().get_database_backend(),
+        &tables,
+    ));
+    let mut vac1 = VacuumTask::new(db.clone(), Arc::clone(&statements), 10_000);
+    let mut vac2 = VacuumTask::new(db.clone(), statements, 10_000);
 
     vac1.execute(&cancel).await.unwrap();
     vac2.execute(&cancel).await.unwrap();

--- a/libs/toolkit-db/src/outbox/manager.rs
+++ b/libs/toolkit-db/src/outbox/manager.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use dashmap::DashMap;
+use sea_orm::ConnectionTrait;
 use tokio::sync::{Notify, Semaphore};
 use tokio_util::sync::CancellationToken;
 
@@ -10,6 +11,7 @@ use super::builder::QueueBuilder;
 use super::core::Outbox;
 use super::prioritizer::SharedPrioritizer;
 use super::stats::{StatsListener, StatsRegistry, StatsReporter};
+use super::tables::OutboxTables;
 use super::taskward::{
     BackoffConfig, Bulkhead, BulkheadConfig, ConcurrencyLimit, PanicPolicy, TaskSet,
     TracingListener, WorkerBuilder, poker,
@@ -112,6 +114,7 @@ pub struct OutboxBuilder {
     sequencer_tuning: Option<WorkerTuning>,
     vacuum_tuning: Option<WorkerTuning>,
     reconciler_tuning: Option<WorkerTuning>,
+    tables: OutboxTables,
     pub(crate) queue_declarations: Vec<QueueDeclaration>,
 }
 
@@ -130,8 +133,23 @@ impl OutboxBuilder {
             sequencer_tuning: None,
             vacuum_tuning: None,
             reconciler_tuning: None,
+            tables: OutboxTables::default(),
             queue_declarations: Vec::new(),
         }
+    }
+
+    /// Select a custom table prefix for this outbox instance.
+    ///
+    /// The same prefix must be used when registering outbox migrations with
+    /// [`super::outbox_migrations_with_prefix`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OutboxError::InvalidTablePrefix`] if the prefix cannot be used
+    /// as a portable SQL identifier.
+    pub fn table_prefix(mut self, prefix: impl Into<String>) -> Result<Self, OutboxError> {
+        self.tables = OutboxTables::new(prefix)?;
+        Ok(self)
     }
 
     /// Maximum number of concurrent partition processors across all queues.
@@ -350,13 +368,18 @@ impl OutboxBuilder {
     /// See the `maintenance()` doc comment for the full two-tier model.
     fn spawn_vacuum_workers(
         ctx: &mut StartContext<'_>,
+        outbox: &Arc<Outbox>,
         tuning: &WorkerTuning,
         shared_sem: &Arc<Semaphore>,
         count: usize,
     ) {
         for i in 0..count {
             #[allow(unused_mut)]
-            let vacuum = VacuumTask::new(ctx.db.clone(), tuning.batch_size as usize);
+            let vacuum = VacuumTask::new(
+                ctx.db.clone(),
+                outbox.statements_arc(),
+                tuning.batch_size as usize,
+            );
             let name = format!("vacuum-{i}");
             let (poker_notify, _poker_handle) = poker(tuning.idle_interval, ctx.cancel.clone());
             let mut builder = WorkerBuilder::<VacuumReport>::new(&name, ctx.cancel.clone())
@@ -461,6 +484,7 @@ impl OutboxBuilder {
         let shared_prioritizer = Arc::new(SharedPrioritizer::new());
 
         let config = OutboxConfig {
+            tables: self.tables.clone(),
             sequencer: SequencerConfig {
                 batch_size: tuning.sequencer.batch_size,
                 poll_interval: tuning.sequencer.idle_interval,
@@ -468,7 +492,8 @@ impl OutboxBuilder {
                 max_inner_iterations: self.max_inner_iterations,
             },
         };
-        let outbox = Arc::new(Outbox::new(config));
+        let backend = self.db.sea_internal().get_database_backend();
+        let outbox = Arc::new(Outbox::new_with_backend(config, backend));
         let cancel = CancellationToken::new();
         let mut task_set = TaskSet::new(cancel.clone());
         let start_notify = Arc::new(Notify::new());
@@ -564,7 +589,7 @@ impl OutboxBuilder {
         Self::spawn_cold_reconciler(&mut ctx, &outbox, &shared_prioritizer, &tuning.reconciler);
 
         // 9. Spawn vacuum workers
-        Self::spawn_vacuum_workers(&mut ctx, &tuning.vacuum, &shared_sem, shared);
+        Self::spawn_vacuum_workers(&mut ctx, &outbox, &tuning.vacuum, &shared_sem, shared);
 
         // 10. Spawn stats reporter (if enabled)
         if let Some(interval) = self.stats_interval {

--- a/libs/toolkit-db/src/outbox/migrations.rs
+++ b/libs/toolkit-db/src/outbox/migrations.rs
@@ -1,28 +1,45 @@
 use sea_orm::{ConnectionTrait, DatabaseBackend, DbErr, Statement};
 use sea_orm_migration::prelude::*;
 
+use super::tables::OutboxTables;
+use super::types::OutboxError;
+
 /// Single migration that creates the entire outbox schema from scratch.
 ///
 /// Tables are created in FK dependency order:
-/// body → partitions → incoming → outgoing → dead-letters → processor
+/// body -> partitions -> incoming -> outgoing -> dead-letters -> processor
 ///
 /// # Idempotency
 ///
 /// All `CREATE TABLE` statements use `IF NOT EXISTS` so the migration is safe
-/// to re-run (e.g., after a partial failure).  `CREATE INDEX` statements do
-/// **not** — `MySQL` has no `IF NOT EXISTS` syntax for indexes, and keeping the
+/// to re-run (e.g., after a partial failure). `CREATE INDEX` statements do
+/// **not** -- `MySQL` has no `IF NOT EXISTS` syntax for indexes, and keeping the
 /// Pg/SQLite paths consistent avoids a false sense of safety on only some
-/// backends.  Because each index immediately follows its `CREATE TABLE IF NOT
+/// backends. Because each index immediately follows its `CREATE TABLE IF NOT
 /// EXISTS`, the index can only pre-exist if the migration crashed between the
 /// two statements *and* the migration runner retries without rolling back.
 /// The sea-orm migration framework tracks completed migrations, so this edge
-/// case requires a crash mid-transaction — acceptable for a `preview-outbox`
+/// case requires a crash mid-transaction -- acceptable for a `preview-outbox`
 /// alpha feature with no production deployments.
-struct CreateOutboxSchema;
+struct CreateOutboxSchema {
+    tables: OutboxTables,
+}
+
+impl CreateOutboxSchema {
+    fn new(tables: OutboxTables) -> Self {
+        Self { tables }
+    }
+}
+
+impl Default for CreateOutboxSchema {
+    fn default() -> Self {
+        Self::new(OutboxTables::default())
+    }
+}
 
 impl MigrationName for CreateOutboxSchema {
-    fn name(&self) -> &'static str {
-        "m001_create_toolkit_outbox_schema"
+    fn name(&self) -> &str {
+        self.tables.migration_name()
     }
 }
 
@@ -31,14 +48,16 @@ impl MigrationTrait for CreateOutboxSchema {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         let conn = manager.get_connection();
         let backend = conn.get_database_backend();
+        let tables = &self.tables;
 
-        create_body(conn, backend).await?;
-        create_partitions(conn, backend).await?;
-        create_incoming(conn, backend).await?;
-        create_outgoing(conn, backend).await?;
-        create_dead_letters(conn, backend).await?;
-        create_processor(conn, backend).await?;
-        create_vacuum_counter(conn, backend).await?;
+        create_body(conn, backend, tables).await?;
+        create_partitions(conn, backend, tables).await?;
+        create_incoming(conn, backend, tables).await?;
+        create_outgoing(conn, backend, tables).await?;
+        create_dead_letters(conn, backend, tables).await?;
+        create_processor(conn, backend, tables).await?;
+        create_vacuum_counter(conn, backend, tables).await?;
+        create_mysql_id_sequence_tables(conn, backend, tables).await?;
 
         Ok(())
     }
@@ -48,13 +67,15 @@ impl MigrationTrait for CreateOutboxSchema {
         let backend = conn.get_database_backend();
 
         for table in [
-            "toolkit_outbox_vacuum_counter",
-            "toolkit_outbox_processor",
-            "toolkit_outbox_dead_letters",
-            "toolkit_outbox_outgoing",
-            "toolkit_outbox_incoming",
-            "toolkit_outbox_partitions",
-            "toolkit_outbox_body",
+            self.tables.incoming_id_sequence(),
+            self.tables.body_id_sequence(),
+            self.tables.vacuum_counter(),
+            self.tables.processor(),
+            self.tables.dead_letters(),
+            self.tables.outgoing(),
+            self.tables.incoming(),
+            self.tables.partitions(),
+            self.tables.body(),
         ] {
             conn.execute(Statement::from_string(
                 backend,
@@ -66,33 +87,44 @@ impl MigrationTrait for CreateOutboxSchema {
     }
 }
 
-async fn create_body(conn: &dyn ConnectionTrait, backend: DatabaseBackend) -> Result<(), DbErr> {
+async fn create_body(
+    conn: &dyn ConnectionTrait,
+    backend: DatabaseBackend,
+    tables: &OutboxTables,
+) -> Result<(), DbErr> {
+    let body_table = tables.body();
     conn.execute(Statement::from_string(
         backend,
         match backend {
             DatabaseBackend::Postgres => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_body (
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {body_table} (
                 id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
                 payload       BYTEA  NOT NULL,
                 payload_type  VARCHAR(1024) NOT NULL,
                 created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
             )"
+                )
             }
             DatabaseBackend::Sqlite => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_body (
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {body_table} (
                 id            INTEGER PRIMARY KEY AUTOINCREMENT,
                 payload       BLOB   NOT NULL,
                 payload_type  TEXT   NOT NULL,
                 created_at    TEXT   NOT NULL DEFAULT (datetime('now'))
             )"
+                )
             }
             DatabaseBackend::MySql => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_body (
-                id            BIGINT AUTO_INCREMENT PRIMARY KEY,
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {body_table} (
+                id            BIGINT PRIMARY KEY,
                 payload       LONGBLOB NOT NULL,
                 payload_type  VARCHAR(1024) NOT NULL,
                 created_at    TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
             )"
+                )
             }
         },
     ))
@@ -103,36 +135,44 @@ async fn create_body(conn: &dyn ConnectionTrait, backend: DatabaseBackend) -> Re
 async fn create_partitions(
     conn: &dyn ConnectionTrait,
     backend: DatabaseBackend,
+    tables: &OutboxTables,
 ) -> Result<(), DbErr> {
+    let partitions = tables.partitions();
     conn.execute(Statement::from_string(
         backend,
         match backend {
             DatabaseBackend::Postgres => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_partitions (
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {partitions} (
                 id        BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
                 queue     VARCHAR(1024) NOT NULL,
                 partition SMALLINT NOT NULL,
                 sequence  BIGINT   NOT NULL DEFAULT 0,
                 UNIQUE (queue, partition)
             )"
+                )
             }
             DatabaseBackend::Sqlite => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_partitions (
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {partitions} (
                 id        INTEGER PRIMARY KEY AUTOINCREMENT,
                 queue     TEXT    NOT NULL,
                 partition INTEGER NOT NULL,
                 sequence  INTEGER NOT NULL DEFAULT 0,
                 UNIQUE (queue, partition)
             )"
+                )
             }
             DatabaseBackend::MySql => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_partitions (
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {partitions} (
                 id        BIGINT AUTO_INCREMENT PRIMARY KEY,
                 queue     VARCHAR(1024) CHARACTER SET ascii NOT NULL,
                 `partition` SMALLINT NOT NULL,
                 sequence  BIGINT   NOT NULL DEFAULT 0,
                 UNIQUE KEY (queue, `partition`)
             )"
+                )
             }
         },
     ))
@@ -143,32 +183,42 @@ async fn create_partitions(
 async fn create_incoming(
     conn: &dyn ConnectionTrait,
     backend: DatabaseBackend,
+    tables: &OutboxTables,
 ) -> Result<(), DbErr> {
+    let incoming = tables.incoming();
+    let partitions = tables.partitions();
+    let body_table = tables.body();
     conn.execute(Statement::from_string(
         backend,
         match backend {
             DatabaseBackend::Postgres => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_incoming (
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {incoming} (
                 id           BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-                partition_id BIGINT   NOT NULL REFERENCES toolkit_outbox_partitions(id),
-                body_id      BIGINT   NOT NULL REFERENCES toolkit_outbox_body(id)
+                partition_id BIGINT   NOT NULL REFERENCES {partitions}(id),
+                body_id      BIGINT   NOT NULL REFERENCES {body_table}(id)
             )"
+                )
             }
             DatabaseBackend::Sqlite => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_incoming (
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {incoming} (
                 id           INTEGER PRIMARY KEY AUTOINCREMENT,
-                partition_id INTEGER NOT NULL REFERENCES toolkit_outbox_partitions(id),
-                body_id      INTEGER NOT NULL REFERENCES toolkit_outbox_body(id)
+                partition_id INTEGER NOT NULL REFERENCES {partitions}(id),
+                body_id      INTEGER NOT NULL REFERENCES {body_table}(id)
             )"
+                )
             }
             DatabaseBackend::MySql => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_incoming (
-                id           BIGINT AUTO_INCREMENT PRIMARY KEY,
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {incoming} (
+                id           BIGINT PRIMARY KEY,
                 partition_id BIGINT NOT NULL,
                 body_id      BIGINT NOT NULL,
-                FOREIGN KEY (partition_id) REFERENCES toolkit_outbox_partitions(id),
-                FOREIGN KEY (body_id) REFERENCES toolkit_outbox_body(id)
+                FOREIGN KEY (partition_id) REFERENCES {partitions}(id),
+                FOREIGN KEY (body_id) REFERENCES {body_table}(id)
             )"
+                )
             }
         },
     ))
@@ -176,25 +226,23 @@ async fn create_incoming(
 
     conn.execute(Statement::from_string(
         backend,
-        match backend {
-            DatabaseBackend::Postgres | DatabaseBackend::Sqlite | DatabaseBackend::MySql => {
-                "CREATE INDEX idx_toolkit_outbox_incoming_partition \
-             ON toolkit_outbox_incoming (partition_id, id)"
-            }
-        },
+        format!(
+            "CREATE INDEX {} ON {} (partition_id, id)",
+            tables.idx_incoming_partition(),
+            tables.incoming()
+        ),
     ))
     .await?;
 
     // Index on body_id to accelerate FK constraint checks during
-    // DELETE FROM toolkit_outbox_body WHERE id IN (...).
+    // DELETE FROM outbox body WHERE id IN (...).
     conn.execute(Statement::from_string(
         backend,
-        match backend {
-            DatabaseBackend::Postgres | DatabaseBackend::Sqlite | DatabaseBackend::MySql => {
-                "CREATE INDEX idx_toolkit_outbox_incoming_body_id \
-             ON toolkit_outbox_incoming (body_id)"
-            }
-        },
+        format!(
+            "CREATE INDEX {} ON {} (body_id)",
+            tables.idx_incoming_body_id(),
+            tables.incoming()
+        ),
     ))
     .await?;
     Ok(())
@@ -203,38 +251,48 @@ async fn create_incoming(
 async fn create_outgoing(
     conn: &dyn ConnectionTrait,
     backend: DatabaseBackend,
+    tables: &OutboxTables,
 ) -> Result<(), DbErr> {
+    let outgoing = tables.outgoing();
+    let partitions = tables.partitions();
+    let body_table = tables.body();
     conn.execute(Statement::from_string(
         backend,
         match backend {
             DatabaseBackend::Postgres => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_outgoing (
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {outgoing} (
                 id           BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-                partition_id BIGINT NOT NULL REFERENCES toolkit_outbox_partitions(id),
-                body_id      BIGINT NOT NULL REFERENCES toolkit_outbox_body(id),
+                partition_id BIGINT NOT NULL REFERENCES {partitions}(id),
+                body_id      BIGINT NOT NULL REFERENCES {body_table}(id),
                 seq          BIGINT NOT NULL,
                 sequenced_at TIMESTAMPTZ NOT NULL DEFAULT now()
             )"
+                )
             }
             DatabaseBackend::Sqlite => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_outgoing (
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {outgoing} (
                 id           INTEGER PRIMARY KEY AUTOINCREMENT,
-                partition_id INTEGER NOT NULL REFERENCES toolkit_outbox_partitions(id),
-                body_id      INTEGER NOT NULL REFERENCES toolkit_outbox_body(id),
+                partition_id INTEGER NOT NULL REFERENCES {partitions}(id),
+                body_id      INTEGER NOT NULL REFERENCES {body_table}(id),
                 seq          INTEGER NOT NULL,
                 sequenced_at TEXT    NOT NULL DEFAULT (datetime('now'))
             )"
+                )
             }
             DatabaseBackend::MySql => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_outgoing (
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {outgoing} (
                 id           BIGINT AUTO_INCREMENT PRIMARY KEY,
                 partition_id BIGINT NOT NULL,
                 body_id      BIGINT NOT NULL,
                 seq          BIGINT NOT NULL,
                 sequenced_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-                FOREIGN KEY (partition_id) REFERENCES toolkit_outbox_partitions(id),
-                FOREIGN KEY (body_id) REFERENCES toolkit_outbox_body(id)
+                FOREIGN KEY (partition_id) REFERENCES {partitions}(id),
+                FOREIGN KEY (body_id) REFERENCES {body_table}(id)
             )"
+                )
             }
         },
     ))
@@ -242,25 +300,23 @@ async fn create_outgoing(
 
     conn.execute(Statement::from_string(
         backend,
-        match backend {
-            DatabaseBackend::Postgres | DatabaseBackend::Sqlite | DatabaseBackend::MySql => {
-                "CREATE UNIQUE INDEX idx_toolkit_outbox_outgoing_partition_seq \
-             ON toolkit_outbox_outgoing (partition_id, seq)"
-            }
-        },
+        format!(
+            "CREATE UNIQUE INDEX {} ON {} (partition_id, seq)",
+            tables.idx_outgoing_partition_seq(),
+            tables.outgoing()
+        ),
     ))
     .await?;
 
     // Index on body_id to accelerate FK constraint checks during
-    // DELETE FROM toolkit_outbox_body WHERE id IN (...).
+    // DELETE FROM outbox body WHERE id IN (...).
     conn.execute(Statement::from_string(
         backend,
-        match backend {
-            DatabaseBackend::Postgres | DatabaseBackend::Sqlite | DatabaseBackend::MySql => {
-                "CREATE INDEX idx_toolkit_outbox_outgoing_body_id \
-             ON toolkit_outbox_outgoing (body_id)"
-            }
-        },
+        format!(
+            "CREATE INDEX {} ON {} (body_id)",
+            tables.idx_outgoing_body_id(),
+            tables.outgoing()
+        ),
     ))
     .await?;
     Ok(())
@@ -269,14 +325,18 @@ async fn create_outgoing(
 async fn create_dead_letters(
     conn: &dyn ConnectionTrait,
     backend: DatabaseBackend,
+    tables: &OutboxTables,
 ) -> Result<(), DbErr> {
+    let dead_letters = tables.dead_letters();
+    let partitions = tables.partitions();
     conn.execute(Statement::from_string(
         backend,
         match backend {
             DatabaseBackend::Postgres => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_dead_letters (
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {dead_letters} (
                 id           BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-                partition_id BIGINT NOT NULL REFERENCES toolkit_outbox_partitions(id),
+                partition_id BIGINT NOT NULL REFERENCES {partitions}(id),
                 seq          BIGINT NOT NULL,
                 payload      BYTEA  NOT NULL,
                 payload_type VARCHAR(1024) NOT NULL,
@@ -288,11 +348,13 @@ async fn create_dead_letters(
                 completed_at TIMESTAMPTZ,
                 deadline     TIMESTAMPTZ
             )"
+                )
             }
             DatabaseBackend::Sqlite => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_dead_letters (
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {dead_letters} (
                 id           INTEGER PRIMARY KEY AUTOINCREMENT,
-                partition_id INTEGER NOT NULL REFERENCES toolkit_outbox_partitions(id),
+                partition_id INTEGER NOT NULL REFERENCES {partitions}(id),
                 seq          INTEGER NOT NULL,
                 payload      BLOB   NOT NULL,
                 payload_type TEXT   NOT NULL,
@@ -304,9 +366,11 @@ async fn create_dead_letters(
                 completed_at TEXT,
                 deadline     TEXT
             )"
+                )
             }
             DatabaseBackend::MySql => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_dead_letters (
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {dead_letters} (
                 id           BIGINT AUTO_INCREMENT PRIMARY KEY,
                 partition_id BIGINT NOT NULL,
                 seq          BIGINT NOT NULL,
@@ -319,8 +383,9 @@ async fn create_dead_letters(
                 status       VARCHAR(32) NOT NULL DEFAULT 'pending',
                 completed_at TIMESTAMP(6) NULL,
                 deadline     TIMESTAMP(6) NULL,
-                FOREIGN KEY (partition_id) REFERENCES toolkit_outbox_partitions(id)
+                FOREIGN KEY (partition_id) REFERENCES {partitions}(id)
             )"
+                )
             }
         },
     ))
@@ -331,13 +396,18 @@ async fn create_dead_letters(
         backend,
         match backend {
             DatabaseBackend::Postgres => {
-                "CREATE INDEX idx_toolkit_outbox_dl_replayable \
-             ON toolkit_outbox_dead_letters (status, deadline) \
-             WHERE status IN ('pending', 'reprocessing')"
+                format!(
+                    "CREATE INDEX {} ON {} (status, deadline) WHERE status IN ('pending', 'reprocessing')",
+                    tables.idx_dl_replayable(),
+                    tables.dead_letters()
+                )
             }
             DatabaseBackend::Sqlite | DatabaseBackend::MySql => {
-                "CREATE INDEX idx_toolkit_outbox_dl_status_deadline \
-             ON toolkit_outbox_dead_letters (status, deadline)"
+                format!(
+                    "CREATE INDEX {} ON {} (status, deadline)",
+                    tables.idx_dl_status_deadline(),
+                    tables.dead_letters()
+                )
             }
         },
     ))
@@ -348,12 +418,18 @@ async fn create_dead_letters(
         backend,
         match backend {
             DatabaseBackend::Postgres => {
-                "CREATE INDEX idx_toolkit_outbox_dl_status_failed \
-             ON toolkit_outbox_dead_letters (status, failed_at DESC)"
+                format!(
+                    "CREATE INDEX {} ON {} (status, failed_at DESC)",
+                    tables.idx_dl_status_failed(),
+                    tables.dead_letters()
+                )
             }
             DatabaseBackend::Sqlite | DatabaseBackend::MySql => {
-                "CREATE INDEX idx_toolkit_outbox_dl_status_failed \
-             ON toolkit_outbox_dead_letters (status, failed_at)"
+                format!(
+                    "CREATE INDEX {} ON {} (status, failed_at)",
+                    tables.idx_dl_status_failed(),
+                    tables.dead_letters()
+                )
             }
         },
     ))
@@ -364,40 +440,49 @@ async fn create_dead_letters(
 async fn create_processor(
     conn: &dyn ConnectionTrait,
     backend: DatabaseBackend,
+    tables: &OutboxTables,
 ) -> Result<(), DbErr> {
+    let processor = tables.processor();
+    let partitions = tables.partitions();
     conn.execute(Statement::from_string(
         backend,
         match backend {
             DatabaseBackend::Postgres => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_processor (
-                partition_id  BIGINT PRIMARY KEY REFERENCES toolkit_outbox_partitions(id),
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {processor} (
+                partition_id  BIGINT PRIMARY KEY REFERENCES {partitions}(id),
                 processed_seq BIGINT   NOT NULL DEFAULT 0,
                 attempts      SMALLINT NOT NULL DEFAULT 0,
                 last_error    TEXT,
                 locked_by     VARCHAR(1024),
                 locked_until  TIMESTAMPTZ
             )"
+                )
             }
             DatabaseBackend::Sqlite => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_processor (
-                partition_id  INTEGER PRIMARY KEY REFERENCES toolkit_outbox_partitions(id),
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {processor} (
+                partition_id  INTEGER PRIMARY KEY REFERENCES {partitions}(id),
                 processed_seq INTEGER NOT NULL DEFAULT 0,
                 attempts      INTEGER NOT NULL DEFAULT 0,
                 last_error    TEXT,
                 locked_by     TEXT,
                 locked_until  TEXT
             )"
+                )
             }
             DatabaseBackend::MySql => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_processor (
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {processor} (
                 partition_id  BIGINT PRIMARY KEY,
                 processed_seq BIGINT   NOT NULL DEFAULT 0,
                 attempts      SMALLINT NOT NULL DEFAULT 0,
                 last_error    TEXT,
                 locked_by     VARCHAR(1024) CHARACTER SET ascii,
                 locked_until  TIMESTAMP(6) NULL,
-                FOREIGN KEY (partition_id) REFERENCES toolkit_outbox_partitions(id)
+                FOREIGN KEY (partition_id) REFERENCES {partitions}(id)
             )"
+                )
             }
         },
     ))
@@ -408,30 +493,39 @@ async fn create_processor(
 async fn create_vacuum_counter(
     conn: &dyn ConnectionTrait,
     backend: DatabaseBackend,
+    tables: &OutboxTables,
 ) -> Result<(), DbErr> {
+    let vacuum_counter = tables.vacuum_counter();
+    let partitions = tables.partitions();
     conn.execute(Statement::from_string(
         backend,
         match backend {
             DatabaseBackend::Postgres => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_vacuum_counter (
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {vacuum_counter} (
                 partition_id BIGINT PRIMARY KEY
-                    REFERENCES toolkit_outbox_partitions(id),
+                    REFERENCES {partitions}(id),
                 counter      BIGINT NOT NULL DEFAULT 0
             )"
+                )
             }
             DatabaseBackend::Sqlite => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_vacuum_counter (
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {vacuum_counter} (
                 partition_id INTEGER PRIMARY KEY
-                    REFERENCES toolkit_outbox_partitions(id),
+                    REFERENCES {partitions}(id),
                 counter      INTEGER NOT NULL DEFAULT 0
             )"
+                )
             }
             DatabaseBackend::MySql => {
-                "CREATE TABLE IF NOT EXISTS toolkit_outbox_vacuum_counter (
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {vacuum_counter} (
                 partition_id BIGINT PRIMARY KEY,
                 counter      BIGINT NOT NULL DEFAULT 0,
-                FOREIGN KEY (partition_id) REFERENCES toolkit_outbox_partitions(id)
+                FOREIGN KEY (partition_id) REFERENCES {partitions}(id)
             )"
+                )
             }
         },
     ))
@@ -439,8 +533,137 @@ async fn create_vacuum_counter(
     Ok(())
 }
 
+async fn create_mysql_id_sequence_tables(
+    conn: &dyn ConnectionTrait,
+    backend: DatabaseBackend,
+    tables: &OutboxTables,
+) -> Result<(), DbErr> {
+    if backend != DatabaseBackend::MySql {
+        return Ok(());
+    }
+
+    for table in [tables.body_id_sequence(), tables.incoming_id_sequence()] {
+        conn.execute(Statement::from_string(
+            backend,
+            mysql_create_id_sequence_sql(table),
+        ))
+        .await?;
+        conn.execute(Statement::from_string(
+            backend,
+            mysql_seed_id_sequence_sql(table),
+        ))
+        .await?;
+    }
+
+    Ok(())
+}
+
+fn mysql_create_id_sequence_sql(table: &str) -> String {
+    format!(
+        "CREATE TABLE IF NOT EXISTS {table} (
+                slot    TINYINT PRIMARY KEY,
+                next_id BIGINT NOT NULL
+            )"
+    )
+}
+
+fn mysql_seed_id_sequence_sql(table: &str) -> String {
+    format!("INSERT IGNORE INTO {table} (slot, next_id) VALUES (1, 1)")
+}
+
 /// Returns all outbox migrations in dependency order.
 #[must_use]
 pub fn outbox_migrations() -> Vec<Box<dyn MigrationTrait>> {
-    vec![Box::new(CreateOutboxSchema)]
+    vec![Box::new(CreateOutboxSchema::default())]
+}
+
+/// Returns all outbox migrations for a custom table prefix in dependency order.
+///
+/// # Errors
+///
+/// Returns [`OutboxError::InvalidTablePrefix`] if the prefix cannot be used as
+/// a portable SQL identifier.
+pub fn outbox_migrations_with_prefix(
+    prefix: impl Into<String>,
+) -> Result<Vec<Box<dyn MigrationTrait>>, OutboxError> {
+    let tables = OutboxTables::new(prefix)?;
+    Ok(vec![Box::new(CreateOutboxSchema::new(tables))])
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use crate::outbox::tables::DEFAULT_OUTBOX_MIGRATION_NAME;
+
+    #[test]
+    fn default_migration_name_is_preserved() {
+        let migrations = outbox_migrations();
+
+        assert_eq!(migrations[0].name(), DEFAULT_OUTBOX_MIGRATION_NAME);
+    }
+
+    #[test]
+    fn prefixed_migration_name_is_deterministic_and_distinct() {
+        let first = outbox_migrations_with_prefix("mini_chat_outbox").unwrap();
+        let second = outbox_migrations_with_prefix("mini_chat_outbox").unwrap();
+
+        assert_eq!(first[0].name(), second[0].name());
+        assert_ne!(first[0].name(), DEFAULT_OUTBOX_MIGRATION_NAME);
+        assert_eq!(
+            first[0].name(),
+            "m001_create_toolkit_outbox_schema__mini_chat_outbox"
+        );
+    }
+
+    #[test]
+    fn invalid_prefix_is_rejected() {
+        let Err(err) = outbox_migrations_with_prefix("public.outbox") else {
+            panic!("expected invalid prefix error")
+        };
+
+        assert!(
+            matches!(err, OutboxError::InvalidTablePrefix(prefix) if prefix == "public.outbox")
+        );
+    }
+
+    #[test]
+    fn default_and_prefixed_migration_names_do_not_collide() {
+        let default = outbox_migrations();
+        let prefixed = outbox_migrations_with_prefix("mini_chat_outbox").unwrap();
+
+        assert_ne!(default[0].name(), prefixed[0].name());
+    }
+
+    #[test]
+    fn mysql_sequence_table_sql_uses_custom_prefix() {
+        let tables = OutboxTables::new("mini_chat_outbox").unwrap();
+
+        let body_create = mysql_create_id_sequence_sql(tables.body_id_sequence());
+        let incoming_create = mysql_create_id_sequence_sql(tables.incoming_id_sequence());
+        let body_seed = mysql_seed_id_sequence_sql(tables.body_id_sequence());
+        let incoming_seed = mysql_seed_id_sequence_sql(tables.incoming_id_sequence());
+
+        assert!(body_create.contains("mini_chat_outbox_body_id_sequence"));
+        assert!(incoming_create.contains("mini_chat_outbox_incoming_id_sequence"));
+        assert!(body_seed.contains("mini_chat_outbox_body_id_sequence"));
+        assert!(incoming_seed.contains("mini_chat_outbox_incoming_id_sequence"));
+        assert!(!body_create.contains("toolkit_outbox_body_id_sequence"));
+        assert!(!incoming_create.contains("toolkit_outbox_incoming_id_sequence"));
+    }
+
+    #[test]
+    fn mysql_sequence_table_sql_has_singleton_primary_key_and_seed() {
+        let tables = OutboxTables::default();
+
+        let create = mysql_create_id_sequence_sql(tables.body_id_sequence());
+        let seed = mysql_seed_id_sequence_sql(tables.body_id_sequence());
+
+        assert!(create.contains("slot    TINYINT PRIMARY KEY"));
+        assert!(create.contains("next_id BIGINT NOT NULL"));
+        assert_eq!(
+            seed,
+            "INSERT IGNORE INTO toolkit_outbox_body_id_sequence (slot, next_id) VALUES (1, 1)"
+        );
+    }
 }

--- a/libs/toolkit-db/src/outbox/mod.rs
+++ b/libs/toolkit-db/src/outbox/mod.rs
@@ -24,6 +24,8 @@
 //! # Usage
 //!
 //! ```ignore
+//! run_migrations_for_testing(&db, outbox_migrations()).await?;
+//!
 //! let handle = Outbox::builder(db)
 //!     .profile(OutboxProfile::low_latency())
 //!     .queue("orders", Partitions::of(4))
@@ -33,13 +35,36 @@
 //! handle.stop().await;
 //! ```
 //!
+//! Custom table prefixes are supported when migrations and runtime use the
+//! same validated prefix:
+//!
+//! ```ignore
+//! run_migrations_for_testing(&db, outbox_migrations_with_prefix("mini_chat_outbox")?).await?;
+//!
+//! let handle = Outbox::builder(db)
+//!     .table_prefix("mini_chat_outbox")?
+//!     .queue("orders", Partitions::of(4))
+//!         .leased(my_handler)
+//!     .start().await?;
+//! ```
+//!
+//! Prefix changes create a new outbox table family; they do not rename or move
+//! existing rows. Prefixes are validated as portable SQL identifiers because
+//! table and index names cannot be bound as SQL parameters.
+//! At runtime the validated table names and detected database backend are
+//! compiled once into an internal statement catalog; fixed SQL is not produced
+//! by repeated default-table-name replacement.
+//!
 //! # Backend notes
 //!
 //! - **`PostgreSQL`** — Full support. Uses `FOR UPDATE SKIP LOCKED` for partition
 //!   locking and `INSERT ... RETURNING` for body ID retrieval.
 //! - **`MySQL` 8.0+** — Requires `MySQL` 8.0 or later for `FOR UPDATE SKIP LOCKED`
 //!   support (added in 8.0.1). Earlier versions will fail at runtime when
-//!   attempting to acquire partition locks. Uses `LAST_INSERT_ID()` for body IDs.
+//!   attempting to acquire partition locks. Batch enqueue reserves explicit IDs
+//!   from `<prefix>_body_id_sequence` and `<prefix>_incoming_id_sequence` in a
+//!   fixed order; retry the whole transaction on deadlock or cluster
+//!   certification failures.
 //! - **`SQLite`** — Single-process only. `SQLite` has no row-level locking; the
 //!   outbox relies on `SQLite`'s single-writer model. Suitable for development,
 //!   testing, and single-instance deployments. Not recommended for production
@@ -93,8 +118,11 @@ mod handler;
 mod manager;
 mod migrations;
 pub(crate) mod prioritizer;
+mod statements;
 pub(crate) mod stats;
+mod store;
 mod strategy;
+mod tables;
 #[doc(hidden)]
 pub mod taskward;
 mod types;
@@ -115,7 +143,7 @@ pub use handler::{
     PerMessageAdapter, TransactionalHandler, TransactionalMessageHandler,
 };
 pub use manager::{OutboxBuilder, OutboxHandle};
-pub use migrations::outbox_migrations;
+pub use migrations::{outbox_migrations, outbox_migrations_with_prefix};
 pub use types::{
     EnqueueMessage, LeaseConfig, OutboxError, OutboxMessageId, OutboxProfile, Partitions,
     WorkerTuning,

--- a/libs/toolkit-db/src/outbox/statements.rs
+++ b/libs/toolkit-db/src/outbox/statements.rs
@@ -1,0 +1,945 @@
+#![allow(dead_code)]
+
+use sea_orm::DbBackend;
+
+use super::dialect::{AllocSql, Dialect, VacuumSql};
+use super::tables::OutboxTables;
+
+pub(super) struct OutboxStatements {
+    backend: DbBackend,
+    dialect: Dialect,
+    tables: OutboxTables,
+    registration: RegistrationStatements,
+    enqueue: EnqueueStatements,
+    sequencer: SequencerStatements,
+    processor: ProcessorStatements,
+    vacuum: VacuumStatements,
+    dead_letters: DeadLetterStatements,
+}
+
+pub(super) struct RegistrationStatements {
+    register_queue_select: String,
+    register_queue_insert: String,
+    insert_vacuum_counter_row: String,
+}
+
+pub(super) struct EnqueueStatements {
+    insert_body_and_incoming_cte: Option<String>,
+    insert_body: String,
+    insert_incoming: String,
+    body_id_reservation: Option<MySqlIdReservationStatements>,
+    incoming_id_reservation: Option<MySqlIdReservationStatements>,
+}
+
+pub(super) struct MySqlIdReservationStatements {
+    select_next_id_for_update: String,
+    advance_next_id: String,
+}
+
+pub(super) struct SequencerStatements {
+    allocate_sequences: AllocSql,
+    lock_partition: Option<String>,
+    discover_dirty_partitions: String,
+}
+
+pub(super) struct ProcessorStatements {
+    insert_processor_row: String,
+    lock_processor: Option<String>,
+    advance_processed_seq: String,
+    record_retry: String,
+    insert_dead_letter: String,
+    lease_acquire: String,
+    lease_ack_advance: String,
+    lease_record_retry: String,
+    lease_release: String,
+    read_processor: String,
+}
+
+pub(super) struct VacuumStatements {
+    cleanup: VacuumSql,
+    bump_counter: String,
+    fetch_dirty_partitions: String,
+    decrement_counter: String,
+    #[cfg(test)]
+    reset_counter: String,
+}
+
+pub(super) struct DeadLetterStatements {
+    select_columns: String,
+    count_base: String,
+    id_select_base: String,
+}
+
+impl OutboxStatements {
+    pub(super) fn new(backend: DbBackend, tables: &OutboxTables) -> Self {
+        let dialect = Dialect::from(backend);
+        Self {
+            backend,
+            dialect,
+            tables: tables.clone(),
+            registration: RegistrationStatements::new(dialect, tables),
+            enqueue: EnqueueStatements::new(dialect, tables),
+            sequencer: SequencerStatements::new(dialect, tables),
+            processor: ProcessorStatements::new(dialect, tables),
+            vacuum: VacuumStatements::new(dialect, tables),
+            dead_letters: DeadLetterStatements::new(tables),
+        }
+    }
+
+    pub(super) fn backend(&self) -> DbBackend {
+        self.backend
+    }
+
+    pub(super) fn dialect(&self) -> Dialect {
+        self.dialect
+    }
+
+    pub(super) fn tables(&self) -> &OutboxTables {
+        &self.tables
+    }
+
+    pub(super) fn registration(&self) -> &RegistrationStatements {
+        &self.registration
+    }
+
+    pub(super) fn enqueue(&self) -> &EnqueueStatements {
+        &self.enqueue
+    }
+
+    pub(super) fn sequencer(&self) -> &SequencerStatements {
+        &self.sequencer
+    }
+
+    pub(super) fn processor(&self) -> &ProcessorStatements {
+        &self.processor
+    }
+
+    pub(super) fn vacuum(&self) -> &VacuumStatements {
+        &self.vacuum
+    }
+
+    pub(super) fn dead_letters(&self) -> &DeadLetterStatements {
+        &self.dead_letters
+    }
+}
+
+impl RegistrationStatements {
+    fn new(dialect: Dialect, tables: &OutboxTables) -> Self {
+        Self {
+            register_queue_select: register_queue_select(dialect, tables),
+            register_queue_insert: register_queue_insert(dialect, tables),
+            insert_vacuum_counter_row: insert_vacuum_counter_row(dialect, tables),
+        }
+    }
+
+    pub(super) fn register_queue_select(&self) -> &str {
+        &self.register_queue_select
+    }
+
+    pub(super) fn register_queue_insert(&self) -> &str {
+        &self.register_queue_insert
+    }
+
+    pub(super) fn insert_vacuum_counter_row(&self) -> &str {
+        &self.insert_vacuum_counter_row
+    }
+}
+
+impl EnqueueStatements {
+    fn new(dialect: Dialect, tables: &OutboxTables) -> Self {
+        Self {
+            insert_body_and_incoming_cte: insert_body_and_incoming_cte(dialect, tables),
+            insert_body: insert_body(dialect, tables),
+            insert_incoming: insert_incoming(dialect, tables),
+            body_id_reservation: mysql_id_reservation(dialect, tables.body_id_sequence()),
+            incoming_id_reservation: mysql_id_reservation(dialect, tables.incoming_id_sequence()),
+        }
+    }
+
+    pub(super) fn insert_body_and_incoming_cte(&self) -> Option<&str> {
+        self.insert_body_and_incoming_cte.as_deref()
+    }
+
+    pub(super) fn insert_body(&self) -> &str {
+        &self.insert_body
+    }
+
+    pub(super) fn insert_incoming(&self) -> &str {
+        &self.insert_incoming
+    }
+
+    pub(super) fn body_id_reservation(&self) -> Option<&MySqlIdReservationStatements> {
+        self.body_id_reservation.as_ref()
+    }
+
+    pub(super) fn incoming_id_reservation(&self) -> Option<&MySqlIdReservationStatements> {
+        self.incoming_id_reservation.as_ref()
+    }
+}
+
+impl MySqlIdReservationStatements {
+    fn new(table: &str) -> Self {
+        Self {
+            select_next_id_for_update: format!(
+                "SELECT next_id FROM {table} WHERE slot = 1 FOR UPDATE"
+            ),
+            advance_next_id: format!("UPDATE {table} SET next_id = next_id + ? WHERE slot = 1"),
+        }
+    }
+
+    pub(super) fn select_next_id_for_update(&self) -> &str {
+        &self.select_next_id_for_update
+    }
+
+    pub(super) fn advance_next_id(&self) -> &str {
+        &self.advance_next_id
+    }
+}
+
+impl SequencerStatements {
+    fn new(dialect: Dialect, tables: &OutboxTables) -> Self {
+        Self {
+            allocate_sequences: allocate_sequences(dialect, tables),
+            lock_partition: lock_partition(dialect, tables),
+            discover_dirty_partitions: discover_dirty_partitions(tables),
+        }
+    }
+
+    pub(super) fn allocate_sequences(&self) -> &AllocSql {
+        &self.allocate_sequences
+    }
+
+    pub(super) fn lock_partition(&self) -> Option<&str> {
+        self.lock_partition.as_deref()
+    }
+
+    pub(super) fn discover_dirty_partitions(&self) -> &str {
+        &self.discover_dirty_partitions
+    }
+}
+
+impl ProcessorStatements {
+    fn new(dialect: Dialect, tables: &OutboxTables) -> Self {
+        Self {
+            insert_processor_row: insert_processor_row(dialect, tables),
+            lock_processor: lock_processor(dialect, tables),
+            advance_processed_seq: advance_processed_seq(dialect, tables),
+            record_retry: record_retry(dialect, tables),
+            insert_dead_letter: insert_dead_letter(dialect, tables),
+            lease_acquire: lease_acquire(dialect, tables),
+            lease_ack_advance: lease_ack_advance(dialect, tables),
+            lease_record_retry: lease_record_retry(dialect, tables),
+            lease_release: lease_release(dialect, tables),
+            read_processor: read_processor(dialect, tables),
+        }
+    }
+
+    pub(super) fn insert_processor_row(&self) -> &str {
+        &self.insert_processor_row
+    }
+
+    pub(super) fn lock_processor(&self) -> Option<&str> {
+        self.lock_processor.as_deref()
+    }
+
+    pub(super) fn advance_processed_seq(&self) -> &str {
+        &self.advance_processed_seq
+    }
+
+    pub(super) fn record_retry(&self) -> &str {
+        &self.record_retry
+    }
+
+    pub(super) fn insert_dead_letter(&self) -> &str {
+        &self.insert_dead_letter
+    }
+
+    pub(super) fn lease_acquire(&self) -> &str {
+        &self.lease_acquire
+    }
+
+    pub(super) fn lease_ack_advance(&self) -> &str {
+        &self.lease_ack_advance
+    }
+
+    pub(super) fn lease_record_retry(&self) -> &str {
+        &self.lease_record_retry
+    }
+
+    pub(super) fn lease_release(&self) -> &str {
+        &self.lease_release
+    }
+
+    pub(super) fn read_processor(&self) -> &str {
+        &self.read_processor
+    }
+}
+
+impl VacuumStatements {
+    fn new(dialect: Dialect, tables: &OutboxTables) -> Self {
+        Self {
+            cleanup: vacuum_cleanup(dialect, tables),
+            bump_counter: bump_vacuum_counter(dialect, tables),
+            fetch_dirty_partitions: fetch_vacuum_dirty_partitions(dialect, tables),
+            decrement_counter: decrement_vacuum_counter(dialect, tables),
+            #[cfg(test)]
+            reset_counter: reset_vacuum_counter(dialect, tables),
+        }
+    }
+
+    pub(super) fn cleanup(&self) -> &VacuumSql {
+        &self.cleanup
+    }
+
+    pub(super) fn bump_counter(&self) -> &str {
+        &self.bump_counter
+    }
+
+    pub(super) fn fetch_dirty_partitions(&self) -> &str {
+        &self.fetch_dirty_partitions
+    }
+
+    pub(super) fn decrement_counter(&self) -> &str {
+        &self.decrement_counter
+    }
+
+    #[cfg(test)]
+    pub(super) fn reset_counter(&self) -> &str {
+        &self.reset_counter
+    }
+}
+
+impl DeadLetterStatements {
+    fn new(tables: &OutboxTables) -> Self {
+        Self {
+            select_columns: format!(
+                "SELECT d.id, d.partition_id, d.seq, d.payload, d.payload_type, \
+                 d.created_at, d.failed_at, d.last_error, d.attempts, d.status, \
+                 d.completed_at, d.deadline FROM {} d",
+                tables.dead_letters()
+            ),
+            count_base: format!("SELECT COUNT(*) AS cnt FROM {} d", tables.dead_letters()),
+            id_select_base: format!("SELECT d.id FROM {} d", tables.dead_letters()),
+        }
+    }
+
+    pub(super) fn select_columns(&self) -> &str {
+        &self.select_columns
+    }
+
+    pub(super) fn count_base(&self) -> &str {
+        &self.count_base
+    }
+
+    pub(super) fn id_select_base(&self) -> &str {
+        &self.id_select_base
+    }
+}
+
+fn register_queue_select(dialect: Dialect, tables: &OutboxTables) -> String {
+    match dialect {
+        Dialect::Postgres | Dialect::Sqlite => format!(
+            "SELECT id FROM {} WHERE queue = $1 ORDER BY partition ASC",
+            tables.partitions()
+        ),
+        Dialect::MySql => format!(
+            "SELECT id FROM {} WHERE queue = ? ORDER BY `partition` ASC",
+            tables.partitions()
+        ),
+    }
+}
+
+fn register_queue_insert(dialect: Dialect, tables: &OutboxTables) -> String {
+    match dialect {
+        Dialect::Postgres => format!(
+            "INSERT INTO {} (queue, partition) \
+             VALUES ($1, $2) ON CONFLICT (queue, partition) DO NOTHING",
+            tables.partitions()
+        ),
+        Dialect::Sqlite => format!(
+            "INSERT OR IGNORE INTO {} (queue, partition) VALUES ($1, $2)",
+            tables.partitions()
+        ),
+        Dialect::MySql => format!(
+            "INSERT IGNORE INTO {} (queue, `partition`) VALUES (?, ?)",
+            tables.partitions()
+        ),
+    }
+}
+
+fn insert_body_and_incoming_cte(dialect: Dialect, tables: &OutboxTables) -> Option<String> {
+    match dialect {
+        Dialect::Postgres => Some(format!(
+            "WITH b AS (\
+               INSERT INTO {} (payload, payload_type) \
+               VALUES ($1, $2) RETURNING id\
+             ) \
+             INSERT INTO {} (partition_id, body_id) \
+             SELECT $3, id FROM b RETURNING id",
+            tables.body(),
+            tables.incoming()
+        )),
+        Dialect::Sqlite | Dialect::MySql => None,
+    }
+}
+
+fn insert_body(dialect: Dialect, tables: &OutboxTables) -> String {
+    match dialect {
+        Dialect::Postgres | Dialect::Sqlite => format!(
+            "INSERT INTO {} (payload, payload_type) VALUES ($1, $2) RETURNING id",
+            tables.body()
+        ),
+        Dialect::MySql => format!(
+            "INSERT INTO {} (payload, payload_type) VALUES (?, ?)",
+            tables.body()
+        ),
+    }
+}
+
+fn insert_incoming(dialect: Dialect, tables: &OutboxTables) -> String {
+    match dialect {
+        Dialect::Postgres | Dialect::Sqlite => format!(
+            "INSERT INTO {} (partition_id, body_id) VALUES ($1, $2) RETURNING id",
+            tables.incoming()
+        ),
+        Dialect::MySql => format!(
+            "INSERT INTO {} (partition_id, body_id) VALUES (?, ?)",
+            tables.incoming()
+        ),
+    }
+}
+
+fn mysql_id_reservation(
+    dialect: Dialect,
+    sequence_table: &str,
+) -> Option<MySqlIdReservationStatements> {
+    match dialect {
+        Dialect::MySql => Some(MySqlIdReservationStatements::new(sequence_table)),
+        Dialect::Postgres | Dialect::Sqlite => None,
+    }
+}
+
+fn allocate_sequences(dialect: Dialect, tables: &OutboxTables) -> AllocSql {
+    match dialect {
+        Dialect::Postgres | Dialect::Sqlite => AllocSql::UpdateReturning(format!(
+            "UPDATE {} \
+             SET sequence = sequence + $2 \
+             WHERE id = $1 \
+             RETURNING sequence - $2 AS start_seq",
+            tables.partitions()
+        )),
+        Dialect::MySql => AllocSql::UpdateThenSelect {
+            update: format!(
+                "UPDATE {} SET sequence = sequence + ? WHERE id = ?",
+                tables.partitions()
+            ),
+            select: format!(
+                "SELECT sequence - ? AS start_seq FROM {} WHERE id = ?",
+                tables.partitions()
+            ),
+        },
+    }
+}
+
+fn lock_partition(dialect: Dialect, tables: &OutboxTables) -> Option<String> {
+    match dialect {
+        Dialect::Postgres => Some(format!(
+            "SELECT id FROM {} WHERE id = $1 FOR UPDATE SKIP LOCKED",
+            tables.partitions()
+        )),
+        Dialect::MySql => Some(format!(
+            "SELECT id FROM {} WHERE id = ? FOR UPDATE SKIP LOCKED",
+            tables.partitions()
+        )),
+        Dialect::Sqlite => None,
+    }
+}
+
+fn discover_dirty_partitions(tables: &OutboxTables) -> String {
+    format!("SELECT DISTINCT partition_id FROM {}", tables.incoming())
+}
+
+fn insert_processor_row(dialect: Dialect, tables: &OutboxTables) -> String {
+    match dialect {
+        Dialect::Postgres => format!(
+            "INSERT INTO {} (partition_id) \
+             VALUES ($1) ON CONFLICT (partition_id) DO NOTHING",
+            tables.processor()
+        ),
+        Dialect::Sqlite => format!(
+            "INSERT OR IGNORE INTO {} (partition_id) VALUES ($1)",
+            tables.processor()
+        ),
+        Dialect::MySql => format!(
+            "INSERT IGNORE INTO {} (partition_id) VALUES (?)",
+            tables.processor()
+        ),
+    }
+}
+
+fn lock_processor(dialect: Dialect, tables: &OutboxTables) -> Option<String> {
+    match dialect {
+        Dialect::Postgres => Some(format!(
+            "SELECT partition_id, processed_seq, attempts \
+             FROM {} WHERE partition_id = $1 FOR UPDATE SKIP LOCKED",
+            tables.processor()
+        )),
+        Dialect::MySql => Some(format!(
+            "SELECT partition_id, processed_seq, attempts \
+             FROM {} WHERE partition_id = ? FOR UPDATE SKIP LOCKED",
+            tables.processor()
+        )),
+        Dialect::Sqlite => None,
+    }
+}
+
+fn advance_processed_seq(dialect: Dialect, tables: &OutboxTables) -> String {
+    match dialect {
+        Dialect::Postgres | Dialect::Sqlite => format!(
+            "UPDATE {} \
+             SET processed_seq = $1, attempts = 0, last_error = NULL \
+             WHERE partition_id = $2",
+            tables.processor()
+        ),
+        Dialect::MySql => format!(
+            "UPDATE {} \
+             SET processed_seq = ?, attempts = 0, last_error = NULL \
+             WHERE partition_id = ?",
+            tables.processor()
+        ),
+    }
+}
+
+fn record_retry(dialect: Dialect, tables: &OutboxTables) -> String {
+    match dialect {
+        Dialect::Postgres | Dialect::Sqlite => format!(
+            "UPDATE {} \
+             SET attempts = attempts + 1, last_error = $1 \
+             WHERE partition_id = $2",
+            tables.processor()
+        ),
+        Dialect::MySql => format!(
+            "UPDATE {} \
+             SET attempts = attempts + 1, last_error = ? \
+             WHERE partition_id = ?",
+            tables.processor()
+        ),
+    }
+}
+
+fn insert_dead_letter(dialect: Dialect, tables: &OutboxTables) -> String {
+    match dialect {
+        Dialect::Postgres | Dialect::Sqlite => format!(
+            "INSERT INTO {} \
+             (partition_id, seq, payload, payload_type, created_at, last_error, attempts) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7)",
+            tables.dead_letters()
+        ),
+        Dialect::MySql => format!(
+            "INSERT INTO {} \
+             (partition_id, seq, payload, payload_type, created_at, last_error, attempts) \
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
+            tables.dead_letters()
+        ),
+    }
+}
+
+fn lease_acquire(dialect: Dialect, tables: &OutboxTables) -> String {
+    match dialect {
+        Dialect::Postgres => format!(
+            "UPDATE {} \
+             SET locked_by = $1, locked_until = NOW() + $2 * INTERVAL '1 second', \
+                 attempts = attempts + 1 \
+             WHERE partition_id = $3 \
+               AND (locked_by IS NULL OR locked_until < NOW()) \
+             RETURNING processed_seq, attempts",
+            tables.processor()
+        ),
+        Dialect::Sqlite => format!(
+            "UPDATE {} \
+             SET locked_by = $1, locked_until = datetime('now', '+' || $2 || ' seconds'), \
+                 attempts = attempts + 1 \
+             WHERE partition_id = $3 \
+               AND (locked_by IS NULL OR locked_until < datetime('now')) \
+             RETURNING processed_seq, attempts",
+            tables.processor()
+        ),
+        Dialect::MySql => format!(
+            "UPDATE {} \
+             SET locked_by = ?, locked_until = DATE_ADD(NOW(6), INTERVAL ? SECOND), \
+                 attempts = attempts + 1 \
+             WHERE partition_id = ? \
+               AND (locked_by IS NULL OR locked_until < NOW(6))",
+            tables.processor()
+        ),
+    }
+}
+
+fn lease_ack_advance(dialect: Dialect, tables: &OutboxTables) -> String {
+    match dialect {
+        Dialect::Postgres | Dialect::Sqlite => format!(
+            "UPDATE {} \
+             SET processed_seq = $1, attempts = 0, last_error = NULL, \
+                 locked_by = NULL, locked_until = NULL \
+             WHERE partition_id = $2 AND locked_by = $3",
+            tables.processor()
+        ),
+        Dialect::MySql => format!(
+            "UPDATE {} \
+             SET processed_seq = ?, attempts = 0, last_error = NULL, \
+                 locked_by = NULL, locked_until = NULL \
+             WHERE partition_id = ? AND locked_by = ?",
+            tables.processor()
+        ),
+    }
+}
+
+fn lease_record_retry(dialect: Dialect, tables: &OutboxTables) -> String {
+    match dialect {
+        Dialect::Postgres | Dialect::Sqlite => format!(
+            "UPDATE {} \
+             SET last_error = $1, locked_by = NULL, locked_until = NULL \
+             WHERE partition_id = $2 AND locked_by = $3",
+            tables.processor()
+        ),
+        Dialect::MySql => format!(
+            "UPDATE {} \
+             SET last_error = ?, locked_by = NULL, locked_until = NULL \
+             WHERE partition_id = ? AND locked_by = ?",
+            tables.processor()
+        ),
+    }
+}
+
+fn lease_release(dialect: Dialect, tables: &OutboxTables) -> String {
+    match dialect {
+        Dialect::Postgres | Dialect::Sqlite => format!(
+            "UPDATE {} \
+             SET attempts = 0, locked_by = NULL, locked_until = NULL \
+             WHERE partition_id = $1 AND locked_by = $2",
+            tables.processor()
+        ),
+        Dialect::MySql => format!(
+            "UPDATE {} \
+             SET attempts = 0, locked_by = NULL, locked_until = NULL \
+             WHERE partition_id = ? AND locked_by = ?",
+            tables.processor()
+        ),
+    }
+}
+
+fn read_processor(dialect: Dialect, tables: &OutboxTables) -> String {
+    match dialect {
+        Dialect::Postgres | Dialect::Sqlite => format!(
+            "SELECT processed_seq, attempts FROM {} WHERE partition_id = $1",
+            tables.processor()
+        ),
+        Dialect::MySql => format!(
+            "SELECT processed_seq, attempts FROM {} WHERE partition_id = ?",
+            tables.processor()
+        ),
+    }
+}
+
+fn vacuum_cleanup(dialect: Dialect, tables: &OutboxTables) -> VacuumSql {
+    match dialect {
+        Dialect::Postgres | Dialect::Sqlite => VacuumSql {
+            select_outgoing_chunk: format!(
+                "SELECT id, body_id FROM {} \
+                 WHERE partition_id = $1 AND seq <= $2 \
+                 ORDER BY seq LIMIT $3",
+                tables.outgoing()
+            ),
+        },
+        Dialect::MySql => VacuumSql {
+            select_outgoing_chunk: format!(
+                "SELECT id, body_id FROM {} \
+                 WHERE partition_id = ? AND seq <= ? \
+                 ORDER BY seq LIMIT ?",
+                tables.outgoing()
+            ),
+        },
+    }
+}
+
+fn bump_vacuum_counter(dialect: Dialect, tables: &OutboxTables) -> String {
+    match dialect {
+        Dialect::Postgres | Dialect::Sqlite => format!(
+            "UPDATE {} SET counter = counter + 1 WHERE partition_id = $1",
+            tables.vacuum_counter()
+        ),
+        Dialect::MySql => format!(
+            "UPDATE {} SET counter = counter + 1 WHERE partition_id = ?",
+            tables.vacuum_counter()
+        ),
+    }
+}
+
+fn fetch_vacuum_dirty_partitions(dialect: Dialect, tables: &OutboxTables) -> String {
+    match dialect {
+        Dialect::Postgres | Dialect::Sqlite => format!(
+            "SELECT partition_id, counter \
+             FROM {} \
+             WHERE counter > 0 AND partition_id > $1 \
+             ORDER BY partition_id LIMIT $2",
+            tables.vacuum_counter()
+        ),
+        Dialect::MySql => format!(
+            "SELECT partition_id, counter \
+             FROM {} \
+             WHERE counter > 0 AND partition_id > ? \
+             ORDER BY partition_id LIMIT ?",
+            tables.vacuum_counter()
+        ),
+    }
+}
+
+fn decrement_vacuum_counter(dialect: Dialect, tables: &OutboxTables) -> String {
+    match dialect {
+        Dialect::Postgres => format!(
+            "UPDATE {} \
+             SET counter = GREATEST(counter - $1, 0) \
+             WHERE partition_id = $2",
+            tables.vacuum_counter()
+        ),
+        Dialect::Sqlite => format!(
+            "UPDATE {} \
+             SET counter = MAX(counter - $1, 0) \
+             WHERE partition_id = $2",
+            tables.vacuum_counter()
+        ),
+        Dialect::MySql => format!(
+            "UPDATE {} \
+             SET counter = GREATEST(counter - ?, 0) \
+             WHERE partition_id = ?",
+            tables.vacuum_counter()
+        ),
+    }
+}
+
+#[cfg(test)]
+fn reset_vacuum_counter(dialect: Dialect, tables: &OutboxTables) -> String {
+    match dialect {
+        Dialect::Postgres | Dialect::Sqlite => format!(
+            "UPDATE {} SET counter = 0 WHERE partition_id = $1",
+            tables.vacuum_counter()
+        ),
+        Dialect::MySql => format!(
+            "UPDATE {} SET counter = 0 WHERE partition_id = ?",
+            tables.vacuum_counter()
+        ),
+    }
+}
+
+fn insert_vacuum_counter_row(dialect: Dialect, tables: &OutboxTables) -> String {
+    match dialect {
+        Dialect::Postgres => format!(
+            "INSERT INTO {} (partition_id) \
+             VALUES ($1) ON CONFLICT (partition_id) DO NOTHING",
+            tables.vacuum_counter()
+        ),
+        Dialect::Sqlite => format!(
+            "INSERT OR IGNORE INTO {} (partition_id) VALUES ($1)",
+            tables.vacuum_counter()
+        ),
+        Dialect::MySql => format!(
+            "INSERT IGNORE INTO {} (partition_id) VALUES (?)",
+            tables.vacuum_counter()
+        ),
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    fn statements(backend: DbBackend) -> OutboxStatements {
+        OutboxStatements::new(backend, &OutboxTables::default())
+    }
+
+    #[test]
+    fn postgres_uses_dollar_placeholders() {
+        let statements = statements(DbBackend::Postgres);
+
+        assert!(statements.enqueue().insert_body().contains("$1"));
+        assert!(statements.enqueue().insert_body().contains("$2"));
+        assert!(statements.enqueue().insert_body().contains("RETURNING id"));
+        assert!(
+            statements
+                .registration()
+                .register_queue_insert()
+                .contains("ON CONFLICT")
+        );
+        assert!(statements.processor().lease_acquire().contains("$3"));
+    }
+
+    #[test]
+    fn sqlite_omits_lock_statements() {
+        let statements = statements(DbBackend::Sqlite);
+
+        assert!(statements.sequencer().lock_partition().is_none());
+        assert!(statements.processor().lock_processor().is_none());
+        assert!(statements.enqueue().insert_body().contains("RETURNING id"));
+    }
+
+    #[test]
+    fn mysql_uses_question_placeholders_and_lock_statements() {
+        let statements = statements(DbBackend::MySql);
+
+        assert!(statements.enqueue().insert_body().contains('?'));
+        assert!(!statements.enqueue().insert_body().contains('$'));
+        assert!(
+            statements
+                .enqueue()
+                .insert_body_and_incoming_cte()
+                .is_none()
+        );
+        assert!(
+            statements
+                .registration()
+                .register_queue_select()
+                .contains("`partition`")
+        );
+        assert!(
+            statements
+                .sequencer()
+                .lock_partition()
+                .expect("mysql lock partition")
+                .contains("FOR UPDATE SKIP LOCKED")
+        );
+        assert!(
+            statements
+                .processor()
+                .lock_processor()
+                .expect("mysql lock processor")
+                .contains("FOR UPDATE SKIP LOCKED")
+        );
+        assert!(
+            statements
+                .enqueue()
+                .body_id_reservation()
+                .expect("body id reservation")
+                .select_next_id_for_update()
+                .contains("toolkit_outbox_body_id_sequence")
+        );
+        assert!(
+            statements
+                .enqueue()
+                .incoming_id_reservation()
+                .expect("incoming id reservation")
+                .advance_next_id()
+                .contains("toolkit_outbox_incoming_id_sequence")
+        );
+    }
+
+    #[test]
+    fn statements_use_custom_prefix_without_replacing_inside_names() {
+        let tables = OutboxTables::new("toolkit_outbox_body").expect("valid prefix");
+        let statements = OutboxStatements::new(DbBackend::Postgres, &tables);
+
+        assert!(
+            statements
+                .enqueue()
+                .insert_body()
+                .contains("toolkit_outbox_body_body")
+        );
+        assert!(
+            statements
+                .enqueue()
+                .insert_incoming()
+                .contains("toolkit_outbox_body_incoming")
+        );
+        assert!(
+            statements
+                .processor()
+                .insert_dead_letter()
+                .contains("toolkit_outbox_body_dead_letters")
+        );
+        assert!(
+            !statements
+                .processor()
+                .insert_dead_letter()
+                .contains("toolkit_outbox_body_body_dead_letters")
+        );
+        assert!(
+            statements
+                .dead_letters()
+                .count_base()
+                .contains("toolkit_outbox_body_dead_letters")
+        );
+    }
+
+    #[test]
+    fn allocation_and_vacuum_groups_keep_backend_syntax() {
+        let pg = statements(DbBackend::Postgres);
+        match pg.sequencer().allocate_sequences() {
+            AllocSql::UpdateReturning(sql) => {
+                assert!(sql.contains("$1"));
+                assert!(sql.contains("$2"));
+                assert!(sql.contains("RETURNING sequence - $2"));
+            }
+            AllocSql::UpdateThenSelect { .. } => panic!("postgres should use returning"),
+        }
+        assert!(
+            pg.vacuum()
+                .cleanup()
+                .select_outgoing_chunk
+                .contains("LIMIT $3")
+        );
+
+        let mysql = statements(DbBackend::MySql);
+        match mysql.sequencer().allocate_sequences() {
+            AllocSql::UpdateReturning(_) => panic!("mysql should use update then select"),
+            AllocSql::UpdateThenSelect { update, select } => {
+                assert!(update.contains('?'));
+                assert!(select.contains('?'));
+                assert!(!update.contains('$'));
+                assert!(!select.contains('$'));
+            }
+        }
+        assert!(
+            mysql
+                .vacuum()
+                .cleanup()
+                .select_outgoing_chunk
+                .contains("LIMIT ?")
+        );
+    }
+
+    #[test]
+    fn registration_processor_vacuum_and_dead_letter_groups_are_present() {
+        let statements = statements(DbBackend::Postgres);
+
+        assert!(
+            statements
+                .registration()
+                .register_queue_select()
+                .contains("toolkit_outbox_partitions")
+        );
+        assert!(
+            statements
+                .registration()
+                .insert_vacuum_counter_row()
+                .contains("toolkit_outbox_vacuum_counter")
+        );
+        assert!(
+            statements
+                .processor()
+                .read_processor()
+                .contains("toolkit_outbox_processor")
+        );
+        assert!(
+            statements
+                .vacuum()
+                .fetch_dirty_partitions()
+                .contains("toolkit_outbox_vacuum_counter")
+        );
+        assert!(
+            statements
+                .dead_letters()
+                .select_columns()
+                .contains("toolkit_outbox_dead_letters")
+        );
+    }
+}

--- a/libs/toolkit-db/src/outbox/store.rs
+++ b/libs/toolkit-db/src/outbox/store.rs
@@ -1,0 +1,562 @@
+use sea_orm::{ConnectionTrait, DbBackend, DbErr, Statement};
+
+use super::dialect::{AllocSql, ClaimSql, Dialect, VacuumSql};
+use super::statements::{MySqlIdReservationStatements, OutboxStatements};
+use super::tables::OutboxTables;
+
+/// Runtime SQL context for one outbox table family on one database backend.
+///
+pub(super) struct OutboxStore<'a> {
+    statements: &'a OutboxStatements,
+}
+
+impl<'a> OutboxStore<'a> {
+    pub(super) fn new(statements: &'a OutboxStatements) -> Self {
+        Self { statements }
+    }
+
+    pub(super) fn backend(&self) -> DbBackend {
+        self.statements.backend()
+    }
+
+    pub(super) fn dialect(&self) -> Dialect {
+        self.statements.dialect()
+    }
+
+    pub(super) fn tables(&self) -> &OutboxTables {
+        self.statements.tables()
+    }
+
+    pub(super) fn register_queue_select(&self) -> &str {
+        self.statements.registration().register_queue_select()
+    }
+
+    pub(super) fn register_queue_insert(&self) -> &str {
+        self.statements.registration().register_queue_insert()
+    }
+
+    pub(super) async fn exec_insert_body_batch(
+        &self,
+        conn: &dyn ConnectionTrait,
+        payloads: &[(&[u8], &str)],
+    ) -> Result<Vec<i64>, DbErr> {
+        if payloads.is_empty() {
+            return Ok(Vec::new());
+        }
+        if self.backend() == DbBackend::MySql {
+            let reservation = self
+                .statements
+                .enqueue()
+                .body_id_reservation()
+                .ok_or_else(|| DbErr::Custom("missing MySQL body ID reservation SQL".to_owned()))?;
+            let ids = self
+                .reserve_mysql_ids(conn, reservation, payloads.len(), "body")
+                .await?;
+            let sql = self.build_insert_body_batch_with_ids(payloads.len());
+            let mut values: Vec<sea_orm::Value> = Vec::with_capacity(payloads.len() * 3);
+            for (id, &(payload, payload_type)) in ids.iter().zip(payloads) {
+                values.push((*id).into());
+                values.push(payload.to_vec().into());
+                values.push(payload_type.into());
+            }
+            conn.execute(Statement::from_sql_and_values(self.backend(), &sql, values))
+                .await?;
+            return Ok(ids);
+        }
+
+        let sql = self
+            .dialect()
+            .build_insert_body_batch(self.tables(), payloads.len());
+        let mut values: Vec<sea_orm::Value> = Vec::with_capacity(payloads.len() * 2);
+        for &(payload, payload_type) in payloads {
+            values.push(payload.to_vec().into());
+            values.push(payload_type.into());
+        }
+
+        if self.dialect().supports_returning() {
+            let rows = conn
+                .query_all(Statement::from_sql_and_values(self.backend(), &sql, values))
+                .await?;
+            rows.iter()
+                .map(|r| {
+                    r.try_get_by_index(0)
+                        .map_err(|e| DbErr::Custom(format!("body id column: {e}")))
+                })
+                .collect()
+        } else {
+            conn.execute(Statement::from_sql_and_values(self.backend(), &sql, values))
+                .await?;
+            let row = conn
+                .query_one(Statement::from_string(
+                    self.backend(),
+                    Dialect::last_insert_id(),
+                ))
+                .await?
+                .ok_or_else(|| {
+                    DbErr::Custom("LAST_INSERT_ID() returned no row for body batch".to_owned())
+                })?;
+            let first_id: i64 = row
+                .try_get_by_index(0)
+                .map_err(|e| DbErr::Custom(format!("body first_id column: {e}")))?;
+            #[allow(clippy::cast_possible_wrap)]
+            Ok((0..payloads.len() as i64).map(|i| first_id + i).collect())
+        }
+    }
+
+    pub(super) async fn exec_insert_incoming_batch(
+        &self,
+        conn: &dyn ConnectionTrait,
+        entries: &[(i64, i64)],
+    ) -> Result<Vec<i64>, DbErr> {
+        if entries.is_empty() {
+            return Ok(Vec::new());
+        }
+        if self.backend() == DbBackend::MySql {
+            let reservation = self
+                .statements
+                .enqueue()
+                .incoming_id_reservation()
+                .ok_or_else(|| {
+                    DbErr::Custom("missing MySQL incoming ID reservation SQL".to_owned())
+                })?;
+            let ids = self
+                .reserve_mysql_ids(conn, reservation, entries.len(), "incoming")
+                .await?;
+            let sql = self.build_insert_incoming_batch_with_ids(entries.len());
+            let mut values: Vec<sea_orm::Value> = Vec::with_capacity(entries.len() * 3);
+            for (id, &(partition_id, body_id)) in ids.iter().zip(entries) {
+                values.push((*id).into());
+                values.push(partition_id.into());
+                values.push(body_id.into());
+            }
+            conn.execute(Statement::from_sql_and_values(self.backend(), &sql, values))
+                .await?;
+            return Ok(ids);
+        }
+
+        let sql = self
+            .dialect()
+            .build_insert_incoming_batch(self.tables(), entries.len());
+        let mut values: Vec<sea_orm::Value> = Vec::with_capacity(entries.len() * 2);
+        for &(partition_id, body_id) in entries {
+            values.push(partition_id.into());
+            values.push(body_id.into());
+        }
+
+        if self.dialect().supports_returning() {
+            let rows = conn
+                .query_all(Statement::from_sql_and_values(self.backend(), &sql, values))
+                .await?;
+            rows.iter()
+                .map(|r| {
+                    r.try_get_by_index(0)
+                        .map_err(|e| DbErr::Custom(format!("incoming id column: {e}")))
+                })
+                .collect()
+        } else {
+            conn.execute(Statement::from_sql_and_values(self.backend(), &sql, values))
+                .await?;
+            let row = conn
+                .query_one(Statement::from_string(
+                    self.backend(),
+                    Dialect::last_insert_id(),
+                ))
+                .await?
+                .ok_or_else(|| {
+                    DbErr::Custom("LAST_INSERT_ID() returned no row for incoming batch".to_owned())
+                })?;
+            let first_id: i64 = row
+                .try_get_by_index(0)
+                .map_err(|e| DbErr::Custom(format!("incoming first_id column: {e}")))?;
+            #[allow(clippy::cast_possible_wrap)]
+            Ok((0..entries.len() as i64).map(|i| first_id + i).collect())
+        }
+    }
+
+    /// Execute an INSERT and return the generated `id` column.
+    ///
+    /// Encapsulates RETURNING (Postgres/SQLite) vs `LAST_INSERT_ID` (`MySQL`).
+    async fn exec_insert_returning_id(
+        &self,
+        conn: &dyn ConnectionTrait,
+        sql: &str,
+        params: Vec<sea_orm::Value>,
+        context: &str,
+    ) -> Result<i64, DbErr> {
+        if self.dialect().supports_returning() {
+            let row = conn
+                .query_one(Statement::from_sql_and_values(self.backend(), sql, params))
+                .await?
+                .ok_or_else(|| {
+                    DbErr::Custom(format!("INSERT RETURNING returned no row for {context}"))
+                })?;
+            row.try_get_by_index(0)
+                .map_err(|e| DbErr::Custom(format!("{context} id column: {e}")))
+        } else {
+            conn.execute(Statement::from_sql_and_values(self.backend(), sql, params))
+                .await?;
+            let row = conn
+                .query_one(Statement::from_string(
+                    self.backend(),
+                    Dialect::last_insert_id(),
+                ))
+                .await?
+                .ok_or_else(|| {
+                    DbErr::Custom(format!("LAST_INSERT_ID() returned no row for {context}"))
+                })?;
+            row.try_get_by_index(0)
+                .map_err(|e| DbErr::Custom(format!("{context} id column: {e}")))
+        }
+    }
+
+    /// Execute a single body INSERT and return the generated ID.
+    async fn exec_insert_body(
+        &self,
+        conn: &dyn ConnectionTrait,
+        payload: Vec<u8>,
+        payload_type: &str,
+    ) -> Result<i64, DbErr> {
+        if self.backend() == DbBackend::MySql {
+            let payloads = [(payload.as_slice(), payload_type)];
+            let mut ids = self.exec_insert_body_batch(conn, &payloads).await?;
+            return ids
+                .pop()
+                .ok_or_else(|| DbErr::Custom("body insert returned no id".to_owned()));
+        }
+
+        let sql = self.statements.enqueue().insert_body();
+        self.exec_insert_returning_id(conn, sql, vec![payload.into(), payload_type.into()], "body")
+            .await
+    }
+
+    /// Execute a single incoming INSERT and return the generated ID.
+    async fn exec_insert_incoming(
+        &self,
+        conn: &dyn ConnectionTrait,
+        partition_id: i64,
+        body_id: i64,
+    ) -> Result<i64, DbErr> {
+        if self.backend() == DbBackend::MySql {
+            let entries = [(partition_id, body_id)];
+            let mut ids = self.exec_insert_incoming_batch(conn, &entries).await?;
+            return ids
+                .pop()
+                .ok_or_else(|| DbErr::Custom("incoming insert returned no id".to_owned()));
+        }
+
+        let sql = self.statements.enqueue().insert_incoming();
+        self.exec_insert_returning_id(
+            conn,
+            sql,
+            vec![partition_id.into(), body_id.into()],
+            "incoming",
+        )
+        .await
+    }
+
+    pub(super) async fn exec_insert_body_and_incoming(
+        &self,
+        conn: &dyn ConnectionTrait,
+        partition_id: i64,
+        payload: Vec<u8>,
+        payload_type: &str,
+    ) -> Result<i64, DbErr> {
+        if let Some(cte) = self.statements.enqueue().insert_body_and_incoming_cte() {
+            self.exec_insert_returning_id(
+                conn,
+                cte,
+                vec![payload.into(), payload_type.into(), partition_id.into()],
+                "incoming",
+            )
+            .await
+        } else {
+            // MySQL: two separate round-trips (no CTE INSERT support).
+            let body_id = self.exec_insert_body(conn, payload, payload_type).await?;
+            self.exec_insert_incoming(conn, partition_id, body_id).await
+        }
+    }
+
+    pub(super) fn lock_partition(&self) -> Option<&str> {
+        self.statements.sequencer().lock_partition()
+    }
+
+    pub(super) fn discover_dirty_partitions(&self) -> &str {
+        self.statements.sequencer().discover_dirty_partitions()
+    }
+
+    pub(super) fn insert_processor_row(&self) -> &str {
+        self.statements.processor().insert_processor_row()
+    }
+
+    pub(super) fn lock_processor(&self) -> Option<&str> {
+        self.statements.processor().lock_processor()
+    }
+
+    pub(super) fn read_outgoing_batch(&self, batch_size: u32) -> String {
+        self.dialect()
+            .read_outgoing_batch(self.tables(), batch_size)
+    }
+
+    pub(super) fn build_read_body_batch(&self, count: usize) -> String {
+        self.dialect().build_read_body_batch(self.tables(), count)
+    }
+
+    pub(super) fn advance_processed_seq(&self) -> &str {
+        self.statements.processor().advance_processed_seq()
+    }
+
+    pub(super) fn record_retry(&self) -> &str {
+        self.statements.processor().record_retry()
+    }
+
+    pub(super) fn insert_dead_letter(&self) -> &str {
+        self.statements.processor().insert_dead_letter()
+    }
+
+    pub(super) fn lease_ack_advance(&self) -> &str {
+        self.statements.processor().lease_ack_advance()
+    }
+
+    pub(super) fn lease_record_retry(&self) -> &str {
+        self.statements.processor().lease_record_retry()
+    }
+
+    pub(super) fn lease_release(&self) -> &str {
+        self.statements.processor().lease_release()
+    }
+
+    pub(super) async fn exec_lease_acquire(
+        &self,
+        conn: &dyn ConnectionTrait,
+        lease_id: &str,
+        lease_secs: i64,
+        partition_id: i64,
+    ) -> Result<Option<(i64, i16)>, DbErr> {
+        let lease_acquire = self.statements.processor().lease_acquire();
+        if self.dialect().supports_returning() {
+            let row = conn
+                .query_one(Statement::from_sql_and_values(
+                    self.backend(),
+                    lease_acquire,
+                    [lease_id.into(), lease_secs.into(), partition_id.into()],
+                ))
+                .await?;
+            match row {
+                Some(r) => {
+                    let processed_seq: i64 = r
+                        .try_get_by_index(0)
+                        .map_err(|e| DbErr::Custom(format!("processed_seq column: {e}")))?;
+                    let attempts: i16 = r
+                        .try_get_by_index(1)
+                        .map_err(|e| DbErr::Custom(format!("attempts column: {e}")))?;
+                    Ok(Some((processed_seq, attempts)))
+                }
+                None => Ok(None),
+            }
+        } else {
+            let result = conn
+                .execute(Statement::from_sql_and_values(
+                    self.backend(),
+                    lease_acquire,
+                    [lease_id.into(), lease_secs.into(), partition_id.into()],
+                ))
+                .await?;
+            if result.rows_affected() == 0 {
+                return Ok(None);
+            }
+            let read_processor = self.read_processor();
+            let row = conn
+                .query_one(Statement::from_sql_and_values(
+                    self.backend(),
+                    read_processor,
+                    [partition_id.into()],
+                ))
+                .await?;
+            match row {
+                Some(r) => {
+                    let processed_seq: i64 = r
+                        .try_get_by_index(0)
+                        .map_err(|e| DbErr::Custom(format!("processed_seq column: {e}")))?;
+                    let attempts: i16 = r
+                        .try_get_by_index(1)
+                        .map_err(|e| DbErr::Custom(format!("attempts column: {e}")))?;
+                    Ok(Some((processed_seq, attempts)))
+                }
+                None => Ok(None),
+            }
+        }
+    }
+
+    pub(super) fn claim_incoming(&self, batch_size: u32) -> ClaimSql {
+        self.dialect().claim_incoming(self.tables(), batch_size)
+    }
+
+    pub(super) fn delete_incoming_batch(&self, count: usize) -> String {
+        self.dialect().delete_incoming_batch(self.tables(), count)
+    }
+
+    pub(super) fn allocate_sequences(&self) -> &AllocSql {
+        self.statements.sequencer().allocate_sequences()
+    }
+
+    pub(super) fn build_insert_outgoing_batch(&self, count: usize) -> String {
+        self.dialect()
+            .build_insert_outgoing_batch(self.tables(), count)
+    }
+
+    pub(super) fn vacuum_cleanup(&self) -> &VacuumSql {
+        self.statements.vacuum().cleanup()
+    }
+
+    pub(super) fn build_delete_outgoing_batch(&self, count: usize) -> String {
+        self.dialect()
+            .build_delete_outgoing_batch(self.tables(), count)
+    }
+
+    pub(super) fn build_delete_body_batch(&self, count: usize) -> String {
+        self.dialect().build_delete_body_batch(self.tables(), count)
+    }
+
+    pub(super) fn read_processor(&self) -> &str {
+        self.statements.processor().read_processor()
+    }
+
+    pub(super) fn bump_vacuum_counter(&self) -> &str {
+        self.statements.vacuum().bump_counter()
+    }
+
+    pub(super) fn fetch_dirty_partitions(&self) -> &str {
+        self.statements.vacuum().fetch_dirty_partitions()
+    }
+
+    pub(super) fn decrement_vacuum_counter(&self) -> &str {
+        self.statements.vacuum().decrement_counter()
+    }
+
+    #[cfg(test)]
+    pub(super) fn reset_vacuum_counter(&self) -> &str {
+        self.statements.vacuum().reset_counter()
+    }
+
+    pub(super) fn insert_vacuum_counter_row(&self) -> &str {
+        self.statements.registration().insert_vacuum_counter_row()
+    }
+
+    pub(super) fn dead_letter_select_columns(&self) -> &str {
+        self.statements.dead_letters().select_columns()
+    }
+
+    pub(super) fn dead_letter_count_base(&self) -> &str {
+        self.statements.dead_letters().count_base()
+    }
+
+    pub(super) fn dead_letter_id_select_base(&self) -> &str {
+        self.statements.dead_letters().id_select_base()
+    }
+
+    async fn reserve_mysql_ids(
+        &self,
+        conn: &dyn ConnectionTrait,
+        reservation: &MySqlIdReservationStatements,
+        count: usize,
+        context: &str,
+    ) -> Result<Vec<i64>, DbErr> {
+        let count = i64::try_from(count)
+            .map_err(|e| DbErr::Custom(format!("{context} batch too large: {e}")))?;
+        let row = conn
+            .query_one(Statement::from_string(
+                self.backend(),
+                reservation.select_next_id_for_update(),
+            ))
+            .await?
+            .ok_or_else(|| {
+                DbErr::Custom(format!(
+                    "MySQL {context} ID sequence table returned no singleton row"
+                ))
+            })?;
+        let first_id: i64 = row
+            .try_get_by_index(0)
+            .map_err(|e| DbErr::Custom(format!("{context} next_id column: {e}")))?;
+
+        conn.execute(Statement::from_sql_and_values(
+            self.backend(),
+            reservation.advance_next_id(),
+            [count.into()],
+        ))
+        .await?;
+
+        Ok((0..count).map(|offset| first_id + offset).collect())
+    }
+
+    fn build_insert_body_batch_with_ids(&self, count: usize) -> String {
+        let mut sql = format!(
+            "INSERT INTO {} (id, payload, payload_type) VALUES ",
+            self.tables().body()
+        );
+        append_mysql_value_tuples(&mut sql, count, 3);
+        sql
+    }
+
+    fn build_insert_incoming_batch_with_ids(&self, count: usize) -> String {
+        let mut sql = format!(
+            "INSERT INTO {} (id, partition_id, body_id) VALUES ",
+            self.tables().incoming()
+        );
+        append_mysql_value_tuples(&mut sql, count, 3);
+        sql
+    }
+}
+
+fn append_mysql_value_tuples(sql: &mut String, row_count: usize, cols: usize) {
+    for row in 0..row_count {
+        if row > 0 {
+            sql.push_str(", ");
+        }
+        sql.push('(');
+        for col in 0..cols {
+            if col > 0 {
+                sql.push_str(", ");
+            }
+            sql.push('?');
+        }
+        sql.push(')');
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use sea_orm::DbBackend;
+
+    use super::*;
+    use crate::outbox::tables::OutboxTables;
+
+    fn mysql_store() -> OutboxStore<'static> {
+        let tables = OutboxTables::default();
+        let statements = OutboxStatements::new(DbBackend::MySql, &tables);
+        let leaked = Box::leak(Box::new(statements));
+        OutboxStore::new(leaked)
+    }
+
+    #[test]
+    fn mysql_explicit_body_insert_includes_ids() {
+        let store = mysql_store();
+        let sql = store.build_insert_body_batch_with_ids(2);
+
+        assert_eq!(
+            sql,
+            "INSERT INTO toolkit_outbox_body (id, payload, payload_type) VALUES (?, ?, ?), (?, ?, ?)"
+        );
+    }
+
+    #[test]
+    fn mysql_explicit_incoming_insert_includes_ids() {
+        let store = mysql_store();
+        let sql = store.build_insert_incoming_batch_with_ids(2);
+
+        assert_eq!(
+            sql,
+            "INSERT INTO toolkit_outbox_incoming (id, partition_id, body_id) VALUES (?, ?, ?), (?, ?, ?)"
+        );
+    }
+}

--- a/libs/toolkit-db/src/outbox/strategy.rs
+++ b/libs/toolkit-db/src/outbox/strategy.rs
@@ -1,17 +1,16 @@
 use std::collections::HashMap;
 
 use super::batch::Batch;
-use super::dialect::Dialect;
 use super::handler::{HandlerResult, LeasedHandler, OutboxMessage, TransactionalHandler};
+use super::store::OutboxStore;
 use super::types::{LeaseConfig, OutboxError};
 use crate::Db;
-use sea_orm::{ConnectionTrait, DbBackend, FromQueryResult, Statement, TransactionTrait};
+use sea_orm::{ConnectionTrait, FromQueryResult, Statement, TransactionTrait};
 
 /// Context for processing a single partition's batch.
 pub struct ProcessContext<'a> {
     pub db: &'a Db,
-    pub backend: DbBackend,
-    pub dialect: Dialect,
+    pub store: OutboxStore<'a>,
     pub partition_id: i64,
 }
 
@@ -71,8 +70,7 @@ struct BodyRow {
 
 async fn read_messages(
     txn: &impl ConnectionTrait,
-    backend: DbBackend,
-    dialect: &Dialect,
+    store: &OutboxStore<'_>,
     partition_id: i64,
     proc_row: &ProcessorRow,
     msg_batch_size: u32,
@@ -80,8 +78,8 @@ async fn read_messages(
     // Use seq > processed_seq (not seq >= processed_seq + 1) - the cursor
     // stores the last processed seq, so `>` is the natural predicate.
     let outgoing_rows = OutgoingRow::find_by_statement(Statement::from_sql_and_values(
-        backend,
-        dialect.read_outgoing_batch(msg_batch_size),
+        store.backend(),
+        store.read_outgoing_batch(msg_batch_size),
         [partition_id.into(), proc_row.processed_seq.into()],
     ))
     .all(txn)
@@ -93,10 +91,10 @@ async fn read_messages(
 
     // Batch body read: single SELECT ... WHERE id IN (...) instead of N+1 queries
     let body_ids: Vec<i64> = outgoing_rows.iter().map(|r| r.body_id).collect();
-    let body_sql = dialect.build_read_body_batch(body_ids.len());
+    let body_sql = store.build_read_body_batch(body_ids.len());
     let body_values: Vec<sea_orm::Value> = body_ids.iter().map(|&id| id.into()).collect();
     let body_rows = BodyRow::find_by_statement(Statement::from_sql_and_values(
-        backend,
+        store.backend(),
         &body_sql,
         body_values,
     ))
@@ -131,8 +129,7 @@ async fn read_messages(
 /// Vacuum handles cleanup of processed outgoing + body rows.
 async fn ack(
     txn: &impl ConnectionTrait,
-    backend: DbBackend,
-    dialect: &Dialect,
+    store: &OutboxStore<'_>,
     partition_id: i64,
     msgs: &[OutboxMessage],
     result: &HandlerResult,
@@ -142,22 +139,22 @@ async fn ack(
     match result {
         HandlerResult::Success => {
             txn.execute(Statement::from_sql_and_values(
-                backend,
-                dialect.advance_processed_seq(),
+                store.backend(),
+                store.advance_processed_seq(),
                 [last_seq.into(), partition_id.into()],
             ))
             .await?;
             txn.execute(Statement::from_sql_and_values(
-                backend,
-                dialect.bump_vacuum_counter(),
+                store.backend(),
+                store.bump_vacuum_counter(),
                 [partition_id.into()],
             ))
             .await?;
         }
         HandlerResult::Retry { reason } => {
             txn.execute(Statement::from_sql_and_values(
-                backend,
-                dialect.record_retry(),
+                store.backend(),
+                store.record_retry(),
                 [reason.as_str().into(), partition_id.into()],
             ))
             .await?;
@@ -165,8 +162,8 @@ async fn ack(
         HandlerResult::Reject { reason } => {
             for msg in msgs {
                 txn.execute(Statement::from_sql_and_values(
-                    backend,
-                    dialect.insert_dead_letter(),
+                    store.backend(),
+                    store.insert_dead_letter(),
                     [
                         partition_id.into(),
                         msg.seq.into(),
@@ -181,14 +178,14 @@ async fn ack(
             }
 
             txn.execute(Statement::from_sql_and_values(
-                backend,
-                dialect.advance_processed_seq(),
+                store.backend(),
+                store.advance_processed_seq(),
                 [last_seq.into(), partition_id.into()],
             ))
             .await?;
             txn.execute(Statement::from_sql_and_values(
-                backend,
-                dialect.bump_vacuum_counter(),
+                store.backend(),
+                store.bump_vacuum_counter(),
                 [partition_id.into()],
             ))
             .await?;
@@ -200,14 +197,13 @@ async fn ack(
 
 async fn try_lock_and_read_state(
     txn: &impl ConnectionTrait,
-    backend: DbBackend,
-    dialect: &Dialect,
+    store: &OutboxStore<'_>,
     partition_id: i64,
 ) -> Result<Option<ProcessorRow>, OutboxError> {
-    if let Some(lock_sql) = dialect.lock_processor() {
+    if let Some(lock_sql) = store.lock_processor() {
         let row = txn
             .query_one(Statement::from_sql_and_values(
-                backend,
+                store.backend(),
                 lock_sql,
                 [partition_id.into()],
             ))
@@ -218,8 +214,8 @@ async fn try_lock_and_read_state(
     }
 
     let proc_row = ProcessorRow::find_by_statement(Statement::from_sql_and_values(
-        backend,
-        dialect.read_processor(),
+        store.backend(),
+        store.read_processor(),
         [partition_id.into()],
     ))
     .one(txn)
@@ -251,8 +247,7 @@ impl ProcessingStrategy for TransactionalStrategy {
         let conn = ctx.db.sea_internal();
         let txn = conn.begin().await?;
 
-        let Some(proc_row) =
-            try_lock_and_read_state(&txn, ctx.backend, &ctx.dialect, ctx.partition_id).await?
+        let Some(proc_row) = try_lock_and_read_state(&txn, &ctx.store, ctx.partition_id).await?
         else {
             txn.commit().await?;
             return Ok(None);
@@ -260,8 +255,7 @@ impl ProcessingStrategy for TransactionalStrategy {
 
         let msgs = read_messages(
             &txn,
-            ctx.backend,
-            &ctx.dialect,
+            &ctx.store,
             ctx.partition_id,
             &proc_row,
             msg_batch_size,
@@ -286,15 +280,7 @@ impl ProcessingStrategy for TransactionalStrategy {
         // the handler's successful work is atomic with the cursor advance.
         // The `processed_count` is still recorded in ProcessResult so the
         // PartitionMode state machine can degrade batch size intelligently.
-        ack(
-            &txn,
-            ctx.backend,
-            &ctx.dialect,
-            ctx.partition_id,
-            &msgs,
-            &result,
-        )
-        .await?;
+        ack(&txn, &ctx.store, ctx.partition_id, &msgs, &result).await?;
 
         txn.commit().await?;
 
@@ -321,8 +307,8 @@ async fn acquire_lease_and_read(
     let txn = sea_conn.begin().await?;
 
     let proc_row = ctx
-        .dialect
-        .exec_lease_acquire(&txn, ctx.backend, lease_id, lease_secs, ctx.partition_id)
+        .store
+        .exec_lease_acquire(&txn, lease_id, lease_secs, ctx.partition_id)
         .await?
         .map(|(processed_seq, attempts)| ProcessorRow {
             processed_seq,
@@ -339,8 +325,7 @@ async fn acquire_lease_and_read(
 
     let msgs = read_messages(
         &txn,
-        ctx.backend,
-        &ctx.dialect,
+        &ctx.store,
         ctx.partition_id,
         &proc_row,
         msg_batch_size,
@@ -358,8 +343,8 @@ async fn acquire_lease_and_read(
         // empty cycles.
         let conn = ctx.db.sea_internal();
         conn.execute(Statement::from_sql_and_values(
-            ctx.backend,
-            ctx.dialect.lease_release(),
+            ctx.store.backend(),
+            ctx.store.lease_release(),
             [ctx.partition_id.into(), lease_id.into()],
         ))
         .await?;
@@ -395,8 +380,8 @@ async fn advance_cursor(
 ) -> Result<bool, OutboxError> {
     if seq == 0 {
         txn.execute(Statement::from_sql_and_values(
-            ctx.backend,
-            ctx.dialect.lease_release(),
+            ctx.store.backend(),
+            ctx.store.lease_release(),
             [ctx.partition_id.into(), lease_id.into()],
         ))
         .await?;
@@ -405,8 +390,8 @@ async fn advance_cursor(
 
     let res = txn
         .execute(Statement::from_sql_and_values(
-            ctx.backend,
-            ctx.dialect.lease_ack_advance(),
+            ctx.store.backend(),
+            ctx.store.lease_ack_advance(),
             [seq.into(), ctx.partition_id.into(), lease_id.into()],
         ))
         .await?;
@@ -415,8 +400,8 @@ async fn advance_cursor(
     }
 
     txn.execute(Statement::from_sql_and_values(
-        ctx.backend,
-        ctx.dialect.bump_vacuum_counter(),
+        ctx.store.backend(),
+        ctx.store.bump_vacuum_counter(),
         [ctx.partition_id.into()],
     ))
     .await?;
@@ -433,8 +418,8 @@ async fn record_retry(
 ) -> Result<bool, OutboxError> {
     let res = txn
         .execute(Statement::from_sql_and_values(
-            ctx.backend,
-            ctx.dialect.lease_record_retry(),
+            ctx.store.backend(),
+            ctx.store.lease_record_retry(),
             [reason.into(), ctx.partition_id.into(), lease_id.into()],
         ))
         .await?;
@@ -524,8 +509,8 @@ async fn insert_dead_letter(
     reason: &str,
 ) -> Result<(), OutboxError> {
     txn.execute(Statement::from_sql_and_values(
-        ctx.backend,
-        ctx.dialect.insert_dead_letter(),
+        ctx.store.backend(),
+        ctx.store.insert_dead_letter(),
         [
             ctx.partition_id.into(),
             msg.seq.into(),

--- a/libs/toolkit-db/src/outbox/tables.rs
+++ b/libs/toolkit-db/src/outbox/tables.rs
@@ -1,0 +1,374 @@
+use super::types::OutboxError;
+
+pub const DEFAULT_OUTBOX_TABLE_PREFIX: &str = "toolkit_outbox";
+pub const DEFAULT_OUTBOX_MIGRATION_NAME: &str = "m001_create_toolkit_outbox_schema";
+
+const MAX_IDENTIFIER_LEN: usize = 63;
+const MAX_PREFIX_LEN: usize = 36;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutboxTables {
+    prefix: String,
+    body: String,
+    partitions: String,
+    incoming: String,
+    outgoing: String,
+    dead_letters: String,
+    processor: String,
+    vacuum_counter: String,
+    body_id_sequence: String,
+    incoming_id_sequence: String,
+    idx_incoming_partition: String,
+    idx_incoming_body_id: String,
+    idx_outgoing_partition_seq: String,
+    idx_outgoing_body_id: String,
+    idx_dl_replayable: String,
+    idx_dl_status_deadline: String,
+    idx_dl_status_failed: String,
+    migration_name: String,
+}
+
+impl Default for OutboxTables {
+    fn default() -> Self {
+        match Self::new(DEFAULT_OUTBOX_TABLE_PREFIX) {
+            Ok(tables) => tables,
+            Err(err) => panic!("default outbox prefix is invalid: {err}"),
+        }
+    }
+}
+
+impl OutboxTables {
+    pub(crate) fn new(prefix: impl Into<String>) -> Result<Self, OutboxError> {
+        let prefix = prefix.into();
+        validate_prefix(&prefix)?;
+
+        let tables = Self {
+            body: suffixed(&prefix, "body"),
+            partitions: suffixed(&prefix, "partitions"),
+            incoming: suffixed(&prefix, "incoming"),
+            outgoing: suffixed(&prefix, "outgoing"),
+            dead_letters: suffixed(&prefix, "dead_letters"),
+            processor: suffixed(&prefix, "processor"),
+            vacuum_counter: suffixed(&prefix, "vacuum_counter"),
+            body_id_sequence: suffixed(&prefix, "body_id_sequence"),
+            incoming_id_sequence: suffixed(&prefix, "incoming_id_sequence"),
+            idx_incoming_partition: indexed(&prefix, "incoming_partition"),
+            idx_incoming_body_id: indexed(&prefix, "incoming_body_id"),
+            idx_outgoing_partition_seq: indexed(&prefix, "outgoing_partition_seq"),
+            idx_outgoing_body_id: indexed(&prefix, "outgoing_body_id"),
+            idx_dl_replayable: indexed(&prefix, "dl_replayable"),
+            idx_dl_status_deadline: indexed(&prefix, "dl_status_deadline"),
+            idx_dl_status_failed: indexed(&prefix, "dl_status_failed"),
+            migration_name: migration_name(&prefix),
+            prefix,
+        };
+
+        tables.validate_derived_identifiers()?;
+        Ok(tables)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn prefix(&self) -> &str {
+        &self.prefix
+    }
+
+    pub(crate) fn body(&self) -> &str {
+        &self.body
+    }
+
+    pub(crate) fn partitions(&self) -> &str {
+        &self.partitions
+    }
+
+    pub(crate) fn incoming(&self) -> &str {
+        &self.incoming
+    }
+
+    pub(crate) fn outgoing(&self) -> &str {
+        &self.outgoing
+    }
+
+    pub(crate) fn dead_letters(&self) -> &str {
+        &self.dead_letters
+    }
+
+    pub(crate) fn processor(&self) -> &str {
+        &self.processor
+    }
+
+    pub(crate) fn vacuum_counter(&self) -> &str {
+        &self.vacuum_counter
+    }
+
+    pub(crate) fn body_id_sequence(&self) -> &str {
+        &self.body_id_sequence
+    }
+
+    pub(crate) fn incoming_id_sequence(&self) -> &str {
+        &self.incoming_id_sequence
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn table_names(&self) -> [&str; 7] {
+        [
+            self.body(),
+            self.partitions(),
+            self.incoming(),
+            self.outgoing(),
+            self.dead_letters(),
+            self.processor(),
+            self.vacuum_counter(),
+        ]
+    }
+
+    pub(crate) fn idx_incoming_partition(&self) -> &str {
+        &self.idx_incoming_partition
+    }
+
+    pub(crate) fn idx_incoming_body_id(&self) -> &str {
+        &self.idx_incoming_body_id
+    }
+
+    pub(crate) fn idx_outgoing_partition_seq(&self) -> &str {
+        &self.idx_outgoing_partition_seq
+    }
+
+    pub(crate) fn idx_outgoing_body_id(&self) -> &str {
+        &self.idx_outgoing_body_id
+    }
+
+    pub(crate) fn idx_dl_replayable(&self) -> &str {
+        &self.idx_dl_replayable
+    }
+
+    pub(crate) fn idx_dl_status_deadline(&self) -> &str {
+        &self.idx_dl_status_deadline
+    }
+
+    pub(crate) fn idx_dl_status_failed(&self) -> &str {
+        &self.idx_dl_status_failed
+    }
+
+    pub(crate) fn migration_name(&self) -> &str {
+        &self.migration_name
+    }
+
+    fn validate_derived_identifiers(&self) -> Result<(), OutboxError> {
+        for ident in [
+            self.body(),
+            self.partitions(),
+            self.incoming(),
+            self.outgoing(),
+            self.dead_letters(),
+            self.processor(),
+            self.vacuum_counter(),
+            self.body_id_sequence(),
+            self.incoming_id_sequence(),
+            self.idx_incoming_partition(),
+            self.idx_incoming_body_id(),
+            self.idx_outgoing_partition_seq(),
+            self.idx_outgoing_body_id(),
+            self.idx_dl_replayable(),
+            self.idx_dl_status_deadline(),
+            self.idx_dl_status_failed(),
+        ] {
+            if ident.len() > MAX_IDENTIFIER_LEN {
+                return Err(OutboxError::InvalidTablePrefix(self.prefix.clone()));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn validate_prefix(prefix: &str) -> Result<(), OutboxError> {
+    if prefix.is_empty() || prefix.len() > MAX_PREFIX_LEN {
+        return Err(OutboxError::InvalidTablePrefix(prefix.to_owned()));
+    }
+
+    let bytes = prefix.as_bytes();
+    if !bytes[0].is_ascii_alphabetic() {
+        return Err(OutboxError::InvalidTablePrefix(prefix.to_owned()));
+    }
+
+    for &b in bytes {
+        if !(b.is_ascii_alphanumeric() || b == b'_') {
+            return Err(OutboxError::InvalidTablePrefix(prefix.to_owned()));
+        }
+    }
+
+    Ok(())
+}
+
+fn suffixed(prefix: &str, suffix: &str) -> String {
+    format!("{prefix}_{suffix}")
+}
+
+fn indexed(prefix: &str, suffix: &str) -> String {
+    format!("idx_{prefix}_{suffix}")
+}
+
+fn migration_name(prefix: &str) -> String {
+    if prefix == DEFAULT_OUTBOX_TABLE_PREFIX {
+        DEFAULT_OUTBOX_MIGRATION_NAME.to_owned()
+    } else {
+        format!("{DEFAULT_OUTBOX_MIGRATION_NAME}__{prefix}")
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_tables_match_existing_names() {
+        let tables = OutboxTables::default();
+
+        assert_eq!(tables.prefix(), "toolkit_outbox");
+        assert_eq!(tables.body(), "toolkit_outbox_body");
+        assert_eq!(tables.partitions(), "toolkit_outbox_partitions");
+        assert_eq!(tables.incoming(), "toolkit_outbox_incoming");
+        assert_eq!(tables.outgoing(), "toolkit_outbox_outgoing");
+        assert_eq!(tables.dead_letters(), "toolkit_outbox_dead_letters");
+        assert_eq!(tables.processor(), "toolkit_outbox_processor");
+        assert_eq!(tables.vacuum_counter(), "toolkit_outbox_vacuum_counter");
+        assert_eq!(tables.body_id_sequence(), "toolkit_outbox_body_id_sequence");
+        assert_eq!(
+            tables.incoming_id_sequence(),
+            "toolkit_outbox_incoming_id_sequence"
+        );
+    }
+
+    #[test]
+    fn default_indexes_match_existing_names() {
+        let tables = OutboxTables::default();
+
+        assert_eq!(
+            tables.idx_incoming_partition(),
+            "idx_toolkit_outbox_incoming_partition"
+        );
+        assert_eq!(
+            tables.idx_incoming_body_id(),
+            "idx_toolkit_outbox_incoming_body_id"
+        );
+        assert_eq!(
+            tables.idx_outgoing_partition_seq(),
+            "idx_toolkit_outbox_outgoing_partition_seq"
+        );
+        assert_eq!(
+            tables.idx_outgoing_body_id(),
+            "idx_toolkit_outbox_outgoing_body_id"
+        );
+        assert_eq!(
+            tables.idx_dl_replayable(),
+            "idx_toolkit_outbox_dl_replayable"
+        );
+        assert_eq!(
+            tables.idx_dl_status_deadline(),
+            "idx_toolkit_outbox_dl_status_deadline"
+        );
+        assert_eq!(
+            tables.idx_dl_status_failed(),
+            "idx_toolkit_outbox_dl_status_failed"
+        );
+    }
+
+    #[test]
+    fn custom_tables_are_derived_from_prefix() {
+        let tables = OutboxTables::new("mini_chat_outbox").unwrap();
+
+        assert_eq!(tables.body(), "mini_chat_outbox_body");
+        assert_eq!(tables.partitions(), "mini_chat_outbox_partitions");
+        assert_eq!(tables.incoming(), "mini_chat_outbox_incoming");
+        assert_eq!(tables.outgoing(), "mini_chat_outbox_outgoing");
+        assert_eq!(tables.dead_letters(), "mini_chat_outbox_dead_letters");
+        assert_eq!(tables.processor(), "mini_chat_outbox_processor");
+        assert_eq!(tables.vacuum_counter(), "mini_chat_outbox_vacuum_counter");
+        assert_eq!(
+            tables.body_id_sequence(),
+            "mini_chat_outbox_body_id_sequence"
+        );
+        assert_eq!(
+            tables.incoming_id_sequence(),
+            "mini_chat_outbox_incoming_id_sequence"
+        );
+        assert_eq!(
+            tables.idx_outgoing_partition_seq(),
+            "idx_mini_chat_outbox_outgoing_partition_seq"
+        );
+    }
+
+    #[test]
+    fn sequence_tables_handle_prefix_containing_default_table_token() {
+        let tables = OutboxTables::new("toolkit_outbox_body").unwrap();
+
+        assert_eq!(tables.body(), "toolkit_outbox_body_body");
+        assert_eq!(
+            tables.body_id_sequence(),
+            "toolkit_outbox_body_body_id_sequence"
+        );
+        assert_eq!(
+            tables.incoming_id_sequence(),
+            "toolkit_outbox_body_incoming_id_sequence"
+        );
+    }
+
+    #[test]
+    fn custom_migration_name_is_deterministic_and_distinct() {
+        let first = OutboxTables::new("mini_chat_outbox").unwrap();
+        let second = OutboxTables::new("mini_chat_outbox").unwrap();
+
+        assert_eq!(first.migration_name(), second.migration_name());
+        assert_ne!(first.migration_name(), DEFAULT_OUTBOX_MIGRATION_NAME);
+        assert_eq!(
+            first.migration_name(),
+            "m001_create_toolkit_outbox_schema__mini_chat_outbox"
+        );
+    }
+
+    #[test]
+    fn default_migration_name_is_preserved() {
+        let tables = OutboxTables::default();
+
+        assert_eq!(tables.migration_name(), DEFAULT_OUTBOX_MIGRATION_NAME);
+    }
+
+    #[test]
+    fn valid_prefixes_are_accepted() {
+        for prefix in ["a", "outbox1", "toolkit_outbox", "mini_chat_outbox"] {
+            assert!(OutboxTables::new(prefix).is_ok(), "{prefix}");
+        }
+    }
+
+    #[test]
+    fn invalid_prefixes_are_rejected() {
+        for prefix in [
+            "",
+            "1outbox",
+            "mini chat",
+            "mini-chat",
+            "public.outbox",
+            "outbox;",
+            "outbox\"",
+            "outbox'",
+            "_outbox",
+            "\u{0434}\u{0430}\u{043d}\u{043d}\u{044b}\u{0435}",
+        ] {
+            assert!(OutboxTables::new(prefix).is_err(), "{prefix}");
+        }
+    }
+
+    #[test]
+    fn boundary_length_prefix_is_accepted() {
+        let prefix = "a".repeat(MAX_PREFIX_LEN);
+
+        assert!(OutboxTables::new(prefix).is_ok());
+    }
+
+    #[test]
+    fn overlong_prefix_is_rejected() {
+        let prefix = "a".repeat(MAX_PREFIX_LEN + 1);
+
+        assert!(OutboxTables::new(prefix).is_err());
+    }
+}

--- a/libs/toolkit-db/src/outbox/types.rs
+++ b/libs/toolkit-db/src/outbox/types.rs
@@ -2,6 +2,8 @@ use std::time::Duration;
 
 use thiserror::Error;
 
+use super::tables::OutboxTables;
+
 /// Default batch size for the sequencer (rows per cycle).
 pub const DEFAULT_SEQUENCER_BATCH_SIZE: u32 = 1000;
 
@@ -101,6 +103,9 @@ pub enum OutboxError {
     #[error("invalid payload type: '{0}'")]
     InvalidPayloadType(String),
 
+    #[error("invalid outbox table prefix: '{0}'")]
+    InvalidTablePrefix(String),
+
     #[error(transparent)]
     Database(#[from] sea_orm::DbErr),
 }
@@ -108,6 +113,7 @@ pub enum OutboxError {
 /// Configuration for the outbox subsystem.
 #[derive(Debug, Clone, Default)]
 pub struct OutboxConfig {
+    pub(crate) tables: OutboxTables,
     pub sequencer: SequencerConfig,
 }
 

--- a/libs/toolkit-db/src/outbox/workers/processor.rs
+++ b/libs/toolkit-db/src/outbox/workers/processor.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use sea_orm::ConnectionTrait;
@@ -5,6 +6,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
 use super::super::handler::HandlerResult;
+use super::super::statements::OutboxStatements;
+use super::super::store::OutboxStore;
 use super::super::strategy::{ProcessContext, ProcessingStrategy};
 use super::super::taskward::{Directive, WorkerAction};
 use super::super::types::OutboxError;
@@ -156,6 +159,7 @@ pub struct PartitionProcessor<S: ProcessingStrategy> {
     partition_id: i64,
     tuning: super::super::types::WorkerTuning,
     db: Db,
+    statements: Arc<OutboxStatements>,
     partition_mode: PartitionMode,
 }
 
@@ -165,12 +169,14 @@ impl<S: ProcessingStrategy> PartitionProcessor<S> {
         partition_id: i64,
         tuning: super::super::types::WorkerTuning,
         db: Db,
+        statements: Arc<OutboxStatements>,
     ) -> Self {
         Self {
             strategy,
             partition_id,
             tuning,
             db,
+            statements,
             partition_mode: PartitionMode::new(),
         }
     }
@@ -184,11 +190,12 @@ impl<S: ProcessingStrategy> WorkerAction for PartitionProcessor<S> {
         &mut self,
         _cancel: &CancellationToken,
     ) -> Result<Directive<ProcessorReport>, OutboxError> {
-        let (backend, dialect) = {
+        let backend = {
             let sea_conn = self.db.sea_internal();
-            let b = sea_conn.get_database_backend();
-            (b, super::super::dialect::Dialect::from(b))
+            sea_conn.get_database_backend()
         };
+        debug_assert_eq!(backend, self.statements.backend());
+        let store = OutboxStore::new(&self.statements);
 
         let effective_size = self
             .partition_mode
@@ -196,8 +203,7 @@ impl<S: ProcessingStrategy> WorkerAction for PartitionProcessor<S> {
 
         let ctx = ProcessContext {
             db: &self.db,
-            backend,
-            dialect,
+            store,
             partition_id: self.partition_id,
         };
 

--- a/libs/toolkit-db/src/outbox/workers/reconciler.rs
+++ b/libs/toolkit-db/src/outbox/workers/reconciler.rs
@@ -6,8 +6,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
 use super::super::core::Outbox;
-use super::super::dialect::Dialect;
 use super::super::prioritizer::SharedPrioritizer;
+use super::super::store::OutboxStore;
 use super::super::taskward::{Directive, WorkerAction};
 use crate::Db;
 
@@ -21,12 +21,12 @@ struct DirtyPartitionRow {
 /// and by the cold reconciler (poker) loop.
 pub async fn reconcile_dirty(outbox: &Outbox, db: &Db, prioritizer: &SharedPrioritizer) {
     let conn = db.sea_internal();
-    let backend = conn.get_database_backend();
-    let dialect = Dialect::from(backend);
+    debug_assert_eq!(conn.get_database_backend(), outbox.statements().backend());
+    let store = OutboxStore::new(outbox.statements());
 
     let rows = match DirtyPartitionRow::find_by_statement(Statement::from_sql_and_values(
-        backend,
-        dialect.discover_dirty_partitions(),
+        store.backend(),
+        store.discover_dirty_partitions(),
         [],
     ))
     .all(&conn)

--- a/libs/toolkit-db/src/outbox/workers/sequencer.rs
+++ b/libs/toolkit-db/src/outbox/workers/sequencer.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
-use sea_orm::{ConnectionTrait, DbBackend, FromQueryResult, Statement, TransactionTrait};
+use sea_orm::{ConnectionTrait, FromQueryResult, Statement, TransactionTrait};
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
 use super::super::Outbox;
-use super::super::dialect::{AllocSql, Dialect};
+use super::super::dialect::AllocSql;
 use super::super::prioritizer::SharedPrioritizer;
+use super::super::store::OutboxStore;
 use super::super::taskward::{Directive, WorkerAction};
 use super::super::types::{OutboxError, SequencerConfig};
 use crate::Db;
@@ -67,8 +68,11 @@ impl Sequencer {
         partition_id: i64,
     ) -> Result<PartitionProcessResult, PartitionError> {
         let conn = self.db.sea_internal();
-        let backend = conn.get_database_backend();
-        let dialect = Dialect::from(backend);
+        debug_assert_eq!(
+            conn.get_database_backend(),
+            self.outbox.statements().backend()
+        );
+        let store = OutboxStore::new(self.outbox.statements());
 
         let mut drained = true;
         let mut total_claimed: u32 = 0;
@@ -77,9 +81,9 @@ impl Sequencer {
             let txn = conn.begin().await?;
 
             // Try to acquire row lock
-            if let Some(lock_sql) = dialect.lock_partition() {
+            if let Some(lock_sql) = store.lock_partition() {
                 let locked = self
-                    .try_lock_partition(&txn, backend, partition_id, lock_sql)
+                    .try_lock_partition(&txn, &store, partition_id, lock_sql)
                     .await?;
                 if !locked {
                     // Rollback (drop txn) and signal skip
@@ -90,7 +94,7 @@ impl Sequencer {
 
             // Claim incoming for this partition
             let claimed = self
-                .claim_incoming_for_partition(&txn, backend, &dialect, partition_id)
+                .claim_incoming_for_partition(&txn, &store, partition_id)
                 .await?;
 
             if claimed.is_empty() {
@@ -108,10 +112,10 @@ impl Sequencer {
 
             // Allocate sequences
             let start_seq = self
-                .allocate_sequences(&txn, backend, &dialect, partition_id, item_count)
+                .allocate_sequences(&txn, &store, partition_id, item_count)
                 .await?;
 
-            let outgoing_sql = dialect.build_insert_outgoing_batch(claimed.len());
+            let outgoing_sql = store.build_insert_outgoing_batch(claimed.len());
             let mut values: Vec<sea_orm::Value> = Vec::with_capacity(claimed.len() * 3);
             for (i, item) in claimed.iter().enumerate() {
                 #[allow(clippy::cast_possible_wrap)]
@@ -121,7 +125,7 @@ impl Sequencer {
                 values.push(seq.into());
             }
             txn.execute(Statement::from_sql_and_values(
-                backend,
+                store.backend(),
                 &outgoing_sql,
                 values,
             ))
@@ -255,13 +259,13 @@ impl Sequencer {
     async fn try_lock_partition(
         &self,
         txn: &impl ConnectionTrait,
-        backend: DbBackend,
+        store: &OutboxStore<'_>,
         partition_id: i64,
         sql: &str,
     ) -> Result<bool, OutboxError> {
         let row = txn
             .query_one(Statement::from_sql_and_values(
-                backend,
+                store.backend(),
                 sql,
                 [partition_id.into()],
             ))
@@ -277,15 +281,14 @@ impl Sequencer {
     async fn claim_incoming_for_partition(
         &self,
         txn: &impl ConnectionTrait,
-        backend: DbBackend,
-        dialect: &Dialect,
+        store: &OutboxStore<'_>,
         partition_id: i64,
     ) -> Result<Vec<ClaimedIncoming>, OutboxError> {
-        let claim = dialect.claim_incoming(self.config.batch_size);
+        let claim = store.claim_incoming(self.config.batch_size);
 
         // SELECT id, body_id ... ORDER BY id
         let rows = ClaimedIncoming::find_by_statement(Statement::from_sql_and_values(
-            backend,
+            store.backend(),
             &claim.select,
             [partition_id.into()],
         ))
@@ -297,10 +300,14 @@ impl Sequencer {
         }
 
         // DELETE the selected rows by id
-        let delete_sql = dialect.delete_incoming_batch(rows.len());
+        let delete_sql = store.delete_incoming_batch(rows.len());
         let values: Vec<sea_orm::Value> = rows.iter().map(|r| r.id.into()).collect();
-        txn.execute(Statement::from_sql_and_values(backend, &delete_sql, values))
-            .await?;
+        txn.execute(Statement::from_sql_and_values(
+            store.backend(),
+            &delete_sql,
+            values,
+        ))
+        .await?;
 
         Ok(rows)
     }
@@ -310,17 +317,16 @@ impl Sequencer {
     async fn allocate_sequences(
         &self,
         txn: &impl ConnectionTrait,
-        backend: DbBackend,
-        dialect: &Dialect,
+        store: &OutboxStore<'_>,
         partition_id: i64,
         count: i64,
     ) -> Result<i64, OutboxError> {
-        match dialect.allocate_sequences() {
+        match store.allocate_sequences() {
             AllocSql::UpdateReturning(sql) => {
                 // Pg/SQLite: UPDATE ... RETURNING — $1 = partition_id, $2 = count
                 let row = txn
                     .query_one(Statement::from_sql_and_values(
-                        backend,
+                        store.backend(),
                         sql,
                         [partition_id.into(), count.into()],
                     ))
@@ -339,14 +345,14 @@ impl Sequencer {
                 // MySQL: UPDATE then SELECT
                 // ? order: (count, partition_id) matching SQL occurrence
                 txn.execute(Statement::from_sql_and_values(
-                    backend,
+                    store.backend(),
                     update,
                     [count.into(), partition_id.into()],
                 ))
                 .await?;
                 let row = txn
                     .query_one(Statement::from_sql_and_values(
-                        backend,
+                        store.backend(),
                         select,
                         [count.into(), partition_id.into()],
                     ))

--- a/libs/toolkit-db/src/outbox/workers/vacuum.rs
+++ b/libs/toolkit-db/src/outbox/workers/vacuum.rs
@@ -1,8 +1,11 @@
-use sea_orm::{ConnectionTrait, DbBackend, Statement, TransactionTrait};
+use std::sync::Arc;
+
+use sea_orm::{ConnectionTrait, Statement, TransactionTrait};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
-use super::super::dialect::Dialect;
+use super::super::statements::OutboxStatements;
+use super::super::store::OutboxStore;
 use super::super::taskward::{Directive, WorkerAction};
 use super::super::types::OutboxError;
 use crate::Db;
@@ -39,16 +42,21 @@ pub struct VacuumReport {
 /// The vacuum never kills itself on a transient failure.
 pub struct VacuumTask {
     db: Db,
+    statements: Arc<OutboxStatements>,
     batch_size: usize,
 }
 
 impl VacuumTask {
-    pub fn new(db: Db, batch_size: usize) -> Self {
+    pub fn new(db: Db, statements: Arc<OutboxStatements>, batch_size: usize) -> Self {
         assert!(
             batch_size > 0,
             "vacuum batch_size must be greater than zero"
         );
-        Self { db, batch_size }
+        Self {
+            db,
+            statements,
+            batch_size,
+        }
     }
 }
 
@@ -60,16 +68,16 @@ impl WorkerAction for VacuumTask {
         &mut self,
         cancel: &CancellationToken,
     ) -> Result<Directive<VacuumReport>, OutboxError> {
-        let (backend, dialect) = {
+        let store = {
             let sea_conn = self.db.sea_internal();
-            let b = sea_conn.get_database_backend();
-            (b, Dialect::from(b))
+            debug_assert_eq!(sea_conn.get_database_backend(), self.statements.backend());
+            OutboxStore::new(&self.statements)
         };
 
         let sweep_start = tokio::time::Instant::now();
 
         // Phase 1: Snapshot dirty partitions (errors propagate to bulkhead)
-        let dirty = Self::snapshot_dirty(&self.db, backend, &dialect, cancel).await?;
+        let dirty = Self::snapshot_dirty(&self.db, &store, cancel).await?;
 
         // Phase 2: Drain each partition (per-partition errors logged, not propagated)
         let mut errors = 0u32;
@@ -79,14 +87,7 @@ impl WorkerAction for VacuumTask {
                 break;
             }
             match self
-                .drain_partition(
-                    &self.db,
-                    backend,
-                    &dialect,
-                    *partition_id,
-                    *snapshot_counter,
-                    cancel,
-                )
+                .drain_partition(&self.db, &store, *partition_id, *snapshot_counter, cancel)
                 .await
             {
                 Ok(deleted) => total_deleted += deleted,
@@ -124,14 +125,13 @@ impl VacuumTask {
     async fn drain_partition(
         &self,
         db: &Db,
-        backend: DbBackend,
-        dialect: &Dialect,
+        store: &OutboxStore<'_>,
         partition_id: i64,
         snapshot_counter: i64,
         cancel: &CancellationToken,
     ) -> Result<u64, OutboxError> {
         let deleted = self
-            .vacuum_partition(db, backend, dialect, partition_id, cancel)
+            .vacuum_partition(db, store, partition_id, cancel)
             .await?;
 
         // Only decrement counter if vacuum completed without cancellation.
@@ -140,8 +140,8 @@ impl VacuumTask {
         if !cancel.is_cancelled() {
             let conn = db.sea_internal();
             conn.execute(Statement::from_sql_and_values(
-                backend,
-                dialect.decrement_vacuum_counter(),
+                store.backend(),
+                store.decrement_vacuum_counter(),
                 [snapshot_counter.into(), partition_id.into()],
             ))
             .await?;
@@ -154,8 +154,7 @@ impl VacuumTask {
     /// Returns `(partition_id, counter)` pairs, snapshot taken once per sweep.
     async fn snapshot_dirty(
         db: &Db,
-        backend: DbBackend,
-        dialect: &Dialect,
+        store: &OutboxStore<'_>,
         cancel: &CancellationToken,
     ) -> Result<Vec<(i64, i64)>, OutboxError> {
         let mut dirty = Vec::new();
@@ -170,8 +169,8 @@ impl VacuumTask {
             let page = DIRTY_PAGE_LIMIT;
             let rows = conn
                 .query_all(Statement::from_sql_and_values(
-                    backend,
-                    dialect.fetch_dirty_partitions(),
+                    store.backend(),
+                    store.fetch_dirty_partitions(),
                     [cursor.into(), page.into()],
                 ))
                 .await?;
@@ -209,8 +208,7 @@ impl VacuumTask {
     async fn vacuum_partition(
         &self,
         db: &Db,
-        backend: DbBackend,
-        dialect: &Dialect,
+        store: &OutboxStore<'_>,
         partition_id: i64,
         cancel: &CancellationToken,
     ) -> Result<u64, OutboxError> {
@@ -218,8 +216,8 @@ impl VacuumTask {
         let row = {
             let conn = db.sea_internal();
             conn.query_one(Statement::from_sql_and_values(
-                backend,
-                dialect.read_processor(),
+                store.backend(),
+                store.read_processor(),
                 [partition_id.into()],
             ))
             .await?
@@ -237,7 +235,7 @@ impl VacuumTask {
             return Ok(0);
         }
 
-        let vacuum_sql = dialect.vacuum_cleanup();
+        let vacuum_sql = store.vacuum_cleanup();
         let mut total_deleted: u64 = 0;
 
         // Delete in bounded chunks until drained.
@@ -249,9 +247,8 @@ impl VacuumTask {
 
             let deleted = Self::delete_chunk(
                 db,
-                backend,
-                dialect,
-                &vacuum_sql,
+                store,
+                vacuum_sql,
                 partition_id,
                 processed_seq,
                 i64::try_from(self.batch_size).unwrap_or(i64::MAX),
@@ -272,8 +269,7 @@ impl VacuumTask {
     /// Returns the number of outgoing rows deleted.
     async fn delete_chunk(
         db: &Db,
-        backend: DbBackend,
-        dialect: &Dialect,
+        store: &OutboxStore<'_>,
         vacuum_sql: &super::super::dialect::VacuumSql,
         partition_id: i64,
         processed_seq: i64,
@@ -286,8 +282,8 @@ impl VacuumTask {
 
         let rows = txn
             .query_all(Statement::from_sql_and_values(
-                backend,
-                vacuum_sql.select_outgoing_chunk,
+                store.backend(),
+                &vacuum_sql.select_outgoing_chunk,
                 [partition_id.into(), processed_seq.into(), limit.into()],
             ))
             .await?;
@@ -313,18 +309,26 @@ impl VacuumTask {
 
         // DELETE outgoing rows by ID.
         if !outgoing_ids.is_empty() {
-            let delete_sql = dialect.build_delete_outgoing_batch(outgoing_ids.len());
+            let delete_sql = store.build_delete_outgoing_batch(outgoing_ids.len());
             let values: Vec<sea_orm::Value> = outgoing_ids.iter().map(|&id| id.into()).collect();
-            txn.execute(Statement::from_sql_and_values(backend, &delete_sql, values))
-                .await?;
+            txn.execute(Statement::from_sql_and_values(
+                store.backend(),
+                &delete_sql,
+                values,
+            ))
+            .await?;
         }
 
         // DELETE body rows by ID.
         if !body_ids.is_empty() {
-            let delete_sql = dialect.build_delete_body_batch(body_ids.len());
+            let delete_sql = store.build_delete_body_batch(body_ids.len());
             let values: Vec<sea_orm::Value> = body_ids.iter().map(|&id| id.into()).collect();
-            txn.execute(Statement::from_sql_and_values(backend, &delete_sql, values))
-                .await?;
+            txn.execute(Statement::from_sql_and_values(
+                store.backend(),
+                &delete_sql,
+                values,
+            ))
+            .await?;
         }
 
         txn.commit().await?;


### PR DESCRIPTION
Add validated outbox table-family configuration for migrations and runtime SQL. Introduce OutboxStore to bind backend, dialect, and table names together, and update workers, dead letters, tests, docs, examples, and benchmarks for custom table prefixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for running the outbox with custom table prefixes, enabling separate table families in the same database.
  * Added a new fluent runtime option for configuring the prefix, plus an example demonstrating its use.
  * Expanded benchmark support for multi-instance outbox scenarios with independent prefixed table families.
* **Bug Fixes**
  * Improved multi-instance tracking, verification, and post-run cleanup so each instance accounts for and cleans the correct prefixed tables.
* **Documentation**
  * Added guidance on using custom prefixes, including strict prefix validation and ensuring migrations and runtime stay aligned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->