### PR TITLE
docs: fix path drift in per-gear OpenAPI artifacts (account-management, resource-group)

### DIFF
--- a/gears/system/account-management/docs/account-management-v1.yaml
+++ b/gears/system/account-management/docs/account-management-v1.yaml
@@ -18,7 +18,7 @@ info:
     shapes, field semantics, and HTTP-level error mapping.
 
     Versioning: breaking changes increment the major version embedded in the URL
-    path (`/account-management/v1/` → `/v2/`) and are coordinated with a
+    path (`/account-management/v1/` → `/account-management/v2/`) and are coordinated with a
     migration window per the Compatibility NFR in DESIGN.md. Additive changes
     within v1 do not rev the path.
 

--- a/gears/system/account-management/docs/account-management-v1.yaml
+++ b/gears/system/account-management/docs/account-management-v1.yaml
@@ -1,6 +1,9 @@
 # Created:  2026-04-19 by Virtuozzo
 # Updated:  2026-06-09 by Virtuozzo
 
+# NOTE: the aggregated, CI-verified schema for the whole platform is
+# docs/api/api.json (also served live by the api-gateway at {prefix}/docs).
+# Paths below are gear-relative: the gateway prepends its prefix_path (e.g. /cf).
 openapi: 3.1.0
 info:
   title: Account Management API
@@ -15,7 +18,7 @@ info:
     shapes, field semantics, and HTTP-level error mapping.
 
     Versioning: breaking changes increment the major version embedded in the URL
-    path (`/api/account-management/v1/` → `/v2/`) and are coordinated with a
+    path (`/account-management/v1/` → `/v2/`) and are coordinated with a
     migration window per the Compatibility NFR in DESIGN.md. Additive changes
     within v1 do not rev the path.
 
@@ -57,7 +60,7 @@ security:
   - bearerAuth: []
 
 paths:
-  /api/account-management/v1/me:
+  /account-management/v1/me:
     get:
       operationId: getMe
       tags: [Identity]
@@ -80,7 +83,7 @@ paths:
         default:
           $ref: '#/components/responses/Problem'
 
-  /api/account-management/v1/tenants:
+  /account-management/v1/tenants:
     post:
       operationId: createTenant
       tags: [tenants]
@@ -112,7 +115,7 @@ paths:
         '5XX':
           $ref: '#/components/responses/Problem'
 
-  /api/account-management/v1/tenants/{tenant_id}:
+  /account-management/v1/tenants/{tenant_id}:
     parameters:
       - $ref: '#/components/parameters/TenantId'
     get:
@@ -183,7 +186,7 @@ paths:
         default:
           $ref: '#/components/responses/Problem'
 
-  /api/account-management/v1/tenants/{tenant_id}/suspend:
+  /account-management/v1/tenants/{tenant_id}/suspend:
     parameters:
       - $ref: '#/components/parameters/TenantId'
     post:
@@ -213,7 +216,7 @@ paths:
         default:
           $ref: '#/components/responses/Problem'
 
-  /api/account-management/v1/tenants/{tenant_id}/unsuspend:
+  /account-management/v1/tenants/{tenant_id}/unsuspend:
     parameters:
       - $ref: '#/components/parameters/TenantId'
     post:
@@ -236,7 +239,7 @@ paths:
         default:
           $ref: '#/components/responses/Problem'
 
-  /api/account-management/v1/tenants/{tenant_id}/children:
+  /account-management/v1/tenants/{tenant_id}/children:
     parameters:
       - $ref: '#/components/parameters/TenantId'
       - $ref: '#/components/parameters/Limit'
@@ -265,7 +268,7 @@ paths:
         default:
           $ref: '#/components/responses/Problem'
 
-  /api/account-management/v1/tenants/{tenant_id}/users:
+  /account-management/v1/tenants/{tenant_id}/users:
     parameters:
       - $ref: '#/components/parameters/TenantId'
     get:
@@ -321,7 +324,7 @@ paths:
         '5XX':
           $ref: '#/components/responses/Problem'
 
-  /api/account-management/v1/tenants/{tenant_id}/users/{user_id}:
+  /account-management/v1/tenants/{tenant_id}/users/{user_id}:
     parameters:
       - $ref: '#/components/parameters/TenantId'
       - $ref: '#/components/parameters/UserId'
@@ -380,7 +383,7 @@ paths:
         default:
           $ref: '#/components/responses/Problem'
 
-  /api/account-management/v1/tenants/{tenant_id}/conversions:
+  /account-management/v1/tenants/{tenant_id}/conversions:
     parameters:
       - $ref: '#/components/parameters/TenantId'
     post:
@@ -444,7 +447,7 @@ paths:
         default:
           $ref: '#/components/responses/Problem'
 
