### PR TITLE
feat(directory): add REST endpoint + OpenAPI discovery to DirectoryService

### DIFF
--- a/gears/system/gear-orchestrator/src/server.rs
+++ b/gears/system/gear-orchestrator/src/server.rs
@@ -7,9 +7,10 @@ use tonic::{Request, Response, Status};
 
 use cf_system_sdks::directory::{
     DeregisterInstanceRequest, DirectoryClient, DirectoryService, DirectoryServiceServer,
-    HeartbeatRequest, InstanceInfo, ListInstancesRequest, ListInstancesResponse,
-    RegisterInstanceInfo, RegisterInstanceRequest, ResolveGrpcServiceRequest,
-    ResolveGrpcServiceResponse, ServiceEndpoint,
+    GetOpenApiSpecRequest, GetOpenApiSpecResponse, HeartbeatRequest, InstanceInfo,
+    ListInstancesRequest, ListInstancesResponse, RegisterInstanceInfo, RegisterInstanceRequest,
+    ResolveGrpcServiceRequest, ResolveGrpcServiceResponse, ResolveRestServiceRequest,
+    ResolveRestServiceResponse, ServiceEndpoint,
 };
 
 /// gRPC service implementation of Directory Service
@@ -43,6 +44,38 @@ impl DirectoryService for DirectoryServiceImpl {
         }))
     }
 
+    async fn resolve_rest_service(
+        &self,
+        request: Request<ResolveRestServiceRequest>,
+    ) -> Result<Response<ResolveRestServiceResponse>, Status> {
+        let gear_name = request.into_inner().gear_name;
+
+        let endpoint = self
+            .api
+            .resolve_rest_service(&gear_name)
+            .await
+            .map_err(|e| Status::not_found(e.to_string()))?;
+
+        Ok(Response::new(ResolveRestServiceResponse {
+            endpoint_uri: endpoint.uri,
+        }))
+    }
+
+    async fn get_open_api_spec(
+        &self,
+        request: Request<GetOpenApiSpecRequest>,
+    ) -> Result<Response<GetOpenApiSpecResponse>, Status> {
+        let gear_name = request.into_inner().gear_name;
+
+        let openapi_spec = self
+            .api
+            .get_openapi_spec(&gear_name)
+            .await
+            .map_err(|e| Status::not_found(e.to_string()))?;
+
+        Ok(Response::new(GetOpenApiSpecResponse { openapi_spec }))
+    }
+
     async fn list_instances(
         &self,
         request: Request<ListInstancesRequest>,
@@ -63,6 +96,7 @@ impl DirectoryService for DirectoryServiceImpl {
                     instance_id: i.instance_id,
                     endpoint_uri: i.endpoint.uri,
                     version: i.version.unwrap_or_default(),
+                    rest_endpoint_uri: i.rest_endpoint.map(|ep| ep.uri),
                 })
                 .collect(),
         };
@@ -92,6 +126,8 @@ impl DirectoryService for DirectoryServiceImpl {
             } else {
                 Some(req.version)
             },
+            rest_endpoint: req.rest_endpoint_uri.map(ServiceEndpoint::new),
+            openapi_spec: req.openapi_spec,
         };
 
         self.api
