### PR TITLE
fix(git workflow):

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -172,6 +172,12 @@ jobs:
           large-packages: true
           swap-storage: true
 
+      - name: Install Go (required for aws-lc-fips-sys FIPS build)
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: '1.21.x'  # pinned - see docs/security/fips/TOOLCHAIN.md
+          cache: false
+
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:


### PR DESCRIPTION
- add Go toolchain for release git workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to install the required Go 1.21 toolchain, improving reliability for FIPS-enabled release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->