### PR TITLE
test(usage-collector): stop the TimescaleDB test harness deleting its own fixtures

### DIFF
--- a/gears/system/usage-collector/plugins/timescaledb-usage-collector-plugin/tests/cleanup_integration_pg.rs
+++ b/gears/system/usage-collector/plugins/timescaledb-usage-collector-plugin/tests/cleanup_integration_pg.rs
@@ -30,7 +30,11 @@ async fn pg_concurrent_post_migration_setup_is_serialized() {
     for _ in 0..8u32 {
         let pool = h.pool.clone();
         tasks.push(tokio::spawn(async move {
-            apply_post_migration_setup(&pool, 31_536_000).await
+            // The window is irrelevant here (this test asserts serialization, and
+            // inserts no rows) — but each re-apply registers a *live* policy, so
+            // use the no-drop window rather than the production one to leave the
+            // container in a state where a later-added row cannot vanish.
+            apply_post_migration_setup(&pool, common::NO_DROP_RETENTION_SECS).await
         }));
     }
     for t in tasks {
@@ -62,7 +66,7 @@ async fn pg_concurrent_post_migration_setup_is_serialized() {
 /// pooled connection must still report the configured value.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn pg_init_lock_does_not_leak_statement_timeout() {
-    let h = common::bring_up_with(17, 2, 2)
+    let h = common::bring_up_with(17, 2, 2, common::NO_DROP_RETENTION_SECS)
         .await
         .expect("timescaledb container (Docker required)");
 
@@ -96,7 +100,10 @@ async fn pg_init_lock_does_not_leak_statement_timeout() {
 /// hypertable + window and that the outbound `gts_id` FK does not block it.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn pg_registered_retention_policy_drops_aged_data() {
-    let h = common::bring_up()
+    // The one harness that needs the production 365-day window: the subject here
+    // IS retention. `bring_up_real_retention` also unschedules the job so the
+    // explicit `CALL run_job` below is the only thing that can drop a chunk.
+    let h = common::bring_up_real_retention()
         .await
         .expect("timescaledb container (Docker required)");
     let catalog = common::catalog_store(&h.pool);
@@ -161,5 +168,72 @@ async fn pg_registered_retention_policy_drops_aged_data() {
     assert_eq!(
         after_fresh, 1,
         "fresh record (inside window) survives retention"
+    );
+}
+
+/// Guard on the harness itself, and the exact inverse of the test above: the
+/// default [`common::bring_up`] must never register a retention policy that can
+/// reach the deliberately-backdated fixtures the query/ingest suites assert on.
+///
+/// `apply_post_migration_setup` registers a live `policy_retention` job whose
+/// background schedule the image fires ~3s after registration — mid-test. With
+/// the production 365-day default, `fixture_usage_record`'s 2023-11-14 instant is
+/// years past the cutoff and its whole 7-day chunk is drop-eligible the moment it
+/// is created, so a stalled test body loses rows it already inserted (observed in
+/// CI as an aggregation bucket short by one record).
+///
+/// Firing the policy explicitly asserts the property directly instead of waiting
+/// on the scheduler, so this test is fast and deterministic rather than a race
+/// that usually happens not to fire.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pg_default_harness_retention_cannot_drop_backdated_fixtures() {
+    let h = common::bring_up()
+        .await
+        .expect("timescaledb container (Docker required)");
+    let catalog = common::catalog_store(&h.pool);
+    catalog
+        .create(common::fixture_usage_type(VCPU_GTS, "counter", &[]))
+        .await
+        .expect("register usage type (satisfies the gts_id FK)");
+    let store = common::record_store(&h.pool);
+    let tenant = Uuid::from_u128(0xBAD_11E);
+
+    // A stock fixture, at the stock backdated `created_at`, via the real ingest path.
+    let rec = common::fixture_usage_record(
+        VCPU_GTS,
+        tenant,
+        "backdated",
+        rust_decimal::Decimal::ONE,
+        0xB01,
+    );
+    let rec_id = rec.id;
+    let created_at = rec.created_at;
+    store.create(rec).await.expect("create backdated record");
+
+    // Fire the harness's own registered policy — whatever window it was given.
+    let job_id: i32 = sqlx::query_scalar(
+        "SELECT job_id FROM timescaledb_information.jobs \
+         WHERE proc_name = 'policy_retention' AND hypertable_name = 'usage_records'",
+    )
+    .fetch_one(&h.pool)
+    .await
+    .expect("the retention policy must be registered against usage_records");
+    sqlx::query("CALL run_job($1)")
+        .bind(job_id)
+        .execute(&h.pool)
+        .await
+        .expect("running the retention policy must not error");
+
+    let survived: i64 = sqlx::query_scalar("SELECT count(*) FROM usage_records WHERE id = $1")
+        .bind(rec_id)
+        .fetch_one(&h.pool)
+        .await
+        .expect("count after");
+    assert_eq!(
+        survived, 1,
+        "the default harness registered a retention policy that can delete a stock \
+         fixture row (created_at = {created_at}); every test inserting fixtures is \
+         then racing the background scheduler. bring_up() must pass a window no \
+         fixture can fall outside of — see common::NO_DROP_RETENTION_SECS"
     );
 }

--- a/gears/system/usage-collector/plugins/timescaledb-usage-collector-plugin/tests/common/mod.rs
+++ b/gears/system/usage-collector/plugins/timescaledb-usage-collector-plugin/tests/common/mod.rs
@@ -40,20 +40,84 @@ pub struct TsHarness {
     _container: ContainerAsync<GenericImage>,
 }
 
+/// Retention window for harnesses whose fixtures are deliberately backdated to a
+/// fixed instant (`fixture_usage_record`'s `created_at`, 2023-11-14).
+///
+/// `apply_post_migration_setup` registers a REAL `policy_retention` job, and the
+/// image's background scheduler fires it on its own roughly 3 seconds after
+/// registration — i.e. while the test body is still running. At the production
+/// default window (365 days) the backdated fixtures are ~2.5 years past the
+/// cutoff and share one 7-day chunk, so that first scheduled run drops the chunk
+/// out from under the test. A stalled insert loop (parallel containers on a
+/// loaded CI box) then sees rows vanish mid-test: one aggregation bucket short,
+/// a `count` off by one, a cursor walk ending early.
+///
+/// At the config's documented ceiling (`MAX_RETENTION_SECS`, `src/config.rs` —
+/// private, so the value is repeated here) the cutoff lands in 1926, no chunk is
+/// ever drop-eligible, and the registered policy is a structural no-op: still
+/// registered, still scheduled, still run — it just finds nothing to delete.
+pub const NO_DROP_RETENTION_SECS: u64 = 100 * 365 * 86_400;
+
+/// The production default (365 days). Only for tests whose subject IS retention.
+pub const REAL_RETENTION_SECS: u64 = 365 * 86_400;
+
 pub async fn bring_up() -> anyhow::Result<TsHarness> {
-    // Default pool bounds and statement timeout (mirrors the config defaults).
-    bring_up_with(30, 2, 16).await
+    // Default pool bounds and statement timeout (mirrors the config defaults),
+    // plus a retention window that cannot reach the backdated fixtures.
+    bring_up_with(30, 2, 16, NO_DROP_RETENTION_SECS).await
 }
 
-/// Like [`bring_up`] but with an explicit request-path `statement_timeout` (secs)
-/// and pool bounds. Used to assert the init path does not leak a modified
-/// `statement_timeout` onto pooled connections: pass a value distinct from any
-/// the init path might set, and a small fixed pool so every connection can be
-/// inspected.
+/// Like [`bring_up`] but with the production 365-day retention window, and with
+/// the registered job's background schedule disabled.
+///
+/// For tests whose subject is retention itself: they insert genuinely aged rows
+/// and fire the policy by hand (`CALL run_job`). Leaving the job scheduled would
+/// let the background scheduler drop those rows first, both flaking the
+/// "exists before retention runs" precondition and letting the assertion pass
+/// for the wrong reason (background run did the work, the manual one was a
+/// no-op). Unscheduling makes the explicit `run_job` the only deleter, so the
+/// test observes exactly the policy it registered.
+pub async fn bring_up_real_retention() -> anyhow::Result<TsHarness> {
+    let h = bring_up_with(30, 2, 16, REAL_RETENTION_SECS).await?;
+    // `alter_job(scheduled => false)` keeps the job row (so the schema test's
+    // "a policy is registered" assertion still holds) and leaves `run_job`
+    // working; it only stops the scheduler from firing it unprompted.
+    let unscheduled = sqlx::query(
+        "SELECT alter_job(job_id, scheduled => false) \
+         FROM timescaledb_information.jobs \
+         WHERE proc_name = 'policy_retention' AND hypertable_name = 'usage_records'",
+    )
+    .execute(&h.pool)
+    .await?
+    .rows_affected();
+    // A `WHERE` that matches nothing is not an error, so an unschedule that
+    // quietly hit zero rows would leave the job scheduled and re-arm the very
+    // race this harness exists to remove — and the retention test would then
+    // pass on the background run's work. Fail loudly instead, so a TimescaleDB
+    // bump that reshapes `timescaledb_information.jobs` surfaces here.
+    anyhow::ensure!(
+        unscheduled == 1,
+        "expected to unschedule exactly 1 policy_retention job on usage_records, \
+         matched {unscheduled}"
+    );
+    Ok(h)
+}
+
+/// Like [`bring_up`] but with an explicit request-path `statement_timeout` (secs),
+/// pool bounds, and retention window. Used to assert the init path does not leak
+/// a modified `statement_timeout` onto pooled connections: pass a value distinct
+/// from any the init path might set, and a small fixed pool so every connection
+/// can be inspected.
+///
+/// `retention_secs` is threaded into the config JSON rather than left to
+/// `#[serde(default)]`: the default is the production 365-day window, which arms
+/// a live chunk-dropper against the backdated fixtures (see
+/// [`NO_DROP_RETENTION_SECS`]).
 pub async fn bring_up_with(
     statement_timeout_secs: u64,
     pool_size_min: u32,
     pool_size_max: u32,
+    retention_secs: u64,
 ) -> anyhow::Result<TsHarness> {
     let image = GenericImage::new("timescale/timescaledb", "2.17.2-pg16")
         .with_wait_for(WaitFor::message_on_stderr(
@@ -73,7 +137,8 @@ pub async fn bring_up_with(
     let cfg: TimescaleDbPluginConfig = serde_json::from_str(&format!(
         r#"{{ "database_url": "postgres://user:pass@127.0.0.1:{port}/app?sslmode=disable",
               "statement_timeout_secs": {statement_timeout_secs},
-              "pool_size_min": {pool_size_min}, "pool_size_max": {pool_size_max} }}"#
+              "pool_size_min": {pool_size_min}, "pool_size_max": {pool_size_max},
+              "retention_period_secs": {retention_secs} }}"#
     ))
     .expect("valid test config json");
 
@@ -183,6 +248,11 @@ pub fn fixture_usage_record(
         status: usage_collector_sdk::UsageRecordStatus::Active,
         // A fixed whole-second instant (no sub-microsecond component) so the
         // value persisted by Postgres equals the value asserted in tests.
+        //
+        // 2023-11-14 — years outside any realistic retention window, so a
+        // harness must NOT arm a droppable retention policy against it or the
+        // registered `policy_retention` job deletes these rows mid-test. See
+        // `NO_DROP_RETENTION_SECS`.
         created_at: OffsetDateTime::from_unix_timestamp(1_700_000_000)
             .expect("fixture created_at must be a valid unix timestamp"),
     }


### PR DESCRIPTION
The TimescaleDB usage-collector plugin's test harness was deleting its own fixtures.

`common::bring_up` left `retention_period_secs` at its `#[serde(default)]`, so every test container registered a live 365-day `policy_retention` job. The suite's fixtures are deliberately backdated to a fixed 2023 instant (`fixture_usage_record`, 2023-11-14) and share a single 7-day chunk, making that chunk drop-eligible the moment it exists — and TimescaleDB's scheduler fires a newly registered policy a few seconds later, while the test body is still running. Any test slow enough to cross that fuse loses rows it has already inserted, then passes unchanged on rerun.

CI hit it as `pg_aggregate_filter_by_tenant_isolates_sum` summing 6 where it expected 4 + 6: the chunk drop landed between two inserts, so the first row went with the chunk and the second landed in a fresh one. Every fixture-inserting test in the query, ingest and id-uniqueness suites carried the same exposure.

Changes, all under `tests/` — nothing in `src/` moves, because retention reaches the database through exactly one config value:

- `bring_up_with` now threads `retention_secs` into the config JSON instead of leaving it to `#[serde(default)]`, and `bring_up` requests the config's documented ceiling (`MAX_RETENTION_SECS`, 100 years) via the new `common::NO_DROP_RETENTION_SECS`. The policy stays registered, scheduled and run — it just never finds anything to delete, so the schema suite's "a policy exists" assertion and the advisory-lock init path keep their coverage.
- `pg_registered_retention_policy_drops_aged_data`, whose subject *is* retention, opts back into the production window through a new `bring_up_real_retention`. That harness also unschedules the job so the test's explicit `CALL run_job` is the only thing that can drop a chunk — otherwise a background run could delete the aged rows first and the assertion would pass for the wrong reason. The unschedule asserts it matched exactly one job, since a `WHERE` matching nothing is not an error and would silently re-arm the race.
- New inverse guard `pg_default_harness_retention_cannot_drop_backdated_fixtures`: insert a stock fixture through the real ingest path, fire the harness's own registered policy by hand, assert the row survives. Firing it directly makes the guard deterministic rather than a race that usually happens not to fire.
- `pg_concurrent_post_migration_setup_is_serialized` re-applies setup 8×; each re-apply registers a live policy, so it now passes the no-drop window too, leaving the container in a state where a later-added row cannot vanish.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue) — test-harness only; no production code paths change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass
- [ ] Manual testing completed
- [x] New tests added for new functionality — `pg_default_harness_retention_cannot_drop_backdated_fixtures` guards the harness invariant this PR establishes, so a future `bring_up` change that re-arms the dropper fails loudly instead of flaking

The affected suites are `#[ignore]`-free integration tests requiring Docker (`timescale/timescaledb:2.17.2-pg16` via testcontainers); CI runs them. The new guard is deterministic — it fires the policy itself rather than waiting on the scheduler — so it does not depend on timing to hold.

## Documentation

- [x] Code is documented with rustdoc comments — `NO_DROP_RETENTION_SECS`, `REAL_RETENTION_SECS`, `bring_up_real_retention` and the `fixture_usage_record` `created_at` field each document why the window matters, so the constraint is discoverable from the code that would break it
- [ ] README updated (if applicable) — n/a
- [ ] API documentation updated (if applicable) — n/a, no public API change

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No linting errors (`cargo clippy`)
- [x] Code is properly formatted (`cargo fmt`)
- [x] Tests pass (`cargo test`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced integration test configuration for retention policy verification.
  * Added test coverage to validate retention behavior with concurrent operations and default settings.
  * Improved test harness to properly verify production-level retention window handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->