### PR TITLE
fix: match companion DESIGN documents in artifact autodetection

### DIFF
--- a/.cf-studio/config/artifacts.toml
+++ b/.cf-studio/config/artifacts.toml
@@ -123,8 +123,14 @@ pattern = "PRD.md"
 traceability = "FULL"
 required = true
 
+# Glob (not a literal name) so a gear may ship companion design documents
+# alongside DESIGN.md — DESIGN-<aspect>.md, for an aspect large enough to
+# carve out of the main design and own its own artifact. Each match is
+# validated as a full DESIGN artifact against the kit constraints.
+# Files that are NOT standalone SDLC artifacts must be listed in [[ignore]]
+# above; ignore takes precedence over this pattern.
 [systems.autodetect.artifacts.DESIGN]
-pattern = "DESIGN.md"
+pattern = "DESIGN*.md"
 traceability = "FULL"
 required = false
 


### PR DESCRIPTION
## Problem

A gear that splits its design across more than one document had no way to get the companion document validated.

Autodetect matched the literal `DESIGN.md`, and it does not pass over what it cannot match — any markdown under an `artifacts_root` matching no artifact pattern is an error:

```
Unmatched markdown under artifacts_root:
path=gears/<gear>/docs/DESIGN_<aspect>.md
```

The only escape was `[[ignore]]` (or keeping the document outside the artifacts root), and that silences the error by excluding the file from **every** structure, cross-reference and traceability check. So a companion design could be **rejected** or **unchecked** — never validated.

The `[[ignore]]` entry already in this config for `serverless-runtime`'s two companion designs is exactly that workaround, not a statement that those documents need no checking.

## Change

`.cf-studio/config/artifacts.toml`, the `cf-gears` autodetect block only:

```diff
 [systems.autodetect.artifacts.DESIGN]
-pattern = "DESIGN.md"
+pattern = "DESIGN*.md"
```

Every match is validated as a full DESIGN artifact against the kit constraints. `[[ignore]]` keeps its proper role for files that sit beside `DESIGN.md` without being standalone SDLC artifacts, and still takes precedence over the pattern — that precedence is now written down next to the pattern instead of left to be rediscovered.

The other six systems in this file are untouched.

## Verification

Measured on this branch by temporarily lifting the `serverless-runtime` ignore entry and running `cfs validate` under both patterns:

| pattern | ignore lifted | artifacts | result |
|---|---|---|---|
| `DESIGN.md` (before) | yes | 220 | **2 errors** — `Unmatched markdown under artifacts_root` |
| `DESIGN*.md` (after) | yes | **222** | 26 errors — real structure checks on the two documents |

With the ignore entry left in place, as committed: `cfs validate` → **0 errors, 220 artifacts**.

## Heads-up for reviewers

This does not un-ignore anything by itself. It makes un-ignoring possible, and the `serverless-runtime` entry is now worth revisiting on its own merits — the table above shows those two documents currently fail 26 structure checks, because they have never been checked.

Expect the same on any gear whose companion design gets picked up for the first time. Missing `cpt-*` identifiers are the likely first hit: traceability rests on them and nothing was enforcing them there.