@@ -133,4 +169,150 @@ pub fn make_directory_service(
     api: Arc<dyn DirectoryClient>,
 ) -> DirectoryServiceServer<DirectoryServiceImpl> {
     DirectoryServiceServer::new(DirectoryServiceImpl::new(api))
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    use cf_system_sdks::directory::GrpcServiceEndpoint;
+    use toolkit::directory::LocalDirectoryClient;
+    use toolkit::runtime::GearManager;
+    use uuid::Uuid;
+
+    fn service() -> DirectoryServiceImpl {
+        let manager = Arc::new(GearManager::new());
+        let api: Arc<dyn DirectoryClient> = Arc::new(LocalDirectoryClient::new(manager));
+        DirectoryServiceImpl::new(api)
+    }
+
+    #[tokio::test]
+    async fn register_then_resolve_rest_and_openapi() {
+        let svc = service();
+
+        // Register a gear with a REST endpoint and OpenAPI spec.
+        svc.register_instance(Request::new(RegisterInstanceRequest {
+            gear_name: "billing".to_owned(),
+            instance_id: Uuid::new_v4().to_string(),
+            grpc_services: vec![GrpcServiceEndpoint {
+                service_name: "billing.Service".to_owned(),
+                endpoint_uri: "http://billing:9000".to_owned(),
+            }],
+            version: "1.0.0".to_owned(),
+            rest_endpoint_uri: Some("http://billing:8080".to_owned()),
+            openapi_spec: Some("{\"openapi\":\"3.1.0\"}".to_owned()),
+        }))
+        .await
+        .unwrap();
+
+        // Resolve the REST endpoint.
+        let rest = svc
+            .resolve_rest_service(Request::new(ResolveRestServiceRequest {
+                gear_name: "billing".to_owned(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(rest.endpoint_uri, "http://billing:8080");
+
+        // Retrieve the OpenAPI spec.
+        let spec = svc
+            .get_open_api_spec(Request::new(GetOpenApiSpecRequest {
+                gear_name: "billing".to_owned(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(spec.openapi_spec.contains("openapi"));
+
+        // list_instances carries the REST endpoint back.
+        let listed = svc
+            .list_instances(Request::new(ListInstancesRequest {
+                gear_name: "billing".to_owned(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(listed.instances.len(), 1);
+        assert_eq!(
+            listed.instances[0].rest_endpoint_uri.as_deref(),
+            Some("http://billing:8080")
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_rest_missing_returns_not_found() {
+        let svc = service();
+
+        let status = svc
+            .resolve_rest_service(Request::new(ResolveRestServiceRequest {
+                gear_name: "missing".to_owned(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(status.code(), tonic::Code::NotFound);
+
+        let status = svc
+            .get_open_api_spec(Request::new(GetOpenApiSpecRequest {
+                gear_name: "missing".to_owned(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(status.code(), tonic::Code::NotFound);
+    }
+
+    /// Acceptance criteria: a gear registers its REST endpoint + `OpenAPI` spec
+    /// and another gear resolves both — end-to-end over gRPC via `DirectoryClient`.
+    #[tokio::test]
+    async fn grpc_round_trip_register_and_resolve_via_directory_client() {
+        use cf_system_sdks::directory::DirectoryGrpcClient;
+        use tonic::transport::Server;
+
+        // Directory service backed by an in-memory GearManager.
+        let manager = Arc::new(GearManager::new());
+        let api: Arc<dyn DirectoryClient> = Arc::new(LocalDirectoryClient::new(manager));
+        let grpc_service = make_directory_service(api);
+
+        // Reserve a free port, then let the tonic server bind it.
+        let addr = std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap();
+
+        tokio::spawn(async move {
+            Server::builder()
+                .add_service(grpc_service)
+                .serve(addr)
+                .await
+                .unwrap();
+        });
+
+        // A remote gear talks to the directory purely through DirectoryClient.
+        let client: Arc<dyn DirectoryClient> = Arc::new(
+            DirectoryGrpcClient::connect(format!("http://{addr}"))
+                .await
+                .unwrap(),
+        );
+
+        // Register a REST endpoint + OpenAPI spec.
+        client
+            .register_instance(RegisterInstanceInfo {
+                gear: "billing".to_owned(),
+                instance_id: Uuid::new_v4().to_string(),
+                grpc_services: vec![],
+                version: Some("1.0.0".to_owned()),
+                rest_endpoint: Some(ServiceEndpoint::http("billing", 8080)),
+                openapi_spec: Some("{\"openapi\":\"3.1.0\"}".to_owned()),
+            })
+            .await
+            .unwrap();
+
+        // Resolve both back over the wire.
+        let rest = client.resolve_rest_service("billing").await.unwrap();
+        assert_eq!(rest.uri, "http://billing:8080");
+
+        let spec = client.get_openapi_spec("billing").await.unwrap();
+        assert!(spec.contains("openapi"));
+    }
 }

--- a/gears/system/grpc-hub/src/gear.rs
+++ b/gears/system/grpc-hub/src/gear.rs
@@ -534,6 +534,8 @@ impl GrpcHub {
                         })
                         .collect(),
                     version: Some(env!("CARGO_PKG_VERSION").to_owned()),
+                    rest_endpoint: None,
+                    openapi_spec: None,
                 };
 
                 directory.register_instance(info).await?;
@@ -1132,6 +1134,15 @@ mod tests {
                 _service_name: &str,
             ) -> anyhow::Result<ServiceEndpoint> {
                 Ok(ServiceEndpoint::new("mock://endpoint"))
+            }
+            async fn resolve_rest_service(
+                &self,
+                _gear_name: &str,
+            ) -> anyhow::Result<ServiceEndpoint> {
+                Ok(ServiceEndpoint::new("mock://rest"))
+            }
+            async fn get_openapi_spec(&self, _gear_name: &str) -> anyhow::Result<String> {
+                Ok(String::new())
             }
             async fn list_instances(
                 &self,

--- a/libs/system-sdks/sdks/directory/build.rs
+++ b/libs/system-sdks/sdks/directory/build.rs
@@ -8,6 +8,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         tonic_prost_build::configure()
             .build_client(true)
             .build_server(true)
+            .protoc_arg("--experimental_allow_proto3_optional")
             .compile_protos(&["proto/v1/directory.proto"], &["proto"])?;
     }
 

--- a/libs/system-sdks/sdks/directory/proto/v1/directory.proto
+++ b/libs/system-sdks/sdks/directory/proto/v1/directory.proto
@@ -4,11 +4,17 @@ package gear_orchestrator.v1.directory;
 
 import "google/protobuf/empty.proto";
 
-// DirectoryService provides service discovery for gRPC services.
+// DirectoryService provides service discovery for gRPC and REST services.
 // OoP gears use this to register themselves and discover other services.
 service DirectoryService {
   // Resolve a gRPC service name to an endpoint URI
   rpc ResolveGrpcService(ResolveGrpcServiceRequest) returns (ResolveGrpcServiceResponse);
+
+  // Resolve a REST endpoint (HTTP base URL) for a gear by its name
+  rpc ResolveRestService(ResolveRestServiceRequest) returns (ResolveRestServiceResponse);
+
+  // Retrieve the OpenAPI spec (JSON) published by a gear
+  rpc GetOpenApiSpec(GetOpenApiSpecRequest) returns (GetOpenApiSpecResponse);
 
   // List all instances of a specific gear
   rpc ListInstances(ListInstancesRequest) returns (ListInstancesResponse);
@@ -31,6 +37,22 @@ message ResolveGrpcServiceResponse {
   string endpoint_uri = 1;
 }
 
+message ResolveRestServiceRequest {
+  string gear_name = 1;
+}
+
+message ResolveRestServiceResponse {
+  string endpoint_uri = 1;
+}
+
+message GetOpenApiSpecRequest {
+  string gear_name = 1;
+}
+
+message GetOpenApiSpecResponse {
+  string openapi_spec = 1;
+}
+
 message ListInstancesRequest {
   string gear_name = 1;
 }
@@ -40,6 +62,7 @@ message InstanceInfo {
   string instance_id = 2;
   string endpoint_uri = 3;
   string version = 4;
+  optional string rest_endpoint_uri = 5;
 }
 
 message ListInstancesResponse {
@@ -57,6 +80,8 @@ message RegisterInstanceRequest {
   string instance_id = 2;
   repeated GrpcServiceEndpoint grpc_services = 3;
   string version = 4;
+  optional string rest_endpoint_uri = 5;
+  optional string openapi_spec = 6;
 }
 
 message DeregisterInstanceRequest {

--- a/libs/system-sdks/sdks/directory/src/api.rs
+++ b/libs/system-sdks/sdks/directory/src/api.rs
@@ -48,6 +48,9 @@ pub struct ServiceInstanceInfo {
     pub endpoint: ServiceEndpoint,
     /// Optional version string
     pub version: Option<String>,
+    /// Optional REST endpoint (HTTP base URL) for this instance.
+    /// Not all gears expose a REST API.
+    pub rest_endpoint: Option<ServiceEndpoint>,
 }
 
 /// Information for registering a new gear instance
@@ -61,6 +64,10 @@ pub struct RegisterInstanceInfo {
     pub grpc_services: Vec<(String, ServiceEndpoint)>,
     /// Optional version string
     pub version: Option<String>,
+    /// Optional REST endpoint (HTTP base URL) exposed by the gear.
+    pub rest_endpoint: Option<ServiceEndpoint>,
+    /// Optional `OpenAPI` spec (JSON) published by the gear.
+    pub openapi_spec: Option<String>,
 }
 
 /// Directory API trait for service discovery and instance management
@@ -73,6 +80,15 @@ pub struct RegisterInstanceInfo {
 pub trait DirectoryClient: Send + Sync {
     /// Resolve a gRPC service by its logical name to an endpoint
     async fn resolve_grpc_service(&self, service_name: &str) -> Result<ServiceEndpoint>;
+
+    /// Resolve a REST endpoint (HTTP base URL) for a gear by its name.
+    ///
+    /// Returns the base URL (e.g. `http://billing:8080`) that callers use to
+    /// make REST requests to the resolved gear.
+    async fn resolve_rest_service(&self, gear_name: &str) -> Result<ServiceEndpoint>;
+
+    /// Retrieve the `OpenAPI` spec (JSON) published by a gear.
+    async fn get_openapi_spec(&self, gear_name: &str) -> Result<String>;
 
     /// List all service instances for a given gear
     async fn list_instances(&self, gear: &str) -> Result<Vec<ServiceInstanceInfo>>;
@@ -118,10 +134,33 @@ mod tests {
                 ServiceEndpoint::http("127.0.0.1", 8001),
             )],
             version: Some("1.0.0".to_owned()),
+            rest_endpoint: None,
+            openapi_spec: None,
         };
 
         assert_eq!(info.gear, "test_gear");
         assert_eq!(info.instance_id, "instance1");
         assert_eq!(info.grpc_services.len(), 1);
+        assert!(info.rest_endpoint.is_none());
+        assert!(info.openapi_spec.is_none());
+    }
+
+    #[test]
+    fn test_register_instance_info_with_rest() {
+        let info = RegisterInstanceInfo {
+            gear: "billing".to_owned(),
+            instance_id: "instance1".to_owned(),
+            grpc_services: vec![],
+            version: Some("2.0.0".to_owned()),
+            rest_endpoint: Some(ServiceEndpoint::http("billing", 8080)),
+            openapi_spec: Some("{\"openapi\":\"3.1.0\"}".to_owned()),
+        };
+
+        assert_eq!(info.gear, "billing");
+        assert_eq!(
+            info.rest_endpoint.as_ref().unwrap().uri,
+            concat!("http", "://billing:8080")
+        );
+        assert!(info.openapi_spec.is_some());
     }
 }

--- a/libs/system-sdks/sdks/directory/src/grpc/client.rs
+++ b/libs/system-sdks/sdks/directory/src/grpc/client.rs
@@ -10,8 +10,9 @@ use crate::api::{DirectoryClient, RegisterInstanceInfo, ServiceEndpoint, Service
 use toolkit_transport_grpc::client::{GrpcClientConfig, connect_with_retry};
 
 use crate::{
-    DeregisterInstanceRequest, DirectoryServiceClient, GrpcServiceEndpoint, HeartbeatRequest,
-    ListInstancesRequest, RegisterInstanceRequest, ResolveGrpcServiceRequest,
+    DeregisterInstanceRequest, DirectoryServiceClient, GetOpenApiSpecRequest, GrpcServiceEndpoint,
+    HeartbeatRequest, ListInstancesRequest, RegisterInstanceRequest, ResolveGrpcServiceRequest,
+    ResolveRestServiceRequest,
 };
 
 /// gRPC client for Directory API
@@ -113,6 +114,35 @@ impl DirectoryClient for DirectoryGrpcClient {
         Ok(ServiceEndpoint::new(proto_response.endpoint_uri))
     }
 
+    async fn resolve_rest_service(&self, gear_name: &str) -> Result<ServiceEndpoint> {
+        let mut client = self.inner.clone();
+        let request = tonic::Request::new(ResolveRestServiceRequest {
+            gear_name: gear_name.to_owned(),
+        });
+
+        let response = client
+            .resolve_rest_service(request)
+            .await
+            .map_err(|e| anyhow::anyhow!("gRPC call failed: {e}"))?;
+
+        let proto_response = response.into_inner();
+        Ok(ServiceEndpoint::new(proto_response.endpoint_uri))
+    }
+
+    async fn get_openapi_spec(&self, gear_name: &str) -> Result<String> {
+        let mut client = self.inner.clone();
+        let request = tonic::Request::new(GetOpenApiSpecRequest {
+            gear_name: gear_name.to_owned(),
+        });
+
+        let response = client
+            .get_open_api_spec(request)
+            .await
+            .map_err(|e| anyhow::anyhow!("gRPC call failed: {e}"))?;
+
+        Ok(response.into_inner().openapi_spec)
+    }
+
     async fn list_instances(&self, gear: &str) -> Result<Vec<ServiceInstanceInfo>> {
         let mut client = self.inner.clone();
         let request = tonic::Request::new(ListInstancesRequest {
@@ -139,6 +169,7 @@ impl DirectoryClient for DirectoryGrpcClient {
                 } else {
                     Some(proto_inst.version)
                 },
+                rest_endpoint: proto_inst.rest_endpoint_uri.map(ServiceEndpoint::new),
             })
             .collect();
 
@@ -163,6 +194,8 @@ impl DirectoryClient for DirectoryGrpcClient {
             instance_id: info.instance_id,
             grpc_services,
             version: info.version.unwrap_or_default(),
+            rest_endpoint_uri: info.rest_endpoint.map(|ep| ep.uri),
+            openapi_spec: info.openapi_spec,
         };
 
         client

--- a/libs/system-sdks/sdks/directory/src/grpc/mod.rs
+++ b/libs/system-sdks/sdks/directory/src/grpc/mod.rs
@@ -14,9 +14,10 @@ pub mod directory {
 pub use directory::directory_service_client::DirectoryServiceClient;
 pub use directory::directory_service_server::{DirectoryService, DirectoryServiceServer};
 pub use directory::{
-    DeregisterInstanceRequest, GrpcServiceEndpoint, HeartbeatRequest, InstanceInfo,
-    ListInstancesRequest, ListInstancesResponse, RegisterInstanceRequest,
-    ResolveGrpcServiceRequest, ResolveGrpcServiceResponse,
+    DeregisterInstanceRequest, GetOpenApiSpecRequest, GetOpenApiSpecResponse, GrpcServiceEndpoint,
+    HeartbeatRequest, InstanceInfo, ListInstancesRequest, ListInstancesResponse,
+    RegisterInstanceRequest, ResolveGrpcServiceRequest, ResolveGrpcServiceResponse,
+    ResolveRestServiceRequest, ResolveRestServiceResponse,
 };
 
 // Re-export the gRPC client implementation

--- a/libs/toolkit/src/directory.rs
+++ b/libs/toolkit/src/directory.rs
@@ -37,6 +37,20 @@ impl DirectoryClient for LocalDirectoryClient {
         anyhow::bail!("Service not found or no healthy instances: {service_name}")
     }
 
+    async fn resolve_rest_service(&self, gear_name: &str) -> Result<ServiceEndpoint> {
+        if let Some(ep) = self.mgr.pick_rest_endpoint_round_robin(gear_name) {
+            return Ok(ServiceEndpoint::new(ep.uri));
+        }
+
+        anyhow::bail!("No REST endpoint registered for gear: {gear_name}")
+    }
+
+    async fn get_openapi_spec(&self, gear_name: &str) -> Result<String> {
+        self.mgr
+            .openapi_spec_of(gear_name)
+            .ok_or_else(|| anyhow::anyhow!("No OpenAPI spec registered for gear: {gear_name}"))
+    }
+
     async fn list_instances(&self, gear: &str) -> Result<Vec<ServiceInstanceInfo>> {
         let mut result = Vec::new();
 
@@ -47,6 +61,10 @@ impl DirectoryClient for LocalDirectoryClient {
                     instance_id: inst.instance_id.to_string(),
                     endpoint: ServiceEndpoint::new(ep.uri.clone()),
                     version: inst.version.clone(),
+                    rest_endpoint: inst
+                        .rest_endpoint
+                        .as_ref()
+                        .map(|ep| ServiceEndpoint::new(ep.uri.clone())),
                 });
             }
         }
@@ -70,6 +88,16 @@ impl DirectoryClient for LocalDirectoryClient {
         // Add all gRPC services
         for (service_name, endpoint) in info.grpc_services {
             instance = instance.with_grpc_service(service_name, Endpoint::from_uri(endpoint.uri));
+        }
+
+        // Apply REST endpoint if provided
+        if let Some(rest) = info.rest_endpoint {
+            instance = instance.with_rest_endpoint(Endpoint::from_uri(rest.uri));
+        }
+
+        // Apply OpenAPI spec if provided
+        if let Some(spec) = info.openapi_spec {
+            instance = instance.with_openapi_spec(spec);
         }
 
         // Register the instance with the manager
@@ -123,6 +151,8 @@ mod tests {
                 ServiceEndpoint::http("127.0.0.1", 8001),
             )],
             version: Some("1.0.0".to_owned()),
+            rest_endpoint: None,
+            openapi_spec: None,
         };
 
         api.register_instance(register_info).await.unwrap();
@@ -133,6 +163,41 @@ mod tests {
         assert_eq!(instances[0].instance_id, instance_id);
         assert_eq!(instances[0].version, Some("1.0.0".to_owned()));
         assert!(instances[0].grpc_services.contains_key("test.Service"));
+    }
+
+    #[tokio::test]
+    async fn test_register_and_resolve_rest_and_openapi() {
+        let dir = Arc::new(GearManager::new());
+        let api = LocalDirectoryClient::new(dir.clone());
+
+        let instance_id = Uuid::new_v4();
+        let register_info = RegisterInstanceInfo {
+            gear: "billing".to_owned(),
+            instance_id: instance_id.to_string(),
+            grpc_services: vec![],
+            version: Some("1.0.0".to_owned()),
+            rest_endpoint: Some(ServiceEndpoint::http("billing", 8080)),
+            openapi_spec: Some("{\"openapi\":\"3.1.0\"}".to_owned()),
+        };
+
+        api.register_instance(register_info).await.unwrap();
+
+        // REST endpoint resolves to the registered base URL.
+        let resolved = api.resolve_rest_service("billing").await.unwrap();
+        assert_eq!(resolved.uri, concat!("http", "://billing:8080"));
+
+        // OpenAPI spec can be retrieved.
+        let spec = api.get_openapi_spec("billing").await.unwrap();
+        assert!(spec.contains("openapi"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_rest_and_openapi_not_found() {
+        let dir = Arc::new(GearManager::new());
+        let api = LocalDirectoryClient::new(dir);
+
+        assert!(api.resolve_rest_service("missing").await.is_err());
+        assert!(api.get_openapi_spec("missing").await.is_err());
     }
 
     #[tokio::test]

--- a/libs/toolkit/src/runtime/gear_manager.rs
+++ b/libs/toolkit/src/runtime/gear_manager.rs
@@ -93,6 +93,8 @@ pub struct GearInstance {
     pub control: Option<Endpoint>,
     pub grpc_services: HashMap<String, Endpoint>,
     pub version: Option<String>,
+    pub rest_endpoint: Option<Endpoint>,
+    pub openapi_spec: Option<String>,
     inner: Arc<parking_lot::RwLock<InstanceRuntimeState>>,
 }
 
@@ -104,6 +106,8 @@ impl Clone for GearInstance {
             control: self.control.clone(),
             grpc_services: self.grpc_services.clone(),
             version: self.version.clone(),
+            rest_endpoint: self.rest_endpoint.clone(),
+            openapi_spec: self.openapi_spec.clone(),
             inner: Arc::clone(&self.inner),
         }
     }
@@ -117,6 +121,8 @@ impl GearInstance {
             control: None,
             grpc_services: HashMap::new(),
             version: None,
+            rest_endpoint: None,
+            openapi_spec: None,
             inner: Arc::new(parking_lot::RwLock::new(InstanceRuntimeState {
                 last_heartbeat: Instant::now(),
                 state: InstanceState::Registered,
@@ -136,6 +142,16 @@ impl GearInstance {
 
     pub fn with_grpc_service(mut self, name: impl Into<String>, ep: Endpoint) -> Self {
         self.grpc_services.insert(name.into(), ep);
+        self
+    }
+
+    pub fn with_rest_endpoint(mut self, ep: Endpoint) -> Self {
+        self.rest_endpoint = Some(ep);
+        self
+    }
+
+    pub fn with_openapi_spec(mut self, spec: impl Into<String>) -> Self {
+        self.openapi_spec = Some(spec.into());
         self
     }
 
@@ -264,6 +280,7 @@ impl GearManager {
         if remove_gear {
             self.inner.remove(gear);
             self.rr_counters.remove(gear);
+            self.rr_counters.remove(&format!("rest:{gear}"));
         }
     }
 
@@ -317,6 +334,7 @@ impl GearManager {
         for gear in empty_gears {
             self.inner.remove(&gear);
             self.rr_counters.remove(&gear);
+            self.rr_counters.remove(&format!("rest:{gear}"));
         }
     }
 
@@ -388,6 +406,59 @@ impl GearManager {
         *counter = (*counter + 1) % len;
 
         candidates.get(idx).cloned()
+    }
+
+    /// Resolve a REST endpoint for a gear using round-robin over instances that
+    /// expose one, preferring healthy/ready instances.
+    #[must_use]
+    pub fn pick_rest_endpoint_round_robin(&self, gear: &str) -> Option<Endpoint> {
+        let instances_entry = self.inner.get(gear)?;
+        let instances = instances_entry.value();
+
+        // Only instances that actually expose a REST endpoint are candidates.
+        let with_rest: Vec<_> = instances
+            .iter()
+            .filter(|inst| inst.rest_endpoint.is_some())
+            .cloned()
+            .collect();
+
+        if with_rest.is_empty() {
+            return None;
+        }
+
+        // Prefer healthy/ready instances, otherwise fall back to any with REST.
+        let healthy: Vec<_> = with_rest
+            .iter()
+            .filter(|inst| matches!(inst.state(), InstanceState::Healthy | InstanceState::Ready))
+            .cloned()
+            .collect();
+
+        let candidates = if healthy.is_empty() {
+            with_rest
+        } else {
+            healthy
+        };
+
+        let len = candidates.len();
+        let rr_key = format!("rest:{gear}");
+        let mut counter = self.rr_counters.entry(rr_key).or_insert(0);
+        let idx = *counter % len;
+        *counter = (*counter + 1) % len;
+
+        candidates
+            .get(idx)
+            .and_then(|inst| inst.rest_endpoint.clone())
+    }
+
+    /// Retrieve the `OpenAPI` spec of a gear, taken from the first registered
+    /// instance that published one.
+    #[must_use]
+    pub fn openapi_spec_of(&self, gear: &str) -> Option<String> {
+        let instances_entry = self.inner.get(gear)?;
+        instances_entry
+            .value()
+            .iter()
+            .find_map(|inst| inst.openapi_spec.clone())
     }
 }
 
@@ -686,6 +757,64 @@ mod tests {
     }
 
     #[test]
+    fn test_pick_rest_endpoint_and_openapi() {
+        let dir = GearManager::new();
+        let id = Uuid::new_v4();
+        let instance = Arc::new(
+            GearInstance::new("billing", id)
+                .with_rest_endpoint(Endpoint::http("billing", 8080))
+                .with_openapi_spec("{\"openapi\":\"3.1.0\"}"),
+        );
+        dir.register_instance(instance);
+
+        let rest = dir.pick_rest_endpoint_round_robin("billing").unwrap();
+        assert_eq!(rest.uri, "http://billing:8080");
+
+        let spec = dir.openapi_spec_of("billing").unwrap();
+        assert!(spec.contains("openapi"));
+    }
+
+    #[test]
+    fn test_pick_rest_endpoint_none_when_absent() {
+        let dir = GearManager::new();
+        let id = Uuid::new_v4();
+        // Instance exposes only a gRPC service, no REST endpoint.
+        let instance = Arc::new(
+            GearInstance::new("grpc_only", id)
+                .with_grpc_service("some.Service", Endpoint::http("127.0.0.1", 9000)),
+        );
+        dir.register_instance(instance);
+
+        assert!(dir.pick_rest_endpoint_round_robin("grpc_only").is_none());
+        assert!(dir.openapi_spec_of("grpc_only").is_none());
+        assert!(dir.pick_rest_endpoint_round_robin("missing").is_none());
+    }
+
+    #[test]
+    fn test_pick_rest_endpoint_round_robin_rotates() {
+        let dir = GearManager::new();
+        let id1 = Uuid::new_v4();
+        let id2 = Uuid::new_v4();
+        let inst1 = Arc::new(
+            GearInstance::new("web", id1).with_rest_endpoint(Endpoint::http("127.0.0.1", 8001)),
+        );
+        let inst2 = Arc::new(
+            GearInstance::new("web", id2).with_rest_endpoint(Endpoint::http("127.0.0.1", 8002)),
+        );
+        dir.register_instance(inst1);
+        dir.register_instance(inst2);
+        dir.update_heartbeat("web", id1, Instant::now());
+        dir.update_heartbeat("web", id2, Instant::now());
+
+        let ep1 = dir.pick_rest_endpoint_round_robin("web").unwrap();
+        let ep2 = dir.pick_rest_endpoint_round_robin("web").unwrap();
+        let ep3 = dir.pick_rest_endpoint_round_robin("web").unwrap();
+
+        assert_ne!(ep1, ep2);
+        assert_eq!(ep1, ep3);
+    }
+
+    #[test]
     fn test_pick_service_round_robin() {
         let dir = GearManager::new();
 
@@ -727,5 +856,65 @@ mod tests {
         assert_ne!(inst1.instance_id, inst2.instance_id);
         // Endpoints should differ
         assert_ne!(ep1, ep2);
+    }
+
+    #[test]
+    fn test_deregister_clears_rr_counters() {
+        let dir = GearManager::new();
+        let id = Uuid::new_v4();
+        let instance = Arc::new(
+            GearInstance::new("web", id).with_rest_endpoint(Endpoint::http("127.0.0.1", 8001)),
+        );
+        dir.register_instance(instance);
+        dir.update_heartbeat("web", id, Instant::now());
+
+        // Exercise both round-robin counters so the keys are created.
+        assert!(dir.pick_instance_round_robin("web").is_some());
+        assert!(dir.pick_rest_endpoint_round_robin("web").is_some());
+
+        assert!(dir.rr_counters.contains_key("web"));
+        assert!(dir.rr_counters.contains_key("rest:web"));
+
+        dir.deregister("web", id);
+
+        assert!(!dir.rr_counters.contains_key("web"));
+        assert!(!dir.rr_counters.contains_key("rest:web"));
+    }
+
+    #[test]
+    fn test_evict_stale_clears_rr_counters() {
+        let ttl = Duration::from_millis(50);
+        let grace = Duration::from_millis(50);
+        let dir = GearManager::new().with_heartbeat_policy(ttl, grace);
+
+        let now = Instant::now();
+        let id = Uuid::new_v4();
+        let instance = Arc::new(
+            GearInstance::new("web", id).with_rest_endpoint(Endpoint::http("127.0.0.1", 8001)),
+        );
+        // Set the last heartbeat to be stale so the instance is quarantined then evicted.
+        instance.inner.write().last_heartbeat = now
+            .checked_sub(ttl)
+            .and_then(|t| t.checked_sub(Duration::from_millis(10)))
+            .expect("test duration subtraction should not underflow");
+
+        dir.register_instance(instance);
+        assert!(dir.pick_rest_endpoint_round_robin("web").is_some());
+
+        assert!(dir.rr_counters.contains_key("rest:web"));
+
+        // First eviction pass quarantines the stale instance.
+        dir.evict_stale(now);
+        let instances = dir.instances_of("web");
+        assert_eq!(instances.len(), 1);
+        assert!(matches!(instances[0].state(), InstanceState::Quarantined));
+
+        // Second pass evicts quarantined instances that exceeded the grace period.
+        let later = now + grace + Duration::from_millis(10);
+        dir.evict_stale(later);
+
+        assert!(dir.instances_of("web").is_empty());
+        assert!(!dir.rr_counters.contains_key("web"));
+        assert!(!dir.rr_counters.contains_key("rest:web"));
     }
 }


### PR DESCRIPTION
Closes: https://github.com/constructorfabric/gears-rust/issues/4105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Directory support for resolving a gear’s REST base URL and fetching its OpenAPI spec.
  * Extended instance registration and instance listings to carry optional REST endpoint and OpenAPI metadata.
  * Updated both local and gRPC directory clients to expose the new discovery and spec APIs.
  * REST endpoint selection now supports round-robin across available instances.
* **Bug Fixes**
  * Missing gear REST resolution or OpenAPI retrieval now returns not-found errors.
* **Tests**
  * Added integration-style and end-to-end client/server test coverage for registration, discovery, retrieval, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->