### PR TITLE
fix(cluster): reference cluster-conformance by path to unblock publish

### DIFF
--- a/gears/system/cluster/cluster/Cargo.toml
+++ b/gears/system/cluster/cluster/Cargo.toml
@@ -40,4 +40,6 @@ tracing-test = { workspace = true }
 parking_lot = { workspace = true }
 # The shared backend-agnostic conformance suite, run against this gear's real
 # cache-derived default backends in `tests/conformance.rs`.
-cf-gears-cluster-conformance = { workspace = true }
+# Path-only, no version on purpose: cargo drops a path-only dev-dependency from the published
+# manifest, so publishing this gear never needs the conformance crate on crates.io.
+cf-gears-cluster-conformance = { path = "../cluster-conformance" }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build configuration to keep conformance tooling out of published package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->