### PR TITLE
fix(security): move secret config/model fields as SecretString

### DIFF
--- a/.claude/skills/gear-creator/SKILL.md
+++ b/.claude/skills/gear-creator/SKILL.md
@@ -120,7 +120,7 @@ Follow the DDD-light layer rules:
 
 - **Contract**: NO serde, NO utoipa, NO HTTP types
 - **API/REST DTOs**: MUST have `Serialize`, `Deserialize`, `ToSchema`; MUST be in `api/rest/`
-- **Domain**: All structs/enums MUST have `#[domain_model]`
+- **Domain**: All non-module-private structs/enums (`pub`/`pub(crate)`/`pub(super)`) MUST have `#[domain_model]` (strictly module-private helpers are exempt)
 - **Entities**: Use `#[derive(Scopable)]` with `#[secure(tenant_col = "...")]`
 - **Endpoints**: MUST follow `/{service-name}/v{N}/{resource}` pattern
 - **Errors**: Use `Problem` (RFC-9457), implement `From<DomainError> for Problem`
@@ -136,6 +136,6 @@ These rules apply to ALL gear work. Violating them will fail CI:
 - SDK pattern is the public API — use `<gear>-sdk` crate
 - `SecureConn` + `AccessScope` for all DB access — no raw connections
 - `OperationBuilder` for all REST routes — with `.authenticated()` and `.standard_errors()`
-- `#[domain_model]` on all domain structs/enums (DE0309 lint)
+- `#[domain_model]` on all non-module-private domain structs/enums (DE0309 lint; strictly private helpers exempt)
 - No `unwrap()` / `expect()` — use proper Result types
 - AuthZ via `PolicyEnforcer` PEP pattern — never construct `AccessScope` manually

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1398,6 +1398,7 @@ dependencies = [
  "cf-gears-toolkit-odata",
  "cf-gears-toolkit-odata-macros",
  "cf-gears-toolkit-security",
+ "cf-gears-toolkit-utils",
  "futures",
  "http",
  "k8s-openapi",
@@ -1423,6 +1424,7 @@ name = "cf-chat-engine-sdk"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "cf-gears-toolkit-utils",
  "futures",
  "serde",
  "serde_json",
@@ -1813,6 +1815,7 @@ dependencies = [
  "cf-gears-toolkit-gts",
  "cf-gears-toolkit-macros",
  "cf-gears-toolkit-security",
+ "cf-gears-toolkit-utils",
  "futures",
  "gts",
  "hex",

--- a/docs/ARCHITECTURE_MANIFEST.md
+++ b/docs/ARCHITECTURE_MANIFEST.md
@@ -74,7 +74,7 @@ See: [GEARS.md](GEARS.md)
 
 Constructor Fabric Gears follows a DDD-light structure in which domain logic is kept free from transport and infrastructure details, while REST/gRPC adapters and infra layers handle boundary-specific concerns.
 
-**How.** The standard gear layout separates SDK contracts, gear bootstrap, domain logic, API adapters, and infrastructure. Domain types and services live under `domain/`, REST DTOs and route wiring stay in API-facing layers, and persistence/integration logic stays in infra. This boundary is reinforced not only by structure but also by custom Dylints and the `#[domain_model]` macro requirement for domain-layer types.
+**How.** The standard gear layout separates SDK contracts, gear bootstrap, domain logic, API adapters, and infrastructure. Domain types and services live under `domain/`, REST DTOs and route wiring stay in API-facing layers, and persistence/integration logic stays in infra. This boundary is reinforced not only by structure but also by custom Dylints and the `#[domain_model]` macro requirement for domain-layer types that are visible beyond their module (strictly module-private helper types are exempt; their fields are still checked for infrastructure leakage by the domain-layer Dylints).
 
 **Why.** Business logic stays easier to test, reuse, and evolve because it is not entangled with HTTP, database, or framework details. At the same time, adapter code remains explicit about where transport translation and persistence concerns begin.
 

--- a/docs/toolkit_unified_system/02_gear_layout_and_sdk_pattern.md
+++ b/docs/toolkit_unified_system/02_gear_layout_and_sdk_pattern.md
@@ -270,7 +270,7 @@ Clients must be registered explicitly in `init()`: `ctx.client_hub().register::<
 
 ### Domain types and `#[domain_model]` macro
 
-All `struct` and `enum` types in `domain/` **must** have the `#[domain_model]` attribute from `toolkit_macros`.
+All `struct` and `enum` types in `domain/` that are visible beyond their own module (`pub`, `pub(crate)`, `pub(super)`, `pub(in ...)`) **must** have the `#[domain_model]` attribute from `toolkit_macros`. Strictly module-private types (no `pub` keyword) are exempt — they never cross a layer boundary, and their fields are still checked for infrastructure leakage by the `DE0301`/`DE0308` domain-layer lints.
 
 #### What it does
 
@@ -343,7 +343,7 @@ error: field 'pool' has type 'sqlx::PgPool' which is forbidden (crate 'sqlx').
 
 #### CI enforcement
 
-The [DE0309 lint](../../tools/dylint_lints/de03_domain_layer/de0309_must_have_domain_model/README.md) runs in CI and **denies** any `struct` or `enum` in `domain/` that is missing the `#[domain_model]` attribute. This ensures the macro cannot be accidentally omitted.
+The [DE0309 lint](../../tools/dylint_lints/de03_domain_layer/de0309_must_have_domain_model/README.md) runs in CI and **denies** any non-module-private `struct` or `enum` in `domain/` that is missing the `#[domain_model]` attribute. This ensures the macro cannot be accidentally omitted. Strictly module-private types are exempt (see above).
 
 ### Gear `src/api/rest/dto.rs` (REST DTOs, OData)
 
@@ -521,7 +521,7 @@ For additional endpoints, see <http://127.0.0.1:8087/cf/docs>.
 - [ ] Create `<gear>-sdk` crate with `api.rs`, `models.rs`, `errors.rs`, `lib.rs`.
 - [ ] Create `<gear>` crate with `gear.rs`, `api/rest/`, `domain/`, `infra/storage/`.
 - [ ] Implement SDK trait with `async_trait` and `SecurityContext` first param.
-- [ ] Add `#[domain_model]` on all `struct`/`enum` types in `domain/` (import `toolkit_macros::domain_model`).
+- [ ] Add `#[domain_model]` on all non-module-private `struct`/`enum` types in `domain/` (import `toolkit_macros::domain_model`; strictly module-private helpers are exempt).
 - [ ] Add `#[derive(ODataFilterable)]` on REST DTOs (import `toolkit_odata_macros::ODataFilterable`).
 - [ ] Add `#[derive(Scopable)]` on SeaORM entities (import `toolkit_db_macros::Scopable`).
 - [ ] Use `SecureConn` + `SecurityContext` for all DB operations.

--- a/gears/chat-engine/chat-engine-sdk/Cargo.toml
+++ b/gears/chat-engine/chat-engine-sdk/Cargo.toml
@@ -29,3 +29,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 futures = { workspace = true }
 tokio-util = { workspace = true }
+# SecretString for the `share_token` bearer secret (redacted Debug + zeroize);
+# `serde` enables its Deserialize so the field can be typed SecretString directly.
+toolkit-utils = { workspace = true, features = ["serde"] }

--- a/gears/chat-engine/chat-engine-sdk/src/models.rs
+++ b/gears/chat-engine/chat-engine-sdk/src/models.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
+use toolkit_utils::SecretString;
 use uuid::Uuid;
 
 /// Tenant identifier. Opaque string from the auth token, used to scope all
@@ -152,7 +153,11 @@ pub struct Session {
     pub lifecycle_state: LifecycleState,
     /// Cryptographically-random token granting read-only access to a shared
     /// view of this session. Present only while sharing is active.
-    pub share_token: Option<String>,
+    #[serde(
+        default,
+        serialize_with = "toolkit_utils::secret_string::serialize_option_exposed"
+    )]
+    pub share_token: Option<SecretString>,
     /// Creation timestamp (UTC, RFC3339 on the wire).
     #[serde(with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,

--- a/gears/chat-engine/chat-engine/Cargo.toml
+++ b/gears/chat-engine/chat-engine/Cargo.toml
@@ -36,6 +36,8 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 futures = { workspace = true }
+# SecretString conversions for Session.share_token (see chat-engine-sdk).
+toolkit-utils = { workspace = true, features = ["serde"] }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/gears/chat-engine/chat-engine/src/domain/service/export_service_tests.rs
+++ b/gears/chat-engine/chat-engine/src/domain/service/export_service_tests.rs
@@ -116,7 +116,12 @@ impl SessionRepo for MockSessionRepo {
             .rows
             .lock()
             .iter()
-            .find(|m| m.share_token.as_deref() == Some(share_token))
+            .find(|m| {
+                m.share_token
+                    .as_ref()
+                    .map(toolkit_utils::SecretString::expose)
+                    == Some(share_token)
+            })
             .cloned())
     }
 
@@ -137,7 +142,7 @@ impl SessionRepo for MockSessionRepo {
                     && m.user_id.as_str() == user_id
             })
             .ok_or_else(|| ChatEngineError::not_found("session", session_id))?;
