### PR TITLE
feat(account-management): report IdP-managed field on update

### DIFF
--- a/docs/api/api.json
+++ b/docs/api/api.json
@@ -8707,7 +8707,7 @@
     },
     "/account-management/v1/tenants/{tenant_id}/users": {
       "get": {
-        "description": "List users provisioned in the tenant via the configured IdP plugin. Filter via OData `$filter` over `id` (Uuid), `username`, `email`, `display_name`, `first_name`, `last_name` (String) with operators `eq`, `ne`, `in`, and `contains` / `startswith` / `endswith` on String fields (case-insensitive); combine via `and` / `or` / `not`. Sort via `$orderby` over the same fields (default: `username ASC, id ASC` with `id ASC` tiebreaker appended even when the caller supplies their own order). Point lookup is `$filter=id eq <uuid>` with `top=1`: empty page is the canonical \"user absent\" signal (no 404). Cursor pagination is opaque; caller MUST NOT change `$filter` or `$orderby` between continuation requests with the same cursor. AM persists no local user state; every read is a pass-through to the IdP.",
+        "description": "List users provisioned in the tenant via the configured IdP plugin. Filter via OData `$filter` over `id` (Uuid), `username`, `email`, `display_name`, `first_name`, `last_name` (String) with operators `eq`, `ne`, `in`, and `contains` / `startswith` / `endswith` on String fields (case-insensitive); combine via `and` / `or` / `not`. Sort via `$orderby` over the same fields (default: `username ASC, id ASC` with `id ASC` tiebreaker appended even when the caller supplies their own order). Point lookup is `$filter=id eq <uuid>` with `limit=1` (the toolkit-style page-size param; `$top` is not honoured): empty page is the canonical \"user absent\" signal (no 404). Cursor pagination is opaque; caller MUST NOT change `$filter` or `$orderby` between continuation requests with the same cursor. AM persists no local user state; every read is a pass-through to the IdP.",
         "operationId": "account_management.list_tenant_users",
         "parameters": [
           {
@@ -8715,6 +8715,24 @@
             "in": "path",
             "name": "tenant_id",
             "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of users to return. Optional in general -- omitting it falls back to a server-chosen page size. Conditionally required: when combined with `$filter=id eq <uuid>` it MUST be exactly 1, or the request is rejected with 400 -- `$top` is not honoured as a substitute.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Cursor for pagination",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
             "schema": {
               "type": "string"
             }
@@ -8916,7 +8934,7 @@
         }
       },
       "post": {
-        "description": "Provision a user in the tenant via the configured IdP plugin. AM persists no local user state -- the IdP becomes the source of truth on success. Returns HTTP 201 Created with the projected user body. AM does NOT expose a per-user GET; clients that need to re-read the user use the filtered listing `GET /tenants/{tenant_id}/users?$filter=id eq <uuid>&$top=1`.",
+        "description": "Provision a user in the tenant via the configured IdP plugin. AM persists no local user state -- the IdP becomes the source of truth on success. Returns HTTP 201 Created with the projected user body. AM does NOT expose a per-user GET; clients that need to re-read the user use the filtered listing `GET /tenants/{tenant_id}/users?$filter=id eq <uuid>&limit=1`.",
         "operationId": "account_management.create_tenant_user",
         "parameters": [
           {
@@ -9183,7 +9201,7 @@
         ]
       },
       "patch": {
-        "description": "Apply a JSON Merge Patch (RFC 7396) to a user's mutable attributes via the configured IdP plugin. AM persists no local user state; the update is a pass-through and the IdP remains the source of truth. Omitted fields are left unchanged; an explicit `null` clears a nullable profile field (`email`, `display_name`, `first_name`, `last_name`); `username` may be renamed (send a value) but NOT cleared (an explicit `null` is rejected); `password` sets a new credential and is never echoed back. Returns 200 OK with the post-update user body projected through `gts.cf.core.am.user.v1~`. An empty patch is rejected with `code=validation`. Unlike DELETE, a patch against a user the IdP reports absent returns 404 -- it is NOT folded into success. A username rename that collides with an existing login returns 409.",
+        "description": "Apply a JSON Merge Patch (RFC 7396) to a user's mutable attributes via the configured IdP plugin. AM persists no local user state; the update is a pass-through and the IdP remains the source of truth. Omitted fields are left unchanged; an explicit `null` clears a nullable profile field (`email`, `display_name`, `first_name`, `last_name`); `username` may be renamed (send a value) but NOT cleared (an explicit `null` is rejected); `password` sets a new credential and is never echoed back. Returns 200 OK with the post-update user body projected through `gts.cf.core.am.user.v1~`. An empty patch is rejected with `code=validation`. Unlike DELETE, a patch against a user the IdP reports absent returns 404 -- it is NOT folded into success. A username rename that collides with an existing login returns 409. Attributes the provider manages and does not allow AM to override (e.g. federated from a read-only mapper) return 400 with one `context.field_violations[]` entry per refused property, each naming the refused request property in `.field` with `.reason=IDP_MANAGED_FIELD`, so a client can disable those inputs in one pass; this is deliberately NOT a 403, since writability is a property of the provider's schema rather than of the caller's grants.",
         "operationId": "account_management.update_tenant_user",
         "parameters": [
           {

--- a/gears/system/account-management/account-management-sdk/src/field.rs
+++ b/gears/system/account-management/account-management-sdk/src/field.rs
@@ -51,6 +51,19 @@ pub const IDP_INVALID_INPUT: &str = "IDP_INVALID_INPUT";
 /// password input; the raw policy text stays provider-side.
 pub const PASSWORD_POLICY: &str = "PASSWORD_POLICY";
 
+/// The patched attribute is managed by the `IdP` and not overridable
+/// through AM (federated from a read-only mapper, or marked
+/// non-writable in the provider's user-profile configuration). The
+/// accompanying `field` is the exact `UserUpdateRequest` property the
+/// caller tried to write, sourced from
+/// [`crate::IdpUserAttribute::as_field_token`], so a client can
+/// attribute the refusal to one input and disable it.
+///
+/// A capability fact about the field, not an authorization decision
+/// about the caller — hence `InvalidArgument` (400) rather than
+/// `PermissionDenied` (403): no grant would make the write succeed.
+pub const IDP_MANAGED_FIELD: &str = "IDP_MANAGED_FIELD";
+
 // ---------------------------------------------------------------------------
 // `field_violations[].field` attribution keys.
 //
@@ -96,7 +109,14 @@ pub const PROVISIONING_METADATA_FIELD: &str = "provisioning_metadata";
 /// catch-all because every `reason` AM emits under `InvalidArgument` is
 /// one of the modeled codes — the catch-all only fires for a future code
 /// added after this SDK version, keeping the projection forward-compatible.
+///
+/// `#[non_exhaustive]`: AM grows its `InvalidArgument` reason vocabulary
+/// over time, so a downstream `match` MUST keep a wildcard arm and a new
+/// reason code is not a breaking SDK release. [`Self::Unknown`] covers the
+/// same growth on the *value* side (an older SDK reading a newer wire
+/// string); this attribute covers it on the *type* side.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ValidationReason {
     /// See [`INVALID_TENANT_TYPE`].
     InvalidTenantType,
@@ -112,6 +132,8 @@ pub enum ValidationReason {
     IdpInvalidInput,
     /// See [`PASSWORD_POLICY`].
     PasswordPolicy,
+    /// See [`IDP_MANAGED_FIELD`].
+    IdpManagedField,
     /// Unmodeled / future reason — preserves the raw wire string.
     Unknown(String),
 }
@@ -130,6 +152,7 @@ impl ValidationReason {
             ROOT_TENANT_CANNOT_CHANGE_STATUS => Self::RootTenantCannotChangeStatus,
             IDP_INVALID_INPUT => Self::IdpInvalidInput,
             PASSWORD_POLICY => Self::PasswordPolicy,
+            IDP_MANAGED_FIELD => Self::IdpManagedField,
             other => Self::Unknown(other.to_owned()),
         }
     }
@@ -146,6 +169,7 @@ impl ValidationReason {
             Self::RootTenantCannotChangeStatus => ROOT_TENANT_CANNOT_CHANGE_STATUS,
             Self::IdpInvalidInput => IDP_INVALID_INPUT,
             Self::PasswordPolicy => PASSWORD_POLICY,
+            Self::IdpManagedField => IDP_MANAGED_FIELD,
             Self::Unknown(s) => s.as_str(),
         }
     }
@@ -180,6 +204,7 @@ mod tests {
             ),
             (IDP_INVALID_INPUT, ValidationReason::IdpInvalidInput),
             (PASSWORD_POLICY, ValidationReason::PasswordPolicy),
+            (IDP_MANAGED_FIELD, ValidationReason::IdpManagedField),
         ] {
             assert_eq!(ValidationReason::from_wire(wire), expected);
             assert_eq!(expected.as_wire(), wire);

--- a/gears/system/account-management/account-management-sdk/src/idp_user.rs
+++ b/gears/system/account-management/account-management-sdk/src/idp_user.rs
@@ -875,6 +875,93 @@ pub enum IdpUserOperationFailure {
     /// user is a `404`, not a silent no-op. AM maps this to the
     /// canonical `not_found` envelope.
     NotFound { detail: String },
+    /// Provider refused to write every attribute in `fields` because
+    /// they are IdP-managed and not overridable through AM -- e.g. the
+    /// realm federates them from a read-only LDAP mapper, or the
+    /// provider's user-profile configuration marks them non-writable.
+    ///
+    /// Distinct from [`Self::UnsupportedOperation`] (the provider does
+    /// not implement `update_user` *at all*, HTTP 501) and from
+    /// [`Self::Rejected`] (the value was bad, not the field). This is a
+    /// per-field capability fact, identical for every caller, so it is
+    /// NOT a permission decision -- AM maps it to the canonical
+    /// validation envelope carrying one structured
+    /// `<field>` / `IDP_MANAGED_FIELD` field-violation per entry (HTTP
+    /// 400) so a client can attribute the refusal to the exact inputs
+    /// and disable them.
+    ///
+    /// `fields` is a *set*, not a single attribute: a merge patch can
+    /// touch five attributes at once and a read-only federated realm
+    /// typically locks several of them, so a provider MUST report every
+    /// refused attribute the patch touched in one failure rather than
+    /// making the client discover them one round-trip at a time.
+    /// Providers MUST NOT emit an empty `fields` -- a refusal with
+    /// nothing to attribute it to is an unclassified rejection and
+    /// belongs in [`Self::Rejected`]; AM degrades an empty set to the
+    /// generic validation envelope.
+    FieldNotWritable {
+        /// The refused attributes. Non-empty; order is not significant
+        /// and duplicates are ignored by AM's boundary.
+        fields: Vec<IdpUserAttribute>,
+        detail: String,
+    },
+}
+
+/// A writable user profile attribute, used to attribute an
+/// [`IdpUserOperationFailure::FieldNotWritable`] refusal to the exact
+/// request field. `#[non_exhaustive]`: the writable surface grows with
+/// [`crate::IdpUserPatch`] without a breaking SDK release.
+///
+/// `password` is deliberately absent: a provider refusing a credential
+/// write reports it through [`IdpUserOperationFailure::PasswordPolicy`],
+/// which already owns the `password` / `PASSWORD_POLICY` tokens.
+///
+/// `Hash` is part of the contract: providers hold their non-writable
+/// attributes as a set, so a `HashSet<IdpUserAttribute>` is the natural
+/// shape on the implementing side.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum IdpUserAttribute {
+    /// The login identifier (`username`).
+    Username,
+    /// The email address (`email`).
+    Email,
+    /// The display name (`display_name`).
+    DisplayName,
+    /// The given name (`first_name`).
+    FirstName,
+    /// The family name (`last_name`).
+    LastName,
+}
+
+impl IdpUserAttribute {
+    /// Stable wire token for canonical `field_violations[].field`.
+    /// MUST match the corresponding `UserUpdateRequest` JSON property
+    /// name -- clients key form-field attribution off this string.
+    #[must_use]
+    pub const fn as_field_token(self) -> &'static str {
+        match self {
+            Self::Username => "username",
+            Self::Email => "email",
+            Self::DisplayName => "display_name",
+            Self::FirstName => "first_name",
+            Self::LastName => "last_name",
+        }
+    }
+
+    /// Human phrase for curated public error details ("the {phrase} is
+    /// managed by the identity provider..."). Centralised here so AM's
+    /// canonical boundary and its tests cannot drift.
+    #[must_use]
+    pub const fn as_human_phrase(self) -> &'static str {
+        match self {
+            Self::Username => "username",
+            Self::Email => "email address",
+            Self::DisplayName => "display name",
+            Self::FirstName => "first name",
+            Self::LastName => "last name",
+        }
+    }
 }
 
 /// Which unique user attribute an [`IdpUserOperationFailure::DuplicateUser`]
@@ -940,6 +1027,7 @@ impl IdpUserOperationFailure {
             Self::DuplicateUser { .. } => "duplicate_user",
             Self::PasswordPolicy { .. } => "password_policy",
             Self::NotFound { .. } => "not_found",
+            Self::FieldNotWritable { .. } => "field_not_writable",
         }
     }
 
