### PR TITLE
fix(resource-group): accept caller-supplied id on REST create-group

### DIFF
--- a/docs/api/api.json
+++ b/docs/api/api.json
@@ -681,6 +681,14 @@
       "CreateGroupDto": {
         "description": "REST DTO for creating a new resource group.",
         "properties": {
+          "id": {
+            "description": "Optional caller-supplied ID. If omitted, the server generates a UUID.\n\nFor tenant-typed groups the ID becomes the group's tenant scope\n(`tenant_id == group.id`), so a platform sync can align the RG tenant\nscope with an existing tenant identifier by supplying it here.",
+            "format": "uuid",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "metadata": {
             "description": "Type-specific metadata."
           },

--- a/docs/api/api.json
+++ b/docs/api/api.json
@@ -682,7 +682,7 @@
         "description": "REST DTO for creating a new resource group.",
         "properties": {
           "id": {
-            "description": "Optional caller-supplied ID. If omitted, the server generates a UUID.\n\nFor tenant-typed groups the ID becomes the group's tenant scope\n(`tenant_id == group.id`), so a platform sync can align the RG tenant\nscope with an existing tenant identifier by supplying it here.",
+            "description": "Optional caller-supplied ID. If omitted, the server generates a UUID.",
             "format": "uuid",
             "type": [
               "string",

--- a/gears/system/resource-group/resource-group/src/api/rest/dto.rs
+++ b/gears/system/resource-group/resource-group/src/api/rest/dto.rs
@@ -172,10 +172,6 @@ pub struct GroupWithDepthDto {
 #[toolkit_macros::api_dto(request)]
 pub struct CreateGroupDto {
     /// Optional caller-supplied ID. If omitted, the server generates a UUID.
-    ///
-    /// For tenant-typed groups the ID becomes the group's tenant scope
-    /// (`tenant_id == group.id`), so a platform sync can align the RG tenant
-    /// scope with an existing tenant identifier by supplying it here.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<Uuid>,
     /// GTS chained type path. Must have prefix `gts.cf.core.rg.type.v1~`.

--- a/gears/system/resource-group/resource-group/src/api/rest/dto.rs
+++ b/gears/system/resource-group/resource-group/src/api/rest/dto.rs
@@ -171,6 +171,13 @@ pub struct GroupWithDepthDto {
 #[derive(Debug, Clone)]
 #[toolkit_macros::api_dto(request)]
 pub struct CreateGroupDto {
+    /// Optional caller-supplied ID. If omitted, the server generates a UUID.
+    ///
+    /// For tenant-typed groups the ID becomes the group's tenant scope
+    /// (`tenant_id == group.id`), so a platform sync can align the RG tenant
+    /// scope with an existing tenant identifier by supplying it here.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<Uuid>,
     /// GTS chained type path. Must have prefix `gts.cf.core.rg.type.v1~`.
     #[serde(rename = "type")]
     pub type_path: String,
@@ -244,7 +251,7 @@ impl From<ResourceGroupWithDepth> for GroupWithDepthDto {
 impl From<CreateGroupDto> for CreateGroupRequest {
     fn from(dto: CreateGroupDto) -> Self {
         Self {
-            id: None,
+            id: dto.id,
             code: dto.type_path,
             name: dto.name,
             parent_id: dto.parent_id,

--- a/gears/system/resource-group/resource-group/src/api/rest/dto_tests.rs
+++ b/gears/system/resource-group/resource-group/src/api/rest/dto_tests.rs
@@ -116,6 +116,38 @@ fn dto_create_group_deserialize_type_key() {
     );
     assert_eq!(dto.name, "X");
     assert!(dto.parent_id.is_none());
+    assert!(dto.id.is_none());
+}
+
+// TC-DTO-05b: Caller-supplied `id` is deserialized and passed through to the SDK request
+#[test]
+fn dto_create_group_id_passthrough() {
+    let id = Uuid::now_v7();
+    let json = serde_json::json!({
+        "id": id,
+        "type": gts_id!("cf.system.rg.type.v1~x.test.dto.mytype.v1~"),
+        "name": "X"
+    })
+    .to_string();
+    let dto: CreateGroupDto = serde_json::from_str(&json).unwrap();
+    assert_eq!(dto.id, Some(id));
+
+    let req: CreateGroupRequest = dto.into();
+    assert_eq!(req.id, Some(id));
+}
+
+// TC-DTO-05c: Omitted `id` maps to `None` in the SDK request (server generates it)
+#[test]
+fn dto_create_group_no_id_maps_to_none() {
+    let dto = CreateGroupDto {
+        id: None,
+        type_path: gts_id!("cf.system.rg.type.v1~x.test.dto.mytype.v1~").to_owned(),
+        name: "X".to_owned(),
+        parent_id: None,
+        metadata: None,
+    };
+    let req: CreateGroupRequest = dto.into();
+    assert!(req.id.is_none());
 }
 
 // TC-DTO-06: Deserialize with no vectors -> defaults to empty


### PR DESCRIPTION
## What

Expose an optional caller-supplied `id` on the REST create-group endpoint, matching the SDK contract.

The SDK `CreateGroupRequest` already carries an optional `id`, but the REST `CreateGroupDto` dropped it and the `From` conversion hard-coded `id: None`. This PR adds `id` to the DTO and passes it through.

## Why

Two problems with the previous divergence:

1. **Silent data loss over REST.** Any SDK call with `id: Some(..)` routed over a REST transport would have the field silently discarded, because the DTO had no `id`. Keeping SDK ⊇ DTO avoids this.
2. **Blocks the platform-sync use case.** For tenant-typed groups `tenant_id == group.id` (`group_service.rs`: `effective_tenant_id = if is_tenant_type { group_id } else { tenant_id }`). To align an RG tenant scope with an existing platform tenant identifier, the caller must be able to supply the id at create time — impossible over REST until now.

## Changes

- Add `CreateGroupDto.id: Option<Uuid>` (`skip_serializing_if = "Option::is_none"`).
- Pass `dto.id` through in `From<CreateGroupDto> for CreateGroupRequest` (was hard-coded `None`).
- Tests: id passthrough through the conversion, omitted-id → `None`, deserialize-without-id → `None`.

Omitting `id` preserves the previous behaviour: the server generates a UUID.

## Notes

- The hand-written design doc `docs/openapi.yaml` already documented this optional `id`; the generated `docs/api/api.json` was the stale artifact and is regenerated in this PR (`make openapi`) — so SDK, DTO and the published spec now agree.
- Security: for tenant-typed groups a caller-supplied `id` sets the tenant scope, so exposure should stay gated to privileged/system callers (platform sync), not arbitrary end-users.

## Test plan

- [x] `cargo check -p cf-gears-resource-group --tests`
- [x] `cargo test -p cf-gears-resource-group --lib dto` — 9 passed
- [x] regenerate `docs/api/api.json` (`make openapi`) — clean 8-line diff, only the new `id` property


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group creation requests can now include an optional caller-provided ID.
  * If the ID field is omitted, the server will generate a UUID automatically.
* **Documentation**
  * Updated the API schema to clarify the optional ID behavior for group creation.
* **Tests**
  * Added/extended DTO tests to verify ID deserialization and correct passthrough when converting the request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->