### PR TITLE
feat(event-broker): scaffold deployment-topology skeleton (#4343)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,6 +1747,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "cf-gears-event-broker"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "cf-gears-cluster",
+ "cf-gears-cluster-sdk",
+ "cf-gears-toolkit",
+ "cf-gears-toolkit-security",
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "cf-gears-event-broker-sdk"
 version = "0.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ members = [
     "gears/bss/ledger/ledger-sdk",
     "gears/bss/libs/coord",
     "gears/system/event-broker/event-broker-sdk",
+    "gears/system/event-broker/event-broker",
 ]
 exclude = ["tools/fuzz"]
 resolver = "3"
@@ -294,6 +295,7 @@ credstore = { package = "cf-gears-credstore", version = "0.2.2", path = "gears/c
 oagw = { package = "cf-gears-oagw", version = "0.3.3", path = "gears/system/oagw/oagw" }
 account-management = { package = "cf-gears-account-management", version = "0.4.3", path = "gears/system/account-management/account-management" }
 usage-collector = { package = "cf-gears-usage-collector", version = "0.2.3", path = "gears/system/usage-collector/usage-collector" }
+cluster = { package = "cf-gears-cluster", version = "0.1.3", path = "gears/system/cluster/cluster" }
 
 cf-gears-cluster-sdk = { version = "0.1.3", path = "gears/system/cluster/cluster-sdk" }
 cf-gears-cluster-conformance = { version = "0.1.3", path = "gears/system/cluster/cluster-conformance" }

--- a/gears/system/event-broker/docs/ADR/0007-service-decomposition.md
+++ b/gears/system/event-broker/docs/ADR/0007-service-decomposition.md
@@ -1,0 +1,113 @@
+# ADR-0007: Service Decomposition — Process Shape, Cluster-Primitive Mapping, and Standalone Dispatcher
+
+<!-- toc -->
+
+- [Status](#status)
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [Single Binary, Multi-Mode](#single-binary-multi-mode)
+  - [Three-Binary Split](#three-binary-split)
+- [More Information](#more-information)
+
+<!-- /toc -->
+
+**ID**: `cpt-cf-evbk-adr-service-decomposition`
+
+## Status
+
+Accepted
+
+## Context and Problem Statement
+
+`DESIGN.md:49-56` defines three roles — Ingest, Delivery, Dispatcher — as domain traits inside a single `event_broker` crate, gated per deployment mode by a `ClusterCapabilities` platform abstraction (pub/sub, leader election, distributed locks, service discovery). This was written before the platform's actual coordination layer existed. Two things needed resolving before any code could be scaffolded:
+
+1. **Process/binary shape.** Does standalone-vs-cluster mean one binary with mode-selected wiring, or three separately-built binaries (ingest/delivery/dispatcher)?
+2. **`ClusterCapabilities` reality.** The platform now ships a real `cluster` gear (`gears/system/cluster/`) exposing `ClusterCacheV1`, `LeaderElectionV1`, `DistributedLockV1`, `ServiceDiscoveryV1` via `cluster-sdk`, with `standalone-cluster-plugin` and `postgres-cluster-plugin` providers already merged. `DESIGN.md:739-768` already documents the mapping from `ClusterCapabilities` prose to these four real primitives in detail — this ADR does not re-derive that mapping, it adopts it as the resolution strategy for `domain/cluster.rs`.
+
+A third, narrower question fell out of scaffolding the module tree: does the dispatcher get constructed at all in standalone mode, and does the planned `infra/workers/` module tree (`cleaner.rs`, `retention.rs`, `reaper.rs`) match the broker's own no-cleaner/no-retention invariant (`DESIGN.md` §3.7 Key Invariants)?
+
+## Decision Drivers
+
+- Every other implemented Gears module in this repo is one-gear-per-crate with a single entry point; introducing a new build/packaging shape (three binaries) needs a real operational justification, not just historical phrasing in the design doc.
+- `DESIGN.md:739-768` already fully specifies how the broker should use the cluster gear's primitives — this ADR should adopt that mapping, not invent a parallel one.
+- `DESIGN.md` §3.7 Key Invariants is an explicit, deliberate statement ("the broker has no Cleaner / Retention workers") and takes precedence over an older module-tree listing that predates it.
+- Downstream tickets (#4345 dispatcher routing, #4346 REST API, #4347 standalone runtime) need this decided once so they don't each re-derive it.
+
+## Considered Options
+
+- Single binary, multi-mode: one `event-broker` crate/binary; `EventBrokerConfig.mode` selects which services/routes `module.rs` constructs at startup.
+- Three-binary split: separate `event-broker-ingest`, `event-broker-delivery`, `event-broker-dispatcher` binaries.
+- For cluster-primitive mapping: wrap the real `cluster` gear directly, vs. bypass it in standalone mode with a hand-rolled in-process implementation.
+- For standalone dispatcher: construct a pass-through dispatcher unconditionally, vs. never construct one in standalone mode.
+
+## Decision Outcome
+
+**Single binary, multi-mode.** The `event-broker` crate ships as one binary/gear. `EventBrokerConfig.mode` (`standalone` | `cluster_ingest` | `cluster_delivery` | `cluster_dispatcher`) selects which services `module.rs` constructs and which routes it mounts at startup, per `DESIGN.md:2224`'s Deployment Modes table. Deploying a "cluster_ingest-only process" means running this same binary N times with that mode config, not compiling a separate ingest-only artifact.
+
+**`domain/cluster.rs` wraps the real `cluster` gear, not a new abstraction.** It resolves `ClusterCacheV1` / `LeaderElectionV1` / `DistributedLockV1` / `ServiceDiscoveryV1` via `ClientHub`, scoped under a fixed `"evbk"` prefix (matching `DESIGN.md:756-764`'s `evbk.*` cache-key table). Both standalone and cluster modes resolve the same facade types — standalone is backed by the zero-dependency `standalone` cluster-gear provider instead of a network-backed one, per `DESIGN.md:2208`'s framing that they are "variants of the same module wiring."
+
+**No dispatcher is constructed in standalone mode.** `module.rs` never constructs a dispatcher instance or mounts a dispatcher route/proxy layer when `mode = standalone`; REST handlers call Ingest/Delivery in-process directly. This resolves the open question raised in the tracking issue in favor of `DESIGN.md:1391,2521`'s framing (dispatcher is cluster-only). It does not conflict with #4345's plan for a pass-through dispatcher *stub* used by that ticket's own tests — that stub exercises the dispatcher's routing code in isolation; it is not a claim that production standalone deployments run a dispatcher process.
+
+**The module tree drops `infra/workers/cleaner.rs` and `retention.rs`.** `DESIGN.md` §3.7 Key Invariants states the storage backend owns all event deletion — "the broker has no Cleaner / Retention workers" — directly contradicting the older module-tree listing. Only `reaper.rs` (expired subscriptions + idempotency-key cleanup, both broker-owned per §3.7 and ADR-0004) remains under `infra/workers/`.
+
+### Consequences
+
+**Removed:**
+- Three-binary-split option (not pursued).
+- `infra/workers/cleaner.rs`, `infra/workers/retention.rs` from the module tree and the example config's `workers:` block (`DESIGN.md:579-612`, `2361-2391`).
+- The "future ADR (service-decomposition)" placeholder at `DESIGN.md:81` (now a real reference to this file).
+
+**Added:**
+- `docs/ADR/0007-service-decomposition.md` (this file).
+- `event-broker` crate skeleton (`gears/system/event-broker/event-broker/`) matching the corrected module tree — structure only, `todo!()`/`unimplemented!()` bodies.
+- `DeploymentMode::{ingest,delivery,dispatcher,reaper}_active()` predicates: report which of {`IngestService`, `DeliveryService`, dispatcher, `reaper`} *should* be active for the configured mode, matching `DESIGN.md:2224` exactly. These are mode predicates only - `module.rs` does not yet construct services or gate real routes/lifecycle work on them; that lands with #4345/#4346/#4347.
+
+**Unchanged:**
+- `DESIGN.md:739-768`'s `ClusterCapabilities`-to-`cluster-sdk` mapping (adopted as-is, not modified).
+- The four deployment modes and their semantics (`DESIGN.md` §4.1).
+
+**Not decided here (explicitly out of scope):**
+- Which cluster-gear *profile name* `event-broker` binds to in cluster mode — operator-config surface, deferred to whichever ticket first wires real cluster-mode config.
+- Whether `evbk.*` notification cache keys carry a payload or are pure version-bump signals — inherits `DESIGN.md` §4.7's still-open long-poll cache/backfill question.
+- Handler bodies (#4346), the dispatcher routing algorithm (#4345), and any real backend (#4347/#4348/#4349/#4350).
+
+### Confirmation
+
+Confirm by checking that: (1) `cargo build -p cf-gears-event-broker` produces one binary/library target, not three; (2) `domain/cluster.rs` imports `cluster_sdk` types directly with no locally-defined `ClusterCapabilities` trait; (3) a unit test booting `EventBrokerModule` in each of the four modes shows no dispatcher active in `standalone`; (4) `infra/workers/` contains only `reaper.rs`.
+
+## Pros and Cons of the Options
+
+### Single Binary, Multi-Mode
+
+Pros:
+
+- Matches every other implemented Gears module's one-gear-per-crate shape.
+- Independent process *scaling* is achieved the same way (N processes, different `mode` config) without new build machinery.
+- Simpler skeleton: one crate, one set of dependencies.
+
+Cons:
+
+- Cannot ship an independently-versioned ingest-only binary artifact — only independently-*configured* processes of the same binary.
+
+### Three-Binary Split
+
+Pros:
+
+- Would allow independent binary versioning per role, if that ever becomes a real requirement.
+
+Cons:
+
+- No precedent in this repo's build/packaging tooling.
+- No current requirement justifies the added complexity — independent process scaling doesn't need independent binaries.
+
+## More Information
+
+- `DESIGN.md:49-56` (role definitions), §3.8 Deployment Topology, §4.1 Deployment Modes (`DESIGN.md:2204-2391`).
+- `DESIGN.md:739-768` — `ClusterCapabilities` (Platform Dependency): the adopted mapping to `cluster-sdk`.
+- `DESIGN.md` §3.7 Key Invariants (`DESIGN.md:2195-2202`) — the no-Cleaner/no-Retention invariant this ADR reconciles the module tree against.
+- Related tracking: gears-rust#4343 (this ADR + skeleton), #4345 (dispatcher routing), #4346 (REST API), #4347 (standalone runtime).

--- a/gears/system/event-broker/docs/DESIGN.md
+++ b/gears/system/event-broker/docs/DESIGN.md
@@ -78,7 +78,7 @@ The **producer client library** (`cf-gears-event-broker-sdk`) is built on top of
 
 **Architecture Decision Records**:
 
-- future ADR (service-decomposition) — Multi-service composite (ingest, delivery, dispatcher, storage backends)
+- `cpt-cf-evbk-adr-service-decomposition` — Multi-service composite (ingest, delivery, dispatcher, storage backends); single-binary/multi-mode process shape; per-mode `cluster` gear resolution. See [`ADR/0007-service-decomposition.md`](ADR/0007-service-decomposition.md).
 - future ADR (storage-backend-plugin) — Storage backends as ModKit plugins with GTS discovery and self-describing config schemas
 - `cpt-cf-evbk-design-sequence-assignment` — Three-sequence model: producer chain (`previous`, `sequence`) for ingest-side dedup (chained / monotonic / stateless modes); outbox sequence (toolkit-db) for in-pipeline order preservation; offset (backend) for consumer-visible ordering
 - future ADR (idempotent-producers) — Idempotent producers via Producer-Id + per-`(producer_id, topic, partition)` sequence tracking. No epoch fencing — sequence ordering itself acts as the fence.
@@ -603,9 +603,9 @@ modules/system/event-broker/
         │   │       └── memory.rs  # InMemoryStorageBackend
         │   ├── cluster/           # ClusterCapabilities integration
         │   │   └── notifications.rs # Event notification via cluster.publish/subscribe
-        │   ├── workers/           # Background workers
-        │   │   ├── cleaner.rs     # Fully-consumed event cleanup
-        │   │   ├── retention.rs   # Retention policy enforcement
+        │   ├── workers/           # Background workers (broker-owned only;
+        │   │   │                 # event deletion is the storage backend's
+        │   │   │                 # responsibility, see §3.7 Key Invariants)
         │   │   └── reaper.rs      # Expired subscription + idempotency cleanup
         │   ├── dispatcher/        # Optional HTTP gateway
         │   │   ├── proxy.rs       # Proxy handler (routes to ingest service)
@@ -2239,7 +2239,7 @@ In cluster mode:
   - The dispatcher resolves `subscription_id` → `consumer_group` via the subscription resolution cache (§3.2 Subscription Resolution Cache). JOIN endpoints (`POST /v1/subscriptions`) carry `consumer_group` and `topics` in the body so the first lookup is skipped.
   - Dispatchers discover ingest/delivery instances via `cluster.discover_shards()`. All dispatcher instances see the same shard membership.
 - **Event notifications** flow directly from ingest to delivery via `cluster.publish()` / `cluster.subscribe()` — they do NOT pass through the dispatcher. This means multiple dispatcher instances require no shared state for notifications.
-- **Worker leader election** uses `cluster.leader_election()` — only one node runs the cleaner for a given `(topic, partition)`, etc.
+- **Worker leader election** uses `cluster.leader_election()` — only one node runs the `reaper` cluster-wide (`evbk.worker.reaper`).
 - All instances share the same database. The ClusterCapabilities provider is the only external dependency beyond the database.
 
 #### Deployment Variants
@@ -2385,8 +2385,6 @@ modules:
       min_session_timeout: PT1S
 
     workers:
-      cleaner_interval_secs: 60
-      retention_interval_secs: 300
       reaper_interval_secs: 60
 ```
 
@@ -2577,6 +2575,7 @@ This DESIGN traces back to the [PRD.md](PRD.md) functional and non-functional re
 - [ADR/0002-partition-selection.md](ADR/0002-partition-selection.md) — `cpt-cf-evbk-adr-partition-selection`. **Revised** to drop the explicit `partition` producer override; the broker is now authoritative for partition assignment, deriving from `partition_key` (when present) or `tenant_id` (default). Realizes the Event-schema partition derivation referenced in §3.1 Event Schema and §3.6 Two Sequences. Native Kafka producer partitioner compatibility is not a supported producer contract.
 - [ADR/0003-event-schema.md](ADR/0003-event-schema.md) — `cpt-cf-evbk-adr-event-schema`. Defines the canonical event schema: single JSON Schema with field-level `readOnly` / `writeOnly` markers (no separate read-side file), optional versioned `meta` block for transport mechanics (marked `writeOnly`), `tenant_id` as producer-supplied, `subject_type` retained, `created_at` dropped, `offset`/`offset_time` renamed to `sequence`/`sequence_time` (`readOnly`), broker-native naming (no CloudEvents conformance), ASCII event-field encoding rule. Realized by `schemas/event.v1.schema.json`.
 - [ADR/0004-idempotent-producer-protocol.md](ADR/0004-idempotent-producer-protocol.md) — `cpt-cf-evbk-adr-idempotent-producer-protocol`. Mode declared at registration (`POST /v1/producers { mode }`), enforced per request. Mode-shape hard errors at the wire boundary. Producer-registration TTL + operator-driven `POST :reset`. Single-writer concurrency. Realized by §3.2 Producer Modes (shrunk) and `docs/features/0001-idempotent-producers.md`.
+- [ADR/0007-service-decomposition.md](ADR/0007-service-decomposition.md) — `cpt-cf-evbk-adr-service-decomposition`. Single binary, multi-mode (not a three-binary split); `domain/cluster.rs` resolves the platform `cluster` gear's real `cluster-sdk` facades directly rather than a bespoke `ClusterCapabilities` abstraction; no dispatcher is constructed in standalone mode. Realized by the `event-broker` crate skeleton and `DeploymentMode`'s per-mode activation predicates (`ingest_active()` etc.) - structure and mode-decision scaffolding only; real service construction and route gating land with #4345/#4346/#4347.
 
 The remaining ADR identifiers referenced in §1.2 (future ADR (cluster-capabilities), future ADR (long-polling), future ADR (topic-sharding), future ADR (dispatcher), `cpt-cf-evbk-design-sequence-assignment`, future ADR (outbox-ingest)) are documented inline in this DESIGN.md and will be extracted into standalone canonical ADR files in follow-up design iterations.
 

--- a/gears/system/event-broker/event-broker/Cargo.toml
+++ b/gears/system/event-broker/event-broker/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "cf-gears-event-broker"
+description = "Event Broker: Ingest/Delivery/Dispatcher composite module (deployment-topology skeleton)"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+keywords = ["constructorfabric", "cf-gears", "event-broker"]
+categories = ["asynchronous"]
+metadata.docs.rs.all-features = true
+
+[lib]
+name = "event_broker"
+
+[lints]
+workspace = true
+
+[dependencies]
+cluster = { workspace = true }
+cluster-sdk = { workspace = true }
+
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+axum = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true, features = ["v4", "serde"] }
+chrono = { workspace = true, features = ["clock", "serde"] }
+
+toolkit = { workspace = true }
+toolkit-security = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/gears/system/event-broker/event-broker/src/api/mod.rs
+++ b/gears/system/event-broker/event-broker/src/api/mod.rs
@@ -1,0 +1,3 @@
+//! Public API surface for the Event Broker module (REST transport layer).
+
+pub mod rest;

--- a/gears/system/event-broker/event-broker/src/api/rest/dto.rs
+++ b/gears/system/event-broker/event-broker/src/api/rest/dto.rs
@@ -1,0 +1,2 @@
+//! REST DTOs (serde + utoipa). Shapes finalized in #4346 against
+//! `docs/openapi.yaml` - intentionally empty until then.

--- a/gears/system/event-broker/event-broker/src/api/rest/error.rs
+++ b/gears/system/event-broker/event-broker/src/api/rest/error.rs
@@ -1,0 +1,3 @@
+//! Error response mapping: `DomainError` → RFC 9457 `Problem`
+//! (`DESIGN.md` §3.3 Error Response Format). Finalized in #4346 -
+//! intentionally empty until then.

--- a/gears/system/event-broker/event-broker/src/api/rest/extractors.rs
+++ b/gears/system/event-broker/event-broker/src/api/rest/extractors.rs
@@ -1,0 +1,2 @@
+//! Custom Axum extractors. Finalized in #4346 - intentionally empty until
+//! then.

--- a/gears/system/event-broker/event-broker/src/api/rest/handlers/consumer_groups.rs
+++ b/gears/system/event-broker/event-broker/src/api/rest/handlers/consumer_groups.rs
@@ -1,0 +1,17 @@
+//! CRUD for consumer groups (`DESIGN.md:584`). Bodies land with #4346.
+
+pub async fn create_consumer_group() {
+    todo!("lands with #4346")
+}
+
+pub async fn list_consumer_groups() {
+    todo!("lands with #4346")
+}
+
+pub async fn get_consumer_group() {
+    todo!("lands with #4346")
+}
+
+pub async fn delete_consumer_group() {
+    todo!("lands with #4346")
+}

--- a/gears/system/event-broker/event-broker/src/api/rest/handlers/delivery.rs
+++ b/gears/system/event-broker/event-broker/src/api/rest/handlers/delivery.rs
@@ -1,0 +1,10 @@
+//! `GET /v1/events:stream`, `GET /v1/events:sse` (`DESIGN.md:581`). Bodies
+//! land with #4346.
+
+pub async fn stream_events() {
+    todo!("wire request/response + DeliveryService::poll - lands with #4346")
+}
+
+pub async fn sse_events() {
+    todo!("post-MVP per DESIGN.md section 4.6 - not wired until scheduled")
+}

--- a/gears/system/event-broker/event-broker/src/api/rest/handlers/event_types.rs
+++ b/gears/system/event-broker/event-broker/src/api/rest/handlers/event_types.rs
@@ -1,0 +1,5 @@
+//! `GET /v1/event-types` (`DESIGN.md:583`). Bodies land with #4346.
+
+pub async fn list_event_types() {
+    todo!("lands with #4346")
+}

--- a/gears/system/event-broker/event-broker/src/api/rest/handlers/ingest.rs
+++ b/gears/system/event-broker/event-broker/src/api/rest/handlers/ingest.rs
@@ -1,0 +1,10 @@
+//! `POST /v1/events`, `POST /v1/events:batch` (`DESIGN.md:579`). Bodies
+//! land with #4346.
+
+pub async fn publish_event() {
+    todo!("wire request/response + IngestService::publish_event - lands with #4346")
+}
+
+pub async fn publish_batch() {
+    todo!("wire request/response + IngestService::publish_batch - lands with #4346")
+}

--- a/gears/system/event-broker/event-broker/src/api/rest/handlers/mod.rs
+++ b/gears/system/event-broker/event-broker/src/api/rest/handlers/mod.rs
@@ -1,0 +1,11 @@
+//! REST handlers, grouped per `DESIGN.md:579-586`'s module tree. Every
+//! handler is a `todo!()` shell - request/response wiring lands with
+//! #4346.
+
+pub mod consumer_groups;
+pub mod delivery;
+pub mod event_types;
+pub mod ingest;
+pub mod producers;
+pub mod subscriptions;
+pub mod topics;

--- a/gears/system/event-broker/event-broker/src/api/rest/handlers/producers.rs
+++ b/gears/system/event-broker/event-broker/src/api/rest/handlers/producers.rs
@@ -1,0 +1,14 @@
+//! `POST /v1/producers`, `GET .../cursors`, `POST .../:reset`
+//! (`DESIGN.md:580`). Bodies land with #4346.
+
+pub async fn register_producer() {
+    todo!("lands with #4346")
+}
+
+pub async fn get_producer_cursors() {
+    todo!("lands with #4346")
+}
+
+pub async fn reset_producer() {
+    todo!("lands with #4346")
+}

--- a/gears/system/event-broker/event-broker/src/api/rest/handlers/subscriptions.rs
+++ b/gears/system/event-broker/event-broker/src/api/rest/handlers/subscriptions.rs
@@ -1,0 +1,22 @@
+//! JOIN, list, read, leave, seek (`DESIGN.md:585`). Bodies land with
+//! #4346.
+
+pub async fn join_subscription() {
+    todo!("wire request/response + DeliveryService::join - lands with #4346")
+}
+
+pub async fn list_subscriptions() {
+    todo!("lands with #4346")
+}
+
+pub async fn get_subscription() {
+    todo!("lands with #4346")
+}
+
+pub async fn leave_subscription() {
+    todo!("wire request/response + DeliveryService::leave - lands with #4346")
+}
+
+pub async fn seek_subscription() {
+    todo!("wire request/response + DeliveryService::seek - lands with #4346")
+}

--- a/gears/system/event-broker/event-broker/src/api/rest/handlers/topics.rs
+++ b/gears/system/event-broker/event-broker/src/api/rest/handlers/topics.rs
@@ -1,0 +1,10 @@
+//! `GET /v1/topics`, `GET /v1/topics/segments` (`DESIGN.md:582`). Bodies
+//! land with #4346.
+
+pub async fn list_topics() {
+    todo!("lands with #4346")
+}
+
+pub async fn list_topic_segments() {
+    todo!("lands with #4346")
+}

--- a/gears/system/event-broker/event-broker/src/api/rest/mod.rs
+++ b/gears/system/event-broker/event-broker/src/api/rest/mod.rs
@@ -1,0 +1,9 @@
+//! REST transport layer (`DESIGN.md` §1.3 Architecture Layers, §3.3 API
+//! Contracts). Handler bodies and DTO wire shapes land with #4346; this
+//! crate only holds the shells `module.rs` will eventually gate per mode.
+
+pub mod dto;
+pub mod error;
+pub mod extractors;
+pub mod handlers;
+pub mod routes;

--- a/gears/system/event-broker/event-broker/src/api/rest/routes/mod.rs
+++ b/gears/system/event-broker/event-broker/src/api/rest/routes/mod.rs
@@ -1,0 +1,19 @@
+//! `OperationBuilder` route registration (`DESIGN.md:586`). Real
+//! registration (DTOs, `OpenAPI` schemas, `OperationBuilder` chains) lands
+//! with #4346 - these shells exist so `module.rs`'s per-mode gating has a
+//! named registration point per route group to call into once bodies
+//! exist. None are called from `module.rs` yet.
+
+use axum::Router;
+
+pub fn register_ingest_routes(router: Router) -> Router {
+    router
+}
+
+pub fn register_delivery_routes(router: Router) -> Router {
+    router
+}
+
+pub fn register_dispatcher_routes(router: Router) -> Router {
+    router
+}

--- a/gears/system/event-broker/event-broker/src/config.rs
+++ b/gears/system/event-broker/event-broker/src/config.rs
@@ -1,0 +1,109 @@
+//! Operator-facing configuration for the Event Broker module
+//! (`DESIGN.md` §4.1 Deployment Modes, example YAML at `DESIGN.md:2363-2391`).
+
+use serde::Deserialize;
+
+/// Which of the four deployment-mode wiring variants this instance runs as.
+/// Drives [`crate::module::EventBrokerModule`]'s per-mode service/route
+/// gating (`DESIGN.md:2224`'s Deployment Modes table;
+/// `docs/ADR/0007-service-decomposition.md`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeploymentMode {
+    Standalone,
+    ClusterIngest,
+    ClusterDelivery,
+    ClusterDispatcher,
+}
+
+/// The `[modules.event_broker]` operator config section.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EventBrokerConfig {
+    pub mode: DeploymentMode,
+
+    /// GTS short alias or full instance ID of the default storage backend,
+    /// resolved via GTS plugin discovery (`DESIGN.md` §"Storage Backend
+    /// Plugin System").
+    pub default_storage_backend: String,
+
+    #[serde(default)]
+    pub batch: BatchConfig,
+    #[serde(default)]
+    pub polling: PollingConfig,
+    #[serde(default)]
+    pub subscription: SubscriptionConfig,
+    #[serde(default)]
+    pub workers: WorkersConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BatchConfig {
+    pub max_size: u32,
+    pub max_payload_bytes: u64,
+}
+
+impl Default for BatchConfig {
+    fn default() -> Self {
+        // `DESIGN.md` §2.2 Constraints: 100 events / 1 MiB batch hard limit.
+        Self {
+            max_size: 100,
+            max_payload_bytes: 1_048_576,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PollingConfig {
+    pub default_timeout_secs: u32,
+    pub max_timeout_secs: u32,
+}
+
+impl Default for PollingConfig {
+    fn default() -> Self {
+        // `DESIGN.md` §2.2 Constraints: 30s long-poll max timeout.
+        Self {
+            default_timeout_secs: 30,
+            max_timeout_secs: 30,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SubscriptionConfig {
+    /// ISO 8601 duration (e.g. `"PT30S"`); parsing lives with the real
+    /// config-loading implementation, not this skeleton.
+    pub default_session_timeout: String,
+    pub min_session_timeout: String,
+}
+
+impl Default for SubscriptionConfig {
+    fn default() -> Self {
+        Self {
+            default_session_timeout: "PT30S".to_owned(),
+            min_session_timeout: "PT1S".to_owned(),
+        }
+    }
+}
+
+/// Broker-owned background workers. Only `reaper` (expired subscriptions +
+/// idempotency-key cleanup) lives here - `DESIGN.md` §3.7 Key Invariants
+/// states the storage backend owns all event deletion, so no
+/// cleaner/retention worker config exists (see
+/// `docs/ADR/0007-service-decomposition.md`).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkersConfig {
+    pub reaper_interval_secs: u32,
+}
+
+impl Default for WorkersConfig {
+    fn default() -> Self {
+        Self {
+            reaper_interval_secs: 60,
+        }
+    }
+}

--- a/gears/system/event-broker/event-broker/src/domain/cluster.rs
+++ b/gears/system/event-broker/event-broker/src/domain/cluster.rs
@@ -1,0 +1,45 @@
+//! `ClusterCapabilities` usage (`DESIGN.md:596,739-768`). Per
+//! `docs/ADR/0007-service-decomposition.md` D2/D3, this wraps the platform
+//! `cluster` gear's real `cluster-sdk` facades directly - no bespoke
+//! coordination abstraction is introduced. There is no separate pub/sub
+//! primitive; notification semantics are realized on top of
+//! `ClusterCacheV1::put` + `ClusterCacheV1::watch`
+//! (`infra::cluster::notifications`).
+
+use cluster_sdk::{
+    ClusterCacheV1, ClusterError, DistributedLockV1, LeaderElectionV1, ServiceDiscoveryV1,
+};
+use toolkit::client_hub::ClientHub;
+
+/// Every Event Broker cache key / lock name / election name is scoped under
+/// this prefix (`DESIGN.md:756-764`'s `evbk.*` cache-key table).
+pub const CLUSTER_SCOPE_PREFIX: &str = "evbk";
+
+/// Resolved handle onto the platform `cluster` gear's four coordination
+/// primitives, scoped for the Event Broker. Both standalone and cluster
+/// modes resolve the same facade types (`DESIGN.md:2208`'s "variants of the
+/// same module wiring") - standalone is simply backed by the
+/// zero-dependency `standalone` cluster-gear provider instead of a
+/// network-backed one.
+pub struct EventBrokerCluster {
+    pub cache: ClusterCacheV1,
+    pub leader_election: LeaderElectionV1,
+    pub lock: DistributedLockV1,
+    pub service_discovery: ServiceDiscoveryV1,
+}
+
+impl EventBrokerCluster {
+    /// Resolves and `"evbk"`-scopes all four primitives from `ClientHub`.
+    /// Wiring the actual resolver-builder calls (profile selection,
+    /// capability requirements) is deferred to whichever ticket first
+    /// exercises real cluster-mode wiring (see design.md Open Questions).
+    ///
+    /// # Errors
+    /// Returns [`ClusterError`] if any primitive fails to resolve (missing
+    /// cluster-gear profile binding, capability mismatch) once implemented.
+    pub fn resolve(_hub: &ClientHub) -> Result<Self, ClusterError> {
+        todo!(
+            "resolve cluster-sdk facades once a cluster-gear profile is bound (see design.md Open Questions)"
+        )
+    }
+}

--- a/gears/system/event-broker/event-broker/src/domain/delivery.rs
+++ b/gears/system/event-broker/event-broker/src/domain/delivery.rs
@@ -1,0 +1,70 @@
+//! `DeliveryService` (`DESIGN.md:641-658`): consumer-facing, owns the read
+//! path and subscription lifecycle. Signatures only; bodies land with #4346
+//! (REST API implementation) and #4347 (standalone runtime).
+
+use async_trait::async_trait;
+use toolkit_security::SecurityContext;
+use uuid::Uuid;
+
+use crate::domain::error::DomainError;
+use crate::domain::model::{Event, Subscription};
+
+/// JOIN request body (`DESIGN.md:692`: `consumer_group` + `interests[]`).
+/// Exact shape (typed filters per ADR-0005) is finalized alongside the REST
+/// DTOs in #4346.
+#[derive(Debug, Clone)]
+pub struct JoinRequest {
+    pub consumer_group: String,
+    pub topics: Vec<String>,
+}
+
+/// Long-poll response - events plus topology-version-aware metadata
+/// (`DESIGN.md:657`). Exact shape finalized in #4346.
+#[derive(Debug, Clone, Default)]
+pub struct PollResponse {
+    pub events: Vec<Event>,
+    pub topology_version: i64,
+}
+
+/// One SEEK target. A subscription can span multiple topics, and
+/// assignments/cursors are identified by the full `(topic, partition)`
+/// pair (`DESIGN.md:658`) - keying by `partition` alone would collapse
+/// partition `0` of two different topics into one entry.
+#[derive(Debug, Clone)]
+pub struct SeekPosition {
+    pub topic: String,
+    pub partition: i32,
+    pub offset: i64,
+}
+
+#[async_trait]
+pub trait DeliveryService: Send + Sync {
+    /// Creates a subscription in cache, claims/joins the group
+    /// (`DESIGN.md:655`).
+    async fn join(
+        &self,
+        ctx: &SecurityContext,
+        request: JoinRequest,
+    ) -> Result<Subscription, DomainError>;
+
+    /// Removes the subscription from its group, triggers rebalance
+    /// (`DESIGN.md:656`).
+    async fn leave(&self, ctx: &SecurityContext, subscription_id: Uuid) -> Result<(), DomainError>;
+
+    /// Long-poll with topology-version-aware response (`DESIGN.md:657`).
+    async fn poll(
+        &self,
+        ctx: &SecurityContext,
+        subscription_id: Uuid,
+        timeout: std::time::Duration,
+    ) -> Result<PollResponse, DomainError>;
+
+    /// Sets the cursor position for each assigned `(topic, partition)`
+    /// (`DESIGN.md:658`).
+    async fn seek(
+        &self,
+        ctx: &SecurityContext,
+        subscription_id: Uuid,
+        positions: Vec<SeekPosition>,
+    ) -> Result<(), DomainError>;
+}

--- a/gears/system/event-broker/event-broker/src/domain/error.rs
+++ b/gears/system/event-broker/event-broker/src/domain/error.rs
@@ -1,0 +1,41 @@
+//! Domain errors for the Event Broker. Canonical RFC 9457 lifting is a
+//! REST-layer concern (`api/rest/error.rs`), not decided here (#4346).
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum DomainError {
+    /// Client-supplied input failed validation (e.g.
+    /// `SpecificationManager::validate_event_data`, `IngestService::publish_event`).
+    /// Distinct from `Internal` so REST error mapping (#4346) can lift it to
+    /// `400`/`422` instead of `500`.
+    #[error("validation failed: {0}")]
+    Validation(String),
+
+    #[error("topic not found: {0}")]
+    TopicNotFound(String),
+
+    #[error("event type not found: {0}")]
+    EventTypeNotFound(String),
+
+    #[error("consumer group not found: {0}")]
+    ConsumerGroupNotFound(String),
+
+    #[error("consumer group not owned by caller: {0}")]
+    ConsumerGroupNotOwned(String),
+
+    #[error("subscription not found: {0}")]
+    SubscriptionNotFound(String),
+
+    #[error("sequence violation on topic {topic} partition {partition}")]
+    SequenceViolation { topic: String, partition: i32 },
+
+    #[error("unauthorized")]
+    Unauthorized,
+
+    #[error("storage backend unavailable: {0}")]
+    StorageUnavailable(String),
+
+    #[error("internal error: {0}")]
+    Internal(String),
+}

--- a/gears/system/event-broker/event-broker/src/domain/idempotency.rs
+++ b/gears/system/event-broker/event-broker/src/domain/idempotency.rs
@@ -1,0 +1,42 @@
+//! Idempotency key computation and checking (`DESIGN.md:597`'s
+//! `domain/idempotency.rs`; realized against `evbk_producer_state` per
+//! `ADR/0004-idempotent-producer-protocol.md`). Signatures only.
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::domain::error::DomainError;
+
+/// Outcome of an idempotency check for one incoming event's producer
+/// chain (`meta.producer_id`, `meta.previous`, `meta.sequence`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdempotencyOutcome {
+    Accept,
+    DuplicateIgnore,
+    SequenceViolation,
+}
+
+#[async_trait]
+pub trait IdempotencyGuard: Send + Sync {
+    /// Checks the incoming `(producer_id, topic, partition)` chain against
+    /// stored `evbk_producer_state.last_sequence` and records the new
+    /// sequence on acceptance.
+    ///
+    /// **Known gap (tracked, not resolved by this signature):** this trait
+    /// and `EventRepo::append` are independent operations with no shared
+    /// transaction/reservation boundary. An implementation that calls both
+    /// without atomicity can durably record `Accept` while the matching
+    /// event append fails (lost event on retry returning
+    /// `DuplicateIgnore`), or durably append before recording (duplicate
+    /// event on retry). Whoever implements the ingest flow (#4346/#4347)
+    /// must provide that boundary (e.g. a shared DB transaction) - it is
+    /// not something a structure-only trait signature can enforce.
+    async fn check_and_record(
+        &self,
+        producer_id: Uuid,
+        topic: &str,
+        partition: i32,
+        previous: i64,
+        sequence: i64,
+    ) -> Result<IdempotencyOutcome, DomainError>;
+}

--- a/gears/system/event-broker/event-broker/src/domain/ingest.rs
+++ b/gears/system/event-broker/event-broker/src/domain/ingest.rs
@@ -1,0 +1,38 @@
+//! `IngestService` (`DESIGN.md:623-639`): producer-facing, owns the write
+//! path. Signatures only; bodies land with #4346 (REST API implementation)
+//! and #4347 (standalone runtime).
+
+use async_trait::async_trait;
+use toolkit_security::SecurityContext;
+use uuid::Uuid;
+
+use crate::domain::error::DomainError;
+use crate::domain::model::Event;
+
+/// Result of a batch publish - which events were accepted (in submission
+/// order) and which were rejected with a reason. Exact shape is finalized
+/// alongside the REST DTOs in #4346.
+#[derive(Debug, Clone, Default)]
+pub struct BatchResult {
+    pub accepted: Vec<Uuid>,
+    pub failed: Vec<(Uuid, String)>,
+}
+
+#[async_trait]
+pub trait IngestService: Send + Sync {
+    /// Validate, sequence, and enqueue one event for persistence
+    /// (`DESIGN.md:638`).
+    async fn publish_event(
+        &self,
+        ctx: &SecurityContext,
+        event: Event,
+    ) -> Result<Event, DomainError>;
+
+    /// Validate and enqueue a batch of events for the same topic
+    /// (`DESIGN.md:639`).
+    async fn publish_batch(
+        &self,
+        ctx: &SecurityContext,
+        events: Vec<Event>,
+    ) -> Result<BatchResult, DomainError>;
+}

--- a/gears/system/event-broker/event-broker/src/domain/mod.rs
+++ b/gears/system/event-broker/event-broker/src/domain/mod.rs
@@ -1,0 +1,17 @@
+//! Domain layer: business logic, service traits, and repository contracts.
+//! No infra dependencies (`DESIGN.md` §1.3 Architecture Layers).
+
+pub mod cluster;
+pub mod delivery;
+pub mod error;
+pub mod idempotency;
+pub mod ingest;
+pub mod model;
+pub mod repo;
+pub mod specification;
+
+pub use cluster::EventBrokerCluster;
+pub use delivery::DeliveryService;
+pub use error::DomainError;
+pub use ingest::IngestService;
+pub use specification::SpecificationManager;

--- a/gears/system/event-broker/event-broker/src/domain/model.rs
+++ b/gears/system/event-broker/event-broker/src/domain/model.rs
@@ -1,0 +1,107 @@
+//! Domain entities (`DESIGN.md` §3.1 Domain Model). Shapes only - no
+//! persistence, validation, or transport concerns live here.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde_json::Value as JsonValue;
+use uuid::Uuid;
+
+/// `gts.cf.core.events.topic.v1~` - a named, partitioned event log.
+#[derive(Debug, Clone)]
+pub struct Topic {
+    pub id: String,
+    pub description: Option<String>,
+    pub partitions: i32,
+    pub streaming: JsonValue,
+    pub retention: JsonValue,
+    pub created_at: DateTime<Utc>,
+}
+
+/// `gts.cf.core.events.event_type.v1~` - schema and constraints for one
+/// category of events within a topic.
+#[derive(Debug, Clone)]
+pub struct EventType {
+    pub id: String,
+    pub topic_id: String,
+    pub description: Option<String>,
+    pub allowed_subject_types: Vec<String>,
+    pub data_schema: JsonValue,
+    pub created_at: DateTime<Utc>,
+}
+
+/// `gts.cf.core.events.event.v1~` - an immutable record in a
+/// `(topic, partition)` log.
+#[derive(Debug, Clone)]
+pub struct Event {
+    pub id: Uuid,
+    pub r#type: String,
+    pub topic: String,
+    pub partition_key: Option<String>,
+    pub tenant_id: Uuid,
+    pub source: String,
+    pub subject: String,
+    pub subject_type: String,
+    pub occurred_at: DateTime<Utc>,
+    pub trace_parent: Option<String>,
+    pub data: JsonValue,
+    /// Publish-input only; stripped on the read projection.
+    pub meta: Option<Meta>,
+    /// Read-projection only; broker-derived.
+    pub partition: Option<i32>,
+    /// Read-projection only; broker-logical consumer-visible ordering key.
+    pub sequence: Option<i64>,
+    pub sequence_time: Option<DateTime<Utc>>,
+}
+
+/// Producer chain metadata. Publish-input only; stripped on read.
+#[derive(Debug, Clone)]
+pub struct Meta {
+    pub version: i32,
+    pub producer_id: Uuid,
+    pub previous: i64,
+    pub sequence: i64,
+}
+
+/// `gts.cf.core.events.subscription.v1~` - ephemeral, in-cache consumer
+/// instance.
+#[derive(Debug, Clone)]
+pub struct Subscription {
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub consumer_group: String,
+    pub topics: Vec<String>,
+    pub assigned: Vec<Assignment>,
+    pub session_timeout: Duration,
+    pub last_seen_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Assignment {
+    pub topic: String,
+    pub partition: i32,
+    pub offset: i64,
+    pub last_examined: i64,
+}
+
+/// Ephemeral, in-cache runtime state of a consumer group.
+#[derive(Debug, Clone)]
+pub struct GroupState {
+    pub consumer_group: String,
+    pub topic: String,
+    pub per_member_filters: HashMap<Uuid, JsonValue>,
+    pub active_members: HashMap<Uuid, Subscription>,
+    pub topology_version: i64,
+    pub owning_delivery_shard_id: String,
+}
+
+/// Ephemeral, in-cache group progress for one `(topic, partition)`.
+#[derive(Debug, Clone)]
+pub struct Cursor {
+    pub topic: String,
+    pub consumer_group: String,
+    pub partition: i32,
+    pub offset: i64,
+}

--- a/gears/system/event-broker/event-broker/src/domain/repo.rs
+++ b/gears/system/event-broker/event-broker/src/domain/repo.rs
@@ -1,0 +1,52 @@
+//! Repository contracts (`DESIGN.md:595`'s `EventRepo`, `TopicRepo`,
+//! `SubscriptionRepo`, `CursorRepo`). Signatures only - no implementation
+//! (backed by `infra::storage` for persisted entities, `domain::cluster`
+//! for ephemeral cache-backed ones per the Domain Model's
+//! persisted-vs-ephemeral split).
+
+use async_trait::async_trait;
+
+use crate::domain::error::DomainError;
+use crate::domain::model::{Cursor, Event, Subscription, Topic};
+
+#[async_trait]
+pub trait TopicRepo: Send + Sync {
+    async fn get(&self, id: &str) -> Result<Option<Topic>, DomainError>;
+}
+
+#[async_trait]
+pub trait EventRepo: Send + Sync {
+    async fn append(
+        &self,
+        topic: &Topic,
+        partition: i32,
+        events: &[Event],
+    ) -> Result<(), DomainError>;
+
+    async fn query(
+        &self,
+        topic: &Topic,
+        partition: i32,
+        offset: i64,
+        limit: i32,
+    ) -> Result<Vec<Event>, DomainError>;
+}
+
+#[async_trait]
+pub trait SubscriptionRepo: Send + Sync {
+    async fn get(&self, id: uuid::Uuid) -> Result<Option<Subscription>, DomainError>;
+    async fn put(&self, subscription: &Subscription) -> Result<(), DomainError>;
+    async fn delete(&self, id: uuid::Uuid) -> Result<(), DomainError>;
+}
+
+#[async_trait]
+pub trait CursorRepo: Send + Sync {
+    async fn get(
+        &self,
+        consumer_group: &str,
+        topic: &str,
+        partition: i32,
+    ) -> Result<Option<Cursor>, DomainError>;
+
+    async fn put(&self, cursor: &Cursor) -> Result<(), DomainError>;
+}

--- a/gears/system/event-broker/event-broker/src/domain/specification.rs
+++ b/gears/system/event-broker/event-broker/src/domain/specification.rs
@@ -1,0 +1,21 @@
+//! `SpecificationManager` (`DESIGN.md:721-737`): shared by Ingest and
+//! Delivery, owns topic/event-type metadata. Signatures only.
+
+use async_trait::async_trait;
+use serde_json::Value as JsonValue;
+
+use crate::domain::error::DomainError;
+use crate::domain::model::{EventType, Topic};
+
+#[async_trait]
+pub trait SpecificationManager: Send + Sync {
+    async fn register_topic(&self, spec: Topic) -> Result<Topic, DomainError>;
+    async fn register_event_type(&self, spec: EventType) -> Result<EventType, DomainError>;
+    async fn get_topic(&self, gts_id: &str) -> Option<Topic>;
+    async fn get_event_type(&self, gts_id: &str) -> Option<EventType>;
+    async fn validate_event_data(
+        &self,
+        event_type: &EventType,
+        data: &JsonValue,
+    ) -> Result<(), DomainError>;
+}

--- a/gears/system/event-broker/event-broker/src/infra/cluster/mod.rs
+++ b/gears/system/event-broker/event-broker/src/infra/cluster/mod.rs
@@ -1,0 +1,4 @@
+//! `ClusterCapabilities` integration: event notification via
+//! `ClusterCacheV1::put` + `watch` (`DESIGN.md:604-605,756-758`).
+
+pub mod notifications;

--- a/gears/system/event-broker/event-broker/src/infra/cluster/notifications.rs
+++ b/gears/system/event-broker/event-broker/src/infra/cluster/notifications.rs
@@ -1,0 +1,24 @@
+//! Event notification realized on top of `ClusterCacheV1::put` +
+//! `ClusterCacheV1::watch` (`DESIGN.md:756-758`; there is no separate
+//! pub/sub primitive, see `docs/ADR/0007-service-decomposition.md` D3).
+//! Shell only - wiring lands with #4345/#4346.
+
+use crate::domain::cluster::EventBrokerCluster;
+
+/// Notifies delivery shards that new events landed on `(topic, partition)`
+/// by bumping `evbk.notif:{topic}:{partition}` (`DESIGN.md:756`). The
+/// watch event carries no payload - delivery re-queries the backend.
+///
+/// # Errors
+/// Returns [`cluster_sdk::ClusterError`] if the cache write fails, once
+/// implemented.
+pub async fn notify_partition_appended(
+    cluster: &EventBrokerCluster,
+    topic: &str,
+    partition: i32,
+) -> Result<(), cluster_sdk::ClusterError> {
+    let _ = (cluster, topic, partition);
+    todo!(
+        "cache.put(\"evbk.notif:{{topic}}:{{partition}}\", marker, ttl=short) - lands with #4345/#4346"
+    )
+}

--- a/gears/system/event-broker/event-broker/src/infra/dispatcher/mod.rs
+++ b/gears/system/event-broker/event-broker/src/infra/dispatcher/mod.rs
@@ -1,0 +1,6 @@
+//! Optional HTTP gateway (`DESIGN.md:610-612`). Not constructed in
+//! standalone mode (`docs/ADR/0007-service-decomposition.md` D4). The
+//! routing algorithm is #4345's job; this crate only holds the shells.
+
+pub mod proxy;
+pub mod router;

--- a/gears/system/event-broker/event-broker/src/infra/dispatcher/proxy.rs
+++ b/gears/system/event-broker/event-broker/src/infra/dispatcher/proxy.rs
@@ -1,0 +1,13 @@
+//! Ingest-routing proxy handler: topic-pattern matching, hetero/sharded
+//! modes, specificity tie-break (`DESIGN.md:1216-1391`). Shell only - the
+//! routing algorithm lands with #4345.
+
+#[derive(Debug, Default)]
+pub struct IngestProxy;
+
+impl IngestProxy {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}

--- a/gears/system/event-broker/event-broker/src/infra/dispatcher/router.rs
+++ b/gears/system/event-broker/event-broker/src/infra/dispatcher/router.rs
@@ -1,0 +1,13 @@
+//! Delivery-routing handler: cache-based lookup, new-group CAS placement,
+//! SD-gated failover cache invalidation (`DESIGN.md:1216-1391`). Shell
+//! only - the routing algorithm lands with #4345.
+
+#[derive(Debug, Default)]
+pub struct DeliveryRouter;
+
+impl DeliveryRouter {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}

--- a/gears/system/event-broker/event-broker/src/infra/mod.rs
+++ b/gears/system/event-broker/event-broker/src/infra/mod.rs
@@ -1,0 +1,8 @@
+//! Infrastructure layer: persistence, cluster coordination, and GTS
+//! provisioning (`DESIGN.md` §1.3 Architecture Layers).
+
+pub mod cluster;
+pub mod dispatcher;
+pub mod storage;
+pub mod type_provisioning;
+pub mod workers;

--- a/gears/system/event-broker/event-broker/src/infra/storage/builtin/memory.rs
+++ b/gears/system/event-broker/event-broker/src/infra/storage/builtin/memory.rs
@@ -1,0 +1,12 @@
+//! `InMemoryStorageBackend` (`DESIGN.md:602-603`): non-persistent backend
+//! for dev/test. Shell only - a runnable implementation lands with #4347.
+
+#[derive(Debug, Default)]
+pub struct InMemoryStorageBackend;
+
+impl InMemoryStorageBackend {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}

--- a/gears/system/event-broker/event-broker/src/infra/storage/builtin/mod.rs
+++ b/gears/system/event-broker/event-broker/src/infra/storage/builtin/mod.rs
@@ -1,0 +1,6 @@
+//! Built-in storage backends bundled with the event broker
+//! (`DESIGN.md:602-603`: in-memory, for dev/test).
+
+pub mod memory;
+
+pub use memory::InMemoryStorageBackend;

--- a/gears/system/event-broker/event-broker/src/infra/storage/mod.rs
+++ b/gears/system/event-broker/event-broker/src/infra/storage/mod.rs
@@ -1,0 +1,7 @@
+//! Storage backend plugin resolution
+//! (`DESIGN.md` §"Storage Backend Plugin System").
+
+pub mod builtin;
+pub mod registry;
+
+pub use registry::StorageBackendRegistry;

--- a/gears/system/event-broker/event-broker/src/infra/storage/registry.rs
+++ b/gears/system/event-broker/event-broker/src/infra/storage/registry.rs
@@ -1,0 +1,17 @@
+//! `StorageBackendRegistry` (`DESIGN.md:770-780`): GTS discovery +
+//! `ClientHub` resolution of a topic's bound storage backend. Shell only.
+//!
+//! The plugin trait itself is mid-reconciliation between `DESIGN.md`'s
+//! `StorageBackend` and the SDK's shipped `EventBrokerBackend`
+//! (`DESIGN.md:782`'s "Deferred (M5b-flattening)" note) - this registry
+//! does not take a position on that reconciliation; it lands with #4348.
+
+#[derive(Debug, Default)]
+pub struct StorageBackendRegistry;
+
+impl StorageBackendRegistry {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}

--- a/gears/system/event-broker/event-broker/src/infra/type_provisioning.rs
+++ b/gears/system/event-broker/event-broker/src/infra/type_provisioning.rs
@@ -1,0 +1,6 @@
+//! GTS type registration for the event broker's own types
+//! (`DESIGN.md:613`). Shell only - lands with #4346/#4347.
+
+pub async fn provision_types() {
+    todo!("register event-broker GTS types into types_registry - lands with #4346/#4347")
+}

--- a/gears/system/event-broker/event-broker/src/infra/workers/mod.rs
+++ b/gears/system/event-broker/event-broker/src/infra/workers/mod.rs
@@ -1,0 +1,9 @@
+//! Background workers. Only `reaper` (expired subscriptions +
+//! idempotency-key cleanup) is broker-owned - `DESIGN.md` §3.7 Key
+//! Invariants states the storage backend owns all event deletion, so no
+//! cleaner/retention worker exists here
+//! (`docs/ADR/0007-service-decomposition.md` D5).
+
+pub mod reaper;
+
+pub use reaper::Reaper;

--- a/gears/system/event-broker/event-broker/src/infra/workers/reaper.rs
+++ b/gears/system/event-broker/event-broker/src/infra/workers/reaper.rs
@@ -1,0 +1,19 @@
+//! `Reaper` worker: expired-subscription and idempotency-key cleanup
+//! (`DESIGN.md` §3.7 Key Invariants). Runs under `LeaderElectionV1`
+//! (`evbk.worker.reaper`, `DESIGN.md:761`) so exactly one instance runs
+//! cluster-wide. Shell only - a runnable implementation lands with
+//! #4346/#4347.
+
+#[derive(Debug, Default)]
+pub struct Reaper;
+
+impl Reaper {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn run_once(&self) {
+        todo!("subscription + idempotency-key expiry sweep - lands with #4346/#4347")
+    }
+}

--- a/gears/system/event-broker/event-broker/src/lib.rs
+++ b/gears/system/event-broker/event-broker/src/lib.rs
@@ -1,0 +1,16 @@
+//! Event Broker module: `Ingest`/`Delivery`/`Dispatcher` composite, wired
+//! per deployment mode by [`module::EventBrokerModule`].
+//!
+//! See `docs/DESIGN.md` (module tree, §3.8 Deployment Topology, §4.1
+//! Deployment Modes) and `docs/ADR/0007-service-decomposition.md`.
+
+pub mod api;
+pub mod config;
+pub mod domain;
+pub mod infra;
+pub mod module;
+#[cfg(test)]
+pub mod test_support;
+
+pub use config::{DeploymentMode, EventBrokerConfig};
+pub use module::EventBrokerModule;

--- a/gears/system/event-broker/event-broker/src/module.rs
+++ b/gears/system/event-broker/event-broker/src/module.rs
@@ -1,0 +1,111 @@
+//! `EventBrokerModule`: the `ModKit` gear that will wire Ingest/Delivery/
+//! Dispatcher/Reaper per deployment mode (`DESIGN.md:2224`'s Deployment
+//! Modes table; `docs/ADR/0007-service-decomposition.md`).
+//!
+//! This is structure-only scaffolding: `init` resolves and stores the
+//! configured [`DeploymentMode`], whose `*_active()` predicates report
+//! which services/routes *should* exist for that mode. No service is
+//! constructed, no route is registered, and `serve()` starts no background
+//! work yet - those predicates are the gate that #4345 (dispatcher
+//! routing), #4346 (REST API), and #4347 (standalone runtime) will branch
+//! real construction and registration on.
+
+use std::sync::OnceLock;
+
+use async_trait::async_trait;
+use tokio_util::sync::CancellationToken;
+use toolkit::api::OpenApiRegistry;
+use toolkit::{Gear, GearCtx, RestApiCapability};
+
+use crate::config::{DeploymentMode, EventBrokerConfig};
+
+/// Expressed as predicates on [`DeploymentMode`] itself so the activation
+/// set can never disagree with the mode it's derived from
+/// (`docs/ADR/0007-service-decomposition.md` D6).
+impl DeploymentMode {
+    /// `DESIGN.md:2224`'s Deployment Modes table, column by column.
+    #[must_use]
+    pub fn ingest_active(self) -> bool {
+        matches!(self, Self::Standalone | Self::ClusterIngest)
+    }
+
+    #[must_use]
+    pub fn delivery_active(self) -> bool {
+        matches!(self, Self::Standalone | Self::ClusterDelivery)
+    }
+
+    #[must_use]
+    pub fn dispatcher_active(self) -> bool {
+        matches!(self, Self::ClusterDispatcher)
+    }
+
+    /// The `reaper` worker runs in every mode except `cluster_dispatcher`
+    /// (a stateless HTTP gateway has nothing for it to reap).
+    #[must_use]
+    pub fn reaper_active(self) -> bool {
+        !matches!(self, Self::ClusterDispatcher)
+    }
+}
+
+#[toolkit::gear(
+    name = "event-broker",
+    deps = [cluster],
+    capabilities = [rest, stateful],
+    lifecycle(entry = "serve", stop_timeout = "30s")
+)]
+#[derive(Default)]
+pub struct EventBrokerModule {
+    mode: OnceLock<DeploymentMode>,
+}
+
+#[async_trait]
+impl Gear for EventBrokerModule {
+    async fn init(&self, ctx: &GearCtx) -> anyhow::Result<()> {
+        let cfg: EventBrokerConfig = ctx.config()?;
+        self.mode
+            .set(cfg.mode)
+            .map_err(|_| anyhow::anyhow!("{} module already initialized", Self::MODULE_NAME))?;
+        tracing::info!(
+            module = Self::MODULE_NAME,
+            mode = ?cfg.mode,
+            "event-broker deployment-mode wiring resolved"
+        );
+        Ok(())
+    }
+}
+
+impl RestApiCapability for EventBrokerModule {
+    /// No routes are registered yet - handler bodies land with #4346.
+    /// `mode()` and its `*_active()` predicates are already the gate future
+    /// route registration will branch on.
+    fn register_rest(
+        &self,
+        _ctx: &GearCtx,
+        router: axum::Router,
+        _openapi: &dyn OpenApiRegistry,
+    ) -> anyhow::Result<axum::Router> {
+        Ok(router)
+    }
+}
+
+impl EventBrokerModule {
+    /// Crate-internal introspection point for the per-mode gating tests
+    /// (`docs/ADR/0007-service-decomposition.md` D6) - not public API.
+    #[cfg(test)]
+    pub(crate) fn mode(&self) -> DeploymentMode {
+        *self.mode.get().expect("init must run before mode()")
+    }
+
+    /// Background lifecycle entry point (`lifecycle(entry = "serve")`).
+    /// No background work is implemented yet - the `reaper` worker lands
+    /// with #4346/#4347. This only honors the gear lifecycle contract by
+    /// waiting for shutdown.
+    pub(crate) async fn serve(&self, cancel: CancellationToken) -> anyhow::Result<()> {
+        cancel.cancelled().await;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "module_tests.rs"]
+mod module_tests;

--- a/gears/system/event-broker/event-broker/src/module_tests.rs
+++ b/gears/system/event-broker/event-broker/src/module_tests.rs
@@ -1,0 +1,143 @@
+//! Per-mode service/route gating tests
+//! (`openspec/changes/eb-service-topology/specs/event-broker-deployment-topology/spec.md`).
+
+use std::sync::Arc;
+
+use serde_json::json;
+use tokio_util::sync::CancellationToken;
+use toolkit::config::ConfigProvider;
+use toolkit::{ClientHub, Gear, GearCtx};
+use uuid::Uuid;
+
+use super::EventBrokerModule;
+use crate::config::DeploymentMode;
+
+struct StaticConfigProvider {
+    root: serde_json::Value,
+}
+
+impl ConfigProvider for StaticConfigProvider {
+    fn get_gear_config(&self, gear: &str) -> Option<&serde_json::Value> {
+        self.root.get(gear)
+    }
+}
+
+fn make_ctx(mode: &str) -> GearCtx {
+    let cfg = json!({
+        "event-broker": {
+            "config": {
+                "mode": mode,
+                "default_storage_backend": "memory",
+            }
+        }
+    });
+    GearCtx::new(
+        EventBrokerModule::MODULE_NAME,
+        Uuid::new_v4(),
+        Arc::new(StaticConfigProvider { root: cfg }),
+        Arc::new(ClientHub::new()),
+        CancellationToken::new(),
+    )
+}
+
+async fn mode_after_init(mode: &str) -> DeploymentMode {
+    let module = EventBrokerModule::default();
+    let ctx = make_ctx(mode);
+    module.init(&ctx).await.expect("init must succeed");
+    module.mode()
+}
+
+#[tokio::test]
+async fn standalone_activates_ingest_delivery_and_reaper_but_no_dispatcher() {
+    let mode = mode_after_init("standalone").await;
+    assert!(mode.ingest_active());
+    assert!(mode.delivery_active());
+    assert!(!mode.dispatcher_active());
+    assert!(mode.reaper_active());
+}
+
+#[tokio::test]
+async fn cluster_ingest_activates_only_ingest_and_reaper() {
+    let mode = mode_after_init("cluster_ingest").await;
+    assert!(mode.ingest_active());
+    assert!(!mode.delivery_active());
+    assert!(!mode.dispatcher_active());
+    assert!(mode.reaper_active());
+}
+
+#[tokio::test]
+async fn cluster_delivery_activates_only_delivery_and_reaper() {
+    let mode = mode_after_init("cluster_delivery").await;
+    assert!(!mode.ingest_active());
+    assert!(mode.delivery_active());
+    assert!(!mode.dispatcher_active());
+    assert!(mode.reaper_active());
+}
+
+#[tokio::test]
+async fn cluster_dispatcher_activates_only_the_dispatcher() {
+    let mode = mode_after_init("cluster_dispatcher").await;
+    assert!(!mode.ingest_active());
+    assert!(!mode.delivery_active());
+    assert!(mode.dispatcher_active());
+    assert!(!mode.reaper_active());
+}
+
+#[tokio::test]
+async fn init_fails_for_unknown_mode() {
+    let module = EventBrokerModule::default();
+    let ctx = make_ctx("not_a_real_mode");
+
+    let err = module
+        .init(&ctx)
+        .await
+        .expect_err("init must reject an unrecognized mode string rather than silently accepting it or panicking");
+
+    let message = format!("{err:#}");
+    assert_eq!(
+        message,
+        "invalid config for gear 'event-broker': unknown variant `not_a_real_mode`, \
+         expected one of `standalone`, `cluster_ingest`, `cluster_delivery`, `cluster_dispatcher`"
+    );
+}
+
+#[test]
+fn for_mode_matches_design_md_deployment_modes_table_exhaustively() {
+    // Mirrors `DESIGN.md:2224`'s table row by row - if a fifth mode is ever
+    // added, this list forces an explicit decision here too.
+    let table = [
+        (DeploymentMode::Standalone, (true, true, false, true)),
+        (DeploymentMode::ClusterIngest, (true, false, false, true)),
+        (DeploymentMode::ClusterDelivery, (false, true, false, true)),
+        (
+            DeploymentMode::ClusterDispatcher,
+            (false, false, true, false),
+        ),
+    ];
+
+    for (mode, (ingest, delivery, dispatcher, reaper)) in table {
+        assert_eq!(mode.ingest_active(), ingest, "ingest mismatch for {mode:?}");
+        assert_eq!(
+            mode.delivery_active(),
+            delivery,
+            "delivery mismatch for {mode:?}"
+        );
+        assert_eq!(
+            mode.dispatcher_active(),
+            dispatcher,
+            "dispatcher mismatch for {mode:?}"
+        );
+        assert_eq!(mode.reaper_active(), reaper, "reaper mismatch for {mode:?}");
+    }
+
+    // Dispatcher is exclusive to cluster_dispatcher; every other mode has
+    // no dispatcher constructed (`docs/ADR/0007-service-decomposition.md` D4).
+    for (mode, _) in table {
+        if mode != DeploymentMode::ClusterDispatcher {
+            assert!(
+                !mode.dispatcher_active(),
+                "{mode:?} must not activate a dispatcher"
+            );
+        }
+    }
+}

--- a/gears/system/event-broker/event-broker/src/test_support/mod.rs
+++ b/gears/system/event-broker/event-broker/src/test_support/mod.rs
@@ -1,0 +1,2 @@
+//! Shared test fixtures (`DESIGN.md:614`). Empty until #4346/#4347 need
+//! shared test doubles.

--- a/libs/toolkit/src/api/error_layer.rs
+++ b/libs/toolkit/src/api/error_layer.rs
@@ -63,15 +63,15 @@ pub fn map_error_to_canonical(error: &dyn Any) -> CanonicalError {
             ConfigError::InvalidConfig { gear, .. } => {
                 format!("Gear '{gear}' has invalid configuration")
             }
-            ConfigError::VarExpand { gear, source } => {
-                // The `source` carries the failing env-var name. It is logged
+            ConfigError::VarExpand { gear, cause } => {
+                // The `cause` carries the failing env-var name. It is logged
                 // locally for operators but intentionally NOT placed into the
                 // canonical's diagnostic — `diagnostic()` is exposed through
                 // `canonical_error_middleware` and we keep the env-var name
                 // out of any path that could reach a downstream consumer.
                 tracing::error!(
                     gear =  %gear,
-                    error = %source,
+                    error = %cause,
                     "Environment variable expansion failed in gear config"
                 );
                 format!("Gear '{gear}' has invalid environment-backed configuration")
@@ -171,7 +171,7 @@ mod tests {
         };
         let canonical = ConfigError::VarExpand {
             gear: "my_mod".to_owned(),
-            source,
+            cause: source,
         }
         .into_canonical();
 

--- a/libs/toolkit/src/bootstrap/config/mod.rs
+++ b/libs/toolkit/src/bootstrap/config/mod.rs
@@ -27,11 +27,11 @@ fn normalize_path(path: &Path) -> String {
 pub enum VendorConfigError {
     #[error("vendor '{vendor}' not found in configuration")]
     NotFound { vendor: String },
-    #[error("invalid config for vendor '{vendor}': {source}")]
+    // Intentionally not named `source`; doing so would duplicate chained error output.
+    #[error("invalid config for vendor '{vendor}': {cause}")]
     InvalidConfig {
         vendor: String,
-        #[source]
-        source: serde_json::Error,
+        cause: serde_json::Error,
     },
 }
 
@@ -472,7 +472,7 @@ impl AppConfig {
             })?;
         T::deserialize(raw).map_err(|e| VendorConfigError::InvalidConfig {
             vendor: vendor_name.to_owned(),
-            source: e,
+            cause: e,
         })
     }
 
@@ -490,7 +490,7 @@ impl AppConfig {
         };
         T::deserialize(raw).map_err(|e| VendorConfigError::InvalidConfig {
             vendor: vendor_name.to_owned(),
-            source: e,
+            cause: e,
         })
     }
 
@@ -3271,10 +3271,11 @@ vendor:
 
         let invalid = VendorConfigError::InvalidConfig {
             vendor: "bad".to_owned(),
-            source: serde_json::from_str::<TestVendorConfig>("invalid").unwrap_err(),
+            cause: serde_json::from_str::<TestVendorConfig>("invalid").unwrap_err(),
         };
         let msg = invalid.to_string();
         assert!(msg.starts_with("invalid config for vendor 'bad':"));
+        assert!(std::error::Error::source(&invalid).is_none());
     }
 
     #[test]

--- a/libs/toolkit/src/config.rs
+++ b/libs/toolkit/src/config.rs
@@ -21,17 +21,16 @@ pub enum ConfigError {
     InvalidGearStructure { gear: String },
     #[error("missing 'config' section in gear '{gear}'")]
     MissingConfigSection { gear: String },
-    #[error("invalid config for gear '{gear}': {source}")]
+    // Intentionally not named `source`; doing so would duplicate chained error output.
+    #[error("invalid config for gear '{gear}': {cause}")]
     InvalidConfig {
         gear: String,
-        #[source]
-        source: serde_json::Error,
+        cause: serde_json::Error,
     },
-    #[error("variable expansion failed for gear '{gear}': {source}")]
+    #[error("variable expansion failed for gear '{gear}': {cause}")]
     VarExpand {
         gear: String,
-        #[source]
-        source: toolkit_utils::var_expand::ExpandVarsError,
+        cause: toolkit_utils::var_expand::ExpandVarsError,
     },
 }
 
@@ -76,7 +75,7 @@ pub fn gear_config_or_default<T: DeserializeOwned + Default>(
     let config: T =
         serde_json::from_value(config_section.clone()).map_err(|e| ConfigError::InvalidConfig {
             gear: gear_name.to_owned(),
-            source: e,
+            cause: e,
         })?;
 
     Ok(config)
@@ -121,7 +120,7 @@ pub fn gear_config_required<T: DeserializeOwned>(
     let config: T =
         serde_json::from_value(config_section.clone()).map_err(|e| ConfigError::InvalidConfig {
             gear: gear_name.to_owned(),
-            source: e,
+            cause: e,
         })?;
 
     Ok(config)
@@ -385,5 +384,49 @@ mod tests {
             missing_config.to_string(),
             "missing 'config' section in gear 'test'"
         );
+    }
+
+    #[test]
+    fn test_invalid_config_message_is_not_duplicated_by_source_chain() {
+        let mut provider = MockConfigProvider::new();
+        provider.gears.insert(
+            "bad_config_gear".to_owned(),
+            json!({
+                "config": {
+                    "api_key": "secret123",
+                    "timeout_ms": "not_a_number",
+                    "enabled": true
+                }
+            }),
+        );
+        let result: Result<TestConfig, ConfigError> =
+            gear_config_required(&provider, "bad_config_gear");
+        let err = result.unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "invalid config for gear 'bad_config_gear': invalid type: string \"not_a_number\", expected u64"
+        );
+
+        assert!(std::error::Error::source(&err).is_none());
+        let anyhow_err: anyhow::Error = err.into();
+        assert_eq!(
+            format!("{anyhow_err:#}"),
+            "invalid config for gear 'bad_config_gear': invalid type: string \"not_a_number\", expected u64"
+        );
+    }
+
+    #[test]
+    fn test_var_expand_message_is_not_duplicated_by_source_chain() {
+        let err = ConfigError::VarExpand {
+            gear: "test".to_owned(),
+            cause: toolkit_utils::var_expand::ExpandVarsError::Regex("boom".to_owned()),
+        };
+
+        assert_eq!(
+            err.to_string(),
+            "variable expansion failed for gear 'test': env expansion regex error: boom"
+        );
+        assert!(std::error::Error::source(&err).is_none());
     }
 }

--- a/libs/toolkit/src/context.rs
+++ b/libs/toolkit/src/context.rs
@@ -264,7 +264,7 @@ impl GearCtx {
         let mut cfg: T = self.config()?;
         cfg.expand_vars().map_err(|e| ConfigError::VarExpand {
             gear: self.gear_name.to_string(),
-            source: e,
+            cause: e,
         })?;
         Ok(cfg)
     }
@@ -299,7 +299,7 @@ impl GearCtx {
         let mut cfg: T = self.config_or_default()?;
         cfg.expand_vars().map_err(|e| ConfigError::VarExpand {
             gear: self.gear_name.to_string(),
-            source: e,
+            cause: e,
         })?;
         Ok(cfg)
     }


### PR DESCRIPTION
Closes #4343

Extract the service-decomposition ADR from DESIGN.md's inline placeholder and scaffold the event-broker crate per the (corrected) module tree so #4345 #4346  #4347 have a real skeleton to build handlers, routing, and a backend against instead of each re-deriving deployment-mode wiring themselves.

- docs/ADR/0007-service-decomposition.md: single binary/multi-mode process shape, domain/cluster.rs wraps the real cluster gear's cluster-sdk facades directly (no bespoke ClusterCapabilities abstraction), no dispatcher constructed in standalone mode
- DESIGN.md: link the ADR from the placeholder; drop infra/workers/cleaner.rs and retention.rs from the module tree and example config (contradicted the broker's no-cleaner/no-retention invariant); fix a stale "runs the cleaner" reference in §4.1
- New cf-gears-event-broker crate: full module tree, structure-only (todo!()/unimplemented!() bodies) except module.rs, which implements per-mode service/route gating (ActiveServices), unit-tested against all four DESIGN.md:2224 deployment modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the foundational Event Broker service, including deployment modes, configuration, event models, storage abstractions, delivery and ingestion contracts, and lifecycle wiring.
  * Added scaffolding for REST APIs, routing, cluster notifications, dispatcher components, built-in storage, and subscription cleanup.
  * Added documentation describing service decomposition and architecture decisions.

* **Bug Fixes**
  * Improved configuration error reporting by preventing sensitive implementation details from appearing in chained diagnostics.

* **Tests**
  * Added coverage for deployment-mode activation and configuration error formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->