### PR TITLE
ci(coverage): fix Codecov upload for fork PRs via OIDC + v7 upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,13 +394,31 @@ jobs:
           cargo llvm-cov clean --workspace
           cargo llvm-cov nextest --workspace --lcov --output-path lcov.info
 
-      # Upload to Codecov; do not fail CI if Codecov is down/misconfigured.
-      - name: Upload to Codecov
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+      # Upload LCOV report as a GitHub Actions artifact so it is always
+      # available, even when Codecov is unavailable or rejects the upload.
+      - name: Upload LCOV artifact
+        if: always()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
+          name: rust-coverage-lcov
+          path: lcov.info
+          if-no-files-found: error
+          retention-days: 14
+
+      # Upload to Codecov. OIDC is used for non-fork events (push, dispatch);
+      # for fork PRs the action auto-detects the fork and falls back to
+      # tokenless upload (GitHub does not grant id-token:write for forks).
+      # fail_ci_if_error is true for non-fork events so upload failures are
+      # visible; for fork PRs it is best-effort (tokenless can be rate-limited).
+      # disable_search prevents auto-discovery of unrelated files (e.g.
+      # coverage_guard.rs) — only lcov.info is sent.
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          use_oidc: ${{ github.event_name != 'pull_request' }}
           files: lcov.info
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}  # Uncomment if required for private repos
+          disable_search: true
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' }}
 
   dylint:
     name: Dylint Tests

--- a/libs/toolkit/tests/lifecycle_macro_tests.rs
+++ b/libs/toolkit/tests/lifecycle_macro_tests.rs
@@ -42,8 +42,13 @@ async fn stays_starting_until_ready_signal() {
 
     // Should be Starting until ReadySignal triggers inside the method
     assert_eq!(m.status(), Status::Starting);
-    tokio::time::sleep(Duration::from_millis(40)).await;
-    assert_eq!(m.status(), Status::Running);
+    tokio::time::timeout(Duration::from_millis(500), async {
+        while !matches!(m.status(), Status::Running) {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("gear did not become Running within 500 ms");
 
     parent.cancel();
     m.stop(CancellationToken::new()).await.unwrap();
@@ -54,10 +59,17 @@ async fn stays_starting_until_ready_signal() {
 async fn auto_notify_when_no_ready_param() {
     let m = AutoNotify.into_gear();
     let parent = CancellationToken::new();
+
     m.start(parent.clone()).await.unwrap();
-    // Await-ready=true but method has no ReadySignal -> auto-notify -> Running quickly
-    tokio::time::sleep(Duration::from_millis(5)).await;
-    assert!(matches!(m.status(), Status::Running | Status::Starting));
+    // await_ready=true, but the method has no ReadySignal parameter,
+    // so readiness must be reported automatically.
+    tokio::time::timeout(Duration::from_millis(500), async {
+        while !matches!(m.status(), Status::Running) {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("gear did not become Running after automatic readiness notification");
 
     parent.cancel();
     m.stop(CancellationToken::new()).await.unwrap();


### PR DESCRIPTION
- Upgrade codecov/codecov-action from v4.6.0 to v7.0.0 (pinned SHA)
- Switch to OIDC auth (use_oidc) for non-PR events; tokenless for fork PRs
- Remove obsolete CODECOV_TOKEN secret input
- Add disable_search: true to prevent auto-discovery of unrelated files
- Set fail_ci_if_error: true for non-PR events; best-effort for fork PRs
- Add Upload LCOV artifact step (actions/upload-artifact v4.6.1, pinned SHA) before Codecov upload so lcov.info is retained even if Codecov rejects it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved code coverage reporting reliability.
  * Coverage reports are now retained as build artifacts for a limited period.
  * Updated coverage upload handling across pull requests and other workflow runs.

* **Tests**
  * Improved lifecycle test stability by waiting for confirmed readiness.
  * Added verification for automatic transitions to the running state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->