@@ -955,7 +1043,8 @@ impl IdpUserOperationFailure {
             | Self::Rejected { detail }
             | Self::DuplicateUser { detail, .. }
             | Self::PasswordPolicy { detail }
-            | Self::NotFound { detail } => detail,
+            | Self::NotFound { detail }
+            | Self::FieldNotWritable { detail, .. } => detail,
         }
     }
 }

--- a/gears/system/account-management/account-management-sdk/src/idp_user_tests.rs
+++ b/gears/system/account-management/account-management-sdk/src/idp_user_tests.rs
@@ -78,6 +78,92 @@ fn user_operation_failure_metric_labels_are_stable() {
         IdpUserOperationFailure::Rejected { detail: "x".into() }.as_metric_label(),
         "rejected"
     );
+    assert_eq!(
+        IdpUserOperationFailure::FieldNotWritable {
+            fields: vec![IdpUserAttribute::Email],
+            detail: "x".into()
+        }
+        .as_metric_label(),
+        "field_not_writable"
+    );
+}
+
+/// The attribute tokens are a wire contract: they land in
+/// `field_violations[].field` and MUST equal the corresponding
+/// `UserUpdateRequest` JSON property name, because clients key
+/// form-field attribution off the string. A rename here silently
+/// breaks a consumer's field mapping, so the tokens are pinned.
+#[test]
+fn user_attribute_field_tokens_match_the_patch_property_names() {
+    for (attribute, expected) in [
+        (IdpUserAttribute::Username, "username"),
+        (IdpUserAttribute::Email, "email"),
+        (IdpUserAttribute::DisplayName, "display_name"),
+        (IdpUserAttribute::FirstName, "first_name"),
+        (IdpUserAttribute::LastName, "last_name"),
+    ] {
+        assert_eq!(attribute.as_field_token(), expected);
+        assert!(
+            !attribute.as_human_phrase().is_empty(),
+            "{expected}: every attribute needs a human phrase for the curated public detail"
+        );
+    }
+}
+
+/// `FieldNotWritable` carries its provider `detail` through the shared
+/// accessor like every other variant — AM's boundary digests it rather
+/// than echoing it, so the accessor MUST expose the raw string.
+#[test]
+fn field_not_writable_exposes_detail() {
+    let f = IdpUserOperationFailure::FieldNotWritable {
+        fields: vec![IdpUserAttribute::FirstName],
+        detail: "attribute is read-only (LDAP federated)".into(),
+    };
+    assert_eq!(f.detail(), "attribute is read-only (LDAP federated)");
+    assert_eq!(
+        f.to_string(),
+        "field_not_writable: attribute is read-only (LDAP federated)"
+    );
+}
+
+/// `FieldNotWritable` carries a *set*: a merge patch can touch several
+/// attributes and a read-only federated realm typically locks more than
+/// one, so the variant MUST be able to name them all in one failure
+/// rather than forcing a round-trip per attribute.
+#[test]
+fn field_not_writable_carries_every_refused_attribute() {
+    let f = IdpUserOperationFailure::FieldNotWritable {
+        fields: vec![
+            IdpUserAttribute::Email,
+            IdpUserAttribute::FirstName,
+            IdpUserAttribute::LastName,
+        ],
+        detail: "attributes are read-only (LDAP federated)".into(),
+    };
+    let IdpUserOperationFailure::FieldNotWritable { fields, .. } = &f else {
+        panic!("expected FieldNotWritable");
+    };
+    assert_eq!(
+        fields,
+        &[
+            IdpUserAttribute::Email,
+            IdpUserAttribute::FirstName,
+            IdpUserAttribute::LastName
+        ]
+    );
+    assert_eq!(f.as_metric_label(), "field_not_writable");
+}
+
+/// `IdpUserAttribute` is the key type providers use to hold their
+/// non-writable set, so it MUST be usable in a `HashSet` directly.
+#[test]
+fn user_attribute_is_hashable_for_provider_side_sets() {
+    let locked: std::collections::HashSet<IdpUserAttribute> =
+        [IdpUserAttribute::Email, IdpUserAttribute::Username]
+            .into_iter()
+            .collect();
+    assert!(locked.contains(&IdpUserAttribute::Email));
+    assert!(!locked.contains(&IdpUserAttribute::LastName));
 }
 
 #[test]

