### PR TITLE
CI: Add per-job path filtering to skip unaffected CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ env:
   SCCACHE_CACHE_SIZE: "2G"
   # Usually better determinism and smaller cache churn in CI.
   CARGO_INCREMENTAL: "0"
+  # Pinned nightly toolchain used by coverage, dylint, and shear jobs.
+  RUSTUP_TOOLCHAIN_NIGHTLY: nightly-2026-04-16
 
 jobs:
   # ── Change detection ──────────────────────────────────────────────────
@@ -450,7 +452,7 @@ jobs:
       contents: read
       id-token: write
     env:
-      RUSTUP_TOOLCHAIN: nightly-2026-04-16
+      RUSTUP_TOOLCHAIN: ${{ env.RUSTUP_TOOLCHAIN_NIGHTLY }}
     steps:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
@@ -512,7 +514,7 @@ jobs:
     if: needs.changes.outputs.dylint == 'true' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
-      RUSTUP_TOOLCHAIN: nightly-2026-04-16
+      RUSTUP_TOOLCHAIN: ${{ env.RUSTUP_TOOLCHAIN_NIGHTLY }}
     steps:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
@@ -576,7 +578,7 @@ jobs:
     # Advisory only — unused-dep warnings should not block PRs.
     continue-on-error: true
     env:
-      RUSTUP_TOOLCHAIN: nightly-2026-04-16
+      RUSTUP_TOOLCHAIN: ${{ env.RUSTUP_TOOLCHAIN_NIGHTLY }}
     steps:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,8 +483,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    env:
-      RUSTUP_TOOLCHAIN: ${{ env.RUSTUP_TOOLCHAIN_NIGHTLY }}
     steps:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
@@ -507,15 +505,20 @@ jobs:
       - name: Install Rust toolchain (with llvm-tools)
         uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
         with:
-          toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
+          toolchain: ${{ env.RUSTUP_TOOLCHAIN_NIGHTLY }}
           components: llvm-tools-preview
+
+      # Override rust-toolchain.toml (which pins stable) for all cargo
+      # commands in this job.
+      - name: Pin nightly for all cargo commands
+        run: echo "RUSTUP_TOOLCHAIN=${{ env.RUSTUP_TOOLCHAIN_NIGHTLY }}" >> "$GITHUB_ENV"
 
       - name: Cache Cargo/target
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-bin: false
           cache-targets: false
-          shared-key: pr-${{ runner.os }}-nightly-${{ env.RUSTUP_TOOLCHAIN }}-llvm-cov
+          shared-key: pr-${{ runner.os }}-nightly-${{ env.RUSTUP_TOOLCHAIN_NIGHTLY }}-llvm-cov
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3
@@ -551,8 +554,6 @@ jobs:
       || needs.changes.outputs.ci == 'true'
       || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
-    env:
-      RUSTUP_TOOLCHAIN: ${{ env.RUSTUP_TOOLCHAIN_NIGHTLY }}
     steps:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
@@ -570,18 +571,23 @@ jobs:
       - name: Install Rust nightly toolchain
         uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
         with:
-          toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
+          toolchain: ${{ env.RUSTUP_TOOLCHAIN_NIGHTLY }}
           components: llvm-tools-preview,rustc-dev
 
+      # Override rust-toolchain.toml (which pins stable) for all cargo
+      # commands in this job.
+      - name: Pin nightly for all cargo commands
+        run: echo "RUSTUP_TOOLCHAIN=${{ env.RUSTUP_TOOLCHAIN_NIGHTLY }}" >> "$GITHUB_ENV"
+
       - name: Set Rust nightly for Dylint temp builds
-        run: rustup override set ${{ env.RUSTUP_TOOLCHAIN }} --path /tmp
+        run: rustup override set ${{ env.RUSTUP_TOOLCHAIN_NIGHTLY }} --path /tmp
 
       - name: Cache Cargo/target
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-bin: false
           cache-targets: false
-          shared-key: pr-${{ runner.os }}-nightly-${{ env.RUSTUP_TOOLCHAIN }}-dylint
+          shared-key: pr-${{ runner.os }}-nightly-${{ env.RUSTUP_TOOLCHAIN_NIGHTLY }}-dylint
 
       # NOTE: sccache is intentionally omitted here. Dylint compiles lint
       # crates that link against rustc-dev via dylint-link; wrapping the
