### PR TITLE
feat(cluster): standalone backend plugin and cluster gear wiring

### DIFF
--- a/.cf-studio/config/artifacts.toml
+++ b/.cf-studio/config/artifacts.toml
@@ -27,7 +27,7 @@ reason = "Ignore 'gears/system/authz-resolver' (not SDLC-documented yet: missing
 patterns = ["gears/system/authz-resolver/*"]
 
 [[ignore]]
-reason = "Ignore module 'cluster' traceability while the gear lands in stacked PRs: docs ship in the first PR but their code markers are split across the standalone-plugin and wiring/examples PRs. Removed in the final cluster PR once all code is present and full bidirectional traceability validates."
+reason = "Ignore module 'cluster' traceability pending a full bidirectional traceability audit now that standalone-plugin and wiring/examples code has landed."
 patterns = ["gears/system/cluster/*"]
 
 [[ignore]]
@@ -274,6 +274,11 @@ extensions = [".rs"]
 [[systems.autodetect.codebase]]
 name = "Nested SDK Tests"
 path = "{system_root}/{system}-sdk/tests"
+extensions = [".rs"]
+
+[[systems.autodetect.codebase]]
+name = "Nested SDK Examples"
+path = "{system_root}/{system}-sdk/examples"
 extensions = [".rs"]
 
 # Nested sub-plugin scope: account-management/docs/tr-plugin/ carries its own PRD/DESIGN/ADR.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,11 +1627,17 @@ dependencies = [
 name = "cf-gears-cluster"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "cf-gears-cluster-conformance",
  "cf-gears-cluster-sdk",
+ "cf-gears-standalone-cluster-plugin",
  "cf-gears-toolkit",
+ "parking_lot",
  "rand 0.10.1",
