### PR TITLE
fix(build): pin PDFIUM_VERSION to keep PDF extraction reproducible

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,22 @@
 [alias]
 xtask = "run --package xtask --"
+
+# PDFium is not a Cargo dependency and Cargo.lock cannot pin it.
+#
+# `kreuzberg`'s `bundled-pdfium` feature does not bundle anything: its build script curls
+# bblanchon/pdfium-binaries `releases/latest` and downloads that prebuilt libpdfium into
+# OUT_DIR, verifying nothing but the archive's gzip magic bytes. The lock file pins the
+# bindings (`kreuzberg-pdfium-render`), not the library behind them, so an upstream PDFium
+# release changes PDF text extraction with no diff anywhere in this repo. It also caches in
+# OUT_DIR, so only builds with a cold target/ pick up the drift — which is every e2e CI run.
+#
+# That is not hypothetical: PDFium 7988 (published 2026-08-03) changed the base direction
+# used when serializing bidirectional text, reversing word order on the Arabic and Hebrew
+# lines and breaking the file_parser golden-markdown e2e tests on every open branch at once.
+#
+# Keep this pinned. To bump it, change the version and regenerate the goldens with
+# testing/e2e/gears/file_parser/generate_file_parser_golden.py in the same commit.
+# Deliberately not `force = true`, so `PDFIUM_VERSION=7988 cargo build` still overrides it
+# for testing a bump. Bare build number — the build script prepends "chromium/".
+[env]
+PDFIUM_VERSION = "7961"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -584,6 +584,8 @@ mime = "0.3"
 
 # Document parsing libraries
 docx-rust = "0.1.11"
+# `bundled-pdfium` downloads a prebuilt libpdfium at build time rather than vendoring one;
+# Cargo.lock does not pin it. The version lives in .cargo/config.toml as PDFIUM_VERSION.
 kreuzberg = { version = "=4.9.8", features = ["html", "excel", "office", "pdf", "bundled-pdfium"] }
 
 # Additional testing utilities


### PR DESCRIPTION
PDFium is not a Cargo dependency, and `Cargo.lock` cannot pin it. The `bundled-pdfium`
feature of `kreuzberg` does not vendor anything: its build script curls
`bblanchon/pdfium-binaries` `releases/latest` and downloads that prebuilt `libpdfium` into
`OUT_DIR`, checking nothing beyond the archive's gzip magic bytes. The lock file pins the
bindings (`kreuzberg-pdfium-render`), not the native library behind them, so PDF text
extraction can change with no diff in this repo and no movement in the lock file.

PDFium 7988, published 2026-08-03T07:32:02Z, changed the base direction used when
serializing bidirectional text. The Arabic and Hebrew lines of
`testing/e2e/testdata/pdf/test_file_two_pages_international.pdf` now extract label-first
with the RTL words reversed. That broke two `file_parser` golden-markdown e2e tests on
every open branch at once, with no commit behind the failure. Only cold-target builds pick
up the drift, because the download caches in `OUT_DIR` — so the cached CI jobs stayed
green and only e2e, which has no cargo cache, flipped.

This PR pins `PDFIUM_VERSION` in `.cargo/config.toml`, so the build resolves one fixed
release instead of whatever upstream published last. It pins 7961: the release the
goldens were generated against, and the one the last green nightly built.

The pin also closes a second, quieter failure mode. The build script's version lookup is
an unauthenticated `curl` to `api.github.com` — rate-limited on shared runner IPs — and on
failure it falls back to a hardcoded 7568. Without a pin, a single CI run could build
against any of three PDFium versions.

The `[env]` entry deliberately omits `force = true`, so `PDFIUM_VERSION=7988 cargo build`
still overrides it when testing a bump. Moving to a newer PDFium stays possible; it just
becomes a deliberate commit that changes the version and regenerates the goldens with
`testing/e2e/gears/file_parser/generate_file_parser_golden.py` together.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [ ] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed
- [ ] New tests added for new functionality

Extracted the fixture with `FPDFText_GetText` — the API that `kreuzberg`'s `text.all()`
wraps — linked against both releases. 7961 reproduces the committed goldens byte for byte;
7988 reproduces the CI failure. Only those two lines differ, out of 866 bytes.

With the pin, a cold `cargo build -p kreuzberg` fetches `chromium/7961`, never consults
`releases/latest`, and the extracted `VERSION` reports `BUILD=7961`. From that cold build,
`E2E_TARGET=testing/e2e/gears/file_parser make e2e-local` reports 37 passed, 3 skipped.
Removing the pinned library and letting the runtime resolve 7988 reproduces the CI
failure exactly: 2 failed, 35 passed, 3 skipped, same two tests, same first difference at
character 365.

No new tests. The regression already has coverage — the golden-markdown e2e tests caught
it. What was missing is a deterministic PDFium under them, which is what this pin adds.

## Documentation
- [ ] Code is documented with rustdoc comments
- [ ] README updated (if applicable)
- [ ] API documentation updated (if applicable)

No Rust code changes, so no rustdoc applies. Both edited files carry comments explaining
why the version lives outside `Cargo.lock` and what to do when bumping it.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No linting errors (`cargo clippy`)
- [x] Code is properly formatted (`cargo fmt`)
- [x] Tests pass (`cargo test`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the bundled PDFium version for more consistent PDF processing across builds.
  * Documented PDFium download behavior, version changes, and the process for updating expected results.
  * Preserved the ability to override the pinned version through the environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->