-  /api/account-management/v1/tenants/{tenant_id}/conversions/{request_id}:
+  /account-management/v1/tenants/{tenant_id}/conversions/{request_id}:
     parameters:
       - $ref: '#/components/parameters/TenantId'
       - $ref: '#/components/parameters/RequestId'
@@ -499,7 +502,7 @@ paths:
         default:
           $ref: '#/components/responses/Problem'
 
-  /api/account-management/v1/tenants/{tenant_id}/child-conversions:
+  /account-management/v1/tenants/{tenant_id}/child-conversions:
     parameters:
       - $ref: '#/components/parameters/TenantId'
     post:
@@ -563,7 +566,7 @@ paths:
         default:
           $ref: '#/components/responses/Problem'
 
-  /api/account-management/v1/tenants/{tenant_id}/child-conversions/{request_id}:
+  /account-management/v1/tenants/{tenant_id}/child-conversions/{request_id}:
     parameters:
       - $ref: '#/components/parameters/TenantId'
       - $ref: '#/components/parameters/RequestId'
@@ -612,7 +615,7 @@ paths:
         default:
           $ref: '#/components/responses/Problem'
 
-  /api/account-management/v1/tenants/{tenant_id}/metadata:
+  /account-management/v1/tenants/{tenant_id}/metadata:
     parameters:
       - $ref: '#/components/parameters/TenantId'
       - $ref: '#/components/parameters/Limit'
@@ -633,7 +636,7 @@ paths:
         default:
           $ref: '#/components/responses/Problem'
 
-  /api/account-management/v1/tenants/{tenant_id}/metadata/{type_id}:
+  /account-management/v1/tenants/{tenant_id}/metadata/{type_id}:
     parameters:
       - $ref: '#/components/parameters/TenantId'
       - $ref: '#/components/parameters/SchemaId'
@@ -687,7 +690,7 @@ paths:
         default:
           $ref: '#/components/responses/Problem'
 
-  /api/account-management/v1/tenants/{tenant_id}/metadata/{type_id}/resolved:
+  /account-management/v1/tenants/{tenant_id}/metadata/{type_id}/resolved:
     parameters:
       - $ref: '#/components/parameters/TenantId'
       - $ref: '#/components/parameters/SchemaId'

--- a/gears/system/resource-group/docs/openapi.yaml
+++ b/gears/system/resource-group/docs/openapi.yaml
@@ -510,8 +510,9 @@ paths:
       description: |
         Returns paginated resource groups.
 
-        For hierarchy traversal (ancestors, descendants, depth),
-        use the dedicated `/{group_id}/hierarchy` endpoint.
+        For hierarchy traversal (ancestors, descendants, depth), use the
+        dedicated `/{group_id}/descendants` and `/{group_id}/ancestors`
+        endpoints.
 
         - `$filter`: `type` (eq, ne, in), `hierarchy/parent_id` (eq, ne, in), `tenant_id` (eq, ne, in), `id` (eq, ne, in), `name` (eq, ne, in)
         - `limit`: page size (1..200), default 25
@@ -816,19 +817,18 @@ paths:
         '204':
           description: Group deleted
 
-  /resource-group/v1/groups/{group_id}/hierarchy:
+  /resource-group/v1/groups/{group_id}/descendants:
     parameters:
       - $ref: '#/components/parameters/GroupId'
     get:
-      operationId: listGroupHierarchy
+      operationId: getGroupDescendants
       tags: [groups]
-      summary: Traverse hierarchy from a reference group
+      summary: Get group descendants
       description: |
-        Returns groups related to the reference group `{group_id}`.
-        `depth` is **relative** to the reference group:
+        Returns descendants of the reference group `{group_id}` (depth >= 0)
+        with OData filtering. `depth` is **relative** to the reference group:
         - `depth = 0` — the reference group itself
         - `depth > 0` — descendants
-        - `depth < 0` — ancestors
 
         - `$filter`: `depth` (eq, ne, gt, ge, lt, le), `type` (eq, ne, in)
         - `limit`: page size (1..200), default 25
@@ -843,7 +843,7 @@ paths:
         - $ref: '#/components/parameters/Cursor'
       responses:
         '200':
-          description: Paginated groups with relative depth
+          description: Paginated descendants with relative depth
           content:
             application/json:
               schema:
@@ -910,11 +910,43 @@ paths:
                         metadata:
                           barrier: true
                     page_info:
-                      next_cursor: "eyJpZCI6Ijc3NzcuLi4ifQ"
+                      next_cursor: null
                       limit: 25
 