-        row.share_token = share_token;
+        row.share_token = share_token.map(toolkit_utils::SecretString::new);
         row.metadata = metadata;
         row.updated_at = OffsetDateTime::now_utc();
         Ok(row.clone())
@@ -346,7 +351,10 @@ async fn create_share_persists_token_and_returns_url() {
         .unwrap()
         .unwrap();
     assert_eq!(
-        stored.share_token.as_deref(),
+        stored
+            .share_token
+            .as_ref()
+            .map(toolkit_utils::SecretString::expose),
         Some(issue.share_token.as_str())
     );
     let metadata_expires = stored
@@ -409,7 +417,7 @@ async fn access_shared_returns_expired_for_past_expiry() {
     let (svc, sessions, _messages) = build_service();
     let session_id = Uuid::new_v4();
     let mut row = sample_session("tenant-a", "user-a", session_id);
-    row.share_token = Some("abcd-token".into());
+    row.share_token = Some(toolkit_utils::SecretString::new("abcd-token"));
     // Build expired metadata manually.
     let past = (OffsetDateTime::now_utc() - time::Duration::hours(1))
         .format(&Rfc3339)
@@ -429,7 +437,7 @@ async fn access_shared_returns_expired_for_soft_deleted_session() {
     let (svc, sessions, _messages) = build_service();
     let session_id = Uuid::new_v4();
     let mut row = sample_session("tenant-a", "user-a", session_id);
-    row.share_token = Some("soft-tok".into());
+    row.share_token = Some(toolkit_utils::SecretString::new("soft-tok"));
     row.lifecycle_state = LifecycleState::SoftDeleted;
     sessions.seed(row);
 

--- a/gears/chat-engine/chat-engine/src/domain/service/session_service_tests.rs
+++ b/gears/chat-engine/chat-engine/src/domain/service/session_service_tests.rs
@@ -50,6 +50,7 @@ fn reject_reserved_metadata_allows_client_keys() {
 }
 
 #[test]
+#[allow(clippy::use_debug)]
 fn redact_session_clears_share_token_and_reserved_metadata() {
     let s = Session {
         session_id: Uuid::nil(),
@@ -63,10 +64,15 @@ fn redact_session_clears_share_token_and_reserved_metadata() {
             "client_field": "ok",
         })),
         lifecycle_state: LifecycleState::Active,
-        share_token: Some("super-secret".into()),
+        share_token: Some(toolkit_utils::SecretString::new("super-secret")),
         created_at: OffsetDateTime::UNIX_EPOCH,
         updated_at: OffsetDateTime::UNIX_EPOCH,
     };
+
+    // Redaction proof: Debug must not leak the share token.
+    let s_debug = format!("{s:?}");
+    assert!(!s_debug.contains("super-secret"));
+
     let redacted = redact_session(s);
     assert!(redacted.share_token.is_none());
     assert_eq!(

--- a/gears/chat-engine/chat-engine/src/infra/db/conversions.rs
+++ b/gears/chat-engine/chat-engine/src/infra/db/conversions.rs
@@ -40,7 +40,7 @@ impl From<session_entity::Model> for Session {
             enabled_capabilities: model.enabled_capabilities,
             metadata: model.metadata,
             lifecycle_state,
-            share_token: model.share_token,
+            share_token: model.share_token.map(toolkit_utils::SecretString::new),
             created_at: model.created_at,
             updated_at: model.updated_at,
         }
@@ -58,7 +58,7 @@ impl From<Session> for session_entity::ActiveModel {
             enabled_capabilities: Set(s.enabled_capabilities),
             metadata: Set(s.metadata),
             lifecycle_state: Set(s.lifecycle_state.as_str().to_string()),
-            share_token: Set(s.share_token),
+            share_token: Set(s.share_token.map(toolkit_utils::SecretString::into_inner)),
             // `deleted_at` / `scheduled_hard_delete_at` are owned by the
             // soft-delete service (Phase 12) — leave untouched here so an
             // accidental `From` round-trip from a non-deleted session does

--- a/gears/file-storage/file-storage/Cargo.toml
+++ b/gears/file-storage/file-storage/Cargo.toml
@@ -41,6 +41,9 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 inventory = { workspace = true }
+# SecretString for config credentials (redacted Debug + zeroize); `serde` enables
+# its Deserialize impl so config fields can be typed SecretString directly.
+toolkit-utils = { workspace = true, features = ["serde"] }
 
 # Serde and JSON schema
 serde = { workspace = true }

--- a/gears/file-storage/file-storage/src/bin/sidecar.rs
+++ b/gears/file-storage/file-storage/src/bin/sidecar.rs
@@ -74,6 +74,7 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use futures::StreamExt;
 use serde::Deserialize;
 use time::OffsetDateTime;
+use toolkit_utils::SecretString;
 use uuid::Uuid;
 
 use file_storage::domain::error::DomainError;
@@ -118,7 +119,7 @@ struct SidecarState {
 #[derive(Debug, Deserialize)]
 struct TokenQuery {
     #[serde(rename = "fs-token")]
-    fs_token: Option<String>,
+    fs_token: Option<SecretString>,
 }
 
 /// Default value for `FS_SIDECAR_MAX_BODY_BYTES` (5 GiB) — comfortably above any
@@ -381,12 +382,15 @@ async fn readyz(State(state): State<SidecarState>) -> Response {
 
 /// Extract the token from the `fs-token` query param or the `X-FS-Token` header.
 fn extract_token(q: &TokenQuery, headers: &HeaderMap) -> Option<String> {
-    q.fs_token.clone().or_else(|| {
-        headers
-            .get("x-fs-token")
-            .and_then(|v| v.to_str().ok())
-            .map(str::to_owned)
-    })
+    q.fs_token
+        .as_ref()
+        .map(|s| s.expose().to_owned())
+        .or_else(|| {
+            headers
+                .get("x-fs-token")
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_owned)
+        })
 }
 
 /// `PUT` upload: verify token (op=PUT), stream bytes straight to the backend.

--- a/gears/file-storage/file-storage/src/config.rs
+++ b/gears/file-storage/file-storage/src/config.rs
@@ -7,6 +7,7 @@
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
+use toolkit_utils::SecretString;
 
 /// Configuration for the `file-storage` gear.
 ///
@@ -50,8 +51,11 @@ pub struct FileStorageConfig {
     /// **stable across restarts**. When absent, an ephemeral key is generated at
     /// boot — fine for local dev, but signed URLs do not survive a restart and
     /// the sidecar must be reconfigured. Configure this in any real deployment.
-    #[serde(default)]
-    pub signing_key_seed: Option<String>,
+    #[serde(
+        default,
+        serialize_with = "toolkit_utils::secret_string::serialize_option_exposed"
+    )]
+    pub signing_key_seed: Option<SecretString>,
 
     /// When `true` (the default), gear init fails fast if `signing_key_seed`
     /// is absent instead of silently minting an ephemeral per-boot key. A
@@ -141,8 +145,11 @@ pub struct FileStorageConfig {
     /// gear — see `docs/ADR/0003-…-sidecar-data-plane.md`'s trust-model
     /// section — at which point the comparator should be swapped for
     /// `InternalAuthenticator`. Never printed by `Debug`.
-    #[serde(default)]
-    pub finalize_internal_secret: Option<String>,
+    #[serde(
+        default,
+        serialize_with = "toolkit_utils::secret_string::serialize_option_exposed"
+    )]
+    pub finalize_internal_secret: Option<SecretString>,
 
     /// When `true`, gear init fails fast if `finalize_internal_secret` is
     /// absent instead of silently accepting the token-only trust model for
@@ -190,8 +197,11 @@ pub struct S3BackendConfig {
     /// Secret access key. `None` resolves `AWS_SECRET_ACCESS_KEY` from the
     /// process environment at construction time instead of a static config
     /// value. Never printed by `Debug` — see the struct-level doc comment.
-    #[serde(default)]
-    pub secret_access_key: Option<String>,
+    #[serde(
+        default,
+        serialize_with = "toolkit_utils::secret_string::serialize_option_exposed"
+    )]
+    pub secret_access_key: Option<SecretString>,
 
     /// `true` for path-style addressing (`MinIO`/`s3s-fs`-style endpoints),
     /// `false` for virtual-hosted-style real S3. Defaults to `true` since

--- a/gears/file-storage/file-storage/src/config_tests.rs
+++ b/gears/file-storage/file-storage/src/config_tests.rs
@@ -119,14 +119,22 @@ fn validate_allows_missing_signing_key_seed_when_required_flag_unset() {
 
 #[test]
 fn validate_allows_present_signing_key_seed_when_required_flag_set() {
+    const SEED: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
     let cfg = FileStorageConfig {
-        signing_key_seed: Some("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_owned()),
+        signing_key_seed: Some(SecretString::new(SEED)),
         require_signing_key_seed: true,
         ..FileStorageConfig::default()
     };
     assert!(
         cfg.validate().is_ok(),
         "a present signing_key_seed must pass validation even when required"
+    );
+
+    // Redaction proof: the raw seed must not appear in Debug output.
+    let cfg_debug = format!("{cfg:?}");
+    assert!(
+        !cfg_debug.contains(SEED),
+        "FileStorageConfig's Debug output must never contain the raw signing_key_seed: {cfg_debug}"
     );
 }
 
@@ -159,15 +167,23 @@ fn require_finalize_internal_secret_without_secret_fails_validate() {
 
 #[test]
 fn require_finalize_internal_secret_with_secret_passes_validate() {
+    const SECRET: &str = "interim-shared-secret";
     let cfg = FileStorageConfig {
         require_signing_key_seed: false,
-        finalize_internal_secret: Some("interim-shared-secret".to_owned()),
+        finalize_internal_secret: Some(SecretString::new(SECRET)),
         require_finalize_internal_secret: true,
         ..FileStorageConfig::default()
     };
     assert!(
         cfg.validate().is_ok(),
         "a present finalize_internal_secret must pass validation even when required"
+    );
+
+    // Redaction proof: the raw secret must not appear in Debug output.
+    let cfg_debug = format!("{cfg:?}");
+    assert!(
+        !cfg_debug.contains(SECRET),
+        "FileStorageConfig's Debug output must never contain the raw finalize_internal_secret: {cfg_debug}"
     );
 }
 
@@ -214,7 +230,7 @@ fn config_s3_backends_serde_round_trip() {
             region: "us-east-1".to_owned(),
             bucket: "my-bucket".to_owned(),
             access_key_id: Some("AKIAEXAMPLE".to_owned()),
-            secret_access_key: Some(SECRET.to_owned()),
+            secret_access_key: Some(SecretString::new(SECRET)),
             path_style: true,
         }],
         ..FileStorageConfig::default()
@@ -230,7 +246,13 @@ fn config_s3_backends_serde_round_trip() {
     assert_eq!(entry.region, "us-east-1");
     assert_eq!(entry.bucket, "my-bucket");
     assert_eq!(entry.access_key_id.as_deref(), Some("AKIAEXAMPLE"));
-    assert_eq!(entry.secret_access_key.as_deref(), Some(SECRET));
+    assert_eq!(
+        entry
+            .secret_access_key
+            .as_ref()
+            .map(toolkit_utils::SecretString::expose),
+        Some(SECRET)
+    );
     assert!(entry.path_style);
 
     // Redaction proof: the raw secret must not appear anywhere in either

--- a/gears/file-storage/file-storage/src/gear.rs
+++ b/gears/file-storage/file-storage/src/gear.rs
@@ -99,7 +99,9 @@ impl Gear for FileStorageGear {
         // rejected an absent secret when `require_finalize_internal_secret`
         // is set, so this is a plain construction.
         let finalize_auth = Arc::new(crate::api::rest::handlers::FinalizeAuth::new(
-            cfg.finalize_internal_secret.clone(),
+            cfg.finalize_internal_secret
+                .as_ref()
+                .map(|s| s.expose().to_owned()),
         ));
         self.finalize_auth
             .set(Arc::clone(&finalize_auth))
@@ -122,7 +124,7 @@ impl Gear for FileStorageGear {
         let max_ttl = i64::try_from(cfg.max_url_ttl_secs).unwrap_or(i64::MAX);
         let issuer = Arc::new(if let Some(seed_b64) = &cfg.signing_key_seed {
             let seed = URL_SAFE_NO_PAD
-                .decode(seed_b64.trim())
+                .decode(seed_b64.expose().trim())
                 .map_err(|e| anyhow::anyhow!("invalid file-storage signing_key_seed: {e}"))?;
             Issuer::from_seed(&seed, max_ttl).map_err(|e| anyhow::anyhow!("signing key: {e}"))?
         } else {

--- a/gears/file-storage/file-storage/src/gear_tests.rs
+++ b/gears/file-storage/file-storage/src/gear_tests.rs
@@ -1,4 +1,5 @@
 use toolkit::DatabaseCapability;
+use toolkit_utils::SecretString;
 
 use super::*;
 
@@ -76,7 +77,7 @@ fn gear_registry_includes_configured_s3_backends() {
             region: "us-east-1".to_owned(),
             bucket: "test-bucket".to_owned(),
             access_key_id: Some("test-access-key".to_owned()),
-            secret_access_key: Some("test-secret-key".to_owned()),
+            secret_access_key: Some(SecretString::new("test-secret-key")),
             path_style: true,
         }],
         ..FileStorageConfig::default()
@@ -107,7 +108,7 @@ fn gear_default_backend_id_falls_back_to_local_fs_when_unset() {
             region: "us-east-1".to_owned(),
             bucket: "test-bucket".to_owned(),
             access_key_id: Some("test-access-key".to_owned()),
-            secret_access_key: Some("test-secret-key".to_owned()),
+            secret_access_key: Some(SecretString::new("test-secret-key")),
             path_style: true,
         }],
         ..FileStorageConfig::default()
@@ -130,7 +131,7 @@ fn gear_default_backend_id_override_selects_configured_backend() {
             region: "us-east-1".to_owned(),
             bucket: "test-bucket".to_owned(),
             access_key_id: Some("test-access-key".to_owned()),
-            secret_access_key: Some("test-secret-key".to_owned()),
+            secret_access_key: Some(SecretString::new("test-secret-key")),
             path_style: true,
         }],
         default_backend_id: Some("s3-primary".to_owned()),

--- a/gears/file-storage/file-storage/src/infra/backend/s3.rs
+++ b/gears/file-storage/file-storage/src/infra/backend/s3.rs
@@ -170,7 +170,8 @@ impl S3Backend {
             })?;
         let secret_access_key = cfg
             .secret_access_key
-            .clone()
+            .as_ref()
+            .map(|s| s.expose().to_owned())
             .or_else(|| std::env::var("AWS_SECRET_ACCESS_KEY").ok())
             .ok_or_else(|| {
                 DomainError::backend(

--- a/gears/system/authn-resolver/plugins/static-authn-plugin/src/config.rs
+++ b/gears/system/authn-resolver/plugins/static-authn-plugin/src/config.rs
@@ -88,7 +88,7 @@ impl Default for IdentityConfig {
 #[serde(deny_unknown_fields)]
 pub struct TokenMapping {
     /// The bearer token value to match.
-    pub token: String,
+    pub token: SecretString,
     /// The identity to return when this token is presented.
     pub identity: IdentityConfig,
 }

--- a/gears/system/authn-resolver/plugins/static-authn-plugin/src/domain/service.rs
+++ b/gears/system/authn-resolver/plugins/static-authn-plugin/src/domain/service.rs
@@ -2,6 +2,7 @@
 //! Service implementation for the static `AuthN` resolver plugin.
 
 use std::collections::HashMap;
+use std::fmt;
 
 use secrecy::{ExposeSecret, SecretString};
 use toolkit_macros::domain_model;
@@ -9,6 +10,40 @@ use toolkit_security::SecurityContext;
 
 use crate::config::{AuthNMode, IdentityConfig, StaticAuthNPluginConfig};
 use authn_resolver_sdk::{AuthenticationResult, ClientCredentialsRequest};
+
+/// Wraps a `SecretString` bearer token so it can be a `HashMap` key.
+///
+/// `secrecy::SecretString` deliberately has no `Hash`/`Eq` — and being a
+/// foreign type, we can't add them directly here either (orphan rule). This
+/// newtype supplies both by delegating to the exposed value, and delegates
+/// `Debug` to `SecretString`'s own redacting impl so a Debug dump of the map
+/// never prints the raw token.
+struct TokenKey(SecretString);
+
+impl PartialEq for TokenKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.expose_secret() == other.0.expose_secret()
+    }
+}
+impl Eq for TokenKey {}
+
+impl std::hash::Hash for TokenKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.expose_secret().hash(state);
+    }
+}
+
+impl std::borrow::Borrow<str> for TokenKey {
+    fn borrow(&self) -> &str {
+        self.0.expose_secret()
+    }
+}
+
+impl fmt::Debug for TokenKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
+    }
+}
 
 /// Static `AuthN` resolver service.
 ///
@@ -19,7 +54,7 @@ use authn_resolver_sdk::{AuthenticationResult, ClientCredentialsRequest};
 pub struct Service {
     mode: AuthNMode,
     default_identity: IdentityConfig,
-    token_map: HashMap<String, IdentityConfig>,
+    token_map: HashMap<TokenKey, IdentityConfig>,
     s2s_credentials: HashMap<String, S2sEntry>,
 }
 
@@ -35,10 +70,10 @@ impl Service {
     /// Create a service from plugin configuration.
     #[must_use]
     pub fn from_config(cfg: &StaticAuthNPluginConfig) -> Self {
-        let token_map: HashMap<String, IdentityConfig> = cfg
+        let token_map = cfg
             .tokens
             .iter()
-            .map(|m| (m.token.clone(), m.identity.clone()))
+            .map(|m| (TokenKey(m.token.clone()), m.identity.clone()))
             .collect();
 
         let s2s_credentials: HashMap<String, S2sEntry> = cfg

--- a/gears/system/authn-resolver/plugins/static-authn-plugin/src/domain/service_tests.rs
+++ b/gears/system/authn-resolver/plugins/static-authn-plugin/src/domain/service_tests.rs
@@ -49,7 +49,7 @@ fn static_tokens_mode_returns_mapped_identity() {
     let cfg = StaticAuthNPluginConfig {
         mode: AuthNMode::StaticTokens,
         tokens: vec![TokenMapping {
-            token: "token-user-a".to_owned(),
+            token: SecretString::from("token-user-a"),
             identity: IdentityConfig {
                 subject_id: user_a_id,
                 subject_tenant_id: tenant_a,
@@ -59,6 +59,10 @@ fn static_tokens_mode_returns_mapped_identity() {
         }],
         ..default_config()
     };
+
+    // Redaction proof: the raw token must not appear in Debug output.
+    let mapping_debug = format!("{:?}", cfg.tokens[0]);
+    assert!(!mapping_debug.contains("token-user-a"));
 
     let service = Service::from_config(&cfg);
 
@@ -81,7 +85,7 @@ fn static_tokens_mode_rejects_unknown_token() {
     let cfg = StaticAuthNPluginConfig {
         mode: AuthNMode::StaticTokens,
         tokens: vec![TokenMapping {
-            token: "known-token".to_owned(),
+            token: SecretString::from("known-token"),
             identity: IdentityConfig::default(),
         }],
         ..default_config()

--- a/libs/toolkit-auth/Cargo.toml
+++ b/libs/toolkit-auth/Cargo.toml
@@ -43,7 +43,7 @@ rand = { workspace = true }
 base64 = { workspace = true }
 
 # Shared utilities
-toolkit-utils = { workspace = true }
+toolkit-utils = { workspace = true, features = ["serde"] }
 zeroize = { workspace = true }
 
 [dev-dependencies]

--- a/libs/toolkit-auth/src/oauth2/fetch.rs
+++ b/libs/toolkit-auth/src/oauth2/fetch.rs
@@ -75,7 +75,7 @@ pub async fn fetch_token(mut config: OAuthClientConfig) -> Result<FetchedToken, 
     let token = source.request_token().await?;
 
     Ok(FetchedToken {
-        bearer: SecretString::new(token.access_token),
+        bearer: token.access_token,
         expires_in: Duration::from_secs(token.lifetime_secs),
     })
 }

--- a/libs/toolkit-auth/src/oauth2/source.rs
+++ b/libs/toolkit-auth/src/oauth2/source.rs
@@ -248,7 +248,7 @@ mod tests {
         let mut source = OAuthTokenSource::new(&test_config(&server)).unwrap();
         let token = source.request_token().await.unwrap();
 
-        assert_eq!(token.access_token, "tok-123");
+        assert_eq!(token.access_token.expose(), "tok-123");
         assert_eq!(token.lifetime_secs, 3600);
         mock.assert();
     }
@@ -504,7 +504,7 @@ mod tests {
         let mut source = OAuthTokenSource::new(&test_config(&server)).unwrap();
         let token = source.request_token().await.unwrap();
 
-        assert_eq!(token.access_token, "tok");
+        assert_eq!(token.access_token.expose(), "tok");
         mock.assert();
     }
 

--- a/libs/toolkit-auth/src/oauth2/token_watcher.rs
+++ b/libs/toolkit-auth/src/oauth2/token_watcher.rs
@@ -13,6 +13,7 @@ use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwap;
 use rand::RngExt as _;
+use toolkit_utils::SecretString;
 
 /// Freshness status of a cached token.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -29,7 +30,7 @@ pub enum TokenStatus {
 /// A cached bearer token with computed refresh / expiry deadlines.
 #[derive(Clone)]
 pub struct CachedToken {
-    access_token: String,
+    access_token: SecretString,
     /// Wall-clock instant the token was received.
     received_at: Instant,
     /// Duration after `received_at` at which the token transitions to `Stale`.
@@ -55,7 +56,7 @@ impl CachedToken {
     /// Returns [`TokenError::InvalidTokenLifetime`] if `lifetime_secs` is zero
     /// or `freshness_ratio` is not in `(0.0, 1.0]`.
     pub(crate) fn new(
-        access_token: String,
+        access_token: SecretString,
         lifetime_secs: u64,
         freshness_ratio: f64,
     ) -> Result<Self, super::error::TokenError> {
@@ -86,7 +87,7 @@ impl CachedToken {
     }
 
     pub(crate) fn access_token(&self) -> &str {
-        &self.access_token
+        self.access_token.expose()
     }
 
     pub(crate) fn token_status(&self) -> TokenStatus {
@@ -160,7 +161,7 @@ impl WatcherConfig {
 /// Result of a single token fetch — the source returns this.
 #[derive(Debug)]
 pub struct FetchedToken {
-    pub access_token: String,
+    pub access_token: SecretString,
     pub lifetime_secs: u64,
     /// Freshness ratio (0.0–1.0): fraction of lifetime during which the token
     /// is considered "fresh". After this fraction, it becomes "stale" and the
@@ -350,14 +351,14 @@ mod tests {
 
     #[test]
     fn cached_token_fresh_immediately() {
-        let ct = CachedToken::new("tok".into(), 3600, 0.8).unwrap();
+        let ct = CachedToken::new(SecretString::new("tok"), 3600, 0.8).unwrap();
         assert_eq!(ct.access_token(), "tok");
         assert_eq!(ct.token_status(), TokenStatus::Fresh);
     }
 
     #[test]
     fn cached_token_zero_lifetime_rejected() {
-        let err = CachedToken::new("tok".into(), 0, 0.8).unwrap_err();
+        let err = CachedToken::new(SecretString::new("tok"), 0, 0.8).unwrap_err();
         assert!(
             err.to_string().contains("lifetime_secs"),
             "expected lifetime error, got: {err}"
@@ -366,7 +367,7 @@ mod tests {
 
     #[test]
     fn cached_token_zero_freshness_rejected() {
-        let err = CachedToken::new("tok".into(), 3600, 0.0).unwrap_err();
+        let err = CachedToken::new(SecretString::new("tok"), 3600, 0.0).unwrap_err();
         assert!(
             err.to_string().contains("freshness_ratio"),
             "expected freshness error, got: {err}"
@@ -375,7 +376,7 @@ mod tests {
 
     #[test]
     fn cached_token_negative_freshness_rejected() {
-        let err = CachedToken::new("tok".into(), 3600, -0.1).unwrap_err();
+        let err = CachedToken::new(SecretString::new("tok"), 3600, -0.1).unwrap_err();
         assert!(
             err.to_string().contains("freshness_ratio"),
             "expected freshness error, got: {err}"
@@ -384,7 +385,7 @@ mod tests {
 
     #[test]
     fn cached_token_freshness_above_one_rejected() {
-        let err = CachedToken::new("tok".into(), 3600, 1.1).unwrap_err();
+        let err = CachedToken::new(SecretString::new("tok"), 3600, 1.1).unwrap_err();
         assert!(
             err.to_string().contains("freshness_ratio"),
             "expected freshness error, got: {err}"
@@ -393,7 +394,7 @@ mod tests {
 
     #[test]
     fn cached_token_nan_freshness_rejected() {
-        let err = CachedToken::new("tok".into(), 3600, f64::NAN).unwrap_err();
+        let err = CachedToken::new(SecretString::new("tok"), 3600, f64::NAN).unwrap_err();
         assert!(
             err.to_string().contains("freshness_ratio"),
             "expected freshness error, got: {err}"
@@ -402,7 +403,7 @@ mod tests {
 
     #[test]
     fn cached_token_inf_freshness_rejected() {
-        let err = CachedToken::new("tok".into(), 3600, f64::INFINITY).unwrap_err();
+        let err = CachedToken::new(SecretString::new("tok"), 3600, f64::INFINITY).unwrap_err();
         assert!(
             err.to_string().contains("freshness_ratio"),
             "expected freshness error, got: {err}"
@@ -411,7 +412,7 @@ mod tests {
 
     #[test]
     fn cached_token_tiny_freshness_zero_window_rejected() {
-        let err = CachedToken::new("tok".into(), 1, 0.000_000_000_01).unwrap_err();
+        let err = CachedToken::new(SecretString::new("tok"), 1, 0.000_000_000_01).unwrap_err();
         assert!(
             err.to_string().contains("freshness window rounds to zero"),
             "expected zero-window error, got: {err}"
@@ -421,19 +422,19 @@ mod tests {
     #[test]
     fn cached_token_full_freshness() {
         // freshness_ratio=1.0 → fresh_until=lifetime → only stale at expiry
-        let ct = CachedToken::new("tok".into(), 3600, 1.0).unwrap();
+        let ct = CachedToken::new(SecretString::new("tok"), 3600, 1.0).unwrap();
         assert_eq!(ct.token_status(), TokenStatus::Fresh);
     }
 
     #[test]
     fn time_until_stale_positive_when_fresh() {
-        let ct = CachedToken::new("tok".into(), 3600, 0.8).unwrap();
+        let ct = CachedToken::new(SecretString::new("tok"), 3600, 0.8).unwrap();
         assert!(ct.time_until_stale() > Duration::ZERO);
     }
 
     #[test]
     fn time_until_expired_positive_when_fresh() {
-        let ct = CachedToken::new("tok".into(), 3600, 0.8).unwrap();
+        let ct = CachedToken::new(SecretString::new("tok"), 3600, 0.8).unwrap();
         assert!(ct.time_until_expired() > Duration::ZERO);
     }
 

--- a/libs/toolkit-auth/src/oauth2/types.rs
+++ b/libs/toolkit-auth/src/oauth2/types.rs
@@ -25,7 +25,7 @@ pub enum ClientAuthMethod {
 #[derive(Deserialize)]
 pub(crate) struct TokenResponse {
     /// The access token issued by the authorization server.
-    pub access_token: String,
+    pub access_token: SecretString,
     /// The lifetime in seconds of the access token (optional per RFC 6749).
     #[serde(default)]
     pub expires_in: Option<u64>,
@@ -48,16 +48,19 @@ mod tests {
     fn deserialize_full_response() {
         let json = r#"{"access_token":"tok","expires_in":3600,"token_type":"Bearer"}"#;
         let r: TokenResponse = serde_json::from_str(json).unwrap();
-        assert_eq!(r.access_token, "tok");
+        assert_eq!(r.access_token.expose(), "tok");
         assert_eq!(r.expires_in, Some(3600));
         assert_eq!(r.token_type.as_deref(), Some("Bearer"));
+
+        // Redaction proof: the raw token must not appear in Debug output.
+        assert!(!format!("{:?}", r.access_token).contains("tok"));
     }
 
     #[test]
     fn deserialize_minimal_response() {
         let json = r#"{"access_token":"tok"}"#;
         let r: TokenResponse = serde_json::from_str(json).unwrap();
-        assert_eq!(r.access_token, "tok");
+        assert_eq!(r.access_token.expose(), "tok");
         assert!(r.expires_in.is_none());
         assert!(r.token_type.is_none());
     }
@@ -66,6 +69,6 @@ mod tests {
     fn deserialize_ignores_unknown_fields() {
         let json = r#"{"access_token":"tok","scope":"read","refresh_token":"rt"}"#;
         let r: TokenResponse = serde_json::from_str(json).unwrap();
-        assert_eq!(r.access_token, "tok");
+        assert_eq!(r.access_token.expose(), "tok");
     }
 }

--- a/libs/toolkit-db/Cargo.toml
+++ b/libs/toolkit-db/Cargo.toml
@@ -122,6 +122,7 @@ required-features = ["preview-outbox", "_any-backend"]
 [dev-dependencies]
 criterion = { workspace = true, features = ["html_reports"] }
 tempfile = { workspace = true }
+toolkit-utils = { workspace = true, features = ["serde"] }
 serde-saphyr = { workspace = true }
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }

--- a/libs/toolkit-db/src/config.rs
+++ b/libs/toolkit-db/src/config.rs
@@ -41,6 +41,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
+use toolkit_utils::SecretString;
 
 /// Global database configuration with server-based DBs.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -69,14 +70,22 @@ pub struct DbConnConfig {
     pub engine: Option<DbEngineCfg>,
 
     // DSN-style (full, valid). Optional: can be absent and rely on fields.
-    pub dsn: Option<String>,
+    #[serde(
+        default,
+        serialize_with = "toolkit_utils::secret_string::serialize_option_exposed"
+    )]
+    pub dsn: Option<SecretString>,
 
     // Field-based style; any of these override DSN parts when present:
     pub host: Option<String>,
     pub port: Option<u16>,
     pub user: Option<String>,
-    pub password: Option<String>, // literal password or ${VAR} for env expansion
-    pub dbname: Option<String>,   // MUST be present in final for server-based DBs
+    #[serde(
+        default,
+        serialize_with = "toolkit_utils::secret_string::serialize_option_exposed"
+    )]
+    pub password: Option<SecretString>, // literal password or ${VAR} for env expansion
+    pub dbname: Option<String>, // MUST be present in final for server-based DBs
     #[serde(default)]
     pub params: Option<HashMap<String, String>>,
 

--- a/libs/toolkit-db/src/options.rs
+++ b/libs/toolkit-db/src/options.rs
@@ -1,5 +1,6 @@
 //! Database connection options and configuration types.
 
+use toolkit_utils::SecretString;
 use toolkit_utils::var_expand::expand_env_vars;
 
 use crate::config::{DbConnConfig, DbEngineCfg, GlobalDatabaseConfig, PoolCfg};
@@ -260,10 +261,10 @@ pub(crate) async fn build_db_handle(
 ) -> Result<DbHandle> {
     // Expand environment variables in DSN and password
     if let Some(dsn) = &cfg.dsn {
-        cfg.dsn = Some(expand_env_vars(dsn)?);
+        cfg.dsn = Some(SecretString::new(expand_env_vars(dsn.expose())?));
     }
     if let Some(password) = &cfg.password {
-        cfg.password = Some(resolve_password(password)?);
+        cfg.password = Some(SecretString::new(resolve_password(password.expose())?));
     }
 
     // Expand environment variables in params
@@ -289,7 +290,7 @@ pub(crate) async fn build_db_handle(
     let pool_cfg = cfg.pool.unwrap_or_default();
 
     // Log connection attempt (without credentials)
-    let log_dsn = redact_credentials_in_dsn(cfg.dsn.as_deref());
+    let log_dsn = redact_credentials_in_dsn(cfg.dsn.as_ref().map(SecretString::expose));
     tracing::debug!(dsn = log_dsn, engine = ?engine, "Building database connection");
 
     // Connect to database
@@ -303,7 +304,7 @@ fn determine_engine(cfg: &DbConnConfig) -> Result<DbEngineCfg> {
     // (We do the same check in validate_config_consistency, but keep this here to ensure
     // determine_engine() never returns a misleading value.)
     if let Some(engine) = cfg.engine {
-        if let Some(dsn) = cfg.dsn.as_deref() {
+        if let Some(dsn) = cfg.dsn.as_ref().map(SecretString::expose) {
             let inferred = engine_from_dsn(dsn)?;
             if inferred != engine {
                 return Err(DbError::ConfigConflict(format!(
@@ -326,7 +327,7 @@ fn determine_engine(cfg: &DbConnConfig) -> Result<DbEngineCfg> {
     }
 
     // Infer from DSN scheme when present.
-    let Some(dsn) = cfg.dsn.as_deref() else {
+    let Some(dsn) = cfg.dsn.as_ref().map(SecretString::expose) else {
         // SAFETY: guarded above by `cfg.dsn.is_none()`.
         return Err(DbError::InvalidParameter(
             "Missing 'dsn': required to infer database engine".to_owned(),
@@ -352,7 +353,7 @@ fn engine_from_dsn(dsn: &str) -> Result<DbEngineCfg> {
 #[cfg(feature = "sqlite")]
 fn build_sqlite_options(cfg: &DbConnConfig) -> Result<DbConnectOptions> {
     let db_path = if let Some(dsn) = &cfg.dsn {
-        parse_sqlite_path_from_dsn(dsn)?
+        parse_sqlite_path_from_dsn(dsn.expose())?
     } else if let Some(path) = &cfg.path {
         path.clone()
     } else if let Some(_file) = &cfg.file {
@@ -571,7 +572,8 @@ fn build_server_options(cfg: &DbConnConfig, engine: DbEngineCfg) -> Result<DbCon
             #[cfg(feature = "pg")]
             {
                 let mut opts = if let Some(dsn) = &cfg.dsn {
-                    dsn.parse::<sqlx::postgres::PgConnectOptions>()
+                    dsn.expose()
+                        .parse::<sqlx::postgres::PgConnectOptions>()
                         .map_err(|e| DbError::InvalidParameter(e.to_string()))?
                 } else {
                     sqlx::postgres::PgConnectOptions::new()
@@ -588,7 +590,7 @@ fn build_server_options(cfg: &DbConnConfig, engine: DbEngineCfg) -> Result<DbCon
                     opts = opts.username(user);
                 }
                 if let Some(password) = &cfg.password {
-                    opts = opts.password(password);
+                    opts = opts.password(password.expose());
                 }
                 if let Some(dbname) = &cfg.dbname {
                     opts = opts.database(dbname);
@@ -614,7 +616,8 @@ fn build_server_options(cfg: &DbConnConfig, engine: DbEngineCfg) -> Result<DbCon
             #[cfg(feature = "mysql")]
             {
                 let mut opts = if let Some(dsn) = &cfg.dsn {
-                    dsn.parse::<sqlx::mysql::MySqlConnectOptions>()
+                    dsn.expose()
+                        .parse::<sqlx::mysql::MySqlConnectOptions>()
                         .map_err(|e| DbError::InvalidParameter(e.to_string()))?
                 } else {
                     sqlx::mysql::MySqlConnectOptions::new()
@@ -631,7 +634,7 @@ fn build_server_options(cfg: &DbConnConfig, engine: DbEngineCfg) -> Result<DbCon
                     opts = opts.username(user);
                 }
                 if let Some(password) = &cfg.password {
-                    opts = opts.password(password);
+                    opts = opts.password(password.expose());
                 }
                 if let Some(dbname) = &cfg.dbname {
                     opts = opts.database(dbname);
@@ -705,7 +708,7 @@ fn resolve_password(password: &str) -> Result<String> {
 /// Validate configuration for consistency and detect conflicts.
 fn validate_config_consistency(cfg: &DbConnConfig) -> Result<()> {
     // Validate engine against DSN if both are present
-    if let (Some(engine), Some(dsn)) = (cfg.engine, cfg.dsn.as_deref()) {
+    if let (Some(engine), Some(dsn)) = (cfg.engine, cfg.dsn.as_ref().map(SecretString::expose)) {
         let inferred = engine_from_dsn(dsn)?;
         if inferred != engine {
             return Err(DbError::ConfigConflict(format!(
@@ -716,7 +719,7 @@ fn validate_config_consistency(cfg: &DbConnConfig) -> Result<()> {
 
     // Check for SQLite vs server engine conflicts
     if let Some(dsn) = &cfg.dsn {
-        let is_sqlite_dsn = dsn.starts_with("sqlite");
+        let is_sqlite_dsn = dsn.expose().starts_with("sqlite");
         let has_sqlite_fields = cfg.file.is_some() || cfg.path.is_some();
         let has_server_fields = cfg.host.is_some() || cfg.port.is_some();
 
@@ -824,7 +827,7 @@ mod tests {
     fn determine_engine_infers_from_dsn_when_engine_missing() {
         let cfg = DbConnConfig {
             engine: None,
-            dsn: Some("sqlite::memory:".to_owned()),
+            dsn: Some(SecretString::new("sqlite::memory:")),
             ..Default::default()
         };
 
@@ -845,7 +848,7 @@ mod tests {
         for (engine, dsn) in cases {
             let cfg = DbConnConfig {
                 engine: Some(engine),
-                dsn: Some(dsn.to_owned()),
+                dsn: Some(SecretString::new(dsn)),
                 ..Default::default()
             };
             validate_config_consistency(&cfg).unwrap();
@@ -864,7 +867,7 @@ mod tests {
         for (engine, dsn) in cases {
             let cfg = DbConnConfig {
                 engine: Some(engine),
-                dsn: Some(dsn.to_owned()),
+                dsn: Some(SecretString::new(dsn)),
                 ..Default::default()
             };
 
@@ -877,7 +880,7 @@ mod tests {
     fn unknown_dsn_is_error() {
         let cfg = DbConnConfig {
             engine: None,
-            dsn: Some("unknown://localhost/db".to_owned()),
+            dsn: Some(SecretString::new("unknown://localhost/db")),
             ..Default::default()
         };
 

--- a/libs/toolkit-db/tests/config_tests.rs
+++ b/libs/toolkit-db/tests/config_tests.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::use_debug)]
 
 //! Tests for configuration types and serialization.
 
@@ -6,16 +6,17 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
 use toolkit_db::{DbConnConfig, GlobalDatabaseConfig, PoolCfg};
+use toolkit_utils::SecretString;
 
 #[test]
 fn test_dbconnconfig_serialization() {
     let config = DbConnConfig {
         engine: None,
-        dsn: Some("postgresql://user:pass@localhost/db".to_owned()),
+        dsn: Some(SecretString::new("postgresql://user:pass@localhost/db")),
         host: Some("localhost".to_owned()),
         port: Some(5432),
         user: Some("testuser".to_owned()),
-        password: Some("testpass".to_owned()),
+        password: Some(SecretString::new("testpass")),
         dbname: Some("testdb".to_owned()),
         params: Some({
             let mut params = HashMap::new();
@@ -32,6 +33,11 @@ fn test_dbconnconfig_serialization() {
         server: Some("test_server".to_owned()),
     };
 
+    // Redaction proof: Debug must not leak the password or the DSN's embedded credential.
+    let config_debug = format!("{config:?}");
+    assert!(!config_debug.contains("testpass"));
+    assert!(!config_debug.contains("postgresql://user:pass@localhost/db"));
+
     // Test serialization to JSON
     let json = serde_json::to_string_pretty(&config).expect("Failed to serialize to JSON");
     assert!(json.contains("postgresql://user:pass@localhost/db"));
@@ -40,7 +46,10 @@ fn test_dbconnconfig_serialization() {
     // Test deserialization from JSON
     let deserialized: DbConnConfig =
         serde_json::from_str(&json).expect("Failed to deserialize from JSON");
-    assert_eq!(deserialized.dsn, config.dsn);
+    assert_eq!(
+        deserialized.dsn.as_ref().map(SecretString::expose),
+        config.dsn.as_ref().map(SecretString::expose)
+    );
     assert_eq!(deserialized.server, config.server);
     assert_eq!(deserialized.host, config.host);
     assert_eq!(deserialized.port, config.port);
@@ -72,7 +81,7 @@ fn test_globaldatabaseconfig_serialization() {
             host: Some("db.example.com".to_owned()),
             port: Some(5432),
             user: Some("appuser".to_owned()),
-            password: Some("${DB_PASSWORD}".to_owned()),
+            password: Some(SecretString::new("${DB_PASSWORD}")),
             dbname: Some("maindb".to_owned()),
             params: Some({
                 let mut params = HashMap::new();

--- a/libs/toolkit-db/tests/manager_tests.rs
+++ b/libs/toolkit-db/tests/manager_tests.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 use tempfile::TempDir;
 use toolkit_db::{DbConnConfig, DbManager, GlobalDatabaseConfig, PoolCfg};
+use toolkit_utils::SecretString;
 
 #[tokio::test]
 async fn test_dbmanager_no_global_config() {
@@ -54,7 +55,7 @@ async fn test_dbmanager_server_merge() {
             host: Some("localhost".to_owned()),
             port: Some(5432),
             user: Some("serveruser".to_owned()),
-            password: Some("serverpass".to_owned()),
+            password: Some(SecretString::new("serverpass")),
             dbname: Some("serverdb".to_owned()),
             params: Some({
                 let mut params = HashMap::new();

--- a/libs/toolkit-db/tests/options_tests.rs
+++ b/libs/toolkit-db/tests/options_tests.rs
@@ -12,7 +12,7 @@ async fn test_build_db_handle_postgres_missing_dbname() {
         host: Some("localhost".to_owned()),
         port: Some(5432),
         user: Some("testuser".to_owned()),
-        password: Some("testpass".to_owned()),
+        password: Some(toolkit_utils::SecretString::new("testpass")),
         // Missing dbname
         ..Default::default()
     };

--- a/libs/toolkit-db/tests/params_integration.rs
+++ b/libs/toolkit-db/tests/params_integration.rs
@@ -158,7 +158,7 @@ async fn pg_params_smoke() -> Result<()> {
     params.insert("application_name".to_owned(), "test_app_toolkit".to_owned());
 
     let config = DbConnConfig {
-        dsn: Some(dut.url),
+        dsn: Some(toolkit_utils::SecretString::new(dut.url)),
         params: Some(params),
         ..Default::default()
     };
@@ -175,7 +175,7 @@ async fn mysql_params_smoke() -> Result<()> {
     params.insert("connect_timeout".to_owned(), "10".to_owned());
 
     let config = DbConnConfig {
-        dsn: Some(dut.url),
+        dsn: Some(toolkit_utils::SecretString::new(dut.url)),
         params: Some(params),
         ..Default::default()
     };
@@ -191,7 +191,7 @@ async fn sqlite_params_smoke() -> Result<()> {
     params.insert("busy_timeout".to_owned(), "5000".to_owned());
 
     let config = DbConnConfig {
-        dsn: Some("sqlite::memory:".to_owned()),
+        dsn: Some(toolkit_utils::SecretString::new("sqlite::memory:")),
         params: Some(params),
         ..Default::default()
     };

--- a/libs/toolkit-db/tests/precedence_tests.rs
+++ b/libs/toolkit-db/tests/precedence_tests.rs
@@ -90,7 +90,10 @@ async fn test_precedence_gear_dsn_override_server() {
                 "sqlite_server".to_owned(),
                 DbConnConfig {
                     engine: Some(DbEngineCfg::Sqlite),
-                    dsn: Some(format!("sqlite://{}?synchronous=FULL", server_db.display())),
+                    dsn: Some(toolkit_utils::SecretString::new(format!(
+                        "sqlite://{}?synchronous=FULL",
+                        server_db.display()
+                    ))),
                     ..Default::default()
                 },
             );

--- a/libs/toolkit-db/tests/sqlite/options.rs
+++ b/libs/toolkit-db/tests/sqlite/options.rs
@@ -13,7 +13,7 @@ fn test_build_db_handle_env_expansion() {
         rt.block_on(async {
             let config = DbConnConfig {
                 engine: Some(toolkit_db::config::DbEngineCfg::Sqlite),
-                dsn: Some("sqlite::memory:".to_owned()),
+                dsn: Some(toolkit_utils::SecretString::new("sqlite::memory:")),
                 params: Some({
                     let mut params = HashMap::new();
                     // Exercise env expansion in params
@@ -35,7 +35,7 @@ fn test_build_db_handle_env_expansion() {
 async fn test_build_db_handle_sqlite_memory() {
     let config = DbConnConfig {
         engine: Some(toolkit_db::config::DbEngineCfg::Sqlite),
-        dsn: Some("sqlite::memory:".to_owned()),
+        dsn: Some(toolkit_utils::SecretString::new("sqlite::memory:")),
         params: Some({
             let mut params = HashMap::new();
             params.insert("journal_mode".to_owned(), "WAL".to_owned());
@@ -80,8 +80,8 @@ async fn test_build_db_handle_sqlite_file() {
 async fn test_build_db_handle_invalid_env_var() {
     let config = DbConnConfig {
         engine: Some(toolkit_db::config::DbEngineCfg::Sqlite),
-        dsn: Some("sqlite::memory:".to_owned()),
-        password: Some("${NONEXISTENT_VAR}".to_owned()),
+        dsn: Some(toolkit_utils::SecretString::new("sqlite::memory:")),
+        password: Some(toolkit_utils::SecretString::new("${NONEXISTENT_VAR}")),
         ..Default::default()
     };
 
@@ -97,7 +97,7 @@ async fn test_build_db_handle_invalid_env_var() {
 async fn test_build_db_handle_invalid_sqlite_pragma() {
     let config = DbConnConfig {
         engine: Some(toolkit_db::config::DbEngineCfg::Sqlite),
-        dsn: Some("sqlite::memory:".to_owned()),
+        dsn: Some(toolkit_utils::SecretString::new("sqlite::memory:")),
         params: Some({
             let mut params = HashMap::new();
             params.insert("invalid_pragma".to_owned(), "some_value".to_owned());
@@ -118,7 +118,7 @@ async fn test_build_db_handle_invalid_sqlite_pragma() {
 async fn test_build_db_handle_invalid_journal_mode() {
     let config = DbConnConfig {
         engine: Some(toolkit_db::config::DbEngineCfg::Sqlite),
-        dsn: Some("sqlite::memory:".to_owned()),
+        dsn: Some(toolkit_utils::SecretString::new("sqlite::memory:")),
         params: Some({
             let mut params = HashMap::new();
             params.insert("journal_mode".to_owned(), "INVALID_MODE".to_owned());
@@ -144,7 +144,7 @@ async fn test_build_db_handle_invalid_journal_mode() {
 async fn test_build_db_handle_pool_config() {
     let config = DbConnConfig {
         engine: Some(toolkit_db::config::DbEngineCfg::Sqlite),
-        dsn: Some("sqlite::memory:".to_owned()),
+        dsn: Some(toolkit_utils::SecretString::new("sqlite::memory:")),
         pool: Some(PoolCfg {
             max_conns: Some(5),
             acquire_timeout: Some(Duration::from_secs(10)),

--- a/libs/toolkit-utils/src/secret_string.rs
+++ b/libs/toolkit-utils/src/secret_string.rs
@@ -25,6 +25,15 @@ impl SecretString {
     pub fn expose(&self) -> &str {
         &self.0
     }
+
+    /// Consume `self` and return the underlying secret, e.g. to move it into
+    /// another owned value without an extra clone.
+    ///
+    /// Callers must not log, store, or otherwise persist the returned value.
+    #[must_use]
+    pub fn into_inner(mut self) -> String {
+        std::mem::take(&mut self.0)
+    }
 }
 
 #[cfg(feature = "serde")]
@@ -34,6 +43,44 @@ impl<'de> serde::Deserialize<'de> for SecretString {
         D: serde::Deserializer<'de>,
     {
         <String as serde::Deserialize>::deserialize(deserializer).map(SecretString::new)
+    }
+}
+
+/// `serialize_with` helper for an `Option<SecretString>` field that must
+/// round-trip (e.g. persisted config).
+///
+/// `SecretString` deliberately has no `Serialize` impl of its own — that would
+/// make *every* field serialize its secret and defeat the type. This opt-in
+/// helper exposes the value for one explicitly-annotated field only:
+///
+/// ```ignore
+/// #[serde(default, serialize_with = "toolkit_utils::secret_string::serialize_option_exposed")]
+/// pub password: Option<SecretString>,
+/// ```
+///
+/// `Debug`/`Display` stay redacted and the field is still zeroized on drop;
+/// deserialization uses `SecretString`'s own `Deserialize` (no annotation needed).
+///
+/// # Security
+///
+/// Annotating a field with this helper re-enables plaintext serialization for
+/// that field — only use it for config fields that must round-trip on disk.
+///
+/// # Errors
+///
+/// Returns the underlying `serde::Serializer`'s error if it fails to write
+/// the value.
+#[cfg(feature = "serde")]
+pub fn serialize_option_exposed<S>(
+    value: &Option<SecretString>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    match value {
+        Some(secret) => serializer.serialize_some(secret.expose()),
+        None => serializer.serialize_none(),
     }
 }
 

--- a/libs/toolkit/src/bootstrap/config/mod.rs
+++ b/libs/toolkit/src/bootstrap/config/mod.rs
@@ -860,7 +860,7 @@ impl DbConfigBuilder {
     ) -> Result<()> {
         // Apply global server DSN
         if let Some(global_dsn) = &global_server.dsn {
-            let expanded_dsn = expand_env_in_dsn(global_dsn)?;
+            let expanded_dsn = expand_env_in_dsn(global_dsn.expose())?;
             // For SQLite, resolve @file() syntax before validation
             let resolved_dsn = if expanded_dsn.starts_with("sqlite") {
                 resolve_sqlite_dsn(&expanded_dsn, home_dir, gear_name, dry_run)?
@@ -881,7 +881,12 @@ impl DbConfigBuilder {
         if let Some(user) = &global_server.user {
             self.user = Some(user.clone());
         }
-        if let Some(password) = resolve_password(global_server.password.as_deref())? {
+        if let Some(password) = resolve_password(
+            global_server
+                .password
+                .as_ref()
+                .map(toolkit_utils::SecretString::expose),
+        )? {
             self.password = Some(password);
         }
         if let Some(dbname) = &global_server.dbname {
@@ -927,7 +932,12 @@ impl DbConfigBuilder {
         if let Some(user) = &gear_db_config.user {
             self.user = Some(user.clone());
         }
-        if let Some(password) = resolve_password(gear_db_config.password.as_deref())? {
+        if let Some(password) = resolve_password(
+            gear_db_config
+                .password
+                .as_ref()
+                .map(toolkit_utils::SecretString::expose),
+        )? {
             self.password = Some(password);
         }
         if let Some(dbname) = &gear_db_config.dbname {
@@ -1281,7 +1291,7 @@ pub fn build_final_db_for_gear(
 
     // Step 2: Apply gear DSN (override global)
     if let Some(gear_dsn) = &gear_db_config.dsn {
-        builder.apply_gear_dsn(gear_dsn, home_dir, gear_name, dry_run)?;
+        builder.apply_gear_dsn(gear_dsn.expose(), home_dir, gear_name, dry_run)?;
     }
 
     // Step 3: Apply gear fields (override everything)
@@ -1670,9 +1680,9 @@ logging:
         let mut app = create_app_with_server(
             "test_server",
             DbConnConfig {
-                dsn: Some(
-                    "postgresql://global_user:global_pass@global_host:5432/global_db".to_owned(),
-                ),
+                dsn: Some(toolkit_utils::SecretString::new(
+                    "postgresql://global_user:global_pass@global_host:5432/global_db",
+                )),
                 ..Default::default()
             },
         );
@@ -1802,7 +1812,9 @@ logging:
         let mut app = create_app_with_server(
             "test_server",
             DbConnConfig {
-                dsn: Some("postgresql://old_user:old_pass@old_host:5432/old_db".to_owned()),
+                dsn: Some(toolkit_utils::SecretString::new(
+                    "postgresql://old_user:old_pass@old_host:5432/old_db",
+                )),
                 host: Some("new_host".to_owned()), // This should override DSN host
                 port: Some(5433),                  // This should override DSN port
                 user: Some("new_user".to_owned()), // This should override DSN user
@@ -1849,7 +1861,7 @@ logging:
                     host: Some("localhost".to_owned()),
                     port: Some(5432),
                     user: Some("testuser".to_owned()),
-                    password: Some("${TEST_DB_PASSWORD}".to_owned()), // Should expand to "secret123"
+                    password: Some(toolkit_utils::SecretString::new("${TEST_DB_PASSWORD}")), // Should expand to "secret123"
                     dbname: Some("testdb".to_owned()),
                     ..Default::default()
                 },
@@ -1885,9 +1897,9 @@ logging:
                 let mut app = create_app_with_server(
                     "test_server",
                     DbConnConfig {
-                        dsn: Some(
-                            "postgresql://user:${DB_PASSWORD}@${DB_HOST}:5432/mydb".to_owned(),
-                        ),
+                        dsn: Some(toolkit_utils::SecretString::new(
+                            "postgresql://user:${DB_PASSWORD}@${DB_HOST}:5432/mydb",
+                        )),
                         ..Default::default()
                     },
                 );
@@ -2033,10 +2045,9 @@ logging:
             "sqlite_users".to_owned(),
             DbConnConfig {
                 engine: None,
-                dsn: Some(
-                    "sqlite://users_info.db?WAL=true&synchronous=NORMAL&busy_timeout=5000"
-                        .to_owned(),
-                ),
+                dsn: Some(toolkit_utils::SecretString::new(
+                    "sqlite://users_info.db?WAL=true&synchronous=NORMAL&busy_timeout=5000",
+                )),
                 host: None,
                 port: None,
                 user: None,
@@ -2268,7 +2279,7 @@ logging:
                 "test_server",
                 DbConnConfig {
                     host: Some("localhost".to_owned()),
-                    password: Some("${NONEXISTENT_PASSWORD}".to_owned()),
+                    password: Some(toolkit_utils::SecretString::new("${NONEXISTENT_PASSWORD}")),
                     dbname: Some("testdb".to_owned()),
                     ..Default::default()
                 },
@@ -2434,7 +2445,9 @@ logging:
                 host: Some("localhost".to_owned()),
                 port: Some(5432),
                 user: Some("user@domain".to_owned()),
-                password: Some("pa@ss:w0rd/with%special&chars".to_owned()),
+                password: Some(toolkit_utils::SecretString::new(
+                    "pa@ss:w0rd/with%special&chars",
+                )),
                 dbname: Some("test/db".to_owned()),
                 ..Default::default()
             },
@@ -2734,7 +2747,7 @@ logging:
                 host: Some("localhost".to_owned()),
                 port: Some(5432),
                 user: Some("user".to_owned()),
-                password: Some("pass".to_owned()),
+                password: Some(toolkit_utils::SecretString::new("pass")),
                 dbname: Some("db".to_owned()),
                 ..Default::default()
             },

--- a/libs/toolkit/src/bootstrap/oop_tests.rs
+++ b/libs/toolkit/src/bootstrap/oop_tests.rs
@@ -541,7 +541,7 @@ mod database_merge {
             DbConnConfig {
                 engine: Some(toolkit_db::config::DbEngineCfg::Sqlite),
                 server: None,
-                dsn: Some("sqlite://new.db".to_owned()),
+                dsn: Some(toolkit_utils::SecretString::new("sqlite://new.db")),
                 host: None,
                 port: None,
                 user: None,

--- a/tools/dylint_lints/Cargo.lock
+++ b/tools/dylint_lints/Cargo.lock
@@ -656,7 +656,6 @@ name = "cf-gears-toolkit-db-macros"
 version = "0.6.3"
 dependencies = [
  "heck 0.5.0",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/tools/dylint_lints/de03_domain_layer/de0309_must_have_domain_model/README.md
+++ b/tools/dylint_lints/de03_domain_layer/de0309_must_have_domain_model/README.md
@@ -2,7 +2,9 @@
 
 ## What it does
 
-Checks that all struct and enum types in domain modules have the `#[domain_model]` attribute.
+Checks that struct and enum types in domain modules that are visible beyond their own
+module (`pub`, `pub(crate)`, `pub(super)`, `pub(in ...)`) have the `#[domain_model]`
+attribute. Strictly module-private types (no `pub` keyword) are exempt.
 
 ## Why is this important?
 
@@ -13,7 +15,7 @@ The `#[domain_model]` macro provides **compile-time validation** of Domain-Drive
 - File system types (`std::fs::*`, `tokio::fs::*`)
 - External service clients (`reqwest::*`, `tonic::*`)
 
-By requiring this attribute on all domain types, we guarantee that infrastructure concerns cannot leak into the domain layer.
+By requiring this attribute on all externally-visible domain types, we guarantee that infrastructure concerns cannot leak into the domain layer. (Strictly module-private types are exempt from this lint — their fields are still guarded by `DE0301`/`DE0308`.)
 
 ## Example
 
@@ -45,15 +47,21 @@ pub struct User {
 
 This lint is configured to **deny** by default.
 
-It checks all `struct` and `enum` definitions in files whose path contains `/domain/`.
+It checks `struct` and `enum` definitions in files whose path contains `/domain/`,
+**except** strictly module-private ones (no `pub` keyword). Private types are pure
+implementation details that never cross a layer boundary, and their fields are still
+guarded against infrastructure leakage by `DE0301_NO_INFRA_IN_DOMAIN` and
+`DE0308_NO_HTTP_IN_DOMAIN`, which check every domain `struct`/`enum` regardless of this
+attribute. This keeps small technical helpers (e.g. a `HashMap`-key newtype) from
+needing either a spurious `#[domain_model]` or an `#[allow(...)]`.
 
 ## TDD Approach
 
 This lint is designed for Test-Driven Development:
 
-1. **Add the lint** - CI will fail for all domain types without the attribute
-2. **Fix each violation** - Add `#[domain_model]` to all domain types
-3. **CI passes** - All domain types are now validated at compile time
+1. **Add the lint** - CI will fail for all externally-visible domain types without the attribute
+2. **Fix each violation** - Add `#[domain_model]` to all externally-visible domain types
+3. **CI passes** - All externally-visible domain types are now validated at compile time
 
 ## See Also
 

--- a/tools/dylint_lints/de03_domain_layer/de0309_must_have_domain_model/src/lib.rs
+++ b/tools/dylint_lints/de03_domain_layer/de0309_must_have_domain_model/src/lib.rs
@@ -5,14 +5,22 @@ extern crate rustc_ast;
 
 use clippy_utils::diagnostics::span_lint_and_then;
 use lint_utils::is_in_domain_path;
-use rustc_ast::{Item, ItemKind};
+use rustc_ast::{Item, ItemKind, VisibilityKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
 
 dylint_linting::declare_pre_expansion_lint! {
     /// DE0309: Domain Structs Must Have `#[domain_model]` Attribute
     ///
-    /// All struct and enum types in the domain layer MUST have the `#[domain_model]`
-    /// attribute to ensure compile-time validation of DDD boundaries.
+    /// Struct and enum types in the domain layer that are visible beyond their own
+    /// module (`pub`, `pub(crate)`, `pub(super)`, `pub(in ...)`) MUST have the
+    /// `#[domain_model]` attribute to ensure compile-time validation of DDD boundaries.
+    ///
+    /// Strictly module-private types (no `pub` keyword) are exempt: they are pure
+    /// implementation details that never cross a layer boundary, and their fields
+    /// are still guarded against infrastructure leakage by `DE0301_NO_INFRA_IN_DOMAIN`
+    /// and `DE0308_NO_HTTP_IN_DOMAIN`, which check every domain struct/enum regardless
+    /// of this attribute. This keeps small technical helpers (e.g. a `HashMap`-key
+    /// newtype) from needing either a spurious `#[domain_model]` or an `#[allow(...)]`.
     ///
     /// ### Why is this important?
     ///
@@ -62,6 +70,14 @@ fn check_domain_model_attribute(cx: &EarlyContext<'_>, item: &Item) {
 
     // Only check items in domain path
     if !is_in_domain_path(cx.sess().source_map(), item.span) {
+        return;
+    }
+
+    // Exempt strictly module-private types (no `pub` keyword). They never cross a
+    // layer boundary, and their fields are still checked for infra leakage by
+    // DE0301/DE0308 regardless of this attribute. `pub`/`pub(crate)`/`pub(super)`/
+    // `pub(in ...)` remain subject to the requirement.
+    if matches!(item.vis.kind, VisibilityKind::Inherited) {
         return;
     }
 

--- a/tools/dylint_lints/de03_domain_layer/de0309_must_have_domain_model/ui/private_types_exempt.rs
+++ b/tools/dylint_lints/de03_domain_layer/de0309_must_have_domain_model/ui/private_types_exempt.rs
@@ -1,0 +1,19 @@
+// simulated_dir=/cf-gears/gears/example/src/domain/
+
+// Test: strictly module-private (no `pub`) domain types are exempt from DE0309.
+// They never cross a layer boundary, and their fields are still guarded against
+// infrastructure leakage by DE0301/DE0308 regardless of the attribute. DE0309 only
+// requires #[domain_model] on types visible beyond their module.
+
+// Should not trigger DE0309 - domain_model attribute
+#[allow(dead_code)]
+struct TokenKey(String);
+
+// Should not trigger DE0309 - domain_model attribute
+#[allow(dead_code)]
+enum InternalState {
+    Ready,
+    Pending,
+}
+
+fn main() {}


### PR DESCRIPTION
A sec audit flagged 8 fields holding credentials as plain String, exposed via Debug/Serialize/accidental whole-struct logging. Type them as SecretString (toolkit_utils, except static-authn-plugin which already uses secrecy::SecretString) for redacted Debug/Display + zeroize-on-drop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Protected sensitive values (share tokens, static auth tokens, OAuth2 access tokens, fs-token, file-storage secrets, and database DSN/password) using a secret wrapper to reduce leakage risk.
  * Standardized serialization/deserialization so secrets are revealed only when explicitly needed.
  * Ensured `Debug` output redacts secrets across affected models and configs.
* **Compatibility**
  * Updated session/authn/authz, file-storage, and database configuration handling to match the new secret types.
* **Documentation**
  * Refined `#[domain_model]` lint guidance to apply only to externally visible domain types.
* **Tests**
  * Adjusted coverage to verify redaction and correct secret exposure during round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->