### PR TITLE
chore: ignore admin-panel frontend build artifacts at the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,14 @@ logs
 # Code coverage reports
 /coverage/
 
+# Frontend build artifacts (apps/admin-panel SPA); unanchored, so they match at any depth
+# npm dependency tree
+node_modules/
+# Vite build output (outDir: "dist")
+dist/
+# tsc -b incremental cache
+*.tsbuildinfo
+
 # Fuzzing artifacts
 /fuzz/target/
 /fuzz/artifacts/


### PR DESCRIPTION
Building the admin-panel SPA leaves `node_modules/`, Vite's `dist/` and `tsconfig.tsbuildinfo` behind, and `apps/admin-panel/.gitignore` only exists on branches carrying the SPA sources — so every other branch shows them as untracked noise in `git status`.

All three patterns are unanchored on purpose: a pattern with an interior slash such as `dist/assets/` is anchored to the directory holding the `.gitignore`, so at the repo root it would not match `apps/admin-panel/dist/assets/`.

Verified: `git status --untracked-files=all -- apps/admin-panel` is now empty, and `git ls-files -i -c --exclude-standard` is empty, so no tracked file is shadowed.