+  /resource-group/v1/groups/{group_id}/ancestors:
+    parameters:
+      - $ref: '#/components/parameters/GroupId'
+    get:
+      operationId: getGroupAncestors
+      tags: [groups]
+      summary: Get group ancestors
+      description: |
+        Returns ancestors of the reference group `{group_id}` (depth <= 0)
+        with OData filtering. `depth` is **relative** to the reference group:
+        - `depth = 0` — the reference group itself
+        - `depth < 0` — ancestors
+
+        - `$filter`: `depth` (eq, ne, gt, ge, lt, le), `type` (eq, ne, in)
+        - `limit`: page size (1..200), default 25
+        - `cursor`: opaque token for pagination
+      x-odata-filter:
+        supported_fields:
+          depth: [eq, ne, gt, ge, lt, le]
+          type: [eq, ne, in]
+      parameters:
+        - $ref: '#/components/parameters/ODataFilter'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Cursor'
+      responses:
+        '200':
+          description: Paginated ancestors with relative depth
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupHierarchyPage'
+              examples:
                 ancestors-of-B3:
-                  summary: "$filter=depth ge -10 and depth le -1 — ancestors of B3"
+                  summary: "Ancestors of B3"
                   value:
                     items:
                       - id: 11111111-1111-1111-1111-111111111111
@@ -933,43 +965,8 @@ paths:
                           category: "finance"
                           short_description: "Mega Department"
                     page_info:
-                      next_cursor: "eyJpZCI6Ijc3NzcuLi4ifQ"
+                      next_cursor: null
                       limit: 25
-
-                full-range-D2:
-                  summary: "Ancestors + self + descendants of D2"
-                  value:
-                    items:
-                      - id: 11111111-1111-1111-1111-111111111111
-                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
-                        name: T1
-                        parent_id: null
-                        tenant_id: 11111111-1111-1111-1111-111111111111
-                        depth: -1
-                      - id: 22222222-2222-2222-2222-222222222222
-                        type: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
-                        name: D2
-                        parent_id: 11111111-1111-1111-1111-111111111111
-                        tenant_id: 11111111-1111-1111-1111-111111111111
-                        depth: 0
-                        metadata:
-                          category: "finance"
-                          short_description: "Mega Department"
-                      - id: 33333333-3333-3333-3333-333333333333
-                        type: "gts.cf.core.rg.type.v1~cf.core.rg.branch.v1~"
-                        name: B3
-                        parent_id: 22222222-2222-2222-2222-222222222222
-                        tenant_id: 11111111-1111-1111-1111-111111111111
-                        depth: 1
-                        metadata:
-                          location: "Building A, Floor 3"
-                    page_info:
-                      next_cursor: "eyJpZCI6Ijc3NzcuLi4ifQ"
-                      limit: 25
-        '404':
-          $ref: '#/components/responses/NotFound'
-
-  # ── Memberships ────────────────────────────────────────────────────
 
   /resource-group/v1/memberships:
     get:
@@ -1212,7 +1209,7 @@ components:
           $ref: '#/components/schemas/PageInfo'
 
     GroupHierarchyItem:
-      description: "Group with relative `depth` from reference group. Returned only by the hierarchy endpoint."
+      description: "Group with relative `depth` from reference group. Returned only by the descendants/ancestors endpoints."
       allOf:
         - $ref: '#/components/schemas/Group'
         - type: object

--- a/gears/system/resource-group/docs/openapi.yaml
+++ b/gears/system/resource-group/docs/openapi.yaml
@@ -1,6 +1,9 @@
 # Created: 2026-03-06 by Constructor Tech
 # Updated: 2026-04-07 by Constructor Tech
 
+# NOTE: the aggregated, CI-verified schema for the whole platform is
+# docs/api/api.json (also served live by the api-gateway at {prefix}/docs).
+# Paths below are gear-relative: the gateway prepends its prefix_path (e.g. /cf).
 openapi: 3.1.0
 info:
   title: Resource Group API
@@ -56,7 +59,7 @@ paths:
 
   # ── Types ──────────────────────────────────────────────────────────
 
-  /api/types-registry/v1/types:
+  /types-registry/v1/types:
     get:
       operationId: listTypes
       tags: [types]
@@ -397,7 +400,7 @@ paths:
                       custom_domain: { type: string, format: hostname }
                       barrier: { type: boolean, default: false }
 
-  /api/types-registry/v1/types/{schema_id}:
+  /types-registry/v1/types/{code}:
     parameters:
       - $ref: '#/components/parameters/TypeSchemaId'
     get:
@@ -499,7 +502,7 @@ paths:
 
   # ── Groups ─────────────────────────────────────────────────────────
 
-  /api/resource-group/v1/groups:
+  /resource-group/v1/groups:
     get:
       operationId: listGroups
       tags: [groups]
