### PR TITLE
(DRAFT)fix(account-management): open the tenant-metadata envelope payload so typed derived schemas can register

### DIFF
--- a/gears/system/account-management/account-management-sdk/src/gts.rs
+++ b/gears/system/account-management/account-management-sdk/src/gts.rs
@@ -411,7 +411,18 @@ pub struct TenantMetadataTraits {
     // the OP#13 rationale. Guarded by
     // `sync_tests::tenant_metadata_envelope_trait_contract_matches_docs`.
     traits = serde_json::json!({ "inheritance_policy": "override_only" }),
-    gts_abstract = true
+    gts_abstract = true,
+    // The envelope's payload is OPEN by contract: derived metadata schemas
+    // own the payload shape (PRD §5.7 — "branding, contacts") and
+    // MetadataService validates entries against the DERIVED schema at PUT
+    // time. Without an explicit `additionalProperties: true` the OP#12
+    // chain-narrowing check treats the envelope as a closed empty object and
+    // rejects every derived schema that declares a single typed property —
+    // making typed tenant metadata unregistrable. The upstream emitter
+    // closes the object unconditionally, so the toolkit wrapper opens it in
+    // the inventory `schema_fn`. Guarded by
+    // `sync_tests::tenant_metadata_envelope_payload_is_open`.
+    open_payload = true
 )]
 pub struct TenantMetadataEnvelopeV1 {
     /// Required by the `gts-macros` base-struct contract; envelopes carry
@@ -608,10 +619,12 @@ mod sync_tests {
     //! (`x-gts-traits-schema` shape + the envelope's `x-gts-traits`
     //! defaults) MUST agree with the documented
     //! `docs/schemas/<name>.v1.schema.json`. The macro additionally emits
-    //! a data-type top-level shape (`id`/`properties`/`required`/
-    //! `additionalProperties`) that the docs omit by design and that is
-    //! inert at runtime (see gear docs), so only the trait subtrees are
-    //! compared.
+    //! a data-type top-level shape (`id`/`properties`/`required`) that the
+    //! docs omit by design, so only the trait subtrees are compared —
+    //! EXCEPT `additionalProperties`, which is NOT inert: the OP#12
+    //! chain-narrowing check reads it to decide whether derived schemas may
+    //! declare payload properties (see
+    //! `tenant_metadata_envelope_payload_is_open`).
 
     use std::fs;
     use std::path::PathBuf;
@@ -708,6 +721,43 @@ mod sync_tests {
             &read_disk_schema("tenant_metadata.v1.schema.json"),
             TenantMetadataEnvelopeV1::TYPE_ID,
             &serde_json::json!({ "inheritance_policy": "override_only" }),
+        );
+    }
+
+    /// The metadata envelope must reach types-registry with an OPEN payload
+    /// (`additionalProperties: true`), otherwise the OP#12 chain-narrowing
+    /// check rejects every derived schema that declares a typed payload
+    /// property — see the typed-tenant-metadata registration bug.
+    ///
+    /// Asserted on the INVENTORY entry (what types-registry actually
+    /// registers): `open_payload = true` opens the schema in the wrapper's
+    /// `schema_fn`, so the raw `gts_schema_with_refs()` accessor still
+    /// reflects the upstream emitter's closed default.
+    #[test]
+    fn tenant_metadata_envelope_payload_is_open() {
+        let registered = toolkit_gts::all_inventory_type_schemas()
+            .expect("collect inventory type schemas")
+            .into_iter()
+            .find(|s| {
+                s.pointer("/$id").and_then(Value::as_str)
+                    == Some(&format!("gts://{}", TenantMetadataEnvelopeV1::TYPE_ID))
+            })
+            .expect("tenant_metadata envelope must be in the type-schema inventory");
+        assert_eq!(
+            registered
+                .pointer("/additionalProperties")
+                .and_then(Value::as_bool),
+            Some(true),
+            "the inventory-registered tenant_metadata envelope must declare \
+             additionalProperties: true so derived schemas can add typed \
+             payload properties",
+        );
+        assert_eq!(
+            read_disk_schema("tenant_metadata.v1.schema.json")
+                .pointer("/additionalProperties")
+                .and_then(Value::as_bool),
+            Some(true),
+            "docs/schemas/tenant_metadata.v1.schema.json must stay in sync",
         );
     }
 }

