### PR TITLE
fix(static-authz-plugin): emit the tenant clamp only when the PEP can bind it

### DIFF
--- a/gears/system/authz-resolver/plugins/static-authz-plugin/src/domain/service.rs
+++ b/gears/system/authz-resolver/plugins/static-authz-plugin/src/domain/service.rs
@@ -12,7 +12,8 @@ use uuid::Uuid;
 /// Static `AuthZ` resolver service.
 ///
 /// - Returns `decision: true` with an `in` predicate on `pep_properties::OWNER_TENANT_ID`
-///   scoped to the context tenant from the request (for all operations including CREATE).
+///   scoped to the context tenant from the request (for all operations including CREATE),
+///   when the PEP declares that property in `context.supported_properties`.
 /// - Additionally emits parallel `InTenantSubtree(<prop>, tid)` constraints (one per
 ///   tenant-shaped supported property) when the PEP advertises
 ///   [`Capability::TenantHierarchy`]. This lets entities whose `Scopable` declaration
@@ -26,7 +27,12 @@ use uuid::Uuid;
 ///   property doesn't resolve to a column on the entity being queried -- so the
 ///   addition is invisible to PEPs that don't advertise the capability and to entities
 ///   that don't expose the property.
-/// - Denies access (`decision: false`) when no valid tenant can be resolved.
+/// - Emits an empty constraint set when the PEP declares none of the properties above.
+///   The PEP compiler turns that into `allow_all()`, or a deny under
+///   `require_constraints` -- this service does not repeat that matrix. Such a permit
+///   means "no row filter", never "the caller owns this row".
+/// - Denies access (`decision: false`) when no valid tenant can be resolved, before any
+///   constraint is built.
 #[domain_model]
 #[derive(Default)]
 pub struct Service;
@@ -73,14 +79,22 @@ impl Service {
             };
         }
 
-        // Baseline OWNER_TENANT_ID clamp -- the universal shape every PEP can bind
-        // when its entity declares `tenant_col`.
-        let mut constraints = vec![Constraint {
-            predicates: vec![Predicate::In(InPredicate::new(
-                pep_properties::OWNER_TENANT_ID,
-                [tid],
-            ))],
-        }];
+        // Baseline OWNER_TENANT_ID clamp -- the universal shape a PEP binds when its
+        // entity declares `tenant_col`. Emitted only when the PEP declares that property:
+        // the compiler fails any constraint naming something outside
+        // `context.supported_properties` (`authz-resolver-sdk/src/pep/compiler.rs`), so an
+        // undeclared clamp is dead on arrival -- and as the only constraint it failed the
+        // whole set (`AllConstraintsFailed`, a deny), losing every request for a
+        // platform-global resource that declares no property at all.
+        let mut constraints = Vec::new();
+        if supports_property(request, pep_properties::OWNER_TENANT_ID) {
+            constraints.push(Constraint {
+                predicates: vec![Predicate::In(InPredicate::new(
+                    pep_properties::OWNER_TENANT_ID,
+                    [tid],
+                ))],
+            });
+        }
 
         // Closes the gap from `gears-rust#1813` (plugin half) for the dev stack:
         // PEPs that advertise `Capability::TenantHierarchy` get an
@@ -114,6 +128,23 @@ impl Service {
                     });
                 }
             }
