### PR TITLE
chore(codeowners): assign owners for a few gears and anchor paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,7 @@
-libs @MikeFalcon77
-gears/mini-chat @MikeFalcon77
+/libs/ @MikeFalcon77
+/gears/bss/ @diffora
+/gears/credstore/ @diffora
+/gears/mini-chat/ @MikeFalcon77
+/gears/system/account-management/ @diffora
+/gears/system/authn-resolver/plugins/oidc-authn-plugin/ @fluiderson
+/gears/system/usage-collector/ @capybutler


### PR DESCRIPTION
Adds review routing to `.github/CODEOWNERS` for the gears whose ownership is unambiguous,
and fixes the two pre-existing patterns.

Before this change the file held two unanchored rules (`libs`, `gears/mini-chat`), so
nearly the whole repo had no code owner and no automatic reviewer request.

**How owners were chosen.** Per-path commit history, counted across both the current
`gears/…` paths and the pre-rename `modules/…` paths — `git log -- gears/x` alone misses
everything before the June path migration, which is most of several gears' history.
Repo-wide sweeps were excluded from the ranking (release automation, the historical mass
renames, dependency and GTS migrations, the `/cf`→`/cw` URL-prefix refactor, the
canonical-projection pass), since they inflate line counts in paths their authors do not own.

**Anchoring fix.** Both pre-existing patterns gained a leading `/`; their owner is unchanged.
Unanchored `libs` matched any directory of that name at any depth, including `gears/bss/libs/`
— BSS code, not toolkit code.

**authn-resolver is routed by sub-path only.** `plugins/oidc-authn-plugin/` goes to its
author, who wrote it in a single +12,608-line commit. The rest of the gear — core, SDK and
static plugin — is left unassigned, so this rule is the only `authn-resolver` pattern in the
file and there is no last-match-wins interaction to reason about.

### Notes for reviewers

- **Write access is unverified.** All four handles were confirmed to exist as GitHub users,
  but the collaborators API is not readable without push access, so I could not confirm any
  of them can actually be assigned as a reviewer. CODEOWNERS silently ignores entries for
  users without write access — no error appears anywhere in the UI. Worth one check by
  someone with push rights.
- **Single-owner rules are inert on their owner's own PRs.** GitHub never requests review
  from the PR author, so `/gears/system/usage-collector/` does nothing on a PR by
  @capybutler, and likewise for the three @diffora rules. Left as-is intentionally; add a
  second owner to any rule where that is not the desired behaviour.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update — repository configuration; no library or binary code is touched

## Testing

- [ ] Unit tests pass — n/a, no code change
- [ ] Integration tests pass — n/a, no code change
- [x] Manual testing completed
- [ ] New tests added for new functionality — n/a

Verification performed:

- All four handles resolve to existing GitHub accounts via `gh api users/<login>`
  (`type: User`, no bots, no typos).
- All seven patterns match a directory that exists in the tree.
- No two patterns overlap, so GitHub's last-match-wins ordering does not affect the result.

## Documentation

- [ ] Code is documented with rustdoc comments — n/a, no code change
- [ ] README updated (if applicable) — n/a
- [ ] API documentation updated (if applicable) — n/a

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] No linting errors (`cargo clippy`) — n/a, not run: no Rust sources changed
- [ ] Code is properly formatted (`cargo fmt`) — n/a, not run: no Rust sources changed
- [ ] Tests pass (`cargo test`) — n/a, not run: no Rust sources changed

## Related Issues

None.