--- a/gears/system/account-management/docs/schemas/tenant_metadata.v1.schema.json
+++ b/gears/system/account-management/docs/schemas/tenant_metadata.v1.schema.json
@@ -3,6 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "Base tenant metadata schema for Account Management. Derived metadata schemas resolve behavioral traits via x-gts-traits. Traits configure how MetadataService treats entries of each schema - they are not part of the metadata payload.",
   "type": "object",
+  "additionalProperties": true,
   "x-gts-abstract": true,
   "x-gts-traits-schema": {
     "type": "object",

--- a/gears/system/types-registry/types-registry/tests/abstract_envelope_tests.rs
+++ b/gears/system/types-registry/types-registry/tests/abstract_envelope_tests.rs
@@ -1,0 +1,77 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! Regression tests for typed derived schemas under abstract envelope bases.
+//!
+//! An `x-gts-abstract` envelope base (the account-management
+//! `tenant_metadata.v1~` pattern: no payload properties of its own, traits in
+//! `x-gts-traits-schema`, payload shape owned by derived schemas) must allow
+//! derived schemas to declare typed payload properties when the envelope
+//! explicitly opens its payload with `additionalProperties: true`. Without
+//! the explicit opt-in, the OP#12 chain-narrowing check treats the envelope
+//! as a closed empty object and rejects every typed derived schema, which
+//! made typed tenant metadata unregistrable end-to-end.
+
+mod common;
+
+use common::create_service;
+use serde_json::json;
+
+#[test]
+fn typed_derived_schema_registers_under_open_abstract_envelope() {
+    let service = create_service();
+
+    // Mirrors gts.cf.core.am.tenant_metadata.v1~ with the payload explicitly
+    // opened (additionalProperties: true).
+    let envelope = json!({
+        "$id": "gts://gts.x.test.am.meta_envelope.v1~",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "Abstract metadata envelope; derived schemas own the payload shape.",
+        "type": "object",
+        "additionalProperties": true,
+        "x-gts-abstract": true,
+        "x-gts-traits-schema": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "inheritance_policy": {
+                    "type": "string",
+                    "enum": ["override_only", "inherit"],
+                    "default": "override_only"
+                }
+            }
+        }
+    });
+
+    // A typed derived schema — the exact shape adopters need for validated
+    // per-tenant settings payloads (AM PRD §5.7).
+    let derived = json!({
+        "$id": "gts://gts.x.test.am.meta_envelope.v1~x.test.am.settings.v1~",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "Typed settings payload derived from the envelope.",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "automation_level": {
+                "type": "string",
+                "enum": ["manual", "recommendations", "autonomous"]
+            },
+            "approved_worker_categories": {
+                "type": "array",
+                "items": { "type": "string" }
+            }
+        },
+        "x-gts-traits": { "inheritance_policy": "override_only" }
+    });
+
+    let results = service.register(vec![envelope, derived]);
+    for result in &results {
+        assert!(
+            matches!(result, types_registry_sdk::RegisterResult::Ok { .. }),
+            "registration must succeed for an open envelope chain, got: {result:?}",
+        );
+    }
+
+    service
+        .switch_to_ready()
+        .expect("typed derived schema under an open abstract envelope must survive ready-mode validation");
+}

--- a/libs/toolkit-gts-macros/src/lib.rs
+++ b/libs/toolkit-gts-macros/src/lib.rs
@@ -238,8 +238,59 @@ pub fn gts_type_schema(attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 }
 
