### PR TITLE
docs(auth): add ADR 0005 for request-scoped VerifiedPrincipal

### DIFF
--- a/docs/arch/authorization/ADR/0005-verified-principal-request-extension.md
+++ b/docs/arch/authorization/ADR/0005-verified-principal-request-extension.md
@@ -1,0 +1,161 @@
+---
+status: accepted
+date: 2026-07-24
+decision-makers: Constructor Fabric Steering Committee
+---
+
+# Verified Principal as a Request Extension
+
+## Context and Problem Statement
+
+Some handlers need verified profile claims about the caller — email, email-verification status,
+identity provider, anonymous flag, and token timestamps (`iat`, `auth_time`, `exp`) — for the **same**
+token that produced the `SecurityContext`.
+
+These claims back real product features — not merely internal diagnostics. A product-facing
+`GET /me`-style endpoint is a first-class API contract: it returns the **server-verified** profile
+(`subject_id`, `provider`, `email`, `is_anonymous`, …) so that clients and downstream server features
+consume backend-verified identity rather than trusting client-supplied hints. This matters because a
+client already holds most of these fields locally (e.g. from its IdP SDK), but those are unverified
+hints; the authoritative answer to "who does the backend believe this caller is" requires server-side
+token verification. Higher-level features build on that trust anchor — account linking (e.g. anonymous
+→ federated), user/installation records, and quota enforcement. The internal `subject_id` in particular
+is server-assigned and cannot be derived by the client at all.
+
+`SecurityContext` deliberately does **not** carry these claims. Per [ADR 0002](./0002-split-authn-authz-resolvers.md)
+it is the PDP identity that flows AuthN → PEP → AuthZ, and per [DESIGN.md](../DESIGN.md) it is kept
+PDP-minimal: token metadata such as `exp` is validated during authentication but intentionally left off
+`SecurityContext` (expiration is token metadata, not identity). Widening `SecurityContext` to carry
+profile/time claims would bloat the authorization identity and blur the AuthN/AuthZ boundary.
+
+Consumers have worked around this by having the AuthN plugin publish verified identity through a
+side-channel — e.g. a process-local `ClientHub` client backed by an in-memory TTL store, keyed by
+`subject_id`. This is an **incorrect correctness boundary**: the profile a handler reads is not
+guaranteed to be the one derived from the token on the current request (eviction, TTL expiry, cross-
+replica misses, or a racing refresh can all return stale or absent data). The verified profile is a
+property of *this request's token* and should ride *this request*.
+
+**Key question:** how do handlers obtain verified profile claims for the current token without
+polluting `SecurityContext` or relying on a cache side-channel?
+
+## Decision Drivers
+
+- **Correctness** — the profile a handler reads must be the one verified from the current request's token.
+- **PDP-minimal `SecurityContext`** — keep authorization identity lean (ADR 0002, DESIGN.md).
+- **Compatibility with the minimalist AuthN interface** — do not add methods to the plugin trait
+  ([ADR 0003](./0003-authn-resolver-minimalist-interface.md)).
+- **Optionality** — most plugins/routes do not need a principal; they must not be forced to produce one.
+- **Multi-replica safety** — no dependence on process-local state for request correctness.
+
+## Considered Options
+
+- **Option A** — Extend `AuthenticationResult` with an optional `VerifiedPrincipal`; the gateway inserts
+  it into the Axum request extensions alongside `SecurityContext`.
+- **Option B** — Extend `SecurityContext` with the profile/time claims.
+- **Option C** — Keep a process-local cache (`ClientHub`/LRU) that handlers query by `subject_id`.
+- **Option D** — A token-digest handoff: middleware stashes claims keyed by a token hash for the
+  handler to look up.
+
+## Decision Outcome
+
+Chosen option: **Option A**, because it puts the verified profile on the request that produced it —
+the correct boundary — while keeping `SecurityContext` PDP-minimal and the plugin interface unchanged.
+
+- `AuthenticationResult` gains an optional field: `principal: Option<VerifiedPrincipal>`.
+- Plugins that have verified profile claims return `AuthenticationResult::with_principal(ctx, principal)`;
+  all others return `AuthenticationResult::authenticated(ctx)` (principal `None`).
+- The AuthN middleware inserts `SecurityContext` into the request extensions as today, and additionally
+  inserts `VerifiedPrincipal` when present.
+- Routes that require a principal treat a **missing** extension on an authenticated request as an
+  **internal error (5xx)**, not a 401 — absence indicates a wiring problem, not a failed credential, and
+  returning 401 would trigger client token-refresh loops.
+
+This adds a field to the **result payload**, not a method to the trait, so it stays compatible with
+ADR 0003. It keeps profile/time claims on the AuthN side of the ADR 0002 boundary.
+
+### Contract
+
+```rust
+pub struct VerifiedPrincipal {
+    pub subject_id: Uuid,
+    pub external_subject: String, // IdP `sub` / provider UID
+    pub issuer: String,
+    pub email: Option<String>,
+    pub email_verified: Option<bool>,
+    pub provider: String,
+    pub is_anonymous: bool,
+    pub issued_at: i64,   // unix seconds (`iat`)
+    pub auth_time: i64,   // unix seconds
+    pub expires_at: i64,  // unix seconds (`exp`)
+}
+
+impl AuthenticationResult {
+    pub fn authenticated(security_context: SecurityContext) -> Self { /* principal: None */ }
+    pub fn with_principal(security_context: SecurityContext, principal: VerifiedPrincipal) -> Self { /* ... */ }
+}
+```
+
+Times are unix seconds (`i64`) to match how token claims (`iat`/`exp`/`auth_time`) arrive and how
+existing plugin identity types already model them.
+
+**Invariant:** if `principal` is `Some`, then `principal.subject_id == security_context.subject_id()`.
+The producing plugin is responsible for upholding this.
+
+### Placement
+
+`VerifiedPrincipal` lives in **`authn-resolver-sdk`** next to `AuthenticationResult` — not in
+`toolkit-security`. This keeps `SecurityContext` PDP-minimal and keeps profile/time claims as AuthN
+output.
+
+### Request flow
+
+```mermaid
+sequenceDiagram
+  participant MW as api_gateway_auth
+  participant AR as authn_resolver
+  participant Plugin as authn_plugin
+  participant H as handler
+
+  MW->>AR: authenticate(token)
+  AR->>Plugin: authenticate(token)
+  Plugin-->>AR: AuthenticationResult
+  AR-->>MW: result
+  MW->>MW: insert SecurityContext
+  opt principal present
+    MW->>MW: insert VerifiedPrincipal
+  end
+  MW->>H: request with extensions
+```
+
+### Consequences
+
+**Good:**
+
+- Correct boundary — the verified profile is scoped to the request that produced it.
+- `SecurityContext` stays PDP-minimal; the AuthN/AuthZ split (ADR 0002) is preserved.
+- Plugin trait unchanged (ADR 0003); plugins opt in per result.
+- Multi-replica safe — no reliance on process-local state for request correctness.
+
+**Bad:**
+
+- Breaking change to `AuthenticationResult` → SDK major bump (`cf-gears-authn-resolver-sdk`
+  `0.3.x → 0.4.0`) and a corresponding `cf-gears-api-gateway` bump; all construction sites migrate to
+  the constructors.
+- Handlers requiring a principal must handle its absence as a 5xx.
+
+### Rejected options
+
+- **Extend `SecurityContext` (B)** — bloats PDP identity with token metadata; contradicts DESIGN.md and
+  ADR 0002.
+- **Process-local cache (C)** — wrong correctness boundary; stale/missing on eviction, TTL, or across
+  replicas; the very failure mode this ADR removes.
+- **Token-digest handoff (D)** — extra middleware and a hashing side-channel for no benefit over
+  carrying the value on the request directly.
+- **Firebase/vendor DTOs in the gateway** — the gateway must stay provider-agnostic; `VerifiedPrincipal`
+  is the provider-neutral shape.
+
+## More Information
+
+- [DESIGN.md](../DESIGN.md) — Authentication and authorization design specification (AuthenticationResult, middleware steps).
+- [ADR 0002: Split AuthN and AuthZ Resolvers](./0002-split-authn-authz-resolvers.md)
+- [ADR 0003: AuthN Resolver Minimalist Interface](./0003-authn-resolver-minimalist-interface.md)