@@ -620,8 +626,6 @@ jobs:
     runs-on: ubuntu-latest
     # Advisory only — unused-dep warnings should not block PRs.
     continue-on-error: true
-    env:
-      RUSTUP_TOOLCHAIN: ${{ env.RUSTUP_TOOLCHAIN_NIGHTLY }}
     steps:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
@@ -646,15 +650,20 @@ jobs:
       - name: Install Rust nightly toolchain
         uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
         with:
-          toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
+          toolchain: ${{ env.RUSTUP_TOOLCHAIN_NIGHTLY }}
           components: llvm-tools-preview,rustc-dev
+
+      # Override rust-toolchain.toml (which pins stable) for all cargo
+      # commands in this job.
+      - name: Pin nightly for all cargo commands
+        run: echo "RUSTUP_TOOLCHAIN=${{ env.RUSTUP_TOOLCHAIN_NIGHTLY }}" >> "$GITHUB_ENV"
 
       - name: Cache Cargo/target
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-bin: false
           cache-targets: false
-          shared-key: pr-${{ runner.os }}-nightly-${{ env.RUSTUP_TOOLCHAIN }}-shear
+          shared-key: pr-${{ runner.os }}-nightly-${{ env.RUSTUP_TOOLCHAIN_NIGHTLY }}-shear
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
               - 'rust-toolchain.toml'
               - '.cargo/**'
             fips:
+              - 'libs/toolkit/**'
               - 'libs/toolkit-http/**'
               - 'libs/rustls-*/**'
             dylint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,16 @@ jobs:
     env:
       RUSTFLAGS: "-C debuginfo=0"
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -149,6 +159,17 @@ jobs:
     env:
       RUSTFLAGS: "-C debuginfo=0"
     steps:
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
       - name: Force LF in working tree (w/a for Windows)
         if: runner.os == 'Windows'
         shell: bash
@@ -217,6 +238,16 @@ jobs:
     env:
       RUSTFLAGS: "-C debuginfo=0"
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -290,6 +321,17 @@ jobs:
     env:
       RUSTFLAGS: "-C debuginfo=0"
     steps:
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
       - name: Force LF in working tree (w/a for Windows)
         if: runner.os == 'Windows'
         shell: bash
@@ -472,6 +514,16 @@ jobs:
     env:
       RUSTUP_TOOLCHAIN: nightly-2026-04-16
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,12 @@ jobs:
   clippy:
     name: Clippy
     needs: changes
