### PR TITLE
fix(lint): detect hard-coded GTS prefixes in attributes

### DIFF
--- a/tools/dylint_lints/de09_gts_layer/de0904_no_hardcoded_gts_prefix/Cargo.toml
+++ b/tools/dylint_lints/de09_gts_layer/de0904_no_hardcoded_gts_prefix/Cargo.toml
@@ -25,6 +25,10 @@ path = "ui/macro_markers.rs"
 name = "hardcoded_prefix_in_macros"
 path = "ui/hardcoded_prefix_in_macros.rs"
 
+[[example]]
+name = "hardcoded_prefix_in_attributes"
+path = "ui/hardcoded_prefix_in_attributes.rs"
+
 [dependencies]
 clippy_utils.workspace = true
 dylint_linting.workspace = true

--- a/tools/dylint_lints/de09_gts_layer/de0904_no_hardcoded_gts_prefix/README.md
+++ b/tools/dylint_lints/de09_gts_layer/de0904_no_hardcoded_gts_prefix/README.md
@@ -1,8 +1,8 @@
 # DE0904: No Hard-Coded GTS Prefix
 
-Rejects Rust source that writes a GTS identifier with the `gts.` prefix.
-Use `gts_id!("<suffix>")` so the final prefix comes from the consuming
-crate's `GTS_ID_PREFIX` configuration.
+Rejects Rust source that writes a GTS identifier with the `gts.` prefix,
+including in every ordinary Rust attribute. Use `gts_id!("<suffix>")` so the
+final prefix comes from the consuming crate's `GTS_ID_PREFIX` configuration.
 
 The lint runs before macro expansion. This deliberately limits it to
 user-authored source and makes it compatible with ToolKit wrappers such as
@@ -17,8 +17,8 @@ const TYPE_ID: &str = "gts.cf.core.users.user.v1~";
 const TYPE_ID: &str = gts_id!("cf.core.users.user.v1~");
 ```
 
-The UI suite also exercises real `toolkit_gts::gts_type_schema`,
-`gts_instance!`, `gts_instance_raw!`, and
+The UI suite also exercises ordinary attributes plus real
+`toolkit_gts::gts_type_schema`, `gts_instance!`, `gts_instance_raw!`, and
 `toolkit_canonical_errors::resource_error` invocations in both forms:
 suffixes wrapped with `gts_id!` are accepted, while a user-written `gts.`
 prefix is rejected.

--- a/tools/dylint_lints/de09_gts_layer/de0904_no_hardcoded_gts_prefix/src/lib.rs
+++ b/tools/dylint_lints/de09_gts_layer/de0904_no_hardcoded_gts_prefix/src/lib.rs
@@ -37,16 +37,7 @@ impl EarlyLintPass for De0904NoHardcodedGtsPrefix {
     }
 
     fn check_attribute(&mut self, cx: &EarlyContext<'_>, attr: &Attribute) {
-        let AttrKind::Normal(normal) = &attr.kind else {
-            return;
-        };
-        let Some(last) = normal.item.path.segments.last() else {
-            return;
-        };
-        if !matches!(
-            last.ident.name.as_str(),
-            "gts_type_schema" | "struct_to_gts_schema" | "resource_error"
-        ) {
+        if !matches!(attr.kind, AttrKind::Normal(_)) {
             return;
         }
 
@@ -64,6 +55,12 @@ impl<'ast, 'a, 'cx> visit::Visitor<'ast> for HardcodedPrefixVisitor<'a, 'cx> {
     fn visit_item(&mut self, _item: &'ast Item) {
         // `EarlyLintPass::check_item` is invoked for every item. Do not walk
         // nested items here, otherwise they are visited repeatedly.
+    }
+
+    fn visit_attribute(&mut self, _attr: &'ast Attribute) {
+        // `EarlyLintPass::check_attribute` checks the complete source span of
+        // every ordinary attribute. Avoid walking attribute values here, which
+        // would report their string literals a second time.
     }
 
     fn visit_expr(&mut self, expr: &'ast Expr) {

--- a/tools/dylint_lints/de09_gts_layer/de0904_no_hardcoded_gts_prefix/ui/hardcoded_prefix_in_attributes.rs
+++ b/tools/dylint_lints/de09_gts_layer/de0904_no_hardcoded_gts_prefix/ui/hardcoded_prefix_in_attributes.rs
@@ -1,0 +1,11 @@
+//! A hard-coded `gts.` prefix is rejected in every ordinary attribute.
+
+#[doc = "gts.cf.de0904.tests.doc.v1~"]
+struct Documented;
+
+#[allow(dead_code, reason = "gts.cf.de0904.tests.reason.v1~")]
+struct Allowed;
+
+fn main() {
+    let _ = (Documented, Allowed);
+}

--- a/tools/dylint_lints/de09_gts_layer/de0904_no_hardcoded_gts_prefix/ui/hardcoded_prefix_in_attributes.stderr
+++ b/tools/dylint_lints/de09_gts_layer/de0904_no_hardcoded_gts_prefix/ui/hardcoded_prefix_in_attributes.stderr
@@ -1,0 +1,19 @@
+error: hard-coded GTS ID prefix; use gts_id!("<suffix>") instead (DE0904)
+  --> $DIR/hardcoded_prefix_in_attributes.rs:3:1
+   |
+LL | #[doc = "gts.cf.de0904.tests.doc.v1~"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for example: gts_id!("cf.core.users.user.v1~")
+   = note: `#[deny(de0904_no_hardcoded_gts_prefix)]` on by default
+
+error: hard-coded GTS ID prefix; use gts_id!("<suffix>") instead (DE0904)
+  --> $DIR/hardcoded_prefix_in_attributes.rs:6:1
+   |
+LL | #[allow(dead_code, reason = "gts.cf.de0904.tests.reason.v1~")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for example: gts_id!("cf.core.users.user.v1~")
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
- Inspect all ordinary attributes while avoiding duplicate reports from nested literals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of hard-coded `gts.` prefixes in regular Rust attributes and documentation attributes.
  * Prevented duplicate diagnostics when the same prefix appears within attribute values.
* **Tests**
  * Added coverage confirming hard-coded prefixes are reported, while explicitly allowed cases remain supported.
* **Documentation**
  * Clarified how to use `gts_id!("<suffix>")` to generate configurable GTS identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->