+        }
+
+        // No constraint means the PEP declared none of the properties above. The compiler
+        // owns what that means -- `allow_all()`, or a deny under `require_constraints`
+        // (`compiler.rs` Step 1, pinned by the composition tests) -- so there is no deny of
+        // our own here. That Step 1 returns without logging, hence the warn.
+        //
+        // Do not narrow the required case with `resource.properties[OWNER_TENANT_ID]`
+        // instead: this plugin has no tenant tree, so it cannot tell an ancestor from a
+        // stranger, and an equality check denies the ancestor-tenant requests the AM e2e
+        // suites exercise.
+        if constraints.is_empty() && request.context.require_constraints {
+            tracing::warn!(
+                resource_type = %request.resource.resource_type,
+                "static-authz: PEP requires constraints but declares none of the properties \
+                 this plugin constrains -- the PEP compiler will fail this closed",
+            );
         }
 
         EvaluationResponse {

--- a/gears/system/authz-resolver/plugins/static-authz-plugin/src/domain/service_tests.rs
+++ b/gears/system/authz-resolver/plugins/static-authz-plugin/src/domain/service_tests.rs
@@ -1,10 +1,12 @@
 // Created: 2026-04-14 by Constructor Tech
 use super::*;
-use authz_resolver_sdk::pep::IntoPropertyValue;
+use authz_resolver_sdk::pep::{ConstraintCompileError, IntoPropertyValue, compile_to_access_scope};
 use authz_resolver_sdk::{Action, EvaluationRequestContext, Resource, Subject, TenantContext};
 use std::collections::HashMap;
 use toolkit_gts::gts_id;
 
+/// Build a request whose PEP declares nothing it can constrain on -- the shape a
+/// platform-global `ResourceType` (`from_static(.., &[])`) sends.
 fn make_request(require_constraints: bool, tenant_id: Option<Uuid>) -> EvaluationRequest {
     let mut subject_properties = HashMap::new();
     subject_properties.insert(
@@ -40,6 +42,18 @@ fn make_request(require_constraints: bool, tenant_id: Option<Uuid>) -> Evaluatio
     }
 }
 
+/// Build a request whose PEP declares `OWNER_TENANT_ID` -- the shape any entity
+/// declared with `tenant_col` sends, and the only shape the baseline clamp binds
+/// against.
+fn make_owner_tenant_request(
+    require_constraints: bool,
+    tenant_id: Option<Uuid>,
+) -> EvaluationRequest {
+    let mut req = make_request(require_constraints, tenant_id);
+    req.context.supported_properties = vec![pep_properties::OWNER_TENANT_ID.to_owned()];
+    req
+}
+
 /// Build a request that mirrors what an AM-style PEP sends:
 /// `Capability::TenantHierarchy` advertised + `RESOURCE_ID` declared on
 /// the supported-properties list, so the plugin should emit the
@@ -59,7 +73,7 @@ fn make_tenant_hierarchy_request(tenant_id: Uuid) -> EvaluationRequest {
 fn list_operation_with_tenant_context() {
     let tenant_id = Uuid::parse_str("33333333-3333-3333-3333-333333333333").unwrap();
     let service = Service::new();
-    let response = service.evaluate(&make_request(true, Some(tenant_id)));
+    let response = service.evaluate(&make_owner_tenant_request(true, Some(tenant_id)));
 
     assert!(response.decision);
     assert_eq!(response.context.constraints.len(), 1);
@@ -79,7 +93,7 @@ fn list_operation_with_tenant_context() {
 #[test]
 fn list_operation_without_tenant_falls_back_to_subject_properties() {
     let service = Service::new();
-    let response = service.evaluate(&make_request(true, None));
+    let response = service.evaluate(&make_owner_tenant_request(true, None));
 
     // Falls back to subject.properties["tenant_id"]
     assert!(response.decision);
@@ -129,6 +143,162 @@ fn missing_tenant_context_and_subject_property_is_denied() {
             tenant_context: None,
             token_scopes: vec!["*".to_owned()],
             require_constraints: true,
+            capabilities: vec![],
+            supported_properties: vec![],
+            bearer_token: None,
+        },
+    };
+
+    let service = Service::new();
+    let response = service.evaluate(&request);
+
+    assert!(!response.decision);
+    assert!(response.context.constraints.is_empty());
+}
+
+#[test]
+fn no_bindable_property_emits_no_constraints() {
+    // The clamp cannot bind, so it must not be emitted: as the only constraint it
+    // failed the whole set (`AllConstraintsFailed`, a deny). Empty either way --
+    // the compiler owns what that means, see the composition tests below.
+    let tenant_id = Uuid::parse_str("66666666-6666-6666-6666-666666666666").unwrap();
+    let service = Service::new();
+
+    for require_constraints in [false, true] {
+        let response = service.evaluate(&make_request(require_constraints, Some(tenant_id)));
+
+        assert!(
+            response.decision,
+            "require_constraints: {require_constraints}"
+        );
+        assert!(
+            response.context.constraints.is_empty(),
+            "require_constraints: {require_constraints}"
+        );
+    }
+}
+
+#[test]
+fn empty_constraint_set_compiles_to_allow_all_when_constraints_are_not_required() {
+    // Composition guard over the real compiler: a PEP that declares nothing gets
+    // the `allow_all` a decision-only caller asked for, not a deny.
+    let tenant_id = Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap();
+    let service = Service::new();
+    let response = service.evaluate(&make_request(false, Some(tenant_id)));
+
+    let scope = compile_to_access_scope(&response, false, &[]).expect("compiles");
+
+    assert!(scope.is_unconstrained());
+}
+
+#[test]
+fn empty_constraint_set_is_denied_by_the_pep_compiler_when_constraints_are_required() {
+    // Who denies when constraints were required but none could be built: the
+    // compiler (`compiler.rs` Step 1), which every gear maps to a 403. That is why
+    // this service does not repeat the check.
+    let tenant_id = Uuid::parse_str("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb").unwrap();
+    let service = Service::new();
+    let response = service.evaluate(&make_request(true, Some(tenant_id)));
+
+    let err = compile_to_access_scope(&response, true, &[]).expect_err("fails closed");
+
+    assert!(
+        matches!(err, ConstraintCompileError::ConstraintsRequiredButAbsent),
+        "expected ConstraintsRequiredButAbsent, got: {err:?}"
+    );
+}
+
+#[test]
+fn require_constraints_false_still_clamps_when_owner_tenant_id_binds() {
+    // Security regression guard. `require_constraints: false` alone must not
+    // drop the clamp. A PEP that declares OWNER_TENANT_ID can bind the clamp, so
+    // the service must deliver the tenant narrowing. Some callers read a row with
+    // an unscoped prefetch, then use the constrained scope to force a scoped
+    // re-read. An `allow_all` scope turns that path into a cross-tenant read.
+    let tenant_id = Uuid::parse_str("77777777-7777-7777-7777-777777777777").unwrap();
+    let request = make_owner_tenant_request(false, Some(tenant_id));
+
+    let service = Service::new();
+    let response = service.evaluate(&request);
+
+    assert!(response.decision);
+    assert_eq!(response.context.constraints.len(), 1);
+    match &response.context.constraints[0].predicates[0] {
+        Predicate::In(in_pred) => {
+            assert_eq!(in_pred.property, pep_properties::OWNER_TENANT_ID);
+            assert_eq!(in_pred.values, vec![tenant_id.into_filter_value()]);
+        }
+        other => panic!("Expected In predicate, got: {other:?}"),
+    }
+}
+
+#[test]
+fn require_constraints_false_still_clamps_when_only_the_subtree_predicate_binds() {
+    // Security regression guard for the `no_tenant, resource_col = "..."` shape.
+    // OWNER_TENANT_ID does not bind here, but the subtree predicate binds with
+    // `Capability::TenantHierarchy` and RESOURCE_ID. The service must emit that
+    // predicate, and not an unconstrained permit.
+    let tenant_id = Uuid::parse_str("88888888-8888-8888-8888-888888888888").unwrap();
+    let mut request = make_request(false, Some(tenant_id));
+    request.context.capabilities = vec![Capability::TenantHierarchy];
+    request.context.supported_properties = vec![pep_properties::RESOURCE_ID.to_owned()];
+
+    let service = Service::new();
+    let response = service.evaluate(&request);
+
+    assert!(response.decision);
+    // No baseline clamp: the compiler would have failed it anyway. The subtree
+    // predicate carries the narrowing on its own.
+    assert_eq!(response.context.constraints.len(), 1);
+    match &response.context.constraints[0].predicates[0] {
+        Predicate::InTenantSubtree(sub_pred) => {
+            assert_eq!(sub_pred.property, pep_properties::RESOURCE_ID);
+            assert_eq!(sub_pred.root_tenant_id, tenant_id.into_filter_value());
+        }
+        other => panic!("Expected InTenantSubtree predicate, got: {other:?}"),
+    }
+
+    // Composition guard: dropping the dead baseline must not widen the compiled
+    // scope to `allow_all`.
+    let scope = compile_to_access_scope(&response, false, &[pep_properties::RESOURCE_ID])
+        .expect("compiles");
+    assert!(!scope.is_unconstrained());
+    assert_eq!(scope.constraints().len(), 1);
+}
+
+#[test]
+fn require_constraints_false_nil_tenant_is_still_denied() {
+    // Security regression guard. The tenant denials run before any constraint is
+    // built, so a permissive constraint set cannot bypass the nil-tenant deny.
+    let service = Service::new();
+    let response = service.evaluate(&make_request(false, Some(Uuid::default())));
+
+    assert!(!response.decision);
+    assert!(response.context.constraints.is_empty());
+}
+
+#[test]
+fn require_constraints_false_unresolvable_tenant_is_still_denied() {
+    // Security regression guard. The tenant denials run before any constraint is
+    // built, so no resolvable tenant is a deny even when the PEP declares nothing.
+    let request = EvaluationRequest {
+        subject: Subject {
+            id: Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap(),
+            subject_type: None,
+            properties: HashMap::new(), // no tenant_id property
+        },
+        action: Action {
+            name: "list".to_owned(),
+        },
+        resource: Resource {
+            resource_type: gts_id!("cf.core.users.user.v1~").to_owned(),
+            id: None,
+            properties: HashMap::new(),
+        },
+        context: EvaluationRequestContext {
+            tenant_context: None,
+            token_scopes: vec!["*".to_owned()],
+            require_constraints: false,
             capabilities: vec![],
             supported_properties: vec![],
             bearer_token: None,


### PR DESCRIPTION
`static-authz-plugin` attached the baseline `pep_properties::OWNER_TENANT_ID` clamp to
every permit, including for a PEP that never declared that property.

The PEP compiler (`authz-resolver-sdk/src/pep/compiler.rs`) fails a constraint naming a
property outside `context.supported_properties`, and when every constraint in the set
fails the result is `AllConstraintsFailed` — a deny. `PolicyEnforcer` fills that list from
`ResourceType::supported_properties` and hands the same slice to the compiler, so a clamp
the PEP never declared is dead on arrival. As the only constraint, it lost **every**
request for a platform-global `ResourceType` that declares no property at all —
usage-collector's `UsageType` catalog, `ResourceType::from_static(.., &[])`.

The clamp is now pushed only when the PEP declares the property, so the constraint set can
come out empty. The PEP compiler owns what that means and this plugin does not repeat the
matrix:

| `require_constraints` | constraints | Outcome |
|---|---|---|
| `false` | empty | `allow_all()` — what a decision-only caller asked for |
| `true` | empty | `ConstraintsRequiredButAbsent` → `CompileFailed` → 403 (unchanged) |

Since the compiler's Step 1 returns without logging, the plugin now warns when it emits an
empty set under `require_constraints: true` — that combination is a PEP misconfiguration
headed for a 403, and the old `AllConstraintsFailed` reason string used to name the
offending property.

**Behaviour change, please review deliberately:** a PEP that declares no bindable property
and passes `require_constraints: false` now gets an unconstrained permit where it
previously got a deny. The exposure is bounded by the caller's own declaration — an empty
set still denies under `require_constraints: true` — and the tenant denials (unresolvable
tenant, nil UUID) still run before any constraint is built. Every other `ResourceType` in
the repo declares `OWNER_TENANT_ID`, so their emitted constraints are unchanged; the only
other difference is that the `no_tenant, resource_col = "..."` shape no longer carries the
dead clamp the compiler used to drop.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

No Rust API change. See the behaviour-change note above for the runtime effect.

## Testing
- [x] Unit tests pass — `cargo test -p cf-gears-static-authz-plugin` (14 passed)
- [ ] Integration tests pass — the plugin has no integration suite; the e2e suites that
      cover this path (`config/e2e-scope-enforcement.yaml`, `config/e2e-local.yaml`) need a
      running stack and were **not** run here
- [ ] Manual testing completed — not performed
- [x] New tests added for new functionality

Added, on top of the existing R-rule coverage:
- `no_bindable_property_emits_no_constraints` — empty set under both `require_constraints`
  values
- `empty_constraint_set_compiles_to_allow_all_when_constraints_are_not_required` and
  `empty_constraint_set_is_denied_by_the_pep_compiler_when_constraints_are_required` —
  composition guards feeding the plugin's real response into the real
  `compile_to_access_scope`, pinning who owns the deny
- `require_constraints_false_still_clamps_when_owner_tenant_id_binds` and
  `..._when_only_the_subtree_predicate_binds` — security regression guards that
  `require_constraints: false` alone never drops the narrowing, plus a compiled-scope
  assertion that dropping the dead clamp does not widen to `allow_all`
- `require_constraints_false_nil_tenant_is_still_denied` and
  `..._unresolvable_tenant_is_still_denied` — the tenant denials still run first

Two existing tests moved to a `make_owner_tenant_request` fixture, since the shared
`make_request` fixture models a PEP that declares nothing.

## Documentation
- [x] Code is documented with rustdoc comments — the `Service` doc comment now lists the
      empty-set outcome and states that an unconstrained permit means "no row filter",
      never "the caller owns this row"
- [ ] README updated (if applicable) — not applicable; the compiler matrix in
      `gears/system/authz-resolver/README.md` is unchanged
- [ ] API documentation updated (if applicable) — not applicable; no API change

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No linting errors (`cargo clippy -p cf-gears-static-authz-plugin --all-targets`)
- [x] Code is properly formatted (`cargo fmt`)
- [x] Tests pass (`cargo test -p cf-gears-static-authz-plugin`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization handling for platform-global resources without tenant constraints.
  * Prevented unsupported-property errors when tenant context is not declared.
  * Continued denying access when no valid tenant can be resolved.
  * Preserved tenant restrictions when applicable, including subtree-only constraints.

* **Tests**
  * Added coverage for empty, optional, and unresolved tenant constraint scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->