+ "serde",
+ "serde-saphyr 0.0.22",
+ "serde_json",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2326,6 +2332,19 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "cf-gears-standalone-cluster-plugin"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "cf-gears-cluster-sdk",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,9 +59,10 @@ members = [
     "gears/system/account-management/account-management-sdk",
     "gears/system/account-management/plugins/static-idp-plugin",
     "gears/system/api-gateway",
-    "gears/system/cluster/cluster-sdk",
     "gears/system/cluster/cluster",
+    "gears/system/cluster/cluster-sdk",
     "gears/system/cluster/cluster-conformance",
+    "gears/system/cluster/plugins/standalone-cluster-plugin",
     "gears/system/grpc-hub",
     "gears/system/nodes-registry/nodes-registry",
     "gears/system/nodes-registry/nodes-registry-sdk",
@@ -284,13 +285,13 @@ cf-gears-cluster-conformance = { version = "0.1.0", path = "gears/system/cluster
 
 # System gears SDKs
 account-management-sdk = { package = "cf-gears-account-management-sdk", version = "0.2.0", path = "gears/system/account-management/account-management-sdk" }
+cluster-sdk = { package = "cf-gears-cluster-sdk", version = "0.1.0", path = "gears/system/cluster/cluster-sdk" }
 types-registry-sdk = { package = "cf-gears-types-registry-sdk", version = "0.3.0", path = "gears/system/types-registry/types-registry-sdk" }
 tenant-resolver-sdk = { package = "cf-gears-tenant-resolver-sdk", version = "0.3.9", path = "gears/system/tenant-resolver/tenant-resolver-sdk" }
 authz-resolver-sdk = { package = "cf-gears-authz-resolver-sdk", version = "0.3.9", path = "gears/system/authz-resolver/authz-resolver-sdk" }
 resource-group-sdk = { package = "cf-gears-resource-group-sdk", version = "0.2.0", path = "gears/system/resource-group/resource-group-sdk" }
 oagw-sdk = { package = "cf-gears-oagw-sdk", version = "0.5.3", path = "gears/system/oagw/oagw-sdk" }
 usage-collector-sdk = { package = "cf-gears-usage-collector-sdk", version = "0.1.0", path = "gears/system/usage-collector/usage-collector-sdk" }
-cluster-sdk = { package = "cf-gears-cluster-sdk", version = "0.1.0", path = "gears/system/cluster/cluster-sdk" }
 
 # BSS gears (ported from vhp-core)
 bss-ledger-sdk = { path = "gears/bss/ledger/ledger-sdk" }

--- a/gears/system/cluster/cluster-sdk/src/lib.rs
+++ b/gears/system/cluster/cluster-sdk/src/lib.rs
@@ -1,4 +1,3 @@
-// Created: 2026-06-03 by Constructor Tech
 //! # Cluster SDK foundation
 //!
 //! `cluster_sdk` is the shared, serde-free, dyn-safe contract foundation every
@@ -74,7 +73,10 @@ pub use observability::{ClusterMetrics, InstrumentedCache, NoopMetrics};
 pub use profile::{
     CLUSTER_NAME_RULE, ClusterProfile, is_valid_cluster_name, validate_cluster_name,
 };
-pub use provider::{ClusterCacheProvider, StopHook};
+pub use provider::{
+    ClusterCacheProvider, ClusterLeaderElectionProvider, ClusterLockProvider,
+    ClusterServiceDiscoveryProvider, StopHook,
+};
 pub use registration::{
     deregister_cache_backend, deregister_leader_election_backend, deregister_lock_backend,
     deregister_service_discovery_backend, register_cache_backend, register_leader_election_backend,

--- a/gears/system/cluster/cluster-sdk/src/provider.rs
+++ b/gears/system/cluster/cluster-sdk/src/provider.rs
@@ -1,66 +1,152 @@
-// Created: 2026-06-16 by Constructor Tech
-//! The plugin-facing backend-provider trait (DESIGN §3.4 / §3.7).
+//! Plugin-facing backend-provider traits (DESIGN §3.4 / §3.7).
 //!
-//! A cluster backend plugin implements [`ClusterCacheProvider`] to turn a set of
-//! operator-supplied options into a constructed cache backend plus a shutdown
-//! hook. The wiring crate (`cf-gears-cluster`) parses operator YAML, collects the
-//! providers into a registry, and calls [`build_cache`](ClusterCacheProvider::build_cache)
-//! per profile — letting the omit-default auto-wrap supply the other three
-//! primitives over the returned cache.
+//! A plugin implements one or more of these traits to turn operator-supplied
+//! config options into a running backend plus a shutdown hook. The wiring crate
+//! (`cf-gears-cluster`) collects providers into a [`ProviderRegistry`] and
+//! dispatches each profile's per-primitive binding against it.
 //!
-//! This trait lives in the SDK, alongside the backend traits and the
-//! [`ClusterPluginSpecV1`](crate::ClusterPluginSpecV1) discovery spec, so a plugin
-//! implements it while depending on the SDK only — never on the wiring crate. The
-//! provider receives its options as a raw serde map; the typed operator YAML
-//! schema (`BackendBinding`) is owned by the wiring crate, keeping the SDK free of
-//! the config schema.
+//! All four provider traits live in the SDK so plugins implement them while
+//! depending only on `cluster-sdk`, never on the wiring crate. Options arrive as
+//! a raw `serde_json::Map` (the wiring strips the framing `provider` and
+//! `secret_ref` keys before the call), keeping the SDK free of any config schema.
 //!
-//! Only the cache anchor is provider-instantiated today. Native leader-election /
-//! lock / service-discovery providers are a follow-up that adds sibling `build_*`
-//! methods.
+//! **Omit-default shorthand**: a profile that omits a primitive gets the SDK
+//! default backend over the cache (`CasBasedLeaderElectionBackend`,
+//! `CasBasedDistributedLockBackend`, `CacheBasedServiceDiscoveryBackend`). An
+//! explicit binding always wins.
+//!
+//! **Non-cache providers do not receive the cache backend.** If a plugin natively
+//! implements leader election (e.g. K8s Lease) it builds that backend from its own
+//! options; it does not need the cache. The wiring layer provides the cache only to
+//! the SDK-default auto-wrap path, not to native providers.
 
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use async_trait::async_trait;
+
 use crate::cache::ClusterCacheBackend;
+use crate::discovery::ServiceDiscoveryBackend;
 use crate::error::ClusterError;
+use crate::leader::LeaderElectionBackend;
+use crate::lock::DistributedLockBackend;
 
 /// A boxed, owned shutdown action for a started backend. The cluster handle owns
 /// it and awaits it once during shutdown — typically a plugin handle's `stop()`.
 pub type StopHook = Box<dyn FnOnce() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send>;
 
-/// Builds the cache backend for one provider, owning the lifecycle of whatever
-/// background work that backend needs (e.g. a TTL sweeper or renewal loop).
+/// Builds the cache backend for one provider.
 ///
-/// Implementors live in the backend plugin crates and depend on the SDK only. The
-/// wiring crate registers them into a provider registry and dispatches on the
-/// operator config's `provider` string.
+/// The cache backend is the foundational primitive; the wiring auto-wraps it with
+/// the SDK-default leader-election, lock, and service-discovery backends for any
+/// primitive the operator leaves unbound.
+///
+/// # Options contract
+/// `options` is the flattened, provider-specific subset of one operator backend
+/// binding. Keys evolve additively — new keys are optional with backward-compatible
+/// defaults. An empty map means "all defaults".
+///
+/// # Errors
+/// Returns [`ClusterError::InvalidConfig`] if `options` are invalid for this
+/// provider, or propagates any startup error.
+///
+/// # Async
+/// Building a backend is inherently async for most providers (opening a
+/// connection pool, running migrations, establishing a subscribe/watch
+/// connection) — Postgres, Redis, NATS, and etcd all need it. The trait is
+/// `#[async_trait]` so plugins can `.await` that setup directly instead of
+/// deferring it behind a readiness gate or a background task. The wiring
+/// crate (`cf-gears-cluster`) calls providers from an already-`async fn`
+/// context (`RunnableCapability::start`), so this never needs `block_on`.
+#[async_trait]
 pub trait ClusterCacheProvider: Send + Sync {
-    /// The provider name this builds for, matched against the operator config's
-    /// `provider` field. Must be stable and unique within a registry.
+    /// The stable provider name matched against the operator config's `provider`
+    /// field. Must be unique within a registry.
     fn provider(&self) -> &'static str;
 
-    /// Builds the cache backend from `options` (the provider-specific keys from
-    /// the operator config) and returns it alongside a hook that stops the
-    /// backend's background work.
-    ///
-    /// # Options contract
-    /// `options` is the flattened, provider-specific subset of one operator
-    /// backend binding (the wiring strips the framing keys like `provider` before
-    /// the call). It is intentionally an untyped `serde_json::Map` so the SDK
-    /// stays free of any provider's config schema: each provider owns its own key
-    /// set and deserializes `options` into its typed config (rejecting unknown
-    /// keys). To preserve the stable plugin contract, that key set must evolve
-    /// additively — new keys are optional with backward-compatible defaults, so a
-    /// binding written for an older provider build still deserializes. An empty
-    /// map means "all defaults".
+    /// Builds and starts the cache backend. Returns the backend and a hook that
+    /// stops any background work (sweeper, renewal loop, connection pool).
     ///
     /// # Errors
-    /// Returns [`ClusterError::InvalidConfig`] if `options` are invalid for this
-    /// provider, or propagates any startup error from the backend.
-    fn build_cache(
+    /// Returns [`ClusterError::InvalidConfig`] if `options` are invalid.
+    async fn build_cache(
         &self,
         options: &serde_json::Map<String, serde_json::Value>,
     ) -> Result<(Arc<dyn ClusterCacheBackend>, StopHook), ClusterError>;
+}
+
+/// Builds a native leader-election backend for one provider.
+///
+/// Implement this for plugins whose backend has a purpose-built leader-election
+/// primitive (e.g. K8s Lease API, etcd election API). Plugins that only implement
+/// cache leave leader election to the SDK default (`CasBasedLeaderElectionBackend`
+/// over their cache).
+///
+/// # Errors
+/// Returns [`ClusterError::InvalidConfig`] if `options` are invalid.
+#[async_trait]
+pub trait ClusterLeaderElectionProvider: Send + Sync {
+    /// The stable provider name matched against the operator config's `provider`
+    /// field for the `leader_election` primitive binding.
+    fn provider(&self) -> &'static str;
+
+    /// Builds and starts the leader-election backend.
+    ///
+    /// # Errors
+    /// Returns [`ClusterError::InvalidConfig`] if `options` are invalid.
+    async fn build_leader_election(
+        &self,
+        options: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<(Arc<dyn LeaderElectionBackend>, StopHook), ClusterError>;
+}
+
+/// Builds a native distributed-lock backend for one provider.
+///
+/// Implement this for plugins whose backend has a purpose-built locking primitive
+/// (e.g. `pg_advisory_lock`, etcd lock API, Redis `SET NX EX`). Plugins that only
+/// implement cache leave locking to the SDK default (`CasBasedDistributedLockBackend`
+/// over their cache).
+///
+/// # Errors
+/// Returns [`ClusterError::InvalidConfig`] if `options` are invalid.
+#[async_trait]
+pub trait ClusterLockProvider: Send + Sync {
+    /// The stable provider name matched against the operator config's `provider`
+    /// field for the `lock` primitive binding.
+    fn provider(&self) -> &'static str;
+
+    /// Builds and starts the distributed-lock backend.
+    ///
+    /// # Errors
+    /// Returns [`ClusterError::InvalidConfig`] if `options` are invalid.
+    async fn build_lock(
+        &self,
+        options: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<(Arc<dyn DistributedLockBackend>, StopHook), ClusterError>;
+}
+
+/// Builds a native service-discovery backend for one provider.
+///
+/// Implement this for plugins whose backend has a purpose-built service-discovery
+/// primitive (e.g. K8s Lease-per-instance). Plugins that only implement cache
+/// leave service discovery to the SDK default (`CacheBasedServiceDiscoveryBackend`
+/// over their cache).
+///
+/// # Errors
+/// Returns [`ClusterError::InvalidConfig`] if `options` are invalid.
+#[async_trait]
+pub trait ClusterServiceDiscoveryProvider: Send + Sync {
+    /// The stable provider name matched against the operator config's `provider`
+    /// field for the `service_discovery` primitive binding.
+    fn provider(&self) -> &'static str;
+
+    /// Builds and starts the service-discovery backend.
+    ///
+    /// # Errors
+    /// Returns [`ClusterError::InvalidConfig`] if `options` are invalid.
+    async fn build_service_discovery(
+        &self,
+        options: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<(Arc<dyn ServiceDiscoveryBackend>, StopHook), ClusterError>;
 }

--- a/gears/system/cluster/cluster/Cargo.toml
+++ b/gears/system/cluster/cluster/Cargo.toml
@@ -6,9 +6,11 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-description = "Cluster gear: wiring, lifecycle, and SDK-default backend implementations for the cluster coordination primitives"
+description = "The cluster gear: a RunnableCapability that reads operator config, registers per-profile, per-primitive coordination backends in the ClientHub, and owns the cluster lifecycle. Also exposes the wiring builder/handle as embeddable library API."
+readme = "README.md"
 keywords = ["constructorfabric", "cf-gears"]
 categories = ["development-tools"]
+metadata.docs.rs.all-features = true
 
 [lib]
 name = "cluster"
@@ -17,18 +19,25 @@ name = "cluster"
 workspace = true
 
 [dependencies]
-cf-gears-cluster-sdk = { workspace = true }
-async-trait = { workspace = true }
-tokio = { workspace = true }
-tokio-util = { workspace = true }
+cluster-sdk = { workspace = true }
+toolkit = { workspace = true }
 tracing = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
+tokio-util = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 rand = { workspace = true }
+cf-gears-standalone-cluster-plugin = { path = "../plugins/standalone-cluster-plugin" }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["test-util"] }
+tokio = { workspace = true, features = ["rt", "macros", "test-util"] }
+serde-saphyr = { workspace = true }
+uuid = { workspace = true }
 tracing-test = { workspace = true }
-toolkit = { workspace = true }
+parking_lot = { workspace = true }
 # The shared backend-agnostic conformance suite, run against this gear's real
 # cache-derived default backends in `tests/conformance.rs`.
 cf-gears-cluster-conformance = { workspace = true }

--- a/gears/system/cluster/cluster/README.md
+++ b/gears/system/cluster/cluster/README.md
@@ -1,0 +1,74 @@
+# Cluster wiring
+
+`cf-gears-cluster` (lib `cluster`) is the wiring crate for the cluster gear
+(DESIGN §3.4 / §3.7, component `cpt-cf-clst-component-wiring`). It registers the
+per-profile, per-primitive coordination backends produced by cluster plugins
+into the `ClientHub` — under the `cluster:{profile}` scope the SDK resolvers look
+them up in — and owns the cluster lifecycle.
+
+The crate plays two roles (DESIGN §3.7, as amended): it **is** the `cluster`
+gear — a ToolKit `RunnableCapability` whose `start` builds the wiring from
+operator config (`ClusterConfig` / `ClusterWiring::from_config`) and whose
+`stop` tears it down — and it also exposes the underlying outbox-style
+builder/handle pair as a `pub` library, so a consumer gear may embed the wiring
+directly instead of depending on the `cluster` gear. Either way, a single
+`RunnableCapability` owns the resulting `ClusterHandle` from its own
+`start`/`stop`:
+
+```rust,no_run
+use cluster::{ClusterWiring, ProfileBackends};
+use cluster_sdk::ClusterProfile;
+
+struct EventBroker;
+impl ClusterProfile for EventBroker {
+    const NAME: &'static str = "event-broker";
+}
+
+# async fn run(
+#     hub: std::sync::Arc<toolkit::client_hub::ClientHub>,
+#     cache: std::sync::Arc<dyn cluster_sdk::ClusterCacheBackend>,
+# ) -> Result<(), cluster_sdk::ClusterError> {
+let handle = ClusterWiring::builder(hub)
+    .profile(EventBroker, ProfileBackends::new(cache)) // omit-default: cache only
+    .build_and_start()?;
+
+// Consumers resolve the four primitives for `EventBroker` via the SDK resolvers.
+
+handle.stop().await; // deregisters all backends, then stops wired plugins
+# Ok(())
+# }
+```
+
+## Routing
+
+- **Per-primitive** — a profile may bind a different backend per primitive
+  (`ProfileBackends::new(cache).with_lock(..).with_leader_election(..)`),
+  realizing `cpt-cf-clst-fr-routing-per-primitive`.
+- **Omit-default** — any primitive left unbound is auto-filled with the SDK
+  default backend over the profile's cache
+  (`cpt-cf-clst-fr-routing-omit-default`).
+
+## Lifecycle
+
+`build_and_start` resolves all backends first (so a failure cannot leave a
+partially-registered hub), then registers them. `ClusterHandle::stop`
+deregisters every backend and runs the registered plugin shutdown hooks; no
+best-effort remote cleanup is attempted — TTL bounds remaining cluster resources
+(`cpt-cf-clst-fr-shutdown-ttl-cleanup`).
+
+## Status
+
+Backends can be wired two ways: programmatically via `ProfileBackends`
+(shown above), or from operator YAML via `ClusterConfig` and
+`ClusterWiring::from_config`, which parses each profile's per-primitive
+`provider` bindings, dispatches them against a `ProviderRegistry` of linked
+plugins, and lets the omit-default auto-wrap supply any primitive left
+unbound. The `cluster` gear (`gear.rs`) uses the YAML-driven path; the
+programmatic path remains available for a consumer gear that wants to embed
+the wiring directly. Today the only linked cache provider is the standalone
+in-process plugin (`cf-gears-standalone-cluster-plugin`); additional backend
+plugins (Postgres, Redis, K8s, NATS, etcd) are follow-up changes.
+
+## License
+
+Apache-2.0

--- a/gears/system/cluster/cluster/examples/capability_mismatch.rs
+++ b/gears/system/cluster/cluster/examples/capability_mismatch.rs
@@ -1,0 +1,94 @@
+//! Showcase: capability-mismatch startup failure and its resolution.
+//!
+//! A consumer declares the capabilities its workload needs at the resolution
+//! site. If the bound backend cannot meet a declared capability, resolution
+//! fails **at startup** — not at the first operation — with a
+//! [`ClusterError::CapabilityNotMet`] that names the primitive, the unmet
+//! capability, and the concrete provider. This turns a subtle runtime
+//! correctness bug into an obvious, immediate configuration error.
+//!
+//! The fix is operational: bind a backend that satisfies the requirement.
+//!
+//! Run with: `cargo run --example capability_mismatch`
+
+mod common;
+
+use cluster_sdk::ClusterCacheV1;
+use cluster_sdk::cache::CacheCapability;
+use cluster_sdk::error::ClusterError;
+use cluster_sdk::profile::ClusterProfile;
+use cluster_sdk::registration::register_cache_backend;
+use common::MemCacheBackend;
+use toolkit::client_hub::ClientHub;
+
+/// The profile whose cache must provide linearizable CAS.
+#[derive(Clone, Copy)]
+struct AppProfile;
+
+impl ClusterProfile for AppProfile {
+    const NAME: &'static str = "app";
+}
+
+#[tokio::main]
+async fn main() -> Result<(), ClusterError> {
+    show_mismatch();
+    show_resolution()?;
+    Ok(())
+}
+
+/// Bind an eventually-consistent cache, then require linearizable CAS — the
+/// requirement is unmet, so resolution fails at startup with a precise error.
+fn show_mismatch() {
+    let hub = ClientHub::new();
+    // A misconfiguration: an eventually-consistent backend bound where the
+    // workload needs linearizable CAS.
+    let registered = register_cache_backend(
+        &hub,
+        AppProfile::NAME,
+        MemCacheBackend::eventually_consistent(),
+    );
+    if registered.is_err() {
+        println!("[mismatch] unexpected registration failure");
+        return;
+    }
+
+    let outcome = ClusterCacheV1::resolver(&hub)
+        .profile(AppProfile)
+        .require(CacheCapability::Linearizable)
+        .resolve();
+
+    match outcome {
+        Ok(_) => println!("[mismatch] unexpectedly resolved against a weaker backend"),
+        Err(ClusterError::CapabilityNotMet {
+            primitive,
+            capability,
+            provider,
+        }) => {
+            // The error names exactly what to fix and where.
+            println!(
+                "[mismatch] startup failed: {primitive} requires capability \
+                 '{capability}', but the bound provider '{provider}' does not \
+                 declare it"
+            );
+            println!("[mismatch] fix: bind a backend whose consistency is linearizable");
+        }
+        Err(other) => println!("[mismatch] resolution failed with another error: {other}"),
+    }
+}
+
+/// The corrected binding: a linearizable backend meets the requirement, so the
+/// same resolution succeeds.
+fn show_resolution() -> Result<(), ClusterError> {
+    let hub = ClientHub::new();
+    register_cache_backend(&hub, AppProfile::NAME, MemCacheBackend::linearizable())?;
+
+    let cache = ClusterCacheV1::resolver(&hub)
+        .profile(AppProfile)
+        .require(CacheCapability::Linearizable)
+        .resolve()?;
+    println!(
+        "[resolved] cache resolved; linearizable requirement met (prefix_watch={})",
+        cache.features().prefix_watch
+    );
+    Ok(())
+}

--- a/gears/system/cluster/cluster/examples/common/mod.rs
+++ b/gears/system/cluster/cluster/examples/common/mod.rs
@@ -1,0 +1,432 @@
+//! Shared fixtures for the cluster-SDK showcase examples.
+//!
+//! # Fixture — NOT a production backend
+//!
+//! [`MemCacheBackend`] is a functional, single-process [`ClusterCacheBackend`]
+//! that lets every showcase example run with no external infrastructure (no
+//! Postgres/Redis/K8s). It mirrors the contract smoke-test stub
+//! (`tests/common`): one state map behind one mutex, one monotonic per-key
+//! version source, one ordered channel per watcher, and a background sweeper
+//! that expires TTL'd entries. It makes no attempt at the durability or
+//! partition tolerance a real backend needs — production backends ship as
+//! separate plugin crates (DECOMPOSITION out-of-scope follow-ups).
+//!
+//! [`register_cache_and_siblings`] shows the "implement cache only, get all four
+//! primitives" guarantee: it registers the cache plus the three default
+//! backends (`CasBased*` / `CacheBased*`) under one profile, exactly as this
+//! wiring crate does.
+//!
+//! This module lives under `examples/common/` (a subdirectory), so Cargo treats
+//! it as a shared module included via `mod common;` rather than as a standalone
+//! example binary.
+
+// Each example includes this module but exercises only the surface it needs, so
+// the unused remainder would otherwise trip `dead_code`.
+#![allow(
+    dead_code,
+    reason = "each example binary includes this module but uses only a subset of the fixture surface"
+)]
+
+use std::collections::HashMap;
+use std::sync::{Arc, Weak};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use cluster::defaults::{
+    CacheBasedServiceDiscoveryBackend, CasBasedDistributedLockBackend,
+    CasBasedLeaderElectionBackend,
+};
+use cluster_sdk::cache::{
+    CacheConsistency, CacheEntry, CacheEvent, CacheFeatures, CacheWatch, CacheWatchEvent,
+    CacheWatchSender, ClusterCacheBackend, PutRequest, Ttl,
+};
+use cluster_sdk::error::ClusterError;
+use cluster_sdk::registration::{
+    register_cache_backend, register_leader_election_backend, register_lock_backend,
+    register_service_discovery_backend,
+};
+use parking_lot::Mutex;
+use tokio::time::Instant;
+use toolkit::client_hub::ClientHub;
+
+/// How often the background sweeper scans for expired entries.
+const SWEEP_INTERVAL: Duration = Duration::from_millis(25);
+
+/// Per-watch in-flight buffer; generous so example workloads never drop events.
+const WATCH_CAPACITY: usize = 256;
+
+/// A stored value with its version and optional expiry deadline.
+struct Stored {
+    value: Vec<u8>,
+    version: u64,
+    expires_at: Option<Instant>,
+}
+
+impl Stored {
+    fn is_expired(&self, now: Instant) -> bool {
+        self.expires_at.is_some_and(|deadline| deadline <= now)
+    }
+
+    fn entry(&self) -> CacheEntry {
+        CacheEntry {
+            value: self.value.clone(),
+            version: self.version,
+        }
+    }
+}
+
+/// The subscription kind a watcher matches keys against.
+enum WatchKind {
+    Exact(String),
+    Prefix(String),
+}
+
+impl WatchKind {
+    fn matches(&self, key: &str) -> bool {
+        match self {
+            Self::Exact(exact) => exact == key,
+            Self::Prefix(prefix) => key.starts_with(prefix.as_str()),
+        }
+    }
+}
+
+/// One live watch subscription, identified so a failed send can prune it.
+struct Watcher {
+    id: u64,
+    kind: WatchKind,
+    sender: CacheWatchSender,
+}
+
+/// The fixture's locked interior: the state map, the monotonic watch-id source,
+/// and the live watchers.
+struct Inner {
+    map: HashMap<String, Stored>,
+    watchers: Vec<Watcher>,
+    next_watch_id: u64,
+}
+
+/// A functional in-memory cache backend for the showcase examples.
+///
+/// See the module docs: this is a fixture, not a production backend.
+pub struct MemCacheBackend {
+    inner: Mutex<Inner>,
+    consistency: CacheConsistency,
+    prefix_watch: bool,
+}
+
+impl MemCacheBackend {
+    /// A linearizable cache with native prefix-watch support — the common case
+    /// that satisfies the consistency-sensitive default backends.
+    #[must_use]
+    pub fn linearizable() -> Arc<Self> {
+        Self::spawn(CacheConsistency::Linearizable, true)
+    }
+
+    /// An eventually-consistent cache, used to show a capability mismatch
+    /// (`CacheCapability::Linearizable` unmet) and the default-backend guard.
+    #[must_use]
+    pub fn eventually_consistent() -> Arc<Self> {
+        Self::spawn(CacheConsistency::EventuallyConsistent, true)
+    }
+
+    /// A linearizable cache that declares no native prefix watch, so
+    /// `watch_prefix` is unsupported and the polling polyfill is needed.
+    #[must_use]
+    pub fn linearizable_without_prefix_watch() -> Arc<Self> {
+        Self::spawn(CacheConsistency::Linearizable, false)
+    }
+
+    fn spawn(consistency: CacheConsistency, prefix_watch: bool) -> Arc<Self> {
+        let cache = Arc::new(Self {
+            inner: Mutex::new(Inner {
+                map: HashMap::new(),
+                watchers: Vec::new(),
+                next_watch_id: 0,
+            }),
+            consistency,
+            prefix_watch,
+        });
+        // The sweeper holds only a weak reference, so it self-terminates once the
+        // example drops the cache.
+        let weak = Arc::downgrade(&cache);
+        tokio::spawn(sweep_loop(weak));
+        cache
+    }
+
+    /// Sends `event` to every watcher matching `key`, pruning any whose consumer
+    /// has dropped the watch. The guard is released before any `.await`.
+    async fn broadcast(&self, key: &str, event: &CacheEvent) {
+        let targets: Vec<(u64, CacheWatchSender)> = {
+            let guard = self.inner.lock();
+            guard
+                .watchers
+                .iter()
+                .filter(|watcher| watcher.kind.matches(key))
+                .map(|watcher| (watcher.id, watcher.sender.clone()))
+                .collect()
+        };
+        let mut dead = Vec::new();
+        for (id, sender) in targets {
+            if sender
+                .send(CacheWatchEvent::Event(event.clone()))
+                .await
+                .is_err()
+            {
+                dead.push(id);
+            }
+        }
+        if !dead.is_empty() {
+            self.inner
+                .lock()
+                .watchers
+                .retain(|watcher| !dead.contains(&watcher.id));
+        }
+    }
+
+    /// Removes every expired entry and emits an `Expired` event for each.
+    async fn sweep_expired(&self) {
+        let now = Instant::now();
+        let expired: Vec<String> = {
+            let mut guard = self.inner.lock();
+            let keys: Vec<String> = guard
+                .map
+                .iter()
+                .filter(|(_, stored)| stored.is_expired(now))
+                .map(|(key, _)| key.clone())
+                .collect();
+            for key in &keys {
+                guard.map.remove(key);
+            }
+            keys
+        };
+        for key in expired {
+            self.broadcast(&key, &CacheEvent::Expired { key: key.clone() })
+                .await;
+        }
+    }
+
+    fn register_watch(&self, kind: WatchKind) -> CacheWatch {
+        let (sender, watch) = CacheWatch::channel(WATCH_CAPACITY);
+        let mut guard = self.inner.lock();
+        let id = guard.next_watch_id;
+        guard.next_watch_id += 1;
+        guard.watchers.push(Watcher { id, kind, sender });
+        watch
+    }
+}
+
+/// The detached sweeper driving TTL expiry; exits once the cache is dropped.
+async fn sweep_loop(weak: Weak<MemCacheBackend>) {
+    let mut ticker = tokio::time::interval(SWEEP_INTERVAL);
+    loop {
+        ticker.tick().await;
+        let Some(cache) = weak.upgrade() else {
+            return;
+        };
+        cache.sweep_expired().await;
+    }
+}
+
+#[async_trait]
+impl ClusterCacheBackend for MemCacheBackend {
+    fn consistency(&self) -> CacheConsistency {
+        self.consistency
+    }
+
+    fn features(&self) -> CacheFeatures {
+        CacheFeatures::new(self.prefix_watch)
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<CacheEntry>, ClusterError> {
+        let now = Instant::now();
+        let guard = self.inner.lock();
+        Ok(match guard.map.get(key) {
+            Some(stored) if !stored.is_expired(now) => Some(stored.entry()),
+            _ => None,
+        })
+    }
+
+    async fn put(&self, req: PutRequest<'_>) -> Result<(), ClusterError> {
+        let now = Instant::now();
+        let key = req.key;
+        {
+            let mut guard = self.inner.lock();
+            let version = match guard.map.get(key) {
+                Some(stored) if !stored.is_expired(now) => stored.version + 1,
+                _ => 1,
+            };
+            guard.map.insert(
+                key.to_owned(),
+                Stored {
+                    value: req.value.to_vec(),
+                    version,
+                    expires_at: req.ttl.as_duration().map(|d| now + d),
+                },
+            );
+        }
+        self.broadcast(
+            key,
+            &CacheEvent::Changed {
+                key: key.to_owned(),
+            },
+        )
+        .await;
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<bool, ClusterError> {
+        let now = Instant::now();
+        let was_live = {
+            let mut guard = self.inner.lock();
+            let live = matches!(guard.map.get(key), Some(stored) if !stored.is_expired(now));
+            guard.map.remove(key);
+            live
+        };
+        if was_live {
+            self.broadcast(
+                key,
+                &CacheEvent::Deleted {
+                    key: key.to_owned(),
+                },
+            )
+            .await;
+        }
+        Ok(was_live)
+    }
+
+    async fn contains(&self, key: &str) -> Result<bool, ClusterError> {
+        let now = Instant::now();
+        let guard = self.inner.lock();
+        Ok(matches!(guard.map.get(key), Some(stored) if !stored.is_expired(now)))
+    }
+
+    async fn put_if_absent(&self, req: PutRequest<'_>) -> Result<Option<CacheEntry>, ClusterError> {
+        let now = Instant::now();
+        let key = req.key;
+        let created = {
+            let mut guard = self.inner.lock();
+            if matches!(guard.map.get(key), Some(stored) if !stored.is_expired(now)) {
+                None
+            } else {
+                let stored = Stored {
+                    value: req.value.to_vec(),
+                    version: 1,
+                    expires_at: req.ttl.as_duration().map(|d| now + d),
+                };
+                let entry = stored.entry();
+                guard.map.insert(key.to_owned(), stored);
+                Some(entry)
+            }
+        };
+        if created.is_some() {
+            self.broadcast(
+                key,
+                &CacheEvent::Changed {
+                    key: key.to_owned(),
+                },
+            )
+            .await;
+        }
+        Ok(created)
+    }
+
+    async fn compare_and_swap(
+        &self,
+        key: &str,
+        expected_version: u64,
+        new_value: &[u8],
+        ttl: Ttl,
+    ) -> Result<CacheEntry, ClusterError> {
+        let now = Instant::now();
+        let outcome = {
+            let mut guard = self.inner.lock();
+            match guard.map.get(key) {
+                Some(stored) if !stored.is_expired(now) => {
+                    if stored.version == expected_version {
+                        let version = stored.version + 1;
+                        let stored = Stored {
+                            value: new_value.to_vec(),
+                            version,
+                            expires_at: ttl.as_duration().map(|d| now + d),
+                        };
+                        let entry = stored.entry();
+                        guard.map.insert(key.to_owned(), stored);
+                        Ok(entry)
+                    } else {
+                        Err(ClusterError::CasConflict {
+                            key: key.to_owned(),
+                            current: Some(stored.entry()),
+                        })
+                    }
+                }
+                _ => Err(ClusterError::CasConflict {
+                    key: key.to_owned(),
+                    current: None,
+                }),
+            }
+        };
+        if outcome.is_ok() {
+            self.broadcast(
+                key,
+                &CacheEvent::Changed {
+                    key: key.to_owned(),
+                },
+            )
+            .await;
+        }
+        outcome
+    }
+
+    async fn watch(&self, key: &str) -> Result<CacheWatch, ClusterError> {
+        Ok(self.register_watch(WatchKind::Exact(key.to_owned())))
+    }
+
+    async fn watch_prefix(&self, prefix: &str) -> Result<CacheWatch, ClusterError> {
+        if !self.prefix_watch {
+            return Err(ClusterError::Unsupported {
+                feature: "prefix_watch",
+            });
+        }
+        Ok(self.register_watch(WatchKind::Prefix(prefix.to_owned())))
+    }
+
+    async fn scan_prefix(&self, prefix: &str) -> Result<Vec<String>, ClusterError> {
+        let now = Instant::now();
+        let guard = self.inner.lock();
+        Ok(guard
+            .map
+            .iter()
+            .filter(|(key, stored)| key.starts_with(prefix) && !stored.is_expired(now))
+            .map(|(key, _)| key.clone())
+            .collect())
+    }
+}
+
+/// Registers a cache backend under `profile_name` together with the three SDK
+/// default backends derived from it — leader election, distributed lock, and
+/// service discovery — so all four primitives resolve against one cache.
+///
+/// This is exactly the "implement cache only, get all four primitives"
+/// composition the follow-up wiring crate performs from operator config.
+///
+/// # Errors
+/// Returns [`ClusterError::InvalidConfig`] if the consistency-sensitive default
+/// backends reject the cache's consistency class, or any registration error
+/// from the [`ClientHub`].
+pub fn register_cache_and_siblings(
+    hub: &ClientHub,
+    profile_name: &'static str,
+    cache: Arc<dyn ClusterCacheBackend>,
+) -> Result<(), ClusterError> {
+    // The two consistency-sensitive defaults reject an eventually-consistent
+    // cache via `new()`; over a linearizable cache they construct cleanly.
+    let leader = CasBasedLeaderElectionBackend::new(Arc::clone(&cache))?;
+    let lock = CasBasedDistributedLockBackend::new(Arc::clone(&cache))?;
+    let discovery = CacheBasedServiceDiscoveryBackend::new(Arc::clone(&cache));
+
+    register_cache_backend(hub, profile_name, cache)?;
+    register_leader_election_backend(hub, profile_name, Arc::new(leader))?;
+    register_lock_backend(hub, profile_name, Arc::new(lock))?;
+    register_service_discovery_backend(hub, profile_name, Arc::new(discovery))?;
+    Ok(())
+}

--- a/gears/system/cluster/cluster/examples/multi_primitive.rs
+++ b/gears/system/cluster/cluster/examples/multi_primitive.rs
@@ -1,0 +1,147 @@
+//! Showcase: multi-primitive usage over a single backend.
+//!
+//! One cache backend, bound under one profile, yields all four coordination
+//! primitives — cache, leader election, distributed lock, and service discovery
+//! — via the SDK default backends (`CasBased*` / `CacheBased*`). This is the
+//! "implement cache only, get all four primitives" guarantee in action.
+//!
+//! Run with: `cargo run --example multi_primitive`
+
+mod common;
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use cluster_sdk::cache::{PutRequest, Ttl};
+use cluster_sdk::discovery::{DiscoveryFilter, ServiceRegistration};
+use cluster_sdk::error::ClusterError;
+use cluster_sdk::leader::{LeaderStatus, LeaderWatch, LeaderWatchEvent};
+use cluster_sdk::profile::ClusterProfile;
+use cluster_sdk::{ClusterCacheV1, DistributedLockV1, LeaderElectionV1, ServiceDiscoveryV1};
+use common::{MemCacheBackend, register_cache_and_siblings};
+use toolkit::client_hub::ClientHub;
+
+/// The single profile all four primitives resolve under.
+#[derive(Clone, Copy)]
+struct AppProfile;
+
+impl ClusterProfile for AppProfile {
+    const NAME: &'static str = "app";
+}
+
+#[tokio::main]
+async fn main() -> Result<(), ClusterError> {
+    // Bind one cache plus its three derived default backends under the profile.
+    let hub = ClientHub::new();
+    register_cache_and_siblings(&hub, AppProfile::NAME, MemCacheBackend::linearizable())?;
+
+    cache_demo(&hub).await?;
+    leader_demo(&hub).await?;
+    lock_demo(&hub).await?;
+    discovery_demo(&hub).await?;
+    Ok(())
+}
+
+/// Shared state behind a versioned key.
+async fn cache_demo(hub: &ClientHub) -> Result<(), ClusterError> {
+    let cache = ClusterCacheV1::resolver(hub)
+        .profile(AppProfile)
+        .resolve()?;
+    cache
+        .put(PutRequest {
+            key: "epoch",
+            value: b"0",
+            ttl: Ttl::Indefinite,
+        })
+        .await?;
+    println!("[cache] stored epoch=0");
+    Ok(())
+}
+
+/// Single-leader election: one candidate enrolls and observes itself as leader.
+async fn leader_demo(hub: &ClientHub) -> Result<(), ClusterError> {
+    let leader = LeaderElectionV1::resolver(hub)
+        .profile(AppProfile)
+        .resolve()?;
+    let mut watch = leader.elect("scheduler").await?;
+    match first_status(&mut watch).await? {
+        LeaderStatus::Leader => println!("[leader] this node is the scheduler leader"),
+        LeaderStatus::Follower => println!("[leader] another node leads; this node follows"),
+        LeaderStatus::Lost => println!("[leader] leadership lost (transient)"),
+    }
+    // Step down gracefully so the claim is released promptly.
+    watch.resign().await?;
+    println!("[leader] resigned");
+    Ok(())
+}
+
+/// Awaits the watch's first leadership status, skipping non-status signals.
+/// Bounded by a timeout so the example never hangs if no status arrives.
+async fn first_status(watch: &mut LeaderWatch) -> Result<LeaderStatus, ClusterError> {
+    let deadline = Duration::from_secs(5);
+    let wait = async {
+        loop {
+            match watch.changed().await {
+                LeaderWatchEvent::Status(status) => return Ok(status),
+                LeaderWatchEvent::Closed(err) => return Err(err),
+                // Lagged / Reset: keep waiting for the next status.
+                _ => {}
+            }
+        }
+    };
+    match tokio::time::timeout(deadline, wait).await {
+        Ok(result) => result,
+        Err(_elapsed) => Err(ClusterError::InvalidConfig {
+            reason: "no leadership status within the demo deadline".to_owned(),
+        }),
+    }
+}
+
+/// TTL-bounded mutual exclusion: acquire, do local-only work, release.
+async fn lock_demo(hub: &ClientHub) -> Result<(), ClusterError> {
+    let lock = DistributedLockV1::resolver(hub)
+        .profile(AppProfile)
+        .resolve()?;
+    let guard = lock
+        .try_lock("rebuild-index", Duration::from_secs(30))
+        .await?;
+    println!("[lock] acquired '{}'", guard.name());
+    // Critical-section rule (ADR-002): no remote I/O while holding the guard —
+    // only local, bounded work belongs here.
+    guard.release().await?;
+    println!("[lock] released 'rebuild-index'");
+    Ok(())
+}
+
+/// Register an instance, discover it, then deregister via the handle.
+async fn discovery_demo(hub: &ClientHub) -> Result<(), ClusterError> {
+    let discovery = ServiceDiscoveryV1::resolver(hub)
+        .profile(AppProfile)
+        .resolve()?;
+
+    let mut metadata = HashMap::new();
+    metadata.insert("region".to_owned(), "us-east".to_owned());
+    let handle = discovery
+        .register(ServiceRegistration {
+            name: "api".to_owned(),
+            instance_id: None,
+            address: "10.0.0.1:8080".to_owned(),
+            metadata,
+        })
+        .await?;
+    println!("[discovery] registered instance {}", handle.instance_id());
+
+    let instances = discovery
+        .discover("api", DiscoveryFilter::default())
+        .await?;
+    for instance in &instances {
+        println!(
+            "[discovery] discovered {} at {}",
+            instance.instance_id, instance.address
+        );
+    }
+
+    handle.deregister().await?;
+    println!("[discovery] deregistered");
+    Ok(())
+}

--- a/gears/system/cluster/cluster/examples/multi_profile.rs
+++ b/gears/system/cluster/cluster/examples/multi_profile.rs
@@ -1,0 +1,109 @@
+//! Showcase: multi-profile usage.
+//!
+//! A single process can coordinate against more than one cluster by binding a
+//! distinct backend under each typed profile. Profiles are independent
+//! namespaces: each resolves its own backend with its own characteristics, and
+//! coordination state never crosses between them.
+//!
+//! Here a `primary` profile is backed by a linearizable cache (for
+//! correctness-sensitive coordination) and an `analytics` profile by an
+//! eventually-consistent cache (cheaper, best-effort). Each is resolved with the
+//! capabilities appropriate to its backend.
+//!
+//! Run with: `cargo run --example multi_profile`
+
+mod common;
+
+use cluster_sdk::ClusterCacheV1;
+use cluster_sdk::cache::{CacheCapability, CacheConsistency, PutRequest, Ttl};
+use cluster_sdk::error::ClusterError;
+use cluster_sdk::profile::ClusterProfile;
+use cluster_sdk::registration::register_cache_backend;
+use common::MemCacheBackend;
+use toolkit::client_hub::ClientHub;
+
+/// Correctness-sensitive coordination — bound to a linearizable backend.
+#[derive(Clone, Copy)]
+struct PrimaryProfile;
+
+impl ClusterProfile for PrimaryProfile {
+    const NAME: &'static str = "primary";
+}
+
+/// Best-effort analytics coordination — bound to an eventually-consistent
+/// backend that is cheaper but cannot promise linearizable CAS.
+#[derive(Clone, Copy)]
+struct AnalyticsProfile;
+
+impl ClusterProfile for AnalyticsProfile {
+    const NAME: &'static str = "analytics";
+}
+
+#[tokio::main]
+async fn main() -> Result<(), ClusterError> {
+    // Each profile binds its own, independent backend.
+    let hub = ClientHub::new();
+    register_cache_backend(&hub, PrimaryProfile::NAME, MemCacheBackend::linearizable())?;
+    register_cache_backend(
+        &hub,
+        AnalyticsProfile::NAME,
+        MemCacheBackend::eventually_consistent(),
+    )?;
+
+    // The primary profile requires linearizable CAS; the analytics profile does
+    // not, so it resolves against the weaker backend without a mismatch.
+    let primary = ClusterCacheV1::resolver(&hub)
+        .profile(PrimaryProfile)
+        .require(CacheCapability::Linearizable)
+        .resolve()?;
+    let analytics = ClusterCacheV1::resolver(&hub)
+        .profile(AnalyticsProfile)
+        .resolve()?;
+
+    // Write the same key in each profile; the namespaces are independent.
+    primary
+        .put(PutRequest {
+            key: "cursor",
+            value: b"primary-1",
+            ttl: Ttl::Indefinite,
+        })
+        .await?;
+    analytics
+        .put(PutRequest {
+            key: "cursor",
+            value: b"analytics-1",
+            ttl: Ttl::Indefinite,
+        })
+        .await?;
+
+    // Each profile observes only its own value — no cross-talk.
+    print_cursor("primary", &primary).await?;
+    print_cursor("analytics", &analytics).await?;
+
+    println!(
+        "primary consistency={}, analytics consistency={}",
+        consistency_label(&primary),
+        consistency_label(&analytics)
+    );
+    Ok(())
+}
+
+/// A human-readable label for a cache's declared consistency class.
+fn consistency_label(cache: &ClusterCacheV1) -> &'static str {
+    match cache.consistency() {
+        CacheConsistency::Linearizable => "linearizable",
+        CacheConsistency::EventuallyConsistent => "eventually-consistent",
+        // `CacheConsistency` is `#[non_exhaustive]`; tolerate future classes.
+        _ => "other",
+    }
+}
+
+/// Reads and prints the `cursor` key for a resolved profile cache.
+async fn print_cursor(label: &str, cache: &ClusterCacheV1) -> Result<(), ClusterError> {
+    let value = cache.get("cursor").await?.map_or_else(
+        || "<absent>".to_owned(),
+        |entry| String::from_utf8_lossy(&entry.value).into_owned(),
+    );
+    println!("[{label}] cursor = {value}");
+    Ok(())
+}

--- a/gears/system/cluster/cluster/examples/observability.rs
+++ b/gears/system/cluster/cluster/examples/observability.rs
@@ -1,0 +1,392 @@
+//! Showcase: observability — emitting the metrics contract *and* custom metrics.
+//!
+//! Two things in one example:
+//!
+//! 1. **Wiring the contract.** The raw cache backend is wrapped in the SDK's
+//!    [`InstrumentedCache`] decorator, and the default lock / leader backends are
+//!    given a metrics sink via `with_observability`. Both carry the bounded
+//!    `provider` label (`"example"`). After this, every facade call emits the
+//!    contracted `cluster.*` spans and `cluster_*` metrics with no extra work at
+//!    the call sites — exactly what a plugin does (the standalone plugin wires
+//!    `OtelClusterMetrics` the same way).
+//!
+//! 2. **Custom, app-defined metrics.** The metrics *sink* is a
+//!    [`ClusterMetrics`] implementation the app owns. Because every contract
+//!    signal flows through it, the app can derive and emit its own metrics in the
+//!    same place — here `app_cache_writes_total`, `app_cas_conflicts_total`, and a
+//!    summed `app_cache_latency_seconds_sum`. These are NOT part of the cluster
+//!    contract (which is fixed/versioned, ADR-004); they live entirely in the
+//!    app's sink.
+//!
+//! The contract method set on [`ClusterMetrics`] is closed on purpose, so this is
+//! the supported way to *augment* contract events with extra signals. To emit a
+//! metric driven by genuinely app-specific logic (not a contract event), an app
+//! would stand up its own meter alongside — independent of this port.
+//!
+//! This example uses a custom in-memory sink (printed at the end) rather than the
+//! `otel` feature's `OtelClusterMetrics`, so it runs with no exporter wired.
+//!
+//! Run with: `cargo run --example observability`
+
+mod common;
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use parking_lot::Mutex;
+
+use cluster::defaults::{CasBasedDistributedLockBackend, CasBasedLeaderElectionBackend};
+use cluster_sdk::cache::{
+    CacheConsistency, CacheEntry, CacheFeatures, CacheWatch, CacheWatchEvent, PutRequest, Ttl,
+};
+use cluster_sdk::error::{ClusterError, ProviderErrorKind};
+use cluster_sdk::leader::{LeaderWatch, LeaderWatchEvent};
+use cluster_sdk::profile::ClusterProfile;
+use cluster_sdk::registration::{
+    register_cache_backend, register_leader_election_backend, register_lock_backend,
+};
+use cluster_sdk::{
+    ClusterCacheBackend, ClusterCacheV1, ClusterMetrics, DistributedLockV1, InstrumentedCache,
+    LeaderElectionV1, RetryPolicy,
+};
+use common::MemCacheBackend;
+use toolkit::client_hub::ClientHub;
+
+/// The bounded `provider` label for everything this app emits. A `&'static str`,
+/// as the SDK's observability seams require.
+const PROVIDER: &str = "example";
+
+/// The typed profile the backends are bound under.
+#[derive(Clone, Copy)]
+struct AppProfile;
+
+impl ClusterProfile for AppProfile {
+    const NAME: &'static str = "app";
+}
+
+/// A second profile for the watch auto-restart demo, bound to a deliberately
+/// flaky cache so its first subscription reconnects.
+#[derive(Clone, Copy)]
+struct WatchProfile;
+
+impl ClusterProfile for WatchProfile {
+    const NAME: &'static str = "watch-demo";
+}
+
+/// A [`ClusterMetrics`] sink the app owns. It records the cluster *contract*
+/// metrics and, in the same methods, derives a few *custom* app metrics from the
+/// contract events. A real deployment would back the contract side with
+/// `cluster_sdk::observability::otel::OtelClusterMetrics` (the `otel` feature)
+/// and keep its custom counters alongside; this in-memory version just tallies so
+/// the example can print them.
+#[derive(Default)]
+struct AppMetrics {
+    // --- contract metrics (the cluster catalog) ---
+    cache_ops: Mutex<BTreeMap<(String, String), u64>>,
+    lock_ops: Mutex<BTreeMap<(String, String), u64>>,
+    leader_transitions: Mutex<BTreeMap<String, u64>>,
+    watch_resets: Mutex<BTreeMap<String, u64>>,
+    // --- custom, app-defined metrics (NOT part of the contract) ---
+    /// Successful mutating cache operations.
+    cache_writes: Mutex<u64>,
+    /// Optimistic-concurrency conflicts observed (a useful business signal).
+    cas_conflicts: Mutex<u64>,
+    /// Summed cache-operation latency (a cheap stand-in for a histogram sum).
+    cache_latency_total_s: Mutex<f64>,
+}
+
+impl AppMetrics {
+    fn bump(map: &Mutex<BTreeMap<(String, String), u64>>, op: &str, result: &str) {
+        *map.lock()
+            .entry((op.to_owned(), result.to_owned()))
+            .or_default() += 1;
+    }
+
+    fn report(&self) {
+        println!("\n=== contract metrics (cluster catalog) ===");
+        for ((op, result), n) in self.cache_ops.lock().iter() {
+            println!(
+                "  cluster_cache_ops_total{{provider=\"{PROVIDER}\", op=\"{op}\", result=\"{result}\"}} = {n}"
+            );
+        }
+        for ((op, result), n) in self.lock_ops.lock().iter() {
+            println!(
+                "  cluster_lock_ops_total{{provider=\"{PROVIDER}\", op=\"{op}\", result=\"{result}\"}} = {n}"
+            );
+        }
+        for (transition, n) in self.leader_transitions.lock().iter() {
+            println!(
+                "  cluster_leader_transitions_total{{provider=\"{PROVIDER}\", transition=\"{transition}\"}} = {n}"
+            );
+        }
+        for (primitive, n) in self.watch_resets.lock().iter() {
+            println!(
+                "  cluster_watch_resets_total{{provider=\"{PROVIDER}\", primitive=\"{primitive}\"}} = {n}"
+            );
+        }
+
+        println!("\n=== custom app metrics (emitted through the same sink) ===");
+        println!("  app_cache_writes_total = {}", *self.cache_writes.lock());
+        println!("  app_cas_conflicts_total = {}", *self.cas_conflicts.lock());
+        println!(
+            "  app_cache_latency_seconds_sum = {:.6}",
+            *self.cache_latency_total_s.lock()
+        );
+    }
+}
+
+impl ClusterMetrics for AppMetrics {
+    fn cache_op(&self, op: &str, result: &str) {
+        // Contract metric.
+        Self::bump(&self.cache_ops, op, result);
+        // Custom metrics derived from the same contract event.
+        if result == "ok" && matches!(op, "put" | "put_if_absent" | "compare_and_swap" | "delete") {
+            *self.cache_writes.lock() += 1;
+        }
+        if result == "conflict" {
+            *self.cas_conflicts.lock() += 1;
+        }
+    }
+
+    fn cache_op_duration(&self, _op: &str, seconds: f64) {
+        // Contract metric is a histogram; here we keep a custom running sum.
+        *self.cache_latency_total_s.lock() += seconds;
+    }
+
+    fn lock_op(&self, op: &str, result: &str) {
+        Self::bump(&self.lock_ops, op, result);
+    }
+
+    fn lock_op_duration(&self, _op: &str, _seconds: f64) {}
+
+    fn leader_transition(&self, transition: &str) {
+        *self
+            .leader_transitions
+            .lock()
+            .entry(transition.to_owned())
+            .or_default() += 1;
+    }
+
+    fn discovery_op(&self, _op: &str, _result: &str) {}
+
+    fn watch_reset(&self, primitive: &str) {
+        *self
+            .watch_resets
+            .lock()
+            .entry(primitive.to_owned())
+            .or_default() += 1;
+    }
+
+    fn provider_error(&self, _kind: &str) {}
+}
+
+/// A cache wrapper whose **first** `watch` hands back a subscription that closes
+/// with a *retryable* error, so an `auto_restart`ed consumer reconnects once —
+/// driving the `cluster_watch_resets_total` / `cluster.watch.reset` signals.
+/// Every other call (including later `watch`es) delegates to the inner backend.
+/// A compact stand-in for a real backend's transient connection drop.
+struct FlakyWatchOnce {
+    inner: Arc<dyn ClusterCacheBackend>,
+    tripped: AtomicBool,
+}
+
+impl FlakyWatchOnce {
+    fn new(inner: Arc<dyn ClusterCacheBackend>) -> Self {
+        Self {
+            inner,
+            tripped: AtomicBool::new(false),
+        }
+    }
+}
+
+#[async_trait]
+impl ClusterCacheBackend for FlakyWatchOnce {
+    fn consistency(&self) -> CacheConsistency {
+        self.inner.consistency()
+    }
+    fn features(&self) -> CacheFeatures {
+        self.inner.features()
+    }
+    async fn get(&self, key: &str) -> Result<Option<CacheEntry>, ClusterError> {
+        self.inner.get(key).await
+    }
+    async fn put(&self, req: PutRequest<'_>) -> Result<(), ClusterError> {
+        self.inner.put(req).await
+    }
+    async fn delete(&self, key: &str) -> Result<bool, ClusterError> {
+        self.inner.delete(key).await
+    }
+    async fn contains(&self, key: &str) -> Result<bool, ClusterError> {
+        self.inner.contains(key).await
+    }
+    async fn put_if_absent(&self, req: PutRequest<'_>) -> Result<Option<CacheEntry>, ClusterError> {
+        self.inner.put_if_absent(req).await
+    }
+    async fn compare_and_swap(
+        &self,
+        key: &str,
+        expected_version: u64,
+        new_value: &[u8],
+        ttl: Ttl,
+    ) -> Result<CacheEntry, ClusterError> {
+        self.inner
+            .compare_and_swap(key, expected_version, new_value, ttl)
+            .await
+    }
+    async fn watch(&self, key: &str) -> Result<CacheWatch, ClusterError> {
+        if self.tripped.swap(true, Ordering::SeqCst) {
+            // Already tripped once — hand out a real subscription.
+            self.inner.watch(key).await
+        } else {
+            // First subscription: a retryable terminal close so the combinator
+            // reconnects (and the reset signals fire).
+            let (tx, watch) = CacheWatch::channel(8);
+            tx.send(CacheWatchEvent::Closed(ClusterError::Provider {
+                kind: ProviderErrorKind::ConnectionLost,
+                message: "demo: transient watch drop".to_owned(),
+            }))
+            .await
+            .ok();
+            Ok(watch)
+        }
+    }
+    async fn watch_prefix(&self, prefix: &str) -> Result<CacheWatch, ClusterError> {
+        self.inner.watch_prefix(prefix).await
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), ClusterError> {
+    let metrics = Arc::new(AppMetrics::default());
+    let hub = ClientHub::new();
+
+    // 1. Wrap the raw cache backend in the SDK's InstrumentedCache decorator,
+    //    routing its signals to our sink under the `example` provider label.
+    let raw: Arc<dyn ClusterCacheBackend> = MemCacheBackend::linearizable();
+    let cache_backend: Arc<dyn ClusterCacheBackend> =
+        Arc::new(InstrumentedCache::new(raw, PROVIDER, metrics.clone()));
+
+    // 2. Build the default lock + leader backends over the instrumented cache,
+    //    each given the same provider label and sink via with_observability. (The
+    //    discovery default is wired the same way; omitted here to keep it short.)
+    let leader = CasBasedLeaderElectionBackend::new(Arc::clone(&cache_backend))?
+        .with_observability(PROVIDER, metrics.clone());
+    let lock = CasBasedDistributedLockBackend::new(Arc::clone(&cache_backend))?
+        .with_observability(PROVIDER, metrics.clone());
+
+    register_cache_backend(&hub, AppProfile::NAME, Arc::clone(&cache_backend))?;
+    register_leader_election_backend(&hub, AppProfile::NAME, Arc::new(leader))?;
+    register_lock_backend(&hub, AppProfile::NAME, Arc::new(lock))?;
+
+    // ---- workload: consumers use the facades exactly as normal; emission is
+    //      entirely transparent to them. ----
+
+    let cache = ClusterCacheV1::resolver(&hub)
+        .profile(AppProfile)
+        .resolve()?;
+    cache
+        .put(PutRequest {
+            key: "config/region",
+            value: b"us-east",
+            ttl: Ttl::Indefinite,
+        })
+        .await?;
+    let _region = cache.get("config/region").await?;
+    let created = cache
+        .put_if_absent(PutRequest {
+            key: "counter",
+            value: b"1",
+            ttl: Ttl::Indefinite,
+        })
+        .await?
+        .ok_or_else(|| ClusterError::InvalidConfig {
+            reason: "counter unexpectedly already present".to_owned(),
+        })?;
+    cache
+        .compare_and_swap("counter", created.version, b"2", Ttl::Indefinite)
+        .await?;
+    // A deliberately stale compare-and-swap (the version moved on) — a normal
+    // `conflict` outcome that drives the custom `app_cas_conflicts_total`.
+    let _stale = cache
+        .compare_and_swap("counter", created.version, b"3", Ttl::Indefinite)
+        .await;
+    println!("[cache] ran put / get / put_if_absent / compare-and-swap (+1 conflict)");
+
+    let lock = DistributedLockV1::resolver(&hub)
+        .profile(AppProfile)
+        .resolve()?;
+    let guard = lock
+        .try_lock("rebuild-index", Duration::from_secs(30))
+        .await?;
+    // A second acquisition of the held lock is contended (a `contended` outcome).
+    let _contended = lock
+        .try_lock("rebuild-index", Duration::from_secs(30))
+        .await;
+    guard.release().await?;
+    println!("[lock] acquired + contended + released");
+
+    let leader = LeaderElectionV1::resolver(&hub)
+        .profile(AppProfile)
+        .resolve()?;
+    let mut watch = leader.elect("scheduler").await?;
+    // Drain the initial status (records the `acquired` transition), then resign
+    // (records `resigned`).
+    first_status(&mut watch).await?;
+    watch.resign().await?;
+    println!("[leader] elected + resigned");
+
+    // Watch auto-restart: a transient (retryable) close is absorbed by the
+    // combinator, which reconnects and emits `cluster_watch_resets_total` +
+    // `cluster.watch.reset`. The flaky cache lives under its own profile so the
+    // coordination above is unaffected.
+    let watch_cache: Arc<dyn ClusterCacheBackend> = Arc::new(InstrumentedCache::new(
+        Arc::new(FlakyWatchOnce::new(MemCacheBackend::linearizable())),
+        PROVIDER,
+        metrics.clone(),
+    ));
+    register_cache_backend(&hub, WatchProfile::NAME, watch_cache)?;
+    let cache = ClusterCacheV1::resolver(&hub)
+        .profile(WatchProfile)
+        .resolve()?;
+    // A fast policy so the demo doesn't wait the default 1s reconnect backoff.
+    let fast = RetryPolicy {
+        initial_backoff: Duration::from_millis(1),
+        max_backoff: Duration::from_millis(1),
+        jitter_factor: 0.0,
+        max_retries: None,
+    };
+    let mut restarting = cache.watch("topic").await?.auto_restart(fast);
+    if let Some(CacheWatchEvent::Reset) = restarting.recv().await {
+        println!("[watch] subscription auto-restarted after a transient close");
+    }
+
+    // The contract metrics and the custom app metrics, side by side. Note the
+    // cache counts include the lock/leader defaults' *internal* coordination
+    // traffic (they run over the instrumented cache): e.g. `put_if_absent` and
+    // `compare_and_delete` appear from lock acquisition and the leader's
+    // value-guarded release, not just the explicit consumer calls above.
+    metrics.report();
+    Ok(())
+}
+
+/// Awaits the watch's first leadership status, bounded by a timeout so the
+/// example never hangs.
+async fn first_status(watch: &mut LeaderWatch) -> Result<(), ClusterError> {
+    let wait = async {
+        loop {
+            match watch.changed().await {
+                LeaderWatchEvent::Status(_) => return Ok(()),
+                LeaderWatchEvent::Closed(err) => return Err(err),
+                _ => {}
+            }
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(5), wait)
+        .await
+        .map_err(|_elapsed| ClusterError::InvalidConfig {
+            reason: "no leadership status within the demo deadline".to_owned(),
+        })?
+}

--- a/gears/system/cluster/cluster/examples/plugin_author.rs
+++ b/gears/system/cluster/cluster/examples/plugin_author.rs
@@ -1,0 +1,263 @@
+//! Showcase: the plugin-author builder/handle shape (ADR-006).
+//!
+//! A backend plugin author writes two things and no framework integration code:
+//!
+//! 1. a **backend trait impl** for each primitive the plugin serves (here
+//!    [`ClusterCacheBackend`]); and
+//! 2. a **builder/handle pair** — `Plugin::builder()` produces a builder whose
+//!    `build_and_start()` spawns the plugin's background tasks (TTL reapers,
+//!    renewal loops, watch fan-out, …) and returns a handle. The handle's
+//!    `stop()` is the single release path; the parent host gear owns the handle
+//!    and calls `stop()` from its own shutdown.
+//!
+//! This example implements that shape against an in-memory store and a
+//! representative background maintenance task, then drives the full lifecycle:
+//! build → register in `ClientHub` → resolve & use → stop.
+//!
+//! Run with: `cargo run --example plugin_author`
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use cluster_sdk::cache::{
+    CacheConsistency, CacheEntry, CacheFeatures, CacheWatch, ClusterCacheBackend, ClusterCacheV1,
+    PutRequest, Ttl,
+};
+use cluster_sdk::error::ClusterError;
+use cluster_sdk::profile::ClusterProfile;
+use cluster_sdk::registration::{deregister_cache_backend, register_cache_backend};
+use common::MemCacheBackend;
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+use toolkit::client_hub::ClientHub;
+
+/// The profile the host binds this plugin's backend under.
+#[derive(Clone, Copy)]
+struct AppProfile;
+
+impl ClusterProfile for AppProfile {
+    const NAME: &'static str = "app";
+}
+
+// ---------------------------------------------------------------------------
+// 1. The backend trait impl.
+// ---------------------------------------------------------------------------
+
+/// The plugin's cache backend. A real plugin implements every method against its
+/// own store (Postgres rows, Redis keys, …); here it delegates to an in-memory
+/// store so the example stays self-contained. The point is the *shape*: a
+/// concrete `ClusterCacheBackend` the wiring crate registers as `Arc<dyn _>`.
+struct ExampleCacheBackend {
+    store: Arc<dyn ClusterCacheBackend>,
+}
+
+#[async_trait]
+impl ClusterCacheBackend for ExampleCacheBackend {
+    fn provider_name(&self) -> &'static str {
+        "ExampleCachePlugin"
+    }
+
+    fn consistency(&self) -> CacheConsistency {
+        self.store.consistency()
+    }
+
+    fn features(&self) -> CacheFeatures {
+        self.store.features()
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<CacheEntry>, ClusterError> {
+        self.store.get(key).await
+    }
+
+    async fn put(&self, req: PutRequest<'_>) -> Result<(), ClusterError> {
+        self.store.put(req).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<bool, ClusterError> {
+        self.store.delete(key).await
+    }
+
+    async fn contains(&self, key: &str) -> Result<bool, ClusterError> {
+        self.store.contains(key).await
+    }
+
+    async fn put_if_absent(&self, req: PutRequest<'_>) -> Result<Option<CacheEntry>, ClusterError> {
+        self.store.put_if_absent(req).await
+    }
+
+    async fn compare_and_swap(
+        &self,
+        key: &str,
+        expected_version: u64,
+        new_value: &[u8],
+        ttl: Ttl,
+    ) -> Result<CacheEntry, ClusterError> {
+        self.store
+            .compare_and_swap(key, expected_version, new_value, ttl)
+            .await
+    }
+
+    async fn watch(&self, key: &str) -> Result<CacheWatch, ClusterError> {
+        self.store.watch(key).await
+    }
+
+    async fn watch_prefix(&self, prefix: &str) -> Result<CacheWatch, ClusterError> {
+        self.store.watch_prefix(prefix).await
+    }
+
+    async fn scan_prefix(&self, prefix: &str) -> Result<Vec<String>, ClusterError> {
+        self.store.scan_prefix(prefix).await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. The builder / handle pair (ADR-006).
+// ---------------------------------------------------------------------------
+
+/// The plugin entry point. `ExampleClusterPlugin::builder()` is the only way in.
+struct ExampleClusterPlugin;
+
+impl ExampleClusterPlugin {
+    fn builder() -> ExampleClusterPluginBuilder {
+        ExampleClusterPluginBuilder {
+            maintenance_interval: Duration::from_millis(50),
+        }
+    }
+}
+
+/// Collects configuration, then `build_and_start()` brings the plugin up.
+struct ExampleClusterPluginBuilder {
+    maintenance_interval: Duration,
+}
+
+impl ExampleClusterPluginBuilder {
+    /// Tunes the background maintenance cadence (in a real plugin: TTL-reaper /
+    /// renewal interval).
+    fn maintenance_interval(mut self, interval: Duration) -> Self {
+        self.maintenance_interval = interval;
+        self
+    }
+
+    /// Builds the backend and starts the plugin's background tasks, returning the
+    /// handle that owns them.
+    ///
+    /// # Errors
+    /// Propagates any [`ClusterError`] from the plugin's startup probe.
+    async fn build_and_start(self) -> Result<ExampleClusterPluginHandle, ClusterError> {
+        let backend: Arc<dyn ClusterCacheBackend> = Arc::new(ExampleCacheBackend {
+            store: MemCacheBackend::linearizable(),
+        });
+
+        // A representative startup probe — a real plugin verifies connectivity
+        // to its store here before declaring itself started.
+        backend.contains("__plugin_health__").await?;
+
+        // Spawn the background maintenance task and keep a shutdown signal so
+        // `stop()` can wind it down gracefully.
+        let shutdown = Arc::new(Notify::new());
+        let task = spawn_maintenance(
+            Arc::clone(&backend),
+            self.maintenance_interval,
+            Arc::clone(&shutdown),
+        );
+
+        Ok(ExampleClusterPluginHandle {
+            backend,
+            shutdown,
+            task: Some(task),
+        })
+    }
+}
+
+/// Owns the plugin's running backend and background task. The host registers
+/// [`backend`](Self::backend) in `ClientHub` and calls [`stop`](Self::stop) at
+/// shutdown — the single release path.
+struct ExampleClusterPluginHandle {
+    backend: Arc<dyn ClusterCacheBackend>,
+    shutdown: Arc<Notify>,
+    task: Option<JoinHandle<()>>,
+}
+
+impl ExampleClusterPluginHandle {
+    /// The backend to register in `ClientHub` (`Arc<dyn _>`, per ADR-005).
+    fn backend(&self) -> Arc<dyn ClusterCacheBackend> {
+        Arc::clone(&self.backend)
+    }
+
+    /// Signals the background task to stop and waits for it to wind down.
+    async fn stop(mut self) {
+        self.shutdown.notify_one();
+        if let Some(task) = self.task.take()
+            && task.await.is_err()
+        {
+            println!("[plugin] maintenance task ended abnormally");
+        }
+        println!("[plugin] stopped");
+    }
+}
+
+/// The plugin's background task: a periodic maintenance pass that runs until the
+/// shutdown signal fires. Stands in for the TTL reapers / renewal loops real
+/// backends own.
+fn spawn_maintenance(
+    backend: Arc<dyn ClusterCacheBackend>,
+    interval: Duration,
+    shutdown: Arc<Notify>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        loop {
+            tokio::select! {
+                () = shutdown.notified() => break,
+                _ = ticker.tick() => {
+                    // A real reaper would expire stale entries here; we just touch
+                    // the keyspace to model periodic work. A gone store ends the loop.
+                    if backend.scan_prefix("").await.is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<(), ClusterError> {
+    // The host owns the plugin lifecycle via the builder/handle pair.
+    let handle = ExampleClusterPlugin::builder()
+        .maintenance_interval(Duration::from_millis(25))
+        .build_and_start()
+        .await?;
+    println!("[plugin] started");
+
+    // Wiring step: register the plugin's backend in ClientHub under the profile.
+    let hub = ClientHub::new();
+    register_cache_backend(&hub, AppProfile::NAME, handle.backend())?;
+
+    // Consumers resolve and use it exactly as in the other examples.
+    let cache = ClusterCacheV1::resolver(&hub)
+        .profile(AppProfile)
+        .resolve()?;
+    cache
+        .put(PutRequest {
+            key: "plugin/demo",
+            value: b"ok",
+            ttl: Ttl::Indefinite,
+        })
+        .await?;
+    if let Some(entry) = cache.get("plugin/demo").await? {
+        println!(
+            "[consumer] read plugin/demo = {} via provider",
+            String::from_utf8_lossy(&entry.value)
+        );
+    }
+
+    // Shutdown: deregister from ClientHub, then stop the plugin (single release
+    // path). After this, resolutions on the profile fail with ProfileNotBound.
+    deregister_cache_backend(&hub, AppProfile::NAME)?;
+    handle.stop().await;
+    Ok(())
+}

--- a/gears/system/cluster/cluster/examples/single_primitive.rs
+++ b/gears/system/cluster/cluster/examples/single_primitive.rs
@@ -1,0 +1,110 @@
+//! Showcase: single-primitive usage.
+//!
+//! The minimal consumer shape — bind one backend under a typed profile, resolve
+//! one primitive (the cache) with the capabilities the workload needs, and use
+//! it: versioned writes, atomic create, compare-and-swap, and a reactive watch.
+//!
+//! Run with: `cargo run --example single_primitive`
+
+mod common;
+
+use cluster_sdk::cache::{
+    CacheCapability, CacheConsistency, CacheEvent, CacheWatchEvent, ClusterCacheV1, PutRequest, Ttl,
+};
+use cluster_sdk::error::ClusterError;
+use cluster_sdk::profile::ClusterProfile;
+use cluster_sdk::registration::register_cache_backend;
+use common::MemCacheBackend;
+use toolkit::client_hub::ClientHub;
+
+/// The typed profile this app binds its cluster backend under. The marker
+/// removes magic-string profile names from resolution sites.
+#[derive(Clone, Copy)]
+struct AppProfile;
+
+impl ClusterProfile for AppProfile {
+    const NAME: &'static str = "app";
+}
+
+#[tokio::main]
+async fn main() -> Result<(), ClusterError> {
+    // 1. Bind a backend under the profile. In production the wiring crate does
+    //    this from operator config; here we register the in-memory fixture.
+    let hub = ClientHub::new();
+    register_cache_backend(&hub, AppProfile::NAME, MemCacheBackend::linearizable())?;
+
+    // 2. Resolve the cache, declaring the capabilities the workload requires.
+    //    Resolution fails fast (at startup) if the bound backend cannot meet them
+    //    — see the `capability_mismatch` example.
+    let cache = ClusterCacheV1::resolver(&hub)
+        .profile(AppProfile)
+        .require(CacheCapability::Linearizable)
+        .require(CacheCapability::PrefixWatch)
+        .resolve()?;
+    let consistency = match cache.consistency() {
+        CacheConsistency::Linearizable => "linearizable",
+        CacheConsistency::EventuallyConsistent => "eventually-consistent",
+        // `CacheConsistency` is `#[non_exhaustive]`; tolerate future classes.
+        _ => "other",
+    };
+    println!(
+        "resolved cache: consistency={consistency}, prefix_watch={}",
+        cache.features().prefix_watch
+    );
+
+    // 3. Versioned writes and reads.
+    cache
+        .put(PutRequest {
+            key: "config/region",
+            value: b"us-east",
+            ttl: Ttl::Indefinite,
+        })
+        .await?;
+    if let Some(entry) = cache.get("config/region").await? {
+        let value = String::from_utf8_lossy(&entry.value);
+        println!("config/region = {value} (version {})", entry.version);
+    }
+
+    // 4. Atomic create-if-absent, then a version-checked compare-and-swap — the
+    //    universal CAS building block every other primitive is built on.
+    let Some(created) = cache
+        .put_if_absent(PutRequest {
+            key: "counter",
+            value: b"1",
+            ttl: Ttl::Indefinite,
+        })
+        .await?
+    else {
+        return Err(ClusterError::InvalidConfig {
+            reason: "counter unexpectedly already present in a fresh cache".to_owned(),
+        });
+    };
+    let swapped = cache
+        .compare_and_swap("counter", created.version, b"2", Ttl::Indefinite)
+        .await?;
+    println!(
+        "counter advanced version {} -> {}",
+        created.version, swapped.version
+    );
+
+    // 5. A reactive watch: subscribe, then observe the next mutation as a
+    //    lightweight key-only event (the consumer re-reads the value via `get`).
+    let mut watch = cache.watch("config/region").await?;
+    cache
+        .put(PutRequest {
+            key: "config/region",
+            value: b"eu-west",
+            ttl: Ttl::Indefinite,
+        })
+        .await?;
+    if let Some(CacheWatchEvent::Event(CacheEvent::Changed { key })) = watch.recv().await {
+        let current = cache.get(&key).await?;
+        let value = current.map_or_else(
+            || "<deleted>".to_owned(),
+            |entry| String::from_utf8_lossy(&entry.value).into_owned(),
+        );
+        println!("watch observed change to {key}; current value = {value}");
+    }
+
+    Ok(())
+}

--- a/gears/system/cluster/cluster/src/config.rs
+++ b/gears/system/cluster/cluster/src/config.rs
@@ -1,0 +1,104 @@
+//! Operator YAML schema for the cluster gear (DESIGN §3.4 / §3.11).
+//!
+//! [`ClusterConfig`] is the operator-facing contract: a map of named profiles,
+//! each binding the four coordination primitives to a backend `provider`. The
+//! `cache` binding is the required anchor; the other three may be omitted to ride
+//! the SDK default backends over that profile's cache
+//! (`cpt-cf-clst-fr-routing-omit-default`), or bound to their own provider for
+//! per-primitive routing (`cpt-cf-clst-fr-routing-per-primitive`).
+//!
+//! These types are serde-deserializable (typically via `ctx.config()` in a host
+//! gear, fed by `serde-saphyr`). They live in the wiring crate, not the SDK — the
+//! SDK coordination contract stays serde-free per `cpt-cf-clst-constraint-no-serde`.
+//!
+//! Per-provider options are **flattened** into the backend binding and parsed by
+//! the provider itself (see [`crate::provider::ClusterCacheProvider`]), so adding
+//! a backend is a new crate plus config, not a schema change here.
+
+use serde::Deserialize;
+
+/// The whole cluster section of operator YAML: a set of named profiles.
+///
+/// ```yaml
+/// cluster:
+///   profiles:
+///     default:
+///       cache: { provider: standalone }
+///       # leader_election / lock / service_discovery omitted → SDK defaults
+/// ```
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClusterConfig {
+    /// Profile name → per-primitive backend bindings. Profile names must conform
+    /// to the cluster name rule (`[a-zA-Z0-9_-]+`); the wiring validates this at
+    /// registration time.
+    #[serde(default)]
+    pub profiles: std::collections::BTreeMap<String, ProfileConfig>,
+}
+
+/// The per-primitive backend bindings for one profile.
+///
+/// `cache` is required (it is the omit-default anchor). Each of the other three
+/// primitives may be bound to its own provider or omitted; an omitted primitive
+/// is auto-filled with the SDK default backend over this profile's cache.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProfileConfig {
+    /// The cache backend — required. Serves as the anchor the SDK default
+    /// leader-election, lock, and service-discovery backends wrap when those
+    /// primitives are omitted.
+    pub cache: BackendBinding,
+    /// An explicit leader-election backend. Omit to use the SDK default over the
+    /// cache.
+    #[serde(default)]
+    pub leader_election: Option<BackendBinding>,
+    /// An explicit distributed-lock backend. Omit to use the SDK default over the
+    /// cache.
+    #[serde(default)]
+    pub lock: Option<BackendBinding>,
+    /// An explicit service-discovery backend. Omit to use the SDK default over the
+    /// cache.
+    #[serde(default)]
+    pub service_discovery: Option<BackendBinding>,
+}
+
+/// One primitive's binding to a backend `provider`, plus that provider's own
+/// options (flattened) and an optional credential reference.
+///
+/// The known keys are `provider` and `secret_ref`; every other key is captured
+/// into [`options`](Self::options) verbatim for the provider to parse. This keeps
+/// the schema open: a new backend defines its own option keys without changing
+/// this struct.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BackendBinding {
+    /// The backend provider name, e.g. `standalone`, `postgres`, `redis`,
+    /// `k8s-lease`. Matched against the registered providers at wiring time; an
+    /// unknown provider fails startup with `ClusterError::InvalidConfig`.
+    pub provider: String,
+    /// A provisional, OPEN reference to the credential the backend uses to reach
+    /// its infrastructure (DESIGN §3 open question — credential wiring is deferred
+    /// to the OOP deployment design). Placeholder shape only; not a committed
+    /// contract. Ignored by the in-process standalone provider.
+    #[serde(default)]
+    pub secret_ref: Option<SecretRef>,
+    /// Provider-specific options captured verbatim (Design A: flattened options).
+    /// The provider deserializes the keys it understands from this map.
+    #[serde(flatten)]
+    pub options: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Provisional placeholder for a backend credential reference (DESIGN §3 open
+/// question, deferred to the OOP deployment design). The concrete resolution —
+/// credstore lookup, K8s service-account fallback, rotation — is intentionally
+/// unspecified here.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SecretRef {
+    /// An opaque name the future credential layer will resolve. Treated as an
+    /// opaque string for now.
+    pub name: String,
+}
+
+#[cfg(test)]
+#[path = "config_tests.rs"]
+mod config_tests;

--- a/gears/system/cluster/cluster/src/config_tests.rs
+++ b/gears/system/cluster/cluster/src/config_tests.rs
@@ -1,0 +1,177 @@
+//! Tests for the operator YAML schema and the config-driven wiring path, wired
+//! against the real [`StandaloneCacheProvider`] from the plugin crate — the same
+//! provider a host assembles into the registry in production.
+
+use std::sync::Arc;
+
+use cluster_sdk::{
+    CacheCapability, ClusterCacheV1, ClusterError, ClusterProfile, DistributedLockV1,
+    LeaderElectionV1, ServiceDiscoveryV1,
+};
+use standalone_cluster_plugin::StandaloneCacheProvider;
+use toolkit::client_hub::ClientHub;
+
+use crate::{ClusterConfig, ClusterWiring, ProviderRegistry};
+
+fn standalone_registry() -> ProviderRegistry {
+    ProviderRegistry::new().with_cache_provider(Arc::new(StandaloneCacheProvider))
+}
+
+// The profile the config fixtures name; matches the `event-broker` YAML key.
+#[derive(Clone, Copy)]
+struct EventBroker;
+impl ClusterProfile for EventBroker {
+    const NAME: &'static str = "event-broker";
+}
+
+#[test]
+fn parses_omit_default_profile() {
+    let yaml = "
+profiles:
+  event-broker:
+    cache: { provider: standalone }
+";
+    let cfg: ClusterConfig = serde_saphyr::from_str(yaml).expect("config parses");
+    let profile = cfg.profiles.get("event-broker").expect("profile present");
+    assert_eq!(profile.cache.provider, "standalone");
+    assert!(profile.cache.options.is_empty(), "no extra options");
+    assert!(profile.leader_election.is_none());
+    assert!(profile.lock.is_none());
+    assert!(profile.service_discovery.is_none());
+}
+
+#[test]
+fn parses_flattened_provider_options() {
+    let yaml = "
+profiles:
+  event-broker:
+    cache:
+      provider: standalone
+      sweep_interval_ms: 50
+";
+    let cfg: ClusterConfig = serde_saphyr::from_str(yaml).expect("config parses");
+    let cache = &cfg.profiles["event-broker"].cache;
+    assert_eq!(cache.provider, "standalone");
+    assert_eq!(
+        cache
+            .options
+            .get("sweep_interval_ms")
+            .and_then(serde_json::Value::as_u64),
+        Some(50),
+        "provider-specific option flows into the flattened options map"
+    );
+}
+
+#[test]
+fn unknown_top_level_key_is_rejected() {
+    // `deny_unknown_fields` on the profile catches operator typos.
+    let yaml = "
+profiles:
+  event-broker:
+    cache: { provider: standalone }
+    leeder_election: { provider: standalone }
+";
+    let parsed: Result<ClusterConfig, _> = serde_saphyr::from_str(yaml);
+    assert!(
+        parsed.is_err(),
+        "a misspelled primitive key must be rejected"
+    );
+}
+
+#[tokio::test]
+async fn from_config_wires_all_four_then_stop_unbinds() {
+    let yaml = "
+profiles:
+  event-broker:
+    cache: { provider: standalone }
+";
+    let cfg: ClusterConfig = serde_saphyr::from_str(yaml).expect("config parses");
+    let hub = Arc::new(ClientHub::new());
+
+    let handle = ClusterWiring::from_config(Arc::clone(&hub), &cfg, &standalone_registry())
+        .await
+        .expect("wiring starts from config");
+
+    assert!(
+        ClusterCacheV1::resolver(&hub)
+            .profile(EventBroker)
+            .require(CacheCapability::Linearizable)
+            .resolve()
+            .is_ok(),
+        "the configured cache resolves"
+    );
+    assert!(
+        LeaderElectionV1::resolver(&hub)
+            .profile(EventBroker)
+            .resolve()
+            .is_ok(),
+        "omit-default leader election resolves"
+    );
+    assert!(
+        DistributedLockV1::resolver(&hub)
+            .profile(EventBroker)
+            .resolve()
+            .is_ok(),
+        "omit-default lock resolves"
+    );
+    assert!(
+        ServiceDiscoveryV1::resolver(&hub)
+            .profile(EventBroker)
+            .resolve()
+            .is_ok(),
+        "omit-default service discovery resolves"
+    );
+
+    handle.stop().await;
+
+    assert!(matches!(
+        ClusterCacheV1::resolver(&hub)
+            .profile(EventBroker)
+            .resolve(),
+        Err(ClusterError::ProfileNotBound { .. })
+    ));
+}
+
+#[tokio::test]
+async fn from_config_unknown_provider_fails() {
+    let yaml = "
+profiles:
+  event-broker:
+    cache: { provider: redis }
+";
+    let cfg: ClusterConfig = serde_saphyr::from_str(yaml).expect("config parses");
+    let hub = Arc::new(ClientHub::new());
+
+    let result = ClusterWiring::from_config(Arc::clone(&hub), &cfg, &standalone_registry()).await;
+    assert!(
+        matches!(result, Err(ClusterError::InvalidConfig { .. })),
+        "an unregistered provider must fail startup"
+    );
+    // No partial registration leaks past the failure.
+    assert!(matches!(
+        ClusterCacheV1::resolver(&hub)
+            .profile(EventBroker)
+            .resolve(),
+        Err(ClusterError::ProfileNotBound { .. })
+    ));
+}
+
+#[tokio::test]
+async fn from_config_explicit_non_cache_binding_is_rejected() {
+    // Explicit non-cache bindings aren't constructible yet — fail loudly rather
+    // than silently ignore the operator's intent.
+    let yaml = "
+profiles:
+  event-broker:
+    cache: { provider: standalone }
+    leader_election: { provider: standalone }
+";
+    let cfg: ClusterConfig = serde_saphyr::from_str(yaml).expect("config parses");
+    let hub = Arc::new(ClientHub::new());
+
+    let result = ClusterWiring::from_config(Arc::clone(&hub), &cfg, &standalone_registry()).await;
+    assert!(
+        matches!(result, Err(ClusterError::InvalidConfig { .. })),
+        "an explicit non-cache binding must be rejected"
+    );
+}

--- a/gears/system/cluster/cluster/src/gear.rs
+++ b/gears/system/cluster/cluster/src/gear.rs
@@ -1,0 +1,113 @@
+//! The `cluster` gear — the `RunnableCapability` that owns the [`ClusterHandle`]
+//! across its lifecycle (DESIGN §3.7, as amended: the wiring library and the host
+//! gear are the same crate, matching the platform's one-gear-per-domain layout).
+//!
+//! `init` captures the hub and parses [`ClusterConfig`]; `start` assembles the
+//! provider registry, calls [`ClusterWiring::from_config`], and takes ownership of
+//! the resulting [`ClusterHandle`]; `stop` runs [`ClusterHandle::stop`] under the
+//! framework's shutdown deadline. The builder/handle and config types remain `pub`
+//! library surface (see crate root) so consumers may embed the wiring directly.
+
+use std::sync::{Arc, Mutex, OnceLock, PoisonError};
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use tokio_util::sync::CancellationToken;
+use toolkit::client_hub::ClientHub;
+use toolkit::contracts::RunnableCapability;
+use toolkit::{Gear, GearCtx};
+
+use crate::config::ClusterConfig;
+use crate::provider::ProviderRegistry;
+use crate::wiring::{ClusterHandle, ClusterWiring};
+
+#[toolkit::gear(name = "cluster", capabilities = [stateful])]
+struct ClusterGear {
+    /// Captured in `init` so `start` (which gets no `GearCtx`) can register
+    /// backends into it.
+    hub: OnceLock<Arc<ClientHub>>,
+    /// Parsed operator config, captured in `init` and consumed in `start`.
+    config: OnceLock<ClusterConfig>,
+    /// The running wiring, owned from `start` to `stop`.
+    handle: Mutex<Option<ClusterHandle>>,
+}
+
+impl Default for ClusterGear {
+    fn default() -> Self {
+        Self {
+            hub: OnceLock::new(),
+            config: OnceLock::new(),
+            handle: Mutex::new(None),
+        }
+    }
+}
+
+impl ClusterGear {
+    /// Assembles the provider registry from the backend plugins linked into this
+    /// build. Today only the in-process standalone provider; future plugins add a
+    /// `with_cache_provider` line here.
+    fn provider_registry() -> ProviderRegistry {
+        ProviderRegistry::new()
+            .with_cache_provider(Arc::new(standalone_cluster_plugin::StandaloneCacheProvider))
+    }
+}
+
+#[async_trait]
+impl Gear for ClusterGear {
+    async fn init(&self, ctx: &GearCtx) -> anyhow::Result<()> {
+        let config: ClusterConfig = ctx.config_or_default()?;
+        self.hub
+            .set(ctx.client_hub())
+            .map_err(|_| anyhow!("{} already initialized", Self::MODULE_NAME))?;
+        self.config
+            .set(config)
+            .map_err(|_| anyhow!("{} already initialized", Self::MODULE_NAME))?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl RunnableCapability for ClusterGear {
+    async fn start(&self, _cancel: CancellationToken) -> anyhow::Result<()> {
+        let hub = self.hub.get().ok_or_else(|| {
+            anyhow!(
+                "{}: hub not set — init must run before start",
+                Self::MODULE_NAME
+            )
+        })?;
+        let config = self.config.get().ok_or_else(|| {
+            anyhow!(
+                "{}: config not set — init must run before start",
+                Self::MODULE_NAME
+            )
+        })?;
+
+        // Backends (and their background tasks) come up here and are registered
+        // under `cluster:{profile}`; the handle owns each plugin's shutdown hook.
+        let handle =
+            ClusterWiring::from_config(Arc::clone(hub), config, &Self::provider_registry()).await?;
+        *self.handle.lock().unwrap_or_else(PoisonError::into_inner) = Some(handle);
+        Ok(())
+    }
+
+    async fn stop(&self, deadline: CancellationToken) -> anyhow::Result<()> {
+        // Take the handle out before awaiting so the lock isn't held across the
+        // shutdown await.
+        let handle = self
+            .handle
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .take();
+        if let Some(handle) = handle {
+            tokio::select! {
+                () = handle.stop() => {}           // graceful: deregister + compose plugin stops
+                () = deadline.cancelled() => {}    // framework deadline elapsed
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "gear_tests.rs"]
+mod gear_tests;

--- a/gears/system/cluster/cluster/src/gear_tests.rs
+++ b/gears/system/cluster/cluster/src/gear_tests.rs
@@ -1,0 +1,108 @@
+//! End-to-end lifecycle test for the `cluster` gear: drive `init` → `start` →
+//! `stop` through a mock `GearCtx` and assert backends register under the
+//! configured profile and unbind on stop.
+
+use std::sync::Arc;
+
+use cluster_sdk::{ClusterCacheV1, ClusterError, ClusterProfile};
+use tokio_util::sync::CancellationToken;
+use toolkit::client_hub::ClientHub;
+use toolkit::contracts::RunnableCapability;
+use toolkit::{ConfigProvider, Gear, GearCtx};
+
+use super::ClusterGear;
+
+/// Returns the `cluster` gear's config entry for `cluster`, and nothing else.
+struct MockConfig(serde_json::Value);
+
+impl ConfigProvider for MockConfig {
+    fn get_gear_config(&self, gear_name: &str) -> Option<&serde_json::Value> {
+        (gear_name == "cluster").then_some(&self.0)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct DefaultProfile;
+impl ClusterProfile for DefaultProfile {
+    const NAME: &'static str = "default";
+}
+
+#[tokio::test]
+async fn gear_lifecycle_registers_then_unbinds() {
+    let hub = Arc::new(ClientHub::default());
+    // The provider returns the gear entry; `ctx.config()` reads its `config` field.
+    let provider = Arc::new(MockConfig(serde_json::json!({
+        "config": { "profiles": { "default": { "cache": { "provider": "standalone" } } } }
+    })));
+    let ctx = GearCtx::new(
+        "cluster",
+        uuid::Uuid::new_v4(),
+        provider,
+        Arc::clone(&hub),
+        CancellationToken::new(),
+    );
+
+    let gear = ClusterGear::default();
+    gear.init(&ctx)
+        .await
+        .expect("init parses config and captures the hub");
+    gear.start(CancellationToken::new())
+        .await
+        .expect("start wires backends from config");
+
+    // The configured cache (and the omit-default trio over it) resolves.
+    assert!(
+        ClusterCacheV1::resolver(&hub)
+            .profile(DefaultProfile)
+            .resolve()
+            .is_ok(),
+        "the standalone cache is registered for the `default` profile"
+    );
+
+    gear.stop(CancellationToken::new())
+        .await
+        .expect("stop tears the wiring down");
+
+    assert!(
+        matches!(
+            ClusterCacheV1::resolver(&hub)
+                .profile(DefaultProfile)
+                .resolve(),
+            Err(ClusterError::ProfileNotBound { .. })
+        ),
+        "stop deregisters the profile's backends"
+    );
+}
+
+#[tokio::test]
+async fn gear_with_no_config_starts_empty() {
+    // No `cluster` entry → default (empty) config → start binds nothing, no panic.
+    let hub = Arc::new(ClientHub::default());
+    let provider = Arc::new(MockConfig(serde_json::json!({})));
+    let ctx = GearCtx::new(
+        "other-gear",
+        uuid::Uuid::new_v4(),
+        provider,
+        Arc::clone(&hub),
+        CancellationToken::new(),
+    );
+
+    let gear = ClusterGear::default();
+    gear.init(&ctx).await.expect("init");
+    gear.start(CancellationToken::new())
+        .await
+        .expect("start with empty config");
+
+    // No profile was bound — an empty config must not register anything.
+    assert!(
+        matches!(
+            ClusterCacheV1::resolver(&hub)
+                .profile(DefaultProfile)
+                .resolve(),
+            Err(ClusterError::ProfileNotBound { .. })
+        ),
+        "an empty config must bind no profile"
+    );
+
+    gear.stop(CancellationToken::new()).await.expect("stop");
+}

--- a/gears/system/cluster/cluster/src/lib.rs
+++ b/gears/system/cluster/cluster/src/lib.rs
@@ -1,16 +1,45 @@
 //! # Cluster gear
 //!
-//! `cluster` is the wiring and lifecycle crate for the cluster coordination
-//! gear. It owns the SDK-default backend implementations (leader election,
-//! distributed lock, service discovery over cache CAS) that the cluster gear
-//! wires up when an operator omits a primitive from their profile config.
+//! `cluster` (`cf-gears-cluster`) is the cluster gear (DESIGN §3.4 / §3.7,
+//! component `cpt-cf-clst-component-wiring`). It registers the per-profile,
+//! per-primitive coordination backends produced by cluster plugins into the
+//! `ClientHub` — under the stable `cluster:{profile}` scope the SDK resolvers look
+//! them up in — and owns the cluster lifecycle.
 //!
-//! Consumer gears never instantiate these backends directly — they resolve the
-//! cluster primitives via the per-primitive facade resolvers in `cluster-sdk`.
-//! Only the cluster gear's wiring layer (this crate) touches the default
-//! backend structs.
+//! The crate plays two roles, in line with the platform's one-gear-per-domain
+//! layout (`<gear>-sdk` + `<gear>` + plugins):
+//!
+//! 1. **The gear** — a `RunnableCapability` (`name = "cluster"`) whose `start`
+//!    builds the wiring from operator config and whose `stop` tears it down. See
+//!    the private `gear` module.
+//! 2. **An embeddable library** — [`ClusterWiring::builder`]`(hub).…build_and_start()
+//!    ->` [`ClusterHandle`] (and [`ClusterWiring::from_config`]) are `pub`, so a
+//!    consumer gear may own the wiring directly instead of depending on the
+//!    `cluster` gear. [`ClusterHandle::stop`] is the single shutdown entry point.
+//!
+//! DESIGN §3.7 originally specified the wiring as a non-gear library owned by a
+//! separate host gear (the outbox analogy). That was collapsed into this single
+//! gear crate — the builder/handle library still exists and is embeddable, but the
+//! reusable surface is `cluster-sdk`, so a dedicated wiring crate added a third
+//! core crate no other gear has. See DESIGN §3.7 (amended).
 
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
 
 pub mod defaults;
+
+mod config;
+mod gear;
+mod provider;
+mod wiring;
+
+pub use config::{BackendBinding, ClusterConfig, ProfileConfig, SecretRef};
+pub use provider::ProviderRegistry;
+pub use wiring::{ClusterHandle, ClusterWiring, ClusterWiringBuilder, ProfileBackends};
+
+// Re-exported for convenience: plugins implement these from the SDK, but the
+// config-driven wiring API surfaces them here too.
+pub use cluster_sdk::{
+    ClusterCacheProvider, ClusterLeaderElectionProvider, ClusterLockProvider,
+    ClusterServiceDiscoveryProvider, StopHook,
+};

--- a/gears/system/cluster/cluster/src/provider.rs
+++ b/gears/system/cluster/cluster/src/provider.rs
@@ -1,0 +1,98 @@
+//! The provider registry the config-driven wiring dispatches on.
+//!
+//! The four provider traits live in the SDK (so plugins implement them depending
+//! on `cluster-sdk` only). This registry is the wiring-side lookup: a host
+//! assembles it from the provider impls in the plugin crates it links, and
+//! [`ClusterWiring::from_config`](crate::ClusterWiring::from_config) resolves each
+//! profile's per-primitive `provider` string against it.
+//!
+//! A profile must bind a cache provider; the other three primitives may be left
+//! unbound (SDK default over the cache) or bound to their own provider. Each
+//! primitive's registry is independent — a K8s plugin can register only
+//! `ClusterLeaderElectionProvider` without a cache provider.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use cluster_sdk::{
+    ClusterCacheProvider, ClusterLeaderElectionProvider, ClusterLockProvider,
+    ClusterServiceDiscoveryProvider,
+};
+
+/// Name → provider lookup for all four primitives, assembled once at startup and
+/// passed to [`ClusterWiring::from_config`](crate::ClusterWiring::from_config).
+#[derive(Default)]
+pub struct ProviderRegistry {
+    cache: HashMap<&'static str, Arc<dyn ClusterCacheProvider>>,
+    leader_election: HashMap<&'static str, Arc<dyn ClusterLeaderElectionProvider>>,
+    lock: HashMap<&'static str, Arc<dyn ClusterLockProvider>>,
+    service_discovery: HashMap<&'static str, Arc<dyn ClusterServiceDiscoveryProvider>>,
+}
+
+impl ProviderRegistry {
+    /// An empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers a cache provider. A later registration for the same name
+    /// replaces the earlier one.
+    #[must_use]
+    pub fn with_cache_provider(mut self, provider: Arc<dyn ClusterCacheProvider>) -> Self {
+        self.cache.insert(provider.provider(), provider);
+        self
+    }
+
+    /// Registers a leader-election provider. A later registration for the same
+    /// name replaces the earlier one.
+    #[must_use]
+    pub fn with_leader_election_provider(
+        mut self,
+        provider: Arc<dyn ClusterLeaderElectionProvider>,
+    ) -> Self {
+        self.leader_election.insert(provider.provider(), provider);
+        self
+    }
+
+    /// Registers a distributed-lock provider. A later registration for the same
+    /// name replaces the earlier one.
+    #[must_use]
+    pub fn with_lock_provider(mut self, provider: Arc<dyn ClusterLockProvider>) -> Self {
+        self.lock.insert(provider.provider(), provider);
+        self
+    }
+
+    /// Registers a service-discovery provider. A later registration for the same
+    /// name replaces the earlier one.
+    #[must_use]
+    pub fn with_service_discovery_provider(
+        mut self,
+        provider: Arc<dyn ClusterServiceDiscoveryProvider>,
+    ) -> Self {
+        self.service_discovery.insert(provider.provider(), provider);
+        self
+    }
+
+    pub(crate) fn cache_provider(&self, name: &str) -> Option<&Arc<dyn ClusterCacheProvider>> {
+        self.cache.get(name)
+    }
+
+    pub(crate) fn leader_election_provider(
+        &self,
+        name: &str,
+    ) -> Option<&Arc<dyn ClusterLeaderElectionProvider>> {
+        self.leader_election.get(name)
+    }
+
+    pub(crate) fn lock_provider(&self, name: &str) -> Option<&Arc<dyn ClusterLockProvider>> {
+        self.lock.get(name)
+    }
+
+    pub(crate) fn service_discovery_provider(
+        &self,
+        name: &str,
+    ) -> Option<&Arc<dyn ClusterServiceDiscoveryProvider>> {
+        self.service_discovery.get(name)
+    }
+}

--- a/gears/system/cluster/cluster/src/wiring.rs
+++ b/gears/system/cluster/cluster/src/wiring.rs
@@ -1,0 +1,470 @@
+//! The cluster wiring builder, per-profile backend bindings, and lifecycle
+//! handle (DESIGN §3.7).
+
+use std::future::Future;
+use std::sync::Arc;
+
+use cluster_sdk::{
+    ClusterCacheBackend, ClusterError, ClusterProfile, DistributedLockBackend,
+    LeaderElectionBackend, ServiceDiscoveryBackend, StopHook, deregister_cache_backend,
+    deregister_leader_election_backend, deregister_lock_backend,
+    deregister_service_discovery_backend, register_cache_backend, register_leader_election_backend,
+    register_lock_backend, register_service_discovery_backend,
+};
+
+use crate::defaults::{
+    CacheBasedServiceDiscoveryBackend, CasBasedDistributedLockBackend,
+    CasBasedLeaderElectionBackend, ShutdownRevoke,
+};
+use toolkit::client_hub::ClientHub;
+
+use crate::config::{ClusterConfig, ProfileConfig};
+use crate::provider::ProviderRegistry;
+
+/// The per-primitive backend bindings for one profile.
+///
+/// `cache` is required; each of the other three primitives may be bound to its
+/// own backend (`cpt-cf-clst-fr-routing-per-primitive`) or left `None`, in which
+/// case [`ClusterWiringBuilder::build_and_start`] auto-fills it with the SDK
+/// default backend over `cache` (`cpt-cf-clst-fr-routing-omit-default`).
+pub struct ProfileBackends {
+    cache: Arc<dyn ClusterCacheBackend>,
+    leader_election: Option<Arc<dyn LeaderElectionBackend>>,
+    lock: Option<Arc<dyn DistributedLockBackend>>,
+    service_discovery: Option<Arc<dyn ServiceDiscoveryBackend>>,
+}
+
+impl ProfileBackends {
+    /// Binds a profile to `cache`, leaving the other three primitives to the SDK
+    /// defaults unless overridden with the `with_*` methods.
+    #[must_use]
+    pub fn new(cache: Arc<dyn ClusterCacheBackend>) -> Self {
+        Self {
+            cache,
+            leader_election: None,
+            lock: None,
+            service_discovery: None,
+        }
+    }
+
+    /// Binds a native leader-election backend, overriding the SDK default.
+    #[must_use]
+    pub fn with_leader_election(mut self, backend: Arc<dyn LeaderElectionBackend>) -> Self {
+        self.leader_election = Some(backend);
+        self
+    }
+
+    /// Binds a native distributed-lock backend, overriding the SDK default.
+    #[must_use]
+    pub fn with_lock(mut self, backend: Arc<dyn DistributedLockBackend>) -> Self {
+        self.lock = Some(backend);
+        self
+    }
+
+    /// Binds a native service-discovery backend, overriding the SDK default.
+    #[must_use]
+    pub fn with_service_discovery(mut self, backend: Arc<dyn ServiceDiscoveryBackend>) -> Self {
+        self.service_discovery = Some(backend);
+        self
+    }
+}
+
+/// The four resolved backends for one profile, ready to register.
+struct ResolvedProfile {
+    name: String,
+    cache: Arc<dyn ClusterCacheBackend>,
+    leader_election: Arc<dyn LeaderElectionBackend>,
+    lock: Arc<dyn DistributedLockBackend>,
+    service_discovery: Arc<dyn ServiceDiscoveryBackend>,
+}
+
+/// Entry point for wiring the cluster gear.
+pub struct ClusterWiring;
+
+impl ClusterWiring {
+    /// Returns a builder that registers backends into `hub`.
+    ///
+    /// `hub` is taken as a shared [`Arc`] (rather than a borrow) so the returned
+    /// [`ClusterHandle`] can outlive the call and deregister at
+    /// [`stop`](ClusterHandle::stop) time.
+    pub fn builder(hub: Arc<ClientHub>) -> ClusterWiringBuilder {
+        ClusterWiringBuilder {
+            hub,
+            profiles: Vec::new(),
+            stop_hooks: Vec::new(),
+        }
+    }
+
+    /// Builds the wiring from operator [`ClusterConfig`], instantiating each
+    /// profile's cache backend through the matching provider in `providers` and
+    /// letting the omit-default auto-wrap supply the other three primitives.
+    ///
+    /// Each provider's shutdown hook is owned by the returned [`ClusterHandle`]
+    /// and awaited on [`stop`](ClusterHandle::stop).
+    ///
+    /// # Errors
+    /// - [`ClusterError::InvalidConfig`] if a profile names an unregistered
+    ///   provider for any primitive, or if a provider rejects its options.
+    /// - Propagates [`ClusterError`] from provider construction, the SDK default
+    ///   backends (consistency guard), and backend registration (invalid name).
+    pub async fn from_config(
+        hub: Arc<ClientHub>,
+        config: &ClusterConfig,
+        providers: &ProviderRegistry,
+    ) -> Result<ClusterHandle, ClusterError> {
+        let mut builder = Self::builder(hub);
+        for (name, profile) in &config.profiles {
+            tracing::debug!(profile = %name, "wiring cluster profile from config");
+            let (cache, cache_stop) = build_cache_for_profile(name, profile, providers).await?;
+            // Pushed immediately, so it matches the cache's actual start-order
+            // position (first). `build_and_start` runs `stop_hooks` in reverse push
+            // order, so pushing here — before the leader/lock/sd hooks below — means
+            // the cache stops LAST, after every primitive layered on top of it for
+            // this profile (true reverse-start order, DESIGN §3.7).
+            builder = builder.on_stop(move || async move { cache_stop().await });
+
+            let mut backends = ProfileBackends::new(Arc::clone(&cache));
+
+            if let Some(binding) = &profile.leader_election {
+                let provider = providers
+                    .leader_election_provider(&binding.provider)
+                    .ok_or_else(|| ClusterError::InvalidConfig {
+                        reason: format!(
+                            "profile `{name}`: unknown leader_election provider `{}`",
+                            binding.provider
+                        ),
+                    })?;
+                let (backend, stop) = provider.build_leader_election(&binding.options).await?;
+                backends = backends.with_leader_election(backend);
+                builder = builder.on_stop(move || async move { stop().await });
+            }
+
+            if let Some(binding) = &profile.lock {
+                let provider = providers.lock_provider(&binding.provider).ok_or_else(|| {
+                    ClusterError::InvalidConfig {
+                        reason: format!(
+                            "profile `{name}`: unknown lock provider `{}`",
+                            binding.provider
+                        ),
+                    }
+                })?;
+                let (backend, stop) = provider.build_lock(&binding.options).await?;
+                backends = backends.with_lock(backend);
+                builder = builder.on_stop(move || async move { stop().await });
+            }
+
+            if let Some(binding) = &profile.service_discovery {
+                let provider = providers
+                    .service_discovery_provider(&binding.provider)
+                    .ok_or_else(|| ClusterError::InvalidConfig {
+                        reason: format!(
+                            "profile `{name}`: unknown service_discovery provider `{}`",
+                            binding.provider
+                        ),
+                    })?;
+                let (backend, stop) = provider.build_service_discovery(&binding.options).await?;
+                backends = backends.with_service_discovery(backend);
+                builder = builder.on_stop(move || async move { stop().await });
+            }
+
+            builder = builder.profile_named(name.clone(), backends);
+        }
+        builder.build_and_start()
+    }
+}
+
+async fn build_cache_for_profile(
+    name: &str,
+    profile: &ProfileConfig,
+    providers: &ProviderRegistry,
+) -> Result<(Arc<dyn ClusterCacheBackend>, StopHook), ClusterError> {
+    let provider = providers
+        .cache_provider(&profile.cache.provider)
+        .ok_or_else(|| ClusterError::InvalidConfig {
+            reason: format!(
+                "profile `{name}`: unknown cache provider `{}`",
+                profile.cache.provider
+            ),
+        })?;
+    provider.build_cache(&profile.cache.options).await
+}
+
+/// A fluent builder collecting per-profile backend bindings and plugin shutdown
+/// hooks. Finish with [`build_and_start`](Self::build_and_start).
+#[must_use = "a wiring builder registers nothing until `.build_and_start()` is called"]
+pub struct ClusterWiringBuilder {
+    hub: Arc<ClientHub>,
+    profiles: Vec<(String, ProfileBackends)>,
+    stop_hooks: Vec<StopHook>,
+}
+
+impl ClusterWiringBuilder {
+    /// Binds `backends` to the typed profile `P`. The marker is passed by value
+    /// (mirroring the SDK resolver builders' `profile(marker)`); only
+    /// [`ClusterProfile::NAME`] is read — the profile string is never re-typed at
+    /// this call site.
+    pub fn profile<P: ClusterProfile>(mut self, _marker: P, backends: ProfileBackends) -> Self {
+        self.profiles.push((P::NAME.to_owned(), backends));
+        self
+    }
+
+    /// Binds `backends` to a profile named at runtime — the config-driven path
+    /// ([`ClusterWiring::from_config`]) where the profile name comes from operator
+    /// YAML rather than a [`ClusterProfile`] marker. The name is validated against
+    /// the cluster name rule during [`build_and_start`](Self::build_and_start).
+    pub fn profile_named(mut self, name: impl Into<String>, backends: ProfileBackends) -> Self {
+        self.profiles.push((name.into(), backends));
+        self
+    }
+
+    /// Registers a shutdown action — typically a wired plugin handle's `stop()`
+    /// future — run once during [`ClusterHandle::stop`] after backends are
+    /// deregistered.
+    pub fn on_stop<F, Fut>(mut self, hook: F) -> Self
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.stop_hooks.push(Box::new(move || Box::pin(hook())));
+        self
+    }
+
+    /// Resolves every profile's four backends (auto-filling unbound primitives
+    /// with the SDK defaults) and registers them in the hub under
+    /// `cluster:{profile}`.
+    ///
+    /// Resolution happens before any hub mutation, so a failure to build a
+    /// default backend cannot leave a partially-registered hub.
+    ///
+    /// # Errors
+    /// - [`ClusterError::InvalidConfig`] if a default leader-election or lock
+    ///   backend is auto-filled over a non-linearizable cache (their consistency
+    ///   guard).
+    /// - [`ClusterError::InvalidName`] if a profile name violates the cluster
+    ///   name rule.
+    pub fn build_and_start(self) -> Result<ClusterHandle, ClusterError> {
+        // Phase 1 — resolve all backends (fallible) before touching the hub.
+        // Default leader-election, lock, and service-discovery backends the
+        // wiring itself creates expose a shutdown-revoke seam; collect them so
+        // `ClusterHandle::stop` can revoke in-flight coordination before shutdown
+        // completes (DESIGN §3.13). Native (explicitly-bound) backends are not
+        // revoked here — they manage shutdown through their own plugin stop hook.
+        let mut resolved = Vec::with_capacity(self.profiles.len());
+        let mut revokers: Vec<Arc<dyn ShutdownRevoke>> = Vec::new();
+        for (name, backends) in self.profiles {
+            resolved.push(resolve_profile_backends(name, backends, &mut revokers)?);
+        }
+
+        // Phase 2 — register every primitive under the profile scope. A failure
+        // partway (e.g. a later profile with an invalid name) must not leave
+        // earlier profiles half-registered, so roll back everything registered
+        // so far before propagating the error — the hub stays all-or-nothing.
+        let mut registered: Vec<String> = Vec::with_capacity(resolved.len());
+        for profile in resolved {
+            let name = register_profile_or_rollback(&self.hub, profile, &registered)?;
+            registered.push(name);
+        }
+
+        Ok(ClusterHandle {
+            hub: self.hub,
+            registered,
+            stop_hooks: self.stop_hooks,
+            revokers,
+            stopped: false,
+        })
+    }
+}
+
+/// Fills any primitive `backends` left unbound with its SDK default over
+/// `backends.cache`, collecting each default's shutdown-revoke seam into
+/// `revokers` (DESIGN §3.13). Explicitly-bound (native) primitives are passed
+/// through untouched.
+fn resolve_profile_backends(
+    name: String,
+    backends: ProfileBackends,
+    revokers: &mut Vec<Arc<dyn ShutdownRevoke>>,
+) -> Result<ResolvedProfile, ClusterError> {
+    let cache = backends.cache;
+    let leader_election: Arc<dyn LeaderElectionBackend> =
+        if let Some(backend) = backends.leader_election {
+            backend
+        } else {
+            let default = Arc::new(CasBasedLeaderElectionBackend::new(Arc::clone(&cache))?);
+            revokers.push(Arc::clone(&default) as Arc<dyn ShutdownRevoke + Send + Sync>);
+            default as Arc<dyn LeaderElectionBackend>
+        };
+    let lock: Arc<dyn DistributedLockBackend> = if let Some(backend) = backends.lock {
+        backend
+    } else {
+        let default = Arc::new(CasBasedDistributedLockBackend::new(Arc::clone(&cache))?);
+        revokers.push(Arc::clone(&default) as Arc<dyn ShutdownRevoke>);
+        default as Arc<dyn DistributedLockBackend>
+    };
+    let service_discovery: Arc<dyn ServiceDiscoveryBackend> =
+        if let Some(backend) = backends.service_discovery {
+            backend
+        } else {
+            let default = Arc::new(CacheBasedServiceDiscoveryBackend::new(Arc::clone(&cache)));
+            revokers.push(Arc::clone(&default) as Arc<dyn ShutdownRevoke>);
+            default as Arc<dyn ServiceDiscoveryBackend>
+        };
+    Ok(ResolvedProfile {
+        name,
+        cache,
+        leader_election,
+        lock,
+        service_discovery,
+    })
+}
+
+/// Registers `profile`'s four primitives in `hub`. On failure, deregisters
+/// `profile` itself and every name in `registered` so the hub stays
+/// all-or-nothing, logs a warning naming the failed profile and rollback
+/// count, and returns the error. On success, logs registration and returns the
+/// profile's name for the caller to add to `registered`.
+fn register_profile_or_rollback(
+    hub: &Arc<ClientHub>,
+    profile: ResolvedProfile,
+    registered: &[String],
+) -> Result<String, ClusterError> {
+    let result = (|| {
+        register_cache_backend(hub, &profile.name, profile.cache)?;
+        register_leader_election_backend(hub, &profile.name, profile.leader_election)?;
+        register_lock_backend(hub, &profile.name, profile.lock)?;
+        register_service_discovery_backend(hub, &profile.name, profile.service_discovery)
+    })();
+    let Err(err) = result else {
+        tracing::info!(profile = %profile.name, "cluster profile registered");
+        return Ok(profile.name);
+    };
+    tracing::warn!(
+        profile = %profile.name,
+        error = %err,
+        rolled_back = registered.len(),
+        "cluster profile registration failed; rolling back all registered profiles"
+    );
+    // Unwind the just-attempted profile and every prior one. Any primitive of
+    // `profile.name` that did register is removed too; deregister of an
+    // unregistered name is a harmless no-op.
+    deregister_profile(hub, &profile.name);
+    for name in registered {
+        deregister_profile(hub, name);
+    }
+    Err(err)
+}
+
+/// The running cluster wiring. Backends are registered in the hub; consumers
+/// resolve them with the SDK resolvers (e.g.
+/// `ClusterCacheV1::resolver(handle.hub())`). Owns the wired plugins' shutdown.
+pub struct ClusterHandle {
+    hub: Arc<ClientHub>,
+    registered: Vec<String>,
+    stop_hooks: Vec<StopHook>,
+    /// Shutdown-revoke seams for the wiring-created default leader-election,
+    /// lock, and service-discovery backends, revoked first on
+    /// [`stop`](ClusterHandle::stop).
+    revokers: Vec<Arc<dyn ShutdownRevoke>>,
+    /// Set by [`stop`](ClusterHandle::stop) so the [`Drop`] guard can tell a
+    /// graceful shutdown apart from a forgotten one (ADR-006 §Confirmation).
+    stopped: bool,
+}
+
+impl ClusterHandle {
+    /// The hub the backends are registered in, for consumers to resolve against.
+    #[must_use]
+    pub fn hub(&self) -> &Arc<ClientHub> {
+        &self.hub
+    }
+
+    /// The single shutdown entry point (DESIGN §3.7, §3.13).
+    ///
+    /// 1. **Revoke in-flight coordination first** (`cpt-cf-clst-fr-shutdown-revoke`):
+    ///    every wiring-created default backend is revoked — an active leader
+    ///    observes `Status(Lost)` then `Closed(Shutdown)`, an in-flight blocking
+    ///    `lock()` waiter returns `Err(Shutdown)`, and an active service-discovery
+    ///    watch observes `Closed(Shutdown)` — before this returns, so no consumer
+    ///    can resume believing it still holds coordination state.
+    /// 2. Deregister every registered backend — so later resolves report
+    ///    [`ClusterError::ProfileNotBound`].
+    /// 3. Run the plugin shutdown hooks in reverse-start order (DESIGN §3.7: last
+    ///    started is stopped first). The standalone plugin's stop hook closes
+    ///    active **cache** watches via the plugin's `StandaloneCache::shutdown`,
+    ///    so a cache-watch consumer observes `Closed(Shutdown)` one phase after the
+    ///    leader/lock/SD revocation — still within `stop()` (the chosen simplest
+    ///    path; the slight ordering is intentional).
+    ///
+    /// No best-effort remote cleanup is attempted; TTL bounds any remaining
+    /// cluster resources — held leader claims, locks, and service registrations
+    /// all lapse via their backend TTL (`cpt-cf-clst-fr-shutdown-ttl-cleanup`).
+    pub async fn stop(mut self) {
+        tracing::info!(
+            profiles = self.registered.len(),
+            "stopping cluster wiring: revoking in-flight coordination"
+        );
+        for revoker in &self.revokers {
+            revoker.revoke().await;
+        }
+        deregister_all(&self.hub, &self.registered);
+        // `mem::take` rather than `into_iter` because `ClusterHandle` now owns a
+        // `Drop` impl, and you cannot move a field out of a type that implements
+        // `Drop`. Draining the hooks in place leaves an empty `Vec` behind.
+        for hook in std::mem::take(&mut self.stop_hooks).into_iter().rev() {
+            hook().await;
+        }
+        // Graceful shutdown completed — tell the `Drop` guard not to fire.
+        self.stopped = true;
+        tracing::info!("cluster wiring stopped");
+    }
+}
+
+/// Deregisters every profile in `names`, logging each at `debug` (DESIGN §3.7).
+fn deregister_all(hub: &Arc<ClientHub>, names: &[String]) {
+    for name in names {
+        tracing::debug!(profile = %name, "deregistering cluster profile");
+        deregister_profile(hub, name);
+    }
+}
+
+/// Diagnostic guard (ADR-006 §Confirmation): a [`ClusterHandle`] must be released
+/// through [`stop`](ClusterHandle::stop). Dropping one without stopping leaks the
+/// wired plugins' background tasks (cache TTL sweepers, leader-renewal loops), so
+/// surface the bug loudly rather than silently — a debug-build panic, a
+/// release-build warn-log. The [`std::thread::panicking`] guard skips the debug
+/// panic during unwind so a forgotten handle dropped *while already panicking*
+/// degrades to a warning instead of a double-panic process abort (ADR-002).
+impl Drop for ClusterHandle {
+    fn drop(&mut self) {
+        if self.stopped {
+            return;
+        }
+        if std::thread::panicking() {
+            tracing::warn!(
+                "ClusterHandle dropped during panic unwind without stop(); \
+                 skipping debug panic to avoid double-panic abort"
+            );
+            return;
+        }
+        #[cfg(debug_assertions)]
+        panic!("ClusterHandle dropped without stop() - programming error");
+        #[cfg(not(debug_assertions))]
+        tracing::warn!(
+            "ClusterHandle dropped without stop() - programming error; \
+             background tasks may leak"
+        );
+    }
+}
+
+/// Deregisters all four primitives bound under `cluster:{name}`. Deregistration
+/// only fails on an invalid name, which cannot occur for a name that registered
+/// successfully, and deregistering an unbound primitive is a harmless no-op — so
+/// the presence reports are discarded.
+fn deregister_profile(hub: &Arc<ClientHub>, name: &str) {
+    deregister_cache_backend(hub, name).ok();
+    deregister_leader_election_backend(hub, name).ok();
+    deregister_lock_backend(hub, name).ok();
+    deregister_service_discovery_backend(hub, name).ok();
+}
+
+#[cfg(test)]
+#[path = "wiring_tests.rs"]
+mod wiring_tests;

--- a/gears/system/cluster/cluster/src/wiring_tests.rs
+++ b/gears/system/cluster/cluster/src/wiring_tests.rs
@@ -1,0 +1,441 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use cluster_sdk::{
+    CacheCapability, CacheWatchEvent, ClusterCacheV1, ClusterError, ClusterProfile,
+    DiscoveryFilter, DistributedLockBackend, DistributedLockV1, ElectionConfig,
+    LeaderElectionBackend, LeaderElectionFeatures, LeaderElectionV1, LeaderStatus, LeaderWatch,
+    LeaderWatchEvent, LockFeatures, LockGuard, ServiceDiscoveryBackend, ServiceDiscoveryFeatures,
+    ServiceDiscoveryV1, ServiceHandle, ServiceInstance, ServiceRegistration, ServiceWatch,
+    ServiceWatchEvent,
+};
+use standalone_cluster_plugin::StandaloneClusterPlugin;
+
+use crate::defaults::{
+    CacheBasedServiceDiscoveryBackend, CasBasedDistributedLockBackend,
+    CasBasedLeaderElectionBackend,
+};
+use toolkit::client_hub::ClientHub;
+use tracing_test::traced_test;
+
+use super::{ClusterWiring, ProfileBackends};
+
+#[derive(Clone, Copy)]
+struct EventBroker;
+impl ClusterProfile for EventBroker {
+    const NAME: &'static str = "event-broker";
+}
+
+#[tokio::test]
+async fn omit_default_registers_all_four_then_stop_unbinds() {
+    let hub = Arc::new(ClientHub::new());
+    let plugin = StandaloneClusterPlugin::builder()
+        .build_and_start()
+        .expect("plugin starts");
+    let cache = plugin.cache();
+
+    // Bind only the cache; the wiring auto-fills the other three with SDK defaults.
+    let handle = ClusterWiring::builder(Arc::clone(&hub))
+        .profile(EventBroker, ProfileBackends::new(cache))
+        .on_stop(move || async move { plugin.stop().await })
+        .build_and_start()
+        .expect("wiring starts");
+
+    assert!(
+        ClusterCacheV1::resolver(&hub)
+            .profile(EventBroker)
+            .require(CacheCapability::Linearizable)
+            .resolve()
+            .is_ok(),
+        "the bound linearizable cache resolves"
+    );
+    assert!(
+        LeaderElectionV1::resolver(&hub)
+            .profile(EventBroker)
+            .resolve()
+            .is_ok(),
+        "omit-default leader election resolves"
+    );
+    assert!(
+        DistributedLockV1::resolver(&hub)
+            .profile(EventBroker)
+            .resolve()
+            .is_ok(),
+        "omit-default lock resolves"
+    );
+    assert!(
+        ServiceDiscoveryV1::resolver(&hub)
+            .profile(EventBroker)
+            .resolve()
+            .is_ok(),
+        "omit-default service discovery resolves"
+    );
+
+    handle.stop().await;
+
+    // Deregistration leaves the profile unbound.
+    assert!(matches!(
+        ClusterCacheV1::resolver(&hub)
+            .profile(EventBroker)
+            .resolve(),
+        Err(ClusterError::ProfileNotBound { .. })
+    ));
+    assert!(matches!(
+        LeaderElectionV1::resolver(&hub)
+            .profile(EventBroker)
+            .resolve(),
+        Err(ClusterError::ProfileNotBound { .. })
+    ));
+}
+
+#[tokio::test]
+async fn stop_revokes_an_active_leader_before_shutdown_completes() {
+    let hub = Arc::new(ClientHub::new());
+    let plugin = StandaloneClusterPlugin::builder()
+        .build_and_start()
+        .expect("plugin starts");
+    let cache = plugin.cache();
+
+    let handle = ClusterWiring::builder(Arc::clone(&hub))
+        .profile(EventBroker, ProfileBackends::new(cache))
+        .on_stop(move || async move { plugin.stop().await })
+        .build_and_start()
+        .expect("wiring starts");
+
+    // A consumer wins the omit-default (CAS-based) election.
+    let leader = LeaderElectionV1::resolver(&hub)
+        .profile(EventBroker)
+        .resolve()
+        .expect("leader election resolves");
+    let mut watch = leader.elect("primary").await.expect("election joins");
+    assert!(matches!(
+        watch.changed().await,
+        LeaderWatchEvent::Status(LeaderStatus::Leader)
+    ));
+
+    // Graceful shutdown must revoke leadership before it completes.
+    handle.stop().await;
+
+    // The former leader observes loss, then a terminal shutdown close, and its
+    // synchronous snapshot no longer claims leadership.
+    assert!(matches!(
+        watch.changed().await,
+        LeaderWatchEvent::Status(LeaderStatus::Lost)
+    ));
+    assert!(matches!(
+        watch.changed().await,
+        LeaderWatchEvent::Closed(ClusterError::Shutdown)
+    ));
+    assert!(!watch.is_leader());
+}
+
+#[tokio::test]
+async fn stop_revokes_active_lock_sd_and_cache_watches_before_shutdown_completes() {
+    let hub = Arc::new(ClientHub::new());
+    let plugin = StandaloneClusterPlugin::builder()
+        .build_and_start()
+        .expect("plugin starts");
+    let cache_backend = plugin.cache();
+
+    let handle = ClusterWiring::builder(Arc::clone(&hub))
+        .profile(EventBroker, ProfileBackends::new(plugin.cache()))
+        .on_stop(move || async move { plugin.stop().await })
+        .build_and_start()
+        .expect("wiring starts");
+
+    // A blocking lock waiter that must keep waiting (the lock is held).
+    let lock = DistributedLockV1::resolver(&hub)
+        .profile(EventBroker)
+        .resolve()
+        .expect("lock resolves");
+    let _held = lock
+        .try_lock("ledger", Duration::from_secs(100))
+        .await
+        .expect("first holder acquires");
+    let lock_waiter = lock.clone();
+    let waiter = tokio::spawn(async move {
+        lock_waiter
+            .lock("ledger", Duration::from_secs(100), Duration::from_secs(100))
+            .await
+    });
+
+    // An active service-discovery watch.
+    let discovery = ServiceDiscoveryV1::resolver(&hub)
+        .profile(EventBroker)
+        .resolve()
+        .expect("service discovery resolves");
+    let mut sd_watch = discovery
+        .watch("delivery")
+        .await
+        .expect("sd watch establishes");
+
+    // An active cache watch.
+    let mut cache_watch = cache_backend
+        .watch("k")
+        .await
+        .expect("cache watch establishes");
+
+    // Let the lock waiter and translator tasks reach their wait points.
+    for _ in 0..16 {
+        tokio::task::yield_now().await;
+    }
+
+    // Graceful shutdown must revoke all in-flight coordination before completing.
+    handle.stop().await;
+
+    // The in-flight lock waiter resolves to Shutdown (not LockTimeout).
+    let joined = waiter.await.expect("waiter task joins");
+    assert!(
+        matches!(joined, Err(ClusterError::Shutdown)),
+        "an in-flight lock waiter must observe Shutdown on stop; got {joined:?}"
+    );
+    // The service-discovery watch observes a terminal Closed(Shutdown).
+    assert!(matches!(
+        sd_watch.recv().await,
+        Some(ServiceWatchEvent::Closed(ClusterError::Shutdown))
+    ));
+    // The cache watch observes a terminal Closed(Shutdown) via the plugin stop hook.
+    assert!(matches!(
+        cache_watch.recv().await,
+        Some(CacheWatchEvent::Closed(ClusterError::Shutdown))
+    ));
+}
+
+// ---- Call-counting wrappers used only to prove an explicitly-bound backend
+// (not the SDK default auto-filled by omit-default) is the instance that
+// actually receives calls. Each wrapper delegates to a real backend and bumps
+// a shared counter first, so a counter of zero after a call through the
+// facade means the wrapped instance was NOT the one registered.
+
+struct MarkerLeaderElectionBackend {
+    inner: Arc<CasBasedLeaderElectionBackend>,
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl LeaderElectionBackend for MarkerLeaderElectionBackend {
+    fn features(&self) -> LeaderElectionFeatures {
+        self.inner.features()
+    }
+
+    async fn elect(&self, name: &str) -> Result<LeaderWatch, ClusterError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.elect(name).await
+    }
+
+    async fn elect_with_config(
+        &self,
+        name: &str,
+        config: ElectionConfig,
+    ) -> Result<LeaderWatch, ClusterError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.elect_with_config(name, config).await
+    }
+}
+
+struct MarkerLockBackend {
+    inner: Arc<CasBasedDistributedLockBackend>,
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl DistributedLockBackend for MarkerLockBackend {
+    fn features(&self) -> LockFeatures {
+        self.inner.features()
+    }
+
+    async fn try_lock(&self, name: &str, ttl: Duration) -> Result<LockGuard, ClusterError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.try_lock(name, ttl).await
+    }
+
+    async fn lock(
+        &self,
+        name: &str,
+        ttl: Duration,
+        timeout: Duration,
+    ) -> Result<LockGuard, ClusterError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.lock(name, ttl, timeout).await
+    }
+}
+
+struct MarkerServiceDiscoveryBackend {
+    inner: Arc<CacheBasedServiceDiscoveryBackend>,
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl ServiceDiscoveryBackend for MarkerServiceDiscoveryBackend {
+    fn features(&self) -> ServiceDiscoveryFeatures {
+        self.inner.features()
+    }
+
+    async fn register(&self, reg: ServiceRegistration) -> Result<ServiceHandle, ClusterError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.register(reg).await
+    }
+
+    async fn discover(
+        &self,
+        name: &str,
+        filter: DiscoveryFilter,
+    ) -> Result<Vec<ServiceInstance>, ClusterError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.discover(name, filter).await
+    }
+
+    async fn watch(&self, name: &str) -> Result<ServiceWatch, ClusterError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.watch(name).await
+    }
+}
+
+/// Proves the explicitly-bound backends are the instances actually registered
+/// and invoked — not the SDK defaults `build_and_start` would otherwise
+/// auto-fill. Each primitive is bound to a marker that delegates to a real
+/// default-flavored backend but increments its own call counter first; a
+/// resolve-and-invoke through the public facade that leaves a counter at zero
+/// would mean the explicit binding was silently dropped in favor of a default.
+#[tokio::test]
+async fn explicit_backends_override_defaults() {
+    let hub = Arc::new(ClientHub::new());
+    let plugin = StandaloneClusterPlugin::builder()
+        .build_and_start()
+        .expect("plugin starts");
+
+    let cache = plugin.cache();
+    let leader_calls = Arc::new(AtomicUsize::new(0));
+    let lock_calls = Arc::new(AtomicUsize::new(0));
+    let discovery_calls = Arc::new(AtomicUsize::new(0));
+
+    let leader = Arc::new(MarkerLeaderElectionBackend {
+        inner: Arc::new(
+            CasBasedLeaderElectionBackend::new(Arc::clone(&cache))
+                .expect("leader backend over linearizable cache"),
+        ),
+        calls: Arc::clone(&leader_calls),
+    });
+    let lock = Arc::new(MarkerLockBackend {
+        inner: Arc::new(
+            CasBasedDistributedLockBackend::new(Arc::clone(&cache))
+                .expect("lock backend over linearizable cache"),
+        ),
+        calls: Arc::clone(&lock_calls),
+    });
+    let discovery = Arc::new(MarkerServiceDiscoveryBackend {
+        inner: Arc::new(CacheBasedServiceDiscoveryBackend::new(Arc::clone(&cache))),
+        calls: Arc::clone(&discovery_calls),
+    });
+    let backends = ProfileBackends::new(cache)
+        .with_leader_election(leader)
+        .with_lock(lock)
+        .with_service_discovery(discovery);
+
+    let handle = ClusterWiring::builder(Arc::clone(&hub))
+        .profile(EventBroker, backends)
+        .on_stop(move || async move { plugin.stop().await })
+        .build_and_start()
+        .expect("wiring starts");
+
+    LeaderElectionV1::resolver(&hub)
+        .profile(EventBroker)
+        .resolve()
+        .expect("leader election resolves")
+        .elect("primary")
+        .await
+        .expect("election joins");
+    assert_eq!(
+        leader_calls.load(Ordering::SeqCst),
+        1,
+        "the explicitly-bound leader-election backend must receive the call, not an SDK default"
+    );
+
+    DistributedLockV1::resolver(&hub)
+        .profile(EventBroker)
+        .resolve()
+        .expect("lock resolves")
+        .try_lock("ledger", Duration::from_secs(30))
+        .await
+        .expect("lock acquires");
+    assert_eq!(
+        lock_calls.load(Ordering::SeqCst),
+        1,
+        "the explicitly-bound lock backend must receive the call, not an SDK default"
+    );
+
+    ServiceDiscoveryV1::resolver(&hub)
+        .profile(EventBroker)
+        .resolve()
+        .expect("service discovery resolves")
+        .watch("delivery")
+        .await
+        .expect("sd watch establishes");
+    assert_eq!(
+        discovery_calls.load(Ordering::SeqCst),
+        1,
+        "the explicitly-bound service-discovery backend must receive the call, not an SDK default"
+    );
+
+    handle.stop().await;
+}
+
+// ---- `ClusterHandle` Drop guard (ADR-006 §Confirmation) ----
+
+/// A graceful `stop()` must disarm the Drop guard: the handle drops at end of
+/// scope without panicking. Reaching the end of the test is the assertion.
+#[tokio::test]
+async fn stop_disarms_the_drop_guard() {
+    let hub = Arc::new(ClientHub::new());
+    let handle = ClusterWiring::builder(hub)
+        .build_and_start()
+        .expect("empty wiring starts");
+    handle.stop().await;
+    // `handle` drops here after a clean stop(); no panic, no warning.
+}
+
+/// Dropping a handle without `stop()` is a programming error that leaks plugin
+/// background tasks — in debug builds the Drop guard turns it into a loud panic
+/// rather than a silent leak.
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "dropped without stop()")]
+fn drop_without_stop_panics_in_debug() {
+    let hub = Arc::new(ClientHub::new());
+    // Even an empty wiring yields a handle that must be `stop()`ped.
+    let handle = ClusterWiring::builder(hub)
+        .build_and_start()
+        .expect("empty wiring starts");
+    drop(handle); // no stop() — the Drop guard fires
+}
+
+/// If a handle is dropped *while a panic is already unwinding*, the Drop guard
+/// must warn instead of panicking again — a second panic during unwind aborts
+/// the process. Catching the original panic here proves the process survived
+/// (a double-panic abort is uncatchable), and the warning confirms the
+/// `thread::panicking()` branch ran instead of the debug panic.
+#[traced_test]
+#[test]
+fn drop_during_panic_warns_instead_of_double_panicking() {
+    let hub = Arc::new(ClientHub::new());
+    let handle = ClusterWiring::builder(hub)
+        .build_and_start()
+        .expect("empty wiring starts");
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+        let _doomed = handle; // dropped as the stack unwinds
+        panic!("simulated consumer panic");
+    }));
+
+    assert!(
+        result.is_err(),
+        "the original panic must propagate - the process must not abort"
+    );
+    assert!(
+        logs_contain("dropped during panic unwind"),
+        "the Drop guard must warn (not panic) during unwind"
+    );
+}

--- a/gears/system/cluster/docs/TRACEABILITY-AUDIT.md
+++ b/gears/system/cluster/docs/TRACEABILITY-AUDIT.md
@@ -29,7 +29,7 @@ resolution of the two open questions.
 - **Feature source**: the assignment recorded in [DECOMPOSITION.md](DECOMPOSITION.md)
   §2 ("Requirements Covered" per feature).
 - **Marker source**: `@cpt-dod:` markers grepped from `cluster-sdk/src`,
-  `cluster-sdk/tests`, `cluster-sdk/examples`, and `tools/dylint_lints/de14_cluster`.
+  `cluster-sdk/tests`, `cluster/examples`, and `tools/dylint_lints/de14_cluster`.
 - **Scope key**: `code` = realized by this change's shipped code; `follow-up` =
   enabling contract shipped here, full realization deferred to the wiring crate /
   parent host gear per PRD §4.1 (each still maps to a realizing ADR/DESIGN section,
@@ -103,7 +103,7 @@ orphan requirements.
 ## 4. Code Marker Verification
 
 34 distinct `@cpt-dod:` markers are wired in code across `cluster-sdk/src`,
-`cluster-sdk/tests`, `cluster-sdk/examples`, and the lint crate; a 35th,
+`cluster-sdk/tests`, `cluster/examples`, and the lint crate; a 35th,
 `cpt-cf-clst-dod-showcase-audit-traceability`, is carried by this audit document
 itself. Every in-scope feature (01–12) has at least one wired DoD marker:
 

--- a/gears/system/cluster/plugins/standalone-cluster-plugin/Cargo.toml
+++ b/gears/system/cluster/plugins/standalone-cluster-plugin/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "cf-gears-standalone-cluster-plugin"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "In-process standalone backend plugin for the cluster gear: a native cache plus the SDK default leader-election, lock, and service-discovery backends — the zero-infrastructure dev/test deployment"
+readme = "README.md"
+keywords = ["constructorfabric", "cf-gears"]
+categories = ["development-tools"]
+metadata.docs.rs.all-features = true
+
+[lib]
+name = "standalone_cluster_plugin"
+
+[lints]
+workspace = true
+
+[dependencies]
+# `otel` pulls in the SDK's OpenTelemetry-backed `ClusterMetrics` adapter
+# (`OtelClusterMetrics`) so the standalone backend emits the cluster metrics
+# contract (ADR-004). Most spans/log events are emitted by the SDK's
+# `InstrumentedCache` decorator; this crate logs directly only for its own
+# lifecycle events (e.g. a panicked TTL sweeper task).
+cluster-sdk = { workspace = true, features = ["otel"] }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+# Reads the provider's flattened operator-config options (e.g. `sweep_interval_ms`)
+# passed through by the wiring crate as a serde map.
+serde_json = { workspace = true }
+serde = { workspace = true }
+
+[dev-dependencies]
+# `test-util` enables `tokio::time::pause`/`advance` so the sweeper and the
+# default backends' TTL/renewal logic can be driven deterministically in tests.
+tokio = { workspace = true, features = ["test-util"] }

--- a/gears/system/cluster/plugins/standalone-cluster-plugin/README.md
+++ b/gears/system/cluster/plugins/standalone-cluster-plugin/README.md
@@ -1,0 +1,50 @@
+# Standalone cluster plugin
+
+`cf-gears-standalone-cluster-plugin` (lib `standalone_cluster_plugin`) is the
+in-process, zero-infrastructure backend for the cluster gear — the default for
+developer laptops and unit/integration tests (PRD §3.1, DESIGN §3.11).
+
+It implements the **cache** primitive natively over an in-memory store
+(`HashMap` + monotonic per-key versions, lazy TTL, a background sweeper emitting
+`Expired`, and exact/prefix watches) and derives **leader election**,
+**distributed lock**, and **service discovery** from the SDK's cache-based
+default backends — the "implement cache only, get all four" guarantee. The cache
+declares `Linearizable` consistency, which the default leader/lock backends
+require.
+
+## Lifecycle
+
+Not a ToolKit `RunnableCapability`. It follows the outbox-style builder/handle
+pattern (DESIGN §3.7) owned by a parent host gear or the cluster wiring crate:
+
+```rust,no_run
+use standalone_cluster_plugin::StandaloneClusterPlugin;
+
+# async fn run() -> Result<(), cluster_sdk::ClusterError> {
+let handle = StandaloneClusterPlugin::builder().build_and_start()?;
+
+// Hand the backends to the wiring crate / register them in the ClientHub:
+let cache     = handle.cache();
+let leader    = handle.leader_election();
+let lock      = handle.lock();
+let discovery = handle.service_discovery();
+
+// On graceful shutdown:
+handle.stop().await;
+# Ok(())
+# }
+```
+
+`build_and_start` starts the cache TTL sweeper; `handle.stop()` cancels it. The
+plugin performs no remote I/O and never relies on `Drop` for cleanup; cluster
+resources are bounded by their TTL.
+
+## Status
+
+Cache is native. Leader election, lock, and service discovery currently ride the
+SDK default backends over the native cache. Native implementations of those three
+(the DESIGN §3.11 end state) are a follow-up optimization.
+
+## License
+
+Apache-2.0

--- a/gears/system/cluster/plugins/standalone-cluster-plugin/src/cache.rs
+++ b/gears/system/cluster/plugins/standalone-cluster-plugin/src/cache.rs
@@ -1,0 +1,487 @@
+//! The native in-process [`ClusterCacheBackend`] backing the standalone plugin.
+//!
+//! A `HashMap`-backed store with monotonic per-key versioning, lazy TTL (an
+//! expired entry reads as absent immediately), a background sweeper that emits
+//! [`CacheEvent::Expired`] to matching watchers, and exact + prefix watches with
+//! closed-channel pruning. It declares [`CacheConsistency::Linearizable`] and
+//! native prefix-watch, which is what the SDK default leader-election and lock
+//! backends require (their consistency guard rejects an eventually-consistent
+//! cache).
+//!
+//! Productionized from the SDK's `defaults::test_cache::MemoryCache` fixture: the
+//! store and watch logic are the same, but the sweeper is driven by an explicit
+//! [`CancellationToken`] so the plugin handle can stop it deterministically.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard, Weak};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use cluster_sdk::cache::types::{PutRequest, Ttl};
+use cluster_sdk::{
+    CacheConsistency, CacheEntry, CacheEvent, CacheFeatures, CacheWatch, CacheWatchEvent,
+    CacheWatchSender, CacheWatchTrySendError, ClusterCacheBackend, ClusterError,
+};
+use tokio::task::JoinHandle;
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+
+/// Per-watch in-flight buffer. Generous so a renewal/heartbeat storm is
+/// absorbed without lag under normal in-process load. On overflow the writer is
+/// never blocked: `broadcast` drops the event for the lagging watcher and
+/// coalesces the drops into a `CacheWatchEvent::Lagged` delivered once the
+/// buffer drains.
+const WATCH_CAPACITY: usize = 256;
+
+/// A stored value with its version and optional expiry deadline.
+struct Stored {
+    value: Vec<u8>,
+    version: u64,
+    expires_at: Option<Instant>,
+}
+
+impl Stored {
+    fn is_expired(&self, now: Instant) -> bool {
+        self.expires_at.is_some_and(|deadline| deadline <= now)
+    }
+
+    fn entry(&self) -> CacheEntry {
+        CacheEntry {
+            value: self.value.clone(),
+            version: self.version,
+        }
+    }
+}
+
+/// The subscription kind a watcher matches keys against.
+enum WatchKind {
+    Exact(String),
+    Prefix(String),
+}
+
+impl WatchKind {
+    fn matches(&self, key: &str) -> bool {
+        match self {
+            Self::Exact(exact) => exact == key,
+            Self::Prefix(prefix) => key.starts_with(prefix.as_str()),
+        }
+    }
+}
+
+/// One live watch subscription, identified so a failed send can prune it.
+struct Watcher {
+    id: u64,
+    kind: WatchKind,
+    sender: CacheWatchSender,
+    /// Events dropped because this watcher's buffer was full, awaiting a
+    /// `Lagged` notice once space frees. Zero in the common (keeping-up) case.
+    dropped: u64,
+}
+
+/// The cache's locked interior.
+struct Inner {
+    map: HashMap<String, Stored>,
+    watchers: Vec<Watcher>,
+    next_watch_id: u64,
+    /// Latched by [`StandaloneCache::shutdown`] on graceful shutdown. Once set,
+    /// mutating ops and new watches are rejected with [`ClusterError::Shutdown`]
+    /// so a racing op cannot resurrect a watcher after the close broadcast.
+    shutting_down: bool,
+}
+
+/// The native in-process cache backend.
+///
+/// Create with [`new`](Self::new) and start its TTL sweeper with
+/// [`spawn_sweeper`](Self::spawn_sweeper); the
+/// [`StandaloneClusterHandle`](crate::StandaloneClusterHandle) wires both
+/// together and owns their lifecycle.
+pub struct StandaloneCache {
+    inner: Mutex<Inner>,
+}
+
+impl StandaloneCache {
+    /// Creates an empty cache. The TTL sweeper is started separately via
+    /// [`spawn_sweeper`](Self::spawn_sweeper).
+    #[must_use]
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            inner: Mutex::new(Inner {
+                map: HashMap::new(),
+                watchers: Vec::new(),
+                next_watch_id: 0,
+                shutting_down: false,
+            }),
+        })
+    }
+
+    /// Spawns the background TTL sweeper, returning its task handle. The sweeper
+    /// holds only a [`Weak`] reference, so it also self-terminates if the cache is
+    /// dropped; `shutdown` lets the owning handle stop it deterministically.
+    pub fn spawn_sweeper(
+        self: &Arc<Self>,
+        interval: Duration,
+        shutdown: CancellationToken,
+    ) -> JoinHandle<()> {
+        let weak = Arc::downgrade(self);
+        tokio::spawn(sweep_loop(weak, interval, shutdown))
+    }
+
+    /// Locks the interior, recovering from a poisoned lock rather than panicking.
+    fn lock(&self) -> MutexGuard<'_, Inner> {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Closes every active watch terminally on graceful shutdown
+    /// (`cpt-cf-clst-fr-shutdown-revoke`, DESIGN §3.13). Latches the
+    /// shutting-down flag, then best-effort delivers a
+    /// [`CacheWatchEvent::Closed(ClusterError::Shutdown)`] to each watcher and
+    /// drops them.
+    ///
+    /// Non-blocking: a watcher whose consumer has dropped the watch (a closed
+    /// channel) is simply pruned, and a full buffer is ignored — the consumer
+    /// will still observe end-of-stream when the sender drops here. After this
+    /// returns, mutating ops and new watches are rejected (see the per-op
+    /// guards), so a racing op cannot register a watcher that would miss the
+    /// close. Reads (`get`/`contains`/`scan_prefix`) stay live — they cannot
+    /// resurrect a watcher and a harmless read during teardown is preferable to
+    /// a spurious error.
+    pub fn shutdown(&self) {
+        let mut guard = self.lock();
+        guard.shutting_down = true;
+        // Drain the watchers under the lock: once removed, no future broadcast
+        // can reference them, and dropping their senders at the end of this scope
+        // ends each stream even if the `Closed` event could not be delivered.
+        let watchers = std::mem::take(&mut guard.watchers);
+        for watcher in &watchers {
+            // Best-effort: a dropped consumer (Closed) or a full buffer (Full)
+            // is ignored — the sender drop below still ends the stream.
+            let _sent = watcher
+                .sender
+                .try_send(CacheWatchEvent::Closed(ClusterError::Shutdown));
+        }
+    }
+
+    /// Sends `event` to every watcher matching `key` without ever blocking the
+    /// caller, pruning any whose consumer has dropped the watch.
+    ///
+    /// Uses the non-blocking [`CacheWatchSender::try_send`]: a watcher whose
+    /// buffer is full has the event dropped and its lag counter incremented; its
+    /// next successful delivery is preceded by a [`CacheWatchEvent::Lagged`] so
+    /// the consumer knows to re-read. Because `try_send` never awaits, the lock
+    /// is held for the whole pass and a slow consumer can never stall the write
+    /// path of other writers on this cache (DESIGN §3.9 at-most-once delivery).
+    fn broadcast(&self, key: &str, event: &CacheEvent) {
+        let mut guard = self.lock();
+        let mut dead = Vec::new();
+        for watcher in guard.watchers.iter_mut().filter(|w| w.kind.matches(key)) {
+            // Flush a pending lag notice first so the consumer re-reads before it
+            // sees the next event.
+            if watcher.dropped > 0 {
+                match watcher.sender.try_send(CacheWatchEvent::Lagged {
+                    dropped: watcher.dropped,
+                }) {
+                    Ok(()) => watcher.dropped = 0,
+                    Err(CacheWatchTrySendError::Full) => {
+                        watcher.dropped += 1;
+                        continue;
+                    }
+                    Err(CacheWatchTrySendError::Closed) => {
+                        dead.push(watcher.id);
+                        continue;
+                    }
+                }
+            }
+            match watcher
+                .sender
+                .try_send(CacheWatchEvent::Event(event.clone()))
+            {
+                Ok(()) => {}
+                Err(CacheWatchTrySendError::Full) => watcher.dropped += 1,
+                Err(CacheWatchTrySendError::Closed) => dead.push(watcher.id),
+            }
+        }
+        if !dead.is_empty() {
+            guard.watchers.retain(|watcher| !dead.contains(&watcher.id));
+        }
+    }
+
+    /// Removes every expired entry and emits an `Expired` event for each.
+    fn sweep_expired(&self) {
+        let now = Instant::now();
+        let expired: Vec<String> = {
+            let mut guard = self.lock();
+            let keys: Vec<String> = guard
+                .map
+                .iter()
+                .filter(|(_, stored)| stored.is_expired(now))
+                .map(|(key, _)| key.clone())
+                .collect();
+            for key in &keys {
+                guard.map.remove(key);
+            }
+            keys
+        };
+        for key in expired {
+            self.broadcast(&key, &CacheEvent::Expired { key: key.clone() });
+        }
+    }
+
+    /// Registers a new watch, or rejects it with [`ClusterError::Shutdown`] once
+    /// the cache is shutting down so a racing subscribe cannot register a watcher
+    /// the [`shutdown`](Self::shutdown) close pass has already gone past.
+    fn register_watch(&self, kind: WatchKind) -> Result<CacheWatch, ClusterError> {
+        let (sender, watch) = CacheWatch::channel(WATCH_CAPACITY);
+        let mut guard = self.lock();
+        if guard.shutting_down {
+            return Err(ClusterError::Shutdown);
+        }
+        let id = guard.next_watch_id;
+        guard.next_watch_id += 1;
+        guard.watchers.push(Watcher {
+            id,
+            kind,
+            sender,
+            dropped: 0,
+        });
+        Ok(watch)
+    }
+}
+
+/// The detached sweeper driving TTL expiry; exits on `shutdown` or once the cache
+/// is dropped (the `Weak` no longer upgrades).
+async fn sweep_loop(weak: Weak<StandaloneCache>, interval: Duration, shutdown: CancellationToken) {
+    let mut ticker = tokio::time::interval(interval);
+    // A slow sweep should not fire a catch-up burst on the next tick.
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            () = shutdown.cancelled() => return,
+            _ = ticker.tick() => {
+                let Some(cache) = weak.upgrade() else {
+                    return;
+                };
+                cache.sweep_expired();
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl ClusterCacheBackend for StandaloneCache {
+    fn consistency(&self) -> CacheConsistency {
+        // An in-process store is linearizable: every operation observes the
+        // effect of all prior operations.
+        CacheConsistency::Linearizable
+    }
+
+    fn features(&self) -> CacheFeatures {
+        // Native prefix watch (and `scan_prefix`) are supported.
+        CacheFeatures::new(true)
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<CacheEntry>, ClusterError> {
+        let now = Instant::now();
+        let guard = self.lock();
+        Ok(match guard.map.get(key) {
+            Some(stored) if !stored.is_expired(now) => Some(stored.entry()),
+            _ => None,
+        })
+    }
+
+    async fn put(&self, req: PutRequest<'_>) -> Result<(), ClusterError> {
+        let now = Instant::now();
+        {
+            let mut guard = self.lock();
+            if guard.shutting_down {
+                return Err(ClusterError::Shutdown);
+            }
+            let version = match guard.map.get(req.key) {
+                Some(stored) if !stored.is_expired(now) => stored.version + 1,
+                _ => 1,
+            };
+            guard.map.insert(
+                req.key.to_owned(),
+                Stored {
+                    value: req.value.to_vec(),
+                    version,
+                    expires_at: req.ttl.as_duration().map(|d| now + d),
+                },
+            );
+        }
+        self.broadcast(
+            req.key,
+            &CacheEvent::Changed {
+                key: req.key.to_owned(),
+            },
+        );
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<bool, ClusterError> {
+        let now = Instant::now();
+        let was_live = {
+            let mut guard = self.lock();
+            if guard.shutting_down {
+                return Err(ClusterError::Shutdown);
+            }
+            let live = matches!(guard.map.get(key), Some(stored) if !stored.is_expired(now));
+            guard.map.remove(key);
+            live
+        };
+        if was_live {
+            self.broadcast(
+                key,
+                &CacheEvent::Deleted {
+                    key: key.to_owned(),
+                },
+            );
+        }
+        Ok(was_live)
+    }
+
+    async fn contains(&self, key: &str) -> Result<bool, ClusterError> {
+        let now = Instant::now();
+        let guard = self.lock();
+        Ok(matches!(guard.map.get(key), Some(stored) if !stored.is_expired(now)))
+    }
+
+    async fn put_if_absent(&self, req: PutRequest<'_>) -> Result<Option<CacheEntry>, ClusterError> {
+        let now = Instant::now();
+        let created = {
+            let mut guard = self.lock();
+            if guard.shutting_down {
+                return Err(ClusterError::Shutdown);
+            }
+            if matches!(guard.map.get(req.key), Some(stored) if !stored.is_expired(now)) {
+                None
+            } else {
+                let stored = Stored {
+                    value: req.value.to_vec(),
+                    version: 1,
+                    expires_at: req.ttl.as_duration().map(|d| now + d),
+                };
+                let entry = stored.entry();
+                guard.map.insert(req.key.to_owned(), stored);
+                Some(entry)
+            }
+        };
+        if created.is_some() {
+            self.broadcast(
+                req.key,
+                &CacheEvent::Changed {
+                    key: req.key.to_owned(),
+                },
+            );
+        }
+        Ok(created)
+    }
+
+    async fn compare_and_swap(
+        &self,
+        key: &str,
+        expected_version: u64,
+        new_value: &[u8],
+        ttl: Ttl,
+    ) -> Result<CacheEntry, ClusterError> {
+        let now = Instant::now();
+        let outcome = {
+            let mut guard = self.lock();
+            if guard.shutting_down {
+                return Err(ClusterError::Shutdown);
+            }
+            match guard.map.get(key) {
+                Some(stored) if !stored.is_expired(now) => {
+                    if stored.version == expected_version {
+                        let version = stored.version + 1;
+                        let stored = Stored {
+                            value: new_value.to_vec(),
+                            version,
+                            expires_at: ttl.as_duration().map(|d| now + d),
+                        };
+                        let entry = stored.entry();
+                        guard.map.insert(key.to_owned(), stored);
+                        Ok(entry)
+                    } else {
+                        Err(ClusterError::CasConflict {
+                            key: key.to_owned(),
+                            current: Some(stored.entry()),
+                        })
+                    }
+                }
+                _ => Err(ClusterError::CasConflict {
+                    key: key.to_owned(),
+                    current: None,
+                }),
+            }
+        };
+        if outcome.is_ok() {
+            self.broadcast(
+                key,
+                &CacheEvent::Changed {
+                    key: key.to_owned(),
+                },
+            );
+        }
+        outcome
+    }
+
+    async fn compare_and_delete(
+        &self,
+        key: &str,
+        expected_value: &[u8],
+    ) -> Result<bool, ClusterError> {
+        let now = Instant::now();
+        let deleted = {
+            let mut guard = self.lock();
+            if guard.shutting_down {
+                return Err(ClusterError::Shutdown);
+            }
+            match guard.map.get(key) {
+                Some(stored)
+                    if !stored.is_expired(now) && stored.value.as_slice() == expected_value =>
+                {
+                    guard.map.remove(key);
+                    true
+                }
+                // A value mismatch or an absent/expired key is a safe no-op: a
+                // successor that re-claimed after our TTL lapsed wrote a different
+                // value, so its fresh claim is never wiped.
+                _ => false,
+            }
+        };
+        if deleted {
+            self.broadcast(
+                key,
+                &CacheEvent::Deleted {
+                    key: key.to_owned(),
+                },
+            );
+        }
+        Ok(deleted)
+    }
+
+    async fn watch(&self, key: &str) -> Result<CacheWatch, ClusterError> {
+        self.register_watch(WatchKind::Exact(key.to_owned()))
+    }
+
+    async fn watch_prefix(&self, prefix: &str) -> Result<CacheWatch, ClusterError> {
+        self.register_watch(WatchKind::Prefix(prefix.to_owned()))
+    }
+
+    async fn scan_prefix(&self, prefix: &str) -> Result<Vec<String>, ClusterError> {
+        let now = Instant::now();
+        let guard = self.lock();
+        Ok(guard
+            .map
+            .iter()
+            .filter(|(key, stored)| key.starts_with(prefix) && !stored.is_expired(now))
+            .map(|(key, _)| key.clone())
+            .collect())
+    }
+}
+
+#[cfg(test)]
+#[path = "cache_tests.rs"]
+mod cache_tests;

--- a/gears/system/cluster/plugins/standalone-cluster-plugin/src/cache_tests.rs
+++ b/gears/system/cluster/plugins/standalone-cluster-plugin/src/cache_tests.rs
@@ -1,0 +1,335 @@
+use std::time::Duration;
+
+use cluster_sdk::cache::types::{PutRequest, Ttl};
+use cluster_sdk::{
+    CacheConsistency, CacheEvent, CacheWatchEvent, ClusterCacheBackend, ClusterError,
+};
+use tokio_util::sync::CancellationToken;
+
+use super::StandaloneCache;
+
+#[tokio::test]
+async fn put_get_and_versioning() {
+    let cache = StandaloneCache::new();
+    assert_eq!(cache.consistency(), CacheConsistency::Linearizable);
+    assert!(cache.features().prefix_watch);
+
+    let Ok(Some(created)) = cache
+        .put_if_absent(PutRequest {
+            key: "k",
+            value: b"a",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+    else {
+        panic!("first claim must create");
+    };
+    assert_eq!(created.version, 1);
+    assert!(
+        cache
+            .put(PutRequest {
+                key: "k",
+                value: b"b",
+                ttl: Ttl::Indefinite,
+            })
+            .await
+            .is_ok()
+    );
+    let Ok(Some(entry)) = cache.get("k").await else {
+        panic!("entry must be present");
+    };
+    assert_eq!(entry.version, 2);
+    assert_eq!(entry.value, b"b");
+}
+
+#[tokio::test(start_paused = true)]
+async fn sweeper_expires_and_emits_then_stops_on_cancel() {
+    let cache = StandaloneCache::new();
+    let shutdown = CancellationToken::new();
+    let sweeper = cache.spawn_sweeper(Duration::from_millis(25), shutdown.clone());
+
+    let Ok(mut watch) = cache.watch("k").await else {
+        panic!("watch must establish");
+    };
+    assert!(
+        cache
+            .put(PutRequest {
+                key: "k",
+                value: b"a",
+                ttl: Ttl::Of(Duration::from_secs(10)),
+            })
+            .await
+            .is_ok()
+    );
+    assert!(matches!(
+        watch.recv().await,
+        Some(CacheWatchEvent::Event(CacheEvent::Changed { .. }))
+    ));
+
+    tokio::time::advance(Duration::from_secs(11)).await;
+    tokio::task::yield_now().await;
+    assert!(matches!(
+        watch.recv().await,
+        Some(CacheWatchEvent::Event(CacheEvent::Expired { .. }))
+    ));
+
+    // Cancelling stops the sweeper task.
+    shutdown.cancel();
+    assert!(sweeper.await.is_ok(), "sweeper must exit on cancellation");
+}
+
+#[tokio::test]
+async fn shutdown_closes_active_watches_and_rejects_later_ops() {
+    let cache = StandaloneCache::new();
+    let Ok(mut exact) = cache.watch("k").await else {
+        panic!("exact watch must establish");
+    };
+    let Ok(mut prefix) = cache.watch_prefix("svc/").await else {
+        panic!("prefix watch must establish");
+    };
+
+    cache.shutdown();
+
+    // Every active watch observes a terminal Closed(Shutdown).
+    assert!(matches!(
+        exact.recv().await,
+        Some(CacheWatchEvent::Closed(ClusterError::Shutdown))
+    ));
+    assert!(matches!(
+        prefix.recv().await,
+        Some(CacheWatchEvent::Closed(ClusterError::Shutdown))
+    ));
+
+    // Post-shutdown mutating ops are rejected so a racing op cannot
+    // resurrect a watcher.
+    assert!(matches!(
+        cache
+            .put(PutRequest {
+                key: "k",
+                value: b"v",
+                ttl: Ttl::Indefinite,
+            })
+            .await,
+        Err(ClusterError::Shutdown)
+    ));
+    assert!(matches!(
+        cache.delete("k").await,
+        Err(ClusterError::Shutdown)
+    ));
+    assert!(matches!(
+        cache
+            .put_if_absent(PutRequest {
+                key: "k",
+                value: b"v",
+                ttl: Ttl::Indefinite,
+            })
+            .await,
+        Err(ClusterError::Shutdown)
+    ));
+    assert!(matches!(
+        cache.compare_and_swap("k", 1, b"v", Ttl::Indefinite).await,
+        Err(ClusterError::Shutdown)
+    ));
+    // New watches are rejected too.
+    assert!(matches!(
+        cache.watch("k").await,
+        Err(ClusterError::Shutdown)
+    ));
+    assert!(matches!(
+        cache.watch_prefix("svc/").await,
+        Err(ClusterError::Shutdown)
+    ));
+    // Reads stay live (harmless and cannot resurrect a watcher).
+    assert!(cache.get("k").await.is_ok());
+    assert!(cache.contains("k").await.is_ok());
+}
+
+#[tokio::test]
+async fn compare_and_swap_increments_on_matching_version() {
+    let cache = StandaloneCache::new();
+    let Ok(Some(created)) = cache
+        .put_if_absent(PutRequest {
+            key: "k",
+            value: b"a",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+    else {
+        panic!("first claim must create");
+    };
+    assert_eq!(created.version, 1);
+
+    let Ok(swapped) = cache
+        .compare_and_swap("k", created.version, b"b", Ttl::Indefinite)
+        .await
+    else {
+        panic!("a matching version must succeed");
+    };
+    assert_eq!(swapped.version, 2);
+    assert_eq!(swapped.value, b"b");
+
+    let Ok(Some(entry)) = cache.get("k").await else {
+        panic!("entry must be present");
+    };
+    assert_eq!(entry.version, 2);
+    assert_eq!(entry.value, b"b");
+}
+
+#[tokio::test]
+async fn compare_and_swap_conflicts_on_version_mismatch() {
+    let cache = StandaloneCache::new();
+    let Ok(Some(created)) = cache
+        .put_if_absent(PutRequest {
+            key: "k",
+            value: b"a",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+    else {
+        panic!("first claim must create");
+    };
+
+    let stale_version = created.version + 1;
+    let result = cache
+        .compare_and_swap("k", stale_version, b"b", Ttl::Indefinite)
+        .await;
+    assert!(
+        matches!(
+            result,
+            Err(ClusterError::CasConflict { current: Some(current), .. }) if current.version == created.version
+        ),
+        "a version mismatch must report the current entry, not silently apply"
+    );
+
+    // The value must be untouched.
+    let Ok(Some(entry)) = cache.get("k").await else {
+        panic!("entry must be present");
+    };
+    assert_eq!(entry.value, b"a");
+}
+
+#[tokio::test]
+async fn compare_and_swap_conflicts_on_absent_key() {
+    let cache = StandaloneCache::new();
+    let result = cache
+        .compare_and_swap("missing", 1, b"b", Ttl::Indefinite)
+        .await;
+    assert!(
+        matches!(result, Err(ClusterError::CasConflict { current: None, .. })),
+        "an absent key must report no current entry"
+    );
+}
+
+#[tokio::test]
+async fn compare_and_delete_removes_on_matching_value_and_emits_deleted() {
+    let cache = StandaloneCache::new();
+    assert!(
+        cache
+            .put(PutRequest {
+                key: "k",
+                value: b"a",
+                ttl: Ttl::Indefinite,
+            })
+            .await
+            .is_ok()
+    );
+    let Ok(mut watch) = cache.watch("k").await else {
+        panic!("watch must establish");
+    };
+
+    let Ok(true) = cache.compare_and_delete("k", b"a").await else {
+        panic!("a matching value must delete");
+    };
+    assert!(matches!(
+        watch.recv().await,
+        Some(CacheWatchEvent::Event(CacheEvent::Deleted { .. }))
+    ));
+    assert!(cache.get("k").await.expect("get succeeds").is_none());
+}
+
+#[tokio::test]
+async fn compare_and_delete_is_a_no_op_on_value_mismatch() {
+    let cache = StandaloneCache::new();
+    assert!(
+        cache
+            .put(PutRequest {
+                key: "k",
+                value: b"a",
+                ttl: Ttl::Indefinite,
+            })
+            .await
+            .is_ok()
+    );
+
+    let Ok(false) = cache.compare_and_delete("k", b"different").await else {
+        panic!("a value mismatch must not delete");
+    };
+    let Ok(Some(entry)) = cache.get("k").await else {
+        panic!("entry must still be present");
+    };
+    assert_eq!(entry.value, b"a");
+}
+
+#[tokio::test]
+async fn compare_and_delete_is_a_no_op_on_absent_key() {
+    let cache = StandaloneCache::new();
+    let Ok(false) = cache.compare_and_delete("missing", b"a").await else {
+        panic!("an absent key must not delete");
+    };
+}
+
+#[tokio::test]
+async fn slow_watcher_never_blocks_writers_and_is_told_it_lagged() {
+    let cache = StandaloneCache::new();
+    // A watcher we deliberately never drain until the end.
+    let Ok(mut watch) = cache.watch("k").await else {
+        panic!("watch must establish");
+    };
+
+    // Fill the buffer exactly, then overflow it. Under a blocking broadcast
+    // the overflowing writes would deadlock here (no consumer is draining);
+    // with the non-blocking broadcast every write must complete promptly.
+    let overflow: usize = 50;
+    for _ in 0..(super::WATCH_CAPACITY + overflow) {
+        assert!(
+            cache
+                .put(PutRequest {
+                    key: "k",
+                    value: b"v",
+                    ttl: Ttl::Indefinite,
+                })
+                .await
+                .is_ok(),
+            "a slow watcher must not stall the write path"
+        );
+    }
+
+    // Drain the buffered events to free space; the dropped count is held
+    // until the next broadcast can deliver a Lagged notice.
+    for _ in 0..super::WATCH_CAPACITY {
+        assert!(matches!(
+            watch.recv().await,
+            Some(CacheWatchEvent::Event(CacheEvent::Changed { .. }))
+        ));
+    }
+
+    // The next write flushes the coalesced lag notice ahead of its event.
+    assert!(
+        cache
+            .put(PutRequest {
+                key: "k",
+                value: b"v",
+                ttl: Ttl::Indefinite,
+            })
+            .await
+            .is_ok()
+    );
+    assert!(
+        matches!(watch.recv().await, Some(CacheWatchEvent::Lagged { dropped }) if dropped == overflow as u64),
+        "consumer must be told exactly how many events it missed"
+    );
+    assert!(matches!(
+        watch.recv().await,
+        Some(CacheWatchEvent::Event(CacheEvent::Changed { .. }))
+    ));
+}

--- a/gears/system/cluster/plugins/standalone-cluster-plugin/src/config.rs
+++ b/gears/system/cluster/plugins/standalone-cluster-plugin/src/config.rs
@@ -1,0 +1,32 @@
+//! Configuration for the standalone in-process cluster plugin.
+
+use std::time::Duration;
+
+/// The default cache TTL-sweep cadence. Coarse enough to avoid needless wakeups,
+/// fine enough that watch subscribers observe `Expired` events (and the default
+/// leader/lock backends observe failover) within roughly this bound after a TTL
+/// elapses. Lazy reads already treat an expired entry as absent immediately, so
+/// this only bounds *eventing* latency, not correctness.
+pub const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Tunables for the standalone cluster plugin.
+///
+/// Construct via [`StandaloneClusterConfig::default`] and override fields, or use
+/// the builder conveniences on
+/// [`StandaloneClusterBuilder`](crate::StandaloneClusterBuilder).
+#[derive(Debug, Clone)]
+pub struct StandaloneClusterConfig {
+    /// How often the cache's background sweeper scans for and evicts expired
+    /// entries, emitting an `Expired` event to matching watchers. Must be
+    /// non-zero — [`build_and_start`](crate::StandaloneClusterBuilder::build_and_start)
+    /// rejects a zero interval.
+    pub sweep_interval: Duration,
+}
+
+impl Default for StandaloneClusterConfig {
+    fn default() -> Self {
+        Self {
+            sweep_interval: DEFAULT_SWEEP_INTERVAL,
+        }
+    }
+}

--- a/gears/system/cluster/plugins/standalone-cluster-plugin/src/lib.rs
+++ b/gears/system/cluster/plugins/standalone-cluster-plugin/src/lib.rs
@@ -1,0 +1,54 @@
+//! # Standalone cluster plugin
+//!
+//! `standalone_cluster_plugin` is the in-process, zero-infrastructure backend for
+//! the cluster gear — the default for developer laptops and unit/integration
+//! tests (PRD §3.1, DESIGN §3.11). It implements the cache primitive natively
+//! over an in-memory store and derives leader election, distributed lock, and
+//! service discovery from the SDK's cache-based default backends, so a single
+//! process gets all four cluster primitives with no external dependencies.
+//!
+//! ## Lifecycle (outbox-style builder/handle, DESIGN §3.7)
+//!
+//! This plugin is **not** registered as a `RunnableCapability`. It exposes a
+//! builder/handle pair owned by a parent host gear (or, in follow-ups, by the
+//! cluster wiring crate):
+//!
+//! ```no_run
+//! # async fn doc() -> Result<(), cluster_sdk::ClusterError> {
+//! use standalone_cluster_plugin::StandaloneClusterPlugin;
+//!
+//! let handle = StandaloneClusterPlugin::builder().build_and_start()?;
+//! // Hand the cache backend to the wiring crate / register it in the ClientHub —
+//! // it derives leader election, lock, and service discovery via the SDK default
+//! // backends (DESIGN §3.11).
+//! let _cache = handle.cache();
+//! // On graceful shutdown:
+//! handle.stop().await;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! `build_and_start` starts the cache's background TTL sweeper; `handle.stop()`
+//! cancels it. The plugin performs no remote I/O and never relies on `Drop` for
+//! cleanup.
+//!
+//! ## Status
+//!
+//! The cache is native. Leader election, lock, and service discovery currently
+//! ride the SDK default backends (`CasBased*` / `CacheBased*`) over the native
+//! cache — the "implement cache only, get all four" guarantee (PRD
+//! §5.5, DESIGN §3.11). Native implementations of those three (the DESIGN §3.11
+//! end state) are a follow-up optimization.
+
+#![forbid(unsafe_code)]
+#![deny(rust_2018_idioms)]
+
+mod cache;
+mod config;
+mod plugin;
+mod provider;
+
+pub use cache::StandaloneCache;
+pub use config::StandaloneClusterConfig;
+pub use plugin::{StandaloneClusterBuilder, StandaloneClusterHandle, StandaloneClusterPlugin};
+pub use provider::{PROVIDER_NAME, StandaloneCacheProvider};

--- a/gears/system/cluster/plugins/standalone-cluster-plugin/src/plugin.rs
+++ b/gears/system/cluster/plugins/standalone-cluster-plugin/src/plugin.rs
@@ -1,0 +1,188 @@
+//! The standalone cluster plugin's outbox-style builder and lifecycle handle
+//! (DESIGN §3.7). The plugin is a library, not a `RunnableCapability`: a parent
+//! host gear (or the cluster wiring crate) owns the [`StandaloneClusterHandle`]
+//! from its own `start`/`stop`.
+
+use std::sync::Arc;
+
+use cluster_sdk::observability::otel::OtelClusterMetrics;
+use cluster_sdk::{ClusterCacheBackend, ClusterError, ClusterMetrics, InstrumentedCache};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::cache::StandaloneCache;
+use crate::config::StandaloneClusterConfig;
+use crate::provider::PROVIDER_NAME;
+
+/// Entry point for constructing the standalone in-process cluster plugin.
+///
+/// ```no_run
+/// # async fn doc() -> Result<(), cluster_sdk::ClusterError> {
+/// use standalone_cluster_plugin::StandaloneClusterPlugin;
+/// let handle = StandaloneClusterPlugin::builder().build_and_start()?;
+/// handle.stop().await;
+/// # Ok(())
+/// # }
+/// ```
+pub struct StandaloneClusterPlugin;
+
+impl StandaloneClusterPlugin {
+    /// Returns a builder with the [`default`](StandaloneClusterConfig::default)
+    /// configuration.
+    pub fn builder() -> StandaloneClusterBuilder {
+        StandaloneClusterBuilder {
+            config: StandaloneClusterConfig::default(),
+        }
+    }
+}
+
+/// A fluent builder for the standalone plugin. Build and start it with
+/// [`build_and_start`](Self::build_and_start).
+#[must_use = "a builder starts nothing until `.build_and_start()` is called"]
+pub struct StandaloneClusterBuilder {
+    config: StandaloneClusterConfig,
+}
+
+impl StandaloneClusterBuilder {
+    /// Replaces the whole configuration.
+    pub fn config(mut self, config: StandaloneClusterConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Overrides just the cache TTL-sweep cadence.
+    pub fn sweep_interval(mut self, interval: std::time::Duration) -> Self {
+        self.config.sweep_interval = interval;
+        self
+    }
+
+    /// Builds the plugin: creates the native cache and starts its TTL sweeper.
+    ///
+    /// The wiring crate (`cf-gears-cluster`) wraps the cache backend with the SDK
+    /// default leader-election, lock, and service-discovery backends (DESIGN §3.11).
+    ///
+    /// # Errors
+    /// - [`ClusterError::InvalidConfig`] if `sweep_interval` is zero.
+    pub fn build_and_start(self) -> Result<StandaloneClusterHandle, ClusterError> {
+        if self.config.sweep_interval.is_zero() {
+            return Err(ClusterError::InvalidConfig {
+                reason: "standalone cluster plugin sweep_interval must be non-zero".to_owned(),
+            });
+        }
+
+        let cache = StandaloneCache::new();
+        let shutdown = CancellationToken::new();
+        let sweeper = cache.spawn_sweeper(self.config.sweep_interval, shutdown.clone());
+
+        // The shared metrics sink for every primitive, labelled `standalone`.
+        // Built over the process-global OTel meter; if no meter provider is
+        // installed (the zero-infra dev path, tests) it is transparently a no-op
+        // (ADR-004). Spans and log events are emitted via `tracing` regardless.
+        let metrics: Arc<dyn ClusterMetrics> =
+            Arc::new(OtelClusterMetrics::from_global_meter(PROVIDER_NAME));
+
+        // Wrap the native cache in the SDK's `InstrumentedCache` decorator so its
+        // operations emit the contracted `cluster.cache.*` signals. The concrete
+        // `Arc<StandaloneCache>` is retained separately for `stop` to call the
+        // native `shutdown()`, which the dyn trait does not expose.
+        let cache_dyn: Arc<dyn ClusterCacheBackend> = Arc::new(InstrumentedCache::new(
+            Arc::clone(&cache) as Arc<dyn ClusterCacheBackend>,
+            PROVIDER_NAME,
+            Arc::clone(&metrics),
+        ));
+
+        Ok(StandaloneClusterHandle {
+            cache,
+            cache_dyn,
+            sweeper,
+            shutdown,
+        })
+    }
+}
+
+/// The running standalone plugin. Hands its cache backend to the wiring crate
+/// for `ClientHub` registration and wrapping with SDK default backends.
+///
+/// Call [`stop`](Self::stop) on graceful shutdown.
+pub struct StandaloneClusterHandle {
+    /// The concrete cache, retained so [`stop`](Self::stop) can close active
+    /// watches via the native [`StandaloneCache::shutdown`] (DESIGN §3.13).
+    cache: Arc<StandaloneCache>,
+    /// The same cache as an instrumented trait object, handed to the wiring crate.
+    cache_dyn: Arc<dyn ClusterCacheBackend>,
+    sweeper: JoinHandle<()>,
+    shutdown: CancellationToken,
+}
+
+impl StandaloneClusterHandle {
+    /// The instrumented cache backend (to be registered in `ClientHub` and
+    /// wrapped with SDK defaults by the wiring crate).
+    #[must_use]
+    pub fn cache(&self) -> Arc<dyn ClusterCacheBackend> {
+        Arc::clone(&self.cache_dyn)
+    }
+
+    /// Stops the plugin: closes every active cache watch terminally, then cancels
+    /// the cache sweeper and waits for it to exit. Consumes the handle.
+    ///
+    /// The cache `shutdown()` runs **first** so any active watch observes a
+    /// terminal `Closed(Shutdown)` (`cpt-cf-clst-fr-shutdown-revoke`, DESIGN
+    /// §3.13) before the sweeper stops and the cache is dropped. TTL bounds any
+    /// remaining in-flight cluster resources (DESIGN §3.7) — there is no
+    /// best-effort remote cleanup.
+    pub async fn stop(self) {
+        self.cache.shutdown();
+        self.shutdown.cancel();
+        if let Err(join_err) = self.sweeper.await {
+            tracing::error!(
+                error = %join_err,
+                "standalone cluster plugin TTL sweeper task panicked during shutdown"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use cluster_sdk::cache::PutRequest;
+
+    use super::StandaloneClusterPlugin;
+
+    #[tokio::test]
+    async fn build_and_start_provides_cache_backend() {
+        let handle = StandaloneClusterPlugin::builder()
+            .build_and_start()
+            .expect("standalone plugin must start");
+
+        let cache = handle.cache();
+        assert!(
+            cache
+                .put(PutRequest {
+                    key: "k",
+                    value: b"v",
+                    ttl: cluster_sdk::cache::Ttl::Indefinite,
+                })
+                .await
+                .is_ok()
+        );
+        let Ok(Some(entry)) = cache.get("k").await else {
+            panic!("value must be present");
+        };
+        assert_eq!(entry.value, b"v");
+
+        handle.stop().await;
+    }
+
+    #[tokio::test]
+    async fn zero_sweep_interval_is_rejected() {
+        let result = StandaloneClusterPlugin::builder()
+            .sweep_interval(Duration::ZERO)
+            .build_and_start();
+        assert!(matches!(
+            result,
+            Err(cluster_sdk::ClusterError::InvalidConfig { .. })
+        ));
+    }
+}

--- a/gears/system/cluster/plugins/standalone-cluster-plugin/src/provider.rs
+++ b/gears/system/cluster/plugins/standalone-cluster-plugin/src/provider.rs
@@ -1,0 +1,74 @@
+//! The [`ClusterCacheProvider`] implementation for the standalone backend.
+//!
+//! This is the production glue the wiring crate dispatches to when an operator
+//! binds a cache to `provider: standalone`. It implements the SDK trait — so this
+//! crate depends on `cluster-sdk` only, never on the wiring crate — and builds
+//! the native in-process cache, owning its TTL sweeper via the returned
+//! [`StopHook`].
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use cluster_sdk::{ClusterCacheBackend, ClusterCacheProvider, ClusterError, StopHook};
+use serde::Deserialize;
+
+use crate::plugin::StandaloneClusterPlugin;
+
+/// The operator config `provider` name that selects the standalone backend.
+pub const PROVIDER_NAME: &str = "standalone";
+
+/// The standalone provider's recognized options (Design A — flattened into the
+/// backend binding). `deny_unknown_fields` turns an operator typo (e.g.
+/// `sweep_interval_m` instead of `sweep_interval_ms`) into a startup
+/// `ClusterError::InvalidConfig` instead of a silently-ignored key.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StandaloneOptions {
+    /// The cache TTL-sweep cadence in milliseconds. Omitted → the plugin
+    /// default. Zero is rejected by the builder.
+    #[serde(default)]
+    sweep_interval_ms: Option<u64>,
+}
+
+/// Builds the standalone in-process cache backend from operator config.
+///
+/// Recognized options (Design A — flattened into the backend binding):
+/// - `sweep_interval_ms` (integer): the cache TTL-sweep cadence in milliseconds.
+///   Omitted → the plugin default. Zero is rejected by the builder.
+pub struct StandaloneCacheProvider;
+
+#[async_trait]
+impl ClusterCacheProvider for StandaloneCacheProvider {
+    fn provider(&self) -> &'static str {
+        PROVIDER_NAME
+    }
+
+    async fn build_cache(
+        &self,
+        options: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<(Arc<dyn ClusterCacheBackend>, StopHook), ClusterError> {
+        // Deserialized as a whole (rather than read key-by-key) so an unknown
+        // key is a startup error, not a silently-dropped typo.
+        let opts: StandaloneOptions =
+            serde_json::from_value(serde_json::Value::Object(options.clone())).map_err(|err| {
+                ClusterError::InvalidConfig {
+                    reason: format!("standalone: invalid options: {err}"),
+                }
+            })?;
+
+        let mut builder = StandaloneClusterPlugin::builder();
+        if let Some(ms) = opts.sweep_interval_ms {
+            builder = builder.sweep_interval(Duration::from_millis(ms));
+        }
+
+        let handle = builder.build_and_start()?;
+        let cache = handle.cache();
+        let stop: StopHook = Box::new(move || Box::pin(async move { handle.stop().await }));
+        Ok((cache, stop))
+    }
+}
+
+#[cfg(test)]
+#[path = "provider_tests.rs"]
+mod provider_tests;

--- a/gears/system/cluster/plugins/standalone-cluster-plugin/src/provider_tests.rs
+++ b/gears/system/cluster/plugins/standalone-cluster-plugin/src/provider_tests.rs
@@ -1,0 +1,115 @@
+//! Tests for the standalone [`ClusterCacheProvider`] impl: the flattened-options
+//! contract and the built cache's lifecycle.
+
+use std::time::Duration;
+
+use cluster_sdk::cache::types::{PutRequest, Ttl};
+use cluster_sdk::{CacheEvent, CacheWatchEvent, ClusterCacheProvider, ClusterError};
+
+use super::StandaloneCacheProvider;
+
+#[test]
+fn provider_name_matches_the_operator_config_key() {
+    // The name is the string an operator writes as `provider = "..."`; a rename
+    // is a breaking config change, so pin the externally-visible value.
+    assert_eq!(StandaloneCacheProvider.provider(), "standalone");
+}
+
+#[tokio::test]
+async fn builds_cache_with_default_options() {
+    let options = serde_json::Map::new();
+    let (cache, stop) = StandaloneCacheProvider
+        .build_cache(&options)
+        .await
+        .expect("default options build a cache");
+
+    assert!(
+        cache
+            .put(PutRequest {
+                key: "k",
+                value: b"v",
+                ttl: Ttl::Indefinite,
+            })
+            .await
+            .is_ok()
+    );
+    let Ok(Some(entry)) = cache.get("k").await else {
+        panic!("value must round-trip");
+    };
+    assert_eq!(entry.value, b"v");
+
+    stop().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn applies_the_flattened_sweep_interval() {
+    let mut options = serde_json::Map::new();
+    options.insert("sweep_interval_ms".to_owned(), serde_json::json!(50));
+    let (cache, stop) = StandaloneCacheProvider
+        .build_cache(&options)
+        .await
+        .expect("a valid sweep interval builds a cache");
+
+    // Prove the flattened option is actually applied to the running sweeper:
+    // a TTL'd entry must be actively reaped (emitting `Expired`) on the
+    // configured cadence, not merely lazily on the next read.
+    let Ok(mut watch) = cache.watch("k").await else {
+        panic!("watch must establish");
+    };
+    assert!(
+        cache
+            .put(PutRequest {
+                key: "k",
+                value: b"v",
+                ttl: Ttl::Of(Duration::from_millis(10)),
+            })
+            .await
+            .is_ok()
+    );
+    assert!(matches!(
+        watch.recv().await,
+        Some(CacheWatchEvent::Event(CacheEvent::Changed { .. }))
+    ));
+
+    // Past the 10ms entry TTL and one 50ms sweep tick.
+    tokio::time::advance(Duration::from_millis(60)).await;
+    tokio::task::yield_now().await;
+    assert!(matches!(
+        watch.recv().await,
+        Some(CacheWatchEvent::Event(CacheEvent::Expired { .. }))
+    ));
+
+    stop().await;
+}
+
+#[tokio::test]
+async fn malformed_sweep_interval_is_rejected() {
+    let mut options = serde_json::Map::new();
+    options.insert("sweep_interval_ms".to_owned(), serde_json::json!("soon"));
+    let result = StandaloneCacheProvider.build_cache(&options).await;
+    assert!(
+        matches!(result, Err(ClusterError::InvalidConfig { .. })),
+        "a non-integer sweep interval must be rejected, not silently ignored"
+    );
+}
+
+#[tokio::test]
+async fn zero_sweep_interval_is_rejected() {
+    let mut options = serde_json::Map::new();
+    options.insert("sweep_interval_ms".to_owned(), serde_json::json!(0));
+    let result = StandaloneCacheProvider.build_cache(&options).await;
+    assert!(matches!(result, Err(ClusterError::InvalidConfig { .. })));
+}
+
+#[tokio::test]
+async fn unknown_option_key_is_rejected() {
+    // A typo'd key (missing the trailing `s`) must fail startup rather than
+    // being silently dropped and the intended setting never taking effect.
+    let mut options = serde_json::Map::new();
+    options.insert("sweep_interval_m".to_owned(), serde_json::json!(50));
+    let result = StandaloneCacheProvider.build_cache(&options).await;
+    assert!(
+        matches!(result, Err(ClusterError::InvalidConfig { .. })),
+        "an unrecognized option key must be rejected, not silently ignored"
+    );
+}


### PR DESCRIPTION
Add cf-gears-standalone-cluster-plugin, the zero-infrastructure dev/test deployment for the cluster gear: a native in-process cache provider plus the SDK default leader-election, lock, and service-discovery backends. Builds against cluster-sdk with the `otel` feature so the standalone backend emits cluster metrics.

Add the cf-gears-cluster wiring crate: gear definition, profile-based configuration, provider registry, and ClientHub wiring that defaults to the standalone in-process backend plugin. Include the cluster-sdk examples (single/multi primitive, multi-profile, capability mismatch, observability, plugin-author) and the cf-studio "Nested SDK Examples" artifact autodetect rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added config-driven cluster wiring with profile-based primitive selection (cache required; others optional) and fluent builder lifecycle.
  * Added a standalone in-process cluster backend and provider (`standalone`) for local usage/testing.
  * Added/expanded examples demonstrating single-primitive, multi-primitive, multi-profile, observability, and plugin authoring flows.

* **Bug Fixes**
  * Improved registration rollback on startup failures and strengthened shutdown/unbinding behavior (including stop/drop safety).

* **Documentation**
  * Expanded cluster and standalone plugin READMEs, plus updated traceability audit references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->