### PR TITLE
feat(toolkit): add REST healthcheck infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,12 @@ make exammple
 # $ make example
 # visit: http://127.0.0.1:8087/cf/docs
 
-# Check if server is ready (detailed JSON response)
-curl http://127.0.0.1:8087/cf/health
-
-# Kubernetes-style liveness probe (simple "ok" response)
-curl http://127.0.0.1:8087/healthz
+# Readiness (detailed JSON) and liveness ("ok"). The example runs with prefix_path=/cf,
+# and in the default health.serve=main mode the probes ride the main listener, so they
+# sit under the same prefix as every other route.
+curl http://127.0.0.1:8087/cf/health     # detailed JSON, all component checks
+curl http://127.0.0.1:8087/cf/readyz      # readiness: 200 ready / 503 not ready
+curl http://127.0.0.1:8087/cf/healthz     # liveness: "ok"
 ```
 
 Other quick start examples:

--- a/docs/WHY_GEARS.md
+++ b/docs/WHY_GEARS.md
@@ -599,8 +599,9 @@ cd gears-rust
 make build      # build libs + example server
 make example    # run the example server -> http://127.0.0.1:8087/cf/docs
 
-curl http://127.0.0.1:8087/cf/health    # detailed JSON
-curl http://127.0.0.1:8087/healthz      # liveness "ok"
+curl http://127.0.0.1:8087/cf/health    # detailed JSON (all component checks)
+curl http://127.0.0.1:8087/cf/readyz    # readiness: 200 ready / 503 not ready
+curl http://127.0.0.1:8087/cf/healthz   # liveness "ok"
 ```
 
 **Next steps**

--- a/docs/web-docs/build-with-gears/add-observability.md
+++ b/docs/web-docs/build-with-gears/add-observability.md
@@ -54,7 +54,22 @@ With tracing enabled the gateway and toolkit give you, without per-gear wiring:
 - **W3C trace-context** propagation in and out (`traceparent`);
 - a **request id** correlated across logs and injected as a response header
   (`inject_request_id_header`);
-- health endpoints **`/health`** and **`/healthz`** exposed by the API Gateway.
+- health endpoints **`/healthz`** (liveness, shallow "ok"), **`/readyz`** (readiness,
+  200/503), and **`/health`** (detailed per-component JSON) exposed by the API Gateway. All
+  three are public (no auth) and run on the gateway's middleware surface.
+
+### Health serving modes
+
+`api-gateway` config controls where the probes are served:
+
+- `health.serve: main` (default) — probes ride the main listener, sharing `prefix_path`
+  (e.g. `/cf/healthz`).
+- `health.serve: separate` — probes are served only on a dedicated listener; set
+  `health.bind_addr` (e.g. `0.0.0.0:8081`) and expect the paths **unprefixed** on that port.
+- `health.serve: both` — served on both. `bind_addr` is required for `separate`/`both`.
+
+Register one composite `Healthcheck` per gear (see `RestApiCapability::healthcheck`); report
+external SaaS/LLM dependencies as `degraded` rather than gating readiness on them.
 
 ## Instrument your own code
 

--- a/gears/system/api-gateway/src/config.rs
+++ b/gears/system/api-gateway/src/config.rs
@@ -8,8 +8,12 @@ fn default_body_limit_bytes() -> usize {
     16 * 1024 * 1024
 }
 
