### PR TITLE
chore(codeowners): route file-storage and resource-group reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,9 @@
 /libs/ @MikeFalcon77
 /gears/bss/ @diffora
 /gears/credstore/ @diffora
+/gears/file-storage/ @ffedoroff
 /gears/mini-chat/ @MikeFalcon77
 /gears/system/account-management/ @diffora
 /gears/system/authn-resolver/plugins/oidc-authn-plugin/ @fluiderson
+/gears/system/resource-group/ @ffedoroff
 /gears/system/usage-collector/ @capybutler


### PR DESCRIPTION
## What

Adds two CODEOWNERS entries routing review of the gears I maintain to `@ffedoroff`:

```
/gears/file-storage/ @ffedoroff
/gears/system/resource-group/ @ffedoroff
```

## Why

Both gears are currently unassigned, so changes to them get no automatic reviewer. This follows up on #4340, which deliberately left most gears unrouted rather than guessing from a weak ownership signal.

## Notes

- Paths verified against the tree: `file-storage` sits at the gears root and the entry covers the gear, its SDK and its docs; `resource-group` sits under `system/`.
- Leading slash anchors both patterns to the repo root, matching the convention established in #4340.
- Entries are placed in the file's existing alphabetical order. They don't overlap any other pattern, so ordering doesn't affect which rule wins.

**One thing for reviewers to decide:** `@ffedoroff` currently has read-only access to this repository. GitHub ignores CODEOWNERS entries for users without write access and will flag both lines as an unknown owner until that changes. Merging is still fine — the entries activate as soon as access is granted — but if you'd rather route to a team handle instead of a personal one, say so and I'll change it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added code ownership assignments for file storage and resource group components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->