+/// Strips the wrapper-only `open_payload = true|false` argument from the
+/// attribute token stream before it is forwarded to the upstream
+/// `struct_to_gts_schema` macro (which rejects unknown attributes).
+///
+/// `open_payload = true` marks the generated schema's payload as OPEN: the
+/// inventory `schema_fn` post-processes the upstream JSON and sets
+/// `additionalProperties: true` at the schema root. Envelope bases (e.g.
+/// account-management's `tenant_metadata.v1~`) need this so the OP#12
+/// chain-narrowing check lets derived schemas declare typed payload
+/// properties — the upstream emitter otherwise closes the object, which the
+/// attribute surface gives no way to override.
+fn strip_open_payload(attr: &TokenStream2) -> (TokenStream2, bool) {
+    use proc_macro2::TokenTree;
+    let mut out = TokenStream2::new();
+    let mut open = false;
+    let mut iter = attr.clone().into_iter().peekable();
+    while let Some(tt) = iter.next() {
+        if let TokenTree::Ident(id) = &tt {
+            if id == "open_payload" {
+                let eq = iter.next();
+                let val = iter.next();
+                let is_eq = matches!(&eq, Some(TokenTree::Punct(p)) if p.as_char() == '=');
+                let truthy = matches!(&val, Some(TokenTree::Ident(v)) if v == "true");
+                let falsy = matches!(&val, Some(TokenTree::Ident(v)) if v == "false");
+                if is_eq && (truthy || falsy) {
+                    open = truthy;
+                    // Swallow the following comma so upstream sees a clean list.
+                    if matches!(iter.peek(), Some(TokenTree::Punct(p)) if p.as_char() == ',') {
+                        iter.next();
+                    }
+                    continue;
+                }
+                // Malformed usage: re-emit consumed tokens verbatim so the
+                // upstream parser reports its canonical error.
+                out.extend([tt]);
+                if let Some(e) = eq {
+                    out.extend([e]);
+                }
+                if let Some(v) = val {
+                    out.extend([v]);
+                }
+                continue;
+            }
+        }
+        out.extend([tt]);
+    }
+    (out, open)
+}
+
 fn expand_gts_type_schema(attr: &TokenStream2, input: &ItemStruct) -> syn::Result<TokenStream2> {
     let crate_path = resolve_crate_path()?;
+    let (attr, open_payload) = strip_open_payload(attr);
+    let attr = &attr;
     let type_id_input = extract_type_id(attr)?;
     let type_id = type_id_input.emitted_expr(&crate_path);
     let struct_name = &input.ident;
@@ -266,10 +317,23 @@ fn expand_gts_type_schema(attr: &TokenStream2, input: &ItemStruct) -> syn::Resul
         ));
     }
     let has_generics = type_param_count == 1;