@@ -740,7 +743,7 @@ paths:
                     detail: "Setting parent_id would create a cycle in the hierarchy"
                     trace_id: 01HXYZRGCYCLE
 
-  /api/resource-group/v1/groups/{group_id}:
+  /resource-group/v1/groups/{group_id}:
     parameters:
       - $ref: '#/components/parameters/GroupId'
     get:
@@ -813,7 +816,7 @@ paths:
         '204':
           description: Group deleted
 
-  /api/resource-group/v1/groups/{group_id}/hierarchy:
+  /resource-group/v1/groups/{group_id}/hierarchy:
     parameters:
       - $ref: '#/components/parameters/GroupId'
     get:
@@ -968,7 +971,7 @@ paths:
 
   # ── Memberships ────────────────────────────────────────────────────
 
-  /api/resource-group/v1/memberships:
+  /resource-group/v1/memberships:
     get:
       operationId: listMemberships
       tags: [memberships]
@@ -1007,7 +1010,7 @@ paths:
                   next_cursor: "eyJpZCI6Ijc3NzcuLi4ifQ"
                   limit: 25
 
-  /api/resource-group/v1/memberships/{group_id}/{resource_type}/{resource_id}:
+  /resource-group/v1/memberships/{group_id}/{resource_type}/{resource_id}:
     parameters:
       - $ref: '#/components/parameters/MembershipGroupId'
       - $ref: '#/components/parameters/MembershipResourceType'
@@ -1050,7 +1053,7 @@ components:
       example: 22222222-2222-2222-2222-222222222222
 
     TypeSchemaId:
-      name: schema_id
+      name: code
       in: path
       required: true
       description: "GTS type path (`$id` value without `gts://` prefix)."


### PR DESCRIPTION

## Description

The committed per-gear OpenAPI artifacts for **account-management** and
**resource-group** declared paths with an `/api/...` prefix that the code never
registers — `OperationBuilder` registers gear-relative paths, and the api-gateway
prepends its configured `prefix_path` (e.g. `/cf`). A client generated from these
artifacts 404s on every call. We hit this in a real integration (Constructor Studio
backend, a 20-gear assembly); Diffora confirmed on Discord that `docs/api/api.json`
is the CI-verified source of truth.

Changes (verified against `docs/api/api.json` and against live routes on a running
assembly):

- `gears/system/account-management/docs/account-management-v1.yaml` — stripped the
  `/api` prefix from all 16 paths; every declared path now exists in `docs/api/api.json`
- `gears/system/resource-group/docs/openapi.yaml` — stripped `/api` from the
  `resource-group` and `types-registry` paths; renamed `{schema_id}` → `{code}` to
  match the registered route `/types-registry/v1/types/{code}`
- both files: header note pointing to `docs/api/api.json` as the aggregated source of
  truth and explaining gateway prefixing

DESIGN.md references are untouched — the files stay in place as valid OpenAPI, so
Cypilot artifact validation is unaffected.

**Known residual (intentionally not fixed here):** `resource-group/docs/openapi.yaml`
still declares `/resource-group/v1/groups/{group_id}/hierarchy`, which has no matching
route — the implementation exposes `/ancestors` and `/descendants`. Mapping one
documented endpoint onto two real ones is a content decision for the gear owner;
happy to follow up once the intended shape is decided.

**Out of scope:** `credstore`, `event-broker`, `usage-collector` artifacts — no
`/api` drift detected (the latter two appear spec-stage / absent from api.json).

**Suggestion:** a CI check diffing per-gear artifacts against `docs/api/api.json`
(the `api_contracts` workflow looks like a natural home) would prevent this class of
drift permanently.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [x] Documentation update

## Testing

- [x] Manual testing completed — every corrected path verified present in
  `docs/api/api.json` (scripted diff) and exercised live against a running
  20-gear assembly (portal + curl)
- [ ] Unit tests pass — n/a, docs-only change (note: CI may skip via docs path filters)
- [ ] New tests added — n/a; see the CI-diff suggestion above for systemic prevention

## Documentation

- [x] API documentation updated (the artifacts themselves + source-of-truth notes)
- [ ] Code is documented with rustdoc comments — n/a
- [ ] README updated — n/a

## Checklist

- [x] Code follows project style guidelines (docs-only; conventional commit, DCO signed)
- [x] Self-review completed
- [ ] No linting errors (`cargo clippy`) — n/a, no Rust touched
- [ ] Code is properly formatted (`cargo fmt`) — n/a
- [ ] Tests pass (`cargo test`) — n/a

## Related Issues

Discussed on Discord with Diffora (2026-07-29): per-gear artifacts vs
`docs/api/api.json` as source of truth. Related upcoming issue: typed derived
tenant-metadata schemas (will cross-link once filed).
