### PR TITLE
feat(cluster): implement Postgres cluster plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,6 +1642,7 @@ dependencies = [
  "cf-gears-cluster-sdk",
  "cf-gears-standalone-cluster-plugin",
  "cf-gears-toolkit",
+ "cf-postgres-cluster-plugin",
  "parking_lot",
  "rand 0.10.1",
  "serde",
@@ -1660,6 +1661,7 @@ version = "0.1.3"
 dependencies = [
  "async-trait",
  "cf-gears-cluster-sdk",
+ "futures",
  "parking_lot",
  "proptest",
  "tokio",
@@ -3141,6 +3143,35 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "uuid",
+]
+
+[[package]]
+name = "cf-postgres-cluster-plugin"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "cf-gears-cluster",
+ "cf-gears-cluster-conformance",
+ "cf-gears-cluster-sdk",
+ "cf-gears-standalone-cluster-plugin",
+ "cf-gears-toolkit",
+ "cf-gears-toolkit-macros",
+ "dashmap",
+ "futures-util",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -6217,9 +6248,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ members = [
     "gears/system/cluster/cluster-sdk",
     "gears/system/cluster/cluster-conformance",
     "gears/system/cluster/plugins/standalone-cluster-plugin",
+    "gears/system/cluster/plugins/postgres-cluster-plugin",
     "gears/system/grpc-hub",
     "gears/system/nodes-registry/nodes-registry",
     "gears/system/nodes-registry/nodes-registry-sdk",

--- a/gears/system/cluster/cluster-conformance/Cargo.toml
+++ b/gears/system/cluster/cluster-conformance/Cargo.toml
@@ -22,6 +22,9 @@ workspace = true
 # The contract under test: every suite is generic over the SDK backend traits.
 cluster-sdk = { workspace = true }
 async-trait = { workspace = true }
+# `FutureExt::catch_unwind`, so `run_scenario` can run a scenario behind an async
+# panic boundary and still await teardown when an assertion panics.
+futures = { workspace = true }
 # `Instant`-based TTL + the background sweeper in the in-memory `MemCache`
 # fixture. The suites themselves are runtime-agnostic plain `async fn`s
 # (see §11 open question) so a caller can drive them under `turmoil`/`madsim`.

--- a/gears/system/cluster/cluster-conformance/src/cache.rs
+++ b/gears/system/cluster/cluster-conformance/src/cache.rs
@@ -6,38 +6,47 @@
 //! a plugin may call directly; [`run_cache_conformance`] drives the full L2 set,
 //! building a fresh backend per scenario via `make` so state never leaks.
 
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
 use cluster_sdk::cache::{
-    CacheConsistency, CacheEvent, CacheWatchEvent, ClusterCacheBackend, PollingPrefixWatch,
-    PutRequest, Ttl,
+    CacheConsistency, CacheEvent, ClusterCacheBackend, PollingPrefixWatch, PutRequest, Ttl,
 };
 use cluster_sdk::error::ClusterError;
 
-/// Runs every implemented L2 cache scenario against a fresh backend from `make`.
+use crate::factory::{ScenarioBackend, run_scenario};
+use crate::time::TimeControl;
+use crate::watch_poll::poll_watch;
+
+/// Runs every implemented L2 cache scenario, each against a fresh backend built
+/// by the async factory `make` and torn down afterward (see
+/// [`ScenarioBackend`]). `time` selects the clock model
+/// ([`TimeControl::Virtual`] for in-memory fixtures, [`TimeControl::Real`] for a
+/// real-I/O backend — see [`crate::time`]).
 ///
 /// Capability-gated scenarios read `consistency()`/`features()` off the backend
 /// and assert strict guarantees only where the backend claims them.
-pub async fn run_cache_conformance<F>(make: F)
+pub async fn run_cache_conformance<F, Fut>(make: F, time: TimeControl)
 where
-    F: Fn() -> Arc<dyn ClusterCacheBackend>,
+    F: Fn() -> Fut,
+    Fut: Future<Output = ScenarioBackend<dyn ClusterCacheBackend>>,
 {
-    scenario_cache_001(make()).await;
-    scenario_cache_002(make()).await;
-    scenario_cache_003(make()).await;
-    scenario_cache_004(make()).await;
-    scenario_cache_005(make()).await;
-    scenario_cache_006(make()).await;
-    scenario_cache_007(make()).await;
-    scenario_cache_008(make()).await;
-    scenario_cache_009(make()).await;
-    scenario_cache_010(make()).await;
-    scenario_cache_011(make()).await;
-    scenario_cache_012(make()).await;
-    scenario_cache_013(make()).await;
-    scenario_cache_014(make()).await;
-    scenario_cache_015(make()).await;
+    run_scenario(make(), scenario_cache_001).await;
+    run_scenario(make(), scenario_cache_002).await;
+    run_scenario(make(), scenario_cache_003).await;
+    run_scenario(make(), scenario_cache_004).await;
+    run_scenario(make(), scenario_cache_005).await;
+    run_scenario(make(), scenario_cache_006).await;
+    run_scenario(make(), scenario_cache_007).await;
+    run_scenario(make(), scenario_cache_008).await;
+    run_scenario(make(), scenario_cache_009).await;
+    run_scenario(make(), |b| scenario_cache_010(b, time)).await;
+    run_scenario(make(), |b| scenario_cache_011(b, time)).await;
+    run_scenario(make(), scenario_cache_012).await;
+    run_scenario(make(), scenario_cache_013).await;
+    run_scenario(make(), |b| scenario_cache_014(b, time)).await;
+    run_scenario(make(), |b| scenario_cache_015(b, time)).await;
 }
 
 /// SC-CACHE-001: `get` on an absent key returns `Ok(None)`, never an error.
@@ -298,8 +307,8 @@ pub async fn scenario_cache_009(backend: Arc<dyn ClusterCacheBackend>) {
 
 /// SC-CACHE-010: TTL expiry removes the entry and emits `CacheEvent::Expired` to
 /// watchers.
-pub async fn scenario_cache_010(backend: Arc<dyn ClusterCacheBackend>) {
-    tokio::time::pause();
+pub async fn scenario_cache_010(backend: Arc<dyn ClusterCacheBackend>, time: TimeControl) {
+    time.begin();
     let mut watch = backend.watch("k").await.expect("watch");
     backend
         .put(PutRequest {
@@ -309,25 +318,30 @@ pub async fn scenario_cache_010(backend: Arc<dyn ClusterCacheBackend>) {
         })
         .await
         .expect("put with ttl");
-    tokio::time::advance(Duration::from_millis(100)).await;
-    tokio::task::yield_now().await;
-    // Drain the initial Changed, then wait for the Expired emission.
-    let expired = wait_for(
-        &mut watch,
-        |event| matches!(event, CacheEvent::Expired { key } if key == "k"),
-    )
-    .await;
+    time.elapse(Duration::from_millis(100)).await;
+    // Drain the initial Changed, then wait for the Expired emission. The poll
+    // keeps reading, so under `Real` it tolerates the sweeper reclaim landing a
+    // little after the elapse (caller must set a sweep interval < the elapse).
+    let expired = poll_watch(&mut watch)
+        .until(|event| matches!(event, CacheEvent::Expired { key } if key == "k"))
+        .await;
     assert!(expired, "SC-CACHE-010: TTL expiry must emit Expired");
     assert!(
         backend.get("k").await.expect("get").is_none(),
         "SC-CACHE-010: expired entry reads as absent"
     );
-    tokio::time::resume();
+    time.end();
 }
 
 /// SC-CACHE-012: exact `watch` yields `Changed`/`Deleted` for the key,
 /// preserving per-key order.
 pub async fn scenario_cache_012(backend: Arc<dyn ClusterCacheBackend>) {
+    /// Which of the two ordered events on key `k` a poll selected.
+    enum Seen {
+        Changed,
+        Deleted,
+    }
+
     let mut watch = backend.watch("k").await.expect("watch");
     backend
         .put(PutRequest {
@@ -338,26 +352,32 @@ pub async fn scenario_cache_012(backend: Arc<dyn ClusterCacheBackend>) {
         .await
         .expect("put");
     backend.delete("k").await.expect("delete");
-    // Enforce order: Changed must precede Deleted on the same watch.
-    let mut saw_changed = false;
-    for _ in 0..64 {
-        match watch.recv().await {
-            Some(CacheWatchEvent::Event(CacheEvent::Changed { key })) if key == "k" => {
-                assert!(!saw_changed, "SC-CACHE-012: duplicate Changed event");
-                saw_changed = true;
-            }
-            Some(CacheWatchEvent::Event(CacheEvent::Deleted { key })) if key == "k" => {
-                assert!(
-                    saw_changed,
-                    "SC-CACHE-012: Deleted arrived before Changed -- order violated"
-                );
-                return; // Both events received in correct order.
-            }
-            Some(CacheWatchEvent::Closed(_)) | None => break,
-            _ => {}
+    // Select on *either* event, so the order is what the two polls assert: the
+    // first must be the Changed, the second the Deleted. A predicate that only
+    // looked for Changed would skip a too-early Deleted instead of failing.
+    let on_key = |event| match event {
+        CacheEvent::Changed { key } if key == "k" => Some(Seen::Changed),
+        CacheEvent::Deleted { key } if key == "k" => Some(Seen::Deleted),
+        _ => None,
+    };
+    match poll_watch(&mut watch)
+        .first_match(on_key)
+        .await
+        .expect_match("SC-CACHE-012: no Changed event for the key")
+    {
+        Seen::Changed => {}
+        Seen::Deleted => {
+            panic!("SC-CACHE-012: Deleted arrived before Changed -- order violated")
         }
     }
-    panic!("SC-CACHE-012: did not observe both Changed then Deleted within the event bound");
+    match poll_watch(&mut watch)
+        .first_match(on_key)
+        .await
+        .expect_match("SC-CACHE-012: no Deleted event after the Changed")
+    {
+        Seen::Deleted => {}
+        Seen::Changed => panic!("SC-CACHE-012: duplicate Changed event"),
+    }
 }
 
 /// SC-CACHE-013: `watch_prefix` yields events for matching keys when the backend
@@ -376,11 +396,9 @@ pub async fn scenario_cache_013(backend: Arc<dyn ClusterCacheBackend>) {
             .await
             .expect("put");
         assert!(
-            wait_for(
-                &mut watch,
-                |e| matches!(e, CacheEvent::Changed { key } if key == "p/a")
-            )
-            .await,
+            poll_watch(&mut watch)
+                .until(|e| matches!(e, CacheEvent::Changed { key } if key == "p/a"))
+                .await,
             "SC-CACHE-013: prefix watch yields events for matching keys"
         );
     } else {
@@ -398,8 +416,8 @@ pub async fn scenario_cache_013(backend: Arc<dyn ClusterCacheBackend>) {
 
 /// SC-CACHE-011: a `Ttl::Indefinite` entry persists well past any default TTL;
 /// it is not removed by the TTL sweeper until explicitly deleted.
-pub async fn scenario_cache_011(backend: Arc<dyn ClusterCacheBackend>) {
-    tokio::time::pause();
+pub async fn scenario_cache_011(backend: Arc<dyn ClusterCacheBackend>, time: TimeControl) {
+    time.begin();
     backend
         .put(PutRequest {
             key: "k",
@@ -408,25 +426,26 @@ pub async fn scenario_cache_011(backend: Arc<dyn ClusterCacheBackend>) {
         })
         .await
         .expect("put");
-    tokio::time::advance(Duration::from_hours(1)).await;
-    // Yield so the sweeper (if any) gets a chance to erroneously remove it.
-    tokio::task::yield_now().await;
+    // A large advance under `Virtual`; under `Real` this is capped to a short
+    // real sleep (several sweep intervals) — enough for a sweeper to run and
+    // (incorrectly) remove the entry if it mishandled the indefinite TTL.
+    time.elapse(Duration::from_hours(1)).await;
     let entry = backend.get("k").await.expect("get");
     assert!(
         entry.is_some(),
         "SC-CACHE-011: an indefinite entry must survive a large time advance"
     );
-    tokio::time::resume();
+    time.end();
 }
 
 /// SC-CACHE-014: `PollingPrefixWatch` synthesizes `Changed`/`Deleted` diffs for
 /// a backend that does not natively support prefix watches.
 /// Capability-gated on `!features().prefix_watch`.
-pub async fn scenario_cache_014(backend: Arc<dyn ClusterCacheBackend>) {
+pub async fn scenario_cache_014(backend: Arc<dyn ClusterCacheBackend>, time: TimeControl) {
     if backend.features().prefix_watch {
         return; // native prefix watch; polyfill is not the subject here
     }
-    tokio::time::pause();
+    time.begin();
     let mut watch = PollingPrefixWatch::spawn(backend.clone(), "p/", Duration::from_millis(25));
 
     // A put under the prefix must be diffed as Changed.
@@ -438,36 +457,42 @@ pub async fn scenario_cache_014(backend: Arc<dyn ClusterCacheBackend>) {
         })
         .await
         .expect("put p/a");
-    tokio::time::advance(Duration::from_millis(50)).await;
-    tokio::task::yield_now().await;
+    time.elapse(Duration::from_millis(50)).await;
     assert!(
-        wait_for(
-            &mut watch,
-            |e| matches!(e, CacheEvent::Changed { key } if key == "p/a")
-        )
-        .await,
+        poll_watch(&mut watch)
+            .until(|e| matches!(e, CacheEvent::Changed { key } if key == "p/a"))
+            .await,
         "SC-CACHE-014: put under prefix must yield a Changed event"
     );
 
     // A delete must be diffed as Deleted.
     backend.delete("p/a").await.expect("delete p/a");
-    tokio::time::advance(Duration::from_millis(50)).await;
-    tokio::task::yield_now().await;
+    time.elapse(Duration::from_millis(50)).await;
     assert!(
-        wait_for(
-            &mut watch,
-            |e| matches!(e, CacheEvent::Deleted { key } if key == "p/a")
-        )
-        .await,
+        poll_watch(&mut watch)
+            .until(|e| matches!(e, CacheEvent::Deleted { key } if key == "p/a"))
+            .await,
         "SC-CACHE-014: delete under prefix must yield a Deleted event"
     );
-    tokio::time::resume();
+    time.end();
 }
 
 /// SC-CACHE-015: watch delivery is at-most-once per mutation — a single `put`
 /// must not cause more than one `Changed` event for the same key on one watch.
-pub async fn scenario_cache_015(backend: Arc<dyn ClusterCacheBackend>) {
-    tokio::time::pause();
+pub async fn scenario_cache_015(backend: Arc<dyn ClusterCacheBackend>, time: TimeControl) {
+    // The second poll's budget is what makes the duplicate check real, and it
+    // must stay a wait rather than a drain of what is already queued: the
+    // duplicate this scenario guards against is a backend echoing the mutation
+    // locally *and* again off its notification channel, so the second copy
+    // arrives a round-trip after the first. Both budgets are
+    // backend-independent — a paused clock auto-advances to the deadline while
+    // the runtime is idle, so `Virtual` pays no wall-clock for either (see
+    // [`crate::watch_poll`]) — and both are shorter than the default because a
+    // *passing* run always spends the second one in full.
+    const FIRST_EVENT_BUDGET: Duration = Duration::from_millis(500);
+    const DUPLICATE_BUDGET: Duration = Duration::from_millis(250);
+
+    time.begin();
     let mut watch = backend.watch("k").await.expect("watch");
     backend
         .put(PutRequest {
@@ -478,48 +503,29 @@ pub async fn scenario_cache_015(backend: Arc<dyn ClusterCacheBackend>) {
         .await
         .expect("put");
 
-    let mut changed_count = 0u32;
-    // Drain all immediately queued events without advancing time — any duplicate
-    // that would arrive synchronously will be in the channel already.
-    for _ in 0..64 {
-        match tokio::time::timeout(Duration::from_millis(0), watch.recv()).await {
-            Ok(Some(CacheWatchEvent::Event(CacheEvent::Changed { key }))) if key == "k" => {
-                changed_count += 1;
-            }
-            Ok(Some(CacheWatchEvent::Closed(_)) | None) | Err(_) => break,
-            _ => {}
-        }
-    }
-    assert_eq!(
-        changed_count, 1,
-        "SC-CACHE-015: a single put must deliver exactly one Changed event (got {changed_count})"
+    // Annotated so the closure is higher-ranked over the borrow, and therefore
+    // reusable across both polls.
+    let changed = |event: &CacheEvent| matches!(event, CacheEvent::Changed { key } if key == "k");
+    assert!(
+        poll_watch(&mut watch)
+            .upto(FIRST_EVENT_BUDGET)
+            .until(changed)
+            .await,
+        "SC-CACHE-015: a single put must deliver a Changed event"
     );
-    tokio::time::resume();
+    assert!(
+        !poll_watch(&mut watch)
+            .upto(DUPLICATE_BUDGET)
+            .until(changed)
+            .await,
+        "SC-CACHE-015: a single put must deliver at most one Changed event"
+    );
+    time.end();
 }
 
 // TODO(SC-CACHE-016/017) [L4]: slow-subscriber `Lagged` and connection-loss
 //   `Reset` are fault-injection scenarios delivered with the L4 harness, not the
 //   in-process suite.
-
-/// Polls a watch for up to a bounded number of events, returning `true` once one
-/// satisfies `pred`. Bounded so a missing event fails fast rather than hanging.
-async fn wait_for<P>(watch: &mut cluster_sdk::cache::CacheWatch, pred: P) -> bool
-where
-    P: Fn(&CacheEvent) -> bool,
-{
-    for _ in 0..64 {
-        match watch.recv().await {
-            Some(CacheWatchEvent::Event(event)) => {
-                if pred(&event) {
-                    return true;
-                }
-            }
-            Some(CacheWatchEvent::Closed(_)) | None => return false,
-            Some(_) => {}
-        }
-    }
-    false
-}
 
 /// A helper plugins may use to assert a backend's self-declared consistency
 /// before handing it to the consistency-sensitive default backends.

--- a/gears/system/cluster/cluster-conformance/src/discovery.rs
+++ b/gears/system/cluster/cluster-conformance/src/discovery.rs
@@ -9,31 +9,44 @@
 //! instances in an unspecified order.
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
 use cluster_sdk::discovery::{
     DiscoveryFilter, InstanceState, MetaMatch, ServiceDiscoveryBackend, ServiceRegistration,
-    ServiceWatchEvent, StateFilter, TopologyChange,
+    StateFilter, TopologyChange,
 };
 
-/// Runs every implemented L2 discovery scenario against a fresh backend from
-/// `make`.
+use crate::factory::{ScenarioBackend, run_scenario};
+use crate::time::TimeControl;
+use crate::watch_poll::poll_watch;
+
+/// Runs every implemented L2 discovery scenario, each against a fresh backend
+/// built by the async factory `make` and torn down afterward (see
+/// [`ScenarioBackend`]).
 ///
-/// # Panics
-/// Requires a `current_thread` Tokio runtime — `scenario_disc_006` calls
-/// `tokio::time::pause()`, which panics under `multi_thread`.
-pub async fn run_discovery_conformance<F>(make: F)
+/// `time` selects the clock model. `SC-DISC-006` runs **only** under
+/// [`TimeControl::Virtual`]: it asserts a registration disappears purely by
+/// letting its TTL (a fixed 30s in the SDK default backend) lapse, driven by a
+/// virtual-time fast-forward. That is not expressible as a bounded real sleep
+/// against a real backend, so it is skipped under [`TimeControl::Real`] (a real
+/// TTL-lapse belongs to L4). `scenario_disc_006` therefore still uses
+/// `tokio::time::pause()` internally and requires a `current_thread` runtime.
+pub async fn run_discovery_conformance<F, Fut>(make: F, time: TimeControl)
 where
-    F: Fn() -> Arc<dyn ServiceDiscoveryBackend>,
+    F: Fn() -> Fut,
+    Fut: Future<Output = ScenarioBackend<dyn ServiceDiscoveryBackend>>,
 {
-    scenario_disc_001(make()).await;
-    scenario_disc_002(make()).await;
-    scenario_disc_003(make()).await;
-    scenario_disc_004(make()).await;
-    scenario_disc_005(make()).await;
-    scenario_disc_006(make()).await;
-    scenario_disc_007(make()).await;
+    run_scenario(make(), scenario_disc_001).await;
+    run_scenario(make(), scenario_disc_002).await;
+    run_scenario(make(), scenario_disc_003).await;
+    run_scenario(make(), scenario_disc_004).await;
+    run_scenario(make(), scenario_disc_005).await;
+    if time == TimeControl::Virtual {
+        run_scenario(make(), scenario_disc_006).await;
+    }
+    run_scenario(make(), scenario_disc_007).await;
 }
 
 /// SC-DISC-001: a registered, enabled instance is returned by `discover` under
@@ -198,11 +211,9 @@ pub async fn scenario_disc_005(backend: Arc<dyn ServiceDiscoveryBackend>) {
         .expect("register");
     // Wait for Joined.
     let id = handle.instance_id().to_owned();
-    wait_for_discovery_event(
-        &mut watch,
-        |e| matches!(e, TopologyChange::Joined(i) if i.instance_id == id),
-    )
-    .await;
+    poll_watch(&mut watch)
+        .until(|e| matches!(e, TopologyChange::Joined(i) if i.instance_id == id))
+        .await;
 
     // Drain.
     handle
@@ -221,10 +232,9 @@ pub async fn scenario_disc_005(backend: Arc<dyn ServiceDiscoveryBackend>) {
     // Deregister.
     handle.deregister().await.expect("deregister");
     assert!(
-        wait_for_discovery_event(&mut watch, |e| {
-            matches!(e, TopologyChange::Left { instance_id } if instance_id == &id)
-        })
-        .await,
+        poll_watch(&mut watch)
+            .until(|e| matches!(e, TopologyChange::Left { instance_id } if instance_id == &id))
+            .await,
         "SC-DISC-005: deregister must emit Left"
     );
     let after_dereg = backend
@@ -277,10 +287,9 @@ pub async fn scenario_disc_007(backend: Arc<dyn ServiceDiscoveryBackend>) {
 
     // Joined.
     assert!(
-        wait_for_discovery_event(&mut watch, |e| {
-            matches!(e, TopologyChange::Joined(i) if i.instance_id == id)
-        })
-        .await,
+        poll_watch(&mut watch)
+            .until(|e| matches!(e, TopologyChange::Joined(i) if i.instance_id == id))
+            .await,
         "SC-DISC-007: register must emit Joined"
     );
 
@@ -292,20 +301,18 @@ pub async fn scenario_disc_007(backend: Arc<dyn ServiceDiscoveryBackend>) {
         .await
         .expect("update metadata");
     assert!(
-        wait_for_discovery_event(&mut watch, |e| {
-            matches!(e, TopologyChange::Updated(i) if i.instance_id == id)
-        })
-        .await,
+        poll_watch(&mut watch)
+            .until(|e| matches!(e, TopologyChange::Updated(i) if i.instance_id == id))
+            .await,
         "SC-DISC-007: update_metadata must emit Updated"
     );
 
     // Left.
     handle.deregister().await.expect("deregister");
     assert!(
-        wait_for_discovery_event(&mut watch, |e| {
-            matches!(e, TopologyChange::Left { instance_id } if instance_id == &id)
-        })
-        .await,
+        poll_watch(&mut watch)
+            .until(|e| matches!(e, TopologyChange::Left { instance_id } if instance_id == &id))
+            .await,
         "SC-DISC-007: deregister must emit Left"
     );
 }
@@ -313,25 +320,6 @@ pub async fn scenario_disc_007(backend: Arc<dyn ServiceDiscoveryBackend>) {
 // TODO(SC-DISC-008): service name is scoped; metadata is not scoped — requires
 //   the `ServiceDiscoveryV1::scoped()` facade (needs `ClientHub`, deferred to L3).
 // TODO(SC-DISC-009) [L4]: recover membership after lag/reset — fault-injection harness.
-
-/// Polls a service watch for up to 64 events, returning `true` once one satisfies
-/// `pred`. Bounded so a missing event fails fast rather than hanging.
-async fn wait_for_discovery_event<P>(
-    watch: &mut cluster_sdk::discovery::ServiceWatch,
-    pred: P,
-) -> bool
-where
-    P: Fn(&TopologyChange) -> bool,
-{
-    for _ in 0..64 {
-        match watch.recv().await {
-            Some(ServiceWatchEvent::Change(change)) if pred(&change) => return true,
-            Some(ServiceWatchEvent::Closed(_)) | None => return false,
-            _ => {}
-        }
-    }
-    false
-}
 
 /// Builds a registration with `metadata` key/value pairs and a backend-assigned
 /// instance id.

--- a/gears/system/cluster/cluster-conformance/src/factory.rs
+++ b/gears/system/cluster/cluster-conformance/src/factory.rs
@@ -1,0 +1,98 @@
+// Created: 2026-07-15 by Constructor Tech
+//! [`ScenarioBackend`] — an async-built backend plus its teardown, the unit a
+//! `run_*_conformance` runner drives one scenario against.
+//!
+//! The runners are generic over an **async** factory `Fn() -> Future<Output =
+//! ScenarioBackend<_>>` so a backend whose construction is genuinely async
+//! (opening a pool, running migrations, starting a container) can be built
+//! fresh per scenario — an in-memory fixture just wraps a ready value. Each
+//! backend is paired with a [`Teardown`] the runner awaits once the scenario
+//! finishes, so a backend that needs an explicit async shutdown (e.g. a plugin
+//! handle whose `Drop` guard panics if `stop()` was skipped) is released
+//! deterministically between scenarios rather than leaked.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+/// The async teardown a runner awaits after a scenario. `Send` so the runner
+/// future stays `Send` for `multi_thread` callers; a no-op for fixtures.
+pub type Teardown = Pin<Box<dyn Future<Output = ()> + Send>>;
+
+/// A backend built for one conformance scenario, plus the teardown to run once
+/// the scenario completes.
+pub struct ScenarioBackend<T: ?Sized> {
+    /// The backend the scenario exercises.
+    pub backend: Arc<T>,
+    /// Awaited by the runner after the scenario — closes pools / stops handles /
+    /// drops containers. [`ScenarioBackend::bare`] makes this a no-op.
+    pub teardown: Teardown,
+}
+
+impl<T: ?Sized> ScenarioBackend<T> {
+    /// A backend that needs no teardown (an in-memory fixture: dropping the
+    /// `Arc` is sufficient).
+    #[must_use]
+    pub fn bare(backend: Arc<T>) -> Self {
+        Self {
+            backend,
+            teardown: Box::pin(std::future::ready(())),
+        }
+    }
+
+    /// A backend with an async `teardown` (e.g. `async move { handle.stop().await }`),
+    /// awaited by the runner once the scenario returns.
+    #[must_use]
+    pub fn with_teardown<F>(backend: Arc<T>, teardown: F) -> Self
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        Self {
+            backend,
+            teardown: Box::pin(teardown),
+        }
+    }
+}
+
+/// Brackets one scenario: awaits the factory to build the backend, runs `run`
+/// against it, then awaits the teardown. The single place every runner threads
+/// a `ScenarioBackend` through, so the build → run → teardown order is
+/// consistent across all suites.
+///
+/// The scenario runs behind an async panic boundary so `teardown` is awaited
+/// **even when a scenario assertion panics** (`AssertUnwindSafe` +
+/// [`FutureExt::catch_unwind`](futures::FutureExt::catch_unwind)). Without it, a
+/// panic would drop the `teardown` future un-awaited; a teardown owning a handle
+/// with a panic-on-drop guard (e.g. `PostgresClusterHandle`) would then panic
+/// during unwind and abort the whole test process, masking the original failure.
+///
+/// `teardown` is awaited behind its own panic boundary too: if it panics after
+/// a scenario panic, resuming the scenario's panic (the actual assertion
+/// failure) takes priority over the teardown's, so the original failure still
+/// surfaces rather than being replaced by a cleanup-time panic. If the scenario
+/// succeeded, a teardown panic is resumed instead.
+pub(crate) async fn run_scenario<T, Fut, S, SFut>(make_fut: Fut, run: S)
+where
+    T: ?Sized,
+    Fut: Future<Output = ScenarioBackend<T>>,
+    S: FnOnce(Arc<T>) -> SFut,
+    SFut: Future<Output = ()>,
+{
+    use futures::FutureExt;
+
+    let scenario_backend = make_fut.await;
+    let outcome = std::panic::AssertUnwindSafe(run(scenario_backend.backend))
+        .catch_unwind()
+        .await;
+    let teardown_outcome = std::panic::AssertUnwindSafe(scenario_backend.teardown)
+        .catch_unwind()
+        .await;
+    match outcome {
+        Err(panic) => std::panic::resume_unwind(panic),
+        Ok(()) => {
+            if let Err(panic) = teardown_outcome {
+                std::panic::resume_unwind(panic);
+            }
+        }
+    }
+}

--- a/gears/system/cluster/cluster-conformance/src/leader.rs
+++ b/gears/system/cluster/cluster-conformance/src/leader.rs
@@ -8,9 +8,12 @@
 //! ```no_run
 //! # use std::sync::Arc;
 //! # use cluster_sdk::LeaderElectionBackend;
-//! # use cluster_conformance::run_leader_conformance;
-//! # async fn run(make_backend: impl Fn() -> Arc<dyn LeaderElectionBackend>) {
-//! run_leader_conformance(make_backend).await;
+//! # use cluster_conformance::{run_leader_conformance, ScenarioBackend, TimeControl};
+//! # async fn run<Fut>(make_backend: impl Fn() -> Fut)
+//! # where Fut: std::future::Future<Output = ScenarioBackend<dyn LeaderElectionBackend>> {
+//! // `TimeControl::Virtual` for in-memory fixtures; `TimeControl::Real` for a
+//! // backend over a real connection pool (see `cluster_conformance::time`).
+//! run_leader_conformance(make_backend, TimeControl::Virtual).await;
 //! # }
 //! ```
 //!
@@ -26,24 +29,55 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use cluster_sdk::error::ClusterError;
-use cluster_sdk::leader::{
-    ElectionConfig, LeaderElectionBackend, LeaderStatus, LeaderWatch, LeaderWatchEvent,
-};
+use std::future::Future;
 
-/// Runs every implemented L2 leader-election scenario against a fresh backend
-/// from `make`. `SC-LEAD-002` is asserted only when the backend declares
-/// `linearizable`; weaker backends skip the single-leader guarantee.
-pub async fn run_leader_conformance<F>(make: F)
+use cluster_sdk::leader::{ElectionConfig, LeaderElectionBackend, LeaderStatus, LeaderWatch};
+
+use crate::factory::{ScenarioBackend, run_scenario};
+use crate::time::TimeControl;
+use crate::watch_poll::poll_watch;
+
+/// Yields spent letting the runtime settle after a virtual-clock `advance`, so
+/// the sweeper, the renewal task and the watch forwarder have all been polled
+/// before a scenario scans the watch stream. Not an event bound: nothing is
+/// consumed from the watch here.
+const SETTLE_YIELDS: usize = 64;
+
+/// Event bound for `SC-LEAD-006`'s scan for `Status(Lost)`. Wider than the
+/// shared default because a deliberately-missed renewal is preceded by whatever
+/// renewal traffic the fast-forward already queued.
+const LOSS_SCAN_EVENTS: usize = 256;
+
+/// Renewal intervals `SC-LEAD-003` holds leadership across; enough for the
+/// auto-renewal task to have fired repeatedly rather than once.
+const RENEWAL_INTERVALS: usize = 5;
+
+/// Runs every implemented L2 leader-election scenario, each against a fresh
+/// backend built by the async factory `make` and torn down afterward (see
+/// [`ScenarioBackend`]). `SC-LEAD-002` is asserted only when the backend
+/// declares `linearizable`; weaker backends skip the single-leader guarantee.
+///
+/// `time` selects the clock model. `SC-LEAD-006` runs **only** under
+/// [`TimeControl::Virtual`]: it asserts a *transient* `Status(Lost)` re-enrols,
+/// which it induces by fast-forwarding virtual time so a lease renewal *misses*.
+/// A healthy real backend never misses a renewal by merely waiting, so under
+/// [`TimeControl::Real`] there would be no `Lost` to observe and the scenario
+/// would hang — inducing a real loss is fault-injection territory (L4). It is
+/// therefore skipped under `Real` rather than run against a real backend.
+pub async fn run_leader_conformance<F, Fut>(make: F, time: TimeControl)
 where
-    F: Fn() -> Arc<dyn LeaderElectionBackend>,
+    F: Fn() -> Fut,
+    Fut: Future<Output = ScenarioBackend<dyn LeaderElectionBackend>>,
 {
-    scenario_lead_001(make()).await;
-    scenario_lead_002(make()).await;
-    scenario_lead_003(make()).await;
-    scenario_lead_004(make()).await;
-    scenario_lead_005(make()).await;
-    scenario_lead_006(make()).await;
-    scenario_lead_007(make()).await;
+    run_scenario(make(), scenario_lead_001).await;
+    run_scenario(make(), scenario_lead_002).await;
+    run_scenario(make(), |b| scenario_lead_003(b, time)).await;
+    run_scenario(make(), scenario_lead_004).await;
+    run_scenario(make(), scenario_lead_005).await;
+    if time == TimeControl::Virtual {
+        run_scenario(make(), scenario_lead_006).await;
+    }
+    run_scenario(make(), scenario_lead_007).await;
 }
 
 /// SC-LEAD-001: a single candidate becomes `Leader`.
@@ -110,30 +144,27 @@ pub async fn scenario_lead_007(_backend: Arc<dyn LeaderElectionBackend>) {
 
 /// SC-LEAD-003: the elected leader's claim auto-renews without any consumer
 /// action; the status stays `Leader` across multiple renewal intervals.
-pub async fn scenario_lead_003(backend: Arc<dyn LeaderElectionBackend>) {
-    tokio::time::pause();
+pub async fn scenario_lead_003(backend: Arc<dyn LeaderElectionBackend>, time: TimeControl) {
+    time.begin();
     // Short TTL so renewals fire quickly under controlled time.
     // max_missed_renewals=2 → renewal_interval = ttl / 3 ≈ 100 ms.
     let config = ElectionConfig::new(Duration::from_millis(300), 2).expect("valid config");
     let mut watch = backend.elect_with_config("e", config).await.expect("elect");
     // Wait until we hold leadership.
-    loop {
-        match watch.changed().await {
-            LeaderWatchEvent::Status(LeaderStatus::Leader) => break,
-            LeaderWatchEvent::Closed(err) => panic!("SC-LEAD-003: watch closed: {err}"),
-            _ => {}
-        }
-    }
-    // Advance across 5 renewal intervals; after each yield the renewal task runs.
-    for _ in 0..5 {
-        tokio::time::advance(Duration::from_millis(100)).await;
-        tokio::task::yield_now().await;
+    assert!(
+        wait_for_leader(&mut watch).await,
+        "SC-LEAD-003: the sole contender must be elected leader"
+    );
+    // Elapse across 5 renewal intervals; the renewal task keeps the lease alive,
+    // so a healthy backend (real or fixture) never loses leadership.
+    for _ in 0..RENEWAL_INTERVALS {
+        time.elapse(Duration::from_millis(100)).await;
         assert!(
             watch.is_leader(),
             "SC-LEAD-003: auto-renewal must keep status Leader across renewal intervals"
         );
     }
-    tokio::time::resume();
+    time.end();
 }
 
 /// SC-LEAD-004: graceful `resign()` releases the claim; a waiting follower is
@@ -142,13 +173,10 @@ pub async fn scenario_lead_004(backend: Arc<dyn LeaderElectionBackend>) {
     let mut a = backend.elect("e").await.expect("elect a");
     let mut b = backend.elect("e").await.expect("elect b");
     // Drive A to Leader.
-    loop {
-        match a.changed().await {
-            LeaderWatchEvent::Status(LeaderStatus::Leader) => break,
-            LeaderWatchEvent::Closed(err) => panic!("SC-LEAD-004: a closed: {err}"),
-            _ => {}
-        }
-    }
+    assert!(
+        wait_for_leader(&mut a).await,
+        "SC-LEAD-004: the first contender must be elected leader"
+    );
     a.resign().await.expect("SC-LEAD-004: resign must succeed");
     assert!(
         wait_for_leader(&mut b).await,
@@ -161,26 +189,20 @@ pub async fn scenario_lead_004(backend: Arc<dyn LeaderElectionBackend>) {
 pub async fn scenario_lead_005(backend: Arc<dyn LeaderElectionBackend>) {
     let mut watch = backend.elect("e").await.expect("elect");
     // After any Status event the cached snapshot must agree.
-    for _ in 0..64 {
-        match watch.changed().await {
-            LeaderWatchEvent::Status(s) => {
-                assert_eq!(
-                    watch.status(),
-                    s,
-                    "SC-LEAD-005: status() must equal the last Status event"
-                );
-                assert_eq!(
-                    watch.is_leader(),
-                    matches!(s, LeaderStatus::Leader),
-                    "SC-LEAD-005: is_leader() must agree with the last Status event"
-                );
-                return;
-            }
-            LeaderWatchEvent::Closed(err) => panic!("SC-LEAD-005: watch closed: {err}"),
-            _ => {}
-        }
-    }
-    panic!("SC-LEAD-005: no Status event observed within the bound");
+    let observed = poll_watch(&mut watch)
+        .first()
+        .await
+        .expect_match("SC-LEAD-005: no Status event observed");
+    assert_eq!(
+        watch.status(),
+        observed,
+        "SC-LEAD-005: status() must equal the last Status event"
+    );
+    assert_eq!(
+        watch.is_leader(),
+        matches!(observed, LeaderStatus::Leader),
+        "SC-LEAD-005: is_leader() must agree with the last Status event"
+    );
 }
 
 /// SC-LEAD-006: `Status(Lost)` is transient — the watch auto-reenrols and
@@ -191,66 +213,48 @@ pub async fn scenario_lead_006(backend: Arc<dyn LeaderElectionBackend>) {
     // Very short TTL with one allowed missed renewal so loss fires quickly.
     let config = ElectionConfig::new(Duration::from_millis(100), 1).expect("valid config");
     let mut watch = backend.elect_with_config("e", config).await.expect("elect");
-    loop {
-        match watch.changed().await {
-            LeaderWatchEvent::Status(LeaderStatus::Leader) => break,
-            LeaderWatchEvent::Closed(err) => panic!("SC-LEAD-006: watch closed: {err}"),
-            _ => {}
-        }
-    }
+    assert!(
+        wait_for_leader(&mut watch).await,
+        "SC-LEAD-006: the sole contender must be elected leader"
+    );
     // Advance past the full TTL so the renewal misses its window. After
-    // `advance`, timer futures wake up but tasks still need to be polled;
-    // 64 yields lets the sweeper, the renewal task, and the watch forwarder
-    // all process their events before we scan the watch stream.
+    // `advance`, timer futures wake up but tasks still need to be polled; the
+    // yields let the sweeper, the renewal task, and the watch forwarder all
+    // process their events before we scan the watch stream.
     tokio::time::advance(Duration::from_millis(500)).await;
-    for _ in 0..64 {
+    for _ in 0..SETTLE_YIELDS {
         tokio::task::yield_now().await;
     }
 
-    let mut saw_lost = false;
-    for _ in 0..256 {
-        match watch.changed().await {
-            LeaderWatchEvent::Status(LeaderStatus::Lost) => {
-                saw_lost = true;
-            }
-            LeaderWatchEvent::Status(_) if saw_lost => {
-                // Re-enrolled on the same watch — scenario passes.
-                tokio::time::resume();
-                return;
-            }
-            LeaderWatchEvent::Closed(err) => panic!("SC-LEAD-006: watch closed: {err}"),
-            _ => {}
-        }
-    }
-    tokio::time::resume();
-    panic!(
+    // Two phases, so the *order* is asserted: the loss must be observed first,
+    // and only then does any further status prove the watch re-enrolled itself.
+    // A repeated `Lost` counts — the original loop accepted that too.
+    assert!(
+        poll_watch(&mut watch)
+            .max_skipped(LOSS_SCAN_EVENTS)
+            .until(|status| matches!(status, LeaderStatus::Lost))
+            .await,
+        "SC-LEAD-006: a missed renewal must surface as Status(Lost)"
+    );
+    assert!(
+        poll_watch(&mut watch).first().await.is_match(),
         "SC-LEAD-006: watch must re-enrol after Lost without the consumer calling elect() again"
     );
+    tokio::time::resume();
 }
 
-/// Polls `watch.changed()` up to 64 times, returning `true` if a `Leader`
-/// status is observed.
+/// Resolves `true` once the watch reports `Leader`, within the shared poll
+/// bounds (see [`crate::watch_poll`]).
 async fn wait_for_leader(watch: &mut LeaderWatch) -> bool {
-    for _ in 0..64 {
-        match watch.changed().await {
-            LeaderWatchEvent::Status(LeaderStatus::Leader) => return true,
-            LeaderWatchEvent::Closed(_) => return false,
-            _ => {}
-        }
-    }
-    false
+    poll_watch(watch)
+        .until(|status| matches!(status, LeaderStatus::Leader))
+        .await
 }
 
 /// Awaits the watch's first leadership status, skipping non-status signals.
 async fn first_status(watch: &mut LeaderWatch) -> LeaderStatus {
-    for _ in 0..64 {
-        match watch.changed().await {
-            LeaderWatchEvent::Status(status) => return status,
-            LeaderWatchEvent::Closed(err) => {
-                panic!("watch closed before reporting status: {err}")
-            }
-            _ => {}
-        }
-    }
-    panic!("watch produced no Status event within the bound");
+    poll_watch(watch)
+        .first()
+        .await
+        .expect_match("watch produced no Status event")
 }

--- a/gears/system/cluster/cluster-conformance/src/lib.rs
+++ b/gears/system/cluster/cluster-conformance/src/lib.rs
@@ -56,18 +56,23 @@
 
 pub mod cache;
 pub mod discovery;
+pub mod factory;
 pub mod fixture;
 pub mod leader;
 pub mod lock;
 pub mod model;
 pub mod restart;
+pub mod time;
 pub mod watch_lifecycle;
+pub(crate) mod watch_poll;
 
 pub use cache::run_cache_conformance;
 pub use discovery::run_discovery_conformance;
+pub use factory::ScenarioBackend;
 pub use fixture::MemCache;
 pub use leader::run_leader_conformance;
 pub use lock::run_lock_conformance;
 pub use model::{CacheModel, CacheOp, VersionTarget, replay_against_model};
 pub use restart::run_restart_conformance;
+pub use time::TimeControl;
 pub use watch_lifecycle::run_watch_lifecycle_conformance;

--- a/gears/system/cluster/cluster-conformance/src/lock.rs
+++ b/gears/system/cluster/cluster-conformance/src/lock.rs
@@ -10,20 +10,37 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use std::future::Future;
+
 use cluster_sdk::error::ClusterError;
 use cluster_sdk::lock::DistributedLockBackend;
 
-/// Runs every implemented L2 lock scenario against a fresh backend from `make`.
-pub async fn run_lock_conformance<F>(make: F)
+use crate::factory::{ScenarioBackend, run_scenario};
+use crate::time::TimeControl;
+
+/// Runs every implemented L2 lock scenario, each against a fresh backend built
+/// by the async factory `make` and torn down afterward (see
+/// [`ScenarioBackend`]). `time` selects the clock model: pass
+/// [`TimeControl::Virtual`] for in-memory / cache-default fixtures, or
+/// [`TimeControl::Real`] for a real-I/O backend (e.g. the Postgres plugin over a
+/// live `sqlx` pool, which cannot use a paused clock — see [`crate::time`]).
+///
+/// A backend using real advisory-lock keyspace scoped to a whole server (e.g.
+/// Postgres `pg_advisory_lock`) should have its `make` factory hand out a fresh
+/// *server* per call, since several scenarios leave a name locked on exit; the
+/// per-scenario teardown returned by the factory stops each one before the next
+/// is built.
+pub async fn run_lock_conformance<F, Fut>(make: F, time: TimeControl)
 where
-    F: Fn() -> Arc<dyn DistributedLockBackend>,
+    F: Fn() -> Fut,
+    Fut: Future<Output = ScenarioBackend<dyn DistributedLockBackend>>,
 {
-    scenario_lock_001(make()).await;
-    scenario_lock_002(make()).await;
-    scenario_lock_003(make()).await;
-    scenario_lock_004(make()).await;
-    scenario_lock_005(make()).await;
-    scenario_lock_007(make()).await;
+    run_scenario(make(), scenario_lock_001).await;
+    run_scenario(make(), |b| scenario_lock_002(b, time)).await;
+    run_scenario(make(), |b| scenario_lock_003(b, time)).await;
+    run_scenario(make(), scenario_lock_004).await;
+    run_scenario(make(), |b| scenario_lock_005(b, time)).await;
+    run_scenario(make(), |b| scenario_lock_007(b, time)).await;
 }
 
 /// SC-LOCK-001: `try_lock` succeeds when free, returns `LockContended` when held.
@@ -42,11 +59,12 @@ pub async fn scenario_lock_001(backend: Arc<dyn DistributedLockBackend>) {
 
 /// SC-LOCK-002: `lock` blocks up to `timeout`, then returns
 /// `LockTimeout { name, waited }`.
-pub async fn scenario_lock_002(backend: Arc<dyn DistributedLockBackend>) {
-    // Paused time auto-advances to the next pending timer once the runtime
-    // has nothing else ready to run, so awaiting `lock()` directly resolves
-    // its internal timeout deterministically without a real 50ms sleep.
-    tokio::time::pause();
+pub async fn scenario_lock_002(backend: Arc<dyn DistributedLockBackend>, time: TimeControl) {
+    // Under `Virtual`, paused time auto-advances to the next pending timer once
+    // the runtime has nothing else ready to run, so awaiting `lock()` directly
+    // resolves its internal timeout deterministically without a real 50ms sleep.
+    // Under `Real`, the 50ms timeout simply elapses in real wall-clock time.
+    time.begin();
     let ttl = Duration::from_secs(30);
     let _guard = backend
         .try_lock("res", ttl)
@@ -59,7 +77,7 @@ pub async fn scenario_lock_002(backend: Arc<dyn DistributedLockBackend>) {
         }
         other => panic!("SC-LOCK-002: expected LockTimeout, got {other:?}"),
     }
-    tokio::time::resume();
+    time.end();
 }
 
 /// SC-LOCK-004: explicit `release()` wakes a waiter blocked in `lock()` —
@@ -95,43 +113,48 @@ pub async fn scenario_lock_004(backend: Arc<dyn DistributedLockBackend>) {
 
 /// SC-LOCK-003: a lock held by a crashed holder (guard dropped without
 /// `release()`) becomes acquirable once its TTL lapses.
-pub async fn scenario_lock_003(backend: Arc<dyn DistributedLockBackend>) {
-    tokio::time::pause();
+pub async fn scenario_lock_003(backend: Arc<dyn DistributedLockBackend>, time: TimeControl) {
+    time.begin();
     let ttl = Duration::from_millis(100);
     let guard = backend
         .try_lock("m", ttl)
         .await
         .expect("SC-LOCK-003: initial acquire must succeed");
     drop(guard); // simulate crash — no I/O, no explicit release
-    tokio::time::advance(Duration::from_millis(200)).await;
-    tokio::task::yield_now().await;
-    let result = backend.try_lock("m", ttl).await;
+    // Past the TTL: a reaper-driven backend (Real) must have reclaimed the
+    // crashed holder's lock by now, so poll rather than single-shot to tolerate
+    // reaper-tick jitter within the real wait.
+    time.elapse(Duration::from_millis(200)).await;
+    let acquired = poll_try_lock(&backend, "m", ttl, time).await;
     assert!(
-        result.is_ok(),
-        "SC-LOCK-003: lock must be acquirable after crashed-holder TTL lapses, got {result:?}"
+        acquired,
+        "SC-LOCK-003: lock must be acquirable after crashed-holder TTL lapses"
     );
-    tokio::time::resume();
+    time.end();
 }
 
 /// SC-LOCK-005: `renew` extends an active lease; renewing an expired lock
 /// returns `LockExpired`.
-pub async fn scenario_lock_005(backend: Arc<dyn DistributedLockBackend>) {
-    tokio::time::pause();
+pub async fn scenario_lock_005(backend: Arc<dyn DistributedLockBackend>, time: TimeControl) {
+    time.begin();
     let ttl = Duration::from_millis(200);
     let guard = backend
         .try_lock("m", ttl)
         .await
         .expect("SC-LOCK-005: acquire must succeed");
-    // Advance to just before expiry and renew — must succeed.
-    tokio::time::advance(Duration::from_millis(150)).await;
-    tokio::task::yield_now().await;
+    // Advance partway into the lease and renew — must succeed. Only 50 ms of the
+    // 200 ms lease is elapsed (not 150) so ~150 ms of margin remains for
+    // scheduling and the database round trip under `Real`; leaving just 50 ms
+    // let a loaded CI runner expire the lease before `renew` landed, flaking the
+    // test (PGR-D5). This still verifies pre-expiry renewal.
+    time.elapse(Duration::from_millis(50)).await;
     guard
         .renew(Duration::from_millis(200))
         .await
         .expect("SC-LOCK-005: renew before expiry must succeed");
-    // Let the lock fully expire.
-    tokio::time::advance(Duration::from_millis(400)).await;
-    tokio::task::yield_now().await;
+    // Let the lock fully expire (well past the TTL so a reaper-driven backend
+    // has reclaimed it under `Real`).
+    time.elapse(Duration::from_millis(400)).await;
     let err = guard
         .renew(Duration::from_millis(100))
         .await
@@ -140,13 +163,13 @@ pub async fn scenario_lock_005(backend: Arc<dyn DistributedLockBackend>) {
         matches!(err, ClusterError::LockExpired { .. }),
         "SC-LOCK-005: renewing an expired lock must return LockExpired, got {err:?}"
     );
-    tokio::time::resume();
+    time.end();
 }
 
 /// SC-LOCK-007: dropping a `LockGuard` performs no remote I/O — the lock
 /// persists until its TTL lapses (ADR-002: TTL is the only safety net).
-pub async fn scenario_lock_007(backend: Arc<dyn DistributedLockBackend>) {
-    tokio::time::pause();
+pub async fn scenario_lock_007(backend: Arc<dyn DistributedLockBackend>, time: TimeControl) {
+    time.begin();
     let ttl = Duration::from_millis(200);
     let guard = backend
         .try_lock("m", ttl)
@@ -161,13 +184,42 @@ pub async fn scenario_lock_007(backend: Arc<dyn DistributedLockBackend>) {
         "SC-LOCK-007: dropping a guard must not eagerly release the lock (got {still_held:?})"
     );
     // After the TTL lapses the lock becomes acquirable again.
-    tokio::time::advance(Duration::from_millis(400)).await;
-    tokio::task::yield_now().await;
+    time.elapse(Duration::from_millis(400)).await;
     assert!(
-        backend.try_lock("m", ttl).await.is_ok(),
+        poll_try_lock(&backend, "m", ttl, time).await,
         "SC-LOCK-007: lock must be acquirable after TTL lapses post-drop"
     );
-    tokio::time::resume();
+    time.end();
+}
+
+/// Attempts `try_lock(name)` until it succeeds or a bounded budget elapses.
+///
+/// Under [`TimeControl::Virtual`] the caller has already advanced past the TTL
+/// and any fixture sweeper has run, so a single attempt is deterministic. Under
+/// [`TimeControl::Real`] a reaper-driven backend (e.g. Postgres) may lag the
+/// wait by up to one reaper interval, so retry with short real sleeps rather
+/// than assert on a single racy attempt.
+async fn poll_try_lock(
+    backend: &Arc<dyn DistributedLockBackend>,
+    name: &str,
+    ttl: Duration,
+    time: TimeControl,
+) -> bool {
+    let attempts = match time {
+        TimeControl::Virtual => 1,
+        TimeControl::Real => 40,
+    };
+    for i in 0..attempts {
+        if backend.try_lock(name, ttl).await.is_ok() {
+            return true;
+        }
+        if time == TimeControl::Real && i + 1 < attempts {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        } else {
+            tokio::task::yield_now().await;
+        }
+    }
+    false
 }
 
 // SC-LOCK-006: a foreign holder cannot release another's lock — impractical

--- a/gears/system/cluster/cluster-conformance/src/time.rs
+++ b/gears/system/cluster/cluster-conformance/src/time.rs
@@ -1,0 +1,80 @@
+// Created: 2026-07-15 by Constructor Tech
+//! [`TimeControl`] — how a time-sensitive conformance scenario makes time pass.
+//!
+//! Time-dependent scenarios (TTL expiry, lock timeout, leader renewal) need to
+//! fast-forward past an interval without a test waiting real seconds. The
+//! original suites did this with [`tokio::time::pause`] + [`tokio::time::advance`]
+//! (virtual time), which is instant and deterministic — but only correct for
+//! **in-memory** fixture backends. Against a backend over a real `sqlx` pool /
+//! network, a paused virtual clock spuriously fires `sqlx`'s own internal
+//! pool-acquire timeout: the paused runtime auto-advances the clock to the next
+//! pending timer deadline while real network I/O is parked, so the acquire
+//! `tokio::time::timeout` wins the race and every `pool.acquire()` returns a
+//! bogus `PoolTimedOut` even on a completely free pool (see the postgres cluster
+//! plugin's `docs/GAP-SOLUTIONS.md` §3 for the full trace).
+//!
+//! [`TimeControl`] lets one scenario body serve both worlds: fixture-backed
+//! callers pass [`TimeControl::Virtual`] (unchanged fast/deterministic
+//! behavior); real-backend callers pass [`TimeControl::Real`], which swaps the
+//! virtual advance for a real (bounded) `tokio::time::sleep` and never pauses the
+//! clock, so `sqlx`'s timers behave normally.
+
+use std::time::Duration;
+
+/// Selects the clock model a time-sensitive scenario uses.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum TimeControl {
+    /// Freeze the clock ([`tokio::time::pause`]) and fast-forward deterministically
+    /// ([`tokio::time::advance`]). Instant and deterministic, but **only** correct
+    /// for in-memory fixture backends that never do real I/O — a paused clock
+    /// breaks a real `sqlx` pool's acquire timeout (see module docs).
+    Virtual,
+    /// Let real wall-clock time pass ([`tokio::time::sleep`]); never pause the
+    /// clock. Required for any backend over a real connection pool / network.
+    /// Callers running reaper-driven backends (e.g. Postgres TTL reclaim) must
+    /// configure a reaper/sweep interval comfortably shorter than the scenario's
+    /// [`elapse`](TimeControl::elapse) durations so the background reclaim
+    /// actually fires within the real wait.
+    Real,
+}
+
+impl TimeControl {
+    /// Upper bound on a single real [`elapse`](Self::elapse) sleep. A scenario
+    /// may advance virtual time by an implausibly large amount (e.g. an hour, to
+    /// prove a TTL-less entry is never swept); under [`Real`](Self::Real) that
+    /// must not translate into an hour-long test, so the real sleep is capped —
+    /// a few sweep intervals is enough to prove the same property.
+    const REAL_CAP: Duration = Duration::from_millis(500);
+
+    /// Freezes virtual time under [`Virtual`](Self::Virtual); a no-op under
+    /// [`Real`](Self::Real). Call once at the start of a time-sensitive scenario.
+    pub fn begin(self) {
+        if self == Self::Virtual {
+            tokio::time::pause();
+        }
+    }
+
+    /// Resumes virtual time under [`Virtual`](Self::Virtual); a no-op under
+    /// [`Real`](Self::Real). Call once at the end of a time-sensitive scenario.
+    pub fn end(self) {
+        if self == Self::Virtual {
+            tokio::time::resume();
+        }
+    }
+
+    /// Advances scenario time, then yields so background reaper / renewal /
+    /// sweeper tasks get a chance to run. Under [`Virtual`](Self::Virtual) this
+    /// advances the clock by exactly `dur` (instant [`tokio::time::advance`]);
+    /// under [`Real`](Self::Real) it sleeps for `dur.min(REAL_CAP)` — i.e. **at
+    /// most** `REAL_CAP`, *not* the full `dur` — so a scenario
+    /// that advances an implausibly large virtual interval does not become a
+    /// multi-second real test. Timing assertions that require the full `dur` to
+    /// have elapsed are therefore only valid under `Virtual`.
+    pub async fn elapse(self, dur: Duration) {
+        match self {
+            Self::Virtual => tokio::time::advance(dur).await,
+            Self::Real => tokio::time::sleep(dur.min(Self::REAL_CAP)).await,
+        }
+        tokio::task::yield_now().await;
+    }
+}

--- a/gears/system/cluster/cluster-conformance/src/watch_poll.rs
+++ b/gears/system/cluster/cluster-conformance/src/watch_poll.rs
@@ -1,0 +1,254 @@
+// Created: 2026-08-03 by Constructor Tech
+//! One bounded polling strategy, shared by every watch-driven scenario.
+//!
+//! Every suite in this crate faces the same problem: drive a watch until an
+//! event satisfies a predicate, without letting a notification/polling
+//! regression hang the whole suite (PGR-D4). [`poll_watch`] is that single
+//! strategy — the cache, discovery and leader watches all reach it through
+//! [`PollableWatch`], so a scenario never hand-rolls a `match watch.recv()`
+//! loop with its own bounds.
+//!
+//! A poll is bounded two ways, both named and both overridable per call site:
+//!
+//! * [`DEFAULT_MAX_SKIPPED_EVENTS`] caps how many non-matching events it will
+//!   skip before giving up — override with [`WatchPoll::max_skipped`].
+//! * [`DEFAULT_WAIT_BUDGET`] wraps the whole poll in a timeout, so an event that
+//!   never arrives (each individual `recv().await` is otherwise unbounded)
+//!   resolves to a verdict rather than blocking forever — override with
+//!   [`WatchPoll::upto`].
+//!
+//! Both bounds are backend-independent. Under
+//! [`TimeControl::Virtual`](crate::time::TimeControl) a paused clock
+//! auto-advances to the timeout while the runtime is idle, so an already-queued
+//! event still returns immediately and an absent one still resolves at once — no
+//! wall-clock cost, and the same code path as a real backend's NOTIFY / polling
+//! round-trip. The defaults are generous enough for that round-trip; a scenario
+//! that needs a tighter or looser bound says so at the call site:
+//!
+//! ```ignore
+//! // Default bounds: 3s / 64 skipped events.
+//! let seen = poll_watch(&mut watch).until(|e| matches!(e, CacheEvent::Changed { .. })).await;
+//!
+//! // Tighter budget: prove a *second* event does not arrive, without paying 3s for it.
+//! let duplicate = poll_watch(&mut watch)
+//!     .upto(Duration::from_millis(250))
+//!     .until(|e| matches!(e, CacheEvent::Changed { .. }))
+//!     .await;
+//! ```
+
+use std::fmt;
+use std::time::Duration;
+
+use cluster_sdk::cache::{CacheEvent, CacheWatch, CacheWatchEvent};
+use cluster_sdk::discovery::{ServiceWatch, ServiceWatchEvent, TopologyChange};
+use cluster_sdk::error::ClusterError;
+use cluster_sdk::leader::{LeaderStatus, LeaderWatch, LeaderWatchEvent};
+
+/// Overall wait budget a poll uses unless the call site calls
+/// [`WatchPoll::upto`]. Generous enough for a real backend's NOTIFY / polling
+/// round-trip; free under a paused clock.
+pub const DEFAULT_WAIT_BUDGET: Duration = Duration::from_secs(3);
+
+/// How many non-matching events a poll skips unless the call site calls
+/// [`WatchPoll::max_skipped`].
+pub const DEFAULT_MAX_SKIPPED_EVENTS: usize = 64;
+
+/// How a watch stopped producing events.
+pub enum WatchEnd {
+    /// The watch delivered its terminal `Closed` event.
+    Closed(ClusterError),
+    /// The channel dropped without a terminal event (the backend went away).
+    Dropped,
+}
+
+impl fmt::Display for WatchEnd {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Closed(err) => write!(f, "watch closed: {err}"),
+            Self::Dropped => write!(f, "watch dropped without a Closed event"),
+        }
+    }
+}
+
+/// One event, classified for the poll loop.
+pub enum PollStep<T> {
+    /// A non-terminal event carrying the watch's payload.
+    Payload(T),
+    /// A non-terminal signal that carries no payload (`Lagged` / `Reset`).
+    Skip,
+    /// The watch is finished; no further events will arrive.
+    End(WatchEnd),
+}
+
+/// Why a poll stopped.
+pub enum Polled<T> {
+    /// An event satisfied the caller's predicate.
+    Matched(T),
+    /// The watch ended before a matching event arrived.
+    Ended(WatchEnd),
+    /// The skip cap was reached without a match.
+    SkipCap(usize),
+    /// The wait budget elapsed without a match.
+    TimedOut(Duration),
+}
+
+impl<T> Polled<T> {
+    /// `true` if an event satisfied the predicate.
+    pub fn is_match(&self) -> bool {
+        matches!(self, Self::Matched(_))
+    }
+
+    /// The matched payload, panicking with `context` and the reason no event
+    /// matched. `context` should name the violated scenario, e.g.
+    /// `"SC-LEAD-005: no Status event"`.
+    pub fn expect_match(self, context: &str) -> T {
+        match self {
+            Self::Matched(payload) => payload,
+            Self::Ended(end) => panic!("{context}: {end}"),
+            Self::SkipCap(cap) => panic!("{context}: skipped {cap} events without a match"),
+            Self::TimedOut(budget) => {
+                panic!(
+                    "{context}: no matching event within {}ms",
+                    budget.as_millis()
+                )
+            }
+        }
+    }
+}
+
+/// A watch this module can poll generically. Implemented for every watch the
+/// SDK hands a scenario; the associated payload is what a predicate sees, with
+/// the wrapper's `Lagged`/`Reset`/`Closed` variants already classified.
+pub trait PollableWatch {
+    /// The payload carried by a non-terminal event.
+    type Payload;
+
+    /// Awaits the next event and classifies it for the poll loop.
+    async fn next_step(&mut self) -> PollStep<Self::Payload>;
+}
+
+impl PollableWatch for CacheWatch {
+    type Payload = CacheEvent;
+
+    async fn next_step(&mut self) -> PollStep<CacheEvent> {
+        match self.recv().await {
+            Some(CacheWatchEvent::Event(event)) => PollStep::Payload(event),
+            Some(CacheWatchEvent::Closed(err)) => PollStep::End(WatchEnd::Closed(err)),
+            None => PollStep::End(WatchEnd::Dropped),
+            // `Lagged`/`Reset` carry no payload, and the enum is `non_exhaustive`
+            // so a future signal must not fail a scenario that predates it.
+            Some(_) => PollStep::Skip,
+        }
+    }
+}
+
+impl PollableWatch for ServiceWatch {
+    type Payload = TopologyChange;
+
+    async fn next_step(&mut self) -> PollStep<TopologyChange> {
+        match self.recv().await {
+            Some(ServiceWatchEvent::Change(change)) => PollStep::Payload(change),
+            Some(ServiceWatchEvent::Closed(err)) => PollStep::End(WatchEnd::Closed(err)),
+            None => PollStep::End(WatchEnd::Dropped),
+            // See the `CacheWatch` impl: payload-less and future signals skip.
+            Some(_) => PollStep::Skip,
+        }
+    }
+}
+
+impl PollableWatch for LeaderWatch {
+    type Payload = LeaderStatus;
+
+    async fn next_step(&mut self) -> PollStep<LeaderStatus> {
+        // `changed()` is infallible, so there is no `Dropped` case to classify.
+        match self.changed().await {
+            LeaderWatchEvent::Status(status) => PollStep::Payload(status),
+            LeaderWatchEvent::Closed(err) => PollStep::End(WatchEnd::Closed(err)),
+            // See the `CacheWatch` impl: payload-less and future signals skip.
+            _ => PollStep::Skip,
+        }
+    }
+}
+
+/// Starts a bounded poll of `watch` with the default bounds. Chain
+/// [`upto`](WatchPoll::upto) / [`max_skipped`](WatchPoll::max_skipped) to
+/// override them, then a terminal — [`until`](WatchPoll::until),
+/// [`first`](WatchPoll::first) or [`first_match`](WatchPoll::first_match).
+pub fn poll_watch<W: PollableWatch>(watch: &mut W) -> WatchPoll<'_, W> {
+    WatchPoll {
+        watch,
+        budget: DEFAULT_WAIT_BUDGET,
+        max_skipped: DEFAULT_MAX_SKIPPED_EVENTS,
+    }
+}
+
+/// A bounded poll in progress; see [`poll_watch`].
+pub struct WatchPoll<'w, W> {
+    watch: &'w mut W,
+    budget: Duration,
+    max_skipped: usize,
+}
+
+impl<W: PollableWatch> WatchPoll<'_, W> {
+    /// Overrides [`DEFAULT_WAIT_BUDGET`] for this poll.
+    #[must_use]
+    pub fn upto(mut self, budget: Duration) -> Self {
+        self.budget = budget;
+        self
+    }
+
+    /// Overrides [`DEFAULT_MAX_SKIPPED_EVENTS`] for this poll.
+    #[must_use]
+    pub fn max_skipped(mut self, max_skipped: usize) -> Self {
+        self.max_skipped = max_skipped;
+        self
+    }
+
+    /// Resolves `true` once an event satisfies `pred`, `false` on any other
+    /// outcome. Use when the assertion is only about whether the event arrived;
+    /// [`first_match`](Self::first_match) when the failure message should say
+    /// *why* none did.
+    pub async fn until<P>(self, pred: P) -> bool
+    where
+        P: Fn(&W::Payload) -> bool,
+    {
+        self.first_match(|payload| pred(&payload).then_some(()))
+            .await
+            .is_match()
+    }
+
+    /// Resolves with the next payload the watch delivers, whatever it is.
+    pub async fn first(self) -> Polled<W::Payload> {
+        self.first_match(Some).await
+    }
+
+    /// Resolves with the first payload `classify` maps to `Some`, so a scenario
+    /// can both select an event and extract from it in one poll.
+    pub async fn first_match<T, F>(self, classify: F) -> Polled<T>
+    where
+        F: Fn(W::Payload) -> Option<T>,
+    {
+        let Self {
+            watch,
+            budget,
+            max_skipped,
+        } = self;
+        let poll = async {
+            for _ in 0..max_skipped {
+                match watch.next_step().await {
+                    PollStep::Payload(payload) => {
+                        if let Some(matched) = classify(payload) {
+                            return Polled::Matched(matched);
+                        }
+                    }
+                    PollStep::Skip => {}
+                    PollStep::End(end) => return Polled::Ended(end),
+                }
+            }
+            Polled::SkipCap(max_skipped)
+        };
+        tokio::time::timeout(budget, poll)
+            .await
+            .unwrap_or(Polled::TimedOut(budget))
+    }
+}

--- a/gears/system/cluster/cluster-conformance/tests/self_test.rs
+++ b/gears/system/cluster/cluster-conformance/tests/self_test.rs
@@ -19,13 +19,20 @@ use std::sync::Arc;
 
 use cluster_conformance::fixture::MemCache;
 use cluster_conformance::{
-    run_cache_conformance, run_restart_conformance, run_watch_lifecycle_conformance,
+    ScenarioBackend, TimeControl, run_cache_conformance, run_restart_conformance,
+    run_watch_lifecycle_conformance,
 };
 use cluster_sdk::ClusterCacheBackend;
 
 #[tokio::test]
 async fn cache_suite_passes_against_memcache() {
-    run_cache_conformance(|| MemCache::linearizable() as Arc<dyn ClusterCacheBackend>).await;
+    run_cache_conformance(
+        || async {
+            ScenarioBackend::bare(MemCache::linearizable() as Arc<dyn ClusterCacheBackend>)
+        },
+        TimeControl::Virtual,
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/gears/system/cluster/cluster-sdk/src/lib.rs
+++ b/gears/system/cluster/cluster-sdk/src/lib.rs
@@ -75,7 +75,7 @@ pub use profile::{
 };
 pub use provider::{
     ClusterCacheProvider, ClusterLeaderElectionProvider, ClusterLockProvider,
-    ClusterServiceDiscoveryProvider, StopHook,
+    ClusterServiceDiscoveryProvider, SD_POLL_INTERVAL_MS_OPTION, StopHook,
 };
 pub use registration::{
     deregister_cache_backend, deregister_leader_election_backend, deregister_lock_backend,

--- a/gears/system/cluster/cluster-sdk/src/provider.rs
+++ b/gears/system/cluster/cluster-sdk/src/provider.rs
@@ -36,6 +36,17 @@ use crate::lock::DistributedLockBackend;
 /// it and awaits it once during shutdown — typically a plugin handle's `stop()`.
 pub type StopHook = Box<dyn FnOnce() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send>;
 
+/// The cache provider-options key the omit-default service-discovery auto-wrap
+/// reads for a non-default poll cadence (PGR-D3): a cache provider whose
+/// options carry this key (e.g. the Postgres plugin's `sd_poll_interval_ms`)
+/// gets that cadence threaded into `with_prefix_watch_polling` instead of the
+/// SDK-default backend's own default. A documented convention over the raw
+/// options map, not a schema field the SDK enforces — a provider opts in
+/// simply by naming its own config field to match this constant, single-
+/// sourcing the key so a rename is a compile error here rather than a
+/// silent fallback to the default cadence at the wiring read site.
+pub const SD_POLL_INTERVAL_MS_OPTION: &str = "sd_poll_interval_ms";
+
 /// Builds the cache backend for one provider.
 ///
 /// The cache backend is the foundational primitive; the wiring auto-wraps it with

--- a/gears/system/cluster/cluster/Cargo.toml
+++ b/gears/system/cluster/cluster/Cargo.toml
@@ -29,6 +29,7 @@ tokio-util = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 rand = { workspace = true }
 cf-gears-standalone-cluster-plugin = { path = "../plugins/standalone-cluster-plugin", version = "0.1.3" }
+cf-postgres-cluster-plugin = { path = "../plugins/postgres-cluster-plugin", version = "0.1.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/gears/system/cluster/cluster/src/defaults/discovery.rs
+++ b/gears/system/cluster/cluster/src/defaults/discovery.rs
@@ -12,7 +12,9 @@ use tracing::Instrument;
 
 use crate::defaults::{SVC_KEY_PREFIX, ShutdownRevoke, identity};
 use cluster_sdk::cache::types::{PutRequest, Ttl};
-use cluster_sdk::cache::{CacheEvent, CacheWatch, CacheWatchEvent, ClusterCacheBackend};
+use cluster_sdk::cache::{
+    CacheEvent, CacheWatch, CacheWatchEvent, ClusterCacheBackend, PollingPrefixWatch,
+};
 use cluster_sdk::discovery::{
     DiscoveryFilter, InstanceState, ServiceCommandReceiver, ServiceDiscoveryBackend,
     ServiceDiscoveryFeatures, ServiceHandle, ServiceInstance, ServiceRegistration, ServiceRequest,
@@ -58,6 +60,16 @@ const DEFAULT_TTL: Duration = Duration::from_secs(30);
 )]
 const DEFAULT_RENEWAL: Duration = Duration::from_secs(DEFAULT_TTL.as_secs() / 3);
 
+/// Default poll interval for the [`PollingPrefixWatch`] fallback used when the
+/// bound cache lacks a native prefix watch (`features().prefix_watch == false`).
+///
+/// Five seconds mirrors the Postgres plugin's `sd_poll_interval` default (its
+/// DESIGN §6) — the canonical `prefix_watch: false` backend — and trades
+/// topology-change latency for a bounded `scan_prefix` + `N` `get` cost per tick
+/// (`PollingPrefixWatch`'s documented cost). Override with
+/// [`with_prefix_watch_polling`](CacheBasedServiceDiscoveryBackend::with_prefix_watch_polling).
+const DEFAULT_PREFIX_WATCH_POLL: Duration = Duration::from_secs(5);
+
 /// The in-flight command buffer for each [`ServiceHandle`].
 const COMMAND_BUFFER: usize = 4;
 
@@ -92,17 +104,23 @@ const WATCH_CAPACITY: usize = 256;
 ///
 /// # Prefix-watch dependency
 ///
-/// Discovery and watch require the cache's native `watch_prefix`. A cache that
-/// declares no prefix watch returns
-/// [`ClusterError::Unsupported`] from `watch_prefix`, so
-/// [`watch`](ServiceDiscoveryBackend::watch) surfaces that error and
-/// [`discover`](ServiceDiscoveryBackend::discover) is **best-effort**: with no
-/// maintainer to reap entries on TTL expiry, [`register`](ServiceDiscoveryBackend::register)
-/// deliberately skips its local pre-insert (an unreapable pre-insert would read
-/// as live forever), so degraded-mode `discover` returns an empty set rather
-/// than a stale view. This is a known limitation pending the
-/// `PollingPrefixWatch` polyfill (DECOMPOSITION §2.7), which is out of scope
-/// here.
+/// Discovery and watch need a prefix stream. When the bound cache has a native
+/// `watch_prefix` (`features().prefix_watch == true`) it is used directly. When
+/// the cache declares no native prefix watch (`prefix_watch == false`, e.g. the
+/// Postgres plugin's cache), the backend transparently falls back to the
+/// [`PollingPrefixWatch`] polyfill over `scan_prefix`
+/// ([`open_prefix_watch`](Self::open_prefix_watch)) — so a maintainer runs and
+/// `register`'s local pre-insert is safe (it is reaped on TTL expiry /
+/// deregistration through the polling stream) over either kind of cache. The
+/// polyfill path pays the documented poll-interval latency and `N+1`
+/// round-trips per tick; tune it with
+/// [`with_prefix_watch_polling`](Self::with_prefix_watch_polling).
+///
+/// The historical degraded, always-empty mode (skip the pre-insert; return an
+/// empty set) only remains reachable if a maintainer genuinely cannot start —
+/// a transient native-`watch_prefix` failure, or a concurrent caller still
+/// bringing the maintainer up — not merely because the cache lacks native
+/// prefix watch.
 pub struct CacheBasedServiceDiscoveryBackend {
     cache: Arc<dyn ClusterCacheBackend>,
     shared: Arc<Shared>,
@@ -124,6 +142,11 @@ pub struct CacheBasedServiceDiscoveryBackend {
     provider: &'static str,
     /// The metrics sink (default [`NoopMetrics`]).
     metrics: Arc<dyn ClusterMetrics>,
+    /// Poll interval for the [`PollingPrefixWatch`] fallback, used only when the
+    /// bound cache declares `features().prefix_watch == false`. Defaults to
+    /// [`DEFAULT_PREFIX_WATCH_POLL`]; override with
+    /// [`with_prefix_watch_polling`](Self::with_prefix_watch_polling).
+    prefix_watch_poll: Duration,
 }
 
 impl CacheBasedServiceDiscoveryBackend {
@@ -142,6 +165,39 @@ impl CacheBasedServiceDiscoveryBackend {
             tasks: Arc::new(Mutex::new(Vec::new())),
             provider: "unknown",
             metrics: Arc::new(NoopMetrics),
+            prefix_watch_poll: DEFAULT_PREFIX_WATCH_POLL,
+        }
+    }
+
+    /// Sets the poll interval for the [`PollingPrefixWatch`] fallback (used only
+    /// over a cache with no native prefix watch). Mirrors
+    /// [`with_observability`](Self::with_observability); without it the backend
+    /// uses [`DEFAULT_PREFIX_WATCH_POLL`].
+    #[must_use]
+    pub fn with_prefix_watch_polling(mut self, interval: Duration) -> Self {
+        self.prefix_watch_poll = interval;
+        self
+    }
+
+    /// Opens the prefix-watch stream backing discovery for `prefix`.
+    ///
+    /// Uses the cache's **native** `watch_prefix` when it supports prefix
+    /// watches (`features().prefix_watch == true`) — that path is unchanged.
+    /// When the bound cache declares no native prefix watch it would return
+    /// [`ClusterError::Unsupported`]; instead of propagating that (which left
+    /// discovery permanently empty over such a cache — the Postgres plugin's
+    /// gap, DESIGN §6 / DECOMPOSITION §2.7), synthesize the stream with the
+    /// [`PollingPrefixWatch`] polyfill over `scan_prefix`, so discovery actually
+    /// works — at the polyfill's documented poll-latency / `N+1`-round-trip cost.
+    async fn open_prefix_watch(&self, prefix: &str) -> Result<CacheWatch, ClusterError> {
+        if self.cache.features().prefix_watch {
+            self.cache.watch_prefix(prefix).await
+        } else {
+            Ok(PollingPrefixWatch::spawn(
+                Arc::clone(&self.cache),
+                prefix,
+                self.prefix_watch_poll,
+            ))
         }
     }
 
@@ -183,8 +239,9 @@ impl CacheBasedServiceDiscoveryBackend {
     /// view.
     ///
     /// # Errors
-    /// Propagates the cache's [`ClusterError::Unsupported`] when it has no native
-    /// prefix watch.
+    /// Propagates a native `watch_prefix` failure. A cache with no native prefix
+    /// watch does **not** error here — it uses the [`PollingPrefixWatch`]
+    /// polyfill (see [`open_prefix_watch`](Self::open_prefix_watch)).
     async fn ensure_maintainer(&self, name: &str) -> Result<MaintainerStatus, ClusterError> {
         {
             let mut registry = self.shared.lock();
@@ -207,11 +264,14 @@ impl CacheBasedServiceDiscoveryBackend {
             registry.instances.entry(name.to_owned()).or_default();
         }
         let prefix = Self::prefix(name);
-        let watch = match self.cache.watch_prefix(&prefix).await {
+        let watch = match self.open_prefix_watch(&prefix).await {
             Ok(watch) => watch,
             Err(err) => {
-                // Roll back the mark so a later call can retry once the cache
-                // gains prefix-watch support.
+                // Roll back the mark so a later call can retry. A native
+                // `watch_prefix` can fail transiently; the polyfill path over a
+                // prefix-watch-incapable cache does not error here (it defers
+                // any backend failure to its own stream), so this branch is now
+                // reached only for a genuine native-watch failure.
                 self.shared.lock().maintained.remove(name);
                 return Err(err);
             }
@@ -290,6 +350,14 @@ impl ServiceDiscoveryBackend for CacheBasedServiceDiscoveryBackend {
                     .entry(reg.name.clone())
                     .or_default()
                     .insert(instance_id.clone(), instance);
+                // Bump the generation so an in-flight `reconcile_view` sweep that
+                // snapshotted the revision before this pre-insert — and whose
+                // `scan_prefix` ran before the `put` above committed — detects the
+                // race and discards its now-stale rebuilt map rather than
+                // clobbering this local registration (PGR-D2). Without this the
+                // pre-insert's "observe immediately" guarantee could be erased by
+                // an older sweep committing afterward.
+                registry.bump_generation(&reg.name);
             }
             // No confirmed maintainer for this process to pre-insert behind: skip
             // it. Either degraded mode (the maintainer could not start) — with
@@ -336,6 +404,17 @@ impl ServiceDiscoveryBackend for CacheBasedServiceDiscoveryBackend {
         let out = async {
             // Best-effort: ensure the membership view is being maintained.
             let _maintainer = self.ensure_maintainer(name).await;
+            // Over a cache with no native prefix watch, the maintained view is
+            // only as fresh as the last `PollingPrefixWatch` tick — up to a poll
+            // interval stale, and a change made moments ago (e.g. a `set_state`)
+            // is not yet reflected. Refresh from a fresh `scan_prefix` sweep of
+            // backend truth so `discover` is current regardless of poll cadence
+            // (the cost the operator accepted by choosing a polling backend). A
+            // native prefix-watch backend keeps its event-maintained view, which
+            // is already current, so this scan is skipped there.
+            if !self.cache.features().prefix_watch {
+                reconcile_view(&self.cache, &self.shared, name, &Self::prefix(name)).await;
+            }
             let registry = self.shared.lock();
             let instances = registry.instances.get(name).map_or_else(Vec::new, |map| {
                 map.values()
@@ -356,9 +435,11 @@ impl ServiceDiscoveryBackend for CacheBasedServiceDiscoveryBackend {
             tracing::info_span!(spans::DISCOVERY_WATCH, provider = %self.provider, name = %name);
         let out = async {
             let prefix = Self::prefix(name);
-            // Each watch gets its own prefix subscription; the cache's `Unsupported`
-            // surfaces here directly.
-            let cache_watch = self.cache.watch_prefix(&prefix).await?;
+            // Each watch gets its own prefix subscription — native when the
+            // cache supports it, else the `PollingPrefixWatch` polyfill (a
+            // prefix-watch-incapable cache no longer surfaces `Unsupported`
+            // here).
+            let cache_watch = self.open_prefix_watch(&prefix).await?;
             let (sender, mut watch) = ServiceWatch::channel(WATCH_CAPACITY);
             // Stamp the watch so an `auto_restart`ed consumer emits the watch-reset
             // signals (`cluster_watch_resets_total` / `cluster.watch.reset`).
@@ -408,6 +489,28 @@ struct Registry {
     instances: HashMap<String, HashMap<String, ServiceInstance>>,
     /// Service names with a maintainer task being started or running.
     maintained: HashMap<String, MaintainerState>,
+    /// `service name → revision`, bumped on every single-instance mutation the
+    /// maintainer's [`apply`](StoreMaintainer::apply) makes (join / departure /
+    /// state change). A `scan_prefix`+`get` reconcile sweep captures the revision
+    /// before its (unlocked, `await`-ing) scan and commits its rebuilt map only
+    /// if the revision is unchanged — so a newer watch event that landed while
+    /// the sweep was in flight is not clobbered by the older sweep result
+    /// (PGR-D2).
+    generations: HashMap<String, u64>,
+}
+
+impl Registry {
+    /// The current revision for `name` (0 if never mutated).
+    fn generation(&self, name: &str) -> u64 {
+        self.generations.get(name).copied().unwrap_or(0)
+    }
+
+    /// Bumps `name`'s revision; called under the registry lock by every
+    /// maintainer mutation so an in-flight reconcile sweep can detect it raced.
+    fn bump_generation(&mut self, name: &str) {
+        let counter = self.generations.entry(name.to_owned()).or_default();
+        *counter = counter.wrapping_add(1);
+    }
 }
 
 /// Lifecycle of a per-service maintainer slot in [`Registry::maintained`].
@@ -556,6 +659,67 @@ fn take_str(bytes: &[u8], pos: &mut usize) -> Option<String> {
     Some(value)
 }
 
+/// Rebuilds `name`'s slice of the shared view from a `scan_prefix` + `get` sweep
+/// of backend truth, replacing whatever was cached. Best-effort: if the backend
+/// lacks `scan_prefix` the view is left untouched (joins still reconverge from
+/// the maintainer's stream). Never holds the registry lock across an `.await` —
+/// the sweep completes before the single locked insert.
+///
+/// Shared by the [`StoreMaintainer`]'s initial/lagged reconcile and, for a cache
+/// without native prefix watch, by [`discover`](CacheBasedServiceDiscoveryBackend::discover)
+/// on each call, so discovery over a polling backend reflects current backend
+/// truth rather than the poll-interval-stale maintained view.
+async fn reconcile_view(
+    cache: &Arc<dyn ClusterCacheBackend>,
+    shared: &Shared,
+    name: &str,
+    prefix: &str,
+) {
+    // Snapshot the revision before the unlocked scan/get sweep below so we can
+    // tell whether a maintainer `apply` mutated this service's slice while we
+    // were awaiting backend truth (PGR-D2).
+    let start_generation = shared.lock().generation(name);
+
+    let Ok(keys) = cache.scan_prefix(prefix).await else {
+        return;
+    };
+    let mut fresh = HashMap::new();
+    for key in keys {
+        let Some(instance_id) = key.strip_prefix(prefix).map(str::to_owned) else {
+            continue;
+        };
+        match cache.get(&key).await {
+            // A live entry: decode and include it. An entry that fails to decode
+            // is corrupt/foreign, not a backend failure, so it is legitimately
+            // omitted (same as before).
+            Ok(Some(entry)) => {
+                if let Some(record) = InstanceRecord::decode(&entry.value) {
+                    fresh.insert(instance_id.clone(), record.to_instance(instance_id));
+                }
+            }
+            // The key vanished between `scan_prefix` and this `get` (TTL expiry /
+            // deregistration): legitimately absent, so omit it and keep sweeping.
+            Ok(None) => {}
+            // A transient backend read failure (pool exhaustion, DB blip). Do NOT
+            // commit a partial view — silently dropping this key would erase a
+            // healthy instance from discovery until the next successful sweep.
+            // Abort now, leaving the existing view intact; the next
+            // reconcile / `discover` re-sweeps, so this is self-healing (PGR-D2).
+            Err(_) => return,
+        }
+    }
+
+    // Commit the rebuilt map only if no newer watch event landed while the sweep
+    // was in flight; otherwise discard this (now-stale) sweep and leave the
+    // maintainer's fresher single-instance updates in place. The next
+    // reconcile / `discover` re-sweeps, so a discarded sweep is self-healing and
+    // never leaves the view permanently stale (PGR-D2).
+    let mut registry = shared.lock();
+    if registry.generation(name) == start_generation {
+        registry.instances.insert(name.to_owned(), fresh);
+    }
+}
+
 /// The background task that keeps the shared membership view fresh from a
 /// `watch_prefix` stream. Self-terminates when the backend is dropped (its
 /// `Weak<Shared>` no longer upgrades), the cache watch ends, or graceful
@@ -612,27 +776,9 @@ impl StoreMaintainer {
     }
 
     /// Rebuilds this service's slice of the shared view from a `scan_prefix` +
-    /// `get` sweep of backend truth, replacing whatever was cached. Best-effort:
-    /// if the backend lacks `scan_prefix` the view is left untouched (joins still
-    /// reconverge from the heartbeat stream). Never holds the registry lock
-    /// across an `.await` — the sweep completes before the single locked insert.
+    /// `get` sweep of backend truth (delegates to [`reconcile_view`]).
     async fn reconcile(&self, shared: &Shared) {
-        let Ok(keys) = self.cache.scan_prefix(&self.prefix).await else {
-            return;
-        };
-        let mut fresh = HashMap::new();
-        for key in keys {
-            let Some(instance_id) = key.strip_prefix(self.prefix.as_str()).map(str::to_owned)
-            else {
-                continue;
-            };
-            if let Ok(Some(entry)) = self.cache.get(&key).await
-                && let Some(record) = InstanceRecord::decode(&entry.value)
-            {
-                fresh.insert(instance_id.clone(), record.to_instance(instance_id));
-            }
-        }
-        shared.lock().instances.insert(self.name.clone(), fresh);
+        reconcile_view(&self.cache, shared, &self.name, &self.prefix).await;
     }
 
     async fn apply(&self, shared: &Shared, event: &CacheEvent) {
@@ -649,17 +795,33 @@ impl StoreMaintainer {
                 };
                 if let Some(instance) = instance {
                     let mut registry = shared.lock();
-                    registry
-                        .instances
-                        .entry(self.name.clone())
-                        .or_default()
-                        .insert(instance_id, instance);
+                    // Bump the revision only when the effective membership
+                    // actually changes — a genuinely new instance or a changed
+                    // record — not on a heartbeat re-insert of an identical
+                    // instance (PGR-D2). Bumping on every `Changed` (including
+                    // routine TTL refreshes, which are frequent) would needlessly
+                    // discard a concurrent `discover` reconcile sweep and revert
+                    // it to poll-interval-stale departures, defeating the point
+                    // of the discover-time reconcile.
+                    let changed = {
+                        let entry = registry.instances.entry(self.name.clone()).or_default();
+                        entry.insert(instance_id, instance.clone()).as_ref() != Some(&instance)
+                    };
+                    if changed {
+                        registry.bump_generation(&self.name);
+                    }
                 }
             }
             CacheEvent::Deleted { .. } | CacheEvent::Expired { .. } => {
                 let mut registry = shared.lock();
-                if let Some(map) = registry.instances.get_mut(&self.name) {
-                    map.remove(&instance_id);
+                let removed = registry
+                    .instances
+                    .get_mut(&self.name)
+                    .is_some_and(|map| map.remove(&instance_id).is_some());
+                // Only a real removal changes membership, so only then invalidate
+                // a concurrent reconcile sweep (PGR-D2).
+                if removed {
+                    registry.bump_generation(&self.name);
                 }
             }
             _ => {}

--- a/gears/system/cluster/cluster/src/defaults/discovery_tests.rs
+++ b/gears/system/cluster/cluster/src/defaults/discovery_tests.rs
@@ -277,82 +277,102 @@ async fn revoke_stops_the_store_maintainer() {
 }
 
 #[tokio::test]
-async fn watch_surfaces_unsupported_prefix_watch() {
+async fn watch_works_over_a_cache_without_native_prefix_watch() {
+    // A cache declaring `prefix_watch: false` no longer surfaces `Unsupported`
+    // from `watch`: the backend synthesizes the stream with the
+    // `PollingPrefixWatch` polyfill over `scan_prefix`. A short poll interval
+    // keeps the test fast under real time (the pre-insert path can't help a
+    // `watch`, which genuinely needs a poll tick to observe the registration).
     let backend =
-        CacheBasedServiceDiscoveryBackend::new(MemoryCache::linearizable_without_prefix_watch());
-    assert!(matches!(
-        backend.watch("delivery").await,
-        Err(ClusterError::Unsupported {
-            feature: "prefix_watch"
-        })
-    ));
-    // Registration still succeeds — only the cross-process view degrades.
+        CacheBasedServiceDiscoveryBackend::new(MemoryCache::linearizable_without_prefix_watch())
+            .with_prefix_watch_polling(Duration::from_millis(10));
+    let Ok(mut watch) = backend.watch("delivery").await else {
+        panic!("watch must establish via the polyfill over a prefix_watch:false cache");
+    };
+    let Ok(handle) = backend.register(registration("delivery", &[])).await else {
+        panic!("register");
+    };
+    let joined = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match watch.recv().await {
+                Some(ServiceWatchEvent::Change(TopologyChange::Joined(instance)))
+                    if instance.instance_id == handle.instance_id() =>
+                {
+                    break true;
+                }
+                Some(_) => {}
+                None => break false,
+            }
+        }
+    })
+    .await
+    .expect("a join event must arrive within the timeout");
     assert!(
-        backend
-            .register(registration("delivery", &[]))
-            .await
-            .is_ok()
+        joined,
+        "the polyfill watch must surface the registration as Joined"
     );
+    backend.revoke().await;
 }
 
 #[tokio::test]
-async fn degraded_register_does_not_leak_an_unreapable_local_instance() {
-    // Without native prefix watch no maintainer runs, so nothing would reap a
-    // pre-inserted instance on TTL expiry. `register` must therefore skip the
-    // pre-insert and `discover` must stay best-effort empty — not surface a
-    // local instance that would read as live forever.
+async fn discover_works_over_a_cache_without_native_prefix_watch() {
+    // Previously a degraded, always-empty mode; now the `PollingPrefixWatch`
+    // polyfill backs a real maintainer, so `register`'s local pre-insert is safe
+    // (the polling stream reaps it on TTL expiry / deregistration) and `discover`
+    // finds the instance immediately — no poll wait needed for the local view.
     let backend =
         CacheBasedServiceDiscoveryBackend::new(MemoryCache::linearizable_without_prefix_watch());
-    assert!(
-        backend
-            .register(registration("delivery", &[]))
-            .await
-            .is_ok()
-    );
+    let Ok(handle) = backend.register(registration("delivery", &[])).await else {
+        panic!("register");
+    };
     settle().await;
     let Ok(found) = backend
         .discover("delivery", DiscoveryFilter::default())
         .await
     else {
-        panic!("discover must succeed (best-effort) even in degraded mode");
+        panic!("discover must succeed over a polyfill-backed cache");
     };
-    assert!(
-        found.is_empty(),
-        "degraded discover must be best-effort empty, not a stale unreapable instance"
+    assert_eq!(
+        found.len(),
+        1,
+        "polyfill-backed discover must find the registered instance, not an empty set"
     );
+    assert_eq!(found[0].instance_id, handle.instance_id());
+    backend.revoke().await;
 }
 
 #[tokio::test]
-async fn concurrent_degraded_registers_do_not_leak_an_unreapable_local_instance() {
-    // Regression: `ensure_maintainer` marked a name maintained *before* awaiting
-    // `watch_prefix`. With a degraded cache two concurrent `register`s for the
-    // same name could interleave so the second observed the first's optimistic
-    // mark, pre-inserted an instance, and then the first's `watch_prefix` failed
-    // and rolled the mark back — leaving an instance no maintainer would ever
-    // reap. The slow `watch_prefix` makes that interleaving deterministic.
-    let backend = CacheBasedServiceDiscoveryBackend::new(
-        MemoryCache::linearizable_without_prefix_watch_slow(),
-    );
+async fn concurrent_registers_over_a_polyfill_cache_are_both_discoverable() {
+    // With the polyfill the maintainer always starts, so the historical
+    // rollback-vs-optimistic-mark leak (the reason `ensure_maintainer` marks
+    // `Pending` before confirming the maintainer live) cannot strand an
+    // unreapable instance here. Two concurrent `register`s for the same name
+    // must both end up discoverable: one caller spawns the maintainer and
+    // pre-inserts; the other sees `Pending` and is picked up by the maintainer's
+    // initial `scan_prefix` reconcile.
+    let backend =
+        CacheBasedServiceDiscoveryBackend::new(MemoryCache::linearizable_without_prefix_watch());
     let (first, second) = tokio::join!(
         backend.register(registration("delivery", &[])),
         backend.register(registration("delivery", &[])),
     );
-    assert!(
-        first.is_ok() && second.is_ok(),
-        "both registrations succeed"
-    );
+    let (Ok(h1), Ok(h2)) = (first, second) else {
+        panic!("both registrations must succeed");
+    };
     settle().await;
     let Ok(found) = backend
         .discover("delivery", DiscoveryFilter::default())
         .await
     else {
-        panic!("discover must succeed (best-effort) even in degraded mode");
+        panic!("discover must succeed over a polyfill-backed cache");
     };
+    let ids: std::collections::HashSet<&str> =
+        found.iter().map(|i| i.instance_id.as_str()).collect();
     assert!(
-        found.is_empty(),
-        "no maintainer is running, so degraded discover must stay best-effort \
-         empty even under concurrent registration, not leak an unreapable instance"
+        ids.contains(h1.instance_id()) && ids.contains(h2.instance_id()),
+        "both concurrent registrations must be discoverable via the polyfill maintainer"
     );
+    backend.revoke().await;
 }
 
 #[test]

--- a/gears/system/cluster/cluster/src/defaults/test_cache.rs
+++ b/gears/system/cluster/cluster/src/defaults/test_cache.rs
@@ -163,18 +163,6 @@ impl MemoryCache {
         )
     }
 
-    /// A linearizable cache with no prefix watch whose `watch_prefix` suspends
-    /// once before returning `Unsupported`, so two concurrent `register`s
-    /// interleave deterministically at the maintainer-startup await.
-    pub(super) fn linearizable_without_prefix_watch_slow() -> Arc<Self> {
-        Self::spawn_full(
-            CacheConsistency::Linearizable,
-            false,
-            WatchBehavior::Normal,
-            true,
-        )
-    }
-
     fn spawn(consistency: CacheConsistency, prefix_watch: bool) -> Arc<Self> {
         Self::spawn_with(consistency, prefix_watch, WatchBehavior::Normal)
     }

--- a/gears/system/cluster/cluster/src/gear.rs
+++ b/gears/system/cluster/cluster/src/gear.rs
@@ -44,11 +44,12 @@ impl Default for ClusterGear {
 
 impl ClusterGear {
     /// Assembles the provider registry from the backend plugins linked into this
-    /// build. Today only the in-process standalone provider; future plugins add a
-    /// `with_cache_provider` line here.
+    /// build; future plugins add a `with_*_provider` line here.
     fn provider_registry() -> ProviderRegistry {
         ProviderRegistry::new()
             .with_cache_provider(Arc::new(standalone_cluster_plugin::StandaloneCacheProvider))
+            .with_cache_provider(Arc::new(postgres_cluster_plugin::PostgresCacheProvider))
+            .with_lock_provider(Arc::new(postgres_cluster_plugin::PostgresLockProvider))
     }
 }
 

--- a/gears/system/cluster/cluster/src/wiring.rs
+++ b/gears/system/cluster/cluster/src/wiring.rs
@@ -3,11 +3,12 @@
 
 use std::future::Future;
 use std::sync::Arc;
+use std::time::Duration;
 
 use cluster_sdk::{
     ClusterCacheBackend, ClusterError, ClusterProfile, DistributedLockBackend,
-    LeaderElectionBackend, ServiceDiscoveryBackend, StopHook, deregister_cache_backend,
-    deregister_leader_election_backend, deregister_lock_backend,
+    LeaderElectionBackend, SD_POLL_INTERVAL_MS_OPTION, ServiceDiscoveryBackend, StopHook,
+    deregister_cache_backend, deregister_leader_election_backend, deregister_lock_backend,
     deregister_service_discovery_backend, register_cache_backend, register_leader_election_backend,
     register_lock_backend, register_service_discovery_backend,
 };
@@ -32,6 +33,12 @@ pub struct ProfileBackends {
     leader_election: Option<Arc<dyn LeaderElectionBackend>>,
     lock: Option<Arc<dyn DistributedLockBackend>>,
     service_discovery: Option<Arc<dyn ServiceDiscoveryBackend>>,
+    /// Operator-configured poll cadence for the auto-wrapped
+    /// [`CacheBasedServiceDiscoveryBackend`]'s `PollingPrefixWatch` polyfill,
+    /// used only when `service_discovery` is left to the SDK default over a
+    /// cache without native prefix watch. `None` keeps `DEFAULT_PREFIX_WATCH_POLL`
+    /// (PGR-D3).
+    sd_poll_interval: Option<Duration>,
 }
 
 impl ProfileBackends {
@@ -44,7 +51,17 @@ impl ProfileBackends {
             leader_election: None,
             lock: None,
             service_discovery: None,
+            sd_poll_interval: None,
         }
+    }
+
+    /// Sets the service-discovery poll interval honoured when the SD primitive is
+    /// auto-wrapped over a non-native-prefix-watch cache (PGR-D3). Ignored when a
+    /// native `service_discovery` backend is bound.
+    #[must_use]
+    pub fn with_sd_poll_interval(mut self, interval: Duration) -> Self {
+        self.sd_poll_interval = Some(interval);
+        self
     }
 
     /// Binds a native leader-election backend, overriding the SDK default.
@@ -124,6 +141,23 @@ impl ClusterWiring {
             builder = builder.on_stop(move || async move { cache_stop().await });
 
             let mut backends = ProfileBackends::new(Arc::clone(&cache));
+
+            // Honour an operator-configured service-discovery poll cadence for
+            // the omit-default auto-wrap (PGR-D3). The interval lives in the
+            // cache provider's own options (e.g. the Postgres plugin's
+            // `sd_poll_interval_ms`, cf. `SD_POLL_INTERVAL_MS_OPTION`); read it
+            // generically here so a non-default cadence reaches
+            // `with_prefix_watch_polling` instead of being silently forced to
+            // the 5s default. A zero/absent value keeps the default.
+            if let Some(interval_ms) = profile
+                .cache
+                .options
+                .get(SD_POLL_INTERVAL_MS_OPTION)
+                .and_then(serde_json::Value::as_u64)
+                .filter(|&ms| ms > 0)
+            {
+                backends = backends.with_sd_poll_interval(Duration::from_millis(interval_ms));
+            }
 
             if let Some(binding) = &profile.leader_election {
                 let provider = providers
@@ -304,7 +338,18 @@ fn resolve_profile_backends(
         if let Some(backend) = backends.service_discovery {
             backend
         } else {
-            let default = Arc::new(CacheBasedServiceDiscoveryBackend::new(Arc::clone(&cache)));
+            // Over a cache with no native prefix watch (`prefix_watch: false`,
+            // e.g. the Postgres backend) the default SD backend drives its
+            // topology watch through the `PollingPrefixWatch` polyfill. The
+            // operator-configured cadence (e.g. the Postgres plugin's
+            // `sd_poll_interval_ms`, surfaced through
+            // [`ProfileBackends::with_sd_poll_interval`]) is threaded in here;
+            // when unset it keeps `DEFAULT_PREFIX_WATCH_POLL` (5s) (PGR-D3).
+            let mut sd = CacheBasedServiceDiscoveryBackend::new(Arc::clone(&cache));
+            if let Some(interval) = backends.sd_poll_interval {
+                sd = sd.with_prefix_watch_polling(interval);
+            }
+            let default = Arc::new(sd);
             revokers.push(Arc::clone(&default) as Arc<dyn ShutdownRevoke>);
             default as Arc<dyn ServiceDiscoveryBackend>
         };

--- a/gears/system/cluster/cluster/tests/conformance.rs
+++ b/gears/system/cluster/cluster/tests/conformance.rs
@@ -23,7 +23,8 @@ use cluster::defaults::{
 };
 use cluster_conformance::MemCache;
 use cluster_conformance::{
-    run_discovery_conformance, run_leader_conformance, run_lock_conformance,
+    ScenarioBackend, TimeControl, run_discovery_conformance, run_leader_conformance,
+    run_lock_conformance,
 };
 use cluster_sdk::discovery::ServiceDiscoveryBackend;
 use cluster_sdk::leader::LeaderElectionBackend;
@@ -31,30 +32,41 @@ use cluster_sdk::lock::DistributedLockBackend;
 
 #[tokio::test]
 async fn leader_election_conformance() {
-    run_leader_conformance(|| {
-        let cache = MemCache::linearizable();
-        Arc::new(CasBasedLeaderElectionBackend::new(cache).expect("linearizable cache is accepted"))
-            as Arc<dyn LeaderElectionBackend>
-    })
+    run_leader_conformance(
+        || async {
+            let cache = MemCache::linearizable();
+            ScenarioBackend::bare(Arc::new(
+                CasBasedLeaderElectionBackend::new(cache).expect("linearizable cache is accepted"),
+            ) as Arc<dyn LeaderElectionBackend>)
+        },
+        TimeControl::Virtual,
+    )
     .await;
 }
 
 #[tokio::test]
 async fn distributed_lock_conformance() {
-    run_lock_conformance(|| {
-        let cache = MemCache::linearizable();
-        Arc::new(
-            CasBasedDistributedLockBackend::new(cache).expect("linearizable cache is accepted"),
-        ) as Arc<dyn DistributedLockBackend>
-    })
+    run_lock_conformance(
+        || async {
+            let cache = MemCache::linearizable();
+            ScenarioBackend::bare(Arc::new(
+                CasBasedDistributedLockBackend::new(cache).expect("linearizable cache is accepted"),
+            ) as Arc<dyn DistributedLockBackend>)
+        },
+        TimeControl::Virtual,
+    )
     .await;
 }
 
 #[tokio::test]
 async fn service_discovery_conformance() {
-    run_discovery_conformance(|| {
-        let cache = MemCache::linearizable();
-        Arc::new(CacheBasedServiceDiscoveryBackend::new(cache)) as Arc<dyn ServiceDiscoveryBackend>
-    })
+    run_discovery_conformance(
+        || async {
+            let cache = MemCache::linearizable();
+            ScenarioBackend::bare(Arc::new(CacheBasedServiceDiscoveryBackend::new(cache))
+                as Arc<dyn ServiceDiscoveryBackend>)
+        },
+        TimeControl::Virtual,
+    )
     .await;
 }

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/Cargo.toml
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/Cargo.toml
@@ -1,0 +1,167 @@
+[package]
+name = "cf-postgres-cluster-plugin"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Postgres backend plugin for the cluster gear: a native ClusterCacheBackend over a sqlx::PgPool plus a native DistributedLockBackend over pg_advisory_lock, for multi-instance, no-K8s deployments"
+readme = "README.md"
+keywords = ["constructorfabric", "cf-gears"]
+categories = ["development-tools"]
+metadata.docs.rs.all-features = true
+
+[lib]
+name = "postgres_cluster_plugin"
+
+# `testcontainers`/`testcontainers-modules` are declared as *optional* entries
+# under `[dependencies]` (not `[dev-dependencies]`) on purpose: Cargo does not
+# allow optional dev-dependencies, and the `integration` feature must name them
+# via `dep:` (see the `[features]` doc below). cargo-shear's "misplaced optional
+# dependency" heuristic flags that placement; ignore it here since the placement
+# is required, not accidental.
+[package.metadata.cargo-shear]
+ignored = ["testcontainers", "testcontainers-modules"]
+
+[lints]
+workspace = true
+
+[features]
+# Gates the Layer 3 testcontainers integration suite (docs/TESTING.md §4, §7)
+# so a default `cargo test` never requires a Docker daemon. `testcontainers`/
+# `testcontainers-modules` are declared as optional entries under
+# `[dependencies]` below (not `[dev-dependencies]`, which Cargo does not allow
+# to be optional) purely so this feature array can name them directly, per
+# docs/TESTING.md §7; every reference to them lives in `tests/`, so enabling
+# this feature has no effect on the plugin's own compiled artifact. Run with
+# `cargo test -p cf-postgres-cluster-plugin --features integration`.
+integration = ["dep:testcontainers", "dep:testcontainers-modules"]
+
+[dependencies]
+# `otel` pulls in the SDK's OpenTelemetry-backed `ClusterMetrics` adapter
+# (`OtelClusterMetrics`), mirroring `standalone-cluster-plugin` so this plugin
+# emits the cluster cache signal set for free via `InstrumentedCache` (DESIGN
+# §8). The lock signals are emitted natively (§8), not via a decorator.
+cluster-sdk = { workspace = true, features = ["otel"] }
+# The lock/cache TTL reapers emit two plugin-local, non-ADR-004 metrics
+# (`cluster_postgres_lock_active_names` gauge, `cluster_postgres_reaper_sweep_duration_seconds`
+# histogram — DESIGN §8) through a meter this plugin owns directly. The
+# `ClusterMetrics` contract sink has no gauge method, so these go via the OTel
+# API straight (same underlying API `OtelClusterMetrics` uses in cluster-sdk).
+opentelemetry = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+serde = { workspace = true }
+# Per-key watcher registry for the LISTEN fan-out task (cache/watch.rs).
+dashmap = { workspace = true }
+# Reads the provider's flattened operator-config options (e.g.
+# `connection_string`, `pool_max_size`) passed through by the wiring crate as
+# a serde map (DESIGN §7), and deserializes `PostgresClusterConfig` /
+# `PostgresLockConfig` from it.
+serde_json = { workspace = true }
+# `${VAR}` / `${VAR:-default}` env-var expansion for `connection_string`
+# (DESIGN §7), the same mechanism `libs/toolkit-db` uses for DB passwords/DSNs.
+# `toolkit` (not `toolkit-utils` directly) because the `ExpandVars` derive
+# macro expands to `::toolkit::var_expand::ExpandVars`.
+toolkit = { workspace = true }
+toolkit-macros = { workspace = true }
+# Direct sqlx usage is a deliberate, lint-sanctioned exception to the
+# platform's normal Sea-ORM/SecureConn DB-access rule — see DESIGN.md §3.1
+# ("Why sqlx directly, not libs/toolkit-db") and
+# tools/dylint_lints/lint_utils::is_in_postgres_cluster_plugin_path. This
+# plugin needs session-pinned advisory locks, LISTEN/NOTIFY streaming, and
+# PgPoolOptions connect/acquire hooks that have no Sea-ORM equivalent.
+# `expires_at`/`acquired_at` are `TIMESTAMPTZ`; the `chrono` feature maps them
+# through sqlx (which pulls `chrono` transitively) — this plugin never names a
+# `chrono` type directly, so `chrono` is not a direct dependency.
+# `cluster_lock.holder_id` is a native `UUID` column bound/decoded as
+# `uuid::Uuid` (the lock ownership fence, PGR-L1); the `uuid` feature is what
+# gives sqlx those `Encode`/`Decode` impls.
+sqlx = { workspace = true, features = [
+    "postgres",
+    "migrate",
+    "macros",
+    "chrono",
+    "uuid",
+] }
+# `lock_key`'s deterministic name -> (key1, key2) hash (DESIGN.md §5.1): xxh3
+# is a well-known, fast, non-cryptographic 64-bit hash, and already a
+# workspace dependency (used by `libs/toolkit-db`) — the specific algorithm is
+# an implementation detail per DESIGN.md §5.1 as long as it stays fixed once
+# shipped.
+xxhash-rust = { workspace = true }
+# Full-jitter on the LISTEN reconnect backoff (cache/watch.rs): without it,
+# every fleet instance retries a shared-database blip on the same deterministic
+# schedule, aligning reconnect attempts into bursts.
+rand = { workspace = true }
+# Layer 3 testcontainers fixture (`tests/common/mod.rs`, DESIGN.md/TESTING.md
+# §4.1) — optional, only pulled in by `--features integration`. See the
+# `[features]` doc above for why these live here rather than
+# `[dev-dependencies]`.
+testcontainers = { workspace = true, optional = true }
+testcontainers-modules = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+# `pg_spec_006` reads the `cluster_postgres_lock_active_names` gauge back through
+# an in-process OTel reader (`InMemoryMetricExporter`, gated by the `testing`
+# feature) over a meter injected into the lock reaper.
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
+# `pg_spec_006` asserts the `cluster.lock.name_cardinality_high` WARN. The WARN
+# is emitted from the reaper's spawned task, so it captures via a process-global
+# subscriber (all threads route to it) rather than `tracing-test`'s thread-local
+# capture, which misses spawned-task events.
+tracing-subscriber = { workspace = true }
+# `FutureExt::now_or_never` in `cache/watch.rs` unit tests, to assert a watch
+# has nothing buffered without risking a hang on a real `.await`.
+futures-util = { workspace = true }
+# Layer 2 conformance suite (TESTING.md §3): the same parametrized suites
+# every other backend runs, wired against this plugin's real Postgres-backed
+# cache/lock/leader/discovery in `tests/conformance.rs`.
+cf-gears-cluster-conformance = { workspace = true }
+# `cluster::defaults::{CasBasedLeaderElectionBackend, CacheBasedServiceDiscoveryBackend}`
+# (TESTING.md §3): leader election and service discovery are always the SDK
+# defaults over this plugin's cache (DESIGN.md §6), so the L2/L3 tests exercise
+# that combination via the `cluster` gear crate itself, not a stand-in. A
+# dev-dependency only — `cf-gears-cluster` does not depend on this plugin (it
+# depends on `cf-gears-standalone-cluster-plugin` for its own default wiring),
+# so this does not introduce a cycle in the normal build graph; a dev-only
+# cycle through test code would be permitted by Cargo either way.
+cluster = { package = "cf-gears-cluster", path = "../../cluster" }
+# `PG-LOCK-011` (docs/TESTING.md §4.3): the "cache on a different provider"
+# half of the end-to-end YAML routing test binds `cache: { provider:
+# standalone }` alongside `lock: { provider: postgres }`.
+cf-gears-standalone-cluster-plugin = { path = "../standalone-cluster-plugin" }
+
+# Layer 2 (conformance) and Layer 3 (testcontainers) test binaries all require
+# a real Docker daemon, so each is gated behind `required-features =
+# ["integration"]` (docs/TESTING.md §7) — `cargo test -p
+# cf-postgres-cluster-plugin` (no flag) skips building these binaries
+# entirely, rather than merely skipping test functions inside them.
+[[test]]
+name = "conformance"
+required-features = ["integration"]
+
+[[test]]
+name = "cache_integration"
+required-features = ["integration"]
+
+[[test]]
+name = "lock_integration"
+required-features = ["integration"]
+
+[[test]]
+name = "watch_integration"
+required-features = ["integration"]
+
+[[test]]
+name = "lifecycle_integration"
+required-features = ["integration"]
+
+[[test]]
+name = "postgres_specific"
+required-features = ["integration"]

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/README.md
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/README.md
@@ -1,0 +1,8 @@
+# cf-postgres-cluster-plugin
+
+The Postgres backend plugin for the `cluster` gear: a native `ClusterCacheBackend`
+over a `sqlx::PgPool` plus a native `DistributedLockBackend` over
+`pg_advisory_lock`. Recommended for multi-instance, no-K8s deployments.
+
+See [`docs/DESIGN.md`](./docs/DESIGN.md) for the full design and
+[`docs/TESTING.md`](./docs/TESTING.md) for the test plan.

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/docs/DESIGN.md
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/docs/DESIGN.md
@@ -1,0 +1,725 @@
+# Technical Design — Postgres Cluster Plugin
+
+<!-- toc -->
+
+- [1. Overview](#1-overview)
+  - [1.1 Role in the Cluster Architecture](#11-role-in-the-cluster-architecture)
+  - [1.2 Primitive Coverage](#12-primitive-coverage)
+- [2. Domain Model](#2-domain-model)
+  - [2.1 Database Tables](#21-database-tables)
+  - [2.2 Version Semantics](#22-version-semantics)
+  - [2.3 NOTIFY Payload Format](#23-notify-payload-format)
+- [3. Component Model](#3-component-model)
+  - [3.1 Crate Structure](#31-crate-structure)
+  - [3.2 Builder / Handle Lifecycle](#32-builder--handle-lifecycle)
+  - [3.3 Connection Pool Split](#33-connection-pool-split)
+  - [3.4 synchronous_commit Enforcement](#34-synchronous_commit-enforcement)
+  - [3.5 Standalone Lock Provider](#35-standalone-lock-provider)
+  - [3.6 Replication Topology Warning](#36-replication-topology-warning)
+- [4. Cache Implementation](#4-cache-implementation)
+  - [4.1 SQL Contract per Operation](#41-sql-contract-per-operation)
+  - [4.2 TTL Reaper](#42-ttl-reaper)
+  - [4.3 Watch via LISTEN / NOTIFY](#43-watch-via-listen--notify)
+  - [4.4 scan_prefix](#44-scan_prefix)
+  - [4.5 Consistency Declaration](#45-consistency-declaration)
+- [5. Distributed Lock Implementation](#5-distributed-lock-implementation)
+  - [5.1 Advisory Lock Mapping](#51-advisory-lock-mapping)
+  - [5.2 TTL Enforcement](#52-ttl-enforcement)
+  - [5.3 Blocking lock()](#53-blocking-lock)
+  - [5.4 PgBouncer Constraint](#54-pgbouncer-constraint)
+- [6. Leader Election and Service Discovery](#6-leader-election-and-service-discovery)
+- [7. Configuration](#7-configuration)
+- [8. Observability](#8-observability)
+- [9. ProviderErrorKind Mapping](#9-providererrorkind-mapping)
+- [10. Shutdown Sequence](#10-shutdown-sequence)
+- [11. Risks / Trade-offs](#11-risks--trade-offs)
+- [12. Open Questions](#12-open-questions)
+
+<!-- /toc -->
+
+## 1. Overview
+
+`cf-postgres-cluster-plugin` is the Postgres backend plugin for the cluster gear. It provides a native `ClusterCacheBackend` over a `sqlx::PgPool` and a native `DistributedLockBackend` over PostgreSQL session-level advisory locks. Leader election and service discovery are derived from the SDK default backends over the Postgres cache — no additional tables or connections are required for those two primitives.
+
+The plugin is the recommended deployment for **multi-instance, no-K8s** environments (DESIGN §4.2): Postgres is already deployed in every Gears environment, zero new infrastructure is required, and the native `pg_advisory_lock` gives ACID-correct mutual exclusion without a distributed lock service.
+
+### 1.1 Role in the Cluster Architecture
+
+The plugin satisfies `cpt-cf-clst-component-plugins` for the Postgres backend. It:
+
+- Implements `ClusterCacheProvider` (the provider trait from `cluster-sdk`) so the wiring crate can instantiate the cache from operator YAML (`cache: { provider: postgres }`).
+- Implements `ClusterLockProvider` so the wiring crate can *independently* instantiate the native lock from operator YAML (`lock: { provider: postgres }`), whether or not `cache` in the same profile is also bound to postgres — see §3.5. This is what makes the native lock actually reachable via YAML; without it, the wiring's per-primitive routing (`cpt-cf-clst-fr-routing-per-primitive`, already implemented in `cluster/src/wiring.rs`) has nothing registered under `provider: postgres` for the `lock` primitive to dispatch to.
+- Exposes a builder/handle pair (`PostgresClusterPlugin::builder(...).build_and_start() -> PostgresClusterHandle`) following the outbox-style lifecycle pattern (DESIGN §3.7, ADR-006). It is NOT a `RunnableCapability`; the cluster gear (`cf-gears-cluster`) owns its lifecycle.
+- Returns a `StopHook` from `build_cache` (and, independently, from `build_lock` — §3.5) that shuts down the relevant connection pool and all background tasks it owns.
+
+### 1.2 Primitive Coverage
+
+| Primitive | Implementation | Consistency | `*Features` |
+|---|---|---|---|
+| `ClusterCacheBackend` | Native — `cluster_cache` table + LISTEN/NOTIFY | `Linearizable` | `prefix_watch: false` (LISTEN channel is key-exact; `watch_prefix` returns `Unsupported`) |
+| `LeaderElectionBackend` | SDK default `CasBasedLeaderElectionBackend` over Postgres cache | Inherits cache — `linearizable: true` | — |
+| `DistributedLockBackend` | Native — `pg_advisory_lock` + `cluster_lock` metadata table. Independently routable via `lock: { provider: postgres }` (§3.5), with its own pool/config — not required to be paired with the postgres cache provider | `linearizable: true` | — |
+| `ServiceDiscoveryBackend` | SDK default `CacheBasedServiceDiscoveryBackend` over Postgres cache | — | `metadata_pushdown: false` |
+
+`prefix_watch: false` means that consumers requiring `CacheCapability::PrefixWatch` cannot bind this backend without the polyfill. The service-discovery default backend uses `watch_prefix` internally and therefore falls back to `PollingPrefixWatch` on a prefix-watch-incapable cache; the wiring crate enables this fallback automatically (see §6).
+
+## 2. Domain Model
+
+### 2.1 Database Tables
+
+Two tables are owned by this plugin, plus one virtual NOTIFY channel. All live in the schema specified by the plugin config (default: `public`). Migration is managed via `sqlx-macros` embedded migrations; the wiring crate runs them at startup before registering backends.
+
+#### `cluster_cache`
+
+```sql
+CREATE TABLE cluster_cache (
+    key        TEXT        NOT NULL,
+    value      BYTEA       NOT NULL,
+    version    BIGINT      NOT NULL DEFAULT 1,
+    expires_at TIMESTAMPTZ,
+    PRIMARY KEY (key),
+    CONSTRAINT cluster_cache_key_len_check CHECK (octet_length(key) <= 2048)
+);
+
+CREATE INDEX cluster_cache_expires_idx ON cluster_cache (expires_at)
+    WHERE expires_at IS NOT NULL;
+```
+
+`key` is the fully-qualified backend key (scope prefix already applied by `ScopedCacheBackend`). `version` starts at 1 on first insert and increments by 1 on every successful write (including CAS). `expires_at IS NULL` means no TTL. The partial index on `expires_at` makes the TTL reaper's scan efficient.
+
+##### Key length
+
+`key` is `TEXT` rather than `VARCHAR(n)` because the two are not different storage: Postgres stores them identically on disk, and `VARCHAR(n)` is just `TEXT` plus a length check. The reason a bound is needed anyway is `PRIMARY KEY (key)` — the value lands in a btree, and a btree index tuple cannot exceed roughly one third of a page (~2704 bytes by default). Past that an `INSERT` fails outright with SQLSTATE `54000`; TOAST does not rescue an indexed key the way it would a non-indexed column.
+
+The plugin therefore caps an indexed key at **2048 bytes** (`limits::MAX_INDEXED_KEY_BYTES`), enforced in two places:
+
+- **In Rust, before the write** — `cache::watch::validate_key_len` on every mutation, returning `ClusterError::InvalidName`. This is the path consumers actually hit.
+- **In SQL, as a backstop** — `cluster_cache_key_len_check`, so a value arriving another way (psql, a future code path) fails as a named constraint violation rather than an opaque btree error. `octet_length`, not `length`: the limit is on bytes, and a multi-byte key has more of them than characters.
+
+#### `cluster_lock`
+
+```sql
+CREATE TABLE cluster_lock (
+    name        TEXT        NOT NULL,
+    holder_id   UUID        NOT NULL,
+    acquired_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at  TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (name),
+    CONSTRAINT cluster_lock_name_len_check CHECK (octet_length(name) <= 2048)
+);
+
+CREATE INDEX cluster_lock_expires_idx ON cluster_lock (expires_at);
+```
+
+Stores lock metadata alongside the advisory lock. `expires_at` is the lock's absolute deadline, computed as `now() + ttl` on the **database** clock at insert and at every renew (PGR-C2, exactly as for `cluster_cache.expires_at`) — not a raw `acquired_at`/`ttl_ms` pair the TTL reaper re-derives for every row on every tick. A derived deadline could not be indexed at all: `timestamptz + interval` is `STABLE`, not `IMMUTABLE` (its result depends on the session `TimeZone`), so Postgres rejects an expression index on `acquired_at + ttl_ms * interval '1ms'`, and `now()` may not appear in a partial-index predicate either — leaving every sweep a guaranteed sequential scan with a per-row interval multiply. Storing the deadline makes the sweep an indexed `WHERE expires_at <= now()` and lets the reaper read `min(expires_at)` index-only, to wake when the next lock is actually due rather than polling blindly (§5.2). The index is unconditional rather than partial like the cache's: a lock TTL is mandatory (`DistributedLockBackend` takes a `Duration`, not a `Ttl`), so there is no `NULL` subset to exclude. `acquired_at` is retained for diagnostics only — no query filters on it. `holder_id` is a random UUID generated at acquire time; `renew()`, `release()`, and the reaper all guard on it to prevent a foreign or stale holder from renewing, releasing, or reclaiming another's lock. It is a native `UUID` column (and a `uuid::Uuid`, not a `String`, in Rust): the only writer is `try_acquire`'s `Uuid::new_v4()`, so the native type costs 16 bytes instead of 36, compares as bytes rather than as a collated string in every fenced query, and makes the invariant the column's own rather than a convention.
+
+`name` is `PRIMARY KEY` and so carries the same btree index-tuple exposure as `cluster_cache.key` — identical bound, identical two-layer enforcement (`lock::validate_lock_name` in Rust, `cluster_lock_name_len_check` as the SQL backstop). Names are rejected at acquisition, before any lock state is mutated, so `release()` never reaches a lock whose metadata row could not be written.
+
+#### `cluster_lock_notify` (virtual — no table)
+
+The Postgres NOTIFY channel `cluster_lock_released` carries the lock name when a holder calls `release()` explicitly. Blocked `lock()` waiters LISTEN on this channel to wake immediately rather than polling.
+
+### 2.2 Version Semantics
+
+Version starts at 1 on first insert and increments by 1 on every successful write. This matches the SDK contract (DESIGN §3.1 `CacheEntry`): version 0 is reserved as the "absent" sentinel; `put_if_absent` returns version 1; each subsequent write increments by 1. The version column is a plain `BIGINT` updated via `version = version + 1` in the UPDATE path — it does not use a global `BIGSERIAL` sequence; each key's counter is independent.
+
+The `compare_and_delete` operation is value-guarded (not version-guarded): `DELETE … WHERE key = $1 AND value = $2`. This survives the delete+recreate version-reset scenario documented in the SDK (DESIGN §3.3, `[cluster-cache-version-reset-caveat]`): a successor that re-claimed after a TTL lapse writes a different value, so the guarded delete is a safe no-op and never wipes the successor's claim.
+
+### 2.3 NOTIFY Payload Format
+
+Postgres caps a NOTIFY payload at 7999 bytes (`MAX_NOTIFY_PAYLOAD_LENGTH` in `src/backend/commands/async.c` — the "8 KB" of folklore rounds up to a nearby power of two but overstates the real hard limit by 193 bytes; verified empirically, see `PG-SPEC-002`). The plugin's cache watch events carry only the key and event type, never the value (DESIGN §2.1 Lightweight Notifications). Payload format:
+
+```
+<event_type>:<key>
+```
+
+Where `<event_type>` is one of `C` (Changed), `D` (Deleted), `E` (Expired). The payload budget alone would allow a key of ≤ 7997 bytes (7999-byte payload limit minus the two-byte `<event_type>:` prefix), but that is *not* the binding limit: `cluster_cache.key` is also a `PRIMARY KEY`, so the ~2704-byte btree index-tuple ceiling (§2.1) bites first. `cache::watch::MAX_KEY_BYTES` is the tighter of the two — 2048 bytes — validated at write time, returning `ClusterError::InvalidName` for keys that would exceed it.
+
+An empty payload — a bare `NOTIFY cluster_cache_changes` (no payload) from an unrelated writer, or any value this plugin's own version never produces — is interpreted by the LISTEN task as a `Reset` signal, broadcasting `CacheWatchEvent::Reset` to all active watchers so consumers re-read their keys (ADR-003 §"NOTIFY overflow mapping"). Note this is *not* how NOTIFY queue overflow surfaces: Postgres does not emit an empty-payload notification on overflow — it aborts the committing *producer* transaction with an error ("too many notifications in the NOTIFY queue") and broadcasts nothing. Overflow does not inherently disconnect the LISTEN connection or increment `cluster_watch_resets_total`; it surfaces on the write side as the failing write's `Provider` error. Reserve reconnect/`Reset` for actual LISTEN connection gaps (below); monitor overflow via write/provider errors and PostgreSQL server logs.
+
+## 3. Component Model
+
+### 3.1 Crate Structure
+
+```
+cf-postgres-cluster-plugin/
+  src/
+    lib.rs          — public API re-exports
+    config.rs       — PostgresClusterConfig, PostgresLockConfig, PostgresClusterOptions (serde)
+    provider.rs     — ClusterCacheProvider impl ("postgres") + ClusterLockProvider impl ("postgres")
+    plugin.rs       — PostgresClusterPlugin, builder, handle (combined cache+lock)
+    cache/
+      mod.rs        — PostgresCache (ClusterCacheBackend impl)
+      watch.rs      — LISTEN connection + per-watcher fan-out
+      reaper.rs     — TTL sweeper background task
+    lock/
+      mod.rs        — PostgresLock (DistributedLockBackend impl); PostgresLockPlugin, builder,
+                       handle (standalone lock-only construction, §3.5)
+      reaper.rs     — advisory lock TTL reaper
+    migrations/     — two independent embedded `sqlx::migrate!()` Migrators, not
+                       one shared Migrator over one folder — see below
+      cache/
+        0001_cluster_cache.sql
+      lock/
+        0002_cluster_lock.sql
+  docs/
+    DESIGN.md       — this document
+    TESTING.md
+```
+
+`0002_cluster_lock.sql` is applied via its own `Migrator` (embedded from `migrations/lock/`, separately from `migrations/cache/`), run whether the plugin is started via the combined `PostgresClusterPlugin` (cache + lock, which runs both Migrators in order) or the standalone `PostgresLockPlugin` (§3.5, which runs only the lock one) — either path only ever runs the migrations its own tables need, so a lock-only deployment never creates `cluster_cache`.
+
+This split is required, not cosmetic: `Migrator::run` unconditionally applies every migration it was embedded with, so a single `Migrator` over one shared folder containing both files cannot support "lock-only migrates only its own table" — running it from the standalone lock plugin would apply `0001_cluster_cache.sql` too. Both Migrators write into the same database's single `_sqlx_migrations` tracking table (there is one table per database, not per `Migrator`), so each is constructed with `.set_ignore_missing(true)`: without it, a `Migrator` that only knows about its own file fails `Migrator::run`'s built-in `validate_applied_migrations` check the moment the *other* plugin's version is already recorded there. `CREATE TABLE IF NOT EXISTS` is deliberately **not** used in either migration file — `sqlx::migrate!()`'s version tracking plus its per-run advisory lock (`Migrator::run`'s `conn.lock()`) already guarantee each file's SQL executes at most once per database, which is what backs `PG-LIFE-002`/`PG-CACHE-007`'s idempotency requirement; adding `IF NOT EXISTS` on top would silently mask a real schema-drift bug (e.g. a manually created table with a stale schema) instead of surfacing `MigrateError::VersionMismatch`.
+
+**Why `sqlx` directly, not `libs/toolkit-db`.** This plugin uses `sqlx::PgPool`/`PgPoolOptions`/`sqlx::migrate!()` directly rather than going through `libs/toolkit-db`'s Sea-ORM/`SecureConn` abstraction — already designated at the SDK level (`cluster/docs/DESIGN.md` §3.5: "External backend libraries… belong to the follow-up plugin crates… and are NOT SDK dependencies"). This isn't a convenience shortcut around the platform's normal "route DB access through `SecureConn`" rule (`docs/toolkit_unified_system/11_database_patterns.md`); it's because three things this plugin needs have no `sea_orm::DatabaseConnection` equivalent to route through in the first place:
+- **Session-pinned advisory locks** (§3.3, §5.1–5.3): `pg_advisory_lock`/`pg_advisory_unlock` must run on the exact same physical connection for the lock's full (arbitrary) duration. `DatabaseConnection`'s only own-a-connection primitive is a transaction, and abusing a long-lived transaction for this collides with the PgBouncer-transaction-mode incompatibility this plugin already rejects at startup (§5.4).
+- **`LISTEN`/`NOTIFY` streaming** (§4.3): there is no Sea-ORM concept of a subscribed, long-lived notification stream; this is a raw `sqlx::postgres::PgListener`/`PgConnection` API with nothing to wrap.
+- **`PgPoolOptions::after_connect`/`before_acquire` hooks** (§3.4, enforcing `synchronous_commit = on` per ADR-009): pool-lifecycle hooks are configured at `sqlx` pool-construction time — even Sea-ORM's own Postgres connector (`SqlxPostgresConnector::from_sqlx_postgres_pool`) takes an already-built `sqlx::PgPool` as input, so there's no lower layer to intercept this from Sea-ORM's side.
+
+The repo's `DE0706_NO_DIRECT_SQLX` dylint lint (`Deny`-level, bans raw `sqlx` usage outside `libs/toolkit-db/`) carries a matching exclusion for `gears/system/cluster/plugins/postgres-cluster-plugin/` (`tools/dylint_lints/lint_utils::is_in_postgres_cluster_plugin_path`) with the same rationale, so this plugin's `sqlx` usage is a documented, lint-sanctioned exception rather than a violation to suppress case-by-case.
+
+### 3.2 Builder / Handle Lifecycle
+
+`ClusterCacheProvider::build_cache` (`cluster-sdk`) is `async fn` — the
+provider traits are `#[async_trait]` precisely because most real backends
+(Postgres, Redis, NATS, etcd) need genuinely async setup (connection pools,
+migrations, subscribe handshakes) to build their backend. The wiring crate
+calls every provider from an already-`async fn` context
+(`RunnableCapability::start` → `ClusterWiring::from_config`), so
+`build_cache`/`build_and_start` can simply `.await` that setup inline:
+
+```rust
+pub struct PostgresClusterPlugin;
+
+impl PostgresClusterPlugin {
+    pub fn builder(config: PostgresClusterConfig) -> PostgresClusterBuilder;
+}
+
+pub struct PostgresClusterBuilder { /* config */ }
+
+impl PostgresClusterBuilder {
+    pub async fn build_and_start(self) -> Result<PostgresClusterHandle, ClusterError>;
+}
+
+pub struct PostgresClusterHandle {
+    cache:  Arc<PostgresCache>,
+    lock:   Arc<PostgresLock>,
+    /* pool, listen_conn, background tasks */
+    /// Set by `stop` so the `Drop` guard can tell a graceful shutdown apart
+    /// from a forgotten one (ADR-006 §Confirmation).
+    stopped: bool,
+}
+
+impl PostgresClusterHandle {
+    pub fn cache(&self)  -> Arc<dyn ClusterCacheBackend>;
+    pub fn lock(&self)   -> Arc<dyn DistributedLockBackend>;
+    pub async fn stop(mut self);
+}
+
+/// Diagnostic guard (ADR-006 §Confirmation), mirroring `ClusterHandle`'s own
+/// guard (`cluster/src/wiring.rs`) field-for-field: dropping a
+/// `PostgresClusterHandle` without calling `stop()` leaks its background
+/// tasks (cache TTL reaper, lock TTL reaper, LISTEN fan-out task) — surfaced
+/// loudly (debug-build panic / release-build warn-log) rather than silently.
+/// The `std::thread::panicking()` check skips the debug panic during unwind
+/// so a forgotten handle dropped *while already panicking* degrades to a
+/// warning instead of a double-panic process abort (ADR-002).
+impl Drop for PostgresClusterHandle {
+    fn drop(&mut self) {
+        if self.stopped {
+            return;
+        }
+        if std::thread::panicking() {
+            tracing::warn!(
+                "PostgresClusterHandle dropped during panic unwind without stop(); \
+                 skipping debug panic to avoid double-panic abort"
+            );
+            return;
+        }
+        #[cfg(debug_assertions)]
+        panic!("PostgresClusterHandle dropped without stop() - programming error");
+        #[cfg(not(debug_assertions))]
+        tracing::warn!(
+            "PostgresClusterHandle dropped without stop() - programming error; \
+             background tasks may leak"
+        );
+    }
+}
+```
+
+`build_and_start`:
+1. Opens `sqlx::PgPool` with the configured pool size (`PgPoolOptions::connect`,
+   `.await`ed).
+2. Runs the embedded migrations (`.await`ed, idempotent).
+3. Opens a dedicated LISTEN connection outside the pool (`.await`ed).
+4. Spawns the cache TTL reaper, the lock TTL reaper, and the LISTEN fan-out
+   task.
+5. Returns the handle. By the time `build_and_start` resolves, the schema
+   exists and the LISTEN connection is live — there is no readiness gate or
+   background-init race for callers to reason about, unlike a design built
+   around a synchronous builder.
+
+`stop`:
+1. Cancels all `CancellationToken`s; awaits background tasks.
+2. Sends `CacheWatchEvent::Closed(ClusterError::Shutdown)` to all active watchers.
+3. Closes the LISTEN connection and the pool.
+4. Sets `self.stopped = true` as the last step — graceful shutdown completed, so the `Drop` guard above must not fire.
+
+### 3.3 Connection Pool Split
+
+| Connection type | Purpose | Pool |
+|---|---|---|
+| Write pool (`PgPool`, default 5 connections) | All cache reads/writes, lock acquire/release, migrations | `sqlx::PgPool` |
+| Cache-watch LISTEN connection (1 dedicated, combined plugin only) | Receives all `NOTIFY cluster_cache_changes` events; never used for queries | A dedicated `sqlx::PgListener`, outside the pool |
+| Lock release-wake LISTEN connection (1 dedicated) | Receives all `NOTIFY cluster_lock_released` events, feeding the in-process `ReleaseWaiters` registry that wakes blocked `lock()` callers (§5.3) | A dedicated `sqlx::PgListener`, outside the pool |
+| Lock connections (session-affine) | `pg_advisory_lock` is session-scoped; each acquired lock holds its advisory slot for the connection duration | Borrowed from the write pool but pinned to one connection per lock |
+
+Advisory locks are session-scoped in Postgres, which means the connection that acquired a lock must be the same connection that releases it. The plugin maps each `LockGuard` to a specific pool connection that it pins (borrows exclusively) for the duration of the lock. The pool must therefore be sized to accommodate the maximum number of simultaneously held locks; the plugin warns at startup if `pool_max_size < expected_concurrent_locks` (a config-level advisory, not a hard failure).
+
+**Total connection count.** Both LISTEN connections live *outside* the `PgPool` (`sqlx::PgListener` owns its own connection and cannot adopt an already-checked-out `PoolConnection`), so an instance's real steady-state connection count is `pool_max_size + 2` for the combined `PostgresClusterPlugin` (cache-watch + lock release-wake) and `pool_max_size + 1` for the standalone `PostgresLockPlugin` (release-wake only — no cache half, so no cache-watch connection).
+
+### 3.4 synchronous_commit Enforcement
+
+Per ADR-009 (`docs/ADR/009-leader-election-backend-safety.md`), this plugin **enforces** `synchronous_commit = on` on every connection it uses — it does not support running with `synchronous_commit = off`, and does not offer an `EventuallyConsistent` mode. `consistency()` unconditionally returns `CacheConsistency::Linearizable` (§4.5); there is no code path that downgrades it. `synchronous_commit = on` is Postgres's own default, so this is "enforce the safe default," not an unusual imposition — the case being closed off is an operator (or a co-tenant on a shared database/role) explicitly setting it to `off` for write-latency, which this plugin's lock and leader-election guarantees cannot tolerate.
+
+Enforcement happens at two points in the connection lifecycle, using `sqlx::PgPoolOptions` hooks:
+
+1. **`after_connect`** — runs `SET synchronous_commit = on` once when a new physical connection is established. Covers the common case (role/database default is `off`, or a session-level `ALTER ROLE ... SET synchronous_commit = off` applies at login).
+2. **`before_acquire`** — re-runs `SET synchronous_commit = on` every time a connection is checked out of the pool for use, whether for a cache operation or a lock acquire. This closes the window ADR-009 flags: `synchronous_commit` is `USERSET` scope, so it can be mutated mid-session by anything sharing the connection (a misbehaving statement, a pooler-level session variable reset, `ALTER ROLE` applied after the connection was opened). Re-asserting on every checkout means a mutation can only affect the *current* checkout, never a later one.
+
+**Residual gap: pinned lock connections.** `before_acquire` fires once, at the moment a connection is checked out — for the write pool's transient per-operation usage (cache reads/writes) that's on every use, but a lock connection is checked out *once* and then pinned (borrowed exclusively) for the entire lifetime of the held lock (§3.3), so `before_acquire` cannot re-assert on it while it's held. To close this, **each lock's own guard task** re-runs `SET synchronous_commit = on` on its pinned connection on its own interval (`lock_reaper_interval_ms`, default 5s), bounding the exposure window to that interval instead of leaving it open for the lock's full duration. The re-assertion lives on the guard task — *not* the lock TTL reaper's sweep — deliberately: the guard task is the sole owner of its key's `held` entry, so it re-asserts without taking a second `held.get_mut` across an `.await` on a live key (which a sweep-side re-assertion would, deadlocking the guard's own `renew`/`release` under the current-thread runtime — see `GAP-SOLUTIONS.md` §5). This is a defense-in-depth measure, not a hard guarantee within that window; see §11 for the accepted residual risk.
+
+A connection on which `SET synchronous_commit = on` fails (e.g. insufficient privilege to alter the GUC) surfaces as a provider error at connect time (§9) rather than silently proceeding with an unverified durability setting.
+
+### 3.5 Standalone Lock Provider
+
+The cluster wiring crate (`cf-gears-cluster`) already implements config-driven per-primitive routing (`cpt-cf-clst-fr-routing-per-primitive`) — `cluster/src/wiring.rs`'s `ClusterWiring::from_config` dispatches a profile's `lock` binding through `ProviderRegistry::lock_provider(name)` and calls `ClusterLockProvider::build_lock` if a provider is registered under that name, completely independently of whichever provider serves that profile's `cache`. That mechanism is real and already works; what's been missing is a plugin that registers something under `lock_provider("postgres")`. This plugin now does, via a second, independent provider trait implementation.
+
+**`PostgresLockProvider`** implements `ClusterLockProvider` (`provider() -> "postgres"`). Its `build_lock(options)` deserializes `options` into `PostgresLockConfig` — a config type scoped to only what the lock primitive needs (`connection_string`, `pool_max_size`, `pool_acquire_timeout_ms`, `schema`, `lock_reaper_interval_ms`, `lock_name_cardinality_warn_threshold`, `pgbouncer_transaction_mode`, `replication_mode`; no `cache_reaper_interval_ms`, `read_cache_capacity`, or `sd_poll_interval_ms` — those don't exist here since there's no cache half) — and constructs a **standalone** `PostgresLockPlugin` (§3.1: `lock/mod.rs`) with its own dedicated pool.
+
+**Always standalone, never shared.** Per the SDK provider trait's own contract ("non-cache providers do not receive the cache backend" — `cluster-sdk/src/provider.rs`), `PostgresLockProvider` never attempts to detect or reuse a pool from a co-located `cache: { provider: postgres }` binding in the same profile, even when both point at the same `connection_string`. This is a deliberate simplicity/independence trade-off: sharing would couple two providers the SDK explicitly designed to be independent, and would need its own lifecycle-ownership story (which provider's `stop()` closes the shared pool?). The cost is a second small pool (default `pool_max_size: 5`) when both primitives happen to point at the same database — considered acceptable relative to the coupling avoided. An operator who wants combined cache+lock sharing one pool still has that option: bind `cache: { provider: postgres, ... }` and omit `lock` entirely, letting the omit-default auto-wrap use the SDK's `CasBasedDistributedLockBackend` over the shared cache instead of the native lock.
+
+**What the standalone path builds, relative to the combined `PostgresClusterPlugin` (§3.2):**
+
+| | Combined (`PostgresClusterPlugin`) | Standalone (`PostgresLockPlugin`) |
+|---|---|---|
+| Migrations run | `0001_cluster_cache.sql` + `0002_cluster_lock.sql` | `0002_cluster_lock.sql` only |
+| Dedicated LISTEN connections | 2: cache watch (`cluster_cache_changes`) + lock release-wake (`cluster_lock_released`) | 1: lock release-wake (`cluster_lock_released`) only — no cache half, so no cache-watch connection |
+| Background tasks | Cache TTL reaper, lock TTL reaper, cache-watch LISTEN task, lock release-wake LISTEN task | Lock TTL reaper + lock release-wake LISTEN task |
+| `synchronous_commit` enforcement (§3.4) | Yes, on the shared pool | Yes, on its own pool |
+
+Operator YAML example — Postgres lock routed independently of a non-Postgres cache:
+
+```yaml
+cluster:
+  profiles:
+    default:
+      cache:
+        provider: standalone
+      lock:
+        provider: postgres
+        connection_string: "postgres://user:${DB_PASSWORD}@db:5432/gears"
+        pool_max_size: 5
+```
+
+Registration mirrors the existing standalone plugin's pattern (`cluster/src/gear.rs:50-51`): the host registers both provider impls into the shared `ProviderRegistry` — `.with_cache_provider(Arc::new(PostgresCacheProvider))` and `.with_lock_provider(Arc::new(PostgresLockProvider))` — so either can be bound independently, or both, or neither.
+
+`PostgresLockPlugin`'s own handle (`lock/mod.rs`) carries the same `stopped: bool` field and the same ADR-006 `Drop` guard as `PostgresClusterHandle` (§3.2) — it owns its own pool and its own lock TTL reaper, so it needs the same "forgotten `stop()` leaks background tasks" protection independently of the combined handle. It is not a special case exempted from ADR-006 just because it's the smaller of the two handles.
+
+### 3.6 Replication Topology Warning
+
+ADR-009's per-backend safety table conditions Postgres leader-election/lock safety on *synchronous* streaming replication — with the common default (async replication, no `synchronous_standby_names` configured), a failover can lose the last few committed transactions, including the row backing a currently-held lock or leadership claim, which is exactly the split-brain risk `synchronous_commit = on` (§3.4) is supposed to prevent. `synchronous_commit` and replication topology are two different knobs; enforcing the former (§3.4) says nothing about the latter, so this plugin also surfaces the latter rather than leaving it silently unaddressed.
+
+Following the same shape as the `pgbouncer_transaction_mode` validation (§5.4/§7) — a config-level flag plus a startup check — but **warn rather than block**, because replication topology (unlike PgBouncer pooling mode) isn't something the plugin can always determine with certainty, and because it is a topology-level operational concern, not a per-request correctness violation the way an unenforced `synchronous_commit` would be:
+
+- `replication_mode: Option<ReplicationMode>` (`ReplicationMode = Async | Sync`, config, §7) — an optional operator-supplied hint. If set, the plugin trusts it and skips the detection query entirely.
+- If unset, `build_and_start` (combined plugin, §3.2) and `build_lock` (standalone lock provider, §3.5) each run `SHOW synchronous_standby_names` once at startup on the pool. An empty result is treated as `Async` (no synchronous standby configured); a non-empty result is treated as `Sync`.
+- If the effective mode (explicit or detected) is `Async`, the plugin logs `cluster.provider.replication_async` (WARN, once at startup, not repeated) naming ADR-009's safety table and stating that leader-election/lock claims are not failover-safe under the current replication topology. `build_and_start`/`build_lock` still return `Ok` — this is advisory, not a startup failure, both because the plugin cannot always detect topology with full confidence (e.g. a synchronous standby configured but not currently connected still shows in `synchronous_standby_names`) and because some deployments (e.g. dev/single-instance) legitimately don't need HA and shouldn't be blocked by it.
+- `Sync` does not upgrade `consistency()` or any `*Features` declaration — it only suppresses the WARN. The plugin's declared safety properties (§4.5, §5) are unaffected either way; this is purely an operational signal for the operator, layered on top of, not instead of, the enforcement in §3.4.
+
+This closes the DESIGN §12 open question that previously flagged this plugin's docs as silent on replication topology — it's no longer silent, but it's also deliberately not a gate.
+
+## 4. Cache Implementation
+
+### 4.1 SQL Contract per Operation
+
+`put` / `put_if_absent` take a `cluster_sdk::cache::PutRequest<'_> { key, value, ttl:
+Ttl }` (`Ttl::Of(Duration) | Ttl::Indefinite`), not positional `key`/`value`/`ttl`
+arguments; `$3`/`$4` below bind `NULL` for `Ttl::Indefinite` or `now() +
+ttl_duration` for `Ttl::Of(d)`.
+
+| Operation | SQL |
+|---|---|
+| `get(key) -> Option<CacheEntry>` | `SELECT value, version FROM cluster_cache WHERE key = $1 AND (expires_at IS NULL OR expires_at > now())` |
+| `put(req: PutRequest) -> ()` | `INSERT INTO cluster_cache (key, value, version, expires_at) VALUES ($1, $2, 1, $3) ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, version = cluster_cache.version + 1, expires_at = EXCLUDED.expires_at` |
+| `delete(key) -> bool` | `DELETE FROM cluster_cache WHERE key = $1 AND (expires_at IS NULL OR expires_at > now()) RETURNING 1` — row returned → `true`; an expired-but-unreaped row is treated as already absent (→ `false`), consistent with `get`/`contains` |
+| `contains(key) -> bool` | `SELECT 1 FROM cluster_cache WHERE key = $1 AND (expires_at IS NULL OR expires_at > now())` |
+| `put_if_absent(req: PutRequest) -> Option<CacheEntry>` | `INSERT INTO cluster_cache (key, value, version, expires_at) VALUES ($1, $2, 1, $3) ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, version = 1, expires_at = EXCLUDED.expires_at WHERE cluster_cache.expires_at IS NOT NULL AND cluster_cache.expires_at <= now() RETURNING value, version` — a row returned means the key was absent **or expired** (treated as a freshly-created version-1 entry); a *live* entry yields no row → `None` (already present). The `WHERE`-guarded overwrite treats an expired-but-unreaped row as logically absent, exactly as `get`/`contains`/`compare_and_swap` do, so leader-election failover (`put_if_absent` on the election key) does not stall on a lingering expired lease until the TTL reaper sweeps it. |
+| `compare_and_swap(key, expected_version: u64, new_value, ttl: Ttl) -> CacheEntry` | `UPDATE cluster_cache SET value = $3, version = version + 1, expires_at = $4 WHERE key = $1 AND version = $2 AND (expires_at IS NULL OR expires_at > now()) RETURNING version` — zero rows → `CasConflict` |
+| `compare_and_delete(key, expected_value) -> bool` | `DELETE FROM cluster_cache WHERE key = $1 AND value = $2 AND (expires_at IS NULL OR expires_at > now()) RETURNING 1` — an expired-but-unreaped row is treated as already absent, consistent with `get`/`contains` |
+| `scan_prefix(prefix) -> Vec<String>` | `SELECT key FROM cluster_cache WHERE key LIKE $1 ESCAPE '\' AND (expires_at IS NULL OR expires_at > now())` — the plugin binds `$1` to the caller's prefix with `%`/`_`/`\` escaped and a `%` suffix appended (`escape_like`), so the caller's own text is matched literally as a prefix rather than interpreted as `LIKE` wildcards |
+
+After every write that emits an observable event, the plugin executes `NOTIFY cluster_cache_changes, '<payload>'` in the same transaction (cache writes) or immediately after (post-commit). NOTIFY is transactional: it only reaches listeners if the transaction commits.
+
+`CasConflict { key, current }` — when `compare_and_swap` finds the row but with a wrong version, the plugin re-reads the current entry to populate `current`. When the row is absent, `current` is `None`.
+
+### 4.2 TTL Reaper
+
+A background task wakes on a configurable interval (default: 10 seconds) and deletes every expired entry, in bounded chunks:
+
+```sql
+DELETE FROM cluster_cache
+WHERE key IN (
+    SELECT key FROM cluster_cache
+    WHERE expires_at IS NOT NULL AND expires_at <= now()
+    ORDER BY expires_at LIMIT n FOR UPDATE SKIP LOCKED
+)
+RETURNING key;
+```
+
+For each deleted key, the task issues `NOTIFY cluster_cache_changes, 'E:<key>'` so watchers receive `CacheWatchEvent::Event(CacheEvent::Expired { key })`. Each chunk's delete and its `NOTIFY`s share one transaction, so a row is never deleted without its `Expired` event nor the reverse (§4.1).
+
+A sweep loops chunks until one comes back short, so a large expired backlog is still cleared in full while no single transaction row-locks an unbounded number of rows or runs an unbounded `NOTIFY` burst — an unbounded `DELETE ... RETURNING` would make a concurrent `put`/`put_if_absent` on a key caught mid-batch wait out the remaining backlog's `NOTIFY` round-trips rather than a quick row lock, and would roll the whole batch back on any single failure, leaving the tick with zero forward progress. Committing per chunk means a failing chunk costs only its own rows. `SKIP LOCKED` keeps the per-instance reapers from serializing behind each other on the same chunk (and makes the outer delete skip, rather than clobber, a row whose `put` is in flight), and `cancel` is re-checked between chunks so shutdown is not held up mid-backlog.
+
+The reaper is driven by a `CancellationToken`; it self-terminates when cancelled. It uses one connection from the write pool per chunk, releasing it immediately after. Its interval uses `MissedTickBehavior::Delay`, so a sweep that overruns the interval restarts the cadence from its completion instead of firing the missed ticks back-to-back.
+
+### 4.3 Watch via LISTEN / NOTIFY
+
+The plugin maintains one dedicated Postgres connection that issues `LISTEN cluster_cache_changes` at startup. An async task reads notifications from this connection in a loop and fans them out to per-watcher channels.
+
+```
+Postgres NOTIFY ──► listen_task
+                         │
+                    parse payload
+                         │
+                    route to matching watchers
+                         │
+                   ┌─────┴──────┐
+                   │ exact match │
+                   │ key == notified_key
+                   └────────────┘
+```
+
+**Exact watches only.** The native NOTIFY channel carries a single key per payload; routing by key prefix is not possible at the Postgres level without one channel per prefix (infeasible). Therefore:
+- `watch(key)` → subscribe to notifications where `notified_key == key`. Returns `Ok(CacheWatch)`.
+- `watch_prefix(prefix)` → returns `Err(ClusterError::Unsupported { feature: "prefix_watch" })`. Consumers use `PollingPrefixWatch` as the polyfill (DESIGN §3.12).
+
+`features().prefix_watch` is `false`, so the capability resolver rejects `CacheCapability::PrefixWatch` at startup for this backend. The SDK-default service-discovery backend auto-selects `PollingPrefixWatch` when `prefix_watch == false` (see §6).
+
+**Empty / unrecognized payload — Reset.** The listen_task interprets `payload.is_empty()` (or any payload not matching `<event>:<key>`) as a `Reset` signal, broadcasts `CacheWatchEvent::Reset` to every active watcher, and clears all watcher subscriptions (consumers must resubscribe). This matches ADR-003's overflow mapping for Postgres. It is the fallback for a bare `NOTIFY` from an external writer or a future format — **not** the NOTIFY-queue-overflow path: overflow aborts the committing *producer* transaction with an error and delivers no notification. Overflow does not disconnect the listener or emit a `Reset`; it surfaces to the *writer* as that write's `Provider` error and in the PostgreSQL server logs, not through this LISTEN-side recovery.
+
+**Connection loss — Reset.** If the dedicated LISTEN connection drops, the listen_task attempts reconnect with exponential backoff. On successful reconnect, it broadcasts `CacheWatchEvent::Reset` before resuming event delivery, signalling that consumers may have missed events during the gap. If reconnect fails beyond the configured retry limit, it broadcasts `CacheWatchEvent::Closed(ClusterError::Provider { kind: ConnectionLost, .. })` and exits.
+
+The Postgres cache is read-through: every `get` hits the database directly. There is no in-process read cache — consumers with hot-key, high-read, staleness-tolerant workloads should route that primitive to a backend built for it (e.g. Redis) rather than expect this plugin to double as a fast local cache; see §11 for the rationale.
+
+### 4.4 scan_prefix
+
+`scan_prefix(prefix)` is implemented via `LIKE prefix%`. The plugin escapes `%`, `_`, and `\` in the caller's prefix before appending `%`, so wildcard characters in `prefix` are matched literally rather than being interpreted by `LIKE`. This is used by `PollingPrefixWatch` to enumerate keys for diffing. Performance degrades with keyspace size; the partial index on `expires_at` does not help here. High-volume prefix scans should use a backend with native prefix watch (Redis, NATS, etcd).
+
+### 4.5 Consistency Declaration
+
+`consistency()` returns `CacheConsistency::Linearizable`. All cache operations run at Postgres's default `READ COMMITTED` isolation level, which provides linearizability for single-row operations (the only kind the cache uses). The CAS path uses an `UPDATE … WHERE version = $expected`, which is an atomic compare-and-set at the row level regardless of isolation level. Under `READ COMMITTED`, concurrent updates do not produce write skew on single rows.
+
+## 5. Distributed Lock Implementation
+
+### 5.1 Advisory Lock Mapping
+
+The plugin uses **session-level advisory locks** via the **two-key form** (`pg_try_advisory_lock(key1, key2)` / `pg_advisory_unlock(key1, key2)`) from the start, rather than the single-`bigint` form. The lock name is hashed once, client-side in Rust, to a stable 64-bit value using a fixed, versioned hash function (e.g. FNV-1a-64 or SipHash-1-3 with a fixed key — the specific algorithm is an implementation detail as long as it is deterministic and documented), then split into two `i32` halves:
+
+```sql
+-- acquire (non-blocking)
+SELECT pg_try_advisory_lock($key1, $key2);  -- returns TRUE if acquired
+
+-- release
+SELECT pg_advisory_unlock($key1, $key2);
+```
+
+Where `$key1` = high 32 bits and `$key2` = low 32 bits of the 64-bit name hash, computed by the plugin before the query is sent. This uses the full 64 bits of hash entropy (unlike `hashtext()`, which only produces 32 bits and would need casting/padding to fill a `bigint` argument), so the birthday-bound collision probability is negligible even at large lock-name cardinalities. It also places this plugin's locks in a namespace disjoint from any other code in the same database using the single-argument `pg_try_advisory_lock(bigint)` form for an unrelated purpose — Postgres treats the one-key and two-key advisory lock spaces as independent, so there is no cross-contention with other single-key advisory-lock users even in the (vanishingly unlikely) event of a hash collision. Residual collision risk between two *of this plugin's own* lock names is tracked as a monitored risk, not eliminated — see §11.
+
+### 5.2 TTL Enforcement
+
+Advisory locks have no native TTL. The plugin layers TTL on top:
+
+1. **Metadata insert**: on `try_lock` success, insert `(name, holder_id, acquired_at, expires_at)` into `cluster_lock` in the same transaction, with `expires_at` computed in SQL as `now() + ttl` (§2.1).
+2. **Background reaper**: scans `cluster_lock` for rows where `expires_at <= now()` — an index scan on `cluster_lock_expires_idx`. For each expired row, recomputes `(key1, key2)` from `name` and calls `pg_advisory_unlock(key1, key2)`, then deletes the row. The advisory unlock must run on the **same connection** that holds the lock (session-scoped). The reaper therefore tracks the connection ID per lock.
+
+    Each sweep deletes in bounded batches (`DELETE ... WHERE name IN (SELECT name ... ORDER BY expires_at LIMIT n FOR UPDATE SKIP LOCKED)`), looping until a batch comes back short, so a large expired backlog is still cleared in full but no single statement holds row locks on an unbounded number of rows. `SKIP LOCKED` keeps the per-instance reapers from serializing behind each other on the same batch, and `cancel` is re-checked between batches so shutdown is not held up mid-backlog.
+
+    **Wake schedule.** After each sweep the reaper sleeps until the earlier of the next metrics tick (`lock_reaper_interval_ms`) and the next row's deadline, read as `SELECT extract(epoch FROM (min(expires_at) - now()))` — an index-only read, with the subtraction done in Postgres so the delay never depends on this instance's wall clock. The interval is the *cap*: it keeps `cluster_postgres_lock_active_names` and the cardinality WARN on their configured cadence (a lock's row count moves with every acquire/release, not only with expiry, so the gauge must not go quiet just because nothing is near its TTL) and only these interval-boundary wakes do the gauge work. `min(expires_at)` only *shortens* an individual sleep, so an expired lock is reclaimed close to its real deadline instead of up to a full interval later.
+
+A sleep is computed from the table as it looked at wake time, so on its own that shortening would miss a lock whose entire lifetime fits inside one sleep (TTL ≲ `lock_reaper_interval_ms`). `try_acquire` and `renew` therefore signal the reaper (an in-process `tokio::sync::Notify`) once their write is committed, and it re-sweeps with the new deadline in view. The signal is deliberately in-process only, and that is sufficient rather than partial: a lock held by a *live* session can only be unlocked by the instance owning that session (advisory locks are session-scoped), so the instance that must act is always the one holding the hint — and a remote holder that died needs no timely sweep at all, since Postgres released its advisory lock at disconnect and `try_acquire` upserts over the stale row (`ON CONFLICT (name) DO UPDATE`) rather than waiting for it to be deleted. Both the expiry-driven and the signalled wake are floored at 100 ms (or at `lock_reaper_interval_ms` when that is shorter, so a deliberately sub-100ms cadence is honoured rather than stretched), so many locks with staggered deadlines — or a burst of acquisitions — coalesce into one wake instead of one wake each. The signal is only a hint: every wake re-derives its schedule from the table, so a spurious or lost notification costs at most one extra or one late sweep, never a missed reclamation. Expiry is deliberately **not** bucketed into coarse slices: for a lock the TTL is the crash/wedge safety net, so rounding deadlines up to a shared boundary would let a stale lock block waiters for up to a full bucket past its TTL, with the extra grace depending on when in the bucket it happened to be acquired.
+3. **Connection pinning**: `LockGuard` pins its pool connection for the duration of the lock. The reaper calls `pg_advisory_unlock` via the same pinned connection.
+4. **Crash / disconnect**: advisory locks auto-release when the Postgres session disconnects. This is the safety net for process crash or network loss — the TTL-based reaper handles the "alive but forgot to release" scenario.
+
+`LockGuard::renew(new_ttl)` pushes `expires_at` out to `now() + new_ttl` and restamps `acquired_at` in `cluster_lock`. It does not touch the advisory lock itself.
+
+`LockGuard::release(self)` calls `pg_advisory_unlock` and deletes the `cluster_lock` row, then issues `NOTIFY cluster_lock_released, '<name>'` to wake blocked `lock()` waiters.
+
+### 5.3 Blocking lock()
+
+`lock(name, ttl, timeout)` retries `pg_try_advisory_lock` and, between attempts, waits on the in-process `ReleaseWaiters` registry for an early wake:
+
+```
+loop {
+    try pg_try_advisory_lock → success? return LockGuard
+    if past deadline → LockTimeout
+    register interest in `name` with the ReleaseWaiters registry
+    wait on (that registration resolving) OR a short heartbeat sleep (250ms)
+}
+```
+
+The wait does **not** LISTEN on the acquiring connection. `sqlx`'s `PgListener` owns its own single connection and has no public way to adopt an already-checked-out `PoolConnection`, so instead a single **dedicated** `cluster_lock_released` LISTEN connection (opened at `build_and_start`, present in both the combined and standalone plugins — §3.3) runs a fan-out task that `notify()`s the in-process `ReleaseWaiters` registry; each blocked `lock()` caller registers a waiter there and is woken when a `NOTIFY cluster_lock_released` for its name arrives. The 250 ms heartbeat sleep is a safety net against a missed notification (registration racing an already-fired `NOTIFY`, or the listen task momentarily reconnecting): a lost wake only costs latency up to the heartbeat interval, never correctness — the loop always re-attempts `pg_try_advisory_lock` itself as the source of truth. A waiter that gives up (timeout or heartbeat-driven re-acquire) deregisters itself from the registry on drop, so no stale waiter accumulates.
+
+This avoids busy-polling: waiters wake promptly when a holder explicitly releases. TTL-based reaper releases also trigger `NOTIFY cluster_lock_released` after unlocking.
+
+### 5.4 PgBouncer Constraint
+
+Session-level advisory locks are **incompatible with PgBouncer in transaction pooling mode**. A session advisory lock lives on the *server* session, but transaction pooling does not pin a client to one server session across transactions: returning the connection to the pool does not release the lock — it leaves it attached to that pooled server session, where it both outlives the holding `LockGuard`'s transactions and can leak to whichever client is next handed that server session. Either way mutual exclusion breaks. The plugin documents this prominently in config validation:
+
+- If `pgbouncer_transaction_mode: true` is set in config, `build_and_start` returns `Err(ClusterError::InvalidConfig { reason: "pg_advisory_lock requires session-mode pooling or a direct connection; transaction-mode PgBouncer incompatible with distributed locks" })`.
+- Operators using PgBouncer must either use session pooling mode for the cluster plugin's connection string, or use a different lock backend.
+
+## 6. Leader Election and Service Discovery
+
+Both primitives use SDK defaults over the Postgres cache backend.
+
+**Leader election** — `CasBasedLeaderElectionBackend::new(Arc::clone(&cache))`. The cache backend is `Linearizable`, so the consistency guard passes. `LeaderElectionFeatures::linearizable == true`.
+
+**Service discovery** — `CacheBasedServiceDiscoveryBackend::new(Arc::clone(&cache))`. The cache backend declares `prefix_watch: false`. The service-discovery default backend detects this when opening its topology watch (`ensure_maintainer`/`watch`) and falls back to `PollingPrefixWatch`, using `scan_prefix` to enumerate keys under the `svc/` prefix at each polling interval; `discover` additionally reconciles from a fresh `scan_prefix` sweep on each call over a polling cache, so it reflects current backend truth rather than lagging the poll interval. The interval is configurable via the backend's `with_prefix_watch_polling` (default 5s; the omit-default wiring path currently uses that backend default — plumbing the operator-config `sd_poll_interval_ms` through the SDK auto-wrap is a tracked follow-up). `ServiceDiscoveryFeatures::metadata_pushdown == false`.
+
+The wiring crate's omit-default auto-wrap (DESIGN §3.11) wires these automatically when a profile declares `cache: { provider: postgres }` and omits `leader_election` and `service_discovery`.
+
+## 7. Configuration
+
+```rust
+#[derive(Deserialize, toolkit_macros::ExpandVars)]
+#[serde(deny_unknown_fields)]
+pub struct PostgresClusterConfig {
+    /// sqlx connection string. Supports `${VAR}` / `${VAR:-default}` env-var
+    /// expansion (e.g. `postgres://user:${DB_PASSWORD}@db:5432/gears`) via
+    /// `toolkit_utils::var_expand`, resolved through `ctx.config_expanded()` —
+    /// the same mechanism `libs/toolkit-db` uses for DB passwords/DSNs. A
+    /// credstore-backed (`secret_ref`) resolution path is deferred to a
+    /// future iteration; not implemented here.
+    #[expand_vars]
+    pub connection_string: String,
+
+    /// Maximum pool size (write pool). Default: 5.
+    #[serde(default = "default_pool_size")]
+    pub pool_max_size: u32,
+
+    /// Pool acquire timeout. Default: 5s.
+    #[serde(default = "default_acquire_timeout")]
+    pub pool_acquire_timeout_ms: u64,
+
+    /// Schema for plugin tables. Default: "public".
+    #[serde(default = "default_schema")]
+    pub schema: String,
+
+    /// TTL reaper interval for cluster_cache. Default: 10s.
+    #[serde(default = "default_reaper_interval")]
+    pub cache_reaper_interval_ms: u64,
+
+    /// TTL reaper interval for cluster_lock — upper bound on the reaper's sleep
+    /// and the cadence of its gauge; an imminent expires_at shortens an
+    /// individual sleep (§5.2). Default: 5s.
+    #[serde(default = "default_lock_reaper_interval")]
+    pub lock_reaper_interval_ms: u64,
+
+    /// Polling interval for the service-discovery PollingPrefixWatch. Default: 5s.
+    #[serde(default = "default_sd_poll_interval")]
+    pub sd_poll_interval_ms: u64,
+
+    /// Set to true to get an InvalidConfig error at startup rather than silent
+    /// mis-behaviour if the connection string points to a PgBouncer in
+    /// transaction mode. Default: false.
+    #[serde(default)]
+    pub pgbouncer_transaction_mode: bool,
+
+    /// Distinct concurrently-held lock-name count past which the lock reaper
+    /// logs `cluster.lock.name_cardinality_high` (WARN) and the
+    /// `cluster_postgres_lock_active_names` gauge should be alerted on.
+    /// Default: 1000 (see DESIGN §5.1/§8/§11 — advisory-lock collision risk).
+    #[serde(default = "default_lock_name_cardinality_warn_threshold")]
+    pub lock_name_cardinality_warn_threshold: u32,
+
+    /// Operator hint for replication topology (`Async` | `Sync`). If omitted,
+    /// detected at startup via `SHOW synchronous_standby_names` (empty →
+    /// `Async`). `Async` logs `cluster.provider.replication_async` (WARN,
+    /// once) per ADR-009's safety table (§3.6) but never fails startup.
+    #[serde(default)]
+    pub replication_mode: Option<ReplicationMode>,
+}
+```
+
+```rust
+#[derive(Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReplicationMode {
+    Async,
+    Sync,
+}
+```
+
+Operator YAML example:
+
+```yaml
+cluster:
+  profiles:
+    default:
+      cache:
+        provider: postgres
+        connection_string: "postgres://user:${DB_PASSWORD}@db:5432/gears"
+        pool_max_size: 10
+```
+
+**`PostgresLockConfig`** (standalone lock provider, §3.5) is a separate, smaller config type — it only carries the fields the lock primitive actually uses, not the cache-only ones (`cache_reaper_interval_ms`, `sd_poll_interval_ms`):
+
+```rust
+#[derive(Deserialize, toolkit_macros::ExpandVars)]
+#[serde(deny_unknown_fields)]
+pub struct PostgresLockConfig {
+    #[expand_vars]
+    pub connection_string: String,
+
+    #[serde(default = "default_pool_size")]
+    pub pool_max_size: u32,
+
+    #[serde(default = "default_acquire_timeout")]
+    pub pool_acquire_timeout_ms: u64,
+
+    #[serde(default = "default_schema")]
+    pub schema: String,
+
+    #[serde(default = "default_lock_reaper_interval")]
+    pub lock_reaper_interval_ms: u64,
+
+    #[serde(default)]
+    pub pgbouncer_transaction_mode: bool,
+
+    #[serde(default = "default_lock_name_cardinality_warn_threshold")]
+    pub lock_name_cardinality_warn_threshold: u32,
+
+    #[serde(default)]
+    pub replication_mode: Option<ReplicationMode>,
+}
+```
+
+The field set is identical in name and default to the corresponding fields on `PostgresClusterConfig` above (implementation should factor the shared subset into one inner struct rather than duplicate the field definitions, to keep the two config types from drifting). `replication_mode`/the detection fallback applies here too — ADR-009's safety table is about leader-election/lock claims specifically, so the standalone lock provider needs the same warning, not just the combined plugin (§3.6).
+
+## 8. Observability
+
+The plugin satisfies the versioned observability contract (ADR-004,
+`OBSERVABILITY.md`) verbatim — it emits no signal names beyond the catalog.
+All metrics, spans, and log events use the label `provider = "postgres"`.
+
+**Cache** — the native `PostgresCache` is wrapped in the SDK's
+`cluster_sdk::observability::InstrumentedCache` decorator (the same mechanism
+the standalone plugin uses), so it emits the full cache signal set for free:
+spans `cluster.cache.get` / `put` / `delete` / `contains` / `put_if_absent` /
+`compare_and_swap` / `watch` / `watch_prefix`; the counter
+`cluster_cache_ops_total{provider,op,result}` and histogram
+`cluster_cache_op_duration_seconds{provider,op}`.
+
+**Lock** — `PostgresLock` is a native trait implementation (not a
+decorator-wrapped default), so it emits lock signals directly at each
+instrumentation site, mirroring the pattern
+`CasBasedDistributedLockBackend::record_lock` uses (`cluster/src/defaults/lock.rs`):
+spans `cluster.lock.try_lock` / `lock` / `renew` / `release` (via `tracing`,
+one per `DistributedLockBackend`/`LockGuard` method); the counter
+`cluster_lock_ops_total{provider,op,result}` and histogram
+`cluster_lock_op_duration_seconds{provider,op}` via the injected
+`cluster_sdk::observability::ClusterMetrics` sink.
+
+**Shared signals** — both paths route backend failures through
+`cluster_sdk::observability::emit_provider_error`, which increments
+`cluster_provider_errors_total{provider,kind}` and logs `cluster.provider.error`
+at ERROR with the `key`/`lock` resource field, `op`, `kind`, and `message`. The
+LISTEN task's `Reset` broadcasts (§4.3 NOTIFY overflow and reconnect) call
+`ClusterMetrics::watch_reset("cache")`, backing
+`cluster_watch_resets_total{provider,primitive}`.
+
+**Plugin-specific, non-contract metrics** — the TTL reapers additionally emit
+`cluster_postgres_reaper_sweep_duration_seconds{provider,primitive}` (histogram,
+`primitive={cache,lock}`), a plugin-local addition tracked outside the ADR-004
+catalog. Per ADR-004, adding a signal is non-breaking; this one exists only to
+let operators monitor reaper health and carries no cross-provider portability
+requirement.
+
+The lock reaper sweep (§5.2) also emits
+`cluster_postgres_lock_active_names{provider}` (gauge) — the current row count
+of `cluster_lock`, i.e. the number of distinct lock names concurrently held.
+This is the operational counterpart to the advisory-lock collision risk
+documented in §5.1/§11: since collision probability rises with the number of
+distinct names in flight, this gauge is what a Grafana panel/alert would watch
+to catch rising exposure before it manifests as an unexplained
+`LockContended`. It is a plain count, not a per-name breakdown — lock names
+are never used as label values (the cardinality rule below). When the count
+exceeds `lock_name_cardinality_warn_threshold` (config, §7; default 1 000), the
+plugin logs `cluster.lock.name_cardinality_high` (WARN, rate-limited to once
+per reaper interval) so the same condition is visible in logs even without a
+dashboard.
+
+All emission is subject to the `METRIC_LABEL_ALLOWLIST` cardinality rule: keys
+and lock names are NEVER used as metric label values, only as span attributes
+and log fields.
+
+Log events follow the `cluster.{primitive}.{event}` naming scheme
+(`OBSERVABILITY.md` §6): `cluster.watch.reset` (WARN), `cluster.provider.error`
+(ERROR), `cluster.lock.name_cardinality_high` (WARN, plugin-local), and
+`cluster.provider.replication_async` (WARN, plugin-local, once at startup —
+§3.6) are the four this plugin emits; it has no leadership transitions of its
+own to report (leader election is the SDK default over this plugin's cache,
+and emits `cluster.leader.transition` itself).
+
+## 9. ProviderErrorKind Mapping
+
+Matches the platform mapping table (`docs/DESIGN.md` §4.1, Postgres/sqlx column):
+
+| `sqlx` error | `ClusterError` / `ProviderErrorKind` |
+|---|---|
+| `sqlx::Error::Configuration` | `InvalidConfig` — a malformed DSN / unparseable connection options is an operator config error, not a runtime backend fault, so it is *not* wrapped as a `Provider` error (`PG-LIFE-006`) |
+| `sqlx::Error::Io` | `ConnectionLost` |
+| `sqlx::Error::PoolTimedOut` | `Timeout` |
+| `sqlx::Error::PoolClosed` | `ConnectionLost` |
+| SQLSTATE `28xxx` (invalid auth) | `AuthFailure` |
+| SQLSTATE `3D000` (invalid catalog/database does not exist) | `Other` — a missing database is a deployment/config problem, not an authentication failure; unlike `pgbouncer_transaction_mode`, this is not distinguishable from the connection string alone, so `build_and_start` cannot reject it as `InvalidConfig` up front and it surfaces at first-connect as a plain `Other` provider error |
+| SQLSTATE `54000` (`program_limit_exceeded`), and `23514` (`check_violation`) on `cluster_cache_key_len_check` / `cluster_lock_name_len_check` | `Other`, with the message rewritten to name the 2048-byte limit (§2.1) and the key that has to shrink. Both mean "an over-long indexed key reached Postgres"; the server's own text is opaque about the cause (`54000` reports an index row size against a btree maximum, `23514` names only the constraint). Neither is retryable. This is a backstop — the Rust guards reject such keys before the write — and `23514` matches on the constraint name so an unrelated future CHECK is not mislabelled as a length problem |
+| Any other `sqlx::Error` | `Other` |
+
+Connection loss during a LISTEN reconnect loop is surfaced as `Provider { kind: ConnectionLost }` to affected watchers after the retry budget is exhausted.
+
+## 10. Shutdown Sequence
+
+`PostgresClusterHandle::stop()` follows DESIGN §3.13:
+
+1. Cancel the `CancellationToken` shared by all background tasks (cache reaper, lock reaper, cache-watch LISTEN task, lock release-wake LISTEN task). Await each task's `JoinHandle`. Cancellation also unparks each held lock's guard task promptly (§3.4), rather than leaving it to run out its reassert interval.
+2. Send `CacheWatchEvent::Closed(ClusterError::Shutdown)` to all active watcher channels (dispatched directly against the watch registry before the LISTEN task is awaited, so every watcher observes it prior to `stop()` returning).
+3. Drop each dedicated `PgListener` (cancelling its task drops the listener, which closes its socket). No explicit `UNLISTEN *` is issued — dropping the connection ends the session, which is functionally equivalent (a closed backend cannot deliver further notifications).
+4. Drain any lock still held at shutdown (`drain_held`: unlock each advisory lock on its own pinned connection, return the connection to the pool) *before* closing the pool, then close the `sqlx::PgPool` — which releases all remaining pooled connections, causing Postgres to auto-release any outstanding advisory locks.
+
+No remote cleanup is performed on a best-effort basis: held claims and locks lapse via their TTL once the connections drop (`cpt-cf-clst-fr-shutdown-ttl-cleanup`).
+
+## 11. Risks / Trade-offs
+
+**[Risk: LISTEN/NOTIFY does not scale under high concurrent write rates]** NOTIFY acquires a global exclusive lock on commit. Under > ~1000 notifying transactions/sec, this becomes a bottleneck. Mitigation: the cache plugin is not recommended for high-throughput subscriber lease workloads (use Redis cache for those — DESIGN §4.2). Queue overflow aborts the *committing* transaction, so it surfaces as the failing write's `Provider` error (and in the PostgreSQL server logs) — monitor those rather than `cluster_watch_resets_total`, which counts LISTEN connection gaps, not overflow.
+
+**[Risk: hash collision in advisory lock names]** The plugin uses the two-argument `pg_try_advisory_lock(key1, key2)` form from the start (§5.1), splitting a 64-bit name hash into two `i32` halves. This uses the full 64-bit hash space (vs. 32 bits from `hashtext()` alone), making collision probability negligible even at large lock-name cardinalities. Residual risk is not zero — any hash function has a nonzero collision probability — so the plugin emits `cluster_postgres_lock_active_names{provider}` (gauge, §8) and logs `cluster.lock.name_cardinality_high` (WARN) past `lock_name_cardinality_warn_threshold` (§7), so operators can build a Grafana panel/alert on the gauge instead of discovering rising exposure via an unexplained `LockContended`.
+
+**[Risk: PgBouncer transaction mode mis-configuration]** Silent mis-behaviour if an operator uses transaction-mode PgBouncer without the `pgbouncer_transaction_mode: true` config flag. The `pg_advisory_lock` appears to succeed but, because transaction pooling does not pin a client to one server session, the lock is stranded on a pooled server session — outliving the guard and leaking to other clients that reuse that session (see §5.4). Mitigation: the startup validation flag; documentation.
+
+**[Trade-off: prefix_watch is polling-based]** `watch_prefix` is serviced by `PollingPrefixWatch`, not a native LISTEN/NOTIFY subscription. This means prefix watch events have a latency of up to the poll interval (default 5s) and the poll cost is N `get` calls per interval. Service discovery use cases that require sub-second topology change propagation should use a backend with native prefix watch (etcd, NATS).
+
+**[Trade-off: connection pinning for advisory locks]** Each simultaneously held lock consumes one pool connection. A large `max_concurrent_locks` relative to `pool_max_size` exhausts the pool and causes `LockTimeout` on otherwise-available locks. Operators must size the pool accordingly.
+
+**[Trade-off: `synchronous_commit = on` enforced, no `off` mode]** The plugin enforces `synchronous_commit = on` on every connection (§3.4) and offers no `EventuallyConsistent`/weak-consistency mode. Operators who need `off`'s write-latency benefit and can tolerate its durability trade-off (risk of losing the last few commits on crash) cannot get it from this plugin — that use case belongs on a backend designed for it. Enforcement is via `after_connect` + `before_acquire` hooks (re-asserted on every checkout), except for pinned lock connections, which are only re-asserted once per `lock_reaper_interval_ms` (default 5s) rather than continuously, since they're checked out once and held for the lock's full duration (§3.3). This leaves a bounded, accepted residual window in which a lock connection's GUC could theoretically have been flipped by an external actor between reaper sweeps — mitigated by scope (this plugin's pool is dedicated, not shared with arbitrary application queries) but not eliminated by design.
+
+**[Risk: async replication is warn-only, not enforced]** ADR-009 requires synchronous streaming replication for Postgres leader/lock safety under failover, but §3.6's `replication_mode` check only warns (`cluster.provider.replication_async`) when it detects or is told the topology is async — it never fails startup. An operator who ignores or doesn't monitor that log line can run indefinitely on an async-replicated, failover-unsafe topology. This is a deliberate choice (topology isn't always confidently detectable, and some deployments legitimately don't need HA), not an oversight — but it means this is an operational monitoring dependency, not a guarantee enforced by the plugin itself; pair the WARN log with an alert, not just a dashboard.
+
+**[Design choice: no read-path cache]** `get` is always read-through to Postgres (§4.3) — the plugin deliberately does not layer an in-process read cache in front of it. An in-process cache here would be local to each service instance, not shared across a fleet: at N instances it multiplies rather than amortizes correctness risk (each instance's cache would independently race NOTIFY-driven invalidation against concurrent reads, so different instances could transiently observe different values for the same key), while doing nothing to relieve the actual write-side bottleneck above (NOTIFY volume is driven by writers, not readers). It would also risk silently reaching the leader-election and service-discovery primitives that ride on this same cache backend (§6) specifically *because* it declares `Linearizable` consistency — caching those reads would undermine the reason this backend was chosen for them. The intended pattern is per-primitive backend selection: route a given primitive to the backend suited to its access pattern (e.g. Redis for a hot, staleness-tolerant application cache; this plugin for Postgres-backed locks/coordination), rather than asking one backend to be good at everything.
+
+## 12. Open Questions
+
+| Question | Owner | Target Resolution | Recommendation |
+|---|---|---|---|
+| Credstore-backed credential resolution for the connection string | Postgres plugin owner + Platform OOP deployment design | Future iteration, once the OOP/credstore wiring contract (`docs/arch/toolkit-oop/DESIGN.md` §Platform Host Composition; parent cluster `DESIGN.md:41`) is committed | Decided for now: `connection_string` uses `${VAR}` / `${VAR:-default}` env-var expansion (`toolkit_utils::var_expand` via `#[derive(toolkit_macros::ExpandVars)]` + `#[expand_vars]`, §7), the same mechanism `libs/toolkit-db` uses for DB passwords/DSNs — no `secret_ref` field is exposed by this plugin's config in the meantime. When the credstore path is eventually added, reuse the wiring crate's existing `BackendBinding.secret_ref: Option<SecretRef>` (`cluster/src/config.rs:83`) rather than reintroducing a plugin-local field of the same name at a different layer — that duplication is exactly what was removed here |

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/docs/TESTING.md
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/docs/TESTING.md
@@ -1,0 +1,358 @@
+# Testing Strategy — Postgres Cluster Plugin
+
+> **Companion documents:**
+> - [DESIGN.md](./DESIGN.md) — implementation design for this plugin
+> - [TESTING-STRATEGY.md](../../docs/TESTING-STRATEGY.md) — platform-wide cluster testing strategy (layers, tooling, CI cadence)
+> - [Scenario Catalog](../../docs/scenarios/README.md) — `SC-*` IDs referenced below
+
+<!-- toc -->
+
+- [1. Overview](#1-overview)
+- [2. Layer 1 — Unit Tests (in-crate)](#2-layer-1--unit-tests-in-crate)
+- [3. Layer 2 — Conformance Suite](#3-layer-2--conformance-suite)
+- [4. Layer 3 — Integration Tests (testcontainers)](#4-layer-3--integration-tests-testcontainers)
+  - [4.1 Container Setup](#41-container-setup)
+  - [4.2 Cache Integration Scenarios](#42-cache-integration-scenarios)
+  - [4.3 Lock Integration Scenarios](#43-lock-integration-scenarios)
+  - [4.4 Watch Integration Scenarios](#44-watch-integration-scenarios)
+  - [4.5 Lifecycle Integration Scenarios](#45-lifecycle-integration-scenarios)
+  - [4.6 Postgres-specific Scenarios](#46-postgres-specific-scenarios)
+- [5. Layer 4 — Fault Injection (Toxiproxy)](#5-layer-4--fault-injection-toxiproxy)
+- [6. Static Analysis](#6-static-analysis)
+- [7. CI Cadence](#7-ci-cadence)
+- [8. Coverage Gaps and Follow-ups](#8-coverage-gaps-and-follow-ups)
+
+<!-- /toc -->
+
+## 1. Overview
+
+> **Branch dependency — resolved:** `docs/TESTING-STRATEGY.md`, `docs/scenarios/`,
+> and the `cf-gears-cluster-conformance` crate (`cluster_conformance`) referenced
+> throughout this document originated on `feat/cluster-test-strategy`; that
+> branch's commit has now been cherry-picked onto this plugin's base branch, so
+> the `[dev-dependencies]` entry on `cf-gears-cluster-conformance` (§3) can be
+> wired up. `SC-SCOP-001..006` (scoping) have no `cluster_conformance` functions
+> and are not expected to gain any — see §3 for why that isn't a gap for this
+> plugin. Scenario IDs cited below (`SC-*`) are drawn from `docs/scenarios/` as
+> of its current state.
+
+The Postgres plugin testing strategy follows the four-layer pyramid from the platform-wide [TESTING-STRATEGY.md](../../docs/TESTING-STRATEGY.md):
+
+```
+L4  Fault injection (Toxiproxy, controlled disconnects)  — nightly
+L3  Integration tests (testcontainers Postgres)          — per-PR in this crate, nightly full
+L2  Conformance suite (cluster-conformance crate)        — driven by L3 container
+L1  Unit tests (co-located, no external dependencies)    — every PR, sub-second
+```
+
+The conformance suite (L2) is the keystone: it runs the same scenario body used by the standalone plugin and every other backend against a real Postgres container. Passing the conformance suite is the primary signal that this plugin correctly implements the `ClusterCacheBackend` and `DistributedLockBackend` contracts.
+
+The Postgres-specific layer-3 and layer-4 tests cover behaviours the conformance suite cannot: NOTIFY overflow, advisory lock TTL reaper, PgBouncer incompatibility, connection loss and reconnect, and `synchronous_commit` enforcement.
+
+## 2. Layer 1 — Unit Tests (in-crate)
+
+Co-located with source (`src/**/*_tests.rs`). No external dependencies; run with `cargo test -p cf-postgres-cluster-plugin --lib`.
+
+| Module | What is tested |
+|---|---|
+| `config.rs` | `serde` round-trip for all config fields; default values (incl. `lock_name_cardinality_warn_threshold` defaulting to 1000, `replication_mode` defaulting to `None`); `pgbouncer_transaction_mode: true` rejected at startup; `connection_string` `${VAR}` / `${VAR:-default}` expansion via `ExpandVars`/`config_expanded()` resolves correctly; missing referenced env var surfaces as an error rather than a literal `${VAR}` in the connection string; `replication_mode: async \| sync` round-trips; unknown variant rejected |
+| `cache/watch.rs` | Payload parser: `Changed`, `Deleted`, `Expired` round-trip; empty payload mapped to `Reset`; key > 2048 bytes mapped to `InvalidName` |
+| `pg_error.rs` | SQLSTATE `54000` and `23514`-on-a-`*_len_check` mapped to a `Provider` error naming the 2048-byte limit; an unrelated `23514` not mislabelled as a length problem; `28xxx` still mapped to `AuthFailure` |
+| `lock/reaper.rs` | The reaper's wake-schedule policy (`next_delay`): with no locks it waits out the metrics cadence; an imminent `min(expires_at)` shortens the sleep; a distant one is still capped by the cadence so the `active_names` gauge cannot go quiet; an already-due or sub-floor deadline is floored at `MIN_WAKE` so staggered deadlines coalesce into one wake; a deadline unrepresentable as a `Duration` falls back rather than panicking |
+| `lock/mod.rs` | Name → `(key1, key2)` two-argument advisory-lock key mapping is stable across calls; lock name with special characters encodes correctly; `key1`/`key2` derivation exercises the full 64-bit hash (high/low `i32` halves) |
+| `provider.rs` | `ClusterCacheProvider::provider()` and `ClusterLockProvider::provider()` both return `"postgres"`; `build_cache` and `build_lock` each return `InvalidConfig` for an invalid connection string; `build_lock` never receives or depends on a cache backend argument (matches the SDK's "non-cache providers do not receive the cache backend" contract) |
+
+No SQL is executed in layer-1 tests. SQL logic is covered at layer 3.
+
+## 3. Layer 2 — Conformance Suite
+
+`cf-gears-cluster-conformance` is added as a `[dev-dependencies]` entry. The integration test file `tests/conformance.rs` wires a real Postgres container (via the layer-3 fixture below) into every conformance entry point:
+
+Each suite goes through one shared `run_*_conformance(factory, time)` entry point. `factory` is an **async** factory the runner calls once per scenario; it returns a [`cluster_conformance::ScenarioBackend`] that **owns the plugin handle** and tears it down via `stop()` before the next scenario is built. Retaining the handle is mandatory, not cosmetic: `PostgresClusterHandle`/`PostgresLockHandle` panic on `drop` if they were never `stop()`ed (a debug guard against leaking pools, LISTEN connections, and reaper tasks). Returning only `handle.cache()`/`handle.lock()` and dropping the handle would trip that panic and abandon background-task teardown — so the factory must move the handle into `ScenarioBackend::with_teardown`.
+
+```rust
+// tests/conformance.rs
+
+use cluster::defaults::{CacheBasedServiceDiscoveryBackend, CasBasedLeaderElectionBackend};
+use cluster_conformance::{
+    run_cache_conformance, run_discovery_conformance, run_lock_conformance,
+    run_leader_conformance, ScenarioBackend, TimeControl,
+};
+use postgres_cluster_plugin::{PostgresClusterPlugin, PostgresLockPlugin};
+
+#[tokio::test]
+async fn cache_conformance() {
+    run_cache_conformance(
+        || async {
+            let handle = PostgresClusterPlugin::builder(test_config())
+                .build_and_start()
+                .await
+                .expect("plugin starts against test container");
+            let cache = handle.cache();
+            // The fixture owns `handle`; the runner calls the teardown (which
+            // `stop()`s it) after the scenario, so the handle is never dropped
+            // un-stopped and its background tasks are terminated cleanly.
+            ScenarioBackend::with_teardown(cache, async move { handle.stop().await })
+        },
+        // Real backend → real (bounded) time, never a paused clock (see below).
+        TimeControl::Real,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn lock_conformance() {
+    run_lock_conformance(
+        |_cache| async {
+            // Standalone lock-only path (§3.5 DESIGN.md), the same one
+            // ClusterLockProvider::build_lock uses in production — not the
+            // combined cache+lock plugin. `_cache` is ignored: this exercises
+            // the real "independently routable" shape, not a shared-pool
+            // shortcut.
+            let handle = PostgresLockPlugin::builder(test_lock_config())
+                .build_and_start()
+                .await
+                .expect("standalone lock plugin starts");
+            let lock = handle.lock();
+            ScenarioBackend::with_teardown(lock, async move { handle.stop().await })
+        },
+        TimeControl::Real,
+    )
+    .await;
+}
+
+// Leader election here is always `CasBasedLeaderElectionBackend` over this
+// plugin's own Postgres cache (DESIGN.md §6), so the fixture still owns the
+// underlying cache handle and stops it on teardown.
+#[tokio::test]
+async fn leader_conformance() {
+    run_leader_conformance(
+        || async {
+            let handle = PostgresClusterPlugin::builder(test_config())
+                .build_and_start()
+                .await
+                .expect("plugin starts against test container");
+            let leader = CasBasedLeaderElectionBackend::new(handle.cache()).expect(
+                "SC-LEAD-008: the postgres cache is Linearizable, so the strict constructor succeeds",
+            );
+            ScenarioBackend::with_teardown(leader, async move { handle.stop().await })
+        },
+        TimeControl::Real,
+    )
+    .await;
+}
+
+// Service discovery is always `CacheBasedServiceDiscoveryBackend` over this
+// plugin's own Postgres cache (DESIGN.md §6); the backend auto-selects
+// `PollingPrefixWatch` internally because `prefix_watch == false` (§4.3).
+#[tokio::test]
+async fn discovery_conformance() {
+    run_discovery_conformance(
+        || async {
+            let handle = PostgresClusterPlugin::builder(test_config())
+                .build_and_start()
+                .await
+                .expect("plugin starts against test container");
+            let discovery = CacheBasedServiceDiscoveryBackend::new(handle.cache());
+            ScenarioBackend::with_teardown(discovery, async move { handle.stop().await })
+        },
+        TimeControl::Real,
+    )
+    .await;
+}
+```
+
+Time-sensitive scenarios pass `TimeControl::Real` (a bounded real sleep), not virtual time: against this plugin's real `sqlx::PgPool` a paused/auto-advancing clock spuriously fires sqlx's own acquire timeout. In-memory/fixture callers still pass `TimeControl::Virtual`. The runner isolates each scenario into its own Postgres schema on a shared container; see the module docs in `tests/conformance.rs` for the full rationale.
+
+Before this turn, `leader_conformance`/`discovery_conformance` were missing entirely — only the cache and lock suites were wired, even though `run_leader_conformance` (`SC-LEAD-001..007`) and `run_discovery_conformance` already exist in `cluster-conformance` and this plugin exposes both primitives (SDK-default-derived, §6). There was no reason not to run them; they're added above.
+
+**Routing conformance is out of scope for this plugin.** `run_routing_conformance` does not exist in `cluster-conformance` and never will — per-primitive routing (`cpt-cf-clst-fr-routing-per-primitive`) is wiring-crate logic owned entirely by `cluster/src/wiring.rs` (`ClusterWiring::from_config` dispatching through `ProviderRegistry`), not backend logic any plugin implements or could meaningfully conformance-test in isolation. That coverage belongs to the `cluster` gear's own test suite (see `PG-LOCK-011` in §4.3 below for this plugin's one routing-adjacent integration test, which exercises the wiring crate end-to-end rather than a `cluster-conformance` entry point).
+
+**Capability-gated assertions.** The conformance suite reads `features()` and `consistency()` from the constructed backend before running scenarios. For this plugin:
+- `CacheConsistency::Linearizable` → single-leader and lock-contention correctness scenarios run.
+- `CacheFeatures::prefix_watch == false` → `CacheCapability::PrefixWatch` mismatch scenario runs (expects `CapabilityNotMet`); `watch_prefix` returns `Unsupported`.
+- `LockFeatures::linearizable == true` → strong-mutual-exclusion scenario runs.
+- `LeaderElectionFeatures::linearizable == true` (inherited from the cache, §6) → `SC-LEAD-002`'s single-leader-among-contenders assertion runs, not skipped.
+- `ServiceDiscoveryFeatures::metadata_pushdown == false` → confirmed by the discovery suite.
+
+**Why `SC-SCOP-001..006` are not, and don't need to be, `cluster_conformance` functions.** The scenario catalog (`docs/scenarios/scoping.md`) marks these ☐ and `scenarios/README.md:237` lists "Scoping wrappers" as owned by `cluster-conformance`, which reads like a per-backend conformance gap. It isn't one, for this plugin or any other backend: `ScopedCacheBackend`, `ScopedDistributedLockBackend`, `ScopedLeaderElectionBackend`, and `ScopedServiceDiscoveryBackend` (`cluster-sdk/src/{cache,lock,leader,discovery}/scoped.rs`) are pure decorators — each holds an `Arc<dyn ClusterCacheBackend>` (etc.) and only ever calls the generic trait interface (`scope::apply`/`scope::strip` around a delegated call). None of them touch any backend-specific code path; the wrapped `inner` could be Postgres, standalone, or a test stub, and the prefix-apply/strip/compose logic behaves identically either way. That's exactly why each one already has its own SDK-level unit tests against a `RecordingBackend`/`RecordingCache` stub (`cluster-sdk/src/cache/scoped_tests.rs` and the inline `#[cfg(test)]` modules in `lock/scoped.rs` and `leader/scoped.rs`) — covering prefix prepend, read-path strip, and nested composition — and why `TESTING-STRATEGY.md` §3 (Layer 1) already lists "scoping round-trips" as **implemented** at that layer. Running the identical decorator logic again through `cluster_conformance` against a real Postgres container would re-exercise the same string-manipulation code already proven backend-agnostic; it would not catch anything Postgres-specific, because the decorator never reaches Postgres-specific code. (The one genuinely Postgres-specific interaction — composed scope prefixes making a key long enough to hit this plugin's 2048-byte indexed-key limit, §2.1 DESIGN.md — is already covered directly by `PG-SPEC-002`, independent of whether the long key came from scoping or anywhere else. Note the SDK caps each prefix but not their composition, so that limit is reachable through legitimate nesting.) `scenarios/README.md`'s ownership table is the one worth correcting upstream; nothing is missing from this plugin's own test plan.
+
+## 4. Layer 3 — Integration Tests (testcontainers)
+
+### 4.1 Container Setup
+
+```rust
+// tests/common/mod.rs
+
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+pub async fn start_postgres() -> (ContainerAsync<Postgres>, PostgresClusterConfig) {
+    let container = Postgres::default()
+        .with_db_name("cluster_test")
+        .start()
+        .await
+        .expect("Postgres container starts");
+
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let config = PostgresClusterConfig {
+        connection_string: format!(
+            "postgres://postgres:postgres@127.0.0.1:{}/cluster_test",
+            port
+        ),
+        pool_max_size: 5,
+        ..PostgresClusterConfig::default()
+    };
+    (container, config)
+}
+
+/// Same container, but returns `PostgresLockConfig` (§3.5 DESIGN.md) for tests
+/// exercising the standalone lock-only provider path.
+pub async fn start_postgres_lock_only() -> (ContainerAsync<Postgres>, PostgresLockConfig) {
+    let container = Postgres::default()
+        .with_db_name("cluster_test")
+        .start()
+        .await
+        .expect("Postgres container starts");
+
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let config = PostgresLockConfig {
+        connection_string: format!(
+            "postgres://postgres:postgres@127.0.0.1:{}/cluster_test",
+            port
+        ),
+        pool_max_size: 5,
+        ..PostgresLockConfig::default()
+    };
+    (container, config)
+}
+```
+
+Each test function starts a fresh container (or reuses a shared one via `once_cell` for the suite run) and runs migrations via `build_and_start`. Containers are dropped at the end of the test function, which shuts down Postgres and auto-releases any held advisory locks.
+
+### 4.2 Cache Integration Scenarios
+
+These mirror the conformance suite scenarios (§3) but add Postgres-specific assertions.
+
+| ID | Scenario | What it verifies |
+|---|---|---|
+| `PG-CACHE-001` | `put` + `get` round-trip | Value and version stored and retrieved correctly from the `cluster_cache` table |
+| `PG-CACHE-002` | Version increment monotonicity | Each `put` increments `version` by exactly 1; `put_if_absent` sets version to 1 |
+| `PG-CACHE-003` | `compare_and_swap` atomicity under concurrent writers | Two goroutines CAS the same key; exactly one wins, one gets `CasConflict` |
+| `PG-CACHE-004` | TTL expiry via reaper | Entry absent after reaper runs past `expires_at`; `Expired` event received on watch |
+| `PG-CACHE-005` | `compare_and_delete` survives version reset | Delete+recreate sequence; `compare_and_delete` with old value is a no-op; new holder's claim intact |
+| `PG-CACHE-006` | `scan_prefix` correctness | All keys under prefix returned; expired keys excluded; keys not under prefix excluded |
+| `PG-CACHE-007` | Migration idempotency | `build_and_start` runs against a database that already has the plugin tables; succeeds without error |
+| `PG-CACHE-008` | Connection pool exhaustion — blocks then succeeds | The single pool connection is pinned by a held lock (shared pool, §3.3); a concurrent `put` genuinely blocks, then completes once the lock frees the connection |
+| `PG-CACHE-008b` | Connection pool exhaustion — timeout path | Same pinned-connection setup with a short `pool_acquire_timeout_ms`; a cache op that cannot get a connection in time returns `Provider { kind: Timeout }` |
+| `PG-CACHE-009` | `put_if_absent` reclaims an expired-but-unreaped row | With the default (slow) reaper, an entry past its TTL still physically present; `put_if_absent` treats it as absent and re-creates it at version 1 (leader-election failover must not wait for the reaper) |
+| `PG-CACHE-010` | One cache sweep clears a multi-chunk expired backlog | Plant 600 already-expired rows (> one 512-row `SWEEP_BATCH`) plus a live-TTL and an indefinite entry, then run a single sweep through the `__test_sweep_once` seam: it must delete every expired row and only those, proving the chunk loop drains the table rather than stopping after one bounded `DELETE`. Uses the seam for the same reason as `PG-SPEC-009` — reaper timing cannot distinguish "one sweep looped" from "several intervals elapsed", which is precisely the 512-rows-per-tick behaviour the chunking exists to avoid. A follow-up sweep must reap 0 |
+| `PG-CACHE-010b` | Chunks past the first still `NOTIFY` their keys | Per-chunk transactions commit the `NOTIFY`s in several batches, so a watcher on the backlog's *least*-expired key (guaranteed by `ORDER BY expires_at` not to be in the first chunk) must still receive `Expired` — `PG-CACHE-004` only covers a single-row sweep |
+
+### 4.3 Lock Integration Scenarios
+
+| ID | Scenario | What it verifies |
+|---|---|---|
+| `PG-LOCK-001` | `try_lock` acquires and `release` frees | Advisory lock held; second `try_lock` returns `LockContended`; after `release`, succeeds |
+| `PG-LOCK-002` | `lock` with timeout | Blocked `lock` returns `LockTimeout` after the timeout elapses; advisory lock is not held |
+| `PG-LOCK-003` | `lock` wakes on explicit release NOTIFY | Blocked `lock` acquires promptly (< 100ms) after the holder calls `release`; NOTIFY-based wake confirmed |
+| `PG-LOCK-004` | TTL reaper releases expired lock | Lock acquired with short TTL; reaper fires; advisory lock released; subsequent `try_lock` succeeds |
+| `PG-LOCK-005` | `renew` extends TTL | Lock acquired; `renew(new_ttl)` pushes `expires_at` out to `now() + new_ttl`; reaper does not release until the new TTL elapses |
+| `PG-LOCK-006` | `LockExpired` on renew past TTL | Lock acquired with short TTL; sleep past TTL; `renew` returns `LockExpired` |
+| `PG-LOCK-007` | Connection drop releases advisory lock | Pool connection holding a lock is forcibly closed (via `pg_terminate_backend`); advisory lock auto-released; subsequent `try_lock` succeeds |
+| `PG-LOCK-008` | Concurrent lockers — at most one holder | 20 concurrent tasks `try_lock` the same name; exactly one succeeds; all others return `LockContended` |
+| `PG-LOCK-009` | `synchronous_commit` enforced on connect and checkout | Start the container with `synchronous_commit = off` as the role/database default; after `build_and_start`, `SHOW synchronous_commit` on a checked-out write-pool connection and on a freshly acquired lock connection both report `on` |
+| `PG-LOCK-010` | Standalone `PostgresLockPlugin` runs without the cache half | `PostgresLockPlugin::builder(test_lock_config()).build_and_start()` against a fresh DB creates only `cluster_lock` (no `cluster_cache` table, no LISTEN connection for cache watch); `try_lock`/`release` work identically to the combined plugin's lock |
+| `PG-LOCK-011` | End-to-end YAML routing: lock on Postgres, cache on a different provider | Via `ClusterWiring::from_config` with a profile binding `cache: { provider: standalone }` and `lock: { provider: postgres, connection_string: ... }`; resolved profile's lock backend is backed by real advisory locks in the test container while its cache backend is the in-process standalone one — confirms `ClusterLockProvider` registration actually makes `provider: postgres` resolvable for `lock` independently of `cache` |
+
+### 4.4 Watch Integration Scenarios
+
+| ID | Scenario | What it verifies |
+|---|---|---|
+| `PG-WATCH-001` | `watch(key)` receives `Changed` on `put` | NOTIFY delivered; `CacheWatchEvent::Event(Changed { key })` received within 200ms |
+| `PG-WATCH-002` | `watch(key)` receives `Deleted` | `delete` triggers NOTIFY; `Deleted` event received |
+| `PG-WATCH-003` | `watch(key)` receives `Expired` | TTL reaper deletes key; `Expired` event received |
+| `PG-WATCH-004` | `watch_prefix` returns `Unsupported` | `Err(ClusterError::Unsupported { feature: "prefix_watch" })` returned; `features().prefix_watch == false` |
+| `PG-WATCH-005` | `Closed(Shutdown)` on `handle.stop()` | Active watch receives terminal `Closed(Shutdown)` before `stop()` returns |
+| `PG-WATCH-006` | No events delivered for different key | Watcher on `"a"` receives no events when `"b"` is written |
+| `PG-WATCH-007` | Multiple watchers on same key | Both receive the event; one watcher dropping does not affect the other |
+
+### 4.5 Lifecycle Integration Scenarios
+
+| ID | Scenario | What it verifies |
+|---|---|---|
+| `PG-LIFE-001` | `build_and_start` runs migrations on fresh DB | Tables created; `build_and_start` returns `Ok` |
+| `PG-LIFE-002` | `build_and_start` is idempotent | Called twice against the same DB; second call does not fail or double-create tables |
+| `PG-LIFE-003` | `stop` closes pool and LISTEN connection | After `stop`, the Postgres server shows zero connections from the plugin; advisory locks released |
+| `PG-LIFE-004` | `stop` delivers `Closed(Shutdown)` before returning | All active watches observe `Closed(Shutdown)` before `stop().await` resolves |
+| `PG-LIFE-005` | PgBouncer transaction mode rejected | Config with `pgbouncer_transaction_mode: true` returns `InvalidConfig` at startup |
+| `PG-LIFE-006` | Invalid connection string rejected | `build_and_start` returns `InvalidConfig` immediately, not a timeout |
+| `PG-LIFE-007` | `Drop` without `stop()` surfaces loudly (ADR-006) | Build a `PostgresClusterHandle` (and, separately, a standalone `PostgresLockPlugin` handle, §3.5) and drop it without calling `stop()`; debug build panics with the "dropped without stop()" message, release build (`cfg(not(debug_assertions))`) logs the WARN instead; calling `stop()` first and then dropping does neither |
+| `PG-LIFE-008` | `Drop` during panic unwind degrades to a warning | Panic inside a closure that owns an un-stopped handle; assert the process does not abort (would happen on a debug-build double panic) and `"skipping debug panic to avoid double-panic abort"` is logged instead of the handle's own panic |
+
+### 4.6 Postgres-specific Scenarios
+
+These cover behaviours unique to the Postgres backend not reachable via the conformance suite.
+
+| ID | Scenario | What it verifies |
+|---|---|---|
+| `PG-SPEC-001` | NOTIFY empty-payload → `Reset` | Directly inject an empty-payload NOTIFY on `cluster_cache_changes`; verify `CacheWatchEvent::Reset` delivered to all active watchers |
+| `PG-SPEC-002` | Key length > 2048 bytes rejected | `put` with a key exceeding the btree index-tuple limit on `cluster_cache.key` returns `InvalidName`; a key at exactly 2048 bytes round-trips through a real server, proving the bound clears both that limit and `cluster_cache_key_len_check` |
+| `PG-SPEC-003` | Lock hash collision (advisory) | Covered by `lock/lock_tests.rs` unit tests (`lock_key_exercises_the_full_64_bit_hash`, `lock_key_split_preserves_the_full_64_bit_hash`), which assert the actual `(key1, key2)` mapping directly against `lock_key` rather than relying on two arbitrary, non-contending names never colliding — a prior integration-suite version of this scenario asserted nothing about the property it claimed to cover and was dropped |
+| `PG-SPEC-004` | Advisory lock released on session disconnect | Drop the pool connection holding a `LockGuard` at the Postgres level; advisory lock gone; next `try_lock` succeeds |
+| `PG-SPEC-005` | Mid-session `synchronous_commit` mutation is corrected | Directly run `SET synchronous_commit = off` on (a) a write-pool connection while it's idle in the pool, and (b) a pinned lock connection while its lock is held; verify (a) is corrected on its next `before_acquire` checkout and (b) is corrected within one `lock_reaper_interval_ms` sweep (§3.4); `consistency()` remains `Linearizable` throughout — the plugin never observes or reports `off` as a supported state |
+| `PG-SPEC-006` | Lock-name cardinality gauge and threshold WARN | Configure `lock_name_cardinality_warn_threshold: 5`; acquire locks under 6 distinct names concurrently; verify `cluster_postgres_lock_active_names{provider="postgres"}` reports 6 and `cluster.lock.name_cardinality_high` (WARN) is logged exactly once per reaper interval while the count stays above threshold; verify the gauge and log both clear once held-lock count drops back to or below the threshold |
+| `PG-SPEC-007` | Async replication detected and warned | Container has no `synchronous_standby_names` configured (the default); `replication_mode` omitted from config; `build_and_start` (and, separately, standalone `PostgresLockPlugin::build_and_start`, §3.5) both return `Ok`, and `cluster.provider.replication_async` (WARN) is logged exactly once at startup, naming ADR-009 |
+| `PG-SPEC-008` | Explicit `replication_mode` skips detection | Set `replication_mode: sync` against a container with no `synchronous_standby_names` configured (i.e. explicit config disagrees with what detection would find); verify no `SHOW synchronous_standby_names` query is issued (e.g. via `pg_stat_statements` — explicit config short-circuits detection) and no WARN is logged |
+| `PG-SPEC-009` | Expired backlog swept in bounded batches, and the next-deadline probe | Seed an expired-row backlog larger than one sweep batch (1500 rows > 512) plus one live lock, then run a single sweep through the `__test_sweep_once` seam: it must delete every expired row and only those, proving the batch loop drains the table rather than stopping after one bounded `DELETE` (reaper timing cannot distinguish that from "several intervals elapsed", hence the seam). Also asserts `__test_seconds_until_next_expiry` — the wake schedule's `min(expires_at)` probe (DESIGN.md §5.2) — reports `None` on an empty table and the live lock's own deadline once one is held, since a regression there would otherwise be silent (the reaper just falls back to the fixed interval on error) |
+| `PG-SPEC-010` | A local acquire/renew wakes the reaper before its interval | With `lock_reaper_interval_ms: 600000`, wait for the reaper to complete its startup sweep and commit to that sleep, then acquire a 1s-TTL lock: it must be reclaimed at its own deadline (re-acquirable within 15s), which only the acquire-time `deadline_hint` signal can achieve. The `010b` half does the same for `renew` shortening a 5-minute TTL down to 1s, the case the acquire-time signal does not cover. Both were confirmed to fail with the signal removed — note the 500ms settle before the write is load-bearing: `#[tokio::test]` is a current-thread runtime, so without it the reaper's startup probe can run after the write and shorten its own sleep, and the test would pass either way |
+
+## 5. Layer 4 — Fault Injection (Toxiproxy)
+
+These tests run nightly. They require a Toxiproxy sidecar alongside the Postgres container.
+
+| ID | Scenario | Fault | Expected behaviour |
+|---|---|---|---|
+| `PG-FAULT-001` | LISTEN connection loss → `Reset` | Kill TCP connection to LISTEN connection | All watchers receive `Reset`; plugin reconnects; subsequent events delivered after reconnect |
+| `PG-FAULT-002` | Write pool connection loss → `ConnectionLost` error | Kill pool connection mid-query | `get`/`put` returns `Provider { kind: ConnectionLost }`; pool retries on a new connection on next call |
+| `PG-FAULT-003` | Latency spike → `PoolTimedOut` | Add 10s latency to all connections; `pool_acquire_timeout_ms = 500` | `get` returns `Provider { kind: Timeout }` after 500ms |
+| `PG-FAULT-004` | Reconnect succeeds after transient loss | 2-second TCP blackhole, then restore | Watchers receive `Reset` on disconnect; after restore, receive new events without requiring consumer action |
+| `PG-FAULT-005` | Reconnect fails past retry budget | Permanent TCP blackhole | Watchers receive `Closed(Provider { kind: ConnectionLost })` after the retry budget is exhausted |
+| `PG-FAULT-006` | NOTIFY queue overflow aborts the writing txn | Generate a sustained NOTIFY flood via direct SQL until the async queue fills | The overflowing `NOTIFY`/commit fails with a queue-full error (Postgres emits no notification); the plugin's recovery is the LISTEN reconnect-then-`Reset` path, not an empty-payload `Reset`. `cluster_watch_resets_total{provider="postgres",primitive="cache"}` increments only when the LISTEN connection itself resets |
+| `PG-FAULT-007` | No split-brain under partition (real backend) | 5 independent `CasBasedLeaderElectionBackend` instances, each with its own Postgres connection pool, all electing the same name concurrently; Toxiproxy partitions a random subset of connections mid-run for several TTL intervals, then restores | Sample every candidate's `status()` throughout the run (via `tokio::time`-driven polling, not wall-clock sleeps); at no sampled instant do two candidates report `Leader`. This is the real-backend counterpart to the cataloged (but non-runnable-against-Postgres) `SC-LEAD-010` — see §8 |
+
+## 6. Static Analysis
+
+- **`cargo check`** — must pass with no errors.
+- **`cargo clippy`** — no warnings beyond the workspace allow-list.
+- **`dylint`** — the workspace `no-remote-in-lock-critical-section` rule is enforced. No remote I/O (SQL queries, NOTIFY, pool acquire) inside a `LockGuard`'s lifetime scope.
+- **No serde in SDK contract types** — enforced by the workspace dylint layer rule. The plugin's `config.rs` may use serde; the plugin does NOT add serde derives to any `cluster-sdk` type.
+- **`cargo test --doc`** — all doc-test examples compile and pass.
+
+## 7. CI Cadence
+
+| Layer | Trigger | Approx. duration |
+|---|---|---|
+| L1 unit tests | Every PR | < 5 seconds |
+| L2 + L3 integration (testcontainers) | Every PR in this crate; nightly for all cluster plugins | ~2–5 minutes |
+| L4 fault injection (Toxiproxy) | Nightly; manually triggered for pre-release | ~10–20 minutes |
+
+L3 tests are gated behind the `integration` feature flag so they do not run in workspaces that have not provisioned a Docker daemon:
+
+```toml
+[features]
+integration = ["testcontainers", "testcontainers-modules"]
+```
+
+Run locally with: `cargo test -p cf-postgres-cluster-plugin --features integration`.
+
+## 8. Coverage Gaps and Follow-ups
+
+| Gap | Severity | Tracking |
+|---|---|---|
+| `Lagged` watch variant not producible from LISTEN/NOTIFY | No action needed — the LISTEN/NOTIFY path surfaces missed events as `Reset` (on reconnect, or an empty/unrecognized payload), never `Lagged` (DESIGN.md §4.3, ADR-003's overflow mapping); NOTIFY-queue overflow itself aborts the writing transaction rather than delivering any watch event. This is a permanent, backend-specific behavior difference, not a missing test. This row is the resolution | N/A — documented |
+| Multi-node split-brain test (L5) — **distinct from `PG-FAULT-007` (§5)** | Future — requires an actual multi-node Postgres deployment with streaming replication and a real failover (promote standby), to empirically verify the risk §3.6 only warns about: an async-replicated failover can lose the last few committed transactions, including a currently-held lock/leadership row. `PG-FAULT-007` only partitions client connections to a single, non-replicated node — it cannot exercise this at all, since there's no second node to fail over to | Out of initial scope |
+| PgBouncer session-mode pooling integration test | Warning — currently only the transaction-mode rejection is tested (`PG-LIFE-005`); a session-mode round-trip test would validate the positive path — that advisory locks actually survive for the connection's session lifetime under session-mode pooling, not just that transaction-mode is rejected | Follow-up |
+| Full Postgres server restart/failover scenario — **distinct from `PG-FAULT-007` (§5) and the multi-node row above** | Warning — a single-node container restart (e.g. `docker restart`, not a Toxiproxy network fault and not a multi-node failover): does `build_and_start` recover cleanly against a server that restarted mid-session (migrations still idempotent, watches reconnect, in-flight locks correctly gone since the session died with the restart)? Toxiproxy (L4, §5) only blackholes/delays TCP; it never actually stops the Postgres process | L4/L5 follow-up |
+| SC-LEAD-009/SC-LEAD-010 (partition, split-brain) cannot be run against this plugin via `turmoil`, as cataloged | Not this plugin's gap to close, and not fixable by "wiring it up" — neither scenario has a `cluster-conformance` function at all (only `SC-LEAD-001..007` are implemented, now run via `leader_conformance`, §3), and `turmoil`'s model (`TESTING-STRATEGY.md` §6: "3+ nodes... over a shared **simulated** backend") has no way to drive real external TCP to a containerized Postgres server in the first place. A future turmoil-based SC-LEAD-010 would validate `CasBasedLeaderElectionBackend`'s own election/renewal state machine against a mock backend — generic SDK logic, not anything Postgres-specific — so it wouldn't tell you whether *this plugin's* actual CAS implementation stays linearizable under real partition. `PG-FAULT-007` (§5) covers that property directly, against the real backend, using this plugin's existing Toxiproxy infrastructure instead | Covered by `PG-FAULT-007` (real-backend) + future SDK-level turmoil suite (generic-algorithm) — no plugin-side follow-up |
+| `scan_prefix` cost-at-scale test for `PollingPrefixWatch` | Warning — DESIGN.md §4.4/§11 flag that `LIKE prefix%` degrades with keyspace size and has no index support, but no integration or load test measures this cost against a realistic keyspace | L3/L4 follow-up |

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/src/cache/mod.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/src/cache/mod.rs
@@ -1,0 +1,464 @@
+//! `PostgresCache` — the native `ClusterCacheBackend` implementation over a
+//! `sqlx::PgPool` (DESIGN.md §4).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cluster_sdk::cache::{PutRequest, Ttl};
+use cluster_sdk::{
+    CacheConsistency, CacheEntry, CacheFeatures, CacheWatch, ClusterCacheBackend, ClusterError,
+    ProviderErrorKind,
+};
+use sqlx::PgPool;
+
+pub mod reaper;
+pub mod watch;
+
+use crate::pg_error::map_sqlx_error;
+use watch::{NotifyEvent, WatchRegistry, validate_key_len};
+
+/// The native Postgres cache backend. Read-through: every `get` hits the
+/// database directly (DESIGN.md §4.3, "no read-path cache" — §11).
+pub struct PostgresCache {
+    pool: PgPool,
+    /// The schema-qualified table name (`"<schema>.cluster_cache"`), computed
+    /// once at construction. `schema` comes from operator config
+    /// (`PostgresClusterConfig`/`PostgresLockConfig`), the same trust boundary
+    /// as `connection_string` — not sanitized against a hostile value the way
+    /// tenant-supplied input would be.
+    table: String,
+    watch_registry: Arc<WatchRegistry>,
+}
+
+impl PostgresCache {
+    #[must_use]
+    pub fn new(pool: PgPool, schema: &str) -> Arc<Self> {
+        Arc::new(Self {
+            pool,
+            table: format!("{schema}.cluster_cache"),
+            watch_registry: WatchRegistry::new(),
+        })
+    }
+
+    /// The watch registry the LISTEN fan-out task dispatches into. Exposed to
+    /// `plugin.rs` so it can spawn `watch::spawn_listen_task` against the same
+    /// registry this cache registers watches into. `pub(crate)`: only the
+    /// wiring in `plugin.rs` uses it, and `WatchRegistry` is not a nameable
+    /// public type (PGR-L3).
+    #[must_use]
+    pub(crate) fn watch_registry(&self) -> Arc<WatchRegistry> {
+        Arc::clone(&self.watch_registry)
+    }
+
+    /// The underlying pool, for the reaper and shutdown path. `pub(crate)`:
+    /// intra-crate wiring only (PGR-L3).
+    #[must_use]
+    pub(crate) fn pool(&self) -> PgPool {
+        self.pool.clone()
+    }
+
+    /// The schema-qualified table name, for the reaper. `pub(crate)`:
+    /// intra-crate wiring only (PGR-L3).
+    #[must_use]
+    pub(crate) fn table(&self) -> String {
+        self.table.clone()
+    }
+
+    /// Test-only: runs one complete TTL sweep — every chunk, exactly as the
+    /// reaper's own wake does — and returns how many expired rows it deleted.
+    /// Lets `PG-CACHE-010` assert that a backlog larger than one
+    /// `reaper::SWEEP_BATCH` is cleared by a *single* sweep's chunk loop, rather
+    /// than inferring it from how many reaper intervals happened to elapse (which
+    /// cannot tell "one sweep looped" apart from "several intervals passed").
+    /// Mirrors `PostgresLock::__test_sweep_once`.
+    ///
+    /// Takes a never-cancelled token: the sweep's own `cancel` check exists to
+    /// abandon a backlog on shutdown, which is not what this seam is for.
+    ///
+    /// Gated behind `--features integration` (PGR-M8).
+    #[cfg(feature = "integration")]
+    #[doc(hidden)]
+    pub async fn __test_sweep_once(&self) -> Result<usize, ClusterError> {
+        reaper::sweep(
+            &self.pool,
+            &self.table,
+            &tokio_util::sync::CancellationToken::new(),
+        )
+        .await
+    }
+}
+
+/// Converts a `Ttl` to the millisecond lifetime bound to the write query, or
+/// `None` for `Ttl::Indefinite` (DESIGN.md §4.1).
+///
+/// The actual `expires_at` is computed **in SQL as `now() + interval`** using
+/// the database clock (PGR-C2), not `chrono::Utc::now()` on the writing
+/// instance: reads (`get`/`contains`/CAS) and the reaper all compare against
+/// Postgres `now()`, so anchoring the write to a service instance's own
+/// (possibly skewed) wall clock could make entries expire early or linger. This
+/// helper only validates and hands the SQL a duration to add to the DB clock.
+fn ttl_to_millis(ttl: Ttl) -> Result<Option<i64>, ClusterError> {
+    match ttl {
+        Ttl::Indefinite => Ok(None),
+        Ttl::Of(duration) => {
+            let millis =
+                i64::try_from(duration.as_millis()).map_err(|_| ClusterError::InvalidConfig {
+                    reason: format!("ttl {duration:?} is out of range: exceeds i64 milliseconds"),
+                })?;
+            Ok(Some(millis))
+        }
+    }
+}
+
+/// The SQL fragment computing `expires_at` from a bound millisecond lifetime
+/// (`$n`) against the database clock: `NULL` (indefinite) when the bind is
+/// `NULL`, else `now() + $n ms` (PGR-C2). `n` is the 1-based bind position of
+/// the `ttl_to_millis` value.
+fn expires_at_sql(n: usize) -> String {
+    format!(
+        "CASE WHEN ${n}::bigint IS NULL THEN NULL \
+         ELSE now() + (${n}::bigint * interval '1 millisecond') END"
+    )
+}
+
+/// The `version` column is `BIGINT` (`i64`); the SDK contract is `u64`
+/// (`>= 1`, DESIGN.md §2.2). This plugin never writes a version beyond
+/// `i64::MAX` in practice (each write increments by exactly 1), but the
+/// conversion is checked rather than cast, per the "no unwrap/expect, use
+/// proper Result types" rule.
+fn version_to_i64(version: u64) -> Result<i64, ClusterError> {
+    i64::try_from(version).map_err(|_| ClusterError::Provider {
+        kind: ProviderErrorKind::Other,
+        message: format!("version {version} exceeds the storable i64 range"),
+    })
+}
+
+fn i64_to_version(version: i64) -> Result<u64, ClusterError> {
+    u64::try_from(version).map_err(|_| ClusterError::Provider {
+        kind: ProviderErrorKind::Other,
+        message: format!("stored version {version} is negative — data corruption"),
+    })
+}
+
+/// Escapes `%`, `_`, and `\` in a `scan_prefix` prefix so `LIKE $1` matches the
+/// prefix literally rather than treating the caller's own text as `LIKE`
+/// metacharacters (DESIGN.md §4.4 says "the caller must not include a
+/// wildcard", covering the trailing `%` this method appends — a key
+/// containing a literal `%`/`_` in its own text still needs escaping to be
+/// matched as data).
+fn escape_like(prefix: &str) -> String {
+    let mut escaped = String::with_capacity(prefix.len());
+    for ch in prefix.chars() {
+        if matches!(ch, '%' | '_' | '\\') {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped
+}
+
+#[async_trait]
+impl ClusterCacheBackend for PostgresCache {
+    fn consistency(&self) -> CacheConsistency {
+        // READ COMMITTED provides linearizability for the single-row operations
+        // this cache uses; CAS is an atomic `UPDATE ... WHERE version = $expected`
+        // regardless of isolation level (DESIGN.md §4.5).
+        CacheConsistency::Linearizable
+    }
+
+    fn features(&self) -> CacheFeatures {
+        // The NOTIFY channel carries a single key per payload — prefix routing
+        // is infeasible at the Postgres level without one channel per prefix
+        // (DESIGN.md §4.3).
+        CacheFeatures::new(false)
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<CacheEntry>, ClusterError> {
+        let row: Option<(Vec<u8>, i64)> = sqlx::query_as(&format!(
+            "SELECT value, version FROM {} WHERE key = $1 AND (expires_at IS NULL OR expires_at > now())",
+            self.table
+        ))
+        .bind(key)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        row.map(|(value, version)| {
+            Ok(CacheEntry {
+                value,
+                version: i64_to_version(version)?,
+            })
+        })
+        .transpose()
+    }
+
+    async fn put(&self, req: PutRequest<'_>) -> Result<(), ClusterError> {
+        validate_key_len(req.key)?;
+        let ttl_millis = ttl_to_millis(req.ttl)?;
+
+        let mut tx = self.pool.begin().await.map_err(map_sqlx_error)?;
+        sqlx::query(&format!(
+            "INSERT INTO {table} (key, value, version, expires_at) VALUES ($1, $2, 1, {expires_at}) \
+             ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, \
+             version = {table}.version + 1, expires_at = EXCLUDED.expires_at",
+            table = self.table,
+            expires_at = expires_at_sql(3),
+        ))
+        .bind(req.key)
+        .bind(req.value)
+        .bind(ttl_millis)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        watch::notify(&mut *tx, NotifyEvent::Changed, req.key).await?;
+        tx.commit().await.map_err(map_sqlx_error)?;
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<bool, ClusterError> {
+        // Live-entry predicate (PGR-C5): an expired-but-not-yet-reaped row is
+        // logically absent to `get`/`contains`/CAS, so deleting it must not
+        // report `true` or emit a spurious `Deleted` — the reaper will physically
+        // remove it and emit `Expired`. Matching the filter keeps `delete`
+        // consistent with the read path.
+        let mut tx = self.pool.begin().await.map_err(map_sqlx_error)?;
+        let deleted: Option<i32> = sqlx::query_scalar(&format!(
+            "DELETE FROM {} WHERE key = $1 AND (expires_at IS NULL OR expires_at > now()) \
+             RETURNING 1",
+            self.table
+        ))
+        .bind(key)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        let existed = deleted.is_some();
+        if existed {
+            watch::notify(&mut *tx, NotifyEvent::Deleted, key).await?;
+        }
+        tx.commit().await.map_err(map_sqlx_error)?;
+        Ok(existed)
+    }
+
+    async fn contains(&self, key: &str) -> Result<bool, ClusterError> {
+        let exists: Option<i32> = sqlx::query_scalar(&format!(
+            "SELECT 1 FROM {} WHERE key = $1 AND (expires_at IS NULL OR expires_at > now())",
+            self.table
+        ))
+        .bind(key)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(map_sqlx_error)?;
+        Ok(exists.is_some())
+    }
+
+    async fn put_if_absent(&self, req: PutRequest<'_>) -> Result<Option<CacheEntry>, ClusterError> {
+        validate_key_len(req.key)?;
+        let ttl_millis = ttl_to_millis(req.ttl)?;
+
+        // `ON CONFLICT (key) DO UPDATE ... WHERE <row is expired>`, not
+        // `DO NOTHING`: a key whose row physically lingers past `expires_at`
+        // (not yet swept by the TTL reaper) is logically *absent*, exactly as
+        // `get`/`contains`/`compare_and_swap` treat it via their
+        // `(expires_at IS NULL OR expires_at > now())` filter. `DO NOTHING`
+        // returned zero rows for such a row → `Ok(None)` ("present"), which
+        // stalled `CasBasedLeaderElectionBackend::claim()`'s failover
+        // `put_if_absent` until the reaper physically deleted the row (up to
+        // `cache_reaper_interval_ms`, default 10s) — a liveness regression on
+        // the leader-election failover path (DESIGN.md §4.1). The guarded
+        // upsert overwrites an expired row (returning it as a freshly-created
+        // version-1 entry) while a live entry still yields no row → `Ok(None)`.
+        let mut tx = self.pool.begin().await.map_err(map_sqlx_error)?;
+        let inserted: Option<(Vec<u8>, i64)> = sqlx::query_as(&format!(
+            "INSERT INTO {table} (key, value, version, expires_at) VALUES ($1, $2, 1, {expires_at}) \
+             ON CONFLICT (key) DO UPDATE \
+               SET value = EXCLUDED.value, version = 1, expires_at = EXCLUDED.expires_at \
+               WHERE {table}.expires_at IS NOT NULL AND {table}.expires_at <= now() \
+             RETURNING value, version",
+            table = self.table,
+            expires_at = expires_at_sql(3),
+        ))
+        .bind(req.key)
+        .bind(req.value)
+        .bind(ttl_millis)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        if let Some((value, version)) = inserted {
+            watch::notify(&mut *tx, NotifyEvent::Changed, req.key).await?;
+            tx.commit().await.map_err(map_sqlx_error)?;
+            Ok(Some(CacheEntry {
+                value,
+                version: i64_to_version(version)?,
+            }))
+        } else {
+            tx.rollback().await.map_err(map_sqlx_error)?;
+            Ok(None)
+        }
+    }
+
+    async fn compare_and_swap(
+        &self,
+        key: &str,
+        expected_version: u64,
+        new_value: &[u8],
+        ttl: Ttl,
+    ) -> Result<CacheEntry, ClusterError> {
+        validate_key_len(key)?;
+        let ttl_millis = ttl_to_millis(ttl)?;
+        let expected_version_i64 = version_to_i64(expected_version)?;
+
+        let mut tx = self.pool.begin().await.map_err(map_sqlx_error)?;
+        let updated: Option<i64> = sqlx::query_scalar(&format!(
+            "UPDATE {table} SET value = $3, version = version + 1, expires_at = {expires_at} \
+             WHERE key = $1 AND version = $2 AND (expires_at IS NULL OR expires_at > now()) \
+             RETURNING version",
+            table = self.table,
+            expires_at = expires_at_sql(4),
+        ))
+        .bind(key)
+        .bind(expected_version_i64)
+        .bind(new_value)
+        .bind(ttl_millis)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        if let Some(version) = updated {
+            watch::notify(&mut *tx, NotifyEvent::Changed, key).await?;
+            tx.commit().await.map_err(map_sqlx_error)?;
+            Ok(CacheEntry {
+                value: new_value.to_vec(),
+                version: i64_to_version(version)?,
+            })
+        } else {
+            tx.rollback().await.map_err(map_sqlx_error)?;
+            let current = self.get(key).await?;
+            Err(ClusterError::CasConflict {
+                key: key.to_owned(),
+                current,
+            })
+        }
+    }
+
+    async fn compare_and_delete(
+        &self,
+        key: &str,
+        expected_value: &[u8],
+    ) -> Result<bool, ClusterError> {
+        // Overridden (not the default get-then-delete) for atomicity, per the
+        // trait doc's guidance for a backend with an atomic store. Survives the
+        // delete+recreate version-reset scenario documented in
+        // `[cluster-cache-version-reset-caveat]` (DESIGN.md §2.2): a successor
+        // that re-claimed after a TTL lapse writes a different value, so this
+        // guarded delete is a safe no-op against it.
+        // Live-entry predicate (PGR-C5): as in `delete`, an expired-but-unreaped
+        // row is logically absent, so a value match against it must not report a
+        // successful delete or emit `Deleted`.
+        let mut tx = self.pool.begin().await.map_err(map_sqlx_error)?;
+        let deleted: Option<i32> = sqlx::query_scalar(&format!(
+            "DELETE FROM {} WHERE key = $1 AND value = $2 \
+             AND (expires_at IS NULL OR expires_at > now()) RETURNING 1",
+            self.table
+        ))
+        .bind(key)
+        .bind(expected_value)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+        let existed = deleted.is_some();
+        if existed {
+            watch::notify(&mut *tx, NotifyEvent::Deleted, key).await?;
+        }
+        tx.commit().await.map_err(map_sqlx_error)?;
+        Ok(existed)
+    }
+
+    async fn watch(&self, key: &str) -> Result<CacheWatch, ClusterError> {
+        Ok(self.watch_registry.register(key))
+    }
+
+    async fn watch_prefix(&self, _prefix: &str) -> Result<CacheWatch, ClusterError> {
+        // DESIGN.md §4.3: exact watches only — prefix routing is infeasible at
+        // the Postgres NOTIFY level. Callers polyfill via `PollingPrefixWatch`.
+        Err(ClusterError::Unsupported {
+            feature: "prefix_watch",
+        })
+    }
+
+    async fn scan_prefix(&self, prefix: &str) -> Result<Vec<String>, ClusterError> {
+        let pattern = format!("{}%", escape_like(prefix));
+        let keys: Vec<String> = sqlx::query_scalar(&format!(
+            "SELECT key FROM {} WHERE key LIKE $1 ESCAPE '\\' AND (expires_at IS NULL OR expires_at > now())",
+            self.table
+        ))
+        .bind(pattern)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(map_sqlx_error)?;
+        Ok(keys)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn ttl_indefinite_has_no_millis() {
+        assert_eq!(ttl_to_millis(Ttl::Indefinite).unwrap(), None);
+    }
+
+    #[test]
+    fn ttl_of_duration_is_positive_millis() {
+        assert_eq!(
+            ttl_to_millis(Ttl::Of(Duration::from_mins(1))).unwrap(),
+            Some(60_000)
+        );
+    }
+
+    #[test]
+    fn expires_at_sql_uses_the_database_clock() {
+        // Guards PGR-C2: expiry is computed as `now() + interval` in SQL, never
+        // from a client-side timestamp bind.
+        let sql = expires_at_sql(3);
+        assert!(sql.contains("now()"), "must anchor to the DB clock: {sql}");
+        assert!(
+            sql.contains("$3::bigint"),
+            "must bind the ms lifetime: {sql}"
+        );
+    }
+
+    #[test]
+    fn version_round_trips_through_i64() {
+        for version in [1_u64, 2, 1_000_000, u64::from(u32::MAX)] {
+            let as_i64 = version_to_i64(version).unwrap();
+            assert_eq!(i64_to_version(as_i64).unwrap(), version);
+        }
+    }
+
+    #[test]
+    fn version_to_i64_rejects_values_beyond_i64_max() {
+        let too_large = u64::try_from(i64::MAX).unwrap() + 1;
+        assert!(version_to_i64(too_large).is_err());
+    }
+
+    #[test]
+    fn i64_to_version_rejects_negative_values() {
+        assert!(i64_to_version(-1).is_err());
+    }
+
+    #[test]
+    fn escape_like_escapes_percent_underscore_and_backslash() {
+        assert_eq!(escape_like("plain"), "plain");
+        assert_eq!(escape_like("100%"), "100\\%");
+        assert_eq!(escape_like("a_b"), "a\\_b");
+        assert_eq!(escape_like("a\\b"), "a\\\\b");
+        assert_eq!(escape_like("100%_off\\"), "100\\%\\_off\\\\");
+    }
+}

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/src/cache/reaper.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/src/cache/reaper.rs
@@ -1,0 +1,226 @@
+//! The `cluster_cache` TTL sweeper background task (DESIGN.md §4.2).
+//!
+//! Wakes on a configurable interval and deletes every expired entry,
+//! `NOTIFY`-ing `E:<key>` for each so watchers receive
+//! `CacheWatchEvent::Event(CacheEvent::Expired { key })`. Driven by a
+//! [`CancellationToken`]; self-terminates when cancelled.
+//!
+//! Takes no [`WatchRegistry`](crate::cache::watch::WatchRegistry) reference:
+//! the `NOTIFY` this sweep issues reaches this same instance's local watchers
+//! (and every other instance's) via the dedicated LISTEN connection's normal
+//! round-trip, exactly like a `put`/`delete` call — see `cache/watch.rs`'s
+//! module doc for why that round-trip is the correct fan-out path, not a
+//! shortcut worth bypassing here.
+//!
+//! ## Chunking
+//!
+//! A sweep is a *loop* of bounded transactions ([`SWEEP_BATCH`] rows each), not
+//! one unbounded `DELETE` — the same shape `lock::reaper` uses, and for two
+//! reasons that both scale with backlog size rather than with the configured
+//! interval:
+//!
+//! * **Lock-hold time.** `DELETE ... RETURNING` holds a row lock on every
+//!   matching row until commit, and each deleted key costs a sequential
+//!   `pg_notify` round-trip before that commit. Unbounded, a concurrent
+//!   `put`/`put_if_absent` on a key caught mid-batch does not wait for a quick
+//!   row lock — it waits out the *rest of the whole backlog's* `NOTIFY` loop,
+//!   on a write-pool connection pinned for that entire span. Chunking caps both
+//!   the pinned-connection span and the `NOTIFY` burst at one batch's worth.
+//! * **Partial progress.** All-or-nothing means one transient failure anywhere
+//!   in the loop rolls back the entire batch, so the tick reclaims *nothing*.
+//!   Should the expiry rate ever outpace one sweep, every later tick would
+//!   re-attempt the same, larger, still-all-or-nothing batch and never eat into
+//!   the backlog. Per-chunk transactions commit as they go, so a failing chunk
+//!   costs only its own rows and the ones already committed stay reclaimed.
+//!
+//! Each chunk keeps its delete and that chunk's `NOTIFY`s in **one**
+//! transaction: the atomicity that matters is per-event (never a row deleted
+//! with its `Expired` event lost, nor the reverse — DESIGN.md §4.1), and that
+//! is preserved by a bounded transaction just as well as by an unbounded one.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use cluster_sdk::observability::fields::label;
+use cluster_sdk::observability::{self, ResourceId};
+use cluster_sdk::{ClusterError, ClusterMetrics};
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::Histogram;
+use sqlx::PgPool;
+use tokio_util::sync::CancellationToken;
+
+use crate::cache::watch::{self, NotifyEvent};
+use crate::pg_error::map_sqlx_error;
+
+/// Expired rows one sweep transaction claims. The sweep loops until a chunk
+/// comes back short, so a backlog of any size is still cleared in full — just
+/// across several bounded transactions instead of one that row-locks every
+/// expired key for as long as that many `NOTIFY` round-trips take (module doc,
+/// "Chunking"). Matches `lock::reaper`'s constant of the same name; kept
+/// separate so either primitive can be tuned without moving the other.
+const SWEEP_BATCH: usize = 512;
+
+/// The bounded delete one chunk runs.
+///
+/// The `LIMIT` lives in a subquery because `DELETE` takes no `LIMIT` of its own.
+/// `ORDER BY expires_at` reaps longest-expired-first and rides
+/// `cluster_cache_expires_idx` (the same partial index the
+/// `expires_at IS NOT NULL AND expires_at <= now()` filter uses), so the
+/// ordering costs nothing.
+///
+/// `FOR UPDATE SKIP LOCKED` does double duty, exactly as in `lock::reaper`. It
+/// keeps concurrent reapers — one per fleet instance, all sweeping this same
+/// table — from serializing behind each other on the same chunk: each skips the
+/// rows another has already claimed and takes the next ones. It is also what
+/// makes the *outer* delete safe while matching on `key` alone rather than
+/// re-checking `expires_at`: a row whose `put` is in flight is already row-locked
+/// by that `INSERT ... ON CONFLICT (key) DO UPDATE`, so this statement skips it
+/// instead of deleting an entry in the act of being rewritten. (A `put` that
+/// commits *before* the subquery runs is excluded by the `expires_at` filter; one
+/// that arrives *after* blocks on this statement's row lock, then finds the row
+/// gone and inserts fresh — the same reaper-wins-then-put-recreates outcome the
+/// unbounded single-statement delete had, `Expired` event included.)
+fn chunk_sql(table: &str) -> String {
+    format!(
+        "DELETE FROM {table} WHERE key IN (\
+             SELECT key FROM {table} \
+             WHERE expires_at IS NOT NULL AND expires_at <= now() \
+             ORDER BY expires_at LIMIT {SWEEP_BATCH} FOR UPDATE SKIP LOCKED\
+         ) RETURNING key"
+    )
+}
+
+/// Runs one chunk: deletes up to [`SWEEP_BATCH`] rows past their `expires_at`
+/// and issues one `NOTIFY` per deleted key in the same transaction (DESIGN.md
+/// §4.2). Returns how many rows it reaped — a count below [`SWEEP_BATCH`] means
+/// the table had nothing more to give.
+async fn sweep_chunk(pool: &PgPool, table: &str) -> Result<usize, ClusterError> {
+    let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+    let expired_keys: Vec<String> = sqlx::query_scalar(&chunk_sql(table))
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    for key in &expired_keys {
+        watch::notify(&mut *tx, NotifyEvent::Expired, key).await?;
+    }
+
+    tx.commit().await.map_err(map_sqlx_error)?;
+    Ok(expired_keys.len())
+}
+
+/// Runs one sweep to completion, chunk by chunk, returning the number of rows
+/// reaped.
+///
+/// A failing chunk ends the sweep rather than skipping ahead: its rows are not
+/// row-locked by anyone, so the very next chunk's subquery would re-select the
+/// same ones and retry them in a tight loop. Ending here instead leaves every
+/// already-committed chunk reclaimed and lets the next tick resume from there —
+/// which is the incremental progress the whole chunking exists for.
+///
+/// Re-checks `cancel` between chunks so a shutdown arriving mid-backlog is not
+/// held up for as many transactions as the backlog needs — the rows left behind
+/// are still expired, so the next reaper to run (here or on another instance)
+/// picks them up.
+pub(super) async fn sweep(
+    pool: &PgPool,
+    table: &str,
+    cancel: &CancellationToken,
+) -> Result<usize, ClusterError> {
+    let mut reaped = 0;
+    loop {
+        let chunk = sweep_chunk(pool, table).await?;
+        reaped += chunk;
+        if chunk < SWEEP_BATCH || cancel.is_cancelled() {
+            return Ok(reaped);
+        }
+    }
+}
+
+/// Spawns the cache TTL reaper.
+///
+/// Each tick records `cluster_postgres_reaper_sweep_duration_seconds` with
+/// `primitive = "cache"` into the shared `sweep_duration` histogram (DESIGN.md
+/// §8, built by `lock::reaper::sweep_duration_histogram`). The cache reaper has
+/// no gauge counterpart — only the lock reaper emits
+/// `cluster_postgres_lock_active_names`.
+pub fn spawn_cache_reaper(
+    pool: PgPool,
+    table: String,
+    interval: Duration,
+    sweep_duration: Histogram<f64>,
+    metrics: Arc<dyn ClusterMetrics>,
+    provider: &'static str,
+    cancel: CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(interval);
+        // A chunked sweep of a real backlog can outrun `interval`, and the
+        // default `Burst` would then fire every missed tick back-to-back with no
+        // delay — hammering a database that is, by definition, already behind.
+        // `Delay` restarts the cadence from when the long sweep actually
+        // finished. Nothing is lost by not catching up: the sweep already loops
+        // until the backlog is drained, so a missed tick has no leftover work to
+        // rush back for — and if the sweep ended on an *error*, waiting out an
+        // interval is exactly right rather than hot-retrying a struggling
+        // backend (the same reasoning as `lock::reaper`'s wake floor).
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            tokio::select! {
+                () = cancel.cancelled() => break,
+                _ = tick.tick() => {
+                    let started = tokio::time::Instant::now();
+                    let swept = sweep(&pool, &table, &cancel).await;
+                    sweep_duration.record(
+                        started.elapsed().as_secs_f64(),
+                        &[
+                            KeyValue::new(label::PROVIDER, provider),
+                            KeyValue::new(label::PRIMITIVE, "cache"),
+                        ],
+                    );
+                    if let Err(err) = swept {
+                        // Route through the shared signal path (ERROR log +
+                        // `cluster_provider_errors_total`), not a free-text WARN
+                        // (PGR-M1 / OBSERVABILITY.md §6). A whole-table sweep has
+                        // no single resource key, so the `cluster_cache` table is
+                        // the `name` resource field.
+                        observability::emit_provider_error(
+                            &*metrics,
+                            provider,
+                            "reaper_sweep",
+                            ResourceId::Name(&table),
+                            &err,
+                        );
+                    }
+                }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A canary, not a formatting assertion: the unbounded `DELETE` this
+    /// statement replaced is precisely the regression being guarded against, and
+    /// both of these clauses are load-bearing (module doc, "Chunking") while
+    /// being invisible in any unit-testable behaviour.
+    #[test]
+    fn the_chunk_delete_is_bounded_and_skips_claimed_rows() {
+        let sql = chunk_sql("public.cluster_cache");
+        assert!(
+            sql.contains(&format!("LIMIT {SWEEP_BATCH}")),
+            "the chunk delete must stay bounded, got: {sql}"
+        );
+        assert!(
+            sql.contains("FOR UPDATE SKIP LOCKED"),
+            "concurrent reapers must not serialize on the same chunk, got: {sql}"
+        );
+        // Without this the sweep would also delete indefinite (`NULL`) entries.
+        assert!(
+            sql.contains("expires_at IS NOT NULL AND expires_at <= now()"),
+            "the chunk delete must only claim expired-with-a-TTL rows, got: {sql}"
+        );
+    }
+}

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/src/cache/watch.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/src/cache/watch.rs
@@ -1,0 +1,555 @@
+//! LISTEN connection management, per-watcher fan-out, and the write-side
+//! `NOTIFY` helper (DESIGN.md §4.3, §2.3).
+//!
+//! The plugin maintains one dedicated Postgres connection that issues `LISTEN
+//! cluster_cache_changes` at startup. An async task reads notifications from
+//! this connection in a loop and fans them out to per-watcher channels
+//! registered here. Because every instance in the fleet runs its own copy of
+//! this task against the same database, a write on any one instance reaches
+//! every instance's local watchers via this same NOTIFY round-trip — Postgres
+//! delivers a NOTIFY back to the sending session too, as long as that session
+//! is itself `LISTENing` on the channel, which this dedicated connection always
+//! is. So the mutation methods in `cache/mod.rs` never call into
+//! [`WatchRegistry`] directly; they only execute SQL + `pg_notify`, and
+//! delivery to local watchers happens the same way it does for watchers on
+//! every other instance.
+//!
+//! **Exact watches only** (DESIGN.md §4.3): the native NOTIFY channel carries a
+//! single key per payload, so `watch_prefix` is not serviceable natively —
+//! callers get [`ClusterError::Unsupported`] and use `PollingPrefixWatch`
+//! instead.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use cluster_sdk::observability::{logs, primitive};
+use cluster_sdk::{
+    CacheEvent, CacheWatch, CacheWatchEvent, CacheWatchSender, CacheWatchTrySendError,
+    ClusterError, ClusterMetrics, ProviderErrorKind,
+};
+use dashmap::DashMap;
+use rand::RngExt as _;
+use sqlx::postgres::PgListener;
+use tokio_util::sync::CancellationToken;
+
+use crate::limits::MAX_INDEXED_KEY_BYTES;
+use crate::pg_error::map_sqlx_error;
+
+/// The Postgres NOTIFY channel this plugin's cache uses (DESIGN.md §4.3).
+pub const CHANNEL: &str = "cluster_cache_changes";
+
+/// Postgres's actual, hardcoded NOTIFY payload limit (`MAX_NOTIFY_PAYLOAD_LENGTH`
+/// in `src/backend/commands/async.c`), confirmed empirically against a real
+/// server while writing `PG-SPEC-002`: `pg_notify('x', repeat('a', 7999))`
+/// succeeds, `repeat('a', 8000)` fails with `payload string too long`. This
+/// is a real Postgres constant, not `8192` (DESIGN.md §2.3's "8 KB" framing
+/// rounds to a nearby power of two but overstates the actual, slightly
+/// smaller hard limit by 193 bytes) — using `8192` here let
+/// [`validate_key_len`] accept keys the database itself would then reject
+/// mid-write, turning a clean startup/validation-time `InvalidName` into a
+/// runtime `Provider` error from `pg_notify` instead.
+const MAX_NOTIFY_PAYLOAD_BYTES: usize = 7999;
+/// `<event_type>:` is always exactly two bytes (a one-character code plus the
+/// separator), leaving the rest of the 8 KB budget for the key.
+const EVENT_PREFIX_BYTES: usize = 2;
+/// The longest key the NOTIFY payload budget alone would permit, so a payload —
+/// one byte event code, one byte `:`, then the key — never exceeds
+/// [`MAX_NOTIFY_PAYLOAD_BYTES`] (DESIGN.md §2.3).
+const MAX_NOTIFY_KEY_BYTES: usize = MAX_NOTIFY_PAYLOAD_BYTES - EVENT_PREFIX_BYTES;
+
+/// The longest key this plugin will accept (DESIGN.md §2.3, `PG-SPEC-002`).
+///
+/// Two independent Postgres limits apply to a cache key and the tighter one has
+/// to win. The NOTIFY payload budget ([`MAX_NOTIFY_KEY_BYTES`], 7997) is the one
+/// this constant used to be defined by outright, but `cluster_cache.key` is also
+/// a `PRIMARY KEY`, so every key lands in a btree bound by the much smaller
+/// index-tuple ceiling ([`MAX_INDEXED_KEY_BYTES`], see `limits.rs`). Bounding
+/// only by the NOTIFY budget left a window — roughly 2705..=7997 bytes — where a
+/// key passed this guard and then failed inside Postgres with SQLSTATE `54000`
+/// mid-write, which is precisely what the guard exists to prevent.
+pub const MAX_KEY_BYTES: usize = if MAX_NOTIFY_KEY_BYTES < MAX_INDEXED_KEY_BYTES {
+    MAX_NOTIFY_KEY_BYTES
+} else {
+    MAX_INDEXED_KEY_BYTES
+};
+
+/// Rejects a key too long for this plugin's storage or notification budget
+/// (DESIGN.md §2.3). Called at write time by every cache mutation, so an
+/// over-long key fails as a clean `InvalidName` before the row is written and
+/// before an un-sendable `NOTIFY` is attempted.
+pub fn validate_key_len(key: &str) -> Result<(), ClusterError> {
+    // `reason` is a `&'static str`, so the bound is a literal; this assertion
+    // keeps it in sync with the actual enforced `MAX_KEY_BYTES`.
+    const _: () = assert!(MAX_KEY_BYTES == 2048);
+    if key.len() > MAX_KEY_BYTES {
+        return Err(ClusterError::InvalidName {
+            name: key.to_owned(),
+            reason: "key exceeds the 2048-byte maximum length (the btree index-tuple limit on \
+                     the cluster_cache primary key; DESIGN.md sec 2.1)",
+        });
+    }
+    Ok(())
+}
+
+/// The `<event_type>` byte of the NOTIFY payload format (DESIGN.md §2.3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotifyEvent {
+    Changed,
+    Deleted,
+    Expired,
+}
+
+impl NotifyEvent {
+    fn code(self) -> char {
+        match self {
+            Self::Changed => 'C',
+            Self::Deleted => 'D',
+            Self::Expired => 'E',
+        }
+    }
+}
+
+/// Issues `NOTIFY cluster_cache_changes, '<event_type>:<key>'` (via the
+/// parameterized `pg_notify(channel, payload)` function, which avoids any
+/// literal-quoting concern for keys containing `'`) on `executor`. Callers run
+/// this inside the same transaction as the write it announces (DESIGN.md §4.1)
+/// so the notification is never observed without the write that caused it.
+pub async fn notify<'e, E>(executor: E, event: NotifyEvent, key: &str) -> Result<(), ClusterError>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    let payload = format!("{}:{key}", event.code());
+    sqlx::query("SELECT pg_notify($1, $2)")
+        .bind(CHANNEL)
+        .bind(payload)
+        .execute(executor)
+        .await
+        .map_err(map_sqlx_error)?;
+    Ok(())
+}
+
+/// A parsed NOTIFY payload (DESIGN.md §2.3): `<event_type>:<key>`, where
+/// `<event_type>` is one of `C` (Changed), `D` (Deleted), `E` (Expired). An
+/// empty or otherwise unrecognized payload — a bare `NOTIFY channel` with no
+/// payload, an unrelated writer on the same channel, or a future format this
+/// plugin's version doesn't know — maps to [`ParsedNotification::Reset`] rather
+/// than being treated as a bug to panic on. (NOTIFY queue overflow does *not*
+/// reach here as an empty payload: Postgres aborts the committing transaction
+/// with an error and broadcasts nothing — overflow recovery is instead the
+/// LISTEN task's reconnect-then-`Reset` path.)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParsedNotification {
+    Changed { key: String },
+    Deleted { key: String },
+    Expired { key: String },
+    Reset,
+}
+
+/// Parses a raw NOTIFY payload per the `<event_type>:<key>` format (DESIGN.md
+/// §2.3). Returns [`ParsedNotification::Reset`] for an empty or malformed
+/// payload.
+pub fn parse_notification(payload: &str) -> ParsedNotification {
+    let Some((event_type, key)) = payload.split_once(':') else {
+        return ParsedNotification::Reset;
+    };
+    match event_type {
+        "C" => ParsedNotification::Changed {
+            key: key.to_owned(),
+        },
+        "D" => ParsedNotification::Deleted {
+            key: key.to_owned(),
+        },
+        "E" => ParsedNotification::Expired {
+            key: key.to_owned(),
+        },
+        _ => ParsedNotification::Reset,
+    }
+}
+
+/// One registered watcher: the sender plus a count of events dropped because
+/// its buffer was full, drained as a synthesized [`CacheWatchEvent::Lagged`]
+/// the next time delivery succeeds (DESIGN.md §4.3 / the `CacheWatchSender`
+/// contract — "the backend should record the drop and emit a `Lagged` once
+/// the buffer drains").
+struct WatcherSlot {
+    sender: CacheWatchSender,
+    dropped: AtomicU64,
+}
+
+/// Delivers `event` to `slot` via `try_send` (a fan-out path must never block
+/// on one slow consumer), first flushing any pending `Lagged` count. Returns
+/// `false` when the slot should be pruned (the consumer dropped its
+/// [`CacheWatch`]).
+fn deliver(slot: &WatcherSlot, event: CacheWatchEvent) -> bool {
+    let dropped = slot.dropped.load(Ordering::Relaxed);
+    if dropped > 0 {
+        match slot.sender.try_send(CacheWatchEvent::Lagged { dropped }) {
+            Ok(()) => slot.dropped.store(0, Ordering::Relaxed),
+            Err(CacheWatchTrySendError::Full) => {
+                slot.dropped.fetch_add(1, Ordering::Relaxed);
+                return true;
+            }
+            Err(CacheWatchTrySendError::Closed) => return false,
+        }
+    }
+    match slot.sender.try_send(event) {
+        Ok(()) => true,
+        Err(CacheWatchTrySendError::Full) => {
+            slot.dropped.fetch_add(1, Ordering::Relaxed);
+            true
+        }
+        Err(CacheWatchTrySendError::Closed) => false,
+    }
+}
+
+/// Registry of active per-key watchers, keyed by the exact key being watched.
+/// The LISTEN fan-out task (spawned by [`spawn_listen_task`]) routes each
+/// parsed notification to every sender registered under the notified key.
+pub struct WatchRegistry {
+    watchers: DashMap<String, Vec<WatcherSlot>>,
+}
+
+impl WatchRegistry {
+    #[must_use]
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            watchers: DashMap::new(),
+        })
+    }
+
+    /// Registers a new exact-key watch, returning the [`CacheWatch`] handed
+    /// back to the caller of
+    /// [`ClusterCacheBackend::watch`](cluster_sdk::cache::ClusterCacheBackend::watch).
+    pub fn register(&self, key: &str) -> CacheWatch {
+        let (sender, watch) = CacheWatch::channel(64);
+        self.watchers
+            .entry(key.to_owned())
+            .or_default()
+            .push(WatcherSlot {
+                sender,
+                dropped: AtomicU64::new(0),
+            });
+        watch
+    }
+
+    /// Fans a parsed notification out to every watcher on the affected key, or
+    /// broadcasts + clears every subscription for [`ParsedNotification::Reset`]
+    /// (DESIGN.md §4.3).
+    ///
+    /// `async` only because the terminal [`Reset`](ParsedNotification::Reset)
+    /// branch guarantees delivery (see [`broadcast_and_clear`](Self::broadcast_and_clear));
+    /// the per-key `Changed`/`Deleted`/`Expired` fan-out is still a non-blocking
+    /// `try_send` and never awaits.
+    pub async fn dispatch(&self, notification: &ParsedNotification) {
+        match notification {
+            ParsedNotification::Changed { key } => {
+                self.deliver_to_key(
+                    key,
+                    &CacheWatchEvent::Event(CacheEvent::Changed { key: key.clone() }),
+                );
+            }
+            ParsedNotification::Deleted { key } => {
+                self.deliver_to_key(
+                    key,
+                    &CacheWatchEvent::Event(CacheEvent::Deleted { key: key.clone() }),
+                );
+            }
+            ParsedNotification::Expired { key } => {
+                self.deliver_to_key(
+                    key,
+                    &CacheWatchEvent::Event(CacheEvent::Expired { key: key.clone() }),
+                );
+            }
+            ParsedNotification::Reset => {
+                self.broadcast_and_clear(|| CacheWatchEvent::Reset).await;
+            }
+        }
+    }
+
+    fn deliver_to_key(&self, key: &str, event: &CacheWatchEvent) {
+        let Some(mut slots) = self.watchers.get_mut(key) else {
+            return;
+        };
+        slots.retain(|slot| deliver(slot, event.clone()));
+        if slots.is_empty() {
+            drop(slots);
+            self.watchers.remove(key);
+        }
+    }
+
+    /// Sends `make_event()` (a fresh clone per watcher, since
+    /// [`CacheWatchEvent`] carries owned data) to every active watcher across
+    /// every key, then clears every subscription — the watcher's own
+    /// [`CacheWatch`] handle stays open but will receive nothing further until
+    /// its owner calls `watch`/`watch_prefix` again (DESIGN.md §4.3:
+    /// "consumers must resubscribe").
+    ///
+    /// Unlike the per-key [`deliver`] fan-out (which drops on a full buffer and
+    /// coalesces a later `Lagged`), this delivers the terminal `Reset`/
+    /// `Closed(Shutdown)` event as the **typed** event to every watcher that is
+    /// draining — even one whose 64-slot buffer is momentarily full — rather than
+    /// letting a full buffer degrade the terminal signal to a bare channel close
+    /// (`None`) the consumer can't tell apart from a dropped sender (PGR-C4).
+    /// `send` returns immediately when the buffer has room (the common case and
+    /// every draining consumer), so the typed event lands at once.
+    ///
+    /// Each delivery is **bounded** by [`TERMINAL_GRACE`](Self) and they run
+    /// concurrently: a consumer that is alive but has stopped draining (full
+    /// buffer, watch not dropped) cannot stall shutdown/reset indefinitely — the
+    /// blocking `send` used to hang `stop()` forever in that case. After the
+    /// grace the sender is dropped and that consumer observes end-of-stream
+    /// (`None`); it was not reading, so a reserved slot would not have reached it
+    /// either. Senders are cloned out first so no `DashMap` shard lock is held
+    /// across an `.await`; the map is cleared before the awaits, and the cloned
+    /// senders keep each channel open until the terminal event lands or the grace
+    /// elapses. A watcher that already dropped its [`CacheWatch`] returns an error
+    /// from `send` immediately and is skipped.
+    async fn broadcast_and_clear(&self, make_event: impl Fn() -> CacheWatchEvent) {
+        /// Upper bound on how long a single terminal delivery waits for a full
+        /// consumer to free a buffer slot before giving up (PGR-C4).
+        const TERMINAL_GRACE: Duration = Duration::from_secs(5);
+
+        let senders: Vec<CacheWatchSender> = self
+            .watchers
+            .iter()
+            .flat_map(|entry| {
+                entry
+                    .value()
+                    .iter()
+                    .map(|slot| slot.sender.clone())
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        self.watchers.clear();
+
+        let mut deliveries = tokio::task::JoinSet::new();
+        for sender in senders {
+            let event = make_event();
+            deliveries.spawn(async move {
+                let _delivered = tokio::time::timeout(TERMINAL_GRACE, sender.send(event)).await;
+            });
+        }
+        while deliveries.join_next().await.is_some() {}
+    }
+
+    /// Closes every active watch terminally with [`ClusterError::Shutdown`]
+    /// (DESIGN.md §10 step 2, `PG-LIFE-004`) before the LISTEN task exits.
+    pub async fn close_all(&self) {
+        self.broadcast_and_clear(|| CacheWatchEvent::Closed(ClusterError::Shutdown))
+            .await;
+    }
+}
+
+/// Backoff policy for the LISTEN task's own reconnect loop, used only when
+/// [`PgListener`]'s internal (single-attempt) reconnect fails outright
+/// (`PG-FAULT-005`) — its transparent same-call reconnect (`PG-FAULT-001`/
+/// `PG-FAULT-004`) never reaches this loop at all. Not exposed as a config
+/// knob (DESIGN.md §7 has none for it); revisit if operators need to tune it.
+struct ListenRetryPolicy {
+    initial_backoff: Duration,
+    max_backoff: Duration,
+    max_retries: u32,
+}
+
+impl ListenRetryPolicy {
+    const DEFAULT: Self = Self {
+        initial_backoff: Duration::from_secs(1),
+        max_backoff: Duration::from_secs(30),
+        max_retries: 10,
+    };
+
+    fn backoff_for(&self, attempt: u32) -> Duration {
+        let factor = 2u32.saturating_pow(attempt);
+        let base = self
+            .initial_backoff
+            .checked_mul(factor)
+            .map_or(self.max_backoff, |grown| grown.min(self.max_backoff));
+        // Full jitter: every instance in the fleet runs this LISTEN task
+        // against the same database, so without jitter a shared blip has every
+        // instance retry on the same deterministic schedule and their
+        // reconnect attempts stampede together.
+        let u: f32 = rand::rng().random();
+        base.mul_f32(1.0 - u)
+    }
+}
+
+/// Establishes the dedicated LISTEN connection and spawns its fan-out loop
+/// (DESIGN.md §4.3).
+///
+/// The initial `connect` + `LISTEN` is done **synchronously, awaited by the
+/// caller**, before anything is spawned — not fired-and-forgotten inside the
+/// spawned task. `build_and_start` awaits this, so by the time it resolves
+/// the LISTEN registration is confirmed live with Postgres, per DESIGN.md
+/// §3.2 step 5's guarantee ("by the time `build_and_start` resolves... the
+/// LISTEN connection is live — there is no readiness gate or background-init
+/// race for callers to reason about"). Doing the initial connect *inside*
+/// the spawned task instead (as an earlier version of this function did)
+/// broke exactly that guarantee: `tokio::spawn` only schedules the task, so
+/// `build_and_start` could return — and a caller's very first `put` could
+/// commit and `NOTIFY` — before the spawned task's own `connect_and_listen`
+/// had actually finished subscribing, silently losing that NOTIFY forever
+/// (Postgres does not queue/replay notifications for a session that starts
+/// listening after they fired). `PG-WATCH-007` caught this directly: both
+/// watchers on the same key would time out *together* (never just one),
+/// exactly matching "the whole notification was never delivered to this
+/// session," not a per-watcher delivery bug.
+///
+/// # Errors
+/// Propagates a connection failure from the initial `connect`/`LISTEN` — the
+/// caller decides how to treat a LISTEN connection that can't even establish
+/// (this plugin's `build_and_start` implementations fail startup on it,
+/// rather than starting a cache with no working watch capability).
+///
+/// [`PgListener`] already reconnects transparently on a single connection
+/// blip and re-subscribes to `CHANNEL` — that path surfaces to us as
+/// `try_recv()` returning `Ok(None)`, at which point we broadcast `Reset`
+/// (events may have been missed during the gap) and resume. If the listener's
+/// own reconnect attempt fails outright (`try_recv()` returns `Err`), this
+/// task takes over with its own bounded backoff (`PG-FAULT-005`); exhausting
+/// it broadcasts `Closed(Provider { kind: ConnectionLost, .. })` and exits.
+///
+/// Every `Reset` dispatched by this task — both DESIGN.md §4.3 triggers, the
+/// empty/unrecognized-payload fallback and a LISTEN connection gap — also
+/// emits the DESIGN.md §8-contracted `ClusterMetrics::watch_reset("cache")`
+/// (backing `cluster_watch_resets_total`) and a `cluster.watch.reset` WARN
+/// log, labelled with `provider`.
+pub async fn spawn_listen_task(
+    connection_string: String,
+    registry: Arc<WatchRegistry>,
+    metrics: Arc<dyn ClusterMetrics>,
+    provider: &'static str,
+    cancel: CancellationToken,
+) -> Result<tokio::task::JoinHandle<()>, ClusterError> {
+    let mut listener = connect_and_listen(&connection_string).await?;
+
+    Ok(tokio::spawn(async move {
+        // Emits the DESIGN.md §8-contracted watch-reset signals
+        // (`cluster_watch_resets_total` / `cluster.watch.reset` WARN) for
+        // every `Reset` this task dispatches — the `RestartingWatch`
+        // combinator (`cluster-sdk`) does not cover this: it only reacts to a
+        // terminal `Closed`, never this task's own internal `Reset`.
+        let emit_watch_reset = || {
+            metrics.watch_reset(primitive::CACHE);
+            tracing::warn!(
+                name: logs::WATCH_RESET,
+                provider = %provider,
+                primitive = primitive::CACHE,
+                "cluster watch reset"
+            );
+        };
+
+        let mut attempt: u32 = 0;
+        loop {
+            tokio::select! {
+                () = cancel.cancelled() => return,
+                received = listener.try_recv() => match received {
+                    Ok(Some(notification)) => {
+                        attempt = 0;
+                        // An empty/unrecognized payload also parses to `Reset`
+                        // (DESIGN.md §4.3's "empty/unrecognized payload"
+                        // trigger, distinct from the connection-loss trigger
+                        // below) — §8 contracts the watch-reset signals for
+                        // both.
+                        let parsed = parse_notification(notification.payload());
+                        if matches!(parsed, ParsedNotification::Reset) {
+                            emit_watch_reset();
+                        }
+                        registry.dispatch(&parsed).await;
+                    }
+                    Ok(None) => {
+                        // `PgListener`'s own transparent reconnect just ran and
+                        // succeeded; events during the gap may have been missed.
+                        attempt = 0;
+                        emit_watch_reset();
+                        registry.dispatch(&ParsedNotification::Reset).await;
+                    }
+                    Err(_lost) => {
+                        match reconnect_with_backoff(&connection_string, &ListenRetryPolicy::DEFAULT, &mut attempt, &cancel).await {
+                            Some(reconnected) => {
+                                listener = reconnected;
+                                emit_watch_reset();
+                                registry.dispatch(&ParsedNotification::Reset).await;
+                            }
+                            // `None` means either the retry budget is exhausted
+                            // or `cancel` fired mid-backoff (graceful shutdown,
+                            // not a connection-loss failure) — only the former
+                            // is a real `Closed(ConnectionLost)`.
+                            None if cancel.is_cancelled() => return,
+                            None => {
+                                registry.broadcast_and_clear(|| {
+                                    CacheWatchEvent::Closed(ClusterError::Provider {
+                                        kind: ProviderErrorKind::ConnectionLost,
+                                        message: "LISTEN connection reconnect retry budget exhausted"
+                                            .to_owned(),
+                                    })
+                                }).await;
+                                return;
+                            }
+                        }
+                    }
+                },
+            }
+        }
+    }))
+}
+
+async fn connect_and_listen(connection_string: &str) -> Result<PgListener, ClusterError> {
+    let mut listener = PgListener::connect(connection_string)
+        .await
+        .map_err(map_sqlx_error)?;
+    listener.listen(CHANNEL).await.map_err(map_sqlx_error)?;
+    Ok(listener)
+}
+
+/// [`connect_and_listen`], but abandoned the instant `cancel` fires so a
+/// shutdown never stalls waiting on a hung `PgListener::connect` network I/O.
+/// Returns `None` if cancellation won the race — the caller must stop rather
+/// than treat it as a connect failure to retry. Mirrors
+/// `lock/notify.rs::connect_and_listen_cancellable`; kept as a separate copy
+/// for the same reason that module gives for not sharing `RetryPolicy`
+/// (`lock/notify.rs` lines ~179-184) — the two channels' payload formats
+/// differ enough that unifying the tasks would add more indirection than it
+/// would save.
+async fn connect_and_listen_cancellable(
+    connection_string: &str,
+    cancel: &CancellationToken,
+) -> Option<Result<PgListener, ClusterError>> {
+    tokio::select! {
+        () = cancel.cancelled() => None,
+        result = connect_and_listen(connection_string) => Some(result),
+    }
+}
+
+/// Retries [`connect_and_listen`] with exponential backoff, up to
+/// `policy.max_retries` attempts. Returns `None` once the budget is exhausted
+/// *or* `cancel` fires mid-backoff — either way the caller's shutdown path
+/// (`return` on `cancel.cancelled()`, checked again on the next loop
+/// iteration) takes it from there rather than a fabricated `Closed` event.
+async fn reconnect_with_backoff(
+    connection_string: &str,
+    policy: &ListenRetryPolicy,
+    attempt: &mut u32,
+    cancel: &CancellationToken,
+) -> Option<PgListener> {
+    while *attempt < policy.max_retries {
+        let backoff = policy.backoff_for(*attempt);
+        *attempt += 1;
+        tokio::select! {
+            () = cancel.cancelled() => return None,
+            () = tokio::time::sleep(backoff) => {}
+        }
+        match connect_and_listen_cancellable(connection_string, cancel).await {
+            // Cancelled mid-connect: stop, don't spin the backoff loop.
+            None => return None,
+            Some(Ok(listener)) => return Some(listener),
+            // Connect failed: fall through to the next backoff attempt.
+            Some(Err(_lost)) => {}
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+#[path = "watch_tests.rs"]
+mod tests;

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/src/cache/watch_tests.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/src/cache/watch_tests.rs
@@ -1,0 +1,211 @@
+use futures_util::FutureExt;
+
+use super::*;
+
+#[test]
+fn parse_notification_round_trips_changed_deleted_expired() {
+    assert_eq!(
+        parse_notification("C:orders/lock"),
+        ParsedNotification::Changed {
+            key: "orders/lock".to_owned()
+        }
+    );
+    assert_eq!(
+        parse_notification("D:orders/lock"),
+        ParsedNotification::Deleted {
+            key: "orders/lock".to_owned()
+        }
+    );
+    assert_eq!(
+        parse_notification("E:orders/lock"),
+        ParsedNotification::Expired {
+            key: "orders/lock".to_owned()
+        }
+    );
+}
+
+#[test]
+fn parse_notification_maps_empty_payload_to_reset() {
+    assert_eq!(parse_notification(""), ParsedNotification::Reset);
+}
+
+#[test]
+fn parse_notification_maps_malformed_payload_to_reset() {
+    // No `:` separator at all.
+    assert_eq!(parse_notification("garbage"), ParsedNotification::Reset);
+    // Unrecognized event-type code.
+    assert_eq!(parse_notification("X:key"), ParsedNotification::Reset);
+}
+
+#[test]
+fn parse_notification_handles_a_key_containing_colons() {
+    // `split_once` splits on the *first* `:` only, so a key that itself
+    // contains `:` round-trips intact.
+    assert_eq!(
+        parse_notification("C:tenant:orders:lock"),
+        ParsedNotification::Changed {
+            key: "tenant:orders:lock".to_owned()
+        }
+    );
+}
+
+#[test]
+fn validate_key_len_accepts_boundary_and_rejects_over_limit() {
+    let at_limit = "k".repeat(MAX_KEY_BYTES);
+    assert!(validate_key_len(&at_limit).is_ok());
+
+    let over_limit = "k".repeat(MAX_KEY_BYTES + 1);
+    assert!(matches!(
+        validate_key_len(&over_limit),
+        Err(ClusterError::InvalidName { .. })
+    ));
+}
+
+#[tokio::test]
+async fn dispatch_delivers_changed_only_to_the_matching_key() {
+    let registry = WatchRegistry::new();
+    let mut watch_a = registry.register("a");
+    let mut watch_b = registry.register("b");
+
+    registry
+        .dispatch(&ParsedNotification::Changed {
+            key: "a".to_owned(),
+        })
+        .await;
+
+    assert!(matches!(
+        watch_a.recv().await,
+        Some(CacheWatchEvent::Event(CacheEvent::Changed { key })) if key == "a"
+    ));
+    // `b`'s watch received nothing — draining it would hang, so just assert
+    // there is no event already buffered.
+    assert!(watch_b.recv().now_or_never().is_none());
+}
+
+#[tokio::test]
+async fn dispatch_reset_broadcasts_to_every_key_and_clears_subscriptions() {
+    let registry = WatchRegistry::new();
+    let mut watch_a = registry.register("a");
+    let mut watch_b = registry.register("b");
+
+    registry.dispatch(&ParsedNotification::Reset).await;
+
+    assert!(matches!(watch_a.recv().await, Some(CacheWatchEvent::Reset)));
+    assert!(matches!(watch_b.recv().await, Some(CacheWatchEvent::Reset)));
+
+    // Subscriptions were cleared: the registry dropped every sender, so
+    // this watch's stream has ended (`CacheWatch::recv`'s documented `None`
+    // contract — "once the backend has dropped the sender without sending
+    // a terminal `Closed`"). DESIGN.md §4.3's "consumers must resubscribe"
+    // means calling `watch()` again for a fresh watch, not continuing to
+    // poll this one.
+    assert!(watch_a.recv().await.is_none());
+
+    // A later Changed on `a` reaches no one — the registry has forgotten
+    // this key entirely.
+    registry
+        .dispatch(&ParsedNotification::Changed {
+            key: "a".to_owned(),
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn close_all_sends_terminal_shutdown_to_every_watcher() {
+    let registry = WatchRegistry::new();
+    let mut watch = registry.register("k");
+
+    registry.close_all().await;
+
+    assert!(matches!(
+        watch.recv().await,
+        Some(CacheWatchEvent::Closed(ClusterError::Shutdown))
+    ));
+}
+
+#[tokio::test]
+async fn dispatch_prunes_a_watcher_whose_consumer_dropped_it() {
+    let registry = WatchRegistry::new();
+    let watch = registry.register("k");
+    drop(watch);
+
+    // Must not panic despite the sole watcher on "k" being gone.
+    registry
+        .dispatch(&ParsedNotification::Changed {
+            key: "k".to_owned(),
+        })
+        .await;
+
+    assert!(
+        registry.watchers.get("k").is_none(),
+        "dispatch must prune the now-empty entry for a key whose sole watcher was dropped"
+    );
+}
+
+/// Fills a watcher's entire 64-slot buffer, then dispatches `Reset` — the typed
+/// terminal event must still be delivered rather than dropped once the buffer
+/// drains (PGR-C4/C3). The broadcast awaits buffer space, so it is driven
+/// concurrently with the drain.
+#[tokio::test]
+async fn reset_is_delivered_even_when_the_watcher_buffer_is_full() {
+    let registry = WatchRegistry::new();
+    let mut watch = registry.register("k");
+
+    // Saturate the 64-slot channel (see `CacheWatch::channel(64)`).
+    for _ in 0..64 {
+        registry
+            .dispatch(&ParsedNotification::Changed {
+                key: "k".to_owned(),
+            })
+            .await;
+    }
+
+    let reg = Arc::clone(&registry);
+    let broadcast = tokio::spawn(async move { reg.dispatch(&ParsedNotification::Reset).await });
+
+    // Drain the buffered `Changed` events; the typed `Reset` must follow.
+    let mut saw_reset = false;
+    while let Some(event) = watch.recv().await {
+        if matches!(event, CacheWatchEvent::Reset) {
+            saw_reset = true;
+            break;
+        }
+    }
+    assert!(
+        saw_reset,
+        "Reset must reach a full-buffer watcher as the typed terminal event"
+    );
+    broadcast.await.expect("broadcast task completes");
+}
+
+/// Same as above for `close_all`: a full-buffer watcher must still observe the
+/// typed `Closed(Shutdown)`, not merely a bare channel close (PGR-C4/C3).
+#[tokio::test]
+async fn shutdown_is_delivered_even_when_the_watcher_buffer_is_full() {
+    let registry = WatchRegistry::new();
+    let mut watch = registry.register("k");
+
+    for _ in 0..64 {
+        registry
+            .dispatch(&ParsedNotification::Changed {
+                key: "k".to_owned(),
+            })
+            .await;
+    }
+
+    let reg = Arc::clone(&registry);
+    let closing = tokio::spawn(async move { reg.close_all().await });
+
+    let mut saw_shutdown = false;
+    while let Some(event) = watch.recv().await {
+        if matches!(event, CacheWatchEvent::Closed(ClusterError::Shutdown)) {
+            saw_shutdown = true;
+            break;
+        }
+    }
+    assert!(
+        saw_shutdown,
+        "Closed(Shutdown) must reach a full-buffer watcher as the typed terminal event"
+    );
+    closing.await.expect("close_all task completes");
+}

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/src/config.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/src/config.rs
@@ -1,0 +1,339 @@
+//! Configuration for the Postgres cluster plugin (DESIGN.md §7).
+//!
+//! Two config types exist because the combined cache+lock plugin and the
+//! standalone lock-only provider (DESIGN.md §3.5) need different field sets:
+//! [`PostgresClusterConfig`] carries the cache-only fields
+//! (`cache_reaper_interval_ms`, `sd_poll_interval_ms`) that
+//! [`PostgresLockConfig`] omits. Defaults for the fields both types share are
+//! centralized in this module's `default_*` functions so the two types cannot
+//! drift (DESIGN.md §7 calls this out explicitly).
+
+use std::fmt;
+use std::time::Duration;
+
+use cluster_sdk::ClusterError;
+use serde::Deserialize;
+
+/// The masked stand-in rendered for `connection_string` in `Debug` output, so a
+/// `{:?}` of a config (in a log line or a panic message) never leaks the DB
+/// password the expanded DSN embeds (PGR-M9). The two config types hand-write
+/// `Debug` rather than `#[derive]`ing it for this reason.
+const REDACTED_DSN: &str = "<redacted>";
+
+/// Default pool size (write pool). DESIGN.md §7.
+pub fn default_pool_size() -> u32 {
+    5
+}
+
+/// Default pool acquire timeout, in milliseconds. DESIGN.md §7.
+pub fn default_acquire_timeout() -> u64 {
+    5_000
+}
+
+/// Default schema for plugin tables. DESIGN.md §7.
+pub fn default_schema() -> String {
+    "public".to_owned()
+}
+
+/// Default TTL reaper interval for `cluster_cache`, in milliseconds. DESIGN.md §7.
+pub fn default_reaper_interval() -> u64 {
+    10_000
+}
+
+/// Default TTL reaper interval for `cluster_lock`, in milliseconds. DESIGN.md §7.
+pub fn default_lock_reaper_interval() -> u64 {
+    5_000
+}
+
+/// Default polling interval for the service-discovery `PollingPrefixWatch`, in
+/// milliseconds. DESIGN.md §7.
+pub fn default_sd_poll_interval() -> u64 {
+    5_000
+}
+
+/// Default lock-name-cardinality WARN threshold. DESIGN.md §7 / §8 / §11.
+pub fn default_lock_name_cardinality_warn_threshold() -> u32 {
+    1_000
+}
+
+/// Operator hint for replication topology (DESIGN.md §3.6).
+///
+/// If omitted from config, the plugin detects the effective mode at startup
+/// via `SHOW synchronous_standby_names` (empty result → `Async`). `Async` logs
+/// `cluster.provider.replication_async` (WARN, once) per ADR-009's safety
+/// table but never fails startup — see DESIGN.md §3.6 for the full rationale.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReplicationMode {
+    /// No synchronous standby configured — the common default. Leader-election
+    /// and lock claims are not failover-safe under this topology.
+    Async,
+    /// A synchronous standby is configured. Does not upgrade this plugin's
+    /// declared `consistency()`/`*Features` — it only suppresses the WARN
+    /// (DESIGN.md §3.6).
+    Sync,
+}
+
+/// Configuration for the combined `PostgresClusterPlugin` (cache + lock,
+/// DESIGN.md §3.2).
+#[derive(Clone, Deserialize, toolkit_macros::ExpandVars)]
+#[serde(deny_unknown_fields)]
+pub struct PostgresClusterConfig {
+    /// sqlx connection string. Supports `${VAR}` / `${VAR:-default}` env-var
+    /// expansion (e.g. `postgres://user:${DB_PASSWORD}@db:5432/gears`) via
+    /// `toolkit_utils::var_expand`, the same mechanism `libs/toolkit-db` uses
+    /// for DB passwords/DSNs. A credstore-backed (`secret_ref`) resolution
+    /// path is deferred to a future iteration (DESIGN.md §12).
+    #[expand_vars]
+    pub connection_string: String,
+
+    /// Maximum pool size (write pool). Default: 5.
+    #[serde(default = "default_pool_size")]
+    pub pool_max_size: u32,
+
+    /// Pool acquire timeout, in milliseconds. Default: 5000.
+    #[serde(default = "default_acquire_timeout")]
+    pub pool_acquire_timeout_ms: u64,
+
+    /// Schema for plugin tables. Default: `"public"`.
+    #[serde(default = "default_schema")]
+    pub schema: String,
+
+    /// TTL reaper interval for `cluster_cache`, in milliseconds. Default: 10000.
+    #[serde(default = "default_reaper_interval")]
+    pub cache_reaper_interval_ms: u64,
+
+    /// TTL reaper interval for `cluster_lock`, in milliseconds. Default: 5000.
+    ///
+    /// The **upper** bound on how long the lock reaper sleeps, and the cadence of
+    /// its `cluster_postgres_lock_active_names` gauge — an imminent `expires_at`
+    /// shortens an individual sleep so an expired lock is reclaimed near its
+    /// actual deadline (`lock::reaper`'s "Wake schedule", DESIGN.md §5.2). Also
+    /// the cadence at which each lock's guard task re-asserts
+    /// `synchronous_commit = on` on its pinned connection (DESIGN.md §3.4).
+    #[serde(default = "default_lock_reaper_interval")]
+    pub lock_reaper_interval_ms: u64,
+
+    /// Polling interval for the service-discovery `PollingPrefixWatch`, in
+    /// milliseconds. Default: 5000.
+    ///
+    /// The field name is the wiring layer's documented options-key convention
+    /// for this behavior (`cluster_sdk::provider::SD_POLL_INTERVAL_MS_OPTION`)
+    /// — `ClusterWiring::from_config`'s omit-default auto-wrap reads this key
+    /// generically off the cache provider's options to honour a non-default
+    /// cadence (PGR-D3).
+    #[serde(default = "default_sd_poll_interval")]
+    pub sd_poll_interval_ms: u64,
+
+    /// Set to `true` to get an `InvalidConfig` error at startup rather than
+    /// silent mis-behaviour if the connection string points to a `PgBouncer` in
+    /// transaction mode. Default: `false`.
+    #[serde(default)]
+    pub pgbouncer_transaction_mode: bool,
+
+    /// Distinct concurrently-held lock-name count past which the lock reaper
+    /// logs `cluster.lock.name_cardinality_high` (WARN) and the
+    /// `cluster_postgres_lock_active_names` gauge should be alerted on.
+    /// Default: 1000 (DESIGN.md §5.1/§8/§11).
+    #[serde(default = "default_lock_name_cardinality_warn_threshold")]
+    pub lock_name_cardinality_warn_threshold: u32,
+
+    /// Operator hint for replication topology. If omitted, detected at
+    /// startup (DESIGN.md §3.6).
+    #[serde(default)]
+    pub replication_mode: Option<ReplicationMode>,
+}
+
+impl fmt::Debug for PostgresClusterConfig {
+    /// Hand-written so `connection_string` (which embeds the DB password after
+    /// `expand_vars`) is masked — see [`REDACTED_DSN`] (PGR-M9).
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PostgresClusterConfig")
+            .field("connection_string", &REDACTED_DSN)
+            .field("pool_max_size", &self.pool_max_size)
+            .field("pool_acquire_timeout_ms", &self.pool_acquire_timeout_ms)
+            .field("schema", &self.schema)
+            .field("cache_reaper_interval_ms", &self.cache_reaper_interval_ms)
+            .field("lock_reaper_interval_ms", &self.lock_reaper_interval_ms)
+            .field("sd_poll_interval_ms", &self.sd_poll_interval_ms)
+            .field(
+                "pgbouncer_transaction_mode",
+                &self.pgbouncer_transaction_mode,
+            )
+            .field(
+                "lock_name_cardinality_warn_threshold",
+                &self.lock_name_cardinality_warn_threshold,
+            )
+            .field("replication_mode", &self.replication_mode)
+            .finish()
+    }
+}
+
+/// Rejects a reaper/poll interval of `0`, which would panic
+/// [`tokio::time::interval`] ("delay is zero") the moment the reaper task
+/// starts (PGR-E2). `field` names the offending config key in the error.
+fn reject_zero_interval(value: u64, field: &str) -> Result<(), ClusterError> {
+    if value == 0 {
+        return Err(ClusterError::InvalidConfig {
+            reason: format!("{field} must be greater than zero"),
+        });
+    }
+    Ok(())
+}
+
+/// Rejects a `pool_max_size` of `0`. A zero-sized pool never has a connection
+/// to hand out, so every `acquire()` would silently block until
+/// `pool_acquire_timeout_ms` elapses instead of failing fast at startup.
+fn reject_zero_pool_size(value: u32) -> Result<(), ClusterError> {
+    if value == 0 {
+        return Err(ClusterError::InvalidConfig {
+            reason: "pool_max_size must be greater than zero".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+impl PostgresClusterConfig {
+    /// Validates config values that can only fail at startup — the schema
+    /// identifier (PGR-L4) and the non-zero reaper/poll intervals (PGR-E2) —
+    /// before any pool or reaper is constructed. Called at the top of
+    /// `build_and_start`.
+    ///
+    /// # Errors
+    /// [`ClusterError::InvalidConfig`] for an unsafe `schema`, a zero
+    /// `pool_max_size`, or a zero `cache_reaper_interval_ms` /
+    /// `lock_reaper_interval_ms` / `sd_poll_interval_ms`.
+    pub fn validate(&self) -> Result<(), ClusterError> {
+        crate::pg_setup::validate_schema(&self.schema)?;
+        reject_zero_pool_size(self.pool_max_size)?;
+        reject_zero_interval(self.cache_reaper_interval_ms, "cache_reaper_interval_ms")?;
+        reject_zero_interval(self.lock_reaper_interval_ms, "lock_reaper_interval_ms")?;
+        reject_zero_interval(self.sd_poll_interval_ms, "sd_poll_interval_ms")?;
+        Ok(())
+    }
+
+    /// The pool acquire timeout as a [`Duration`].
+    #[must_use]
+    pub fn pool_acquire_timeout(&self) -> Duration {
+        Duration::from_millis(self.pool_acquire_timeout_ms)
+    }
+
+    /// The cache TTL reaper interval as a [`Duration`].
+    #[must_use]
+    pub fn cache_reaper_interval(&self) -> Duration {
+        Duration::from_millis(self.cache_reaper_interval_ms)
+    }
+
+    /// The lock TTL reaper interval as a [`Duration`].
+    #[must_use]
+    pub fn lock_reaper_interval(&self) -> Duration {
+        Duration::from_millis(self.lock_reaper_interval_ms)
+    }
+
+    /// The service-discovery polling interval as a [`Duration`].
+    #[must_use]
+    pub fn sd_poll_interval(&self) -> Duration {
+        Duration::from_millis(self.sd_poll_interval_ms)
+    }
+}
+
+/// Configuration for the standalone `PostgresLockPlugin` (DESIGN.md §3.5).
+///
+/// A separate, smaller config type — it only carries the fields the lock
+/// primitive actually uses, not the cache-only ones
+/// (`cache_reaper_interval_ms`, `sd_poll_interval_ms`).
+#[derive(Clone, Deserialize, toolkit_macros::ExpandVars)]
+#[serde(deny_unknown_fields)]
+pub struct PostgresLockConfig {
+    /// See [`PostgresClusterConfig::connection_string`].
+    #[expand_vars]
+    pub connection_string: String,
+
+    /// See [`PostgresClusterConfig::pool_max_size`].
+    #[serde(default = "default_pool_size")]
+    pub pool_max_size: u32,
+
+    /// See [`PostgresClusterConfig::pool_acquire_timeout_ms`].
+    #[serde(default = "default_acquire_timeout")]
+    pub pool_acquire_timeout_ms: u64,
+
+    /// See [`PostgresClusterConfig::schema`].
+    #[serde(default = "default_schema")]
+    pub schema: String,
+
+    /// See [`PostgresClusterConfig::lock_reaper_interval_ms`].
+    #[serde(default = "default_lock_reaper_interval")]
+    pub lock_reaper_interval_ms: u64,
+
+    /// See [`PostgresClusterConfig::pgbouncer_transaction_mode`].
+    #[serde(default)]
+    pub pgbouncer_transaction_mode: bool,
+
+    /// See [`PostgresClusterConfig::lock_name_cardinality_warn_threshold`].
+    #[serde(default = "default_lock_name_cardinality_warn_threshold")]
+    pub lock_name_cardinality_warn_threshold: u32,
+
+    /// See [`PostgresClusterConfig::replication_mode`].
+    #[serde(default)]
+    pub replication_mode: Option<ReplicationMode>,
+}
+
+impl fmt::Debug for PostgresLockConfig {
+    /// Hand-written so `connection_string` is masked — see [`REDACTED_DSN`]
+    /// (PGR-M9).
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PostgresLockConfig")
+            .field("connection_string", &REDACTED_DSN)
+            .field("pool_max_size", &self.pool_max_size)
+            .field("pool_acquire_timeout_ms", &self.pool_acquire_timeout_ms)
+            .field("schema", &self.schema)
+            .field("lock_reaper_interval_ms", &self.lock_reaper_interval_ms)
+            .field(
+                "pgbouncer_transaction_mode",
+                &self.pgbouncer_transaction_mode,
+            )
+            .field(
+                "lock_name_cardinality_warn_threshold",
+                &self.lock_name_cardinality_warn_threshold,
+            )
+            .field("replication_mode", &self.replication_mode)
+            .finish()
+    }
+}
+
+impl PostgresLockConfig {
+    /// Validates the schema identifier (PGR-L4) and the non-zero lock reaper
+    /// interval (PGR-E2) before any pool or reaper is constructed. Called at the
+    /// top of `build_and_start`.
+    ///
+    /// # Errors
+    /// [`ClusterError::InvalidConfig`] for an unsafe `schema`, a zero
+    /// `pool_max_size`, or a zero `lock_reaper_interval_ms`.
+    pub fn validate(&self) -> Result<(), ClusterError> {
+        crate::pg_setup::validate_schema(&self.schema)?;
+        reject_zero_pool_size(self.pool_max_size)?;
+        reject_zero_interval(self.lock_reaper_interval_ms, "lock_reaper_interval_ms")?;
+        Ok(())
+    }
+
+    /// The pool acquire timeout as a [`Duration`].
+    #[must_use]
+    pub fn pool_acquire_timeout(&self) -> Duration {
+        Duration::from_millis(self.pool_acquire_timeout_ms)
+    }
+
+    /// The lock TTL reaper interval as a [`Duration`].
+    #[must_use]
+    pub fn lock_reaper_interval(&self) -> Duration {
+        Duration::from_millis(self.lock_reaper_interval_ms)
+    }
+}
+
+// Layer-1 unit tests (TESTING.md §2, config.rs row). Pure serde/expansion — no
+// container. `pgbouncer_transaction_mode: true` rejection is builder-level (a
+// `build_and_start` concern that needs a pool), covered by the Layer-3 suite,
+// not here. Out-of-line (DE1101: an inline test block over 100 lines must live
+// in a separate `*_tests.rs` file), mirroring `lock_tests.rs` / `watch_tests.rs`.
+#[cfg(test)]
+#[path = "config_tests.rs"]
+mod tests;

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/src/config_tests.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/src/config_tests.rs
@@ -1,0 +1,167 @@
+use super::*;
+use serde_json::json;
+use toolkit::var_expand::ExpandVars;
+
+#[test]
+fn cluster_config_applies_documented_defaults() {
+    let config: PostgresClusterConfig =
+        serde_json::from_value(json!({ "connection_string": "postgres://u@h/db" }))
+            .expect("minimal config deserializes");
+    assert_eq!(config.pool_max_size, 5);
+    assert_eq!(config.pool_acquire_timeout_ms, 5_000);
+    assert_eq!(config.schema, "public");
+    assert_eq!(config.cache_reaper_interval_ms, 10_000);
+    assert_eq!(config.lock_reaper_interval_ms, 5_000);
+    assert_eq!(config.sd_poll_interval_ms, 5_000);
+    assert!(!config.pgbouncer_transaction_mode);
+    assert_eq!(config.lock_name_cardinality_warn_threshold, 1_000);
+    assert_eq!(config.replication_mode, None);
+}
+
+#[test]
+fn lock_config_applies_documented_defaults() {
+    let config: PostgresLockConfig =
+        serde_json::from_value(json!({ "connection_string": "postgres://u@h/db" }))
+            .expect("minimal lock config deserializes");
+    assert_eq!(config.pool_max_size, 5);
+    assert_eq!(config.pool_acquire_timeout_ms, 5_000);
+    assert_eq!(config.schema, "public");
+    assert_eq!(config.lock_reaper_interval_ms, 5_000);
+    assert!(!config.pgbouncer_transaction_mode);
+    assert_eq!(config.lock_name_cardinality_warn_threshold, 1_000);
+    assert_eq!(config.replication_mode, None);
+}
+
+#[test]
+fn cluster_config_round_trips_every_field() {
+    let config: PostgresClusterConfig = serde_json::from_value(json!({
+        "connection_string": "postgres://u@h/db",
+        "pool_max_size": 12,
+        "pool_acquire_timeout_ms": 1_234,
+        "schema": "cluster",
+        "cache_reaper_interval_ms": 2_222,
+        "lock_reaper_interval_ms": 3_333,
+        "sd_poll_interval_ms": 4_444,
+        "pgbouncer_transaction_mode": true,
+        "lock_name_cardinality_warn_threshold": 42,
+        "replication_mode": "sync",
+    }))
+    .expect("full config deserializes");
+    assert_eq!(config.pool_max_size, 12);
+    assert_eq!(config.pool_acquire_timeout_ms, 1_234);
+    assert_eq!(config.schema, "cluster");
+    assert_eq!(config.cache_reaper_interval_ms, 2_222);
+    assert_eq!(config.lock_reaper_interval_ms, 3_333);
+    assert_eq!(config.sd_poll_interval_ms, 4_444);
+    assert!(config.pgbouncer_transaction_mode);
+    assert_eq!(config.lock_name_cardinality_warn_threshold, 42);
+    assert_eq!(config.replication_mode, Some(ReplicationMode::Sync));
+}
+
+#[test]
+fn replication_mode_variants_round_trip() {
+    for (raw, expected) in [
+        ("async", ReplicationMode::Async),
+        ("sync", ReplicationMode::Sync),
+    ] {
+        let config: PostgresClusterConfig = serde_json::from_value(json!({
+            "connection_string": "postgres://u@h/db",
+            "replication_mode": raw,
+        }))
+        .expect("config with replication_mode deserializes");
+        assert_eq!(config.replication_mode, Some(expected));
+    }
+}
+
+#[test]
+fn unknown_replication_mode_variant_is_rejected() {
+    let result: Result<PostgresClusterConfig, _> = serde_json::from_value(json!({
+        "connection_string": "postgres://u@h/db",
+        "replication_mode": "semi_sync",
+    }));
+    assert!(
+        result.is_err(),
+        "an unknown replication_mode variant must be rejected"
+    );
+}
+
+#[test]
+fn unknown_field_is_rejected() {
+    // `deny_unknown_fields` on both config types.
+    let cluster: Result<PostgresClusterConfig, _> = serde_json::from_value(json!({
+        "connection_string": "postgres://u@h/db",
+        "not_a_real_field": true,
+    }));
+    assert!(
+        cluster.is_err(),
+        "cluster config must reject unknown fields"
+    );
+
+    // A cache-only field on the lock config is likewise unknown to it.
+    let lock: Result<PostgresLockConfig, _> = serde_json::from_value(json!({
+        "connection_string": "postgres://u@h/db",
+        "sd_poll_interval_ms": 1_000,
+    }));
+    assert!(lock.is_err(), "lock config must reject cache-only fields");
+}
+
+#[test]
+fn connection_string_expands_default_when_var_unset() {
+    let mut config: PostgresClusterConfig = serde_json::from_value(json!({
+        "connection_string": "postgres://u:${PG_CLUSTER_PW_M5_UNSET:-fallbackpw}@h/db",
+    }))
+    .expect("config deserializes");
+    config
+        .expand_vars()
+        .expect("expansion with a default succeeds");
+    assert_eq!(config.connection_string, "postgres://u:fallbackpw@h/db");
+}
+
+#[test]
+fn missing_env_var_without_default_surfaces_as_error() {
+    let mut config: PostgresClusterConfig = serde_json::from_value(json!({
+        "connection_string": "postgres://u:${PG_CLUSTER_PW_M5_UNSET_NODEFAULT}@h/db",
+    }))
+    .expect("config deserializes");
+    assert!(
+        config.expand_vars().is_err(),
+        "a referenced env var with no default and no value must surface as an error"
+    );
+}
+
+#[test]
+fn debug_masks_the_connection_string() {
+    // PGR-M9: the DSN (which embeds the DB password after expansion) must
+    // never appear in `{:?}` output.
+    let cluster: PostgresClusterConfig = serde_json::from_value(json!({
+        "connection_string": "postgres://user:supersecret@h/db",
+    }))
+    .expect("config deserializes");
+    let rendered = format!("{cluster:?}");
+    assert!(
+        !rendered.contains("supersecret"),
+        "Debug must not leak the password"
+    );
+    assert!(
+        !rendered.contains("postgres://"),
+        "Debug must not leak the DSN"
+    );
+    assert!(
+        rendered.contains(REDACTED_DSN),
+        "Debug must show the redaction marker"
+    );
+
+    let lock: PostgresLockConfig = serde_json::from_value(json!({
+        "connection_string": "postgres://user:supersecret@h/db",
+    }))
+    .expect("lock config deserializes");
+    let rendered = format!("{lock:?}");
+    assert!(
+        !rendered.contains("supersecret"),
+        "lock Debug must not leak the password"
+    );
+    assert!(
+        rendered.contains(REDACTED_DSN),
+        "lock Debug must show the redaction marker"
+    );
+}

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/src/lib.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/src/lib.rs
@@ -1,0 +1,87 @@
+//! # Postgres cluster plugin
+//!
+//! `postgres_cluster_plugin` is the Postgres backend plugin for the cluster
+//! gear (DESIGN.md §1). It provides a native `ClusterCacheBackend` over a
+//! `sqlx::PgPool` and a native `DistributedLockBackend` over `PostgreSQL`
+//! session-level advisory locks. Leader election and service discovery are
+//! derived from the SDK default backends over the Postgres cache — no
+//! additional tables or connections are required for those two primitives
+//! (DESIGN.md §6).
+//!
+//! This is the recommended deployment for **multi-instance, no-K8s**
+//! environments (DESIGN.md §1): Postgres is already deployed in every Gears
+//! environment, zero new infrastructure is required, and the native
+//! `pg_advisory_lock` gives ACID-correct mutual exclusion without a
+//! distributed lock service.
+//!
+//! ## Lifecycle (outbox-style builder/handle, ADR-006)
+//!
+//! Like `standalone_cluster_plugin`, this plugin is **not** registered as a
+//! `RunnableCapability`. It exposes a builder/handle pair owned by the cluster
+//! wiring crate:
+//!
+//! ```no_run
+//! # async fn doc(config: postgres_cluster_plugin::PostgresClusterConfig) -> Result<(), cluster_sdk::ClusterError> {
+//! use postgres_cluster_plugin::PostgresClusterPlugin;
+//!
+//! let handle = PostgresClusterPlugin::builder(config).build_and_start().await?;
+//! let _cache = handle.cache();
+//! let _lock = handle.lock();
+//! // On graceful shutdown:
+//! handle.stop().await;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! The lock primitive is also independently reachable via the standalone
+//! [`PostgresLockPlugin`] (DESIGN.md §3.5), so an operator can route `lock` to
+//! Postgres without binding `cache` to it in the same profile.
+//!
+//! ## Why `sqlx` directly, not `libs/toolkit-db`
+//!
+//! See DESIGN.md §3.1 — this plugin needs session-pinned advisory locks,
+//! `LISTEN`/`NOTIFY` streaming, and `PgPoolOptions` connect/acquire hooks that
+//! have no Sea-ORM equivalent. This is a documented, deliberate architectural
+//! exception, not a convenience shortcut — hence the crate-level
+//! `#![allow(de0706_no_direct_sqlx)]` below. It used to be a lint-sanctioned
+//! exclusion baked into this repo's own `tools/dylint_lints` (via
+//! `lint_utils::is_in_postgres_cluster_plugin_path`); that local lint crate was
+//! removed in favor of the published `cargo-gears-lints`, whose `DE0706`
+//! implementation carries no equivalent per-repo path allowlist, so the
+//! exception now lives here instead.
+//!
+//! ## Status
+//!
+//! `PostgresCache`, `PostgresLock`, and both builders' `build_and_start` are
+//! implemented per DESIGN.md §3.1's crate structure — this is not scaffolding.
+//! The `synchronous_commit = on` re-assertion on pinned lock connections (on
+//! each guard task's own interval, §3.4) and the plugin-local
+//! `cluster_postgres_lock_active_names` gauge /
+//! `cluster_postgres_reaper_sweep_duration_seconds` histogram (DESIGN.md §8) are
+//! now implemented (see `docs/GAP-SOLUTIONS.md` §5/§6). Layer 4 fault-injection
+//! tests (`docs/TESTING.md` §5) against a real Postgres container are not yet
+//! written.
+
+#![forbid(unsafe_code)]
+#![deny(rust_2018_idioms)]
+// See "Why `sqlx` directly, not `libs/toolkit-db`" above. `unknown_lints` is
+// needed alongside: `de0706_no_direct_sqlx` only exists as a registered lint
+// under the `cargo gears lint --dylint` driver, not plain `cargo
+// build`/`clippy`, so without it this `allow` itself would warn.
+#![allow(unknown_lints)]
+#![allow(de0706_no_direct_sqlx)]
+
+mod cache;
+mod config;
+mod limits;
+mod lock;
+mod pg_error;
+mod pg_setup;
+mod plugin;
+mod provider;
+
+pub use cache::PostgresCache;
+pub use config::{PostgresClusterConfig, PostgresLockConfig, ReplicationMode};
+pub use lock::{PostgresLock, PostgresLockBuilder, PostgresLockHandle, PostgresLockPlugin};
+pub use plugin::{PostgresClusterBuilder, PostgresClusterHandle, PostgresClusterPlugin};
+pub use provider::{PROVIDER_NAME, PostgresCacheProvider, PostgresLockProvider};

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/src/limits.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/src/limits.rs
@@ -1,0 +1,43 @@
+//! The length ceiling shared by every value this plugin stores in an indexed
+//! `TEXT` primary key (DESIGN.md §2.1).
+//!
+//! Both owned tables key on an unbounded `TEXT` column — `cluster_cache.key`
+//! and `cluster_lock.name` — and both are `PRIMARY KEY`, so the value lands in
+//! a btree. That is the binding constraint, and it is *not* the same as the
+//! NOTIFY payload budget the two backends previously bounded themselves by:
+//! `MAX_KEY_BYTES` (7997) and `MAX_LOCK_NAME_BYTES` (7999) were both derived
+//! from `MAX_NOTIFY_PAYLOAD_LENGTH` and both sit well *above* the btree limit,
+//! leaving a window in which a key passed the plugin's own guard and then
+//! failed mid-write inside Postgres.
+//!
+//! Storage width is not the issue: Postgres stores `TEXT` and `VARCHAR(n)`
+//! identically on disk, and `VARCHAR(n)` is just `TEXT` plus a length check.
+//! TOAST does not help either — an indexed key is not `TOAST`ed out of the
+//! index tuple, so the tuple has to fit as-is.
+
+/// `PostgreSQL`'s hard ceiling on a single btree index tuple: roughly one third
+/// of an 8 KB page, reported by the server as `index row size N exceeds btree
+/// version 4 maximum 2704 for index "..."` (SQLSTATE `54000`,
+/// `program_limit_exceeded`). An insert past this fails outright — there is no
+/// degraded mode to fall back to.
+pub const BTREE_MAX_INDEX_TUPLE_BYTES: usize = 2704;
+
+/// The longest value, in UTF-8 bytes, this plugin will accept for an indexed
+/// key or lock name.
+///
+/// Deliberately below [`BTREE_MAX_INDEX_TUPLE_BYTES`] rather than equal to it:
+/// the quoted 2704 is the budget for the whole index tuple, not just the key
+/// bytes, so per-tuple header overhead has to fit alongside. The headroom also
+/// leaves room for the reaper's and `scan_prefix`'s composite lookups without
+/// re-deriving the arithmetic per call site.
+///
+/// This is generous against what the SDK can legitimately produce: a consumer
+/// key and each scope prefix are independently capped at 255 bytes
+/// (`cluster_sdk::scope::MAX_SCOPE_PREFIX_LEN`), so 2048 accommodates a leaf key
+/// under roughly seven levels of maximum-length scope nesting. Note that the SDK
+/// caps each prefix but *not* their composition, so nesting depth is unbounded.
+pub const MAX_INDEXED_KEY_BYTES: usize = 2048;
+
+// The point of the constant is the margin; assert it rather than trusting the
+// two literals to stay in the right order through a later edit.
+const _: () = assert!(MAX_INDEXED_KEY_BYTES < BTREE_MAX_INDEX_TUPLE_BYTES);

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/src/lock/lock_tests.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/src/lock/lock_tests.rs
@@ -1,0 +1,166 @@
+use std::time::Duration;
+
+use super::*;
+use crate::lock::notify::ReleaseWaiters;
+
+#[test]
+fn lock_key_is_stable_across_calls() {
+    assert_eq!(lock_key("orders/lock"), lock_key("orders/lock"));
+}
+
+#[test]
+fn lock_key_differs_for_different_names() {
+    assert_ne!(lock_key("orders/lock"), lock_key("inventory/lock"));
+}
+
+#[test]
+fn lock_key_handles_names_with_special_characters() {
+    // Must not panic on non-ASCII/punctuation-heavy names, and must still be
+    // stable for the same input.
+    let name = "tenant:\u{e1}\u{e7}\u{e7}/lock #1!";
+    assert_eq!(lock_key(name), lock_key(name));
+}
+
+#[test]
+fn lock_key_exercises_the_full_64_bit_hash() {
+    // `key1`/`key2` are independent halves of the same 64-bit hash, not a
+    // 32-bit hash duplicated into both halves — a regression collapsing back
+    // to `hashtext()`'s 32 bits (DESIGN.md §5.1) would very likely make one
+    // of a few sample names collide on `key1` while still differing on
+    // `key2`, or vice versa. This isn't a proof, but it would probably catch
+    // an accidental 32-bit-only regression.
+    let (key1_a, key2_a) = lock_key("a");
+    let (key1_b, key2_b) = lock_key("b");
+    assert!(key1_a != key1_b || key2_a != key2_b);
+}
+
+#[test]
+fn lock_key_split_preserves_the_full_64_bit_hash() {
+    // PGR-L4: the collision surface of `lock_key` is *exactly* xxh3_64's — the
+    // (high i32, low i32) split introduces no additional collisions, and any two
+    // names with the same 64-bit hash necessarily map to the same `(key1, key2)`
+    // advisory-lock argument pair (so they *would* contend on the same
+    // `pg_advisory_lock` slot). Reconstruct the u64 from the two halves and
+    // confirm it round-trips to the raw hash for a spread of names, including
+    // near-identical ones (a naive split bug — e.g. duplicating one half —
+    // would surface here). Because the split is thus a faithful bijection of the
+    // hash, no natural collision pair needs to be brute-forced out of xxh3's
+    // 64-bit space to exercise the collision path (DESIGN.md §5.1).
+    for name in [
+        "",
+        "a",
+        "collision-probe-a",
+        "collision-probe-b",
+        "svc/leader",
+        "svc/leadeR",
+    ] {
+        let (key1, key2) = lock_key(name);
+        let reconstructed =
+            (u64::from(key1.cast_unsigned()) << 32) | u64::from(key2.cast_unsigned());
+        assert_eq!(
+            reconstructed,
+            xxhash_rust::xxh3::xxh3_64(name.as_bytes()),
+            "lock_key must split the 64-bit hash losslessly into (high, low) i32 halves so \
+             its collision surface is exactly the hash's (DESIGN.md §5.1); name = {name:?}"
+        );
+    }
+}
+
+#[test]
+fn validate_lock_name_accepts_a_name_at_the_index_limit() {
+    // Exactly MAX_LOCK_NAME_BYTES (2048) bytes must be accepted: it still fits
+    // the `cluster_lock.name` btree tuple *and* the release NOTIFY payload, so
+    // the acquire/release round-trip is clean. ASCII → one byte per char, so
+    // length == byte length here.
+    let name = "a".repeat(MAX_LOCK_NAME_BYTES);
+    assert_eq!(name.len(), 2048);
+    assert!(validate_lock_name(&name).is_ok());
+}
+
+#[test]
+fn validate_lock_name_rejects_a_name_over_the_index_limit() {
+    // One byte past the limit must be rejected *before* any lock state is
+    // mutated, so the metadata INSERT never trips `cluster_lock_name_len_check`
+    // and `release` never reaches a lock it cannot NOTIFY about.
+    let name = "a".repeat(MAX_LOCK_NAME_BYTES + 1);
+    assert_eq!(name.len(), 2049);
+    assert!(matches!(
+        validate_lock_name(&name),
+        Err(ClusterError::InvalidName { .. })
+    ));
+}
+
+#[test]
+fn validate_lock_name_counts_utf8_bytes_not_chars() {
+    // The limit is a *byte* limit (both the btree tuple and NOTIFY's payload
+    // are sized in bytes) — matching the migration's `octet_length`, not
+    // `length`. A multi-byte name with fewer than 2048 chars but more than 2048
+    // bytes must be rejected. U+00E9 ('e' + acute) is 2 UTF-8 bytes, so 1025 of
+    // them = 2050 bytes > limit.
+    let name = "\u{e9}".repeat(1025);
+    assert_eq!(name.chars().count(), 1025);
+    assert_eq!(name.len(), 2050);
+    assert!(matches!(
+        validate_lock_name(&name),
+        Err(ClusterError::InvalidName { .. })
+    ));
+}
+
+#[test]
+fn ttl_to_millis_converts_normal_durations() {
+    assert_eq!(ttl_to_millis(Duration::from_secs(30)).unwrap(), 30_000);
+}
+
+#[test]
+fn ttl_to_millis_rejects_values_beyond_i64_millis_range() {
+    // `Duration::MAX.as_millis()` is far beyond `i64::MAX`.
+    assert!(ttl_to_millis(Duration::MAX).is_err());
+}
+
+#[test]
+fn expires_at_sql_uses_the_database_clock() {
+    // PGR-C2: the deadline must be `now() + ttl` evaluated by Postgres, never a
+    // timestamp this instance computed from its own (possibly skewed) wall clock
+    // — the reaper compares `expires_at` against Postgres `now()`.
+    let sql = expires_at_sql(3);
+    assert!(
+        sql.contains("now()"),
+        "must anchor on the database clock: {sql}"
+    );
+    assert!(
+        sql.contains("$3::bigint"),
+        "must add the bound ttl at $3: {sql}"
+    );
+}
+
+#[tokio::test]
+async fn release_waiters_wakes_a_registered_waiter() {
+    let waiters = ReleaseWaiters::new();
+    let waiter = waiters.wait_for("l");
+
+    waiters.notify("l");
+
+    assert!(waiter.await.is_ok());
+}
+
+#[tokio::test]
+async fn release_waiters_notify_on_an_unregistered_name_is_a_no_op() {
+    let waiters = ReleaseWaiters::new();
+    // Must not panic when nobody is waiting on this name.
+    waiters.notify("nobody-waiting");
+}
+
+#[tokio::test]
+async fn release_waiters_only_wakes_the_matching_name() {
+    let waiters = ReleaseWaiters::new();
+    let waiter_a = waiters.wait_for("a");
+    let waiter_b = waiters.wait_for("b");
+
+    waiters.notify("a");
+
+    assert!(waiter_a.await.is_ok());
+    // `b`'s waiter was never notified — dropping the registry (end of scope)
+    // closes its sender, so `await` resolves to `Err` rather than hanging.
+    drop(waiters);
+    assert!(waiter_b.await.is_err());
+}

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/src/lock/mod.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/src/lock/mod.rs
@@ -1,0 +1,1193 @@
+//! `PostgresLock` — the native `DistributedLockBackend` implementation over
+//! `pg_advisory_lock` (DESIGN.md §5), plus the standalone `PostgresLockPlugin`
+//! builder/handle (DESIGN.md §3.5) that lets an operator route `lock` to
+//! Postgres independently of `cache`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use cluster_sdk::observability::{self, result, spans};
+use cluster_sdk::{ClusterError, ClusterMetrics, DistributedLockBackend, LockFeatures, LockGuard};
+use dashmap::DashMap;
+use sqlx::PgPool;
+use sqlx::pool::PoolConnection;
+use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
+use tracing::{Instrument, warn};
+use uuid::Uuid;
+
+pub mod notify;
+pub mod reaper;
+
+use crate::config::PostgresLockConfig;
+use crate::limits::MAX_INDEXED_KEY_BYTES;
+use crate::pg_error::map_sqlx_error;
+use crate::pg_setup::{
+    base_pool_options, ensure_schema, lock_migrator, reject_pgbouncer_transaction_mode,
+    run_migrator, warn_if_async_replication,
+};
+use notify::ReleaseWaiters;
+
+/// Hashes a lock `name` to the two `i32` halves of a 64-bit value, for the
+/// two-argument `pg_try_advisory_lock(key1, key2)` form (DESIGN.md §5.1).
+///
+/// Deterministic and stable across calls/processes: uses `xxh3_64` (already a
+/// workspace dependency) over the name's UTF-8 bytes — the specific algorithm
+/// is an implementation detail (DESIGN.md §5.1) as long as it stays fixed once
+/// shipped, since a change would silently stop recognizing locks held under
+/// the old mapping. `key1` is the high 32 bits, `key2` the low 32 bits, using
+/// the full 64-bit hash space rather than `hashtext()`'s 32 bits (§5.1).
+// Deliberately truncating: splitting a 64-bit hash into its high/low 32-bit
+// halves, each reinterpreted (not clamped) as `i32` for
+// `pg_try_advisory_lock`'s two-argument form (DESIGN.md §5.1) — not a
+// narrowing bug, so the `as` casts below are exactly what's wanted.
+#[must_use]
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+pub fn lock_key(name: &str) -> (i32, i32) {
+    let hash = xxhash_rust::xxh3::xxh3_64(name.as_bytes());
+    let key1 = (hash >> 32) as u32 as i32;
+    let key2 = hash as u32 as i32;
+    (key1, key2)
+}
+
+/// Maximum lock-name length, in UTF-8 bytes, this backend accepts.
+///
+/// Two `PostgreSQL` limits bear on a lock name and this is the tighter:
+/// `cluster_lock.name` is a `PRIMARY KEY`, so every name lands in a btree bound
+/// by the index-tuple ceiling (see `limits.rs`). The looser one is the release
+/// path — `NOTIFY cluster_lock_released, '<name>'` (`notify::notify_released`)
+/// carries the bare name as its payload, and `PostgreSQL` rejects payloads of
+/// 8000 bytes or more, so a name that cannot fit could never be cleanly
+/// released: `release` would unlock and delete the row and only *then* fail on
+/// the notify, returning an error for a lock that is already gone.
+///
+/// Bounding by the btree limit satisfies both. Names are rejected at
+/// acquisition, before any lock state is mutated, so `release` never sees an
+/// un-notifiable name and the metadata INSERT never trips its own CHECK.
+const MAX_LOCK_NAME_BYTES: usize = MAX_INDEXED_KEY_BYTES;
+
+/// Rejects a lock `name` too long to index or to notify on, so the acquisition
+/// never enters a state its release cannot cleanly signal (see
+/// [`MAX_LOCK_NAME_BYTES`]). Returns [`ClusterError::InvalidName`] without
+/// touching any lock state.
+fn validate_lock_name(name: &str) -> Result<(), ClusterError> {
+    // `reason` is a `&'static str`, so the bound is a literal; keep it in sync
+    // with the constant actually enforced.
+    const _: () = assert!(MAX_LOCK_NAME_BYTES == 2048);
+    if name.len() > MAX_LOCK_NAME_BYTES {
+        return Err(ClusterError::InvalidName {
+            name: name.to_owned(),
+            reason: "lock name must be at most 2048 UTF-8 bytes (the btree index-tuple limit on \
+                     the cluster_lock primary key)",
+        });
+    }
+    Ok(())
+}
+
+/// Records the metric side of a finished lock op (duration + bounded-`result`
+/// counter) and the shared provider-error signals, mirroring
+/// `CasBasedDistributedLockBackend::record_lock` (`cluster/src/defaults/lock.rs`)
+/// so the native Postgres lock emits the exact same ADR-004 signal set the
+/// CAS-based default does (DESIGN.md §8). Used by both the backend
+/// (`try_lock`/`lock`) and the per-guard task (`renew`/`release`).
+fn record_lock<T>(
+    metrics: &dyn ClusterMetrics,
+    provider: &'static str,
+    op: &'static str,
+    lock: &str,
+    started: std::time::Instant,
+    outcome: &Result<T, ClusterError>,
+) {
+    metrics.lock_op_duration(op, started.elapsed().as_secs_f64());
+    metrics.lock_op(op, result::label(outcome));
+    if let Err(err) = outcome {
+        observability::emit_provider_error(
+            metrics,
+            provider,
+            op,
+            observability::ResourceId::Lock(lock),
+            err,
+        );
+    }
+}
+
+/// Converts a lock TTL to the millisecond lifetime bound to the write query
+/// (`BIGINT`), which SQL adds to the database clock — see [`expires_at_sql`].
+fn ttl_to_millis(ttl: Duration) -> Result<i64, ClusterError> {
+    i64::try_from(ttl.as_millis()).map_err(|_| ClusterError::InvalidConfig {
+        reason: format!("ttl {ttl:?} exceeds the storable millisecond range"),
+    })
+}
+
+/// The SQL fragment computing `cluster_lock.expires_at` from a bound millisecond
+/// lifetime (`$n`, a [`ttl_to_millis`] value). `n` is its 1-based bind position.
+///
+/// The deadline is computed **in SQL against the database clock**, never from
+/// `chrono::Utc::now()` on the acquiring instance — exactly as
+/// `cache::expires_at_sql` does for `cluster_cache` (PGR-C2). The reaper's sweep
+/// compares this column to Postgres `now()`, so anchoring the write to a fleet
+/// instance's own (possibly skewed) wall clock could reap a live lock early or
+/// let a dead holder's lock linger. Unconditional, with no `NULL` branch: a lock
+/// TTL is mandatory (`DistributedLockBackend` takes a `Duration`, not a `Ttl`),
+/// so unlike the cache there is no indefinite case to encode.
+fn expires_at_sql(n: usize) -> String {
+    format!("now() + (${n}::bigint * interval '1 millisecond')")
+}
+
+/// A lock this process currently believes it holds: the pinned connection
+/// (checked out of the pool for the lock's full duration, per DESIGN.md §3.3
+/// — advisory locks are session-scoped, so only the connection that acquired
+/// one can release it) plus the advisory-lock key pair needed to unlock it.
+///
+/// The connection lives behind an async [`tokio::sync::Mutex`] so no accessor
+/// ever holds the `DashMap` shard lock across an `.await`. Every operation that
+/// touches the connection (`renew`, `release`, the guard task's
+/// `synchronous_commit` re-assertion, and the reaper's `reclaim`) clones this
+/// `Arc` out of the map under a brief synchronous `get`/`remove`, then awaits on
+/// the async mutex — so a concurrent reaper `remove` on the same key/shard can
+/// never block a shard lock held across an `.await`, which would deadlock the
+/// single worker under a current-thread runtime (`GAP-SOLUTIONS.md` §5). The
+/// mutex serializes the accessors with a plain `.await`, not a thread-blocking
+/// wait.
+struct HeldLock {
+    conn: Arc<tokio::sync::Mutex<PoolConnection<sqlx::Postgres>>>,
+    key1: i32,
+    key2: i32,
+    /// The random UUID stamped on this acquisition's `cluster_lock` row and on
+    /// the guard task that owns it. Used as an end-to-end ownership fence: after
+    /// a TTL lapse frees this name and a *newer* holder re-acquires it, the
+    /// original holder's stale guard (or a foreign reaper) must not renew,
+    /// release, or reclaim the successor's live lock. Every `renew`/`release`/
+    /// reaper path therefore matches this id before touching the entry, so a
+    /// stale actor's operation is a no-op instead of silently unlocking the
+    /// live holder and breaking mutual exclusion (PGR-L1 ownership fence).
+    ///
+    /// A `Uuid`, matching the native `UUID` column it is stamped on
+    /// (`0002_cluster_lock.sql`): `Copy`, compared as 16 bytes rather than as a
+    /// 36-character string, and unable to hold a non-UUID value at all.
+    holder_id: Uuid,
+}
+
+/// The native Postgres distributed-lock backend.
+pub struct PostgresLock {
+    pool: PgPool,
+    /// The schema-qualified table name. See `PostgresCache::table`'s doc for
+    /// the trust-boundary note — same reasoning applies here.
+    table: String,
+    /// Every lock this process currently holds, keyed by name. Both the
+    /// per-guard command task (on `Release`) and the TTL reaper race to
+    /// `remove` a given entry — `DashMap::remove` is atomic per key, so
+    /// exactly one of them ever gets `Some` for a given lock, which is the
+    /// whole basis for safely handing the pinned connection between them
+    /// (see `reaper.rs`'s module doc for why the reaper needs this at all).
+    held: Arc<DashMap<String, HeldLock>>,
+    /// In-process wake-up registry for blocked `lock()` callers, fed by the
+    /// `cluster_lock_released` LISTEN task (`notify::spawn_release_listen_task`,
+    /// started by the plugin's `build_and_start` — DESIGN.md §5.3).
+    release_waiters: Arc<ReleaseWaiters>,
+    /// Cadence at which each guard task re-asserts `synchronous_commit = on` on
+    /// its own pinned connection (DESIGN.md §3.4 residual gap). Bounds the GUC
+    /// re-assertion window to this interval; shares the value with the TTL
+    /// reaper (`lock_reaper_interval_ms`, default 5s).
+    reassert_interval: Duration,
+    /// The ADR-004 metrics sink this lock emits `cluster_lock_ops_total` /
+    /// `cluster_lock_op_duration_seconds` / `cluster_provider_errors_total`
+    /// through (DESIGN.md §8). Native (not decorator-wrapped): `try_lock`/`lock`
+    /// and the guard task's `renew`/`release` call [`record_lock`] directly.
+    metrics: Arc<dyn ClusterMetrics>,
+    /// The bounded `provider` label attached to every emitted signal.
+    provider: &'static str,
+    /// Cancelled on `stop()` (the same token the reapers/LISTEN tasks observe).
+    /// Each guard task selects on it so, after shutdown, a guard whose consumer
+    /// still holds its `LockGuard` exits promptly instead of parking on its
+    /// `reassert_interval` timer until the guard drops (PGR-L2).
+    guard_shutdown: CancellationToken,
+    /// Signalled after every `try_acquire`/`renew` that writes a new
+    /// `expires_at`, waking the TTL reaper so it re-reads the earliest deadline
+    /// (`reaper`'s "Wake schedule").
+    ///
+    /// Without it the reaper only learns about deadlines that already existed at
+    /// its last wake, so a lock whose whole lifetime fits inside one sleep
+    /// (TTL ≲ `lock_reaper_interval_ms`) would not be reclaimed until that sleep
+    /// ended. That matters specifically for a lock **this** process holds: its
+    /// advisory lock is session-scoped, so only this process's own reaper can
+    /// unlock it, and until it does every waiter on that name stays blocked.
+    /// A purely local signal is therefore the whole fix, not half of one — each
+    /// instance wakes its own reaper for its own locks, and no instance could
+    /// act on another's anyway.
+    deadline_hint: Arc<Notify>,
+}
+
+impl PostgresLock {
+    #[must_use]
+    pub fn new(
+        pool: PgPool,
+        schema: &str,
+        reassert_interval: Duration,
+        metrics: Arc<dyn ClusterMetrics>,
+        provider: &'static str,
+        guard_shutdown: CancellationToken,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            pool,
+            table: format!("{schema}.cluster_lock"),
+            held: Arc::new(DashMap::new()),
+            release_waiters: ReleaseWaiters::new(),
+            reassert_interval,
+            metrics,
+            provider,
+            guard_shutdown,
+            deadline_hint: Arc::new(Notify::new()),
+        })
+    }
+
+    /// Bundles the per-guard fields into a [`GuardContext`] for `try_acquire` /
+    /// `run_guard_task` (keeps their signatures within a sane arg count).
+    fn guard_context(&self) -> GuardContext {
+        GuardContext {
+            reassert_interval: self.reassert_interval,
+            metrics: Arc::clone(&self.metrics),
+            provider: self.provider,
+            shutdown: self.guard_shutdown.clone(),
+            deadline_hint: Arc::clone(&self.deadline_hint),
+        }
+    }
+
+    /// The underlying pool, for the shutdown path. `pub(crate)`: intra-crate
+    /// wiring only (PGR-L3).
+    #[must_use]
+    pub(crate) fn pool(&self) -> PgPool {
+        self.pool.clone()
+    }
+
+    /// The release-wake registry, for the LISTEN task
+    /// (`notify::spawn_release_listen_task`). `pub(crate)`: intra-crate wiring
+    /// only, and `ReleaseWaiters` is not a nameable public type (PGR-L3).
+    #[must_use]
+    pub(crate) fn release_waiters(&self) -> Arc<ReleaseWaiters> {
+        Arc::clone(&self.release_waiters)
+    }
+
+    /// Drains every lock this process currently holds: unlocks each advisory
+    /// lock on its own pinned connection, wakes any blocked `lock()` waiters,
+    /// and drops the connection back to the pool (DESIGN.md §10 step 4).
+    ///
+    /// Called by both `stop()` paths *before* `pool.close()`. It is required,
+    /// not optional: `sqlx::Pool::close()` waits for every checked-out
+    /// connection to be returned, and a held lock's connection is pinned in
+    /// `held` (checked out for the lock's full duration, §3.3) entirely outside
+    /// the pool's tracking — so without this drain, `close()` blocks forever on
+    /// a lock still held at shutdown (`PG-LIFE-003`; the same block was the
+    /// unresolved `PG-LOCK-007`/`PG-SPEC-004` hang).
+    ///
+    /// Unconditional, unlike the TTL reaper's sweep (which only reclaims
+    /// expired rows) — but it reuses the reaper's exact per-lock `reclaim`
+    /// path. Collecting names first and then `held.remove` per name keeps the
+    /// same `DashMap::remove` atomic hand-off the guard task's `release()` and
+    /// the reaper's `sweep` already rely on: if a guard's `release()` wins the
+    /// race for a given name, `remove` here returns `None` and there is simply
+    /// nothing left to reclaim.
+    pub async fn drain_held(&self) {
+        // Loop until `held` is observed empty rather than draining a single
+        // snapshot (PGR-L2): a `try_acquire` that passed its shutdown check just
+        // before `stop()` cancelled can still register a lock after an earlier
+        // pass collected its names, so one pass cannot guarantee `pool.close()`
+        // won't then block on that stranded pinned connection. New acquisitions
+        // are rejected once `guard_shutdown` is cancelled (which `stop()` does
+        // before calling this), so the loop converges.
+        loop {
+            let names: Vec<String> = self.held.iter().map(|entry| entry.key().clone()).collect();
+            if names.is_empty() {
+                break;
+            }
+            for name in names {
+                if let Some((_, held_lock)) = self.held.remove(&name) {
+                    reaper::reclaim(&name, held_lock, &*self.metrics, self.provider).await;
+                }
+            }
+        }
+    }
+
+    /// Spawns the TTL reaper for this lock's `held` registry.
+    ///
+    /// A method on `PostgresLock` itself (delegating to `reaper::spawn_lock_reaper`),
+    /// not a free function callers invoke with the pieces of a `PostgresLock`
+    /// spread out — `HeldLock` is private to this module and its descendants
+    /// (`reaper`), so nothing outside `lock/` could even name the type a
+    /// free-function signature would need to expose.
+    #[must_use]
+    pub(crate) fn spawn_reaper(
+        self: &Arc<Self>,
+        interval: Duration,
+        metrics: reaper::LockReaperMetrics,
+        warn_threshold: i64,
+        cancel: CancellationToken,
+    ) -> tokio::task::JoinHandle<()> {
+        reaper::spawn_lock_reaper(
+            self.pool.clone(),
+            self.table.clone(),
+            Arc::clone(&self.held),
+            interval,
+            metrics,
+            warn_threshold,
+            reaper::ReaperWakeup {
+                deadline_hint: Arc::clone(&self.deadline_hint),
+                cancel,
+            },
+        )
+    }
+
+    /// Test-only: reads `SHOW synchronous_commit` on the named held lock's own
+    /// pinned connection, returning `None` if this process doesn't currently
+    /// hold `name`. There is no production API that hands out a raw pinned
+    /// `PoolConnection`, so `pg_spec_005` reaches the GUC through this seam.
+    ///
+    /// Gated behind `--features integration` (the `tests/` suite's feature) so
+    /// this seam is compiled out of release builds entirely (PGR-M8).
+    #[cfg(feature = "integration")]
+    #[doc(hidden)]
+    pub async fn __test_synchronous_commit(&self, name: &str) -> Option<String> {
+        let conn = Arc::clone(&self.held.get(name)?.conn);
+        let mut conn = conn.lock().await;
+        sqlx::query_scalar("SHOW synchronous_commit")
+            .fetch_one(&mut **conn)
+            .await
+            .ok()
+    }
+
+    /// Test-only: runs one complete TTL sweep — every batch, exactly as the
+    /// reaper's own wake does — and returns how many expired rows it reclaimed.
+    /// Lets `PG-SPEC-009` assert that a backlog larger than one
+    /// `reaper::SWEEP_BATCH` is cleared by a *single* sweep's batch loop, rather
+    /// than inferring it from how many reaper intervals happened to elapse.
+    ///
+    /// Gated behind `--features integration` (PGR-M8).
+    #[cfg(feature = "integration")]
+    #[doc(hidden)]
+    pub async fn __test_sweep_once(&self) -> Result<usize, ClusterError> {
+        reaper::sweep(
+            &self.pool,
+            &self.table,
+            &self.held,
+            &*self.metrics,
+            self.provider,
+            &self.guard_shutdown,
+        )
+        .await
+    }
+
+    /// Test-only: the reaper's own "how long until the next lock is due" probe
+    /// (`None` when no locks exist), which its wake schedule shortens sleeps
+    /// with. Exercised directly by `PG-SPEC-009` because a regression in that
+    /// query would otherwise be invisible — the reaper falls back to the plain
+    /// interval on error, so nothing else would fail.
+    ///
+    /// Gated behind `--features integration` (PGR-M8).
+    #[cfg(feature = "integration")]
+    #[doc(hidden)]
+    pub async fn __test_seconds_until_next_expiry(&self) -> Result<Option<f64>, ClusterError> {
+        reaper::seconds_until_next_expiry(&self.pool, &self.table).await
+    }
+
+    /// Test-only: flips `synchronous_commit` to `off` on the named held lock's
+    /// pinned connection, simulating an external mid-session GUC mutation
+    /// (DESIGN.md §3.4).
+    ///
+    /// Gated behind `--features integration` (PGR-M8): this in particular would
+    /// otherwise let any release-build consumer flip `synchronous_commit=off` on
+    /// a live lock connection — the exact durability footgun the plugin exists
+    /// to prevent.
+    #[cfg(feature = "integration")]
+    #[doc(hidden)]
+    pub async fn __test_flip_synchronous_commit_off(&self, name: &str) {
+        let Some(conn) = self.held.get(name).map(|entry| Arc::clone(&entry.conn)) else {
+            return;
+        };
+        let mut conn = conn.lock().await;
+        let _flipped = sqlx::query("SET synchronous_commit = off")
+            .execute(&mut **conn)
+            .await;
+    }
+
+    /// Test-only: runs one re-assertion pass — exactly the code the guard task's
+    /// interval arm runs. `pg_spec_005` drives it directly (with a long reaper
+    /// interval so the guard's own timer never fires during the test) so the
+    /// correction is deterministic and never races the guard task's own
+    /// `held.get_mut`-across-`.await` (a DashMap current-thread deadlock hazard,
+    /// `GAP-SOLUTIONS.md` §5).
+    ///
+    /// Gated behind `--features integration` (PGR-M8).
+    #[cfg(feature = "integration")]
+    #[doc(hidden)]
+    pub async fn __test_reassert_synchronous_commit(&self, name: &str) {
+        // Resolve the current holder for `name` and pass it through the same
+        // `holder_id` fence the guard task uses (PGR-L1), so the seam exercises
+        // the matching path rather than bypassing the fence.
+        let Some(holder_id) = self.held.get(name).map(|entry| entry.holder_id) else {
+            return;
+        };
+        let _reasserted = reassert_synchronous_commit(&self.held, name, holder_id).await;
+    }
+
+    /// Test-only: the number of blocked `lock()` callers currently registered as
+    /// release-NOTIFY waiters for `name`. Lets `pg_lock_003` synchronize on the
+    /// waiter having reached its registration before the holder releases (PGR-E3).
+    /// Gated behind `--features integration` (PGR-M8).
+    #[cfg(feature = "integration")]
+    #[doc(hidden)]
+    #[must_use]
+    pub fn __test_release_waiter_count(&self, name: &str) -> usize {
+        self.release_waiters.__test_registered_count(name)
+    }
+}
+
+/// The per-guard context `try_acquire` hands to each spawned guard task:
+/// everything a held lock needs beyond its own name/pool/table. Grouped into
+/// one value (rather than threaded as separate parameters) to keep
+/// `try_acquire`/`run_guard_task` within a sane argument count. Cheap to clone
+/// (an `Arc`, a `&'static str`, a `Duration`, and a `CancellationToken` clone).
+#[derive(Clone)]
+struct GuardContext {
+    /// See [`PostgresLock::reassert_interval`].
+    reassert_interval: Duration,
+    /// The ADR-004 metrics sink (DESIGN.md §8).
+    metrics: Arc<dyn ClusterMetrics>,
+    /// The bounded `provider` label.
+    provider: &'static str,
+    /// The shutdown token guard tasks observe (PGR-L2).
+    shutdown: CancellationToken,
+    /// See [`PostgresLock::deadline_hint`] — signalled by `try_acquire` and by
+    /// the guard task's `renew`.
+    deadline_hint: Arc<Notify>,
+}
+
+/// Attempts the non-blocking acquisition shared by `try_lock` and `lock`'s
+/// retry loop: `pg_try_advisory_lock`, then (on success) the metadata insert,
+/// registering the pinned connection in `held` and spawning the guard task.
+async fn try_acquire(
+    pool: &PgPool,
+    table: &str,
+    held: &Arc<DashMap<String, HeldLock>>,
+    name: &str,
+    ttl: Duration,
+    ctx: &GuardContext,
+) -> Result<Option<LockGuard>, ClusterError> {
+    // Reject un-notifiable names before mutating any lock state, so `release`
+    // never reaches a lock it cannot cleanly signal (see `validate_lock_name`).
+    validate_lock_name(name)?;
+    let (key1, key2) = lock_key(name);
+    let ttl_ms = ttl_to_millis(ttl)?;
+
+    let mut conn = pool.acquire().await.map_err(map_sqlx_error)?;
+    let acquired: bool = sqlx::query_scalar("SELECT pg_try_advisory_lock($1, $2)")
+        .bind(key1)
+        .bind(key2)
+        .fetch_one(&mut *conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    if !acquired {
+        // `conn` drops here, returning to the pool.
+        return Ok(None);
+    }
+
+    let holder_id = Uuid::new_v4();
+    // `ON CONFLICT (name) DO UPDATE`, not a bare `INSERT`: reaching this line
+    // means `pg_try_advisory_lock` just told us, authoritatively, that no
+    // live session holds this name's advisory lock right now — Postgres
+    // itself already ruled out a live foreign holder. A pre-existing
+    // `cluster_lock` row for `name` can therefore only be stale metadata left
+    // behind by a crashed holder whose session died before its own
+    // `release()` could delete it (DESIGN.md §5.2 point 4's crash/disconnect
+    // safety net — the advisory lock auto-releases on disconnect, but
+    // nothing else automatically cleans up this bookkeeping row). A bare
+    // `INSERT` would fail that row's `PRIMARY KEY (name)` constraint on every
+    // such re-acquisition, turning a documented crash-recovery path into a
+    // permanent `Provider` error until the TTL reaper happens to sweep the
+    // stale row first (`PG-LOCK-007`/`PG-SPEC-004` exercise exactly this).
+    let insert_result = sqlx::query(&format!(
+        "INSERT INTO {table} (name, holder_id, acquired_at, expires_at) \
+         VALUES ($1, $2, now(), {expires_at}) \
+         ON CONFLICT (name) DO UPDATE SET holder_id = EXCLUDED.holder_id, \
+         acquired_at = EXCLUDED.acquired_at, expires_at = EXCLUDED.expires_at",
+        expires_at = expires_at_sql(3),
+    ))
+    .bind(name)
+    .bind(holder_id)
+    .bind(ttl_ms)
+    .execute(&mut *conn)
+    .await;
+
+    if let Err(err) = insert_result {
+        // Compensate: we hold the advisory lock but failed to record it, so
+        // release it now rather than leak a lock the reaper can never find
+        // (its sweep only ever looks at `cluster_lock` rows). Surface a failed
+        // compensating unlock the same way `reaper::reclaim` does (PGR-L1) —
+        // otherwise the advisory lock silently leaks until session disconnect.
+        let compensating_unlock: Result<bool, ClusterError> =
+            sqlx::query_scalar("SELECT pg_advisory_unlock($1, $2)")
+                .bind(key1)
+                .bind(key2)
+                .fetch_one(&mut *conn)
+                .await
+                .map_err(map_sqlx_error);
+        if let Err(unlock_err) = &compensating_unlock {
+            observability::emit_provider_error(
+                &*ctx.metrics,
+                ctx.provider,
+                "try_lock_compensating_unlock",
+                observability::ResourceId::Lock(name),
+                unlock_err,
+            );
+        }
+        return Err(map_sqlx_error(err));
+    }
+
+    // Serialize against shutdown (PGR-L2): `stop()` cancels `shutdown` and then
+    // drains a snapshot of `held` (looping until empty) before `pool.close()`.
+    // If we registered this lock after that drain observed `held` empty, the
+    // guard task would exit immediately on the already-cancelled token and leave
+    // its pinned connection stranded in the pool's checked-out set, so
+    // `pool.close()` would block forever.
+    //
+    // Two-part guard. First, a cheap pre-insert bail: if shutdown is already
+    // observed here we undo the advisory lock + row and never register, avoiding
+    // the work entirely (the common single-thread case).
+    if ctx.shutdown.is_cancelled() {
+        let _unlocked: Result<bool, _> = sqlx::query_scalar("SELECT pg_advisory_unlock($1, $2)")
+            .bind(key1)
+            .bind(key2)
+            .fetch_one(&mut *conn)
+            .await;
+        let _deleted = sqlx::query(&format!(
+            "DELETE FROM {table} WHERE name = $1 AND holder_id = $2"
+        ))
+        .bind(name)
+        .bind(holder_id)
+        .execute(&mut *conn)
+        .await;
+        return Err(ClusterError::Shutdown);
+    }
+
+    let (rx, guard) = LockGuard::channel(name.to_owned(), 4);
+    held.insert(
+        name.to_owned(),
+        HeldLock {
+            conn: Arc::new(tokio::sync::Mutex::new(conn)),
+            key1,
+            key2,
+            holder_id,
+        },
+    );
+
+    tokio::spawn(run_guard_task(
+        name.to_owned(),
+        Arc::clone(held),
+        table.to_owned(),
+        ctx.clone(),
+        holder_id,
+        rx,
+    ));
+
+    // Second, a post-insert re-check that closes the multi-thread window the
+    // pre-insert check alone cannot: on a multi-worker runtime a concurrent
+    // `stop()` may cancel and finish draining *between* the check above and this
+    // `held.insert`. If shutdown is observed after the insert we reject this
+    // acquisition (returning the guard would hand back a lock that shutdown is
+    // about to — or already did — forcibly reclaim), reclaiming the connection
+    // ourselves if we still hold it so it is never stranded (PGR-L2).
+    // `remove_if` is atomic with `drain_held`'s own `remove`, so at most one path
+    // reclaims it (`None` here means `drain_held` already did). The consumer's
+    // `guard` is dropped on this early return, unwinding its guard task too.
+    if ctx.shutdown.is_cancelled() {
+        if let Some((_, held_lock)) = held.remove_if(name, |_, entry| entry.holder_id == holder_id)
+        {
+            reaper::reclaim(name, held_lock, &*ctx.metrics, ctx.provider).await;
+        }
+        return Err(ClusterError::Shutdown);
+    }
+
+    // Wake the TTL reaper so this acquisition's deadline is visible to its next
+    // sleep instead of only from its next interval wake (`deadline_hint`).
+    // Signalled last, once the lock is committed, registered, and definitely
+    // ours: an earlier signal could send the reaper to probe a row that one of
+    // the shutdown bails above is about to delete.
+    ctx.deadline_hint.notify_one();
+
+    Ok(Some(guard))
+}
+
+/// Drives one held lock's [`LockCommandReceiver`](cluster_sdk::LockCommandReceiver)
+/// until [`Release`](cluster_sdk::LockRequest::Release) or the consumer drops
+/// the [`LockGuard`] without releasing — in which case this task simply exits,
+/// leaving the connection in `held` for the TTL reaper to reclaim, exactly per
+/// the trait's TTL safety-net contract (no I/O in `Drop`).
+async fn run_guard_task(
+    name: String,
+    held: Arc<DashMap<String, HeldLock>>,
+    table: String,
+    ctx: GuardContext,
+    holder_id: Uuid,
+    mut commands: cluster_sdk::LockCommandReceiver,
+) {
+    // Re-assert `synchronous_commit = on` on this lock's own pinned connection
+    // on its own interval (DESIGN.md §3.4 residual gap): `before_acquire` fires
+    // only at checkout, but a lock connection is checked out once and pinned
+    // for the lock's whole lifetime (§3.3), so an external mid-session flip
+    // would otherwise persist unchecked. Done *here*, on the guard task, rather
+    // than in the TTL reaper's sweep (`GAP-SOLUTIONS.md` §5). The pinned
+    // connection is behind an async mutex (`HeldLock`), so this autonomous
+    // re-assertion never holds the `DashMap` shard lock across its `.await` and
+    // cannot deadlock a concurrent reaper `remove`. First tick is one full
+    // interval out, so a just-acquired connection (already `on`) is not
+    // needlessly re-asserted immediately.
+    let mut reassert = tokio::time::interval_at(
+        tokio::time::Instant::now() + ctx.reassert_interval,
+        ctx.reassert_interval,
+    );
+    reassert.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            // Graceful shutdown: exit promptly rather than parking on the next
+            // reassert tick (PGR-L2). The pinned connection is left in `held`
+            // for `drain_held` (DESIGN.md §10 step 4) to unlock and return —
+            // exactly as it is for a consumer that drops its guard without
+            // releasing, so renew/release/reassert are all no-ops from here.
+            () = ctx.shutdown.cancelled() => return,
+            _ = reassert.tick() => {
+                if let Err(err) = reassert_synchronous_commit(&held, &name, holder_id).await {
+                    observability::emit_provider_error(
+                        &*ctx.metrics,
+                        ctx.provider,
+                        "reassert_synchronous_commit",
+                        observability::ResourceId::Lock(&name),
+                        &err,
+                    );
+                }
+            }
+            request = commands.recv() => {
+                let Some(request) = request else {
+                    // Consumer dropped the guard without releasing: exit, leaving
+                    // the connection in `held` for the TTL reaper to reclaim.
+                    return;
+                };
+                match request {
+                    cluster_sdk::LockRequest::Renew { new_ttl, responder } => {
+                        let span = tracing::info_span!(
+                            spans::LOCK_RENEW, provider = %ctx.provider, lock = %name
+                        );
+                        let started = std::time::Instant::now();
+                        let result =
+                            renew(&held, &name, &table, new_ttl, holder_id, &ctx.deadline_hint)
+                                .instrument(span)
+                                .await;
+                        record_lock(&*ctx.metrics, ctx.provider, "renew", &name, started, &result);
+                        responder.respond(result);
+                    }
+                    cluster_sdk::LockRequest::Release { responder } => {
+                        let span = tracing::info_span!(
+                            spans::LOCK_RELEASE, provider = %ctx.provider, lock = %name
+                        );
+                        let started = std::time::Instant::now();
+                        let result = release(&held, &name, &table, holder_id)
+                            .instrument(span)
+                            .await;
+                        record_lock(&*ctx.metrics, ctx.provider, "release", &name, started, &result);
+                        responder.respond(result);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Re-asserts `synchronous_commit = on` on the lock's own pinned connection
+/// (DESIGN.md §3.4). A no-op if the entry is gone — the TTL reaper reclaimed it
+/// or `release` already ran. Clones the connection handle out under a brief
+/// `get` and awaits on its async mutex (see [`HeldLock`]), so it never holds the
+/// `DashMap` shard lock across the `.await`.
+///
+/// Fences on `holder_id` (PGR-L1), exactly as `renew`/`release` do: after a TTL
+/// lapse frees `name` and a *newer* holder re-acquires it, the original holder's
+/// stale guard task keeps ticking. Without this fence it would resolve the
+/// successor's entry and run `SET` on the successor's pinned connection,
+/// contending with that holder's own renew/release. A non-matching (or absent)
+/// entry means the lock is no longer ours — no-op.
+async fn reassert_synchronous_commit(
+    held: &Arc<DashMap<String, HeldLock>>,
+    name: &str,
+    holder_id: Uuid,
+) -> Result<(), ClusterError> {
+    // Clone the connection handle out under a brief synchronous `get`, then
+    // release the shard lock before awaiting (see `HeldLock`): this is what
+    // keeps the autonomous, timer-driven re-assertion from deadlocking the
+    // reaper's `remove` of an expired-but-still-guarded key under a
+    // current-thread runtime.
+    let conn = {
+        let Some(entry) = held.get(name) else {
+            return Ok(());
+        };
+        if entry.holder_id != holder_id {
+            return Ok(());
+        }
+        Arc::clone(&entry.conn)
+    };
+    let mut conn = conn.lock().await;
+    sqlx::query("SET synchronous_commit = on")
+        .execute(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+    Ok(())
+}
+
+/// `Renew`: pushes `expires_at` out (and restamps `acquired_at`) on our own
+/// pinned connection without relinquishing it (`held.get_mut`, not `remove`).
+/// Zero rows updated means the TTL reaper already reclaimed this lock out from
+/// under us — the row is gone, so the caller no longer holds it
+/// (`ClusterError::LockExpired`).
+///
+/// Signals `deadline_hint` on success. A renew usually pushes the deadline
+/// *later*, which only ever makes the reaper's current sleep conservative — but
+/// `renew` takes an arbitrary `new_ttl`, so a short one can move the earliest
+/// deadline *earlier* than the sleep already in flight was told about.
+async fn renew(
+    held: &Arc<DashMap<String, HeldLock>>,
+    name: &str,
+    table: &str,
+    new_ttl: Duration,
+    holder_id: Uuid,
+    deadline_hint: &Notify,
+) -> Result<(), ClusterError> {
+    // Clone the connection handle out under a brief synchronous `get`, then
+    // release the shard lock before awaiting on the async mutex (see `HeldLock`).
+    // Fence on `holder_id` (PGR-L1): if the entry now belongs to a newer holder
+    // that re-acquired `name` after our TTL lapsed, our lock is gone — report it
+    // expired rather than resetting the successor's TTL on its own connection.
+    let conn = {
+        let Some(entry) = held.get(name) else {
+            return Err(ClusterError::LockExpired {
+                name: name.to_owned(),
+            });
+        };
+        if entry.holder_id != holder_id {
+            return Err(ClusterError::LockExpired {
+                name: name.to_owned(),
+            });
+        }
+        Arc::clone(&entry.conn)
+    };
+    let ttl_ms = ttl_to_millis(new_ttl)?;
+    let mut conn = conn.lock().await;
+    let updated: Option<i32> = sqlx::query_scalar(&format!(
+        "UPDATE {table} SET acquired_at = now(), expires_at = {expires_at} \
+         WHERE name = $2 AND holder_id = $3 RETURNING 1",
+        expires_at = expires_at_sql(1),
+    ))
+    .bind(ttl_ms)
+    .bind(name)
+    .bind(holder_id)
+    .fetch_optional(&mut **conn)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    if updated.is_some() {
+        deadline_hint.notify_one();
+        Ok(())
+    } else {
+        Err(ClusterError::LockExpired {
+            name: name.to_owned(),
+        })
+    }
+}
+
+/// `Release`: reclaims our pinned connection from `held` (atomically —
+/// `held.get_mut` in a concurrent `renew` cannot observe a half-removed
+/// entry), unlocks, deletes the metadata row, and wakes any blocked `lock()`
+/// waiters. If `held` no longer has our entry, the TTL reaper already
+/// reclaimed it before this release arrived — best-effort `Ok(())` per the
+/// trait's TTL-lapsed narrowing (DESIGN.md §3.7): there is nothing left for us
+/// to release.
+async fn release(
+    held: &Arc<DashMap<String, HeldLock>>,
+    name: &str,
+    table: &str,
+    holder_id: Uuid,
+) -> Result<(), ClusterError> {
+    // Fence on `holder_id` (PGR-L1): `remove_if` atomically removes the entry
+    // only when it is still *our* acquisition, so a stale guard whose lock
+    // already lapsed and was re-acquired by a newer holder cannot unlock the
+    // successor's live connection. A non-matching (or absent) entry means the
+    // TTL reaper reclaimed us or a successor owns `name` now — best-effort
+    // `Ok(())` per the trait's TTL-lapsed narrowing (DESIGN.md §3.7).
+    let Some((_, held_lock)) = held.remove_if(name, |_, entry| entry.holder_id == holder_id) else {
+        return Ok(());
+    };
+    let mut conn = held_lock.conn.lock().await;
+
+    let _unlocked: bool = sqlx::query_scalar("SELECT pg_advisory_unlock($1, $2)")
+        .bind(held_lock.key1)
+        .bind(held_lock.key2)
+        .fetch_one(&mut **conn)
+        .await
+        .map_err(map_sqlx_error)?;
+
+    sqlx::query(&format!(
+        "DELETE FROM {table} WHERE name = $1 AND holder_id = $2"
+    ))
+    .bind(name)
+    .bind(holder_id)
+    .execute(&mut **conn)
+    .await
+    .map_err(map_sqlx_error)?;
+
+    notify::notify_released(&mut **conn, name).await?;
+    // The guard drops here; `conn` returns to the pool once the last `Arc`
+    // (any in-flight renew/reassert clone) is also dropped.
+    Ok(())
+}
+
+#[async_trait]
+impl DistributedLockBackend for PostgresLock {
+    fn features(&self) -> LockFeatures {
+        // `pg_advisory_lock` + a metadata table under the same
+        // `synchronous_commit = on` enforcement (DESIGN.md §3.4) as the cache —
+        // ACID-correct mutual exclusion, not merely advisory coordination.
+        LockFeatures::new(true)
+    }
+
+    async fn try_lock(&self, name: &str, ttl: Duration) -> Result<LockGuard, ClusterError> {
+        let span =
+            tracing::info_span!(spans::LOCK_TRY_LOCK, provider = %self.provider, lock = %name);
+        let started = std::time::Instant::now();
+        let ctx = self.guard_context();
+        let out = async {
+            match try_acquire(&self.pool, &self.table, &self.held, name, ttl, &ctx).await? {
+                Some(guard) => Ok(guard),
+                None => Err(ClusterError::LockContended {
+                    name: name.to_owned(),
+                }),
+            }
+        }
+        .instrument(span)
+        .await;
+        record_lock(
+            &*self.metrics,
+            self.provider,
+            "try_lock",
+            name,
+            started,
+            &out,
+        );
+        out
+    }
+
+    async fn lock(
+        &self,
+        name: &str,
+        ttl: Duration,
+        timeout: Duration,
+    ) -> Result<LockGuard, ClusterError> {
+        // DESIGN.md §5.3's loop, adapted to sqlx's public API: rather than
+        // `LISTEN`ing on the same pinned connection the eventual lock will
+        // hold (sqlx's `PgListener` owns its own single-connection pool, with
+        // no public way to hand it an already-checked-out `PoolConnection`),
+        // wait on the in-process `release_waiters` registry the dedicated
+        // LISTEN task (`notify::spawn_release_listen_task`) feeds. A short
+        // heartbeat retry runs alongside the wake-up as a safety net against
+        // a missed notification (task not started yet, a dropped wake), so a
+        // lost wake only costs latency up to the heartbeat interval, never
+        // correctness — the loop always re-attempts `pg_try_advisory_lock`
+        // itself as the source of truth.
+        const HEARTBEAT: Duration = Duration::from_millis(250);
+
+        let span = tracing::info_span!(spans::LOCK_LOCK, provider = %self.provider, lock = %name);
+        let op_started = std::time::Instant::now();
+        let ctx = self.guard_context();
+        let out = async {
+            let started = tokio::time::Instant::now();
+            let deadline = started + timeout;
+
+            let mut first_attempt = true;
+            loop {
+                // Bound each *subsequent* acquire attempt by the remaining budget,
+                // not just the gap between attempts (PGR-L3): `pool.acquire()`
+                // alone can block up to `pool_acquire_timeout` (default 5s), so
+                // checking `deadline` only after each full `try_acquire` let a
+                // single attempt overshoot the caller's `timeout`. If the wrapped
+                // attempt is cancelled mid-acquisition, the pool's `after_release`
+                // hook releases any advisory lock the dropped future had taken
+                // (see `pg_setup::base_pool_options`), so no pooled connection
+                // retains a live lock.
+                //
+                // The *first* attempt always runs (bounded only by the pool's own
+                // acquire timeout), even when `timeout` is 0/expired — matching the
+                // CAS-based default's attempt-before-budget-check ordering, so
+                // `lock(free_lock, ttl, Duration::ZERO)` still acquires instead of
+                // returning `LockTimeout` without ever trying.
+                let now = tokio::time::Instant::now();
+                let remaining = deadline.saturating_duration_since(now);
+                if remaining.is_zero() && !first_attempt {
+                    return Err(ClusterError::LockTimeout {
+                        name: name.to_owned(),
+                        waited: started.elapsed(),
+                    });
+                }
+
+                let acquire = try_acquire(&self.pool, &self.table, &self.held, name, ttl, &ctx);
+                let attempted = if remaining.is_zero() {
+                    // First attempt with no remaining budget: run it unbounded
+                    // (pool-acquire-timeout bounds it in practice) rather than skip.
+                    acquire.await?
+                } else {
+                    match tokio::time::timeout(remaining, acquire).await {
+                        Ok(result) => result?,
+                        Err(_elapsed) => {
+                            return Err(ClusterError::LockTimeout {
+                                name: name.to_owned(),
+                                waited: started.elapsed(),
+                            });
+                        }
+                    }
+                };
+                first_attempt = false;
+                if let Some(guard) = attempted {
+                    return Ok(guard);
+                }
+
+                let now = tokio::time::Instant::now();
+                if now >= deadline {
+                    return Err(ClusterError::LockTimeout {
+                        name: name.to_owned(),
+                        waited: started.elapsed(),
+                    });
+                }
+
+                let wait_for_release = self.release_waiters.wait_for(name);
+                let remaining = deadline - now;
+                let heartbeat = HEARTBEAT.min(remaining);
+                tokio::select! {
+                    _ = wait_for_release => {}
+                    () = tokio::time::sleep(heartbeat) => {}
+                }
+            }
+        }
+        .instrument(span)
+        .await;
+        record_lock(
+            &*self.metrics,
+            self.provider,
+            "lock",
+            name,
+            op_started,
+            &out,
+        );
+        out
+    }
+}
+
+/// Standalone lock-only plugin (DESIGN.md §3.5): lets an operator route `lock`
+/// to Postgres independently of `cache`. Migrates only `0002_cluster_lock.sql`
+/// — a lock-only deployment never creates `cluster_cache`.
+pub struct PostgresLockPlugin;
+
+impl PostgresLockPlugin {
+    // No `#[must_use]` here: `PostgresLockBuilder` itself already carries a
+    // `#[must_use = "..."]` message, so a bare attribute on this function
+    // would be a `clippy::double_must_use` no-op.
+    pub fn builder(config: PostgresLockConfig) -> PostgresLockBuilder {
+        PostgresLockBuilder {
+            config,
+            reaper_meter: None,
+        }
+    }
+}
+
+/// Fluent builder for [`PostgresLockPlugin`].
+#[must_use = "a builder starts nothing until `.build_and_start()` is called"]
+pub struct PostgresLockBuilder {
+    config: PostgresLockConfig,
+    /// Optional override for the meter the lock TTL reaper emits its
+    /// plugin-local gauge/histogram through (DESIGN.md §8). `None` in
+    /// production (uses the process-global meter); tests inject a meter over an
+    /// in-memory reader so `pg_spec_006` can read the gauge back in isolation
+    /// from other tests' reapers.
+    reaper_meter: Option<opentelemetry::metrics::Meter>,
+}
+
+impl PostgresLockBuilder {
+    /// Test-only: routes the lock reaper's plugin-local metrics through `meter`
+    /// instead of the process-global meter, so a test can attach an in-memory
+    /// reader and observe `cluster_postgres_lock_active_names` without
+    /// contention from other concurrently-running tests' reapers.
+    ///
+    /// Gated behind `--features integration` (PGR-M8).
+    #[cfg(feature = "integration")]
+    #[doc(hidden)]
+    pub fn __with_reaper_meter(mut self, meter: opentelemetry::metrics::Meter) -> Self {
+        self.reaper_meter = Some(meter);
+        self
+    }
+}
+
+impl PostgresLockBuilder {
+    /// Builds the plugin: opens its own dedicated `sqlx::PgPool`, runs the
+    /// `0002_cluster_lock.sql` migration, enforces `synchronous_commit = on`
+    /// (DESIGN.md §3.4), and starts the lock TTL reaper.
+    ///
+    /// # Errors
+    /// - [`ClusterError::InvalidConfig`] if `pgbouncer_transaction_mode: true`
+    ///   is set (DESIGN.md §5.4) or the connection string is invalid
+    ///   (`PG-LIFE-006`).
+    pub async fn build_and_start(self) -> Result<PostgresLockHandle, ClusterError> {
+        let config = self.config;
+        let reaper_meter = self.reaper_meter;
+        reject_pgbouncer_transaction_mode(config.pgbouncer_transaction_mode)?;
+        // Reject an unsafe schema (PGR-L4) and a zero lock reaper interval
+        // (PGR-E2) before opening the pool or spawning the reaper.
+        config.validate()?;
+
+        let pool = base_pool_options(&config.schema)
+            .max_connections(config.pool_max_size)
+            .acquire_timeout(config.pool_acquire_timeout())
+            .connect(&config.connection_string)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        // Create the configured schema (if non-`public`) before the migrator's
+        // unqualified `CREATE TABLE` runs — the pool's `search_path` already
+        // points every connection at it (PGR-L4). Only the `migrations/lock/`
+        // Migrator — never `migrations/cache/` — so a lock-only deployment
+        // never creates `cluster_cache`.
+        ensure_schema(&pool, &config.schema).await?;
+        run_migrator(lock_migrator(), &pool).await?;
+        warn_if_async_replication(&pool, config.replication_mode).await?;
+
+        // The single ADR-004 metrics sink, shared by the native lock backend
+        // (its `try_lock`/`lock`/`renew`/`release` signals, DESIGN.md §8) and
+        // the lock TTL reaper (its `emit_provider_error` failure signals).
+        let metrics: Arc<dyn ClusterMetrics> = Arc::new(
+            cluster_sdk::observability::otel::OtelClusterMetrics::from_global_meter(
+                crate::provider::PROVIDER_NAME,
+            ),
+        );
+
+        // Created before the lock so guard tasks can observe the same shutdown
+        // signal the reaper/LISTEN tasks do (PGR-L2).
+        let shutdown = CancellationToken::new();
+        let lock = PostgresLock::new(
+            pool,
+            &config.schema,
+            config.lock_reaper_interval(),
+            Arc::clone(&metrics),
+            crate::provider::PROVIDER_NAME,
+            shutdown.clone(),
+        );
+
+        let meter = reaper_meter.unwrap_or_else(reaper::reaper_meter);
+        let reaper = lock.spawn_reaper(
+            config.lock_reaper_interval(),
+            reaper::LockReaperMetrics::new(
+                &meter,
+                crate::provider::PROVIDER_NAME,
+                Arc::clone(&metrics),
+            ),
+            i64::from(config.lock_name_cardinality_warn_threshold),
+            shutdown.clone(),
+        );
+        let release_listener = notify::spawn_release_listen_task(
+            config.connection_string.clone(),
+            lock.release_waiters(),
+            shutdown.clone(),
+        );
+
+        Ok(PostgresLockHandle {
+            lock,
+            reaper: Some(reaper),
+            release_listener: Some(release_listener),
+            shutdown,
+            stopped: false,
+        })
+    }
+}
+
+/// The running standalone lock plugin. Carries the same `stopped: bool` field
+/// and ADR-006 `Drop` guard as [`crate::PostgresClusterHandle`] (DESIGN.md
+/// §3.5) — it owns its own pool and lock TTL reaper independently.
+pub struct PostgresLockHandle {
+    lock: Arc<PostgresLock>,
+    // `Option` (not a bare `JoinHandle`) because `PostgresLockHandle` owns a
+    // `Drop` impl below, and you cannot move a field out of a type that
+    // implements `Drop` — `stop` uses `.take()` to drain it in place, mirroring
+    // `ClusterHandle::stop`'s `std::mem::take` (`cluster/src/wiring.rs`).
+    reaper: Option<tokio::task::JoinHandle<()>>,
+    release_listener: Option<tokio::task::JoinHandle<()>>,
+    shutdown: CancellationToken,
+    /// Set by `stop` so the `Drop` guard can tell a graceful shutdown apart
+    /// from a forgotten one (ADR-006 §Confirmation).
+    stopped: bool,
+}
+
+impl PostgresLockHandle {
+    /// The native lock backend.
+    #[must_use]
+    pub fn lock(&self) -> Arc<dyn DistributedLockBackend> {
+        Arc::clone(&self.lock) as Arc<dyn DistributedLockBackend>
+    }
+
+    /// Test-only access to the concrete [`PostgresLock`], for `pg_spec_005`'s
+    /// pinned-connection GUC probing (the `dyn` [`lock`](Self::lock) has no such
+    /// seam). Gated behind `--features integration` (PGR-M8).
+    #[cfg(feature = "integration")]
+    #[doc(hidden)]
+    #[must_use]
+    pub fn __test_lock(&self) -> Arc<PostgresLock> {
+        Arc::clone(&self.lock)
+    }
+
+    /// Cancels the lock TTL reaper and release-wake listener, then closes the
+    /// pool. Advisory locks held by pinned connections auto-release when the
+    /// pool closes (DESIGN.md §10).
+    pub async fn stop(mut self) {
+        self.shutdown.cancel();
+        for task in [self.reaper.take(), self.release_listener.take()]
+            .into_iter()
+            .flatten()
+        {
+            let _exited = task.await;
+        }
+        // Drain any lock still held at shutdown before closing the pool — see
+        // `PostgresLock::drain_held` for why `pool.close()` would otherwise
+        // block forever on a still-pinned lock connection (DESIGN.md §10).
+        self.lock.drain_held().await;
+        self.lock.pool().close().await;
+        self.stopped = true;
+    }
+}
+
+impl Drop for PostgresLockHandle {
+    fn drop(&mut self) {
+        if self.stopped {
+            return;
+        }
+        if std::thread::panicking() {
+            warn!(
+                "PostgresLockHandle dropped during panic unwind without stop(); \
+                 skipping debug panic to avoid double-panic abort"
+            );
+            return;
+        }
+        #[cfg(debug_assertions)]
+        panic!("PostgresLockHandle dropped without stop() - programming error");
+        #[cfg(not(debug_assertions))]
+        warn!(
+            "PostgresLockHandle dropped without stop() - programming error; \
+             background tasks may leak"
+        );
+    }
+}
+
+#[cfg(test)]
+#[path = "lock_tests.rs"]
+mod tests;

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/src/lock/notify.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/src/lock/notify.rs
@@ -1,0 +1,400 @@
+//! The `cluster_lock_released` NOTIFY channel (DESIGN.md §2.1, §5.3): wakes
+//! blocked [`lock()`](cluster_sdk::DistributedLockBackend::lock) waiters
+//! promptly instead of relying solely on the polling fallback in
+//! `lock/mod.rs`'s acquisition loop.
+//!
+//! Unlike the cache's `cluster_cache_changes` channel (DESIGN.md §2.3), this
+//! payload is the bare lock name — no `<event_type>:` prefix — per DESIGN.md
+//! §2.1: "The Postgres NOTIFY channel `cluster_lock_released` carries the
+//! lock name when a holder calls `release()` explicitly."
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Weak};
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use cluster_sdk::ClusterError;
+use dashmap::DashMap;
+use sqlx::postgres::PgListener;
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+
+use crate::pg_error::map_sqlx_error;
+
+pub const RELEASE_CHANNEL: &str = "cluster_lock_released";
+
+/// Issues `NOTIFY cluster_lock_released, '<name>'` via `pg_notify` (avoids any
+/// literal-quoting concern for names containing `'`).
+pub async fn notify_released<'e, E>(executor: E, name: &str) -> Result<(), ClusterError>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    sqlx::query("SELECT pg_notify($1, $2)")
+        .bind(RELEASE_CHANNEL)
+        .bind(name)
+        .execute(executor)
+        .await
+        .map_err(map_sqlx_error)?;
+    Ok(())
+}
+
+/// Registry of in-process waiters blocked in
+/// [`lock()`](cluster_sdk::DistributedLockBackend::lock), keyed by the lock
+/// name they're waiting to retry. `lock/mod.rs`'s acquisition loop also polls
+/// on a short heartbeat independent of this registry, so a missed wake here
+/// (a waiter registered just after `notify` already fired, or this task not
+/// running yet) only costs latency, never correctness.
+pub struct ReleaseWaiters {
+    /// Per-name set of live waiters, each keyed by a process-unique id so a
+    /// waiter can remove *its own* registration on drop (see [`ReleaseWait`])
+    /// without disturbing the others. A plain `Vec<Sender>` (as an earlier
+    /// version used) had no such handle: senders were only ever removed by
+    /// `notify`, so `lock()`'s per-heartbeat `wait_for` call left a dead sender
+    /// behind on every 250ms tick, and a name that is renewed-but-never-released
+    /// (no `NOTIFY` ever fires) grew the `Vec` unbounded for the waiter's whole
+    /// duration (PGR-M7).
+    waiters: DashMap<String, HashMap<u64, oneshot::Sender<()>>>,
+    /// Monotonic source of the per-waiter ids above.
+    next_id: AtomicU64,
+}
+
+impl ReleaseWaiters {
+    #[must_use]
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            waiters: DashMap::new(),
+            next_id: AtomicU64::new(0),
+        })
+    }
+
+    /// Registers interest in `name`'s next release, returning a [`ReleaseWait`]
+    /// future that resolves once [`notify`](Self::notify) is called for that
+    /// name (or resolves immediately if this registry is dropped first — the
+    /// caller's own heartbeat/timeout bound covers that case). Dropping the
+    /// returned future without it resolving deregisters this waiter, so a
+    /// caller that gives up (timeout, or re-acquired via the heartbeat) never
+    /// leaves a stale sender behind.
+    pub fn wait_for(self: &Arc<Self>, name: &str) -> ReleaseWait {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = oneshot::channel();
+        self.waiters
+            .entry(name.to_owned())
+            .or_default()
+            .insert(id, tx);
+        ReleaseWait {
+            // A `Weak`, not an `Arc`: the wait must not keep the registry alive
+            // past `PostgresLock`'s own lifetime (dropping the registry closes
+            // this waiter's sender, resolving the wait — see the unit tests).
+            registry: Arc::downgrade(self),
+            name: name.to_owned(),
+            id,
+            rx,
+        }
+    }
+
+    /// Wakes every waiter registered under `name` (best-effort — a waiter that
+    /// has already given up and dropped its receiver is silently skipped).
+    pub fn notify(&self, name: &str) {
+        if let Some((_, senders)) = self.waiters.remove(name) {
+            for (_id, sender) in senders {
+                // `Err` just means the waiter already gave up (dropped its
+                // receiver) — nothing to do either way, so the outcome is
+                // deliberately unused (named, not `_`, to satisfy
+                // `clippy::let_underscore_must_use`).
+                let _send_result = sender.send(());
+            }
+        }
+    }
+
+    /// Test-only: the number of live waiters currently registered under `name`.
+    /// Lets an integration test synchronize on a blocked `lock()` caller having
+    /// actually reached its [`wait_for`](Self::wait_for) registration before
+    /// releasing, so the release provably races an already-registered NOTIFY
+    /// waiter rather than an unscheduled task (PGR-E3). Gated behind
+    /// `--features integration` (PGR-M8).
+    #[cfg(feature = "integration")]
+    #[doc(hidden)]
+    #[must_use]
+    pub fn __test_registered_count(&self, name: &str) -> usize {
+        self.waiters.get(name).map_or(0, |entry| entry.len())
+    }
+
+    /// Deregisters waiter `id` under `name` (called from [`ReleaseWait::drop`]).
+    fn deregister(&self, name: &str, id: u64) {
+        let now_empty = {
+            let Some(mut entry) = self.waiters.get_mut(name) else {
+                return;
+            };
+            entry.remove(&id);
+            entry.is_empty()
+        };
+        // Prune the now-empty per-name entry, but only if a concurrent
+        // `wait_for` hasn't repopulated it in the gap after we dropped the
+        // `get_mut` guard (dropping the guard first avoids a same-shard
+        // re-entrant lock).
+        if now_empty {
+            self.waiters
+                .remove_if(name, |_, waiters| waiters.is_empty());
+        }
+    }
+}
+
+/// A registered blocked-`lock()` waiter. Resolves when a `cluster_lock_released`
+/// NOTIFY for its name wakes it; deregisters itself from [`ReleaseWaiters`] on
+/// drop so an abandoned wait (timeout / heartbeat re-acquire) leaves nothing
+/// behind (PGR-M7).
+pub struct ReleaseWait {
+    registry: Weak<ReleaseWaiters>,
+    name: String,
+    id: u64,
+    rx: oneshot::Receiver<()>,
+}
+
+impl Future for ReleaseWait {
+    /// `Ok(())` — woken by a `notify` for this name. `Err(())` — the sender was
+    /// dropped (the registry went away). Both mean "stop waiting and re-attempt
+    /// the acquire"; the caller re-checks `pg_try_advisory_lock` as the source
+    /// of truth regardless, so the distinction only matters to the unit tests.
+    type Output = Result<(), ()>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), ()>> {
+        Pin::new(&mut self.rx)
+            .poll(cx)
+            .map(|result| result.map_err(|_| ()))
+    }
+}
+
+impl Drop for ReleaseWait {
+    fn drop(&mut self) {
+        // If the registry is already gone there is nothing to deregister from.
+        if let Some(registry) = self.registry.upgrade() {
+            registry.deregister(&self.name, self.id);
+        }
+    }
+}
+
+/// Backoff policy for this task's own reconnect loop, used only when
+/// [`PgListener`]'s internal (single-attempt) reconnect fails outright —
+/// mirrors `cache/watch.rs::ListenRetryPolicy` exactly; kept as a separate
+/// copy rather than a shared type since the two channels' dispatch payloads
+/// differ enough (bare name vs. `<event>:<key>`) that unifying the two tasks
+/// would add more indirection than it would save.
+struct RetryPolicy {
+    initial_backoff: Duration,
+    max_backoff: Duration,
+    max_retries: u32,
+}
+
+impl RetryPolicy {
+    const DEFAULT: Self = Self {
+        initial_backoff: Duration::from_secs(1),
+        max_backoff: Duration::from_secs(30),
+        max_retries: 10,
+    };
+
+    fn backoff_for(&self, attempt: u32) -> Duration {
+        let factor = 2u32.saturating_pow(attempt);
+        self.initial_backoff
+            .checked_mul(factor)
+            .map_or(self.max_backoff, |grown| grown.min(self.max_backoff))
+    }
+}
+
+async fn connect_and_listen(connection_string: &str) -> Result<PgListener, ClusterError> {
+    let mut listener = PgListener::connect(connection_string)
+        .await
+        .map_err(map_sqlx_error)?;
+    listener
+        .listen(RELEASE_CHANNEL)
+        .await
+        .map_err(map_sqlx_error)?;
+    Ok(listener)
+}
+
+/// [`connect_and_listen`], but abandoned the instant `cancel` fires so a
+/// shutdown never stalls waiting on a hung `PgListener::connect` network I/O.
+/// Returns `None` if cancellation won the race — the caller must stop rather
+/// than treat it as a connect failure to retry.
+async fn connect_and_listen_cancellable(
+    connection_string: &str,
+    cancel: &CancellationToken,
+) -> Option<Result<PgListener, ClusterError>> {
+    tokio::select! {
+        () = cancel.cancelled() => None,
+        result = connect_and_listen(connection_string) => Some(result),
+    }
+}
+
+/// Logs the permanent loss of `cluster_lock_released` NOTIFY wakeups once
+/// [`reconnect_with_backoff`] returns `None` for a genuine reason: the retry
+/// budget was exhausted, not `cancel` firing mid-backoff (a graceful
+/// shutdown, which needs no log). Called at both `reconnect_with_backoff`
+/// call sites in [`spawn_release_listen_task`] right before they `return`.
+///
+/// A missed wake-up here only costs latency, never correctness —
+/// `lock/mod.rs`'s heartbeat poll is the acquisition loop's correctness
+/// backstop (see this module's doc comment) — so an error log satisfies
+/// "observable" without any change to that fallback behavior.
+fn log_release_listen_exhausted_if_not_cancelled(cancel: &CancellationToken) {
+    if !cancel.is_cancelled() {
+        tracing::error!(
+            name: "cluster.lock.release_listen_lost",
+            "cluster_lock_released LISTEN reconnect retry budget exhausted; \
+             lock() callers now rely solely on the heartbeat poll fallback"
+        );
+    }
+}
+
+async fn reconnect_with_backoff(
+    connection_string: &str,
+    policy: &RetryPolicy,
+    attempt: &mut u32,
+    cancel: &CancellationToken,
+) -> Option<PgListener> {
+    while *attempt < policy.max_retries {
+        let backoff = policy.backoff_for(*attempt);
+        *attempt += 1;
+        tokio::select! {
+            () = cancel.cancelled() => return None,
+            () = tokio::time::sleep(backoff) => {}
+        }
+        match connect_and_listen_cancellable(connection_string, cancel).await {
+            // Cancelled mid-connect: stop, don't spin the backoff loop.
+            None => return None,
+            Some(Ok(listener)) => return Some(listener),
+            // Connect failed: fall through to the next backoff attempt.
+            Some(Err(_lost)) => {}
+        }
+    }
+    None
+}
+
+/// Spawns the dedicated LISTEN connection for `cluster_lock_released`
+/// (DESIGN.md §5.3). Mirrors `cache/watch.rs::spawn_listen_task`'s
+/// reconnect/backoff shape; unlike the cache channel there is no `Reset`
+/// concept here to broadcast on reconnect — a lost wake-up during a gap only
+/// costs a waiter its heartbeat-interval latency (`lock/mod.rs`), never
+/// correctness, so silently resuming is sufficient.
+pub fn spawn_release_listen_task(
+    connection_string: String,
+    waiters: Arc<ReleaseWaiters>,
+    cancel: CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let policy = RetryPolicy::DEFAULT;
+        let mut attempt: u32 = 0;
+
+        // Initial connect: try once immediately (no backoff), interruptible by
+        // `cancel`. On failure, fall into the *same* cancellation-aware backoff
+        // retry the mid-stream reconnect path uses — a Postgres blip at startup
+        // no longer permanently disables NOTIFY wakeups (they'd otherwise
+        // silently degrade to `lock/mod.rs`'s heartbeat-only fallback forever).
+        let mut listener = match connect_and_listen_cancellable(&connection_string, &cancel).await {
+            // Cancelled before we ever connected: shutdown, stop here.
+            None => return,
+            Some(Ok(listener)) => listener,
+            Some(Err(_lost)) => {
+                if let Some(reconnected) =
+                    reconnect_with_backoff(&connection_string, &policy, &mut attempt, &cancel).await
+                {
+                    reconnected
+                } else {
+                    log_release_listen_exhausted_if_not_cancelled(&cancel);
+                    return;
+                }
+            }
+        };
+        attempt = 0;
+
+        loop {
+            tokio::select! {
+                () = cancel.cancelled() => return,
+                received = listener.try_recv() => match received {
+                    Ok(Some(notification)) => {
+                        attempt = 0;
+                        waiters.notify(notification.payload());
+                    }
+                    Ok(None) => {
+                        // Transparent reconnect already happened inside
+                        // `try_recv`; nothing else to do.
+                        attempt = 0;
+                    }
+                    Err(_lost) => {
+                        if let Some(reconnected) =
+                            reconnect_with_backoff(&connection_string, &policy, &mut attempt, &cancel).await
+                        {
+                            listener = reconnected;
+                        } else {
+                            log_release_listen_exhausted_if_not_cancelled(&cancel);
+                            return;
+                        }
+                    }
+                },
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// PGR-M7: dropping an abandoned `ReleaseWait` (the timeout/heartbeat
+    /// give-up path) removes its own registration, pruning the now-empty
+    /// per-name entry.
+    #[tokio::test]
+    async fn abandoned_wait_deregisters_itself_on_drop() {
+        let waiters = ReleaseWaiters::new();
+        {
+            let _wait = waiters.wait_for("x");
+            assert_eq!(
+                waiters.waiters.get("x").map(|entry| entry.len()),
+                Some(1),
+                "wait_for must register exactly one waiter"
+            );
+        }
+        assert!(
+            waiters.waiters.get("x").is_none(),
+            "dropping an abandoned wait must deregister it and prune the empty entry"
+        );
+    }
+
+    /// PGR-M7 regression: `lock()`'s per-heartbeat `wait_for` must not leave a
+    /// dead sender behind on every tick. The pre-fix `Vec<Sender>` grew by one
+    /// per call for a never-notified name; the drop-guard keeps it at zero.
+    #[tokio::test]
+    async fn repeated_wait_for_does_not_accumulate_dead_senders() {
+        let waiters = ReleaseWaiters::new();
+        for _ in 0..100 {
+            let _wait = waiters.wait_for("y");
+        }
+        assert!(
+            waiters.waiters.get("y").is_none(),
+            "abandoned waits must not accumulate stale senders"
+        );
+    }
+
+    /// A live waiter must survive another waiter's drop under the same name.
+    #[tokio::test]
+    async fn dropping_one_waiter_leaves_a_sibling_registered() {
+        let waiters = ReleaseWaiters::new();
+        let live = waiters.wait_for("z");
+        {
+            let _abandoned = waiters.wait_for("z");
+            assert_eq!(waiters.waiters.get("z").map(|entry| entry.len()), Some(2));
+        }
+        assert_eq!(
+            waiters.waiters.get("z").map(|entry| entry.len()),
+            Some(1),
+            "dropping one waiter must not deregister its sibling"
+        );
+        waiters.notify("z");
+        assert!(
+            live.await.is_ok(),
+            "the surviving waiter must still be woken"
+        );
+    }
+}

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/src/lock/reaper.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/src/lock/reaper.rs
@@ -1,0 +1,625 @@
+//! The `cluster_lock` TTL reaper background task (DESIGN.md §5.2).
+//!
+//! Scans `cluster_lock` for rows past `expires_at <= now()`, deletes them in
+//! bounded batches, and — for each one this process itself still has pinned
+//! (`held.remove(name)` returns `Some`) — calls `pg_advisory_unlock` **on that
+//! exact connection**, since
+//! `pg_advisory_unlock` called from any other session is a silent no-op
+//! (session-scoped advisory locks can only be released by the session that
+//! acquired them). That's why this reaper needs `held` at all, rather than
+//! just running the unlock on a connection of its own: DESIGN.md §5.2 says it
+//! plainly — "The advisory unlock must run on the same connection that holds
+//! the lock... The reaper therefore tracks the connection ID per lock." This
+//! plugin tracks the connection object itself, one step more directly than an
+//! ID, via the same `held` registry `lock/mod.rs`'s guard task uses.
+//!
+//! A row whose name isn't in this process's own `held` map belongs to a
+//! different fleet instance (or was already reclaimed by a racing `release()`
+//! in this same process — `DashMap::remove` makes exactly one of the two
+//! win). Either way, deleting the metadata row is still correct: the actual
+//! mutual-exclusion guarantee lives in Postgres's advisory-lock table, not in
+//! this bookkeeping row, so a stale row for a lock still legitimately held by
+//! a live remote session costs that session nothing — a subsequent
+//! `pg_try_advisory_lock` from elsewhere still correctly fails while that
+//! session is alive. This is the accepted, documented nature of a TTL layered
+//! on top of a primitive with no native TTL (DESIGN.md §5.2's opening line).
+//!
+//! ## Wake schedule
+//!
+//! Each loop iteration sweeps, then sleeps until the *earlier* of the next
+//! metrics tick (`interval`) and the next row's deadline
+//! (`min(expires_at)`, an index-only read on `cluster_lock_expires_idx`):
+//!
+//! * The **`interval` cap** is what keeps `cluster_postgres_lock_active_names`
+//!   and the cardinality WARN on their configured cadence. A lock's row count
+//!   moves with every acquire/release, not only with expiry, so the gauge cannot
+//!   be allowed to go quiet just because nothing is near its TTL — that is why
+//!   the reaper does not simply sleep until `min(expires_at)` however far out it
+//!   is. Only these interval-boundary wakes do the gauge work; expiry-driven
+//!   wakes skip it and stay two indexed queries wide.
+//! * The **`min(expires_at)` shortening** makes reclamation prompt: an expired
+//!   lock is reaped near its actual deadline instead of up to a full `interval`
+//!   late, which shortens how long a "holder is alive but forgot to release"
+//!   lock (DESIGN.md §5.2 point 4) blocks every waiter behind it.
+//! * The **`deadline_hint` signal** is what makes that hold for a lock acquired
+//!   *after* a wake, too. The sleep is computed from the table as it looked at
+//!   wake time, so without a signal a lock whose whole lifetime fits inside one
+//!   sleep (TTL ≲ `interval`) would go unreclaimed until that sleep ended.
+//!   `try_acquire` and `renew` therefore notify this task once their write is
+//!   committed, and it re-sweeps. Local-only by design, and that is sufficient
+//!   rather than partial: a lock held by a *live* session can only be unlocked
+//!   by the instance that owns that session (advisory locks are session-scoped),
+//!   so the instance that needs to act is always the one holding the hint. A
+//!   remote holder that died needs no timely sweep at all — Postgres released
+//!   its advisory lock at disconnect, and `try_acquire` upserts over the stale
+//!   row (`ON CONFLICT (name) DO UPDATE`) rather than waiting for its deletion.
+//! * [`wake_floor`] floors both the expiry-driven and the signalled wake. Without
+//!   it, N locks with staggered deadlines that keep getting renewed would wake
+//!   this task once per deadline that passes, and a burst of acquisitions would
+//!   wake it once per acquisition; the floor coalesces either into at most one
+//!   wake per floor. It is [`MIN_WAKE`] capped by `interval`, so a deliberately
+//!   sub-100ms cadence is honoured rather than stretched.
+//!
+//! The signal is only ever a *hint*: every wake re-derives its own schedule from
+//! the table, so a spurious or a lost notification costs at most one extra or one
+//! late sweep, never a missed reclamation.
+//!
+//! Deliberately *not* bucketed into coarse expiry slices: for a lock the TTL is
+//! the crash/wedge safety net, so rounding a deadline up to a shared boundary
+//! would let a stale lock block waiters for up to a full bucket past its TTL,
+//! and would make that extra grace depend on *when in the bucket* the lock
+//! happened to be acquired. The exact deadline plus this schedule gets the
+//! cheap-idle and sleep-until-due properties without buying them with TTL
+//! precision.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use cluster_sdk::observability::fields::label;
+use cluster_sdk::observability::{self, ResourceId};
+use cluster_sdk::{ClusterError, ClusterMetrics};
+use dashmap::DashMap;
+use opentelemetry::metrics::{Gauge, Histogram, Meter};
+use opentelemetry::{InstrumentationScope, KeyValue, global};
+use sqlx::PgPool;
+use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
+use tracing::warn;
+use uuid::Uuid;
+
+use super::HeldLock;
+use crate::lock::notify;
+use crate::pg_error::map_sqlx_error;
+
+/// Instrumentation scope for this plugin's own, non-contract metrics (DESIGN.md
+/// §8): the lock-name cardinality gauge and the reaper-sweep-duration histogram.
+/// Distinct from the shared `cf-gears-cluster` scope `OtelClusterMetrics` uses
+/// for the ADR-004 contract signals — these two are plugin-local additions
+/// emitted via a meter this plugin owns directly, not through the
+/// `ClusterMetrics` port (which has no gauge method).
+const REAPER_SCOPE: &str = "cf-postgres-cluster-plugin";
+
+/// The process-global meter under [`REAPER_SCOPE`], used when no meter is
+/// injected (production). Tests inject their own meter over an in-memory reader
+/// to read the gauge back (see `PostgresLockBuilder::__with_reaper_meter`).
+pub fn reaper_meter() -> Meter {
+    global::meter_with_scope(InstrumentationScope::builder(REAPER_SCOPE).build())
+}
+
+/// Builds the shared `cluster_postgres_reaper_sweep_duration_seconds` histogram
+/// (DESIGN.md §8). Both TTL reapers (`primitive={cache,lock}`) record into it;
+/// creating it by the same name on the same meter yields the same instrument.
+pub fn sweep_duration_histogram(meter: &Meter) -> Histogram<f64> {
+    meter
+        .f64_histogram("cluster_postgres_reaper_sweep_duration_seconds")
+        .with_description("Postgres cluster TTL reaper sweep duration")
+        .with_unit("s")
+        .build()
+}
+
+/// Plugin-local (non-ADR-004) lock-reaper metrics, emitted via a directly-owned
+/// OpenTelemetry meter rather than the `ClusterMetrics` contract sink — DESIGN.md
+/// §8 classifies both of these as plugin-local, and `ClusterMetrics` exposes no
+/// gauge method anyway (see `GAP-SOLUTIONS.md` §6).
+pub struct LockReaperMetrics {
+    provider: &'static str,
+    /// `cluster_postgres_lock_active_names{provider}` — the cluster-wide count
+    /// of distinct held lock names (`= count(*)` of `cluster_lock`, not
+    /// `held.len()`, which is only this instance's slice — DESIGN.md §8).
+    active_names: Gauge<i64>,
+    /// `cluster_postgres_reaper_sweep_duration_seconds{provider,primitive=lock}`.
+    sweep_duration: Histogram<f64>,
+    /// The ADR-004 sink the reaper routes backend failures through
+    /// (`emit_provider_error` → `cluster_provider_errors_total` + a
+    /// `cluster.provider.error` ERROR log). Distinct from the plugin-local
+    /// `OTel` instruments above (DESIGN.md §8 / PGR-M1).
+    errors: Arc<dyn ClusterMetrics>,
+}
+
+impl LockReaperMetrics {
+    pub fn new(meter: &Meter, provider: &'static str, errors: Arc<dyn ClusterMetrics>) -> Self {
+        Self {
+            provider,
+            active_names: meter
+                .i64_gauge("cluster_postgres_lock_active_names")
+                .with_description("Distinct lock names currently held cluster-wide")
+                .build(),
+            sweep_duration: sweep_duration_histogram(meter),
+            errors,
+        }
+    }
+
+    /// The ADR-004 error sink and the bounded `provider` label, for the sweep's
+    /// `emit_provider_error` calls.
+    fn errors(&self) -> (&dyn ClusterMetrics, &'static str) {
+        (&*self.errors, self.provider)
+    }
+
+    fn record_active_names(&self, count: i64) {
+        self.active_names
+            .record(count, &[KeyValue::new(label::PROVIDER, self.provider)]);
+    }
+
+    fn record_sweep_duration(&self, seconds: f64) {
+        self.sweep_duration.record(
+            seconds,
+            &[
+                KeyValue::new(label::PROVIDER, self.provider),
+                KeyValue::new(label::PRIMITIVE, "lock"),
+            ],
+        );
+    }
+}
+
+/// Reclaims one lock this process still has pinned: releases the advisory lock
+/// on its exact connection and wakes any blocked `lock()` waiters. Best-effort
+/// throughout — logs and continues on either failure, since the connection is
+/// being dropped either way (returning to the pool), and a failed unlock just
+/// means the session-disconnect safety net (DESIGN.md §5.2 point 4) is what
+/// eventually frees it instead.
+///
+/// `pub(super)` so the shutdown drain (`PostgresLock::drain_held`, DESIGN.md
+/// §10 step 4) can reuse this exact per-lock release path rather than
+/// duplicating it — the drain is just this, run unconditionally for every
+/// still-held lock instead of only the TTL-expired ones the sweep targets.
+pub(super) async fn reclaim(
+    name: &str,
+    held_lock: HeldLock,
+    metrics: &dyn ClusterMetrics,
+    provider: &'static str,
+) {
+    // `held_lock` was just `remove`d from the map, so we own an `Arc` to the
+    // connection; lock the async mutex (waiting out any in-flight renew/reassert
+    // clone, without blocking a thread). The connection returns to the pool once
+    // this `Arc` and any concurrent clone are dropped.
+    let mut conn = held_lock.conn.lock().await;
+    if let Err(err) = sqlx::query("SELECT pg_advisory_unlock($1, $2)")
+        .bind(held_lock.key1)
+        .bind(held_lock.key2)
+        .execute(&mut **conn)
+        .await
+    {
+        observability::emit_provider_error(
+            metrics,
+            provider,
+            "reaper_reclaim",
+            ResourceId::Lock(name),
+            &map_sqlx_error(err),
+        );
+    }
+    if let Err(err) = notify::notify_released(&mut **conn, name).await {
+        observability::emit_provider_error(
+            metrics,
+            provider,
+            "reaper_reclaim_notify",
+            ResourceId::Lock(name),
+            &err,
+        );
+    }
+    // `conn` drops here, returning to the pool.
+}
+
+/// The two signals driving the reaper's wake schedule, bundled so
+/// [`spawn_lock_reaper`] stays within a sane argument count (same reason
+/// `lock/mod.rs` bundles `GuardContext`).
+pub(super) struct ReaperWakeup {
+    /// See [`PostgresLock::deadline_hint`](super::PostgresLock): signalled by a
+    /// local `try_acquire`/`renew` so a sleep computed before that write is
+    /// recomputed with the new deadline in view.
+    pub deadline_hint: Arc<Notify>,
+    /// Cancelled on `stop()`; ends the task from any point in its sleep.
+    pub cancel: CancellationToken,
+}
+
+/// Expired rows one sweep statement claims. The sweep loops until a batch comes
+/// back short, so a large backlog is still reclaimed in full — just across
+/// several bounded statements instead of one unbounded `DELETE` holding row
+/// locks on every matching row for however long that takes.
+const SWEEP_BATCH: usize = 512;
+
+/// Default floor on an expiry-driven or signalled wake — see the module doc's
+/// wake schedule. Always applied via [`wake_floor`], which caps it by the
+/// configured reaper interval so a deliberately sub-100ms cadence is still
+/// honoured rather than silently stretched to this value.
+const MIN_WAKE: Duration = Duration::from_millis(100);
+
+/// The effective wake floor for a reaper configured with `interval`.
+///
+/// [`MIN_WAKE`] exists to stop deadline churn (many staggered TTLs, or a burst of
+/// acquisitions) from waking the reaper faster than it can usefully sweep. It is
+/// deliberately *not* allowed to override an explicitly configured cadence: an
+/// operator who sets `lock_reaper_interval_ms: 50` asked for 50ms sweeps, and
+/// flooring those at 100ms would silently halve their configured rate (the
+/// plugin's own tests configure intervals in that range).
+fn wake_floor(interval: Duration) -> Duration {
+    MIN_WAKE.min(interval)
+}
+
+/// Deletes up to [`SWEEP_BATCH`] expired rows, returning the `(name, holder_id)`
+/// of each.
+///
+/// The `LIMIT` lives in a subquery because `DELETE` takes no `LIMIT` of its own.
+/// `ORDER BY expires_at` reaps longest-expired-first and rides
+/// `cluster_lock_expires_idx` (the same index the `expires_at <= now()` filter
+/// uses), so ordering costs nothing.
+///
+/// `FOR UPDATE SKIP LOCKED` does double duty. It keeps concurrent reapers — one
+/// per fleet instance, all sweeping the same table — from serializing behind each
+/// other on the same batch: each skips rows another has already claimed and takes
+/// the next ones instead. It is also what makes the *outer* delete safe despite
+/// matching on `name` alone rather than re-checking `expires_at`: a row whose
+/// `renew` is in flight is already row-locked by that `UPDATE`, so this statement
+/// skips it instead of deleting a lock that is in the act of being extended. (A
+/// renew that commits *before* the subquery runs is excluded by the
+/// `expires_at <= now()` filter; one that arrives *after* blocks on this
+/// statement's own row lock and then finds the row gone, reporting `LockExpired`
+/// — the same reaper-wins outcome the unbounded single-statement delete had.)
+async fn sweep_batch(pool: &PgPool, table: &str) -> Result<Vec<(String, Uuid)>, ClusterError> {
+    sqlx::query_as(&format!(
+        "DELETE FROM {table} WHERE name IN (\
+             SELECT name FROM {table} WHERE expires_at <= now() \
+             ORDER BY expires_at LIMIT {SWEEP_BATCH} FOR UPDATE SKIP LOCKED\
+         ) RETURNING name, holder_id"
+    ))
+    .fetch_all(pool)
+    .await
+    .map_err(map_sqlx_error)
+}
+
+/// Runs one sweep to completion, batch by batch. Returns the number of expired
+/// rows reclaimed (regardless of whether this process could act on the advisory
+/// lock for each one).
+///
+/// Re-checks `cancel` between batches so a shutdown arriving mid-backlog is not
+/// held up for as many statements as the backlog needs — the rows left behind
+/// are still expired, so the next reaper to run (here or on another instance)
+/// picks them up.
+pub(super) async fn sweep(
+    pool: &PgPool,
+    table: &str,
+    held: &Arc<DashMap<String, HeldLock>>,
+    metrics: &dyn ClusterMetrics,
+    provider: &'static str,
+    cancel: &CancellationToken,
+) -> Result<usize, ClusterError> {
+    let mut reclaimed = 0;
+    loop {
+        let expired = sweep_batch(pool, table).await?;
+
+        for (name, holder_id) in &expired {
+            // Fence reclamation on `holder_id` (PGR-L1): reclaim the pinned
+            // connection only when *this* process still holds the exact
+            // acquisition whose row just expired. A non-matching entry means a
+            // newer holder re-acquired `name` (its fresh row is not expired, so
+            // it was not among the deleted rows) — reclaiming it would unlock a
+            // live lock. `None` means the row belongs to a different fleet
+            // instance, or a racing `release()` in this process already
+            // reclaimed it.
+            if let Some((_, held_lock)) =
+                held.remove_if(name, |_, entry| entry.holder_id == *holder_id)
+            {
+                reclaim(name, held_lock, metrics, provider).await;
+            }
+        }
+
+        reclaimed += expired.len();
+        // A short batch means the table had nothing more to give.
+        if expired.len() < SWEEP_BATCH || cancel.is_cancelled() {
+            return Ok(reclaimed);
+        }
+    }
+}
+
+/// Seconds until the earliest deadline in `cluster_lock`, or `None` when the
+/// table is empty. Negative when a row is already due (an aggregate over rows
+/// this sweep's `SKIP LOCKED` left to another reaper, say).
+///
+/// The subtraction happens **in Postgres**, so what comes back is a delay
+/// measured entirely on the database clock — this task can then sleep on its own
+/// monotonic clock without ever comparing a Postgres timestamp against a
+/// possibly-skewed local wall clock (PGR-C2). `min(expires_at)` is an index-only
+/// read of `cluster_lock_expires_idx`'s leftmost entry, not a scan.
+pub(super) async fn seconds_until_next_expiry(
+    pool: &PgPool,
+    table: &str,
+) -> Result<Option<f64>, ClusterError> {
+    sqlx::query_scalar(&format!(
+        "SELECT extract(epoch FROM (min(expires_at) - now()))::float8 FROM {table}"
+    ))
+    .fetch_one(pool)
+    .await
+    .map_err(map_sqlx_error)
+}
+
+/// How long to sleep before the next sweep: the earlier of the next metrics tick
+/// (`until_metrics`) and the next row's deadline, with the latter floored at
+/// `floor` (see [`wake_floor`]). See the module doc's wake schedule.
+fn next_delay(
+    until_metrics: Duration,
+    seconds_until_expiry: Option<f64>,
+    floor: Duration,
+) -> Duration {
+    match seconds_until_expiry {
+        Some(secs) if secs.is_finite() => {
+            // `max(0.0)` covers an already-due row (negative seconds); the
+            // `try_from` fallback covers a deadline so distant it overflows a
+            // `Duration` — either way the metrics cap below still applies.
+            let due_in = Duration::try_from_secs_f64(secs.max(0.0)).unwrap_or(until_metrics);
+            until_metrics.min(due_in.max(floor))
+        }
+        // No rows (`None`), or a value there is nothing sensible to derive a
+        // deadline from (a non-finite epoch, which `extract` does not produce):
+        // nothing to wake early for.
+        _ => until_metrics,
+    }
+}
+
+/// Counts every row in `cluster_lock` — the cluster-wide number of distinct
+/// lock names currently held (DESIGN.md §8), the value behind the
+/// `cluster_postgres_lock_active_names` gauge. Deliberately **not** `held.len()`,
+/// which is only this instance's slice of the fleet's locks.
+async fn active_name_count(pool: &PgPool, table: &str) -> Result<i64, ClusterError> {
+    sqlx::query_scalar(&format!("SELECT count(*) FROM {table}"))
+        .fetch_one(pool)
+        .await
+        .map_err(map_sqlx_error)
+}
+
+/// Spawns the lock TTL reaper.
+///
+/// `interval` is the metrics cadence and the upper bound on how long this task
+/// sleeps; an imminent `expires_at` shortens an individual sleep (module doc,
+/// "Wake schedule").
+///
+/// Besides the TTL sweep, every wake records the reaper-sweep-duration
+/// histogram, and each `interval`-boundary wake records the
+/// `cluster_postgres_lock_active_names` gauge and logs
+/// `cluster.lock.name_cardinality_high` (WARN) while the distinct-name count is
+/// over `warn_threshold` (DESIGN.md §8). Tying the WARN to the interval-boundary
+/// wake rather than to every sweep is what keeps it rate-limited to once per
+/// interval now that expiry-driven wakes can land in between.
+///
+/// `synchronous_commit = on` re-assertion on pinned connections is **not** done
+/// here: it lives on each guard task's own interval (`run_guard_task`,
+/// `lock/mod.rs`), so no second accessor takes `held.get_mut` on a live key
+/// across an `.await` (which would deadlock the guard's own renew/release under
+/// the current-thread runtime — see `GAP-SOLUTIONS.md` §5).
+pub(super) fn spawn_lock_reaper(
+    pool: PgPool,
+    table: String,
+    held: Arc<DashMap<String, HeldLock>>,
+    interval: Duration,
+    metrics: LockReaperMetrics,
+    warn_threshold: i64,
+    wakeup: ReaperWakeup,
+) -> tokio::task::JoinHandle<()> {
+    let ReaperWakeup {
+        deadline_hint,
+        cancel,
+    } = wakeup;
+    let floor = wake_floor(interval);
+    tokio::spawn(async move {
+        // Due immediately, so the first iteration sweeps and records the gauge
+        // right away rather than after one full `interval`.
+        let mut metrics_due = tokio::time::Instant::now();
+        loop {
+            let (errors, provider) = metrics.errors();
+            let started = tokio::time::Instant::now();
+            let swept = sweep(&pool, &table, &held, errors, provider, &cancel).await;
+            metrics.record_sweep_duration(started.elapsed().as_secs_f64());
+
+            // Shutdown observed (possibly *during* the sweep, which bails between
+            // batches): leave now rather than running the gauge and next-deadline
+            // queries against a pool `stop()` is about to close — those would fail
+            // and emit `cluster.provider.error` ERRORs on every clean shutdown.
+            if cancel.is_cancelled() {
+                break;
+            }
+
+            // On a failed sweep, skip both the gauge and the next-expiry probe
+            // (the same backend is almost certainly still unhealthy) and wait out
+            // the metrics cadence before trying again.
+            let delay = if let Err(err) = swept {
+                observability::emit_provider_error(
+                    errors,
+                    provider,
+                    "reaper_sweep",
+                    ResourceId::Name(&table),
+                    &err,
+                );
+                metrics_due.saturating_duration_since(tokio::time::Instant::now())
+            } else {
+                if tokio::time::Instant::now() >= metrics_due {
+                    metrics_due = tokio::time::Instant::now() + interval;
+                    // Distinct held names = live row count *after* the TTL
+                    // delete, so expired-but-not-yet-swept rows never inflate it.
+                    match active_name_count(&pool, &table).await {
+                        Ok(count) => {
+                            metrics.record_active_names(count);
+                            if count > warn_threshold {
+                                warn!(
+                                    active_names = count,
+                                    threshold = warn_threshold,
+                                    "cluster.lock.name_cardinality_high"
+                                );
+                            }
+                        }
+                        Err(err) => observability::emit_provider_error(
+                            errors,
+                            provider,
+                            "reaper_active_name_count",
+                            ResourceId::Name(&table),
+                            &err,
+                        ),
+                    }
+                }
+
+                let until_metrics =
+                    metrics_due.saturating_duration_since(tokio::time::Instant::now());
+                match seconds_until_next_expiry(&pool, &table).await {
+                    Ok(secs) => next_delay(until_metrics, secs, floor),
+                    // Can't tell when the next lock is due; fall back to the
+                    // fixed cadence, which is the pre-existing behaviour.
+                    Err(err) => {
+                        observability::emit_provider_error(
+                            errors,
+                            provider,
+                            "reaper_next_expiry",
+                            ResourceId::Name(&table),
+                            &err,
+                        );
+                        until_metrics
+                    }
+                }
+            };
+
+            // Floor every sleep, not just the expiry-driven one: a sweep that
+            // overran `interval` (or an unhealthy backend on the error path
+            // above) leaves `metrics_due` already elapsed, and sleeping zero
+            // there would turn this loop into a hot retry against the very
+            // database that is already struggling.
+            tokio::select! {
+                () = cancel.cancelled() => break,
+                () = tokio::time::sleep(delay.max(floor)) => {}
+                // A local acquire/renew just wrote a deadline this sleep was
+                // computed without. Re-sweep, but only after the wake floor:
+                // `Notify` coalesces concurrent signals into a single permit, so
+                // the floor is what stops a *stream* of acquisitions from
+                // turning every one of them into its own sweep.
+                () = deadline_hint.notified() => {
+                    tokio::select! {
+                        () = cancel.cancelled() => break,
+                        () = tokio::time::sleep(floor) => {}
+                    }
+                }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_delay_falls_back_to_the_metrics_cadence_with_no_locks() {
+        // Empty table: nothing can expire, so the only thing left to wake for is
+        // the gauge/WARN tick.
+        assert_eq!(
+            next_delay(Duration::from_secs(5), None, MIN_WAKE),
+            Duration::from_secs(5)
+        );
+    }
+
+    #[test]
+    fn next_delay_shortens_to_an_imminent_deadline() {
+        // A lock due in 800ms must not wait out the full 5s interval — this is
+        // the whole point of reading `min(expires_at)`.
+        assert_eq!(
+            next_delay(Duration::from_secs(5), Some(0.8), MIN_WAKE),
+            Duration::from_millis(800)
+        );
+    }
+
+    #[test]
+    fn next_delay_caps_a_distant_deadline_at_the_metrics_cadence() {
+        // A deadline an hour out must not silence the `active_names` gauge for an
+        // hour: the row count moves with every acquire/release, not just expiry.
+        assert_eq!(
+            next_delay(Duration::from_secs(5), Some(3600.0), MIN_WAKE),
+            Duration::from_secs(5)
+        );
+    }
+
+    #[test]
+    fn next_delay_floors_an_already_due_deadline() {
+        // Negative seconds mean a row is already past its deadline but survived
+        // this sweep (another reaper's `SKIP LOCKED` claim, or a batch boundary).
+        // Re-sweeping must be floored, not immediate, or the task spins.
+        assert_eq!(
+            next_delay(Duration::from_secs(5), Some(-2.0), MIN_WAKE),
+            MIN_WAKE
+        );
+        assert_eq!(
+            next_delay(Duration::from_secs(5), Some(0.0), MIN_WAKE),
+            MIN_WAKE
+        );
+    }
+
+    #[test]
+    fn next_delay_floors_a_deadline_inside_the_wake_floor() {
+        // Many locks with staggered sub-floor deadlines would otherwise wake this
+        // task once per deadline; the floor coalesces them.
+        assert_eq!(
+            next_delay(Duration::from_secs(5), Some(0.001), MIN_WAKE),
+            MIN_WAKE
+        );
+    }
+
+    #[test]
+    fn next_delay_never_outlasts_the_metrics_cadence_even_at_the_floor() {
+        // The metrics cap wins over the floor: with the tick due sooner than
+        // `MIN_WAKE`, the gauge is not pushed out by up to a floor's worth.
+        let until_metrics = Duration::from_millis(10);
+        assert_eq!(
+            next_delay(until_metrics, Some(0.0), MIN_WAKE),
+            until_metrics
+        );
+    }
+
+    #[test]
+    fn wake_floor_never_overrides_a_shorter_configured_interval() {
+        // A configured cadence below MIN_WAKE is an explicit request, not churn:
+        // flooring it at 100ms would silently halve a 50ms reaper's rate.
+        assert_eq!(
+            wake_floor(Duration::from_millis(50)),
+            Duration::from_millis(50)
+        );
+        assert_eq!(wake_floor(Duration::from_secs(5)), MIN_WAKE);
+    }
+
+    #[test]
+    fn next_delay_honours_a_floor_below_min_wake() {
+        // With a 50ms interval the floor is 50ms, so a due-now deadline re-sweeps
+        // at that cadence rather than being stretched to MIN_WAKE.
+        let floor = wake_floor(Duration::from_millis(50));
+        assert_eq!(
+            next_delay(Duration::from_millis(50), Some(0.0), floor),
+            Duration::from_millis(50)
+        );
+    }
+
+    #[test]
+    fn next_delay_survives_an_unrepresentable_deadline() {
+        // A deadline beyond `Duration`'s range (a hand-inserted row with an
+        // absurd `expires_at`) must not panic `Duration::from_secs_f64`.
+        assert_eq!(
+            next_delay(Duration::from_secs(5), Some(f64::MAX), MIN_WAKE),
+            Duration::from_secs(5)
+        );
+        assert_eq!(
+            next_delay(Duration::from_secs(5), Some(f64::NAN), MIN_WAKE),
+            Duration::from_secs(5)
+        );
+    }
+}

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/src/migrations/cache/0001_cluster_cache.sql
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/src/migrations/cache/0001_cluster_cache.sql
@@ -1,0 +1,28 @@
+-- cluster_cache: the native ClusterCacheBackend store (DESIGN.md §2.1).
+--
+-- `version` starts at 1 on first insert and increments by 1 on every
+-- successful write (including CAS) — see DESIGN.md §2.2 for the version
+-- semantics this plugin follows (matching cluster_sdk::cache::CacheEntry).
+--
+-- `expires_at IS NULL` means no TTL. The partial index makes the TTL reaper's
+-- sweep (DESIGN.md §4.2) efficient without touching indefinite entries.
+--
+-- `key` is the PRIMARY KEY, so it lands in a btree and is bound by the ~2704
+-- byte index-tuple limit — past that an INSERT fails outright with SQLSTATE
+-- 54000. `limits::MAX_INDEXED_KEY_BYTES` rejects an over-long key in Rust
+-- before the write; this CHECK is the backstop for anything reaching the table
+-- another way (psql, a future code path), turning a mid-write server error
+-- into a named constraint violation. Keep the bound in sync with that Rust
+-- constant. `octet_length`, not `length`: the limit is on bytes, and a
+-- multi-byte key has more of them than it has characters.
+CREATE TABLE cluster_cache (
+    key        TEXT        NOT NULL,
+    value      BYTEA       NOT NULL,
+    version    BIGINT      NOT NULL DEFAULT 1,
+    expires_at TIMESTAMPTZ,
+    PRIMARY KEY (key),
+    CONSTRAINT cluster_cache_key_len_check CHECK (octet_length(key) <= 2048)
+);
+
+CREATE INDEX cluster_cache_expires_idx ON cluster_cache (expires_at)
+    WHERE expires_at IS NOT NULL;

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/src/migrations/lock/0002_cluster_lock.sql
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/src/migrations/lock/0002_cluster_lock.sql
@@ -1,0 +1,60 @@
+-- cluster_lock: metadata alongside the native pg_advisory_lock (DESIGN.md §2.1).
+--
+-- This migration is applied via its own `Migrator` (embedded from this
+-- `migrations/lock/` subdirectory, separately from `migrations/cache/`), run
+-- by both the combined `PostgresClusterPlugin` (cache + lock) and the
+-- standalone `PostgresLockPlugin` (DESIGN.md §3.5) — either path only ever
+-- runs the migrations its own tables need, so a lock-only deployment never
+-- creates `cluster_cache`. Both `Migrator`s share the database's single
+-- `_sqlx_migrations` tracking table, so each must be constructed with
+-- `.set_ignore_missing(true)` — otherwise a lock-only `Migrator` (which only
+-- knows about this file) fails validation the moment it sees the *other*
+-- plugin's already-applied `0001_cluster_cache.sql` version recorded there.
+--
+-- `expires_at` is the lock's **absolute** deadline, computed as `now() + ttl` on
+-- the *database* clock at insert and at every renew — not a raw
+-- `acquired_at`/`ttl_ms` pair the TTL reaper (DESIGN.md §5.2) re-derives for
+-- every row on every tick. A derived deadline cannot be indexed at all:
+-- `timestamptz + interval` is `STABLE`, not `IMMUTABLE` (its result depends on
+-- the session `TimeZone`), so Postgres rejects an expression index on
+-- `acquired_at + ttl_ms * interval '1ms'`, and `now()` may not appear in a
+-- partial-index predicate either — leaving the sweep a guaranteed sequential
+-- scan with a per-row interval multiply. Storing the deadline makes that sweep
+-- an indexed `WHERE expires_at <= now()`, and lets the reaper read
+-- `min(expires_at)` (index-only) to wake when the next lock is actually due
+-- instead of polling blindly. Same shape as `cluster_cache.expires_at`
+-- (`0001_cluster_cache.sql`), and computed off the database clock for the same
+-- reason (PGR-C2): a service instance's skewed wall clock must not be able to
+-- make a lock expire early or linger. The index is unconditional, not partial
+-- like the cache's — a lock TTL is mandatory, so there is no `NULL` subset to
+-- exclude.
+--
+-- `acquired_at` is kept for diagnostics only ("how long has this been held?"
+-- when reading the table by hand); no query filters on it.
+--
+-- `holder_id` is a random UUID generated at acquire time and used as an
+-- end-to-end ownership fence (PGR-L1): `renew()`, `release()`, and the reaper
+-- all match on it, so a stale guard whose lock lapsed and was re-acquired by a
+-- newer holder cannot renew, release, or reclaim the successor's live lock.
+-- Native `UUID`, not `TEXT`: the only writer is `try_acquire`'s
+-- `Uuid::new_v4()` (`lock/mod.rs`), so every value is a UUID by construction.
+-- The native type stores it in a fixed 16 bytes instead of a 36-byte string,
+-- makes the `holder_id = $n` fence in every `renew`/`release`/reaper query a
+-- 16-byte comparison rather than a collation-aware string one, and makes the
+-- contract the column's own rather than an implicit convention.
+--
+-- `name` is the PRIMARY KEY, so — exactly as with `cluster_cache.key`, see
+-- `0001_cluster_cache.sql` — it lands in a btree bound by the ~2704 byte
+-- index-tuple limit. `validate_lock_name` rejects an over-long name in Rust
+-- before any lock state is mutated; this CHECK is the backstop. Keep the bound
+-- in sync with `limits::MAX_INDEXED_KEY_BYTES`.
+CREATE TABLE cluster_lock (
+    name        TEXT        NOT NULL,
+    holder_id   UUID        NOT NULL,
+    acquired_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at  TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (name),
+    CONSTRAINT cluster_lock_name_len_check CHECK (octet_length(name) <= 2048)
+);
+
+CREATE INDEX cluster_lock_expires_idx ON cluster_lock (expires_at);

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/src/pg_error.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/src/pg_error.rs
@@ -1,0 +1,218 @@
+//! Shared `sqlx::Error` → `ClusterError` mapping (DESIGN.md §9), used by both
+//! the cache and lock backends.
+
+use cluster_sdk::{ClusterError, ProviderErrorKind};
+
+/// Maps a `sqlx::Error` to `ClusterError::Provider` per the `ProviderErrorKind`
+/// mapping table (DESIGN.md §9):
+///
+/// | `sqlx` error | `ClusterError` |
+/// |---|---|
+/// | `sqlx::Error::Configuration` | `InvalidConfig` |
+/// | `sqlx::Error::Io` | `Provider { ConnectionLost }` |
+/// | `sqlx::Error::PoolTimedOut` | `Provider { Timeout }` |
+/// | `sqlx::Error::PoolClosed` | `Provider { ConnectionLost }` |
+/// | SQLSTATE `28xxx` (invalid auth) | `Provider { AuthFailure }` |
+/// | SQLSTATE `54000` / `23514` (over-long indexed key) | `Provider { Other }`, message rewritten to name the length limit |
+/// | Any other `sqlx::Error` | `Provider { Other }` |
+///
+/// Takes `err` by value (not `&sqlx::Error`) so call sites can pass this
+/// directly as `.map_err(map_sqlx_error)` without a wrapping closure — the
+/// dominant call pattern across `cache/mod.rs` — rather than for its own sake.
+#[allow(clippy::needless_pass_by_value)]
+pub fn map_sqlx_error(err: sqlx::Error) -> ClusterError {
+    // A malformed connection string (bad DSN, unparseable options) surfaces as
+    // `sqlx::Error::Configuration`. That is an operator *config* error, not a
+    // runtime backend fault, so it maps to `InvalidConfig` rather than the
+    // catch-all `Provider { Other }` (DESIGN.md §3.2 / §9, TESTING.md §2 /
+    // `PG-LIFE-006`).
+    if matches!(err, sqlx::Error::Configuration(_)) {
+        return ClusterError::InvalidConfig {
+            reason: err.to_string(),
+        };
+    }
+    // An over-long indexed key is normally caught in Rust before the write
+    // (`cache::watch::validate_key_len`, `lock::validate_lock_name`, both bounded
+    // by `limits::MAX_INDEXED_KEY_BYTES`). If one still reaches Postgres, the
+    // server's own message is opaque about the cause — `54000` reads as `index
+    // row size 2712 exceeds btree version 4 maximum 2704 for index "..."` and
+    // `23514` names only the constraint. Rewrite both to say what actually has to
+    // change, since neither is retryable and the raw text does not point at the
+    // key. `Other` is the correct kind for both: not retryable, operator/caller
+    // action required (DESIGN.md §2.1 / §9).
+    if let sqlx::Error::Database(db_err) = &err
+        && let Some(message) = over_long_key_message(db_err.as_ref())
+    {
+        return ClusterError::Provider {
+            kind: ProviderErrorKind::Other,
+            message,
+        };
+    }
+
+    let kind = match &err {
+        sqlx::Error::Io(_) | sqlx::Error::PoolClosed => ProviderErrorKind::ConnectionLost,
+        sqlx::Error::PoolTimedOut => ProviderErrorKind::Timeout,
+        sqlx::Error::Database(db_err) => {
+            if db_err
+                .code()
+                .as_deref()
+                .is_some_and(|code| code.starts_with("28"))
+            {
+                ProviderErrorKind::AuthFailure
+            } else {
+                ProviderErrorKind::Other
+            }
+        }
+        _ => ProviderErrorKind::Other,
+    };
+    ClusterError::Provider {
+        kind,
+        message: err.to_string(),
+    }
+}
+
+/// Returns an explanatory message when `db_err` is Postgres rejecting an
+/// over-long value for one of this plugin's indexed primary keys, or `None` for
+/// any other database error.
+///
+/// Two SQLSTATEs mean this, depending on which guard the value tripped first:
+/// `54000` (`program_limit_exceeded`) is the btree refusing an index tuple past
+/// its ~2704-byte ceiling, and `23514` (`check_violation`) is one of the
+/// `*_len_check` CHECK constraints the migrations declare in front of it. The
+/// `23514` arm matches on the constraint name so an unrelated future CHECK is
+/// not mislabelled as a length problem.
+fn over_long_key_message(db_err: &dyn sqlx::error::DatabaseError) -> Option<String> {
+    const LEN_CHECK_CONSTRAINTS: [&str; 2] =
+        ["cluster_cache_key_len_check", "cluster_lock_name_len_check"];
+
+    let is_over_long = match db_err.code().as_deref()? {
+        "54000" => true,
+        "23514" => db_err
+            .constraint()
+            .is_some_and(|name| LEN_CHECK_CONSTRAINTS.contains(&name)),
+        _ => false,
+    };
+
+    is_over_long.then(|| {
+        format!(
+            "key or lock name exceeds the {}-byte maximum this plugin indexes \
+             (the btree index-tuple limit on the cluster_cache / cluster_lock primary key; \
+             DESIGN.md sec 2.1): {db_err}",
+            crate::limits::MAX_INDEXED_KEY_BYTES,
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::map_sqlx_error;
+    use cluster_sdk::{ClusterError, ProviderErrorKind};
+    use sqlx::error::{DatabaseError, ErrorKind};
+
+    /// A stand-in for `PgDatabaseError`, whose fields the driver keeps private —
+    /// only the three accessors `over_long_key_message` reads need to be real.
+    #[derive(Debug)]
+    struct FakeDbError {
+        code: &'static str,
+        constraint: Option<&'static str>,
+    }
+
+    impl std::fmt::Display for FakeDbError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("server said no")
+        }
+    }
+
+    impl std::error::Error for FakeDbError {}
+
+    impl DatabaseError for FakeDbError {
+        fn message(&self) -> &'static str {
+            "server said no"
+        }
+        fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
+            Some(std::borrow::Cow::Borrowed(self.code))
+        }
+        fn constraint(&self) -> Option<&str> {
+            self.constraint
+        }
+        fn kind(&self) -> ErrorKind {
+            ErrorKind::Other
+        }
+        fn as_error(&self) -> &(dyn std::error::Error + Send + Sync + 'static) {
+            self
+        }
+        fn as_error_mut(&mut self) -> &mut (dyn std::error::Error + Send + Sync + 'static) {
+            self
+        }
+        fn into_error(self: Box<Self>) -> Box<dyn std::error::Error + Send + Sync + 'static> {
+            self
+        }
+    }
+
+    fn map(code: &'static str, constraint: Option<&'static str>) -> ClusterError {
+        map_sqlx_error(sqlx::Error::Database(Box::new(FakeDbError {
+            code,
+            constraint,
+        })))
+    }
+
+    #[test]
+    fn btree_index_tuple_overflow_is_explained() {
+        // 54000 carries no constraint name — the btree rejects the tuple before
+        // any CHECK runs — so the code alone has to be enough to recognize it.
+        let err = map("54000", None);
+        let ClusterError::Provider { kind, message } = err else {
+            panic!("expected a Provider error, got {err:?}");
+        };
+        assert_eq!(kind, ProviderErrorKind::Other);
+        assert!(
+            message.contains("2048-byte maximum"),
+            "the message must name the limit the caller has to get under, got {message:?}"
+        );
+        assert!(
+            message.contains("server said no"),
+            "the underlying server message must be preserved, got {message:?}"
+        );
+    }
+
+    #[test]
+    fn length_check_violations_are_explained_for_both_tables() {
+        for constraint in ["cluster_cache_key_len_check", "cluster_lock_name_len_check"] {
+            let err = map("23514", Some(constraint));
+            let ClusterError::Provider { message, .. } = err else {
+                panic!("expected a Provider error for {constraint}, got {err:?}");
+            };
+            assert!(
+                message.contains("2048-byte maximum"),
+                "{constraint} must map to the length explanation, got {message:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unrelated_check_violation_is_not_mislabelled() {
+        // The point of matching on the constraint name: a future CHECK that has
+        // nothing to do with key length must fall through to the generic arm
+        // rather than telling the caller to shorten a key.
+        let err = map("23514", Some("cluster_lock_ttl_positive_check"));
+        let ClusterError::Provider { kind, message } = err else {
+            panic!("expected a Provider error, got {err:?}");
+        };
+        assert_eq!(kind, ProviderErrorKind::Other);
+        assert!(
+            !message.contains("2048-byte maximum"),
+            "an unrelated CHECK must not be reported as a length problem, got {message:?}"
+        );
+    }
+
+    #[test]
+    fn auth_failure_mapping_still_wins_for_28xxx() {
+        // The new arm runs before the existing SQLSTATE match; make sure it did
+        // not shadow a code it should ignore.
+        let err = map("28P01", None);
+        let ClusterError::Provider { kind, .. } = err else {
+            panic!("expected a Provider error, got {err:?}");
+        };
+        assert_eq!(kind, ProviderErrorKind::AuthFailure);
+    }
+}

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/src/pg_setup.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/src/pg_setup.rs
@@ -1,0 +1,212 @@
+//! Shared pool/migration/startup-validation helpers used by both the
+//! combined [`crate::PostgresClusterPlugin`] and the standalone
+//! [`crate::PostgresLockPlugin`] builders (DESIGN.md §3.2, §3.5).
+
+use cluster_sdk::ClusterError;
+use sqlx::PgConnection;
+use sqlx::migrate::Migrator;
+use sqlx::postgres::PgPoolOptions;
+use tracing::warn;
+
+use crate::config::ReplicationMode;
+use crate::pg_error::map_sqlx_error;
+
+/// A [`PgPoolOptions`] with the `after_connect`/`before_acquire`/`after_release`
+/// hooks wired (DESIGN.md §3.4) — callers still need to chain
+/// `.max_connections(...)`, `.acquire_timeout(...)`, and `.connect(...)`.
+///
+/// `after_connect` pins every connection's `search_path` to `schema` so the
+/// migrations' unqualified `CREATE TABLE`s land in the same schema the runtime
+/// queries target with their `{schema}.cluster_*` qualifiers (PGR-L4). `schema`
+/// must already have passed [`validate_schema`] — it is interpolated unquoted.
+pub fn base_pool_options(schema: &str) -> PgPoolOptions {
+    let schema = schema.to_owned();
+    PgPoolOptions::new()
+        .after_connect(move |conn, _meta| {
+            let schema = schema.clone();
+            Box::pin(async move {
+                set_synchronous_commit(conn).await?;
+                set_search_path(conn, &schema).await?;
+                Ok(())
+            })
+        })
+        .before_acquire(|conn, _meta| {
+            Box::pin(async move {
+                set_synchronous_commit(conn).await?;
+                Ok(true)
+            })
+        })
+        .after_release(|conn, _meta| Box::pin(release_session_advisory_locks(conn)))
+}
+
+/// Validates that `schema` is a simple, safe SQL identifier (PGR-L4). The schema
+/// is interpolated **unquoted** into DDL (`CREATE SCHEMA`, `SET search_path`) and
+/// into every runtime table identifier (`{schema}.cluster_*`), so restricting it
+/// to the identifier charset keeps the migration schema and the query schema
+/// resolving to the same object (an unquoted identifier is case-folded by
+/// Postgres) and forecloses any injection via the config value.
+///
+/// # Errors
+/// [`ClusterError::InvalidConfig`] if `schema` is empty, longer than Postgres's
+/// 63-byte identifier limit, or contains anything other than ASCII letters,
+/// digits, and underscores (and does not start with a digit).
+pub fn validate_schema(schema: &str) -> Result<(), ClusterError> {
+    let valid = !schema.is_empty()
+        && schema.len() <= 63
+        && schema
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && schema
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_');
+    if !valid {
+        return Err(ClusterError::InvalidConfig {
+            reason: format!(
+                "schema {schema:?} must be a simple identifier (ASCII letters, digits, and \
+                 underscores; not starting with a digit; at most 63 bytes) — it is interpolated \
+                 unquoted into DDL and query identifiers"
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// `SET search_path TO <schema>`, enforced on every connection via
+/// `after_connect` (PGR-L4) so unqualified migration DDL creates its tables in
+/// the configured schema. `schema` must have passed [`validate_schema`].
+pub async fn set_search_path(conn: &mut PgConnection, schema: &str) -> Result<(), sqlx::Error> {
+    sqlx::query(&format!("SET search_path TO {schema}"))
+        .execute(conn)
+        .await?;
+    Ok(())
+}
+
+/// `CREATE SCHEMA IF NOT EXISTS <schema>`, run once before the migrators so the
+/// unqualified `CREATE TABLE`s have a schema to land in when an operator points
+/// the plugin at a non-`public` schema (PGR-L4). `schema` must have passed
+/// [`validate_schema`]. A no-op for the default `public` schema.
+///
+/// # Errors
+/// Propagates any connectivity/permission error creating the schema.
+pub async fn ensure_schema(pool: &sqlx::PgPool, schema: &str) -> Result<(), ClusterError> {
+    sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS {schema}"))
+        .execute(pool)
+        .await
+        .map_err(map_sqlx_error)?;
+    Ok(())
+}
+
+/// Releases every session-level advisory lock still held on a connection being
+/// returned to the pool (PGR-L3 cancellation safety net).
+///
+/// A lock acquisition future can be cancelled after `pg_try_advisory_lock`
+/// succeeds but before the connection is pinned in `PostgresLock`'s `held` map
+/// (e.g. `lock()`'s per-attempt timeout elapsing mid-acquire): the pooled
+/// connection would otherwise return to the pool still carrying a live advisory
+/// lock, which the TTL reaper can never find (no `cluster_lock` row was
+/// committed) and which no other session can release (advisory locks are
+/// session-scoped) — wedging that lock name until the connection is recycled.
+/// `pg_advisory_unlock_all()` runs on every checkin as a defensive sweep. It is
+/// a no-op for connections that hold nothing (the common case, and every cache
+/// connection), and for a legitimately held lock it is *also* a no-op here:
+/// pinned lock connections are only returned to the pool after `release`/
+/// `reclaim` already unlocked them. Returns `Ok(true)` so the connection is
+/// kept; a failed sweep discards it rather than risk returning a locked
+/// connection to the pool.
+pub async fn release_session_advisory_locks(conn: &mut PgConnection) -> Result<bool, sqlx::Error> {
+    sqlx::query("SELECT pg_advisory_unlock_all()")
+        .execute(conn)
+        .await?;
+    Ok(true)
+}
+
+/// Rejects `pgbouncer_transaction_mode: true` at startup (DESIGN.md §5.4):
+/// session-level advisory locks are released the moment `PgBouncer` returns the
+/// connection to the pool between transactions in transaction-pooling mode,
+/// even though the Rust code still holds a `LockGuard` — silent, hard to
+/// diagnose mis-behaviour rather than a clear startup failure.
+pub fn reject_pgbouncer_transaction_mode(enabled: bool) -> Result<(), ClusterError> {
+    if enabled {
+        return Err(ClusterError::InvalidConfig {
+            reason: "pg_advisory_lock requires session-mode pooling or a direct connection; \
+                      transaction-mode PgBouncer is incompatible with distributed locks"
+                .to_owned(),
+        });
+    }
+    Ok(())
+}
+
+/// `SET synchronous_commit = on`, enforced on every connection this plugin
+/// uses (DESIGN.md §3.4) via both `after_connect` (new connections) and
+/// `before_acquire` (re-asserted on every checkout, since the setting is
+/// `USERSET` scope and can be mutated mid-session by anything sharing the
+/// connection).
+pub async fn set_synchronous_commit(conn: &mut PgConnection) -> Result<(), sqlx::Error> {
+    sqlx::query("SET synchronous_commit = on")
+        .execute(conn)
+        .await?;
+    Ok(())
+}
+
+/// The embedded `Migrator` over `migrations/cache/` (`0001_cluster_cache.sql`
+/// only) — see `lib.rs`'s crate doc / DESIGN.md §3.1 for why this is a
+/// separate `Migrator` from [`lock_migrator`], not one shared folder.
+pub fn cache_migrator() -> Migrator {
+    sqlx::migrate!("./src/migrations/cache")
+}
+
+/// The embedded `Migrator` over `migrations/lock/` (`0002_cluster_lock.sql`
+/// only).
+pub fn lock_migrator() -> Migrator {
+    sqlx::migrate!("./src/migrations/lock")
+}
+
+/// Runs `migrator` against `pool`, tolerating the *other* Migrator's version
+/// already being recorded in the database's shared `_sqlx_migrations` table
+/// (DESIGN.md §3.1) — required whenever the combined plugin and the
+/// standalone lock plugin ever point at the same database.
+pub async fn run_migrator(mut migrator: Migrator, pool: &sqlx::PgPool) -> Result<(), ClusterError> {
+    migrator.set_ignore_missing(true);
+    migrator
+        .run(pool)
+        .await
+        .map_err(|err| ClusterError::Provider {
+            kind: cluster_sdk::ProviderErrorKind::Other,
+            message: format!("migration failed: {err}"),
+        })
+}
+
+/// Detects (or trusts an explicit override for) replication topology and logs
+/// `cluster.provider.replication_async` once if the effective mode is
+/// `Async` (DESIGN.md §3.6). Never fails startup on its own account — only a
+/// genuine connectivity error querying `SHOW synchronous_standby_names`
+/// propagates.
+pub async fn warn_if_async_replication(
+    pool: &sqlx::PgPool,
+    configured: Option<ReplicationMode>,
+) -> Result<(), ClusterError> {
+    let effective = if let Some(mode) = configured {
+        mode
+    } else {
+        let synchronous_standby_names: String =
+            sqlx::query_scalar("SHOW synchronous_standby_names")
+                .fetch_one(pool)
+                .await
+                .map_err(map_sqlx_error)?;
+        if synchronous_standby_names.is_empty() {
+            ReplicationMode::Async
+        } else {
+            ReplicationMode::Sync
+        }
+    };
+
+    if effective == ReplicationMode::Async {
+        warn!(
+            "cluster.provider.replication_async: no synchronous standby configured - \
+             per ADR-009's safety table, leader-election/lock claims are not failover-safe \
+             under this replication topology"
+        );
+    }
+    Ok(())
+}

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/src/plugin.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/src/plugin.rs
@@ -1,0 +1,340 @@
+//! The combined `PostgresClusterPlugin` (cache + lock) builder and lifecycle
+//! handle (DESIGN.md §3.2), following the outbox-style builder/handle pattern
+//! (ADR-006). Not a `RunnableCapability` — the cluster gear
+//! (`cf-gears-cluster`) owns its lifecycle via `build_and_start`/`stop`.
+
+use std::sync::Arc;
+
+use cluster_sdk::observability::otel::OtelClusterMetrics;
+use cluster_sdk::{ClusterCacheBackend, ClusterError, ClusterMetrics, InstrumentedCache};
+use sqlx::PgPool;
+use tokio_util::sync::CancellationToken;
+
+use crate::cache::PostgresCache;
+use crate::config::PostgresClusterConfig;
+use crate::lock::PostgresLock;
+use crate::pg_error::map_sqlx_error;
+use crate::pg_setup::{
+    base_pool_options, cache_migrator, ensure_schema, lock_migrator,
+    reject_pgbouncer_transaction_mode, run_migrator, warn_if_async_replication,
+};
+use crate::provider::PROVIDER_NAME;
+
+/// Entry point for constructing the combined Postgres cluster plugin.
+///
+/// ```no_run
+/// # async fn doc(config: postgres_cluster_plugin::PostgresClusterConfig) -> Result<(), cluster_sdk::ClusterError> {
+/// use postgres_cluster_plugin::PostgresClusterPlugin;
+/// let handle = PostgresClusterPlugin::builder(config).build_and_start().await?;
+/// handle.stop().await;
+/// # Ok(())
+/// # }
+/// ```
+pub struct PostgresClusterPlugin;
+
+impl PostgresClusterPlugin {
+    // No `#[must_use]` here: `PostgresClusterBuilder` itself already carries a
+    // `#[must_use = "..."]` message, so a bare attribute on this function
+    // would be a `clippy::double_must_use` no-op.
+    pub fn builder(config: PostgresClusterConfig) -> PostgresClusterBuilder {
+        PostgresClusterBuilder {
+            config,
+            reaper_meter: None,
+        }
+    }
+}
+
+/// Fluent builder for [`PostgresClusterPlugin`].
+#[must_use = "a builder starts nothing until `.build_and_start()` is called"]
+pub struct PostgresClusterBuilder {
+    config: PostgresClusterConfig,
+    /// Optional override for the meter both TTL reapers emit their plugin-local
+    /// gauge/histogram through (DESIGN.md §8). `None` in production (uses the
+    /// process-global meter); tests inject a meter over an in-memory reader.
+    reaper_meter: Option<opentelemetry::metrics::Meter>,
+}
+
+impl PostgresClusterBuilder {
+    /// Test-only: routes both reapers' plugin-local metrics through `meter`
+    /// instead of the process-global meter, so a test can attach an in-memory
+    /// reader and observe the reaper-sweep-duration histogram
+    /// (`primitive={cache,lock}`) and the lock active-names gauge in isolation.
+    ///
+    /// Gated behind `--features integration` (the `tests/` suite's feature) so
+    /// this seam is compiled out of release builds entirely (PGR-M8).
+    #[cfg(feature = "integration")]
+    #[doc(hidden)]
+    pub fn __with_reaper_meter(mut self, meter: opentelemetry::metrics::Meter) -> Self {
+        self.reaper_meter = Some(meter);
+        self
+    }
+
+    /// Builds the plugin (DESIGN.md §3.2):
+    /// 1. Opens `sqlx::PgPool` with `PgPoolOptions` `after_connect`/
+    ///    `before_acquire` hooks enforcing `synchronous_commit = on` (§3.4).
+    /// 2. Runs **two** embedded `Migrator`s in order — one over
+    ///    `migrations/cache/` (`0001_cluster_cache.sql`), one over
+    ///    `migrations/lock/` (`0002_cluster_lock.sql`) — each constructed with
+    ///    `.set_ignore_missing(true)`. A single `Migrator` over one shared
+    ///    folder can't support §3.5's "lock-only migrates only its own table"
+    ///    requirement: `Migrator::run` applies every migration it knows about,
+    ///    and without `ignore_missing` each `Migrator` would fail validation
+    ///    the moment the *other* plugin's version shows up in the shared
+    ///    `_sqlx_migrations` tracking table.
+    /// 3. Opens a dedicated LISTEN connection outside the pool (§4.3).
+    /// 4. Spawns the cache TTL reaper, the lock TTL reaper, and the LISTEN
+    ///    fan-out task.
+    /// 5. Detects/logs replication topology per §3.6.
+    ///
+    /// # Errors
+    /// - [`ClusterError::InvalidConfig`] if `pgbouncer_transaction_mode: true`
+    ///   is set (§5.4) or the connection string is invalid (`PG-LIFE-006`).
+    pub async fn build_and_start(self) -> Result<PostgresClusterHandle, ClusterError> {
+        let config = self.config;
+        let reaper_meter_override = self.reaper_meter;
+        reject_pgbouncer_transaction_mode(config.pgbouncer_transaction_mode)?;
+        // Reject an unsafe schema (PGR-L4) and any zero reaper/poll interval
+        // (PGR-E2) before opening the pool or spawning any reaper.
+        config.validate()?;
+
+        let pool = base_pool_options(&config.schema)
+            .max_connections(config.pool_max_size)
+            .acquire_timeout(config.pool_acquire_timeout())
+            .connect(&config.connection_string)
+            .await
+            .map_err(map_sqlx_error)?;
+
+        // Create the configured schema (if non-`public`) before the migrators'
+        // unqualified `CREATE TABLE`s run — the pool's `search_path` already
+        // points every connection at it (PGR-L4).
+        ensure_schema(&pool, &config.schema).await?;
+        run_migrator(cache_migrator(), &pool).await?;
+        run_migrator(lock_migrator(), &pool).await?;
+        warn_if_async_replication(&pool, config.replication_mode).await?;
+
+        // The single ADR-004 metrics sink shared across this plugin: the
+        // `InstrumentedCache` decorator, the native `PostgresLock` backend
+        // (its `try_lock`/`lock`/`renew`/`release` signals, DESIGN.md §8), and
+        // both TTL reapers' `emit_provider_error` failure signals (PGR-M1).
+        let metrics: Arc<dyn ClusterMetrics> =
+            Arc::new(OtelClusterMetrics::from_global_meter(PROVIDER_NAME));
+
+        // Created before the lock so its guard tasks observe the same shutdown
+        // signal the reapers/LISTEN tasks do (PGR-L2).
+        let shutdown = CancellationToken::new();
+
+        let cache = PostgresCache::new(pool.clone(), &config.schema);
+        let lock = PostgresLock::new(
+            pool.clone(),
+            &config.schema,
+            config.lock_reaper_interval(),
+            Arc::clone(&metrics),
+            PROVIDER_NAME,
+            shutdown.clone(),
+        );
+        let cache_dyn = instrumented_cache(&cache, Arc::clone(&metrics));
+        // Both TTL reapers emit the plugin-local, non-contract signals of
+        // DESIGN.md §8 (the reaper-sweep-duration histogram, plus the lock
+        // reaper's active-names gauge) through a meter this plugin owns
+        // directly — not the `ClusterMetrics` contract sink (which has no gauge
+        // method). One meter, shared, so the `primitive={cache,lock}` histogram
+        // is a single instrument.
+        let reaper_meter = reaper_meter_override.unwrap_or_else(crate::lock::reaper::reaper_meter);
+        let cache_reaper = crate::cache::reaper::spawn_cache_reaper(
+            cache.pool(),
+            cache.table(),
+            config.cache_reaper_interval(),
+            crate::lock::reaper::sweep_duration_histogram(&reaper_meter),
+            Arc::clone(&metrics),
+            PROVIDER_NAME,
+            shutdown.clone(),
+        );
+        let lock_reaper = lock.spawn_reaper(
+            config.lock_reaper_interval(),
+            crate::lock::reaper::LockReaperMetrics::new(
+                &reaper_meter,
+                PROVIDER_NAME,
+                Arc::clone(&metrics),
+            ),
+            i64::from(config.lock_name_cardinality_warn_threshold),
+            shutdown.clone(),
+        );
+        // Awaited, not fire-and-forgotten: the LISTEN connection must be
+        // confirmed live before `build_and_start` returns (DESIGN.md §3.2
+        // step 5's "no readiness gate" guarantee — see
+        // `cache::watch::spawn_listen_task`'s doc for the race this closes).
+        //
+        // If it fails, the cache/lock reapers spawned just above are already
+        // running and holding `PgPool` clones; returning the error directly
+        // would detach them (nothing cancels `shutdown` on this path, and no
+        // handle whose `Drop` calls `stop()` is ever constructed), leaking the
+        // tasks and keeping the pool alive until process exit (PGR-L5). Cancel
+        // the shared token and await both reapers before propagating.
+        let listen_task = match crate::cache::watch::spawn_listen_task(
+            config.connection_string.clone(),
+            cache.watch_registry(),
+            Arc::clone(&metrics),
+            PROVIDER_NAME,
+            shutdown.clone(),
+        )
+        .await
+        {
+            Ok(task) => task,
+            Err(err) => {
+                shutdown.cancel();
+                let _cache_reaper_exited = cache_reaper.await;
+                let _lock_reaper_exited = lock_reaper.await;
+                pool.close().await;
+                return Err(err);
+            }
+        };
+        let release_listener = crate::lock::notify::spawn_release_listen_task(
+            config.connection_string.clone(),
+            lock.release_waiters(),
+            shutdown.clone(),
+        );
+
+        Ok(PostgresClusterHandle {
+            cache,
+            cache_dyn,
+            lock,
+            pool,
+            cache_reaper: Some(cache_reaper),
+            lock_reaper: Some(lock_reaper),
+            listen_task: Some(listen_task),
+            release_listener: Some(release_listener),
+            shutdown,
+            stopped: false,
+        })
+    }
+}
+
+/// The running combined plugin. Hands its cache and lock backends to the
+/// wiring crate for `ClientHub` registration.
+///
+/// Call [`stop`](Self::stop) on graceful shutdown (DESIGN.md §10).
+pub struct PostgresClusterHandle {
+    /// The concrete cache, retained so `stop` can close active watches via the
+    /// native watch registry (mirrors `StandaloneClusterHandle`).
+    cache: Arc<PostgresCache>,
+    /// The same cache as an instrumented trait object, handed to the wiring
+    /// crate (DESIGN.md §8).
+    cache_dyn: Arc<dyn ClusterCacheBackend>,
+    lock: Arc<PostgresLock>,
+    pool: PgPool,
+    // `Option`, not bare `JoinHandle`s: `PostgresClusterHandle` owns a `Drop`
+    // impl below, and you cannot move a field out of a type that implements
+    // `Drop` — `stop` uses `.take()` to drain each in place, mirroring
+    // `ClusterHandle::stop`'s `std::mem::take` (`cluster/src/wiring.rs`).
+    cache_reaper: Option<tokio::task::JoinHandle<()>>,
+    lock_reaper: Option<tokio::task::JoinHandle<()>>,
+    listen_task: Option<tokio::task::JoinHandle<()>>,
+    release_listener: Option<tokio::task::JoinHandle<()>>,
+    shutdown: CancellationToken,
+    /// Set by `stop` so the `Drop` guard can tell a graceful shutdown apart
+    /// from a forgotten one (ADR-006 §Confirmation).
+    stopped: bool,
+}
+
+impl PostgresClusterHandle {
+    /// The instrumented cache backend (DESIGN.md §8).
+    #[must_use]
+    pub fn cache(&self) -> Arc<dyn ClusterCacheBackend> {
+        Arc::clone(&self.cache_dyn)
+    }
+
+    /// The native lock backend.
+    #[must_use]
+    pub fn lock(&self) -> Arc<dyn cluster_sdk::DistributedLockBackend> {
+        Arc::clone(&self.lock) as Arc<dyn cluster_sdk::DistributedLockBackend>
+    }
+
+    /// Test-only access to the concrete [`PostgresCache`], for `PG-CACHE-010`'s
+    /// sweep seam (the `dyn` [`cache`](Self::cache) has no such seam). Mirrors
+    /// `PostgresLockHandle::__test_lock`. Gated behind `--features integration`
+    /// (PGR-M8).
+    #[cfg(feature = "integration")]
+    #[doc(hidden)]
+    #[must_use]
+    pub fn __test_cache(&self) -> Arc<PostgresCache> {
+        Arc::clone(&self.cache)
+    }
+
+    /// Shuts the plugin down (DESIGN.md §10):
+    /// 1. Cancels the shared `CancellationToken`; awaits each background task.
+    /// 2. Sends `CacheWatchEvent::Closed(ClusterError::Shutdown)` to all active
+    ///    watchers.
+    /// 3. Closes the LISTEN connection (`UNLISTEN *` then close).
+    /// 4. Closes the `sqlx::PgPool` — releases all pinned connections, causing
+    ///    Postgres to auto-release any outstanding advisory locks.
+    pub async fn stop(mut self) {
+        self.shutdown.cancel();
+        // Close all active cache watches terminally *before* awaiting the
+        // listen task below, so every watcher observes `Closed(Shutdown)`
+        // prior to `stop()` returning (§10 step 2) — `close_all` dispatches
+        // directly against the registry, independent of whether the listen
+        // task has noticed `cancel` yet.
+        self.cache.watch_registry().close_all().await;
+        for task in [
+            self.cache_reaper.take(),
+            self.lock_reaper.take(),
+            self.listen_task.take(),
+            self.release_listener.take(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            let _exited = task.await;
+        }
+        // Drain any lock still held at shutdown before closing the pool: a
+        // pinned lock connection lives in `PostgresLock`'s `held` map (checked
+        // out, outside the pool's tracking), and `pool.close()` blocks until
+        // every checked-out connection is returned — so a still-held lock would
+        // otherwise hang `stop()` forever (DESIGN.md §10 step 4, `PG-LIFE-003`).
+        self.lock.drain_held().await;
+        self.pool.close().await;
+        self.stopped = true;
+    }
+}
+
+/// Diagnostic guard (ADR-006 §Confirmation), mirroring `ClusterHandle`'s own
+/// guard (`cluster/src/wiring.rs`) field-for-field: dropping a
+/// `PostgresClusterHandle` without calling `stop()` leaks its background
+/// tasks (cache TTL reaper, lock TTL reaper, LISTEN fan-out task) — surfaced
+/// loudly (debug-build panic / release-build warn-log) rather than silently.
+impl Drop for PostgresClusterHandle {
+    fn drop(&mut self) {
+        if self.stopped {
+            return;
+        }
+        if std::thread::panicking() {
+            tracing::warn!(
+                "PostgresClusterHandle dropped during panic unwind without stop(); \
+                 skipping debug panic to avoid double-panic abort"
+            );
+            return;
+        }
+        #[cfg(debug_assertions)]
+        panic!("PostgresClusterHandle dropped without stop() - programming error");
+        #[cfg(not(debug_assertions))]
+        tracing::warn!(
+            "PostgresClusterHandle dropped without stop() - programming error; \
+             background tasks may leak"
+        );
+    }
+}
+
+/// Wraps a native cache in the SDK's `InstrumentedCache` decorator so its
+/// operations emit the contracted `cluster.cache.*` signals (DESIGN.md §8),
+/// mirroring `StandaloneClusterHandle`'s construction
+/// (`standalone-cluster-plugin/src/plugin.rs`).
+fn instrumented_cache(
+    cache: &Arc<PostgresCache>,
+    metrics: Arc<dyn ClusterMetrics>,
+) -> Arc<dyn ClusterCacheBackend> {
+    Arc::new(InstrumentedCache::new(
+        Arc::clone(cache) as Arc<dyn ClusterCacheBackend>,
+        PROVIDER_NAME,
+        metrics,
+    ))
+}

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/src/provider.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/src/provider.rs
@@ -1,0 +1,160 @@
+//! The [`ClusterCacheProvider`] and [`ClusterLockProvider`] implementations
+//! for the Postgres backend (DESIGN.md §1.1, §3.5).
+//!
+//! Two independent provider impls, not one: `PostgresLockProvider` lets the
+//! wiring crate route `lock: { provider: postgres }` even when `cache` in the
+//! same profile is bound elsewhere (or omitted) — see DESIGN.md §3.5 for why
+//! this is *always standalone, never shared* with a co-located cache pool.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cluster_sdk::{
+    ClusterCacheBackend, ClusterCacheProvider, ClusterError, ClusterLockProvider,
+    DistributedLockBackend, StopHook,
+};
+use toolkit::var_expand::ExpandVars;
+
+use crate::config::{PostgresClusterConfig, PostgresLockConfig};
+use crate::lock::PostgresLockPlugin;
+use crate::plugin::PostgresClusterPlugin;
+
+/// The operator config `provider` name that selects the Postgres backend, for
+/// both the `cache` and `lock` primitive bindings.
+pub const PROVIDER_NAME: &str = "postgres";
+
+/// Deserializes `options` into `T` and applies `#[derive(ExpandVars)]`
+/// expansion, mapping both failure modes to
+/// [`ClusterError::InvalidConfig`] — a malformed option or a missing
+/// referenced env var is an operator error, not a silent fallback (DESIGN.md
+/// §7 / `docs/pr-review` TOOLKIT-DB config conventions).
+fn deserialize_and_expand<T>(
+    options: &serde_json::Map<String, serde_json::Value>,
+) -> Result<T, ClusterError>
+where
+    T: serde::de::DeserializeOwned + ExpandVars,
+{
+    let mut config: T = serde_json::from_value(serde_json::Value::Object(options.clone()))
+        .map_err(|err| ClusterError::InvalidConfig {
+            reason: format!("postgres: invalid options: {err}"),
+        })?;
+    config
+        .expand_vars()
+        .map_err(|err| ClusterError::InvalidConfig {
+            reason: format!("postgres: `connection_string` env-var expansion failed: {err}"),
+        })?;
+    Ok(config)
+}
+
+/// Builds the combined Postgres cache backend from operator config.
+pub struct PostgresCacheProvider;
+
+#[async_trait]
+impl ClusterCacheProvider for PostgresCacheProvider {
+    fn provider(&self) -> &'static str {
+        PROVIDER_NAME
+    }
+
+    async fn build_cache(
+        &self,
+        options: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<(Arc<dyn ClusterCacheBackend>, StopHook), ClusterError> {
+        let config: PostgresClusterConfig = deserialize_and_expand(options)?;
+        let handle = PostgresClusterPlugin::builder(config)
+            .build_and_start()
+            .await?;
+        let cache = handle.cache();
+        let stop: StopHook = Box::new(move || Box::pin(async move { handle.stop().await }));
+        Ok((cache, stop))
+    }
+}
+
+/// Builds the standalone Postgres lock backend from operator config
+/// (DESIGN.md §3.5). Never receives or depends on a cache backend argument —
+/// matches the SDK provider trait's "non-cache providers do not receive the
+/// cache backend" contract.
+pub struct PostgresLockProvider;
+
+#[async_trait]
+impl ClusterLockProvider for PostgresLockProvider {
+    fn provider(&self) -> &'static str {
+        PROVIDER_NAME
+    }
+
+    async fn build_lock(
+        &self,
+        options: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<(Arc<dyn DistributedLockBackend>, StopHook), ClusterError> {
+        let config: PostgresLockConfig = deserialize_and_expand(options)?;
+        let handle = PostgresLockPlugin::builder(config)
+            .build_and_start()
+            .await?;
+        let lock = handle.lock();
+        let stop: StopHook = Box::new(move || Box::pin(async move { handle.stop().await }));
+        Ok((lock, stop))
+    }
+}
+
+// Layer-1 unit tests (TESTING.md §2, provider.rs row). The `build_cache` /
+// `build_lock` cases below fail at config deserialization / env-var expansion —
+// *before* any pool is opened — so they need no container.
+#[cfg(test)]
+mod provider_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn options(value: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+        match value {
+            serde_json::Value::Object(map) => map,
+            _ => panic!("options must be a JSON object"),
+        }
+    }
+
+    #[test]
+    fn provider_names_are_postgres() {
+        assert_eq!(PostgresCacheProvider.provider(), "postgres");
+        assert_eq!(PostgresLockProvider.provider(), "postgres");
+    }
+
+    #[tokio::test]
+    async fn build_cache_rejects_missing_connection_string_as_invalid_config() {
+        // No `connection_string` field → deserialization fails before any pool
+        // is opened, so this needs no container.
+        let result = PostgresCacheProvider
+            .build_cache(&options(json!({ "pool_max_size": 5 })))
+            .await;
+        assert!(
+            matches!(result, Err(ClusterError::InvalidConfig { .. })),
+            "a malformed options map must surface as InvalidConfig, got {:?}",
+            result.as_ref().map(|_| ())
+        );
+    }
+
+    #[tokio::test]
+    async fn build_lock_rejects_missing_connection_string_as_invalid_config() {
+        let result = PostgresLockProvider
+            .build_lock(&options(json!({ "pool_max_size": 5 })))
+            .await;
+        assert!(
+            matches!(result, Err(ClusterError::InvalidConfig { .. })),
+            "a malformed options map must surface as InvalidConfig, got {:?}",
+            result.as_ref().map(|_| ())
+        );
+    }
+
+    #[tokio::test]
+    async fn build_cache_rejects_unresolvable_env_var_as_invalid_config() {
+        // A `${VAR}` with no value and no default fails at `expand_vars`, again
+        // before any connection attempt.
+        let result = PostgresCacheProvider
+            .build_cache(&options(json!({
+                "connection_string": "postgres://u:${PG_CLUSTER_PROVIDER_M5_UNSET}@h/db",
+            })))
+            .await;
+        assert!(
+            matches!(result, Err(ClusterError::InvalidConfig { .. })),
+            "an unresolvable env var must surface as InvalidConfig, got {:?}",
+            result.as_ref().map(|_| ())
+        );
+    }
+}

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/tests/cache_integration.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/tests/cache_integration.rs
@@ -1,0 +1,734 @@
+//! Layer 3 — cache integration scenarios (docs/TESTING.md §4.2, `PG-CACHE-001..010`).
+
+#![cfg(feature = "integration")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration tests: a setup failure IS the test failure"
+)]
+
+mod common;
+
+use std::time::Duration;
+
+use cluster_sdk::cache::{PutRequest, Ttl};
+use cluster_sdk::error::{ClusterError, ProviderErrorKind};
+use postgres_cluster_plugin::PostgresClusterPlugin;
+use serde_json::json;
+
+/// `PG-CACHE-001`: `put` + `get` round-trip, verified both through the
+/// backend API and directly against the `cluster_cache` table.
+#[tokio::test]
+async fn pg_cache_001_put_get_round_trip() {
+    let (_container, config) = common::start_postgres().await;
+    let connection_string = config.connection_string.clone();
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let cache = handle.cache();
+
+    cache
+        .put(PutRequest {
+            key: "k1",
+            value: b"v1",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put succeeds");
+
+    let entry = cache
+        .get("k1")
+        .await
+        .expect("get succeeds")
+        .expect("present");
+    assert_eq!(entry.value, b"v1");
+    assert_eq!(entry.version, 1);
+
+    let pool = common::raw_pool(&connection_string).await;
+    let (value, version): (Vec<u8>, i64) =
+        sqlx::query_as("SELECT value, version FROM public.cluster_cache WHERE key = $1")
+            .bind("k1")
+            .fetch_one(&pool)
+            .await
+            .expect("row exists");
+    assert_eq!(value, b"v1");
+    assert_eq!(version, 1);
+
+    handle.stop().await;
+}
+
+/// `PG-CACHE-002`: each `put` increments `version` by exactly 1;
+/// `put_if_absent` sets version to 1.
+#[tokio::test]
+async fn pg_cache_002_version_increments_by_one() {
+    let (_container, config) = common::start_postgres().await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let cache = handle.cache();
+
+    let first = cache
+        .put_if_absent(PutRequest {
+            key: "k2",
+            value: b"a",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put_if_absent succeeds")
+        .expect("key was absent");
+    assert_eq!(
+        first.version, 1,
+        "PG-CACHE-002: put_if_absent sets version 1"
+    );
+
+    for expected_version in 2_u64..=4 {
+        cache
+            .put(PutRequest {
+                key: "k2",
+                value: b"b",
+                ttl: Ttl::Indefinite,
+            })
+            .await
+            .expect("put succeeds");
+        let entry = cache.get("k2").await.expect("get").expect("present");
+        assert_eq!(
+            entry.version, expected_version,
+            "PG-CACHE-002: version must increment by exactly 1 per put"
+        );
+    }
+
+    // A second `put_if_absent` against an occupied key is a no-op returning
+    // `None`, not a fresh version-1 entry.
+    let second = cache
+        .put_if_absent(PutRequest {
+            key: "k2",
+            value: b"c",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put_if_absent succeeds");
+    assert!(
+        second.is_none(),
+        "PG-CACHE-002: put_if_absent on an occupied key is a no-op"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-CACHE-003`: two concurrent `compare_and_swap` writers race the same
+/// key; exactly one wins, the other observes `CasConflict`.
+#[tokio::test]
+async fn pg_cache_003_cas_atomicity_under_concurrent_writers() {
+    let (_container, config) = common::start_postgres().await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let cache = handle.cache();
+
+    let created = cache
+        .put_if_absent(PutRequest {
+            key: "k3",
+            value: b"base",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put_if_absent")
+        .expect("absent");
+
+    let a = {
+        let cache = cache.clone();
+        tokio::spawn(async move {
+            cache
+                .compare_and_swap("k3", created.version, b"from-a", Ttl::Indefinite)
+                .await
+        })
+    };
+    let b = {
+        let cache = cache.clone();
+        tokio::spawn(async move {
+            cache
+                .compare_and_swap("k3", created.version, b"from-b", Ttl::Indefinite)
+                .await
+        })
+    };
+
+    let (result_a, result_b) = (a.await.unwrap(), b.await.unwrap());
+    let outcomes = [result_a.is_ok(), result_b.is_ok()];
+    assert_eq!(
+        outcomes.iter().filter(|ok| **ok).count(),
+        1,
+        "PG-CACHE-003: exactly one concurrent CAS writer must win, got {outcomes:?}"
+    );
+    let loser = if result_a.is_ok() { result_b } else { result_a };
+    assert!(
+        matches!(loser, Err(ClusterError::CasConflict { .. })),
+        "PG-CACHE-003: the losing writer must observe CasConflict, got {loser:?}"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-CACHE-004`: an entry past its TTL is absent after the reaper runs, and
+/// an active watcher observes `Expired`.
+#[tokio::test]
+async fn pg_cache_004_ttl_expiry_via_reaper() {
+    let (_container, config) =
+        common::start_postgres_with(json!({ "cache_reaper_interval_ms": 100 })).await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let cache = handle.cache();
+
+    let mut watch = cache.watch("k4").await.expect("watch succeeds");
+    cache
+        .put(PutRequest {
+            key: "k4",
+            value: b"soon-gone",
+            ttl: Ttl::Of(Duration::from_millis(50)),
+        })
+        .await
+        .expect("put succeeds");
+
+    // The `put` itself round-trips a `Changed` event through this same
+    // watch (NOTIFY self-delivery, DESIGN.md §4.3) before the reaper ever
+    // runs — drain it first so the assertion below is actually checking the
+    // *second* event, not racing the first one.
+    let changed = tokio::time::timeout(Duration::from_secs(2), watch.recv())
+        .await
+        .expect("the put's own Changed event arrives before the timeout");
+    assert!(
+        matches!(
+            changed,
+            Some(cluster_sdk::CacheWatchEvent::Event(cluster_sdk::CacheEvent::Changed { ref key }))
+                if key == "k4"
+        ),
+        "PG-CACHE-004 setup: expected the put's own Changed event first, got {changed:?}"
+    );
+
+    let expired = common::wait_until(
+        Duration::from_secs(5),
+        Duration::from_millis(50),
+        || async { cache.get("k4").await.expect("get succeeds").is_none() },
+    )
+    .await;
+    assert!(
+        expired,
+        "PG-CACHE-004: entry must be gone once the reaper runs past expiry"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(2), watch.recv())
+        .await
+        .expect("an event arrives before the timeout");
+    assert!(
+        matches!(
+            event,
+            Some(cluster_sdk::CacheWatchEvent::Event(cluster_sdk::CacheEvent::Expired { ref key }))
+                if key == "k4"
+        ),
+        "PG-CACHE-004: watcher must receive Expired{{key: \"k4\"}}, got {event:?}"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-CACHE-005`: `compare_and_delete` survives the delete+recreate
+/// version-reset scenario — a stale `compare_and_delete` against the old
+/// value is a safe no-op against a successor's claim.
+#[tokio::test]
+async fn pg_cache_005_compare_and_delete_survives_version_reset() {
+    let (_container, config) = common::start_postgres().await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let cache = handle.cache();
+
+    cache
+        .put(PutRequest {
+            key: "k5",
+            value: b"holder-a",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("initial claim");
+    assert!(cache.delete("k5").await.expect("delete succeeds"));
+    cache
+        .put(PutRequest {
+            key: "k5",
+            value: b"holder-b",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("successor re-claims");
+
+    // Holder A's stale compare_and_delete against its own old value must be a
+    // no-op, never wiping holder B's claim.
+    let stale_delete = cache
+        .compare_and_delete("k5", b"holder-a")
+        .await
+        .expect("compare_and_delete succeeds");
+    assert!(
+        !stale_delete,
+        "PG-CACHE-005: stale compare_and_delete must be a no-op"
+    );
+
+    let entry = cache.get("k5").await.expect("get").expect("still present");
+    assert_eq!(
+        entry.value, b"holder-b",
+        "PG-CACHE-005: successor's claim must survive"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-CACHE-006`: `scan_prefix` returns every key under the prefix,
+/// excludes keys outside it and expired keys, and correctly escapes a
+/// literal `%`/`_` in the prefix (`cache::escape_like`).
+#[tokio::test]
+async fn pg_cache_006_scan_prefix_correctness() {
+    let (_container, config) = common::start_postgres().await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let cache = handle.cache();
+
+    for key in ["svc/a", "svc/b", "other/c"] {
+        cache
+            .put(PutRequest {
+                key,
+                value: b"v",
+                ttl: Ttl::Indefinite,
+            })
+            .await
+            .expect("put succeeds");
+    }
+    cache
+        .put(PutRequest {
+            key: "svc/expired",
+            value: b"v",
+            ttl: Ttl::Of(Duration::from_millis(1)),
+        })
+        .await
+        .expect("put succeeds");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let mut found = cache
+        .scan_prefix("svc/")
+        .await
+        .expect("scan_prefix succeeds");
+    found.sort();
+    assert_eq!(
+        found,
+        vec!["svc/a".to_owned(), "svc/b".to_owned()],
+        "PG-CACHE-006: scan_prefix must include only non-expired keys under the prefix"
+    );
+
+    // A prefix containing a literal LIKE metacharacter must be matched
+    // literally, not as a wildcard (`cache::escape_like`).
+    cache
+        .put(PutRequest {
+            key: "100%-done",
+            value: b"v",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put succeeds");
+    cache
+        .put(PutRequest {
+            key: "100X-done",
+            value: b"v",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put succeeds");
+    let percent_scan = cache
+        .scan_prefix("100%")
+        .await
+        .expect("scan_prefix succeeds");
+    assert_eq!(
+        percent_scan,
+        vec!["100%-done".to_owned()],
+        "PG-CACHE-006: a literal '%' in the prefix must be escaped, not treated as a wildcard"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-CACHE-007`: `build_and_start` against a database that already has the
+/// plugin's tables succeeds without error (migration idempotency).
+#[tokio::test]
+async fn pg_cache_007_migration_idempotency() {
+    let (_container, config) = common::start_postgres().await;
+    let handle_one = PostgresClusterPlugin::builder(config.clone())
+        .build_and_start()
+        .await
+        .expect("first build_and_start succeeds");
+    handle_one.stop().await;
+
+    let handle_two = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("PG-CACHE-007: build_and_start against an already-migrated database must succeed");
+    handle_two.stop().await;
+}
+
+/// `PG-CACHE-008`: with the write pool constrained to a single connection and
+/// that one connection pinned by a held lock (the combined plugin shares one
+/// pool across cache and lock — DESIGN.md §3.3), a concurrent cache `put`
+/// *genuinely blocks* waiting for a connection, then completes once the lock
+/// releases the connection back to the pool. Pinning via a real held lock —
+/// rather than firing N short puts that merely serialize in microseconds —
+/// is what actually forces the "caller waits for a connection" behaviour this
+/// scenario is about.
+#[tokio::test]
+async fn pg_cache_008_blocked_acquire_succeeds_once_connection_frees() {
+    let (_container, config) = common::start_postgres_with(json!({
+        "pool_max_size": 1,
+        "pool_acquire_timeout_ms": 5_000,
+    }))
+    .await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let cache = handle.cache();
+    let lock = handle.lock();
+
+    // Pin the single pool connection for the held lock's duration (§3.3).
+    let guard = lock
+        .try_lock("cache8-blocker", Duration::from_secs(30))
+        .await
+        .expect("acquiring the lock pins the only pool connection");
+
+    // A cache `put` now has no connection available and must block.
+    let put_cache = cache.clone();
+    let put = tokio::spawn(async move {
+        put_cache
+            .put(PutRequest {
+                key: "k8",
+                value: b"v",
+                ttl: Ttl::Indefinite,
+            })
+            .await
+    });
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert!(
+        !put.is_finished(),
+        "PG-CACHE-008: the put must genuinely block while the only connection is pinned"
+    );
+
+    // Releasing the lock returns the connection; the blocked put then completes.
+    guard.release().await.expect("release frees the connection");
+    let result = tokio::time::timeout(Duration::from_secs(5), put)
+        .await
+        .expect("the unblocked put resolves within the timeout")
+        .expect("put task must not panic");
+    assert!(
+        result.is_ok(),
+        "PG-CACHE-008: the queued put must succeed once a connection frees, got {result:?}"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-CACHE-008b`: pool exhaustion that outlasts `pool_acquire_timeout_ms`
+/// surfaces as `Provider { kind: Timeout }` (the timeout-exceeded error path
+/// the happy-path scenario above does not cover). Same single-connection,
+/// lock-pinned setup, but a short acquire timeout the blocked op cannot beat.
+#[tokio::test]
+async fn pg_cache_008b_pool_exhaustion_times_out_as_provider_timeout() {
+    let (_container, config) = common::start_postgres_with(json!({
+        "pool_max_size": 1,
+        "pool_acquire_timeout_ms": 250,
+    }))
+    .await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let cache = handle.cache();
+    let lock = handle.lock();
+
+    let guard = lock
+        .try_lock("cache8b-blocker", Duration::from_secs(30))
+        .await
+        .expect("acquiring the lock pins the only pool connection");
+
+    // No connection can be obtained within 250ms → sqlx `PoolTimedOut` →
+    // `Provider { Timeout }` (DESIGN.md §9).
+    let result = cache
+        .put(PutRequest {
+            key: "k8b",
+            value: b"v",
+            ttl: Ttl::Indefinite,
+        })
+        .await;
+    assert!(
+        matches!(
+            result,
+            Err(ClusterError::Provider {
+                kind: ProviderErrorKind::Timeout,
+                ..
+            })
+        ),
+        "PG-CACHE-008b: a cache op that cannot get a pool connection within \
+         pool_acquire_timeout_ms must return Provider{{Timeout}}, got {result:?}"
+    );
+
+    guard.release().await.expect("release");
+    handle.stop().await;
+}
+
+/// `PG-CACHE-009`: `put_if_absent` over an expired-but-not-yet-reaped row
+/// treats the key as absent and re-creates it at version 1, rather than
+/// reporting it present until the TTL reaper physically deletes the row. This
+/// is the leader-election failover path (`CasBasedLeaderElectionBackend::claim`
+/// re-claims an expired election lease via `put_if_absent`): a slow reaper must
+/// not delay failover. The reaper interval is left at its 10s default and the
+/// TTL is 50ms, so the row is guaranteed still-present-but-expired when the
+/// second `put_if_absent` runs (regression test for the `ON CONFLICT DO
+/// NOTHING` bug — DESIGN.md §4.1).
+#[tokio::test]
+async fn pg_cache_009_put_if_absent_reclaims_expired_row() {
+    let (_container, config) = common::start_postgres().await;
+    let connection_string = config.connection_string.clone();
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let cache = handle.cache();
+
+    let first = cache
+        .put_if_absent(PutRequest {
+            key: "k9",
+            value: b"incumbent",
+            ttl: Ttl::Of(Duration::from_millis(50)),
+        })
+        .await
+        .expect("put_if_absent succeeds")
+        .expect("key was absent");
+    assert_eq!(first.version, 1, "PG-CACHE-009: first claim is version 1");
+
+    // Wait past the TTL. The default 10s reaper cannot have run yet, so the
+    // expired row physically lingers — the exact state the bug mishandled.
+    let expired = common::wait_until(
+        Duration::from_secs(5),
+        Duration::from_millis(25),
+        || async { cache.get("k9").await.expect("get succeeds").is_none() },
+    )
+    .await;
+    assert!(
+        expired,
+        "PG-CACHE-009: entry must read as absent once past its TTL"
+    );
+
+    // The row is still physically present (reaper hasn't swept it): confirm
+    // the scenario is actually exercising the expired-but-unreaped window.
+    let pool = common::raw_pool(&connection_string).await;
+    let still_present: bool =
+        sqlx::query_scalar("SELECT EXISTS (SELECT 1 FROM public.cluster_cache WHERE key = $1)")
+            .bind("k9")
+            .fetch_one(&pool)
+            .await
+            .expect("existence query succeeds");
+    assert!(
+        still_present,
+        "PG-CACHE-009: the expired row must still physically exist (reaper has not run)"
+    );
+
+    let reclaimed = cache
+        .put_if_absent(PutRequest {
+            key: "k9",
+            value: b"successor",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put_if_absent succeeds")
+        .expect("PG-CACHE-009: put_if_absent must treat an expired row as absent and re-create it");
+    assert_eq!(
+        reclaimed.version, 1,
+        "PG-CACHE-009: reclaimed entry is a fresh version 1"
+    );
+
+    let entry = cache.get("k9").await.expect("get").expect("present");
+    assert_eq!(
+        entry.value, b"successor",
+        "PG-CACHE-009: successor's value must win"
+    );
+
+    handle.stop().await;
+}
+
+/// Rows planted for `PG-CACHE-010`/`010b`, deliberately more than one
+/// `SWEEP_BATCH` (512, `cache::reaper`), so clearing them cannot be done by a
+/// single chunk.
+const BACKLOG_ROWS: i32 = 600;
+
+/// Plants `BACKLOG_ROWS` already-expired rows in one statement.
+///
+/// Planted directly rather than through `put`: this is about the reaper's
+/// behaviour on a pre-existing backlog, and `BACKLOG_ROWS` round-trips through
+/// the API would both be slow and let a fast reaper nibble the early rows away
+/// while the later ones were still being written. One statement commits
+/// atomically, so the reaper sees the whole backlog or none of it.
+///
+/// `expires_at = now() - (BACKLOG_ROWS + 1 - i)s` staggers the rows already into
+/// the past, longest-expired first, so under the sweep's `ORDER BY expires_at`
+/// `backlog-1` heads the first chunk and `backlog-<BACKLOG_ROWS>` is last in
+/// line — which is what lets `010b` name a key that can only fall in a later
+/// chunk.
+async fn plant_expired_backlog(pool: &sqlx::PgPool) {
+    sqlx::query(
+        "INSERT INTO public.cluster_cache (key, value, expires_at) \
+         SELECT 'backlog-' || i, '\\x2a'::bytea, now() - (($1 + 1 - i) * interval '1 second') \
+         FROM generate_series(1, $1) AS s(i)",
+    )
+    .bind(BACKLOG_ROWS)
+    .execute(pool)
+    .await
+    .expect("planting the expired backlog succeeds");
+}
+
+/// `PG-CACHE-010`: **one** sweep clears an expired backlog larger than a single
+/// chunk, and deletes only expired rows.
+///
+/// Driven through the `__test_sweep_once` seam rather than by waiting on the
+/// reaper's own timer, for the same reason `PG-SPEC-009` does it for the lock
+/// reaper: what's under test is that a *single* sweep loops until the table is
+/// drained, and reaper-interval timing cannot distinguish that from "several
+/// intervals elapsed" — the latter being exactly the 512-rows-per-tick behaviour
+/// the chunking exists to avoid. `cache_reaper_interval_ms` is set long so the
+/// reaper's own sweeps never race these assertions.
+#[tokio::test]
+async fn pg_cache_010_one_sweep_clears_a_multi_chunk_backlog() {
+    let (_container, config) =
+        common::start_postgres_with(json!({ "cache_reaper_interval_ms": 600_000 })).await;
+    let connection_string = config.connection_string.clone();
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    // The seam lives on the concrete backend, as in PG-SPEC-005/009.
+    let cache = handle.__test_cache();
+    let pool = common::raw_pool(&connection_string).await;
+
+    plant_expired_backlog(&pool).await;
+    // The plugin's own reaper ticks once immediately at startup (before the rows
+    // above exist) and then not again for ten minutes, so it cannot be the thing
+    // that drains this backlog. Asserted rather than assumed: were that ordering
+    // ever to change, the sweep below would return a short count and read as a
+    // chunk-loop bug instead of the setup race it actually is.
+    let planted: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM public.cluster_cache WHERE key LIKE 'backlog-%'")
+            .fetch_one(&pool)
+            .await
+            .expect("count query succeeds");
+    assert_eq!(
+        planted,
+        i64::from(BACKLOG_ROWS),
+        "PG-CACHE-010 setup: the backlog must be intact before the sweep under test runs"
+    );
+
+    // Two rows the sweep must leave alone: one with a live TTL, one indefinite.
+    handle
+        .cache()
+        .put(PutRequest {
+            key: "backlog-live",
+            value: b"live",
+            ttl: Ttl::Of(Duration::from_mins(10)),
+        })
+        .await
+        .expect("put succeeds");
+    handle
+        .cache()
+        .put(PutRequest {
+            key: "backlog-forever",
+            value: b"forever",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put succeeds");
+
+    let swept = cache.__test_sweep_once().await.expect("sweep");
+    assert_eq!(
+        swept,
+        usize::try_from(BACKLOG_ROWS).unwrap(),
+        "PG-CACHE-010: a single sweep must keep chunking until the whole expired backlog is \
+         gone, not stop after one bounded DELETE"
+    );
+
+    let mut remaining: Vec<String> =
+        sqlx::query_scalar("SELECT key FROM public.cluster_cache WHERE key LIKE 'backlog-%'")
+            .fetch_all(&pool)
+            .await
+            .expect("listing remaining rows succeeds");
+    remaining.sort();
+    assert_eq!(
+        remaining,
+        vec!["backlog-forever".to_owned(), "backlog-live".to_owned()],
+        "PG-CACHE-010: the sweep must delete every expired row and only those: a live TTL and \
+         an indefinite entry both survive"
+    );
+
+    // A second sweep over a table with nothing expired left is a no-op, so the
+    // loop's short-chunk exit is what ended the first one, not the row supply.
+    assert_eq!(
+        cache.__test_sweep_once().await.expect("sweep"),
+        0,
+        "PG-CACHE-010: a sweep with nothing expired must reap nothing"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-CACHE-010b`: keys reaped by a chunk *after* the first still get their
+/// `Expired` event.
+///
+/// Per-chunk transactions mean the `NOTIFY`s are committed in several batches
+/// rather than one, so this pins that no batch past the first is dropped —
+/// `PG-CACHE-004` only ever covers a single-row sweep. The watched key is the
+/// least-expired row of the backlog, so `ORDER BY expires_at` guarantees it is
+/// not in the first chunk. A fast reaper here (rather than `010`'s deliberately
+/// long one) so the watcher can be registered before any sweep runs.
+#[tokio::test]
+async fn pg_cache_010b_later_chunks_still_notify_their_keys() {
+    let (_container, config) =
+        common::start_postgres_with(json!({ "cache_reaper_interval_ms": 100 })).await;
+    let connection_string = config.connection_string.clone();
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+
+    // Registered before the rows exist: a watcher only receives events from the
+    // point it subscribes (DESIGN.md §4.3), and the reaper may sweep as soon as
+    // the insert commits.
+    let last_key = format!("backlog-{BACKLOG_ROWS}");
+    let mut watch = handle
+        .cache()
+        .watch(&last_key)
+        .await
+        .expect("watch succeeds");
+
+    let pool = common::raw_pool(&connection_string).await;
+    plant_expired_backlog(&pool).await;
+
+    let event = tokio::time::timeout(Duration::from_secs(30), watch.recv())
+        .await
+        .expect("an event arrives before the timeout");
+    assert!(
+        matches!(
+            event,
+            Some(cluster_sdk::CacheWatchEvent::Event(cluster_sdk::CacheEvent::Expired { ref key }))
+                if *key == last_key
+        ),
+        "PG-CACHE-010b: a later chunk's keys must still get their Expired event, got {event:?}"
+    );
+
+    handle.stop().await;
+}

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/tests/common/mod.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/tests/common/mod.rs
@@ -1,0 +1,318 @@
+//! Shared testcontainers fixture for the Postgres cluster plugin's Layer 2/3
+//! test suites (docs/TESTING.md §4.1). Not a test binary itself — every
+//! `tests/*.rs` file that needs it declares `mod common;`.
+//!
+//! Gated behind `--features integration` end to end (docs/TESTING.md §7): this
+//! whole module is compiled out of a default `cargo test`, so it never
+//! requires a Docker daemon unless the feature is explicitly enabled.
+
+#![cfg(feature = "integration")]
+#![allow(
+    dead_code,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test harness: a fixture setup failure IS the test failure, and \
+              not every helper below is used by every test binary that `mod \
+              common;`s this file"
+)]
+
+use std::time::Duration;
+
+use postgres_cluster_plugin::{PostgresClusterConfig, PostgresLockConfig};
+use serde_json::json;
+use sqlx::PgPool;
+use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
+use std::str::FromStr;
+use testcontainers::ContainerAsync;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+/// `application_name` tagged onto every [`raw_pool`] connection so tests that
+/// assert on `pg_stat_activity`/`pg_locks` can exclude the control pool's own
+/// connections by name instead of relying on `pid <> pg_backend_pid()`, which
+/// only excludes the single connection actively running the query — not the
+/// control pool's other (possibly idle) connections.
+pub const CONTROL_POOL_APPLICATION_NAME: &str = "cluster_test_control";
+
+/// Builds a [`PostgresClusterConfig`] from `connection_string` plus any
+/// `overrides` (a JSON object merged over the minimal required fields),
+/// going through `serde_json`/`serde(default = ...)` rather than a `Default`
+/// impl — `PostgresClusterConfig` deliberately doesn't derive `Default`
+/// (DESIGN.md §7: `connection_string` has no sensible default), so this is
+/// the test-only equivalent TESTING.md §4.1's `..PostgresClusterConfig::default()`
+/// spread would have needed.
+fn cluster_config_json(
+    connection_string: &str,
+    overrides: serde_json::Value,
+) -> PostgresClusterConfig {
+    let mut base = json!({
+        "connection_string": connection_string,
+        "pool_max_size": 5,
+    });
+    merge(&mut base, overrides);
+    serde_json::from_value(base).expect("valid PostgresClusterConfig")
+}
+
+fn lock_config_json(connection_string: &str, overrides: serde_json::Value) -> PostgresLockConfig {
+    let mut base = json!({
+        "connection_string": connection_string,
+        "pool_max_size": 5,
+    });
+    merge(&mut base, overrides);
+    serde_json::from_value(base).expect("valid PostgresLockConfig")
+}
+
+/// Shallow object merge — sufficient for the flat config shapes here.
+fn merge(base: &mut serde_json::Value, overrides: serde_json::Value) {
+    let (serde_json::Value::Object(base_map), serde_json::Value::Object(override_map)) =
+        (base, overrides)
+    else {
+        return;
+    };
+    for (key, value) in override_map {
+        base_map.insert(key, value);
+    }
+}
+
+/// Starts a fresh Postgres container and returns it alongside a
+/// `postgres://.../cluster_test` connection string pointed at its mapped host
+/// port.
+///
+/// Retries the whole create -> `.start()` -> `get_host_port_ipv4` sequence up
+/// to 5 times with backoff. Under parallel test load the container's own
+/// wait-strategy passes but the follow-up Docker port-inspect
+/// (`get_host_port_ipv4`) transiently fails; a fresh container per attempt
+/// side-steps that flake so every acquisition path here inherits the retry.
+async fn spawn_postgres() -> (ContainerAsync<Postgres>, String) {
+    // 250ms, 500ms, 1s, 2s between the 5 attempts (last attempt has no sleep).
+    let backoffs = [
+        Duration::from_millis(250),
+        Duration::from_millis(500),
+        Duration::from_secs(1),
+        Duration::from_secs(2),
+    ];
+    let attempts = backoffs.len() + 1;
+    let mut last_error = String::new();
+    for attempt in 1..=attempts {
+        let container = match Postgres::default()
+            .with_db_name("cluster_test")
+            .start()
+            .await
+        {
+            Ok(container) => container,
+            Err(error) => {
+                last_error = format!("container start: {error}");
+                if let Some(backoff) = backoffs.get(attempt - 1) {
+                    tokio::time::sleep(*backoff).await;
+                }
+                continue;
+            }
+        };
+        match container.get_host_port_ipv4(5432).await {
+            Ok(port) => {
+                let connection_string =
+                    format!("postgres://postgres:postgres@127.0.0.1:{port}/cluster_test");
+                return (container, connection_string);
+            }
+            Err(error) => {
+                last_error = format!("mapped host port: {error}");
+                // Drop the failed container before backing off and retrying.
+                drop(container);
+                if let Some(backoff) = backoffs.get(attempt - 1) {
+                    tokio::time::sleep(*backoff).await;
+                }
+            }
+        }
+    }
+    panic!(
+        "Postgres container acquisition failed after {attempts} attempts; last error: {last_error}"
+    );
+}
+
+/// Starts a fresh Postgres container and returns a [`PostgresClusterConfig`]
+/// pointed at it (docs/TESTING.md §4.1).
+pub async fn start_postgres() -> (ContainerAsync<Postgres>, PostgresClusterConfig) {
+    start_postgres_with(json!({})).await
+}
+
+/// Like [`start_postgres`], but lets the caller override any
+/// `PostgresClusterConfig` field (e.g. `lock_reaper_interval_ms`,
+/// `lock_name_cardinality_warn_threshold`) for scenarios that need a
+/// non-default value.
+pub async fn start_postgres_with(
+    overrides: serde_json::Value,
+) -> (ContainerAsync<Postgres>, PostgresClusterConfig) {
+    let (container, connection_string) = spawn_postgres().await;
+    let config = cluster_config_json(&connection_string, overrides);
+    (container, config)
+}
+
+/// Same container, but returns a [`PostgresLockConfig`] (DESIGN.md §3.5) for
+/// tests exercising the standalone lock-only provider path.
+pub async fn start_postgres_lock_only() -> (ContainerAsync<Postgres>, PostgresLockConfig) {
+    start_postgres_lock_only_with(json!({})).await
+}
+
+/// Like [`start_postgres_lock_only`], with field overrides.
+pub async fn start_postgres_lock_only_with(
+    overrides: serde_json::Value,
+) -> (ContainerAsync<Postgres>, PostgresLockConfig) {
+    let (container, connection_string) = spawn_postgres().await;
+    let config = lock_config_json(&connection_string, overrides);
+    (container, config)
+}
+
+/// Creates `schema` (if missing) on the container behind
+/// `base_connection_string` and returns a connection string whose default
+/// `search_path` is that schema — via the standard libpq `options` startup
+/// parameter (`?options[search_path]=<schema>`, which `sqlx::PgConnectOptions`
+/// parses into `-c search_path=<schema>`; confirmed empirically against a
+/// real server).
+///
+/// This is how the Layer 2 conformance tests (`tests/conformance.rs`) get N
+/// genuinely independent backends — each its own migrated
+/// `cluster_cache`/`cluster_lock` pair, with its own `_sqlx_migrations`
+/// tracking row — on a **single shared container**, rather than needing N
+/// separate containers or a fragile async-reset-inside-a-sync-closure
+/// bridge (the latter was tried and reverted: see this crate's `tests/
+/// conformance.rs` module doc for why it deadlocked).
+pub async fn isolated_schema_connection_string(
+    base_connection_string: &str,
+    schema: &str,
+) -> String {
+    let pool = raw_pool(base_connection_string).await;
+    sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS {schema}"))
+        .execute(&pool)
+        .await
+        .expect("create schema succeeds");
+    pool.close().await;
+    format!("{base_connection_string}?options[search_path]={schema}")
+}
+
+/// Builds a [`PostgresClusterConfig`] pointed at `connection_string` with
+/// `schema` as both the migration target (via `connection_string`'s
+/// `search_path`, see [`isolated_schema_connection_string`]) and the
+/// query-qualification schema (`PostgresClusterConfig::schema`) — the two
+/// must agree, or migrations land in one schema while queries look in
+/// another.
+///
+/// `pool_max_size` defaults to 1 here: callers that pre-build many
+/// independent instances on one shared container (`tests/conformance.rs`)
+/// need to stay well under the server's global `max_connections` (the stock
+/// image's default is 100). Measured empirically (`pg_stat_activity`), a
+/// combined-plugin instance's *real* steady-state connection cost is `2
+/// (dedicated LISTEN connections — cache watch + lock release-wake) +
+/// pool_max_size` — **not** `pool_max_size + 1` as a first pass assumed,
+/// because the cache TTL reaper and the lock TTL reaper each grab their own
+/// pool connection on their first sweep and then sit idle-but-open in the
+/// pool afterward (normal pool reuse — sqlx doesn't close an idle pooled
+/// connection just because nothing is using it right now), so with
+/// `pool_max_size: 2` both reapers' connections alone consumed the *entire*
+/// per-instance pool budget: `4 * N` measured for `N` cache-conformance
+/// instances, not the originally-assumed `3 * N`. Cache/leader instances
+/// (this function) never hold a connection indefinitely the way a lock does
+/// (`PostgresLock`'s `held` map only pins connections for the standalone
+/// lock plugin's own `try_lock`/`lock`, which nothing calls when the
+/// combined plugin is only being used for its cache half here), so `1` is
+/// safe — see [`lock_config_for_schema`] for why the standalone lock plugin
+/// needs `2`.
+pub fn cluster_config_for_schema(connection_string: &str, schema: &str) -> PostgresClusterConfig {
+    cluster_config_json(
+        connection_string,
+        json!({ "schema": schema, "pool_max_size": 1 }),
+    )
+}
+
+/// Like [`cluster_config_for_schema`], with extra field `overrides` merged in
+/// (e.g. a short `cache_reaper_interval_ms` for real-time TTL-expiry
+/// conformance scenarios that need the sweeper to actually fire within a real
+/// wait). `pool_max_size` defaults to `2` here rather than `1`, since a fast
+/// reaper competes with the scenario's own `get`/`watch` for a pool connection.
+pub fn cluster_config_for_schema_with(
+    connection_string: &str,
+    schema: &str,
+    overrides: serde_json::Value,
+) -> PostgresClusterConfig {
+    let mut base = json!({ "schema": schema, "pool_max_size": 2 });
+    merge(&mut base, overrides);
+    cluster_config_json(connection_string, base)
+}
+
+/// Like [`cluster_config_for_schema`], for the standalone lock-only plugin.
+/// Kept at `2`, not `1`: some `SC-LOCK-*` scenarios (`scenario_lock_004`)
+/// spawn a concurrent waiter that needs its own connection *while* the
+/// holder's connection is still pinned, so a given lock instance can
+/// legitimately need two connections at once (this doesn't apply to
+/// [`cluster_config_for_schema`]'s cache/leader use, which never pins a
+/// connection).
+pub fn lock_config_for_schema(connection_string: &str, schema: &str) -> PostgresLockConfig {
+    lock_config_json(
+        connection_string,
+        json!({ "schema": schema, "pool_max_size": 2 }),
+    )
+}
+
+/// Like [`lock_config_for_schema`], with extra field `overrides` merged in
+/// (e.g. a short `lock_reaper_interval_ms` for real-time TTL-reclaim scenarios).
+pub fn lock_config_for_schema_with(
+    connection_string: &str,
+    schema: &str,
+    overrides: serde_json::Value,
+) -> PostgresLockConfig {
+    let mut base = json!({ "schema": schema, "pool_max_size": 2 });
+    merge(&mut base, overrides);
+    lock_config_json(connection_string, base)
+}
+
+/// A bare `sqlx::PgPool` against the same container, for tests that need to
+/// assert Postgres-level state directly (catalog views, `pg_terminate_backend`,
+/// raw `SET`/`SHOW`) rather than only through the plugin's own API.
+pub async fn raw_pool(connection_string: &str) -> PgPool {
+    let options = PgConnectOptions::from_str(connection_string)
+        .expect("connection string parses")
+        .application_name(CONTROL_POOL_APPLICATION_NAME);
+    PgPoolOptions::new()
+        .max_connections(5)
+        .acquire_timeout(Duration::from_secs(5))
+        .connect_with(options)
+        .await
+        .expect("raw pool connects")
+}
+
+/// Whether `table` (schema-qualified, e.g. `"public.cluster_cache"`) exists.
+pub async fn table_exists(pool: &PgPool, schema: &str, table: &str) -> bool {
+    let exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS (SELECT 1 FROM information_schema.tables \
+         WHERE table_schema = $1 AND table_name = $2)",
+    )
+    .bind(schema)
+    .bind(table)
+    .fetch_one(pool)
+    .await
+    .expect("information_schema query succeeds");
+    exists
+}
+
+/// Polls `condition` until it returns `true` or `timeout` elapses, sleeping
+/// `interval` between attempts. Used in place of a single fixed `sleep` for
+/// assertions on state that changes asynchronously in the background (a
+/// reaper sweep, a LISTEN-driven watch delivery) without hard-coding a
+/// latency bound tighter than the scenario is actually about.
+pub async fn wait_until<F>(timeout: Duration, interval: Duration, mut condition: F) -> bool
+where
+    F: AsyncFnMut() -> bool,
+{
+    // Bound the *whole* wait — including each in-flight `condition().await` — by
+    // `timeout` (PGR-E5). Checking the deadline only after `condition` returns
+    // let a stalled SQL/network call inside it overrun `timeout` indefinitely.
+    tokio::time::timeout(timeout, async {
+        loop {
+            if condition().await {
+                return true;
+            }
+            tokio::time::sleep(interval).await;
+        }
+    })
+    .await
+    .unwrap_or(false)
+}

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/tests/conformance.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/tests/conformance.rs
@@ -1,0 +1,365 @@
+//! Layer 2 — conformance suite (docs/TESTING.md §3), wired against a real
+//! Postgres container.
+//!
+//! # Single entry point per suite via an async factory
+//!
+//! Each suite goes through one shared `run_*_conformance(make, time)` entry
+//! point. `make` is an **async** factory (`Fn() -> Future<Output =
+//! ScenarioBackend<_>>`) the runner calls once per scenario, so a
+//! Postgres-backed backend — whose construction is unavoidably async (opening a
+//! pool, running migrations, opening the LISTEN connection) — is built fresh per
+//! scenario, and its [`cluster_conformance::ScenarioBackend`] teardown `stop()`s
+//! the handle before the next scenario is built.
+//!
+//! A genuinely fresh backend per scenario is required, not cosmetic — confirmed
+//! empirically: a single shared backend failed `SC-CACHE-004`, exhausted the
+//! lock pool via intentionally-leaked advisory locks, and left stale leader
+//! candidate tasks running across scenarios. All three suites isolate each
+//! scenario into its **own Postgres schema** on **one shared container**
+//! (`PostgresClusterConfig::schema`, DESIGN.md §7 — routed to an isolated
+//! `search_path` via `common::isolated_schema_connection_string`). The lock
+//! suite additionally relies on per-scenario teardown draining held advisory
+//! locks (`PostgresLock::drain_held`) before the next scenario's handle is
+//! built, since `pg_advisory_lock`'s key space is server-wide, not schema-scoped
+//! (see `lock_conformance`).
+//!
+//! # Time-sensitive scenarios run under `TimeControl::Real`, not virtual time
+//!
+//! A second, orthogonal problem surfaced once the fresh-backend-per-scenario
+//! fix above was in place: `SC-CACHE-010/011/014/015`, `SC-LOCK-002/003/005/007`,
+//! and `SC-LEAD-003` originally drove time with `tokio::time::pause()` +
+//! `advance()`. Against this plugin's real `sqlx::PgPool` a paused virtual clock
+//! reliably produced a spurious `Provider { kind: Timeout }` from
+//! `pool.acquire()` — confirmed not to be resource exhaustion: the paused
+//! runtime auto-advances the clock to the next pending timer deadline while a
+//! real `pool.acquire()`'s network I/O is parked, so sqlx's own acquire
+//! `tokio::time::timeout` (`sqlx-core/src/pool/inner.rs`) fires immediately even
+//! on a free pool (full trace in `docs/GAP-SOLUTIONS.md` §3).
+//!
+//! The fix (that doc's §3 Proposal A) lives in `cluster-conformance`: the
+//! affected scenarios now take a [`cluster_conformance::TimeControl`]. Fixture /
+//! in-memory callers pass `Virtual` (unchanged, instant, deterministic); this
+//! plugin, running over a real pool, passes `Real`, which swaps the virtual
+//! `advance` for a real bounded `tokio::time::sleep` and never pauses the clock,
+//! so sqlx's timers behave normally. The reaper-driven scenarios additionally
+//! configure a short reaper/sweep interval (so the TTL reclaim actually fires
+//! within the real wait), and the reclaim assertions poll rather than
+//! single-shot to tolerate reaper-tick jitter.
+//!
+//! `SC-LEAD-006` is the one exception still not run here — see
+//! `leader_conformance`'s doc comment: it is a *virtual-time fault-simulation*
+//! scenario (it forces a renewal *miss* to assert `Status(Lost)` re-enrols),
+//! which a healthy real backend never exhibits by merely waiting, so it maps to
+//! real fault injection (L4/Toxiproxy, `PG-FAULT-007`), not a real sleep.
+//!
+//! # `discovery_conformance`: now runs (was an SDK gap, now fixed)
+//!
+//! This was previously `#[ignore]`d: `cluster::defaults::CacheBasedServiceDiscoveryBackend`
+//! held a raw cache and called its trait `watch_prefix` directly, which this
+//! plugin's `prefix_watch: false` cache answers with `Unsupported`, so `discover`
+//! degraded to an always-empty set (`SC-DISC-001` failed on a fresh backend).
+//! DESIGN.md §6 claimed the SDK "detects [`prefix_watch: false`] at construction
+//! and initialises with `PollingPrefixWatch`", but nothing in the SDK actually
+//! did that (GAP-SOLUTIONS.md §4).
+//!
+//! That is now implemented in the SDK (`cluster::defaults::discovery`): the
+//! backend falls back to the `PollingPrefixWatch` polyfill over `scan_prefix`
+//! when the cache declares no native prefix watch, so `discover`/`watch` work
+//! over this plugin's cache and the suite runs. `SC-DISC-006` (a virtual-time
+//! TTL-lapse) is still skipped by `run_discovery_conformance` under `Real`, as
+//! for the other suites.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration tests: a setup failure IS the test failure"
+)]
+
+mod common;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use cluster_conformance::{ScenarioBackend, TimeControl};
+use postgres_cluster_plugin::PostgresClusterPlugin;
+
+/// Runs every `SC-CACHE-*` scenario through the shared `run_cache_conformance`
+/// entry point under [`TimeControl::Real`] (a real `sqlx` pool cannot use a
+/// paused clock — see this module's doc comment and `docs/GAP-SOLUTIONS.md` §3).
+///
+/// The async factory builds a fresh, fully-migrated combined-plugin cache in its
+/// own schema on one shared container per scenario, and its
+/// [`ScenarioBackend`] teardown `stop()`s that handle before the next scenario
+/// is built. A short `cache_reaper_interval_ms` (50ms) makes the TTL sweeper
+/// fire within `SC-CACHE-010`'s real wait.
+#[tokio::test]
+async fn cache_conformance() {
+    use cluster_conformance::run_cache_conformance;
+
+    let (_container, base_config) = common::start_postgres().await;
+    let base_connection_string = base_config.connection_string;
+    let scenario_index = AtomicUsize::new(0);
+
+    run_cache_conformance(
+        || {
+            let base_connection_string = base_connection_string.clone();
+            let index = scenario_index.fetch_add(1, Ordering::Relaxed);
+            async move {
+                let schema = format!("conformance_cache_{index}");
+                let connection_string =
+                    common::isolated_schema_connection_string(&base_connection_string, &schema)
+                        .await;
+                let config = common::cluster_config_for_schema_with(
+                    &connection_string,
+                    &schema,
+                    serde_json::json!({ "cache_reaper_interval_ms": 50 }),
+                );
+                let handle = PostgresClusterPlugin::builder(config)
+                    .build_and_start()
+                    .await
+                    .expect("fresh per-scenario schema starts");
+                let cache = handle.cache();
+                ScenarioBackend::with_teardown(cache, async move { handle.stop().await })
+            }
+        },
+        TimeControl::Real,
+    )
+    .await;
+}
+
+/// Runs every `SC-LOCK-*` scenario through the shared `run_lock_conformance`
+/// entry point under [`TimeControl::Real`].
+///
+/// The async factory shares **one** container across scenarios (like cache /
+/// leader), each scenario in its own schema (`isolated_schema_connection_string`).
+/// This previously used a fresh container **per scenario**: `pg_advisory_lock`'s
+/// key space is server-wide (`SET search_path` has no effect on it), and the
+/// scenarios reuse the same lock names (`"res"`, `"m"`), so a lock still held
+/// past a scenario's teardown would collide with the next. That no longer
+/// happens: `PostgresLockHandle::stop` now drains every held lock
+/// (`PostgresLock::drain_held`, the `PG-LIFE-003`/§1 fix) — `pg_advisory_unlock`
+/// on each pinned connection, synchronously, before `pool.close()` — so the
+/// server's advisory locks are clear before the next scenario's fresh handle
+/// acquires them. Per-scenario schemas isolate the `cluster_lock` **table**;
+/// the drain isolates the server-wide advisory **locks**. Confirmed clean and
+/// ~3× faster (1 container, not 6). A short `lock_reaper_interval_ms` (25ms)
+/// lets the TTL-reclaim scenarios reclaim within their real waits (harmless for
+/// the non-reclaim ones).
+#[tokio::test]
+async fn lock_conformance() {
+    use cluster_conformance::run_lock_conformance;
+    use postgres_cluster_plugin::PostgresLockPlugin;
+
+    let (_container, base_config) = common::start_postgres_lock_only().await;
+    let base_connection_string = base_config.connection_string;
+    let scenario_index = AtomicUsize::new(0);
+
+    run_lock_conformance(
+        || {
+            let base_connection_string = base_connection_string.clone();
+            let index = scenario_index.fetch_add(1, Ordering::Relaxed);
+            async move {
+                let schema = format!("conformance_lock_{index}");
+                let connection_string =
+                    common::isolated_schema_connection_string(&base_connection_string, &schema)
+                        .await;
+                let config = common::lock_config_for_schema_with(
+                    &connection_string,
+                    &schema,
+                    serde_json::json!({ "lock_reaper_interval_ms": 25 }),
+                );
+                let handle = PostgresLockPlugin::builder(config)
+                    .build_and_start()
+                    .await
+                    .expect("fresh per-scenario schema starts");
+                let lock = handle.lock();
+                ScenarioBackend::with_teardown(lock, async move { handle.stop().await })
+            }
+        },
+        TimeControl::Real,
+    )
+    .await;
+}
+
+/// Runs the `SC-LEAD-*` scenarios through the shared `run_leader_conformance`
+/// entry point under [`TimeControl::Real`], against a fresh
+/// `CasBasedLeaderElectionBackend` over its own fresh Postgres cache per scenario
+/// (DESIGN.md §6: leader election is always the SDK default over this plugin's
+/// cache, never a native implementation).
+///
+/// `run_leader_conformance` itself skips `SC-LEAD-006` under `Real` — it is a
+/// virtual-time fault-simulation (it forces a lease-renewal *miss* to assert a
+/// transient `Status(Lost)` re-enrols), which a healthy real backend never
+/// exhibits by merely waiting; that property belongs to L4 fault injection
+/// (`PG-FAULT-007`), not a real sleep.
+#[tokio::test]
+async fn leader_conformance() {
+    use cluster::defaults::CasBasedLeaderElectionBackend;
+    use cluster_conformance::run_leader_conformance;
+    use cluster_sdk::LeaderElectionBackend;
+
+    let (_container, base_config) = common::start_postgres().await;
+    let base_connection_string = base_config.connection_string;
+    let scenario_index = AtomicUsize::new(0);
+
+    run_leader_conformance(
+        || {
+            let base_connection_string = base_connection_string.clone();
+            let index = scenario_index.fetch_add(1, Ordering::Relaxed);
+            async move {
+                let schema = format!("conformance_leader_{index}");
+                let connection_string =
+                    common::isolated_schema_connection_string(&base_connection_string, &schema)
+                        .await;
+                let config = common::cluster_config_for_schema_with(
+                    &connection_string,
+                    &schema,
+                    serde_json::json!({}),
+                );
+                let handle = PostgresClusterPlugin::builder(config)
+                    .build_and_start()
+                    .await
+                    .expect("fresh per-scenario schema starts");
+                let leader = Arc::new(CasBasedLeaderElectionBackend::new(handle.cache()).expect(
+                    "SC-LEAD-008: the postgres cache is Linearizable, so the strict constructor must succeed",
+                )) as Arc<dyn LeaderElectionBackend>;
+                ScenarioBackend::with_teardown(leader, async move { handle.stop().await })
+            }
+        },
+        TimeControl::Real,
+    )
+    .await;
+}
+
+/// `SC-DISC-*` against `CacheBasedServiceDiscoveryBackend` over the real
+/// Postgres cache (DESIGN.md §6), under [`TimeControl::Real`].
+///
+/// Now runs (previously `#[ignore]`d): the SDK default SD backend detects this
+/// plugin's `prefix_watch: false` cache and drives its topology watch through
+/// the `PollingPrefixWatch` polyfill over `scan_prefix` (GAP-SOLUTIONS.md §4,
+/// implemented in `cluster::defaults::discovery`). A short
+/// `with_prefix_watch_polling` interval keeps the `watch`-driven scenarios
+/// (`SC-DISC-005/007`) fast under real time — the pre-insert path already makes
+/// `discover` immediate, but a `watch` genuinely needs a poll tick.
+#[tokio::test]
+async fn discovery_conformance() {
+    use cluster::defaults::CacheBasedServiceDiscoveryBackend;
+    use cluster_conformance::run_discovery_conformance;
+    use cluster_sdk::ServiceDiscoveryBackend;
+
+    let (_container, base_config) = common::start_postgres().await;
+    let base_connection_string = base_config.connection_string;
+    let scenario_index = AtomicUsize::new(0);
+
+    run_discovery_conformance(
+        || {
+            let base_connection_string = base_connection_string.clone();
+            let index = scenario_index.fetch_add(1, Ordering::Relaxed);
+            async move {
+                let schema = format!("conformance_discovery_{index}");
+                let connection_string =
+                    common::isolated_schema_connection_string(&base_connection_string, &schema)
+                        .await;
+                // A larger pool than the test default (2): the polyfill's
+                // `scan_prefix` + N concurrent `get`s per tick, plus per-instance
+                // heartbeat renewals and the cache reaper, would otherwise starve
+                // it and make a `get` transiently miss (dropping an instance from
+                // the polled view).
+                let config = common::cluster_config_for_schema_with(
+                    &connection_string,
+                    &schema,
+                    serde_json::json!({ "pool_max_size": 12 }),
+                );
+                let handle = PostgresClusterPlugin::builder(config)
+                    .build_and_start()
+                    .await
+                    .expect("fresh per-scenario schema starts");
+                let discovery = Arc::new(
+                    CacheBasedServiceDiscoveryBackend::new(handle.cache())
+                        .with_prefix_watch_polling(std::time::Duration::from_millis(100)),
+                ) as Arc<dyn ServiceDiscoveryBackend>;
+                ScenarioBackend::with_teardown(discovery, async move { handle.stop().await })
+            }
+        },
+        TimeControl::Real,
+    )
+    .await;
+}
+
+/// End-to-end wiring: an operator who binds only `cache: { provider: postgres }`
+/// and lets the omit-default auto-wrap supply service discovery
+/// (`ClusterWiring::from_config` → `resolve_profile_backends`) gets a **working**
+/// SD backed by the `PollingPrefixWatch` polyfill over the Postgres cache
+/// (DESIGN.md §6). This exercises the wiring path that the direct-backend
+/// `discovery_conformance` above does not — the auto-wrap constructs the SD
+/// default itself, so this proves the fallback is reached through real wiring,
+/// not only when a test constructs the backend by hand.
+#[tokio::test]
+async fn discovery_auto_wrap_over_postgres_cache_via_wiring() {
+    use cluster::{ClusterConfig, ClusterWiring, ProviderRegistry};
+    use cluster_sdk::discovery::{DiscoveryFilter, ServiceDiscoveryV1, ServiceRegistration};
+    use cluster_sdk::profile::ClusterProfile;
+    use postgres_cluster_plugin::PostgresCacheProvider;
+    use std::collections::HashMap;
+    use toolkit::client_hub::ClientHub;
+
+    #[derive(Clone, Copy)]
+    struct SdProfile;
+    impl ClusterProfile for SdProfile {
+        const NAME: &'static str = "sdautowrap";
+    }
+
+    let (_container, base_config) = common::start_postgres().await;
+    let connection_string = base_config.connection_string;
+
+    let mut profiles = serde_json::Map::new();
+    profiles.insert(
+        SdProfile::NAME.to_owned(),
+        serde_json::json!({
+            "cache": {
+                "provider": "postgres",
+                "connection_string": connection_string,
+                "pool_max_size": 8,
+            },
+        }),
+    );
+    let cluster_config: ClusterConfig =
+        serde_json::from_value(serde_json::json!({ "profiles": profiles }))
+            .expect("sd auto-wrap profile config parses");
+
+    let providers = ProviderRegistry::new().with_cache_provider(Arc::new(PostgresCacheProvider));
+    let hub = Arc::new(ClientHub::new());
+    let handle = ClusterWiring::from_config(Arc::clone(&hub), &cluster_config, &providers)
+        .await
+        .expect("wiring must resolve SD as the omit-default over the postgres cache");
+
+    let sd = ServiceDiscoveryV1::resolver(&hub)
+        .profile(SdProfile)
+        .resolve()
+        .expect("service-discovery facade resolves for the auto-wrapped profile");
+
+    let reg = ServiceRegistration {
+        name: "delivery".to_owned(),
+        instance_id: None,
+        address: "10.0.0.1:9000".to_owned(),
+        metadata: HashMap::new(),
+    };
+    let svc_handle = sd
+        .register(reg)
+        .await
+        .expect("register must succeed through the auto-wrapped SD");
+    let found = sd
+        .discover("delivery", DiscoveryFilter::default())
+        .await
+        .expect("discover must succeed through the auto-wrapped SD");
+    assert!(
+        found
+            .iter()
+            .any(|i| i.instance_id == svc_handle.instance_id()),
+        "the auto-wrapped, polyfill-backed SD over the postgres cache must discover \
+         a registered instance, proving DESIGN.md section 6's omit-default promise holds"
+    );
+
+    drop(svc_handle);
+    handle.stop().await;
+}

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/tests/lifecycle_integration.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/tests/lifecycle_integration.rs
@@ -1,0 +1,425 @@
+//! Layer 3 — lifecycle integration scenarios (docs/TESTING.md §4.5,
+//! `PG-LIFE-001..008`).
+
+#![cfg(feature = "integration")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration tests: a setup failure IS the test failure"
+)]
+
+mod common;
+
+use std::time::Duration;
+
+use cluster_sdk::error::ClusterError;
+use postgres_cluster_plugin::{PostgresClusterPlugin, PostgresLockPlugin};
+use serde_json::json;
+
+/// A `Write` sink appending to a shared buffer, for capturing `tracing` output
+/// in the `PG-LIFE-007/008` handle-`Drop` scenarios.
+#[derive(Clone)]
+struct SharedWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+impl std::io::Write for SharedWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SharedWriter {
+    type Writer = SharedWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// Installs a thread-local WARN-level subscriber for the current test.
+/// `#[tokio::test]` uses a current-thread runtime, so a `Drop` running during a
+/// spawned task's unwind executes on this same thread and its warn is captured.
+#[allow(dead_code)] // only used by the debug-vs-release-gated variants below
+fn scoped_warn_capture() -> (
+    tracing::subscriber::DefaultGuard,
+    std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+) {
+    let buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(SharedWriter(std::sync::Arc::clone(&buf)))
+        .with_max_level(tracing::Level::WARN)
+        .finish();
+    let guard = tracing::subscriber::set_default(subscriber);
+    (guard, buf)
+}
+
+#[allow(dead_code)]
+fn captured(buf: &std::sync::Arc<std::sync::Mutex<Vec<u8>>>) -> String {
+    String::from_utf8_lossy(&buf.lock().unwrap()).into_owned()
+}
+
+/// Downcasts a `catch_unwind` panic payload to its string message.
+#[allow(dead_code)]
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    payload
+        .downcast_ref::<&str>()
+        .map(|s| (*s).to_owned())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+        .unwrap_or_default()
+}
+
+/// `PG-LIFE-001`: `build_and_start` against a fresh database creates the
+/// plugin's tables and returns `Ok`.
+#[tokio::test]
+async fn pg_life_001_build_and_start_runs_migrations_on_fresh_db() {
+    let (_container, config) = common::start_postgres().await;
+    let connection_string = config.connection_string.clone();
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("PG-LIFE-001: build_and_start must succeed against a fresh database");
+
+    let pool = common::raw_pool(&connection_string).await;
+    assert!(common::table_exists(&pool, "public", "cluster_cache").await);
+    assert!(common::table_exists(&pool, "public", "cluster_lock").await);
+
+    handle.stop().await;
+}
+
+/// `PG-LIFE-002`: calling `build_and_start` twice against the same database
+/// does not fail or double-create tables (mirrors `PG-CACHE-007` at the
+/// lifecycle level, additionally checking `_sqlx_migrations` bookkeeping).
+#[tokio::test]
+async fn pg_life_002_build_and_start_is_idempotent() {
+    let (_container, config) = common::start_postgres().await;
+    let connection_string = config.connection_string.clone();
+
+    let handle_one = PostgresClusterPlugin::builder(config.clone())
+        .build_and_start()
+        .await
+        .expect("first build_and_start succeeds");
+    handle_one.stop().await;
+
+    let handle_two = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("PG-LIFE-002: second build_and_start must not fail");
+
+    let pool = common::raw_pool(&connection_string).await;
+    let migration_count: i64 = sqlx::query_scalar("SELECT count(*) FROM _sqlx_migrations")
+        .fetch_one(&pool)
+        .await
+        .expect("migrations table query succeeds");
+    assert_eq!(
+        migration_count, 2,
+        "PG-LIFE-002: exactly the two plugin migrations must be recorded, not duplicated"
+    );
+
+    handle_two.stop().await;
+}
+
+/// `PG-LIFE-003`: after `stop`, the Postgres server shows zero connections
+/// from the plugin and any advisory locks it held are released.
+///
+/// Regression guard for the `held`-drain fix (DESIGN.md §10 step 4): a lock's
+/// pinned connection lives in `PostgresLock`'s `held: DashMap`, checked out of
+/// the pool for the lock's full duration and outside the pool's own tracking.
+/// `sqlx::Pool::close()` blocks until every checked-out connection is returned,
+/// so before the fix a lock still held at `stop()` time made `stop()` hang
+/// forever (this was also the root cause of the previously-unresolved
+/// `PG-LOCK-007`/`PG-SPEC-004` hang). `stop()` now calls
+/// `PostgresLock::drain_held` (unlock + drop each pinned connection, reusing the
+/// TTL reaper's `reclaim`) before `pool.close()`, so a still-held lock is
+/// released and its connection returned — leaving zero plugin connections.
+#[tokio::test]
+async fn pg_life_003_stop_closes_pool_and_listen_connection() {
+    let (_container, config) = common::start_postgres().await;
+    let connection_string = config.connection_string.clone();
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let lock = handle.lock();
+    let guard = lock
+        .try_lock("res", Duration::from_secs(30))
+        .await
+        .expect("acquire");
+    std::mem::forget(guard); // simulate a still-held lock at shutdown time
+
+    let control_pool = common::raw_pool(&connection_string).await;
+    let before: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM pg_stat_activity WHERE datname = 'cluster_test' AND application_name <> $1",
+    )
+    .bind(common::CONTROL_POOL_APPLICATION_NAME)
+    .fetch_one(&control_pool)
+    .await
+    .expect("pg_stat_activity query succeeds");
+    assert!(
+        before > 0,
+        "setup: the plugin must actually hold connections before stop()"
+    );
+
+    handle.stop().await;
+
+    // `pool.close()` returns once the client has closed its sockets, but
+    // Postgres tears the backend processes down asynchronously — they leave
+    // `pg_stat_activity` a beat later. Poll for the zero rather than sampling
+    // once: a real connection leak still times out and fails, this only
+    // tolerates the server-side exit lag (which widens under CPU contention in
+    // a full parallel run).
+    //
+    // Filtered by `application_name` rather than `pid <> pg_backend_pid()`:
+    // the latter only excludes the single connection actively running this
+    // query, not the rest of `control_pool`'s own (possibly idle) connections,
+    // which would otherwise be miscounted as plugin connections.
+    let drained = common::wait_until(Duration::from_secs(5), Duration::from_millis(25), || async {
+        let after: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM pg_stat_activity WHERE datname = 'cluster_test' AND application_name <> $1",
+        )
+        .bind(common::CONTROL_POOL_APPLICATION_NAME)
+        .fetch_one(&control_pool)
+        .await
+        .expect("pg_stat_activity query succeeds");
+        after == 0
+    })
+    .await;
+    assert!(
+        drained,
+        "PG-LIFE-003: stop() must leave zero plugin connections open"
+    );
+
+    // The advisory unlock runs synchronously inside `drain_held` *before*
+    // `pool.close()`, so unlike the connection count this is not subject to the
+    // backend-exit lag — assert it directly.
+    let advisory_locks: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM pg_locks WHERE locktype = 'advisory'")
+            .fetch_one(&control_pool)
+            .await
+            .expect("pg_locks query succeeds");
+    assert_eq!(
+        advisory_locks, 0,
+        "PG-LIFE-003: stop() must release any held advisory locks"
+    );
+}
+
+/// `PG-LIFE-004`: every active watch observes `Closed(Shutdown)` before
+/// `stop()` returns (see also `PG-WATCH-005`; here with multiple concurrent
+/// watches to confirm `stop()` drains all of them, not just one).
+#[tokio::test]
+async fn pg_life_004_stop_delivers_closed_shutdown_to_all_watches() {
+    let (_container, config) = common::start_postgres().await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let cache = handle.cache();
+
+    let mut watches = Vec::new();
+    for key in ["l4-a", "l4-b", "l4-c"] {
+        watches.push(cache.watch(key).await.expect("watch succeeds"));
+    }
+
+    handle.stop().await;
+
+    for mut watch in watches {
+        let event = tokio::time::timeout(Duration::from_millis(200), watch.recv())
+            .await
+            .expect("event arrives")
+            .expect("channel carries a terminal event, not a bare close");
+        assert!(
+            matches!(
+                event,
+                cluster_sdk::CacheWatchEvent::Closed(ClusterError::Shutdown)
+            ),
+            "PG-LIFE-004: every watch must observe Closed(Shutdown), got {event:?}"
+        );
+    }
+}
+
+/// `PG-LIFE-005`: `pgbouncer_transaction_mode: true` is rejected with
+/// `InvalidConfig` at startup, before any connection attempt.
+#[tokio::test]
+async fn pg_life_005_pgbouncer_transaction_mode_rejected() {
+    // No real container needed: the rejection runs before the pool ever
+    // connects (`plugin.rs::build_and_start` calls
+    // `reject_pgbouncer_transaction_mode` first), so an unreachable
+    // connection string still exercises the same code path.
+    let config: postgres_cluster_plugin::PostgresClusterConfig = serde_json::from_value(json!({
+        "connection_string": "postgres://postgres:postgres@127.0.0.1:1/unreachable",
+        "pgbouncer_transaction_mode": true,
+    }))
+    .expect("config parses");
+
+    // `PostgresClusterHandle` (the `Ok` payload) does not implement `Debug`
+    // (DESIGN.md never requires it, and it holds a live pool/task handles),
+    // so match explicitly rather than formatting `result` as a whole.
+    match PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+    {
+        Err(ClusterError::InvalidConfig { .. }) => {}
+        Err(other) => panic!("PG-LIFE-005: expected InvalidConfig, got {other:?}"),
+        Ok(_handle) => {
+            panic!("PG-LIFE-005: expected pgbouncer_transaction_mode to be rejected, got Ok")
+        }
+    }
+}
+
+/// `PG-LIFE-006`: an invalid connection string is rejected immediately with
+/// `ClusterError::InvalidConfig` (DESIGN.md §3.2 / §9), not after a
+/// connection-timeout wait and not as an opaque `Provider` error. A malformed
+/// DSN produces `sqlx::Error::Configuration`, which `map_sqlx_error` maps to
+/// `InvalidConfig` (PGR-M3).
+#[tokio::test]
+async fn pg_life_006_invalid_connection_string_rejected_promptly() {
+    let config: postgres_cluster_plugin::PostgresClusterConfig = serde_json::from_value(json!({
+        "connection_string": "not a valid connection string",
+    }))
+    .expect("config parses");
+
+    let started = tokio::time::Instant::now();
+    match PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+    {
+        Err(ClusterError::InvalidConfig { .. }) => {}
+        Err(other) => panic!(
+            "PG-LIFE-006: expected InvalidConfig for a malformed connection string, got {other:?}"
+        ),
+        Ok(_handle) => panic!("PG-LIFE-006: expected rejection, got Ok"),
+    }
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "PG-LIFE-006: rejection must be prompt, not a connection-timeout wait"
+    );
+}
+
+/// `PG-LIFE-007`: dropping a handle without calling `stop()` panics loudly in
+/// a debug build (ADR-006); calling `stop()` first, then dropping, does not.
+/// Exercised for both the combined `PostgresClusterHandle` and the
+/// standalone `PostgresLockHandle` (DESIGN.md §3.5).
+#[cfg(debug_assertions)]
+#[tokio::test]
+async fn pg_life_007_drop_without_stop_panics_in_debug_combined() {
+    let (_container, config) = common::start_postgres().await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || drop(handle)));
+    let payload = result.expect_err(
+        "PG-LIFE-007: dropping an un-stopped PostgresClusterHandle must panic in debug",
+    );
+    let message = panic_message(&*payload);
+    assert!(
+        message.contains("PostgresClusterHandle dropped without stop()"),
+        "PG-LIFE-007: the debug panic must name the forgotten-stop programming error, got {message:?}"
+    );
+}
+
+#[cfg(debug_assertions)]
+#[tokio::test]
+async fn pg_life_007_drop_without_stop_panics_in_debug_standalone() {
+    let (_container, config) = common::start_postgres_lock_only().await;
+    let handle = PostgresLockPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || drop(handle)));
+    let payload = result
+        .expect_err("PG-LIFE-007: dropping an un-stopped PostgresLockHandle must panic in debug");
+    let message = panic_message(&*payload);
+    assert!(
+        message.contains("PostgresLockHandle dropped without stop()"),
+        "PG-LIFE-007: the debug panic must name the forgotten-stop programming error, got {message:?}"
+    );
+}
+
+/// `PG-LIFE-007` (release branch): in a **release** build the `Drop` guard does
+/// not panic — it logs the programming-error WARN and lets the drop proceed
+/// (ADR-006). Compiled only when `debug_assertions` is off, so this covers the
+/// `#[cfg(not(debug_assertions))]` arm that the debug tests above cannot reach.
+#[cfg(not(debug_assertions))]
+#[tokio::test]
+async fn pg_life_007_drop_without_stop_warns_not_panics_in_release() {
+    let (_guard, warns) = scoped_warn_capture();
+    {
+        let (_container, config) = common::start_postgres().await;
+        let handle = PostgresClusterPlugin::builder(config)
+            .build_and_start()
+            .await
+            .unwrap();
+        // No panic in release — dropping just logs and proceeds.
+        drop(handle);
+    }
+    assert!(
+        captured(&warns).contains("PostgresClusterHandle dropped without stop()"),
+        "PG-LIFE-007: a release-build drop-without-stop must log the programming-error WARN"
+    );
+}
+
+#[tokio::test]
+async fn pg_life_007_stop_then_drop_panics_neither() {
+    let (_container, config) = common::start_postgres().await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    // `stop(mut self)` consumes `handle`; `self.stopped = true` is set as its
+    // last step (DESIGN.md §3.2 step 4) before `self` falls out of scope at
+    // the end of `stop`'s own body, so calling `stop()` at all — reaching the
+    // line below without a panic — already is "stop() then drop, panics
+    // neither"; there is no separate external drop for this test to add.
+    handle.stop().await;
+
+    let (_container2, config2) = common::start_postgres_lock_only().await;
+    let handle2 = PostgresLockPlugin::builder(config2)
+        .build_and_start()
+        .await
+        .unwrap();
+    handle2.stop().await; // same property, standalone handle
+}
+
+/// `PG-LIFE-008`: a panic inside a task that owns an un-stopped handle must
+/// not abort the process — the handle's `Drop` impl checks
+/// `std::thread::panicking()` and degrades to a warning log instead of its
+/// own debug-build panic, avoiding a double-panic abort.
+///
+/// This asserts both process survival (reaching the assertion below at all is
+/// only possible if the runtime did not abort) **and** — via a thread-local
+/// WARN capture — that the degrade path actually logged its double-panic-avoidance
+/// message rather than silently swallowing the forgotten stop (PGR-L5). The
+/// spawned task runs on the current-thread runtime's single worker (this test's
+/// thread), so its unwind-time `Drop` warn is captured here.
+#[tokio::test]
+async fn pg_life_008_drop_during_panic_unwind_degrades_to_warning() {
+    let (_guard, warns) = scoped_warn_capture();
+    let (_container, config) = common::start_postgres().await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+
+    let outcome = tokio::spawn(async move {
+        let _still_owns_handle = handle;
+        panic!("PG-LIFE-008: intentional panic while holding an un-stopped handle");
+    })
+    .await;
+
+    assert!(
+        outcome.is_err(),
+        "the spawned task must have panicked (and the handle must have dropped during that unwind)"
+    );
+    // Reaching here at all already proves no double-panic abort. Additionally
+    // assert the degrade path logged its intent, so a regression that dropped
+    // the `std::thread::panicking()` guard (and thus re-introduced the abort
+    // risk) would fail here rather than pass silently.
+    assert!(
+        captured(&warns).contains("skipping debug panic to avoid double-panic abort"),
+        "PG-LIFE-008: the panic-unwind drop must log the double-panic-avoidance WARN"
+    );
+}

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/tests/lock_integration.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/tests/lock_integration.rs
@@ -1,0 +1,528 @@
+//! Layer 3 — lock integration scenarios (docs/TESTING.md §4.3, `PG-LOCK-001..011`).
+
+#![cfg(feature = "integration")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration tests: a setup failure IS the test failure"
+)]
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use cluster_sdk::error::ClusterError;
+use postgres_cluster_plugin::PostgresLockPlugin;
+use serde_json::json;
+
+/// `PG-LOCK-001`: `try_lock` acquires and holds the advisory lock; a second
+/// `try_lock` returns `LockContended`; after `release`, it succeeds again.
+#[tokio::test]
+async fn pg_lock_001_try_lock_acquires_and_release_frees() {
+    let (_container, config) = common::start_postgres_lock_only().await;
+    let handle = PostgresLockPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let lock = handle.lock();
+
+    let guard = lock
+        .try_lock("res", Duration::from_secs(30))
+        .await
+        .expect("first acquire");
+    let contended = lock.try_lock("res", Duration::from_secs(30)).await;
+    assert!(
+        matches!(contended, Err(ClusterError::LockContended { .. })),
+        "PG-LOCK-001: a held lock must contend, got {contended:?}"
+    );
+    guard.release().await.expect("release succeeds");
+    let reacquired = lock.try_lock("res", Duration::from_secs(30)).await;
+    assert!(
+        reacquired.is_ok(),
+        "PG-LOCK-001: lock must be free again after release"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-LOCK-002`: a blocked `lock()` returns `LockTimeout` once its timeout
+/// elapses, and the advisory lock is not left held by the timed-out waiter.
+#[tokio::test]
+async fn pg_lock_002_lock_with_timeout() {
+    let (_container, config) = common::start_postgres_lock_only().await;
+    let handle = PostgresLockPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let lock = handle.lock();
+
+    let holder = lock
+        .try_lock("res", Duration::from_secs(30))
+        .await
+        .expect("holder acquires");
+    let started = tokio::time::Instant::now();
+    let timed_out = lock
+        .lock("res", Duration::from_secs(30), Duration::from_millis(200))
+        .await;
+    assert!(
+        matches!(timed_out, Err(ClusterError::LockTimeout { .. })),
+        "PG-LOCK-002: expected LockTimeout, got {timed_out:?}"
+    );
+    assert!(started.elapsed() >= Duration::from_millis(200));
+
+    holder.release().await.expect("holder releases");
+    let now_free = lock.try_lock("res", Duration::from_secs(30)).await;
+    assert!(
+        now_free.is_ok(),
+        "PG-LOCK-002: the timed-out waiter must not have left the advisory lock held"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-LOCK-003`: a blocked `lock()` wakes promptly (well under the
+/// heartbeat fallback's 250ms) after the holder calls `release`, confirming
+/// the NOTIFY-driven wake path (not just the heartbeat).
+#[tokio::test]
+async fn pg_lock_003_lock_wakes_on_release_notify() {
+    let (_container, config) = common::start_postgres_lock_only().await;
+    let handle = PostgresLockPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let lock = handle.lock();
+
+    let guard = lock
+        .try_lock("res", Duration::from_secs(30))
+        .await
+        .expect("holder acquires");
+
+    let waiter_lock = Arc::clone(&lock);
+    let waiter = tokio::spawn(async move {
+        let started = tokio::time::Instant::now();
+        let result = waiter_lock
+            .lock("res", Duration::from_secs(30), Duration::from_secs(5))
+            .await;
+        (started.elapsed(), result)
+    });
+
+    // Synchronize on the waiter having actually registered as a release-NOTIFY
+    // waiter (i.e. its first `try_acquire` contended and it parked in `wait_for`)
+    // before releasing — otherwise `!is_finished()` alone only proves the task
+    // has not returned, so an unscheduled task could acquire immediately after
+    // release and satisfy the latency assertion without ever exercising the
+    // NOTIFY wake path (PGR-E3).
+    let pg_lock = handle.__test_lock();
+    let registered = common::wait_until(Duration::from_secs(5), Duration::from_millis(5), || {
+        let pg_lock = std::sync::Arc::clone(&pg_lock);
+        async move { pg_lock.__test_release_waiter_count("res") > 0 }
+    })
+    .await;
+    assert!(
+        registered,
+        "setup: waiter must register as a release-NOTIFY waiter before release"
+    );
+    assert!(!waiter.is_finished(), "setup: waiter must still be blocked");
+
+    guard.release().await.expect("release succeeds");
+    let (elapsed, result) = waiter.await.expect("waiter task must not panic");
+    assert!(
+        result.is_ok(),
+        "PG-LOCK-003: waiter must acquire after release, got {result:?}"
+    );
+    // A NOTIFY-driven wake must land comfortably below the 250ms heartbeat
+    // fallback, with enough margin (50ms) that a wake at ~one heartbeat cannot
+    // masquerade as a NOTIFY wake — the previous 230ms bound sat so close to
+    // 250ms it barely distinguished the two (PGR-L5). Still not the DESIGN §5.3
+    // "well under 100ms" ideal, to leave headroom for container/CI scheduling
+    // jitter, but tight enough that only the NOTIFY path can satisfy it.
+    assert!(
+        elapsed < Duration::from_millis(200),
+        "PG-LOCK-003: wake latency {elapsed:?} is too close to the 250ms heartbeat fallback; \
+         the NOTIFY-driven wake should be well under it"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-LOCK-004`: once the TTL reaper sweeps an expired lock, the advisory
+/// lock is released and a subsequent `try_lock` succeeds.
+#[tokio::test]
+async fn pg_lock_004_ttl_reaper_releases_expired_lock() {
+    let (_container, config) =
+        common::start_postgres_lock_only_with(json!({ "lock_reaper_interval_ms": 100 })).await;
+    let handle = PostgresLockPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let lock = handle.lock();
+
+    let guard = lock
+        .try_lock("res", Duration::from_millis(150))
+        .await
+        .expect("acquire");
+    // Deliberately never released — simulates a crashed holder; the TTL
+    // reaper is the only thing that can free this.
+    std::mem::forget(guard);
+
+    let reacquired = common::wait_until(
+        Duration::from_secs(5),
+        Duration::from_millis(50),
+        || async { lock.try_lock("res", Duration::from_secs(30)).await.is_ok() },
+    )
+    .await;
+    assert!(
+        reacquired,
+        "PG-LOCK-004: reaper must release the expired lock"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-LOCK-005`: `renew` resets the TTL clock; the reaper does not release
+/// the lock while renewals keep it alive.
+#[tokio::test]
+async fn pg_lock_005_renew_extends_ttl() {
+    let (_container, config) =
+        common::start_postgres_lock_only_with(json!({ "lock_reaper_interval_ms": 250 })).await;
+    let handle = PostgresLockPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let lock = handle.lock();
+
+    // Deliberately generous margins: this runs under real wall-clock time (a
+    // real `sqlx` pool can't use a paused clock — see `conformance.rs`), so the
+    // renew interval must sit well under the TTL even when `sleep` overshoots by
+    // tens of ms under CPU contention in a full parallel run. Renew every 300ms
+    // against a 1000ms TTL (700ms slack); 4 renews span ~1.2s, comfortably past
+    // the original 1000ms the lock would have survived unrenewed — which is the
+    // property under test.
+    let guard = lock
+        .try_lock("res", Duration::from_secs(1))
+        .await
+        .expect("acquire");
+    for _ in 0..4 {
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        guard
+            .renew(Duration::from_secs(1))
+            .await
+            .expect("PG-LOCK-005: renew before expiry must succeed");
+    }
+    let still_contended = lock.try_lock("res", Duration::from_secs(30)).await;
+    assert!(
+        matches!(still_contended, Err(ClusterError::LockContended { .. })),
+        "PG-LOCK-005: renewed lock must still be held, got {still_contended:?}"
+    );
+
+    guard.release().await.expect("release succeeds");
+    handle.stop().await;
+}
+
+/// `PG-LOCK-006`: once the reaper has actually reclaimed an expired lock,
+/// `renew` on the stale guard returns `LockExpired`.
+#[tokio::test]
+async fn pg_lock_006_lock_expired_on_renew_past_ttl() {
+    let (_container, config) =
+        common::start_postgres_lock_only_with(json!({ "lock_reaper_interval_ms": 100 })).await;
+    let handle = PostgresLockPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let lock = handle.lock();
+
+    let guard = lock
+        .try_lock("res", Duration::from_millis(150))
+        .await
+        .expect("acquire");
+    // Wait past both the TTL and at least one reaper sweep so the row is
+    // actually reclaimed, not merely virtually past its TTL.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let err = guard
+        .renew(Duration::from_millis(200))
+        .await
+        .expect_err("PG-LOCK-006: renewing a reaper-reclaimed lock must fail");
+    assert!(
+        matches!(err, ClusterError::LockExpired { .. }),
+        "PG-LOCK-006: expected LockExpired, got {err:?}"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-LOCK-007`: forcibly closing the Postgres backend holding a lock's
+/// pinned connection (`pg_terminate_backend`) auto-releases the advisory
+/// lock; a subsequent `try_lock` succeeds.
+///
+/// The advisory lock's auto-release on session disconnect and the
+/// re-acquisition afterward both work: `try_acquire`'s `ON CONFLICT (name) DO
+/// UPDATE` (justified inline in `lock/mod.rs`) overwrites the stale
+/// `cluster_lock` row a `pg_terminate_backend`-killed holder left behind.
+///
+/// This previously hung — root cause found and fixed: the hang was not in the
+/// re-acquire (which succeeds) but in `handle.stop()` → `pool.close()`. The
+/// re-acquired lock's connection is pinned in `PostgresLock`'s `held` map and,
+/// because this test `std::mem::forget`s the guard, is never returned to the
+/// pool; `sqlx::Pool::close()` blocks until every checked-out connection is
+/// returned, so it hung forever. `stop()` now drains `held` first (see
+/// `PostgresLock::drain_held` / `PG-LIFE-003`), so it completes cleanly.
+#[tokio::test]
+async fn pg_lock_007_connection_drop_releases_advisory_lock() {
+    let (_container, config) = common::start_postgres_lock_only().await;
+    let connection_string = config.connection_string.clone();
+    let handle = PostgresLockPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let lock = handle.lock();
+
+    let guard = lock
+        .try_lock("res", Duration::from_secs(30))
+        .await
+        .expect("acquire");
+
+    let control_pool = common::raw_pool(&connection_string).await;
+    let pid: i32 = sqlx::query_scalar(
+        "SELECT pid FROM pg_locks WHERE locktype = 'advisory' AND granted = true LIMIT 1",
+    )
+    .fetch_one(&control_pool)
+    .await
+    .expect("exactly one advisory lock is held by this test");
+    let terminated: bool = sqlx::query_scalar("SELECT pg_terminate_backend($1)")
+        .bind(pid)
+        .fetch_one(&control_pool)
+        .await
+        .expect("pg_terminate_backend succeeds");
+    assert!(
+        terminated,
+        "PG-LOCK-007: pg_terminate_backend must report success"
+    );
+
+    let released = common::wait_until(
+        Duration::from_secs(5),
+        Duration::from_millis(50),
+        || async { lock.try_lock("res", Duration::from_secs(30)).await.is_ok() },
+    )
+    .await;
+    assert!(
+        released,
+        "PG-LOCK-007: advisory lock must auto-release on session disconnect"
+    );
+
+    // The guard's own background task has lost its connection; drop it
+    // without calling `release()` (there is nothing left to release).
+    std::mem::forget(guard);
+    handle.stop().await;
+}
+
+/// `PG-LOCK-008`: of 20 concurrent `try_lock` callers on the same name,
+/// exactly one succeeds and every other returns `LockContended`.
+#[tokio::test]
+async fn pg_lock_008_concurrent_lockers_at_most_one_holder() {
+    let (_container, config) = common::start_postgres_lock_only().await;
+    let handle = PostgresLockPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let lock = handle.lock();
+
+    let mut tasks = Vec::new();
+    for _ in 0..20 {
+        let lock = Arc::clone(&lock);
+        tasks.push(tokio::spawn(async move {
+            lock.try_lock("shared", Duration::from_secs(30)).await
+        }));
+    }
+    let mut successes = 0;
+    for task in tasks {
+        if task.await.unwrap().is_ok() {
+            successes += 1;
+        }
+    }
+    assert_eq!(
+        successes, 1,
+        "PG-LOCK-008: exactly one of 20 concurrent try_lock callers must win"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-LOCK-009`: `synchronous_commit` is enforced even when the database's
+/// own default is `off`. The precondition (fresh sessions really do inherit
+/// `off`) is confirmed directly, and — via the `__test_synchronous_commit`
+/// seam (the same one `pg_spec_005` uses to read a pinned lock connection's
+/// GUC) — the *distinguishing* observable is asserted: the held lock's own
+/// pinned connection reports `on`. Asserting the GUC directly (rather than
+/// only that acquire/release succeeds, which they would even if enforcement
+/// no-oped) is what actually exercises the `after_connect`/`before_acquire`
+/// enforcement (DESIGN.md §3.4).
+#[tokio::test]
+async fn pg_lock_009_synchronous_commit_enforced_over_off_default() {
+    use postgres_cluster_plugin::PostgresLock;
+
+    let (_container, config) = common::start_postgres_lock_only().await;
+    let connection_string = config.connection_string.clone();
+
+    let control_pool = common::raw_pool(&connection_string).await;
+    sqlx::query("ALTER DATABASE cluster_test SET synchronous_commit = off")
+        .execute(&control_pool)
+        .await
+        .expect("can set the database-level default");
+    // A brand-new session (this plugin hasn't connected yet) must pick up
+    // the database default, confirming the precondition this scenario is
+    // about actually holds.
+    let fresh_pool = common::raw_pool(&connection_string).await;
+    let default_setting: String = sqlx::query_scalar("SHOW synchronous_commit")
+        .fetch_one(&fresh_pool)
+        .await
+        .expect("SHOW succeeds");
+    assert_eq!(
+        default_setting, "off",
+        "setup: database default must actually be off"
+    );
+
+    let handle = PostgresLockPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("PG-LOCK-009: build_and_start must succeed despite the off database default");
+    let lock = handle.lock();
+    let concrete: Arc<PostgresLock> = handle.__test_lock();
+    let guard = lock
+        .try_lock("res", Duration::from_secs(30))
+        .await
+        .expect("PG-LOCK-009: lock acquire must succeed under enforced synchronous_commit");
+
+    // The held lock's pinned connection must report `on`, proving the
+    // `before_acquire`/`after_connect` hooks actually overrode the `off`
+    // database default (not merely that the ops didn't error).
+    assert_eq!(
+        concrete.__test_synchronous_commit("res").await.as_deref(),
+        Some("on"),
+        "PG-LOCK-009: the pinned lock connection must be synchronous_commit=on despite the \
+         off database default; enforcement must override it, not no-op"
+    );
+
+    guard.release().await.expect("release succeeds");
+
+    handle.stop().await;
+}
+
+/// `PG-LOCK-010`: the standalone `PostgresLockPlugin` migrates only
+/// `cluster_lock` — never `cluster_cache` — and its `try_lock`/`release`
+/// behave identically to the combined plugin's lock.
+#[tokio::test]
+async fn pg_lock_010_standalone_plugin_creates_only_lock_table() {
+    let (_container, config) = common::start_postgres_lock_only().await;
+    let connection_string = config.connection_string.clone();
+    let handle = PostgresLockPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("standalone plugin starts");
+
+    let pool = common::raw_pool(&connection_string).await;
+    assert!(
+        common::table_exists(&pool, "public", "cluster_lock").await,
+        "PG-LOCK-010: cluster_lock must exist"
+    );
+    assert!(
+        !common::table_exists(&pool, "public", "cluster_cache").await,
+        "PG-LOCK-010: a lock-only deployment must never create cluster_cache"
+    );
+
+    let lock = handle.lock();
+    let guard = lock
+        .try_lock("res", Duration::from_secs(30))
+        .await
+        .expect("try_lock works");
+    let contended = lock.try_lock("res", Duration::from_secs(30)).await;
+    assert!(matches!(contended, Err(ClusterError::LockContended { .. })));
+    guard.release().await.expect("release works");
+
+    handle.stop().await;
+}
+
+/// `PG-LOCK-011`: end-to-end YAML routing — `lock: { provider: postgres }`
+/// resolves to real advisory locks in the test container while
+/// `cache: { provider: standalone }` in the same profile is the in-process
+/// backend, confirming `ClusterLockProvider` registration makes
+/// `provider: postgres` independently resolvable for the `lock` primitive
+/// (DESIGN.md §3.5) via the wiring crate's per-primitive routing, not merely
+/// callable directly off this plugin's own builder.
+#[tokio::test]
+async fn pg_lock_011_end_to_end_yaml_routing_lock_postgres_cache_standalone() {
+    use cluster::{ClusterConfig, ClusterWiring, ProviderRegistry};
+    use cluster_sdk::lock::DistributedLockV1;
+    use cluster_sdk::profile::ClusterProfile;
+    use postgres_cluster_plugin::PostgresLockProvider;
+    use standalone_cluster_plugin::StandaloneCacheProvider;
+    use toolkit::client_hub::ClientHub;
+
+    #[derive(Clone, Copy)]
+    struct RoutingProfile;
+    impl ClusterProfile for RoutingProfile {
+        const NAME: &'static str = "pglockrouting";
+    }
+
+    let (_container, config) = common::start_postgres_lock_only().await;
+    let connection_string = config.connection_string.clone();
+
+    // Operator config is normally YAML (`serde-saphyr`), but `ClusterConfig`
+    // is a plain `serde::Deserialize` type — building it from an equivalent
+    // JSON value exercises the exact same `BackendBinding`/per-provider
+    // `options` flattening (DESIGN.md §3.5's "Design A") without adding a
+    // YAML-parsing dev-dependency just for this one test.
+    let mut profiles = serde_json::Map::new();
+    profiles.insert(
+        RoutingProfile::NAME.to_owned(),
+        serde_json::json!({
+            "cache": { "provider": "standalone" },
+            "lock": {
+                "provider": "postgres",
+                "connection_string": connection_string,
+                "pool_max_size": 5,
+            },
+        }),
+    );
+    let cluster_config: ClusterConfig =
+        serde_json::from_value(serde_json::json!({ "profiles": profiles }))
+            .expect("routing profile config parses");
+
+    let providers = ProviderRegistry::new()
+        .with_cache_provider(Arc::new(StandaloneCacheProvider))
+        .with_lock_provider(Arc::new(PostgresLockProvider));
+    let hub = Arc::new(ClientHub::new());
+    let handle = ClusterWiring::from_config(Arc::clone(&hub), &cluster_config, &providers)
+        .await
+        .expect(
+            "PG-LOCK-011: wiring must resolve lock: postgres independently of cache: standalone",
+        );
+
+    let lock = DistributedLockV1::resolver(&hub)
+        .profile(RoutingProfile)
+        .resolve()
+        .expect("lock facade resolves for the routing profile");
+
+    let guard = lock
+        .try_lock("res", Duration::from_secs(30))
+        .await
+        .expect("try_lock succeeds through the resolved facade");
+
+    // Confirm this is a *real* Postgres advisory lock, not the standalone
+    // in-process lock — a second, direct connection must see it held.
+    let control_pool = common::raw_pool(&connection_string).await;
+    let advisory_locks_held: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM pg_locks WHERE locktype = 'advisory' AND granted = true",
+    )
+    .fetch_one(&control_pool)
+    .await
+    .expect("pg_locks query succeeds");
+    assert_eq!(
+        advisory_locks_held, 1,
+        "PG-LOCK-011: the resolved lock facade must be backed by a real Postgres advisory lock"
+    );
+
+    guard.release().await.expect("release succeeds");
+    handle.stop().await;
+}

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/tests/postgres_specific.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/tests/postgres_specific.rs
@@ -1,0 +1,899 @@
+//! Layer 3 — Postgres-specific scenarios (docs/TESTING.md §4.6,
+//! `PG-SPEC-001..008`): behaviours unique to this backend that the
+//! conformance suite (Layer 2) cannot reach.
+
+#![cfg(feature = "integration")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration tests: a setup failure IS the test failure"
+)]
+
+mod common;
+
+use std::time::Duration;
+
+use cluster_sdk::cache::{PutRequest, Ttl};
+use cluster_sdk::error::ClusterError;
+use postgres_cluster_plugin::{PostgresClusterPlugin, PostgresLockPlugin};
+use serde_json::json;
+
+/// `PG-SPEC-001`: an empty-payload `NOTIFY` on `cluster_cache_changes`
+/// (Postgres's own overflow signal, DESIGN.md §2.3/§4.3) is interpreted as
+/// `Reset` and delivered to every active watcher — injected directly here
+/// rather than via a real NOTIFY-queue overflow, which isn't reproducible on
+/// demand.
+#[tokio::test]
+async fn pg_spec_001_empty_payload_notify_maps_to_reset() {
+    let (_container, config) = common::start_postgres().await;
+    let connection_string = config.connection_string.clone();
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let cache = handle.cache();
+
+    let mut watch_a = cache.watch("spec1-a").await.expect("watch a");
+    let mut watch_b = cache.watch("spec1-b").await.expect("watch b");
+
+    let control_pool = common::raw_pool(&connection_string).await;
+    sqlx::query("SELECT pg_notify('cluster_cache_changes', '')")
+        .execute(&control_pool)
+        .await
+        .expect("empty-payload NOTIFY succeeds");
+
+    for watch in [&mut watch_a, &mut watch_b] {
+        // Match the neighbouring LISTEN/NOTIFY watch-delivery timeout (2-3s):
+        // this asserts arrival, not latency, so a 500ms deadline only invited CI
+        // flakiness under load (PGR-E4).
+        let event = tokio::time::timeout(Duration::from_secs(3), watch.recv())
+            .await
+            .expect("event arrives within 3s");
+        assert!(
+            matches!(event, Some(cluster_sdk::CacheWatchEvent::Reset)),
+            "PG-SPEC-001: an empty NOTIFY payload must map to Reset, got {event:?}"
+        );
+    }
+
+    handle.stop().await;
+}
+
+/// `PG-SPEC-002`: a `put` with a key exceeding `cache::watch::MAX_KEY_BYTES` is
+/// rejected with `InvalidName`.
+///
+/// The boundary is 2048 bytes. Two Postgres limits bear on a cache key and the
+/// tighter wins. The NOTIFY payload budget is the looser one: Postgres's hard
+/// payload limit is 7999 bytes (confirmed empirically — `pg_notify('x',
+/// repeat('a', 8000))` fails with `payload string too long`, not the 8192 or the
+/// 8190 earlier notes assumed), leaving 7997 after the two-byte `<event>:`
+/// prefix. But `cluster_cache.key` is a `PRIMARY KEY`, so every key also has to
+/// fit a btree index tuple (~2704 bytes). Bounding only by NOTIFY left keys in
+/// roughly 2705..=7997 passing this guard and then failing mid-write with
+/// SQLSTATE `54000`; the effective bound is now `limits::MAX_INDEXED_KEY_BYTES`.
+///
+/// The accept case is the load-bearing half: 2048 bytes must round-trip through
+/// a real server, proving the bound clears both the btree tuple limit and the
+/// `cluster_cache_key_len_check` CHECK the migration declares.
+#[tokio::test]
+async fn pg_spec_002_key_length_over_2048_bytes_rejected() {
+    let (_container, config) = common::start_postgres().await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let cache = handle.cache();
+
+    let too_long_key = "k".repeat(2_049);
+    let result = cache
+        .put(PutRequest {
+            key: &too_long_key,
+            value: b"v",
+            ttl: Ttl::Indefinite,
+        })
+        .await;
+    assert!(
+        matches!(result, Err(ClusterError::InvalidName { .. })),
+        "PG-SPEC-002: a key over 2048 bytes must be rejected as InvalidName, got {result:?}"
+    );
+
+    // The boundary itself must still be accepted — and actually reach the table,
+    // which is what proves 2048 is under the btree limit rather than merely
+    // under the NOTIFY budget.
+    let boundary_key = "k".repeat(2_048);
+    let ok = cache
+        .put(PutRequest {
+            key: &boundary_key,
+            value: b"v",
+            ttl: Ttl::Indefinite,
+        })
+        .await;
+    assert!(
+        ok.is_ok(),
+        "PG-SPEC-002: a key at exactly 2048 bytes must be accepted, got {ok:?}"
+    );
+    assert!(
+        cache.get(&boundary_key).await.unwrap().is_some(),
+        "PG-SPEC-002: a key at exactly 2048 bytes must survive the round-trip"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-SPEC-004`: dropping the pool connection holding a `LockGuard` at the
+/// Postgres level (`pg_terminate_backend`) releases the advisory lock; the
+/// next `try_lock` succeeds. Mechanically the same probe as `PG-LOCK-007`,
+/// listed separately in DESIGN.md/TESTING.md as the Postgres-specific
+/// counterpart of the general lock-integration scenario.
+///
+/// Same probe as `PG-LOCK-007`; the disconnect-then-reacquire path works and
+/// the previously-observed hang was `handle.stop()` → `pool.close()` blocking
+/// on the forgotten-guard's still-pinned connection, now fixed by `stop()`
+/// draining `held` first (see `pg_lock_007`'s doc comment and
+/// `PostgresLock::drain_held`).
+#[tokio::test]
+async fn pg_spec_004_advisory_lock_released_on_session_disconnect() {
+    let (_container, config) = common::start_postgres_lock_only().await;
+    let connection_string = config.connection_string.clone();
+    let handle = PostgresLockPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let lock = handle.lock();
+
+    let guard = lock
+        .try_lock("spec4", Duration::from_secs(30))
+        .await
+        .expect("acquire");
+    let control_pool = common::raw_pool(&connection_string).await;
+    // Exactly one advisory lock must be held: the guard acquired above. A bare
+    // `LIMIT 1` would silently pick an arbitrary holder if another session
+    // happened to hold an unrelated advisory lock at the same moment.
+    let pids: Vec<i32> = sqlx::query_scalar(
+        "SELECT pid FROM pg_locks WHERE locktype = 'advisory' AND granted = true",
+    )
+    .fetch_all(&control_pool)
+    .await
+    .expect("holder pid found");
+    assert_eq!(
+        pids.len(),
+        1,
+        "PG-SPEC-004: expected exactly one advisory-lock holder, got {pids:?}"
+    );
+    let pid = pids[0];
+    let _terminated: bool = sqlx::query_scalar("SELECT pg_terminate_backend($1)")
+        .bind(pid)
+        .fetch_one(&control_pool)
+        .await
+        .expect("terminate succeeds");
+
+    let released = common::wait_until(
+        Duration::from_secs(5),
+        Duration::from_millis(50),
+        || async {
+            lock.try_lock("spec4", Duration::from_secs(30))
+                .await
+                .is_ok()
+        },
+    )
+    .await;
+    assert!(
+        released,
+        "PG-SPEC-004: advisory lock must be gone once the session disconnects"
+    );
+
+    std::mem::forget(guard);
+    handle.stop().await;
+}
+
+/// `PG-SPEC-005`: mid-session `synchronous_commit` mutation correction on a
+/// pinned lock connection (DESIGN.md §3.4).
+///
+/// The re-assertion lives on each **guard task**, not the reaper sweep
+/// (GAP-SOLUTIONS.md §5): the guard is the sole owner of its key's `held`
+/// access, so it re-asserts on its own pinned connection without the
+/// reaper-vs-guard `held.get_mut`-across-`.await` deadlock a sweep-side
+/// re-assertion would introduce under the current-thread runtime.
+///
+/// This test drives the exact re-assertion code the guard's interval arm runs
+/// (`__test_reassert_synchronous_commit`) directly, under a deliberately long
+/// reaper interval so the guard's own timer never fires during the test's
+/// pinned-connection manipulation — otherwise the test's `held.get_mut`
+/// (through the `__test_*` seams) would race the guard's timer-driven `get_mut`
+/// on the same key and deadlock. The interval-timer plumbing itself mirrors the
+/// established `HeartbeatTask` pattern and is not separately raced here.
+#[tokio::test]
+async fn pg_spec_005_mid_session_synchronous_commit_mutation_corrected() {
+    use postgres_cluster_plugin::PostgresLock;
+    use std::sync::Arc;
+
+    // Long reaper/reassert interval: the guard task's own timer must not fire
+    // while the test is holding the pinned connection's `held` entry.
+    let (_container, config) =
+        common::start_postgres_lock_only_with(json!({ "lock_reaper_interval_ms": 3_600_000 }))
+            .await;
+    let handle = PostgresLockPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let lock_backend = handle.lock();
+    let concrete: Arc<PostgresLock> = handle.__test_lock();
+
+    let guard = lock_backend
+        .try_lock("spec5", Duration::from_secs(30))
+        .await
+        .expect("acquire");
+
+    // Baseline: `before_acquire` enforced `on` at checkout (§3.4).
+    assert_eq!(
+        concrete.__test_synchronous_commit("spec5").await.as_deref(),
+        Some("on"),
+        "PG-SPEC-005: a freshly pinned lock connection must start at synchronous_commit=on"
+    );
+
+    // Simulate an external mid-session flip on the pinned connection.
+    concrete.__test_flip_synchronous_commit_off("spec5").await;
+    assert_eq!(
+        concrete.__test_synchronous_commit("spec5").await.as_deref(),
+        Some("off"),
+        "PG-SPEC-005: the flip must take effect on the pinned connection"
+    );
+
+    // One re-assertion pass — exactly what the guard task runs each interval —
+    // must restore it.
+    concrete.__test_reassert_synchronous_commit("spec5").await;
+    assert_eq!(
+        concrete.__test_synchronous_commit("spec5").await.as_deref(),
+        Some("on"),
+        "PG-SPEC-005: the guard task's re-assertion must restore synchronous_commit=on"
+    );
+
+    guard.release().await.expect("release");
+    handle.stop().await;
+}
+
+/// `PG-SPEC-005` (timer half): proves the guard task's *interval timer* actually
+/// fires and re-asserts on its own cadence — not just the reassert function
+/// exercised directly by `pg_spec_005`. Runs on a **multi-thread** runtime so
+/// the test's pinned-connection read (`held.get_mut` across an `.await`) cannot
+/// deadlock against the guard's own timer-driven `held.get_mut` on the same key:
+/// the current-thread deadlock that dictates `pg_spec_005`'s long-interval,
+/// direct-seam design does not arise with more than one worker (at most brief
+/// shard-lock contention, which resolves). Uses a short reaper interval so the
+/// timer fires within a few hundred ms.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pg_spec_005b_guard_task_reasserts_on_its_own_interval() {
+    use postgres_cluster_plugin::PostgresLock;
+    use std::sync::Arc;
+
+    let (_container, config) =
+        common::start_postgres_lock_only_with(json!({ "lock_reaper_interval_ms": 150 })).await;
+    let handle = PostgresLockPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let lock_backend = handle.lock();
+    let concrete: Arc<PostgresLock> = handle.__test_lock();
+
+    let guard = lock_backend
+        .try_lock("spec5b", Duration::from_secs(30))
+        .await
+        .expect("acquire");
+
+    // Flip off now; the guard's first re-assert tick is ~150ms out.
+    concrete.__test_flip_synchronous_commit_off("spec5b").await;
+    assert_eq!(
+        concrete
+            .__test_synchronous_commit("spec5b")
+            .await
+            .as_deref(),
+        Some("off"),
+        "PG-SPEC-005: the flip must take effect before the guard's timer fires"
+    );
+
+    // Do not touch the connection again except to observe: the guard task's own
+    // `tokio::time::interval` arm must re-assert `on` without any test-driven
+    // reassert call.
+    let restored = common::wait_until(
+        Duration::from_secs(3),
+        Duration::from_millis(25),
+        || async {
+            concrete
+                .__test_synchronous_commit("spec5b")
+                .await
+                .as_deref()
+                == Some("on")
+        },
+    )
+    .await;
+    assert!(
+        restored,
+        "PG-SPEC-005: the guard task's interval timer must re-assert synchronous_commit=on"
+    );
+
+    guard.release().await.expect("release");
+    handle.stop().await;
+}
+
+/// A `Write` sink that appends to a shared byte buffer, so a process-global
+/// `tracing` subscriber can capture events emitted from any thread (including
+/// the reaper's spawned task, which thread-local capture would miss).
+#[derive(Clone)]
+struct SharedWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+impl std::io::Write for SharedWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SharedWriter {
+    type Writer = SharedWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// Installs a process-global WARN-level `tracing` subscriber (once) writing to a
+/// shared buffer and returns that buffer. Global — not thread-local — so events
+/// from the reaper's spawned task are captured regardless of runtime thread.
+/// Safe to share across tests: `pg_spec_006` asserts only on a message unique
+/// to the over-threshold cardinality condition, so other tests' WARNs cannot
+/// false-positive it.
+fn install_global_warn_capture() -> std::sync::Arc<std::sync::Mutex<Vec<u8>>> {
+    use std::sync::OnceLock;
+    static BUF: OnceLock<std::sync::Arc<std::sync::Mutex<Vec<u8>>>> = OnceLock::new();
+    std::sync::Arc::clone(BUF.get_or_init(|| {
+        let buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(SharedWriter(std::sync::Arc::clone(&buf)))
+            .with_max_level(tracing::Level::WARN)
+            .finish();
+        // Ignore an already-installed global (nothing else in this binary sets one).
+        let _installed = tracing::subscriber::set_global_default(subscriber);
+        buf
+    }))
+}
+
+/// Installs a **thread-local** WARN-level `tracing` subscriber for the current
+/// test, returning its uninstall guard and capture buffer. Uses `set_default`
+/// (thread-local), not `set_global_default`, so each test's capture is isolated
+/// from every other test's plugin — required for asserting the *absence* of a
+/// WARN (`pg_spec_008`), which a shared process-global buffer (polluted by other
+/// tests' plugins) could never do. `#[tokio::test]` runs on a current-thread
+/// runtime, so the WARN emitted inline by `build_and_start`'s replication
+/// detection lands on this thread and is captured.
+fn scoped_warn_capture() -> (
+    tracing::subscriber::DefaultGuard,
+    std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+) {
+    let buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(SharedWriter(std::sync::Arc::clone(&buf)))
+        .with_max_level(tracing::Level::WARN)
+        .finish();
+    let guard = tracing::subscriber::set_default(subscriber);
+    (guard, buf)
+}
+
+/// Number of times `needle` appears in a capture buffer.
+fn count_occurrences(buf: &std::sync::Arc<std::sync::Mutex<Vec<u8>>>, needle: &str) -> usize {
+    let bytes = buf.lock().unwrap();
+    String::from_utf8_lossy(&bytes).matches(needle).count()
+}
+
+/// Reads the most-recent value of an `i64` gauge named `name` back out of an
+/// in-memory metric exporter, scanning every accumulated `ResourceMetrics` and
+/// returning the last matching data point (the newest recorded value). Requires
+/// a prior `force_flush` on the provider.
+fn gauge_value(
+    exporter: &opentelemetry_sdk::metrics::InMemoryMetricExporter,
+    name: &str,
+) -> Option<i64> {
+    use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+    let metrics = exporter.get_finished_metrics().ok()?;
+    let mut latest = None;
+    for rm in &metrics {
+        for sm in rm.scope_metrics() {
+            for metric in sm.metrics() {
+                if metric.name() == name
+                    && let AggregatedMetrics::I64(MetricData::Gauge(gauge)) = metric.data()
+                    && let Some(dp) = gauge.data_points().last()
+                {
+                    latest = Some(dp.value());
+                }
+            }
+        }
+    }
+    latest
+}
+
+/// Total recorded sample count of an `f64` histogram named `name` whose data
+/// point carries `primitive = <primitive>`, summed across all accumulated
+/// `ResourceMetrics`. Requires a prior `force_flush`.
+fn histogram_sample_count(
+    exporter: &opentelemetry_sdk::metrics::InMemoryMetricExporter,
+    name: &str,
+    primitive: &str,
+) -> u64 {
+    use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+    let Ok(metrics) = exporter.get_finished_metrics() else {
+        return 0;
+    };
+    let mut total = 0;
+    for rm in &metrics {
+        for sm in rm.scope_metrics() {
+            for metric in sm.metrics() {
+                if metric.name() == name
+                    && let AggregatedMetrics::F64(MetricData::Histogram(hist)) = metric.data()
+                {
+                    for dp in hist.data_points() {
+                        if dp.attributes().any(|kv| {
+                            kv.key.as_str() == "primitive"
+                                && kv.value.as_str().as_ref() == primitive
+                        }) {
+                            total += dp.count();
+                        }
+                    }
+                }
+            }
+        }
+    }
+    total
+}
+
+/// `PG-SPEC-006`: the `cluster_postgres_lock_active_names` gauge tracks the
+/// cluster-wide distinct-held-name count (`= count(*)` of `cluster_lock`, not
+/// `held.len()`), and the lock reaper logs `cluster.lock.name_cardinality_high`
+/// (WARN, once per sweep) while that count is over
+/// `lock_name_cardinality_warn_threshold` (DESIGN.md §8).
+///
+/// The gauge is a plugin-local, non-ADR-004 metric emitted through a meter this
+/// plugin owns directly (not `ClusterMetrics`, which has no gauge method). The
+/// test injects its own meter over an in-memory reader (via
+/// `__with_reaper_meter`) so the readback is isolated from any other test's
+/// reaper. The WARN is captured with a process-global subscriber (the reaper's
+/// spawned task may run on any thread), asserting on a message unique to this
+/// over-threshold condition.
+#[tokio::test]
+async fn pg_spec_006_lock_name_cardinality_gauge_and_warn_threshold() {
+    use opentelemetry::metrics::MeterProvider;
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
+
+    let warn_log = install_global_warn_capture();
+
+    let exporter = InMemoryMetricExporter::default();
+    let provider = SdkMeterProvider::builder()
+        .with_reader(PeriodicReader::builder(exporter.clone()).build())
+        .build();
+    let meter = provider.meter("pg-spec-006");
+
+    // threshold 5 so 6 distinct held names trip the WARN; a short reaper
+    // interval so a sweep records the gauge/WARN quickly; a pool large enough
+    // for 6 concurrently-pinned lock connections plus the reaper's own
+    // per-sweep `count(*)` checkout (each held lock pins one connection, §3.3).
+    let (_container, config) = common::start_postgres_lock_only_with(json!({
+        "lock_name_cardinality_warn_threshold": 5,
+        "lock_reaper_interval_ms": 100,
+        "pool_max_size": 10,
+    }))
+    .await;
+    let handle = PostgresLockPlugin::builder(config)
+        .__with_reaper_meter(meter)
+        .build_and_start()
+        .await
+        .unwrap();
+    let lock = handle.lock();
+
+    // Acquire 6 distinct names → 6 rows in cluster_lock → gauge 6 (> threshold 5).
+    let mut guards = Vec::new();
+    for i in 0..6 {
+        guards.push(
+            lock.try_lock(&format!("card-{i}"), Duration::from_secs(30))
+                .await
+                .expect("acquire"),
+        );
+    }
+
+    // A sweep must record the gauge at 6.
+    let reached = common::wait_until(
+        Duration::from_secs(5),
+        Duration::from_millis(50),
+        || async {
+            provider.force_flush().ok();
+            gauge_value(&exporter, "cluster_postgres_lock_active_names") == Some(6)
+        },
+    )
+    .await;
+    assert!(
+        reached,
+        "PG-SPEC-006: gauge must reach the 6 distinct held names"
+    );
+    let warned = {
+        let bytes = warn_log.lock().unwrap();
+        String::from_utf8_lossy(&bytes).contains("cluster.lock.name_cardinality_high")
+    };
+    assert!(
+        warned,
+        "PG-SPEC-006: an over-threshold distinct-name count must emit the \
+         cluster.lock.name_cardinality_high WARN"
+    );
+
+    // The same sweeps must record the lock reaper's sweep-duration histogram
+    // (DESIGN.md §8, primitive=lock).
+    provider.force_flush().ok();
+    assert!(
+        histogram_sample_count(
+            &exporter,
+            "cluster_postgres_reaper_sweep_duration_seconds",
+            "lock",
+        ) >= 1,
+        "PG-SPEC-006: the lock reaper must record sweep-duration samples (primitive=lock)"
+    );
+
+    // Release all → count drops to 0 (≤ threshold) → gauge clears, WARN stops.
+    for guard in guards {
+        guard.release().await.expect("release");
+    }
+    let cleared = common::wait_until(
+        Duration::from_secs(5),
+        Duration::from_millis(50),
+        || async {
+            provider.force_flush().ok();
+            gauge_value(&exporter, "cluster_postgres_lock_active_names") == Some(0)
+        },
+    )
+    .await;
+    assert!(
+        cleared,
+        "PG-SPEC-006: gauge must clear to 0 once every lock is released"
+    );
+
+    // The WARN must *stop* once the count is back under threshold (PGR-L5):
+    // snapshot the occurrence count now that the gauge reads 0, then confirm a
+    // handful more sweep intervals (100ms each) add none — the message is
+    // unique to this over-threshold condition, so its count reflects only this
+    // test's reaper.
+    let count_at_clear = count_occurrences(&warn_log, "cluster.lock.name_cardinality_high");
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    assert_eq!(
+        count_occurrences(&warn_log, "cluster.lock.name_cardinality_high"),
+        count_at_clear,
+        "PG-SPEC-006: the cardinality WARN must stop firing once the distinct-name count drops \
+         back under the threshold"
+    );
+
+    handle.stop().await;
+    let _shutdown = provider.shutdown();
+}
+
+/// `PG-SPEC-006` (histogram half): the combined plugin's **cache** and **lock**
+/// TTL reapers both record `cluster_postgres_reaper_sweep_duration_seconds`
+/// (DESIGN.md §8) under `primitive={cache,lock}`. Each reaper records on every
+/// tick regardless of whether the sweep deletes anything, so short intervals +
+/// a brief wait produce samples for both primitives. Uses the combined-plugin
+/// `__with_reaper_meter` seam so the readback is isolated from other tests.
+#[tokio::test]
+async fn pg_spec_006b_reaper_sweep_duration_histograms_recorded() {
+    use opentelemetry::metrics::MeterProvider;
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
+
+    let exporter = InMemoryMetricExporter::default();
+    let provider = SdkMeterProvider::builder()
+        .with_reader(PeriodicReader::builder(exporter.clone()).build())
+        .build();
+    let meter = provider.meter("pg-spec-006b");
+
+    let (_container, config) = common::start_postgres_with(
+        json!({ "cache_reaper_interval_ms": 50, "lock_reaper_interval_ms": 50 }),
+    )
+    .await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .__with_reaper_meter(meter)
+        .build_and_start()
+        .await
+        .unwrap();
+
+    let histogram = "cluster_postgres_reaper_sweep_duration_seconds";
+    let both = common::wait_until(
+        Duration::from_secs(5),
+        Duration::from_millis(50),
+        || async {
+            provider.force_flush().ok();
+            histogram_sample_count(&exporter, histogram, "cache") >= 1
+                && histogram_sample_count(&exporter, histogram, "lock") >= 1
+        },
+    )
+    .await;
+    assert!(
+        both,
+        "PG-SPEC-006: both reapers must record cluster_postgres_reaper_sweep_duration_seconds \
+         (primitive=cache and primitive=lock)"
+    );
+
+    handle.stop().await;
+    let _shutdown = provider.shutdown();
+}
+
+/// `PG-SPEC-007`: with no `synchronous_standby_names` configured (the
+/// container's default) and `replication_mode` omitted, both the combined and
+/// standalone builders detect `Async`, log `cluster.provider.replication_async`
+/// (WARN) **exactly once**, and still return `Ok` (never block startup —
+/// TESTING.md §4.6). Each build runs under its own thread-local capture scope,
+/// so the "exactly once" count is per-build.
+#[tokio::test]
+async fn pg_spec_007_async_replication_detected_and_warned_combined_and_standalone() {
+    {
+        let (_guard, warns) = scoped_warn_capture();
+        let (_container, config) = common::start_postgres().await;
+        let handle = PostgresClusterPlugin::builder(config)
+            .build_and_start()
+            .await
+            .expect(
+                "PG-SPEC-007: async replication must only warn, never block startup (combined)",
+            );
+        assert_eq!(
+            count_occurrences(&warns, "cluster.provider.replication_async"),
+            1,
+            "PG-SPEC-007: the combined plugin must log cluster.provider.replication_async exactly once"
+        );
+        handle.stop().await;
+    }
+
+    {
+        let (_guard, warns) = scoped_warn_capture();
+        let (_container2, lock_config) = common::start_postgres_lock_only().await;
+        let lock_handle = PostgresLockPlugin::builder(lock_config)
+            .build_and_start()
+            .await
+            .expect(
+                "PG-SPEC-007: async replication must only warn, never block startup (standalone)",
+            );
+        assert_eq!(
+            count_occurrences(&warns, "cluster.provider.replication_async"),
+            1,
+            "PG-SPEC-007: the standalone plugin must log cluster.provider.replication_async exactly once"
+        );
+        lock_handle.stop().await;
+    }
+}
+
+/// `PG-SPEC-008`: an explicit `replication_mode: sync` short-circuits detection
+/// (DESIGN.md §3.6). The container has **no** synchronous standby configured, so
+/// had detection run it would have found `Async` and logged
+/// `cluster.provider.replication_async`. Asserting that WARN is *absent* is the
+/// distinguishing observable that the detection path was skipped — not merely
+/// that `build_and_start` returned `Ok` (which it would either way). A
+/// thread-local capture scope (not the process-global one) is required so
+/// another test's plugin cannot pollute the "absence" assertion.
+#[tokio::test]
+async fn pg_spec_008_explicit_replication_mode_skips_detection() {
+    let (_guard, warns) = scoped_warn_capture();
+    let (_container, config) =
+        common::start_postgres_with(json!({ "replication_mode": "sync" })).await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect(
+            "PG-SPEC-008: an explicit replication_mode must not be second-guessed by detection, \
+         even though this container has no synchronous standby actually configured",
+        );
+    assert_eq!(
+        count_occurrences(&warns, "cluster.provider.replication_async"),
+        0,
+        "PG-SPEC-008: an explicit replication_mode must skip Async detection; no \
+         cluster.provider.replication_async WARN expected"
+    );
+    handle.stop().await;
+}
+
+/// `PG-SPEC-009`: one lock-reaper sweep clears an expired backlog larger than a
+/// single `DELETE` batch, and the wake schedule's next-deadline probe reports the
+/// earliest live deadline (DESIGN.md §5.2).
+///
+/// Driven through the `__test_sweep_once` / `__test_seconds_until_next_expiry`
+/// seams rather than by waiting on the reaper's own timer: what's under test is
+/// that *one* sweep loops until the table is drained (an unbounded single-statement
+/// `DELETE`, or a bounded one without the loop, would both differ observably here),
+/// which reaper-interval timing cannot distinguish from "several intervals
+/// elapsed". `lock_reaper_interval_ms` is set long so the reaper's own sweeps
+/// never race these assertions.
+#[tokio::test]
+async fn pg_spec_009_expired_backlog_swept_in_bounded_batches() {
+    use postgres_cluster_plugin::PostgresLock;
+    use std::sync::Arc;
+
+    // 1500 rows spans several `reaper::SWEEP_BATCH` (512) batches, with the last
+    // one deliberately partial.
+    const BACKLOG: i64 = 1500;
+
+    let (_container, config) =
+        common::start_postgres_lock_only_with(json!({ "lock_reaper_interval_ms": 600_000 })).await;
+    let connection_string = config.connection_string.clone();
+    let schema = config.schema.clone();
+    let handle = PostgresLockPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    // The seams live on the concrete backend, as in PG-SPEC-005.
+    let lock: Arc<PostgresLock> = handle.__test_lock();
+    let lock_backend = handle.lock();
+    let control_pool = common::raw_pool(&connection_string).await;
+
+    // An empty table has no next deadline at all.
+    assert_eq!(
+        lock.__test_seconds_until_next_expiry()
+            .await
+            .expect("next-expiry probe"),
+        None,
+        "PG-SPEC-009: with no locks there is no deadline to wake for"
+    );
+
+    // Seed already-expired rows as a *foreign* holder would leave them behind —
+    // no advisory locks and no `held` entries here, so the sweep's job is purely
+    // to drain the metadata table.
+    sqlx::query(&format!(
+        "INSERT INTO {schema}.cluster_lock (name, holder_id, acquired_at, expires_at) \
+         SELECT 'spec9-' || g, md5('spec9-' || g)::uuid, now() - interval '2 minutes', \
+                now() - interval '1 minute' \
+         FROM generate_series(1, {BACKLOG}) AS g"
+    ))
+    .execute(&control_pool)
+    .await
+    .expect("seed the expired backlog");
+
+    // A row that is *not* expired must survive the sweep and then be what the
+    // next-deadline probe reports.
+    let _guard = lock_backend
+        .try_lock("spec9-live", Duration::from_mins(5))
+        .await
+        .expect("acquire a live lock");
+
+    let swept = lock.__test_sweep_once().await.expect("sweep");
+    assert_eq!(
+        swept,
+        usize::try_from(BACKLOG).unwrap(),
+        "PG-SPEC-009: a single sweep must keep batching until the whole expired \
+         backlog is gone, not stop after one bounded DELETE"
+    );
+
+    let remaining: Vec<String> =
+        sqlx::query_scalar(&format!("SELECT name FROM {schema}.cluster_lock"))
+            .fetch_all(&control_pool)
+            .await
+            .expect("count remaining rows");
+    assert_eq!(
+        remaining,
+        vec!["spec9-live".to_owned()],
+        "PG-SPEC-009: the sweep must delete every expired row and only those"
+    );
+
+    // The live lock's 5-minute TTL is now the earliest (only) deadline, and the probe
+    // must report it as a delay measured on the database clock.
+    let next = lock
+        .__test_seconds_until_next_expiry()
+        .await
+        .expect("next-expiry probe")
+        .expect("a live lock must have a deadline");
+    assert!(
+        (240.0..=300.0).contains(&next),
+        "PG-SPEC-009: the probe must report the live lock's own deadline as seconds \
+         from the database clock's now(); got {next}"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-SPEC-010`: a lock acquired by *this* process is reclaimed at its own TTL
+/// even when that TTL is far shorter than `lock_reaper_interval_ms`, because
+/// `try_acquire` signals the reaper's `deadline_hint` (DESIGN.md §5.2, "Wake
+/// schedule").
+///
+/// The reaper's sleep is computed from `min(expires_at)` as the table looked at
+/// its last wake, so without that signal a lock whose whole lifetime fits inside
+/// one sleep would sit expired until the sleep ended. The 10-minute interval here
+/// is what makes the assertion meaningful: it is the *only* other thing that could
+/// wake the reaper, so a pass means the acquisition itself did.
+///
+/// This is the case that actually costs something — the holder's session is alive,
+/// so its advisory lock is only releasable by this process's own reaper, and until
+/// that runs every `try_lock` on the name fails. The guard is deliberately never
+/// released: the reaper reclaiming it out from under a live guard is the scenario.
+#[tokio::test]
+async fn pg_spec_010_local_acquire_wakes_the_reaper_before_its_interval() {
+    let (_container, config) =
+        common::start_postgres_lock_only_with(json!({ "lock_reaper_interval_ms": 600_000 })).await;
+    let handle = PostgresLockPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let lock = handle.lock();
+
+    // Let the reaper finish its startup sweep against the still-empty table and
+    // commit to its 600s sleep *before* the acquisition below. Without this the
+    // test proves nothing: `#[tokio::test]` is a current-thread runtime, so the
+    // reaper task first gets scheduled at the test's next await point, which can
+    // be inside `try_lock` — its startup probe would then already see this lock's
+    // deadline and shorten the sleep on its own.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Acquired *after* the reaper's startup sweep, so its deadline was not in the
+    // table when the current sleep was computed.
+    let _guard = lock
+        .try_lock("spec10", Duration::from_secs(1))
+        .await
+        .expect("acquire");
+
+    // Well inside the 600s interval: only the acquire-time signal can get the
+    // reaper to reclaim this within the window.
+    let reclaimed = common::wait_until(Duration::from_secs(15), Duration::from_millis(100), || {
+        let lock = std::sync::Arc::clone(&lock);
+        async move {
+            lock.try_lock("spec10", Duration::from_secs(30))
+                .await
+                .is_ok()
+        }
+    })
+    .await;
+    assert!(
+        reclaimed,
+        "PG-SPEC-010: a 1s-TTL lock must be reclaimed at its own deadline, not held \
+         until the 600s reaper interval elapses; the acquire must wake the reaper"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-SPEC-010` (renew half): `renew` also signals the reaper's `deadline_hint`,
+/// so shortening a lock's TTL below the reaper's current sleep still gets it
+/// reclaimed at the new deadline (DESIGN.md §5.2, "Wake schedule").
+///
+/// `renew` takes an arbitrary `new_ttl`, so it can move the earliest deadline
+/// *earlier* than the sleep in flight was computed with — the acquire-time signal
+/// alone would not cover this. Here the lock is acquired with a 5-minute TTL (the
+/// reaper commits to sleeping until roughly that), then renewed down to 1s.
+#[tokio::test]
+async fn pg_spec_010b_renew_wakes_the_reaper_when_it_shortens_a_ttl() {
+    let (_container, config) =
+        common::start_postgres_lock_only_with(json!({ "lock_reaper_interval_ms": 600_000 })).await;
+    let handle = PostgresLockPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let lock = handle.lock();
+
+    let guard = lock
+        .try_lock("spec10b", Duration::from_mins(5))
+        .await
+        .expect("acquire");
+
+    // Let the reaper observe the 5-minute deadline and commit to sleeping on it,
+    // so the renew below is the only thing that can pull the wake forward (see
+    // the current-thread scheduling note in PG-SPEC-010).
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    guard
+        .renew(Duration::from_secs(1))
+        .await
+        .expect("renew to a shorter TTL");
+
+    let reclaimed = common::wait_until(Duration::from_secs(15), Duration::from_millis(100), || {
+        let lock = std::sync::Arc::clone(&lock);
+        async move {
+            lock.try_lock("spec10b", Duration::from_secs(30))
+                .await
+                .is_ok()
+        }
+    })
+    .await;
+    assert!(
+        reclaimed,
+        "PG-SPEC-010: renewing down to a 1s TTL must be reclaimed at that new deadline, \
+         not at the 5-minute one the reaper was already sleeping on"
+    );
+
+    handle.stop().await;
+}

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/tests/watch_integration.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/tests/watch_integration.rs
@@ -1,0 +1,282 @@
+//! Layer 3 — cache watch integration scenarios (docs/TESTING.md §4.4,
+//! `PG-WATCH-001..007`).
+//!
+//! Every scenario here constructs the cache through the real
+//! `PostgresClusterPlugin::build_and_start` path deliberately — `put`/`delete`
+//! never call the watch registry directly, only `NOTIFY`; delivery happens
+//! through the plugin's own dedicated LISTEN task started by
+//! `build_and_start` (DESIGN.md §4.3, `cache/watch.rs`'s module doc). A
+//! bare `PostgresCache` (if constructed directly, bypassing the plugin)
+//! would never receive a single watch event.
+
+#![cfg(feature = "integration")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration tests: a setup failure IS the test failure"
+)]
+
+mod common;
+
+use std::time::Duration;
+
+use cluster_sdk::cache::{PutRequest, Ttl};
+use cluster_sdk::error::ClusterError;
+use cluster_sdk::{CacheEvent, CacheWatchEvent};
+use postgres_cluster_plugin::PostgresClusterPlugin;
+use serde_json::json;
+
+/// `PG-WATCH-001`: `watch(key)` receives `Changed` on `put`.
+#[tokio::test]
+async fn pg_watch_001_receives_changed_on_put() {
+    let (_container, config) = common::start_postgres().await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let cache = handle.cache();
+
+    let mut watch = cache.watch("w1").await.expect("watch succeeds");
+    cache
+        .put(PutRequest {
+            key: "w1",
+            value: b"v",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put succeeds");
+
+    let event = tokio::time::timeout(Duration::from_secs(3), watch.recv())
+        .await
+        .expect("event arrives within 3s");
+    assert!(
+        matches!(event, Some(CacheWatchEvent::Event(CacheEvent::Changed { ref key })) if key == "w1"),
+        "PG-WATCH-001: expected Changed{{key: \"w1\"}}, got {event:?}"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-WATCH-002`: `watch(key)` receives `Deleted` on `delete`.
+#[tokio::test]
+async fn pg_watch_002_receives_deleted_on_delete() {
+    let (_container, config) = common::start_postgres().await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let cache = handle.cache();
+
+    // The watch is registered *before* the setup `put`, and that put's own
+    // `Changed` event is explicitly drained first — registering a watch
+    // after an unrelated write to the same key risks catching that write's
+    // still-in-flight NOTIFY instead of (or ahead of) the delete's, since
+    // NOTIFY delivery is asynchronous relative to the writing transaction's
+    // commit (see `PG-CACHE-004`'s identical race and fix).
+    let mut watch = cache.watch("w2").await.expect("watch succeeds");
+    cache
+        .put(PutRequest {
+            key: "w2",
+            value: b"v",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put succeeds");
+    let changed = tokio::time::timeout(Duration::from_secs(3), watch.recv())
+        .await
+        .expect("the setup put's own Changed event arrives");
+    assert!(
+        matches!(changed, Some(CacheWatchEvent::Event(CacheEvent::Changed { ref key })) if key == "w2"),
+        "PG-WATCH-002 setup: expected the put's own Changed event first, got {changed:?}"
+    );
+
+    cache.delete("w2").await.expect("delete succeeds");
+
+    let event = tokio::time::timeout(Duration::from_secs(3), watch.recv())
+        .await
+        .expect("event arrives within 3s");
+    assert!(
+        matches!(event, Some(CacheWatchEvent::Event(CacheEvent::Deleted { ref key })) if key == "w2"),
+        "PG-WATCH-002: expected Deleted{{key: \"w2\"}}, got {event:?}"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-WATCH-003`: the TTL reaper deleting an expired key emits `Expired`.
+#[tokio::test]
+async fn pg_watch_003_receives_expired_on_reaper_sweep() {
+    let (_container, config) =
+        common::start_postgres_with(json!({ "cache_reaper_interval_ms": 100 })).await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let cache = handle.cache();
+
+    let mut watch = cache.watch("w3").await.expect("watch succeeds");
+    cache
+        .put(PutRequest {
+            key: "w3",
+            value: b"v",
+            ttl: Ttl::Of(Duration::from_millis(50)),
+        })
+        .await
+        .expect("put succeeds");
+
+    // Drain the put's own `Changed` event (NOTIFY self-delivery, DESIGN.md
+    // §4.3) before waiting for the reaper's `Expired` — otherwise this races
+    // the first event on the same watch (see `PG-CACHE-004`'s identical fix).
+    let changed = tokio::time::timeout(Duration::from_secs(2), watch.recv())
+        .await
+        .expect("the put's own Changed event arrives before the timeout");
+    assert!(
+        matches!(changed, Some(CacheWatchEvent::Event(CacheEvent::Changed { ref key })) if key == "w3"),
+        "PG-WATCH-003 setup: expected the put's own Changed event first, got {changed:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(2), watch.recv())
+        .await
+        .expect("event arrives before the timeout");
+    assert!(
+        matches!(event, Some(CacheWatchEvent::Event(CacheEvent::Expired { ref key })) if key == "w3"),
+        "PG-WATCH-003: expected Expired{{key: \"w3\"}}, got {event:?}"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-WATCH-004`: `watch_prefix` returns `Unsupported`; `features().prefix_watch == false`.
+#[tokio::test]
+async fn pg_watch_004_watch_prefix_unsupported() {
+    let (_container, config) = common::start_postgres().await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let cache = handle.cache();
+
+    assert!(
+        !cache.features().prefix_watch,
+        "PG-WATCH-004: prefix_watch must be false"
+    );
+    let result = cache.watch_prefix("svc/").await;
+    assert!(
+        matches!(
+            result,
+            Err(ClusterError::Unsupported {
+                feature: "prefix_watch"
+            })
+        ),
+        "PG-WATCH-004: expected Unsupported{{feature: \"prefix_watch\"}}, got {result:?}"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-WATCH-005`: an active watch receives terminal `Closed(Shutdown)`
+/// before `stop()` returns.
+#[tokio::test]
+async fn pg_watch_005_closed_shutdown_before_stop_returns() {
+    let (_container, config) = common::start_postgres().await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let cache = handle.cache();
+
+    let mut watch = cache.watch("w5").await.expect("watch succeeds");
+    handle.stop().await;
+
+    let event = tokio::time::timeout(Duration::from_secs(3), watch.recv())
+        .await
+        .expect("event arrives")
+        .expect("channel not closed without a terminal event");
+    assert!(
+        matches!(event, CacheWatchEvent::Closed(ClusterError::Shutdown)),
+        "PG-WATCH-005: expected Closed(Shutdown), got {event:?}"
+    );
+}
+
+/// `PG-WATCH-006`: a watcher on key `"a"` receives nothing when key `"b"` is
+/// written.
+#[tokio::test]
+async fn pg_watch_006_no_events_for_different_key() {
+    let (_container, config) = common::start_postgres().await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let cache = handle.cache();
+
+    let mut watch = cache.watch("a").await.expect("watch succeeds");
+    cache
+        .put(PutRequest {
+            key: "b",
+            value: b"v",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put succeeds");
+
+    let outcome = tokio::time::timeout(Duration::from_secs(3), watch.recv()).await;
+    assert!(
+        outcome.is_err(),
+        "PG-WATCH-006: watcher on \"a\" must receive nothing when \"b\" is written, got {outcome:?}"
+    );
+
+    handle.stop().await;
+}
+
+/// `PG-WATCH-007`: two watchers on the same key both receive the event; one
+/// dropping does not affect the other.
+#[tokio::test]
+async fn pg_watch_007_multiple_watchers_same_key() {
+    let (_container, config) = common::start_postgres().await;
+    let handle = PostgresClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .unwrap();
+    let cache = handle.cache();
+
+    let mut watch_a = cache.watch("w7").await.expect("watch a succeeds");
+    let mut watch_b = cache.watch("w7").await.expect("watch b succeeds");
+
+    cache
+        .put(PutRequest {
+            key: "w7",
+            value: b"v1",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put succeeds");
+
+    for watch in [&mut watch_a, &mut watch_b] {
+        let event = tokio::time::timeout(Duration::from_secs(3), watch.recv())
+            .await
+            .expect("event arrives within 3s");
+        assert!(
+            matches!(event, Some(CacheWatchEvent::Event(CacheEvent::Changed { ref key })) if key == "w7"),
+            "PG-WATCH-007: both watchers must receive Changed, got {event:?}"
+        );
+    }
+
+    drop(watch_a);
+    cache
+        .put(PutRequest {
+            key: "w7",
+            value: b"v2",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("second put succeeds");
+    let event = tokio::time::timeout(Duration::from_secs(3), watch_b.recv())
+        .await
+        .expect("survivor still receives events after the other watcher dropped");
+    assert!(
+        matches!(event, Some(CacheWatchEvent::Event(CacheEvent::Changed { ref key })) if key == "w7"),
+        "PG-WATCH-007: the surviving watcher must be unaffected by the dropped one, got {event:?}"
+    );
+
+    handle.stop().await;
+}


### PR DESCRIPTION
Closes #4393

Adds the Postgres cache and distributed-lock provider implementations for the cluster gear (sqlx-backed pool, pg_advisory_lock, LISTEN/NOTIFY watch), wires both providers into the cluster gear's provider registry, and extends the shared conformance suite so it runs against the new backend alongside the existing standalone plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PostgreSQL-backed cluster plugin for distributed caching and locking.
  * Added standalone PostgreSQL lock-provider support.
  * Added polling-based service discovery for caches without native prefix-watch support.
  * Added configurable polling, cache reaping, lock reaping, replication, and connection settings.
* **Bug Fixes**
  * Improved membership consistency during concurrent updates.
  * Improved watch, lock expiry, reconnection, and graceful shutdown behavior.
* **Documentation**
  * Added PostgreSQL plugin design, configuration, and testing documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
