### PR TITLE
feat(account-management): implement `update_user` for `LazyIdpProvider`

### DIFF
--- a/gears/system/account-management/account-management/src/infra/idp/lazy.rs
+++ b/gears/system/account-management/account-management/src/infra/idp/lazy.rs
@@ -52,7 +52,8 @@ use std::sync::Arc;
 use account_management_sdk::{
     IdpDeprovisionFailure, IdpDeprovisionTenantRequest, IdpDeprovisionUserRequest,
     IdpListUsersRequest, IdpPluginClient, IdpPluginSpecV1, IdpProvisionFailure, IdpProvisionResult,
-    IdpProvisionTenantRequest, IdpProvisionUserRequest, IdpUser, IdpUserOperationFailure,
+    IdpProvisionTenantRequest, IdpProvisionUserRequest, IdpUpdateUserRequest, IdpUser,
+    IdpUserOperationFailure,
 };
 use async_trait::async_trait;
 use toolkit::ClientHub;
@@ -254,6 +255,26 @@ impl IdpPluginClient for LazyIdpProvider {
             })
         } else {
             self.fallback.deprovision_user(ctx, req).await
+        }
+    }
+
+    async fn update_user(
+        &self,
+        ctx: &SecurityContext,
+        req: &IdpUpdateUserRequest,
+    ) -> Result<IdpUser, IdpUserOperationFailure> {
+        if let Some(plugin) = self.resolve().await {
+            return plugin.update_user(ctx, req).await;
+        }
+        if self.required {
+            Err(IdpUserOperationFailure::Unavailable {
+                detail: format!(
+                    "idp provider plugin (vendor `{}`) not yet resolvable",
+                    self.vendor
+                ),
+            })
+        } else {
+            self.fallback.update_user(ctx, req).await
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for updating users through deferred identity provider integrations, enabling account management flows to refresh existing user details.
* **Bug Fixes**
  * Improved handling when an identity provider is not yet resolvable: returns an “unavailable” error when required, and applies a safe no-op fallback when optional.
* **Chores**
  * Minor SDK import formatting cleanup (no user-facing impact).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->