### PR TITLE
chore(claude): disable Claude Code attribution in commits and PRs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "attribution": {
+    "commit": "",
+    "pr": "",
+    "sessionUrl": false
+  }
+}


### PR DESCRIPTION
Adds `.claude/settings.json` to turn off Claude Code's attribution metadata for this repository: empty `commit`/`pr` trailer text and `sessionUrl: false`. Commits and PRs made with Claude Code assistance will no longer carry a co-authorship trailer, PR footer, or Claude-Session link.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Tooling / repository configuration (no code or behavior change)

## Testing
- [x] N/A — configuration-only change, validated as syntactically correct JSON
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] New tests added for new functionality

## Documentation
- [ ] Code is documented with rustdoc comments
- [ ] README updated (if applicable)
- [ ] API documentation updated (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] No linting errors (`cargo clippy`) — N/A, no Rust code touched
- [ ] Code is properly formatted (`cargo fmt`) — N/A, no Rust code touched
- [ ] Tests pass (`cargo test`) — N/A, no Rust code touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project configuration for Claude Code settings and attribution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->