### PR TITLE
chore(ci): trying to resolve "No space left on device" in release wor…

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
-          tool-cache: false
+          tool-cache: true
           android: true
           dotnet: true
           haskell: true
@@ -189,6 +189,9 @@ jobs:
 
       - name: cargo test (workspace)
         run: make test-no-macros
+
+      - name: Clean build artifacts
+        run: rm -rf target
 
       - name: Clear cargo registry index (workaround gix slotmap overflow)
         run: rm -rf ~/.cargo/registry/index

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ codegen-units = 16
 [profile.test]
 incremental = false
 codegen-units = 16
+debug = "line-tables-only" # to minimize build sizes in gitworkflows
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
…kflow

- Add debug = "line-tables-only" to [profile.test] to reduce test artifact sizes (full DWARF debug info was consuming ~100+ GB)
- Enable tool-cache removal in free-disk-space action (+~10 GB)
- Clean target/ after cargo test before release-plz runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow disk-space management by enabling tool-cache cleanup and removing build artifacts before releases.
  * Configured test builds to use lightweight line-table debug information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->