--- a/docs/arch/authorization/DESIGN.md
+++ b/docs/arch/authorization/DESIGN.md
@@ -370,8 +370,8 @@ api-gateway:
 Authentication is performed by **AuthN middleware** within the gear that accepts the request. The middleware:
 1. Extracts the bearer token from the request
 2. Calls **AuthN Resolver** to do authentication
-3. Receives `AuthenticationResult` containing validated subject identity
-4. Passes the `SecurityContext` from `AuthenticationResult` to the gear's handler (PEP)
+3. Receives `AuthenticationResult` containing validated subject identity (and, optionally, a `VerifiedPrincipal`)
+4. Passes the `SecurityContext` from `AuthenticationResult` to the gear's handler (PEP); when the result also carries a `VerifiedPrincipal`, the middleware inserts it into the request extensions as well (see [ADR 0005](./ADR/0005-verified-principal-request-extension.md))
 
 Authentication is handled by the **AuthN Resolver** — a gear with plugins and a minimalist interface that validates bearer tokens and produces `AuthenticationResult`.
 
@@ -444,7 +444,11 @@ sequenceDiagram
     Plugin->>Plugin: Map to AuthenticationResult
     Plugin-->>Resolver: AuthenticationResult
     Resolver-->>Middleware: AuthenticationResult