--- a/gears/system/account-management/account-management-sdk/src/lib.rs
+++ b/gears/system/account-management/account-management-sdk/src/lib.rs
@@ -59,9 +59,9 @@ pub use idp::{
 };
 pub use idp_user::{
     IdpDeprovisionUserRequest, IdpListUsersRequest, IdpNewUser, IdpProvisionUserRequest,
-    IdpTenantContext, IdpUpdateUserRequest, IdpUser, IdpUserDuplicateField, IdpUserFilterField,
-    IdpUserOperationFailure, IdpUserPagination, IdpUserPaginationError, IdpUserPatch, IdpUserQuery,
-    ListUsersQuery, NewUserPassword,
+    IdpTenantContext, IdpUpdateUserRequest, IdpUser, IdpUserAttribute, IdpUserDuplicateField,
+    IdpUserFilterField, IdpUserOperationFailure, IdpUserPagination, IdpUserPaginationError,
+    IdpUserPatch, IdpUserQuery, ListUsersQuery, NewUserPassword,
 };
 pub use metadata::{
     MetadataEntry, MetadataEntryFilterField, MetadataEntryQuery, UpsertMetadataRequest,

--- a/gears/system/account-management/account-management/src/api/rest/routes/users.rs
+++ b/gears/system/account-management/account-management/src/api/rest/routes/users.rs
@@ -27,7 +27,8 @@ pub(super) fn register_users_routes(mut router: Router, openapi: &dyn OpenApiReg
              String fields (case-insensitive); combine via `and` / `or` / `not`. \
              Sort via `$orderby` over the same fields (default: `username ASC, id ASC` \
              with `id ASC` tiebreaker appended even when the caller supplies their own \
-             order). Point lookup is `$filter=id eq <uuid>` with `top=1`: empty page \
+             order). Point lookup is `$filter=id eq <uuid>` with `limit=1` (the \
+             toolkit-style page-size param; `$top` is not honoured): empty page \
              is the canonical \"user absent\" signal (no 404). Cursor pagination is \
              opaque; caller MUST NOT change `$filter` or `$orderby` between \
              continuation requests with the same cursor. AM persists no local user \
@@ -37,6 +38,18 @@ pub(super) fn register_users_routes(mut router: Router, openapi: &dyn OpenApiReg
         .authenticated()
         .no_license_required()
         .path_param("tenant_id", "Tenant UUID")
+        .query_param_typed(
+            "limit",
+            false,
+            "Maximum number of users to return. Optional in general -- \
+             omitting it falls back to a server-chosen page size. \
+             Conditionally required: when combined with \
+             `$filter=id eq <uuid>` it MUST be exactly 1, or the request \
+             is rejected with 400 -- `$top` is not honoured as a \
+             substitute.",
+            "integer",
+        )
+        .query_param("cursor", false, "Cursor for pagination")
         .with_odata_filter::<account_management_sdk::IdpUserFilterField>()
         .with_odata_orderby::<account_management_sdk::IdpUserFilterField>()
         .handler(handlers::list_users)
@@ -69,7 +82,7 @@ pub(super) fn register_users_routes(mut router: Router, openapi: &dyn OpenApiReg
              local user state -- the IdP becomes the source of truth on success. Returns \
              HTTP 201 Created with the projected user body. AM does NOT expose a per-user \
              GET; clients that need to re-read the user use the filtered listing \
-             `GET /tenants/{tenant_id}/users?$filter=id eq <uuid>&$top=1`.",
+             `GET /tenants/{tenant_id}/users?$filter=id eq <uuid>&limit=1`.",
         )
         .tag(API_TAG)
         .authenticated()
@@ -142,7 +155,13 @@ pub(super) fn register_users_routes(mut router: Router, openapi: &dyn OpenApiReg
              body projected through `gts.cf.core.am.user.v1~`. An empty patch is rejected \
              with `code=validation`. Unlike DELETE, a patch against a user the IdP reports \
              absent returns 404 -- it is NOT folded into success. A username rename that \
-             collides with an existing login returns 409.",
+             collides with an existing login returns 409. Attributes the provider manages \
+             and does not allow AM to override (e.g. federated from a read-only mapper) \
+             return 400 with one `context.field_violations[]` entry per refused property, \
+             each naming the refused request property in `.field` with \
+             `.reason=IDP_MANAGED_FIELD`, so a client can disable those inputs in one pass; \
+             this is deliberately NOT a 403, since writability is a property of the \
+             provider's schema rather than of the caller's grants.",
         )
         .tag(API_TAG)
         .authenticated()

--- a/gears/system/account-management/account-management/src/domain/error.rs
+++ b/gears/system/account-management/account-management/src/domain/error.rs
@@ -97,6 +97,47 @@ pub enum DomainError {
         field: Option<String>,
     },
 
+    /// The `IdP` rejected the supplied password against its configured
+    /// password policy. Distinct from [`Self::Validation`]
+    /// so the canonical envelope carries the structured
+    /// `password` / `PASSWORD_POLICY` field-violation tokens instead
+    /// of the generic `request` / `VALIDATION` pair — clients can
+    /// attribute the failure to the password input. The raw policy
+    /// text is redacted upstream (digest in `am.idp` logs); `detail`
+    /// is the curated public summary. Surfaces as HTTP 400
+    /// `invalid_argument`.
+    #[error("password rejected by IdP policy: {detail}")]
+    IdpPasswordPolicy { detail: String },
+
+    /// The `IdP` refused to write one or more patched attributes because
+    /// they are provider-managed and not overridable through AM
+    /// (federated from a read-only mapper, or marked non-writable in the
+    /// provider's user-profile configuration). Distinct from
+    /// [`Self::UnsupportedOperation`] (the provider implements no
+    /// `update_user` at all, HTTP 501) and from [`Self::Validation`]
+    /// (the *value* was rejected, not the field).
+    ///
+    /// Carries the typed attributes only — the boundary mapping derives
+    /// both each `field_violations[].field` token and the curated public
+    /// detail from them, so the wording lives in exactly one place and no
+    /// caller can pair an inconsistent detail/field. Surfaces as HTTP
+    /// 400 `invalid_argument` with `reason = "IDP_MANAGED_FIELD"`, one
+    /// violation per refused attribute, so a client learns the whole
+    /// refused set from a single round-trip.
+    ///
+    /// `fields` is non-empty by contract; the canonical mapping degrades
+    /// an empty set to the generic `request` / `VALIDATION` pair rather
+    /// than emitting a 400 that attributes the refusal to nothing.
+    ///
+    /// Deliberately NOT 403: writability is a property of the provider's
+    /// schema, identical for every caller, so no grant would make the
+    /// write succeed. Modelling it as a permission denial would make a
+    /// configuration fact look like a privilege problem.
+    #[error("IdP-managed fields not writable ({})", fields.iter().map(|f| f.as_field_token()).collect::<Vec<_>>().join(", "))]
+    IdpFieldNotWritable {
+        fields: Vec<account_management_sdk::IdpUserAttribute>,
+    },
+
     // ---- NotFound (HTTP 404) ----
     // For every variant in this group, `resource` is the stable id
     // surfaced through the AIP-193 `NotFound` envelope's `with_resource`,
@@ -167,18 +208,6 @@ pub enum DomainError {
     UserAlreadyExists {
         field: account_management_sdk::IdpUserDuplicateField,
     },
-
-    /// The `IdP` rejected the supplied password against its configured
-    /// password policy. Distinct from [`Self::Validation`]
-    /// so the canonical envelope carries the structured
-    /// `password` / `PASSWORD_POLICY` field-violation tokens instead
-    /// of the generic `request` / `VALIDATION` pair — clients can
-    /// attribute the failure to the password input. The raw policy
-    /// text is redacted upstream (digest in `am.idp` logs); `detail`
-    /// is the curated public summary. Surfaces as HTTP 400
-    /// `invalid_argument`.
-    #[error("password rejected by IdP policy: {detail}")]
-    IdpPasswordPolicy { detail: String },
 
     // ---- Aborted (HTTP 409) ----
     /// Retry-budget-exhausted serialization failure surfaced by

--- a/gears/system/account-management/account-management/src/domain/error_tests.rs
+++ b/gears/system/account-management/account-management/src/domain/error_tests.rs
@@ -318,6 +318,7 @@ impl DomainError {
             Self::AlreadyExists { .. } => "already_exists",
             Self::UserAlreadyExists { .. } => "user_already_exists",
             Self::IdpPasswordPolicy { .. } => "idp_password_policy",
+            Self::IdpFieldNotWritable { .. } => "idp_field_not_writable",
             Self::Aborted { .. } => "aborted",
             Self::TypeNotAllowed { .. } => "type_not_allowed",
             Self::TenantDepthExceeded { .. } => "tenant_depth_exceeded",
@@ -368,6 +369,7 @@ impl DomainError {
             | Self::AlreadyResolved
             | Self::Conflict { .. }
             | Self::IdpPasswordPolicy { .. }
+            | Self::IdpFieldNotWritable { .. }
             | Self::FeatureDisabled { .. } => 400,
             Self::NotFound { .. }
             | Self::UserNotFound { .. }

--- a/gears/system/account-management/account-management/src/domain/idp/mod.rs
+++ b/gears/system/account-management/account-management/src/domain/idp/mod.rs
@@ -281,6 +281,13 @@ impl ProvisionFailureExt for IdpProvisionFailure {
 ///   mapping refinement is owned by `feature-errors-observability`
 ///   and may diverge per provider in a follow-up. The Validation
 ///   surface is the most conservative public envelope today.
+/// * `FieldNotWritable` → [`DomainError::IdpFieldNotWritable`] (HTTP
+///   400). The attributes are provider-managed and not overridable, so
+///   the envelope carries one set of structured `<field>` /
+///   `IDP_MANAGED_FIELD` field-violation tokens per refused attribute
+///   rather than the generic `request` / `VALIDATION` pair. An empty
+///   refused set is a provider contract violation and degrades to
+///   [`DomainError::Validation`].
 ///
 /// Provider-supplied detail strings are redacted via
 /// [`redact_provider_detail`] before reaching public envelopes:
@@ -396,6 +403,43 @@ impl UserOperationFailureExt for IdpUserOperationFailure {
                     detail: "the supplied password does not meet the identity provider's password policy"
                         .to_owned(),
                 }
+            }
+            // Classified non-writable-attribute reject: surface one
+            // structured `<field>` / `IDP_MANAGED_FIELD` violation per
+            // refused attribute so a client can disable the exact
+            // inputs, instead of collapsing into the redacted generic
+            // Validation. The typed attributes are safe to log
+            // un-redacted (they are AM's own field tokens, not vendor
+            // text); only the provider `detail` is digested.
+            Self::FieldNotWritable { fields, detail } => {
+                let (digest, len) = redact_provider_detail(&detail);
+                // A provider MUST name what it refused; an empty set
+                // carries no attribution, so it degrades to the generic
+                // rejection rather than a 400 pointing at nothing.
+                if fields.is_empty() {
+                    tracing::warn!(
+                        target: "am.idp",
+                        tenant_id = %tenant_id,
+                        provider_detail_digest = digest,
+                        provider_detail_len = len,
+                        "IdP user operation FieldNotWritable with an empty field set (provider contract violation); surfacing Validation, raw detail redacted"
+                    );
+                    return DomainError::Validation {
+                        detail: format!(
+                            "identity provider rejected the user operation (detail redacted; \
+                             digest=0x{digest:016x} len={len})"
+                        ),
+                    };
+                }
+                tracing::warn!(
+                    target: "am.idp",
+                    tenant_id = %tenant_id,
+                    fields = fields.iter().map(|f| f.as_field_token()).collect::<Vec<_>>().join(","),
+                    provider_detail_digest = digest,
+                    provider_detail_len = len,
+                    "IdP user operation FieldNotWritable; surfacing IDP_MANAGED_FIELD violations, raw detail redacted"
+                );
+                DomainError::IdpFieldNotWritable { fields }
             }
             // Absent target user. `update_user` surfaces this as a
             // `404`; the shared mapping here carries no `user_id`, so

--- a/gears/system/account-management/account-management/src/domain/user/service.rs
+++ b/gears/system/account-management/account-management/src/domain/user/service.rs
@@ -638,6 +638,13 @@ impl UserService {
     ///   rejection (incl. rejected password).
     /// * [`DomainError::UserAlreadyExists`] -- a username rename
     ///   collided with an existing login (HTTP 409).
+    /// * [`DomainError::IdpFieldNotWritable`] -- the provider refused one
+    ///   or more patched attributes as `IdP`-managed and not overridable
+    ///   (HTTP 400, carrying every offending field as its own
+    ///   `field_violations[].field` with `reason =
+    ///   "IDP_MANAGED_FIELD"`). Distinct from
+    ///   [`DomainError::UnsupportedOperation`], which means the provider
+    ///   implements no `update_user` at all.
     /// * [`DomainError::UserNotFound`] -- the `IdP` reports the target
     ///   user absent in this tenant scope (HTTP 404).
     /// * [`DomainError::NotFound`] -- `tenant_id` does not resolve.

--- a/gears/system/account-management/account-management/src/infra/sdk_error_mapping.rs
+++ b/gears/system/account-management/account-management/src/infra/sdk_error_mapping.rs
@@ -70,6 +70,17 @@ pub(crate) struct TenantMetadataResource;
 #[resource_error(gts_id!("cf.core.am.conversion_request.v1~"))]
 pub(crate) struct ConversionRequestResource;
 
+/// Curated public `field_violations[].description` for one
+/// [`DomainError::IdpFieldNotWritable`] attribute. Derived from the typed
+/// attribute so the wording lives in exactly one place no matter how many
+/// attributes a single refusal carries, and no vendor text is echoed.
+fn idp_managed_field_description(attribute: account_management_sdk::IdpUserAttribute) -> String {
+    format!(
+        "the {} is managed by the identity provider and cannot be changed through this API",
+        attribute.as_human_phrase()
+    )
+}
+
 // ---------------------------------------------------------------------------
 // DomainError → CanonicalError (the single AIP-193 ladder).
 // ---------------------------------------------------------------------------
@@ -152,6 +163,48 @@ impl From<DomainError> for CanonicalError {
                     account_management_sdk::field::PASSWORD_POLICY,
                 )
                 .create(),
+            // IdP-managed attribute reject: each `field` token is the
+            // exact `UserUpdateRequest` property name, so a client keys
+            // form-field attribution off it and disables those inputs.
+            // One violation per refused attribute — a merge patch can
+            // touch several locked attributes at once and the client
+            // learns the whole refused set from this one response.
+            // The public description is derived from the typed attribute
+            // here (single source of wording — the variant carries no
+            // caller- or vendor-supplied string to echo). Duplicates a
+            // provider may repeat collapse to one violation each.
+            DomainError::IdpFieldNotWritable { fields } => {
+                let mut seen = std::collections::HashSet::new();
+                let mut refused = fields.into_iter().filter(|a| seen.insert(*a));
+                match refused.next() {
+                    Some(first) => {
+                        let mut builder = UserResource::invalid_argument().with_field_violation(
+                            first.as_field_token(),
+                            idp_managed_field_description(first),
+                            account_management_sdk::field::IDP_MANAGED_FIELD,
+                        );
+                        for attribute in refused {
+                            builder = builder.with_field_violation(
+                                attribute.as_field_token(),
+                                idp_managed_field_description(attribute),
+                                account_management_sdk::field::IDP_MANAGED_FIELD,
+                            );
+                        }
+                        builder.create()
+                    }
+                    // Contract violation — the variant documents a
+                    // non-empty set. A 400 whose `field_violations[]` is
+                    // empty attributes the refusal to nothing, so degrade
+                    // to the generic `request` / `VALIDATION` pair.
+                    None => UserResource::invalid_argument()
+                        .with_field_violation(
+                            field::REQUEST_FIELD,
+                            "the identity provider refused the update",
+                            field::VALIDATION,
+                        )
+                        .create(),
+                }
+            }
 
             // ---- NotFound (HTTP 404) — one resource per variant ----
             DomainError::NotFound { detail, resource } => TenantResource::not_found(detail)

--- a/gears/system/account-management/account-management/src/infra/sdk_error_mapping_tests.rs
+++ b/gears/system/account-management/account-management/src/infra/sdk_error_mapping_tests.rs
@@ -338,6 +338,143 @@ fn idp_password_policy_maps_to_400_with_password_field_violation() {
     );
 }
 
+/// An `IdP`-managed attribute reject lands on 400 `invalid_argument`
+/// carrying the *patched property's own name* as
+/// `field_violations[].field` plus the `IDP_MANAGED_FIELD` reason, so a
+/// client can disable exactly that form input. Every
+/// [`account_management_sdk::IdpUserAttribute`] is exercised: the field
+/// token MUST equal the `UserUpdateRequest` JSON property name, because
+/// clients key form-field attribution off that string.
+///
+/// The `description` is pinned to the exact curated sentence, not merely
+/// checked non-empty: the typed-attribute design exists so the public
+/// wording lives in one place and cannot drift, which only holds if the
+/// wording is asserted somewhere.
+#[test]
+fn idp_field_not_writable_maps_to_400_with_the_patched_field_violation() {
+    for (attribute, expected_field, expected_description) in [
+        (
+            account_management_sdk::IdpUserAttribute::Username,
+            "username",
+            "the username is managed by the identity provider and cannot be changed through this API",
+        ),
+        (
+            account_management_sdk::IdpUserAttribute::Email,
+            "email",
+            "the email address is managed by the identity provider and cannot be changed through this API",
+        ),
+        (
+            account_management_sdk::IdpUserAttribute::DisplayName,
+            "display_name",
+            "the display name is managed by the identity provider and cannot be changed through this API",
+        ),
+        (
+            account_management_sdk::IdpUserAttribute::FirstName,
+            "first_name",
+            "the first name is managed by the identity provider and cannot be changed through this API",
+        ),
+        (
+            account_management_sdk::IdpUserAttribute::LastName,
+            "last_name",
+            "the last name is managed by the identity provider and cannot be changed through this API",
+        ),
+    ] {
+        let canonical = round_trip(DomainError::IdpFieldNotWritable {
+            fields: vec![attribute],
+        });
+        assert_eq!(
+            canonical.status_code(),
+            400,
+            "{expected_field}: writability is a field capability, not an authz decision -- \
+             it MUST NOT surface as 403"
+        );
+        assert_eq!(
+            canonical.resource_type(),
+            Some(account_management_sdk::gts::USER_RESOURCE_TYPE)
+        );
+        let CanonicalError::InvalidArgument { ctx, .. } = canonical else {
+            panic!("{expected_field}: expected CanonicalError::InvalidArgument");
+        };
+        let InvalidArgument::FieldViolations { field_violations } = ctx else {
+            panic!("{expected_field}: expected InvalidArgument::FieldViolations ctx");
+        };
+        assert_eq!(field_violations.len(), 1);
+        assert_eq!(
+            field_violations[0].field, expected_field,
+            "field token MUST match the UserUpdateRequest property name"
+        );
+        assert_eq!(
+            field_violations[0].reason,
+            account_management_sdk::field::IDP_MANAGED_FIELD
+        );
+        assert_eq!(
+            field_violations[0].description, expected_description,
+            "{expected_field}: the curated public wording is a contract -- it lives in exactly \
+             one place and MUST NOT drift"
+        );
+    }
+}
+
+/// A patch touching several locked attributes yields one violation per
+/// refused attribute in a single envelope, so the client learns the whole
+/// refused set from one round-trip instead of discovering it field by
+/// field. Repeats a provider may send collapse to one violation each.
+#[test]
+fn idp_field_not_writable_emits_one_violation_per_refused_attribute() {
+    let canonical = round_trip(DomainError::IdpFieldNotWritable {
+        fields: vec![
+            account_management_sdk::IdpUserAttribute::Email,
+            account_management_sdk::IdpUserAttribute::FirstName,
+            account_management_sdk::IdpUserAttribute::LastName,
+            account_management_sdk::IdpUserAttribute::Email,
+        ],
+    });
+    assert_eq!(canonical.status_code(), 400);
+    let CanonicalError::InvalidArgument { ctx, .. } = canonical else {
+        panic!("expected CanonicalError::InvalidArgument");
+    };
+    let InvalidArgument::FieldViolations { field_violations } = ctx else {
+        panic!("expected InvalidArgument::FieldViolations ctx");
+    };
+    let fields: Vec<&str> = field_violations.iter().map(|v| v.field.as_str()).collect();
+    assert_eq!(
+        fields,
+        ["email", "first_name", "last_name"],
+        "every refused attribute MUST get its own violation, de-duplicated"
+    );
+    assert!(
+        field_violations
+            .iter()
+            .all(|v| v.reason == account_management_sdk::field::IDP_MANAGED_FIELD),
+        "every violation in the set carries the IDP_MANAGED_FIELD reason"
+    );
+}
+
+/// An empty refused set is a provider contract violation. A 400 whose
+/// `field_violations[]` is empty attributes the refusal to nothing, so
+/// the mapping degrades to the generic `request` / `VALIDATION` pair
+/// rather than emitting an unattributable `IDP_MANAGED_FIELD`.
+#[test]
+fn idp_field_not_writable_with_no_attributes_degrades_to_the_generic_violation() {
+    let canonical = round_trip(DomainError::IdpFieldNotWritable { fields: Vec::new() });
+    assert_eq!(canonical.status_code(), 400);
+    let CanonicalError::InvalidArgument { ctx, .. } = canonical else {
+        panic!("expected CanonicalError::InvalidArgument");
+    };
+    let InvalidArgument::FieldViolations { field_violations } = ctx else {
+        panic!("expected InvalidArgument::FieldViolations ctx");
+    };
+    assert_eq!(field_violations.len(), 1);
+    assert_eq!(
+        field_violations[0].field,
+        account_management_sdk::field::REQUEST_FIELD
+    );
+    assert_eq!(
+        field_violations[0].reason,
+        account_management_sdk::field::VALIDATION
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Aborted (HTTP 409 with reason)
 // ---------------------------------------------------------------------------

--- a/gears/system/account-management/account-management/tests/api_users_test.rs
+++ b/gears/system/account-management/account-management/tests/api_users_test.rs
@@ -671,6 +671,185 @@ async fn update_user_rename_collision_returns_409() {
 }
 
 #[tokio::test]
+async fn update_user_idp_managed_field_returns_400_naming_the_locked_field() {
+    // A provider that federates `email` from a read-only mapper refuses
+    // the write. AM MUST surface a 400 whose `field_violations[0]` names
+    // the exact request property (`email`) with reason
+    // `IDP_MANAGED_FIELD`, so the caller can disable that one input
+    // rather than guessing from `detail`.
+    //
+    // Explicitly NOT 403: writability is a property of the provider's
+    // schema, identical for every caller — no grant makes it succeed.
+    let h = setup_sqlite().await.expect("sqlite");
+    let root = Uuid::new_v4();
+    seed_root(&h, root).await;
+    let services = build_services_full(
+        &h,
+        fake_idp_with_locked_attribute(account_management_sdk::IdpUserAttribute::Email),
+        empty_metadata_registry(),
+        types_registry_for_users(),
+    );
+    let router = build_test_router(&services);
+
+    let id = provision_and_id(&router, root, serde_json::json!({ "username": "alice" })).await;
+
+    let req = json_request(
+        "PATCH",
+        &format!("/account-management/v1/tenants/{root}/users/{id}"),
+        Some(serde_json::json!({ "email": "new@example.com" })),
+        ctx_for(root),
+    );
+    let resp = router.oneshot(req).await.expect("router");
+    let (status, body) = response_problem(resp).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "IdP-managed field reject MUST be 400, not 403/422: {body}"
+    );
+    assert_eq!(
+        body["context"]["field_violations"][0]["field"], "email",
+        "the violation MUST name the patched property so a client can disable that input: {body}"
+    );
+    assert_eq!(
+        body["context"]["field_violations"][0]["reason"], "IDP_MANAGED_FIELD",
+        "reason MUST be the stable IDP_MANAGED_FIELD token: {body}"
+    );
+}
+
+#[tokio::test]
+async fn update_user_idp_managed_field_refuses_an_explicit_null_clear() {
+    // The refusal is scoped to attributes the patch *touches*, and an
+    // explicit `null` (clear) touches the attribute just as much as a
+    // value does. This is the shape where the REST-DTO lowering could
+    // silently collapse `Some(None)` to `None` and bypass the refusal
+    // entirely, so the clear path is pinned to the same 400 / `email` /
+    // `IDP_MANAGED_FIELD` triple as the set-a-value path.
+    let h = setup_sqlite().await.expect("sqlite");
+    let root = Uuid::new_v4();
+    seed_root(&h, root).await;
+    let services = build_services_full(
+        &h,
+        fake_idp_with_locked_attribute(account_management_sdk::IdpUserAttribute::Email),
+        empty_metadata_registry(),
+        types_registry_for_users(),
+    );
+    let router = build_test_router(&services);
+
+    let id = provision_and_id(&router, root, serde_json::json!({ "username": "alice" })).await;
+
+    let req = json_request(
+        "PATCH",
+        &format!("/account-management/v1/tenants/{root}/users/{id}"),
+        Some(serde_json::json!({ "email": null })),
+        ctx_for(root),
+    );
+    let resp = router.oneshot(req).await.expect("router");
+    let (status, body) = response_problem(resp).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "clearing a locked attribute MUST be refused exactly like setting it: {body}"
+    );
+    assert_eq!(
+        body["context"]["field_violations"][0]["field"], "email",
+        "the explicit-null clear MUST survive DTO lowering and name `email`: {body}"
+    );
+    assert_eq!(
+        body["context"]["field_violations"][0]["reason"], "IDP_MANAGED_FIELD",
+        "reason MUST be the stable IDP_MANAGED_FIELD token: {body}"
+    );
+}
+
+#[tokio::test]
+async fn update_user_idp_managed_fields_are_all_reported_in_one_response() {
+    // A realm that federates a block of profile attributes locks several
+    // at once. A patch touching more than one MUST come back naming every
+    // offender, so the caller disables them in one pass instead of
+    // rediscovering the next one on each retry.
+    let h = setup_sqlite().await.expect("sqlite");
+    let root = Uuid::new_v4();
+    seed_root(&h, root).await;
+    let services = build_services_full(
+        &h,
+        fake_idp_with_locked_attributes([
+            account_management_sdk::IdpUserAttribute::Email,
+            account_management_sdk::IdpUserAttribute::FirstName,
+            account_management_sdk::IdpUserAttribute::LastName,
+        ]),
+        empty_metadata_registry(),
+        types_registry_for_users(),
+    );
+    let router = build_test_router(&services);
+
+    let id = provision_and_id(&router, root, serde_json::json!({ "username": "alice" })).await;
+
+    let req = json_request(
+        "PATCH",
+        &format!("/account-management/v1/tenants/{root}/users/{id}"),
+        Some(serde_json::json!({
+            "email": "new@example.com",
+            "first_name": "Alice",
+            "display_name": "Alice A."
+        })),
+        ctx_for(root),
+    );
+    let resp = router.oneshot(req).await.expect("router");
+    let (status, body) = response_problem(resp).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+
+    let violations = body["context"]["field_violations"]
+        .as_array()
+        .unwrap_or_else(|| panic!("field_violations MUST be an array: {body}"));
+    let refused: Vec<&str> = violations
+        .iter()
+        .map(|v| v["field"].as_str().unwrap_or_default())
+        .collect();
+    assert_eq!(
+        refused,
+        ["email", "first_name"],
+        "every touched locked attribute MUST be named -- and only those: \
+         `last_name` is locked but untouched, `display_name` is touched but writable: {body}"
+    );
+    assert!(
+        violations
+            .iter()
+            .all(|v| v["reason"] == "IDP_MANAGED_FIELD"),
+        "every violation MUST carry the stable IDP_MANAGED_FIELD token: {body}"
+    );
+}
+
+#[tokio::test]
+async fn update_user_untouched_locked_field_still_succeeds() {
+    // The refusal is scoped to *touched* attributes: with `email`
+    // locked, a patch that only sets `first_name` MUST still apply.
+    // Guards against a guard that rejects on provider policy alone
+    // rather than on the intersection with the patch.
+    let h = setup_sqlite().await.expect("sqlite");
+    let root = Uuid::new_v4();
+    seed_root(&h, root).await;
+    let services = build_services_full(
+        &h,
+        fake_idp_with_locked_attribute(account_management_sdk::IdpUserAttribute::Email),
+        empty_metadata_registry(),
+        types_registry_for_users(),
+    );
+    let router = build_test_router(&services);
+
+    let id = provision_and_id(&router, root, serde_json::json!({ "username": "alice" })).await;
+
+    let req = json_request(
+        "PATCH",
+        &format!("/account-management/v1/tenants/{root}/users/{id}"),
+        Some(serde_json::json!({ "first_name": "Alice" })),
+        ctx_for(root),
+    );
+    let resp = router.oneshot(req).await.expect("router");
+    let (status, body) = response_problem(resp).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["first_name"], "Alice");
+}
+
+#[tokio::test]
 async fn update_user_unknown_user_returns_404() {
     // Unlike DELETE, a PATCH against an absent user is a 404 — the
     // provider's NotFound is NOT folded into success.

--- a/gears/system/account-management/account-management/tests/common/mod.rs
+++ b/gears/system/account-management/account-management/tests/common/mod.rs
@@ -726,7 +726,7 @@ use account_management::infra::storage::repo_impl::{ConversionRepoImpl, Metadata
 use account_management_sdk::{
     IdpDeprovisionTenantRequest, IdpDeprovisionUserRequest, IdpListUsersRequest, IdpPluginClient,
     IdpProvisionFailure, IdpProvisionResult, IdpProvisionTenantRequest, IdpProvisionUserRequest,
-    IdpUpdateUserRequest, IdpUser, IdpUserDuplicateField, IdpUserFilterField,
+    IdpUpdateUserRequest, IdpUser, IdpUserAttribute, IdpUserDuplicateField, IdpUserFilterField,
     IdpUserOperationFailure,
 };
 use axum::Router;
@@ -795,6 +795,14 @@ pub struct FakeIdpPlugin {
     users: parking_lot::Mutex<
         std::collections::HashMap<Uuid, std::collections::HashMap<Uuid, IdpUser>>,
     >,
+    /// Attributes this provider refuses to write, standing in for a
+    /// realm that federates them from a read-only LDAP mapper (or marks
+    /// them non-writable in its user-profile config). Empty by default
+    /// so every existing test sees a fully-writable provider; opt in via
+    /// [`Self::with_locked_attribute`]. A `HashSet` — the natural shape
+    /// for a provider's non-writable set, and what the `Hash` bound on
+    /// the public SDK enum exists for.
+    locked_attributes: std::collections::HashSet<IdpUserAttribute>,
 }
 
 impl FakeIdpPlugin {
@@ -802,7 +810,40 @@ impl FakeIdpPlugin {
     pub fn new() -> Self {
         Self {
             users: parking_lot::Mutex::new(std::collections::HashMap::new()),
+            locked_attributes: std::collections::HashSet::new(),
         }
+    }
+
+    /// Mark `attribute` as IdP-managed: `update_user` then refuses any
+    /// patch touching it with
+    /// [`IdpUserOperationFailure::FieldNotWritable`].
+    #[must_use]
+    pub fn with_locked_attribute(mut self, attribute: IdpUserAttribute) -> Self {
+        self.locked_attributes.insert(attribute);
+        self
+    }
+
+    /// Every locked attribute the patch tries to write. Checked against
+    /// the *touched* fields (`Some(_)`, including an explicit clear) —
+    /// refusing a locked attribute does not depend on whether the caller
+    /// set or cleared it. Returns the full set (not the first hit) so a
+    /// patch touching several locked attributes is refused in one
+    /// round-trip, matching the `FieldNotWritable` contract.
+    fn locked_attributes_in(
+        &self,
+        patch: &account_management_sdk::IdpUserPatch,
+    ) -> Vec<IdpUserAttribute> {
+        [
+            (IdpUserAttribute::Username, patch.username.is_some()),
+            (IdpUserAttribute::Email, patch.email.is_some()),
+            (IdpUserAttribute::DisplayName, patch.display_name.is_some()),
+            (IdpUserAttribute::FirstName, patch.first_name.is_some()),
+            (IdpUserAttribute::LastName, patch.last_name.is_some()),
+        ]
+        .into_iter()
+        .filter(|(attribute, touched)| *touched && self.locked_attributes.contains(attribute))
+        .map(|(attribute, _)| attribute)
+        .collect()
     }
 
     fn build_user(tenant_id: Uuid, req: &IdpProvisionUserRequest) -> IdpUser {
@@ -897,6 +938,24 @@ impl IdpPluginClient for FakeIdpPlugin {
                 detail: format!("user {} not found in tenant {tenant_id}", req.user_id),
             });
         }
+        // Refuse IdP-managed attributes before the uniqueness check: a
+        // locked field cannot be written whatever the new value is, so
+        // whether it would also collide is moot.
+        let locked = self.locked_attributes_in(&req.patch);
+        if !locked.is_empty() {
+            let detail = format!(
+                "attributes {} are read-only (federated from a read-only mapper)",
+                locked
+                    .iter()
+                    .map(|a| a.as_field_token())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+            return Err(IdpUserOperationFailure::FieldNotWritable {
+                fields: locked,
+                detail,
+            });
+        }
         // Username uniqueness on rename, checked against OTHER users.
         if let Some(new_username) = &req.patch.username
             && scope
@@ -988,6 +1047,28 @@ impl IdpPluginClient for FakeIdpPlugin {
 #[must_use]
 pub fn fake_idp() -> Arc<dyn IdpPluginClient> {
     Arc::new(FakeIdpPlugin::new())
+}
+
+/// [`fake_idp`] with `attribute` marked IdP-managed, so any patch
+/// touching it is refused with
+/// [`IdpUserOperationFailure::FieldNotWritable`].
+#[must_use]
+pub fn fake_idp_with_locked_attribute(attribute: IdpUserAttribute) -> Arc<dyn IdpPluginClient> {
+    Arc::new(FakeIdpPlugin::new().with_locked_attribute(attribute))
+}
+
+/// [`fake_idp`] with several attributes marked IdP-managed, standing in
+/// for a realm that federates a whole block of profile attributes from a
+/// read-only mapper. A patch touching more than one of them is refused
+/// once, naming every offender.
+#[must_use]
+pub fn fake_idp_with_locked_attributes(
+    attributes: impl IntoIterator<Item = IdpUserAttribute>,
+) -> Arc<dyn IdpPluginClient> {
+    let plugin = attributes
+        .into_iter()
+        .fold(FakeIdpPlugin::new(), FakeIdpPlugin::with_locked_attribute);
+    Arc::new(plugin)
 }
 
 // ── Inert collaborators (resource checker, types registry) ───────────

--- a/gears/system/account-management/docs/account-management-v1.yaml
+++ b/gears/system/account-management/docs/account-management-v1.yaml
@@ -348,6 +348,19 @@ paths:
         (`code=already_exists`). Unsupported by a legacy provider surfaces as
         `code=idp_unsupported_operation` (501); IdP transport failure as
         `code=idp_unavailable` (503).
+
+        An attribute the IdP manages and does not allow AM to override — e.g.
+        federated from a read-only LDAP mapper, or marked non-writable in the
+        provider's user-profile configuration — is refused with
+        `code=validation` (400) whose `context.field_violations[0]` carries
+        `field` = the refused request property (`username`, `email`,
+        `display_name`, `first_name`, or `last_name`) and
+        `reason=IDP_MANAGED_FIELD`. Clients key form-field attribution off
+        `field` and disable exactly that input. Deliberately NOT a 403:
+        writability is a property of the provider's schema, identical for
+        every caller, so no additional grant would let the write succeed. The
+        refusal is scoped to attributes the patch actually touches — a patch
+        that omits a locked attribute still applies.
       requestBody:
         required: true
         content:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clear validation responses when updating identity-provider-managed, non-writable user fields.
  * Identifies all affected fields with HTTP 400 errors and structured `IDP_MANAGED_FIELD` details.
  * Allows updates to other writable fields when managed fields are locked.

* **Documentation**
  * Updated API documentation with managed-field validation behavior and error-response examples.
  * Clarified point lookups using `limit=1`.

* **Bug Fixes**
  * Preserved provider error details while preventing sensitive information from appearing in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->