### PR TITLE
feat(cluster): add testing strategy and scenario documentation + add cluster-conformance crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,6 +1590,7 @@ name = "cf-gears-cluster"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "cf-gears-cluster-conformance",
  "cf-gears-cluster-sdk",
  "cf-gears-toolkit",
  "rand 0.10.1",
@@ -1598,6 +1599,17 @@ dependencies = [
  "tracing",
  "tracing-test",
  "uuid",
+]
+
+[[package]]
+name = "cf-gears-cluster-conformance"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "cf-gears-cluster-sdk",
+ "parking_lot",
+ "proptest",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ members = [
     "gears/system/api-gateway",
     "gears/system/cluster/cluster-sdk",
     "gears/system/cluster/cluster",
+    "gears/system/cluster/cluster-conformance",
     "gears/system/grpc-hub",
     "gears/system/nodes-registry/nodes-registry",
     "gears/system/nodes-registry/nodes-registry-sdk",
@@ -279,6 +280,7 @@ cf-gears-system-sdk-directory = { version = "0.1.37", path = "libs/system-sdks/s
 types-registry = { package = "cf-gears-types-registry", version = "0.1.23", path = "gears/system/types-registry/types-registry" }
 
 cf-gears-cluster-sdk = { version = "0.1.0", path = "gears/system/cluster/cluster-sdk" }
+cf-gears-cluster-conformance = { version = "0.1.0", path = "gears/system/cluster/cluster-conformance" }
 
 # System gears SDKs
 account-management-sdk = { package = "cf-gears-account-management-sdk", version = "0.2.0", path = "gears/system/account-management/account-management-sdk" }
@@ -288,6 +290,7 @@ authz-resolver-sdk = { package = "cf-gears-authz-resolver-sdk", version = "0.3.9
 resource-group-sdk = { package = "cf-gears-resource-group-sdk", version = "0.2.0", path = "gears/system/resource-group/resource-group-sdk" }
 oagw-sdk = { package = "cf-gears-oagw-sdk", version = "0.5.3", path = "gears/system/oagw/oagw-sdk" }
 usage-collector-sdk = { package = "cf-gears-usage-collector-sdk", version = "0.1.0", path = "gears/system/usage-collector/usage-collector-sdk" }
+cluster-sdk = { package = "cf-gears-cluster-sdk", version = "0.1.0", path = "gears/system/cluster/cluster-sdk" }
 
 # BSS gears (ported from vhp-core)
 bss-ledger-sdk = { path = "gears/bss/ledger/ledger-sdk" }
@@ -402,6 +405,9 @@ rand = "0.10"
 
 # Synchronous locks for better performance
 parking_lot = "0.12"
+
+# Property / model-based testing (cluster conformance suite reference model)
+proptest = "1"
 
 # CLI support
 clap = { version = "4.5", features = ["derive"] }

--- a/gears/system/cluster/cluster-conformance/Cargo.toml
+++ b/gears/system/cluster/cluster-conformance/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "cf-gears-cluster-conformance"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Parametrized backend conformance suites for the cluster gear: one shared test body run against every backend to operationalize cross-backend behavioral stability (cpt-cf-clst-nfr-cross-backend-stability)"
+readme = "README.md"
+keywords = ["constructorfabric", "cf-gears"]
+categories = ["development-tools"]
+metadata.docs.rs.all-features = true
+
+[lib]
+name = "cluster_conformance"
+
+[lints]
+workspace = true
+
+[dependencies]
+# The contract under test: every suite is generic over the SDK backend traits.
+cluster-sdk = { workspace = true }
+async-trait = { workspace = true }
+# `Instant`-based TTL + the background sweeper in the in-memory `MemCache`
+# fixture. The suites themselves are runtime-agnostic plain `async fn`s
+# (see §11 open question) so a caller can drive them under `turmoil`/`madsim`.
+tokio = { workspace = true, features = ["test-util"] }
+# The `MemCache` fixture's interior is guarded by a synchronous mutex whose
+# critical sections never span an `.await`, so `parking_lot` is preferred over
+# `std::sync::Mutex` per the project dependency guideline.
+parking_lot = { workspace = true }
+
+[dev-dependencies]
+# `test-util` enables `tokio::time::pause`/`advance` so TTL/renewal scenarios
+# run deterministically without real sleeps when self-testing the fixture.
+tokio = { workspace = true, features = ["test-util", "macros", "rt"] }
+# Model-based / property variants: random op sequences compared against a
+# trivial reference model (§4 "Model-based / property variants", `model.rs`).
+proptest = { workspace = true }

--- a/gears/system/cluster/cluster-conformance/README.md
+++ b/gears/system/cluster/cluster-conformance/README.md
@@ -1,0 +1,64 @@
+# cf-gears-cluster-conformance
+
+Parametrized **backend conformance suites** for the cluster gear — the keystone
+of [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md) §4 (Layer 2).
+
+One shared test body, run against every backend, is the only mechanism that
+operationalizes `cpt-cf-clst-nfr-cross-backend-stability`: "a consumer gear's
+behavior MUST NOT change when an operator switches the backend." You can only
+test "identical observable behavior" by running identical assertions everywhere.
+
+## Using it from a plugin
+
+A plugin's integration test reduces to ~10 lines: build the real backend (in a
+container, for L3), hand it to the matching runner.
+
+```rust
+use std::sync::Arc;
+use cluster_conformance::run_cache_conformance;
+use cluster_sdk::ClusterCacheBackend;
+
+#[tokio::test]
+async fn my_backend_is_conformant() {
+    run_cache_conformance(|| {
+        // build the real backend; the runner calls this once per scenario so
+        // state never leaks between cases.
+        Arc::new(MyCacheBackend::connect(/* container endpoint */)) as Arc<dyn ClusterCacheBackend>
+    })
+    .await;
+}
+```
+
+Cache-only plugins get the other three primitives for free by feeding their cache
+through the `cluster` gear's `CasBased*` / `CacheBased*` defaults, then running
+`run_leader_conformance` / `run_lock_conformance` / `run_discovery_conformance` over
+the result — see the rustdoc on [`run_leader_conformance`](src/leader.rs). This crate
+doesn't wire that composition itself (it deliberately has no dependency on `cluster`,
+even for its own tests — see [routing.md](../docs/scenarios/routing.md)'s ownership
+note); a plugin or the `cluster` gear does the wiring and calls in.
+
+## Layout
+
+| File | Contents |
+|---|---|
+| `fixture.rs` | `MemCache` — a compact linearizable in-process backend the suite self-tests against; reference fixture for the cache-derived suites |
+| `cache.rs` | `SC-CACHE-*` scenarios + `run_cache_conformance` |
+| `leader.rs` | `SC-LEAD-*` scenarios + `run_leader_conformance` |
+| `lock.rs` | `SC-LOCK-*` scenarios + `run_lock_conformance` |
+| `discovery.rs` | `SC-DISC-*` scenarios + `run_discovery_conformance` |
+| `model.rs` | reference-model replay engine (`replay_against_model`) for CAS/version invariants; the `proptest` strategy driving it lives in `tests/model.rs` |
+
+## Capability gating
+
+Each suite reads the backend's `features()` / `consistency()` and asserts strict
+guarantees **only** where the backend claims them (e.g. single-leader-under-
+contention only when `linearizable == true`). A backend that lies about a
+capability fails the suite — this is how `cpt-cf-clst-fr-validation-honest-
+declaration` is tested.
+
+## Coverage status
+
+Each `scenario_*` maps to an `SC-*` row in the
+[scenario catalog](../docs/scenarios/README.md). Catalog rows still marked ☐/◑
+appear here as `// TODO(SC-*)` markers; L4 rows (fault injection, DST) are
+delivered with their respective harnesses, not this in-process suite.

--- a/gears/system/cluster/cluster-conformance/src/cache.rs
+++ b/gears/system/cluster/cluster-conformance/src/cache.rs
@@ -1,0 +1,529 @@
+// Created: 2026-06-24 by Constructor Tech
+//! Cache conformance scenarios (`SC-CACHE-*`).
+//!
+//! See the [scenario catalog](../docs/scenarios/cache.md) for per-scenario
+//! intent/steps/expected/done-when. Each `scenario_cache_*` is a `pub async fn`
+//! a plugin may call directly; [`run_cache_conformance`] drives the full L2 set,
+//! building a fresh backend per scenario via `make` so state never leaks.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use cluster_sdk::cache::{
+    CacheConsistency, CacheEvent, CacheWatchEvent, ClusterCacheBackend, PollingPrefixWatch,
+    PutRequest, Ttl,
+};
+use cluster_sdk::error::ClusterError;
+
+/// Runs every implemented L2 cache scenario against a fresh backend from `make`.
+///
+/// Capability-gated scenarios read `consistency()`/`features()` off the backend
+/// and assert strict guarantees only where the backend claims them.
+pub async fn run_cache_conformance<F>(make: F)
+where
+    F: Fn() -> Arc<dyn ClusterCacheBackend>,
+{
+    scenario_cache_001(make()).await;
+    scenario_cache_002(make()).await;
+    scenario_cache_003(make()).await;
+    scenario_cache_004(make()).await;
+    scenario_cache_005(make()).await;
+    scenario_cache_006(make()).await;
+    scenario_cache_007(make()).await;
+    scenario_cache_008(make()).await;
+    scenario_cache_009(make()).await;
+    scenario_cache_010(make()).await;
+    scenario_cache_011(make()).await;
+    scenario_cache_012(make()).await;
+    scenario_cache_013(make()).await;
+    scenario_cache_014(make()).await;
+    scenario_cache_015(make()).await;
+}
+
+/// SC-CACHE-001: `get` on an absent key returns `Ok(None)`, never an error.
+pub async fn scenario_cache_001(backend: Arc<dyn ClusterCacheBackend>) {
+    let got = backend.get("absent").await;
+    assert!(
+        matches!(got, Ok(None)),
+        "SC-CACHE-001: get on absent key must be Ok(None), got {got:?}"
+    );
+}
+
+/// SC-CACHE-002: `put` then `get` returns the stored value at version 1.
+pub async fn scenario_cache_002(backend: Arc<dyn ClusterCacheBackend>) {
+    backend
+        .put(PutRequest {
+            key: "k",
+            value: b"v",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put must succeed");
+    let entry = backend
+        .get("k")
+        .await
+        .expect("get must succeed")
+        .expect("entry must be present");
+    assert_eq!(
+        entry.value, b"v",
+        "SC-CACHE-002: stored value must round-trip"
+    );
+    assert_eq!(entry.version, 1, "SC-CACHE-002: first write is version 1");
+}
+
+/// SC-CACHE-003: each overwrite strictly increments the version; version 0 is
+/// never observed (it is the reserved sentinel).
+pub async fn scenario_cache_003(backend: Arc<dyn ClusterCacheBackend>) {
+    backend
+        .put(PutRequest {
+            key: "k",
+            value: b"a",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put");
+    let v1 = backend
+        .get("k")
+        .await
+        .expect("get")
+        .expect("present")
+        .version;
+    backend
+        .put(PutRequest {
+            key: "k",
+            value: b"b",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put");
+    let v2 = backend
+        .get("k")
+        .await
+        .expect("get")
+        .expect("present")
+        .version;
+    assert_ne!(v1, 0, "SC-CACHE-003: version 0 is reserved as a sentinel");
+    assert!(
+        v2 > v1,
+        "SC-CACHE-003: each overwrite must strictly increment version ({v1} -> {v2})"
+    );
+}
+
+/// SC-CACHE-004: `put_if_absent` returns `Some(entry)` on create, `None` when
+/// already present (atomic create).
+pub async fn scenario_cache_004(backend: Arc<dyn ClusterCacheBackend>) {
+    let created = backend
+        .put_if_absent(PutRequest {
+            key: "k",
+            value: b"a",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("pia");
+    assert!(created.is_some(), "SC-CACHE-004: first create returns Some");
+    let again = backend
+        .put_if_absent(PutRequest {
+            key: "k",
+            value: b"b",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("pia");
+    assert!(
+        again.is_none(),
+        "SC-CACHE-004: create when present returns None"
+    );
+}
+
+/// SC-CACHE-005: `compare_and_swap` succeeds iff `expected_version == current`.
+pub async fn scenario_cache_005(backend: Arc<dyn ClusterCacheBackend>) {
+    let created = backend
+        .put_if_absent(PutRequest {
+            key: "k",
+            value: b"a",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("pia")
+        .expect("created");
+    let swapped = backend
+        .compare_and_swap("k", created.version, b"b", Ttl::Indefinite)
+        .await
+        .expect("CAS at current version must succeed");
+    assert_eq!(
+        swapped.value, b"b",
+        "SC-CACHE-005: CAS applies the new value"
+    );
+    assert!(
+        swapped.version > created.version,
+        "SC-CACHE-005: successful CAS bumps the version"
+    );
+}
+
+/// SC-CACHE-006: CAS on a stale version returns `CasConflict { key, current }`
+/// carrying the current entry.
+pub async fn scenario_cache_006(backend: Arc<dyn ClusterCacheBackend>) {
+    let created = backend
+        .put_if_absent(PutRequest {
+            key: "k",
+            value: b"a",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("pia")
+        .expect("created");
+    // Use an unambiguously stale version (far ahead of 1) — avoids the reserved
+    // sentinel 0 that wrapping_sub(1) would produce for a freshly-created entry.
+    let stale = created.version.wrapping_add(100);
+    let err = backend
+        .compare_and_swap("k", stale, b"b", Ttl::Indefinite)
+        .await
+        .expect_err("CAS on a stale version must conflict");
+    match err {
+        ClusterError::CasConflict { key, current } => {
+            assert_eq!(key, "k", "SC-CACHE-006: conflict reports the key");
+            let current = current.expect("SC-CACHE-006: conflict carries the current entry");
+            assert_eq!(
+                current.version, created.version,
+                "SC-CACHE-006: conflict carries the live version"
+            );
+        }
+        other => panic!("SC-CACHE-006: expected CasConflict, got {other:?}"),
+    }
+}
+
+/// SC-CACHE-007: `delete` removes the entry and reports prior existence.
+pub async fn scenario_cache_007(backend: Arc<dyn ClusterCacheBackend>) {
+    backend
+        .put(PutRequest {
+            key: "k",
+            value: b"v",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put");
+    assert!(
+        backend.delete("k").await.expect("delete"),
+        "SC-CACHE-007: deleting a present key reports true"
+    );
+    assert!(
+        backend.get("k").await.expect("get").is_none(),
+        "SC-CACHE-007: deleted key reads as absent"
+    );
+    assert!(
+        !backend.delete("k").await.expect("delete"),
+        "SC-CACHE-007: deleting an absent key reports false"
+    );
+}
+
+/// SC-CACHE-008: `compare_and_delete` removes only when the owner token matches;
+/// a mismatch or absent key returns `Ok(false)`, never an error.
+pub async fn scenario_cache_008(backend: Arc<dyn ClusterCacheBackend>) {
+    backend
+        .put(PutRequest {
+            key: "k",
+            value: b"owner-a",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put");
+    assert!(
+        !backend
+            .compare_and_delete("k", b"owner-b")
+            .await
+            .expect("c&d must not error on mismatch"),
+        "SC-CACHE-008: mismatched owner token must not delete"
+    );
+    assert!(
+        backend
+            .compare_and_delete("k", b"owner-a")
+            .await
+            .expect("c&d"),
+        "SC-CACHE-008: matching owner token deletes"
+    );
+    assert!(
+        !backend
+            .compare_and_delete("absent", b"x")
+            .await
+            .expect("c&d on absent must be Ok(false)"),
+        "SC-CACHE-008: absent key returns Ok(false)"
+    );
+}
+
+/// SC-CACHE-009: a key deleted and re-created resets to version 1, and a
+/// value/owner guard still distinguishes the successor — a named regression for
+/// the version-reset caveat (a version guard would alias a successor's fresh
+/// claim).
+pub async fn scenario_cache_009(backend: Arc<dyn ClusterCacheBackend>) {
+    // Holder A claims, then its claim lapses and it is deleted.
+    backend
+        .put(PutRequest {
+            key: "lock",
+            value: b"holder-a",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put");
+    backend.delete("lock").await.expect("delete");
+    // Successor B re-creates the key — version resets to 1.
+    let b = backend
+        .put_if_absent(PutRequest {
+            key: "lock",
+            value: b"holder-b",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("pia")
+        .expect("created");
+    assert_eq!(b.version, 1, "SC-CACHE-009: re-create resets version to 1");
+    // A's late guarded release must NOT remove B's fresh claim.
+    assert!(
+        !backend
+            .compare_and_delete("lock", b"holder-a")
+            .await
+            .expect("c&d"),
+        "SC-CACHE-009: stale owner token must not delete the successor's claim"
+    );
+    assert_eq!(
+        backend
+            .get("lock")
+            .await
+            .expect("get")
+            .expect("present")
+            .value,
+        b"holder-b",
+        "SC-CACHE-009: successor's claim survives the stale release"
+    );
+}
+
+/// SC-CACHE-010: TTL expiry removes the entry and emits `CacheEvent::Expired` to
+/// watchers.
+pub async fn scenario_cache_010(backend: Arc<dyn ClusterCacheBackend>) {
+    tokio::time::pause();
+    let mut watch = backend.watch("k").await.expect("watch");
+    backend
+        .put(PutRequest {
+            key: "k",
+            value: b"v",
+            ttl: Ttl::Of(Duration::from_millis(50)),
+        })
+        .await
+        .expect("put with ttl");
+    tokio::time::advance(Duration::from_millis(100)).await;
+    tokio::task::yield_now().await;
+    // Drain the initial Changed, then wait for the Expired emission.
+    let expired = wait_for(
+        &mut watch,
+        |event| matches!(event, CacheEvent::Expired { key } if key == "k"),
+    )
+    .await;
+    assert!(expired, "SC-CACHE-010: TTL expiry must emit Expired");
+    assert!(
+        backend.get("k").await.expect("get").is_none(),
+        "SC-CACHE-010: expired entry reads as absent"
+    );
+    tokio::time::resume();
+}
+
+/// SC-CACHE-012: exact `watch` yields `Changed`/`Deleted` for the key,
+/// preserving per-key order.
+pub async fn scenario_cache_012(backend: Arc<dyn ClusterCacheBackend>) {
+    let mut watch = backend.watch("k").await.expect("watch");
+    backend
+        .put(PutRequest {
+            key: "k",
+            value: b"v",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put");
+    backend.delete("k").await.expect("delete");
+    // Enforce order: Changed must precede Deleted on the same watch.
+    let mut saw_changed = false;
+    for _ in 0..64 {
+        match watch.recv().await {
+            Some(CacheWatchEvent::Event(CacheEvent::Changed { key })) if key == "k" => {
+                assert!(!saw_changed, "SC-CACHE-012: duplicate Changed event");
+                saw_changed = true;
+            }
+            Some(CacheWatchEvent::Event(CacheEvent::Deleted { key })) if key == "k" => {
+                assert!(
+                    saw_changed,
+                    "SC-CACHE-012: Deleted arrived before Changed -- order violated"
+                );
+                return; // Both events received in correct order.
+            }
+            Some(CacheWatchEvent::Closed(_)) | None => break,
+            _ => {}
+        }
+    }
+    panic!("SC-CACHE-012: did not observe both Changed then Deleted within the event bound");
+}
+
+/// SC-CACHE-013: `watch_prefix` yields events for matching keys when the backend
+/// declares the `prefix_watch` feature; backends without it return
+/// `Unsupported` (capability-gated).
+pub async fn scenario_cache_013(backend: Arc<dyn ClusterCacheBackend>) {
+    let watch = backend.watch_prefix("p/").await;
+    if backend.features().prefix_watch {
+        let mut watch = watch.expect("SC-CACHE-013: prefix-watch backend must establish a watch");
+        backend
+            .put(PutRequest {
+                key: "p/a",
+                value: b"v",
+                ttl: Ttl::Indefinite,
+            })
+            .await
+            .expect("put");
+        assert!(
+            wait_for(
+                &mut watch,
+                |e| matches!(e, CacheEvent::Changed { key } if key == "p/a")
+            )
+            .await,
+            "SC-CACHE-013: prefix watch yields events for matching keys"
+        );
+    } else {
+        assert!(
+            matches!(
+                watch,
+                Err(ClusterError::Unsupported {
+                    feature: "prefix_watch"
+                })
+            ),
+            "SC-CACHE-013: backend without prefix_watch must return Unsupported"
+        );
+    }
+}
+
+/// SC-CACHE-011: a `Ttl::Indefinite` entry persists well past any default TTL;
+/// it is not removed by the TTL sweeper until explicitly deleted.
+pub async fn scenario_cache_011(backend: Arc<dyn ClusterCacheBackend>) {
+    tokio::time::pause();
+    backend
+        .put(PutRequest {
+            key: "k",
+            value: b"v",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put");
+    tokio::time::advance(Duration::from_hours(1)).await;
+    // Yield so the sweeper (if any) gets a chance to erroneously remove it.
+    tokio::task::yield_now().await;
+    let entry = backend.get("k").await.expect("get");
+    assert!(
+        entry.is_some(),
+        "SC-CACHE-011: an indefinite entry must survive a large time advance"
+    );
+    tokio::time::resume();
+}
+
+/// SC-CACHE-014: `PollingPrefixWatch` synthesizes `Changed`/`Deleted` diffs for
+/// a backend that does not natively support prefix watches.
+/// Capability-gated on `!features().prefix_watch`.
+pub async fn scenario_cache_014(backend: Arc<dyn ClusterCacheBackend>) {
+    if backend.features().prefix_watch {
+        return; // native prefix watch; polyfill is not the subject here
+    }
+    tokio::time::pause();
+    let mut watch = PollingPrefixWatch::spawn(backend.clone(), "p/", Duration::from_millis(25));
+
+    // A put under the prefix must be diffed as Changed.
+    backend
+        .put(PutRequest {
+            key: "p/a",
+            value: b"1",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put p/a");
+    tokio::time::advance(Duration::from_millis(50)).await;
+    tokio::task::yield_now().await;
+    assert!(
+        wait_for(
+            &mut watch,
+            |e| matches!(e, CacheEvent::Changed { key } if key == "p/a")
+        )
+        .await,
+        "SC-CACHE-014: put under prefix must yield a Changed event"
+    );
+
+    // A delete must be diffed as Deleted.
+    backend.delete("p/a").await.expect("delete p/a");
+    tokio::time::advance(Duration::from_millis(50)).await;
+    tokio::task::yield_now().await;
+    assert!(
+        wait_for(
+            &mut watch,
+            |e| matches!(e, CacheEvent::Deleted { key } if key == "p/a")
+        )
+        .await,
+        "SC-CACHE-014: delete under prefix must yield a Deleted event"
+    );
+    tokio::time::resume();
+}
+
+/// SC-CACHE-015: watch delivery is at-most-once per mutation — a single `put`
+/// must not cause more than one `Changed` event for the same key on one watch.
+pub async fn scenario_cache_015(backend: Arc<dyn ClusterCacheBackend>) {
+    tokio::time::pause();
+    let mut watch = backend.watch("k").await.expect("watch");
+    backend
+        .put(PutRequest {
+            key: "k",
+            value: b"v",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put");
+
+    let mut changed_count = 0u32;
+    // Drain all immediately queued events without advancing time — any duplicate
+    // that would arrive synchronously will be in the channel already.
+    for _ in 0..64 {
+        match tokio::time::timeout(Duration::from_millis(0), watch.recv()).await {
+            Ok(Some(CacheWatchEvent::Event(CacheEvent::Changed { key }))) if key == "k" => {
+                changed_count += 1;
+            }
+            Ok(Some(CacheWatchEvent::Closed(_)) | None) | Err(_) => break,
+            _ => {}
+        }
+    }
+    assert_eq!(
+        changed_count, 1,
+        "SC-CACHE-015: a single put must deliver exactly one Changed event (got {changed_count})"
+    );
+    tokio::time::resume();
+}
+
+// TODO(SC-CACHE-016/017) [L4]: slow-subscriber `Lagged` and connection-loss
+//   `Reset` are fault-injection scenarios delivered with the L4 harness, not the
+//   in-process suite.
+
+/// Polls a watch for up to a bounded number of events, returning `true` once one
+/// satisfies `pred`. Bounded so a missing event fails fast rather than hanging.
+async fn wait_for<P>(watch: &mut cluster_sdk::cache::CacheWatch, pred: P) -> bool
+where
+    P: Fn(&CacheEvent) -> bool,
+{
+    for _ in 0..64 {
+        match watch.recv().await {
+            Some(CacheWatchEvent::Event(event)) => {
+                if pred(&event) {
+                    return true;
+                }
+            }
+            Some(CacheWatchEvent::Closed(_)) | None => return false,
+            Some(_) => {}
+        }
+    }
+    false
+}
+
+/// A helper plugins may use to assert a backend's self-declared consistency
+/// before handing it to the consistency-sensitive default backends.
+#[must_use]
+pub fn is_linearizable(backend: &dyn ClusterCacheBackend) -> bool {
+    matches!(backend.consistency(), CacheConsistency::Linearizable)
+}

--- a/gears/system/cluster/cluster-conformance/src/discovery.rs
+++ b/gears/system/cluster/cluster-conformance/src/discovery.rs
@@ -1,0 +1,348 @@
+// Created: 2026-06-24 by Constructor Tech
+//! Service-discovery conformance scenarios (`SC-DISC-*`).
+//!
+//! See the [scenario catalog](../docs/scenarios/discovery.md). Cache-only
+//! plugins feed the `cluster` gear's `CacheBasedServiceDiscoveryBackend`
+//! (`cluster::defaults::CacheBasedServiceDiscoveryBackend` — not a
+//! `cluster-conformance` dependency, so not an intra-doc link here) into this
+//! suite. The suite must NOT assume a result ordering — `discover` returns
+//! instances in an unspecified order.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use cluster_sdk::discovery::{
+    DiscoveryFilter, InstanceState, MetaMatch, ServiceDiscoveryBackend, ServiceRegistration,
+    ServiceWatchEvent, StateFilter, TopologyChange,
+};
+
+/// Runs every implemented L2 discovery scenario against a fresh backend from
+/// `make`.
+///
+/// # Panics
+/// Requires a `current_thread` Tokio runtime — `scenario_disc_006` calls
+/// `tokio::time::pause()`, which panics under `multi_thread`.
+pub async fn run_discovery_conformance<F>(make: F)
+where
+    F: Fn() -> Arc<dyn ServiceDiscoveryBackend>,
+{
+    scenario_disc_001(make()).await;
+    scenario_disc_002(make()).await;
+    scenario_disc_003(make()).await;
+    scenario_disc_004(make()).await;
+    scenario_disc_005(make()).await;
+    scenario_disc_006(make()).await;
+    scenario_disc_007(make()).await;
+}
+
+/// SC-DISC-001: a registered, enabled instance is returned by `discover` under
+/// the default (enabled-only) filter.
+pub async fn scenario_disc_001(backend: Arc<dyn ServiceDiscoveryBackend>) {
+    let handle = backend
+        .register(registration("svc", "10.0.0.1:8080", &[]))
+        .await
+        .expect("register must succeed");
+    assert!(
+        !handle.instance_id().is_empty(),
+        "SC-DISC-001: a registered instance must be assigned a non-empty id"
+    );
+    let found = backend
+        .discover("svc", DiscoveryFilter::default())
+        .await
+        .expect("discover must succeed");
+    let instance = found
+        .iter()
+        .find(|inst| inst.instance_id == handle.instance_id())
+        .expect("SC-DISC-001: a registered enabled instance must be discoverable");
+    assert_eq!(
+        instance.state,
+        InstanceState::Enabled,
+        "SC-DISC-001: a freshly registered instance must default to Enabled"
+    );
+}
+
+/// SC-DISC-002: the default filter returns only `Enabled` instances;
+/// `StateFilter::Any` includes disabled ones too.
+pub async fn scenario_disc_002(backend: Arc<dyn ServiceDiscoveryBackend>) {
+    let ha = backend
+        .register(registration("svc", "a:1", &[]))
+        .await
+        .expect("register a");
+    let hb = backend
+        .register(registration("svc", "b:1", &[]))
+        .await
+        .expect("register b");
+    hb.set_state(InstanceState::Disabled)
+        .await
+        .expect("disable b");
+
+    let enabled_only = backend
+        .discover("svc", DiscoveryFilter::default())
+        .await
+        .expect("discover enabled");
+    let ids: std::collections::HashSet<&str> = enabled_only
+        .iter()
+        .map(|i| i.instance_id.as_str())
+        .collect();
+    assert!(
+        ids.contains(ha.instance_id()),
+        "SC-DISC-002: enabled instance must appear under the default filter"
+    );
+    assert!(
+        !ids.contains(hb.instance_id()),
+        "SC-DISC-002: disabled instance must be excluded by the default filter"
+    );
+
+    let mut any_filter = DiscoveryFilter::default();
+    any_filter.state = StateFilter::Any;
+    let all = backend
+        .discover("svc", any_filter)
+        .await
+        .expect("discover any");
+    assert!(
+        all.iter().any(|i| i.instance_id == hb.instance_id()),
+        "SC-DISC-002: disabled instance must appear under StateFilter::Any"
+    );
+}
+
+/// SC-DISC-003: metadata predicates AND-combine — `Equals` and `OneOf` both
+/// participate, and an instance is returned only when it satisfies *every*
+/// predicate.
+pub async fn scenario_disc_003(backend: Arc<dyn ServiceDiscoveryBackend>) {
+    // Instance A: region=us-east, tier=gold  → matches both predicates
+    // Instance B: region=us-east, tier=silver → fails the tier predicate
+    // Instance C: region=eu-west, tier=gold   → fails the region predicate
+    let ha = backend
+        .register(registration(
+            "svc",
+            "a:1",
+            &[("region", "us-east"), ("tier", "gold")],
+        ))
+        .await
+        .expect("register a");
+    let hb = backend
+        .register(registration(
+            "svc",
+            "b:1",
+            &[("region", "us-east"), ("tier", "silver")],
+        ))
+        .await
+        .expect("register b");
+    let hc = backend
+        .register(registration(
+            "svc",
+            "c:1",
+            &[("region", "eu-west"), ("tier", "gold")],
+        ))
+        .await
+        .expect("register c");
+
+    // region=us-east (Equals) AND tier=OneOf([gold]) → only A matches.
+    let mut filter = DiscoveryFilter::default();
+    filter.metadata = vec![
+        ("region".to_owned(), MetaMatch::Equals("us-east".to_owned())),
+        ("tier".to_owned(), MetaMatch::OneOf(vec!["gold".to_owned()])),
+    ];
+    let found = backend
+        .discover("svc", filter)
+        .await
+        .expect("discover must succeed");
+    let ids: std::collections::HashSet<&str> =
+        found.iter().map(|i| i.instance_id.as_str()).collect();
+    assert!(
+        ids.contains(ha.instance_id()),
+        "SC-DISC-003: A (us-east + gold) must satisfy both predicates"
+    );
+    assert!(
+        !ids.contains(hb.instance_id()),
+        "SC-DISC-003: B (us-east + silver) must fail the tier predicate"
+    );
+    assert!(
+        !ids.contains(hc.instance_id()),
+        "SC-DISC-003: C (eu-west + gold) must fail the region predicate"
+    );
+}
+
+/// SC-DISC-004: `discover`'s result order is unspecified — the suite must
+/// compare result sets, never assume positional ordering.
+pub async fn scenario_disc_004(backend: Arc<dyn ServiceDiscoveryBackend>) {
+    let h1 = backend
+        .register(registration("svc", "a:1", &[]))
+        .await
+        .expect("register a");
+    let h2 = backend
+        .register(registration("svc", "b:1", &[]))
+        .await
+        .expect("register b");
+    let found = backend
+        .discover("svc", DiscoveryFilter::default())
+        .await
+        .expect("discover must succeed");
+    let ids: std::collections::HashSet<&str> =
+        found.iter().map(|i| i.instance_id.as_str()).collect();
+    assert_eq!(
+        ids,
+        [h1.instance_id(), h2.instance_id()].into_iter().collect(),
+        "SC-DISC-004: discover must return both instances regardless of registration order"
+    );
+}
+
+/// SC-DISC-005: draining an instance via `set_state(Disabled)` removes it from
+/// the default filter; explicit `deregister()` sends `Left` and removes it fully.
+pub async fn scenario_disc_005(backend: Arc<dyn ServiceDiscoveryBackend>) {
+    let mut watch = backend.watch("svc").await.expect("watch");
+    let handle = backend
+        .register(registration("svc", "a:1", &[]))
+        .await
+        .expect("register");
+    // Wait for Joined.
+    let id = handle.instance_id().to_owned();
+    wait_for_discovery_event(
+        &mut watch,
+        |e| matches!(e, TopologyChange::Joined(i) if i.instance_id == id),
+    )
+    .await;
+
+    // Drain.
+    handle
+        .set_state(InstanceState::Disabled)
+        .await
+        .expect("disable");
+    let after_drain = backend
+        .discover("svc", DiscoveryFilter::default())
+        .await
+        .expect("discover after drain");
+    assert!(
+        !after_drain.iter().any(|i| i.instance_id == id),
+        "SC-DISC-005: disabled instance must be excluded by the default filter"
+    );
+
+    // Deregister.
+    handle.deregister().await.expect("deregister");
+    assert!(
+        wait_for_discovery_event(&mut watch, |e| {
+            matches!(e, TopologyChange::Left { instance_id } if instance_id == &id)
+        })
+        .await,
+        "SC-DISC-005: deregister must emit Left"
+    );
+    let after_dereg = backend
+        .discover("svc", DiscoveryFilter::any())
+        .await
+        .expect("discover any after deregister");
+    assert!(
+        !after_dereg.iter().any(|i| i.instance_id == id),
+        "SC-DISC-005: deregistered instance must not appear under any filter"
+    );
+}
+
+/// SC-DISC-006: a registration that stops heartbeating disappears after its TTL
+/// lapses — purely via time, no explicit `set_state`/`deregister` call.
+///
+/// # Panics
+/// Requires a `current_thread` Tokio runtime — `tokio::time::pause()` panics
+/// under `multi_thread`.
+pub async fn scenario_disc_006(backend: Arc<dyn ServiceDiscoveryBackend>) {
+    tokio::time::pause();
+    let handle = backend
+        .register(registration("svc", "a:1", &[]))
+        .await
+        .expect("register");
+    let id = handle.instance_id().to_owned();
+    // Advance past the backend's default TTL (30 s) without renewing.
+    tokio::time::advance(Duration::from_secs(31)).await;
+    tokio::task::yield_now().await;
+    let found = backend
+        .discover("svc", DiscoveryFilter::any())
+        .await
+        .expect("discover");
+    assert!(
+        !found.iter().any(|i| i.instance_id == id),
+        "SC-DISC-006: registration must disappear after TTL lapses without heartbeat"
+    );
+    tokio::time::resume();
+}
+
+/// SC-DISC-007: `watch` surfaces raw `Joined`/`Updated`/`Left` events unfiltered
+/// — the watch is not subject to `DiscoveryFilter` (filtering is consumer-side).
+pub async fn scenario_disc_007(backend: Arc<dyn ServiceDiscoveryBackend>) {
+    let mut watch = backend.watch("svc").await.expect("watch");
+
+    let handle = backend
+        .register(registration("svc", "a:1", &[("env", "prod")]))
+        .await
+        .expect("register");
+    let id = handle.instance_id().to_owned();
+
+    // Joined.
+    assert!(
+        wait_for_discovery_event(&mut watch, |e| {
+            matches!(e, TopologyChange::Joined(i) if i.instance_id == id)
+        })
+        .await,
+        "SC-DISC-007: register must emit Joined"
+    );
+
+    // Updated (metadata change).
+    let mut new_meta = HashMap::new();
+    new_meta.insert("env".to_owned(), "staging".to_owned());
+    handle
+        .update_metadata(new_meta)
+        .await
+        .expect("update metadata");
+    assert!(
+        wait_for_discovery_event(&mut watch, |e| {
+            matches!(e, TopologyChange::Updated(i) if i.instance_id == id)
+        })
+        .await,
+        "SC-DISC-007: update_metadata must emit Updated"
+    );
+
+    // Left.
+    handle.deregister().await.expect("deregister");
+    assert!(
+        wait_for_discovery_event(&mut watch, |e| {
+            matches!(e, TopologyChange::Left { instance_id } if instance_id == &id)
+        })
+        .await,
+        "SC-DISC-007: deregister must emit Left"
+    );
+}
+
+// TODO(SC-DISC-008): service name is scoped; metadata is not scoped — requires
+//   the `ServiceDiscoveryV1::scoped()` facade (needs `ClientHub`, deferred to L3).
+// TODO(SC-DISC-009) [L4]: recover membership after lag/reset — fault-injection harness.
+
+/// Polls a service watch for up to 64 events, returning `true` once one satisfies
+/// `pred`. Bounded so a missing event fails fast rather than hanging.
+async fn wait_for_discovery_event<P>(
+    watch: &mut cluster_sdk::discovery::ServiceWatch,
+    pred: P,
+) -> bool
+where
+    P: Fn(&TopologyChange) -> bool,
+{
+    for _ in 0..64 {
+        match watch.recv().await {
+            Some(ServiceWatchEvent::Change(change)) if pred(&change) => return true,
+            Some(ServiceWatchEvent::Closed(_)) | None => return false,
+            _ => {}
+        }
+    }
+    false
+}
+
+/// Builds a registration with `metadata` key/value pairs and a backend-assigned
+/// instance id.
+fn registration(name: &str, address: &str, metadata: &[(&str, &str)]) -> ServiceRegistration {
+    ServiceRegistration {
+        name: name.to_owned(),
+        instance_id: None,
+        address: address.to_owned(),
+        metadata: metadata
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .collect::<HashMap<_, _>>(),
+    }
+}

--- a/gears/system/cluster/cluster-conformance/src/fixture.rs
+++ b/gears/system/cluster/cluster-conformance/src/fixture.rs
@@ -1,0 +1,435 @@
+// Created: 2026-06-24 by Constructor Tech
+//! [`MemCache`]: a compact, linearizable in-process [`ClusterCacheBackend`] the
+//! conformance suite self-tests against, and a reference fixture for the three
+//! cache-derived suites (leader/lock/discovery feed it through the SDK
+//! `CasBased*`/`CacheBased*` defaults).
+//!
+//! It implements real versioning (monotonic per key, reset to `1` on a fresh
+//! create), lazy + swept TTL expiry that emits [`CacheEvent::Expired`], exact
+//! and prefix watches, and an **atomic** [`compare_and_delete`] so the
+//! owner-token guard (SC-CACHE-008/009) holds under contention rather than
+//! relying on the best-effort get-then-delete default.
+//!
+//! It is deliberately compact — one state map behind one mutex — and makes no
+//! attempt at the durability or partition tolerance a real backend needs. It
+//! exists to (a) prove the suite's assertions pass against a known-correct
+//! backend and (b) give cache-only behavior a backend in tests that don't stand
+//! up a container.
+//!
+//! [`compare_and_delete`]: ClusterCacheBackend::compare_and_delete
+
+use std::collections::HashMap;
+use std::sync::{Arc, Weak};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use cluster_sdk::cache::{
+    CacheConsistency, CacheEntry, CacheEvent, CacheFeatures, CacheWatch, CacheWatchEvent,
+    CacheWatchSender, ClusterCacheBackend, PutRequest, Ttl,
+};
+use cluster_sdk::error::ClusterError;
+use parking_lot::Mutex;
+use tokio::time::Instant;
+
+/// How often the background sweeper scans for expired entries. Fine enough that
+/// a `tokio::time::advance` past a TTL deterministically triggers an `Expired`
+/// emission, coarse enough to avoid needless wakeups.
+const SWEEP_INTERVAL: Duration = Duration::from_millis(25);
+
+/// Per-watch in-flight buffer. Generous so a renewal/heartbeat storm in a test
+/// never spuriously drops events.
+const WATCH_CAPACITY: usize = 256;
+
+/// A stored value with its version and optional expiry deadline.
+struct Stored {
+    value: Vec<u8>,
+    version: u64,
+    expires_at: Option<Instant>,
+}
+
+impl Stored {
+    fn is_expired(&self, now: Instant) -> bool {
+        self.expires_at.is_some_and(|deadline| deadline <= now)
+    }
+
+    fn entry(&self) -> CacheEntry {
+        CacheEntry {
+            value: self.value.clone(),
+            version: self.version,
+        }
+    }
+}
+
+/// The subscription kind a watcher matches keys against.
+enum WatchKind {
+    Exact(String),
+    Prefix(String),
+}
+
+impl WatchKind {
+    fn matches(&self, key: &str) -> bool {
+        match self {
+            Self::Exact(exact) => exact == key,
+            Self::Prefix(prefix) => key.starts_with(prefix.as_str()),
+        }
+    }
+}
+
+/// One live watch subscription, identified so a failed send can prune it.
+struct Watcher {
+    id: u64,
+    kind: WatchKind,
+    sender: CacheWatchSender,
+}
+
+/// The fixture's locked interior: a single state map and a single monotonic
+/// version source, plus the live watchers.
+struct Inner {
+    map: HashMap<String, Stored>,
+    watchers: Vec<Watcher>,
+    next_watch_id: u64,
+}
+
+/// A compact, linearizable in-memory [`ClusterCacheBackend`] for the
+/// conformance suite. See the module docs: a fixture, not a production backend.
+pub struct MemCache {
+    inner: Mutex<Inner>,
+    consistency: CacheConsistency,
+    prefix_watch: bool,
+}
+
+impl MemCache {
+    /// A linearizable cache with native prefix-watch support — the default
+    /// fixture, which satisfies every capability-gated assertion in the suite.
+    ///
+    /// # Panics
+    /// Panics if called outside the context of a Tokio runtime (the
+    /// constructor spawns a background TTL sweeper task).
+    #[must_use]
+    pub fn linearizable() -> Arc<Self> {
+        Self::spawn(CacheConsistency::Linearizable, true)
+    }
+
+    /// An eventually-consistent cache, for exercising the suite's capability
+    /// gating (linearizable-only assertions must be skipped, not failed) and the
+    /// default-backend consistency guard (ADR-009).
+    ///
+    /// # Panics
+    /// Panics if called outside the context of a Tokio runtime (the
+    /// constructor spawns a background TTL sweeper task).
+    #[must_use]
+    pub fn eventually_consistent() -> Arc<Self> {
+        Self::spawn(CacheConsistency::EventuallyConsistent, true)
+    }
+
+    /// A linearizable cache that declares no native prefix watch, so
+    /// `watch_prefix` returns [`ClusterError::Unsupported`] — for the
+    /// prefix-watch capability gate and the polling polyfill.
+    ///
+    /// # Panics
+    /// Panics if called outside the context of a Tokio runtime (the
+    /// constructor spawns a background TTL sweeper task).
+    #[must_use]
+    pub fn linearizable_without_prefix_watch() -> Arc<Self> {
+        Self::spawn(CacheConsistency::Linearizable, false)
+    }
+
+    fn spawn(consistency: CacheConsistency, prefix_watch: bool) -> Arc<Self> {
+        let cache = Arc::new(Self {
+            inner: Mutex::new(Inner {
+                map: HashMap::new(),
+                watchers: Vec::new(),
+                next_watch_id: 0,
+            }),
+            consistency,
+            prefix_watch,
+        });
+        // The sweeper holds only a weak reference, so it self-terminates once
+        // the test drops the cache.
+        let weak = Arc::downgrade(&cache);
+        tokio::spawn(sweep_loop(weak));
+        cache
+    }
+
+    /// Sends `event` to every watcher matching `key`, pruning any whose consumer
+    /// has dropped the watch.
+    async fn broadcast(&self, key: &str, event: CacheEvent) {
+        let targets: Vec<(u64, CacheWatchSender)> = {
+            let guard = self.inner.lock();
+            guard
+                .watchers
+                .iter()
+                .filter(|watcher| watcher.kind.matches(key))
+                .map(|watcher| (watcher.id, watcher.sender.clone()))
+                .collect()
+        };
+        let mut dead = Vec::new();
+        for (id, sender) in targets {
+            if sender
+                .send(CacheWatchEvent::Event(event.clone()))
+                .await
+                .is_err()
+            {
+                dead.push(id);
+            }
+        }
+        if !dead.is_empty() {
+            self.inner
+                .lock()
+                .watchers
+                .retain(|watcher| !dead.contains(&watcher.id));
+        }
+    }
+
+    /// Removes every expired entry and emits an `Expired` event for each.
+    async fn sweep_expired(&self) {
+        let now = Instant::now();
+        let expired: Vec<String> = {
+            let mut guard = self.inner.lock();
+            let keys: Vec<String> = guard
+                .map
+                .iter()
+                .filter(|(_, stored)| stored.is_expired(now))
+                .map(|(key, _)| key.clone())
+                .collect();
+            for key in &keys {
+                guard.map.remove(key);
+            }
+            keys
+        };
+        for key in expired {
+            self.broadcast(&key, CacheEvent::Expired { key: key.clone() })
+                .await;
+        }
+    }
+
+    fn register_watch(&self, kind: WatchKind) -> CacheWatch {
+        let (sender, watch) = CacheWatch::channel(WATCH_CAPACITY);
+        let mut guard = self.inner.lock();
+        let id = guard.next_watch_id;
+        guard.next_watch_id += 1;
+        guard.watchers.push(Watcher { id, kind, sender });
+        watch
+    }
+}
+
+/// The detached sweeper driving TTL expiry; exits once the cache is dropped.
+async fn sweep_loop(weak: Weak<MemCache>) {
+    let mut ticker = tokio::time::interval(SWEEP_INTERVAL);
+    loop {
+        ticker.tick().await;
+        let Some(cache) = weak.upgrade() else {
+            return;
+        };
+        cache.sweep_expired().await;
+    }
+}
+
+#[async_trait]
+impl ClusterCacheBackend for MemCache {
+    fn consistency(&self) -> CacheConsistency {
+        self.consistency
+    }
+
+    fn features(&self) -> CacheFeatures {
+        CacheFeatures::new(self.prefix_watch)
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<CacheEntry>, ClusterError> {
+        let now = Instant::now();
+        let guard = self.inner.lock();
+        Ok(match guard.map.get(key) {
+            Some(stored) if !stored.is_expired(now) => Some(stored.entry()),
+            _ => None,
+        })
+    }
+
+    async fn put(&self, req: PutRequest<'_>) -> Result<(), ClusterError> {
+        let PutRequest { key, value, ttl } = req;
+        let now = Instant::now();
+        {
+            let mut guard = self.inner.lock();
+            let version = match guard.map.get(key) {
+                Some(stored) if !stored.is_expired(now) => stored.version + 1,
+                _ => 1,
+            };
+            guard.map.insert(
+                key.to_owned(),
+                Stored {
+                    value: value.to_vec(),
+                    version,
+                    expires_at: ttl.as_duration().map(|d| now + d),
+                },
+            );
+        }
+        self.broadcast(
+            key,
+            CacheEvent::Changed {
+                key: key.to_owned(),
+            },
+        )
+        .await;
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<bool, ClusterError> {
+        let now = Instant::now();
+        let was_live = {
+            let mut guard = self.inner.lock();
+            let live = matches!(guard.map.get(key), Some(stored) if !stored.is_expired(now));
+            guard.map.remove(key);
+            live
+        };
+        if was_live {
+            self.broadcast(
+                key,
+                CacheEvent::Deleted {
+                    key: key.to_owned(),
+                },
+            )
+            .await;
+        }
+        Ok(was_live)
+    }
+
+    async fn contains(&self, key: &str) -> Result<bool, ClusterError> {
+        let now = Instant::now();
+        let guard = self.inner.lock();
+        Ok(matches!(guard.map.get(key), Some(stored) if !stored.is_expired(now)))
+    }
+
+    async fn put_if_absent(&self, req: PutRequest<'_>) -> Result<Option<CacheEntry>, ClusterError> {
+        let PutRequest { key, value, ttl } = req;
+        let now = Instant::now();
+        let created = {
+            let mut guard = self.inner.lock();
+            if matches!(guard.map.get(key), Some(stored) if !stored.is_expired(now)) {
+                None
+            } else {
+                let stored = Stored {
+                    value: value.to_vec(),
+                    version: 1,
+                    expires_at: ttl.as_duration().map(|d| now + d),
+                };
+                let entry = stored.entry();
+                guard.map.insert(key.to_owned(), stored);
+                Some(entry)
+            }
+        };
+        if created.is_some() {
+            self.broadcast(
+                key,
+                CacheEvent::Changed {
+                    key: key.to_owned(),
+                },
+            )
+            .await;
+        }
+        Ok(created)
+    }
+
+    async fn compare_and_swap(
+        &self,
+        key: &str,
+        expected_version: u64,
+        new_value: &[u8],
+        ttl: Ttl,
+    ) -> Result<CacheEntry, ClusterError> {
+        let now = Instant::now();
+        let outcome = {
+            let mut guard = self.inner.lock();
+            match guard.map.get(key) {
+                Some(stored) if !stored.is_expired(now) => {
+                    if stored.version == expected_version {
+                        let version = stored.version + 1;
+                        let stored = Stored {
+                            value: new_value.to_vec(),
+                            version,
+                            expires_at: ttl.as_duration().map(|d| now + d),
+                        };
+                        let entry = stored.entry();
+                        guard.map.insert(key.to_owned(), stored);
+                        Ok(entry)
+                    } else {
+                        Err(ClusterError::CasConflict {
+                            key: key.to_owned(),
+                            current: Some(stored.entry()),
+                        })
+                    }
+                }
+                _ => Err(ClusterError::CasConflict {
+                    key: key.to_owned(),
+                    current: None,
+                }),
+            }
+        };
+        if outcome.is_ok() {
+            self.broadcast(
+                key,
+                CacheEvent::Changed {
+                    key: key.to_owned(),
+                },
+            )
+            .await;
+        }
+        outcome
+    }
+
+    /// Atomic owner-token-guarded delete: removes `key` only if its current
+    /// value equals `expected_value`, under the same lock as the read, so a
+    /// successor that re-created the key (resetting its version to 1) is not
+    /// aliased by a stale claim (SC-CACHE-009).
+    async fn compare_and_delete(
+        &self,
+        key: &str,
+        expected_value: &[u8],
+    ) -> Result<bool, ClusterError> {
+        let now = Instant::now();
+        let deleted = {
+            let mut guard = self.inner.lock();
+            match guard.map.get(key) {
+                Some(stored)
+                    if !stored.is_expired(now) && stored.value.as_slice() == expected_value =>
+                {
+                    guard.map.remove(key);
+                    true
+                }
+                _ => false,
+            }
+        };
+        if deleted {
+            self.broadcast(
+                key,
+                CacheEvent::Deleted {
+                    key: key.to_owned(),
+                },
+            )
+            .await;
+        }
+        Ok(deleted)
+    }
+
+    async fn watch(&self, key: &str) -> Result<CacheWatch, ClusterError> {
+        Ok(self.register_watch(WatchKind::Exact(key.to_owned())))
+    }
+
+    async fn watch_prefix(&self, prefix: &str) -> Result<CacheWatch, ClusterError> {
+        if !self.prefix_watch {
+            return Err(ClusterError::Unsupported {
+                feature: "prefix_watch",
+            });
+        }
+        Ok(self.register_watch(WatchKind::Prefix(prefix.to_owned())))
+    }
+
+    async fn scan_prefix(&self, prefix: &str) -> Result<Vec<String>, ClusterError> {
+        let now = Instant::now();
+        let guard = self.inner.lock();
+        Ok(guard
+            .map
+            .iter()
+            .filter(|(key, stored)| key.starts_with(prefix) && !stored.is_expired(now))
+            .map(|(key, _)| key.clone())
+            .collect())
+    }
+}

--- a/gears/system/cluster/cluster-conformance/src/leader.rs
+++ b/gears/system/cluster/cluster-conformance/src/leader.rs
@@ -1,0 +1,256 @@
+// Created: 2026-06-24 by Constructor Tech
+//! Leader-election conformance scenarios (`SC-LEAD-*`).
+//!
+//! See the [scenario catalog](../docs/scenarios/leader.md). Every plugin
+//! feeds its `LeaderElectionBackend` — whether a native implementation or the
+//! `cluster` gear's cache-derived default — into this suite:
+//!
+//! ```no_run
+//! # use std::sync::Arc;
+//! # use cluster_sdk::LeaderElectionBackend;
+//! # use cluster_conformance::run_leader_conformance;
+//! # async fn run(make_backend: impl Fn() -> Arc<dyn LeaderElectionBackend>) {
+//! run_leader_conformance(make_backend).await;
+//! # }
+//! ```
+//!
+//! `SC-LEAD-008` (the ADR-009 weak-consistency constructor guard) is not a
+//! scenario here — it exercises the concrete `CasBasedLeaderElectionBackend`
+//! constructors directly, which this crate deliberately does not depend on
+//! (every plugin depends on `cluster-conformance`, so this crate's real
+//! dependencies stay limited to `cluster-sdk`). That guard is covered by the
+//! `cluster` gear's own test suite
+//! (`cluster/src/defaults/leader_tests.rs::new_rejects_eventually_consistent_cache`).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use cluster_sdk::error::ClusterError;
+use cluster_sdk::leader::{
+    ElectionConfig, LeaderElectionBackend, LeaderStatus, LeaderWatch, LeaderWatchEvent,
+};
+
+/// Runs every implemented L2 leader-election scenario against a fresh backend
+/// from `make`. `SC-LEAD-002` is asserted only when the backend declares
+/// `linearizable`; weaker backends skip the single-leader guarantee.
+pub async fn run_leader_conformance<F>(make: F)
+where
+    F: Fn() -> Arc<dyn LeaderElectionBackend>,
+{
+    scenario_lead_001(make()).await;
+    scenario_lead_002(make()).await;
+    scenario_lead_003(make()).await;
+    scenario_lead_004(make()).await;
+    scenario_lead_005(make()).await;
+    scenario_lead_006(make()).await;
+    scenario_lead_007(make()).await;
+}
+
+/// SC-LEAD-001: a single candidate becomes `Leader`.
+pub async fn scenario_lead_001(backend: Arc<dyn LeaderElectionBackend>) {
+    let mut watch = backend.elect("svc").await.expect("elect must succeed");
+    let status = first_status(&mut watch).await;
+    assert_eq!(
+        status,
+        LeaderStatus::Leader,
+        "SC-LEAD-001: the sole candidate must become Leader"
+    );
+}
+
+/// SC-LEAD-002: with N candidates, at most one observes `Leader` at any time.
+/// Capability-gated on `linearizable` — advisory backends may transiently elect
+/// two leaders under partition, so the strict assertion does not apply.
+pub async fn scenario_lead_002(backend: Arc<dyn LeaderElectionBackend>) {
+    if !backend.features().linearizable {
+        // Documented fallback: the suite does not assert single-leadership for a
+        // backend that does not claim linearizable election.
+        return;
+    }
+    let mut a = backend.elect("svc").await.expect("elect a");
+    let mut b = backend.elect("svc").await.expect("elect b");
+    let leaders = [first_status(&mut a).await, first_status(&mut b).await]
+        .into_iter()
+        .filter(|s| *s == LeaderStatus::Leader)
+        .count();
+    assert_eq!(
+        leaders, 1,
+        "SC-LEAD-002: a linearizable backend must elect exactly one leader among contenders"
+    );
+}
+
+/// SC-LEAD-007: `ElectionConfig::new` rejects a zero `ttl`/`max_missed_renewals`
+/// (a pure config-validation scenario; the backend is unused).
+#[allow(
+    clippy::unused_async,
+    reason = "kept `async` so every `scenario_lead_*` shares one signature the runner can `.await` uniformly"
+)]
+pub async fn scenario_lead_007(_backend: Arc<dyn LeaderElectionBackend>) {
+    assert!(
+        matches!(
+            ElectionConfig::new(Duration::ZERO, 3),
+            Err(ClusterError::InvalidConfig { .. })
+        ),
+        "SC-LEAD-007: zero ttl must be rejected"
+    );
+    assert!(
+        matches!(
+            ElectionConfig::new(Duration::from_secs(15), 0),
+            Err(ClusterError::InvalidConfig { .. })
+        ),
+        "SC-LEAD-007: zero max_missed_renewals must be rejected"
+    );
+    assert!(
+        matches!(
+            ElectionConfig::new(Duration::from_nanos(1), 250),
+            Err(ClusterError::InvalidConfig { .. })
+        ),
+        "SC-LEAD-007: a ttl too small for the renewal budget must be rejected"
+    );
+}
+
+/// SC-LEAD-003: the elected leader's claim auto-renews without any consumer
+/// action; the status stays `Leader` across multiple renewal intervals.
+pub async fn scenario_lead_003(backend: Arc<dyn LeaderElectionBackend>) {
+    tokio::time::pause();
+    // Short TTL so renewals fire quickly under controlled time.
+    // max_missed_renewals=2 → renewal_interval = ttl / 3 ≈ 100 ms.
+    let config = ElectionConfig::new(Duration::from_millis(300), 2).expect("valid config");
+    let mut watch = backend.elect_with_config("e", config).await.expect("elect");
+    // Wait until we hold leadership.
+    loop {
+        match watch.changed().await {
+            LeaderWatchEvent::Status(LeaderStatus::Leader) => break,
+            LeaderWatchEvent::Closed(err) => panic!("SC-LEAD-003: watch closed: {err}"),
+            _ => {}
+        }
+    }
+    // Advance across 5 renewal intervals; after each yield the renewal task runs.
+    for _ in 0..5 {
+        tokio::time::advance(Duration::from_millis(100)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            watch.is_leader(),
+            "SC-LEAD-003: auto-renewal must keep status Leader across renewal intervals"
+        );
+    }
+    tokio::time::resume();
+}
+
+/// SC-LEAD-004: graceful `resign()` releases the claim; a waiting follower is
+/// elected within a bounded number of events on the same backend.
+pub async fn scenario_lead_004(backend: Arc<dyn LeaderElectionBackend>) {
+    let mut a = backend.elect("e").await.expect("elect a");
+    let mut b = backend.elect("e").await.expect("elect b");
+    // Drive A to Leader.
+    loop {
+        match a.changed().await {
+            LeaderWatchEvent::Status(LeaderStatus::Leader) => break,
+            LeaderWatchEvent::Closed(err) => panic!("SC-LEAD-004: a closed: {err}"),
+            _ => {}
+        }
+    }
+    a.resign().await.expect("SC-LEAD-004: resign must succeed");
+    assert!(
+        wait_for_leader(&mut b).await,
+        "SC-LEAD-004: successor must be elected promptly after resign"
+    );
+}
+
+/// SC-LEAD-005: `status()`/`is_leader()` synchronously reflect the most recently
+/// observed transition without additional I/O.
+pub async fn scenario_lead_005(backend: Arc<dyn LeaderElectionBackend>) {
+    let mut watch = backend.elect("e").await.expect("elect");
+    // After any Status event the cached snapshot must agree.
+    for _ in 0..64 {
+        match watch.changed().await {
+            LeaderWatchEvent::Status(s) => {
+                assert_eq!(
+                    watch.status(),
+                    s,
+                    "SC-LEAD-005: status() must equal the last Status event"
+                );
+                assert_eq!(
+                    watch.is_leader(),
+                    matches!(s, LeaderStatus::Leader),
+                    "SC-LEAD-005: is_leader() must agree with the last Status event"
+                );
+                return;
+            }
+            LeaderWatchEvent::Closed(err) => panic!("SC-LEAD-005: watch closed: {err}"),
+            _ => {}
+        }
+    }
+    panic!("SC-LEAD-005: no Status event observed within the bound");
+}
+
+/// SC-LEAD-006: `Status(Lost)` is transient — the watch auto-reenrols and
+/// eventually delivers `Leader` or `Follower` without the consumer calling
+/// `elect()` again.
+pub async fn scenario_lead_006(backend: Arc<dyn LeaderElectionBackend>) {
+    tokio::time::pause();
+    // Very short TTL with one allowed missed renewal so loss fires quickly.
+    let config = ElectionConfig::new(Duration::from_millis(100), 1).expect("valid config");
+    let mut watch = backend.elect_with_config("e", config).await.expect("elect");
+    loop {
+        match watch.changed().await {
+            LeaderWatchEvent::Status(LeaderStatus::Leader) => break,
+            LeaderWatchEvent::Closed(err) => panic!("SC-LEAD-006: watch closed: {err}"),
+            _ => {}
+        }
+    }
+    // Advance past the full TTL so the renewal misses its window. After
+    // `advance`, timer futures wake up but tasks still need to be polled;
+    // 64 yields lets the sweeper, the renewal task, and the watch forwarder
+    // all process their events before we scan the watch stream.
+    tokio::time::advance(Duration::from_millis(500)).await;
+    for _ in 0..64 {
+        tokio::task::yield_now().await;
+    }
+
+    let mut saw_lost = false;
+    for _ in 0..256 {
+        match watch.changed().await {
+            LeaderWatchEvent::Status(LeaderStatus::Lost) => {
+                saw_lost = true;
+            }
+            LeaderWatchEvent::Status(_) if saw_lost => {
+                // Re-enrolled on the same watch — scenario passes.
+                tokio::time::resume();
+                return;
+            }
+            LeaderWatchEvent::Closed(err) => panic!("SC-LEAD-006: watch closed: {err}"),
+            _ => {}
+        }
+    }
+    tokio::time::resume();
+    panic!(
+        "SC-LEAD-006: watch must re-enrol after Lost without the consumer calling elect() again"
+    );
+}
+
+/// Polls `watch.changed()` up to 64 times, returning `true` if a `Leader`
+/// status is observed.
+async fn wait_for_leader(watch: &mut LeaderWatch) -> bool {
+    for _ in 0..64 {
+        match watch.changed().await {
+            LeaderWatchEvent::Status(LeaderStatus::Leader) => return true,
+            LeaderWatchEvent::Closed(_) => return false,
+            _ => {}
+        }
+    }
+    false
+}
+
+/// Awaits the watch's first leadership status, skipping non-status signals.
+async fn first_status(watch: &mut LeaderWatch) -> LeaderStatus {
+    for _ in 0..64 {
+        match watch.changed().await {
+            LeaderWatchEvent::Status(status) => return status,
+            LeaderWatchEvent::Closed(err) => {
+                panic!("watch closed before reporting status: {err}")
+            }
+            _ => {}
+        }
+    }
+    panic!("watch produced no Status event within the bound");
+}

--- a/gears/system/cluster/cluster-conformance/src/lib.rs
+++ b/gears/system/cluster/cluster-conformance/src/lib.rs
@@ -1,0 +1,73 @@
+// Created: 2026-06-24 by Constructor Tech
+//! # Cluster backend conformance suites
+//!
+//! `cluster_conformance` is the **keystone** of the cluster testing strategy
+//! (see `docs/TESTING-STRATEGY.md` §4): a set of parametrized suites, each
+//! generic over a backend *factory*, that assert the cluster contract
+//! independent of *which* backend implements it.
+//!
+//! This is the only mechanism that operationalizes
+//! `cpt-cf-clst-nfr-cross-backend-stability` — "a consumer gear's behavior MUST
+//! NOT change when an operator switches the backend" is a claim you can only
+//! test by running **one shared test body against every backend**. A plugin's
+//! integration test then reduces to ~10 lines: build the real backend in a
+//! container, hand it to the matching `run_*_conformance` entry point.
+//!
+//! ## Capability-gated assertions
+//!
+//! Each suite reads the backend's `features()` / `consistency()` and asserts
+//! strict guarantees *only* where the backend claims them (e.g.
+//! single-leader-under-contention only when
+//! [`LeaderElectionFeatures::linearizable`](cluster_sdk::LeaderElectionFeatures)
+//! is `true`). A backend that lies about a capability fails the suite — this is
+//! how the honest-declaration requirement
+//! (`cpt-cf-clst-fr-validation-honest-declaration`) is tested.
+//!
+//! ## Entry-point shape
+//!
+//! Each scenario is its own `pub async fn scenario_<id>(backend)` so a plugin
+//! can run the whole suite or cherry-pick one case. The `run_*_conformance`
+//! runners build a **fresh backend per scenario** via the supplied `make`
+//! closure, so state never leaks between scenarios.
+//!
+//! The suites are plain `async fn`s the caller drives (rather than
+//! macro-generated `#[tokio::test]` cases) so they compose with the simulated
+//! runtimes used by L4 DST (`turmoil`/`madsim`). This resolves the §11 open
+//! question for the first scaffold; revisit if a backend needs per-scenario
+//! `#[tokio::test]` isolation.
+//!
+//! ## Scenario coverage
+//!
+//! Every scenario maps to an `SC-*` row in the
+//! [scenario catalog](../docs/scenarios/README.md). Rows still marked ☐/◑ in the
+//! catalog appear here as scenario functions with a `// TODO(SC-*)` marker until
+//! the behavior (and, for L4 rows, the fault-injection harness) lands.
+
+#![forbid(unsafe_code)]
+#![deny(rust_2018_idioms)]
+#![allow(
+    clippy::expect_used,
+    reason = "the conformance suite's job is to assert: an `expect`/`panic` IS the test failure, with a message naming the violated SC-* scenario"
+)]
+#![allow(
+    clippy::missing_panics_doc,
+    reason = "every scenario panics by design when the contract is violated; documenting `# Panics` on each would restate the assertion"
+)]
+
+pub mod cache;
+pub mod discovery;
+pub mod fixture;
+pub mod leader;
+pub mod lock;
+pub mod model;
+pub mod restart;
+pub mod watch_lifecycle;
+
+pub use cache::run_cache_conformance;
+pub use discovery::run_discovery_conformance;
+pub use fixture::MemCache;
+pub use leader::run_leader_conformance;
+pub use lock::run_lock_conformance;
+pub use model::{CacheModel, CacheOp, VersionTarget, replay_against_model};
+pub use restart::run_restart_conformance;
+pub use watch_lifecycle::run_watch_lifecycle_conformance;

--- a/gears/system/cluster/cluster-conformance/src/lock.rs
+++ b/gears/system/cluster/cluster-conformance/src/lock.rs
@@ -1,0 +1,179 @@
+// Created: 2026-06-24 by Constructor Tech
+//! Distributed-lock conformance scenarios (`SC-LOCK-*`).
+//!
+//! See the [scenario catalog](../docs/scenarios/lock.md). Cache-only plugins
+//! feed the `cluster` gear's `CasBasedDistributedLockBackend`
+//! (`cluster::defaults::CasBasedDistributedLockBackend` — not a
+//! `cluster-conformance` dependency, so not an intra-doc link here) into this
+//! suite.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use cluster_sdk::error::ClusterError;
+use cluster_sdk::lock::DistributedLockBackend;
+
+/// Runs every implemented L2 lock scenario against a fresh backend from `make`.
+pub async fn run_lock_conformance<F>(make: F)
+where
+    F: Fn() -> Arc<dyn DistributedLockBackend>,
+{
+    scenario_lock_001(make()).await;
+    scenario_lock_002(make()).await;
+    scenario_lock_003(make()).await;
+    scenario_lock_004(make()).await;
+    scenario_lock_005(make()).await;
+    scenario_lock_007(make()).await;
+}
+
+/// SC-LOCK-001: `try_lock` succeeds when free, returns `LockContended` when held.
+pub async fn scenario_lock_001(backend: Arc<dyn DistributedLockBackend>) {
+    let ttl = Duration::from_secs(30);
+    let _guard = backend
+        .try_lock("res", ttl)
+        .await
+        .expect("SC-LOCK-001: try_lock on a free lock must succeed");
+    let contended = backend.try_lock("res", ttl).await;
+    assert!(
+        matches!(contended, Err(ClusterError::LockContended { .. })),
+        "SC-LOCK-001: try_lock on a held lock must return LockContended, got {contended:?}"
+    );
+}
+
+/// SC-LOCK-002: `lock` blocks up to `timeout`, then returns
+/// `LockTimeout { name, waited }`.
+pub async fn scenario_lock_002(backend: Arc<dyn DistributedLockBackend>) {
+    // Paused time auto-advances to the next pending timer once the runtime
+    // has nothing else ready to run, so awaiting `lock()` directly resolves
+    // its internal timeout deterministically without a real 50ms sleep.
+    tokio::time::pause();
+    let ttl = Duration::from_secs(30);
+    let _guard = backend
+        .try_lock("res", ttl)
+        .await
+        .expect("hold the lock so the next acquisition must wait");
+    let timed_out = backend.lock("res", ttl, Duration::from_millis(50)).await;
+    match timed_out {
+        Err(ClusterError::LockTimeout { name, .. }) => {
+            assert_eq!(name, "res", "SC-LOCK-002: timeout reports the lock name");
+        }
+        other => panic!("SC-LOCK-002: expected LockTimeout, got {other:?}"),
+    }
+    tokio::time::resume();
+}
+
+/// SC-LOCK-004: explicit `release()` wakes a waiter blocked in `lock()` —
+/// the waiter acquires promptly after release, well before its own timeout.
+pub async fn scenario_lock_004(backend: Arc<dyn DistributedLockBackend>) {
+    let ttl = Duration::from_secs(30);
+    let guard = backend.try_lock("res", ttl).await.expect("acquire");
+
+    let waiter_backend = Arc::clone(&backend);
+    let waiter = tokio::spawn(async move {
+        waiter_backend
+            .lock("res", ttl, Duration::from_secs(5))
+            .await
+    });
+    // Give B time to attempt the claim and start waiting before A releases.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert!(
+        !waiter.is_finished(),
+        "SC-LOCK-004 setup: B must still be waiting on the held lock"
+    );
+
+    guard
+        .release()
+        .await
+        .expect("explicit release must succeed");
+
+    let acquired = waiter
+        .await
+        .expect("waiter task must not panic")
+        .expect("SC-LOCK-004: a blocked waiter must acquire promptly after release");
+    drop(acquired);
+}
+
+/// SC-LOCK-003: a lock held by a crashed holder (guard dropped without
+/// `release()`) becomes acquirable once its TTL lapses.
+pub async fn scenario_lock_003(backend: Arc<dyn DistributedLockBackend>) {
+    tokio::time::pause();
+    let ttl = Duration::from_millis(100);
+    let guard = backend
+        .try_lock("m", ttl)
+        .await
+        .expect("SC-LOCK-003: initial acquire must succeed");
+    drop(guard); // simulate crash — no I/O, no explicit release
+    tokio::time::advance(Duration::from_millis(200)).await;
+    tokio::task::yield_now().await;
+    let result = backend.try_lock("m", ttl).await;
+    assert!(
+        result.is_ok(),
+        "SC-LOCK-003: lock must be acquirable after crashed-holder TTL lapses, got {result:?}"
+    );
+    tokio::time::resume();
+}
+
+/// SC-LOCK-005: `renew` extends an active lease; renewing an expired lock
+/// returns `LockExpired`.
+pub async fn scenario_lock_005(backend: Arc<dyn DistributedLockBackend>) {
+    tokio::time::pause();
+    let ttl = Duration::from_millis(200);
+    let guard = backend
+        .try_lock("m", ttl)
+        .await
+        .expect("SC-LOCK-005: acquire must succeed");
+    // Advance to just before expiry and renew — must succeed.
+    tokio::time::advance(Duration::from_millis(150)).await;
+    tokio::task::yield_now().await;
+    guard
+        .renew(Duration::from_millis(200))
+        .await
+        .expect("SC-LOCK-005: renew before expiry must succeed");
+    // Let the lock fully expire.
+    tokio::time::advance(Duration::from_millis(400)).await;
+    tokio::task::yield_now().await;
+    let err = guard
+        .renew(Duration::from_millis(100))
+        .await
+        .expect_err("SC-LOCK-005: renewing an expired lock must fail");
+    assert!(
+        matches!(err, ClusterError::LockExpired { .. }),
+        "SC-LOCK-005: renewing an expired lock must return LockExpired, got {err:?}"
+    );
+    tokio::time::resume();
+}
+
+/// SC-LOCK-007: dropping a `LockGuard` performs no remote I/O — the lock
+/// persists until its TTL lapses (ADR-002: TTL is the only safety net).
+pub async fn scenario_lock_007(backend: Arc<dyn DistributedLockBackend>) {
+    tokio::time::pause();
+    let ttl = Duration::from_millis(200);
+    let guard = backend
+        .try_lock("m", ttl)
+        .await
+        .expect("SC-LOCK-007: acquire must succeed");
+    drop(guard);
+    // Immediately after drop — before the TTL — the lock must still be "held"
+    // because no remote release occurred.
+    let still_held = backend.try_lock("m", ttl).await;
+    assert!(
+        matches!(still_held, Err(ClusterError::LockContended { .. })),
+        "SC-LOCK-007: dropping a guard must not eagerly release the lock (got {still_held:?})"
+    );
+    // After the TTL lapses the lock becomes acquirable again.
+    tokio::time::advance(Duration::from_millis(400)).await;
+    tokio::task::yield_now().await;
+    assert!(
+        backend.try_lock("m", ttl).await.is_ok(),
+        "SC-LOCK-007: lock must be acquirable after TTL lapses post-drop"
+    );
+    tokio::time::resume();
+}
+
+// SC-LOCK-006: a foreign holder cannot release another's lock — impractical
+//   through the `DistributedLockBackend` trait alone (the owner-token is an
+//   implementation detail not exposed by the trait). The invariant is covered at
+//   the cache layer by SC-CACHE-008/009. Cherry-pickers can call those scenarios
+//   directly; there is no `scenario_lock_006` stub to avoid implying otherwise.
+// TODO(SC-LOCK-008) [L4]: a blocked `lock()` waiter is woken promptly on release
+//   — fault-injection harness.

--- a/gears/system/cluster/cluster-conformance/src/model.rs
+++ b/gears/system/cluster/cluster-conformance/src/model.rs
@@ -1,0 +1,334 @@
+// Created: 2026-06-24 by Constructor Tech
+//! Property / model-based variant for the cache contract (§4 "Model-based /
+//! property variants").
+//!
+//! A random sequence of cache operations is replayed against both the backend
+//! under test and a trivial reference model, asserting — after *every* op — the
+//! invariants the contract guarantees under any interleaving the single-threaded
+//! sequence permits. Where example-based [`cache`](crate::cache) scenarios pin
+//! specific behaviors, this catches the CAS/version races a fixed example never
+//! reaches.
+//!
+//! # What the oracle may and may not assert
+//!
+//! The reference model tracks **value and presence** exactly — those *are*
+//! contract-guaranteed (`get` returns the last write; `delete` removes it). It
+//! deliberately does **not** track an absolute version, because version
+//! numbering is backend-specific: an in-memory backend mints `1` per key and
+//! increments by one, but etcd (`mod_revision`) and NATS (stream revision) use a
+//! store-wide counter that jumps. Asserting exact version equality would fail a
+//! conformant revision-based backend. The contract guarantees only:
+//!
+//! - a present entry's version is **≠ 0** (0 is the reserved sentinel);
+//! - each *successful mutation* of a continuously-present key **strictly
+//!   increases** its version (a `delete` clears the watermark, so a re-create may
+//!   reset lower — SC-CACHE-009);
+//! - a *non-mutating* op (a conflicted CAS, a no-op delete) leaves the version
+//!   **unchanged** — so a backend that bumps a version on a failed CAS is caught;
+//! - `compare_and_swap` succeeds **iff** `expected_version` equals the backend's
+//!   *own* current version — which is why [`VersionTarget`] is resolved against a
+//!   live read at replay time, not baked into the generated op.
+//!
+//! The `proptest` strategy that generates the op sequences lives in the crate's
+//! `tests/model.rs` (proptest is a dev-dependency); this module is the
+//! runtime-agnostic replay engine those tests drive.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use cluster_sdk::cache::{ClusterCacheBackend, PutRequest, Ttl};
+use cluster_sdk::error::ClusterError;
+
+/// A trivial single-threaded reference cache: value + presence only, the part of
+/// the contract that holds identically across every backend. Version invariants
+/// are checked by [`replay_against_model`] from the backend's own readings, not
+/// stored here (see the module docs).
+#[derive(Debug, Default)]
+pub struct CacheModel {
+    map: HashMap<String, Vec<u8>>,
+}
+
+impl CacheModel {
+    /// The value currently stored under `key`, if any.
+    #[must_use]
+    pub fn get(&self, key: &str) -> Option<&Vec<u8>> {
+        self.map.get(key)
+    }
+
+    /// Whether `key` is present.
+    #[must_use]
+    pub fn contains(&self, key: &str) -> bool {
+        self.map.contains_key(key)
+    }
+
+    /// Unconditional overwrite.
+    pub fn put(&mut self, key: &str, value: &[u8]) {
+        self.map.insert(key.to_owned(), value.to_vec());
+    }
+
+    /// Create-if-absent; returns whether it created.
+    pub fn create_if_absent(&mut self, key: &str, value: &[u8]) -> bool {
+        if self.map.contains_key(key) {
+            false
+        } else {
+            self.map.insert(key.to_owned(), value.to_vec());
+            true
+        }
+    }
+
+    /// Delete; returns whether the key existed.
+    pub fn remove(&mut self, key: &str) -> bool {
+        self.map.remove(key).is_some()
+    }
+}
+
+/// How a generated [`CacheOp::CompareAndSwap`] picks its `expected_version`. The
+/// concrete version is resolved against a live read at replay time so the
+/// success path fires regardless of a backend's version numbering scheme.
+#[derive(Debug, Clone, Copy)]
+pub enum VersionTarget {
+    /// Use the key's current backend version — CAS should succeed iff present.
+    Current,
+    /// Use a deliberately-stale version — CAS should always conflict.
+    Stale,
+}
+
+/// One operation in the model alphabet. A `proptest` strategy (in `tests/`)
+/// generates `Vec<CacheOp>` sequences over a small key/value space so create /
+/// CAS / delete collisions are frequent.
+#[derive(Debug, Clone)]
+pub enum CacheOp {
+    /// Unconditional overwrite (always mutates; version strictly increases).
+    Put { key: String, value: Vec<u8> },
+    /// Atomic create-if-absent (mutates iff it created).
+    PutIfAbsent { key: String, value: Vec<u8> },
+    /// Version-guarded compare-and-swap (mutates iff it succeeded).
+    CompareAndSwap {
+        key: String,
+        target: VersionTarget,
+        value: Vec<u8>,
+    },
+    /// Unconditional delete (mutates iff the key existed).
+    Delete { key: String },
+}
+
+impl CacheOp {
+    /// The key this op targets.
+    #[must_use]
+    pub fn key(&self) -> &str {
+        match self {
+            Self::Put { key, .. }
+            | Self::PutIfAbsent { key, .. }
+            | Self::CompareAndSwap { key, .. }
+            | Self::Delete { key } => key,
+        }
+    }
+}
+
+/// Per-key high-water version mark, used to enforce strict monotonicity across
+/// consecutive present states and equality across non-mutating ops.
+type Watermarks = HashMap<String, u64>;
+
+/// Replays `ops` against a fresh backend from `make`, asserting the contract's
+/// value/presence and version invariants against the reference model after every
+/// op. Returns `Err(reason)` on the first divergence so `proptest` can shrink to
+/// a minimal failing sequence.
+///
+/// # Errors
+/// Returns a human-readable description of the first invariant violation (or an
+/// unexpected backend error), tagged with the op index and key.
+pub async fn replay_against_model<F>(ops: &[CacheOp], make: F) -> Result<(), String>
+where
+    F: Fn() -> Arc<dyn ClusterCacheBackend>,
+{
+    let backend = make();
+    let mut model = CacheModel::default();
+    let mut marks: Watermarks = HashMap::new();
+
+    for (i, op) in ops.iter().enumerate() {
+        let mutated = apply_op(backend.as_ref(), &mut model, op, i).await?;
+        check_after(backend.as_ref(), &model, &mut marks, op, i, mutated).await?;
+    }
+    Ok(())
+}
+
+/// Applies `op` to both the backend and the model, asserting the success/failure
+/// of conditional ops agrees with the model. Returns whether the op mutated the
+/// key (drives the post-op version check).
+async fn apply_op(
+    backend: &dyn ClusterCacheBackend,
+    model: &mut CacheModel,
+    op: &CacheOp,
+    i: usize,
+) -> Result<bool, String> {
+    match op {
+        CacheOp::Put { key, value } => {
+            backend
+                .put(PutRequest {
+                    key,
+                    value,
+                    ttl: Ttl::Indefinite,
+                })
+                .await
+                .map_err(|e| fail(i, key, &format!("put errored: {e:?}")))?;
+            model.put(key, value);
+            Ok(true)
+        }
+        CacheOp::PutIfAbsent { key, value } => {
+            let created = backend
+                .put_if_absent(PutRequest {
+                    key,
+                    value,
+                    ttl: Ttl::Indefinite,
+                })
+                .await
+                .map_err(|e| fail(i, key, &format!("put_if_absent errored: {e:?}")))?
+                .is_some();
+            let model_created = model.create_if_absent(key, value);
+            if created != model_created {
+                return Err(fail(
+                    i,
+                    key,
+                    &format!("put_if_absent created={created} but model expected {model_created}"),
+                ));
+            }
+            Ok(created)
+        }
+        CacheOp::CompareAndSwap { key, target, value } => {
+            let current = backend
+                .get(key)
+                .await
+                .map_err(|e| fail(i, key, &format!("get (for CAS) errored: {e:?}")))?
+                .map_or(0, |entry| entry.version);
+            let expected = match target {
+                VersionTarget::Current => current,
+                // Distinct from the live version, so a present key always
+                // mismatches and an absent key (current 0) conflicts anyway.
+                VersionTarget::Stale => current.wrapping_add(1),
+            };
+            let should_succeed = matches!(target, VersionTarget::Current) && model.contains(key);
+            let result = backend
+                .compare_and_swap(key, expected, value, Ttl::Indefinite)
+                .await;
+            match (result, should_succeed) {
+                (Ok(_), true) => {
+                    model.put(key, value);
+                    Ok(true)
+                }
+                (Err(ClusterError::CasConflict { .. }), false) => Ok(false),
+                (Ok(_), false) => Err(fail(
+                    i,
+                    key,
+                    "compare_and_swap succeeded but the model expected a conflict",
+                )),
+                (Err(ClusterError::CasConflict { .. }), true) => Err(fail(
+                    i,
+                    key,
+                    "compare_and_swap conflicted but the model expected success",
+                )),
+                (Err(other), _) => Err(fail(
+                    i,
+                    key,
+                    &format!("compare_and_swap errored: {other:?}"),
+                )),
+            }
+        }
+        CacheOp::Delete { key } => {
+            let existed = backend
+                .delete(key)
+                .await
+                .map_err(|e| fail(i, key, &format!("delete errored: {e:?}")))?;
+            let model_existed = model.remove(key);
+            if existed != model_existed {
+                return Err(fail(
+                    i,
+                    key,
+                    &format!("delete existed={existed} but model expected {model_existed}"),
+                ));
+            }
+            Ok(existed)
+        }
+    }
+}
+
+/// Asserts the backend's observed state for the touched key matches the model
+/// (value + presence) and the version invariants hold (≠ 0; strictly increasing
+/// on a mutation, unchanged otherwise). Updates the per-key watermark.
+async fn check_after(
+    backend: &dyn ClusterCacheBackend,
+    model: &CacheModel,
+    marks: &mut Watermarks,
+    op: &CacheOp,
+    i: usize,
+    mutated: bool,
+) -> Result<(), String> {
+    let key = op.key();
+    let observed = backend
+        .get(key)
+        .await
+        .map_err(|e| fail(i, key, &format!("get (post-op) errored: {e:?}")))?;
+
+    match (observed, model.get(key)) {
+        (Some(entry), Some(model_value)) => {
+            if &entry.value != model_value {
+                return Err(fail(
+                    i,
+                    key,
+                    &format!(
+                        "value divergence: backend {:?} vs model {model_value:?}",
+                        entry.value
+                    ),
+                ));
+            }
+            if entry.version == 0 {
+                return Err(fail(i, key, "present entry has version 0 (sentinel)"));
+            }
+            if let Some(&prev) = marks.get(key) {
+                if mutated && entry.version <= prev {
+                    return Err(fail(
+                        i,
+                        key,
+                        &format!(
+                            "version not strictly increasing on mutation: {prev} -> {}",
+                            entry.version
+                        ),
+                    ));
+                }
+                if !mutated && entry.version != prev {
+                    return Err(fail(
+                        i,
+                        key,
+                        &format!(
+                            "version changed on a non-mutating op: {prev} -> {}",
+                            entry.version
+                        ),
+                    ));
+                }
+            }
+            marks.insert(key.to_owned(), entry.version);
+            Ok(())
+        }
+        (None, None) => {
+            marks.remove(key);
+            Ok(())
+        }
+        (Some(entry), None) => Err(fail(
+            i,
+            key,
+            &format!(
+                "backend has the key (v{}) but the model deleted it",
+                entry.version
+            ),
+        )),
+        (None, Some(model_value)) => Err(fail(
+            i,
+            key,
+            &format!("backend is missing the key but the model holds {model_value:?}"),
+        )),
+    }
+}
+
+/// Formats an invariant-violation message tagged with the op index and key.
+fn fail(index: usize, key: &str, reason: &str) -> String {
+    format!("op #{index} on key {key:?}: {reason}")
+}

--- a/gears/system/cluster/cluster-conformance/src/restart.rs
+++ b/gears/system/cluster/cluster-conformance/src/restart.rs
@@ -1,0 +1,210 @@
+// Created: 2026-06-30 by Constructor Tech
+//! Watch auto-restart combinator scenarios (`SC-REST-*`).
+//!
+//! See the [scenario catalog](../docs/scenarios/restart.md). The combinator is
+//! SDK-level (no backend required): it wraps a watch and transparently reconnects
+//! on retryable closes.
+//!
+//! ## Scope
+//!
+//! The reconnect path (SC-REST-001, 003, 004) requires a watch with a
+//! resubscribe seam installed by the facade (`LeaderElectionV1`, etc.), which
+//! needs a `ClientHub`. Those scenarios are deferred to the L3 wiring-crate
+//! integration tests. The scenarios implemented here cover:
+//!
+//! - SC-REST-002: non-retryable closes propagate verbatim to the consumer.
+//! - Smoke test: `Lagged`/`Reset` events pass through the combinator unchanged.
+//! - Smoke test: `RetryPolicy::default()` produces a sensible configuration.
+//!
+//! The full SC-REST-001/003/004 assertions (retryable close → backoff →
+//! reconnect → synthesized `Reset`) are added once the facade resubscribe seam
+//! is accessible without a running `ClientHub`.
+
+use cluster_sdk::cache::{CacheWatch, CacheWatchEvent};
+use cluster_sdk::error::{ClusterError, ProviderErrorKind};
+use cluster_sdk::leader::{LeaderStatus, LeaderWatch, LeaderWatchEvent};
+use cluster_sdk::{RestartingWatch, RetryPolicy, ServiceWatch, ServiceWatchEvent};
+
+/// Runs every implemented SC-REST-* scenario. No backend factory is needed —
+/// all scenarios drive the combinator via the watch test-harness channels.
+pub async fn run_restart_conformance() {
+    scenario_rest_002_cache().await;
+    scenario_rest_002_leader().await;
+    scenario_rest_002_service().await;
+    scenario_rest_002_capability_and_other().await;
+    scenario_rest_pass_through().await;
+    scenario_rest_retry_policy_smoke().await;
+}
+
+/// SC-REST-002 (cache): a non-retryable close (`AuthFailure`) reaches the consumer
+/// verbatim; the combinator does not swallow or retry it.
+pub async fn scenario_rest_002_cache() {
+    let (tx, watch) = CacheWatch::channel(8);
+    let mut restarting: RestartingWatch<CacheWatch> = watch.auto_restart(RetryPolicy::default());
+
+    // Non-retryable close: AuthFailure.
+    tx.send(CacheWatchEvent::Closed(ClusterError::Provider {
+        kind: ProviderErrorKind::AuthFailure,
+        message: "SC-REST-002".into(),
+    }))
+    .await
+    .ok();
+
+    let event = restarting
+        .recv()
+        .await
+        .expect("SC-REST-002(cache): must receive the Closed event");
+    assert!(
+        matches!(
+            event,
+            CacheWatchEvent::Closed(ClusterError::Provider {
+                kind: ProviderErrorKind::AuthFailure,
+                ..
+            })
+        ),
+        "SC-REST-002(cache): non-retryable AuthFailure must propagate verbatim, got {event:?}"
+    );
+    assert!(
+        restarting.recv().await.is_none(),
+        "SC-REST-002(cache): no further events after a terminal non-retryable close"
+    );
+}
+
+/// SC-REST-002 (leader): a non-retryable `Shutdown` close propagates verbatim.
+pub async fn scenario_rest_002_leader() {
+    let (tx, _resign_rx, watch) = LeaderWatch::channel(8, LeaderStatus::Follower);
+    let mut restarting: RestartingWatch<LeaderWatch> = watch.auto_restart(RetryPolicy::default());
+
+    tx.send(LeaderWatchEvent::Closed(ClusterError::Shutdown))
+        .await
+        .ok();
+
+    let event = restarting
+        .recv()
+        .await
+        .expect("SC-REST-002(leader): must receive Closed");
+    assert!(
+        matches!(event, LeaderWatchEvent::Closed(ClusterError::Shutdown)),
+        "SC-REST-002(leader): Shutdown must propagate verbatim, got {event:?}"
+    );
+}
+
+/// SC-REST-002 (service): a non-retryable `Shutdown` close propagates verbatim.
+pub async fn scenario_rest_002_service() {
+    let (tx, watch) = ServiceWatch::channel(8);
+    let mut restarting: RestartingWatch<ServiceWatch> = watch.auto_restart(RetryPolicy::default());
+
+    tx.send(ServiceWatchEvent::Closed(ClusterError::Shutdown))
+        .await
+        .ok();
+
+    let event = restarting
+        .recv()
+        .await
+        .expect("SC-REST-002(service): must receive Closed");
+    assert!(
+        matches!(event, ServiceWatchEvent::Closed(ClusterError::Shutdown)),
+        "SC-REST-002(service): Shutdown must propagate verbatim, got {event:?}"
+    );
+}
+
+/// SC-REST-002 (cache, cont'd): `CapabilityNotMet` and `Provider { kind: Other }`
+/// also propagate verbatim — the combinator treats every non-`Provider` error,
+/// and every non-retryable `ProviderErrorKind`, as terminal.
+pub async fn scenario_rest_002_capability_and_other() {
+    let (tx, watch) = CacheWatch::channel(8);
+    let mut restarting: RestartingWatch<CacheWatch> = watch.auto_restart(RetryPolicy::default());
+
+    tx.send(CacheWatchEvent::Closed(ClusterError::CapabilityNotMet {
+        primitive: "ClusterCacheV1",
+        capability: "prefix_watch",
+        provider: "SC-REST-002",
+    }))
+    .await
+    .ok();
+
+    let event = restarting
+        .recv()
+        .await
+        .expect("SC-REST-002(capability): must receive the Closed event");
+    assert!(
+        matches!(
+            event,
+            CacheWatchEvent::Closed(ClusterError::CapabilityNotMet { .. })
+        ),
+        "SC-REST-002(capability): CapabilityNotMet must propagate verbatim, got {event:?}"
+    );
+
+    let (tx2, watch2) = CacheWatch::channel(8);
+    let mut restarting2: RestartingWatch<CacheWatch> = watch2.auto_restart(RetryPolicy::default());
+
+    tx2.send(CacheWatchEvent::Closed(ClusterError::Provider {
+        kind: ProviderErrorKind::Other,
+        message: "SC-REST-002".into(),
+    }))
+    .await
+    .ok();
+
+    let event2 = restarting2
+        .recv()
+        .await
+        .expect("SC-REST-002(other): must receive the Closed event");
+    assert!(
+        matches!(
+            event2,
+            CacheWatchEvent::Closed(ClusterError::Provider {
+                kind: ProviderErrorKind::Other,
+                ..
+            })
+        ),
+        "SC-REST-002(other): Provider{{kind: Other}} must propagate verbatim, got {event2:?}"
+    );
+}
+
+/// Smoke test: `Lagged` and `Reset` events pass through the combinator unchanged
+/// and do not trigger a reconnect attempt.
+pub async fn scenario_rest_pass_through() {
+    let (tx, watch) = CacheWatch::channel(8);
+    let mut restarting: RestartingWatch<CacheWatch> = watch.auto_restart(RetryPolicy::default());
+
+    tx.send(CacheWatchEvent::Lagged { dropped: 7 }).await.ok();
+    tx.send(CacheWatchEvent::Reset).await.ok();
+
+    let e1 = restarting.recv().await.expect("must receive Lagged");
+    assert!(
+        matches!(e1, CacheWatchEvent::Lagged { dropped: 7 }),
+        "restart pass-through: Lagged must arrive unchanged, got {e1:?}"
+    );
+    let e2 = restarting.recv().await.expect("must receive Reset");
+    assert!(
+        matches!(e2, CacheWatchEvent::Reset),
+        "restart pass-through: Reset must arrive unchanged, got {e2:?}"
+    );
+}
+
+/// Smoke: `RetryPolicy::default()` produces a sensible configuration — the
+/// fields satisfy the documented invariants (initial ≤ max, jitter ∈ [0,1]).
+/// Not tagged SC-REST-003 (that scenario requires the facade resubscribe seam).
+#[allow(clippy::unused_async, reason = "uniform async signature")]
+pub async fn scenario_rest_retry_policy_smoke() {
+    let policy = RetryPolicy::default();
+    assert!(
+        !policy.initial_backoff.is_zero(),
+        "retry-policy smoke: default initial_backoff must be positive"
+    );
+    assert!(
+        policy.initial_backoff <= policy.max_backoff,
+        "retry-policy smoke: initial_backoff must be <= max_backoff"
+    );
+    assert!(
+        (0.0..=1.0).contains(&policy.jitter_factor),
+        "retry-policy smoke: jitter_factor must be in [0, 1]"
+    );
+}
+
+// TODO(SC-REST-001) [deferred]: retryable close → backoff → resubscribe → Reset
+//   requires a facade-installed resubscribe seam (needs ClientHub). Defer to L3.
+// TODO(SC-REST-003) [deferred]: backoff schedule and retry-cap enforcement
+//   require the resubscribe path — same reason.
+// TODO(SC-REST-004) [deferred]: uniform across CacheWatch/LeaderWatch/ServiceWatch
+//   for the reconnect path — same reason.

--- a/gears/system/cluster/cluster-conformance/src/watch_lifecycle.rs
+++ b/gears/system/cluster/cluster-conformance/src/watch_lifecycle.rs
@@ -1,0 +1,144 @@
+// Created: 2026-06-30 by Constructor Tech
+//! Watch lifecycle uniformity scenarios (`SC-WLU-*`).
+//!
+//! See the [scenario catalog](../docs/scenarios/watch-lifecycle.md). These
+//! scenarios are SDK-level: they assert the uniform `{value, Lagged, Reset,
+//! Closed}` union shape and terminal-signal semantics across all three watch
+//! types, with no backend required.
+
+use cluster_sdk::cache::{CacheWatch, CacheWatchEvent};
+use cluster_sdk::error::ClusterError;
+use cluster_sdk::leader::{LeaderStatus, LeaderWatch, LeaderWatchEvent};
+use cluster_sdk::{ServiceWatch, ServiceWatchEvent};
+
+/// SC-WLU-001: every watch event type carries exactly the four-variant union
+/// `{value, Lagged, Reset, Closed}`. This is a structural compile-time check:
+/// if any variant is removed the match arm below becomes unreachable (dead code
+/// warning → error) or the non-exhaustive catch-all fires where it should not.
+#[allow(
+    clippy::unused_async,
+    reason = "kept `async` so the runner can `.await` it uniformly with the other scenarios"
+)]
+pub async fn scenario_wlu_001() {
+    fn _check_cache(e: &CacheWatchEvent) {
+        let _ = match e {
+            CacheWatchEvent::Event(_) => 0u8,
+            CacheWatchEvent::Lagged { dropped: _ } => 1,
+            CacheWatchEvent::Reset => 2,
+            CacheWatchEvent::Closed(_) => 3,
+            _ => 4, // non_exhaustive catch-all
+        };
+    }
+    fn _check_leader(e: &LeaderWatchEvent) {
+        let _ = match e {
+            LeaderWatchEvent::Status(_) => 0u8,
+            LeaderWatchEvent::Lagged { dropped: _ } => 1,
+            LeaderWatchEvent::Reset => 2,
+            LeaderWatchEvent::Closed(_) => 3,
+            _ => 4,
+        };
+    }
+    fn _check_service(e: &ServiceWatchEvent) {
+        let _ = match e {
+            ServiceWatchEvent::Change(_) => 0u8,
+            ServiceWatchEvent::Lagged { dropped: _ } => 1,
+            ServiceWatchEvent::Reset => 2,
+            ServiceWatchEvent::Closed(_) => 3,
+            _ => 4,
+        };
+    }
+    // The check functions are intentionally dead — the value is in compilation.
+    let _ = (
+        _check_cache as fn(&CacheWatchEvent),
+        _check_leader as fn(&LeaderWatchEvent),
+        _check_service as fn(&ServiceWatchEvent),
+    );
+}
+
+/// SC-WLU-004: a terminal `Closed` event is final — no further events arrive on
+/// the stream after it. Transient blips are retried internally (no event emitted).
+/// Verified over all three watch types via their test-harness channels.
+pub async fn scenario_wlu_004() {
+    // CacheWatch
+    {
+        let (tx, mut watch) = CacheWatch::channel(8);
+        tx.send(CacheWatchEvent::Closed(ClusterError::Shutdown))
+            .await
+            .ok();
+        let event = watch
+            .recv()
+            .await
+            .expect("SC-WLU-004(cache): must receive Closed");
+        assert!(
+            matches!(event, CacheWatchEvent::Closed(ClusterError::Shutdown)),
+            "SC-WLU-004(cache): Closed must be surfaced verbatim, got {event:?}"
+        );
+        // `recv` has no terminal-event latching — it's a bare channel
+        // passthrough (see `CacheWatch::recv`'s doc comment) — so the sender
+        // must be dropped for the channel to actually close, or this next
+        // `recv` blocks forever waiting for a message that will never come.
+        drop(tx);
+        assert!(
+            watch.recv().await.is_none(),
+            "SC-WLU-004(cache): no further events must arrive after terminal Closed"
+        );
+    }
+
+    // LeaderWatch — note: `changed()` always returns an event (it does not
+    // return `Option`), so we assert on the variant and then check `is_leader()`
+    // is no longer true as a proxy for terminal state.
+    {
+        let (tx, _resign_rx, mut watch) = LeaderWatch::channel(8, LeaderStatus::Follower);
+        tx.send(LeaderWatchEvent::Closed(ClusterError::Shutdown))
+            .await
+            .ok();
+        let event = watch.changed().await;
+        assert!(
+            matches!(event, LeaderWatchEvent::Closed(ClusterError::Shutdown)),
+            "SC-WLU-004(leader): Closed must be surfaced verbatim, got {event:?}"
+        );
+        // Drop tx so the channel is closed; the next changed() must return Closed(Shutdown)
+        // or a stream-end signal — a well-behaved watch must not deliver more events.
+        drop(tx);
+        let next = watch.changed().await;
+        assert!(
+            matches!(next, LeaderWatchEvent::Closed(_)),
+            "SC-WLU-004(leader): no further value events must arrive after terminal Closed, got {next:?}"
+        );
+    }
+
+    // ServiceWatch
+    {
+        let (tx, mut watch) = ServiceWatch::channel(8);
+        tx.send(ServiceWatchEvent::Closed(ClusterError::Shutdown))
+            .await
+            .ok();
+        let event = watch
+            .recv()
+            .await
+            .expect("SC-WLU-004(service): must receive Closed");
+        assert!(
+            matches!(event, ServiceWatchEvent::Closed(ClusterError::Shutdown)),
+            "SC-WLU-004(service): Closed must be surfaced verbatim, got {event:?}"
+        );
+        // Same bare-passthrough `recv` behavior as `CacheWatch` — drop the
+        // sender first or the channel never closes and this hangs forever.
+        drop(tx);
+        assert!(
+            watch.recv().await.is_none(),
+            "SC-WLU-004(service): no further events must arrive after terminal Closed"
+        );
+    }
+}
+
+/// Runs every implemented SC-WLU-* scenario. No backend factory is needed —
+/// all scenarios are SDK-level structural or channel-harness tests.
+pub async fn run_watch_lifecycle_conformance() {
+    scenario_wlu_001().await;
+    scenario_wlu_004().await;
+}
+
+// TODO(SC-WLU-002) [L4]: Lagged under backpressure (all three watch types) —
+//   fault-injection harness.
+// TODO(SC-WLU-003) [L4]: Reset and recovery (all three watch types) —
+//   fault-injection harness (Toxiproxy/induced reconnect).

--- a/gears/system/cluster/cluster-conformance/tests/model.rs
+++ b/gears/system/cluster/cluster-conformance/tests/model.rs
@@ -1,0 +1,70 @@
+// Created: 2026-06-24 by Constructor Tech
+//! Property/model-based cache conformance: a `proptest`-generated op sequence is
+//! replayed against the reference model and a backend, asserting the contract's
+//! value/presence and version invariants hold under every interleaving.
+//!
+//! The strategy lives here (not in the library) because `proptest` is a
+//! dev-dependency; the library exposes the runtime-agnostic replay engine
+//! ([`replay_against_model`]) this test drives. A plugin reuses this exact
+//! pattern against its real backend by swapping the factory.
+
+use std::sync::Arc;
+
+use cluster_conformance::fixture::MemCache;
+use cluster_conformance::{CacheOp, VersionTarget, replay_against_model};
+use cluster_sdk::cache::ClusterCacheBackend;
+use proptest::collection::vec;
+use proptest::prelude::*;
+use proptest::test_runner::TestRunner;
+
+/// A small key space so create/CAS/delete operations collide frequently — the
+/// regime where version/CAS races surface.
+fn key() -> impl Strategy<Value = String> {
+    prop_oneof![Just("k0"), Just("k1"), Just("k2")].prop_map(str::to_owned)
+}
+
+/// Tiny values so equality checks are cheap and overwrites with identical bytes
+/// (which must still bump the version) are common.
+fn value() -> impl Strategy<Value = Vec<u8>> {
+    prop_oneof![Just(vec![b'a']), Just(vec![b'b']), Just(vec![b'c'])]
+}
+
+/// One operation drawn uniformly across the alphabet.
+fn op() -> impl Strategy<Value = CacheOp> {
+    prop_oneof![
+        (key(), value()).prop_map(|(key, value)| CacheOp::Put { key, value }),
+        (key(), value()).prop_map(|(key, value)| CacheOp::PutIfAbsent { key, value }),
+        (
+            key(),
+            prop_oneof![Just(VersionTarget::Current), Just(VersionTarget::Stale)],
+            value(),
+        )
+            .prop_map(|(key, target, value)| CacheOp::CompareAndSwap {
+                key,
+                target,
+                value
+            }),
+        key().prop_map(|key| CacheOp::Delete { key }),
+    ]
+}
+
+#[test]
+fn cache_invariants_hold_under_random_op_sequences() {
+    // A current-thread runtime with time enabled: `MemCache` spawns a TTL
+    // sweeper on construction. Reused across cases; each case builds (and drops)
+    // its own backend, so the sweeper self-terminates via its weak reference.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("test runtime");
+    let mut runner = TestRunner::default();
+    runner
+        .run(&vec(op(), 1..40), |ops| {
+            let result = rt.block_on(replay_against_model(&ops, || {
+                MemCache::linearizable() as Arc<dyn ClusterCacheBackend>
+            }));
+            prop_assert!(result.is_ok(), "{}", result.err().unwrap_or_default());
+            Ok(())
+        })
+        .expect("the linearizable MemCache must satisfy every cache invariant");
+}

--- a/gears/system/cluster/cluster-conformance/tests/self_test.rs
+++ b/gears/system/cluster/cluster-conformance/tests/self_test.rs
@@ -1,0 +1,39 @@
+// Created: 2026-06-24 by Constructor Tech
+//! Self-test: the conformance suites must pass against the known-correct
+//! [`MemCache`] fixture. This proves the cache suite's assertions are
+//! satisfiable (it doesn't reject a correct backend).
+//!
+//! The `run_leader_conformance`/`run_lock_conformance`/`run_discovery_conformance`
+//! suites are not self-tested here against a concrete backend: this crate is a
+//! dependency of every plugin (so its real `[dependencies]` stay limited to
+//! `cluster-sdk`, deliberately excluding the `cluster` gear's SDK-default
+//! backends), and it has no in-crate implementation of `LeaderElectionBackend`
+//! / `DistributedLockBackend` / `ServiceDiscoveryBackend` to dogfood them
+//! against. They get their first real exercise once a plugin (including the
+//! `cluster` gear's own `CasBasedLeaderElectionBackend`,
+//! `CasBasedDistributedLockBackend`, and `CacheBasedServiceDiscoveryBackend`,
+//! already covered by `cluster/src/defaults/{leader,lock,discovery}_tests.rs`)
+//! adopts them.
+
+use std::sync::Arc;
+
+use cluster_conformance::fixture::MemCache;
+use cluster_conformance::{
+    run_cache_conformance, run_restart_conformance, run_watch_lifecycle_conformance,
+};
+use cluster_sdk::ClusterCacheBackend;
+
+#[tokio::test]
+async fn cache_suite_passes_against_memcache() {
+    run_cache_conformance(|| MemCache::linearizable() as Arc<dyn ClusterCacheBackend>).await;
+}
+
+#[tokio::test]
+async fn restart_suite_passes() {
+    run_restart_conformance().await;
+}
+
+#[tokio::test]
+async fn watch_lifecycle_suite_passes() {
+    run_watch_lifecycle_conformance().await;
+}

--- a/gears/system/cluster/cluster/Cargo.toml
+++ b/gears/system/cluster/cluster/Cargo.toml
@@ -29,3 +29,6 @@ rand = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tracing-test = { workspace = true }
 toolkit = { workspace = true }
+# The shared backend-agnostic conformance suite, run against this gear's real
+# cache-derived default backends in `tests/conformance.rs`.
+cf-gears-cluster-conformance = { workspace = true }

--- a/gears/system/cluster/cluster/src/defaults/leader.rs
+++ b/gears/system/cluster/cluster/src/defaults/leader.rs
@@ -453,7 +453,20 @@ impl ElectionTask {
                     true
                 }
             }
-            None => self.claim().await,
+            None => {
+                if self.am_leader {
+                    // Our own claim vanished (a TTL lapse observed via the watch)
+                    // while we still believed we were leader. Surface the loss
+                    // before reclaiming, mirroring the renewal timer's
+                    // `Ok(None) => lose_then_reclaim()` path — otherwise
+                    // `claim()`'s re-win would flow through `ensure_leader()`,
+                    // whose `am_leader` short-circuit would silently swallow the
+                    // lost-then-reacquired transition.
+                    self.lose_then_reclaim().await
+                } else {
+                    self.claim().await
+                }
+            }
         }
     }
 

--- a/gears/system/cluster/cluster/tests/conformance.rs
+++ b/gears/system/cluster/cluster/tests/conformance.rs
@@ -1,0 +1,60 @@
+//! Runs the shared, backend-agnostic conformance suites from
+//! `cf-gears-cluster-conformance` against this gear's real cache-derived default
+//! backends (`CasBasedLeaderElectionBackend`, `CasBasedDistributedLockBackend`,
+//! `CacheBasedServiceDiscoveryBackend`), each built over the crate's known-good
+//! linearizable `MemCache` fixture.
+//!
+//! This is the "first real exercise" the conformance crate's docs describe: the
+//! suites live next to the SDK contract, and every plugin — starting with this
+//! gear — feeds its concrete backend through the `run_*_conformance` entry
+//! points. The runners build a fresh backend per scenario via the `make`
+//! closure, so a fresh `MemCache` per call keeps state from leaking between
+//! scenarios.
+//!
+//! Each suite runs under the default `current_thread` runtime because the
+//! timeout/TTL scenarios drive time with `tokio::time::pause()`/`advance()`,
+//! which panics on a `multi_thread` runtime.
+
+use std::sync::Arc;
+
+use cluster::defaults::{
+    CacheBasedServiceDiscoveryBackend, CasBasedDistributedLockBackend,
+    CasBasedLeaderElectionBackend,
+};
+use cluster_conformance::MemCache;
+use cluster_conformance::{
+    run_discovery_conformance, run_leader_conformance, run_lock_conformance,
+};
+use cluster_sdk::discovery::ServiceDiscoveryBackend;
+use cluster_sdk::leader::LeaderElectionBackend;
+use cluster_sdk::lock::DistributedLockBackend;
+
+#[tokio::test]
+async fn leader_election_conformance() {
+    run_leader_conformance(|| {
+        let cache = MemCache::linearizable();
+        Arc::new(CasBasedLeaderElectionBackend::new(cache).expect("linearizable cache is accepted"))
+            as Arc<dyn LeaderElectionBackend>
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn distributed_lock_conformance() {
+    run_lock_conformance(|| {
+        let cache = MemCache::linearizable();
+        Arc::new(
+            CasBasedDistributedLockBackend::new(cache).expect("linearizable cache is accepted"),
+        ) as Arc<dyn DistributedLockBackend>
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn service_discovery_conformance() {
+    run_discovery_conformance(|| {
+        let cache = MemCache::linearizable();
+        Arc::new(CacheBasedServiceDiscoveryBackend::new(cache)) as Arc<dyn ServiceDiscoveryBackend>
+    })
+    .await;
+}

--- a/gears/system/cluster/docs/TESTING-STRATEGY.md
+++ b/gears/system/cluster/docs/TESTING-STRATEGY.md
@@ -1,0 +1,353 @@
+# Testing Strategy — Cluster
+
+> **Status: DRAFT — for iteration.** This document captures the intended testing
+> strategy for the cluster gear as it grows from an SDK-only change into a wiring
+> crate plus a family of real backend plugins (standalone, Postgres, K8s, Redis,
+> NATS, etcd). It is a living strategy, not a feature spec — the per-backend
+> integration suites it describes are delivered by the follow-up plugin changes.
+>
+> **Companion document:** the concrete, ordered list of behaviors to test — with
+> stable IDs, layer, status, and traceability — lives in the
+> [scenario catalog](./scenarios/README.md). This document defines the *how* (layers,
+> tooling, crate layout); the catalog enumerates the *what*.
+
+<!-- toc -->
+
+- [1. Context & Goals](#1-context--goals)
+  - [1.1 Where we are today](#11-where-we-are-today)
+  - [1.2 The governing requirement](#12-the-governing-requirement)
+  - [1.3 What in-process stubs cannot prove](#13-what-in-process-stubs-cannot-prove)
+- [2. The Test Pyramid](#2-the-test-pyramid)
+- [3. Layer 1 — Unit & Smoke (in-process)](#3-layer-1--unit--smoke-in-process)
+- [4. Layer 2 — Backend Conformance Suite (the keystone)](#4-layer-2--backend-conformance-suite-the-keystone)
+- [5. Layer 3 — Per-Backend Integration (testcontainers)](#5-layer-3--per-backend-integration-testcontainers)
+- [6. Layer 4 — Fault Injection & Deterministic Simulation](#6-layer-4--fault-injection--deterministic-simulation)
+- [7. Cross-Cutting Tooling](#7-cross-cutting-tooling)
+- [8. Lifecycle & Contract Gaps to Close First](#8-lifecycle--contract-gaps-to-close-first)
+- [9. CI Cadence](#9-ci-cadence)
+- [10. Open Questions](#10-open-questions)
+
+<!-- /toc -->
+
+## 1. Context & Goals
+
+### 1.1 Where we are today
+
+`cluster-sdk` is the only crate. Test coverage is:
+
+- **Unit tests** co-located with source (`src/**/*_tests.rs`) — resolver builders,
+  scoping wrappers, polyfill diffing, default backends, observability instrumentation.
+- **Smoke / integration tests** (`tests/coordination.rs`, `tests/resolution.rs`,
+  `tests/watch_lifecycle.rs`) driving an in-process stub cache
+  (`src/defaults/test_cache.rs`) through the public contract.
+
+This satisfies `cpt-cf-clst-feature-smoke-tests` and is explicitly scoped (per the
+smoke-test feature and DESIGN §6) to **API shape**, not distributed correctness. The
+wiring crate (`cf-gears-cluster`) and every real backend are follow-up changes — and
+that is precisely where the deeper testing described here applies.
+
+### 1.2 The governing requirement
+
+The central NFR drives the entire strategy:
+
+> `cpt-cf-clst-nfr-cross-backend-stability` — *a consumer gear's behavior MUST NOT
+> change when an operator switches the backend bound to a primitive, provided the new
+> backend meets the consumer's declared capability requirements.* Threshold: *gear
+> integration tests pass identically against any backend that satisfies the declared
+> capability requirements.*
+
+"Pass identically against any backend" is only verifiable with **one shared test
+body run against every backend**. That observation produces the keystone of this
+strategy (§4).
+
+A second NFR sets the bar for the strong-guarantee backends:
+
+> `cpt-cf-clst-nfr-leader-guarantee` — under contention testing with 10+ concurrent
+> candidates across 3+ nodes against a linearizable backend, **zero observed
+> split-brain occurrences**.
+
+### 1.3 What in-process stubs cannot prove
+
+The stub backend has, by design (smoke-test feature §3), **one state map, one clock,
+one FIFO event channel**. It therefore cannot reproduce: network partition, clock
+skew, split-brain, cross-subscriber message reordering, connection loss / reconnect,
+backpressure-induced lag from a real broker, or backend-specific failure semantics
+(Redis AOF loss, Postgres `synchronous_commit` windows, NATS JetStream sequence gaps,
+K8s API-server throttling). DESIGN §6 calls these out as the deliberate boundary of
+smoke testing and assigns them to per-plugin verification. The layers below fill that
+gap.
+
+## 2. The Test Pyramid
+
+Ordered cheap+fast → expensive+slow. Higher layers run more often; lower layers gate
+releases.
+
+```
+ ┌──────────────────────────────────────────────────────────┐
+ │ L4  Fault injection (Toxiproxy) + DST (turmoil)           │  nightly + per-PR (DST is fast)
+ ├──────────────────────────────────────────────────────────┤
+ │ L3  Per-backend integration (testcontainers, envtest/kind)│  per-PR in plugin crate, nightly full
+ ├──────────────────────────────────────────────────────────┤
+ │ L2  Backend conformance suite (shared, parametrized)      │  per-PR (stub) + per-backend (L3 infra)
+ ├──────────────────────────────────────────────────────────┤
+ │ L1  Unit + smoke (in-process stub)                        │  every PR, milliseconds
+ └──────────────────────────────────────────────────────────┘
+```
+
+Every scenario in the [scenario catalog](./scenarios/README.md) is tagged with the
+layer it belongs to (`L2`/`L4`), so the catalog is the per-layer work-list for
+this pyramid.
+
+## 3. Layer 1 — Unit & Smoke (in-process)
+
+**Status: implemented.** Keep as-is. Per-PR, no external dependencies, sub-second.
+Covers public API shape, resolver/capability-mismatch error paths, scoping
+round-trips, polyfill diffing, and the watch-union variants the stub can emit
+(`Lagged`, `Reset`, `Closed(Shutdown)`, `CasConflict`, `CapabilityNotMet`).
+
+This layer remains the contract's first gate. Everything below verifies that real
+backends *reproduce* what this layer specifies.
+
+## 4. Layer 2 — Backend Conformance Suite (the keystone)
+
+**Status: to build. Highest leverage.**
+
+**Decision: a standalone `cluster-conformance` crate** (not a `conformance` feature on
+`cluster-sdk`). Standalone keeps plugin crates depending on it as a normal
+dev-dependency without a feature-flag cycle through the SDK, and lets the suite carry
+its own test-only dependencies (`proptest`, fault-injection mocks) that the SDK
+contract crate must not pull in.
+
+The crate exposes parametrized suites that accept a backend factory and assert the
+contract — independent of *which* backend:
+
+```rust
+pub fn cache_conformance_suite(factory: impl Fn() -> Arc<dyn ClusterCacheBackend>);
+pub fn leader_conformance_suite(factory: impl Fn() -> Arc<dyn LeaderElectionBackend>);
+pub fn lock_conformance_suite(factory: impl Fn() -> Arc<dyn DistributedLockBackend>);
+pub fn sd_conformance_suite(factory: impl Fn() -> Arc<dyn ServiceDiscoveryBackend>);
+```
+
+Every plugin's integration tests then reduce to ~10 lines: build the backend, hand it
+to the suite. This is the *only* mechanism that operationalizes
+`cpt-cf-clst-nfr-cross-backend-stability` — "identical observable behavior" is a claim
+you can only test by running identical assertions everywhere.
+
+**Capability-gated assertions.** Each run declares the backend's `features()` /
+`consistency()`. The suite asserts strict guarantees *only* where the backend claims
+them — e.g. single-leader-under-contention is asserted only when
+`LeaderElectionFeatures::linearizable == true`. This simultaneously tests the
+honest-declaration requirement (`cpt-cf-clst-fr-validation-honest-declaration`): a
+backend that lies about a feature fails the suite.
+
+**Contract items the suite must cover** (drawn from DESIGN §3.1/§3.3 and the NFRs;
+each maps to an `SC-*` row in the [scenario catalog](./scenarios/README.md)):
+
+- Version monotonicity; version 0 reserved as sentinel; each `put` increments.
+- CAS conflict surfaces `current` entry; `compare_and_swap` succeeds iff
+  `expected_version == current`.
+- `compare_and_delete` survives a key's version resetting to 1 on delete+recreate
+  (the value/owner-token guard, DESIGN §3.3 backend-trait note) — a named regression
+  test, since a version guard would alias a successor's fresh claim.
+- TTL expiry removes the entry and emits an `Expired` notification.
+- Per-key watch ordering preserved; delivery at-most-once
+  (`cpt-cf-clst-nfr-watch-delivery`).
+- Default `DiscoveryFilter` returns enabled-only; metadata predicates AND-combine;
+  result ordering is unspecified (suite must NOT assume order).
+- Scoping round-trip: `scoped(p)` write/read strips back to the bare key/name.
+
+**Model-based / property variants.** Where practical, pair example-based tests with
+`proptest`: generate random op sequences and compare the backend against a trivial
+`HashMap` reference model, asserting the version/CAS invariants hold under any
+interleaving the single-threaded model permits.
+
+### 4.1 Proposed crate layout
+
+A sketch, not committed code — to be scaffolded when we build the suite. One module
+per primitive, plus a reusable in-memory fixture and a `proptest` reference model.
+
+```
+gears/system/cluster/cluster-conformance/
+  Cargo.toml                # pkg cf-gears-cluster-conformance, lib cluster_conformance
+                            #   deps: cluster-sdk, async-trait, tokio
+                            #   dev-deps: tokio (test-util, macros, rt), proptest
+  src/
+    lib.rs                  # crate docs + re-exports of the run_*_conformance entry points
+    fixture.rs              # MemCache: a compact in-process ClusterCacheBackend
+                            #   (Linearizable, real versioning/TTL/watch) the suite
+                            #   self-tests against; doubles as a reference fixture
+    cache.rs                # SC-CACHE-* scenarios + run_cache_conformance(factory)
+    leader.rs               # SC-LEAD-*   scenarios + run_leader_conformance(factory)
+    lock.rs                 # SC-LOCK-*   scenarios + run_lock_conformance(factory)
+    discovery.rs            # SC-DISC-*   scenarios + run_discovery_conformance(factory)
+    model.rs                # (later) proptest HashMap reference model for CAS/version
+```
+
+Entry-point shape (factory-per-scenario so state never leaks; capability-gated
+assertions read `features()`/`consistency()`):
+
+```rust
+pub async fn run_cache_conformance<F>(make: F)
+where F: Fn() -> Arc<dyn ClusterCacheBackend>;
+
+// Each scenario is its own `pub async fn scenario_<id>(backend)` so a plugin can
+// run the whole suite or cherry-pick one case. The runner builds a fresh backend
+// per scenario via `make()`.
+```
+
+Cache-only plugins feed the SDK defaults into the other three suites. `CasBased*` /
+`CacheBased*` live in the `cluster` gear crate (`cluster::defaults::*`), not in
+`cluster-sdk` or `cluster-conformance` — `cluster-conformance` deliberately has no
+dependency on `cluster` (every plugin depends on `cluster-conformance`, so its real
+dependency graph stays limited to `cluster-sdk`), so this wiring is the plugin's own
+code, not something `cluster-conformance` provides:
+
+```rust
+run_leader_conformance(|| {
+    let cache: Arc<dyn ClusterCacheBackend> = make_cache();
+    Arc::new(cluster::defaults::CasBasedLeaderElectionBackend::new(cache).unwrap()) as _
+}).await;
+```
+
+A plugin's integration test then reduces to: build the real backend in a container,
+hand it to `run_*_conformance`. Open question on the async-runtime entry shape (plain
+`async fn` vs. macro-generated `#[tokio::test]` cases) is tracked in §10.
+
+The `cluster` gear itself is the one exception that proves this composition works at
+all (`SC-ROUTE-001`/`002`): since it can't depend on `cluster-conformance` without
+creating a plugin-facing dependency problem, it proves the "cache-only in, all four
+primitives out" guarantee with its own bespoke tests
+(`cluster/src/defaults/{leader,lock,discovery}_tests.rs`) rather than by calling
+`run_*_conformance` — see [scenarios/routing.md](./scenarios/routing.md).
+
+## 5. Layer 3 — Per-Backend Integration (testcontainers)
+
+**Status: per plugin follow-up.** Two artifacts are required per backend, and both are
+mandatory — they are complementary, not alternatives:
+
+1. **Conformance-suite usage** — the plugin's integration tests instantiate the §4
+   `cluster-conformance` suites against the real backend in a container. This proves
+   the cross-backend baseline (`cpt-cf-clst-nfr-cross-backend-stability`) without
+   restating it.
+2. **A per-plugin testing design** — a `TESTING.md` (or a testing section in the
+   plugin's own DESIGN) that documents the backend-specific surface: the container
+   topology, which native paths are tested, the backend's `*Features` /
+   `consistency()` declaration and *why*, the `ProviderErrorKind` mapping, and the
+   fault-injection / DST scenarios that apply. Per-plugin designs **reference** this
+   strategy for the shared layers rather than duplicating them; this document owns the
+   cross-cutting strategy, each plugin owns its specifics.
+
+Beyond the conformance baseline, each plugin tests native-path behavior the suite
+can't express generically:
+
+| Backend | Container | Native paths beyond the conformance suite |
+|---|---|---|
+| **Standalone** | none (in-process) | Conformance suite + `loom` concurrency (§7) |
+| **Postgres** | `testcontainers` postgres image | `LISTEN/NOTIFY` watch + 8KB payload limit (why events are key-only); `pg_advisory_lock`; the `synchronous_commit=off` path that makes the cache `EventuallyConsistent` and MUST reject the default leader-election constructor (ADR-009) |
+| **Redis** | redis image + **Sentinel** topology | Lua CAS scripts; `SET NX EX` locks; keyspace notifications; **Sentinel failover** is where the `EventuallyConsistent` declaration must hold |
+| **K8s** | `envtest` (apiserver+etcd) for fast; `kind` / `k3s` (k3s testcontainers module) for e2e | Lease API; CRD + `resourceVersion`; watch streams; RBAC; Lease-per-instance for SD (ADR-008) |
+| **NATS** | `async-nats`-compatible image | JetStream KV bucket + revision-based CAS; watch subscriptions |
+| **etcd** | `etcd` image | Native `mod_revision` CAS; native lease/lock/election APIs |
+
+The conformance suite is the *baseline*; these tables list only the
+backend-specific additions.
+
+## 6. Layer 4 — Fault Injection & Deterministic Simulation
+
+**Status: to introduce.** This is the layer currently missing between in-process
+stubs and full distributed testing — it tests the watch lifecycle and coordination
+*recovery* the contract promises but stubs only fake.
+
+- **Toxiproxy** (`toxiproxy-rust`, or via testcontainers) sits between the plugin and
+  a real backend container and injects latency, bandwidth caps, connection drops, and
+  partial partitions. This is the fastest path to exercising:
+  - `CacheWatchEvent` / `LeaderWatchEvent` / `ServiceWatchEvent` `Lagged` / `Reset` /
+    `Closed` signals against a real connection (`cpt-cf-clst-fr-watch-lifecycle-signals`).
+  - The `RestartingWatch` auto-restart combinator's backoff + retryability
+    classification (`cpt-cf-clst-fr-watch-auto-restart`) — verify retryable kinds
+    (`ConnectionLost`, `Timeout`, `ResourceExhausted`) reconnect and emit `Reset`,
+    while non-retryable kinds (`AuthFailure`, `Shutdown`, `CapabilityNotMet`)
+    propagate unchanged.
+  - `ProviderErrorKind` mapping per backend (DESIGN §4.1 table).
+
+- **Deterministic simulation testing — `turmoil` (recommended).** A simulated network
+  and controllable clock with seeded, replayable multi-node scenarios. This is the
+  clean way to test:
+  - Leader election under partition and the `TTL + observation_lag` dual-leadership
+    window formalized in DESIGN §3.3, without flaky wall-clock timing.
+  - Split-brain avoidance under controlled message reorder / drop, modelling 3+ nodes
+    that each hold their own SDK instance over a shared simulated backend.
+
+  **Why `turmoil` over `madsim`:** `turmoil` is tokio-native and adopted
+  incrementally — no global runtime swap, no `--cfg madsim` build, and no requirement
+  that every dependency have a madsim-compatible shim. The cluster plugins depend on
+  mainstream client crates (`sqlx`, `fred`, `kube`, `async-nats`) that have no madsim
+  forks, so madsim's whole-system determinism would force us to either fork those or
+  exclude them from simulation — a poor trade. `madsim` is the more powerful tool when
+  you need fully deterministic task scheduling across an entire system; if a class of
+  heisenbug surfaces that `turmoil` + `tokio::time` control cannot reproduce
+  deterministically, revisit madsim for that specific backend. Until then, `turmoil`
+  for multi-node scenarios plus a programmable fault-injecting mock cache backend (with
+  `tokio::time` pause/advance) for the SDK default backends' renewal/TTL timing.
+
+DST gives reproducible failure scenarios cheap enough to run per-PR; Toxiproxy tests
+typically run nightly alongside the L3 containers.
+
+## 7. Cross-Cutting Tooling
+
+| Tool | Buys | Target |
+|---|---|---|
+| **`loom`** | Exhaustive interleaving check of concurrent code | SDK default backends + standalone plugin: `AtomicU64` version source, watch fan-out, TTL reaper vs. renewal races, the `shutdown_observed` `AtomicBool` (DESIGN §3.7) |
+| **`proptest`** | Property / model-based testing | CAS & version invariants, scoping round-trips, `DiscoveryFilter` AND-semantics — folded into the §4 suite |
+| **`cargo-mutants`** | Mutation testing — proves tests fail when logic breaks | SDK default backends, capability-validation logic (coverage % lies; mutants don't) |
+| **`ui_test` (dylint)** | Lint fires on violations, no false positives | The no-remote-I/O-in-critical-section rule (`cpt-cf-clst-nfr-bounded-critical-section`) — needs positive/negative fixtures or it silently rots |
+| **`miri`** | UB / leak detection | SDK unit tests; cheap insurance for any `unsafe`/FFI in plugins |
+
+## 8. Lifecycle & Contract Gaps to Close First
+
+Three contractual behaviors are currently only stub-tested (or not testable yet) and
+should get dedicated coverage as the relevant code lands:
+
+1. **Shutdown sequence** (DESIGN §3.13, `cpt-cf-clst-fr-shutdown-revoke`): once the
+   wiring crate lands, a lifecycle integration test must assert the ordering —
+   `LeaderWatchEvent::Status(Lost)` *then* `Closed(Shutdown)`; an in-flight blocking
+   `lock()` waiter returns `Err(Shutdown)` (distinct from `LockTimeout`); active
+   cache/SD watches receive `Closed(Shutdown)`; and **no remote release** is performed
+   (resources lapse via TTL, `cpt-cf-clst-fr-shutdown-ttl-cleanup`).
+
+2. **Dylint rule** (`cpt-cf-clst-constraint-no-remote-in-critical-section`): the
+   compile-time guarantee needs `ui_test` fixtures *now* — nothing currently proves
+   the lint actually triggers, so it could regress to aspirational documentation.
+
+3. **Watch auto-restart reconnect path** (`SC-REST-001/003/004`,
+   `cpt-cf-clst-fr-watch-auto-restart`): the retryable-close → backoff → resubscribe →
+   `Reset` path cannot be exercised at L2 because it needs a facade-installed
+   resubscribe seam that only exists once a `ClientHub` is wired up. `cluster-conformance`
+   currently proves only the pass-through and non-retryable-close paths (`SC-REST-002`).
+   Once the wiring crate lands, these three scenarios move from L2-blocked to L3
+   integration tests.
+
+## 9. CI Cadence
+
+| Trigger | Runs |
+|---|---|
+| Every PR | L1 (unit + smoke); L2 conformance against stub/standalone; L4 DST (turmoil, fast); dylint `ui_test`; `miri` on SDK |
+| Nightly | L3 testcontainers (Postgres, Redis+Sentinel, NATS, etcd); L3 K8s via envtest/kind; L4 Toxiproxy fault injection; `loom`; `cargo-mutants` |
+
+## 10. Open Questions
+
+**Resolved:**
+
+| Decision | Resolution |
+|---|---|
+| Conformance suite crate boundary | **Standalone `cluster-conformance` crate** (§4) — avoids a feature-flag cycle through the SDK and isolates test-only dependencies. |
+| DST tool | **`turmoil`** (§6) — tokio-native, incremental adoption, no madsim shim requirement for mainstream client crates. Revisit `madsim` only for a backend where `turmoil` can't reproduce a heisenbug deterministically. |
+| Conformance vs. per-plugin design | **Both, mandatory** (§5) — every plugin ships conformance-suite usage *and* a per-plugin testing design that references this strategy for shared layers. |
+
+**Still open:**
+
+| Question | Notes |
+|---|---|
+| `cluster-conformance` async-runtime entry shape | Whether the suites are plain `async fn`s the caller drives, or macro-generated `#[tokio::test]` cases. Plain async fns compose better with `turmoil`/`madsim` runtimes; decide when the first suite is scaffolded. |
+| K8s integration: `envtest` vs. `kind` as the per-PR default | `envtest` is faster (apiserver+etcd only) but not a full cluster; `kind`/`k3s` is fuller but slower. Likely `envtest` per-PR, `kind` nightly — confirm once the K8s plugin starts. |
+| Traceability IDs for test artifacts | Whether the conformance suite and per-plugin designs get `cpt-cf-clst-*` IDs in the traceability audit, or remain referenced informally. |

--- a/gears/system/cluster/docs/scenarios/README.md
+++ b/gears/system/cluster/docs/scenarios/README.md
@@ -1,0 +1,286 @@
+# Cluster Test Scenarios — Ordered Catalog
+
+> **Status: DRAFT — for iteration.** This is the master, ordered list of behaviors the
+> cluster gear must be tested against. Each scenario has a stable ID, the test layer it
+> belongs to (see [TESTING-STRATEGY.md](../TESTING-STRATEGY.md) §2), and the
+> requirement it traces to. The `cluster-conformance` crate implements the **L2**
+> scenarios as a parametrized suite run against every backend; **L4** scenarios are
+> implemented per-backend with fault injection / simulation.
+
+## Legend
+
+- **Layer** — `L2` shared conformance suite · `L4` fault-injection / deterministic
+  simulation.
+- **Status** — ☐ not started · ◑ scaffolded (stub exists) · ☑ implemented · ⊘ intentionally
+  not tested directly at this layer (covered elsewhere — see the row's notes).
+- **Capability gate** — assertion applies only when the backend declares the listed
+  feature; otherwise the scenario asserts the documented fallback (e.g. `Unsupported`).
+
+Each `SC-*` table below is an **index**. Full per-scenario detail lives in a
+per-primitive file (linked under each section heading) using a fixed template:
+
+- *Intent* — the behavior this guards and why it matters.
+- *Steps* — the stimulus applied to a fresh backend.
+- *Expected* — the observable outcome the suite asserts.
+- *Done-when* — the acceptance bar for marking the row ☑.
+
+---
+
+## 1. Cache (`SC-CACHE-*`)
+
+| ID | Layer | Status | Scenario | Capability gate | Traces to |
+|----|-------|--------|----------|-----------------|-----------|
+| SC-CACHE-001 | L2 | ☑ | `get` on an absent key returns `Ok(None)`, never an error | — | `fr-cache-storage` |
+| SC-CACHE-002 | L2 | ☑ | `put` then `get` returns the stored value at version 1 | — | `fr-cache-storage` |
+| SC-CACHE-003 | L2 | ☑ | each overwrite strictly increments the version; version 0 never observed | — | `principle-version-based-cas` |
+| SC-CACHE-004 | L2 | ☑ | `put_if_absent` returns `Some(entry)` on create, `None` when present (atomic) | — | `fr-cache-atomic` |
+| SC-CACHE-005 | L2 | ☑ | `compare_and_swap` succeeds iff `expected_version == current` | — | `fr-cache-atomic` |
+| SC-CACHE-006 | L2 | ☑ | CAS on a stale version returns `CasConflict { key, current }` carrying the current entry | — | `fr-cache-atomic` |
+| SC-CACHE-007 | L2 | ☑ | `delete` removes the entry and reports prior existence | — | `fr-cache-storage` |
+| SC-CACHE-008 | L2 | ☑ | `compare_and_delete` removes only when the owner token matches; mismatch/absent → `Ok(false)` | — | DESIGN §3.3 backend note |
+| SC-CACHE-009 | L2 | ☑ | a key deleted and re-created resets to version 1, and a value/owner guard still distinguishes the successor | — | [DESIGN.md §3.3](../DESIGN.md#33-api-contracts) |
+| SC-CACHE-010 | L2 | ☑ | TTL expiry removes the entry and emits `CacheEvent::Expired` to watchers | — | `fr-cache-ttl` |
+| SC-CACHE-011 | L2 | ☑ | indefinite (no-TTL) entries persist until explicit delete; in-memory backends document the constraint | — | `fr-cache-ttl` |
+| SC-CACHE-012 | L2 | ☑ | exact `watch` yields `Changed`/`Deleted` for the key, preserving per-key order | — | `fr-cache-watch`, `nfr-watch-delivery` |
+| SC-CACHE-013 | L2 | ☑ | `watch_prefix` yields events for matching keys; unsupported backends return `Unsupported` | `prefix_watch` | `fr-cache-watch` |
+| SC-CACHE-014 | L2 | ☑ | `PollingPrefixWatch` polyfill synthesizes prefix diffs (Changed/Deleted) on a non-native backend | `!prefix_watch` | §3.12 polyfill |
+| SC-CACHE-015 | L2 | ☑ | watch delivery is at-most-once per subscriber per key | — | `nfr-watch-delivery` |
+| SC-CACHE-016 | L4 | ☐ | a slow subscriber receives `Lagged { dropped }` rather than blocking writers | — | `fr-watch-lifecycle-signals` |
+| SC-CACHE-017 | L4 | ☐ | connection loss surfaces `Reset` on resubscribe; consumer re-reads | — | `fr-watch-lifecycle-signals` |
+
+**Details:** [cache.md](./cache.md)
+
+## 2. Leader Election (`SC-LEAD-*`)
+
+| ID | Layer | Status | Scenario | Capability gate | Traces to |
+|----|-------|--------|----------|-----------------|-----------|
+| SC-LEAD-001 | L2 | ☐ | a single candidate becomes `Leader` | — | `fr-leader-elect` |
+| SC-LEAD-002 | L2 | ☐ | with N candidates, at most one observes `Leader` at any time | `linearizable` | `nfr-leader-guarantee` |
+| SC-LEAD-003 | L2 | ☐ | the leader's claim auto-renews without consumer renewal code | — | `fr-leader-elect` |
+| SC-LEAD-004 | L2 | ☐ | `resign()` releases the claim; a successor is elected within a round-trip | — | `fr-leader-resign` |
+| SC-LEAD-005 | L2 | ☐ | `is_leader()`/`status()` reflect the cached snapshot synchronously | — | `fr-leader-observability` |
+| SC-LEAD-006 | L2 | ☐ | `Status(Lost)` is transient — the watch auto-reenrolls to `Leader`/`Follower` | — | `fr-leader-observability` |
+| SC-LEAD-007 | L2 | ☐ | `ElectionConfig::new` rejects zero `ttl`/`max_missed_renewals` | — | `fr-leader-config` |
+| SC-LEAD-008 | L2 | ☐ | default-constructor leader election rejects an `EventuallyConsistent` cache; `new_allow_weak_consistency` warns | — | ADR-009 |
+| SC-LEAD-009 | L4 | ☐ | under partition, the leader observes `Status(Lost)` within the configured TTL | `linearizable` | DESIGN §3.3 staleness bound |
+| SC-LEAD-010 | L4 | ☐ | 10+ candidates across 3+ nodes under partition: zero split-brain | `linearizable` | `nfr-leader-guarantee` |
+
+**Details:** [leader.md](./leader.md)
+
+## 3. Distributed Lock (`SC-LOCK-*`)
+
+| ID | Layer | Status | Scenario | Capability gate | Traces to |
+|----|-------|--------|----------|-----------------|-----------|
+| SC-LOCK-001 | L2 | ☐ | `try_lock` succeeds when free, returns `LockContended` when held | — | `fr-lock-acquire` |
+| SC-LOCK-002 | L2 | ☐ | `lock` blocks up to `timeout`, then returns `LockTimeout { name, waited }` | — | `fr-lock-acquire` |
+| SC-LOCK-003 | L2 | ☐ | a held lock is acquirable by another holder after its TTL lapses (crashed-holder recovery) | — | `fr-lock-release` |
+| SC-LOCK-004 | L2 | ☐ | explicit `release()` frees the lock immediately; a waiter acquires it | — | `fr-lock-release` |
+| SC-LOCK-005 | L2 | ☐ | `renew` extends an active lease; renewing an expired lock returns `LockExpired` | — | `fr-lock-release` |
+| SC-LOCK-006 | L2 | ⊘ | a foreign holder cannot release another's lock (owner-token guard) — not exercised directly (no owner-token seam on `DistributedLockBackend`); covered indirectly by [SC-CACHE-008/009](./cache.md) | — | §3.11 defaults |
+| SC-LOCK-007 | L2 | ☐ | `LockGuard::drop` performs no I/O (TTL is the only safety net) | — | ADR-002 |
+| SC-LOCK-008 | L4 | ☐ | a blocked `lock()` waiter is woken promptly on release notification | — | §3.11 defaults |
+
+**Details:** [lock.md](./lock.md)
+
+## 4. Service Discovery (`SC-DISC-*`)
+
+| ID | Layer | Status | Scenario | Capability gate | Traces to |
+|----|-------|--------|----------|-----------------|-----------|
+| SC-DISC-001 | L2 | ☐ | `register` assigns an `instance_id` when omitted; new registrations default to `Enabled` | — | `fr-sd-register` |
+| SC-DISC-002 | L2 | ☐ | default `DiscoveryFilter` returns only `Enabled` instances | — | `fr-sd-discover` |
+| SC-DISC-003 | L2 | ☐ | metadata predicates AND-combine; `Equals` and `OneOf` match correctly | `metadata_pushdown` (else client-side) | `fr-sd-discover` |
+| SC-DISC-004 | L2 | ☐ | result-set order is treated as unspecified (suite sorts before asserting) | — | `fr-sd-discover` |
+| SC-DISC-005 | L2 | ☐ | `set_state(Disabled)` drains an instance; `deregister` removes it (watchers see `Left`) | — | `fr-sd-state` |
+| SC-DISC-006 | L2 | ☐ | a registration disappears after its heartbeat/TTL stops (liveness ≠ intent) | — | `fr-sd-state`, ADR-008 |
+| SC-DISC-007 | L2 | ☐ | `watch` yields `Joined`/`Left`/`Updated`; filtering is client-side | — | `fr-sd-watch` |
+| SC-DISC-008 | L2 | ☐ | metadata keys are NOT scoped; service `name` IS scoped | — | `fr-namespacing-sd-metadata-unscoped` |
+| SC-DISC-009 | L4 | ☐ | after `Lagged`/`Reset`, re-reading membership via `discover` recovers state | — | `fr-sd-watch` |
+
+**Details:** [discovery.md](./discovery.md)
+
+## 5. Resolution & Capability Validation (`SC-RESV-*`)
+
+| ID | Layer | Status | Scenario | Capability gate | Traces to |
+|----|-------|--------|----------|-----------------|-----------|
+| SC-RESV-001 | L2 | ☑ | resolution succeeds for a bound backend meeting all declared capabilities | — | `fr-validation-typed-profile` |
+| SC-RESV-002 | L2 | ☑ | a declared capability unmet by the backend fails with `CapabilityNotMet` naming primitive/capability/provider | — | `fr-validation-startup-fail` |
+| SC-RESV-003 | L2 | ☑ | resolving an unbound profile returns `ProfileNotBound` | — | §3.6 resolution |
+| SC-RESV-004 | L2 | ☐ | a backend that under-declares a feature still fails the capability gate (honest declaration) | — | `fr-validation-honest-declaration` |
+
+**Details:** [resolution.md](./resolution.md)
+
+## 6. Scoping & Namespacing (`SC-SCOP-*`)
+
+| ID | Layer | Status | Scenario | Capability gate | Traces to |
+|----|-------|--------|----------|-----------------|-----------|
+| SC-SCOP-001 | L2 | ☐ | cache `scoped(p)` prepends `p/` on write and strips it on read-path events | — | `fr-namespacing-scoped` |
+| SC-SCOP-002 | L2 | ☐ | scoping composes: `scoped("a").scoped("b")` → effective prefix `a/b/` | — | §3.8 |
+| SC-SCOP-003 | L2 | ☐ | an invalid prefix fails with `InvalidName` | — | §3.8 |
+| SC-SCOP-004 | L2 | ☐ | the polyfill composes with scoping (full keys stripped on read) | `!prefix_watch` | §3.12 |
+| SC-SCOP-005 | L2 | ☐ | leader-election names are scoped by `scoped(p)` | — | §3.8 |
+| SC-SCOP-006 | L2 | ☐ | lock names are scoped by `scoped(p)` | — | §3.8 |
+
+(Service-discovery name scoping — and metadata staying unscoped — is [SC-DISC-008](./discovery.md).)
+
+**Details:** [scoping.md](./scoping.md)
+
+## 7. Watch Auto-Restart Combinator (`SC-REST-*`)
+
+| ID | Layer | Status | Scenario | Capability gate | Traces to |
+|----|-------|--------|----------|-----------------|-----------|
+| SC-REST-001 | L2 | ☐ | retryable `Closed` (`ConnectionLost`/`Timeout`/`ResourceExhausted`) reconnects and emits `Reset` | — | `fr-watch-auto-restart` |
+| SC-REST-002 | L2 | ☐ | non-retryable `Closed` (`AuthFailure`/`Shutdown`/`CapabilityNotMet`) propagates unchanged | — | `fr-watch-auto-restart` |
+| SC-REST-003 | L2 | ☐ | backoff honors `RetryPolicy` (initial/max/jitter); exhausting `max_retries` propagates the last `Closed` | — | `fr-watch-auto-restart` |
+| SC-REST-004 | L2 | ☐ | the combinator is available for all three watch types via one `RetryPolicy` | — | `fr-watch-auto-restart` |
+
+**Details:** [restart.md](./restart.md)
+
+## 8. Lifecycle & Shutdown (`SC-LIFE-*`) — requires the wiring crate
+
+| ID | Layer | Status | Scenario | Capability gate | Traces to |
+|----|-------|--------|----------|-----------------|-----------|
+| SC-LIFE-001 | L3 | ☐ | `stop()` delivers `Status(Lost)` then `Closed(Shutdown)` to active leaders, in that order | — | `fr-shutdown-revoke` |
+| SC-LIFE-002 | L3 | ☐ | an in-flight blocking `lock()` waiter returns `Err(Shutdown)`, distinct from `LockTimeout` | — | `fr-shutdown-revoke` |
+| SC-LIFE-003 | L3 | ☐ | active cache and SD watches receive `Closed(Shutdown)` | — | `fr-shutdown-revoke` |
+| SC-LIFE-004 | L3 | ☐ | `stop()` performs no remote release — held claims/locks/registrations lapse via TTL only | — | `fr-shutdown-ttl-cleanup` |
+| SC-LIFE-005 | L3 | ☐ | after `stop()`, `resolver().resolve()` returns `ProfileNotBound` | — | §3.13 |
+| SC-LIFE-006 | L3 | ☐ | omitting non-cache primitives auto-wraps SDK defaults over the cache; binding a native non-cache backend is rejected with `InvalidConfig` | — | `fr-routing-omit-default`, `fr-routing-per-primitive` |
+
+**Details:** [lifecycle.md](./lifecycle.md)
+
+## 9. Static Analysis (`SC-LINT-*`)
+
+| ID | Layer | Status | Scenario | Capability gate | Traces to |
+|----|-------|--------|----------|-----------------|-----------|
+| SC-LINT-001 | L1 | ☐ | the dylint rule fires on a remote call inside a lock critical section (positive fixture) | — | `nfr-bounded-critical-section`, `constraint-no-remote-in-critical-section` |
+| SC-LINT-002 | L1 | ☐ | the dylint rule does NOT fire on compliant code (negative fixture) | — | `nfr-bounded-critical-section`, `constraint-no-remote-in-critical-section` |
+
+**Details:** [static-analysis.md](./static-analysis.md)
+
+## 10. Watch Lifecycle Uniformity (`SC-WLU-*`)
+
+Cross-cutting: the three watches (cache, leader, service-discovery) must expose the same
+union shape and the same recovery model. Per-primitive instances of these signals also
+appear above (e.g. [SC-CACHE-016/017](./cache.md), [SC-DISC-009](./discovery.md)); this
+section asserts the *uniformity* itself.
+
+| ID | Layer | Status | Scenario | Capability gate | Traces to |
+|----|-------|--------|----------|-----------------|-----------|
+| SC-WLU-001 | L2 | ☐ | all three `*WatchEvent` enums share the union shape `{value-variant, Lagged, Reset, Closed}` | — | `principle-watch-union-shape`, ADR-003 |
+| SC-WLU-002 | L4 | ☐ | each watch surfaces `Lagged { dropped }` under backpressure (parametrized over all three) | — | `fr-watch-lifecycle-signals` |
+| SC-WLU-003 | L4 | ☐ | each watch surfaces `Reset` on resubscribe and the consumer recovers per its primitive | — | `fr-watch-lifecycle-signals` |
+| SC-WLU-004 | L2 | ☐ | each watch ends terminally via `Closed(err)`; transient backend errors are retried internally, not surfaced | — | `fr-watch-lifecycle-signals`, `nfr-watch-delivery` |
+
+**Details:** [watch-lifecycle.md](./watch-lifecycle.md)
+
+## 11. Naming & Validation (`SC-NAME-*`)
+
+The cluster name rule (`[a-zA-Z0-9_/-]+`-style) is uniform across all coordination names
+so consumers reuse one convention; invalid names are rejected with `InvalidName`.
+
+| ID | Layer | Status | Scenario | Capability gate | Traces to |
+|----|-------|--------|----------|-----------------|-----------|
+| SC-NAME-001 | L2 | ☐ | an invalid cache key is rejected with `InvalidName { name, reason }` | — | `fr-cache-storage` |
+| SC-NAME-002 | L2 | ☐ | an invalid election name is rejected with `InvalidName` | — | `fr-cache-storage` |
+| SC-NAME-003 | L2 | ☐ | an invalid lock name is rejected with `InvalidName` | — | `fr-cache-storage` |
+| SC-NAME-004 | L2 | ☐ | an invalid service name is rejected with `InvalidName` | — | `fr-sd-register` |
+| SC-NAME-005 | L2 | ☐ | the rule is uniform — a name valid (or invalid) for one primitive is so for all four | — | `fr-cache-storage` |
+
+**Details:** [naming.md](./naming.md)
+
+## 12. Routing & SDK Defaults (`SC-ROUTE-*`)
+
+| ID | Layer | Status | Scenario | Capability gate | Traces to |
+|----|-------|--------|----------|-----------------|-----------|
+| SC-ROUTE-001 | L2 | ☑ (in `cluster`, not this crate) | a cache-only backend yields working leader/lock/SD via the SDK defaults | — | `fr-routing-cache-only-plugin` |
+| SC-ROUTE-002 | L2 | ☑ (in `cluster`, not this crate) | SDK-default features derive from the cache: `LeaderElection/LockFeatures.linearizable == (cache.consistency() == Linearizable)` | — | §3.11 |
+
+(Operator-config auto-wrap of omitted primitives, and rejection of a native non-cache
+binding, are wiring-level: [SC-LIFE-006](./lifecycle.md).)
+
+**Details:** [routing.md](./routing.md)
+
+## 13. Observability Contract (`SC-OBS-*`)
+
+Per `cpt-cf-clst-nfr-observability` / ADR-004, signal *names* are a contract every plugin
+must honor. Authoritative catalog: [OBSERVABILITY.md](../OBSERVABILITY.md).
+
+| ID | Layer | Status | Scenario | Capability gate | Traces to |
+|----|-------|--------|----------|-----------------|-----------|
+| SC-OBS-001 | L2 | ☐ | each facade operation emits its catalogued OTel span (`cluster.<primitive>.<op>`) with the specified attributes | — | `nfr-observability` |
+| SC-OBS-002 | L2 | ☐ | operations emit the catalogued Prometheus metrics (`cluster_<primitive>_<subject>_<unit>`) | — | `nfr-observability` |
+| SC-OBS-003 | L2 | ☐ | cardinality rule: keys/lock/election/instance names never appear as metric labels (only the bounded allowlist does) | — | `nfr-observability`, ADR-004 |
+| SC-OBS-004 | L2 | ☐ | structured log events use the catalogued names (`cluster.<primitive>.<event>`) | — | `nfr-observability` |
+| SC-OBS-005 | L3 | ☐ | every plugin emits every signal in the observability reference (cross-plugin completeness) | — | `nfr-observability` |
+
+**Details:** [observability.md](./observability.md)
+
+---
+
+## Applicability per backend
+
+**A backend does *not* run every scenario.** The `cluster-conformance` suite is shared,
+but which scenarios a given backend exercises is filtered along three axes — so a
+cache-only plugin author is *not* on the hook to implement or test all four primitives.
+
+### Axis 1 — SDK-level scenarios run once, not per-backend
+
+These exercise SDK code that sits *above* the backend trait, so no backend changes their
+outcome. Most run once in the `cluster-conformance` crate itself; the exception is
+SDK-default derivation, which runs once in the `cluster` gear's own test suite instead
+(see the ownership note in [routing.md](./routing.md) — `cluster-conformance` never
+depends on `cluster`, so it can't be the one to prove this):
+
+| Area | Scenarios | Runs once in |
+|---|---|---|
+| Resolution & capability validation | [SC-RESV-*](./resolution.md) | `cluster-conformance` |
+| Scoping wrappers | [SC-SCOP-*](./scoping.md) | `cluster-conformance` |
+| Watch auto-restart combinator | [SC-REST-*](./restart.md) | `cluster-conformance` |
+| Watch union shape (type-level) | [SC-WLU-001](./watch-lifecycle.md) | `cluster-conformance` |
+| Name validation | [SC-NAME-*](./naming.md) | `cluster-conformance` |
+| Dylint rule | [SC-LINT-*](./static-analysis.md) | `cluster-conformance` |
+| SDK-default derivation | [SC-ROUTE-*](./routing.md) | `cluster` (the wiring gear) |
+
+### Axis 2 — per-backend, only for primitives implemented *natively*
+
+Every backend implements cache, so **every backend runs the cache suite**
+([SC-CACHE-*](./cache.md)) against its real store. Leader/lock/SD obtained from the SDK
+defaults are proven **once**, in the `cluster` gear's own test suite (SC-ROUTE-001); a
+backend re-runs the `cluster-conformance` leader/lock/discovery suites **only when it
+ships a native override**. From DESIGN §4.1:
+
+| Backend | Runs natively (own conformance run) | Derived — proven once via SDK defaults |
+|---|---|---|
+| **NATS** | cache | leader, lock, service-discovery |
+| **Postgres** | cache, lock (`pg_advisory_lock`) | leader, service-discovery |
+| **Redis** | cache, lock (`SET NX EX`) | leader, service-discovery |
+| **etcd** | cache, leader, lock (native) | service-discovery |
+| **K8s** | cache, leader, lock, service-discovery (Lease/CRD) | — |
+| **Standalone** | cache, leader, lock, service-discovery (in-process) | — |
+
+So NATS runs ≈ one suite; K8s runs four. Neither runs the full catalog.
+
+### Axis 3 — capability gates and layers filter within a run
+
+- A scenario asserts its strict branch only when the backend *declares* the feature
+  (`features()` / `consistency()`); otherwise it asserts the documented fallback. E.g.
+  `linearizable` gates [SC-LEAD-002](./leader.md); `prefix_watch` selects
+  [SC-CACHE-013](./cache.md) (native) vs. [SC-CACHE-014](./cache.md) (polyfill);
+  `metadata_pushdown` selects server-side vs. client-side [SC-DISC-003](./discovery.md).
+- **L4** scenarios run selectively — typically only for backends claiming strong
+  guarantees (e.g. split-brain testing a `linearizable` backend), not every backend.
+- **Observability** ([SC-OBS-*](./observability.md)): the contract assertions (001–004)
+  ride the SDK's instrumented facade (largely once); per-plugin completeness (SC-OBS-005)
+  is the per-backend obligation, run at L3.
+
+## Ownership
+
+- **L2** scenarios live in the shared `cluster-conformance` crate; each backend runs the
+  subset that applies to it (see *Applicability per backend* above) — not all of them.
+- **L3** scenarios live with the wiring crate (`cf-gears-cluster`) integration tests.
+- **L4** scenarios are implemented per-plugin (Toxiproxy / `turmoil`) and
+  documented in each plugin's own testing design ([TESTING-STRATEGY.md](../TESTING-STRATEGY.md) §5).
+
+See [TESTING-STRATEGY.md](../TESTING-STRATEGY.md) for the layer definitions (§2), the
+`cluster-conformance` crate layout (§4.1), tooling choices (§6–§7), and the still-open
+lifecycle/contract gaps (§8) referenced by the rows above.

--- a/gears/system/cluster/docs/scenarios/cache.md
+++ b/gears/system/cluster/docs/scenarios/cache.md
@@ -1,0 +1,106 @@
+# Cache — Scenario Details (`SC-CACHE-*`)
+
+> Detail for §1 of the [scenario catalog](./README.md). Template: *Intent / Steps /
+> Expected / Done-when*. Implemented by `cluster-conformance` (`cache.rs`).
+
+**SC-CACHE-001 — `get` on an absent key** · L2 · ☑
+- *Intent:* a miss is a normal result, not an error — consumers branch on `Option`, never on a thrown error.
+- *Steps:* on a fresh backend, `get("absent")`.
+- *Expected:* `Ok(None)`.
+- *Done-when:* asserts `None`; confirms no error variant is returned for a missing key.
+
+**SC-CACHE-002 — `put` then `get`** · L2 · ☑
+- *Intent:* the basic store/load round-trip preserves bytes and assigns the first version.
+- *Steps:* `put("k", b"v", None)`, then `get("k")`.
+- *Expected:* `Some(CacheEntry { value: b"v", version: 1 })`.
+- *Done-when:* asserts value equality and `version == 1` (versions start at 1, not 0).
+
+**SC-CACHE-003 — version monotonicity** · L2 · ☑
+- *Intent:* version is the basis for all optimistic concurrency; it must strictly increase and never be the 0 sentinel.
+- *Steps:* `put` the same key N times, reading the version each time.
+- *Expected:* each version strictly greater than the last; never 0.
+- *Done-when:* asserts strict increase across ≥4 writes and `version != 0`.
+
+**SC-CACHE-004 — `put_if_absent` atomicity** · L2 · ☑
+- *Intent:* insert-if-absent is the create primitive for locks/leases/idempotent init — it must not overwrite.
+- *Steps:* `put_if_absent("k", b"first")` then `put_if_absent("k", b"second")`.
+- *Expected:* first → `Some(entry)`; second → `None`; final value is `b"first"`.
+- *Done-when:* asserts the `Some`/`None` pair and that the original value survives.
+
+**SC-CACHE-005 — CAS success** · L2 · ☑
+- *Intent:* version-based compare-and-swap is the universal coordination operation; a matching version must commit.
+- *Steps:* `put` a key, read its version `v`, `compare_and_swap(key, v, new)`.
+- *Expected:* `Ok(entry)` with the new value and `version > v`.
+- *Done-when:* asserts the new value and an advanced version.
+
+**SC-CACHE-006 — CAS conflict surfaces current** · L2 · ☑
+- *Intent:* a losing CAS must hand back the live entry so the consumer can re-read-and-retry without an extra round-trip.
+- *Steps:* read version `v`, advance the key with another `put`, then CAS with the stale `v`.
+- *Expected:* `Err(CasConflict { key, current: Some(live_entry) })`.
+- *Done-when:* asserts the `CasConflict` variant, the key, and that `current` carries the live value.
+
+**SC-CACHE-007 — `delete` reports existence** · L2 · ☑
+- *Intent:* delete is idempotent and tells the caller whether it removed something.
+- *Steps:* `put` then `delete` twice.
+- *Expected:* first delete → `Ok(true)`, second → `Ok(false)`; subsequent `get` → `None`.
+- *Note:* a backend that cannot determine prior existence MAY return `true` unconditionally (per the contract); the suite relaxes this assertion for such backends.
+
+**SC-CACHE-008 — `compare_and_delete` owner guard** · L2 · ☑
+- *Intent:* a holder releases only its *own* claim — the value-guarded delete underpins safe lock/lease release.
+- *Steps:* store an owner token, attempt delete with a foreign token, then with the matching token, then against an absent key.
+- *Expected:* foreign → `Ok(false)`; matching → `Ok(true)`; absent → `Ok(false)` (never an error).
+- *Done-when:* asserts all three outcomes.
+
+**SC-CACHE-009 — version reset on delete+recreate** · L2 · ☑
+- *Intent:* regression guard for the version-reset caveat documented in [DESIGN.md §3.3](../DESIGN.md#33-api-contracts) — version resets to 1 on recreate, so a *version* guard would alias a successor's fresh claim; an *owner-token* guard must not.
+- *Steps:* write+overwrite a key (version > 1), delete it, recreate via `put_if_absent`, then `compare_and_delete` with the *old* owner token.
+- *Expected:* the recreated entry is `version == 1`; the stale-owner `compare_and_delete` returns `Ok(false)`.
+- *Done-when:* asserts the reset to version 1 and that the predecessor cannot delete the successor.
+
+**SC-CACHE-010 — TTL expiry emits `Expired`** · L2 · ☑
+- *Intent:* TTL is the safety net for every cluster resource; expiry must remove the entry *and* notify watchers so a watch-driven waiter wakes.
+- *Steps:* `watch(key)`, `put(key, v, Some(ttl))`, advance time past the TTL (`tokio::time::advance`).
+- *Expected:* `get` returns `None`; the watcher receives `CacheEvent::Expired { key }`.
+- *Done-when:* both the read-side eviction and the `Expired` emission are observed. Backed by `MemCache`'s background TTL sweeper (`fixture.rs`), which emits `Expired` on its own sweep tick rather than only on next access.
+
+**SC-CACHE-011 — indefinite entries persist** · L2 · ☑
+- *Intent:* a no-TTL value lives until explicitly deleted; backends that cannot persist indefinitely must declare it.
+- *Steps:* `put(key, v, None)`, advance time well beyond any default TTL, `get`.
+- *Expected:* the entry is still present. Backends without indefinite persistence (e.g. in-memory) document the constraint and the suite skips the persistence assertion for them.
+- *Done-when:* asserts persistence on durable backends; records the documented exception otherwise.
+
+**SC-CACHE-012 — exact watch ordering** · L2 · ☑
+- *Intent:* per-key event order must match write order so consumers never apply updates out of sequence.
+- *Steps:* `watch(key)`, then a known sequence of `put`/`delete` on that key.
+- *Expected:* `Changed`/`Deleted` events arrive in exactly the write order.
+- *Done-when:* asserts the event sequence equals the stimulus sequence.
+
+**SC-CACHE-013 — native `watch_prefix`** · L2 · ☑ · gate `prefix_watch`
+- *Intent:* prefix subscriptions enable reactive shard/topology observation without polling.
+- *Steps:* `watch_prefix(p)`, then mutate several keys under and outside `p`.
+- *Expected:* events for matching keys only. If `features().prefix_watch == false`, `watch_prefix` returns `Err(Unsupported { feature: "prefix_watch" })`.
+- *Done-when:* asserts matching-key events when supported, or the `Unsupported` error otherwise.
+
+**SC-CACHE-014 — polyfill prefix watch** · L2 · ☑ · gate `!prefix_watch`
+- *Intent:* a backend without native prefix watch still gets prefix semantics via `PollingPrefixWatch`.
+- *Steps:* spawn `PollingPrefixWatch` over a non-native backend, mutate keys under the prefix, advance time past the poll interval.
+- *Expected:* synthesized `CacheEvent::Changed`/`Deleted` diffs for the changed keys.
+- *Done-when:* asserts the diffed events match the mutations after one poll cycle.
+
+**SC-CACHE-015 — at-most-once delivery** · L2 · ☑
+- *Intent:* the contract is at-most-once (not exactly-once); no event is delivered twice to a subscriber for a single mutation.
+- *Steps:* `watch(key)`, perform a single mutation, drain the stream.
+- *Expected:* exactly one event for that mutation — never a duplicate.
+- *Done-when:* asserts no duplicate events per key in normal (non-lagged) operation.
+
+**SC-CACHE-016 — slow subscriber lags, not blocks** · L4 · ☐
+- *Intent:* a subscriber falling behind must surface `Lagged` rather than apply backpressure to writers.
+- *Steps:* `watch(key)`, flood writes faster than the subscriber drains, with the channel bounded.
+- *Expected:* writers never block; the subscriber receives `CacheWatchEvent::Lagged { dropped }`.
+- *Done-when:* asserts a `Lagged` event and that write throughput is unaffected. *(Needs a fault/throughput harness — hence L4.)*
+
+**SC-CACHE-017 — reconnect surfaces `Reset`** · L4 · ☐
+- *Intent:* after a dropped subscription is re-established, prior assumptions are invalid; the consumer must be told to re-read.
+- *Steps:* establish a watch, sever the backend connection (Toxiproxy), restore it.
+- *Expected:* `CacheWatchEvent::Reset` on resubscribe; re-reading via `get` recovers current state.
+- *Done-when:* asserts a `Reset` event after reconnect against a real backend. *(Requires fault injection — L4, per-plugin.)*

--- a/gears/system/cluster/docs/scenarios/discovery.md
+++ b/gears/system/cluster/docs/scenarios/discovery.md
@@ -1,0 +1,60 @@
+# Service Discovery — Scenario Details (`SC-DISC-*`)
+
+> Detail for §4 of the [scenario catalog](./README.md). Template: *Intent / Steps /
+> Expected / Done-when*. Cache-only backends obtain discovery via
+> `CacheBasedServiceDiscoveryBackend` (metadata filtering client-side,
+> `metadata_pushdown == false`); native backends may push filtering down.
+
+**SC-DISC-001 — registration assigns id; defaults Enabled** · L2 · ☐
+- *Intent:* a registrant need not mint its own id, and instances are serving by default.
+- *Steps:* `register(ServiceRegistration { instance_id: None, .. })`; then `discover` with the default filter.
+- *Expected:* an `instance_id` is assigned; the instance appears with `state: Enabled`.
+- *Done-when:* asserts a non-empty id and `Enabled` default.
+
+**SC-DISC-002 — default filter is Enabled-only** · L2 · ☐
+- *Intent:* the default discovery path must never route to drained instances.
+- *Steps:* register two instances, set one `Disabled`; `discover(name, DiscoveryFilter::default())`.
+- *Expected:* only the `Enabled` instance is returned.
+- *Done-when:* asserts the disabled instance is excluded under the default filter.
+
+**SC-DISC-003 — metadata predicates AND-combine** · L2 · ☐ · gate `metadata_pushdown` (else client-side)
+- *Intent:* multi-attribute routing (e.g. region AND topic-shard) needs conjunctive matching with `Equals`/`OneOf`.
+- *Steps:* register instances with varied metadata; `discover` with two predicates (`Equals`, `OneOf`).
+- *Expected:* only instances matching *every* predicate are returned.
+- *Done-when:* asserts AND-semantics for both predicate kinds. Pushdown backends assert server-side; others assert the SDK's client-side filter produces the same set.
+
+**SC-DISC-004 — result order is unspecified** · L2 · ☐
+- *Intent:* the contract makes no ordering guarantee; consumers needing determinism sort client-side.
+- *Steps:* register several instances; `discover`; compare to expected *as a set*.
+- *Expected:* the returned set equals the expected set, independent of order.
+- *Done-when:* the suite compares result sets (e.g. via a `HashSet` of instance ids) and never depends on backend order.
+
+**SC-DISC-005 — drain and deregister** · L2 · ☐
+- *Intent:* gears flip serving intent for graceful drain, and remove themselves on shutdown.
+- *Steps:* register, `set_state(Disabled)` (drain), then `deregister()`; a watcher observes events.
+- *Expected:* after drain the instance is absent from the default filter but present under `Any`; after deregister the watcher sees `Left` and it is fully gone.
+- *Done-when:* asserts the drain (filter exclusion) and the `Left` on deregister.
+
+**SC-DISC-006 — liveness via TTL, not intent** · L2 · ☐
+- *Intent:* intent ≠ health (ADR-008) — a registration disappears when its heartbeat/TTL stops, independent of `state`.
+- *Steps:* register (Enabled), stop heartbeating, advance time past the registration TTL; `discover`.
+- *Expected:* the instance disappears purely via TTL lapse, with no `set_state` call.
+- *Done-when:* asserts TTL-driven disappearance distinct from the intent flag.
+
+**SC-DISC-007 — topology watch is unfiltered** · L2 · ☐
+- *Intent:* watches surface raw `Joined`/`Left`/`Updated`; filtering is the consumer's job, client-side.
+- *Steps:* `watch(name)`, then register / update-metadata / deregister instances.
+- *Expected:* `Change(Joined)`, `Change(Updated)`, `Change(Left)` events in mutation order, unfiltered.
+- *Done-when:* asserts each `TopologyChange` variant is observed for the matching mutation.
+
+**SC-DISC-008 — name scoped, metadata not scoped** · L2 · ☐
+- *Intent:* the coordination namespace lives on the service `name`; metadata keys/values pass through unchanged (`fr-namespacing-sd-metadata-unscoped`).
+- *Steps:* `scoped("eb").register(reg { name: "delivery", metadata: { region: "us-east" } })`; inspect backend keys and the discovered instance.
+- *Expected:* backend sees service name `eb/delivery`; metadata key stays `region` (not `eb/region`).
+- *Done-when:* asserts the name is prefixed and metadata is verbatim.
+
+**SC-DISC-009 — recover membership after lag/reset** · L4 · ☐
+- *Intent:* after a `Lagged`/`Reset`, re-reading via `discover` reconciles the consumer's view.
+- *Steps:* establish a watch, induce lag/reset (Toxiproxy/backpressure), then `discover` to re-read.
+- *Expected:* a `Lagged`/`Reset` signal followed by a `discover` that returns the true current membership.
+- *Done-when:* asserts recovery to correct membership after the signal. *(L4 — fault injection.)*

--- a/gears/system/cluster/docs/scenarios/leader.md
+++ b/gears/system/cluster/docs/scenarios/leader.md
@@ -1,0 +1,66 @@
+# Leader Election — Scenario Details (`SC-LEAD-*`)
+
+> Detail for §2 of the [scenario catalog](./README.md). Template: *Intent / Steps /
+> Expected / Done-when*. Most backends obtain leader election via
+> `CasBasedLeaderElectionBackend` over their cache; native backends (K8s Lease, etcd)
+> override it. Timing scenarios use `tokio::time` pause/advance.
+
+**SC-LEAD-001 — single candidate becomes leader** · L2 · ☐
+- *Intent:* with no contention, the sole participant must win — the baseline of the primitive.
+- *Steps:* `elect("e")` on one node; await the first `Status` event.
+- *Expected:* `LeaderStatus::Leader`; `is_leader()` returns `true`.
+- *Done-when:* asserts the watch reaches `Leader` and the cached snapshot agrees.
+
+**SC-LEAD-002 — at most one leader under contention** · L2 · ☐ · gate `linearizable`
+- *Intent:* the core safety property — no split-brain when many candidates race.
+- *Steps:* spawn N candidates against one backend; sample `status()` across all over a window.
+- *Expected:* at no observed instant do two candidates report `Leader`.
+- *Done-when:* asserts a single `Leader` at every sample. *Asserted only when `features().linearizable == true`; weak backends assert the documented advisory bound instead.*
+
+**SC-LEAD-003 — automatic renewal** · L2 · ☐
+- *Intent:* the leader keeps its claim with no consumer renewal code; a quiet leader does not lose leadership.
+- *Steps:* `elect`, become leader, advance time across several renewal intervals without other activity.
+- *Expected:* `status()` stays `Leader`; no `Lost` event fires.
+- *Done-when:* asserts leadership persists across ≥3 renewal intervals.
+
+**SC-LEAD-004 — graceful step-down** · L2 · ☐
+- *Intent:* explicit resignation hands off within a round-trip rather than waiting for TTL.
+- *Steps:* leader A `resign()`; a waiting candidate B awaits its next `Status`.
+- *Expected:* A's `resign()` returns `Ok`; B observes `Leader` well within one TTL.
+- *Done-when:* asserts B is promoted promptly after A resigns.
+
+**SC-LEAD-005 — synchronous status snapshot** · L2 · ☐
+- *Intent:* timer-driven workers need a non-async gate (`is_leader()`/`status()`) usable inside select arms.
+- *Steps:* drive a transition, then call `status()`/`is_leader()` without awaiting the watch.
+- *Expected:* the cached snapshot reflects the most recently observed transition; no I/O.
+- *Done-when:* asserts the snapshot matches the last `Status` event.
+
+**SC-LEAD-006 — `Status(Lost)` is transient** · L2 · ☐
+- *Intent:* loss is not terminal — the watch auto-reenrolls without consumer re-`elect()` boilerplate.
+- *Steps:* force a lost claim (e.g. TTL lapse under simulated stall), keep consuming the watch.
+- *Expected:* a `Status(Lost)` followed by a later `Status(Leader|Follower)` on the *same* watch.
+- *Done-when:* asserts re-enrollment without the consumer calling `elect()` again.
+
+**SC-LEAD-007 — `ElectionConfig` validation** · L2 · ☐
+- *Intent:* misconfigured timing must fail loudly at construction, not silently at runtime.
+- *Steps:* `ElectionConfig::new(0, _)` and `ElectionConfig::new(_, 0)`.
+- *Expected:* both return `Err(InvalidConfig)`; valid values derive `renewal_interval = ttl / (max_missed_renewals + 1)`.
+- *Done-when:* asserts rejection of zero values and the derived interval for a valid pair.
+
+**SC-LEAD-008 — weak-consistency guard** · L2 · ☐
+- *Intent:* per ADR-009, the default constructor must refuse an `EventuallyConsistent` cache; the opt-in must warn.
+- *Steps:* `CasBasedLeaderElectionBackend::new(eventually_consistent_cache)`; then `new_allow_weak_consistency(...)`.
+- *Expected:* `new` → `Err(InvalidConfig)`; `new_allow_weak_consistency` → `Ok`, emitting a warning log (the `weak_consistency` field / split-brain message).
+- *Done-when:* asserts the rejection and the warning (capture via `tracing-test`).
+
+**SC-LEAD-009 — partition surfaces `Lost` within TTL** · L4 · ☐ · gate `linearizable`
+- *Intent:* a partitioned leader must observe loss within the configured TTL (DESIGN §3.3 staleness bound).
+- *Steps:* under `turmoil`, partition the leader from the backend; advance the simulated clock.
+- *Expected:* the leader observes `Status(Lost)` within `TTL + observation_lag`.
+- *Done-when:* asserts the `Lost` transition lands inside the bound. *(Deterministic simulation — L4.)*
+
+**SC-LEAD-010 — no split-brain under partition** · L4 · ☐ · gate `linearizable`
+- *Intent:* the headline guarantee `nfr-leader-guarantee` — zero split-brain under adversarial partition.
+- *Steps:* under `turmoil`, model 10+ candidates across 3+ simulated nodes sharing one backend; inject partitions and message reorder/drop; sample every candidate's `status()` across the run.
+- *Expected:* at no simulated instant do two candidates report `Leader`.
+- *Done-when:* asserts zero concurrent-`Leader` samples across the run, replayable from a fixed seed. *(Deterministic simulation — L4, per linearizable backend.)*

--- a/gears/system/cluster/docs/scenarios/lifecycle.md
+++ b/gears/system/cluster/docs/scenarios/lifecycle.md
@@ -1,0 +1,42 @@
+# Lifecycle & Shutdown — Scenario Details (`SC-LIFE-*`)
+
+> Detail for §8 of the [scenario catalog](./README.md). Template: *Intent / Steps /
+> Expected / Done-when*. **Requires the wiring crate** (`cf-gears-cluster`) — these are
+> L3 integration tests over a built `ClusterHandle`, not L2 conformance. Source of
+> truth: DESIGN §3.13 shutdown sequence.
+
+**SC-LIFE-001 — leader revocation order** · L3 · ☐
+- *Intent:* a leader must lose confidence *before* it sees shutdown, so it never acts stale (`fr-shutdown-revoke`).
+- *Steps:* build the handle, become leader on a watch, call `handle.stop()`.
+- *Expected:* the active `LeaderWatch` receives `Status(Lost)` and *then* `Closed(Shutdown)` — two distinct events, in that order.
+- *Done-when:* asserts both events and their ordering on the leader's watch.
+
+**SC-LIFE-002 — in-flight `lock()` returns `Shutdown`** · L3 · ☐
+- *Intent:* a blocked acquirer must distinguish "cluster going down" from "I timed out".
+- *Steps:* start a blocking `lock("m", ttl, timeout)` that cannot acquire; call `stop()` while it waits.
+- *Expected:* the waiter returns `Err(Shutdown)` — never `LockTimeout`.
+- *Done-when:* asserts the `Shutdown` variant on the in-flight waiter.
+
+**SC-LIFE-003 — cache & SD watches close with `Shutdown`** · L3 · ☐
+- *Intent:* every active watch ends terminally with a clear cause on shutdown.
+- *Steps:* open a cache `watch` and a service-discovery `watch`; call `stop()`.
+- *Expected:* both receive `Closed(Shutdown)` as their terminal event.
+- *Done-when:* asserts the `Closed(Shutdown)` on both watch types.
+
+**SC-LIFE-004 — no remote release; TTL cleanup** · L3 · ☐
+- *Intent:* shutdown makes no best-effort remote cleanup calls (`fr-shutdown-ttl-cleanup`); resources lapse via TTL.
+- *Steps:* hold a lock / leader claim / registration; `stop()`; observe the backend state immediately after.
+- *Expected:* no delete/release/deregister calls are issued; entries remain until their TTL lapses.
+- *Done-when:* asserts the absence of remote-cleanup calls (e.g. via a recording backend) and TTL-bounded disappearance.
+
+**SC-LIFE-005 — post-stop resolution fails** · L3 · ☐
+- *Intent:* after teardown, backends are deregistered, so a late resolve fails cleanly.
+- *Steps:* `stop()`, then `*V1::resolver(hub).profile(P).resolve()`.
+- *Expected:* `Err(ProfileNotBound)`.
+- *Done-when:* asserts resolution returns `ProfileNotBound` after stop.
+
+**SC-LIFE-006 — omit-primitive auto-wrap; reject native non-cache** · L3 · ☐
+- *Intent:* a single-backend profile is one line (omit non-cache primitives → SDK defaults over the cache); binding a native non-cache backend is rejected until the routing follow-up lands.
+- *Steps:* build from YAML that (a) binds only `cache` and omits the rest, then (b) binds an explicit native `leader_election` provider.
+- *Expected:* (a) the three omitted primitives resolve as `CasBased*`/`CacheBased*` over the cache; (b) startup fails with `InvalidConfig` naming the primitive.
+- *Done-when:* asserts the auto-wrap resolves working defaults and the explicit native binding is rejected with `InvalidConfig`.

--- a/gears/system/cluster/docs/scenarios/lock.md
+++ b/gears/system/cluster/docs/scenarios/lock.md
@@ -1,0 +1,53 @@
+# Distributed Lock — Scenario Details (`SC-LOCK-*`)
+
+> Detail for §3 of the [scenario catalog](./README.md). Template: *Intent / Steps /
+> Expected / Done-when*. Most backends obtain locking via
+> `CasBasedDistributedLockBackend` over their cache; Redis/Postgres/etcd may override
+> with a native lock. Timeout/TTL scenarios use `tokio::time` pause/advance.
+
+**SC-LOCK-001 — `try_lock` contention** · L2 · ☐
+- *Intent:* non-blocking acquisition fails fast so callers can shed load.
+- *Steps:* holder A `try_lock("m", ttl)`; B `try_lock("m", ttl)` while A holds.
+- *Expected:* A → `Ok(LockGuard)`; B → `Err(LockContended { name: "m" })`.
+- *Done-when:* asserts A succeeds and B is contended.
+
+**SC-LOCK-002 — `lock` blocks then times out** · L2 · ☐
+- *Intent:* blocking acquisition waits up to `timeout`, then reports a timeout (distinct from contention).
+- *Steps:* A holds "m"; B `lock("m", ttl, timeout)`; advance time past `timeout` without A releasing.
+- *Expected:* B → `Err(LockTimeout { name: "m", waited })` with `waited ≈ timeout`.
+- *Done-when:* asserts the `LockTimeout` variant and a plausible `waited`.
+
+**SC-LOCK-003 — crashed-holder TTL recovery** · L2 · ☐
+- *Intent:* a holder that crashes without releasing must not block others past its TTL.
+- *Steps:* A acquires "m" then drops its guard without `release()`; advance time past the TTL; B `try_lock("m")`.
+- *Expected:* B acquires once the TTL lapses.
+- *Done-when:* asserts B acquires after TTL expiry with no explicit release by A.
+
+**SC-LOCK-004 — explicit release wakes a waiter** · L2 · ☐
+- *Intent:* `release()` frees the lock immediately so a blocked waiter proceeds without waiting for TTL.
+- *Steps:* A holds "m"; B begins `lock("m", ttl, timeout)`; A `release()`.
+- *Expected:* B acquires shortly after A releases, well within `timeout`.
+- *Done-when:* asserts B acquires promptly post-release.
+
+**SC-LOCK-005 — `renew` extends; expired `renew` fails** · L2 · ☐
+- *Intent:* long operations extend the lease; renewing a lapsed lease must tell the holder it lost the lock.
+- *Steps:* acquire with a short TTL, `renew(new_ttl)` before expiry (succeeds); separately, let a lock expire then `renew`.
+- *Expected:* timely `renew` → `Ok`; renewing after expiry → `Err(LockExpired { name })`.
+- *Done-when:* asserts both the successful extension and the `LockExpired` on a lapsed lease.
+
+**SC-LOCK-006 — foreign-holder release guard** · L2 · ⊘ (covered indirectly)
+- *Intent:* only the owner may release — a non-holder must not free someone else's lock (owner-token / CAS guard).
+- *Steps:* not exercised directly — `DistributedLockBackend` does not expose the owner token, so there is no seam to drive a foreign-release attempt at this layer.
+- *Expected/Done-when:* covered indirectly by [SC-CACHE-008/009](./cache.md), which exercise the same value/owner-token guard the SDK-default lock backend (`CasBasedDistributedLockBackend`) is built on. A backend with a native (non-cache-derived) lock implementation is responsible for its own equivalent guard test in its L3 per-plugin design (TESTING-STRATEGY.md §5).
+
+**SC-LOCK-007 — `Drop` performs no I/O** · L2 · ☐
+- *Intent:* per ADR-002, dropping a `LockGuard` must not make remote calls — TTL is the only safety net.
+- *Steps:* acquire then drop the guard; observe that the lock is *not* released before its TTL.
+- *Expected:* the lock remains held (from peers' view) until the TTL lapses; no release I/O on drop.
+- *Done-when:* asserts a dropped guard does not eagerly free the lock (contrast with SC-LOCK-004's explicit release).
+
+**SC-LOCK-008 — blocked waiter woken on release notification** · L4 · ☐
+- *Intent:* the CAS-based default uses a watch to wake waiters promptly rather than busy-polling.
+- *Steps:* B blocks on `lock("m", ...)`; A releases; measure B's wake latency under induced watch jitter.
+- *Expected:* B wakes on the release notification within a small bound.
+- *Done-when:* asserts prompt wake under fault injection. *(L4 — needs a timing/fault harness.)*

--- a/gears/system/cluster/docs/scenarios/naming.md
+++ b/gears/system/cluster/docs/scenarios/naming.md
@@ -1,0 +1,37 @@
+# Naming & Validation — Scenario Details (`SC-NAME-*`)
+
+> Detail for §11 of the [scenario catalog](./README.md). Template: *Intent / Steps /
+> Expected / Done-when*. `fr-cache-storage` mandates one uniform name rule across cache
+> keys, lock names, election names, and service names; the SDK exposes
+> `validate_cluster_name`. (Scope *prefixes* are validated separately by
+> [SC-SCOP-003](./scoping.md).)
+
+**SC-NAME-001 — invalid cache key rejected** · L2 · ☐
+- *Intent:* malformed keys fail fast rather than landing as corrupt entries.
+- *Steps:* call a cache write/read with a key violating the name rule (e.g. whitespace, control chars).
+- *Expected:* `Err(InvalidName { name, reason })`; a valid key succeeds.
+- *Done-when:* asserts rejection of an invalid key and acceptance of a valid one.
+
+**SC-NAME-002 — invalid election name rejected** · L2 · ☐
+- *Intent:* the same rule guards election names.
+- *Steps:* `elect(invalid_name)`.
+- *Expected:* `Err(InvalidName)`.
+- *Done-when:* asserts rejection.
+
+**SC-NAME-003 — invalid lock name rejected** · L2 · ☐
+- *Intent:* the same rule guards lock names.
+- *Steps:* `try_lock(invalid_name, ttl)`.
+- *Expected:* `Err(InvalidName)`.
+- *Done-when:* asserts rejection.
+
+**SC-NAME-004 — invalid service name rejected** · L2 · ☐
+- *Intent:* the same rule guards service names (metadata keys/values are *not* subject to it — see SC-DISC-008).
+- *Steps:* `register(ServiceRegistration { name: invalid_name, .. })`.
+- *Expected:* `Err(InvalidName)`.
+- *Done-when:* asserts rejection of the service name while metadata with the same characters is accepted.
+
+**SC-NAME-005 — rule is uniform across primitives** · L2 · ☐
+- *Intent:* the whole point of `fr-cache-storage`'s uniform convention — consumers learn one rule, not four.
+- *Steps:* take a small set of names spanning the valid/invalid boundary; submit each to cache key, election, lock, and service name.
+- *Expected:* every name's validity verdict is identical across all four primitives.
+- *Done-when:* asserts no primitive accepts a name another rejects (or vice versa).

--- a/gears/system/cluster/docs/scenarios/observability.md
+++ b/gears/system/cluster/docs/scenarios/observability.md
@@ -1,0 +1,39 @@
+# Observability Contract — Scenario Details (`SC-OBS-*`)
+
+> Detail for §13 of the [scenario catalog](./README.md). Template: *Intent / Steps /
+> Expected / Done-when*. Per `cpt-cf-clst-nfr-observability` / ADR-004, signal names are a
+> versioned contract on par with the trait signatures. Authoritative catalog:
+> [OBSERVABILITY.md](../OBSERVABILITY.md); names mirrored in code as
+> `cluster_sdk::observability` constants. SC-OBS-001..004 are assertable at L2 (capture
+> emitted signals via a test exporter / `tracing` subscriber); SC-OBS-005 is per-plugin
+> completeness (L3).
+
+**SC-OBS-001 — spans emitted with catalogued names & attributes** · L2 · ☐
+- *Intent:* every facade operation produces its named span so traces are consistent across backends.
+- *Steps:* with a capturing tracing subscriber, drive each operation (e.g. `cache.get`, `leader.elect`, `lock.try_lock`, `discovery.register`).
+- *Expected:* a span named per the catalog (e.g. `cluster.cache.get`) carrying the specified attributes (`provider`, `key`/`election`/`lock`/`name`, …).
+- *Done-when:* asserts span name and required attributes for each catalogued operation.
+
+**SC-OBS-002 — metrics emitted with catalogued names** · L2 · ☐
+- *Intent:* dashboards built on metric names stay stable across plugin versions.
+- *Steps:* drive operations with a capturing metrics exporter (the `otel` feature's adapter).
+- *Expected:* metrics named per the catalog (e.g. `cluster_cache_ops_total`) are recorded with the `result` outcome label set correctly (`ok`/`conflict`/`timeout`/`contended`).
+- *Done-when:* asserts metric name and bounded labels for the exercised operations.
+
+**SC-OBS-003 — cardinality rule** · L2 · ☐
+- *Intent:* unbounded values must never become metric labels (`OBSERVABILITY.md` §2) or they explode Prometheus cardinality.
+- *Steps:* drive operations whose keys/lock/election/instance names are high-cardinality; inspect emitted metric labels.
+- *Expected:* metric labels are confined to the bounded allowlist (`provider`, `op`, `result`, `transition`, `kind`, `primitive`); `key`/`lock`/`election`/`instance_id` appear only as span attributes / log fields, never as metric labels.
+- *Done-when:* asserts no metric carries a label outside `METRIC_LABEL_ALLOWLIST`.
+
+**SC-OBS-004 — log events use catalogued names** · L2 · ☐
+- *Intent:* structured log events are part of the contract too (e.g. `cluster.leader.transition`).
+- *Steps:* with a capturing subscriber, trigger event-bearing transitions (leadership change, cas conflict, lock timeout).
+- *Expected:* log events named per the catalog with the expected severity and fields.
+- *Done-when:* asserts the event name and fields for each catalogued log event.
+
+**SC-OBS-005 — every plugin emits every signal** · L3 · ☐
+- *Intent:* cluster is foundational; inconsistent observability across plugins leaves gaps during incidents. The contract is *complete* per plugin, not just per-SDK.
+- *Steps:* run SC-OBS-001..004 against each real backend (not just the stub) in its container.
+- *Expected:* each plugin emits the full set of catalogued spans/metrics/log-events applicable to the operations it supports.
+- *Done-when:* the observability assertions pass per-plugin. *(L3 — runs alongside the per-backend integration suite.)*

--- a/gears/system/cluster/docs/scenarios/resolution.md
+++ b/gears/system/cluster/docs/scenarios/resolution.md
@@ -1,0 +1,30 @@
+# Resolution & Capability Validation — Scenario Details (`SC-RESV-*`)
+
+> Detail for §5 of the [scenario catalog](./README.md). Template: *Intent / Steps /
+> Expected / Done-when*. These exercise the SDK resolver (`*V1::resolver(hub).profile(P)
+> .require(cap).resolve()`); SC-RESV-001..003 are already covered by the SDK smoke tests
+> (`tests/resolution.rs`).
+
+**SC-RESV-001 — resolution succeeds for a satisfied backend** · L2 · ☑
+- *Intent:* a consumer that declares only capabilities the bound backend provides gets a working facade.
+- *Steps:* register a backend under profile `P`; `resolver(hub).profile(P).require(cap_it_has).resolve()`.
+- *Expected:* `Ok(*V1)` — a usable, cheap-clone facade.
+- *Done-when:* asserts a successful resolve and a working call through the facade.
+
+**SC-RESV-002 — capability mismatch fails startup** · L2 · ☑
+- *Intent:* a guarantee the backend cannot meet must fail loudly at resolution, never silently degrade in production.
+- *Steps:* register a backend lacking a feature; `require` that feature and `resolve()`.
+- *Expected:* `Err(CapabilityNotMet { primitive, capability, provider })` naming all three.
+- *Done-when:* asserts the variant and that the message names primitive, capability, and the concrete provider.
+
+**SC-RESV-003 — unbound profile** · L2 · ☑
+- *Intent:* resolving a profile no operator bound is a clear, distinct error.
+- *Steps:* `resolver(hub).profile(Unbound).resolve()` with nothing registered under it.
+- *Expected:* `Err(ProfileNotBound { profile })`. (Omitting `.profile(...)` entirely → `ProfileNotSpecified`.)
+- *Done-when:* asserts `ProfileNotBound`, and separately `ProfileNotSpecified` for the no-profile path.
+
+**SC-RESV-004 — honest-declaration enforcement** · L2 · ☐
+- *Intent:* the capability gate must bind to the backend's *declared* `features()`/`consistency()`, so an honestly-under-declaring backend is correctly rejected (the inverse of a backend that lies).
+- *Steps:* a backend declaring `features().prefix_watch == false`; a consumer `require(CacheCapability::PrefixWatch)`.
+- *Expected:* `Err(CapabilityNotMet)` — the gate trusts the declaration, not the runtime behavior.
+- *Done-when:* asserts rejection driven purely by the declared characteristic. *(Cross-checked in the conformance suite: a backend whose declaration disagrees with its observed behavior fails some `SC-*` scenario.)*

--- a/gears/system/cluster/docs/scenarios/restart.md
+++ b/gears/system/cluster/docs/scenarios/restart.md
@@ -1,0 +1,30 @@
+# Watch Auto-Restart Combinator — Scenario Details (`SC-REST-*`)
+
+> Detail for §7 of the [scenario catalog](./README.md). Template: *Intent / Steps /
+> Expected / Done-when*. Exercises `*Watch::auto_restart(RetryPolicy)` →
+> `RestartingWatch<W>` (DESIGN §3.9). A scripted/mock watch source that emits chosen
+> `Closed(_)` payloads keeps these at L2 (no real backend needed).
+
+**SC-REST-001 — retryable close reconnects with `Reset`** · L2 · ☐
+- *Intent:* transient terminal causes should self-heal transparently and tell the consumer to re-read.
+- *Steps:* wrap a watch in `auto_restart(policy)`; have the source emit `Closed(Provider { kind: ConnectionLost })` (also `Timeout`, `ResourceExhausted`).
+- *Expected:* the combinator reconnects after backoff and surfaces a `Reset` to the consumer on each successful resubscribe; no `Closed` reaches the consumer.
+- *Done-when:* asserts a `Reset` (not `Closed`) for each retryable kind.
+
+**SC-REST-002 — non-retryable close propagates** · L2 · ☐
+- *Intent:* causes that retrying cannot fix must reach the consumer unchanged.
+- *Steps:* emit `Closed(Provider { kind: AuthFailure })`, `Closed(Shutdown)`, `Closed(CapabilityNotMet { .. })`, and `Closed(Provider { kind: Other })`.
+- *Expected:* each is propagated to the consumer as `Closed(err)` verbatim; the combinator does not retry.
+- *Done-when:* asserts the consumer observes the original `Closed` for every non-retryable cause.
+
+**SC-REST-003 — backoff honors `RetryPolicy`** · L2 · ☐
+- *Intent:* reconnect timing must follow the configured policy and stop at the retry cap, preventing thundering-herd storms.
+- *Steps:* configure `RetryPolicy { initial_backoff, max_backoff, jitter_factor, max_retries: Some(n) }`; emit repeated retryable closes under `tokio::time` control.
+- *Expected:* backoff grows from initial toward max within the jitter band; after `n` retries the last `Closed(err)` is propagated unchanged.
+- *Done-when:* asserts the backoff schedule (within jitter) and propagation on exhaustion.
+
+**SC-REST-004 — uniform across all three watch types** · L2 · ☐
+- *Intent:* one `RetryPolicy` type drives the combinator for cache, leader, and service-discovery watches — one canonical pattern.
+- *Steps:* construct `RestartingWatch` over `CacheWatch`, `LeaderWatch`, and `ServiceWatch` with the same policy; run SC-REST-001's retryable-close case on each.
+- *Expected:* identical reconnect/`Reset` behavior across all three.
+- *Done-when:* asserts the same outcome for each watch type under one policy.

--- a/gears/system/cluster/docs/scenarios/routing.md
+++ b/gears/system/cluster/docs/scenarios/routing.md
@@ -1,0 +1,29 @@
+# Routing & SDK Defaults — Scenario Details (`SC-ROUTE-*`)
+
+> Detail for §12 of the [scenario catalog](./README.md). Template: *Intent / Steps /
+> Expected / Done-when*. These assert the "implement cache only, get all four primitives"
+> guarantee at the SDK-default level. Operator-config auto-wrap and native-binding
+> rejection are wiring-level ([SC-LIFE-006](./lifecycle.md)).
+>
+> **Ownership.** Unlike every other `SC-*` family, these two scenarios are **not**
+> implemented in `cluster-conformance` — they live in the `cluster` gear crate's own
+> test suite (`cluster/src/defaults/{leader,lock,discovery}_tests.rs`). Reason:
+> `cluster-conformance` is a dependency of every backend plugin, so its real
+> `[dependencies]` deliberately stay limited to `cluster-sdk`; it never depends on
+> `cluster` (the wiring gear that implements `CasBasedLeaderElectionBackend` /
+> `CasBasedDistributedLockBackend` / `CacheBasedServiceDiscoveryBackend`), even as a
+> dev-dependency. `cluster` is the only crate that has both a bare cache fixture and
+> the concrete defaults, so proving "cache-only in, all four primitives out" has to
+> happen there.
+
+**SC-ROUTE-001 — cache-only backend yields all four primitives** · L2 · ☑ (`cluster/src/defaults/{leader,lock,discovery}_tests.rs`)
+- *Intent:* `fr-routing-cache-only-plugin` — a plugin that implements only `ClusterCacheBackend` must get working leader election, lock, and service discovery for free.
+- *Steps:* wrap a cache-only backend (`MemoryCache`) in `CasBasedLeaderElectionBackend` / `CasBasedDistributedLockBackend` / `CacheBasedServiceDiscoveryBackend`, then exercise each primitive's contract directly.
+- *Expected:* leader election (`single_candidate_becomes_leader`, `second_candidate_is_follower`, `foreign_takeover_emits_lost_then_resolves`, ...), lock (`try_lock_acquires_then_contends_while_held`, `release_frees_the_lock_for_a_new_acquirer`, ...), and discovery (`register_then_discover_finds_the_instance`, `watch_observes_join_then_leave`, ...) all behave correctly over the cache-derived defaults.
+- *Done-when:* `cluster/src/defaults/leader_tests.rs`, `lock_tests.rs`, and `discovery_tests.rs` are green. These are bespoke assertions rather than a literal run of the shared `cluster-conformance` suite (see the ownership note above) — the property proven is the same claim, just not via the identical shared test body used for external backends.
+
+**SC-ROUTE-002 — default features derive from the cache** · L2 · ☑ (`cluster/src/defaults/{leader,lock,discovery}_tests.rs`)
+- *Intent:* a default backend must honestly inherit its guarantee from the cache it wraps — no over-claiming (ties into capability validation, §3.11).
+- *Steps:* build the SDK defaults over (a) a `Linearizable` cache and (b) an `EventuallyConsistent` cache (via `new_allow_weak_consistency`); read `features()`.
+- *Expected:* `LeaderElectionFeatures.linearizable` and `LockFeatures.linearizable` equal `cache.consistency() == Linearizable`; `CacheBasedServiceDiscoveryBackend` reports `metadata_pushdown == false`.
+- *Done-when:* `leader_tests.rs::weak_consistency_constructor_always_succeeds_and_features_track_cache`, `lock_tests.rs::weak_consistency_constructor_succeeds_and_features_track_cache`, and `discovery_tests.rs::features_report_no_metadata_pushdown` are green.

--- a/gears/system/cluster/docs/scenarios/scoping.md
+++ b/gears/system/cluster/docs/scenarios/scoping.md
@@ -1,0 +1,40 @@
+# Scoping & Namespacing — Scenario Details (`SC-SCOP-*`)
+
+> Detail for §6 of the [scenario catalog](./README.md). Template: *Intent / Steps /
+> Expected / Done-when*. Exercises `*V1::scoped(prefix)` across primitives (DESIGN §3.8).
+
+**SC-SCOP-001 — cache scoping prepends and strips** · L2 · ☐
+- *Intent:* a consumer sees name-relative keys; the prefix is invisible inside its own code yet isolates it from other consumers on the same profile.
+- *Steps:* `cache.scoped("eb")`; `put("k", v)`; `watch("k")`; trigger an event; inspect backend key and the event delivered to the consumer.
+- *Expected:* the backend stores `eb/k`; the read-path event key the consumer sees is `k` (prefix stripped).
+- *Done-when:* asserts the write-path prefixing and the read-path stripping round-trip.
+
+**SC-SCOP-002 — scoping composes** · L2 · ☐
+- *Intent:* a sharded gear nests a per-shard namespace inside its per-gear namespace.
+- *Steps:* `cache.scoped("eb").scoped("shard-0")`; `put("k", v)`.
+- *Expected:* effective backend key is `eb/shard-0/k`; reads strip both layers back to `k`.
+- *Done-when:* asserts the composed prefix on write and full stripping on read.
+
+**SC-SCOP-003 — invalid prefix rejected** · L2 · ☐
+- *Intent:* a malformed scope must fail at construction, not corrupt keys silently.
+- *Steps:* `scoped("bad prefix!")` (violates `[a-zA-Z0-9_/-]+`).
+- *Expected:* `Err(InvalidName { name, reason })`.
+- *Done-when:* asserts the `InvalidName` error for an invalid prefix and success for a valid one.
+
+**SC-SCOP-004 — polyfill composes with scoping** · L2 · ☐ · gate `!prefix_watch`
+- *Intent:* the polling polyfill emits full backend keys like a native prefix watch, so scoping must strip them on the read path.
+- *Steps:* on a non-prefix-watch backend, `cache.scoped("eb")`, then a polyfilled `watch_prefix("")`; mutate keys under the scope.
+- *Expected:* events arrive with scope-relative keys (e.g. `k`, not `eb/k`).
+- *Done-when:* asserts the `ScopedCacheBackend` strips the prefix from polyfill-emitted keys.
+
+**SC-SCOP-005 — election names scoped** · L2 · ☐
+- *Intent:* two gears on the same profile must not collide on election names; scoping isolates them invisibly.
+- *Steps:* `leader.scoped("eb")`; `elect("shard-leader")`.
+- *Expected:* the backend election key is `eb/shard-leader`; the consumer used the bare name. (`LeaderWatch` carries no name, so there is no read-path strip — see §3.8.)
+- *Done-when:* asserts the backend sees the prefixed election name.
+
+**SC-SCOP-006 — lock names scoped** · L2 · ☐
+- *Intent:* lock names are namespaced per consumer the same way.
+- *Steps:* `lock.scoped("eb")`; `try_lock("budget", ttl)`.
+- *Expected:* the backend lock key is `eb/budget`. (`LockGuard` is opaque — no read-path strip.)
+- *Done-when:* asserts the backend sees the prefixed lock name.

--- a/gears/system/cluster/docs/scenarios/static-analysis.md
+++ b/gears/system/cluster/docs/scenarios/static-analysis.md
@@ -1,0 +1,23 @@
+# Static Analysis — Scenario Details (`SC-LINT-*`)
+
+> Detail for §9 of the [scenario catalog](./README.md). Template: *Intent / Steps /
+> Expected / Done-when*. These are **L1** dylint `ui_test` fixtures, not runtime tests —
+> they verify the compile-time rule that enforces `nfr-bounded-critical-section`
+> (no remote I/O inside a lock critical section; ADR-002). Without them the rule can
+> rot into aspirational documentation.
+
+**SC-LINT-001 — positive fixture: rule fires** · L1 · ☐
+- *Intent:* a remote call between `try_lock`/`lock` and `release` must be flagged at compile time.
+- *Steps:* a `ui_test` fixture holding a `LockGuard` and issuing a cluster remote call (e.g. `cache.get(...)`) inside the critical section.
+- *Expected:* the dylint rule emits a diagnostic at the offending call, with the expected message captured in the fixture's `.stderr`.
+- *Done-when:* the `ui_test` passes with the diagnostic at the correct span.
+
+**SC-LINT-002 — negative fixture: no false positive** · L1 · ☐
+- *Intent:* compliant code (remote effects *before* acquire or *after* release; local-only critical section) must not be flagged.
+- *Steps:* a `ui_test` fixture with a lock whose critical section does only local work, with remote calls outside the guard's scope.
+- *Expected:* no diagnostic is emitted.
+- *Done-when:* the `ui_test` compiles clean with an empty `.stderr`.
+
+> **Scope note:** the rule is initially scoped to the four cluster backend traits within
+> `try_lock`/`release` scopes; DB-transaction enforcement is a follow-up rule extension
+> (DESIGN §2.2). Fixtures should be added for that scope when it lands.

--- a/gears/system/cluster/docs/scenarios/watch-lifecycle.md
+++ b/gears/system/cluster/docs/scenarios/watch-lifecycle.md
@@ -1,0 +1,31 @@
+# Watch Lifecycle Uniformity — Scenario Details (`SC-WLU-*`)
+
+> Detail for §10 of the [scenario catalog](./README.md). Template: *Intent / Steps /
+> Expected / Done-when*. These assert the *uniform* watch contract (ADR-003) across all
+> three watches; per-primitive instances live in [cache.md](./cache.md) (SC-CACHE-016/017)
+> and [discovery.md](./discovery.md) (SC-DISC-009). The recovery action differs per
+> primitive but the *signal shape* and the *obligation to recover* are identical.
+
+**SC-WLU-001 — uniform union shape** · L2 · ☐
+- *Intent:* one mental model for watches — every watch event is `{value-variant, Lagged, Reset, Closed}`, infallible at the type level (no `Result`-returning `changed()`).
+- *Steps:* type-level / structural check of `CacheWatchEvent`, `LeaderWatchEvent`, `ServiceWatchEvent`.
+- *Expected:* each carries exactly `Event/Status/Change`, `Lagged { dropped }`, `Reset`, `Closed(ClusterError)`; all `#[non_exhaustive]`; none expose a fallible `changed()`.
+- *Done-when:* asserts the three enums share the variant set (a compile-time/structural test, no backend needed).
+
+**SC-WLU-002 — `Lagged` under backpressure (all three)** · L4 · ☐
+- *Intent:* a slow subscriber on *any* watch is told it fell behind rather than blocking the producer.
+- *Steps:* for each of cache / leader / SD, subscribe, then drive events faster than the subscriber drains against a bounded channel.
+- *Expected:* each watch yields `Lagged { dropped }`; the producer is never blocked.
+- *Done-when:* asserts a `Lagged` event on every watch type. *(Generalizes SC-CACHE-016; L4 — needs a throughput harness.)*
+
+**SC-WLU-003 — `Reset` and recovery (all three)** · L4 · ☐
+- *Intent:* after a re-established subscription, the consumer must re-sync — and the recovery recipe is the same regardless of primitive.
+- *Steps:* for each watch, sever and restore the subscription (Toxiproxy / induced reconnect); follow the documented recovery.
+- *Expected:* each yields `Reset`; recovery succeeds — cache re-reads via `get`, leader awaits the next `Status`, SD re-reads via `discover`.
+- *Done-when:* asserts `Reset` on each watch and that the per-primitive recovery restores correct state. *(Generalizes SC-CACHE-017 / SC-DISC-009.)*
+
+**SC-WLU-004 — terminal `Closed`; transients retried internally** · L2 · ☐
+- *Intent:* terminal failure is explicit (`Closed(err)`) and final; transient backend errors (`ConnectionLost`/`Timeout`/`ResourceExhausted`) are retried by the watch's background task and never surface as events.
+- *Steps:* for each watch, induce a terminal cause (e.g. via the scripted source) and, separately, a transient blip.
+- *Expected:* terminal → exactly one `Closed(err)`, no further events; transient → no event emitted (silently retried).
+- *Done-when:* asserts the single terminal `Closed` and the absence of any event for transients, on each watch type.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added backend-agnostic conformance suites for cache, discovery, leader election, distributed locks, watch lifecycle, and watch restart.
  * Introduced an in-memory cache fixture and model-based replay for cache property testing.
* **Bug Fixes**
  * Leader reconciliation now emits a lost-then-reacquire transition when leadership is retained but the cache entry is missing (e.g., after TTL lapses).
* **Documentation**
  * Added a testing strategy and a full scenario catalog (including cache/discovery/leader/lock/lifecycle/scoping/routing/observability/validation).
* **Tests**
  * Added self-tests and randomized cache conformance, plus expanded conformance runs against the gear’s default cache-backed implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->