-    Middleware->>Handler: Request + SecurityContext
+    Middleware->>Middleware: Insert SecurityContext into request extensions
+    opt VerifiedPrincipal present
+        Middleware->>Middleware: Insert VerifiedPrincipal into request extensions
+    end
+    Middleware->>Handler: Request + SecurityContext (+ VerifiedPrincipal)
     Handler-->>Middleware: Response
     Middleware-->>Client: Response
 ```
@@ -457,8 +461,18 @@ The `AuthenticationResult` is returned by the AuthN Resolver upon successful aut
 pub struct AuthenticationResult {
     /// The validated security context.
     pub security_context: SecurityContext,
+
+    /// Optional verified profile/time claims for the same token (ADR 0005).
+    /// Populated only by plugins that expose them; most leave it `None`.
+    /// Kept off `SecurityContext` so the PDP identity stays minimal.
+    pub principal: Option<VerifiedPrincipal>,
 }
 ```
+
+Construct via `AuthenticationResult::authenticated(ctx)` (no principal) or
+`AuthenticationResult::with_principal(ctx, principal)`. When `principal` is `Some`, its `subject_id`
+equals `security_context.subject_id()`. Handlers that require a principal treat a missing extension on
+an authenticated request as an internal error (5xx), not a 401 — see [ADR 0005](./ADR/0005-verified-principal-request-extension.md).
 
 ### SecurityContext
 
@@ -468,7 +482,7 @@ The `SecurityContext` is extracted from `AuthenticationResult` and flows from Au
 use secrecy::Secret;
 
 SecurityContext {
-    subject_id: String,                    // required - from `sub` claim or IdP response
+    subject_id: Uuid,                      // required - internal, server-assigned subject id
     subject_type: Option<GtsTypeId>,       // optional - vendor-specific subject type
     subject_tenant_id: TenantId,           // required - Subject Tenant
     token_scopes: Vec<String>,             // required - capability restrictions (["*"] for first-party)
@@ -493,6 +507,48 @@ SecurityContext {
 - The token is included for:
   1. **PDP validation** — In out-of-process deployments, AuthZ Resolver may independently validate the token for defense-in-depth
   2. **Forwarding** — AuthZ Resolver plugin may need to call external vendor services requiring authentication
+
+### VerifiedPrincipal
+
+`SecurityContext` is the **authorization** identity: it stays PDP-minimal and carries only what the PDP
+needs to make a decision. But some handlers also need the caller's **verified profile** — email,
+identity provider, anonymous flag, and token timestamps — for the *same* token that authenticated the
+request. The canonical case is a product-facing `GET /me` endpoint that returns the backend-verified
+profile so clients and downstream features rely on server-verified identity instead of trusting
+client-supplied hints (the internal `subject_id`, for instance, is server-assigned and cannot be
+computed by the client).
+
+Those profile claims do **not** belong on `SecurityContext` (that would bloat the PDP identity and blur
+the AuthN/AuthZ boundary — see [ADR 0002](./ADR/0002-split-authn-authz-resolvers.md)). Instead, the
+AuthN Resolver may attach an optional, provider-agnostic `VerifiedPrincipal` to `AuthenticationResult`,
+and the AuthN middleware inserts it into the request extensions alongside `SecurityContext`. Carrying it
+on the request — rather than looking it up from a process-local cache — guarantees the handler reads the
+profile derived from *this* request's token (correct across evictions, TTLs, and replicas).
+
+```rust
+pub struct VerifiedPrincipal {
+    subject_id: Uuid,               // matches SecurityContext.subject_id
+    external_subject: String,       // IdP `sub` / provider UID
+    issuer: String,                 // token `iss`
+    email: Option<String>,
+    email_verified: Option<bool>,
+    provider: String,               // identity provider / sign-in method
+    is_anonymous: bool,
+    issued_at: i64,                 // unix seconds (`iat`)
+    auth_time: i64,                 // unix seconds
+    expires_at: i64,                // unix seconds (`exp`)
+}
+```
+
+**Notes:**
+- **Optional** — most plugins/routes never need it, so plugins leave it `None` and the field costs them
+  nothing (`AuthenticationResult::authenticated(ctx)`). Plugins that expose a profile use
+  `AuthenticationResult::with_principal(ctx, principal)`.
+- **Invariant** — when present, `principal.subject_id == security_context.subject_id()`.
+- **Missing on a route that requires it** → treat as an internal error (5xx), not 401: absence is a
+  wiring problem, not a failed credential, and a 401 would trigger client token-refresh loops.
+- See [ADR 0005](./ADR/0005-verified-principal-request-extension.md) for the full rationale and rejected
+  alternatives (extending `SecurityContext`, a process-local cache, a token-digest handoff).
 
 ### Plugin Responsibilities
 


### PR DESCRIPTION
Document the decision to carry verified profile claims (email, provider, is_anonymous, token times) on AuthenticationResult/request extensions instead of a process-local ClientHub cache, which is the wrong correctness boundary (stale/missing on eviction, TTL, or across replicas). Keeps SecurityContext PDP-minimal (per ADR 0002) and adds no new AuthNResolverPluginClient method (per ADR 0003).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented support for optional, server-verified identity profiles alongside authentication context.
  * Defined available identity and token claims, including subject, issuer, provider, email verification, anonymity, and timestamps.
  * Clarified identity consistency requirements and error handling when required identity information is unavailable.
  * Updated authentication flow and architecture documentation to describe request-level identity propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->