### PR TITLE
feat(toolkit/oop): out-of-process HTTP serving lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2651,9 +2651,12 @@ dependencies = [
  "cf-gears-toolkit-canonical-errors",
  "cf-gears-toolkit-db",
  "cf-gears-toolkit-gts",
+ "cf-gears-toolkit-http-middleware",
+ "cf-gears-toolkit-k8s-auth",
  "cf-gears-toolkit-macros",
  "cf-gears-toolkit-odata",
  "cf-gears-toolkit-sdk",
+ "cf-gears-toolkit-security",
  "cf-gears-toolkit-utils",
  "chrono",
  "dashmap",
@@ -2890,6 +2893,18 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tower",
+ "tracing",
+]
+
+[[package]]
+name = "cf-gears-toolkit-k8s-auth"
+version = "0.1.0"
+dependencies = [
+ "cf-gears-toolkit-security",
+ "k8s-openapi",
+ "kube",
+ "thiserror 2.0.18",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "libs/toolkit-gts-macros",
     "libs/toolkit-http",
     "libs/toolkit-http-middleware",
+    "libs/toolkit-k8s-auth",
     "libs/toolkit-sdk",
     "libs/toolkit-odata-macros",
     "libs/toolkit-security",
@@ -244,6 +245,8 @@ verbose_file_reads = "deny"
 # libs
 toolkit = { package = "cf-gears-toolkit", version = "0.6.17", path = "libs/toolkit" }
 toolkit-http = { package = "cf-gears-toolkit-http", version = "0.6.9", path = "libs/toolkit-http" }
+toolkit-http-middleware = { package = "cf-gears-toolkit-http-middleware", version = "0.1.0", path = "libs/toolkit-http-middleware" }
+toolkit-k8s-auth = { package = "cf-gears-toolkit-k8s-auth", version = "0.1.0", path = "libs/toolkit-k8s-auth" }
 toolkit-auth = { package = "cf-gears-toolkit-auth", version = "0.7.3", path = "libs/toolkit-auth" }
 toolkit-canonical-errors = { package = "cf-gears-toolkit-canonical-errors", version = "0.7.6", path = "libs/toolkit-canonical-errors" }
 toolkit-canonical-errors-macro = { package = "cf-gears-toolkit-canonical-errors-macro", version = "0.6.2", path = "libs/toolkit-canonical-errors-macro" }

--- a/docs/arch/toolkit-oop/ADR/0004-cpt-cf-adr-helm-chart-organization.md
+++ b/docs/arch/toolkit-oop/ADR/0004-cpt-cf-adr-helm-chart-organization.md
@@ -23,8 +23,8 @@ DRY (no duplicated templates), and (d) users with existing k8s clusters can easi
 
 * **Independent deployability**: each gear is a separate microservice in Profile 3 — its chart must be self-contained
   and installable standalone.
-* **DRY templates**: all ToolKit gears share the same structure (HTTP server on configurable port, `/healthz` +
-  `/readyz` probe endpoints provided by ToolKit runtime, optional gRPC, config via env/ConfigMap). Duplicating
+* **DRY templates**: all ToolKit gears share the same structure (HTTP server on configurable port, `/healthz`,
+  `/readyz`, and `/health` probe endpoints provided by ToolKit runtime, optional gRPC, config via env/ConfigMap). Duplicating
   Deployment/Service/Ingress templates across 20+ gears is unmaintainable.
 * **One-command platform install**: operators deploying the full platform should not need to install 15 charts manually.
   An umbrella chart with sensible defaults is essential.

--- a/docs/arch/toolkit-oop/ADR/0005-cpt-cf-adr-eventual-readiness.md
+++ b/docs/arch/toolkit-oop/ADR/0005-cpt-cf-adr-eventual-readiness.md
@@ -61,22 +61,36 @@ existing `deps` metadata for readiness gating.
 * Liveness returns `200 OK` as soon as the HTTP server is listening (process is alive, not deadlocked).
 * **Readiness has four states** mapped to the gear lifecycle:
     - **Starting** → `503` with body `{"state":"starting","unresolved_deps":[...]}`. Returned until all `deps` are
-      resolved AND every registered custom check returns `Ready`.
+      resolved AND the gear's registered healthcheck reports it can serve (`Healthy`/`Degraded`).
     - **Ready** → `200` with body `{"state":"ready"}`. Gear is fully serving traffic.
-    - **Degraded** → `200` with body `{"state":"degraded","reasons":[...]}`. At least one custom check returned
-      `Degraded` (e.g. Redis down, but cache fallback is acceptable). Still serves traffic — operators read the body to
-      decide whether to page.
+    - **Degraded** → `200` with body `{"state":"degraded"}`. The gear's healthcheck returned
+      `Degraded` (e.g. Redis down, but cache fallback is acceptable). Still serves traffic; operators read `/health`
+      for the per-component report to decide whether to page.
     - **Draining** → `503` with body `{"state":"draining"}`. Set by the SIGTERM handler before deregistering from
       DirectoryService, so kubernetes / gateway upstream removes the instance from LB pools while in-flight requests
-      complete (see DESIGN.md § Drain order).
-* Gears MAY register custom readiness checks via `ctx.runtime().register_readiness_check(name, impl ReadinessCheck)`.
-  Checks are polled on every `/readyz` request with 1s cache; `NotReady` from any check forces `Starting` state.
-* Gears with no `deps` and no custom checks (e.g., Flight Control itself, types-registry) become ready immediately
+      complete (see `cpt-cf-component-oop-bootstrap`).
+    - The body carries a boolean `ready` mirror (`true` for `ready`/`degraded`) so clients need not know
+      the `state → status` mapping. `unresolved_deps` is omitted when empty.
+    - A separate `/health` endpoint returns the full `health` report (aggregate `status` + per-component detail,
+      identical to the in-process `api-gateway` `/health` body). `/readyz` uses this report internally to determine
+      readiness, but does not echo it in its response body.
+    - **Registration status is not a readiness signal.** Self-registration is a background retry loop; transient
+      DirectoryService or network failures must not pull a healthy pod out of rotation. Directory visibility is
+      tracked by heartbeats, logs, and metrics (and can be exposed as a `/health` component), not by the readiness
+      probe.
+* Readiness reuses the framework's standard healthcheck mechanism: a gear returns one composite `Healthcheck` from
+  `RestApiCapability::healthcheck()` and it is honored identically in-process (`api-gateway`) and OoP. The OoP bootstrap
+  aggregates these in a shared `RestHealthcheckRegistry`, evaluated on every `/readyz` and `/health` request (checks run
+  concurrently, timeout-bounded, panic-isolated, cached to avoid storm; per-check timeout configurable via
+  `oop_http.healthcheck_timeout_ms`). `Unhealthy` from the check forces `Starting`/`503`; `Degraded` stays `200`.
+  The full per-component health report is returned by `/health`; `/readyz` only uses the aggregate status internally.
+* Gears with no `deps` and no healthcheck (e.g., Flight Control itself, types-registry) become ready immediately
   after `start()`.
-* **Use `startupProbe` for slow-bootstrapping gears.** k8s `startupProbe` runs before liveness/readiness and has its
-  own (typically longer) failure budget. A gear that needs ≥30s to warm caches or fetch initial state from a remote
-  source MUST declare a `startupProbe` in its Helm chart pointing at `/readyz` with `failureThreshold` sized to its
-  worst-case bootstrap time. Without `startupProbe`, the liveness budget would force k8s to kill the pod mid-bootstrap.
+* **`startupProbe` is an optional safety-net.** The framework serves `/healthz` as soon as the listener binds —
+  *before* the gear's `start()` phase (see `cpt-cf-component-oop-bootstrap`) — so a slow bootstrap no longer trips the
+  liveness budget and a `startupProbe` is **not** required. Gears with very long bootstraps MAY still declare one
+  (pointing at `/readyz`) to defer liveness/readiness evaluation and suppress not-ready noise during a known startup
+  window.
 * The Helm chart library (`toolkit-common`) configures `livenessProbe`, `readinessProbe`, and a conservative
   `startupProbe` (failureThreshold=30, periodSeconds=5 → 150s bootstrap budget) by default; gears tune
   `startupProbe.failureThreshold` per their `deps` count and external-resource expectations. No init containers are
@@ -157,6 +171,7 @@ The OoP bootstrap (`toolkit::bootstrap::oop`) gains these framework-managed beha
 │  1. Start HTTP server (Axum)                             │
 │     └─ /healthz → 200 (immediate)                        │
 │     └─ /readyz  → 503 until deps resolved                │
+│     └─ /health  → full healthcheck report                │
 │     └─ /openapi.json → gear's OpenAPI spec               │
 │     └─ /{gear-routes} → gear's OperationBuilder routes   │
 │                                                          │
@@ -182,43 +197,45 @@ The OoP bootstrap (`toolkit::bootstrap::oop`) gains these framework-managed beha
 
 **`/healthz` (liveness)**:
 
-```json
-{
-  "status": "alive"
-}
+```
+ok
 ```
 
-Always 200 once HTTP server is up.
+Always `200 OK` with the plain body `ok` once the HTTP server is listening.
 
-**`/readyz` (readiness)** — not ready:
-
-```json
-{
-  "status": "starting",
-  "deps": {
-    "authn-resolver": "waiting",
-    "types-registry": "resolved"
-  },
-  "registered": false
-}
-```
-
-Returns 503.
-
-**`/readyz` (readiness)** — ready:
+**`/readyz` (readiness)** — not ready (`503`):
 
 ```json
 {
-  "status": "ready",
-  "deps": {
-    "authn-resolver": "resolved",
-    "types-registry": "resolved"
-  },
-  "registered": true
+  "state": "starting",
+  "ready": false,
+  "unresolved_deps": ["authn-resolver"]
 }
 ```
 
-Returns 200.
+The `503` status comes from `ready: false`.
+
+**`/readyz` (readiness)** — ready (`200`):
+
+```json
+{
+  "state": "ready",
+  "ready": true
+}
+```
+
+`unresolved_deps` is omitted from the body when empty.
+
+**`/health` (diagnostics)** — healthy (`200`):
+
+```json
+{
+  "status": "healthy",
+  "components": []
+}
+```
+
+`/health` returns the full per-component `HealthcheckReport` (same body as `api-gateway` `/health`). `Unhealthy` returns `503`; `Healthy` and `Degraded` return `200`.
 
 ### Interaction with Existing `deps` Macro
 

--- a/docs/arch/toolkit-oop/DESIGN.md
+++ b/docs/arch/toolkit-oop/DESIGN.md
@@ -44,7 +44,7 @@ OoP gear lifecycle, discovery coordination, and gateway registration. The archit
    similar) registers routes via the gateway's admin API or CRDs.
 
 4. **SecurityContext propagates across process boundaries** (tenant plane) by forwarding `Authorization: Bearer <jwt>`,
-   which each hop **re-validates** via AuthN Resolver (ADR-0008). Infra calls use a separate tenant-less platform-plane
+   which each hop **re-validates** via AuthN Resolver (cpt-cf-adr-two-plane-auth). Infra calls use a separate tenant-less platform-plane
    identity (SA token first phase, mTLS+SPIFFE next). `x-secctx-bin` is not used over HTTP.
 
 ### 1.2 Architecture Drivers
@@ -57,7 +57,7 @@ OoP gear lifecycle, discovery coordination, and gateway registration. The archit
 | `cpt-cf-fr-client-transparency`    | ClientHub returns in-process impl or generated `RestXxxClient` based on DirectoryService resolution. Callers use the same SDK trait.                                                     |
 | `cpt-cf-fr-rest-primary`           | Each OoP gear runs Axum with full ToolKit middleware. No gRPC bridge or transcoding layer.                                                                                              |
 | `cpt-cf-fr-direct-communication`   | Generated REST clients resolve target endpoints via DirectoryService (or k8s DNS) and call directly. Gateway is not in the inter-gear path.                                            |
-| `cpt-cf-fr-secctx-propagation`     | `toolkit-http` forwards `Authorization: Bearer <jwt>`; OoP `security_context_middleware` re-validates it via AuthN Resolver and reconstructs SecurityContext (ADR-0008). No `x-secctx-bin` over HTTP.                                                          |
+| `cpt-cf-fr-secctx-propagation`     | `toolkit-http` forwards `Authorization: Bearer <jwt>`; OoP `security_context_middleware` re-validates it via AuthN Resolver and reconstructs SecurityContext (cpt-cf-adr-two-plane-auth). No `x-secctx-bin` over HTTP.                                                          |
 | `cpt-cf-fr-gateway-registration`   | OoP bootstrap calls `GatewayProvider::register_routes()` after HTTP server starts.                                                                                                       |
 | `cpt-cf-fr-gateway-abstraction`    | `GatewayProvider` trait with `ToolKitGatewayProvider` as first implementation.                                                                                                            |
 | `cpt-cf-fr-rest-client-gen`        | Trait-first codegen: `#[toolkit::rest_contract]` emits `RestXxxClient` from the SDK trait (`openapi.json` is a published output, not a codegen input).                                     |
@@ -68,7 +68,7 @@ OoP gear lifecycle, discovery coordination, and gateway registration. The archit
 | NFR ID                            | NFR Summary                  | Allocated To                                               | Design Response                                                                           | Verification Approach                                            |
 |-----------------------------------|------------------------------|------------------------------------------------------------|-------------------------------------------------------------------------------------------|------------------------------------------------------------------|
 | `cpt-cf-nfr-oop-latency`          | OoP call overhead < 5 ms p95 (localhost; 10 ms k8s) | `toolkit-http`, OoP HTTP server                             | Connection pooling in `toolkit-http`; Axum's zero-copy routing; UDS transport on same-host | Automated benchmark: 1000 echo requests, measure p95             |
-| `cpt-cf-nfr-per-hop-revalidation`  | One JWT verify per hop (~0.5 ms) | `api-gateway` authn + OoP `security_context_middleware` | Each hop re-validates via `authn-resolver` with cached JWKS (ADR-0008); single IdP trust root | Latency benchmark + forged-signature rejection test |
+| `cpt-cf-nfr-per-hop-revalidation`  | One JWT verify per hop (~0.5 ms) | `api-gateway` authn + OoP `security_context_middleware` | Each hop re-validates via `authn-resolver` with cached JWKS (cpt-cf-adr-two-plane-auth); single IdP trust root | Latency benchmark + forged-signature rejection test |
 | `cpt-cf-nfr-graceful-degradation` | Unavailable OoP → 503        | Generated REST client, `toolkit-http`                       | `toolkit-http` timeout + connection error → mapped to 503 Problem response                 | Integration test: stop target, assert 503                        |
 
 #### Key ADRs
@@ -209,7 +209,7 @@ MUST continue to work without modification.
 - [ ] `p1` - **ID**: `cpt-cf-constraint-secctx-serde`
 
 The `bearer_token` field on SecurityContext is `#[serde(skip)]`. Per
-[ADR-0008](ADR/0008-cpt-cf-adr-two-plane-auth.md), HTTP propagation carries only `Authorization: Bearer <jwt>`; the
+[cpt-cf-adr-two-plane-auth](ADR/0008-cpt-cf-adr-two-plane-auth.md), HTTP propagation carries only `Authorization: Bearer <jwt>`; the
 receiving gear re-validates it via AuthN Resolver and reconstructs the full SecurityContext (including the bearer
 token). `encode_bin` / `decode_bin` (which exclude `bearer_token`) remain in use only for in-process gRPC metadata
 (Profile 1).
@@ -231,7 +231,7 @@ token). `encode_bin` / `decode_bin` (which exclude `bearer_token`) remain in use
 | ServiceEndpoint          | Extended with `rest_url` field. Represents a discovered gear's HTTP endpoint.                   |
 | RegisterInstanceInfo     | Extended with `rest_endpoint` and `openapi_spec` fields for REST service registration.            |
 | GatewayRouteRegistration | Struct carrying gear name, OpenAPI spec, and target endpoint for gateway registration.          |
-| SecurityContextHeaders   | Helper for single-header tenant-plane propagation (`Authorization: Bearer <jwt>`), re-validated per hop (ADR-0008). |
+| SecurityContextHeaders   | Helper for single-header tenant-plane propagation (`Authorization: Bearer <jwt>`), re-validated per hop (cpt-cf-adr-two-plane-auth). |
 
 ### 3.2 Component Model
 
@@ -291,7 +291,7 @@ The host side (`libs/toolkit/src/runtime/host_runtime.rs`, `run_oop_spawn_phase`
 What is **missing** and needs to be added:
 
 - Starting an Axum HTTP server from the gear's OperationBuilder routes.
-- Framework-managed `/healthz` (liveness) and `/readyz` (readiness) probe endpoints.
+- Framework-managed `/healthz` (liveness), `/readyz` (readiness), and `/health` (diagnostics) probe endpoints.
 - Background self-registration with Flight Control (DirectoryService) — retry with exponential backoff, re-register on
   connection loss.
 - Background dependency resolution — poll DirectoryService for each `deps` entry, wire REST clients into ClientHub as
@@ -306,29 +306,44 @@ What is **missing** and needs to be added:
 ##### Responsibility scope
 
 - Start an Axum HTTP server from the gear's OperationBuilder routes.
-- **Provide `/healthz` and `/readyz` probe endpoints** (framework-level, not gear code):
-    - `/healthz` → `200` as soon as HTTP server is listening (process alive).
-    - `/readyz` → `503` with unresolved deps list until all `deps` are resolved AND every registered custom check
-      returns `Ready`; then `200`.
+- **Provide `/healthz`, `/readyz`, and `/health` probe endpoints** (framework-level, not gear code):
+    - `/healthz` → `200` from the moment the listener binds — **before** `start()`. The framework serves probes first
+      (gear routes reply `503 starting`) and atomically swaps the composed gear routes in after `start()` (no port
+      rebind), so liveness survives a slow startup without needing a `startupProbe`.
+    - `/readyz` → `503` with unresolved deps list until all `deps` are resolved AND the gear's registered
+      healthcheck reports it can serve (`Healthy`/`Degraded`); then `200`. The JSON body is state-tagged
+      (`{"state":"starting|ready|degraded|draining", ...}`) — see cpt-cf-adr-eventual-readiness for the schema.
+      The body does not include the full health report; that belongs on `/health`.
+    - `/health` → full per-component `HealthcheckReport` (`status` + `components`). `200` for `Healthy`/`Degraded`,
+      `503` for `Unhealthy` — identical to the in-process `api-gateway` `/health` body.
     - **Probes MAY be exposed on a separate bind address** via `probe_bind_addr` config (default: same as main
-      HTTP server). Operators typically route `/healthz`, `/readyz`, `/metrics` to a sidecar port that is NOT
+      HTTP server). Operators typically route `/healthz`, `/readyz`, `/health`, `/metrics` to a sidecar port that is NOT
       mapped through the k8s Service so external traffic cannot reach them.
-- **Custom readiness checks**: gears MAY register additional checks via the runtime API:
+- **Custom readiness checks**: readiness reuses the framework's standard healthcheck mechanism, so a gear expresses
+  readiness once and it is honored identically whether the gear is hosted in-process by `api-gateway` or run OoP. A
+  gear returns **one composite healthcheck** from its REST capability:
 
     ```rust
-    ctx.runtime().register_readiness_check("cache_warm", Arc::new(MyCacheCheck));
-    ctx.runtime().register_readiness_check("indexer_bootstrapped", Arc::new(MyIndexerCheck));
+    impl RestApiCapability for MyGear {
+        fn healthcheck(&self, ctx: &GearCtx) -> Option<Arc<dyn Healthcheck>> {
+            Some(Arc::new(MyGearHealthcheck { /* deps snapshot */ }))
+        }
+    }
 
     #[async_trait]
-    pub trait ReadinessCheck: Send + Sync {
-        async fn check(&self) -> CheckResult; // Ready / NotReady { reason } / Degraded { reason }
+    pub trait Healthcheck: Send + Sync + 'static {
+        fn name(&self) -> &'static str;
+        async fn check(&self) -> HealthcheckResult; // healthy / degraded(msg) / unhealthy(msg)
     }
     ```
 
-    Registered checks are evaluated on every `/readyz` request (cached for 1s to avoid storm). `NotReady` from any
-    check forces `/readyz → 503` and lists the failing check name + reason. `Degraded` is reported in the JSON body
-    but still returns `200` — distinguishes "can serve traffic but with reduced functionality" from "can't serve
-    traffic at all" (Spring Boot-style health groups).
+    The OoP bootstrap collects each gear's `healthcheck()` into a shared `RestHealthcheckRegistry` (the same registry
+    the `api-gateway` host uses) during router composition. The registry is evaluated on both `/readyz` and `/health`
+    requests, with the same run behavior — timeout-bounded, panic-isolated, message-sanitized, and cached (2s) to
+    avoid storm. `ReadinessState` layers the OoP-only concerns (unresolved-deps gating + drain flip) on top. `Unhealthy`
+    forces `/readyz → 503`; `Degraded` still returns `200` (`state = degraded`) but the per-component detail stays on
+    `/health`. `/health` returns the full per-component report (Spring Boot-style health groups). The per-check timeout is configurable via
+    `oop_http.healthcheck_timeout_ms` (default 500ms).
 - **Background self-registration** with Flight Control (DirectoryService):
     - Retry `RegisterInstance()` with exponential backoff (100ms → 200ms → ... → 30s cap).
     - Re-register on connection loss or Flight Control restart.
@@ -342,10 +357,12 @@ What is **missing** and needs to be added:
 - **Initialize `InternalCredential`** from configuration (bootstrap token from env, SA token from projected volume) and
   attach to all system-level outgoing calls automatically.
 - **Install `InternalAuthMiddleware`** (platform plane) to validate incoming system calls — SA token in the first
