### PR TITLE
chore: expand CODEOWNERS coverage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,15 @@
 /libs/ @MikeFalcon77
+/libs/toolkit-gts @aviator5
+/libs/toolkit-gts-macros @aviator5
 /gears/bss/ @diffora
 /gears/credstore/ @diffora
 /gears/mini-chat/ @MikeFalcon77
 /gears/system/account-management/ @diffora
 /gears/system/authn-resolver/plugins/oidc-authn-plugin/ @fluiderson
 /gears/system/usage-collector/ @capybutler
+/gears/system/types-registry @aviator5
+/gears/system/authn-resolver/authn-resolver @aviator5
+/gears/system/authn-resolver/authn-resolver-sdk @aviator5
+/gears/system/authz-resolver @aviator5
+/gears/system/tenant-resolver @aviator5
+/docs/arch/authorization @aviator5


### PR DESCRIPTION
- Assign ownership for GTS libraries and the types registry.
- Cover resolver gears and authorization architecture docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added code ownership assignments for toolkit, resolver, registry, tenant, and authorization documentation areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->