### PR TITLE
ci(code-ranker): add fork-PR report handler

### DIFF
--- a/.github/workflows/code-ranker-fork.yml
+++ b/.github/workflows/code-ranker-fork.yml
@@ -1,0 +1,30 @@
+# .github/workflows/code-ranker-fork.yml
+#
+# Fork-PR companion to code-ranker.yml. Fork PRs run with a read-only GITHUB_TOKEN
+# and no OIDC id-token, so the main workflow (report.yml) skips the report upload
+# and the sticky PR comment for them, and instead publishes the HTML report as an
+# ordinary artifact. This workflow is phase B: it runs AFTER the main workflow, in
+# the privileged BASE-repo context (via workflow_run), downloads that artifact,
+# performs the OIDC upload, and posts the sticky comment on the fork PR.
+#
+# workflow_run is the SAFE trigger here -- NOT pull_request_target. The reusable
+# workflow never checks out or executes fork code; it treats the artifact as
+# opaque data and correlates the PR from GitHub-controlled metadata.
+name: code-ranker fork report
+on:
+  workflow_run:
+    workflows: ["code-ranker"]
+    types: [completed]
+jobs:
+  publish:
+    # Only for fork PRs (cross-repository); same-repo PRs are fully handled by
+    # code-ranker.yml itself.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name != github.repository
+    uses: code-ranker-com/actions/.github/workflows/fork-report.yml@v1
+    permissions:
+      id-token: write          # OIDC upload from the privileged base context
+      pull-requests: write     # post the sticky comment on the fork PR
+      actions: read            # download the artifact from the triggering run
+      contents: read


### PR DESCRIPTION
## Что и зачем

Добавляет `.github/workflows/code-ranker-fork.yml` — companion к существующему `code-ranker.yml` для **PR из форков**.

### Проблема
PR из форка (напр. `ffedoroff/gears-rust` → `constructorfabric/gears-rust`) получают **read-only** `GITHUB_TOKEN` и не имеют OIDC id-token. Поэтому шаг **Sticky comment** в code-ranker падал с `Resource not accessible by integration` → джоб краснел (см. run 29733108294).

### Решение (двухфазное, штатное для code-ranker)
- **Phase A** — `code-ranker.yml` (reusable `report.yml@v1`, уже обновлён): на fork-PR пропускает upload/комментарий и выкладывает HTML-отчёт артефактом `code-ranker-fork-report`.
- **Phase B** — этот новый workflow: по `workflow_run` в привилегированном контексте базового репо скачивает артефакт, делает OIDC-upload и постит sticky-комментарий в fork-PR.

### Безопасность
Триггер — `workflow_run`, **не** `pull_request_target`. Reusable-workflow **не** чекаутит и не исполняет код форка: артефакт трактуется как непроверенные данные, номер PR берётся из метаданных GitHub (head_sha). Права выданы минимальные.

После мержа fork-PR снова станут зелёными и будут получать комментарий-отчёт.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated reporting for pull requests originating from forks after code-ranking checks complete.
  * Reports can be uploaded securely and posted back to the relevant pull request as a persistent comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->