-  phase; sets `PeerAuthenticated` for workload policy (ADR-0006).
-- Attach `security_context_middleware` (tenant plane) that re-validates the forwarded JWT via AuthN Resolver and reconstructs
-  SecurityContext.
-- Send heartbeats to DirectoryService (already implemented).
+  phase; sets `PeerAuthenticated` for workload policy (cpt-cf-adr-platform-plane-auth).
+- Attach `security_context_middleware` (tenant plane) that delegates forwarded-JWT validation to the AuthN Resolver and reconstructs
+  `SecurityContext` from the resolver result; it does not perform validation itself.
+- Maintain DirectoryService presence via a **single** background task (`oop_registration::presence_loop`) that owns
+  registration, periodic heartbeats, and idempotent self-heal re-registration — one writer per instance record, so
+  heartbeat and re-registration can never race to conflicting liveness state.
 - Deregister from DirectoryService on graceful shutdown.
 - Call GatewayProvider to register/deregister public routes.
 
@@ -369,7 +386,8 @@ extended for the cross-process case:
    process this is the in-process `HostRuntime` topo order; across processes it relies on (4) — the orchestrator /
    k8s preStop hook is responsible for ordering pod termination via dependency-aware shutdown, NOT via simultaneous
    `SIGTERM` blasts.
-6. **Stop runtime services** — heartbeat task, registration retry task, internal-auth refresh task.
+6. **Stop runtime services** — the presence task (heartbeat + registration/self-heal, stopped when the root token is
+   cancelled) and the internal-auth refresh task.
 7. **Close HTTP listener and exit.**
 
 In Profile 1 (in-process), steps 1-3 are no-ops (no LB to flip); the reverse-topo STOP loop in `HostRuntime` handles
@@ -378,7 +396,7 @@ reverse-dependency order; this is documented as an operator requirement, not enf
 
 ##### Responsibility boundaries
 
