### PR TITLE
fix(docs): fix broken dylint lints link

### DIFF
--- a/docs/arch/database/ADR/0001-cpt-cf-database-adr-object-namespacing.md
+++ b/docs/arch/database/ADR/0001-cpt-cf-database-adr-object-namespacing.md
@@ -278,7 +278,7 @@ Keep current names and rely on `CREATE ... IF NOT EXISTS`, migration ordering, o
 
 * ToolKit currently isolates only per-gear migration history tables: [migration runner](../../../../libs/toolkit-db/src/migration_runner.rs).
 * ToolKit database execution and migration patterns: [database patterns](../../../toolkit_unified_system/11_database_patterns.md).
-* Project-specific architectural rules and their validation commands: [Dylint lint catalog](../../../../tools/dylint_lints/README.md).
+* Project-specific architectural rules and their validation commands: [architecture lints and validation commands](../../../../CONTRIBUTING.md).
 * The reusable outbox already supports caller-provided prefixes: [outbox migrations](../../../../libs/toolkit-db/src/outbox/migrations.rs).
 * Existing incompatible `messages` entities: [Chat Engine](../../../../gears/chat-engine/chat-engine/src/infra/db/entity/message.rs) and [Mini Chat](../../../../gears/mini-chat/mini-chat/src/infra/db/entity/message.rs).
 * File Storage documents why its runtime migrations currently use a flat namespace: [File Storage initial migration](../../../../gears/file-storage/file-storage/src/infra/storage/migrations/m20260624_000001_p1_initial.rs).


### PR DESCRIPTION
Fixes failed CI check: https://github.com/constructorfabric/gears-rust/actions/runs/30570584735/job/90966000789?pr=4282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the architecture decision record’s reference link to point to the project’s architecture linting and validation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->