### PR TITLE
fix(file-storage): Postgres jsonb binding, S3 readiness probe, standalone doc corrections

### DIFF
--- a/gears/file-storage/docs/ADR/0006-cpt-cf-file-storage-adr-content-hash-modes.md
+++ b/gears/file-storage/docs/ADR/0006-cpt-cf-file-storage-adr-content-hash-modes.md
@@ -98,7 +98,9 @@ upload with no re-read of the stored object, with no non-approved algorithm anyw
 ## Decision Outcome
 
 Chosen option: **exactly two content-hash modes, both SHA-256, each computed on-the-fly during upload, with no
-re-read of the stored object at finalize/complete time:**
+re-*hashing* re-read of the stored object at multipart `complete` time.** (Single-part `finalize` retains its
+existing whole-object read-back for defense-in-depth size/hash/MIME re-verification — see point 3 below; only the
+multipart-composite mode's assembly step avoids a full re-read.)
 
 1. **Non-multipart upload → plain `sha256(whole object bytes)`.** The canonical whole-object hash — unchanged in
    shape. Computed by the sidecar's `put_stream` as bytes transit it. It is **not** represented as a
@@ -111,11 +113,17 @@ re-read of the stored object at finalize/complete time:**
    `manifest` string are stored and returned by the API, so a client that has the file can independently re-verify
    with cryptographic precision: split the object at the recorded offsets, `sha256` each part, rebuild the manifest,
    check `sha256(manifest) == root`.
-3. **The hash is never computed by re-downloading/re-reading the stored object.** It is always computed on-the-fly, as
-   bytes flow to the backend, inside the sidecar's streaming `put_stream`/`upload_part`. This removes the existing
-   single-part finalize read-back (`write.rs`'s `read_back_and_hash_streaming`) and the S3 `complete_multipart`
-   re-`GetObject`. See [below](#the-on-the-fly--no-re-read-principle-and-its-trust-model) for why this still closes the
-   0.1 vulnerability.
+3. **The multipart composite hash is never computed by re-downloading/re-reading the assembled stored object.** It is
+   always computed on-the-fly, from the per-part digests already collected as bytes flow to the backend, inside the
+   sidecar's streaming `upload_part`. This removes the S3 `complete_multipart` re-`GetObject` that a flat-rehash
+   design would otherwise need. **This does not extend to single-part uploads**: `write.rs`'s
+   `read_back_and_hash_streaming` is still called on every single-part `finalize` (both `finalize_upload` and
+   `finalize_upload_by_token`) as a defense-in-depth re-derivation of size/hash/MIME from the real backend object —
+   that read-back was never proposed for elimination by this ADR and remains unchanged. `complete_multipart` does
+   still issue one bounded (~8 KiB) ranged `GetObject`/`get_range` against the assembled object, but only for MIME
+   magic-byte sniffing (P2 remediation item 1.10), not to (re)compute the hash. See
+   [below](#the-on-the-fly--no-re-read-principle-and-its-trust-model) for why this still closes the 0.1
+   vulnerability.
 4. **Mode selection is not a user- or operator-facing choice.** There is no per-request algorithm override and no
    gear-level default-config knob to set — the mode is a pure function of which upload path executed. A
    non-multipart completion always produces `whole-sha256`; a multipart completion always produces
@@ -187,9 +195,14 @@ client-side re-verification possible without any out-of-band knowledge of the up
 
 ### Client and migrate_backend re-verification
 
-Because the manifest records offsets and per-part digests, and both `root` and `manifest` are returned by the API,
-**every verifier — a client, or the control plane's own `migrate_backend`** — can independently re-derive everything
-from the object bytes plus the stored manifest, with no dependency on any other retained state:
+Because the manifest records offsets and per-part digests, and both `root` and `manifest` are returned by the
+`POST .../multipart/{upload_id}/complete` response, **every verifier — a client, or the control plane's own
+`migrate_backend`** — can independently re-derive everything from the object bytes plus the manifest, with no
+dependency on any other retained state. **Tracked API-exposure gap**: `manifest` is returned only in that one-shot
+`complete` response — `VersionDto` (`GET /files/{id}/versions`) has no `manifest` field, so a client that wants to
+re-verify **later** (not at complete time) must have retained the manifest text itself from the original `complete`
+response; there is no way to re-fetch it from the control plane's REST surface today. `migrate_backend` does not
+have this limitation — it reads `version_hash_manifest` directly, server-side.
 
 1. Split the object at the manifest's recorded offsets (the final part's length follows from the version's known
    `size`).
@@ -265,9 +278,11 @@ manifest and root from the hashes and offsets you were given."
 
 ### Consequences
 
-* **Removes a full read pass from every completed upload.** `finalize_upload[_by_token]`'s read-back-and-rehash and
-  `S3Backend::complete_multipart`'s post-completion `GetObject` are both eliminated — a genuine bandwidth/cost win at
-  fleet scale.
+* **Removes the full-object re-hash read pass from multipart completion.** `S3Backend::complete_multipart`'s
+  post-completion `GetObject`-and-rehash is eliminated — a genuine bandwidth/cost win at fleet scale for multipart
+  uploads specifically. **Single-part `finalize_upload[_by_token]`'s read-back-and-rehash is retained** (defense in
+  depth against a forged size/hash claim) and was never in scope for elimination; `complete_multipart` also still
+  issues one small bounded ranged read for MIME sniffing (see point 3 of the Decision Outcome above).
 * **The stored `(hash_mode, hash_value)`, plus the `version_hash_manifest` row where applicable, is the sole ground
   truth for verification going forward** — not something re-derived from gear config, and not dependent on any
   configuration existing in the first place, since there is none to configure.
@@ -307,8 +322,13 @@ All confirmation items are satisfied by the shipped code and tests:
 * [x] Unit test confirming the manifest wire format is unambiguous: a fixed set of `(offset, digest)` pairs always
   serializes to the same expected byte string, and `sha256` of that string matches an independently-computed
   reference `root`. (`src/infra/content/hash_mode_tests.rs`)
-* [x] Integration test asserting **no `GetObject`/re-read call** occurs at `complete_multipart` time — a
-  request-counting wrapper backend. (`tests/content_hash_modes_test.rs::complete_multipart_issues_no_object_reread`)
+* [x] Integration test asserting **no whole-object `GetObject`/re-read call** occurs at `complete_multipart` time —
+  a request-counting wrapper backend that counts `get`/`get_stream` but deliberately not `get_range` (a bounded
+  range read is not a "whole-object read" for this guarantee's purposes — see the test's own `CountingBackend` doc
+  comment). This qualifier matters in practice: `complete_multipart_upload` does issue one small (~8 KiB) `get_range`
+  against the assembled object for MIME magic-byte sniffing (P2 remediation item 1.10, added after this test), which
+  is intentionally excluded from what this test guards.
+  (`tests/content_hash_modes_test.rs::complete_multipart_issues_no_object_reread`)
 * [x] Integration test asserting a client-side re-verification helper — split the object at the manifest's offsets,
   rehash each part, rebuild the manifest, compare to `root` — succeeds against real uploaded content and fails when
   any byte in any part is tampered with.

--- a/gears/file-storage/docs/features/content-hash-modes.md
+++ b/gears/file-storage/docs/features/content-hash-modes.md
@@ -119,13 +119,14 @@ The one genuinely new actor-facing journey this feature enables is independent c
   error (`whole-sha256` versions carry no manifest; re-verification is a direct `sha256(object bytes)` comparison)
 
 **Steps**:
-1. [ ] - `p2` - Client: fetch version metadata (`GET /files/{id}/versions`), obtaining `hash_mode`, `hash_value`
-   (`root`), and `part_count`. **`manifest` is NOT available from this or any other GET endpoint** (`VersionDto` has
+1. [ ] - `p2` - Client: fetch version metadata (`GET /files/{id}/versions`), obtaining `hash_mode`, the stored hash
+   (wire field `hash` on `VersionDto`; the `root` for a composite version — stored as `hash_value` in the DB), and
+   `part_count`. **`manifest` is NOT available from this or any other GET endpoint** (`VersionDto` has
    no `manifest` field — a tracked API-exposure gap); for a `multipart-composite-sha256` version the client must
    already be holding the `manifest` text it retained from the original `POST .../complete` response
    - `inst-reverify-fetch-metadata`
 2. [ ] - `p2` - **IF** `hash_mode == whole-sha256`: compute `sha256(object bytes)` directly and compare to
-   `hash_value` - `inst-reverify-whole`
+   the fetched hash (`VersionDto.hash`) - `inst-reverify-whole`
 3. [ ] - `p2` - **ELSE** (`hash_mode == multipart-composite-sha256`): Algorithm: re-derive and verify using
    `cpt-cf-file-storage-algo-content-hash-modes-verify` - `inst-reverify-composite`
 4. [ ] - `p2` - **RETURN** verification result (match / mismatch, with the specific diverging part offset when
@@ -732,7 +733,7 @@ existing session-scoped lifecycle.
 |---|---|---|---|
 | Single-part `finalize_upload[_by_token]` (`write.rs`) | re-read whole object, `hash::sha256`, compare | unchanged | N/A (multipart only) |
 | Multipart `complete_multipart_upload` (`multipart_service.rs`) | `backend.complete_multipart` re-reads + flat SHA-256 | N/A | build manifest from already-collected `(offset, part_hash)` pairs, `root = sha256(manifest)` — **no re-read** |
-| Client-side re-verification | N/A (no multipart mode existed with an independent client check) | re-read/re-fetch the object, `sha256`, compare to `hash_value` — unchanged, always possible from object bytes alone | **retain `root` and `manifest` from the `POST .../complete` response** (they are not re-fetchable later — `VersionDto`/`GET /files/{id}/versions` has no `manifest` field, a tracked API-exposure gap), split the object at the manifest's recorded offsets, `sha256` each part, rebuild the manifest string per §3, `sha256(manifest) == root` — self-contained given object bytes + the retained manifest; not possible from object bytes alone |
+| Client-side re-verification | N/A (no multipart mode existed with an independent client check) | re-read/re-fetch the object, `sha256`, compare to `hash_value` — unchanged, always possible from object bytes alone | **retain the composite root (wire field `content_hash` on the `POST .../complete` response) and `manifest`** (they are not re-fetchable later — `VersionDto`/`GET /files/{id}/versions` has no `manifest` field, a tracked API-exposure gap), split the object at the manifest's recorded offsets, `sha256` each part, rebuild the manifest string per §3, `sha256(manifest) == root` — self-contained given object bytes + the retained manifest; not possible from object bytes alone |
 | `migrate_backend` (`backend.rs:35-170`) | `Store::verify_content_hash` = hard-coded `hash::sha256(blob)` | unchanged: re-read + whole-object SHA-256 rehash, compare to `hash_value` | fetch the `version_hash_manifest` row alongside the version; re-read the (already necessarily re-read, since this is a backend copy) object bytes; split at the manifest's offsets, `sha256` each part, rebuild the manifest, compare `sha256(manifest)` to `hash_value` — **fully self-contained from object bytes + the stored manifest row, no dependency on `multipart_upload_parts` surviving** |
 | Any future generic "re-verify a version's integrity" tool | implicit, whole-object | dispatch by `hash_mode`, whole-object rehash | dispatch by `hash_mode`; fetch the manifest row, re-derive per the migrate_backend path above |
 

--- a/gears/file-storage/docs/features/content-hash-modes.md
+++ b/gears/file-storage/docs/features/content-hash-modes.md
@@ -75,7 +75,7 @@ SHA-256 is the only algorithm for both modes and there is no remaining choice to
 
 | Actor | Role in Feature |
 |-------|-----------------|
-| `cpt-cf-file-storage-actor-platform-user` | Receives `hash_mode`, `part_count`, and (for multipart-composite versions) the `manifest` text in complete/metadata responses; may independently re-derive and verify the stored `root` from the object bytes plus the manifest |
+| `cpt-cf-file-storage-actor-platform-user` | Receives `hash_mode`/`part_count` in both the `complete` response and version-metadata (`GET /files/{id}/versions`) responses; the `manifest` text itself is returned **only** by the one-shot `complete` response (not by metadata responses — a tracked API-exposure gap) and must be retained client-side to re-derive and verify the stored `root` from the object bytes plus the manifest later |
 | `cpt-cf-file-storage-actor-cf-gears` | Peer gear / service consuming the same additive metadata fields; also the actor that triggers `migrate_backend`, whose mode-aware verification this feature makes self-contained |
 
 ### 1.4 References
@@ -108,9 +108,9 @@ The one genuinely new actor-facing journey this feature enables is independent c
 **Actor**: `cpt-cf-file-storage-actor-platform-user`
 
 **Success Scenarios**:
-- Client holding the full object bytes plus the API-returned `root` and `manifest` independently re-derives `root`
-  using nothing but a stock SHA-256 implementation and confirms it matches, with no dependency on any
-  multipart-session state or trust in the server's claimed offsets alone
+- Client holding the full object bytes plus the `root` and `manifest` it retained from the multipart `complete`
+  response independently re-derives `root` using nothing but a stock SHA-256 implementation and confirms it matches,
+  with no dependency on any multipart-session state or trust in the server's claimed offsets alone
 
 **Error Scenarios**:
 - Any byte in any part has been tampered with or corrupted — the recomputed per-part digest does not match the
@@ -119,8 +119,11 @@ The one genuinely new actor-facing journey this feature enables is independent c
   error (`whole-sha256` versions carry no manifest; re-verification is a direct `sha256(object bytes)` comparison)
 
 **Steps**:
-1. [ ] - `p2` - Client: fetch version metadata, obtaining `hash_mode`, `hash_value` (`root`), `part_count`, and (for
-   `multipart-composite-sha256` versions only) `manifest` - `inst-reverify-fetch-metadata`
+1. [ ] - `p2` - Client: fetch version metadata (`GET /files/{id}/versions`), obtaining `hash_mode`, `hash_value`
+   (`root`), and `part_count`. **`manifest` is NOT available from this or any other GET endpoint** (`VersionDto` has
+   no `manifest` field — a tracked API-exposure gap); for a `multipart-composite-sha256` version the client must
+   already be holding the `manifest` text it retained from the original `POST .../complete` response
+   - `inst-reverify-fetch-metadata`
 2. [ ] - `p2` - **IF** `hash_mode == whole-sha256`: compute `sha256(object bytes)` directly and compare to
    `hash_value` - `inst-reverify-whole`
 3. [ ] - `p2` - **ELSE** (`hash_mode == multipart-composite-sha256`): Algorithm: re-derive and verify using
@@ -568,8 +571,14 @@ never diverge:**
 7. **Part count is implicit but also stored redundantly.** The number of
    `part` entries in the manifest always equals the version row's
    `part_count` column (§5); a manifest whose entry count disagrees with the
-   stored `part_count` is corrupt and MUST be treated as a verification
-   failure, not silently trusted from either source alone.
+   stored `part_count` **should** be treated as corrupt/a verification
+   failure, not silently trusted from either source alone. **Known gap
+   (tracked, not implemented)**: `Store::verify_content_hash` takes no
+   `part_count` parameter and `migrate_backend` never compares the manifest's
+   entry count against the stored column — this cross-check does not
+   actually run anywhere in code today. Do not infer it is enforced from this
+   normative description; treat it as a documented intent pending
+   implementation, not a shipped invariant.
 8. **Empty / degenerate cases.** A multipart upload always has at least one
    part by construction (S3 and this gear's own multipart flow both reject
    zero-part completion), so the manifest always has at least one `part`
@@ -723,7 +732,7 @@ existing session-scoped lifecycle.
 |---|---|---|---|
 | Single-part `finalize_upload[_by_token]` (`write.rs`) | re-read whole object, `hash::sha256`, compare | unchanged | N/A (multipart only) |
 | Multipart `complete_multipart_upload` (`multipart_service.rs`) | `backend.complete_multipart` re-reads + flat SHA-256 | N/A | build manifest from already-collected `(offset, part_hash)` pairs, `root = sha256(manifest)` — **no re-read** |
-| Client-side re-verification | N/A (no multipart mode existed with an independent client check) | re-read/re-fetch the object, `sha256`, compare to `hash_value` — unchanged, always possible from object bytes alone | fetch `root` **and** `manifest` from the metadata API, split the object at the manifest's recorded offsets, `sha256` each part, rebuild the manifest string per §3, `sha256(manifest) == root` — **self-contained given object bytes + manifest; not possible from object bytes alone** |
+| Client-side re-verification | N/A (no multipart mode existed with an independent client check) | re-read/re-fetch the object, `sha256`, compare to `hash_value` — unchanged, always possible from object bytes alone | **retain `root` and `manifest` from the `POST .../complete` response** (they are not re-fetchable later — `VersionDto`/`GET /files/{id}/versions` has no `manifest` field, a tracked API-exposure gap), split the object at the manifest's recorded offsets, `sha256` each part, rebuild the manifest string per §3, `sha256(manifest) == root` — self-contained given object bytes + the retained manifest; not possible from object bytes alone |
 | `migrate_backend` (`backend.rs:35-170`) | `Store::verify_content_hash` = hard-coded `hash::sha256(blob)` | unchanged: re-read + whole-object SHA-256 rehash, compare to `hash_value` | fetch the `version_hash_manifest` row alongside the version; re-read the (already necessarily re-read, since this is a backend copy) object bytes; split at the manifest's offsets, `sha256` each part, rebuild the manifest, compare `sha256(manifest)` to `hash_value` — **fully self-contained from object bytes + the stored manifest row, no dependency on `multipart_upload_parts` surviving** |
 | Any future generic "re-verify a version's integrity" tool | implicit, whole-object | dispatch by `hash_mode`, whole-object rehash | dispatch by `hash_mode`; fetch the manifest row, re-derive per the migrate_backend path above |
 

--- a/gears/file-storage/file-storage-sdk/README.md
+++ b/gears/file-storage/file-storage-sdk/README.md
@@ -2,3 +2,7 @@
 
 Public API surface (client trait, model types, GTS constants, error envelope) for the
 `file-storage` gear. See `gears/file-storage/docs/DESIGN.md`.
+
+**Status**: model types (`File`, `FileVersion`, `ByteRange`, owner/metadata types, …) and GTS constants are real and
+used by the gear today. The inter-gear client trait (`FileStorageClientV1` in `src/api.rs`) is still a stub — it
+exposes only a placeholder `module_name()` method, with no presign/bind/metadata-CRUD operations wired yet.

--- a/gears/file-storage/file-storage/src/infra/backend/s3.rs
+++ b/gears/file-storage/file-storage/src/infra/backend/s3.rs
@@ -57,13 +57,6 @@ const SIGN_DURATION: Duration = Duration::from_mins(1);
 /// megabytes of data.
 const DEFAULT_MULTIPART_THRESHOLD_BYTES: u64 = 8 * 1024 * 1024;
 
-/// Backend path probed by `is_ready` (P2 1.6). Deliberately never written by
-/// any real upload (`file_versions.backend_path` is always
-/// `/{file_id}/{version_id}`, a UUID pair, so this literal can never collide)
-/// — the probe only cares whether the round trip to the endpoint succeeds and
-/// is authenticated, not whether the object exists.
-const READYZ_PROBE_PATH: &str = "/__file_storage_readyz_probe__";
-
 /// An S3-compatible storage backend. Talks to any S3-compatible HTTP API
 /// (real AWS S3, `MinIO`, `s3s-fs` in tests) via path-style addressing.
 pub struct S3Backend {
@@ -768,16 +761,31 @@ impl StorageBackend for S3Backend {
         Ok(paths)
     }
 
-    /// Readiness probe: a `HeadObject` against `READYZ_PROBE_PATH`, a
-    /// well-known key no real upload ever writes. Reuses `exists` rather than
-    /// adding a new S3 API surface: `exists` already treats a clean 404 as
-    /// `Ok(false)` (endpoint reachable, credentials valid, object absent —
-    /// exactly the expected outcome here) and any other status
-    /// (auth failure, 5xx) or transport error as `Err`, so mapping its `Ok`
-    /// case to `()` is sufficient — the probed key's actual presence/absence
-    /// is irrelevant to readiness.
+    /// Readiness probe: `ListObjectsV2` (`max-keys=1`) against the bucket
+    /// itself, not a `HeadObject` against a well-known probe key.
+    ///
+    /// `HeadObject` cannot distinguish "bucket exists, probe key absent"
+    /// from "bucket does not exist (or is misconfigured)": both come back as
+    /// a bare `404` with no body — HEAD responses never carry one, so there
+    /// is nothing in the response to tell `NoSuchBucket` apart from
+    /// `NoSuchKey`. `exists`'s 404-means-absent mapping (correct for its own
+    /// contract) previously leaked into readiness via this method, so a
+    /// missing/misconfigured bucket reported `Ok(false)` — "reachable,
+    /// object absent" — same as the expected steady-state, and `/readyz`
+    /// passed while every real read/write against that backend would fail.
+    ///
+    /// `ListObjectsV2` is bucket-scoped: it returns `200` (with an empty
+    /// `<Contents>` list) for *any* existing, accessible bucket regardless of
+    /// its contents, and a genuine error status (404 `NoSuchBucket`, 403
+    /// `AccessDenied`, etc.) only when the bucket itself is missing or
+    /// inaccessible. `send_and_check` already maps any non-2xx status to
+    /// `Err`, so success/failure of this call alone is the bucket-level
+    /// signal readiness needs — the returned listing body is discarded.
     async fn is_ready(&self) -> Result<(), DomainError> {
-        self.exists(READYZ_PROBE_PATH).await.map(|_| ())
+        let mut action = self.bucket.list_objects_v2(Some(&self.credentials));
+        action.with_max_keys(1);
+        let url = action.sign(SIGN_DURATION);
+        self.send_and_check(self.http.get(url)).await.map(|_| ())
     }
 }
 

--- a/gears/file-storage/file-storage/src/infra/backend/s3_tests.rs
+++ b/gears/file-storage/file-storage/src/infra/backend/s3_tests.rs
@@ -201,8 +201,9 @@ async fn s3_backend_exists_distinguishes_missing_from_error() {
 }
 
 /// P2 1.6: `is_ready` against a reachable, correctly-authenticated `s3s-fs`
-/// endpoint must succeed — the probed key is expected to be absent (a clean
-/// 404), which `is_ready` must still treat as "ready".
+/// endpoint with an existing (empty) bucket must succeed — `ListObjectsV2`
+/// returns `200` with an empty listing, which `is_ready` must treat as
+/// "ready".
 #[tokio::test]
 async fn s3_is_ready_ok_against_s3s_fs() {
     let (addr, dir) = start_s3s_fs().await;
@@ -245,6 +246,36 @@ async fn s3_is_ready_err_against_closed_port() {
         .is_ready()
         .await
         .expect_err("is_ready must fail against an unreachable endpoint");
+}
+
+/// Regression test for the bucket-missing false positive: `is_ready` must
+/// fail against a reachable, correctly-authenticated endpoint whose target
+/// bucket does not exist. Deliberately does NOT go through `make_backend`
+/// (which pre-creates the bucket directory) — `s3s-fs` has no bucket at this
+/// path, so `HeadObject` and `ListObjectsV2` both 404, but only
+/// `ListObjectsV2`'s `NoSuchBucket` can be told apart from a merely-absent
+/// key. Before the `ListObjectsV2`-based probe, this same 404 was folded
+/// into `exists`'s "key absent" `Ok(false)` and `is_ready` reported ready.
+#[tokio::test]
+async fn s3_is_ready_err_against_missing_bucket() {
+    let (addr, _dir) = start_s3s_fs().await;
+    let endpoint: url::Url = format!("http://{addr}")
+        .parse()
+        .expect("valid endpoint url");
+    let backend = S3Backend::new(
+        "s3-test",
+        endpoint,
+        "us-east-1",
+        unique_bucket(),
+        TEST_ACCESS_KEY,
+        TEST_SECRET_KEY,
+    )
+    .expect("construct S3Backend");
+
+    backend
+        .is_ready()
+        .await
+        .expect_err("is_ready must fail when the target bucket does not exist");
 }
 
 #[tokio::test]

--- a/gears/file-storage/file-storage/src/infra/mod.rs
+++ b/gears/file-storage/file-storage/src/infra/mod.rs
@@ -2,9 +2,11 @@
 //!
 //! - `storage` — SeaORM entities + tenant-scoped repositories + migrations
 //! - `content` — hashing, magic-byte mime validation, Range parsing
-//! - `backend` — pluggable storage-backend abstraction (local-fs, in-memory)
+//! - `backend` — pluggable storage-backend abstraction (local-fs, in-memory, S3)
 //! - `signed_url` — Ed25519-signed opaque content tokens (issuer + verifier)
 //! - `external_clients` — optional external-service adapters (quota, usage reporting)
+//! - `authz` — `Authorizer` adapter over the platform's `PolicyEnforcer`
+//! - `metrics` — OTel-backed `FileStorageMetricsPort` implementation
 
 pub mod authz;
 pub mod backend;

--- a/gears/file-storage/file-storage/src/infra/storage/entity/policy.rs
+++ b/gears/file-storage/file-storage/src/infra/storage/entity/policy.rs
@@ -25,8 +25,13 @@ pub struct Model {
     /// `None` when `scope = "tenant"`; the user's `owner_id` when `scope = "user"`.
     pub scope_owner_id: Option<Uuid>,
     /// Policy body serialized as JSON (see `PolicyBody`).
-    #[sea_orm(column_type = "Text")]
-    pub body: String,
+    ///
+    /// Stored as `jsonb` on `Postgres` and `TEXT` on `SQLite` (`SeaORM`'s `Json`
+    /// column type maps transparently to both), matching the DDL in
+    /// `migrations::m20260701_000001_p2_initial`. Mirrors the pattern used by
+    /// `audit_outbox::Model::detail` / `events_outbox::Model::payload`.
+    #[sea_orm(column_type = "Json")]
+    pub body: Json,
     pub created_at: OffsetDateTime,
     pub updated_at: OffsetDateTime,
 }
@@ -35,3 +40,19 @@ pub struct Model {
 pub enum Relation {}
 
 impl ActiveModelBehavior for ActiveModel {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for the entity/DDL type mismatch: the Postgres DDL
+    /// (`migrations::m20260701_000001_p2_initial::POSTGRES_UP`) declares
+    /// `body jsonb NOT NULL`. If this column ever drifts back to
+    /// `ColumnType::Text`, inserts against Postgres fail with "column is of
+    /// type jsonb but expression is of type text" even though the `SQLite`
+    /// test suite (where the column really is `TEXT`) would still pass.
+    #[test]
+    fn body_column_is_json_typed() {
+        assert_eq!(Column::Body.def().get_column_type(), &ColumnType::Json);
+    }
+}

--- a/gears/file-storage/file-storage/src/infra/storage/entity/retention_rule.rs
+++ b/gears/file-storage/file-storage/src/infra/storage/entity/retention_rule.rs
@@ -22,8 +22,13 @@ pub struct Model {
     /// Target id -- NULL for tenant scope, `user_id` for user scope, `file_id` for file scope.
     pub scope_target_id: Option<Uuid>,
     /// Retention rule body serialized as JSON (see `RetentionRuleBody`).
-    #[sea_orm(column_type = "Text")]
-    pub body: String,
+    ///
+    /// Stored as `jsonb` on `Postgres` and `TEXT` on `SQLite` (`SeaORM`'s `Json`
+    /// column type maps transparently to both), matching the DDL in
+    /// `migrations::m20260701_000001_p2_initial`. Mirrors the pattern used by
+    /// `audit_outbox::Model::detail` / `events_outbox::Model::payload`.
+    #[sea_orm(column_type = "Json")]
+    pub body: Json,
     pub created_at: OffsetDateTime,
 }
 
@@ -31,3 +36,19 @@ pub struct Model {
 pub enum Relation {}
 
 impl ActiveModelBehavior for ActiveModel {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for the entity/DDL type mismatch: the Postgres DDL
+    /// (`migrations::m20260701_000001_p2_initial::POSTGRES_UP`) declares
+    /// `body jsonb NOT NULL`. If this column ever drifts back to
+    /// `ColumnType::Text`, inserts against Postgres fail with "column is of
+    /// type jsonb but expression is of type text" even though the `SQLite`
+    /// test suite (where the column really is `TEXT`) would still pass.
+    #[test]
+    fn body_column_is_json_typed() {
+        assert_eq!(Column::Body.def().get_column_type(), &ColumnType::Json);
+    }
+}

--- a/gears/file-storage/file-storage/src/infra/storage/repo/policy_repo.rs
+++ b/gears/file-storage/file-storage/src/infra/storage/repo/policy_repo.rs
@@ -93,7 +93,7 @@ impl PolicyRepo {
             .map_err(db_err)?;
 
         let policy_id = Uuid::now_v7();
-        let body_json = serde_json::to_string(body)
+        let body_json = serde_json::to_value(body)
             .map_err(|e| DomainError::database(format!("policy body serialization: {e}")))?;
 
         let am = ActiveModel {
@@ -116,7 +116,7 @@ impl PolicyRepo {
 fn map_model(m: Model) -> Result<StoredPolicy, DomainError> {
     let scope = PolicyScope::parse(&m.scope)
         .ok_or_else(|| DomainError::database(format!("invalid policy scope in DB: {}", m.scope)))?;
-    let body: PolicyBody = serde_json::from_str(&m.body)
+    let body: PolicyBody = serde_json::from_value(m.body)
         .map_err(|e| DomainError::database(format!("policy body deserialization: {e}")))?;
     Ok(StoredPolicy {
         policy_id: m.policy_id,

--- a/gears/file-storage/file-storage/src/infra/storage/repo/retention_rule_repo.rs
+++ b/gears/file-storage/file-storage/src/infra/storage/repo/retention_rule_repo.rs
@@ -66,7 +66,7 @@ impl RetentionRuleRepo {
         params: InsertRetentionRule<'_>,
     ) -> Result<Uuid, DomainError> {
         let rule_id = Uuid::now_v7();
-        let body_json = serde_json::to_string(params.body)
+        let body_json = serde_json::to_value(params.body)
             .map_err(|e| DomainError::database(format!("retention body serialization: {e}")))?;
 
         let am = ActiveModel {
@@ -150,7 +150,7 @@ fn map_model(m: Model) -> Result<StoredRetentionRule, DomainError> {
     let scope = RetentionScope::parse(&m.scope).ok_or_else(|| {
         DomainError::database(format!("invalid retention scope in DB: {}", m.scope))
     })?;
-    let body: RetentionRuleBody = serde_json::from_str(&m.body)
+    let body: RetentionRuleBody = serde_json::from_value(m.body)
         .map_err(|e| DomainError::database(format!("retention body deserialization: {e}")))?;
     Ok(StoredRetentionRule {
         rule_id: m.rule_id,


### PR DESCRIPTION
## Summary

Independent fixes split out of #4218 (the file-storage audit-remediation PR) to keep both PRs under the 50-file review limit. This PR is fully standalone — it does not depend on #4218 and can merge in any order relative to it.

### Postgres jsonb compatibility (HIGH)
`policies.body` / `retention_rules.body` SeaORM entities declared `Text`/`String` while the Postgres DDL declares `jsonb` — binding a text parameter into a `jsonb` column fails on Postgres ("column is of type jsonb but expression is of type text"). The test suite runs SQLite only, so every policy/retention write on the documented production target was unexercised and broken.

- Entities switched to `column_type = "Json"` (same pattern as the audit/events outbox entities); repos bind `serde_json::Value` via `to_value`/`from_value`.
- Regression tests assert the entity column types stay `Json`.

### S3 readiness probe false positive
`S3Backend::is_ready` probed a well-known key with `HeadObject`; a HEAD 404 carries no body, so `NoSuchBucket` was indistinguishable from `NoSuchKey` and a missing/misconfigured bucket reported ready while all real I/O failed. Now probes the bucket itself via `ListObjectsV2` (`max-keys=1`). Regression test included.

### Standalone doc corrections (describe current behavior, no code dependency)
- **ADR-0006**: only the multipart full re-read was eliminated — the single-part finalize read-back is retained, and `complete` still issues an 8 KiB ranged read for MIME sniffing.
- **content-hash-modes.md**: `part_count`-vs-manifest cross-check marked as a known gap (not implemented); the client re-verification flow now says the manifest must be retained from the `complete` response (no metadata endpoint returns it).
- **infra module doc**: lists the `authz`/`metrics` submodules and the S3 backend.
- **SDK README**: honest note that the inter-gear client trait (`FileStorageClientV1`) is still a stub.

## Test plan

- [x] `cargo test -p cf-gears-file-storage` on this branch alone — **361 passed, 0 failed**
- [x] `cargo clippy --all-targets` clean, `cargo fmt --check` clean
- [x] `cfs validate` — 0 errors
- [x] New regression tests: entity column types are `Json`; `is_ready` errors against a missing bucket

https://claude.ai/code/session_01WZUBxb7myjUZHMYmbRtJqG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified multipart content-hash verification semantics, including where `manifest` is available and updated client re-verification requirements.
  - Refined assertions around what multipart completion does (hashing vs. MIME sniffing) and noted a documented gap in manifest/part-count cross-checking.
  - Updated file-storage API README to reflect current public surface status.
- **Bug Fixes**
  - Improved S3 backend readiness probing to correctly treat reachable buckets as ready and missing buckets as errors.
  - Corrected JSON persistence for policy and retention-rule bodies by aligning stored column types and serialization/deserialization.
- **Tests**
  - Added/updated regression coverage for S3 readiness and JSON column typing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->