-- Does NOT validate JWTs (that is the gateway's job).
+- Does NOT validate JWTs itself — it delegates forwarded-JWT validation to the AuthN Resolver and reconstructs `SecurityContext` from the result.
 - Does NOT manage gear business logic (delegates to the Gear trait).
 - Does NOT implement service discovery (delegates to DirectoryService).
 - Does NOT require gear developers to write any retry, probe, registration, or internal auth code — all handled by the
@@ -505,7 +523,7 @@ gears, the gateway needs to reverse-proxy requests to remote OoP gears.
 - Provide `ToolKitGatewayProvider`: parses the OpenAPI spec to extract public route paths (where
   `OperationSpec.is_public == true`), adds reverse-proxy routes to the built-in api-gateway using
   `toolkit-http::HttpClient` to forward requests to OoP gears. Must forward the `Authorization: Bearer <jwt>` header
-  (re-validated downstream per ADR-0008) on the proxied request.
+  (re-validated downstream per cpt-cf-adr-two-plane-auth) on the proxied request.
 - Future: `KongGatewayProvider`, `TykGatewayProvider`.
 
 ##### Responsibility boundaries
@@ -643,7 +661,7 @@ Pipeline:
 ##### Why this component exists
 
 When a gear runs out-of-process, the tenant `SecurityContext` must be rebuilt on the far side of each hop. The chosen
-model (ADR-0008) forwards the original `Authorization: Bearer <jwt>` as-is and **re-validates** it at every hop,
+model (cpt-cf-adr-two-plane-auth) forwards the original `Authorization: Bearer <jwt>` as-is and **re-validates** it at every hop,
 reconstructing `SecurityContext` from the validated claims — rather than serializing the context into an envelope. This
 component owns that single-header propagation + re-validation path. Because `bearer_token` is `#[serde(skip)]`, there is
 no serialized context on the wire anyway: the JWT in the header is the only thing carried, and the receiving gear
@@ -678,7 +696,7 @@ rebuilds the full context (including the bearer token) from it.
 
 ##### Responsibility boundaries
 
-- Re-validates the JWT at each hop (the gateway validated it too — intentional defense in depth per ADR-0008).
+- Re-validates the JWT at each hop (the gateway validated it too — intentional defense in depth per cpt-cf-adr-two-plane-auth).
 - Does NOT decide whether to propagate (callers decide by including SecurityContext in the call context).
 
 ##### Related components (by ID)
@@ -692,12 +710,12 @@ rebuilds the full context (including the bearer token) from it.
 
 ##### Why this component exists
 
-The tenant plane (per-hop JWT re-validation, ADR-0008) covers user-initiated traffic (JWT → SecurityContext). But
+The tenant plane (per-hop JWT re-validation, cpt-cf-adr-two-plane-auth) covers user-initiated traffic (JWT → SecurityContext). But
 system-level calls — registration with DirectoryService, heartbeats, background inter-gear calls — have no user context.
 Without authentication, any process that can reach DirectoryService can register as a gear or deregister others. This
 component implements the platform-plane authentication mechanism defined in
-[ADR-0006](ADR/0006-cpt-cf-adr-platform-plane-auth.md) (SA tokens first, mTLS+SPIFFE next); the `PlatformSecurityContext`
-contract it carries is defined by the two-plane model ([ADR-0008](ADR/0008-cpt-cf-adr-two-plane-auth.md)).
+[cpt-cf-adr-platform-plane-auth](ADR/0006-cpt-cf-adr-platform-plane-auth.md) (SA tokens first, mTLS+SPIFFE next); the `PlatformSecurityContext`
+contract it carries is defined by the two-plane model ([cpt-cf-adr-two-plane-auth](ADR/0008-cpt-cf-adr-two-plane-auth.md)).
 
 ##### Current state
 
@@ -738,7 +756,7 @@ pub enum InternalCredential {
 4. Flight Control validates via k8s TokenReview API (cached, configurable TTL).
 5. Response includes gear identity: `{namespace, serviceAccountName, podName}`.
 
-**One plane per request** (per [ADR-0008](ADR/0008-cpt-cf-adr-two-plane-auth.md)): a request carries either the tenant
+**One plane per request** (per [cpt-cf-adr-two-plane-auth](ADR/0008-cpt-cf-adr-two-plane-auth.md)): a request carries either the tenant
 plane (user JWT) or the platform plane (gear identity), not both. The two planes travel in distinct headers.
 
 | Call type                            | Plane          | Header                                                       |
@@ -773,7 +791,7 @@ Neither is ever passed to the tenant `PolicyEnforcer`, and neither substitutes f
 ###### Platform SecurityContext (non-tenant operations)
 
 Platform-scoped operations carry a dedicated **`PlatformSecurityContext`** — a type **distinct** from the tenant
-`SecurityContext`, per [ADR-0008](ADR/0008-cpt-cf-adr-two-plane-auth.md). It is **not** a tenant context with a
+`SecurityContext`, per [cpt-cf-adr-two-plane-auth](ADR/0008-cpt-cf-adr-two-plane-auth.md). It is **not** a tenant context with a
 nil/sentinel tenant id. The separation is deliberate: reusing the request-scoped tenant context for platform
 calls is the seam where confused-deputy / cross-tenant-leak regressions begin, so a separate type makes "no tenant"
 unrepresentable-as-a-tenant.
@@ -842,7 +860,7 @@ belong on the tenant plane — they are *not* candidates for `PlatformSecurityCo
 
 ##### Responsibility boundaries
 
-- Does NOT replace tenant-plane SecurityContext propagation (ADR-0008) — those are complementary layers.
+- Does NOT replace tenant-plane SecurityContext propagation (cpt-cf-adr-two-plane-auth) — those are complementary layers.
 - Does NOT manage k8s ServiceAccount creation (that's the Helm chart / operator's job).
 - Does NOT implement mTLS (P2 scope for multi-node Profile 2).
 
@@ -955,8 +973,9 @@ Key design decisions:
 
 | Method | Path               | Description                                  | Response                                                             | Stability |
 |--------|--------------------|----------------------------------------------|----------------------------------------------------------------------|-----------|
-| `GET`  | `/healthz`         | Liveness probe — process alive               | `200` always (once HTTP server up)                                   | stable    |
-| `GET`  | `/readyz`          | Readiness probe — deps resolved              | `200` when all `deps` resolved; `503` with unresolved list otherwise | stable    |
+| `GET`  | `/healthz`         | Liveness probe — process is up               | `200` + plain text body `ok` (from listener bind, before `start()`)    | stable    |
+| `GET`  | `/readyz`          | Readiness probe — critical `deps` resolved **and** gear healthcheck reports `Healthy` or `Degraded` | `200` + state-tagged JSON (`state: ready` or `state: degraded`) when ready; `503` + JSON (`state: starting` with `unresolved_deps`, or `state: draining` during shutdown) otherwise | stable    |
+| `GET`  | `/health`          | Diagnostic health report                     | `200`/`503` + full `HealthcheckReport` JSON (`status` + `components`) | stable    |
 | `GET`  | `/.well-known/openapi.json` | Gear's OpenAPI spec (canonical discovery path; fetched by the service directory at registration) | `200` + JSON                                                         | stable    |
 | `*`    | `/{gear-routes}` | Gear-specific routes from OperationBuilder | per-gear                                                           |
 
@@ -1064,7 +1083,7 @@ sequenceDiagram
 
 **Description**: An external request enters through api-gateway, which validates the JWT via authn-resolver and
 reverse-proxies to the target OoP gear, forwarding `Authorization: Bearer <jwt>`. The worker **re-validates** the JWT
-(per ADR-0008) to reconstruct SecurityContext and executes the handler.
+(per cpt-cf-adr-two-plane-auth) to reconstruct SecurityContext and executes the handler.
 
 #### Inter-Gear Call (OoP → OoP)
 
@@ -1371,7 +1390,7 @@ gears/<group>/<name>/
 
 #### Library Chart — `toolkit-common`
 
-All ToolKit gears share the same process structure: an HTTP server on a configurable port, `/healthz` and `/readyz`
+All ToolKit gears share the same process structure: an HTTP server on a configurable port, `/healthz`, `/readyz`, and `/health`
 probe endpoints (provided by ToolKit runtime), optional gRPC port, config via `TOOLKIT_MODULE_CONFIG` env var, and Flight
 Control's `TOOLKIT_DIRECTORY_ENDPOINT` for service registration. The `toolkit-common` library chart codifies these
 conventions into reusable named templates.
@@ -1383,7 +1402,7 @@ conventions into reusable named templates.
 | Container image    | `image.registry/image.repository:image.tag` pattern                       | `image.registry`, `image.repository`, `image.tag` |
 | HTTP port          | Named `http` port on container and Service                                | `service.port` (default: `8080`)                  |
 | gRPC port          | Conditional named `grpc` port                                             | `grpc.enabled`, `grpc.port` (default: `50051`)    |
-| Health probes      | `/healthz` (liveness), `/readyz` (readiness) — provided by ToolKit runtime | `health.liveness.*`, `health.readiness.*`         |
+| Health probes      | `/healthz` (liveness), `/readyz` (readiness), `/health` (diagnostics) — provided by ToolKit runtime | `health.liveness.*`, `health.readiness.*`         |
 | Gear config      | `TOOLKIT_MODULE_CONFIG` from ConfigMap                                     | `gearConfig` (arbitrary map → JSON)             |
 | Directory endpoint | `TOOLKIT_DIRECTORY_ENDPOINT` env var                                       | `global.directoryEndpoint`                        |
 | Internal auth      | Projected SA token volume (audience: `toolkit-internal`) for Profile 3     | `internalAuth.audience`, `internalAuth.tokenPath` |
@@ -1595,7 +1614,7 @@ is transparent to application code.
 | Tenant resolution (`subject_id` → `tenant_id`, membership)       | identity-broker (P2)                | Tenant lifecycle                               |
 | Platform token issuance                                          | identity-broker (P2)                | Issues tokens that authn-resolver validates    |
 | Token exchange (external credential → platform token)            | identity-broker (P2)                | Mode B2 integration endpoint                   |
-| External gateway route registration                              | GatewayProvider adapters (ADR-0003) | Kong/Tyk admin API calls                       |
+| External gateway route registration                              | GatewayProvider adapters (cpt-cf-adr-gateway-abstraction) | Kong/Tyk admin API calls                       |
 
 #### api-gateway — Explicit Scope Constraint
 

--- a/docs/arch/toolkit-oop/PRD.md
+++ b/docs/arch/toolkit-oop/PRD.md
@@ -308,8 +308,10 @@ The ToolKit OoP runtime MUST manage the full gear startup lifecycle without gear
 3. In the background, resolve all dependencies declared in the gear's `deps` via DirectoryService. Wire REST clients
    into ClientHub as dependencies become available.
 4. Serve readiness probe (`/readyz`) returning 503 with unresolved dependency list until all critical `deps` are
-   resolved; then 200.
-5. Gear developers MUST NOT write retry loops, health-check polling, or registration code. The `deps` declaration in
+   resolved and the gear's registered healthcheck reports `Healthy`/`Degraded`; then 200.
+5. Serve diagnostics endpoint (`/health`) returning the full `HealthcheckReport` (`status` + per-component `components`),
+   `200` for `Healthy`/`Degraded` and `503` for `Unhealthy`.
+6. Gear developers MUST NOT write retry loops, health-check polling, or registration code. The `deps` declaration in
    `#[toolkit::gear(deps = [...])]` is the only input required.
 
 Gears with no `deps` (e.g., Flight Control, types-registry) become ready immediately after `start()`.

--- a/docs/toolkit_unified_system/09_oop_grpc_sdk_pattern.md
+++ b/docs/toolkit_unified_system/09_oop_grpc_sdk_pattern.md
@@ -67,6 +67,7 @@ async fn main() -> anyhow::Result<()> {
         verbose: 0,
         print_config: false,
         heartbeat_interval_secs: 5,
+        version: None,
     };
 
     run_oop_with_options(opts).await
@@ -84,6 +85,7 @@ async fn main() -> anyhow::Result<()> {
 | `verbose` | Log verbosity (0=default, 1=info, 2=debug, 3=trace) |
 | `print_config` | Print effective config and exit |
 | `heartbeat_interval_secs` | Heartbeat interval (default: 5) |
+| `version` | Gear version used for `DirectoryService` registration and the generated `OpenAPI` spec version; `None` means no explicit version |
 
 ## OoP Lifecycle
 

--- a/docs/toolkit_unified_system/10_checklists_and_templates.md
+++ b/docs/toolkit_unified_system/10_checklists_and_templates.md
@@ -322,6 +322,7 @@ async fn main() -> anyhow::Result<()> {
         verbose: 0,
         print_config: false,
         heartbeat_interval_secs: 5,
+        version: None,
     };
 
     run_oop_with_options(opts).await

--- a/libs/toolkit-k8s-auth/Cargo.toml
+++ b/libs/toolkit-k8s-auth/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "cf-gears-toolkit-k8s-auth"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Kubernetes TokenReview-based platform-plane (InternalAuthenticator) for ToolKit"
+readme = "README.md"
+keywords = ["constructorfabric", "cf-gears", "cf-gears-toolkit"]
+categories = ["authentication"]
+metadata.docs.rs.all-features = true
+
+[lib]
+name = "toolkit_k8s_auth"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Platform-plane authentication trait + identity/error types.
+toolkit-security = { workspace = true }
+
+kube = { workspace = true, features = ["client", "rustls-tls", "aws-lc-rs"] }
+k8s-openapi = { workspace = true, features = ["latest"] }
+
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/libs/toolkit-k8s-auth/README.md
+++ b/libs/toolkit-k8s-auth/README.md
@@ -1,0 +1,13 @@
+# cf-gears-toolkit-k8s-auth
+
+Kubernetes `TokenReview`-based platform-plane authenticator for ToolKit.
+
+Provides `K8sTokenReviewAuthenticator`, a concrete
+`toolkit_security::InternalAuthenticator` that validates an inbound
+`X-ToolKit-Internal-Token` (a projected `ServiceAccount` JWT) via the Kubernetes
+`TokenReview` API and resolves the caller to a
+`PlatformIdentity::KubernetesServiceAccount`.
+
+Kept in its own leaf crate so foundational crates stay free of the `kube` /
+`k8s-openapi` dependency. Wire it into the OoP bootstrap via
+`DynInternalAuthenticator` for Profile 3 (`InternalCredential::KubeServiceAccountToken`).

--- a/libs/toolkit-k8s-auth/src/lib.rs
+++ b/libs/toolkit-k8s-auth/src/lib.rs
@@ -1,0 +1,245 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+//! Kubernetes `TokenReview`-based platform-plane authenticator for `ToolKit`.
+//!
+//! Provides [`K8sTokenReviewAuthenticator`], a concrete
+//! [`InternalAuthenticator`](toolkit_security::InternalAuthenticator) that
+//! validates an inbound `X-ToolKit-Internal-Token` (a projected `ServiceAccount`
+//! JWT) by submitting it to the Kubernetes `TokenReview` API. On success it
+//! resolves the caller to a
+//! [`PlatformIdentity::KubernetesServiceAccount`](toolkit_security::PlatformIdentity).
+//!
+//! This lives in its own leaf crate (pulling in `kube` / `k8s-openapi`) so the
+//! foundational crates stay free of the Kubernetes client. Wire it into the
+//! `OoP` bootstrap via `DynInternalAuthenticator` when the deployment uses
+//! `InternalCredential::KubeServiceAccountToken` (Profile 3).
+//!
+//! ```rust,no_run
+//! use toolkit_k8s_auth::{K8sAuthError, K8sTokenReviewAuthenticator};
+//!
+//! # async fn wire() -> Result<(), K8sAuthError> {
+//! // Validates tokens scoped to the `toolkit-internal` audience.
+//! let authenticator =
+//!     K8sTokenReviewAuthenticator::try_default(vec!["toolkit-internal".to_owned()]).await?;
+//! # let _ = authenticator;
+//! # Ok(())
+//! # }
+//! ```
+
+use k8s_openapi::api::authentication::v1::{TokenReview, TokenReviewSpec};
+use kube::api::{Api, PostParams};
+use toolkit_security::{InternalAuthNError, InternalAuthenticator, PlatformIdentity};
+
+/// Prefix of the `user.username` returned by `TokenReview` for a
+/// `ServiceAccount`: `system:serviceaccount:<namespace>:<name>`.
+const SA_USERNAME_PREFIX: &str = "system:serviceaccount:";
+
+/// Extra key carrying the originating pod name, when the API server includes it.
+const POD_NAME_EXTRA_KEY: &str = "authentication.kubernetes.io/pod-name";
+
+/// Per-request timeout for the Kubernetes `TokenReview` API call.
+const TOKEN_REVIEW_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Error constructing a [`K8sTokenReviewAuthenticator`].
+#[derive(Debug, thiserror::Error)]
+pub enum K8sAuthError {
+    /// The Kubernetes client could not be constructed (no in-cluster config or
+    /// kubeconfig, or the config was invalid).
+    #[error("failed to construct Kubernetes client: {0}")]
+    Client(#[from] kube::Error),
+}
+
+/// A platform-plane authenticator backed by the Kubernetes `TokenReview` API.
+#[derive(Clone)]
+pub struct K8sTokenReviewAuthenticator {
+    client: kube::Client,
+    /// Expected token audiences. When non-empty they are sent to the API server,
+    /// which rejects tokens not scoped to (at least) one of them.
+    audiences: Vec<String>,
+    /// Per-request timeout for the `TokenReview` API call.
+    timeout: std::time::Duration,
+}
+
+impl std::fmt::Debug for K8sTokenReviewAuthenticator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("K8sTokenReviewAuthenticator")
+            .field("audiences", &self.audiences)
+            .field("timeout", &self.timeout)
+            .finish_non_exhaustive()
+    }
+}
+
+impl K8sTokenReviewAuthenticator {
+    /// Build an authenticator from an existing [`kube::Client`] with the
+    /// default per-request timeout.
+    #[must_use]
+    pub fn new(client: kube::Client, audiences: Vec<String>) -> Self {
+        Self {
+            client,
+            audiences,
+            timeout: TOKEN_REVIEW_TIMEOUT,
+        }
+    }
+
+    /// Override the per-request timeout for the `TokenReview` API call.
+    #[must_use]
+    pub fn with_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Build an authenticator using the ambient Kubernetes configuration
+    /// (in-cluster service account, or a local kubeconfig for development).
+    ///
+    /// # Errors
+    /// Returns [`K8sAuthError::Client`] if no valid configuration is available.
+    pub async fn try_default(audiences: Vec<String>) -> Result<Self, K8sAuthError> {
+        let client = kube::Client::try_default().await?;
+        Ok(Self::new(client, audiences))
+    }
+
+    /// Submit a `TokenReview` for `token` and resolve the platform identity.
+    async fn review(&self, token: &str) -> Result<PlatformIdentity, InternalAuthNError> {
+        let audiences = if self.audiences.is_empty() {
+            None
+        } else {
+            Some(self.audiences.clone())
+        };
+
+        let review = TokenReview {
+            spec: TokenReviewSpec {
+                token: Some(token.to_owned()),
+                audiences,
+            },
+            ..Default::default()
+        };
+
+        let api: Api<TokenReview> = Api::all(self.client.clone());
+        let response =
+            match tokio::time::timeout(self.timeout, api.create(&PostParams::default(), &review))
+                .await
+            {
+                Ok(Ok(response)) => response,
+                Ok(Err(e)) => {
+                    // A failed API call is a backend problem, not a bad credential.
+                    tracing::warn!(error = %e, "TokenReview API call failed");
+                    return Err(InternalAuthNError::Unavailable);
+                }
+                Err(_) => {
+                    tracing::warn!("TokenReview API call timed out");
+                    return Err(InternalAuthNError::Unavailable);
+                }
+            };
+
+        let status = response.status.ok_or_else(|| {
+            InternalAuthNError::Other("TokenReview returned no status".to_owned())
+        })?;
+
+        if !status.authenticated.unwrap_or(false) {
+            if let Some(err) = status.error.as_deref() {
+                tracing::debug!(error = %err, "TokenReview rejected credential");
+            }
+            return Err(InternalAuthNError::InvalidToken);
+        }
+
+        // When audiences are requested, the API server returns the token's
+        // audiences in the status. Reject tokens that do not satisfy at least
+        // one of the configured expected audiences.
+        if !self.audiences.is_empty() {
+            let response_audiences = status.audiences.as_deref().unwrap_or_default();
+            if !self
+                .audiences
+                .iter()
+                .any(|a| response_audiences.contains(a))
+            {
+                tracing::debug!(
+                    expected = ?self.audiences,
+                    got = ?response_audiences,
+                    "TokenReview audience mismatch"
+                );
+                return Err(InternalAuthNError::InvalidToken);
+            }
+        }
+
+        let user = status
+            .user
+            .ok_or_else(|| InternalAuthNError::Other("TokenReview missing user info".to_owned()))?;
+        let username = user.username.unwrap_or_default();
+
+        let (namespace, service_account) = parse_sa_username(&username).ok_or_else(|| {
+            InternalAuthNError::Other(format!(
+                "authenticated principal is not a ServiceAccount: {username}"
+            ))
+        })?;
+
+        let pod = user
+            .extra
+            .as_ref()
+            .and_then(|extra| extra.get(POD_NAME_EXTRA_KEY))
+            .and_then(|pods| pods.first())
+            .cloned();
+
+        Ok(PlatformIdentity::KubernetesServiceAccount {
+            namespace,
+            service_account,
+            pod,
+        })
+    }
+}
+
+impl InternalAuthenticator for K8sTokenReviewAuthenticator {
+    async fn authenticate(&self, token: &str) -> Result<PlatformIdentity, InternalAuthNError> {
+        self.review(token).await
+    }
+}
+
+/// Parse a `ServiceAccount` `TokenReview` username
+/// (`system:serviceaccount:<namespace>:<name>`) into `(namespace, name)`.
+///
+/// Returns `None` for non-`ServiceAccount` principals or malformed values.
+fn parse_sa_username(username: &str) -> Option<(String, String)> {
+    let rest = username.strip_prefix(SA_USERNAME_PREFIX)?;
+    let (namespace, name) = rest.split_once(':')?;
+    if namespace.is_empty() || name.is_empty() {
+        return None;
+    }
+    Some((namespace.to_owned(), name.to_owned()))
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_valid_service_account_username() {
+        assert_eq!(
+            parse_sa_username("system:serviceaccount:toolkit:flight-control"),
+            Some(("toolkit".to_owned(), "flight-control".to_owned()))
+        );
+    }
+
+    #[test]
+    fn rejects_non_service_account_principal() {
+        assert_eq!(parse_sa_username("system:node:node-1"), None);
+        assert_eq!(parse_sa_username("alice"), None);
+    }
+
+    #[test]
+    fn rejects_malformed_service_account_username() {
+        // Missing name component.
+        assert_eq!(parse_sa_username("system:serviceaccount:toolkit"), None);
+        // Empty namespace / name.
+        assert_eq!(parse_sa_username("system:serviceaccount::name"), None);
+        assert_eq!(parse_sa_username("system:serviceaccount:ns:"), None);
+    }
+
+    #[test]
+    fn keeps_name_with_trailing_colon_segments() {
+        // `split_once` keeps everything after the first ':' as the name.
+        assert_eq!(
+            parse_sa_username("system:serviceaccount:ns:a:b"),
+            Some(("ns".to_owned(), "a:b".to_owned()))
+        );
+    }
+}

--- a/libs/toolkit/Cargo.toml
+++ b/libs/toolkit/Cargo.toml
@@ -56,6 +56,10 @@ fips = [
 # Database integration (toolkit-db, migrations, DbManager/DbHandle in contexts/runtime)
 db = ["dep:toolkit-db", "dep:sea-orm-migration"]
 
+# Concrete Kubernetes TokenReview platform-plane authenticator, auto-wired into
+# the OoP bootstrap when `oop_http.internal_auth` is configured (Profile 3).
+k8s-auth = ["bootstrap", "dep:toolkit-k8s-auth"]
+
 # OpenTelemetry support for distributed tracing
 otel = [
     "dep:opentelemetry",
@@ -81,6 +85,9 @@ bootstrap = [
     "dep:dsn",
     "dep:supports-color",
     "dep:enable-ansi-support",
+    # OoP HTTP server: two-plane auth middleware + security primitives
+    "dep:toolkit-security",
+    "dep:toolkit-http-middleware",
 ]
 
 [dependencies]
@@ -92,6 +99,12 @@ sea-orm-migration = { workspace = true, optional = true }
 toolkit-odata = { workspace = true }
 toolkit-sdk = { workspace = true }
 cf-gears-system-sdks = { workspace = true, features = ["directory"] }
+
+# OoP HTTP server (bootstrap feature): two-plane auth middleware + primitives
+toolkit-security = { workspace = true, optional = true }
+toolkit-http-middleware = { workspace = true, optional = true }
+# Concrete K8s TokenReview InternalAuthenticator (k8s-auth feature).
+toolkit-k8s-auth = { workspace = true, optional = true }
 
 # Core deps
 anyhow = { workspace = true }
@@ -130,6 +143,9 @@ toolkit-gts = { workspace = true }
 parking_lot = { workspace = true }
 dashmap = { workspace = true }
 arc-swap = { workspace = true }
+# `util` provides `ServiceExt::oneshot`, used by the OoP probe-first serve path
+# to delegate to the gear router that is swapped in after `start()`.
+tower = { workspace = true, features = ["util"] }
 thiserror = { workspace = true }
 uuid = { workspace = true, features = ["v7"] }
 urlencoding = { workspace = true }
@@ -170,7 +186,6 @@ nix = { version = "0.31", default-features = false, features = ["signal"] }
 rustls-cng-crypto = { workspace = true, optional = true }
 
 [dev-dependencies]
-tower = { workspace = true }
 trybuild = { workspace = true }
 tempfile = { workspace = true }
 temp-env = { workspace = true }

--- a/libs/toolkit/src/bootstrap/config/mod.rs
+++ b/libs/toolkit/src/bootstrap/config/mod.rs
@@ -117,6 +117,13 @@ pub struct AppConfig {
     /// Allows vendors to add their own typed configuration sections.
     #[serde(default)]
     pub vendor: VendorConfig,
+    /// Out-of-process HTTP server configuration.
+    ///
+    /// When present, an `OoP` gear starts an Axum HTTP server (probes,
+    /// gear routes, self-registration, dependency resolution, graceful drain)
+    /// instead of the legacy gRPC-only lifecycle (`cpt-cf-component-oop-bootstrap`).
+    #[serde(default)]
+    pub oop_http: Option<OopHttpConfig>,
 }
 
 impl Default for AppConfig {
@@ -130,8 +137,57 @@ impl Default for AppConfig {
             gears_dir: None,
             gears: HashMap::new(),
             vendor: VendorConfig::new(),
+            oop_http: None,
         }
     }
+}
+
+/// Out-of-process HTTP server configuration (`cpt-cf-component-oop-bootstrap`).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct OopHttpConfig {
+    /// Address the main HTTP server binds to (gear routes + probes),
+    /// e.g. `"0.0.0.0:8080"`.
+    pub listen_addr: String,
+    /// Optional separate bind address for probe endpoints (sidecar port).
+    /// When set, `/healthz` and `/readyz` are also served here.
+    #[serde(default)]
+    pub probe_bind_addr: Option<String>,
+    /// Maximum seconds to wait for in-flight requests to drain on shutdown.
+    #[serde(default = "default_drain_timeout_secs")]
+    pub drain_timeout_secs: u64,
+    /// Per-check timeout (ms) for readiness healthchecks on `/readyz`; raise for
+    /// slow dependencies. Mirrors the `api-gateway` `healthcheck_timeout_ms`.
+    #[serde(default = "default_healthcheck_timeout_ms")]
+    pub healthcheck_timeout_ms: u64,
+    /// Base URL other services use to reach this instance (registered as the
+    /// instance's REST endpoint). Defaults to `http://<listen_addr>` with an
+    /// unspecified host (`0.0.0.0`) rewritten to `127.0.0.1`.
+    #[serde(default)]
+    pub advertise_uri: Option<String>,
+    /// Platform-plane (`InternalAuthenticator`) configuration. When present and
+    /// the `k8s-auth` feature is enabled, the bootstrap installs the Kubernetes
+    /// `TokenReview` authenticator on incoming system calls.
+    #[serde(default)]
+    pub internal_auth: Option<InternalAuthConfig>,
+}
+
+fn default_drain_timeout_secs() -> u64 {
+    30
+}
+
+fn default_healthcheck_timeout_ms() -> u64 {
+    500
+}
+
+/// Platform-plane authentication configuration for the `OoP` HTTP server.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct InternalAuthConfig {
+    /// Expected token audiences for Kubernetes `TokenReview`. When empty, the
+    /// API server's default audience validation applies.
+    #[serde(default)]
+    pub audiences: Vec<String>,
 }
 
 impl ConfigProvider for AppConfig {

--- a/libs/toolkit/src/bootstrap/oop.rs
+++ b/libs/toolkit/src/bootstrap/oop.rs
@@ -36,6 +36,7 @@
 //!         verbose: 0,
 //!         print_config: false,
 //!         heartbeat_interval_secs: 5,
+//!         version: None,
 //!     };
 //!
 //!     run_oop_with_options(opts).await
@@ -58,8 +59,8 @@ use super::config::{
 };
 use crate::bootstrap::host::{init_logging_unified, init_panic_tracing};
 use crate::runtime::{
-    ClientRegistration, DbOptions, RunOptions, ShutdownOptions, TOOLKIT_DIRECTORY_ENDPOINT_ENV,
-    run, shutdown,
+    ClientRegistration, DbOptions, OopServeOptions, RunOptions, ShutdownOptions,
+    TOOLKIT_DIRECTORY_ENDPOINT_ENV, run, run_oop_serving, shutdown,
 };
 use cf_system_sdks::directory::{DirectoryClient, DirectoryGrpcClient};
 
@@ -86,6 +87,10 @@ pub struct OopRunOptions {
 
     /// Heartbeat interval in seconds (default: 5)
     pub heartbeat_interval_secs: u64,
+
+    /// Gear version (used for `DirectoryService` registration and `OpenAPI` version).
+    /// Defaults to `None`.
+    pub version: Option<String>,
 }
 
 impl Default for OopRunOptions {
@@ -106,6 +111,7 @@ impl Default for OopRunOptions {
             verbose: 0,
             print_config: false,
             heartbeat_interval_secs: 5,
+            version: None,
         }
     }
 }
@@ -382,6 +388,7 @@ fn merge_json_objects(target: &mut serde_json::Value, source: &serde_json::Value
 ///         verbose: 1,
 ///         print_config: false,
 ///         heartbeat_interval_secs: 5,
+///         version: None,
 ///     };
 ///
 ///     run_oop_with_options(opts).await
@@ -537,64 +544,72 @@ pub async fn run_oop_with_options(opts: OopRunOptions) -> Result<()> {
 
     info!("Successfully connected to directory service");
 
-    // Start heartbeat loop in background using a child token from the root.
-    // This allows the heartbeat to be cancelled when the root token is cancelled.
-    let heartbeat_directory = Arc::clone(&directory_api);
-    let heartbeat_gear = opts.gear_name.clone();
-    let heartbeat_instance_id_str = instance_id.to_string();
-    let heartbeat_interval = Duration::from_secs(opts.heartbeat_interval_secs);
-    let heartbeat_cancel = cancel.child_token();
-
-    tokio::spawn(async move {
-        info!(
-            interval_secs = opts.heartbeat_interval_secs,
-            "Starting heartbeat loop"
-        );
-
-        loop {
-            tokio::select! {
-                () = heartbeat_cancel.cancelled() => {
-                    info!("Heartbeat loop stopping due to cancellation");
-                    break;
-                }
-                () = sleep(heartbeat_interval) => {
-                    match heartbeat_directory
-                        .send_heartbeat(&heartbeat_gear, &heartbeat_instance_id_str)
-                        .await
-                    {
-                        Ok(()) => {
-                            tracing::debug!("Heartbeat sent successfully");
-                        }
-                        Err(e) => {
-                            warn!(error = %e, "Failed to send heartbeat, will retry");
-                        }
-                    }
-                }
-            }
-        }
-    });
+    // Capture OoP HTTP config (if any) before moving the config into the provider.
+    let oop_http = final_config.oop_http.clone();
 
     // Build config provider for gears
     let config_provider = Arc::new(final_config);
 
-    // Keep a reference to directory_api for deregistration after shutdown
-    // Run the gear lifecycle with the root cancellation token.
-    // Shutdown is driven by the signal handler spawned above, not by ShutdownOptions::Signals.
     // The DirectoryClient (gRPC client) is injected into the ClientHub so gears can access it.
-    info!("Starting gear lifecycle");
     let run_options = RunOptions {
         gears_cfg: config_provider,
         db: db_options,
         shutdown: ShutdownOptions::Token(cancel.clone()),
-        clients: vec![ClientRegistration::new::<dyn DirectoryClient>(
-            directory_api,
-        )],
+        clients: vec![ClientRegistration::new::<dyn DirectoryClient>(Arc::clone(
+            &directory_api,
+        ))],
         instance_id,
         oop: None, // OoP gears don't spawn other OoP gears
         shutdown_deadline: None,
     };
 
-    let result = run(run_options).await;
+    // When `oop_http` is configured, run the HTTP-serving lifecycle:
+    // Axum server + probes + directory presence (registration + heartbeat +
+    // self-heal, owned by `presence_loop`) + dependency resolution + drain.
+    // Otherwise fall back to the legacy gRPC-only lifecycle.
+    let result = if let Some(http_cfg) = oop_http {
+        info!("Starting OoP HTTP-serving lifecycle");
+        let serve = build_oop_serve_options(
+            &http_cfg,
+            &opts.gear_name,
+            instance_id,
+            opts.version.clone(),
+            Duration::from_secs(opts.heartbeat_interval_secs),
+            Arc::clone(&directory_api),
+        )
+        .await?;
+        run_oop_serving(run_options, serve).await
+    } else {
+        info!("Starting gear lifecycle (legacy gRPC-only)");
+        // Legacy path: presence is not self-managed by an HTTP serve lifecycle,
+        // so run a standalone heartbeat on a child token. (A no-op unless the
+        // instance is registered by an external orchestrator.)
+        let heartbeat_directory = Arc::clone(&directory_api);
+        let heartbeat_gear = opts.gear_name.clone();
+        let heartbeat_instance_id_str = instance_id.to_string();
+        let heartbeat_interval = Duration::from_secs(opts.heartbeat_interval_secs.max(1));
+        let heartbeat_cancel = cancel.child_token();
+        tokio::spawn(async move {
+            info!(interval_secs = ?heartbeat_interval, "Starting legacy heartbeat loop");
+            loop {
+                tokio::select! {
+                    () = heartbeat_cancel.cancelled() => {
+                        info!("Heartbeat loop stopping due to cancellation");
+                        break;
+                    }
+                    () = sleep(heartbeat_interval) => {
+                        if let Err(e) = heartbeat_directory
+                            .send_heartbeat(&heartbeat_gear, &heartbeat_instance_id_str)
+                            .await
+                        {
+                            warn!(error = %e, "Failed to send heartbeat, will retry");
+                        }
+                    }
+                }
+            }
+        });
+        run(run_options).await
+    };
 
     if let Err(ref e) = result {
         error!(error = %e, "Gear runtime failed");
@@ -603,6 +618,107 @@ pub async fn run_oop_with_options(opts: OopRunOptions) -> Result<()> {
     }
 
     result
+}
+
+/// Build [`OopServeOptions`] from configuration.
+///
+/// The tenant-plane `BearerAuthenticator` injection point is left unset here;
+/// the app/gear binary supplies that adapter when it needs the tenant-plane
+/// middleware installed. The platform-plane authenticator is constructed from
+/// `oop_http.internal_auth` when the `k8s-auth` feature is enabled.
+async fn build_oop_serve_options(
+    cfg: &super::config::OopHttpConfig,
+    gear_name: &str,
+    instance_id: Uuid,
+    version: Option<String>,
+    heartbeat_interval: Duration,
+    directory: Arc<dyn DirectoryClient>,
+) -> Result<OopServeOptions> {
+    let listen_addr: std::net::SocketAddr = cfg
+        .listen_addr
+        .parse()
+        .with_context(|| format!("invalid oop_http.listen_addr: {}", cfg.listen_addr))?;
+
+    let probe_bind_addr = cfg
+        .probe_bind_addr
+        .as_deref()
+        .map(|s| {
+            s.parse::<std::net::SocketAddr>()
+                .with_context(|| format!("invalid oop_http.probe_bind_addr: {s}"))
+        })
+        .transpose()?;
+
+    let advertise_uri = cfg
+        .advertise_uri
+        .clone()
+        .unwrap_or_else(|| default_advertise_uri(listen_addr));
+
+    let internal_authenticator = build_internal_authenticator(cfg.internal_auth.as_ref()).await?;
+
+    Ok(OopServeOptions {
+        gear_name: gear_name.to_owned(),
+        instance_id: instance_id.to_string(),
+        version,
+        advertise_uri,
+        listen_addr,
+        probe_bind_addr,
+        drain_timeout: Duration::from_secs(cfg.drain_timeout_secs),
+        heartbeat_interval,
+        healthcheck_timeout: Duration::from_millis(cfg.healthcheck_timeout_ms),
+        directory,
+        bearer_authenticator: None,
+        internal_authenticator,
+    })
+}
+
+/// Construct the platform-plane authenticator from configuration.
+///
+/// With the `k8s-auth` feature enabled and `internal_auth` configured, this
+/// initializes the Kubernetes `TokenReview` authenticator. Without the feature,
+/// a configured `internal_auth` is an error; `Ok(None)` is returned only when no
+/// `internal_auth` is configured.
+#[cfg_attr(not(feature = "k8s-auth"), allow(clippy::unused_async))]
+async fn build_internal_authenticator(
+    cfg: Option<&super::config::InternalAuthConfig>,
+) -> Result<Option<crate::runtime::DynInternalAuthenticator>> {
+    #[cfg(feature = "k8s-auth")]
+    {
+        if let Some(internal_auth) = cfg {
+            info!("Initializing Kubernetes TokenReview platform-plane authenticator");
+            let authenticator = toolkit_k8s_auth::K8sTokenReviewAuthenticator::try_default(
+                internal_auth.audiences.clone(),
+            )
+            .await
+            .context("failed to initialize Kubernetes TokenReview authenticator")?;
+            return Ok(Some(crate::runtime::DynInternalAuthenticator::new(
+                authenticator,
+            )));
+        }
+        Ok(None)
+    }
+    #[cfg(not(feature = "k8s-auth"))]
+    {
+        if cfg.is_some() {
+            anyhow::bail!(
+                "oop_http.internal_auth is configured but the `k8s-auth` feature is disabled"
+            );
+        }
+        Ok(None)
+    }
+}
+
+/// Derive a default advertise URI from the bind address. Unspecified hosts
+/// (`0.0.0.0` / `[::]`) are rewritten to loopback, and every IPv6 host is
+/// enclosed in brackets so the resulting URI is valid when registered as a
+/// REST endpoint.
+fn default_advertise_uri(listen_addr: std::net::SocketAddr) -> String {
+    let host = match listen_addr {
+        std::net::SocketAddr::V4(addr) if addr.ip().is_unspecified() => "127.0.0.1".to_owned(),
+        std::net::SocketAddr::V4(addr) => addr.ip().to_string(),
+        std::net::SocketAddr::V6(addr) if addr.ip().is_unspecified() => "[::1]".to_owned(),
+        std::net::SocketAddr::V6(addr) => format!("[{}]", addr.ip()),
+    };
+    format!("http://{host}:{}", listen_addr.port())
 }
 
 #[allow(unknown_lints, de1301_no_print_macros)] // direct stdout config print before exit

--- a/libs/toolkit/src/runtime/gear_manager.rs
+++ b/libs/toolkit/src/runtime/gear_manager.rs
@@ -114,6 +114,25 @@ impl Clone for GearInstance {
 }
 
 impl GearInstance {
+    /// Build a new instance record using `other`'s metadata but preserving
+    /// `self`'s `inner` runtime-state lock. This makes re-registration atomic:
+    /// concurrent `update_heartbeat` calls continue to write to the same state
+    /// object instead of racing with a copied/swapped `InstanceRuntimeState`.
+    fn with_metadata_of(&self, other: &GearInstance) -> GearInstance {
+        GearInstance {
+            gear: other.gear.clone(),
+            instance_id: other.instance_id,
+            control: other.control.clone(),
+            grpc_services: other.grpc_services.clone(),
+            version: other.version.clone(),
+            rest_endpoint: other.rest_endpoint.clone(),
+            openapi_spec: other.openapi_spec.clone(),
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl GearInstance {
     pub fn new(gear: impl Into<String>, instance_id: Uuid) -> Self {
         Self {
             gear: gear.into(),
@@ -208,6 +227,15 @@ impl GearManager {
     }
 
     /// Register or update a gear instance
+    ///
+    /// Re-registering an existing `instance_id` is an idempotent endpoint /
+    /// metadata refresh, NOT a liveness reset: the existing runtime state
+    /// (`last_heartbeat` + [`InstanceState`]) is carried over onto the new
+    /// record by preserving the same `Arc<RwLock<InstanceRuntimeState>>`.
+    /// Without this, a periodic self-heal re-registration (see
+    /// `oop_registration::presence_loop`) would knock a `Healthy` instance back
+    /// to `Registered`, dropping it out of gRPC round-robin until the next
+    /// heartbeat. It would also race with concurrent `update_heartbeat` calls.
     pub fn register_instance(&self, instance: Arc<GearInstance>) {
         let gear = instance.gear.clone();
         let mut vec = self.inner.entry(gear).or_default();
@@ -216,7 +244,7 @@ impl GearManager {
             .iter()
             .position(|i| i.instance_id == instance.instance_id)
         {
-            vec[pos] = instance;
+            vec[pos] = Arc::new(vec[pos].with_metadata_of(&instance));
         } else {
             vec.push(instance);
         }
@@ -530,6 +558,90 @@ mod tests {
         let registered = dir.instances_of("test_gear");
         assert_eq!(registered.len(), 1, "Should not duplicate instance");
         assert_eq!(registered[0].version, Some("2.0.0".to_owned()));
+    }
+
+    #[test]
+    fn test_reregistration_preserves_liveness_state() {
+        let dir = GearManager::new();
+        let instance_id = Uuid::new_v4();
+
+        // Register, then heartbeat so the instance is Healthy (routable).
+        dir.register_instance(Arc::new(
+            GearInstance::new("test_gear", instance_id).with_version("1.0.0"),
+        ));
+        dir.update_heartbeat("test_gear", instance_id, Instant::now());
+        assert!(matches!(
+            dir.instances_of("test_gear")[0].state(),
+            InstanceState::Healthy
+        ));
+
+        // A periodic self-heal re-registration must NOT reset liveness back to
+        // Registered — otherwise the instance drops out of gRPC round-robin
+        // until the next heartbeat (the "split-brain" flap).
+        dir.register_instance(Arc::new(
+            GearInstance::new("test_gear", instance_id).with_version("2.0.0"),
+        ));
+
+        let instances = dir.instances_of("test_gear");
+        assert_eq!(instances.len(), 1);
+        assert!(
+            matches!(instances[0].state(), InstanceState::Healthy),
+            "re-registration must preserve the Healthy state"
+        );
+        assert_eq!(
+            instances[0].version,
+            Some("2.0.0".to_owned()),
+            "re-registration must still refresh metadata/endpoints"
+        );
+    }
+
+    #[test]
+    fn test_concurrent_reregister_and_heartbeat_preserves_state() {
+        let dir = GearManager::new();
+        let instance_id = Uuid::new_v4();
+
+        let initial = Arc::new(GearInstance::new("test_gear", instance_id).with_version("1.0.0"));
+        dir.register_instance(initial);
+        dir.update_heartbeat("test_gear", instance_id, Instant::now());
+        assert!(matches!(
+            dir.instances_of("test_gear")[0].state(),
+            InstanceState::Healthy
+        ));
+
+        let start = Instant::now();
+
+        std::thread::scope(|s| {
+            s.spawn(|| {
+                for _ in 0..1000 {
+                    dir.update_heartbeat("test_gear", instance_id, Instant::now());
+                }
+            });
+            s.spawn(|| {
+                for i in 0..1000 {
+                    let version = if i % 2 == 0 { "2.0.0" } else { "3.0.0" };
+                    let reinst = Arc::new(
+                        GearInstance::new("test_gear", instance_id)
+                            .with_version(version)
+                            .with_rest_endpoint(Endpoint::http(
+                                "127.0.0.1",
+                                8000u16 + u16::try_from(i % 10).expect("i % 10 fits in u16"),
+                            )),
+                    );
+                    dir.register_instance(reinst);
+                }
+            });
+        });
+
+        let instances = dir.instances_of("test_gear");
+        assert_eq!(instances.len(), 1);
+        assert!(
+            matches!(instances[0].state(), InstanceState::Healthy),
+            "concurrent re-registration must not reset Healthy state"
+        );
+        assert!(
+            instances[0].last_heartbeat() >= start,
+            "concurrent re-registration must not lose heartbeat updates"
+        );
     }
 
     #[test]

--- a/libs/toolkit/src/runtime/host_runtime.rs
+++ b/libs/toolkit/src/runtime/host_runtime.rs
@@ -660,6 +660,46 @@ impl HostRuntime {
         Ok(())
     }
 
+    /// Run the stop phase with a watchdog that force-exits the process if the
+    /// stop phase hangs on a blocking syscall. The watchdog is disarmed whether
+    /// the stop phase succeeds or fails, so a failing stop phase does not leave
+    /// the watchdog active and eventually force-exit the process.
+    async fn run_stop_phase_guarded(&self) -> Result<(), RegistryError> {
+        let gear_count = u32::try_from(self.registry.gears().len().max(1)).unwrap_or(1);
+        let stop_timeout = self
+            .shutdown_deadline
+            .checked_mul(gear_count)
+            .and_then(|d| d.checked_add(std::time::Duration::from_secs(5)))
+            .unwrap_or(self.shutdown_deadline);
+
+        // Use a channel to arm/disarm the watchdog. If the lifecycle future is
+        // dropped before the stop phase finishes (e.g. an outer timeout), the
+        // sender is dropped and the watchdog exits without killing the process.
+        let (disarm_tx, disarm_rx) = std::sync::mpsc::channel::<()>();
+        std::thread::spawn(move || {
+            match disarm_rx.recv_timeout(stop_timeout) {
+                Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                    // Stop phase completed, or the lifecycle future was cancelled.
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                    tracing::warn!(
+                        timeout_secs = stop_timeout.as_secs(),
+                        "shutdown: stop phase timed out, force exiting"
+                    );
+                    std::process::exit(1);
+                }
+            }
+        });
+
+        let stop_result = self.run_stop_phase().await;
+        // Disarm the watchdog before propagating the stop-phase result. This runs
+        // for both success and failure so a failing stop phase does not leave the
+        // watchdog armed and eventually force-exit the process.
+        let _ = disarm_tx.send(()).ok();
+
+        stop_result
+    }
+
     /// `OoP` SPAWN phase: spawn out-of-process gears after start phase.
     ///
     /// This phase runs after `grpc-hub` is already listening, so we can pass
@@ -856,30 +896,186 @@ impl HostRuntime {
         self.cancel.cancelled().await;
 
         // 10. Stop phase with hard timeout.
-        //     Blocking syscalls (e.g. libc getaddrinfo in tokio spawn_blocking)
-        //     can saturate all tokio worker threads, preventing tokio timers
-        //     from firing. Use an OS thread so the watchdog works even when
-        //     the tokio runtime is fully blocked.
-        let stop_timeout = std::time::Duration::from_secs(15);
-        let disarm = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let disarm_clone = std::sync::Arc::clone(&disarm);
-        std::thread::spawn(move || {
-            std::thread::sleep(stop_timeout);
-            if !disarm_clone.load(std::sync::atomic::Ordering::Relaxed) {
-                tracing::warn!(
-                    timeout_secs = stop_timeout.as_secs(),
-                    "shutdown: stop phase timed out, force exiting"
-                );
-                std::process::exit(1);
-            }
-        });
-
-        self.run_stop_phase().await?;
-        disarm.store(true, std::sync::atomic::Ordering::Relaxed);
-
+        //     Blocking stop implementations are guarded by a watchdog thread so
+        //     a hang cannot block shutdown, whether in the in-process or OoP path.
+        self.run_stop_phase_guarded().await?;
         Ok(())
     }
 }
+
+/// Out-of-process HTTP serving lifecycle (`cpt-cf-component-oop-bootstrap`).
+#[cfg(feature = "bootstrap")]
+impl HostRuntime {
+    /// Declared dependencies that are **not** satisfied in-process and must be
+    /// resolved via `DirectoryService` (or k8s DNS). In-process deps are already
+    /// guaranteed by the topo-sorted lifecycle, so they are excluded.
+    fn external_deps(&self) -> Vec<String> {
+        use std::collections::{BTreeSet, HashSet};
+
+        let present: HashSet<&str> = self.registry.gears().iter().map(|e| e.name).collect();
+        let mut deps = BTreeSet::new();
+        for entry in self.registry.gears() {
+            for dep in entry.deps() {
+                if !present.contains(dep) {
+                    deps.insert((*dep).to_owned());
+                }
+            }
+        }
+        deps.into_iter().collect()
+    }
+
+    /// Compose a **host-less** REST router from all `RestApiCap` gears, plus the
+    /// gear's generated `OpenAPI` document (serialized JSON).
+    ///
+    /// Unlike [`run_rest_phase`](Self::run_rest_phase), this does not require an
+    /// `ApiGatewayCap` host: `OoP` gears serve their own routes directly.
+    async fn compose_oop_router(
+        &self,
+        options: &crate::runtime::OopServeOptions,
+        hc_registry: &Arc<crate::healthcheck::RestHealthcheckRegistry>,
+    ) -> anyhow::Result<(Router, String)> {
+        use crate::api::{OpenApiInfo, OpenApiRegistryImpl};
+        use anyhow::Context as _;
+
+        let registry = OpenApiRegistryImpl::new();
+        let mut router = Router::new();
+
+        for entry in self.registry.gears() {
+            if let Some(rest) = entry.caps.query::<RestApiCap>() {
+                let ctx = self
+                    .ctx_builder
+                    .for_gear(entry.name)
+                    .await
+                    .with_context(|| format!("OoP router: build context for '{}'", entry.name))?;
+                router = rest
+                    .register_rest(&ctx, router, &registry)
+                    .with_context(|| format!("OoP router: register_rest for '{}'", entry.name))?;
+
+                // Register the gear's readiness healthcheck (the same mechanism
+                // the api-gateway host uses), so /readyz reflects it identically
+                // whether the gear runs in-process or OoP.
+                if let Some(hc) = rest.healthcheck(&ctx) {
+                    hc_registry.register(entry.name, hc);
+                }
+            }
+        }
+
+        let info = OpenApiInfo {
+            title: options.gear_name.clone(),
+            version: options
+                .version
+                .clone()
+                .unwrap_or_else(|| "0.0.0".to_owned()),
+            description: None,
+            servers: vec![],
+        };
+        let openapi = registry
+            .build_openapi(&info)
+            .context("OoP router: build OpenAPI document")?;
+        let json = serde_json::to_string(&openapi).context("OoP router: serialize OpenAPI")?;
+
+        Ok((router, json))
+    }
+
+    /// Run the full `OoP` gear lifecycle: phases (`pre_init` … `start`), then
+    /// serve the composed router with framework probes, background
+    /// self-registration, dependency resolution, and graceful drain, then the
+    /// `stop` phase.
+    ///
+    /// # Errors
+    /// Returns an error if any lifecycle phase or the HTTP server fails.
+    pub async fn run_oop_serving(
+        self,
+        options: crate::runtime::OopServeOptions,
+    ) -> anyhow::Result<()> {
+        use crate::runtime::{ReadinessState, ResolvedRestEndpoints};
+
+        tracing::info!("Running OoP serving lifecycle");
+
+        // Shared gear healthcheck registry (same mechanism as the api-gateway
+        // host path). Seeded with the root cancellation token so in-flight
+        // checks are aborted on shutdown. Populated during router composition.
+        let hc_registry = Arc::new(
+            crate::healthcheck::RestHealthcheckRegistry::with_cancellation(self.cancel.clone()),
+        );
+
+        // External deps gate readiness; the healthcheck registry supplies the
+        // per-gear readiness dimension. Both feed the /readyz aggregate.
+        let deps = self.external_deps();
+        let readiness = ReadinessState::with_check_timeout(
+            deps.clone(),
+            Arc::clone(&hc_registry),
+            options.healthcheck_timeout,
+        );
+
+        // Expose resolved dependency endpoints to gears via the ClientHub.
+        let resolved = Arc::new(ResolvedRestEndpoints::new());
+        self.client_hub
+            .register::<ResolvedRestEndpoints>(Arc::clone(&resolved));
+
+        // Bind the HTTP server and serve probes BEFORE the (possibly slow)
+        // lifecycle phases, so the kubelet's liveness probe (`/healthz`) passes
+        // immediately instead of getting connection-refused during `start()`.
+        // Gear routes reply `503 starting` until attached below.
+        let mut server = super::oop_serve::OopHttpServer::start(
+            Arc::clone(&readiness),
+            Arc::clone(&resolved),
+            options,
+            self.cancel.clone(),
+        )
+        .await?;
+
+        // Lifecycle phases up to start, then compose the host-less REST router +
+        // OpenAPI spec (collecting each gear's healthcheck into the shared
+        // registry). Grouped so a failure tears the probe server down cleanly.
+        let mut started = false;
+        let composed: anyhow::Result<(Router, String)> = async {
+            self.run_pre_init_phase()?;
+            #[cfg(feature = "db")]
+            self.run_db_phase().await?;
+            self.run_init_phase().await?;
+            self.run_post_init_phase().await?;
+            self.run_grpc_phase().await?;
+            self.run_start_phase().await?;
+            started = true;
+            self.compose_oop_router(server.options(), &hc_registry)
+                .await
+        }
+        .await;
+
+        let serve_result = match composed {
+            Ok((gear_router, openapi_json)) => {
+                // Publish gear routes (they go live) + start presence/dep resolution.
+                server.attach(gear_router, openapi_json, deps);
+                // Serve until cancelled, drain, then deregister.
+                server.join().await
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "OoP startup failed before serving gear routes");
+                // Tear down the probe server that is already bound.
+                self.cancel.cancel();
+                if let Err(join_err) = server.join().await {
+                    tracing::warn!(error = %join_err, "OoP probe server teardown after startup failure errored");
+                }
+                Err(e)
+            }
+        };
+
+        // Stop phase runs only if start completed successfully. Errors are logged
+        // but do not fail the shutdown process (same contract as run_stop_phase).
+        if started && let Err(e) = self.run_stop_phase_guarded().await {
+            tracing::warn!(error = %e, "OoP stop phase reported an error");
+        }
+
+        serve_result
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "bootstrap")]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "host_runtime_oop_tests.rs"]
+mod host_runtime_oop_tests;
 
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]

--- a/libs/toolkit/src/runtime/host_runtime_oop_tests.rs
+++ b/libs/toolkit/src/runtime/host_runtime_oop_tests.rs
@@ -1,0 +1,272 @@
+//! Full-stack end-to-end test for an `OoP` gear booted through
+//! [`HostRuntime::run_oop_serving`] (`cpt-cf-component-oop-bootstrap`).
+//!
+//! Unlike the serve-edge test in `oop_serve_tests.rs` (which drives
+//! `OopHttpServer` directly with a hand-built router), this test exercises the
+//! *entire* lifecycle a real gear goes through:
+//!
+//! - gear discovery via a manually-built [`RegistryBuilder`],
+//! - the full phase sequence (`pre_init` → `init` → `post_init` → `grpc` →
+//!   `start`),
+//! - [`HostRuntime::compose_oop_router`] building routes + `OpenAPI` from an
+//!   actual [`RestApiCapability`] gear (not a synthetic router),
+//! - a real bound HTTP server serving the gear's route,
+//! - background self-registration with a live `DirectoryClient`,
+//! - graceful shutdown draining and deregistration,
+//! - the `stop` phase running after the server exits.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use axum::Router;
+use axum::routing::get;
+use parking_lot::Mutex;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use cf_system_sdks::directory::{
+    DirectoryClient, RegisterInstanceInfo, ServiceEndpoint, ServiceInstanceInfo,
+};
+
+use super::{DbOptions, HostRuntime};
+use crate::client_hub::ClientHub;
+use crate::config::ConfigProvider;
+use crate::context::GearCtx;
+use crate::contracts::{Gear, OpenApiRegistry, RestApiCapability};
+use crate::registry::RegistryBuilder;
+use crate::runtime::OopServeOptions;
+
+/// A minimal gear that serves a single REST route. Implements both [`Gear`]
+/// (lifecycle) and [`RestApiCapability`] (routing) so it is composed into the
+/// host-less router exactly like a production gear.
+#[derive(Default)]
+struct PingGear;
+
+#[async_trait]
+impl Gear for PingGear {
+    async fn init(&self, _ctx: &GearCtx) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+impl RestApiCapability for PingGear {
+    fn register_rest(
+        &self,
+        _ctx: &GearCtx,
+        router: Router,
+        _openapi: &dyn OpenApiRegistry,
+    ) -> anyhow::Result<Router> {
+        Ok(router.route("/ping", get(|| async { "pong" })))
+    }
+}
+
+/// In-memory `DirectoryClient` that records registration / deregistration and
+/// captures the REST endpoint the gear advertised.
+#[derive(Default)]
+struct RecordingDirectory {
+    register_calls: AtomicUsize,
+    deregister_calls: AtomicUsize,
+    registered_endpoint: Mutex<Option<String>>,
+}
+
+#[async_trait]
+impl DirectoryClient for RecordingDirectory {
+    async fn resolve_grpc_service(&self, _service: &str) -> anyhow::Result<ServiceEndpoint> {
+        Ok(ServiceEndpoint::new("http://grpc"))
+    }
+    async fn resolve_rest_service(&self, gear: &str) -> anyhow::Result<ServiceEndpoint> {
+        Ok(ServiceEndpoint::new(format!("http://{gear}:8080")))
+    }
+    async fn get_openapi_spec(&self, _gear: &str) -> anyhow::Result<String> {
+        Ok(String::new())
+    }
+    async fn list_instances(&self, _gear: &str) -> anyhow::Result<Vec<ServiceInstanceInfo>> {
+        Ok(vec![])
+    }
+    async fn register_instance(&self, info: RegisterInstanceInfo) -> anyhow::Result<()> {
+        if let Some(ep) = &info.rest_endpoint {
+            *self.registered_endpoint.lock() = Some(ep.uri.clone());
+        }
+        self.register_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+    async fn deregister_instance(&self, _gear: &str, _instance: &str) -> anyhow::Result<()> {
+        self.deregister_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+    async fn send_heartbeat(&self, _gear: &str, _instance: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+struct EmptyConfigProvider;
+impl ConfigProvider for EmptyConfigProvider {
+    fn get_gear_config(&self, _gear_name: &str) -> Option<&serde_json::Value> {
+        None
+    }
+}
+
+/// Reserve an ephemeral port and return it (closing the listener so the server
+/// can rebind it).
+fn free_addr() -> SocketAddr {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    listener.local_addr().expect("local_addr")
+}
+
+/// Minimal raw HTTP/1.1 GET returning `(status, body)`. Uses `Connection: close`
+/// so the read completes on EOF.
+async fn http_get(addr: SocketAddr, path: &str) -> Option<(u16, String)> {
+    let mut stream = tokio::net::TcpStream::connect(addr).await.ok()?;
+    let req = format!("GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    stream.write_all(req.as_bytes()).await.ok()?;
+    let mut buf = Vec::new();
+    stream.read_to_end(&mut buf).await.ok()?;
+    let text = String::from_utf8_lossy(&buf);
+    let status = text
+        .lines()
+        .next()
+        .and_then(|l| l.split_whitespace().nth(1))
+        .and_then(|s| s.parse().ok())?;
+    let body = text
+        .split_once("\r\n\r\n")
+        .map_or(String::new(), |(_, b)| b.to_owned());
+    Some((status, body))
+}
+
+/// Poll `path` until it returns `want` or the deadline elapses.
+async fn poll_status(addr: SocketAddr, path: &str, want: u16, timeout: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if let Some((status, _)) = http_get(addr, path).await
+            && status == want
+        {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+#[tokio::test]
+async fn e2e_oop_gear_boots_serves_registers_and_shuts_down() {
+    let addr = free_addr();
+    let directory = Arc::new(RecordingDirectory::default());
+
+    // 1. Build a registry with a single REST-capable gear, exactly as discovery
+    //    would produce it.
+    let gear = Arc::new(PingGear);
+    let mut builder = RegistryBuilder::default();
+    builder.register_core_with_meta("ping-gear", &[], gear.clone() as Arc<dyn Gear>);
+    builder.register_rest_with_meta("ping-gear", gear as Arc<dyn RestApiCapability>);
+    let registry = builder.build_topo_sorted().unwrap();
+
+    let hub = Arc::new(ClientHub::new());
+    let cancel = CancellationToken::new();
+    let config: Arc<dyn ConfigProvider> = Arc::new(EmptyConfigProvider);
+
+    let host = HostRuntime::new(
+        registry,
+        config,
+        DbOptions::None,
+        hub,
+        cancel.clone(),
+        Uuid::new_v4(),
+        None,
+    );
+
+    let options = OopServeOptions {
+        gear_name: "ping-gear".to_owned(),
+        instance_id: "i-1".to_owned(),
+        version: Some("1.2.3".to_owned()),
+        advertise_uri: format!("http://{addr}"),
+        listen_addr: addr,
+        probe_bind_addr: None,
+        drain_timeout: Duration::from_secs(5),
+        heartbeat_interval: Duration::from_secs(30),
+        healthcheck_timeout: Duration::from_millis(500),
+        directory: Arc::clone(&directory) as Arc<dyn DirectoryClient>,
+        bearer_authenticator: None,
+        internal_authenticator: None,
+    };
+
+    // 2. Drive the full OoP serving lifecycle on a background task.
+    let server = tokio::spawn(host.run_oop_serving(options));
+
+    // 3. Liveness comes up once phases complete and the server binds.
+    assert!(
+        poll_status(addr, "/healthz", 200, Duration::from_secs(5)).await,
+        "/healthz should return 200 once the gear has booted"
+    );
+
+    // 4. The gear's OWN route is served — proves compose_oop_router wired a real
+    //    RestApiCapability gear into the host-less router.
+    let ping = http_get(addr, "/ping").await;
+    assert_eq!(
+        ping,
+        Some((200, "pong".to_owned())),
+        "the gear's REST route should serve its response body"
+    );
+
+    // 5. No external dependencies → /readyz becomes 200.
+    assert!(
+        poll_status(addr, "/readyz", 200, Duration::from_secs(3)).await,
+        "/readyz should be 200 when the gear has no unresolved deps"
+    );
+
+    // 6. The gear's OpenAPI is published at the well-known path.
+    let (oas_status, oas_body) = http_get(addr, "/.well-known/openapi.json")
+        .await
+        .expect("openapi endpoint should respond");
+    assert_eq!(oas_status, 200);
+    assert!(
+        oas_body.contains("ping-gear") && oas_body.contains("1.2.3"),
+        "OpenAPI document should carry the gear title + version, got: {oas_body}"
+    );
+
+    // 7. Self-registration ran through the full stack with the advertised URI.
+    let registered = {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+        loop {
+            if directory.register_calls.load(Ordering::SeqCst) >= 1 {
+                break true;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                break false;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    };
+    assert!(
+        registered,
+        "the gear should self-register with the directory"
+    );
+    assert_eq!(
+        directory.registered_endpoint.lock().clone(),
+        Some(format!("http://{addr}")),
+        "the advertised REST endpoint should be registered"
+    );
+
+    // 8. Graceful shutdown: cancel, the server drains + deregisters, the stop
+    //    phase runs, and the lifecycle returns Ok.
+    cancel.cancel();
+    let result = tokio::time::timeout(Duration::from_secs(5), server)
+        .await
+        .expect("run_oop_serving should finish promptly after cancel")
+        .expect("run_oop_serving task should not panic");
+    assert!(
+        result.is_ok(),
+        "OoP serving lifecycle should end cleanly: {result:?}"
+    );
+
+    assert_eq!(
+        directory.deregister_calls.load(Ordering::SeqCst),
+        1,
+        "the gear should deregister exactly once on graceful shutdown"
+    );
+}

--- a/libs/toolkit/src/runtime/mod.rs
+++ b/libs/toolkit/src/runtime/mod.rs
@@ -1,6 +1,11 @@
 mod gear_manager;
 mod grpc_installers;
 mod host_runtime;
+#[cfg(feature = "bootstrap")]
+mod oop_registration;
+#[cfg(feature = "bootstrap")]
+mod oop_serve;
+mod readiness;
 mod runner;
 mod system_context;
 
@@ -16,6 +21,15 @@ pub use host_runtime::{
     DEFAULT_SHUTDOWN_DEADLINE, DbOptions, HostRuntime, TOOLKIT_DIRECTORY_ENDPOINT_ENV,
     TOOLKIT_MODULE_CONFIG_ENV,
 };
+#[cfg(feature = "bootstrap")]
+pub use oop_registration::ResolvedRestEndpoints;
+#[cfg(feature = "bootstrap")]
+pub use oop_serve::{DynBearerAuthenticator, DynInternalAuthenticator, OopServeOptions};
+pub use readiness::{
+    DEFAULT_HEALTHCHECK_TIMEOUT, ReadinessLifecycle, ReadinessReport, ReadinessState,
+};
+#[cfg(feature = "bootstrap")]
+pub use runner::run_oop_serving;
 pub use runner::{
     ClientRegistration, OopGearSpawnConfig, OopSpawnOptions, RunOptions, ShutdownOptions, run,
 };

--- a/libs/toolkit/src/runtime/oop_registration.rs
+++ b/libs/toolkit/src/runtime/oop_registration.rs
@@ -1,0 +1,249 @@
+//! Background self-registration and dependency resolution for `OoP` gears
+//! (`cpt-cf-component-oop-bootstrap`).
+//!
+//! Both run as non-blocking background tasks so the HTTP server and its probes
+//! are up immediately:
+//!
+//! - **Presence** ([`presence_loop`]) is the single owner of this instance's
+//!   `DirectoryService` presence. It registers the instance's gRPC/REST
+//!   endpoints and `OpenAPI` spec (retrying with exponential backoff,
+//!   100ms → 30s cap), then runs one loop that both sends periodic **heartbeats**
+//!   (the steady-state liveness signal the directory uses to keep the instance
+//!   routable) and periodically **re-registers** to self-heal after a
+//!   `DirectoryService` restart / connection loss. Consolidating both into one task (owned
+//!   by the `OoP` serve lifecycle) avoids the split-brain where an independent
+//!   heartbeat task and a re-registration task raced to write conflicting
+//!   liveness state onto the same directory record.
+//! - **Dependency resolution** ([`resolve_deps`]) polls
+//!   `DirectoryService.resolve_rest_service` for each declared dependency, wires
+//!   the resolved base URL into the [`ClientHub`] via [`ResolvedRestEndpoints`],
+//!   and marks the dep resolved so `/readyz` can flip to `200`.
+//!
+//! In Profile 1 (in-process) dependency resolution is a no-op — the topo-sorted
+//! `HostRuntime` already guarantees deps are initialized.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use dashmap::DashMap;
+use tokio_util::sync::CancellationToken;
+
+use cf_system_sdks::directory::{DirectoryClient, RegisterInstanceInfo};
+
+use super::readiness::ReadinessState;
+
+/// Initial retry backoff for registration and dependency polling.
+const INITIAL_BACKOFF: Duration = Duration::from_millis(100);
+/// Maximum retry backoff (cap).
+const MAX_BACKOFF: Duration = Duration::from_secs(30);
+/// Interval at which a successfully-registered instance re-registers to
+/// self-heal after a directory restart / connection loss.
+const RE_REGISTER_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Next backoff in the exponential schedule (doubles, capped at [`MAX_BACKOFF`]).
+fn next_backoff(current: Duration) -> Duration {
+    current.saturating_mul(2).min(MAX_BACKOFF)
+}
+
+/// Sleep for `dur`, returning early (`false`) if `cancel` fires first.
+async fn sleep_or_cancel(dur: Duration, cancel: &CancellationToken) -> bool {
+    tokio::select! {
+        () = cancel.cancelled() => false,
+        () = tokio::time::sleep(dur) => true,
+    }
+}
+
+/// Resolved REST base URLs for the gear's dependencies, keyed by gear name.
+///
+/// Registered into the [`ClientHub`] by the `OoP` bootstrap and populated as
+/// dependencies resolve. Until typed REST client codegen lands, gears look up a
+/// dependency's base URL here (`hub.get::<ResolvedRestEndpoints>()`).
+#[derive(Debug, Default)]
+pub struct ResolvedRestEndpoints {
+    inner: DashMap<String, String>,
+}
+
+impl ResolvedRestEndpoints {
+    /// Create an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a resolved base URL for `gear`.
+    pub fn set(&self, gear: impl Into<String>, uri: impl Into<String>) {
+        self.inner.insert(gear.into(), uri.into());
+    }
+
+    /// Look up the resolved base URL for `gear`, if known.
+    #[must_use]
+    pub fn get(&self, gear: &str) -> Option<String> {
+        self.inner.get(gear).map(|v| v.value().clone())
+    }
+
+    /// Number of resolved dependencies.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns `true` if no dependencies have been resolved yet.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+}
+
+/// Register `info` with the directory, retrying with exponential backoff until
+/// success or cancellation. Returns `true` on success, `false` if cancelled.
+async fn register_once_with_backoff(
+    directory: &Arc<dyn DirectoryClient>,
+    info: &RegisterInstanceInfo,
+    cancel: &CancellationToken,
+) -> bool {
+    let mut backoff = INITIAL_BACKOFF;
+    loop {
+        if cancel.is_cancelled() {
+            return false;
+        }
+        match directory.register_instance(info.clone()).await {
+            Ok(()) => {
+                tracing::info!(gear = %info.gear, instance = %info.instance_id, "registered with DirectoryService");
+                return true;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    gear = %info.gear,
+                    error = %e,
+                    backoff_ms = backoff.as_millis(),
+                    "registration attempt failed; retrying"
+                );
+                if !sleep_or_cancel(backoff, cancel).await {
+                    return false;
+                }
+                backoff = next_backoff(backoff);
+            }
+        }
+    }
+}
+
+/// Single directory-presence loop for an `OoP` instance.
+///
+/// Registers `info` (with backoff), then owns **both** liveness signals in one
+/// task until `cancel` fires:
+///
+/// - a **heartbeat** every `heartbeat_interval` — the steady-state signal the
+///   directory uses to keep the instance `Healthy`/routable (and to avoid
+///   heartbeat-timeout eviction);
+/// - an idempotent **re-registration** every [`RE_REGISTER_INTERVAL`] — self-heals
+///   after a `DirectoryService` restart / connection loss (a heartbeat alone cannot,
+///   since the directory silently ignores heartbeats for an instance it has
+///   forgotten). Re-registration preserves the directory-side liveness state
+///   (see `GearManager::register_instance`), so it does not disturb the
+///   heartbeat-maintained `Healthy` state.
+///
+/// Registering *before* the first heartbeat is deliberate: a heartbeat for an
+/// unregistered instance is a no-op on the directory.
+pub(super) async fn presence_loop(
+    directory: Arc<dyn DirectoryClient>,
+    info: RegisterInstanceInfo,
+    heartbeat_interval: Duration,
+    cancel: CancellationToken,
+) {
+    if !register_once_with_backoff(&directory, &info, &cancel).await {
+        return;
+    }
+
+    // `tokio::time::interval` panics on a zero period; clamp defensively.
+    let heartbeat_interval = heartbeat_interval.max(Duration::from_secs(1));
+    let mut heartbeat = tokio::time::interval(heartbeat_interval);
+    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    heartbeat.tick().await; // consume the immediate first tick
+
+    let mut reregister = tokio::time::interval(RE_REGISTER_INTERVAL);
+    reregister.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    reregister.tick().await; // consume the immediate first tick
+
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => return,
+            _ = heartbeat.tick() => {
+                if let Err(e) = directory.send_heartbeat(&info.gear, &info.instance_id).await {
+                    tracing::warn!(
+                        gear = %info.gear,
+                        instance = %info.instance_id,
+                        error = %e,
+                        "heartbeat failed; re-registering to self-heal"
+                    );
+                    if !register_once_with_backoff(&directory, &info, &cancel).await {
+                        return;
+                    }
+                } else {
+                    tracing::trace!(gear = %info.gear, "heartbeat sent");
+                }
+            }
+            _ = reregister.tick() => {
+                if !register_once_with_backoff(&directory, &info, &cancel).await {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// Poll for a single dependency until resolved (or cancelled), then wire it into
+/// the resolved-endpoints registry and mark it resolved in readiness.
+async fn resolve_one_dep(
+    directory: Arc<dyn DirectoryClient>,
+    dep: String,
+    readiness: Arc<ReadinessState>,
+    resolved: Arc<ResolvedRestEndpoints>,
+    cancel: CancellationToken,
+) {
+    let mut backoff = INITIAL_BACKOFF;
+    loop {
+        if cancel.is_cancelled() {
+            return;
+        }
+        match directory.resolve_rest_service(&dep).await {
+            Ok(endpoint) => {
+                tracing::info!(dep = %dep, endpoint = %endpoint.uri, "resolved REST dependency");
+                resolved.set(dep.clone(), endpoint.uri);
+                readiness.mark_dep_resolved(&dep);
+                return;
+            }
+            Err(e) => {
+                tracing::debug!(dep = %dep, error = %e, "dependency not yet resolvable; retrying");
+                if !sleep_or_cancel(backoff, &cancel).await {
+                    return;
+                }
+                backoff = next_backoff(backoff);
+            }
+        }
+    }
+}
+
+/// Spawn one resolution task per dependency. Each resolves independently and
+/// gates `/readyz` via `readiness`. A no-op when `deps` is empty (Profile 1).
+pub(super) fn resolve_deps(
+    directory: &Arc<dyn DirectoryClient>,
+    deps: Vec<String>,
+    readiness: &Arc<ReadinessState>,
+    resolved: &Arc<ResolvedRestEndpoints>,
+    cancel: &CancellationToken,
+) {
+    for dep in deps {
+        tokio::spawn(resolve_one_dep(
+            Arc::clone(directory),
+            dep,
+            Arc::clone(readiness),
+            Arc::clone(resolved),
+            cancel.clone(),
+        ));
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "oop_registration_tests.rs"]
+mod tests;

--- a/libs/toolkit/src/runtime/oop_registration_tests.rs
+++ b/libs/toolkit/src/runtime/oop_registration_tests.rs
@@ -1,0 +1,195 @@
+//! Tests for `OoP` self-registration and dependency resolution.
+
+use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use cf_system_sdks::directory::{ServiceEndpoint, ServiceInstanceInfo};
+
+/// Stub directory: fails `register`/`resolve` a configurable number of times,
+/// then succeeds; records register calls and heartbeats.
+struct StubDirectory {
+    fail_register: AtomicUsize,
+    register_calls: AtomicUsize,
+    heartbeats: AtomicUsize,
+    fail_resolve: AtomicUsize,
+}
+
+impl StubDirectory {
+    fn new(fail_register: usize, fail_resolve: usize) -> Self {
+        Self {
+            fail_register: AtomicUsize::new(fail_register),
+            register_calls: AtomicUsize::new(0),
+            heartbeats: AtomicUsize::new(0),
+            fail_resolve: AtomicUsize::new(fail_resolve),
+        }
+    }
+}
+
+#[async_trait]
+impl DirectoryClient for StubDirectory {
+    async fn resolve_grpc_service(&self, _service: &str) -> anyhow::Result<ServiceEndpoint> {
+        Ok(ServiceEndpoint::new("http://grpc"))
+    }
+
+    async fn resolve_rest_service(&self, gear: &str) -> anyhow::Result<ServiceEndpoint> {
+        if self.fail_resolve.load(Ordering::SeqCst) > 0 {
+            self.fail_resolve.fetch_sub(1, Ordering::SeqCst);
+            anyhow::bail!("not yet available");
+        }
+        Ok(ServiceEndpoint::new(format!("http://{gear}:8080")))
+    }
+
+    async fn get_openapi_spec(&self, _gear: &str) -> anyhow::Result<String> {
+        Ok(String::new())
+    }
+
+    async fn list_instances(&self, _gear: &str) -> anyhow::Result<Vec<ServiceInstanceInfo>> {
+        Ok(vec![])
+    }
+
+    async fn register_instance(&self, _info: RegisterInstanceInfo) -> anyhow::Result<()> {
+        self.register_calls.fetch_add(1, Ordering::SeqCst);
+        if self.fail_register.load(Ordering::SeqCst) > 0 {
+            self.fail_register.fetch_sub(1, Ordering::SeqCst);
+            anyhow::bail!("directory unavailable");
+        }
+        Ok(())
+    }
+
+    async fn deregister_instance(&self, _gear: &str, _instance: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn send_heartbeat(&self, _gear: &str, _instance: &str) -> anyhow::Result<()> {
+        self.heartbeats.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+fn info() -> RegisterInstanceInfo {
+    RegisterInstanceInfo {
+        gear: "billing".to_owned(),
+        instance_id: "i-1".to_owned(),
+        grpc_services: vec![],
+        version: Some("1.0.0".to_owned()),
+        rest_endpoint: Some(ServiceEndpoint::new("http://billing:8080")),
+        openapi_spec: Some("{}".to_owned()),
+    }
+}
+
+#[test]
+fn backoff_doubles_and_caps() {
+    assert_eq!(
+        next_backoff(Duration::from_millis(100)),
+        Duration::from_millis(200)
+    );
+    assert_eq!(
+        next_backoff(Duration::from_millis(200)),
+        Duration::from_millis(400)
+    );
+    assert_eq!(next_backoff(Duration::from_secs(20)), MAX_BACKOFF);
+    assert_eq!(next_backoff(MAX_BACKOFF), MAX_BACKOFF);
+}
+
+#[tokio::test]
+async fn registration_retries_until_success() {
+    let directory: Arc<dyn DirectoryClient> = Arc::new(StubDirectory::new(2, 0));
+    let cancel = CancellationToken::new();
+    let ok = register_once_with_backoff(&directory, &info(), &cancel).await;
+    assert!(ok);
+}
+
+#[tokio::test]
+async fn registration_returns_false_when_cancelled() {
+    let directory: Arc<dyn DirectoryClient> = Arc::new(StubDirectory::new(1000, 0));
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+    let ok = register_once_with_backoff(&directory, &info(), &cancel).await;
+    assert!(!ok, "cancelled registration must return false");
+}
+
+#[tokio::test]
+async fn presence_loop_registers_once_then_heartbeats_until_cancel() {
+    let stub = Arc::new(StubDirectory::new(0, 0));
+    let directory: Arc<dyn DirectoryClient> = stub.clone();
+    let cancel = CancellationToken::new();
+
+    // 1s is the minimum interval presence_loop clamps to; wait past one tick so
+    // at least one heartbeat fires.
+    let task = tokio::spawn(presence_loop(
+        Arc::clone(&directory),
+        info(),
+        Duration::from_secs(1),
+        cancel.clone(),
+    ));
+
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    assert_eq!(
+        stub.register_calls.load(Ordering::SeqCst),
+        1,
+        "steady state registers exactly once (self-heal re-register is 30s, not fired here)"
+    );
+    assert!(
+        stub.heartbeats.load(Ordering::SeqCst) >= 1,
+        "the single presence task must send heartbeats"
+    );
+
+    cancel.cancel();
+    task.await.unwrap();
+}
+
+#[tokio::test]
+async fn dep_resolution_marks_readiness_and_wires_endpoint() {
+    let directory: Arc<dyn DirectoryClient> = Arc::new(StubDirectory::new(0, 2));
+    let readiness = ReadinessState::new(
+        ["catalog"],
+        Arc::new(crate::healthcheck::RestHealthcheckRegistry::new()),
+    );
+    let resolved = Arc::new(ResolvedRestEndpoints::new());
+    let cancel = CancellationToken::new();
+
+    resolve_one_dep(
+        Arc::clone(&directory),
+        "catalog".to_owned(),
+        Arc::clone(&readiness),
+        Arc::clone(&resolved),
+        cancel,
+    )
+    .await;
+
+    assert!(readiness.all_deps_resolved());
+    assert_eq!(
+        resolved.get("catalog"),
+        Some("http://catalog:8080".to_owned())
+    );
+}
+
+#[tokio::test]
+async fn resolve_deps_empty_is_noop() {
+    let directory: Arc<dyn DirectoryClient> = Arc::new(StubDirectory::new(0, 0));
+    let readiness = ReadinessState::new(
+        Vec::<String>::new(),
+        Arc::new(crate::healthcheck::RestHealthcheckRegistry::new()),
+    );
+    let resolved = Arc::new(ResolvedRestEndpoints::new());
+    resolve_deps(
+        &directory,
+        vec![],
+        &readiness,
+        &resolved,
+        &CancellationToken::new(),
+    );
+    assert!(readiness.all_deps_resolved());
+}
+
+#[test]
+fn resolved_endpoints_basic_ops() {
+    let r = ResolvedRestEndpoints::new();
+    assert!(r.is_empty());
+    r.set("a", "http://a");
+    assert_eq!(r.len(), 1);
+    assert_eq!(r.get("a"), Some("http://a".to_owned()));
+    assert_eq!(r.get("b"), None);
+}

--- a/libs/toolkit/src/runtime/oop_serve.rs
+++ b/libs/toolkit/src/runtime/oop_serve.rs
@@ -1,0 +1,819 @@
+//! Out-of-process (`OoP`) HTTP server: probes, two-plane auth, and graceful
+//! drain (`cpt-cf-component-oop-bootstrap`).
+//!
+//! This module owns the edge of an `OoP` gear's HTTP surface:
+//!
+//! - **Framework probes** — `/healthz` (liveness), `/readyz` (readiness, gated
+//!   on dependency resolution + custom checks), `/health` (diagnostics, full
+//!   healthcheck report), and `/.well-known/openapi.json` (the canonical
+//!   discovery path; `cpt-cf-binding-constraint-openapi-well-known`).
+//! - **Two-plane auth** — platform-plane ([`internal_auth_middleware`]) runs
+//!   *before* tenant-plane ([`security_context_middleware`]) per
+//!   `cpt-cf-adr-two-plane-auth`,
+//!   but only when the corresponding authenticator is injected. Because both
+//!   authenticator traits use return-position `impl Trait` (not `dyn`-safe),
+//!   callers inject the object-safe [`DynBearerAuthenticator`] /
+//!   [`DynInternalAuthenticator`] adapters.
+//! - **Graceful drain** — a drain guard rejects new gear-route requests with
+//!   `503 + Retry-After` once draining begins, while in-flight requests finish.
+//! - **Framework middleware** — a canonical-error layer normalizes gear/auth
+//!   error responses into `problem+json` (`trace_id` / `instance` filled),
+//!   matching the in-process (`api-gateway`) path. The drain guard also catches
+//!   panics so a panic can neither drop the client connection nor leak the
+//!   in-flight counter (which would otherwise stall graceful drain).
+//!
+//! The server is driven by [`OopHttpServer`], invoked from the `HostRuntime`
+//! `OoP` path: it binds and serves the probes **before** the gear's `start()`
+//! phase (so `/healthz` is up during a slow startup), then swaps in the composed
+//! gear routes. Self-registration and dependency resolution live in
+//! [`super::oop_registration`].
+
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use axum::{
+    Json, Router,
+    extract::{Request, State},
+    http::{StatusCode, header::RETRY_AFTER},
+    middleware::{Next, from_fn, from_fn_with_state},
+    response::{IntoResponse, Response},
+    routing::get,
+};
+use futures_util::FutureExt as _;
+use tokio_util::sync::CancellationToken;
+use tower::ServiceExt as _;
+use url::Url;
+
+use cf_system_sdks::directory::{DirectoryClient, RegisterInstanceInfo, ServiceEndpoint};
+use toolkit_canonical_errors::CanonicalError;
+use toolkit_http_middleware::{internal_auth_middleware, security_context_middleware};
+use toolkit_security::{
+    AuthNError, BearerAuthenticator, InternalAuthNError, InternalAuthenticator, PlatformIdentity,
+    SecurityContext,
+};
+
+use super::readiness::ReadinessState;
+use crate::api::canonical_error_middleware;
+
+/// `Retry-After` (seconds) advertised while the gear is draining.
+const DRAIN_RETRY_AFTER_SECONDS: u64 = 5;
+
+/// `Retry-After` (seconds) advertised for gear routes before the gear has
+/// finished starting (probes are already live; routes come up shortly).
+const STARTING_RETRY_AFTER_SECONDS: u64 = 1;
+
+// ---------------------------------------------------------------------------
+// Object-safe authenticator adapters
+// ---------------------------------------------------------------------------
+
+type BearerFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<SecurityContext, AuthNError>> + Send + 'a>>;
+type InternalFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<PlatformIdentity, InternalAuthNError>> + Send + 'a>>;
+
+/// Object-safe erasure of [`BearerAuthenticator`].
+///
+/// [`BearerAuthenticator::authenticate`] returns `impl Future`, so the trait is
+/// not `dyn`-compatible. This trait boxes the future so a concrete authenticator
+/// can be stored behind an `Arc` and injected at the bootstrap layer.
+trait ErasedBearer: Send + Sync {
+    fn authenticate<'a>(&'a self, token: &'a str) -> BearerFuture<'a>;
+}
+
+impl<A: BearerAuthenticator> ErasedBearer for A {
+    fn authenticate<'a>(&'a self, token: &'a str) -> BearerFuture<'a> {
+        Box::pin(BearerAuthenticator::authenticate(self, token))
+    }
+}
+
+/// Injectable, object-safe tenant-plane authenticator.
+///
+/// Wrap a concrete [`BearerAuthenticator`] (e.g. an `AuthNResolverClient`
+/// adapter supplied by the app/gear binary) with [`DynBearerAuthenticator::new`]
+/// and hand it to [`OopServeOptions::bearer_authenticator`].
+#[derive(Clone)]
+pub struct DynBearerAuthenticator(Arc<dyn ErasedBearer>);
+
+impl DynBearerAuthenticator {
+    /// Wrap a concrete [`BearerAuthenticator`] in the object-safe adapter.
+    #[must_use]
+    pub fn new<A: BearerAuthenticator + 'static>(authenticator: A) -> Self {
+        Self(Arc::new(authenticator))
+    }
+
+    /// Wrap an already-`Arc`'d [`BearerAuthenticator`] in the object-safe adapter.
+    #[must_use]
+    pub fn from_arc<A: BearerAuthenticator + 'static>(authenticator: Arc<A>) -> Self {
+        // Adapt Arc<A> to Arc<dyn ErasedBearer> via a thin wrapper.
+        struct W<A>(Arc<A>);
+        impl<A: BearerAuthenticator> ErasedBearer for W<A> {
+            fn authenticate<'a>(&'a self, token: &'a str) -> BearerFuture<'a> {
+                Box::pin(BearerAuthenticator::authenticate(&*self.0, token))
+            }
+        }
+        Self(Arc::new(W(authenticator)))
+    }
+}
+
+impl BearerAuthenticator for DynBearerAuthenticator {
+    async fn authenticate(&self, token: &str) -> Result<SecurityContext, AuthNError> {
+        self.0.authenticate(token).await
+    }
+}
+
+/// Object-safe erasure of [`InternalAuthenticator`] (same rationale as
+/// [`ErasedBearer`]).
+trait ErasedInternal: Send + Sync {
+    fn authenticate<'a>(&'a self, token: &'a str) -> InternalFuture<'a>;
+}
+
+impl<A: InternalAuthenticator> ErasedInternal for A {
+    fn authenticate<'a>(&'a self, token: &'a str) -> InternalFuture<'a> {
+        Box::pin(InternalAuthenticator::authenticate(self, token))
+    }
+}
+
+/// Injectable, object-safe platform-plane authenticator.
+///
+/// Wrap a concrete [`InternalAuthenticator`] (e.g. the K8s `TokenReview`
+/// validator) with [`DynInternalAuthenticator::new`] and hand it to
+/// [`OopServeOptions::internal_authenticator`].
+#[derive(Clone)]
+pub struct DynInternalAuthenticator(Arc<dyn ErasedInternal>);
+
+impl DynInternalAuthenticator {
+    /// Wrap a concrete [`InternalAuthenticator`] in the object-safe adapter.
+    #[must_use]
+    pub fn new<A: InternalAuthenticator + 'static>(authenticator: A) -> Self {
+        Self(Arc::new(authenticator))
+    }
+
+    /// Wrap an already-`Arc`'d [`InternalAuthenticator`] in the object-safe adapter.
+    #[must_use]
+    pub fn from_arc<A: InternalAuthenticator + 'static>(authenticator: Arc<A>) -> Self {
+        struct W<A>(Arc<A>);
+        impl<A: InternalAuthenticator> ErasedInternal for W<A> {
+            fn authenticate<'a>(&'a self, token: &'a str) -> InternalFuture<'a> {
+                Box::pin(InternalAuthenticator::authenticate(&*self.0, token))
+            }
+        }
+        Self(Arc::new(W(authenticator)))
+    }
+}
+
+impl InternalAuthenticator for DynInternalAuthenticator {
+    async fn authenticate(&self, token: &str) -> Result<PlatformIdentity, InternalAuthNError> {
+        self.0.authenticate(token).await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Serve options
+// ---------------------------------------------------------------------------
+
+/// Configuration and collaborators for the `OoP` HTTP runtime, assembled by the
+/// bootstrap layer and consumed by `HostRuntime`'s `OoP` serving path.
+pub struct OopServeOptions {
+    /// Logical gear name (used for registration + `OpenAPI` title).
+    pub gear_name: String,
+    /// Process instance id (used for registration/deregistration).
+    pub instance_id: String,
+    /// Optional gear version (used for registration + `OpenAPI` version).
+    pub version: Option<String>,
+    /// Base URL other services use to reach this instance's REST endpoint
+    /// (e.g. `http://billing.default.svc.cluster.local:8080`). Registered with
+    /// `DirectoryService` as the instance's `rest_endpoint`.
+    pub advertise_uri: String,
+    /// Address the main HTTP server binds to (gear routes + probes).
+    pub listen_addr: std::net::SocketAddr,
+    /// Optional separate address for probe endpoints (sidecar port). When set,
+    /// probes are served here *and* on the main listener.
+    pub probe_bind_addr: Option<std::net::SocketAddr>,
+    /// Maximum time to wait for in-flight requests to drain on shutdown.
+    pub drain_timeout: Duration,
+    /// Interval between `DirectoryService` heartbeats. The single presence task
+    /// ([`presence_loop`](super::oop_registration)) sends a heartbeat every
+    /// interval to keep the instance `Healthy`/routable and avoid
+    /// heartbeat-timeout eviction. The presence loop clamps this to a 1s minimum.
+    pub heartbeat_interval: Duration,
+    /// Per-check timeout for readiness healthchecks (`/readyz`). A gear's
+    /// [`Healthcheck`](crate::healthcheck::Healthcheck) that exceeds this is
+    /// reported `Unhealthy`. Mirrors the `api-gateway` `healthcheck_timeout_ms`.
+    pub healthcheck_timeout: Duration,
+    /// Directory client used for self-registration and dependency resolution.
+    pub directory: Arc<dyn DirectoryClient>,
+    /// Tenant-plane authenticator; when `Some`, `security_context_middleware`
+    /// is installed on gear routes.
+    pub bearer_authenticator: Option<DynBearerAuthenticator>,
+    /// Platform-plane authenticator; when `Some`, `internal_auth_middleware` is
+    /// installed on gear routes (runs before the tenant plane).
+    pub internal_authenticator: Option<DynInternalAuthenticator>,
+}
+
+impl std::fmt::Debug for OopServeOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OopServeOptions")
+            .field("gear_name", &self.gear_name)
+            .field("instance_id", &self.instance_id)
+            .field("version", &self.version)
+            .field("advertise_uri", &self.advertise_uri)
+            .field("listen_addr", &self.listen_addr)
+            .field("probe_bind_addr", &self.probe_bind_addr)
+            .field("drain_timeout", &self.drain_timeout)
+            .field("heartbeat_interval", &self.heartbeat_interval)
+            .field("healthcheck_timeout", &self.healthcheck_timeout)
+            .field("bearer_authenticator", &self.bearer_authenticator.is_some())
+            .field(
+                "internal_authenticator",
+                &self.internal_authenticator.is_some(),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Probe router
+// ---------------------------------------------------------------------------
+
+/// Composed gear routes + `OpenAPI` document, published *after* the gear's
+/// `start()` phase completes.
+///
+/// Held behind an [`arc_swap::ArcSwapOption`] so the probe listener can bind and
+/// serve `/healthz` immediately (while a slow `start()` runs), then have the gear
+/// routes swapped in atomically — no port rebind, so liveness never blips.
+#[derive(Clone, Default)]
+struct LateRoutes {
+    inner: Arc<arc_swap::ArcSwapOption<LateRoutesInner>>,
+}
+
+struct LateRoutesInner {
+    /// Fully-layered gear router (auth planes + drain guard + canonical errors).
+    gear: Router,
+    /// Serialized `OpenAPI` document served at the well-known path.
+    openapi: Arc<str>,
+}
+
+impl LateRoutes {
+    /// Publish the composed gear routes; subsequent requests are served by them.
+    fn publish(&self, gear: Router, openapi: Arc<str>) {
+        self.inner
+            .store(Some(Arc::new(LateRoutesInner { gear, openapi })));
+    }
+
+    /// The current gear router, if the gear has finished starting.
+    fn gear(&self) -> Option<Router> {
+        self.inner.load_full().map(|i| i.gear.clone())
+    }
+
+    /// The current `OpenAPI` document, if published.
+    fn openapi(&self) -> Option<Arc<str>> {
+        self.inner.load_full().map(|i| Arc::clone(&i.openapi))
+    }
+}
+
+/// `503 + Retry-After` returned for gear routes before the gear has started.
+fn starting_response() -> Response {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        [(RETRY_AFTER, STARTING_RETRY_AFTER_SECONDS.to_string())],
+        "starting",
+    )
+        .into_response()
+}
+
+/// Shared state for the probe endpoints.
+#[derive(Clone)]
+struct ProbeState {
+    readiness: Arc<ReadinessState>,
+    late: LateRoutes,
+}
+
+/// Build the outer router bound at startup: framework probes plus a gear-route
+/// fallback that is `503 starting` until [`LateRoutes::publish`] swaps in the
+/// composed gear router. Probes are live as soon as the listener binds.
+fn build_outer_router(readiness: Arc<ReadinessState>, late: LateRoutes) -> Router {
+    let fallback_late = late.clone();
+    build_probe_router(readiness, late).fallback_service(tower::util::service_fn(
+        move |req: Request| {
+            let late = fallback_late.clone();
+            async move {
+                match late.gear() {
+                    // `Router`'s service error is `Infallible`, hence `match e {}`.
+                    Some(router) => Ok::<_, std::convert::Infallible>(
+                        router.oneshot(req).await.unwrap_or_else(|e| match e {}),
+                    ),
+                    None => Ok::<_, std::convert::Infallible>(starting_response()),
+                }
+            }
+        },
+    ))
+}
+
+/// Build the framework probe router: `/healthz`, `/readyz`, `/health`, and the
+/// well-known `OpenAPI` discovery path.
+///
+/// These routes carry no tenant JWT and are never subject to the drain guard or
+/// the auth middlewares (they must respond during startup and drain).
+fn build_probe_router(readiness: Arc<ReadinessState>, late: LateRoutes) -> Router {
+    let state = ProbeState { readiness, late };
+
+    Router::new()
+        .route("/healthz", get(healthz))
+        .route("/readyz", get(readyz))
+        .route("/health", get(health))
+        .route("/.well-known/openapi.json", get(openapi))
+        .route("/openapi.json", get(openapi))
+        .with_state(state)
+}
+
+/// Liveness: always `200` with plain body `ok` once the server is listening.
+async fn healthz() -> &'static str {
+    "ok"
+}
+
+/// Readiness: `200` when ready, `503` with the unresolved-deps / failing-checks
+/// body otherwise. `Degraded` checks keep the response `200`.
+async fn readyz(State(state): State<ProbeState>) -> Response {
+    let report = state.readiness.evaluate().await;
+    let status = if report.ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (status, Json(report)).into_response()
+}
+
+/// Health: returns the full `HealthcheckReport` (`status` + per-component
+/// detail). `200` for `Healthy`/`Degraded`, `503` for `Unhealthy`.
+async fn health(State(state): State<ProbeState>) -> impl IntoResponse {
+    let report = state.readiness.health_report().await;
+    let status = if report.is_ready() {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (status, Json(report))
+}
+
+/// Serve the gear's generated `OpenAPI` document once published (after
+/// `start()`); `503 starting` beforehand.
+async fn openapi(State(state): State<ProbeState>) -> Response {
+    match state.late.openapi() {
+        Some(spec) => (
+            StatusCode::OK,
+            [(axum::http::header::CONTENT_TYPE, "application/json")],
+            spec.to_string(),
+        )
+            .into_response(),
+        None => starting_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Drain guard
+// ---------------------------------------------------------------------------
+
+/// Tracks in-flight gear-route requests and enforces the drain state.
+#[derive(Clone)]
+struct DrainGuard {
+    readiness: Arc<ReadinessState>,
+    in_flight: Arc<AtomicUsize>,
+}
+
+impl DrainGuard {
+    fn new(readiness: Arc<ReadinessState>) -> Self {
+        Self {
+            readiness,
+            in_flight: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    /// Current number of in-flight gear-route requests.
+    fn in_flight(&self) -> usize {
+        self.in_flight.load(Ordering::SeqCst)
+    }
+
+    /// Begin draining: flip readiness to `503` so upstreams stop routing new
+    /// traffic and the guard starts rejecting new requests (drain step 1/2).
+    fn begin_drain(&self) {
+        self.readiness.set_draining(true);
+    }
+}
+
+/// RAII guard that increments the in-flight request counter on creation and
+/// decrements it on drop, so cancellation or panic cannot leak a count.
+struct InFlightGuard(Arc<AtomicUsize>);
+
+impl InFlightGuard {
+    fn new(counter: Arc<AtomicUsize>) -> Self {
+        counter.fetch_add(1, Ordering::SeqCst);
+        Self(counter)
+    }
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+/// Middleware: reject new requests with `503 + Retry-After` while draining;
+/// otherwise track the request as in-flight until it completes.
+async fn drain_guard_middleware(
+    State(guard): State<DrainGuard>,
+    request: axum::extract::Request,
+    next: Next,
+) -> Response {
+    if guard.readiness.is_draining() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            [(RETRY_AFTER, DRAIN_RETRY_AFTER_SECONDS.to_string())],
+            "draining",
+        )
+            .into_response();
+    }
+
+    // The in-flight counter is tracked by an RAII guard so it is decremented
+    // whether the handler completes normally, panics, or the future is cancelled.
+    // Panics are caught and converted to a canonical 500 (enriched by the outer
+    // canonical-error layer) instead of dropping the connection — the OoP
+    // equivalent of `tower_http`'s `CatchPanicLayer`.
+    let _in_flight = InFlightGuard::new(guard.in_flight.clone());
+    let outcome = AssertUnwindSafe(next.run(request)).catch_unwind().await;
+
+    match outcome {
+        Ok(response) => response,
+        Err(panic) => {
+            let detail = panic_message(panic.as_ref());
+            tracing::error!(panic = %detail, "OoP gear handler panicked");
+            // `detail` is a server-side diagnostic only; `CanonicalError::internal`
+            // keeps it off the wire (`#[serde(skip)]`) per the error contract.
+            CanonicalError::internal(format!("gear handler panicked: {detail}"))
+                .create()
+                .into_response()
+        }
+    }
+}
+
+/// Extract a human-readable message from a caught panic payload.
+fn panic_message(panic: &(dyn std::any::Any + Send)) -> String {
+    panic
+        .downcast_ref::<&str>()
+        .map(|s| (*s).to_owned())
+        .or_else(|| panic.downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "unknown panic".to_owned())
+}
+
+// ---------------------------------------------------------------------------
+// Router assembly
+// ---------------------------------------------------------------------------
+
+/// Apply the framework middleware stack to the composed gear router: auth planes
+/// (when injected), the drain guard, and the canonical-error layer.
+///
+/// Probes are NOT layered here — they live on the outer router (see
+/// [`build_outer_router`]) so they stay unguarded and answerable during startup
+/// and drain.
+fn layer_gear_router(
+    gear_router: Router,
+    drain_guard: DrainGuard,
+    options: &OopServeOptions,
+) -> Router {
+    let mut gear = gear_router;
+
+    // Auth planes (installed only when injected). Add tenant plane first so it
+    // is *inner* to the platform plane — `internal_auth_middleware` must run
+    // BEFORE `security_context_middleware` (`cpt-cf-adr-two-plane-auth`).
+    if let Some(bearer) = options.bearer_authenticator.clone() {
+        gear = gear.layer(from_fn_with_state(
+            Arc::new(bearer),
+            security_context_middleware::<DynBearerAuthenticator>,
+        ));
+    }
+    if let Some(internal) = options.internal_authenticator.clone() {
+        gear = gear.layer(from_fn_with_state(
+            Arc::new(internal),
+            internal_auth_middleware::<DynInternalAuthenticator>,
+        ));
+    }
+
+    // Drain guard sits just inside the canonical-error layer: it rejects new
+    // requests while draining and tracks the in-flight count (catching handler
+    // panics so the counter can never leak and stall the drain).
+    gear = gear.layer(from_fn_with_state(drain_guard, drain_guard_middleware));
+
+    // Canonical-error middleware is the outermost gear layer so it post-processes
+    // every gear/auth response into `problem+json` with `trace_id` / `instance`
+    // filled — matching the in-process (`api-gateway`) path.
+    gear.layer(from_fn(canonical_error_middleware))
+}
+
+// ---------------------------------------------------------------------------
+// Serve
+// ---------------------------------------------------------------------------
+
+/// Serve the pre-bound `OoP` listener(s) until `cancel` fires, then drain.
+///
+/// Binding happens earlier in [`OopHttpServer::start`] so `/healthz` is up
+/// before the gear's (possibly slow) `start()` phase; this loop only drives the
+/// accept + graceful-shutdown machinery:
+/// 1. Serve with graceful shutdown wired to `cancel`.
+/// 2. On `cancel`: flip readiness to draining (via the caller-owned
+///    `ReadinessState`), wait up to `drain_timeout` for in-flight to reach zero,
+///    then let `axum` close the listener.
+///
+/// The `DirectoryService` deregistration is orchestrated by [`OopHttpServer::join`]
+/// so the full drain sequence (`cpt-cf-component-oop-bootstrap`) is honored.
+///
+/// # Errors
+/// Returns an error if the server task fails.
+async fn serve_loop(
+    listener: tokio::net::TcpListener,
+    router: Router,
+    drain_guard: DrainGuard,
+    sidecar: Option<(tokio::net::TcpListener, Router)>,
+    drain_timeout: Duration,
+    cancel: CancellationToken,
+) -> anyhow::Result<()> {
+    // Optional sidecar probe listener (bound by the caller).
+    let sidecar = match sidecar {
+        Some((probe_listener, probe_router)) => {
+            let shutdown = {
+                let cancel = cancel.clone();
+                async move { cancel.cancelled().await }
+            };
+            Some(tokio::spawn(async move {
+                if let Err(e) = axum::serve(probe_listener, probe_router)
+                    .with_graceful_shutdown(shutdown)
+                    .await
+                {
+                    tracing::warn!(error = %e, "OoP probe sidecar server error");
+                }
+            }))
+        }
+        None => None,
+    };
+
+    // Main server: graceful shutdown waits for cancellation, then drains.
+    let shutdown = {
+        let cancel = cancel.clone();
+        let guard = drain_guard.clone();
+        async move {
+            cancel.cancelled().await;
+            // Drain step 1/2: flip readiness to 503 and start rejecting new work.
+            guard.begin_drain();
+            tracing::info!("OoP HTTP server draining (graceful shutdown)");
+            // Drain step 3: wait for in-flight requests to complete.
+            drain_in_flight(&guard, drain_timeout).await;
+        }
+    };
+
+    let result = axum::serve(
+        listener,
+        router.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown)
+    .await
+    .map_err(anyhow::Error::from);
+
+    if let Some(handle) = sidecar {
+        handle.abort();
+        if let Err(e) = handle.await
+            && !e.is_cancelled()
+        {
+            tracing::warn!(error = %e, "OoP probe sidecar task join error");
+        }
+    }
+
+    result
+}
+
+/// Owns an `OoP` gear's HTTP surface across the startup boundary.
+///
+/// [`start`](Self::start) binds the listener and serves the framework probes
+/// **immediately** — `/healthz` → `200`, `/readyz` → `starting`/`503`, and gear
+/// routes → `503 starting` — so the kubelet's liveness probe passes while the
+/// gear's (possibly slow) `start()` phase runs. Once the gear router is composed,
+/// [`attach`](Self::attach) swaps it in atomically (no port rebind) and starts
+/// background directory presence + dependency resolution. [`join`](Self::join)
+/// waits for the graceful drain on shutdown, then deregisters from
+/// `DirectoryService` (drain step 4, `cpt-cf-component-oop-bootstrap`).
+///
+/// Steps 5–7 of the drain order (reverse-dependency wait, stopping runtime
+/// services, process exit) are the caller's / operator's responsibility;
+/// the presence task stops when `cancel` fires.
+pub(super) struct OopHttpServer {
+    readiness: Arc<ReadinessState>,
+    resolved: Arc<super::oop_registration::ResolvedRestEndpoints>,
+    late: LateRoutes,
+    drain_guard: DrainGuard,
+    options: OopServeOptions,
+    cancel: CancellationToken,
+    registration_task: Option<tokio::task::JoinHandle<()>>,
+    serve: tokio::task::JoinHandle<anyhow::Result<()>>,
+}
+
+impl OopHttpServer {
+    /// Bind the listener(s) and start serving probes immediately; gear routes
+    /// reply `503 starting` until [`attach`](Self::attach) publishes them.
+    ///
+    /// # Errors
+    /// Returns an error if the main (or sidecar) listener cannot be bound.
+    pub(super) async fn start(
+        readiness: Arc<ReadinessState>,
+        resolved: Arc<super::oop_registration::ResolvedRestEndpoints>,
+        options: OopServeOptions,
+        cancel: CancellationToken,
+    ) -> anyhow::Result<Self> {
+        let late = LateRoutes::default();
+        let drain_guard = DrainGuard::new(Arc::clone(&readiness));
+        let mut options = options;
+
+        let listener = tokio::net::TcpListener::bind(options.listen_addr).await?;
+        let bound = listener.local_addr()?;
+        let configured_port = options.listen_addr.port();
+        if bound.port() != configured_port {
+            if let Some(rewritten) =
+                rewrite_advertise_uri_port(&options.advertise_uri, bound.port(), configured_port)
+            {
+                tracing::info!(
+                    old = %options.advertise_uri,
+                    new = %rewritten,
+                    "advertise_uri rewritten to use actually bound port"
+                );
+                options.advertise_uri = rewritten;
+            } else {
+                tracing::info!(
+                    advertise_uri = %options.advertise_uri,
+                    bound_port = bound.port(),
+                    configured_port,
+                    "bound port differs from configured; leaving advertise_uri unchanged"
+                );
+            }
+        }
+        options.listen_addr = bound;
+        tracing::info!(
+            addr = %options.listen_addr,
+            "OoP HTTP server bound (probes live; gear routes attach after start)"
+        );
+
+        let outer = build_outer_router(Arc::clone(&readiness), late.clone());
+
+        let sidecar = if let Some(addr) = options.probe_bind_addr {
+            let probe_listener = tokio::net::TcpListener::bind(addr).await?;
+            let bound_probe = probe_listener.local_addr()?;
+            options.probe_bind_addr = Some(bound_probe);
+            tracing::info!(addr = %bound_probe, "OoP probe sidecar bound");
+            Some((
+                probe_listener,
+                build_probe_router(Arc::clone(&readiness), late.clone()),
+            ))
+        } else {
+            None
+        };
+
+        let serve = tokio::spawn(serve_loop(
+            listener,
+            outer,
+            drain_guard.clone(),
+            sidecar,
+            options.drain_timeout,
+            cancel.clone(),
+        ));
+
+        Ok(Self {
+            readiness,
+            resolved,
+            late,
+            drain_guard,
+            options,
+            cancel,
+            registration_task: None,
+            serve,
+        })
+    }
+
+    /// The serve options (used by the caller to compose the `OpenAPI` document).
+    pub(super) fn options(&self) -> &OopServeOptions {
+        &self.options
+    }
+
+    /// Publish the composed gear routes (they go live atomically) and start
+    /// background directory presence + dependency resolution.
+    ///
+    /// Presence (registration + heartbeat) and dep resolution start here — only
+    /// once the gear can actually serve — so the directory never advertises a
+    /// not-yet-serving instance.
+    pub(super) fn attach(&mut self, gear_router: Router, openapi_json: String, deps: Vec<String>) {
+        let openapi_arc: Arc<str> = Arc::from(openapi_json);
+        let layered = layer_gear_router(gear_router, self.drain_guard.clone(), &self.options);
+        self.late.publish(layered, Arc::clone(&openapi_arc));
+        self.readiness.mark_startup_complete();
+        tracing::info!(gear = %self.options.gear_name, "OoP gear routes attached (now serving)");
+
+        // Single directory-presence task: registration + heartbeat + self-heal.
+        let registration_info = RegisterInstanceInfo {
+            gear: self.options.gear_name.clone(),
+            instance_id: self.options.instance_id.clone(),
+            grpc_services: vec![],
+            version: self.options.version.clone(),
+            rest_endpoint: Some(ServiceEndpoint::new(self.options.advertise_uri.clone())),
+            openapi_spec: Some(openapi_arc.to_string()),
+        };
+        self.registration_task = Some(tokio::spawn(super::oop_registration::presence_loop(
+            Arc::clone(&self.options.directory),
+            registration_info,
+            self.options.heartbeat_interval,
+            self.cancel.clone(),
+        )));
+
+        // Background dependency resolution (gates /readyz). No-op if `deps` empty.
+        super::oop_registration::resolve_deps(
+            &self.options.directory,
+            deps,
+            &self.readiness,
+            &self.resolved,
+            &self.cancel,
+        );
+    }
+
+    /// Wait for the server to drain on shutdown, then deregister from
+    /// `DirectoryService` (drain step 4 — after in-flight requests finish so
+    /// consumers don't see stale "ready" state).
+    ///
+    /// # Errors
+    /// Propagates a serve error; deregistration failures are logged only.
+    pub(super) async fn join(mut self) -> anyhow::Result<()> {
+        let serve_result = match self.serve.await {
+            Ok(r) => r,
+            Err(e) => Err(anyhow::anyhow!("OoP serve task join error: {e}")),
+        };
+
+        if let Some(task) = self.registration_task.take() {
+            task.abort();
+        }
+        if let Err(e) = self
+            .options
+            .directory
+            .deregister_instance(&self.options.gear_name, &self.options.instance_id)
+            .await
+        {
+            tracing::warn!(
+                gear = %self.options.gear_name,
+                error = %e,
+                "deregistration from DirectoryService failed on shutdown"
+            );
+        } else {
+            tracing::info!(gear = %self.options.gear_name, "deregistered from DirectoryService");
+        }
+
+        serve_result
+    }
+}
+
+/// Rewrite `advertise_uri` to use the actually bound port, but only if the
+/// URI currently uses the `configured_port` (i.e. the port the caller asked
+/// the server to bind to). This preserves user-provided load-balancer URLs
+/// that intentionally advertise a different port from the local socket.
+fn rewrite_advertise_uri_port(
+    advertise_uri: &str,
+    bound_port: u16,
+    configured_port: u16,
+) -> Option<String> {
+    let mut url = Url::parse(advertise_uri).ok()?;
+    if url.port_or_known_default() != Some(configured_port) {
+        return None;
+    }
+    url.set_port(Some(bound_port)).ok()?;
+    Some(url.to_string())
+}
+
+/// Wait up to `timeout` for the in-flight counter to reach zero.
+async fn drain_in_flight(guard: &DrainGuard, timeout: Duration) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let in_flight = guard.in_flight();
+        if in_flight == 0 {
+            tracing::info!("OoP drain complete: no in-flight requests");
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            tracing::warn!(
+                in_flight,
+                timeout_secs = timeout.as_secs(),
+                "OoP drain timed out with in-flight requests remaining"
+            );
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "oop_serve_tests.rs"]
+mod tests;

--- a/libs/toolkit/src/runtime/oop_serve_tests.rs
+++ b/libs/toolkit/src/runtime/oop_serve_tests.rs
@@ -1,0 +1,565 @@
+//! Tests for the `OoP` HTTP serve edge (probes, drain guard, auth wiring).
+
+use super::*;
+use axum::body::{Body, to_bytes};
+use axum::http::Request;
+use serde_json::Value;
+use tower::ServiceExt; // for `oneshot`
+
+use crate::healthcheck::RestHealthcheckRegistry;
+
+/// Build a readiness state with an empty healthcheck registry (no gear checks).
+fn readiness<I, S>(deps: I) -> Arc<ReadinessState>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    ReadinessState::new(deps, Arc::new(RestHealthcheckRegistry::new()))
+}
+
+fn probe_router() -> Router {
+    let readiness = readiness(Vec::<String>::new());
+    let late = LateRoutes::default();
+    late.publish(Router::new(), Arc::from("{\"openapi\":\"3.1.0\"}"));
+    build_probe_router(readiness, late)
+}
+
+#[tokio::test]
+async fn healthz_is_always_ok() {
+    let app = probe_router();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/healthz")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(bytes, "ok");
+}
+
+#[tokio::test]
+async fn readyz_reports_503_until_deps_resolved_then_200() {
+    let readiness = readiness(["billing"]);
+    let app = build_probe_router(Arc::clone(&readiness), LateRoutes::default());
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/readyz")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let body: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(body["state"], "starting");
+    assert_eq!(body["ready"], false);
+
+    readiness.mark_dep_resolved("billing");
+    readiness.mark_startup_complete();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/readyz")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let body: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(body["state"], "ready");
+    assert_eq!(body["ready"], true);
+}
+
+#[tokio::test]
+async fn health_returns_full_report() {
+    let app = probe_router();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let body: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(body["status"], "healthy");
+    assert_eq!(body["components"], serde_json::json!([]));
+}
+
+#[tokio::test]
+async fn readyz_503_when_draining() {
+    let readiness = readiness(Vec::<String>::new());
+    readiness.mark_startup_complete();
+    readiness.set_draining(true);
+    let app = build_probe_router(Arc::clone(&readiness), LateRoutes::default());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/readyz")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn well_known_openapi_is_served() {
+    let app = probe_router();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/.well-known/openapi.json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok()),
+        Some("application/json")
+    );
+}
+
+#[tokio::test]
+async fn drain_guard_rejects_new_requests_while_draining() {
+    let readiness = readiness(Vec::<String>::new());
+    let guard = DrainGuard::new(Arc::clone(&readiness));
+
+    let gear = Router::new().route("/work", get(|| async { "done" }));
+    let app = gear.layer(from_fn_with_state(guard.clone(), drain_guard_middleware));
+
+    // Not draining: request succeeds.
+    let resp = app
+        .clone()
+        .oneshot(Request::builder().uri("/work").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Draining: request rejected with 503 + Retry-After.
+    readiness.set_draining(true);
+    let resp = app
+        .oneshot(Request::builder().uri("/work").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert!(resp.headers().get(RETRY_AFTER).is_some());
+}
+
+#[tokio::test]
+async fn drain_guard_tracks_in_flight_and_resets() {
+    let readiness = readiness(Vec::<String>::new());
+    let guard = DrainGuard::new(readiness);
+    assert_eq!(guard.in_flight(), 0);
+
+    let gear = Router::new().route("/work", get(|| async { "done" }));
+    let app = gear.layer(from_fn_with_state(guard.clone(), drain_guard_middleware));
+
+    let resp = app
+        .oneshot(Request::builder().uri("/work").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    // After completion the counter returns to zero.
+    assert_eq!(guard.in_flight(), 0);
+}
+
+#[tokio::test]
+async fn drain_in_flight_returns_when_zero() {
+    let readiness = readiness(Vec::<String>::new());
+    let guard = DrainGuard::new(readiness);
+    // No in-flight requests: must return promptly.
+    drain_in_flight(&guard, Duration::from_secs(5)).await;
+    assert_eq!(guard.in_flight(), 0);
+}
+
+async fn panicking_handler() -> &'static str {
+    panic!("handler exploded");
+}
+
+#[tokio::test]
+async fn drain_guard_catches_handler_panic_without_leaking_in_flight() {
+    let readiness = readiness(Vec::<String>::new());
+    let guard = DrainGuard::new(readiness);
+
+    let gear = Router::new().route("/boom", get(panicking_handler));
+    let app = gear.layer(from_fn_with_state(guard.clone(), drain_guard_middleware));
+
+    let resp = app
+        .oneshot(Request::builder().uri("/boom").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    // The panic is converted to a 500 (client gets a response, not a dropped
+    // connection)...
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    // ...and, crucially, the in-flight counter returns to zero so graceful drain
+    // cannot stall for the full timeout.
+    assert_eq!(guard.in_flight(), 0);
+}
+
+// --- auth adapter smoke tests ---
+
+struct AllowAuthN;
+impl BearerAuthenticator for AllowAuthN {
+    async fn authenticate(&self, _token: &str) -> Result<SecurityContext, AuthNError> {
+        Ok(SecurityContext::anonymous())
+    }
+}
+
+#[tokio::test]
+async fn dyn_bearer_adapter_delegates() {
+    let dynamic = DynBearerAuthenticator::new(AllowAuthN);
+    let result = BearerAuthenticator::authenticate(&dynamic, "token").await;
+    assert!(result.is_ok());
+}
+
+struct AllowInternal;
+impl InternalAuthenticator for AllowInternal {
+    async fn authenticate(&self, _token: &str) -> Result<PlatformIdentity, InternalAuthNError> {
+        Ok(PlatformIdentity::KubernetesServiceAccount {
+            namespace: "ns".to_owned(),
+            service_account: "sa".to_owned(),
+            pod: None,
+        })
+    }
+}
+
+#[tokio::test]
+async fn dyn_internal_adapter_delegates() {
+    let dynamic = DynInternalAuthenticator::new(AllowInternal);
+    let result = InternalAuthenticator::authenticate(&dynamic, "token").await;
+    assert!(result.is_ok());
+}
+
+// --- end-to-end: real bound server, acceptance criteria ---
+
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicUsize;
+
+use async_trait::async_trait;
+use cf_system_sdks::directory::{
+    DirectoryClient, RegisterInstanceInfo, ServiceEndpoint, ServiceInstanceInfo,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::runtime::ResolvedRestEndpoints;
+
+/// Stub directory that fails `resolve_rest_service` a fixed number of times
+/// before succeeding, so `/readyz` can be observed transitioning 503 → 200.
+struct E2eDirectory {
+    fail_resolve: AtomicUsize,
+    deregistered: AtomicUsize,
+}
+
+#[async_trait]
+impl DirectoryClient for E2eDirectory {
+    async fn resolve_grpc_service(&self, _s: &str) -> anyhow::Result<ServiceEndpoint> {
+        Ok(ServiceEndpoint::new("http://grpc"))
+    }
+    async fn resolve_rest_service(&self, gear: &str) -> anyhow::Result<ServiceEndpoint> {
+        if self.fail_resolve.load(Ordering::SeqCst) > 0 {
+            self.fail_resolve.fetch_sub(1, Ordering::SeqCst);
+            anyhow::bail!("not yet");
+        }
+        Ok(ServiceEndpoint::new(format!("http://{gear}:8080")))
+    }
+    async fn get_openapi_spec(&self, _g: &str) -> anyhow::Result<String> {
+        Ok(String::new())
+    }
+    async fn list_instances(&self, _g: &str) -> anyhow::Result<Vec<ServiceInstanceInfo>> {
+        Ok(vec![])
+    }
+    async fn register_instance(&self, _i: RegisterInstanceInfo) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn deregister_instance(&self, _g: &str, _i: &str) -> anyhow::Result<()> {
+        self.deregistered.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+    async fn send_heartbeat(&self, _g: &str, _i: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+/// Reserve an ephemeral port and return it (closing the listener so the server
+/// can rebind it).
+fn free_addr() -> SocketAddr {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.local_addr().unwrap()
+}
+
+/// Minimal raw HTTP/1.1 GET returning the status code. Uses `Connection: close`
+/// so the read completes on EOF.
+async fn http_get(addr: SocketAddr, path: &str) -> Option<u16> {
+    let mut stream = tokio::net::TcpStream::connect(addr).await.ok()?;
+    let req = format!("GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    stream.write_all(req.as_bytes()).await.ok()?;
+    let mut buf = Vec::new();
+    stream.read_to_end(&mut buf).await.ok()?;
+    let text = String::from_utf8_lossy(&buf);
+    text.lines()
+        .next()
+        .and_then(|l| l.split_whitespace().nth(1))
+        .and_then(|s| s.parse().ok())
+}
+
+/// Poll `path` until it returns `want` or the deadline elapses.
+async fn poll_status(addr: SocketAddr, path: &str, want: u16, timeout: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if http_get(addr, path).await == Some(want) {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+#[tokio::test]
+async fn e2e_startup_readiness_transition_and_graceful_shutdown() {
+    let addr = free_addr();
+    let directory: Arc<dyn DirectoryClient> = Arc::new(E2eDirectory {
+        fail_resolve: AtomicUsize::new(3),
+        deregistered: AtomicUsize::new(0),
+    });
+
+    let readiness = readiness(["dep"]);
+    let resolved = Arc::new(ResolvedRestEndpoints::new());
+    let cancel = CancellationToken::new();
+
+    let gear_router = Router::new().route("/ping", get(|| async { "pong" }));
+
+    let options = OopServeOptions {
+        gear_name: "test-gear".to_owned(),
+        instance_id: "i-1".to_owned(),
+        version: Some("1.0.0".to_owned()),
+        advertise_uri: format!("http://{addr}"),
+        listen_addr: addr,
+        probe_bind_addr: None,
+        drain_timeout: Duration::from_secs(5),
+        heartbeat_interval: Duration::from_secs(30),
+        healthcheck_timeout: Duration::from_millis(500),
+        directory: Arc::clone(&directory),
+        bearer_authenticator: None,
+        internal_authenticator: None,
+    };
+
+    let mut server =
+        super::OopHttpServer::start(Arc::clone(&readiness), resolved, options, cancel.clone())
+            .await
+            .expect("server should bind");
+
+    // 1. Liveness is up BEFORE gear routes are attached (probe-first bind).
+    assert!(
+        poll_status(addr, "/healthz", 200, Duration::from_secs(3)).await,
+        "/healthz should return 200 as soon as the listener binds, before start()"
+    );
+
+    // 2. Gear routes reply 503 "starting" until attached.
+    assert_eq!(
+        http_get(addr, "/ping").await,
+        Some(503),
+        "gear route should be 503 starting before attach"
+    );
+
+    // 3. Attach the composed gear routes (simulates post-start()).
+    server.attach(
+        gear_router,
+        "{\"openapi\":\"3.1.0\"}".to_owned(),
+        vec!["dep".to_owned()],
+    );
+
+    // 4. Gear routes now serve.
+    assert!(
+        poll_status(addr, "/ping", 200, Duration::from_secs(3)).await,
+        "gear route should serve after attach"
+    );
+
+    // 5. /readyz is 503 until the dependency resolves, then flips to 200.
+    assert!(
+        poll_status(addr, "/readyz", 200, Duration::from_secs(3)).await,
+        "/readyz should transition to 200 after dep resolves"
+    );
+    assert!(readiness.all_deps_resolved());
+
+    // 6. Well-known OpenAPI is served (published at attach).
+    assert_eq!(http_get(addr, "/.well-known/openapi.json").await, Some(200));
+
+    // 7. Graceful shutdown completes.
+    cancel.cancel();
+    let result = tokio::time::timeout(Duration::from_secs(5), server.join())
+        .await
+        .expect("server should finish promptly after cancel");
+    assert!(
+        result.is_ok(),
+        "graceful shutdown should succeed: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn ephemeral_listen_port_updates_advertise_uri() {
+    let readiness = readiness(Vec::<String>::new());
+    let resolved = Arc::new(ResolvedRestEndpoints::new());
+    let cancel = CancellationToken::new();
+
+    let options = OopServeOptions {
+        gear_name: "ephemeral-gear".to_owned(),
+        instance_id: "i-1".to_owned(),
+        version: None,
+        advertise_uri: "http://127.0.0.1:0".to_owned(),
+        listen_addr: "127.0.0.1:0".parse().unwrap(),
+        probe_bind_addr: None,
+        drain_timeout: Duration::from_secs(5),
+        heartbeat_interval: Duration::from_secs(30),
+        healthcheck_timeout: Duration::from_millis(500),
+        directory: Arc::new(E2eDirectory {
+            fail_resolve: AtomicUsize::new(0),
+            deregistered: AtomicUsize::new(0),
+        }),
+        bearer_authenticator: None,
+        internal_authenticator: None,
+    };
+
+    let server = super::OopHttpServer::start(readiness, resolved, options, cancel.clone())
+        .await
+        .expect("server should bind on ephemeral port");
+
+    let actual_port = server.options().listen_addr.port();
+    assert_ne!(actual_port, 0, "ephemeral port should be assigned");
+
+    let advertise_url =
+        url::Url::parse(&server.options().advertise_uri).expect("advertise_uri should parse");
+    assert_eq!(
+        advertise_url.port_or_known_default(),
+        Some(actual_port),
+        "advertise_uri should use the actually bound port, got {}",
+        server.options().advertise_uri
+    );
+
+    cancel.cancel();
+    let result = tokio::time::timeout(Duration::from_secs(5), server.join())
+        .await
+        .expect("server should shut down promptly after cancel");
+    assert!(result.is_ok(), "server shutdown should succeed: {result:?}");
+}
+
+#[tokio::test]
+async fn user_advertise_uri_is_not_overwritten_by_ephemeral_bind_port() {
+    let readiness = readiness(Vec::<String>::new());
+    let resolved = Arc::new(ResolvedRestEndpoints::new());
+    let cancel = CancellationToken::new();
+
+    let options = OopServeOptions {
+        gear_name: "ephemeral-gear".to_owned(),
+        instance_id: "i-1".to_owned(),
+        version: None,
+        advertise_uri: "http://load-balancer.example.com:8080".to_owned(),
+        listen_addr: "127.0.0.1:0".parse().unwrap(),
+        probe_bind_addr: None,
+        drain_timeout: Duration::from_secs(5),
+        heartbeat_interval: Duration::from_secs(30),
+        healthcheck_timeout: Duration::from_millis(500),
+        directory: Arc::new(E2eDirectory {
+            fail_resolve: AtomicUsize::new(0),
+            deregistered: AtomicUsize::new(0),
+        }),
+        bearer_authenticator: None,
+        internal_authenticator: None,
+    };
+
+    let server = super::OopHttpServer::start(readiness, resolved, options, cancel.clone())
+        .await
+        .expect("server should bind on ephemeral port");
+
+    assert_eq!(
+        server.options().advertise_uri,
+        "http://load-balancer.example.com:8080",
+        "user-provided advertise_uri with a non-matching port must be preserved"
+    );
+
+    cancel.cancel();
+    let result = tokio::time::timeout(Duration::from_secs(5), server.join())
+        .await
+        .expect("server should shut down promptly after cancel");
+    assert!(result.is_ok(), "server shutdown should succeed: {result:?}");
+}
+
+#[tokio::test]
+async fn gear_handler_receives_connect_info_through_fallback() {
+    use axum::extract::ConnectInfo;
+
+    async fn peer(ConnectInfo(peer): ConnectInfo<SocketAddr>) -> String {
+        peer.to_string()
+    }
+
+    let addr = free_addr();
+    let readiness = readiness(Vec::<String>::new());
+    let resolved = Arc::new(ResolvedRestEndpoints::new());
+    let cancel = CancellationToken::new();
+
+    let options = OopServeOptions {
+        gear_name: "peer-gear".to_owned(),
+        instance_id: "i-1".to_owned(),
+        version: None,
+        advertise_uri: format!("http://{addr}"),
+        listen_addr: addr,
+        probe_bind_addr: None,
+        drain_timeout: Duration::from_secs(5),
+        heartbeat_interval: Duration::from_secs(30),
+        healthcheck_timeout: Duration::from_millis(500),
+        directory: Arc::new(E2eDirectory {
+            fail_resolve: AtomicUsize::new(0),
+            deregistered: AtomicUsize::new(0),
+        }),
+        bearer_authenticator: None,
+        internal_authenticator: None,
+    };
+
+    let mut server = super::OopHttpServer::start(readiness, resolved, options, cancel.clone())
+        .await
+        .expect("server should bind");
+
+    server.attach(
+        Router::new().route("/peer", get(peer)),
+        "{}".to_owned(),
+        vec![],
+    );
+
+    // A `200` proves the gear handler's `ConnectInfo<SocketAddr>` extractor found
+    // the connect-info in the request extensions *through* the swap fallback — a
+    // missing extension would surface as `500`.
+    assert!(
+        poll_status(addr, "/peer", 200, Duration::from_secs(3)).await,
+        "gear handler extracting ConnectInfo must succeed through the fallback"
+    );
+
+    cancel.cancel();
+    let joined = tokio::time::timeout(Duration::from_secs(5), server.join()).await;
+    assert!(
+        joined.is_ok(),
+        "server should shut down promptly after cancel"
+    );
+}

--- a/libs/toolkit/src/runtime/readiness.rs
+++ b/libs/toolkit/src/runtime/readiness.rs
@@ -1,0 +1,244 @@
+//! Framework-managed readiness state for the `OoP` bootstrap (`cpt-cf-fr-eventual-readiness`).
+//!
+//! An `OoP` gear becomes *live* the moment its HTTP server binds (`/healthz`),
+//! but only becomes *ready* (`/readyz`) once startup is complete, every critical
+//! dependency has been resolved, **and** the gear's registered healthchecks
+//! report it can serve traffic (Spring Boot-style health groups per
+//! `cpt-cf-fr-eventual-readiness`).
+//!
+//! Readiness reuses the framework's standard healthcheck mechanism
+//! ([`crate::healthcheck`]): a gear expresses readiness once, via
+//! [`RestApiCapability::healthcheck`](crate::contracts::RestApiCapability::healthcheck),
+//! and it is honored identically whether the gear is hosted in-process by the
+//! `api-gateway` or run `OoP`. This module layers the three `OoP`-only concerns
+//! the gateway path lacks — startup completion, critical-dependency resolution
+//! gating, and the graceful-drain readiness flip — on top of that shared
+//! healthcheck report.
+//!
+//! The healthcheck report itself is fanned out concurrently, timeout-bounded,
+//! panic-isolated, and cached inside the [`RestHealthcheckRegistry`], so a burst
+//! of probe traffic cannot storm the registered checks. The dependency and
+//! draining state layered on top are cheap live reads.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use parking_lot::Mutex;
+
+use crate::healthcheck::{HealthcheckReport, HealthcheckStatus, RestHealthcheckRegistry};
+
+/// Default per-check timeout for readiness healthchecks.
+///
+/// Matches the `api-gateway` `healthcheck_timeout_ms` default so a gear's
+/// healthcheck behaves identically in-process and `OoP`.
+pub const DEFAULT_HEALTHCHECK_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Lifecycle state reported on `/readyz` (`cpt-cf-adr-eventual-readiness`).
+///
+/// Serialized lowercase; the four variants are a stable wire contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ReadinessLifecycle {
+    /// Not yet able to serve — startup is not complete, critical deps are
+    /// unresolved, or a healthcheck is `Unhealthy`. Maps to `503`.
+    Starting,
+    /// Fully serving traffic. Maps to `200`.
+    Ready,
+    /// Serving with reduced functionality — a healthcheck reported `Degraded`
+    /// (e.g. an optional backend is down but a fallback is acceptable). Kept in
+    /// rotation: maps to `200`.
+    Degraded,
+    /// Graceful shutdown in progress; upstreams should stop routing. Maps to
+    /// `503`.
+    Draining,
+}
+
+/// The aggregate readiness report rendered as the `/readyz` response body.
+///
+/// Readiness still depends on the aggregated [`HealthcheckReport`] internally,
+/// but the detailed per-component report is intentionally not echoed here; it
+/// belongs on the separate `/health` endpoint (see `oop_serve.rs`).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ReadinessReport {
+    /// Lifecycle state — the primary readiness signal (`cpt-cf-adr-eventual-readiness`).
+    pub state: ReadinessLifecycle,
+    /// Whether the gear is ready to receive traffic (`true` → `200`, else `503`).
+    /// Convenience mirror of `state ∈ {ready, degraded}` for probes/clients that
+    /// do not want to know the `state → status` mapping.
+    pub ready: bool,
+    /// Critical dependencies not yet resolved via `DirectoryService` / DNS.
+    /// Non-empty only while `starting`. Omitted from the body when empty.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub unresolved_deps: Vec<String>,
+}
+
+/// Shared, framework-owned readiness state for an `OoP` gear instance.
+///
+/// Created by the `OoP` bootstrap with the gear's critical dependency names and
+/// a shared [`RestHealthcheckRegistry`] (populated from each gear's
+/// [`RestApiCapability::healthcheck`](crate::contracts::RestApiCapability::healthcheck)).
+/// Cloned as an `Arc` into the probe router and the dependency-resolution task.
+pub struct ReadinessState {
+    /// Critical deps still awaiting resolution. Empty ⇒ deps satisfied.
+    unresolved_deps: Mutex<BTreeSet<String>>,
+    /// Graceful-shutdown flag; when set, `/readyz` reports `503` (readiness flip).
+    draining: AtomicBool,
+    /// Whether the gear has finished startup and is actually serving traffic.
+    /// Remains `false` until the bootstrap publishes the composed routes.
+    startup_complete: AtomicBool,
+    /// Shared gear healthcheck registry; supplies the "custom checks" dimension
+    /// of readiness (fan-out, timeout, panic isolation, and caching live here).
+    healthchecks: Arc<RestHealthcheckRegistry>,
+    /// Per-check timeout passed to [`RestHealthcheckRegistry::report`].
+    check_timeout: Duration,
+}
+
+impl std::fmt::Debug for ReadinessState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReadinessState")
+            .field("unresolved_deps", &self.unresolved_deps.lock())
+            .field("draining", &self.draining.load(Ordering::Relaxed))
+            .field(
+                "startup_complete",
+                &self.startup_complete.load(Ordering::Relaxed),
+            )
+            .field("check_timeout", &self.check_timeout)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ReadinessState {
+    /// Create a new readiness state seeded with the gear's critical dependency
+    /// names and the shared healthcheck registry. All listed deps start
+    /// unresolved; the gear is not ready until startup is complete, each dep is
+    /// marked resolved via [`mark_dep_resolved`](Self::mark_dep_resolved), and
+    /// the healthchecks pass. Uses [`DEFAULT_HEALTHCHECK_TIMEOUT`] as the
+    /// per-check timeout.
+    #[must_use]
+    pub fn new<I, S>(critical_deps: I, healthchecks: Arc<RestHealthcheckRegistry>) -> Arc<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self::with_check_timeout(critical_deps, healthchecks, DEFAULT_HEALTHCHECK_TIMEOUT)
+    }
+
+    /// Like [`new`](Self::new) but with an explicit per-check timeout.
+    #[must_use]
+    pub fn with_check_timeout<I, S>(
+        critical_deps: I,
+        healthchecks: Arc<RestHealthcheckRegistry>,
+        check_timeout: Duration,
+    ) -> Arc<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Arc::new(Self {
+            unresolved_deps: Mutex::new(critical_deps.into_iter().map(Into::into).collect()),
+            draining: AtomicBool::new(false),
+            startup_complete: AtomicBool::new(false),
+            healthchecks,
+            check_timeout,
+        })
+    }
+
+    /// Mark startup as complete. Idempotent; subsequent calls are ignored.
+    /// `/readyz` will not report `Ready` or `Degraded` until this is called.
+    pub fn mark_startup_complete(&self) {
+        self.startup_complete.store(true, Ordering::SeqCst);
+    }
+
+    /// Whether startup is complete.
+    #[must_use]
+    pub fn is_startup_complete(&self) -> bool {
+        self.startup_complete.load(Ordering::SeqCst)
+    }
+
+    /// Mark a critical dependency as resolved. Idempotent; unknown names are
+    /// ignored.
+    pub fn mark_dep_resolved(&self, name: &str) {
+        let removed = self.unresolved_deps.lock().remove(name);
+        if removed {
+            tracing::info!(dep = %name, "critical dependency resolved");
+        }
+    }
+
+    /// Whether all critical dependencies have been resolved.
+    #[must_use]
+    pub fn all_deps_resolved(&self) -> bool {
+        self.unresolved_deps.lock().is_empty()
+    }
+
+    /// Set (or clear) the draining flag. Setting it flips `/readyz` to `503`
+    /// immediately so upstreams pull the instance out of rotation while
+    /// in-flight requests drain.
+    pub fn set_draining(&self, draining: bool) {
+        self.draining.store(draining, Ordering::SeqCst);
+    }
+
+    /// Whether the gear is currently draining.
+    #[must_use]
+    pub fn is_draining(&self) -> bool {
+        self.draining.load(Ordering::SeqCst)
+    }
+
+    /// Run the registered healthchecks and return the aggregated report.
+    ///
+    /// Used by `/health` to expose full per-component detail and by
+    /// [`Self::evaluate`] to decide readiness state. The registry caches the
+    /// report, so repeated calls within the cache window do not re-run checks.
+    pub async fn health_report(&self) -> HealthcheckReport {
+        self.healthchecks.report(self.check_timeout).await
+    }
+
+    /// Evaluate the aggregate readiness.
+    ///
+    /// The gear is ready when it is not draining, startup is complete, all
+    /// critical deps are resolved, and the aggregated healthcheck report is not
+    /// `Unhealthy`. `Degraded` healthchecks keep the gear ready (`state =
+    /// degraded`, `ready = true`) but the detailed per-component messages belong
+    /// on `/health`, not `/readyz`. The healthcheck fan-out is cached inside the
+    /// registry, so repeated probe traffic does not re-run checks; dependency and
+    /// draining state are read live so transitions take effect immediately.
+    pub async fn evaluate(&self) -> ReadinessReport {
+        let health = self.health_report().await;
+        let draining = self.is_draining();
+        let startup_complete = self.is_startup_complete();
+        let unresolved_deps: Vec<String> = self.unresolved_deps.lock().iter().cloned().collect();
+
+        // Draining wins; then any not-ready condition (startup not complete,
+        // unresolved deps, or an Unhealthy check) is `Starting`; then `Degraded`;
+        // else `Ready`.
+        let state = if draining {
+            ReadinessLifecycle::Draining
+        } else if !startup_complete
+            || !unresolved_deps.is_empty()
+            || health.status == HealthcheckStatus::Unhealthy
+        {
+            ReadinessLifecycle::Starting
+        } else if health.status == HealthcheckStatus::Degraded {
+            ReadinessLifecycle::Degraded
+        } else {
+            ReadinessLifecycle::Ready
+        };
+
+        let ready = matches!(
+            state,
+            ReadinessLifecycle::Ready | ReadinessLifecycle::Degraded
+        );
+
+        ReadinessReport {
+            state,
+            ready,
+            unresolved_deps,
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "readiness_tests.rs"]
+mod tests;

--- a/libs/toolkit/src/runtime/readiness_tests.rs
+++ b/libs/toolkit/src/runtime/readiness_tests.rs
@@ -1,0 +1,155 @@
+//! Tests for the readiness subsystem.
+
+use super::*;
+use crate::healthcheck::{Healthcheck, HealthcheckResult, HealthcheckStatus};
+use async_trait::async_trait;
+
+/// A healthcheck that always returns a fixed result.
+struct StaticCheck {
+    name: &'static str,
+    result: HealthcheckResult,
+}
+
+#[async_trait]
+impl Healthcheck for StaticCheck {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+    async fn check(&self) -> HealthcheckResult {
+        self.result.clone()
+    }
+}
+
+fn empty_registry() -> Arc<RestHealthcheckRegistry> {
+    Arc::new(RestHealthcheckRegistry::new())
+}
+
+/// A registry seeded with a single gear healthcheck.
+fn registry_with(
+    gear: &'static str,
+    name: &'static str,
+    result: HealthcheckResult,
+) -> Arc<RestHealthcheckRegistry> {
+    let registry = Arc::new(RestHealthcheckRegistry::new());
+    registry.register(gear, Arc::new(StaticCheck { name, result }));
+    registry
+}
+
+#[tokio::test]
+async fn no_deps_no_checks_is_ready() {
+    let state = ReadinessState::new(Vec::<String>::new(), empty_registry());
+
+    let report = state.evaluate().await;
+    assert!(!report.ready);
+    assert_eq!(report.state, ReadinessLifecycle::Starting);
+
+    state.mark_startup_complete();
+    let report = state.evaluate().await;
+    let health = state.health_report().await;
+    assert!(report.ready);
+    assert_eq!(report.state, ReadinessLifecycle::Ready);
+    assert!(report.unresolved_deps.is_empty());
+    assert!(health.components.is_empty());
+    assert_eq!(health.status, HealthcheckStatus::Healthy);
+}
+
+#[tokio::test]
+async fn unresolved_deps_block_readiness_until_resolved() {
+    let state = ReadinessState::new(["billing", "catalog"], empty_registry());
+
+    let report = state.evaluate().await;
+    assert!(!report.ready);
+    assert_eq!(report.state, ReadinessLifecycle::Starting);
+    assert_eq!(report.unresolved_deps, vec!["billing", "catalog"]);
+
+    state.mark_dep_resolved("billing");
+    let report = state.evaluate().await;
+    assert!(!report.ready);
+    assert_eq!(report.unresolved_deps, vec!["catalog"]);
+
+    state.mark_dep_resolved("catalog");
+    state.mark_startup_complete();
+    let report = state.evaluate().await;
+    assert!(report.ready);
+    assert!(report.unresolved_deps.is_empty());
+}
+
+#[tokio::test]
+async fn mark_unknown_dep_is_ignored() {
+    let state = ReadinessState::new(["billing"], empty_registry());
+    state.mark_dep_resolved("does-not-exist");
+    assert!(!state.all_deps_resolved());
+    let report = state.evaluate().await;
+    assert!(!report.ready);
+    assert_eq!(report.unresolved_deps, vec!["billing"]);
+}
+
+#[tokio::test]
+async fn unhealthy_check_forces_not_ready() {
+    let state = ReadinessState::new(
+        Vec::<String>::new(),
+        registry_with(
+            "cache",
+            "cache-warm",
+            HealthcheckResult::unhealthy("cache cold"),
+        ),
+    );
+
+    state.mark_startup_complete();
+    let report = state.evaluate().await;
+    let health = state.health_report().await;
+    assert!(!report.ready);
+    assert_eq!(report.state, ReadinessLifecycle::Starting);
+    assert_eq!(health.status, HealthcheckStatus::Unhealthy);
+    assert_eq!(health.components.len(), 1);
+    assert_eq!(health.components[0].check, "cache-warm");
+}
+
+#[tokio::test]
+async fn degraded_check_stays_ready_but_reported() {
+    let state = ReadinessState::new(
+        Vec::<String>::new(),
+        registry_with(
+            "indexer",
+            "index",
+            HealthcheckResult::degraded("rebuilding index"),
+        ),
+    );
+
+    state.mark_startup_complete();
+    let report = state.evaluate().await;
+    let health = state.health_report().await;
+    assert!(report.ready, "degraded must still be ready (200)");
+    assert_eq!(report.state, ReadinessLifecycle::Degraded);
+    assert_eq!(health.status, HealthcheckStatus::Degraded);
+    assert_eq!(health.components.len(), 1);
+    assert_eq!(health.components[0].check, "index");
+}
+
+#[tokio::test]
+async fn unresolved_dep_beats_healthy_check() {
+    let state = ReadinessState::new(
+        ["billing"],
+        registry_with("gear", "ok", HealthcheckResult::healthy()),
+    );
+    state.mark_startup_complete();
+    let report = state.evaluate().await;
+    let health = state.health_report().await;
+    assert!(
+        !report.ready,
+        "an unresolved dep must gate readiness even when checks are healthy"
+    );
+    assert_eq!(health.status, HealthcheckStatus::Healthy);
+}
+
+#[tokio::test]
+async fn draining_flips_to_not_ready() {
+    let state = ReadinessState::new(Vec::<String>::new(), empty_registry());
+    state.mark_startup_complete();
+    assert!(state.evaluate().await.ready);
+
+    state.set_draining(true);
+    let report = state.evaluate().await;
+    assert!(!report.ready);
+    assert_eq!(report.state, ReadinessLifecycle::Draining);
+}

--- a/libs/toolkit/src/runtime/runner.rs
+++ b/libs/toolkit/src/runtime/runner.rs
@@ -73,25 +73,27 @@ pub enum ShutdownOptions {
 /// Configuration for a single `OoP` gear to be spawned.
 #[derive(Clone)]
 pub struct OopGearSpawnConfig {
-    /// Gear name (e.g., "calculator")
+    /// Name of the gear (e.g., "calculator").
     pub gear_name: String,
-    /// Path to the executable
+    /// Path to the gear executable.
     pub binary: PathBuf,
-    /// Command-line arguments (user controls --config via execution.args in master config)
+    /// Command-line arguments passed to the gear binary.
+    ///
+    /// Note: the user controls `--config` via `execution.args` in the master config.
     pub args: Vec<String>,
-    /// Environment variables to set
+    /// Environment variables to set for the spawned process.
     pub env: HashMap<String, String>,
-    /// Working directory for the process
+    /// Working directory for the spawned process.
     pub working_directory: Option<String>,
-    /// Rendered gear config JSON (for `TOOLKIT_MODULE_CONFIG` env var)
+    /// Rendered gear configuration JSON, injected as the `TOOLKIT_MODULE_CONFIG` environment variable.
     pub rendered_config_json: String,
 }
 
 /// Options for spawning `OoP` gears.
 pub struct OopSpawnOptions {
-    /// List of `OoP` gears to spawn after the start phase
+    /// Gears to spawn after the start phase, once shared infrastructure is ready.
     pub gears: Vec<OopGearSpawnConfig>,
-    /// Backend for spawning `OoP` gears (e.g., `LocalProcessBackend`)
+    /// Backend used to spawn gear processes (e.g. `LocalProcessBackend`).
     pub backend: Box<dyn OopBackend>,
 }
 
@@ -128,21 +130,19 @@ pub struct RunOptions {
     pub shutdown_deadline: Option<std::time::Duration>,
 }
 
-/// Full cycle is orchestrated by `HostRuntime` (see `runtime/host_runtime.rs` docs).
+/// Construct a `HostRuntime` by wiring shutdown, discovering gears, building
+/// the `ClientHub`, and injecting pre-registered clients.
 ///
-/// This function is a thin wrapper around `HostRuntime` that handles shutdown signal setup
-/// and then delegates all lifecycle orchestration to the `HostRuntime`.
-///
-/// # Errors
-/// Returns an error if any lifecycle phase fails.
-pub async fn run(opts: RunOptions) -> anyhow::Result<()> {
-    // 1. Prepare cancellation token based on shutdown options
+/// Shared by [`run`] and [`run_oop_serving`]. `opts` is consumed; the returned
+/// `HostRuntime` owns the root lifecycle `CancellationToken`.
+fn build_host_runtime(opts: RunOptions) -> anyhow::Result<HostRuntime> {
+    // 1. Prepare cancellation token based on shutdown options.
     let cancel = match &opts.shutdown {
         ShutdownOptions::Token(t) => t.clone(),
         _ => CancellationToken::new(),
     };
 
-    // 2. Spawn shutdown waiter (Signals / Future) just like before
+    // 2. Spawn shutdown waiter (Signals / Future).
     match opts.shutdown {
         ShutdownOptions::Signals => {
             let c = cancel.clone();
@@ -176,33 +176,56 @@ pub async fn run(opts: RunOptions) -> anyhow::Result<()> {
         }
     }
 
-    // 3. Discover gears
+    // 3. Discover gears.
     let registry = GearRegistry::discover_and_build()?;
 
-    // 4. Build shared ClientHub
+    // 4. Build shared `ClientHub` and inject pre-registered clients.
     let hub = Arc::new(ClientHub::default());
-
-    // 4b. Apply pre-registered clients from RunOptions
     for registration in opts.clients {
         registration.apply(&hub);
     }
 
-    // 5. Instantiate HostRuntime
+    // 5. Instantiate `HostRuntime`.
     let mut host = HostRuntime::new(
         registry,
         opts.gears_cfg.clone(),
         opts.db,
         hub,
-        cancel.clone(),
+        cancel,
         opts.instance_id,
         opts.oop,
     );
-
-    // 5b. Apply custom shutdown deadline if provided
     if let Some(deadline) = opts.shutdown_deadline {
         host = host.with_shutdown_deadline(deadline);
     }
 
-    // 6. Run full lifecycle
+    Ok(host)
+}
+
+/// Run the full gear lifecycle.
+///
+/// Discovers gears, wires shutdown, and delegates phase execution to [`HostRuntime`].
+///
+/// # Errors
+/// Returns an error if any lifecycle phase fails.
+pub async fn run(opts: RunOptions) -> anyhow::Result<()> {
+    let host = build_host_runtime(opts)?;
     host.run_gear_phases().await
+}
+
+/// Run an out-of-process gear and serve its HTTP routes.
+///
+/// Uses the same setup as [`run`], then drives the `OoP` serving lifecycle:
+/// lifecycle phases, an Axum HTTP server with framework probes, background
+/// self-registration, dependency resolution, and graceful drain.
+///
+/// # Errors
+/// Returns an error if discovery, any lifecycle phase, or the HTTP server fails.
+#[cfg(feature = "bootstrap")]
+pub async fn run_oop_serving(
+    opts: RunOptions,
+    serve: crate::runtime::OopServeOptions,
+) -> anyhow::Result<()> {
+    let host = build_host_runtime(opts)?;
+    host.run_oop_serving(serve).await
 }


### PR DESCRIPTION
Closes https://github.com/constructorfabric/gears-rust/issues/4106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added out-of-process HTTP serving for `/healthz`, `/readyz`, `/health`, and OpenAPI discovery, with readiness based on dependency resolution plus aggregated healthchecks.
  * Introduced optional Kubernetes TokenReview-based internal authentication (feature-flagged) and new OoP HTTP configuration options (including drain and timeout settings).
* **Bug Fixes**
  * Instance re-registration now preserves existing health/heartbeat progress while refreshing metadata.
* **Documentation**
  * Updated OoP readiness/health endpoint contracts and bootstrap guidance, including the new `/health` diagnostics.
* **Tests**
  * Added end-to-end coverage for probe behavior, readiness transitions, OpenAPI publishing, and graceful shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->