### PR TITLE
fix(resource-group): map duplicate group id to 409

### DIFF
--- a/gears/system/resource-group/resource-group/src/api/rest/error.rs
+++ b/gears/system/resource-group/resource-group/src/api/rest/error.rs
@@ -128,6 +128,11 @@ impl From<DomainError> for CanonicalError {
             DomainError::DuplicateMembership { key, message } => {
                 RgError::already_exists(message).with_resource(key).create()
             }
+            DomainError::GroupAlreadyExists { id } => {
+                RgError::already_exists(format!("Resource group with id '{id}' already exists"))
+                    .with_resource(id.to_string())
+                    .create()
+            }
             DomainError::TenantRootAlreadyExists {
                 existing_root_id,
                 detail,

--- a/gears/system/resource-group/resource-group/src/domain/error.rs
+++ b/gears/system/resource-group/resource-group/src/domain/error.rs
@@ -28,6 +28,9 @@ pub enum DomainError {
     #[error("Group not found: {id}")]
     GroupNotFound { id: uuid::Uuid },
 
+    #[error("Group already exists: {id}")]
+    GroupAlreadyExists { id: uuid::Uuid },
+
     #[error("Membership not found: {key}")]
     MembershipNotFound { key: String },
 
@@ -140,6 +143,11 @@ impl DomainError {
     #[must_use]
     pub fn group_not_found(id: uuid::Uuid) -> Self {
         Self::GroupNotFound { id }
+    }
+
+    #[must_use]
+    pub fn group_already_exists(id: uuid::Uuid) -> Self {
+        Self::GroupAlreadyExists { id }
     }
 
     pub fn membership_not_found(key: impl Into<String>) -> Self {

--- a/gears/system/resource-group/resource-group/src/infra/storage/group_repo.rs
+++ b/gears/system/resource-group/resource-group/src/infra/storage/group_repo.rs
@@ -649,9 +649,16 @@ impl GroupRepositoryTrait for GroupRepository {
             ..Default::default()
         };
 
+        // The group PK is global, so a caller-supplied `id` may already be taken.
         toolkit_db::secure::secure_insert::<ResourceGroupEntity>(model, &scope, db)
             .await
-            .map_err(|e| DomainError::database(e.to_string()))?;
+            .map_err(|e| {
+                if e.is_unique_violation() {
+                    DomainError::group_already_exists(id)
+                } else {
+                    DomainError::database(e.to_string())
+                }
+            })?;
 
         self.find_model_by_id(db, id)
             .await?

--- a/gears/system/resource-group/resource-group/src/infra/storage/membership_repo.rs
+++ b/gears/system/resource-group/resource-group/src/infra/storage/membership_repo.rs
@@ -114,8 +114,7 @@ impl MembershipRepositoryTrait for MembershipRepository {
         toolkit_db::secure::secure_insert::<MembershipEntity>(model, &scope, db)
             .await
             .map_err(|e| {
-                let msg = e.to_string();
-                if msg.contains("duplicate key") || msg.contains("UNIQUE constraint") {
+                if e.is_unique_violation() {
                     DomainError::duplicate_membership(
                         format!("({group_id}, type_id={gts_type_id}, {resource_id})"),
                         format!(
@@ -123,7 +122,7 @@ impl MembershipRepositoryTrait for MembershipRepository {
                         ),
                     )
                 } else {
-                    DomainError::database(msg)
+                    DomainError::database(e.to_string())
                 }
             })?;
 

--- a/gears/system/resource-group/resource-group/tests/api_rest_test.rs
+++ b/gears/system/resource-group/resource-group/tests/api_rest_test.rs
@@ -9,7 +9,7 @@
 mod common;
 
 use std::sync::Arc;
-use toolkit_gts::gts_id;
+use toolkit_gts::{gts_id, gts_uri};
 
 use async_trait::async_trait;
 use axum::Router;
@@ -45,6 +45,8 @@ macro_rules! rg_type_id {
         format!("{}{}", gts_id!("cf.core.rg.type.v1~"), format_args!($($arg)*))
     };
 }
+
+const ALREADY_EXISTS_TYPE: &str = gts_uri!("cf.core.errors.err.v1~cf.core.err.already_exists.v1~");
 
 // ── Noop OpenAPI Registry for tests ─────────────────────────────────────
 
@@ -446,6 +448,61 @@ async fn get_group_not_found_returns_404() {
     );
     let resp = router.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+/// POST group with an already-taken id returns 409 with a problem body.
+#[tokio::test]
+async fn create_group_duplicate_id_returns_409() {
+    let (router, type_svc) = build_test_router().await;
+    let tenant_id = Uuid::now_v7();
+    let type_code = rg_type_id!("test.dupid.{}.v1~", Uuid::now_v7().as_simple());
+
+    type_svc
+        .create_type(resource_group_sdk::CreateTypeRequest {
+            code: type_code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: None,
+        })
+        .await
+        .unwrap();
+
+    let id = Uuid::now_v7();
+    let payload = |name: &str| {
+        serde_json::json!({
+            "id": id,
+            "type": type_code,
+            "name": name
+        })
+    };
+
+    let req = json_request(
+        "POST",
+        "/resource-group/v1/groups",
+        Some(payload("First")),
+        tenant_id,
+    );
+    let resp = router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let req = json_request(
+        "POST",
+        "/resource-group/v1/groups",
+        Some(payload("Second")),
+        tenant_id,
+    );
+    let resp = router.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+
+    let body = response_body(resp).await;
+    assert_eq!(body["type"], ALREADY_EXISTS_TYPE, "problem type: {body}");
+    assert_eq!(body["status"], 409, "problem status: {body}");
+    assert_eq!(
+        body["context"]["resource_name"],
+        id.to_string(),
+        "problem resource_name: {body}"
+    );
 }
 
 // ── Error format tests (RFC 9457 Problem Details) ───────────────────────

--- a/gears/system/resource-group/resource-group/tests/domain_unit_test.rs
+++ b/gears/system/resource-group/resource-group/tests/domain_unit_test.rs
@@ -487,6 +487,14 @@ fn domain_error_group_not_found_format() {
 }
 
 #[test]
+fn domain_error_group_already_exists_format() {
+    let id = uuid::Uuid::now_v7();
+    let err = DomainError::group_already_exists(id);
+    assert!(matches!(err, DomainError::GroupAlreadyExists { .. }));
+    assert!(err.to_string().contains(&id.to_string()));
+}
+
+#[test]
 fn domain_error_cycle_detected_format() {
     let err = DomainError::cycle_detected("A -> B -> A");
     assert!(matches!(err, DomainError::CycleDetected { .. }));
@@ -604,6 +612,16 @@ fn domain_to_sdk_type_already_exists() {
     use resource_group_sdk::ResourceGroupError;
     match project(DomainError::type_already_exists("code")) {
         ResourceGroupError::AlreadyExists { name, .. } => assert_eq!(name, "code"),
+        other => panic!("expected AlreadyExists, got {other:?}"),
+    }
+}
+
+#[test]
+fn domain_to_sdk_group_already_exists() {
+    use resource_group_sdk::ResourceGroupError;
+    let id = uuid::Uuid::now_v7();
+    match project(DomainError::group_already_exists(id)) {
+        ResourceGroupError::AlreadyExists { name, .. } => assert_eq!(name, id.to_string()),
         other => panic!("expected AlreadyExists, got {other:?}"),
     }
 }
@@ -728,6 +746,16 @@ fn domain_to_problem_type_already_exists_is_409() {
     assert_eq!(problem.problem_type, ALREADY_EXISTS_TYPE);
     assert_eq!(problem.context["resource_type"], RG_GTS);
     assert_eq!(problem.context["resource_name"], "dup");
+}
+
+#[test]
+fn domain_to_problem_group_already_exists_is_409() {
+    let id = uuid::Uuid::now_v7();
+    let problem = wire(DomainError::group_already_exists(id));
+    assert_eq!(problem.status, 409);
+    assert_eq!(problem.problem_type, ALREADY_EXISTS_TYPE);
+    assert_eq!(problem.context["resource_type"], RG_GTS);
+    assert_eq!(problem.context["resource_name"], id.to_string());
 }
 
 #[test]

--- a/gears/system/resource-group/resource-group/tests/group_service_test.rs
+++ b/gears/system/resource-group/resource-group/tests/group_service_test.rs
@@ -2726,3 +2726,44 @@ async fn get_group_unscoped_missing_is_not_found() {
         "expected GroupNotFound, got: {err:?}"
     );
 }
+
+/// Creating a group with an id that is already taken yields
+/// `GroupAlreadyExists`, not a generic database error. The second create runs
+/// in a different tenant, so this pins the group id as globally unique rather
+/// than unique per tenant.
+#[tokio::test]
+async fn group_create_duplicate_id_is_already_exists() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+
+    let tenant_a = Uuid::now_v7();
+    let tenant_b = Uuid::now_v7();
+    let ctx_a = common::make_ctx(tenant_a);
+    let ctx_b = common::make_ctx(tenant_b);
+    let root_type = common::create_root_type(&type_svc, "dupid").await;
+
+    let id = Uuid::now_v7();
+    let req = |name: &str| CreateGroupRequest {
+        id: Some(id),
+        code: root_type.code.clone(),
+        name: name.to_owned(),
+        parent_id: None,
+        metadata: None,
+    };
+
+    group_svc
+        .create_group(&ctx_a, req("First"), tenant_a)
+        .await
+        .expect("first create should succeed");
+
+    let err = group_svc
+        .create_group(&ctx_b, req("Second"), tenant_b)
+        .await
+        .expect_err("the id is taken globally, so another tenant cannot reuse it");
+
+    assert!(
+        matches!(err, DomainError::GroupAlreadyExists { id: got } if got == id),
+        "expected GroupAlreadyExists({id}), got: {err:?}"
+    );
+}

--- a/gears/system/resource-group/resource-group/tests/group_service_test.rs
+++ b/gears/system/resource-group/resource-group/tests/group_service_test.rs
@@ -2766,4 +2766,54 @@ async fn group_create_duplicate_id_is_already_exists() {
         matches!(err, DomainError::GroupAlreadyExists { id: got } if got == id),
         "expected GroupAlreadyExists({id}), got: {err:?}"
     );
+
+    // Verify entity state: the rejected insert left the first group untouched
+    let conn = db.conn().expect("conn");
+    let scope = AccessScope::allow_all();
+    let model = RgEntity::find()
+        .filter(RgColumn::Id.eq(id))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query")
+        .expect("found");
+    assert_eq!(model.name, "First");
+    assert_eq!(model.tenant_id, tenant_a);
+}
+
+/// Duplicate id inside the caller's own tenant also yields `GroupAlreadyExists`.
+#[tokio::test]
+async fn group_create_duplicate_id_same_tenant_is_already_exists() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+
+    let tenant = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant);
+    let root_type = common::create_root_type(&type_svc, "dupidsame").await;
+
+    let id = Uuid::now_v7();
+    let req = |name: &str| CreateGroupRequest {
+        id: Some(id),
+        code: root_type.code.clone(),
+        name: name.to_owned(),
+        parent_id: None,
+        metadata: None,
+    };
+
+    group_svc
+        .create_group(&ctx, req("First"), tenant)
+        .await
+        .expect("first create should succeed");
+
+    let err = group_svc
+        .create_group(&ctx, req("Second"), tenant)
+        .await
+        .expect_err("the id is already taken in this tenant");
+
+    assert!(
+        matches!(err, DomainError::GroupAlreadyExists { id: got } if got == id),
+        "expected GroupAlreadyExists({id}), got: {err:?}"
+    );
 }


### PR DESCRIPTION
## Description

`create_group` lets the caller supply the group `id`. The group primary key is
global across tenants, so that id may already be taken. Until now every insert
error — including a duplicate-key violation — became `DomainError::database`,
which reaches the client as a generic **500**.

A conflict the caller caused is not a server fault. The contract already said so:
the route declares `.error_409(openapi)` and `openapi.yaml` lists `201, 400, 409`
for `createGroup`. The implementation simply never produced the 409.

This change makes the implementation match the contract it already publishes.
No schema change, no route change, no spec change — the generated OpenAPI is
byte-identical.

**What changed**

- New typed variant `DomainError::GroupAlreadyExists { id }`, shaped like its
  neighbour `GroupNotFound`.
- `GroupRepository::insert` now classifies the failure with the shared
  `ScopeError::is_unique_violation` helper instead of matching the driver's
  message text inline. The helper reads SQLSTATE first (23505 on PostgreSQL,
  1555/2067 on SQLite, 1062 and friends on MySQL) and only falls back to text
  when a proxy has stripped the code.
- `MembershipRepository::insert` switched to the same helper, so this decision is
  made in one place rather than two. Its inline matching was case-sensitive and
  had no branch for MySQL's "Duplicate entry".
- The new variant maps to `already_exists` (409), placed with the other
  duplicate-on-create variants in `api/rest/error.rs`.

**Why the message cannot be wrong**

`id` is the only unique constraint on `resource_group`, and the composite primary
key is the only one on `resource_group_membership`. Both tables come from a single
migration; every other index is non-unique and the remaining constraints are
foreign keys. So a unique violation on either insert can only be the collision the
error names.

**Version bump — maintainer call**

`DomainError` is `pub` and not `#[non_exhaustive]`, so adding a variant is
breaking by the letter of the versioning guide: a downstream exhaustive `match`
would stop compiling.

The exposure is nominal. `docs/toolkit_unified_system/02_gear_layout_and_sdk_pattern.md`
marks `domain/` as "internal business logic" and states consumers need "only one
dependency" — the `-sdk` crate. Both reverse dependencies on crates.io,
`cf-gears-account-management` and `cf-gears-rg-tr-plugin`, follow that and depend
on `cf-gears-resource-group-sdk`; neither references `DomainError`. Reaching this
type at all means bypassing the SDK contract.

Flagging it rather than deciding it — pre-1.0 a strict reading gives `0.3.0`.

**Overlap with #4269**

That PR rewrites this same `insert` to drop the post-insert re-read. The two
changes touch adjacent lines, so whichever lands second gets a three-line
conflict. Happy to rebase on top of it.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Ticked "Bug fix" for the wire behaviour, which is a pure fix. See the version-bump
note above for the Rust surface — that box is a maintainer decision.

## Testing
- [x] Unit tests pass
- [x] Integration tests pass
- [ ] Manual testing completed — n/a, no live instance was exercised
- [x] New tests added for new functionality

`make check` passes end to end: 9305/9305 tests across 332 binaries, plus fmt,
cfs-validate, clippy, lychee, cargo-deny, dylint, dylint-test and gts-docs.

Four tests added, all on the group path. The one that matters is
`group_create_duplicate_id_is_already_exists` in `tests/group_service_test.rs`.
It creates a group with an explicit id in one tenant, then tries the same id from
a **different** tenant, and asserts the typed variant — so it pins the id as
globally unique rather than unique per tenant, which is the premise this whole fix
rests on. (Thanks to the review bot for catching that the first version used one
tenant for both creates and therefore proved the weaker property.)

I checked that it actually bites: disabling the classification makes it fail,
restoring it makes it pass. The same check on `membership_add_duplicate`
(`tests/membership_service_test.rs`) confirms the membership change is covered by
that existing test, so no new one was needed there.

The other three tests cover the variant and its `Display`, the SDK projection, and
the wire `Problem` status.

## Documentation
- [ ] Code is documented with rustdoc comments — n/a, no rustdoc on production
      code; the variant documents itself via `#[error]`, as all variants here do
- [ ] README updated (if applicable) — n/a
- [ ] API documentation updated (if applicable) — n/a, 409 was already declared
      on the route and in `openapi.yaml`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No linting errors (`cargo clippy`) — and `cargo dylint`
- [x] Code is properly formatted (`cargo fmt`)
- [x] Tests pass (`cargo test`)

## Related Issues

None.

## Follow-up

`DomainError` here is not `#[non_exhaustive]`, so every future error variant
raises the same version-bump question this PR does. Worth noting this looks like
a repo-wide default rather than an oversight in this gear: of the 17 gears with a
`domain/error.rs`, only `account-management` and `credstore` carry the attribute.
That seems better settled as a repo-wide decision than inside a bug fix — happy to
raise it separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate group IDs now return a clear “already exists” error instead of a generic database error.
  * Conflict responses now include the affected resource ID and use the appropriate HTTP 409 status.
  * Improved detection and handling of duplicate membership records.

* **Tests**
  * Added coverage for duplicate group creation, error details, and API response mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->