-    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch'
+    if: >-
+      !cancelled()
+      && (needs.changes.result != 'success'
+      || needs.changes.outputs.rust == 'true'
+      || needs.changes.outputs.ci == 'true'
+      || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: "-C debuginfo=0"
@@ -152,7 +157,12 @@ jobs:
   test:
     name: Test Suite (${{ matrix.os }})
     needs: changes
-    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch'
+    if: >-
+      !cancelled()
+      && (needs.changes.result != 'success'
+      || needs.changes.outputs.rust == 'true'
+      || needs.changes.outputs.ci == 'true'
+      || github.event_name == 'workflow_dispatch')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -235,7 +245,12 @@ jobs:
   integration:
     name: Integration tests
     needs: changes
-    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch'
+    if: >-
+      !cancelled()
+      && (needs.changes.result != 'success'
+      || needs.changes.outputs.rust == 'true'
+      || needs.changes.outputs.ci == 'true'
+      || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: "-C debuginfo=0"
@@ -314,7 +329,13 @@ jobs:
   test-fips:
     name: FIPS verification (${{ matrix.os }})
     needs: changes
-    if: needs.changes.outputs.fips == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch'
+    if: >-
+      !cancelled()
+      && (needs.changes.result != 'success'
+      || needs.changes.outputs.fips == 'true'
+      || needs.changes.outputs.deps == 'true'
+      || needs.changes.outputs.ci == 'true'
+      || github.event_name == 'workflow_dispatch')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -422,7 +443,12 @@ jobs:
   security:
     name: Security (cargo-deny & cargo-audit on Ubuntu)
     needs: changes
-    if: needs.changes.outputs.deps == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch'
+    if: >-
+      !cancelled()
+      && (needs.changes.result != 'success'
+      || needs.changes.outputs.deps == 'true'
+      || needs.changes.outputs.ci == 'true'
+      || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -446,7 +472,12 @@ jobs:
   coverage:
     name: Code Coverage (cargo-llvm-cov)
     needs: changes
-    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch'
+    if: >-
+      !cancelled()
+      && (needs.changes.result != 'success'
+      || needs.changes.outputs.rust == 'true'
+      || needs.changes.outputs.ci == 'true'
+      || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -511,7 +542,13 @@ jobs:
   dylint:
     name: Dylint Tests
     needs: changes
-    if: needs.changes.outputs.dylint == 'true' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch'
+    if: >-
+      !cancelled()
+      && (needs.changes.result != 'success'
+      || needs.changes.outputs.dylint == 'true'
+      || needs.changes.outputs.rust == 'true'
+      || needs.changes.outputs.ci == 'true'
+      || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     env:
       RUSTUP_TOOLCHAIN: ${{ env.RUSTUP_TOOLCHAIN_NIGHTLY }}
@@ -573,7 +610,12 @@ jobs:
   shear:
     name: Unused Deps (cargo-shear)
     needs: changes
-    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch'
+    if: >-
+      !cancelled()
+      && (needs.changes.result != 'success'
+      || needs.changes.outputs.rust == 'true'
+      || needs.changes.outputs.ci == 'true'
+      || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     # Advisory only — unused-dep warnings should not block PRs.
     continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+# NOTE: workflow-level paths-ignore above still skips the entire workflow for
+# pure doc/markdown changes.  The per-job path filters below provide finer
+# granularity so that, e.g., a Cargo.toml-only change skips FIPS/dylint.
+
 # Concurrency strategy:
 # - On pull_request: group by PR number. New commits cancel the in-flight run.
 # - On push (main/develop): include run_id so pushes never cancel each other,
@@ -29,11 +33,59 @@ env:
   CARGO_INCREMENTAL: "0"
 
 jobs:
+  # ── Change detection ──────────────────────────────────────────────────
+  # Lightweight first job that classifies which areas of the repo changed.
+  # Downstream jobs use these outputs to skip work that can't be affected.
+  # On workflow_dispatch every filter defaults to true (run everything).
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      rust:   ${{ steps.filter.outputs.rust }}
+      fips:   ${{ steps.filter.outputs.fips }}
+      dylint: ${{ steps.filter.outputs.dylint }}
+      deps:   ${{ steps.filter.outputs.deps }}
+      ci:     ${{ steps.filter.outputs.ci }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Detect changed paths
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            rust:
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - 'Cargo.lock'
+              - 'Makefile'
+              - 'rust-toolchain.toml'
+              - '.cargo/**'
+            fips:
+              - 'libs/toolkit-http/**'
+              - 'libs/rustls-*/**'
+            dylint:
+              - 'tools/dylint_lints/**'
+            deps:
+              - '**/Cargo.toml'
+              - 'Cargo.lock'
+              - 'deny.toml'
+            ci:
+              - '.github/workflows/**'
+
+  # ── Jobs ──────────────────────────────────────────────────────────────
+
   # Fast clippy: ubuntu only, 2-pass strategy (~5-6 min vs 30-40 min before).
   # Linting output is platform-independent; platform-specific paths (fips) are
   # covered by the test-fips job. Full feature matrix runs nightly (clippy-nightly.yml).
   clippy:
     name: Clippy
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: "-C debuginfo=0"
@@ -87,6 +139,8 @@ jobs:
 
   test:
     name: Test Suite (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -157,6 +211,8 @@ jobs:
 
   integration:
     name: Integration tests
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: "-C debuginfo=0"
@@ -224,6 +280,8 @@ jobs:
 
   test-fips:
     name: FIPS verification (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.fips == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -319,6 +377,8 @@ jobs:
 
   security:
     name: Security (cargo-deny & cargo-audit on Ubuntu)
+    needs: changes
+    if: needs.changes.outputs.deps == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -341,6 +401,8 @@ jobs:
 
   coverage:
     name: Code Coverage (cargo-llvm-cov)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -404,6 +466,8 @@ jobs:
 
   dylint:
     name: Dylint Tests
+    needs: changes
+    if: needs.changes.outputs.dylint == 'true' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       RUSTUP_TOOLCHAIN: nightly-2026-04-16
@@ -443,6 +507,8 @@ jobs:
 
   shear:
     name: Unused Deps (cargo-shear)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       RUSTUP_TOOLCHAIN: nightly-2026-04-16

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,6 +484,17 @@ jobs:
       - name: Set Rust nightly for Dylint temp builds
         run: rustup override set ${{ env.RUSTUP_TOOLCHAIN }} --path /tmp
 
+      - name: Cache Cargo/target
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          cache-bin: false
+          cache-targets: false
+          shared-key: pr-${{ runner.os }}-nightly-${{ env.RUSTUP_TOOLCHAIN }}-dylint
+
+      # NOTE: sccache is intentionally omitted here. Dylint compiles lint
+      # crates that link against rustc-dev via dylint-link; wrapping the
+      # compiler with RUSTC_WRAPPER=sccache can break this toolchain.
+
       - name: Install nextest
         uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3
         with:
@@ -538,6 +549,26 @@ jobs:
         with:
           toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
           components: llvm-tools-preview,rustc-dev
+
+      - name: Cache Cargo/target
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          cache-bin: false
+          cache-targets: false
+          shared-key: pr-${{ runner.os }}-nightly-${{ env.RUSTUP_TOOLCHAIN }}-shear
+
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
+      - name: Probe sccache & set RUSTC_WRAPPER
+        shell: bash
+        run: |
+          if sccache --start-server >/dev/null 2>&1; then
+            echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+            echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          else
+            echo "sccache failed, falling back to plain rustc"
+          fi
 
       - name: Install dylint-link from source
         run: cargo install --locked dylint-link

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         with:
           cache-bin: false
           cache-targets: false
-          shared-key: pr-clippy-stable-1.95
+          shared-key: pr-clippy-${{ hashFiles('rust-toolchain.toml') }}
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
@@ -210,7 +210,7 @@ jobs:
         with:
           cache-bin: false
           cache-targets: false
-          shared-key: pr-${{ runner.os }}-stable-1.95
+          shared-key: pr-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}
 
       # Install sccache (cross-platform)
       - name: Install sccache
@@ -277,7 +277,7 @@ jobs:
         with:
           cache-bin: false
           cache-targets: false
-          shared-key: pr-${{ runner.os }}-integration-stable-1.95
+          shared-key: pr-${{ runner.os }}-integration-${{ hashFiles('rust-toolchain.toml') }}
 
       # Install sccache (cross-platform)
       - name: Install sccache
@@ -374,7 +374,7 @@ jobs:
         with:
           cache-bin: false
           cache-targets: false
-          shared-key: pr-${{ runner.os }}-stable-1.95-fips
+          shared-key: pr-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}-fips
 
       # Install sccache (cross-platform)
       - name: Install sccache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,6 +521,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    # Advisory only — unused-dep warnings should not block PRs.
+    continue-on-error: true
     env:
       RUSTUP_TOOLCHAIN: nightly-2026-04-16
     steps:


### PR DESCRIPTION
Add a lightweight `changes` job using dorny/paths-filter that detects which areas of the repo changed.  Downstream jobs now conditionally run based on these outputs:

  - `clippy`/`test`/`integration`/`coverage`/`shear`: Rust source or CI changes.
  - `test-fips`: FIPS-related files, deps, or CI changes.
  - `security`: Dependency files or CI changes.
  - `dylint`: dylint sources, rust sources, or CI changes.

`workflow_dispatch` always runs all jobs (no filtering).

This avoids re-running the full pipeline when only a subset of the codebase is touched (e.g. skipping FIPS, dylint, and security checks when only gear source code changes).

Other smaller changes / improvements:

  - Caching for dylint/shear — rust-cache + sccache (minus sccache for dylint).
  - Shear advisory-only — `continue-on-error: true`.
  - Free disk space — added to all heavy compilation jobs.
  - Dynamic cache keys — `hashFiles('rust-toolchain.toml')` instead of hardcoded version.
  - Centralised nightly version — single definition for all nightly jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI efficiency by running only the checks that correspond to the files changed.
  * Documentation-only updates can now skip unnecessary validation workflows.
  * Enhanced runner stability with improved disk-space handling and more consistent build/test caching.

* **Chores**
  * Standardized nightly toolchain selection across coverage and analysis-related checks.
  * Improved cache key determinism for stable and FIPS lanes.
  * Updated compiler-caching behavior for analysis runs to avoid toolchain conflicts; caching is enabled conditionally where safe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->