+fn default_healthcheck_timeout_ms() -> u64 {
+    500
+}
+
 /// API gateway configuration - reused from `api_gateway` gear
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct ApiGatewayConfig {
@@ -57,6 +61,71 @@ pub struct ApiGatewayConfig {
     /// HTTP metrics configuration.
     #[serde(default)]
     pub metrics: MetricsConfig,
+
+    /// Per-check `/health`/`/readyz` timeout (ms); raise for slow dependencies.
+    #[serde(default = "default_healthcheck_timeout_ms")]
+    pub healthcheck_timeout_ms: u64,
+
+    /// Health-probe serving configuration (listener placement, bind address).
+    #[serde(default)]
+    pub health: HealthConfig,
+}
+
+/// Which listener(s) serve the health-probe endpoints (`/healthz`, `/readyz`, `/health`).
+///
+/// Health endpoints are unauthenticated in every mode; see [`HealthConfig`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum HealthServeMode {
+    /// Serve health endpoints on the main gateway listener (`bind_addr`). Default.
+    #[default]
+    Main,
+    /// Serve health endpoints only on a separate listener (`health.bind_addr`), e.g. a
+    /// private/management port not exposed alongside the main API.
+    Separate,
+    /// Serve health endpoints on both the main and the separate listener.
+    Both,
+}
+
+/// Health-probe serving configuration.
+///
+/// The endpoints (`/healthz`, `/readyz`, `/health`) never require authentication in any mode.
+/// In `main`/`both` mode they ride the main listener as public routes on the gateway
+/// middleware surface and inherit `prefix_path` (e.g. `/cf/healthz`); operators must keep the
+/// main gateway on a private network if the per-component detail in `/health` is sensitive. In
+/// `separate`/`both` mode they are also served at unprefixed paths on `bind_addr`, protected
+/// only by network placement of that listener.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields, default)]
+pub struct HealthConfig {
+    /// Which listener(s) serve the health endpoints.
+    pub serve: HealthServeMode,
+    /// Bind address for the separate health listener (e.g. `"0.0.0.0:8081"`).
+    /// Required when `serve` is `separate` or `both`; unused for `main`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bind_addr: Option<String>,
+}
+
+impl Default for ApiGatewayConfig {
+    // Manual (not derived) so defaults match the `#[serde(default = ...)]` fns above;
+    // a derived Default would zero each field (e.g. timeout 0 = instant probe failure).
+    fn default() -> Self {
+        Self {
+            bind_addr: String::default(),
+            enable_docs: false,
+            cors_enabled: false,
+            cors: None,
+            openapi: OpenApiConfig::default(),
+            defaults: Defaults::default(),
+            auth_disabled: false,
+            require_auth_by_default: default_require_auth_by_default(),
+            prefix_path: String::default(),
+            route_policies: RoutePoliciesConfig::default(),
+            metrics: MetricsConfig::default(),
+            healthcheck_timeout_ms: default_healthcheck_timeout_ms(),
+            health: HealthConfig::default(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/gears/system/api-gateway/src/gear.rs
+++ b/gears/system/api-gateway/src/gear.rs
@@ -3,7 +3,7 @@
 //! Contains the `ApiGateway` gear struct and its trait implementations.
 
 use async_trait::async_trait;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
@@ -12,7 +12,7 @@ use anyhow::Result;
 use axum::error_handling::HandleErrorLayer;
 use axum::http::Method;
 use axum::middleware::from_fn_with_state;
-use axum::{Router, extract::DefaultBodyLimit, middleware::from_fn, routing::get};
+use axum::{Extension, Router, extract::DefaultBodyLimit, middleware::from_fn, routing::get};
 use parking_lot::Mutex;
 use std::net::SocketAddr;
 use std::time::Duration;
@@ -49,7 +49,7 @@ async fn timeout_to_canonical(err: BoxError) -> axum::response::Response {
 
 use authn_resolver_sdk::AuthNResolverClient;
 
-use crate::config::ApiGatewayConfig;
+use crate::config::{ApiGatewayConfig, HealthServeMode};
 use crate::middleware::auth;
 use toolkit_security::SecurityContext;
 use toolkit_security::constants::{DEFAULT_SUBJECT_ID, DEFAULT_TENANT_ID};
@@ -77,6 +77,12 @@ pub struct ApiGateway {
     pub(crate) final_router: Mutex<Option<axum::Router>>,
     // AuthN Resolver client (resolved during init, None when auth_disabled)
     pub(crate) authn_client: Mutex<Option<Arc<dyn AuthNResolverClient>>>,
+    // Readiness registry, set once from `rest_prepare`; `OnceLock` = lock-free reads.
+    pub(crate) healthcheck_registry: OnceLock<Arc<toolkit::RestHealthcheckRegistry>>,
+    // Built-once standalone health router. Served on the separate health listener in
+    // `separate`/`both` mode and merged onto the main router in `main`/`both` mode. Cached
+    // so repeat `health_router()`/`build_health_router()` calls are cheap.
+    pub(crate) health_router: OnceLock<axum::Router>,
 
     // Duplicate detection (per (method, path) and per handler id)
     pub(crate) registered_routes: DashMap<(Method, String), ()>,
@@ -92,24 +98,84 @@ impl Default for ApiGateway {
             router_cache: RouterCache::new(default_router),
             final_router: Mutex::new(None),
             authn_client: Mutex::new(None),
+            healthcheck_registry: OnceLock::new(),
+            health_router: OnceLock::new(),
             registered_routes: DashMap::new(),
             registered_handlers: DashMap::new(),
         }
     }
 }
 
+// Built-in health-probe paths, shared by route registration and auth policy so they can't drift.
+const HEALTH_DETAIL_PATH: &str = "/health";
+const HEALTHZ_PATH: &str = "/healthz";
+const READYZ_PATH: &str = "/readyz";
+
 impl ApiGateway {
-    fn apply_prefix_nesting(mut router: Router, prefix: &str) -> Router {
+    /// Nest `router` under `prefix`. Returns `router` unchanged when `prefix` is empty.
+    ///
+    /// Auth matching is keyed on unprefixed `OperationBuilder` paths, so the caller must
+    /// apply `router`'s middleware before this strips/adds the prefix via `nest()`.
+    fn apply_prefix(router: Router, prefix: &str) -> Router {
         if prefix.is_empty() {
-            return router;
+            router
+        } else {
+            Router::new().nest(prefix, router)
         }
+    }
 
-        let top = Router::new()
-            .route("/health", get(web::health_check))
-            .route("/healthz", get(|| async { "ok" }));
+    /// Standalone health-probe router (`/health`, `/healthz`, `/readyz`): all public, no
+    /// gateway middleware, no auth, and NOT part of the `OpenAPI` document. In `separate`/`both`
+    /// mode the framework binds this on the separate health listener (`health.bind_addr`) from
+    /// [`serve`](Self::serve); it is also exposed for embedders that want to serve it themselves.
+    ///
+    /// # Errors
+    /// Returns an error if [`rest_prepare`](toolkit::contracts::ApiGatewayCapability::rest_prepare)
+    /// has not run yet (the healthcheck registry is unset).
+    pub fn health_router(&self) -> Result<Router> {
+        let hc_registry = self.healthcheck_registry.get().cloned().ok_or_else(|| {
+            anyhow::anyhow!(
+                "healthcheck_registry not set; call rest_prepare before health_router()"
+            )
+        })?;
+        let config = self.get_cached_config();
+        Ok(self.build_health_router(
+            hc_registry,
+            Duration::from_millis(config.healthcheck_timeout_ms),
+        ))
+    }
 
-        router = Router::new().nest(prefix, router);
-        top.merge(router)
+    /// Build (or return the cached) standalone health router. Deps (`hc_registry`,
+    /// `healthcheck_timeout`) are fixed after `rest_prepare`, so the first build is
+    /// authoritative; later calls reuse the clone.
+    fn build_health_router(
+        &self,
+        hc_registry: Arc<toolkit::RestHealthcheckRegistry>,
+        healthcheck_timeout: Duration,
+    ) -> Router {
+        if let Some(cached) = self.health_router.get() {
+            return cached.clone();
+        }
+        let built = Self::health_routes(hc_registry, healthcheck_timeout);
+        // First build wins; a concurrent racer's `set` is a no-op (builds are sequential
+        // during lifecycle setup, so this is a belt-and-braces guard).
+        drop(self.health_router.set(built.clone()));
+        built
+    }
+
+    /// Health-probe routes as plain Axum routes (no `OperationBuilder`, so they never enter
+    /// the `OpenAPI` registry). All three are public; deps injected via `Extension`. Merged
+    /// onto the main router in `main`/`both` mode and used standalone on the separate listener.
+    fn health_routes(
+        hc_registry: Arc<toolkit::RestHealthcheckRegistry>,
+        healthcheck_timeout: Duration,
+    ) -> Router {
+        Router::new()
+            .route(HEALTH_DETAIL_PATH, get(web::health_detail))
+            .route(HEALTHZ_PATH, get(|| async { "ok" }))
+            .route(READYZ_PATH, get(web::readyz_check))
+            .layer(Extension(hc_registry))
+            .layer(Extension(web::HealthcheckTimeout(healthcheck_timeout)))
     }
 
     /// Create a new `ApiGateway` instance with the given configuration
@@ -122,6 +188,8 @@ impl ApiGateway {
             router_cache: RouterCache::new(default_router),
             final_router: Mutex::new(None),
             authn_client: Mutex::new(None),
+            healthcheck_registry: OnceLock::new(),
+            health_router: OnceLock::new(),
             registered_routes: DashMap::new(),
             registered_handlers: DashMap::new(),
         }
@@ -157,12 +225,22 @@ impl ApiGateway {
         let mut authenticated_routes = std::collections::HashSet::new();
         let mut public_routes = std::collections::HashSet::new();
 
-        // Always mark built-in health check routes as public
-        public_routes.insert((Method::GET, "/health".to_owned()));
-        public_routes.insert((Method::GET, "/healthz".to_owned()));
-
         public_routes.insert((Method::GET, "/docs".to_owned()));
         public_routes.insert((Method::GET, "/openapi.json".to_owned()));
+
+        // In main/both mode the health probes are merged onto the main router *before* the
+        // middleware stack (see `rest_finalize`), so the auth layer resolves them: mark them
+        // explicitly public so no bearer token is ever required. Auth matches on the unprefixed
+        // path, so these keys stay unprefixed even when `prefix_path` is set.
+        let config = self.get_cached_config();
+        if matches!(
+            config.health.serve,
+            HealthServeMode::Main | HealthServeMode::Both
+        ) {
+            for path in [HEALTHZ_PATH, READYZ_PATH, HEALTH_DETAIL_PATH] {
+                public_routes.insert((Method::GET, path.to_owned()));
+            }
+        }
 
         for spec in &self.openapi_registry.operation_specs {
             let spec = spec.value();
@@ -178,7 +256,6 @@ impl ApiGateway {
             }
         }
 
-        let config = self.get_cached_config();
         let requirements_count = authenticated_routes.len();
         let public_routes_count = public_routes.len();
 
@@ -256,7 +333,11 @@ impl ApiGateway {
         // 14) Propagate MatchedPath to response extensions (route_layer — innermost).
         // This copies MatchedPath from the request (populated by Axum route matching)
         // into the response so outer layer() middleware (metrics) can read it.
-        router = router.route_layer(from_fn(middleware::http_metrics::propagate_matched_path));
+        // `route_layer` panics on a routeless router — reachable when no REST provider
+        // has registered anything yet.
+        if router.has_routes() {
+            router = router.route_layer(from_fn(middleware::http_metrics::propagate_matched_path));
+        }
 
         let config = self.get_cached_config();
 
@@ -484,19 +565,14 @@ impl ApiGateway {
         }
 
         tracing::debug!("Building new router (standalone/fallback mode)");
-        // In standalone mode (no REST pipeline), register both health endpoints here.
-        // In normal operation, rest_prepare() registers these instead.
-        let mut router = Router::new()
-            .route("/health", get(web::health_check))
-            .route("/healthz", get(|| async { "ok" }));
-
-        // Apply all middleware layers including auth, above the router
+        // No "main" routes here — the empty router is tolerated (`has_routes` guard).
+        // Health probes are not part of this router; see `health_router`.
         let authn_client = self.authn_client.lock().clone();
-        router = self.apply_middleware_stack(router, authn_client)?;
+        let router = self.apply_middleware_stack(Router::new(), authn_client)?;
 
         let config = self.get_cached_config();
         let prefix = Self::normalize_prefix_path(&config.prefix_path)?;
-        router = Self::apply_prefix_nesting(router, &prefix);
+        let router = Self::apply_prefix(router, &prefix);
 
         // Cache the built router for future use
         self.router_cache.store(router.clone());
@@ -527,6 +603,29 @@ impl ApiGateway {
             .map_err(|e| anyhow::anyhow!("Invalid bind address '{bind_addr}': {e}"))
     }
 
+    /// Resolve the separate health listener address, if the config demands one.
+    ///
+    /// `Ok(None)` for `serve = main`. For `separate`/`both`, `health.bind_addr` must be present
+    /// and parseable — used both to fail fast at `init` and to bind at `serve`.
+    ///
+    /// # Errors
+    /// Returns an error if `serve` needs a separate listener but `health.bind_addr` is missing
+    /// or not a valid socket address.
+    fn health_bind_addr(cfg: &ApiGatewayConfig) -> anyhow::Result<Option<SocketAddr>> {
+        match cfg.health.serve {
+            HealthServeMode::Main => Ok(None),
+            HealthServeMode::Separate | HealthServeMode::Both => {
+                let raw = cfg.health.bind_addr.as_deref().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "health.serve = {:?} requires health.bind_addr to be set",
+                        cfg.health.serve
+                    )
+                })?;
+                Ok(Some(Self::parse_bind_address(raw)?))
+            }
+        }
+    }
+
     /// Get the finalized router or build a default one.
     fn get_or_build_router(self: &Arc<Self>) -> anyhow::Result<Router> {
         let stored = { self.final_router.lock().take() };
@@ -553,27 +652,53 @@ impl ApiGateway {
         let addr = Self::parse_bind_address(&cfg.bind_addr)?;
         let router = self.get_or_build_router()?;
 
-        // Bind the socket, only now consider the service "ready"
+        // Bind the main socket.
         let listener = tokio::net::TcpListener::bind(addr).await?;
         tracing::info!("HTTP server bound on {}", addr);
+
+        // Bind the separate health listener (if `serve` = separate|both) BEFORE signalling
+        // ready, so readiness reflects every listener the pod must accept traffic on.
+        let health_bound = self.bind_health_listener(&cfg).await?;
+
         ready.notify(); // Starting -> Running
 
-        // Graceful shutdown on cancel
-        let shutdown = {
-            let cancel = cancel.clone();
-            async move {
-                cancel.cancelled().await;
-                tracing::info!("HTTP server shutting down gracefully (cancellation)");
-            }
-        };
-
-        axum::serve(
+        let main_server = axum::serve(
             listener,
             router.into_make_service_with_connect_info::<SocketAddr>(),
         )
-        .with_graceful_shutdown(shutdown)
-        .await
-        .map_err(|e| anyhow::anyhow!(e))
+        .with_graceful_shutdown(Self::shutdown_signal(cancel.clone(), "HTTP server"));
+
+        // Both listeners share the runtime cancellation token, so shutdown fans out to both.
+        if let Some((health_listener, health_router)) = health_bound {
+            let health_server = axum::serve(health_listener, health_router.into_make_service())
+                .with_graceful_shutdown(Self::shutdown_signal(cancel, "health server"));
+            tokio::try_join!(
+                async { main_server.await.map_err(|e| anyhow::anyhow!(e)) },
+                async { health_server.await.map_err(|e| anyhow::anyhow!(e)) },
+            )?;
+            Ok(())
+        } else {
+            main_server.await.map_err(|e| anyhow::anyhow!(e))
+        }
+    }
+
+    /// Bind the separate health listener when `serve` = separate|both, else `None`.
+    async fn bind_health_listener(
+        &self,
+        cfg: &ApiGatewayConfig,
+    ) -> anyhow::Result<Option<(tokio::net::TcpListener, Router)>> {
+        let Some(health_addr) = Self::health_bind_addr(cfg)? else {
+            return Ok(None);
+        };
+        let health_listener = tokio::net::TcpListener::bind(health_addr).await?;
+        tracing::info!("health server bound on {}", health_addr);
+        Ok(Some((health_listener, self.health_router()?)))
+    }
+
+    /// Future that resolves when `cancel` fires, logging the graceful-shutdown of `name`.
+    async fn shutdown_signal(cancel: CancellationToken, name: &'static str) {
+        cancel.cancelled().await;
+        tracing::info!("{name} shutting down gracefully (cancellation)");
     }
 
     /// Check if `handler_id` is already registered (returns true if duplicate)
@@ -683,6 +808,10 @@ impl toolkit::Gear for ApiGateway {
         // tower-http would otherwise assert-panic during eager router
         // layering — a startup crash-loop with no pointer at the config.
         crate::cors::validate_cors_config(&cfg).map_err(|e| anyhow::anyhow!(e))?;
+        // Fail fast when health.serve needs a separate listener but health.bind_addr is
+        // missing or unparseable, rather than crashing later in serve() after other gears
+        // have started.
+        Self::health_bind_addr(&cfg)?;
         self.config.store(Arc::new(cfg.clone()));
 
         debug!(
@@ -712,16 +841,15 @@ impl toolkit::contracts::ApiGatewayCapability for ApiGateway {
         &self,
         _ctx: &toolkit::context::GearCtx,
         router: axum::Router,
+        hc_registry: Arc<toolkit::RestHealthcheckRegistry>,
     ) -> anyhow::Result<axum::Router> {
-        // Add health check endpoints:
-        // - /health: detailed JSON response with status and timestamp
-        // - /healthz: simple "ok" liveness probe (Kubernetes-style)
-        let router = router
-            .route("/health", get(web::health_check))
-            .route("/healthz", get(|| async { "ok" }));
+        // Store for use when health routes are added in rest_finalize. A second set
+        // means rest_prepare ran twice — a lifecycle bug; fail fast rather than mask it.
+        if self.healthcheck_registry.set(hc_registry).is_err() {
+            anyhow::bail!("healthcheck_registry already set; rest_prepare called more than once");
+        }
 
-        // You may attach global middlewares here (trace, compression, cors), but do not start server.
-        tracing::debug!("REST host prepared base router with health check endpoints");
+        tracing::debug!("REST host prepared base router");
         Ok(router)
     }
 
@@ -729,6 +857,7 @@ impl toolkit::contracts::ApiGatewayCapability for ApiGateway {
         &self,
         _ctx: &toolkit::context::GearCtx,
         mut router: axum::Router,
+        hc_registry: Arc<toolkit::RestHealthcheckRegistry>,
     ) -> anyhow::Result<axum::Router> {
         let config = self.get_cached_config();
 
@@ -736,15 +865,33 @@ impl toolkit::contracts::ApiGatewayCapability for ApiGateway {
             router = self.add_openapi_routes(router)?;
         }
 
-        // Apply middleware stack (including auth) to the final router
+        // Health probes (`main`/`both` mode): merge them onto the main router BEFORE the
+        // middleware stack, so they share the gateway's unified surface (request id, tracing,
+        // metrics, error mapping, ...). They are marked public in the route policy (see
+        // `build_route_policy_from_specs`), so the auth layer lets them through without a bearer
+        // token. Like every other route they inherit `prefix_path` via the nesting below.
+        // `separate` mode omits them here; `serve()` binds them on the dedicated health listener.
+        if matches!(
+            config.health.serve,
+            HealthServeMode::Main | HealthServeMode::Both
+        ) {
+            let health = Self::health_routes(
+                hc_registry,
+                Duration::from_millis(config.healthcheck_timeout_ms),
+            );
+            router = router.merge(health);
+        }
+
+        // Middleware on the main router before nesting (auth matching keyed on
+        // unprefixed OperationBuilder paths; layers run before nest() strips the prefix).
         tracing::debug!("Applying middleware stack to finalized router");
         let authn_client = self.authn_client.lock().clone();
         router = self.apply_middleware_stack(router, authn_client)?;
 
         let prefix = Self::normalize_prefix_path(&config.prefix_path)?;
-        router = Self::apply_prefix_nesting(router, &prefix);
+        router = Self::apply_prefix(router, &prefix);
 
-        // Keep the finalized router to be used by `serve()`
+        // Keep the finalized router to be used by `serve()`.
         *self.final_router.lock() = Some(router.clone());
 
         tracing::info!("REST host finalized router with OpenAPI endpoints and auth middleware");

--- a/gears/system/api-gateway/src/web.rs
+++ b/gears/system/api-gateway/src/web.rs
@@ -1,10 +1,19 @@
 use axum::{
+    extract::Extension,
     http::StatusCode,
-    response::{Html, Json},
+    response::{Html, IntoResponse, Json, Response},
     routing::{MethodRouter, get},
 };
 use chrono::{SecondsFormat, Utc};
-use serde_json::{Value, json};
+use serde_json::json;
+use std::sync::Arc;
+use std::time::Duration;
+use toolkit::RestHealthcheckRegistry;
+
+/// Per-check timeout (from `ApiGatewayConfig::healthcheck_timeout_ms`), injected as an
+/// `Extension`. A newtype avoids colliding with any other `Duration` extension.
+#[derive(Clone, Copy)]
+pub struct HealthcheckTimeout(pub Duration);
 
 /// Returns a 501 Not Implemented handler for operations without implementations
 #[allow(dead_code)]
@@ -20,11 +29,39 @@ pub fn placeholder_handler_501() -> MethodRouter {
     })
 }
 
-pub async fn health_check() -> Json<Value> {
-    Json(json!({
-        "status": "healthy",
-        "timestamp": Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
-    }))
+/// `GET /health`: runs all checks, returns JSON with per-component detail. Public (no auth) in
+/// every serving mode; the per-component detail is protected by network placement, not auth,
+/// and check messages are sanitized. 200 (Healthy/Degraded), 503 (Unhealthy).
+pub async fn health_detail(
+    Extension(registry): Extension<Arc<RestHealthcheckRegistry>>,
+    Extension(timeout): Extension<HealthcheckTimeout>,
+) -> Response {
+    let report = registry.report(timeout.0).await;
+    let status_code = status_for_report(report.is_ready());
+    let body = Json(json!({
+        "status": report.status,
+        "timestamp": Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
+        "components": report.components,
+    }));
+    (status_code, body).into_response()
+}
+
+/// `GET /readyz`: runs all checks, public, status code only (no detail).
+/// 200 (Healthy/Degraded), 503 (Unhealthy).
+pub async fn readyz_check(
+    Extension(registry): Extension<Arc<RestHealthcheckRegistry>>,
+    Extension(timeout): Extension<HealthcheckTimeout>,
+) -> StatusCode {
+    let report = registry.report(timeout.0).await;
+    status_for_report(report.is_ready())
+}
+
+fn status_for_report(report_ready: bool) -> StatusCode {
+    if report_ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    }
 }
 
 #[cfg(not(feature = "embed_elements"))]

--- a/gears/system/api-gateway/tests/access_log_tests.rs
+++ b/gears/system/api-gateway/tests/access_log_tests.rs
@@ -349,7 +349,11 @@ async fn e2e_full_middleware_stack_logs_remote_addr() -> anyhow::Result<()> {
         .handler(get(e2e_handler))
         .register(Router::new(), &api);
 
-    let app = api.rest_finalize(&ctx, router)?;
+    let app = api.rest_finalize(
+        &ctx,
+        router,
+        Arc::new(toolkit::RestHealthcheckRegistry::new()),
+    )?;
 
     // Set up capturing layer for the access log.
     let layer = CapturingLayer::default();

--- a/gears/system/api-gateway/tests/auth_middleware.rs
+++ b/gears/system/api-gateway/tests/auth_middleware.rs
@@ -228,7 +228,11 @@ async fn test_auth_disabled_mode() {
 
     // Finalize router (applies middleware)
     let router = api_gateway
-        .rest_finalize(&api_ctx, router)
+        .rest_finalize(
+            &api_ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize");
 
     // Test protected route WITHOUT token (should work because auth is disabled)
@@ -290,7 +294,11 @@ async fn test_public_routes_accessible() {
     // First call rest_prepare to add built-in routes
     let router = Router::new();
     let router = api_gateway
-        .rest_prepare(&api_ctx, router)
+        .rest_prepare(
+            &api_ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to prepare");
 
     // Then register test gear routes
@@ -301,28 +309,14 @@ async fn test_public_routes_accessible() {
 
     // Finally finalize
     let router = api_gateway
-        .rest_finalize(&api_ctx, router)
+        .rest_finalize(
+            &api_ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize");
 
-    // Test built-in health endpoints
-    let response = router
-        .clone()
-        .oneshot(
-            Request::builder()
-                .uri("/healthz")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .expect("Request failed");
-
-    assert_eq!(
-        response.status(),
-        StatusCode::OK,
-        "Health endpoint should be accessible"
-    );
-
-    // Test OpenAPI endpoint
+    // Test OpenAPI endpoint (health probes are not served on the main gateway)
     let response = router
         .oneshot(
             Request::builder()
@@ -364,7 +358,11 @@ async fn test_public_routes_with_prefix_accessible() {
     // First call rest_prepare to add built-in routes
     let router = Router::new();
     let router = api_gateway
-        .rest_prepare(&api_ctx, router)
+        .rest_prepare(
+            &api_ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to prepare");
 
     // Then register test gear routes
@@ -375,28 +373,14 @@ async fn test_public_routes_with_prefix_accessible() {
 
     // Finally finalize
     let router = api_gateway
-        .rest_finalize(&api_ctx, router)
+        .rest_finalize(
+            &api_ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize");
 
-    // Test built-in health endpoints
-    let response = router
-        .clone()
-        .oneshot(
-            Request::builder()
-                .uri("/healthz")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .expect("Request failed");
-
-    assert_eq!(
-        response.status(),
-        StatusCode::OK,
-        "Health endpoint should be accessible"
-    );
-
-    // Test OpenAPI endpoint
+    // Test OpenAPI endpoint (health probes are not served on the main gateway)
     let response = router
         .clone()
         .oneshot(
@@ -459,7 +443,11 @@ async fn test_middleware_always_inserts_security_ctx() {
         .expect("Failed to register routes");
 
     let router = api_gateway
-        .rest_finalize(&api_ctx, router)
+        .rest_finalize(
+            &api_ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize");
 
     // Make request to protected handler that extracts SecurityContext
@@ -570,7 +558,11 @@ async fn test_route_pattern_matching_with_path_params() {
         .expect("Failed to register routes");
 
     let router = api_gateway
-        .rest_finalize(&api_ctx, router)
+        .rest_finalize(
+            &api_ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize");
 
     // Test that /tests/v1/api/users/123 is accessible (matches /tests/v1/api/users/{id})
@@ -638,7 +630,11 @@ async fn test_route_pattern_matching_with_prefix_path_params() {
         .expect("Failed to register routes");
 
     let router = api_gateway
-        .rest_finalize(&api_ctx, router)
+        .rest_finalize(
+            &api_ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize");
 
     // Test that /tests/v1/api/users/123 is accessible (matches /tests/v1/api/users/{id})
@@ -777,7 +773,11 @@ async fn create_router(config: serde_json::Value, mock: MockAuthNResolverClient)
         .expect("Failed to register routes");
 
     api_gateway
-        .rest_finalize(&api_ctx, router)
+        .rest_finalize(
+            &api_ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize")
 }
 

--- a/gears/system/api-gateway/tests/body_limit_tests.rs
+++ b/gears/system/api-gateway/tests/body_limit_tests.rs
@@ -116,7 +116,11 @@ async fn test_body_limit_configured() {
         .expect("Failed to register routes");
 
     let _final_router = api_gateway
-        .rest_finalize(&ctx, router)
+        .rest_finalize(
+            &ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize router");
 
     // Verify router builds with custom body limit
@@ -141,7 +145,11 @@ async fn test_body_limit_with_cors() {
         .expect("Failed to register routes");
 
     let _final_router = api_gateway
-        .rest_finalize(&ctx, router)
+        .rest_finalize(
+            &ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize router");
 
     // Both CORS and body limit should be active
@@ -180,7 +188,11 @@ async fn test_default_body_limit() {
         .expect("Failed to register routes");
 
     let _final_router = api_gateway
-        .rest_finalize(&ctx, router)
+        .rest_finalize(
+            &ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize router");
 
     // Verify default body limit is applied (16MB)

--- a/gears/system/api-gateway/tests/cors_tests.rs
+++ b/gears/system/api-gateway/tests/cors_tests.rs
@@ -145,7 +145,11 @@ async fn test_cors_layer_builds_with_config() {
 
     // Build the final router with CORS middleware
     let _final_router = api_gateway
-        .rest_finalize(&ctx, router)
+        .rest_finalize(
+            &ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize router");
 
     // Verify router builds successfully with CORS enabled
@@ -165,7 +169,11 @@ async fn test_cors_permissive_mode() {
         .expect("Failed to register routes");
 
     let _final_router = api_gateway
-        .rest_finalize(&ctx, router)
+        .rest_finalize(
+            &ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize router");
 
     // Verify permissive CORS builds successfully
@@ -199,7 +207,11 @@ async fn test_cors_disabled() {
         .expect("Failed to register routes");
 
     let _final_router = api_gateway
-        .rest_finalize(&ctx, router)
+        .rest_finalize(
+            &ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize router");
 
     // Verify router builds without CORS layer
@@ -226,7 +238,11 @@ async fn test_cors_default_exposes_etag_header() {
         .register_rest(&ctx, Router::new(), &api_gateway)
         .expect("Failed to register routes");
     let app = api_gateway
-        .rest_finalize(&ctx, router)
+        .rest_finalize(
+            &ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize router");
 
     let response = app
@@ -291,7 +307,11 @@ async fn test_cors_configured_exposed_headers_reach_response() {
         .register_rest(&ctx, Router::new(), &api_gateway)
         .expect("Failed to register routes");
     let app = api_gateway
-        .rest_finalize(&ctx, router)
+        .rest_finalize(
+            &ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize router");
 
     let response = app

--- a/gears/system/api-gateway/tests/health_endpoints.rs
+++ b/gears/system/api-gateway/tests/health_endpoints.rs
@@ -1,0 +1,504 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! Integration tests for health endpoints (`/health`, `/healthz`, `/readyz`).
+//!
+//! Health endpoints are unauthenticated in every serving mode. In `main`/`both` mode they are
+//! merged onto the main gateway router at stable, unprefixed paths and outside the auth layer;
+//! in `separate`/`both` mode the standalone health router (`health_router()`) is served on a
+//! dedicated listener.
+
+use async_trait::async_trait;
+use authn_resolver_sdk::{
+    AuthNResolverClient, AuthNResolverError, AuthenticationResult, ClientCredentialsRequest,
+};
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode, header},
+};
+use serde_json::json;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+use toolkit::{
+    ClientHub, GearCtx, Healthcheck, HealthcheckResult, RestHealthcheckRegistry,
+    contracts::ApiGatewayCapability,
+};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+// ---------- helpers ----------
+
+/// A `ConfigProvider` backed by a single JSON blob, keyed by gear name.
+struct JsonConfigProvider(serde_json::Value);
+
+impl toolkit::config::ConfigProvider for JsonConfigProvider {
+    fn get_gear_config(&self, gear: &str) -> Option<&serde_json::Value> {
+        self.0.get(gear)
+    }
+}
+
+/// Mock `AuthN` client that rejects every token. Registered for auth-enabled tests to prove
+/// health endpoints never reach the auth layer (a real request would be rejected).
+struct RejectingAuthN;
+
+#[async_trait]
+impl AuthNResolverClient for RejectingAuthN {
+    async fn authenticate(&self, _token: &str) -> Result<AuthenticationResult, AuthNResolverError> {
+        Err(AuthNResolverError::Unauthorized(
+            "health tests: auth must never be invoked for health endpoints".to_owned(),
+        ))
+    }
+
+    async fn exchange_client_credentials(
+        &self,
+        _request: &ClientCredentialsRequest,
+    ) -> Result<AuthenticationResult, AuthNResolverError> {
+        Err(AuthNResolverError::Internal("not implemented".to_owned()))
+    }
+}
+
+/// `init` + `rest_prepare` + `rest_finalize` the gateway with the given `api-gateway.config`
+/// object, an optional `AuthN` client, and a registry populated by `setup`. Returns the
+/// finalized main router, or the first error (used by fail-fast config tests).
+async fn finalize_main_router(
+    config_obj: serde_json::Value,
+    authn: Option<Arc<dyn AuthNResolverClient>>,
+    setup: impl FnOnce(&RestHealthcheckRegistry),
+) -> anyhow::Result<Router> {
+    use api_gateway::ApiGateway;
+    use toolkit::Gear;
+
+    let registry = Arc::new(RestHealthcheckRegistry::new());
+    setup(&registry);
+
+    let config = json!({ "api-gateway": { "config": config_obj } });
+    let hub = Arc::new(ClientHub::new());
+    if let Some(client) = authn {
+        hub.register::<dyn AuthNResolverClient>(client);
+    }
+    let ctx = GearCtx::new(
+        "api-gateway",
+        Uuid::new_v4(),
+        Arc::new(JsonConfigProvider(config)),
+        hub,
+        CancellationToken::new(),
+    );
+
+    let gw = ApiGateway::default();
+    gw.init(&ctx).await?;
+    let router = gw.rest_prepare(&ctx, Router::new(), registry.clone())?;
+    gw.rest_finalize(&ctx, router, registry)
+}
+
+/// Build the standalone health router (`rest_prepare` + `health_router`). This is the router
+/// the framework serves on the separate health listener in `separate`/`both` mode.
+async fn build_standalone_health_router(setup: impl FnOnce(&RestHealthcheckRegistry)) -> Router {
+    use api_gateway::ApiGateway;
+    use toolkit::Gear;
+
+    let registry = Arc::new(RestHealthcheckRegistry::new());
+    setup(&registry);
+
+    let config =
+        json!({ "api-gateway": { "config": { "bind_addr": "0.0.0.0:0", "auth_disabled": true } } });
+    let ctx = GearCtx::new(
+        "api-gateway",
+        Uuid::new_v4(),
+        Arc::new(JsonConfigProvider(config)),
+        Arc::new(ClientHub::new()),
+        CancellationToken::new(),
+    );
+
+    let gw = ApiGateway::default();
+    gw.init(&ctx).await.expect("init failed");
+    let _base = gw
+        .rest_prepare(&ctx, Router::new(), registry)
+        .expect("rest_prepare failed");
+    gw.health_router().expect("health_router failed")
+}
+
+async fn get(router: Router, path: &str) -> axum::http::Response<axum::body::Body> {
+    router
+        .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+        .await
+        .unwrap()
+}
+
+async fn get_with_bearer(
+    router: Router,
+    path: &str,
+    token: &str,
+) -> axum::http::Response<axum::body::Body> {
+    router
+        .oneshot(
+            Request::builder()
+                .uri(path)
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+async fn body_json(resp: axum::http::Response<axum::body::Body>) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+const HEALTH_PATHS: [&str; 3] = ["/healthz", "/readyz", "/health"];
+
+// ---------- check stubs ----------
+
+struct HealthyCheck;
+#[async_trait]
+impl Healthcheck for HealthyCheck {
+    fn name(&self) -> &'static str {
+        "always-healthy"
+    }
+}
+
+struct DegradedCheck;
+#[async_trait]
+impl Healthcheck for DegradedCheck {
+    fn name(&self) -> &'static str {
+        "always-degraded"
+    }
+    async fn check(&self) -> HealthcheckResult {
+        HealthcheckResult::degraded("cache warming up")
+    }
+}
+
+struct UnhealthyCheck;
+#[async_trait]
+impl Healthcheck for UnhealthyCheck {
+    fn name(&self) -> &'static str {
+        "always-unhealthy"
+    }
+    async fn check(&self) -> HealthcheckResult {
+        HealthcheckResult::unhealthy("database unreachable")
+    }
+}
+
+struct CodedUnhealthyCheck;
+#[async_trait]
+impl Healthcheck for CodedUnhealthyCheck {
+    fn name(&self) -> &'static str {
+        "coded-unhealthy"
+    }
+    async fn check(&self) -> HealthcheckResult {
+        HealthcheckResult::unhealthy("database unreachable").with_code("db_unreachable")
+    }
+}
+
+// ---------- default (main) mode: health on the main router, no auth ----------
+
+#[tokio::test]
+async fn default_main_serves_all_health_endpoints() {
+    let router = finalize_main_router(
+        json!({ "bind_addr": "0.0.0.0:0", "auth_disabled": true }),
+        None,
+        |reg| reg.register("my-gear", Arc::new(HealthyCheck)),
+    )
+    .await
+    .expect("finalize failed");
+
+    assert_eq!(
+        get(router.clone(), "/healthz").await.status(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        get(router.clone(), "/readyz").await.status(),
+        StatusCode::OK
+    );
+
+    let resp = get(router, "/health").await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["status"], "healthy");
+    assert_eq!(body["components"][0]["gear"], "my-gear");
+}
+
+#[tokio::test]
+async fn main_readyz_returns_503_when_unhealthy() {
+    let router = finalize_main_router(
+        json!({ "bind_addr": "0.0.0.0:0", "auth_disabled": true }),
+        None,
+        |reg| reg.register("gear", Arc::new(UnhealthyCheck)),
+    )
+    .await
+    .expect("finalize failed");
+
+    assert_eq!(
+        get(router.clone(), "/readyz").await.status(),
+        StatusCode::SERVICE_UNAVAILABLE
+    );
+    // /healthz is liveness only — stays 200 even when a readiness check is unhealthy.
+    assert_eq!(get(router, "/healthz").await.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn main_health_component_exposes_stable_code() {
+    let router = finalize_main_router(
+        json!({ "bind_addr": "0.0.0.0:0", "auth_disabled": true }),
+        None,
+        |reg| reg.register("gear", Arc::new(CodedUnhealthyCheck)),
+    )
+    .await
+    .expect("finalize failed");
+
+    let resp = get(router, "/health").await;
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let body = body_json(resp).await;
+    assert_eq!(body["components"][0]["code"], "db_unreachable");
+}
+
+#[tokio::test]
+async fn main_health_paths_inherit_prefix() {
+    // In main/both mode health rides the gateway's unified surface, so it inherits prefix_path
+    // like every other route.
+    let router = finalize_main_router(
+        json!({ "bind_addr": "0.0.0.0:0", "auth_disabled": true, "prefix_path": "/cf" }),
+        None,
+        |reg| reg.register("gear", Arc::new(HealthyCheck)),
+    )
+    .await
+    .expect("finalize failed");
+
+    for path in HEALTH_PATHS {
+        let prefixed = format!("/cf{path}");
+        assert_eq!(
+            get(router.clone(), &prefixed).await.status(),
+            StatusCode::OK,
+            "{prefixed} must be served under the configured prefix"
+        );
+        assert_eq!(
+            get(router.clone(), path).await.status(),
+            StatusCode::NOT_FOUND,
+            "unprefixed {path} must be absent when prefix_path is set"
+        );
+    }
+}
+
+// ---------- auth enabled: health bypasses auth ----------
+
+async fn auth_enabled_main_router() -> Router {
+    finalize_main_router(
+        json!({ "bind_addr": "0.0.0.0:0", "auth_disabled": false }),
+        Some(Arc::new(RejectingAuthN)),
+        |reg| reg.register("gear", Arc::new(HealthyCheck)),
+    )
+    .await
+    .expect("finalize failed")
+}
+
+#[tokio::test]
+async fn auth_enabled_health_accepts_missing_bearer() {
+    let router = auth_enabled_main_router().await;
+    for path in HEALTH_PATHS {
+        assert_eq!(
+            get(router.clone(), path).await.status(),
+            StatusCode::OK,
+            "{path} must be reachable without a bearer token when auth is enabled"
+        );
+    }
+}
+
+#[tokio::test]
+async fn auth_enabled_health_ignores_invalid_bearer() {
+    // A malformed/invalid bearer would be rejected by RejectingAuthN on any authed route;
+    // health must never reach it.
+    let router = auth_enabled_main_router().await;
+    for path in HEALTH_PATHS {
+        assert_eq!(
+            get_with_bearer(router.clone(), path, "garbage-token")
+                .await
+                .status(),
+            StatusCode::OK,
+            "{path} must ignore an invalid bearer token"
+        );
+    }
+}
+
+// ---------- separate mode ----------
+
+#[tokio::test]
+async fn separate_mode_omits_health_from_main_router() {
+    let router = finalize_main_router(
+        json!({
+            "bind_addr": "0.0.0.0:0",
+            "auth_disabled": true,
+            "health": { "serve": "separate", "bind_addr": "0.0.0.0:0" }
+        }),
+        None,
+        |reg| reg.register("gear", Arc::new(HealthyCheck)),
+    )
+    .await
+    .expect("finalize failed");
+
+    for path in HEALTH_PATHS {
+        assert_eq!(
+            get(router.clone(), path).await.status(),
+            StatusCode::NOT_FOUND,
+            "{path} must not be on the main router in separate mode"
+        );
+    }
+}
+
+#[tokio::test]
+async fn separate_health_router_serves_all_endpoints_without_auth() {
+    let router = build_standalone_health_router(|reg| {
+        reg.register("gear", Arc::new(HealthyCheck));
+    })
+    .await;
+
+    assert_eq!(
+        get(router.clone(), "/healthz").await.status(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        get(router.clone(), "/readyz").await.status(),
+        StatusCode::OK
+    );
+    assert_eq!(get(router, "/health").await.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn separate_health_router_readyz_reflects_degraded_and_unhealthy() {
+    let degraded = build_standalone_health_router(|reg| {
+        reg.register("gear", Arc::new(DegradedCheck));
+    })
+    .await;
+    // Degraded keeps the pod in rotation.
+    assert_eq!(get(degraded, "/readyz").await.status(), StatusCode::OK);
+
+    let unhealthy = build_standalone_health_router(|reg| {
+        reg.register("gear", Arc::new(UnhealthyCheck));
+    })
+    .await;
+    assert_eq!(
+        get(unhealthy, "/readyz").await.status(),
+        StatusCode::SERVICE_UNAVAILABLE
+    );
+}
+
+// ---------- both mode ----------
+
+#[tokio::test]
+async fn both_mode_serves_health_on_main_and_separate_router() {
+    use api_gateway::ApiGateway;
+    use toolkit::Gear;
+
+    let registry = Arc::new(RestHealthcheckRegistry::new());
+    registry.register("gear", Arc::new(HealthyCheck));
+
+    let config = json!({
+        "api-gateway": { "config": {
+            "bind_addr": "0.0.0.0:0",
+            "auth_disabled": true,
+            "health": { "serve": "both", "bind_addr": "0.0.0.0:0" }
+        } }
+    });
+    let ctx = GearCtx::new(
+        "api-gateway",
+        Uuid::new_v4(),
+        Arc::new(JsonConfigProvider(config)),
+        Arc::new(ClientHub::new()),
+        CancellationToken::new(),
+    );
+
+    let gw = ApiGateway::default();
+    gw.init(&ctx).await.expect("init failed");
+    let base = gw
+        .rest_prepare(&ctx, Router::new(), registry.clone())
+        .expect("rest_prepare failed");
+    let main = gw
+        .rest_finalize(&ctx, base, registry.clone())
+        .expect("rest_finalize failed");
+    let separate = gw.health_router().expect("health_router failed");
+
+    for (label, router) in [("main", main), ("separate", separate)] {
+        for path in HEALTH_PATHS {
+            assert_eq!(
+                get(router.clone(), path).await.status(),
+                StatusCode::OK,
+                "{label} listener must serve {path}"
+            );
+        }
+    }
+}
+
+// ---------- fail-fast config validation ----------
+
+#[tokio::test]
+async fn separate_mode_without_bind_addr_fails_init() {
+    let result = finalize_main_router(
+        json!({ "bind_addr": "0.0.0.0:0", "auth_disabled": true, "health": { "serve": "separate" } }),
+        None,
+        |_| {},
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "serve = separate without health.bind_addr must fail init"
+    );
+}
+
+#[tokio::test]
+async fn both_mode_without_bind_addr_fails_init() {
+    let result = finalize_main_router(
+        json!({ "bind_addr": "0.0.0.0:0", "auth_disabled": true, "health": { "serve": "both" } }),
+        None,
+        |_| {},
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "serve = both without health.bind_addr must fail init"
+    );
+}
+
+#[tokio::test]
+async fn separate_mode_with_invalid_bind_addr_fails_init() {
+    let result = finalize_main_router(
+        json!({
+            "bind_addr": "0.0.0.0:0",
+            "auth_disabled": true,
+            "health": { "serve": "separate", "bind_addr": "not-a-socket-addr" }
+        }),
+        None,
+        |_| {},
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "serve = separate with an unparseable health.bind_addr must fail init"
+    );
+}
+
+// ---------- absent from OpenAPI ----------
+
+#[tokio::test]
+async fn health_endpoints_absent_from_openapi() {
+    let router = finalize_main_router(
+        json!({ "bind_addr": "0.0.0.0:0", "auth_disabled": true, "enable_docs": true }),
+        None,
+        |reg| reg.register("gear", Arc::new(HealthyCheck)),
+    )
+    .await
+    .expect("finalize failed");
+
+    let resp = get(router, "/openapi.json").await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let doc = body_json(resp).await;
+    let paths = doc["paths"].as_object().expect("openapi paths object");
+    for path in HEALTH_PATHS {
+        assert!(
+            !paths.contains_key(path),
+            "{path} must not appear in the OpenAPI document"
+        );
+    }
+}

--- a/gears/system/api-gateway/tests/http_metrics_tests.rs
+++ b/gears/system/api-gateway/tests/http_metrics_tests.rs
@@ -158,7 +158,11 @@ async fn metrics_capture_successful_request() -> Result<()> {
         .json_response(StatusCode::OK, "OK")
         .handler(axum::routing::get(ok_handler))
         .register(Router::new(), &api);
-    let app = api.rest_finalize(&ctx, router)?;
+    let app = api.rest_finalize(
+        &ctx,
+        router,
+        Arc::new(toolkit::RestHealthcheckRegistry::new()),
+    )?;
 
     let res = app
         .oneshot(
@@ -212,7 +216,11 @@ async fn metrics_capture_mime_rejection() -> Result<()> {
         .json_response(StatusCode::OK, "OK")
         .handler(axum::routing::post(ok_handler))
         .register(Router::new(), &api);
-    let app = api.rest_finalize(&ctx, router)?;
+    let app = api.rest_finalize(
+        &ctx,
+        router,
+        Arc::new(toolkit::RestHealthcheckRegistry::new()),
+    )?;
 
     let res = app
         .oneshot(
@@ -275,7 +283,11 @@ async fn metrics_capture_rate_limit() -> Result<()> {
         .json_response(StatusCode::OK, "OK")
         .handler(axum::routing::get(ok_handler))
         .register(Router::new(), &api);
-    let app = api.rest_finalize(&ctx, router)?;
+    let app = api.rest_finalize(
+        &ctx,
+        router,
+        Arc::new(toolkit::RestHealthcheckRegistry::new()),
+    )?;
 
     // First request — succeeds and consumes the token
     let res1 = app
@@ -335,7 +347,11 @@ async fn metrics_route_attribute_uses_template() -> Result<()> {
         .json_response(StatusCode::OK, "OK")
         .handler(axum::routing::get(ok_handler))
         .register(Router::new(), &api);
-    let app = api.rest_finalize(&ctx, router)?;
+    let app = api.rest_finalize(
+        &ctx,
+        router,
+        Arc::new(toolkit::RestHealthcheckRegistry::new()),
+    )?;
 
     let res = app
         .oneshot(
@@ -387,7 +403,11 @@ async fn metrics_unmatched_route() -> Result<()> {
         .json_response(StatusCode::OK, "OK")
         .handler(axum::routing::get(ok_handler))
         .register(Router::new(), &api);
-    let app = api.rest_finalize(&ctx, router)?;
+    let app = api.rest_finalize(
+        &ctx,
+        router,
+        Arc::new(toolkit::RestHealthcheckRegistry::new()),
+    )?;
 
     let res = app
         .oneshot(
@@ -453,7 +473,11 @@ async fn metrics_prefix_applied_to_instrument_names() -> Result<()> {
         .json_response(StatusCode::OK, "OK")
         .handler(axum::routing::get(ok_handler))
         .register(Router::new(), &api);
-    let app = api.rest_finalize(&ctx, router)?;
+    let app = api.rest_finalize(
+        &ctx,
+        router,
+        Arc::new(toolkit::RestHealthcheckRegistry::new()),
+    )?;
 
     let res = app
         .oneshot(

--- a/gears/system/api-gateway/tests/license_middleware.rs
+++ b/gears/system/api-gateway/tests/license_middleware.rs
@@ -157,7 +157,11 @@ async fn rejects_non_base_feature_requirement() {
         .expect("Failed to register routes");
 
     router = api_gateway
-        .rest_finalize(&api_ctx, router)
+        .rest_finalize(
+            &api_ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize");
 
     let response = router
@@ -214,7 +218,11 @@ async fn rejects_non_base_feature_requirement_with_prefix() {
         .expect("Failed to register routes");
 
     router = api_gateway
-        .rest_finalize(&api_ctx, router)
+        .rest_finalize(
+            &api_ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize");
 
     let response = router
@@ -269,7 +277,11 @@ async fn allows_base_feature_requirement() {
         .expect("Failed to register routes");
 
     let router = api_gateway
-        .rest_finalize(&api_ctx, router)
+        .rest_finalize(
+            &api_ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize");
 
     let response = router
@@ -312,7 +324,11 @@ async fn allows_base_feature_requirement_with_prefix() {
         .expect("Failed to register routes");
 
     let router = api_gateway
-        .rest_finalize(&api_ctx, router)
+        .rest_finalize(
+            &api_ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize");
 
     let response = router
@@ -354,7 +370,11 @@ async fn allows_no_license_requirement() {
         .expect("Failed to register routes");
 
     let router = api_gateway
-        .rest_finalize(&api_ctx, router)
+        .rest_finalize(
+            &api_ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize");
 
     let response = router

--- a/gears/system/api-gateway/tests/middleware_order.rs
+++ b/gears/system/api-gateway/tests/middleware_order.rs
@@ -84,7 +84,11 @@ async fn real_middlewares_observe_documented_order() -> Result<()> {
         .register(router, &api);
 
     // Apply the real gateway middleware stack.
-    let app = api.rest_finalize(&ctx, router)?;
+    let app = api.rest_finalize(
+        &ctx,
+        router,
+        Arc::new(toolkit::RestHealthcheckRegistry::new()),
+    )?;
 
     // --------------------
     // Req1: invalid Content-Type -> should be rejected by MIME validation (BAD_REQUEST / 400),
@@ -203,7 +207,11 @@ async fn real_middlewares_observe_documented_order_with_prefix() -> Result<()> {
         .register(router, &api);
 
     // Apply the real gateway middleware stack.
-    let app = api.rest_finalize(&ctx, router)?;
+    let app = api.rest_finalize(
+        &ctx,
+        router,
+        Arc::new(toolkit::RestHealthcheckRegistry::new()),
+    )?;
 
     // --------------------
     // Req1: invalid Content-Type -> should be rejected by MIME validation (BAD_REQUEST / 400),

--- a/gears/system/api-gateway/tests/rate_limit_tests.rs
+++ b/gears/system/api-gateway/tests/rate_limit_tests.rs
@@ -173,7 +173,11 @@ async fn test_rate_limit_enforcement() {
 
     // Build the final router with middleware
     let _final_router = api_gateway
-        .rest_finalize(&ctx, router)
+        .rest_finalize(
+            &ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize router");
 
     // Note: Full HTTP testing would require starting a server and making real requests
@@ -291,7 +295,11 @@ async fn test_rate_limit_returns_canonical_problem_with_headers() {
         .expect("Failed to register routes");
 
     let app = api_gateway
-        .rest_finalize(&ctx, router)
+        .rest_finalize(
+            &ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize router");
 
     // First request consumes the only token.
@@ -389,7 +397,11 @@ async fn test_in_flight_limit_returns_canonical_service_unavailable() {
         .register(Router::new(), &api_gateway);
 
     let app = api_gateway
-        .rest_finalize(&ctx, router)
+        .rest_finalize(
+            &ctx,
+            router,
+            Arc::new(toolkit::RestHealthcheckRegistry::new()),
+        )
         .expect("Failed to finalize router");
 
     // Start one slow request and immediately fire a second one while the first holds the only permit.

--- a/libs/toolkit/src/contracts.rs
+++ b/libs/toolkit/src/contracts.rs
@@ -60,22 +60,45 @@ pub trait RestApiCapability: Send + Sync {
         router: Router,
         openapi: &dyn OpenApiRegistry,
     ) -> anyhow::Result<Router>;
+
+    /// Readiness healthcheck for this gear, run on every `/readyz` and `/health`.
+    /// `None` (default) opts out.
+    ///
+    /// Return **one composite check per gear** that aggregates the gear's critical
+    /// dependencies, rather than many fine-grained probes — the aggregate is what decides
+    /// whether the pod stays in traffic. External SaaS/LLM dependencies should usually **not**
+    /// gate readiness: a provider outage would evict every pod from rotation and take the
+    /// whole service down. Report such dependencies as `degraded` (kept in rotation), reserving
+    /// `unhealthy` for failures the gear itself cannot serve through.
+    fn healthcheck(
+        &self,
+        _ctx: &crate::context::GearCtx,
+    ) -> Option<std::sync::Arc<dyn crate::healthcheck::Healthcheck>> {
+        None
+    }
 }
 
 /// API Gateway capability: handles gateway hosting with prepare/finalize phases.
 /// Must be sync. Runs during REST phase, but doesn't start the server.
 #[allow(dead_code)]
 pub trait ApiGatewayCapability: Send + Sync + 'static {
-    /// Prepare a base Router (e.g., global middlewares, /healthz) and optionally touch `OpenAPI` meta.
-    /// Do NOT start the server here.
+    /// Prepare a base Router (e.g., global middlewares) and optionally touch `OpenAPI` meta.
+    /// Do NOT start the server here. `hc_registry` is the runtime's shared healthcheck
+    /// registry, passed explicitly (not via `ClientHub`, which is for inter-gear clients).
     ///
     /// # Errors
     /// Returns an error if router preparation fails.
-    fn rest_prepare(&self, ctx: &crate::context::GearCtx, router: Router)
-    -> anyhow::Result<Router>;
+    fn rest_prepare(
+        &self,
+        ctx: &crate::context::GearCtx,
+        router: Router,
+        hc_registry: std::sync::Arc<crate::healthcheck::RestHealthcheckRegistry>,
+    ) -> anyhow::Result<Router>;
 
-    /// Finalize before start: attach /openapi.json, /docs, persist the Router internally if needed.
-    /// Do NOT start the server here.
+    /// Finalize before start: attach /openapi.json, /docs, health endpoints, persist the
+    /// Router internally if needed. Do NOT start the server here.
+    ///
+    /// `hc_registry` is the same registry instance passed to [`rest_prepare`](Self::rest_prepare).
     ///
     /// # Errors
     /// Returns an error if router finalization fails.
@@ -83,6 +106,7 @@ pub trait ApiGatewayCapability: Send + Sync + 'static {
         &self,
         ctx: &crate::context::GearCtx,
         router: Router,
+        hc_registry: std::sync::Arc<crate::healthcheck::RestHealthcheckRegistry>,
     ) -> anyhow::Result<Router>;
 
     // Return OpenAPI registry of the gear, e.g., to register endpoints

--- a/libs/toolkit/src/healthcheck.rs
+++ b/libs/toolkit/src/healthcheck.rs
@@ -1,0 +1,774 @@
+//! REST readiness healthcheck infrastructure for probing gear health.
+//!
+//! This module provides concurrent healthcheck execution with timeout protection.
+//! Gears implement [`Healthcheck`] and register themselves via [`RestHealthcheckRegistry`].
+//! The API Gateway calls [`report()`](RestHealthcheckRegistry::report) on `/health` and `/readyz`
+//! requests to aggregate per-component readiness status.
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use async_trait::async_trait;
+//! use std::sync::Arc;
+//! use toolkit::{Healthcheck, HealthcheckResult, contracts::RestApiCapability};
+//!
+//! struct MyHealthcheck;
+//!
+//! #[async_trait]
+//! impl Healthcheck for MyHealthcheck {
+//!     fn name(&self) -> &'static str {
+//!         "my-gear-readiness"
+//!     }
+//!
+//!     async fn check(&self) -> HealthcheckResult {
+//!         HealthcheckResult::healthy()
+//!     }
+//! }
+//!
+//! impl RestApiCapability for MyGear {
+//!     fn healthcheck(
+//!         &self,
+//!         _ctx: &toolkit::context::GearCtx,
+//!     ) -> Option<Arc<dyn Healthcheck>> {
+//!         Some(Arc::new(MyHealthcheck))
+//!     }
+//!
+//!     fn register_rest(
+//!         &self,
+//!         ctx: &toolkit::context::GearCtx,
+//!         router: axum::Router,
+//!         openapi: &dyn toolkit::contracts::OpenApiRegistry,
+//!     ) -> anyhow::Result<axum::Router> {
+//!         Ok(router)
+//!     }
+//! }
+//! ```
+//!
+//! # Kubernetes probe configuration
+//!
+//! ```yaml
+//! livenessProbe:
+//!   httpGet:
+//!     path: /healthz
+//!     port: http
+//!   periodSeconds: 10
+//!   timeoutSeconds: 2
+//!   failureThreshold: 3
+//!
+//! readinessProbe:
+//!   httpGet:
+//!     path: /readyz
+//!     port: http
+//!   periodSeconds: 5
+//!   timeoutSeconds: 2
+//!   failureThreshold: 3
+//! ```
+//!
+//! `/healthz` is liveness — always shallow, never runs user checks.
+//! `/readyz` is readiness — runs user REST healthchecks and removes the pod
+//! from traffic when unhealthy without triggering a restart.
+//! `/health` is the detailed diagnostic endpoint — its JSON body includes per-component
+//! check names and messages.
+//!
+//! Probe port and path depend on the serving mode (`api-gateway` `health.serve`): with `main`
+//! or `both` the endpoints ride the main gateway listener (target the main `http` port) and
+//! inherit `prefix_path` like any other route (e.g. `/cf/healthz`); with `separate` they are
+//! served only on the health listener (`health.bind_addr`) at unprefixed paths, so probes must
+//! target that port and the bare `/healthz`/`/readyz`/`/health` paths.
+//!
+//! # Threat model
+//!
+//! All three endpoints are **unauthenticated in every serving mode**: on the main listener
+//! they are registered as explicit public routes so the auth layer waves them through without
+//! a bearer token, and the separate listener runs no auth at all. They are protected by
+//! deployment controls, not credentials: a `separate` health listener is expected to sit on a
+//! private/management network, and `main`-mounted endpoints inherit whatever network placement
+//! the main gateway has.
+//! Because `/health` can expose per-component names and messages without auth, check messages
+//! are sanitized (see [`sanitize_message`]) so a secret, DSN, credential, or panic backtrace
+//! cannot leak to an unauthenticated caller.
+
+use async_trait::async_trait;
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex as AsyncMutex;
+use tokio_util::sync::CancellationToken;
+
+/// Single-check and aggregate readiness status.
+/// Serialized lowercase into `/health`/`/readyz`; variants are a stable API contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HealthcheckStatus {
+    Healthy,
+    Degraded,
+    Unhealthy,
+}
+
+/// Result of one [`Healthcheck::check`]; fields are part of the stable `/health` JSON contract.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HealthcheckResult {
+    pub status: HealthcheckStatus,
+    pub message: Option<String>,
+    /// Stable, machine-readable code (e.g. `"db_unreachable"`), surfaced on `/health`. Lets
+    /// operators alert on a stable signal even when the human-readable `message` is collapsed
+    /// by sanitization. Because `/health` is unauthenticated, the code is constrained (see
+    /// [`sanitize_code`]) to a short `[a-z0-9_.-]` identifier and dropped if it does not
+    /// conform — it must never carry secrets or free-form detail.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+}
+
+impl HealthcheckResult {
+    #[must_use]
+    pub fn healthy() -> Self {
+        Self {
+            status: HealthcheckStatus::Healthy,
+            message: None,
+            code: None,
+        }
+    }
+
+    #[must_use]
+    pub fn degraded(message: impl Into<String>) -> Self {
+        Self {
+            status: HealthcheckStatus::Degraded,
+            message: Some(message.into()),
+            code: None,
+        }
+    }
+
+    #[must_use]
+    pub fn unhealthy(message: impl Into<String>) -> Self {
+        Self {
+            status: HealthcheckStatus::Unhealthy,
+            message: Some(message.into()),
+            code: None,
+        }
+    }
+
+    /// Attach a stable machine-readable code (see [`HealthcheckResult::code`]).
+    #[must_use]
+    pub fn with_code(mut self, code: impl Into<String>) -> Self {
+        self.code = Some(code.into());
+        self
+    }
+}
+
+impl Default for HealthcheckResult {
+    fn default() -> Self {
+        Self::healthy()
+    }
+}
+
+/// Readiness probe implemented by a gear.
+///
+/// `name` must be an explicit human-readable id (no type paths); it is exposed on
+/// `/health`. `check` must be cancellation-safe and should not leak secrets in its
+/// message (the registry sanitises anyway); panics and per-check timeouts are caught
+/// and mapped to [`HealthcheckStatus::Unhealthy`]. Default `check` returns healthy.
+#[async_trait]
+pub trait Healthcheck: Send + Sync + 'static {
+    /// Human-readable check name, exposed verbatim in `/health` JSON.
+    fn name(&self) -> &'static str;
+
+    async fn check(&self) -> HealthcheckResult {
+        HealthcheckResult::healthy()
+    }
+}
+
+/// One gear's healthcheck result. All fields are part of the stable `/health` JSON contract.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HealthcheckComponentReport {
+    pub gear: String,
+    pub check: String,
+    pub status: HealthcheckStatus,
+    /// Sanitized (see [`sanitize_message`]).
+    pub message: Option<String>,
+    /// Stable machine-readable code from [`HealthcheckResult::code`]; passed through unsanitized.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    pub latency_ms: u64,
+}
+
+/// Aggregate report from [`RestHealthcheckRegistry::report`]; stable `/health`/`/readyz` JSON contract.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HealthcheckReport {
+    pub status: HealthcheckStatus,
+    pub components: Vec<HealthcheckComponentReport>,
+}
+
+impl HealthcheckReport {
+    /// Ready unless `Unhealthy` (`Healthy` and `Degraded` both keep the pod in rotation).
+    #[must_use]
+    pub fn is_ready(&self) -> bool {
+        self.status != HealthcheckStatus::Unhealthy
+    }
+}
+
+struct RegistryEntry {
+    gear: String,
+    check: Arc<dyn Healthcheck>,
+}
+
+/// Bursty probes within this window reuse the last report instead of re-running checks.
+/// Kept > the default per-check timeout (500 ms) so a timed-out check still buffers.
+const REPORT_CACHE_TTL: Duration = Duration::from_secs(2);
+
+/// Holds the REST healthchecks registered during REST wiring; the gateway calls
+/// [`report`](Self::report) on every `/readyz` and `/health` request.
+#[derive(Default)]
+pub struct RestHealthcheckRegistry {
+    entries: RwLock<Vec<RegistryEntry>>,
+    cached_report: AsyncMutex<Option<(Instant, HealthcheckReport)>>,
+    /// Runtime shutdown token; aborts in-flight checks. Default never fires.
+    cancel: CancellationToken,
+}
+
+impl RestHealthcheckRegistry {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registry whose in-flight checks are aborted when `cancel` fires.
+    #[must_use]
+    pub fn with_cancellation(cancel: CancellationToken) -> Self {
+        Self {
+            cancel,
+            ..Self::default()
+        }
+    }
+
+    /// Register a healthcheck for the given gear.
+    pub fn register(&self, gear: impl Into<String>, check: Arc<dyn Healthcheck>) {
+        self.entries.write().push(RegistryEntry {
+            gear: gear.into(),
+            check,
+        });
+    }
+
+    /// Run all checks concurrently, aggregate, and cache for [`REPORT_CACHE_TTL`].
+    /// Panics and per-check timeouts map to [`HealthcheckStatus::Unhealthy`]. The cache
+    /// lock is held across the compute so concurrent cache-misses coalesce into one fan-out.
+    pub async fn report(&self, timeout_per_check: Duration) -> HealthcheckReport {
+        let mut guard = self.cached_report.lock().await;
+        if let Some((ts, cached)) = guard.as_ref()
+            && ts.elapsed() < REPORT_CACHE_TTL
+        {
+            return cached.clone();
+        }
+
+        let entries: Vec<(_, _)> = {
+            let r = self.entries.read();
+            r.iter()
+                .map(|e| (e.gear.clone(), e.check.clone()))
+                .collect()
+        };
+
+        let report = if entries.is_empty() {
+            HealthcheckReport {
+                status: HealthcheckStatus::Healthy,
+                components: vec![],
+            }
+        } else {
+            let cancel = &self.cancel;
+            let checks = entries
+                .into_iter()
+                .map(|(gear, check)| run_one_check(gear, check, timeout_per_check, cancel));
+            let components = futures_util::future::join_all(checks).await;
+            let aggregate = compute_aggregate(&components);
+            HealthcheckReport {
+                status: aggregate,
+                components,
+            }
+        };
+
+        *guard = Some((Instant::now(), report.clone()));
+        report
+    }
+}
+
+async fn run_one_check(
+    gear: String,
+    check: Arc<dyn Healthcheck>,
+    timeout_per_check: Duration,
+    cancel: &CancellationToken,
+) -> HealthcheckComponentReport {
+    let name = check.name();
+    let start = Instant::now();
+
+    let mut handle = tokio::spawn(async move { check.check().await });
+
+    let (status, message, code) = tokio::select! {
+        result = &mut handle => match result {
+            Ok(r) => (
+                r.status,
+                r.message.as_deref().map(sanitize_message),
+                r.code.as_deref().and_then(sanitize_code),
+            ),
+            Err(join_err) => {
+                tracing::error!(gear = %gear, check = name, error = %join_err, "healthcheck task panicked");
+                (
+                    HealthcheckStatus::Unhealthy,
+                    Some("health check failed".to_owned()),
+                    None,
+                )
+            }
+        },
+        () = tokio::time::sleep(timeout_per_check) => {
+            handle.abort();
+            if let Err(join_err) = handle.await
+                && !join_err.is_cancelled()
+            {
+                tracing::warn!(gear = %gear, check = name, error = %join_err, "healthcheck task join error after timeout abort");
+            }
+            tracing::warn!(gear = %gear, check = name, timeout_ms = timeout_per_check.as_millis(), "healthcheck timed out");
+            (
+                HealthcheckStatus::Unhealthy,
+                Some("health check timed out".to_owned()),
+                None,
+            )
+        }
+        () = cancel.cancelled() => {
+            handle.abort();
+            if let Err(join_err) = handle.await
+                && !join_err.is_cancelled()
+            {
+                tracing::warn!(gear = %gear, check = name, error = %join_err, "healthcheck task join error after shutdown abort");
+            }
+            tracing::warn!(gear = %gear, check = name, "healthcheck cancelled by runtime shutdown");
+            (
+                HealthcheckStatus::Unhealthy,
+                Some("health check cancelled".to_owned()),
+                None,
+            )
+        }
+    };
+
+    HealthcheckComponentReport {
+        gear,
+        check: name.to_owned(),
+        status,
+        message,
+        code,
+        latency_ms: u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+    }
+}
+
+fn compute_aggregate(components: &[HealthcheckComponentReport]) -> HealthcheckStatus {
+    let mut status = HealthcheckStatus::Healthy;
+    for c in components {
+        match c.status {
+            HealthcheckStatus::Unhealthy => return HealthcheckStatus::Unhealthy,
+            HealthcheckStatus::Degraded => {
+                status = HealthcheckStatus::Degraded;
+            }
+            HealthcheckStatus::Healthy => {}
+        }
+    }
+    status
+}
+
+const MAX_MESSAGE_LEN: usize = 256;
+
+// Blocklist targeting the actual threat: `/health` is unauthenticated (protected only by
+// private listener/network placement), so a check message must never carry a secret, DSN,
+// credential, or panic backtrace to an anonymous caller. Deliberately excludes operator-useful
+// terms (tenant ids, SQL verbs, "private" network hints) that are not secrets — keeping them
+// readable makes the endpoint actually diagnostic. Matched substrings collapse the message to
+// the generic string.
+static SUSPICIOUS_SUBSTRINGS: &[&str] = &[
+    "password",
+    "passwd",
+    "secret",
+    "token",
+    "bearer",
+    "authorization",
+    "api_key",
+    "apikey",
+    "private_key",
+    "credential",
+    "access_key",
+    "aws_",
+    "client_secret",
+    "postgres://",
+    "postgresql://",
+    "mysql://",
+    "sqlite://",
+    "mongodb://",
+    "redis://",
+    "amqp://",
+    "jdbc:",
+    "panic",
+    "stack backtrace",
+];
+
+fn sanitize_message(msg: &str) -> String {
+    if msg.len() > MAX_MESSAGE_LEN {
+        return "health check failed".to_owned();
+    }
+    let lower = msg.to_lowercase();
+    for sub in SUSPICIOUS_SUBSTRINGS {
+        if lower.contains(sub) {
+            return "health check failed".to_owned();
+        }
+    }
+    msg.to_owned()
+}
+
+const MAX_CODE_LEN: usize = 64;
+
+/// Validate a health `code` for exposure on the unauthenticated `/health` endpoint.
+///
+/// A code must be a short machine identifier, not free text — so unlike `message` (which is
+/// scrubbed by a blocklist), `code` is validated by an allowlist: non-empty, `<= MAX_CODE_LEN`,
+/// and only `[a-z0-9_.-]`. Non-conforming codes are dropped (`None`) rather than surfaced,
+/// closing the hole where a permissive code could smuggle a secret past `sanitize_message`.
+fn sanitize_code(code: &str) -> Option<String> {
+    let ok = !code.is_empty()
+        && code.len() <= MAX_CODE_LEN
+        && code.bytes().all(|b| {
+            b.is_ascii_lowercase() || b.is_ascii_digit() || matches!(b, b'_' | b'.' | b'-')
+        });
+    if ok {
+        Some(code.to_owned())
+    } else {
+        tracing::debug!(
+            code,
+            "health check code dropped: not a [a-z0-9_.-] identifier"
+        );
+        None
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+    use tokio::sync::Notify;
+
+    struct AlwaysDegraded;
+    #[async_trait]
+    impl Healthcheck for AlwaysDegraded {
+        fn name(&self) -> &'static str {
+            "always-degraded"
+        }
+        async fn check(&self) -> HealthcheckResult {
+            HealthcheckResult::degraded("cache warming")
+        }
+    }
+
+    struct AlwaysUnhealthy;
+    #[async_trait]
+    impl Healthcheck for AlwaysUnhealthy {
+        fn name(&self) -> &'static str {
+            "always-unhealthy"
+        }
+        async fn check(&self) -> HealthcheckResult {
+            HealthcheckResult::unhealthy("database unreachable")
+        }
+    }
+
+    struct SlowCheck;
+    #[async_trait]
+    impl Healthcheck for SlowCheck {
+        fn name(&self) -> &'static str {
+            "slow-check"
+        }
+        async fn check(&self) -> HealthcheckResult {
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            HealthcheckResult::healthy()
+        }
+    }
+
+    struct AbortTrackingCheck {
+        entered: Arc<Notify>,
+        dropped: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl Healthcheck for AbortTrackingCheck {
+        fn name(&self) -> &'static str {
+            "abort-tracking-check"
+        }
+        async fn check(&self) -> HealthcheckResult {
+            struct DropFlag(Arc<AtomicBool>);
+            impl Drop for DropFlag {
+                fn drop(&mut self) {
+                    self.0.store(true, Ordering::SeqCst);
+                }
+            }
+
+            let _drop_flag = DropFlag(self.dropped.clone());
+            self.entered.notify_one();
+            std::future::pending::<HealthcheckResult>().await
+        }
+    }
+
+    struct PanickingCheck;
+    #[async_trait]
+    impl Healthcheck for PanickingCheck {
+        fn name(&self) -> &'static str {
+            "panicking-check"
+        }
+        async fn check(&self) -> HealthcheckResult {
+            panic!("intentional panic in healthcheck");
+        }
+    }
+
+    #[test]
+    fn healthcheck_result_default_is_healthy() {
+        let r = HealthcheckResult::default();
+        assert_eq!(r.status, HealthcheckStatus::Healthy);
+        assert!(r.message.is_none());
+    }
+
+    #[tokio::test]
+    async fn empty_registry_report_is_healthy_and_ready() {
+        let registry = RestHealthcheckRegistry::new();
+        let report = registry.report(Duration::from_millis(500)).await;
+        assert_eq!(report.status, HealthcheckStatus::Healthy);
+        assert!(report.is_ready());
+        assert!(report.components.is_empty());
+    }
+
+    #[tokio::test]
+    async fn unhealthy_component_makes_aggregate_unhealthy_and_not_ready() {
+        let registry = RestHealthcheckRegistry::new();
+        registry.register("my-gear", Arc::new(AlwaysUnhealthy));
+        let report = registry.report(Duration::from_millis(500)).await;
+        assert_eq!(report.status, HealthcheckStatus::Unhealthy);
+        assert!(!report.is_ready());
+    }
+
+    #[tokio::test]
+    async fn mixed_degraded_and_unhealthy_aggregate_is_unhealthy() {
+        let registry = RestHealthcheckRegistry::new();
+        registry.register("degraded-gear", Arc::new(AlwaysDegraded));
+        registry.register("unhealthy-gear", Arc::new(AlwaysUnhealthy));
+        let report = registry.report(Duration::from_millis(500)).await;
+        assert_eq!(
+            report.status,
+            HealthcheckStatus::Unhealthy,
+            "unhealthy must take priority over degraded"
+        );
+        assert!(!report.is_ready());
+    }
+
+    #[tokio::test]
+    async fn slow_check_times_out_and_becomes_unhealthy() {
+        let registry = RestHealthcheckRegistry::new();
+        registry.register("slow-gear", Arc::new(SlowCheck));
+        let report = registry.report(Duration::from_millis(100)).await;
+        assert_eq!(report.status, HealthcheckStatus::Unhealthy);
+        let comp = &report.components[0];
+        assert_eq!(comp.status, HealthcheckStatus::Unhealthy);
+        assert_eq!(comp.message.as_deref(), Some("health check timed out"));
+    }
+
+    #[tokio::test]
+    async fn timed_out_check_is_aborted() {
+        let registry = RestHealthcheckRegistry::new();
+        let entered = Arc::new(Notify::new());
+        let dropped = Arc::new(AtomicBool::new(false));
+        registry.register(
+            "slow-gear",
+            Arc::new(AbortTrackingCheck {
+                entered: entered.clone(),
+                dropped: dropped.clone(),
+            }),
+        );
+
+        let report_task =
+            tokio::spawn(async move { registry.report(Duration::from_millis(10)).await });
+        entered.notified().await;
+        let report = report_task.await.expect("report task panicked");
+
+        assert_eq!(report.status, HealthcheckStatus::Unhealthy);
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "timed-out healthcheck future must be dropped after abort"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_registry_aborts_in_flight_check_and_reports_unhealthy() {
+        let cancel = CancellationToken::new();
+        let registry = RestHealthcheckRegistry::with_cancellation(cancel.clone());
+        let entered = Arc::new(Notify::new());
+        let dropped = Arc::new(AtomicBool::new(false));
+        registry.register(
+            "slow-gear",
+            Arc::new(AbortTrackingCheck {
+                entered: entered.clone(),
+                dropped: dropped.clone(),
+            }),
+        );
+
+        // Long per-check timeout so cancellation, not the timeout, ends the check.
+        let report_task =
+            tokio::spawn(async move { registry.report(Duration::from_mins(1)).await });
+        entered.notified().await;
+        cancel.cancel();
+        let report = report_task.await.expect("report task panicked");
+
+        assert_eq!(report.status, HealthcheckStatus::Unhealthy);
+        assert_eq!(
+            report.components[0].message.as_deref(),
+            Some("health check cancelled")
+        );
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "cancelled healthcheck future must be dropped after abort"
+        );
+    }
+
+    #[tokio::test]
+    async fn panicking_check_becomes_unhealthy_without_panicking_caller() {
+        let registry = RestHealthcheckRegistry::new();
+        registry.register("panic-gear", Arc::new(PanickingCheck));
+        let report = registry.report(Duration::from_millis(500)).await;
+        assert_eq!(report.status, HealthcheckStatus::Unhealthy);
+    }
+
+    #[tokio::test]
+    async fn second_call_within_ttl_reuses_cached_report_without_rerunning_checks() {
+        use std::sync::atomic::AtomicUsize;
+
+        struct CountingCheck(Arc<AtomicUsize>);
+        #[async_trait]
+        impl Healthcheck for CountingCheck {
+            fn name(&self) -> &'static str {
+                "counting-check"
+            }
+            async fn check(&self) -> HealthcheckResult {
+                self.0.fetch_add(1, Ordering::SeqCst);
+                HealthcheckResult::healthy()
+            }
+        }
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let registry = RestHealthcheckRegistry::new();
+        registry.register("counted-gear", Arc::new(CountingCheck(calls.clone())));
+
+        let first = registry.report(Duration::from_millis(500)).await;
+        let second = registry.report(Duration::from_millis(500)).await;
+
+        assert_eq!(first.status, HealthcheckStatus::Healthy);
+        assert_eq!(second.status, HealthcheckStatus::Healthy);
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "second report() within REPORT_CACHE_TTL must reuse the cached result"
+        );
+    }
+
+    #[test]
+    fn sensitive_message_is_sanitized() {
+        assert_eq!(
+            sanitize_message("connection to postgres://user:pass@host/db failed"),
+            "health check failed"
+        );
+        assert_eq!(
+            sanitize_message("invalid token in header"),
+            "health check failed"
+        );
+        assert_eq!(
+            sanitize_message("thread panicked at some_file.rs:42"),
+            "health check failed"
+        );
+        assert_eq!(
+            sanitize_message("invalid api_key provided"),
+            "health check failed"
+        );
+        assert_eq!(
+            sanitize_message("connection to mongodb://host/db failed"),
+            "health check failed"
+        );
+    }
+
+    #[test]
+    fn long_message_is_sanitized() {
+        let long = "x".repeat(257);
+        assert_eq!(sanitize_message(&long), "health check failed");
+    }
+
+    #[test]
+    fn clean_message_passes_through() {
+        assert_eq!(
+            sanitize_message("upstream service unavailable"),
+            "upstream service unavailable"
+        );
+    }
+
+    #[test]
+    fn operator_useful_messages_pass_through() {
+        // These are not secrets and are useful when diagnosing an unhealthy pod, so the
+        // narrowed blocklist deliberately leaves them intact.
+        for msg in [
+            "tenant acme-corp migration pending",
+            "SELECT on read replica timed out",
+            "private subnet route unreachable",
+        ] {
+            assert_eq!(sanitize_message(msg), msg);
+        }
+    }
+
+    #[test]
+    fn code_allowlist_accepts_identifiers_and_drops_the_rest() {
+        assert_eq!(
+            sanitize_code("db_unreachable"),
+            Some("db_unreachable".to_owned())
+        );
+        assert_eq!(sanitize_code("v1.2-beta_3"), Some("v1.2-beta_3".to_owned()));
+        // Rejected: empty, uppercase, whitespace/free text, over length.
+        assert_eq!(sanitize_code(""), None);
+        assert_eq!(sanitize_code("DB_UNREACHABLE"), None);
+        assert_eq!(sanitize_code("postgres://user:pw@host/db"), None);
+        assert_eq!(sanitize_code("connection failed"), None);
+        assert_eq!(sanitize_code(&"a".repeat(MAX_CODE_LEN + 1)), None);
+    }
+
+    #[tokio::test]
+    async fn component_report_carries_conforming_code() {
+        struct CodedUnhealthy;
+        #[async_trait]
+        impl Healthcheck for CodedUnhealthy {
+            fn name(&self) -> &'static str {
+                "coded"
+            }
+            async fn check(&self) -> HealthcheckResult {
+                HealthcheckResult::unhealthy("database unreachable").with_code("db_unreachable")
+            }
+        }
+
+        let registry = RestHealthcheckRegistry::new();
+        registry.register("gear", Arc::new(CodedUnhealthy));
+        let report = registry.report(Duration::from_millis(500)).await;
+        assert_eq!(report.components[0].code.as_deref(), Some("db_unreachable"));
+    }
+
+    #[tokio::test]
+    async fn component_report_drops_nonconforming_code() {
+        struct BadCode;
+        #[async_trait]
+        impl Healthcheck for BadCode {
+            fn name(&self) -> &'static str {
+                "bad-code"
+            }
+            async fn check(&self) -> HealthcheckResult {
+                // A code carrying free-form detail (a DSN) must never reach the report.
+                HealthcheckResult::unhealthy("down").with_code("postgres://u:p@host/db")
+            }
+        }
+
+        let registry = RestHealthcheckRegistry::new();
+        registry.register("gear", Arc::new(BadCode));
+        let report = registry.report(Duration::from_millis(500)).await;
+        assert!(report.components[0].code.is_none());
+    }
+}

--- a/libs/toolkit/src/lib.rs
+++ b/libs/toolkit/src/lib.rs
@@ -136,6 +136,14 @@ pub use directory::{
     ServiceInstanceInfo,
 };
 
+// REST healthcheck infrastructure. Module private so types have one public path
+// (flat re-export below), not two.
+mod healthcheck;
+pub use healthcheck::{
+    Healthcheck, HealthcheckComponentReport, HealthcheckReport, HealthcheckResult,
+    HealthcheckStatus, RestHealthcheckRegistry,
+};
+
 // GTS schema support
 pub mod gts;
 

--- a/libs/toolkit/src/registry.rs
+++ b/libs/toolkit/src/registry.rs
@@ -1071,6 +1071,7 @@ mod tests {
             &self,
             _ctx: &crate::context::GearCtx,
             router: axum::Router,
+            _hc_registry: std::sync::Arc<crate::healthcheck::RestHealthcheckRegistry>,
         ) -> anyhow::Result<axum::Router> {
             Ok(router)
         }
@@ -1078,6 +1079,7 @@ mod tests {
             &self,
             _ctx: &crate::context::GearCtx,
             router: axum::Router,
+            _hc_registry: std::sync::Arc<crate::healthcheck::RestHealthcheckRegistry>,
         ) -> anyhow::Result<axum::Router> {
             Ok(router)
         }

--- a/libs/toolkit/src/runtime/host_runtime.rs
+++ b/libs/toolkit/src/runtime/host_runtime.rs
@@ -439,13 +439,22 @@ impl HostRuntime {
         // use host as the registry
         let registry: &dyn crate::contracts::OpenApiRegistry = host.as_registry();
 
+        // Healthcheck registry, passed explicitly to the REST host and providers below
+        // (not via ClientHub). Seeded with the host's shutdown token so in-flight checks
+        // are aborted on shutdown.
+        let hc_registry = Arc::new(
+            crate::healthcheck::RestHealthcheckRegistry::with_cancellation(
+                host_ctx.cancellation_token().clone(),
+            ),
+        );
+
         // 1) Host prepare: base Router / global middlewares / basic OAS meta
-        router =
-            host.rest_prepare(&host_ctx, router)
-                .map_err(|source| RegistryError::RestPrepare {
-                    gear: host_entry.name,
-                    source,
-                })?;
+        router = host
+            .rest_prepare(&host_ctx, router, hc_registry.clone())
+            .map_err(|source| RegistryError::RestPrepare {
+                gear: host_entry.name,
+                source,
+            })?;
 
         // 2) Register all REST providers (in the current discovery order)
         for e in self.registry.gears() {
@@ -463,16 +472,21 @@ impl HostRuntime {
                         gear: e.name,
                         source,
                     })?;
+
+                // Register the gear's readiness healthcheck after successful route registration.
+                if let Some(hc) = rest.healthcheck(&ctx) {
+                    hc_registry.register(e.name, hc);
+                }
             }
         }
 
         // 3) Host finalize: attach /openapi.json and /docs, persist Router if needed (no server start)
-        router = host.rest_finalize(&host_ctx, router).map_err(|source| {
-            RegistryError::RestFinalize {
+        router = host
+            .rest_finalize(&host_ctx, router, hc_registry)
+            .map_err(|source| RegistryError::RestFinalize {
                 gear: host_entry.name,
                 source,
-            }
-        })?;
+            })?;
 
         Ok(router)
     }

--- a/libs/toolkit/tests/macro_tests.rs
+++ b/libs/toolkit/tests/macro_tests.rs
@@ -188,6 +188,7 @@ impl ApiGatewayCapability for TestApiGatewayGear {
         &self,
         _ctx: &toolkit::context::GearCtx,
         router: axum::Router,
+        _hc_registry: std::sync::Arc<toolkit::RestHealthcheckRegistry>,
     ) -> anyhow::Result<axum::Router> {
         Ok(router)
     }
@@ -196,6 +197,7 @@ impl ApiGatewayCapability for TestApiGatewayGear {
         &self,
         _ctx: &toolkit::context::GearCtx,
         router: axum::Router,
+        _hc_registry: std::sync::Arc<toolkit::RestHealthcheckRegistry>,
     ) -> anyhow::Result<axum::Router> {
         Ok(router)
     }


### PR DESCRIPTION
- Concurrent healthcheck execution with timeout protection
- HealthcheckRegistry for registering and running per-gear probes
- Message sanitization to prevent secret leaks in responses
- API Gateway integration for /health and /readyz endpoints
- Comprehensive test coverage with panic/timeout/degradation scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added readiness-focused `/health`, `/healthz`, and `/readyz` endpoints with JSON status, RFC3339 timestamp, and per-component details.
  * Introduced a shared readiness healthcheck registry and a new REST readiness hook for services to publish checks.
  * Ensured health endpoints remain reachable at root paths even when the gateway is configured with a non-root prefix.
* **Bug Fixes**
  * Health responses now consistently reflect aggregated healthy/degraded/unhealthy readiness with correct `200` vs `503`.
* **Tests**
  * Added integration tests covering endpoint behavior, aggregation semantics, prefix handling, and readiness hook default/override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->