-    let schema_fn_body = if has_generics {
+    let raw_schema_call = if has_generics {
         quote! { <#struct_name::<()>>::gts_schema_with_refs_as_string() }
     } else {
         quote! { <#struct_name>::gts_schema_with_refs_as_string() }
+    };
+    let schema_fn_body = if open_payload {
+        // Post-process the upstream schema: open the payload at the root so
+        // OP#12 chain-narrowing admits typed properties in derived schemas.
+        quote! {{
+            let mut schema: #crate_path::serde_json::Value =
+                #crate_path::serde_json::from_str(&#raw_schema_call)
+                    .expect("gts_type_schema: macro-generated schema must be valid JSON");
+            schema["additionalProperties"] = #crate_path::serde_json::Value::Bool(true);
+            schema.to_string()
+        }}
+    } else {
+        raw_schema_call
     };
 
     Ok(quote! {

--- a/libs/toolkit-gts/src/lib.rs
+++ b/libs/toolkit-gts/src/lib.rs
@@ -43,6 +43,9 @@ pub use gts::{GTS_ID_PREFIX, GTS_ID_URI_PREFIX, GtsId, GtsInstanceId, GtsSchema}
 // `inventory` as a direct dep.
 #[doc(hidden)]
 pub use inventory;
+// Re-exported for `#[gts_type_schema(open_payload = true)]`-generated code,
+// which post-processes the upstream schema JSON before inventory submission.
+pub use serde_json;
 
 // Re-export the companion proc-macros so consumers need only one crate dep.
 pub use gts_macros::GtsTraitsSchema;


### PR DESCRIPTION
### Description
The `gts.cf.core.am.tenant_metadata.v1~` envelope reached types-registry with
`additionalProperties: false`: the upstream gts-macros emitter closes the generated
object unconditionally, and its attribute surface offers no override (a
`#[schemars(extend(...))]` on the struct is overwritten by the emitter — we tried).
The OP#12 chain-narrowing check therefore rejected **any** derived metadata schema
declaring a typed payload property (`switch_to_ready` fails, gear init aborts). That
made the PRD §5.7 promise — "extensible tenant metadata with GTS-validated payloads
(branding, contacts)" — unrealisable: only free-form `type: object` derived schemas
could register. Found while building the Constructor Studio backend; confirmed as a
bug on Discord (2026-07-29). Fixes #<issue>.

The fix, entirely within this repo:

- **toolkit-gts-macros**: new wrapper-only `gts_type_schema` argument
  `open_payload = true` — stripped before forwarding to upstream (which rejects
  unknown attributes); the inventory `schema_fn` post-processes the emitted JSON and
  sets `additionalProperties: true` at the schema root. `toolkit-gts` re-exports
  `serde_json` for the generated code.
- **account-management-sdk**: `TenantMetadataEnvelopeV1` declares
  `open_payload = true`; `docs/schemas/tenant_metadata.v1.schema.json` synced.

Semantically the envelope payload was always meant to be open: derived schemas own
the payload shape, and `MetadataService` validates entries against the **derived**
schema at PUT time (`metadata_schema_registry`) — the base is an envelope, not a
payload contract. Traits stay strict (`x-gts-traits-schema` unchanged,
`additionalProperties: false` inside it). Verified along the way that OP#12 honours
an explicit `additionalProperties: true` — the narrowing rule itself needs no change.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Testing

- [x] New tests added:
  - `types-registry/tests/abstract_envelope_tests.rs` — a typed derived schema under
    an open abstract envelope registers and survives `switch_to_ready`;
  - `account-management-sdk` sync test `tenant_metadata_envelope_payload_is_open` —
    asserts the **inventory entry** (what types-registry actually registers) and the
    docs artifact both carry `additionalProperties: true` (the raw
    `gts_schema_with_refs()` accessor intentionally still reflects the upstream
    emitter's closed default — documented in the test).
- [x] Unit tests pass (`cargo test -p cf-gears-toolkit-gts-macros -p cf-gears-toolkit-gts -p cf-gears-account-management-sdk -p cf-gears-types-registry`)
- [x] Manual testing completed — original repro (one typed entry in
  `types-registry.config.entities`) previously aborted post-init on a 20-gear
  assembly.

### Documentation

- [x] API documentation updated (`docs/schemas/tenant_metadata.v1.schema.json`)

### Checklist

- [x] Code follows project style guidelines (conventional commit, DCO signed)
- [x] Self-review completed
- [x] No linting errors (`cargo clippy`)
- [x] Code is properly formatted (`cargo fmt`)
- [x] Tests pass (`cargo test`)

### Related Issues

Fixes #4338 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tenant metadata envelope schemas now allow additional, unspecified payload properties.
  * Typed tenant metadata schemas can be registered and validated when extending the open envelope.

* **Bug Fixes**
  * Improved schema consistency checks to ensure registered and documented schemas both support open payloads.

* **Tests**
  * Added regression coverage for schema registration and ready-mode validation of derived tenant metadata schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->