### PR TITLE
docs(keycloak-idp-plugin): add PRD and Design Document

### DIFF
--- a/.cf-studio/config/artifacts.toml
+++ b/.cf-studio/config/artifacts.toml
@@ -61,22 +61,6 @@ patterns = ["gears/system/oagw/docs/adr-*.md"]
 
 
 [[ignore]]
-# Guardrail record (registry/autodetect ignore change).
-# Guardrail: gears/system/$system autodetect requires a PRD per module.
-# Rationale: 'service-principal' ships only the SDK contract crate (no gear
-#   implementation, no REST surface); its consumer-facing lifecycle owner is
-#   undecided, so no PRD/DESIGN can be authored yet. The
-#   contract is documented in the Keycloak IdP plugin's PRD §5.4 and DESIGN §3.2,
-#   which allocate every service-principal requirement.
-# Owner: @platform-iam-team (owner of record in the Keycloak IdP plugin DESIGN).
-# Validation: `make cfs-validate` passes with 0 errors; the ignore is scoped to
-#   this subtree only and does not widen any sibling module's scope.
-# Removal condition: drop this entry when the service-principal lifecycle owner
-#   is selected and the module gains its own PRD (tracked as PRD open question 4).
-reason = "Ignore module 'service-principal' (SDK-only contract crate; not SDLC-documented yet: missing required PRD/DESIGN). Owner: @platform-iam-team. Requirements are allocated in the Keycloak IdP plugin PRD §5.4 / DESIGN §3.2 until the lifecycle owner is selected."
-patterns = ["gears/system/service-principal/*"]
-
-[[ignore]]
 reason = "Ignore module 'tenant-resolver' (not SDLC-documented yet: missing required PRD/DESIGN)."
 patterns = ["gears/system/tenant-resolver/*"]
 

--- a/.cf-studio/config/artifacts.toml
+++ b/.cf-studio/config/artifacts.toml
@@ -63,9 +63,9 @@ patterns = ["gears/system/oagw/docs/adr-*.md"]
 [[ignore]]
 # Guardrail record (registry/autodetect ignore change).
 # Guardrail: gears/system/$system autodetect requires a PRD per module.
-# Rationale: 'service-principal' ships only the SDK contract crate ported from
-#   vhp-core (no gear implementation, no REST surface); its consumer-facing
-#   lifecycle owner is undecided, so no PRD/DESIGN can be authored yet. The
+# Rationale: 'service-principal' ships only the SDK contract crate (no gear
+#   implementation, no REST surface); its consumer-facing lifecycle owner is
+#   undecided, so no PRD/DESIGN can be authored yet. The
 #   contract is documented in the Keycloak IdP plugin's PRD §5.4 and DESIGN §3.2,
 #   which allocate every service-principal requirement.
 # Owner: @platform-iam-team (owner of record in the Keycloak IdP plugin DESIGN).
@@ -73,7 +73,7 @@ patterns = ["gears/system/oagw/docs/adr-*.md"]
 #   this subtree only and does not widen any sibling module's scope.
 # Removal condition: drop this entry when the service-principal lifecycle owner
 #   is selected and the module gains its own PRD (tracked as PRD open question 4).
-reason = "Ignore module 'service-principal' (SDK-only contract crate ported from vhp-core; not SDLC-documented yet: missing required PRD/DESIGN). Owner: @platform-iam-team. Requirements are allocated in the Keycloak IdP plugin PRD §5.4 / DESIGN §3.2 until the lifecycle owner is selected."
+reason = "Ignore module 'service-principal' (SDK-only contract crate; not SDLC-documented yet: missing required PRD/DESIGN). Owner: @platform-iam-team. Requirements are allocated in the Keycloak IdP plugin PRD §5.4 / DESIGN §3.2 until the lifecycle owner is selected."
 patterns = ["gears/system/service-principal/*"]
 
 [[ignore]]

--- a/.cf-studio/config/artifacts.toml
+++ b/.cf-studio/config/artifacts.toml
@@ -326,6 +326,43 @@ require_kind_registered_in_kit = true
 require_md_extension = true
 fail_on_unmatched_markdown = true
 
+# Nested sub-plugin scope: Keycloak IdP plugin carries its own PRD/DESIGN/DECOMPOSITION
+# under gears/system/account-management/plugins/keycloak-idp-plugin/docs.
+[[systems.autodetect.children]]
+kit = "gears"
+system_root = "{project_root}/gears/system/account-management/plugins/keycloak-idp-plugin/docs"
+artifacts_root = "{system_root}"
+
+[systems.autodetect.children.artifacts.PRD]
+pattern = "PRD.md"
+traceability = "DOCS-ONLY"
+required = false
+
+[systems.autodetect.children.artifacts.DESIGN]
+pattern = "DESIGN.md"
+traceability = "DOCS-ONLY"
+required = false
+
+[systems.autodetect.children.artifacts.ADR]
+pattern = "ADR/*.md"
+traceability = "DOCS-ONLY"
+required = false
+
+[systems.autodetect.children.artifacts.DECOMPOSITION]
+pattern = "DECOMPOSITION.md"
+traceability = "DOCS-ONLY"
+required = false
+
+[systems.autodetect.children.artifacts.FEATURE]
+pattern = "features/*.md"
+traceability = "DOCS-ONLY"
+required = false
+
+[systems.autodetect.children.validation]
+require_kind_registered_in_kit = true
+require_md_extension = true
+fail_on_unmatched_markdown = true
+
 # Nested sub-plugin scope: OIDC AuthN plugin carries its own PRD/DESIGN/DECOMPOSITION
 # under gears/system/authn-resolver/plugins/oidc-authn-plugin/docs.
 [[systems.autodetect.children]]

--- a/.cf-studio/config/artifacts.toml
+++ b/.cf-studio/config/artifacts.toml
@@ -61,6 +61,10 @@ patterns = ["gears/system/oagw/docs/adr-*.md"]
 
 
 [[ignore]]
+reason = "Ignore module 'service-principal' (SDK-only contract crate ported from vhp-core; not SDLC-documented yet: missing required PRD/DESIGN)."
+patterns = ["gears/system/service-principal/*"]
+
+[[ignore]]
 reason = "Ignore module 'tenant-resolver' (not SDLC-documented yet: missing required PRD/DESIGN)."
 patterns = ["gears/system/tenant-resolver/*"]
 

--- a/.cf-studio/config/artifacts.toml
+++ b/.cf-studio/config/artifacts.toml
@@ -61,7 +61,19 @@ patterns = ["gears/system/oagw/docs/adr-*.md"]
 
 
 [[ignore]]
-reason = "Ignore module 'service-principal' (SDK-only contract crate ported from vhp-core; not SDLC-documented yet: missing required PRD/DESIGN)."
+# Guardrail record (registry/autodetect ignore change).
+# Guardrail: gears/system/$system autodetect requires a PRD per module.
+# Rationale: 'service-principal' ships only the SDK contract crate ported from
+#   vhp-core (no gear implementation, no REST surface); its consumer-facing
+#   lifecycle owner is undecided, so no PRD/DESIGN can be authored yet. The
+#   contract is documented in the Keycloak IdP plugin's PRD §5.4 and DESIGN §3.2,
+#   which allocate every service-principal requirement.
+# Owner: @platform-iam-team (owner of record in the Keycloak IdP plugin DESIGN).
+# Validation: `make cfs-validate` passes with 0 errors; the ignore is scoped to
+#   this subtree only and does not widen any sibling module's scope.
+# Removal condition: drop this entry when the service-principal lifecycle owner
+#   is selected and the module gains its own PRD (tracked as PRD open question 4).
+reason = "Ignore module 'service-principal' (SDK-only contract crate ported from vhp-core; not SDLC-documented yet: missing required PRD/DESIGN). Owner: @platform-iam-team. Requirements are allocated in the Keycloak IdP plugin PRD §5.4 / DESIGN §3.2 until the lifecycle owner is selected."
 patterns = ["gears/system/service-principal/*"]
 
 [[ignore]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9495,6 +9495,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "service-principal"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "cf-gears-authz-resolver",
+ "cf-gears-authz-resolver-sdk",
+ "cf-gears-toolkit",
+ "cf-gears-toolkit-canonical-errors",
+ "cf-gears-toolkit-gts",
+ "cf-gears-toolkit-macros",
+ "cf-gears-toolkit-security",
+ "cf-gears-types-registry",
+ "gts",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "service-principal-sdk",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tracing",
+ "utoipa",
+ "uuid",
+]
+
+[[package]]
+name = "service-principal-sdk"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "cf-gears-tenant-resolver-sdk",
+ "cf-gears-toolkit",
+ "cf-gears-toolkit-gts",
+ "cf-gears-toolkit-security",
+ "gts",
+ "gts-macros",
+ "schemars 1.2.1",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "sfv"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,6 +1814,7 @@ dependencies = [
  "cf-gears-file-storage",
  "cf-gears-gear-orchestrator",
  "cf-gears-grpc-hub",
+ "cf-gears-keycloak-idp-plugin",
  "cf-gears-mini-chat",
  "cf-gears-nodes-registry",
  "cf-gears-oagw",
@@ -1988,6 +1989,49 @@ dependencies = [
  "tower",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "cf-gears-keycloak-idp-plugin"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "cf-gears-account-management-sdk",
+ "cf-gears-credstore",
+ "cf-gears-credstore-sdk",
+ "cf-gears-toolkit",
+ "cf-gears-toolkit-gts",
+ "cf-gears-toolkit-macros",
+ "cf-gears-toolkit-odata",
+ "cf-gears-toolkit-security",
+ "cf-gears-types-registry",
+ "cf-gears-types-registry-sdk",
+ "dashmap",
+ "gts",
+ "humantime-serde",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "rand 0.10.1",
+ "rcgen",
+ "regex",
+ "reqwest 0.13.3",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "service-principal-sdk",
+ "temp-env",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+ "url",
+ "urlencoding",
+ "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -3920,6 +3964,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "debug_unsafe"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5173,6 +5235,16 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
 
 [[package]]
 name = "hybrid-array"
@@ -11979,6 +12051,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,8 @@ members = [
     "gears/system/authz-resolver/authz-resolver",
     "gears/system/authz-resolver/plugins/static-authz-plugin",
     "gears/system/authz-resolver/plugins/tr-authz-plugin",
+    "gears/system/service-principal/service-principal-sdk",
+    "gears/system/service-principal/service-principal",
     "gears/system/oagw/oagw",
     "gears/system/oagw/oagw-sdk",
     "gears/system/usage-collector/usage-collector-sdk",
@@ -309,6 +311,10 @@ authz-resolver-sdk = { package = "cf-gears-authz-resolver-sdk", version = "0.3.1
 resource-group-sdk = { package = "cf-gears-resource-group-sdk", version = "0.2.2", path = "gears/system/resource-group/resource-group-sdk" }
 oagw-sdk = { package = "cf-gears-oagw-sdk", version = "0.5.5", path = "gears/system/oagw/oagw-sdk" }
 usage-collector-sdk = { package = "cf-gears-usage-collector-sdk", version = "0.3.2", path = "gears/system/usage-collector/usage-collector-sdk" }
+
+# Service Principal gear (ported from vhp-core)
+service-principal = { path = "gears/system/service-principal/service-principal" }
+service-principal-sdk = { path = "gears/system/service-principal/service-principal-sdk" }
 
 # BSS gears (ported from vhp-core)
 bss-ledger-sdk = { path = "gears/bss/ledger/ledger-sdk" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ members = [
     "gears/system/account-management/account-management",
     "gears/system/account-management/account-management-sdk",
     "gears/system/account-management/plugins/static-idp-plugin",
+    "gears/system/account-management/plugins/keycloak-idp-plugin",
     "gears/system/api-gateway",
     "gears/system/cluster/cluster",
     "gears/system/cluster/cluster-sdk",
@@ -487,6 +488,7 @@ k8s-openapi = { version = "0.27", default-features = false }
 # DSN parsing
 dsn = "1.1.1"
 humantime = "2.3.0"
+humantime-serde = "1.1"
 
 # URL parsing
 url = "2.5"
@@ -602,6 +604,8 @@ kreuzberg = { version = "=4.9.8", features = ["html", "excel", "office", "pdf", 
 
 # Additional testing utilities
 temp-env = { version = "0.3", features = ["async_closure"] }
+wiremock = "0.6"
+serde_yaml = "0.9"
 
 # Additional utilities
 nanoid = "0.4"

--- a/apps/cf-gears-example-server/Cargo.toml
+++ b/apps/cf-gears-example-server/Cargo.toml
@@ -29,6 +29,9 @@ k8s = ["mini-chat/k8s", "chat-engine?/k8s"]
 otel = ["toolkit/otel"]
 account-management = ["dep:account_management"]
 static-idp = ["dep:static-idp-plugin"]
+# Opt-in: the Keycloak IdP plugin requires a reachable Keycloak and fails
+# module init when its bootstrap-token pre-warm budget is exhausted.
+keycloak-idp = ["dep:keycloak-idp-plugin"]
 file-storage = ["dep:file_storage"]
 bss-ledger = ["dep:bss_ledger"]
 usage-collector = ["dep:usage_collector"]
@@ -84,6 +87,7 @@ chat-engine = { package = "cf-chat-engine", path = "../../gears/chat-engine/chat
 # Optional Account Management gear
 account_management = { package = "cf-gears-account-management", path = "../../gears/system/account-management/account-management", optional = true }
 static-idp-plugin = { package = "cf-gears-static-idp-plugin", path = "../../gears/system/account-management/plugins/static-idp-plugin", optional = true }
+keycloak-idp-plugin = { package = "cf-gears-keycloak-idp-plugin", path = "../../gears/system/account-management/plugins/keycloak-idp-plugin", optional = true }
 
 # Optional BSS Billing Ledger gear
 bss_ledger = { package = "bss-ledger", path = "../../gears/bss/ledger/ledger", optional = true }

--- a/apps/cf-gears-example-server/src/registered_gears.rs
+++ b/apps/cf-gears-example-server/src/registered_gears.rs
@@ -71,6 +71,9 @@ use calculator as _;
 #[cfg(feature = "static-idp")]
 use static_idp_plugin as _;
 
+#[cfg(feature = "keycloak-idp")]
+use keycloak_idp_plugin as _;
+
 #[cfg(feature = "account-management")]
 use account_management as _;
 

--- a/gears/system/account-management/account-management-sdk/src/idp.rs
+++ b/gears/system/account-management/account-management-sdk/src/idp.rs
@@ -328,27 +328,19 @@ impl IdpDeprovisionTenantRequest {
 
 /// Failure discriminant for `deprovision_tenant`.
 ///
-/// `Terminal` means the tenant cannot be deprovisioned safely without
-/// operator intervention. This includes any mutating request that may
-/// have reached the provider when its result cannot be proven, even if
-/// the immediate error is a timeout or transient transport failure.
-/// `Retryable` defers to the next tick and is valid only when no
-/// deprovisioning mutation has an unknown outcome: no mutating request
-/// may have reached the provider, or completed partial work is proven
-/// replay-safe with no uncertain attempted stage. `UnsupportedOperation`
-/// is the default path that preserves Phase 1/2 behaviour when no
-/// provider plugin is registered. `NotFound` is the "vendor-side already
-/// gone" path — AM treats it as a success-equivalent and proceeds with
-/// the local DB teardown (see the trait-level doc on idempotency vs typed
-/// errors).
+/// `Terminal` means the tenant cannot be deprovisioned by this
+/// provider and the operator must intervene; `Retryable` defers to the
+/// next tick; `UnsupportedOperation` is the default path that
+/// preserves Phase 1/2 behaviour when no provider plugin is
+/// registered. `NotFound` is the "vendor-side already gone" path — AM
+/// treats it as a success-equivalent and proceeds with the local DB
+/// teardown (see the trait-level doc on idempotency vs typed errors).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum IdpDeprovisionFailure {
-    /// Non-recoverable or uncertain after a mutation may have reached
-    /// the provider; logs/audits and parks the tenant for operator action.
+    /// Non-recoverable; logs/audits and skips the tenant this tick.
     Terminal { detail: String },
-    /// Proven safe to retry: no mutation has an unknown outcome. Defer
-    /// the tenant to the next retention tick.
+    /// Transient; defer the tenant to the next retention tick.
     Retryable { detail: String },
     /// Provider does not support deprovisioning at all.
     UnsupportedOperation { detail: String },
@@ -533,12 +525,6 @@ pub trait IdpPluginClient: Send + Sync + 'static {
     ///   so plugins do NOT need to magic-map "already gone" into
     ///   `Ok(())` themselves. Idempotency by error-mapping is the
     ///   contract.
-    /// * MUST classify a failure as [`IdpDeprovisionFailure::Retryable`]
-    ///   only when no deprovisioning mutation has an unknown outcome.
-    ///   If a mutating request may have reached the provider and its
-    ///   result cannot be proven, MUST return
-    ///   [`IdpDeprovisionFailure::Terminal`] even when the immediate
-    ///   error is a timeout or transient transport failure.
     /// * MUST own retry / backoff / rate-limiting policy (see trait-
     ///   level doc). AM issues at most one call per reaper /
     ///   retention tick per row (rows are claimed via the same

--- a/gears/system/account-management/account-management-sdk/src/idp.rs
+++ b/gears/system/account-management/account-management-sdk/src/idp.rs
@@ -328,19 +328,27 @@ impl IdpDeprovisionTenantRequest {
 
 /// Failure discriminant for `deprovision_tenant`.
 ///
-/// `Terminal` means the tenant cannot be deprovisioned by this
-/// provider and the operator must intervene; `Retryable` defers to the
-/// next tick; `UnsupportedOperation` is the default path that
-/// preserves Phase 1/2 behaviour when no provider plugin is
-/// registered. `NotFound` is the "vendor-side already gone" path — AM
-/// treats it as a success-equivalent and proceeds with the local DB
-/// teardown (see the trait-level doc on idempotency vs typed errors).
+/// `Terminal` means the tenant cannot be deprovisioned safely without
+/// operator intervention. This includes any mutating request that may
+/// have reached the provider when its result cannot be proven, even if
+/// the immediate error is a timeout or transient transport failure.
+/// `Retryable` defers to the next tick and is valid only when no
+/// deprovisioning mutation has an unknown outcome: no mutating request
+/// may have reached the provider, or completed partial work is proven
+/// replay-safe with no uncertain attempted stage. `UnsupportedOperation`
+/// is the default path that preserves Phase 1/2 behaviour when no
+/// provider plugin is registered. `NotFound` is the "vendor-side already
+/// gone" path — AM treats it as a success-equivalent and proceeds with
+/// the local DB teardown (see the trait-level doc on idempotency vs typed
+/// errors).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum IdpDeprovisionFailure {
-    /// Non-recoverable; logs/audits and skips the tenant this tick.
+    /// Non-recoverable or uncertain after a mutation may have reached
+    /// the provider; logs/audits and parks the tenant for operator action.
     Terminal { detail: String },
-    /// Transient; defer the tenant to the next retention tick.
+    /// Proven safe to retry: no mutation has an unknown outcome. Defer
+    /// the tenant to the next retention tick.
     Retryable { detail: String },
     /// Provider does not support deprovisioning at all.
     UnsupportedOperation { detail: String },
@@ -525,6 +533,12 @@ pub trait IdpPluginClient: Send + Sync + 'static {
     ///   so plugins do NOT need to magic-map "already gone" into
     ///   `Ok(())` themselves. Idempotency by error-mapping is the
     ///   contract.
+    /// * MUST classify a failure as [`IdpDeprovisionFailure::Retryable`]
+    ///   only when no deprovisioning mutation has an unknown outcome.
+    ///   If a mutating request may have reached the provider and its
+    ///   result cannot be proven, MUST return
+    ///   [`IdpDeprovisionFailure::Terminal`] even when the immediate
+    ///   error is a timeout or transient transport failure.
     /// * MUST own retry / backoff / rate-limiting policy (see trait-
     ///   level doc). AM issues at most one call per reaper /
     ///   retention tick per row (rows are claimed via the same

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/Cargo.toml
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/Cargo.toml
@@ -1,8 +1,22 @@
 [package]
-name = "vp-idp-plugin"
+name = "cf-gears-keycloak-idp-plugin"
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
-description = "VHP IdP Plugin (Keycloak) — IdpPluginClient implementation"
+authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Keycloak IdP plugin for Account Management — IdpPluginClient and ServicePrincipalClientV1 implementations"
+keywords = ["constructorfabric", "cf-gears"]
+categories = ["authentication"]
+metadata.docs.rs.all-features = true
+
+# The runtime identifiers stay on the `vp-idp-plugin` / `vp_idp_plugin` lineage
+# on purpose: the gear name is a deployment config key, and the metric prefix
+# and tracing targets are an operator-facing contract. Renaming the Cargo
+# package is a build-level change; renaming those would break existing deploys.
+[lib]
+name = "keycloak_idp_plugin"
 
 [lints]
 workspace = true

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/Cargo.toml
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/Cargo.toml
@@ -11,10 +11,6 @@ keywords = ["constructorfabric", "cf-gears"]
 categories = ["authentication"]
 metadata.docs.rs.all-features = true
 
-# The runtime identifiers stay on the `vp-idp-plugin` / `vp_idp_plugin` lineage
-# on purpose: the gear name is a deployment config key, and the metric prefix
-# and tracing targets are an operator-facing contract. Renaming the Cargo
-# package is a build-level change; renaming those would break existing deploys.
 [lib]
 name = "keycloak_idp_plugin"
 

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/Cargo.toml
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/Cargo.toml
@@ -1,0 +1,62 @@
+[package]
+name = "vp-idp-plugin"
+edition.workspace = true
+license.workspace = true
+description = "VHP IdP Plugin (Keycloak) — IdpPluginClient implementation"
+
+[lints]
+workspace = true
+
+[dependencies]
+toolkit.workspace = true
+toolkit-macros.workspace = true
+toolkit-gts.workspace = true
+toolkit-security.workspace = true
+toolkit-odata.workspace = true
+account-management-sdk.workspace = true
+credstore-sdk = { workspace = true }
+service-principal-sdk = { workspace = true }
+types-registry-sdk.workspace = true
+# Full gear crates for the `deps = [types_registry, credstore]` gear-macro arg
+# (force-linked via the macro's `::types_registry` / `::credstore` re-exports).
+types-registry = { workspace = true }
+credstore = { workspace = true }
+reqwest = { workspace = true, features = ["form", "json", "rustls"] }
+serde.workspace = true
+serde_json.workspace = true
+humantime-serde.workspace = true
+secrecy.workspace = true
+thiserror.workspace = true
+anyhow.workspace = true
+async-trait.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-opentelemetry.workspace = true
+opentelemetry = { workspace = true, features = ["metrics"] }
+opentelemetry_sdk = { workspace = true, features = ["trace"] }
+dashmap.workspace = true
+uuid.workspace = true
+url = { workspace = true, features = ["serde"] }
+urlencoding.workspace = true
+base64.workspace = true
+regex.workspace = true
+rand.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tracing-subscriber = { workspace = true, features = ["registry"] }
+serde_yaml.workspace = true
+wiremock.workspace = true
+temp-env = { workspace = true }
+gts.workspace = true
+# Self-signed CA generation for `tls_ca_bundle_ref` factory tests.
+# The cert is never used over the wire — we only need a syntactically-valid
+# PEM so reqwest's `ClientBuilder::add_root_certificate` accepts it.
+rcgen = { workspace = true, features = ["aws_lc_rs", "pem"] }
+# The remaining direct test imports (account-management-sdk, credstore-sdk,
+# toolkit-security, toolkit-odata, openbao-credstore-gateway, reqwest,
+# async-trait, serde_json, uuid, url) are pulled in transitively via
+# `[dependencies]` above and so do not need to be re-declared here.
+
+[features]
+default = []

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
@@ -1,0 +1,490 @@
+---
+refs:
+  - PRD.md
+  - ../../../docs/DESIGN.md
+  - ../../../docs/ADR/0001-cpt-cf-account-management-adr-idp-contract-separation.md
+  - ../../../docs/ADR/0005-cpt-cf-account-management-adr-idp-user-identity-source-of-truth.md
+  - ../../../docs/ADR/0006-cpt-cf-account-management-adr-idp-user-tenant-binding.md
+  - ../../../docs/ADR/0008-cpt-cf-account-management-adr-user-attribute-update.md
+---
+
+# Technical Design — Keycloak IdP Plugin
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-design-keycloak-idp-plugin`
+
+**Owners:** @platform-iam-team  
+**Scope:** Overall architecture for the priority-1 (V1) shared-realm plugin. In this document, **P2 means priority 2/deferred**, not version 2.
+
+<!-- toc -->
+
+- [1. Architecture Overview](#1-architecture-overview)
+  - [1.1 Architectural Vision](#11-architectural-vision)
+  - [1.2 Architecture Drivers](#12-architecture-drivers)
+  - [1.3 Architecture Layers](#13-architecture-layers)
+- [2. Principles & Constraints](#2-principles--constraints)
+  - [2.1 Design Principles](#21-design-principles)
+  - [2.2 Constraints](#22-constraints)
+  - [2.3 Applicability Matrix](#23-applicability-matrix)
+- [3. Technical Architecture](#3-technical-architecture)
+  - [3.1 Domain Model](#31-domain-model)
+  - [3.2 Component Model](#32-component-model)
+  - [3.3 API Contracts](#33-api-contracts)
+  - [3.4 Internal Dependencies](#34-internal-dependencies)
+  - [3.5 External Dependencies](#35-external-dependencies)
+  - [3.6 Interactions & Sequences](#36-interactions--sequences)
+  - [3.7 Database schemas & tables](#37-database-schemas--tables)
+- [4. Additional context](#4-additional-context)
+  - [4.1 Security and Data Protection](#41-security-and-data-protection)
+  - [4.2 Verification Architecture](#42-verification-architecture)
+  - [4.3 Risks and Enablement Gates](#43-risks-and-enablement-gates)
+- [5. Traceability](#5-traceability)
+  - [5.1 Authoritative Contracts](#51-authoritative-contracts)
+  - [5.2 P1 Requirement Allocation](#52-p1-requirement-allocation)
+
+<!-- /toc -->
+
+The adjacent [PRD](./PRD.md) is authoritative for WHAT, WHY, release priority, actors, and acceptance criteria. The Account Management SDK is authoritative for method signatures, request and result shapes, failure variants, filtering, ordering, and cursor envelopes. This document defines only the V1 architecture and its safety invariants.
+
+## 1. Architecture Overview
+
+### 1.1 Architectural Vision
+
+The Keycloak IdP plugin is a provider adapter inside Account Management. It implements the provider-neutral `IdpPluginClient` boundary and administers tenant-scoped identity resources in an operator-approved shared Keycloak realm. Account Management owns authorization, tenant lifecycle orchestration, and persistence of opaque provider metadata; Keycloak remains the user source of truth.
+
+V1 does not adopt or create realms, write administrator secrets, manage service principals, expose public REST endpoints, or participate in token validation. Requests for deferred `adopted` or `created` modes are rejected as unsupported before any provider or Credential Store mutation. Those modes require a separate future DESIGN and approval.
+
+### 1.2 Architecture Drivers
+
+| Driver | Design allocation |
+|---|---|
+| Provider-neutral publication and operation-based readiness | GTS-scoped ClientHub publication, coordinated Account Management selection, and per-operation dependency classification |
+| Shared-realm tenant isolation | Versioned routing metadata, a provider-owned tenant group, an immutable tenant marker, and mandatory boundary checks before reads or mutations |
+| Safe external mutation | Tenant clean/ambiguous classification, replay-safe user operations, bounded retries, and operator reconciliation evidence |
+| Hard access termination | Session revocation and identity deletion precede tenant-group deletion; unproven cleanup is terminal |
+| Provider compatibility | Keycloak 26.x startup compatibility check plus a read-only realm authentication-profile verifier |
+| Protected administration | Least-privileged per-realm administrator, Credential Store SecretRefs, shared ToolKit HTTP/auth, and no V1 master-realm administrator |
+| Audit completeness | Exactly one privacy-preserving terminal outcome for every successful or failed supported mutation |
+| User query correctness | SDK filter/order semantics, `CursorV1`, global deterministic sorting, and no stable-order claim based on Keycloak offset pages |
+| Lifecycle safety | ToolKit cancellation and bounded drain; V1 has no periodic background task |
+
+#### NFR Allocation
+
+| NFR | Architectural response | Release verification |
+|---|---|---|
+| Tenant isolation | `TenantBoundaryGuard` validates both group membership and immutable tenant marker | Negative-isolation contract and real-Keycloak tests |
+| Secret non-disclosure | Secret wrappers, allowlisted diagnostics, protected SecretRefs, and output scanning | Logs, metrics, audit, errors, and debug output contain no injected secret |
+| Lifecycle latency | Shared HTTP pooling, bounded calls, point-lookup optimization, and measured full-group query scans | PRD qualification profile: 20 concurrent operations and stated p95 limits |
+| Failure classification | Current SDK enums are the only failure vocabulary | Exhaustive enum mapping and failure injection |
+| Audit completeness | Common completion boundary emits exactly one terminal outcome | One-to-one call/event correlation |
+| Provider compatibility | Startup version gate and release compatibility matrix | Supported 26.x matrix passes; unsupported major fails deterministically |
+| Personal-data lifecycle | No local user directory; hard deletion removes identities and sessions | Hard-delete and output-minimization verification |
+| Availability recovery | Dependency state is evaluated per affected operation after startup | Dependency loss/recovery tests without fallback or default realm |
+
+#### Decision Provenance
+
+V1 introduces no approved exception to the repository architecture. Its significant decisions inherit these accepted records and standards:
+
+- [Separate Account Management from the IdP provider](../../../docs/ADR/0001-cpt-cf-account-management-adr-idp-contract-separation.md).
+- [Keep the IdP as user source of truth](../../../docs/ADR/0005-cpt-cf-account-management-adr-idp-user-identity-source-of-truth.md).
+- [Use provider-enforced tenant binding](../../../docs/ADR/0006-cpt-cf-account-management-adr-idp-user-tenant-binding.md).
+- [Preserve provider-backed partial user updates](../../../docs/ADR/0008-cpt-cf-account-management-adr-user-attribute-update.md).
+- [Use the first-party ToolKit HTTP client](../../../../../../docs/adrs/toolkit/0001-toolkit-hyper-tower-http-client.md).
+- Follow [ClientHub and plugin scoping](../../../../../../docs/toolkit_unified_system/03_clienthub_and_plugins.md), [lifecycle rules](../../../../../../docs/toolkit_unified_system/08_lifecycle_stateful_tasks.md), the [Architecture Manifest](../../../../../../docs/ARCHITECTURE_MANIFEST.md), and [Security Guidelines](../../../../../../guidelines/SECURITY.md).
+
+A proposal to add a master-realm administrator, direct `reqwest`, direct OpenBao mutation, unscoped publication, or plugin-owned user storage is a material deviation and requires a new accepted ADR before this DESIGN can change.
+
+### 1.3 Architecture Layers
+
+```mermaid
+flowchart LR
+  operator([Platform operator])
+  iac[IaC and protected configuration]
+  cred[(Credential Store)]
+  kc[(Keycloak 26.x shared realm)]
+  authn[OIDC AuthN Resolver]
+  subgraph am[Account Management process]
+    api[Account Management application layer]
+    domain[Plugin domain coordinators and boundary guard]
+    infra[Credential and Keycloak adapters]
+  end
+
+  operator --> iac
+  iac -->|approved realm profiles and SecretRefs| infra
+  api -->|scoped IdpPluginClient| domain
+  domain --> infra
+  infra -->|protected secret read| cred
+  infra -->|Admin REST over toolkit-http| kc
+  authn -->|OIDC discovery and JWKS; no plugin call| kc
+```
+
+| Layer | Responsibility |
+|---|---|
+| Account Management application | Public authorization, tenant saga orchestration, opaque metadata persistence, scoped provider selection |
+| Plugin domain | Tenant/user lifecycle, boundary enforcement, replay safety, error classification, terminal outcomes |
+| Plugin infrastructure | ToolKit HTTP/auth, Credential Store resolution, Keycloak representation mapping, telemetry transport |
+| Platform dependencies | Keycloak identity state, Credential Store secrets, audit sink, operator-owned realm configuration |
+
+## 2. Principles & Constraints
+
+### 2.1 Design Principles
+
+#### Explicit provider intent
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-explicit-provider-intent`
+
+Never infer a default realm or mode from missing metadata.
+
+#### Two-factor tenant binding
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-two-factor-tenant-binding`
+
+A shared realm is routing context, not tenant authorization; tenant marker and group membership must agree.
+
+#### Operator-owned realm
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-operator-owned-realm`
+
+V1 may create and delete plugin-owned tenant groups and users, but never the shared realm or realm-level authentication configuration.
+
+#### Correctness before retry
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-correctness-before-retry`
+
+Retry only reads and operations proven replay-safe; never convert uncertain tenant mutation into a clean failure.
+
+#### SDK authority
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-sdk-authority`
+
+Duplicate local DTO, cursor, and failure specifications are prohibited.
+
+#### No silent success
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-no-silent-success`
+
+Unsupported mutation and unproven cleanup produce typed failures.
+
+#### Least privilege
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-least-privilege`
+
+Use one approved realm-administrator profile per shared realm; V1 has no master-realm credential.
+
+#### Privacy-preserving evidence
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-privacy-preserving-evidence`
+
+Operation outcomes are observable without credentials or user profile values.
+
+### 2.2 Constraints
+
+#### Shared-realm-only V1
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-shared-realm-only-v1`
+
+V1 supports only `mode = shared` against an operator-approved Keycloak 26.x realm.
+
+#### External consistency boundaries
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-external-consistency-boundaries`
+
+Keycloak and Credential Store are external consistency boundaries; plugin calls occur outside Account Management database transactions.
+
+#### Opaque metadata replay
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-opaque-metadata-replay`
+
+Account Management persists plugin metadata as opaque JSON and replays it on later calls.
+
+#### No plugin persistence
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-no-plugin-persistence`
+
+The plugin owns no database table and no persistent user cache.
+
+#### Scoped provider selection
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-scoped-provider-selection`
+
+Account Management requires a coordinated change to select a GTS-scoped provider instance; no unscoped compatibility fallback is allowed.
+
+#### Bounded offline-token exposure
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-bounded-offline-token-exposure`
+
+A previously issued access JWT can remain valid until `exp`; the approved realm profile caps V1 access-token lifetime at 15 minutes.
+
+#### Correct global query ordering
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-correct-global-query-ordering`
+
+Query correctness requires a global view of the tenant group because Keycloak does not guarantee stable ordering across offset pages. V1 accepts linear provider-read cost and must prove the PRD latency target on the release qualification population.
+
+### 2.3 Applicability Matrix
+
+| Checklist domain | Disposition |
+|---|---|
+| Architecture and semantic alignment | Applicable; addressed in §§1–3 and §5. |
+| Performance and capacity | Applicable; query complexity and release gates are addressed in §§1.2, 2.2, 3.6, and 4.3. |
+| Security and compliance controls | Applicable; trust boundaries and controls are addressed in §4.1. No plugin-specific regulatory regime is added because the PRD and platform security baseline own regulatory classification. |
+| Reliability | Applicable; mutation uncertainty, replay, cancellation, and recovery are addressed in §3.6. |
+| Data | Applicable only to ownership and lifecycle because the plugin owns no database; addressed in §§3.1, 3.7, and 4.1. |
+| Integration | Applicable; Account Management, Keycloak, Credential Store, audit, and ClientHub boundaries are addressed in §§3.2–3.6. |
+| Operations | Applicable; deployment, observability, compatibility, and enablement gates are addressed in §§3.2, 3.6, and 4.3. |
+| Maintainability | Applicable; SDK authority, component boundaries, and decision provenance are addressed in §§1.2, 2.1, and 3.2–3.4. |
+| Testing | Applicable; verification architecture is addressed in §4.2. |
+| Usability | Not applicable because the plugin exposes no human interface; Account Management owns public API usability. |
+| Accessibility | Not applicable because the plugin exposes no visual or interactive user interface. |
+| Business and time-to-market | Not applicable because prioritization, business outcomes, and delivery timing are owned by the adjacent PRD and planning artifacts. |
+| Plugin-specific cost budget | Not applicable because V1 adds no independently deployed service or persistent store; infrastructure cost is inherited from Account Management, Keycloak, Credential Store, and the release qualification profile. |
+| Documentation quality | Applicable; authoritative references and bidirectional traceability are provided in §5. |
+
+## 3. Technical Architecture
+
+### 3.1 Domain Model
+
+The provider metadata is a versioned, non-secret routing envelope owned by the plugin and persisted opaquely by Account Management. It identifies the shared realm, provider-owned tenant group, immutable tenant identity, and a non-secret administrator-profile reference. Exact serialization belongs to the implementation specification; compatibility rules are architectural:
+
+- all versions in the declared rolling-upgrade window can read and safely deprovision metadata written by one another;
+- malformed or unknown newer-major metadata fails closed without provider mutation;
+- metadata never contains administrator secrets, tokens, passwords, or user profile values;
+- realm and tenant identifiers come from replayed metadata, not caller-controlled defaults on later operations.
+
+Provider ownership is split as follows:
+
+| Resource | Owner | Plugin authority |
+|---|---|---|
+| Shared realm and authentication profile | Platform operator | Read and verify only |
+| Realm-administrator client and secret | Platform operator | Authenticate with least privilege; never create or disclose |
+| Tenant group and immutable tenant marker | Plugin | Create, inspect, and delete for the owning tenant |
+| Human identity and sessions in the tenant boundary | Plugin through Account Management | Create, update, query, revoke, and delete after boundary verification |
+| Opaque provider metadata row | Account Management | Persist/replay only; plugin owns interpretation |
+| Access-token validation | OIDC AuthN Resolver | No call to this plugin |
+
+### 3.2 Component Model
+
+#### Keycloak IdP plugin
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-component-keycloak-idp-plugin`
+
+The plugin is one logical architecture component. The following entries are responsibility partitions inside that component, not independently deployed services.
+
+| Responsibility partition | Architectural responsibility |
+|---|---|
+| Plugin module | Configuration, startup compatibility, lifecycle, and GTS-scoped ClientHub publication |
+| Approved realm registry | Maps explicit shared-realm intent to operator-approved realm and non-secret credential profile |
+| Realm profile verifier | Read-only verification of Keycloak version, issuer, clients, scopes, protocol mappers, claims, signing, session/token policy, password/login policy, and required administration privileges |
+| Metadata codec | Versioned opaque metadata compatibility and fail-closed decoding |
+| Tenant lifecycle coordinator | Tenant-boundary provisioning, hard-deletion ordering, uncertainty classification, and reconciliation evidence |
+| Tenant boundary guard | Verifies tenant marker and group membership before every user read or mutation |
+| User lifecycle coordinator | Replay-safe user create/update/delete and provider projection |
+| User query adapter | Tenant-scoped filtering, ordering, point existence, global sorting, and `CursorV1` generation |
+| Keycloak adapter | ToolKit HTTP/auth integration, bounded provider calls, response classification, and allowlisted diagnostics |
+| Credential resolver | Protected SecretRef resolution under a least-privileged plugin system actor, including ownership validation and rotation refresh |
+| Terminal outcome emitter | Exactly-once completion audit and bounded-cardinality metrics |
+
+#### Deployment, Publication, and Readiness
+
+The plugin is an in-process ModKit module in each Account Management replica. It opens no listener and owns no independent deployment or database.
+
+Each instance publishes `IdpPluginClient` with `ClientScope::gts_id(instance_id)`. Account Management must select the configured provider instance through scoped ClientHub resolution. This coordinated consumer change is a V1 implementation prerequisite; ambiguous selection or unscoped fallback fails closed.
+
+Initialization validates configuration, approved realm profiles, SecretRef syntax, TLS policy, and GTS identity; resolves standard ClientHub dependencies; resolves the selected realm administrator through Credential Store; and proves the provider reports a supported Keycloak 26.x major. The scoped client is published only after mandatory startup compatibility succeeds.
+
+No V1 initialization path resolves P2 OpenBao mutation APIs or a master-realm bootstrap administrator. After successful publication, dependency loss is classified on the operation that needs it; the module remains registered so recovery does not require process restart.
+
+### 3.3 API Contracts
+
+The current [`idp.rs`](../../../account-management-sdk/src/idp.rs) and [`idp_user.rs`](../../../account-management-sdk/src/idp_user.rs) contracts are authoritative. This DESIGN does not redefine request fields, output structs, method signatures, or complete error tables.
+
+Architectural contract invariants are:
+
+- malformed shared-realm intent uses `IdpProvisionFailure::InvalidInput` before provider mutation;
+- deferred modes use `UnsupportedOperation` before provider or Credential Store mutation;
+- only pre-provision failures proven to retain no provider state use `CleanFailure`;
+- uncertain tenant provisioning preserves `Ambiguous`;
+- duplicate users, password-policy rejection, absent update targets, and unavailability use their current classified user variants;
+- `Rejected` is reserved for provider rejection that cannot be classified further;
+- already-absent deprovisioning follows the SDK's success-equivalent semantics;
+- typed filter/order and `CursorV1` are used without a plugin-specific parallel contract.
+
+The plugin emits no public HTTP API. Account Management owns public status, validation-envelope, and redaction mapping.
+
+### 3.4 Internal Dependencies
+
+Domain components depend on plugin-owned ports rather than transport types. Direct `reqwest`, raw `hyper`, `tonic`, or Credential Store implementation types do not cross into the domain layer.
+
+| Internal dependency | Purpose |
+|---|---|
+| Account Management SDK | Provider-neutral trait, DTO, failure, and pagination authority |
+| ModKit and ClientHub | Module initialization, lifecycle context, GTS-scoped publication and dependency resolution |
+| `toolkit-http` | Shared TLS, redirects, timeout, retry, concurrency, body-limit, and telemetry policy |
+| `toolkit-auth` | Supported OAuth client-credential integration and token refresh |
+| `toolkit-odata` | Typed filter/order interpretation and `CursorV1` compatibility |
+| Credential Store SDK | Protected SecretRef reads without implementation coupling |
+
+### 3.5 External Dependencies
+
+| Dependency | Contract and failure boundary |
+|---|---|
+| Account Management | Authorizes calls, selects the scoped plugin, persists/replays opaque metadata, and consumes typed outcomes |
+| Keycloak 26.x | User/session/group source of truth and Admin REST provider; another major is unsupported until compatibility approval |
+| Credential Store | Protects operator-created realm-administrator secrets; ownership or availability failure blocks only dependent administration |
+| Platform audit sink | Stores terminal mutation outcomes append-only with finite retention |
+| Operator IaC | Creates the shared realm, realm-local administrator, required authentication profile, SecretRefs, and approved realm registry |
+| OIDC AuthN Resolver | Independently validates tokens; the two plugins do not call each other |
+
+### 3.6 Interactions & Sequences
+
+#### Realm Admissibility and Tenant Provisioning
+
+**ID**: `cpt-cf-keycloak-idp-plugin-seq-tenant-provisioning`
+
+A realm is admissible only when explicit `mode = shared` intent names an operator-approved realm and the read-only verifier proves the supported provider version plus the complete platform authentication profile. The profile includes trusted issuer/discovery, required clients, scopes, protocol mappers and claims, signing policy, session/token limits, password/login controls, and least-privileged administration. A mismatch is a pre-mutation failure; the plugin never repairs operator-owned realm configuration.
+
+After admissibility succeeds, the tenant lifecycle coordinator creates or reconciles the plugin-owned tenant group with its immutable marker and returns provider metadata only after the boundary is usable. The verifier and lifecycle coordinator use the least-privileged administrator for the target realm; V1 has no master-realm administrator.
+
+#### User Mutation Safety
+
+**ID**: `cpt-cf-keycloak-idp-plugin-seq-user-mutation`
+
+Every user operation resolves realm and tenant group from replayed provider metadata. Before reading, updating, revoking, or deleting a user, `TenantBoundaryGuard` requires membership in the resolved tenant group and an immutable tenant marker equal to the target tenant. A mismatch performs no mutation, follows the operation's non-disclosing absence semantics, and emits a security-classified terminal outcome without profile values.
+
+User provisioning is a recoverable unit even though provider creation and tenant binding are separate effects. The created representation carries the immutable tenant marker, and replay uses the stable `(tenant_id, username)` identity key to distinguish a matching partial creation from another tenant's uniqueness collision. Matching partial work is completed; a conflicting identity uses `DuplicateUser`. User operations do not invent an ambiguity variant outside the SDK.
+
+#### Hard Tenant Deprovisioning
+
+**ID**: `cpt-cf-keycloak-idp-plugin-seq-hard-tenant-deprovisioning`
+
+Hard deprovisioning proves access termination before boundary deletion. It obtains a complete tenant-group membership view, verifies each tenant marker, revokes sessions, deletes every tenant identity, verifies cleanup, and only then deletes the plugin-owned group. The shared realm and unrelated identities are never deleted.
+
+Already-absent plugin-owned resources are success-equivalent. Ownership mismatch, incomplete enumeration, failed session revocation, or unproven identity removal is terminal. Transient failure before proof of cleanup uses the SDK retryable category. The process blocks refresh and new sessions but does not claim immediate invalidation of an already-issued JWT; exposure is bounded by the 15-minute profile limit.
+
+#### User Query Architecture
+
+**ID**: `cpt-cf-keycloak-idp-plugin-seq-user-query`
+
+`IdpListUsersRequest` is authoritative. Because Keycloak 26.x does not document stable global order for group-member offset pages, V1 obtains a complete per-request tenant-group view, verifies tenant binding, applies supported SDK filter/order, and globally sorts with a unique provider-ID tiebreaker. The continuation token is a valid `CursorV1` that pins filter, order, tenant context, and the last emitted key tuple.
+
+This is a correctness-first linear scan, not an `O(page)` claim. Point existence may use a direct provider lookup followed by the same boundary guard. No persistent local index or user cache is introduced. Release qualification must prove the PRD 100-user-page latency target at the declared tenant population; failure requires an upstream capacity or contract decision rather than per-page sorting over unstable offsets.
+
+#### Failure, Retry, and Reconciliation
+
+**ID**: `cpt-cf-keycloak-idp-plugin-seq-reconciliation`
+
+Retries are bounded and limited to idempotent reads, token refresh, or operations whose replay contract proves safety. A provider mutation is never blindly retried merely because transport failed. Circuit breaking is dependency-specific and never selects a default realm or stale user projection.
+
+Ambiguous tenant provisioning remains operator-owned in V1. Terminal outcomes provide non-secret stage and ownership evidence. Production enablement requires a reconciliation runbook whose resolution ends as compensated, accepted complete, blocked for investigation, or escalated for controlled cleanup.
+
+#### HTTP, Credentials, and Rotation
+
+**ID**: `cpt-cf-keycloak-idp-plugin-seq-credential-resolution`
+
+All Keycloak OAuth and Admin REST traffic uses `toolkit-http` and the supported `toolkit-auth` integration. Direct `reqwest` is prohibited. Administrator credentials are operator-created SecretRefs read through the canonical Credential Store client under a stable plugin system actor restricted to configured references. The resolver validates returned ownership/sharing metadata and rejects inherited or cross-tenant material inconsistent with the approved platform credential profile.
+
+Credential values remain protected secret types and never enter metadata, errors, events, metrics, or debug formatting. Provider authentication rejection invalidates cached material, re-resolves the SecretRef, and permits one replay through the shared auth layer. V1 uses reactive refresh and has no scheduled credential-refresh task.
+
+#### Lifecycle and Shutdown
+
+**ID**: `cpt-cf-keycloak-idp-plugin-seq-lifecycle-shutdown`
+
+The module receives a ToolKit `CancellationToken`. Shutdown stops new work, cancels idle provider activity, and drains in-flight mutations for a bounded interval before connection teardown. Mutation coordinators preserve their normal replay/reconciliation evidence if the timeout expires. V1 owns no periodic or detached background task.
+
+#### Audit and Observability
+
+**ID**: `cpt-cf-keycloak-idp-plugin-seq-terminal-outcome`
+
+Every supported mutating tenant or user call passes through one completion boundary that emits exactly one terminal audit outcome for success or failure. It carries operation, classified SDK outcome, correlation and initiating actor, target tenant, provider IDs when known, mutation stage, and reconciliation requirement. Fields unknowable before metadata resolution are absent or use a documented non-sensitive sentinel.
+
+Usernames, emails, display names, passwords, tokens, administrator secrets, and raw provider bodies are prohibited. The same completion boundary records bounded-cardinality duration, dependency, failure, credential-refresh, and reconciliation metrics. Production requires platform append-only audit routing; development logs alone do not satisfy the PRD.
+
+### 3.7 Database schemas & tables
+
+Not applicable because the plugin owns no database schema, table, migration, or persistent user index. Account Management owns its existing opaque provider-metadata row and Keycloak owns provider identity state. This DESIGN references those ownership boundaries without duplicating their code-level schemas.
+
+## 4. Additional context
+
+### 4.1 Security and Data Protection
+
+#### Trust Boundaries
+
+| Boundary | Control |
+|---|---|
+| Account Management caller to plugin | AM authorizes; forwarded `SecurityContext` identifies the audit actor but never substitutes for provider tenant checks |
+| Plugin to Credential Store | Dedicated system actor, configured SecretRef allowlist, response ownership validation, and no caller-tenant credential ownership |
+| Plugin to Keycloak | Least-privileged realm administrator, TLS verification, ToolKit HTTP policy, and provider-version/profile checks |
+| Tenant A to tenant B in one realm | Mandatory group-plus-marker guard on every read and mutation |
+| Plugin to audit/metrics | Allowlisted fields and no profile or credential values |
+
+The V1 administrator has only realm-local permissions needed to inspect the authentication profile and administer users, sessions, and the configured tenant-group subtree. It cannot create/delete realms, administer another realm, read client secrets, or alter operator-owned authentication configuration.
+
+Missing, malformed, contradictory, unknown-major, or deferred-mode metadata causes no provider mutation. A realm outside the approved registry is rejected even if reachable. Tenant marker and group disagreement blocks access. Credential or TLS failure never falls back to plaintext, another realm, or cached user data.
+
+Keycloak is the sole user directory. The plugin holds request data only for the operation lifetime and stores no local profile. Provider metadata contains routing identifiers rather than profile data. Hard deprovisioning removes identities and sessions before the group; failed proof is terminal. Audit and metrics use provider IDs only where operationally necessary and follow platform retention.
+
+### 4.2 Verification Architecture
+
+Verification is split by boundary rather than duplicated as method-level test cases in this overall DESIGN:
+
+| Level | Purpose |
+|---|---|
+| Unit | Metadata compatibility, boundary predicates, cursor construction, error classification, redaction, and completion-event cardinality |
+| SDK contract | Conformance to current `IdpPluginClient`, failure enums, typed filter/order, and `CursorV1` |
+| Real-Keycloak integration | Supported-version/profile checks, least privilege, user replay, cross-tenant denial, complete hard deletion, provider failures, and global query behavior |
+| Credential Store integration | SecretRef ownership, rotation refresh, authorization denial, and non-disclosure |
+| Lifecycle integration | Cancellation during provider stages, bounded drain, restart/replay safety, and absence of detached tasks |
+| End to end | Account Management scoped selection, tenant/user lifecycle, append-only audit routing, reconciliation evidence, and PRD latency profile |
+
+Tests that claim provider semantics use a supported real Keycloak 26.x instance. Test doubles are limited to deterministic local classification and failure injection; they do not establish Keycloak compatibility, tenant isolation, TLS, credential authorization, or latency.
+
+### 4.3 Risks and Enablement Gates
+
+| Gate | Required resolution before V1 production enablement |
+|---|---|
+| Scoped provider selection | Account Management resolves the configured GTS instance; two-instance selection passes; no unscoped fallback remains |
+| Realm profile | Operator-approved profile is versioned and every required property is verified before tenant mutation |
+| Query capacity | Correct full-group scan meets PRD latency at the declared release population; otherwise upstream capacity/contract is revised |
+| User replay | Failure injection after each provider effect converges to one correctly bound identity |
+| Hard deletion | Two-tenant integration proves sessions and identities for the retiring tenant are removed without touching the active tenant |
+| Audit | Every success/failure mutation produces exactly one append-only terminal outcome with no profile or credential value |
+| Reconciliation | Operator runbook exists and consumes emitted evidence without secret inspection |
+| Compatibility | Supported Keycloak 26.x matrix passes and representative unsupported majors fail startup |
+| Lifecycle | Cancellation and rolling-restart tests prove bounded shutdown and replay safety |
+
+Deferred adopted realms, plugin-created realms, OpenBao secret mutation, and service-principal lifecycle are not designed here. Each requires its own upstream contract, security review, DESIGN, ADRs where decisions depart from accepted standards, and release gates.
+
+## 5. Traceability
+
+### 5.1 Authoritative Contracts
+
+- [Adjacent PRD](./PRD.md)
+- [Account Management DESIGN](../../../docs/DESIGN.md)
+- [`IdpPluginClient` tenant contract](../../../account-management-sdk/src/idp.rs)
+- [`IdpPluginClient` user contract](../../../account-management-sdk/src/idp_user.rs)
+- [Unified ToolKit architecture](../../../../../../docs/toolkit_unified_system/README.md)
+
+### 5.2 P1 Requirement Allocation
+
+| PRD requirement IDs | Design sections |
+|---|---|
+| `cpt-cf-keycloak-idp-plugin-fr-provider-publication`, `cpt-cf-keycloak-idp-plugin-fr-readiness`, `cpt-cf-keycloak-idp-plugin-interface-provider-instance` | §§3.2, 3.6, 4.3 |
+| `cpt-cf-keycloak-idp-plugin-fr-tenant-realm-binding`, `cpt-cf-keycloak-idp-plugin-fr-shared-realm-admissibility`, `cpt-cf-keycloak-idp-plugin-fr-tenant-provision`, `cpt-cf-keycloak-idp-plugin-usecase-bind-shared-tenant` | §§3.1, 3.6 |
+| `cpt-cf-keycloak-idp-plugin-fr-realm-authentication-profile`, `cpt-cf-keycloak-idp-plugin-nfr-provider-compatibility`, `cpt-cf-keycloak-idp-plugin-contract-keycloak-admin` | §§3.2, 3.6, 4.3 |
+| `cpt-cf-keycloak-idp-plugin-fr-provider-metadata` | §§3.1, 3.3 |
+| `cpt-cf-keycloak-idp-plugin-fr-tenant-deprovision`, `cpt-cf-keycloak-idp-plugin-fr-tenant-user-access-termination`, `cpt-cf-keycloak-idp-plugin-usecase-retire-tenant` | §§3.6, 4.1 |
+| `cpt-cf-keycloak-idp-plugin-fr-tenant-failure-contract`, `cpt-cf-keycloak-idp-plugin-fr-external-mutation-resilience`, `cpt-cf-keycloak-idp-plugin-nfr-failure-classification` | §§3.3, 3.6 |
+| `cpt-cf-keycloak-idp-plugin-fr-user-provision`, `cpt-cf-keycloak-idp-plugin-fr-user-update`, `cpt-cf-keycloak-idp-plugin-fr-user-update-outcomes`, `cpt-cf-keycloak-idp-plugin-fr-user-deprovision`, `cpt-cf-keycloak-idp-plugin-usecase-update-user` | §3.6 |
+| `cpt-cf-keycloak-idp-plugin-fr-user-query` | §3.6 |
+| `cpt-cf-keycloak-idp-plugin-fr-user-source-of-truth` | §§3.1, 4.1 |
+| `cpt-cf-keycloak-idp-plugin-fr-administrator-credentials`, `cpt-cf-keycloak-idp-plugin-contract-credstore` | §§3.5–3.6, 4.1 |
+| `cpt-cf-keycloak-idp-plugin-fr-operator-reconciliation`, `cpt-cf-keycloak-idp-plugin-usecase-reconcile-ambiguous-mutation` | §§3.6, 4.3 |
+| `cpt-cf-keycloak-idp-plugin-fr-offline-token-lifetime` | §§2.2, 3.6 |
+| `cpt-cf-keycloak-idp-plugin-fr-audit-metrics`, `cpt-cf-keycloak-idp-plugin-nfr-audit-completeness` | §§3.6, 4.3 |
+| `cpt-cf-keycloak-idp-plugin-nfr-tenant-isolation` | §§3.6, 4.1 |
+| `cpt-cf-keycloak-idp-plugin-nfr-secret-nondisclosure` | §§3.6, 4.1 |
+| `cpt-cf-keycloak-idp-plugin-nfr-lifecycle-latency` | §§1.2, 2.2, 3.6, 4.3 |
+| `cpt-cf-keycloak-idp-plugin-nfr-personal-data-lifecycle` | §4.1 |
+| `cpt-cf-keycloak-idp-plugin-nfr-availability-recovery` | §§3.2, 3.6 |
+| `cpt-cf-keycloak-idp-plugin-interface-idp-plugin-client`, `cpt-cf-keycloak-idp-plugin-contract-account-management` | §§1.1, 2.1, 3.2–3.3 |
+
+P2 requirements remain traceable in the PRD but are intentionally not allocated to V1 implementation components in this DESIGN.

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
@@ -13,7 +13,7 @@ refs:
 
 **Owners:** @platform-iam-team
 
-**Scope:** Architecture of the shipped plugin implementation (crate `vp-idp-plugin`, ported from vhp-core). The implementation is authoritative; this document describes what the code does. In-code comments citing `DESIGN §N` refer to the original vhp-core implementation specification (`DESIGN-vp-idp-plugin-202605192055`) from which this crate lineage descends, not to section numbers in this document.
+**Scope:** Architecture of the shipped plugin implementation (crate `vp-idp-plugin`, ported from vhp-core). The implementation is authoritative; this document describes what the code does, deliberately mirroring implementation-level constants and behaviors (an implementation-mirror altitude) — a change to those constants in code owns the matching edit here. In-code comments citing `DESIGN §N` refer to the original vhp-core implementation specification (`DESIGN-vp-idp-plugin-202605192055`) from which this crate lineage descends, not to section numbers in this document.
 
 <!-- toc -->
 
@@ -56,7 +56,7 @@ The Keycloak IdP plugin is a provider adapter running as an in-process ToolKit g
 
 The plugin talks to the Keycloak Admin REST and OAuth token endpoints directly over HTTPS (reqwest transport). It authenticates with OAuth2 `client_credentials` using two administrator tiers: a **bootstrap admin** client (in the `master` realm by default, secret supplied via environment-expanded configuration) for realm-level work, and a per-realm **realm-admin** client for tenant/user work inside a bound realm. Realm-admin secrets are environment-backed for the default shared realm and Credential-Store-backed (OpenBao) for adopted and created realms; the plugin reads and — for realms it creates — writes those secrets itself through `credstore-sdk` under a plugin-owned system security context.
 
-Three realm bindings are supported: `shared` (default; tenants share an operator-provisioned realm), `adopted` (an existing empty operator realm bound to one tenant), and `created` (the plugin creates and lifecycle-manages a realm named `realm-{tenant_id}`). Keycloak remains the user source of truth; the plugin persists nothing locally and returns a versioned opaque metadata envelope that Account Management stores and replays.
+Three realm bindings are supported: `shared` (default; tenants share an operator-provisioned realm), `adopted` (an existing empty operator realm bound to one tenant), and `created` (the plugin creates and lifecycle-manages a dedicated realm — generated as `realm-{tenant_id}` for child tenants, while a root-target created realm requires an explicit operator-supplied name). Keycloak remains the user source of truth; the plugin persists nothing locally and returns a versioned opaque metadata envelope that Account Management stores and replays.
 
 `update_user` is intentionally not implemented in this revision: the plugin inherits the SDK default, which returns `IdpUserOperationFailure::UnsupportedOperation`.
 
@@ -64,7 +64,7 @@ Three realm bindings are supported: `shared` (default; tenants share an operator
 
 | Driver | Design allocation |
 |---|---|
-| Provider-neutral publication and selection | `PluginV1<IdpPluginSpecV1>` published to types-registry (instance `vz.virtuozzo.vp_idp.plugin.v1`, vendor `virtuozzo`, priority 50); scoped ClientHub registration keyed on the instance id; AM resolves via `choose_plugin_instance` against `idp.vendor` |
+| Provider-neutral publication and selection | `PluginV1<IdpPluginSpecV1>` published to types-registry (vendor-namespaced instance segment `vz.virtuozzo.vp_idp.plugin.v1`; full catalogue id in §3.2, vendor `virtuozzo`, priority 50); scoped ClientHub registration keyed on the instance id; AM resolves via `choose_plugin_instance` against `idp.vendor` |
 | Fail-fast configuration errors | Init validates typed config (`deny_unknown_fields`), the `secret_ref_template`, and the service-principal section, then pre-warms the bootstrap admin token with a bounded retry budget; exhausting the budget fails `Gear::init` |
 | Shared-realm tenant isolation | Per-tenant Keycloak group under `/tenants`, immutable `tenant_id` user attribute (ADR-0006), and an ownership marker attribute (`vhp.provisioning.tenant_id`) on created realms and service-principal clients |
 | Safe external mutation | Parse-then-probe saga ordering, per-step reactive-401 wrapping, idempotent replay paths (probe-adopt realm ensure, 409 group reuse), and stage-attributed `AmbiguousCreated` classification with an `ambig:` prefix contract for reconciliation tooling |
@@ -96,6 +96,8 @@ The significant decisions inherit these accepted records and standards:
 Durable audit delivery remains owned by Account Management and the platform audit owner. The plugin's structured-event emitters (`vp.idp.plugin.events`) are an explicit development stand-in until the platform audit sink lands.
 
 ### 1.3 Architecture Layers
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-tech-inprocess-gear-stack`
 
 ```mermaid
 flowchart LR
@@ -169,7 +171,7 @@ Shared and adopted realms are asserted, never created, repaired, or deleted. Onl
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-correctness-before-retry`
 
-Automatic HTTP retry applies to idempotent verbs and retryable statuses (5xx/429) only; `POST` is never replayed on transport failure. Reactive-401 re-mints exactly once because an auth rejection provably had no side effect. Uncertain created-mode work is stage-attributed `AmbiguousCreated`, never a clean failure.
+Automatic HTTP retry splits by what is known. A retryable status (5xx/429) means Keycloak answered: bounded retry applies to all methods — including administrative `POST`s, whose replays converge through the idempotent-ensure and 409-reuse paths. A connect or timeout failure means the outcome is unknown: only idempotent requests (GET/PUT/DELETE and the token form-POST) are replayed, and administrative `POST`s never are. Reactive-401 re-mints exactly once because an auth rejection provably had no side effect. Uncertain created-mode work is stage-attributed `AmbiguousCreated`, never a clean failure.
 
 #### SDK authority
 
@@ -237,7 +239,7 @@ The plugin owns no database table and no persistent user cache. Its only in-memo
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-scoped-provider-selection`
 
-Account Management selects the plugin through the types-registry catalogue instance and scoped ClientHub resolution. On restart the plugin re-registers idempotently: an `AlreadyExists` catalogue answer is accepted only when the stored spec matches the current serialization byte-for-byte; drift fails init.
+Account Management selects the plugin through the types-registry catalogue instance and scoped ClientHub resolution. On restart the plugin re-registers idempotently: an `AlreadyExists` catalogue answer is accepted only when the stored spec is structurally equal JSON to the current registration (key order and formatting are irrelevant; any field-value difference fails init).
 
 #### Bounded offline-token exposure
 
@@ -249,7 +251,7 @@ A previously issued access JWT can remain valid until `exp`. The plugin revokes 
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-correct-global-query-ordering`
 
-Keycloak does not guarantee stable ordering across group-member offset pages, so `list_users` drains the entire tenant-group membership per request (pages of `list_users_page_limit_max`, default 200), sorts globally on `(createdTimestamp, id)`, and filters client-side. The drain is bounded by a 10,000-member hard cap; exceeding it truncates the member set and logs a loud warning. Page size to the caller is capped at 200.
+Keycloak does not guarantee stable ordering across group-member offset pages, so `list_users` drains the entire tenant-group membership per request (pages of `list_users_page_limit_max`, default 200), sorts globally on `(createdTimestamp, id)`, and filters client-side. The drain is bounded by a 10,000-member hard cap: it stops after the first page that reaches the cap (bounded overshoot of at most one fetch page) and logs a loud truncation warning. Page size to the caller is capped at 200.
 
 ### 2.3 Applicability Matrix
 
@@ -274,7 +276,11 @@ Keycloak does not guarantee stable ordering across group-member offset pages, so
 
 ### 3.1 Domain Model
 
-The provider metadata is the versioned, non-secret routing envelope `TenantIdpMetadataV1`, owned by the plugin and persisted opaquely by Account Management:
+#### Tenant IdP metadata envelope
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-entity-tenant-idp-metadata`
+
+The provider metadata is the versioned, non-secret routing envelope `TenantIdpMetadataV1` (Rust type and serde shape defined in [`domain/metadata_codec.rs`](../src/domain/metadata_codec.rs)), owned by the plugin and persisted opaquely by Account Management:
 
 | Field | Meaning |
 |---|---|
@@ -290,7 +296,7 @@ Provider ownership is split as follows:
 | Resource | Owner | Plugin authority |
 |---|---|---|
 | Shared and adopted realms, their authentication profile, protocol mappers, and the bootstrap/realm-admin clients in them | Platform operator (IaC / realm bootstrap) | Assert existence (and emptiness for adopted); use the configured admin clients |
-| Created realms (`realm-{tenant_id}`, marked `vhp.provisioning.tenant_id`) | Plugin | Create, administer, and delete on last-tenant deprovisioning |
+| Created realms (child tenants: generated `realm-{tenant_id}`; root target: operator-named; all marked `vhp.provisioning.tenant_id`) | Plugin | Create, administer, and delete on last-tenant deprovisioning |
 | Realm-admin client and its 7 `realm-management` roles in created realms | Plugin | Create and grant during created-mode provisioning |
 | Per-tenant group under `/tenants` and the `tenant_id`/`user_type` user attributes | Plugin | Create, inspect, delete for the owning tenant |
 | Human identities and sessions in the tenant boundary | Plugin through Account Management | Create, delete, revoke, and query after boundary verification; updates are unsupported in this revision |
@@ -314,7 +320,7 @@ The plugin is one logical architecture component. The following entries are resp
 | Plugin root | `idp_impl.rs`, `sp_impl.rs` | SDK trait surface; failure translation tables |
 | Tenant lifecycle coordinator | `domain/tenant_facade.rs` | Provision/deprovision sagas for all three bindings, saga timeout, idempotent replay, ambiguity staging, service-principal purge hook |
 | User lifecycle coordinator | `domain/user_facade.rs` | User provision/deprovision/list, tenant boundary guard, orphan compensation, cursor pagination |
-| Service-principal facade | `domain/service_principal_facade.rs` | Machine-identity lifecycle against the configured shared realm; ownership markers; quota and scope allowlist |
+| Service-principal facade | `domain/service_principal_facade.rs` | Machine-identity lifecycle against the configured service-principal realm (`service_principal.realm`, default `platform`); ownership markers; quota and scope allowlist |
 | Metadata codec | `domain/metadata_codec.rs` | Versioned fail-closed envelope encode/decode |
 | KC admin client factory | `domain/kc/` | `client_credentials` token acquisition, `(realm, client_id)` token cache with single-flight refresh, reactive-401, health probe |
 | Credential Store wrappers | `domain/credstore/` | System-ctx-bound reader (secrets, CA bundle) and writer (create-or-replace, delete with absent-as-success) |
@@ -324,7 +330,7 @@ The plugin is one logical architecture component. The following entries are resp
 
 #### Deployment, Publication, and Readiness
 
-The plugin is an in-process gear (`#[toolkit::gear(name = "vp-idp-plugin", deps = [types_registry, credstore])]`) in each host replica. It opens no listener and owns no independent deployment or database.
+The plugin is an in-process gear (gear name `vp-idp-plugin`, with declared gear dependencies on `types-registry` and `credstore`) in each host replica. It opens no listener and owns no independent deployment or database.
 
 Initialization proceeds in phases:
 
@@ -333,14 +339,14 @@ Initialization proceeds in phases:
 3. **Static validation** — the `secret_ref_template` is validated by interpolating a 64-character synthetic realm name through `SecretRef::new`; the service-principal section is validated.
 4. **Transport construction** — the reqwest client is built; if `tls_ca_bundle_ref` is set, the PEM bundle is read from the Credential Store and added as a root certificate.
 5. **Bootstrap pre-warm** — the bootstrap admin token is acquired with bounded retry (default 5 × 3 s). Retryable causes: 5xx/429/transport/timeout and Credential Store read failures (deploy-ordering races). Permanent causes fail on the first attempt. Budget exhaustion fails init.
-6. **Catalogue publish** — `PluginV1<IdpPluginSpecV1>` (`vz.virtuozzo.vp_idp.plugin.v1`, configured vendor/priority) is registered with types-registry; `AlreadyExists` is accepted only when the stored spec matches exactly.
+6. **Catalogue publish** — `PluginV1<IdpPluginSpecV1>` is registered with types-registry under the full catalogue instance id `gts.cf.toolkit.plugins.plugin.v1~cf.core.idp.plugin.v1~vz.virtuozzo.vp_idp.plugin.v1` (base plugin type `gts.cf.toolkit.plugins.plugin.v1~`, derived IdP spec type `…~cf.core.idp.plugin.v1~`, vendor-namespaced instance segment `vz.virtuozzo.vp_idp.plugin.v1`), carrying the configured vendor/priority. `AlreadyExists` is accepted only when the stored spec is structurally equal JSON to the current registration.
 7. **ClientHub registration** — `Arc<dyn IdpPluginClient>` scoped by the catalogue instance id; `Arc<dyn ServicePrincipalClientV1>` unscoped.
 
 After init, readiness is operation-based: every tenant provision/deprovision saga begins with an unauthenticated Keycloak health probe (`GET realms/master`), and every call re-resolves credentials on 401. Recovery from provider or Credential Store outages therefore needs no process restart.
 
 ### 3.3 API Contracts
 
-The current [`idp.rs`](../../../account-management-sdk/src/idp.rs) and [`idp_user.rs`](../../../account-management-sdk/src/idp_user.rs) contracts are authoritative for tenant/user work; [`service-principal-sdk`](../../../../service-principal/service-principal-sdk/src/api.rs) is authoritative for machine identities.
+The current [`idp.rs`](../../../account-management-sdk/src/idp.rs) and [`idp_user.rs`](../../../account-management-sdk/src/idp_user.rs) contracts are authoritative for tenant/user work; [`service-principal-sdk`](../../../../service-principal/service-principal-sdk/src/api.rs) is authoritative for machine identities. This boundary realizes the PRD interface contracts `cpt-cf-keycloak-idp-plugin-interface-idp-plugin-client`, `cpt-cf-keycloak-idp-plugin-interface-service-principal-client`, and `cpt-cf-keycloak-idp-plugin-interface-provider-instance`, under the external contracts `cpt-cf-keycloak-idp-plugin-contract-account-management`, `cpt-cf-keycloak-idp-plugin-contract-keycloak-admin`, and `cpt-cf-keycloak-idp-plugin-contract-credstore`.
 
 Contract invariants implemented at the boundary (`idp_impl.rs`, `sp_impl.rs`):
 
@@ -350,7 +356,7 @@ Contract invariants implemented at the boundary (`idp_impl.rs`, `sp_impl.rs`):
 - missing bootstrap permissions (`BootstrapPermsMissing`) map to `UnsupportedOperation` with an operator-runbook detail;
 - tenant deprovisioning maps `DeprovisionNotFound` → `NotFound` (success-equivalent), `DeprovisionRetryable` → `Retryable`, and everything else — including metadata decode failures — → `Terminal`;
 - user failures use only `IdpUserOperationFailure` variants: KC 409 on create is `DuplicateUser` with the field refined from the provider message (`Username`/`Email`/`UsernameOrEmail`), password-policy rejections are `PasswordPolicy`, unsupported filters and the unimplemented `update_user` are `UnsupportedOperation`, provider/transport trouble is `Unavailable`;
-- service-principal failures use the closed `ServicePrincipalFailure` set: `InvalidInput` (bad name, disallowed scope, quota, taken client id), `NotFound` (absent or foreign principal — indistinguishable by design), `Ambiguous` (stage-attributed transport uncertainty), `CleanFailure` (pre-mutation failures);
+- service-principal failures use the closed `ServicePrincipalFailure` set: `InvalidInput` (bad name, disallowed scope, quota, taken client id), `NotFound` (absent or foreign principal — indistinguishable by design), `Ambiguous` (stage-attributed transport uncertainty; stage tokens tabulated in §3.6), `CleanFailure` (pre-mutation failures);
 - every mutating return carries redacted, truncated, grep-friendly detail (`kc:{METHOD} {path_template} -> {status}: {body≤2KiB}` or `internal:{component}: …`).
 
 The plugin emits no public HTTP API.
@@ -385,19 +391,53 @@ Domain components depend on plugin-owned ports rather than transport types: `req
 
 **ID**: `cpt-cf-keycloak-idp-plugin-seq-tenant-provisioning`
 
+**Use cases**: `cpt-cf-keycloak-idp-plugin-usecase-bind-shared-tenant`, `cpt-cf-keycloak-idp-plugin-usecase-adopt-tenant-realm`, `cpt-cf-keycloak-idp-plugin-usecase-create-tenant-realm` — **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-credstore`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
+
 `provision_tenant` runs under a 30 s (configurable) timeout; a timeout is `AmbiguousCreated { Timeout }`. The saga parses intent first (fail-fast, no provider round-trip), then health-probes Keycloak (failure = clean `Config` error — nothing mutated), then dispatches on the binding:
 
 - **Shared** (default; child tenants inherit the parent's realm from replayed parent metadata; root bootstrap must name the realm): assert the realm exists (bootstrap admin), then under the env-backed realm-admin ensure the per-tenant group `/tenants/{tenant_id}` and optionally bind the operator-declared admin user's `tenant_id`/`user_type` attributes (idempotent; a foreign or multi-valued existing binding is rejected as a hijack attempt).
 - **Adopted**: assert the realm exists and is empty of tenant boundaries (no subgroups under the group root), then ensure the tenant group using the operator-provisioned Credential Store secret reference.
-- **Created**: idempotent realm ensure (probe → adopt if marked as ours → reject foreign → create with the ownership attribute and a fail-closed allowlist over operator `realm_defaults`: `displayNameHtml`, `defaultLocale`, `supportedLocales`, `internationalizationEnabled`), bootstrap-token invalidation (the pre-create token lacks the auto-granted role on the new realm), realm-admin client creation, grant of the seven `realm-management` roles, secret read-back, Credential Store write (point of no return — failure is `AmbiguousCreated { OpenBaoPutAfterKcSuccess }`), and tenant-group creation under the new realm-admin.
+- **Created** (child tenants use the generated name `realm-{tenant_id}` and reject an explicit one; a root-target created realm requires an explicit operator-supplied name): idempotent realm ensure (probe → adopt if marked as ours → reject foreign → create with the ownership attribute and a fail-closed allowlist over operator `realm_defaults`: `displayNameHtml`, `defaultLocale`, `supportedLocales`, `internationalizationEnabled`), unconditional bootstrap-token invalidation after realm ensure — whether the realm was just created or idempotently adopted — so the next bootstrap call carries the new realm's auto-granted role, realm-admin client creation, grant of the seven `realm-management` roles, secret read-back, Credential Store write (point of no return — failure is `AmbiguousCreated { OpenBaoPutAfterKcSuccess }`), and tenant-group creation under the new realm-admin.
 
-Every step that can fail after provider state exists carries a stage: `ambig:kc_realm_create`, `ambig:kc_client_create`, `ambig:kc_role_mapping`, `ambig:kc_client_secret_read`, `ambig:openbao_put_after_kc_success`, `ambig:admin_user_bind`, `ambig:timeout`. Reconciliation tooling parses the `ambig:` prefix.
+```mermaid
+sequenceDiagram
+  participant P as Plugin (created-mode saga)
+  participant K as Keycloak
+  participant CS as Credential Store
+
+  P->>K: Probe realm (adopt if ours / reject foreign)
+  P->>K: Create realm + ownership marker [ambig:kc_realm_create]
+  P-->>P: Invalidate bootstrap token (unconditional)
+  P->>K: Create realm-admin client [ambig:kc_client_create]
+  P->>K: Grant 7 realm-management roles [ambig:kc_role_mapping]
+  P->>K: Read generated client secret [ambig:kc_client_secret_read]
+  P->>CS: Store secret under templated ref [ambig:openbao_put_after_kc_success]
+  P->>K: Ensure tenant group (new realm-admin)
+```
+
+Every step that can fail after provider state exists carries a stage token that reconciliation tooling parses by its `ambig:` prefix. The complete stage contract (one row per `AmbiguousStage` variant):
+
+| Stage token | Emitting saga |
+|---|---|
+| `ambig:kc_realm_create` | Created-mode realm creation |
+| `ambig:kc_client_create` | Created-mode realm-admin client creation; service-principal client creation and post-create lookup |
+| `ambig:kc_role_mapping` | Created-mode `realm-management` role grants |
+| `ambig:kc_client_secret_read` | Created-mode realm-admin secret read-back; service-principal secret read at creation |
+| `ambig:openbao_put_after_kc_success` | Created-mode Credential Store write after Keycloak state exists |
+| `ambig:admin_user_bind` | Shared-mode admin-user attribute bind |
+| `ambig:timeout` | Provisioning saga timeout |
+| `ambig:kc_sa_attr_set` | Service-principal service-account attribute bind after client creation |
+| `ambig:kc_client_scope_attach` | Service-principal client-scope attachment |
+| `ambig:kc_client_secret_rotate` | Service-principal secret rotation |
+| `ambig:kc_client_delete` | Service-principal revocation and tenant-deprovision purge |
 
 Success returns the metadata envelope, records `provision_tenant_duration` and `realms_bound`, and emits `tenant.bound` (plus `realm.created` and/or `admin_user.bound` where applicable).
 
 #### User Mutation Safety
 
 **ID**: `cpt-cf-keycloak-idp-plugin-seq-user-mutation`
+
+**Use cases**: user provisioning/deprovisioning are exercised through the parent Account Management use cases; `cpt-cf-keycloak-idp-plugin-usecase-update-user` is p2 — **Actors**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`, `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`
 
 User operations resolve realm, admin client, and tenant group from replayed metadata and run each Keycloak step under an exactly-once reactive-401 wrapper.
 
@@ -410,6 +450,8 @@ User operations resolve realm, admin client, and tenant group from replayed meta
 #### Tenant Deprovisioning
 
 **ID**: `cpt-cf-keycloak-idp-plugin-seq-hard-tenant-deprovisioning`
+
+**Use cases**: `cpt-cf-keycloak-idp-plugin-usecase-retire-tenant` — **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-credstore`, `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`
 
 Ordering: local metadata resolution → service-principal purge → tenant-group deletion → (created-mode only) last-tenant realm teardown → Credential Store secret deletion.
 
@@ -426,7 +468,9 @@ The whole saga shares the 30 s timeout (timeout → `Retryable`).
 
 **ID**: `cpt-cf-keycloak-idp-plugin-seq-user-query`
 
-`IdpListUsersRequest` is authoritative. Because Keycloak documents no stable global order for group-member offset pages, each list call drains the full tenant-group membership (pages of `list_users_page_limit_max`, default 200) into memory, bounded by a 10,000-member hard cap (exceeding it truncates and logs loudly), then sorts on `(createdTimestamp ASC, id ASC)`, deduplicates by id, applies the cursor skip, applies filters, and pages.
+**Use cases**: tenant-scoped user queries back the parent Account Management listing surfaces — **Actors**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`, `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`
+
+`IdpListUsersRequest` is authoritative. Because Keycloak documents no stable global order for group-member offset pages, each list call drains the full tenant-group membership (pages of `list_users_page_limit_max`, default 200) into memory, bounded by a 10,000-member hard cap (the drain stops after the first page that reaches the cap — overshoot of at most one fetch page — and logs a loud truncation warning), then sorts on `(createdTimestamp ASC, id ASC)`, deduplicates by id, applies the cursor skip, applies filters, and pages.
 
 Supported filters, lowered client-side: `eq` (exact) and `contains` (case-insensitive) over `username`, `email`, `first_name`, `last_name`, `display_name`; `id eq` as a point filter; `and`/`or` composition. Everything else (`ne`, ranges, `in`, `not`, `id eq` inside `or`) returns `UnsupportedOperation` before any provider call. Requested ordering is not consulted; the sort is fixed.
 
@@ -436,13 +480,17 @@ The continuation token is a `CursorV1` (the same envelope Account Management use
 
 **ID**: `cpt-cf-keycloak-idp-plugin-seq-reconciliation`
 
-Transport-level retry is bounded (default 3 retries, exponential backoff 100 ms → 5 s cap, full jitter, `Retry-After` honored in delta-seconds form) and applies only to idempotent requests (GET/PUT/DELETE and the token form-POST) on retryable statuses (5xx/429) or connect/timeout errors; admin POSTs are never replayed on transport failure. Reactive-401 re-mints credentials exactly once per call.
+**Use cases**: `cpt-cf-keycloak-idp-plugin-usecase-reconcile-ambiguous-mutation` — **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
+
+HTTP-level retry is bounded (default 3 retries, exponential backoff 100 ms → 5 s cap, full jitter, `Retry-After` honored in delta-seconds form) and splits by what is known: retryable statuses (5xx/429) — where Keycloak answered — are retried for all methods, including administrative POSTs (create-path replays converge through the idempotent-ensure and 409-reuse paths); connect/timeout errors — where the outcome is unknown — are retried only for idempotent requests (GET/PUT/DELETE and the token form-POST), never for administrative POSTs. Reactive-401 re-mints credentials exactly once per call.
 
 Classification is closed: internal `PluginError` variants translate to SDK failures per the fixed tables in §3.3, and each variant has a stable metric label on `vp_idp_plugin_failure_total`. Ambiguous created-mode provisioning remains operator-owned: terminal evidence carries the `ambig:{stage}` token, the realm, and redacted provider detail. Production enablement requires a reconciliation runbook keyed on those stage tokens.
 
 #### Credentials, Token Cache, and Rotation
 
 **ID**: `cpt-cf-keycloak-idp-plugin-seq-credential-resolution`
+
+**Use cases**: credential handling underpins every mutating use case above — **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
 
 All Keycloak traffic authenticates with OAuth2 `client_credentials`. Secrets resolve by tier:
 
@@ -452,6 +500,8 @@ All Keycloak traffic authenticates with OAuth2 `client_credentials`. Secrets res
 | Shared-realm admin | `vp-idp-plugin-realm-admin` (default) | `${VAR}`-expanded configuration (`default_shared_realm_secret`) |
 | Adopted/created-realm admin | `admin_client_id` from metadata | Credential Store reference from `secret_ref_template` (created-mode secrets are written by the plugin during provisioning) |
 
+Service-principal administration always uses the bootstrap admin tier, against the dedicated service-principal realm (`service_principal.realm`, default `platform` — the shared realm whose issuer tenants trust), independent of any tenant's realm binding.
+
 Tokens are cached per `(realm, client_id)` with an expiry safety margin (default 30 s, floor 5 s), single-flight refresh (one concurrent mint per key), and read-time eviction. A 401 on any wrapped call invalidates the cache entry, re-resolves the secret from its source, and retries exactly once — so operator secret rotation converges without restart. Cache hits emit no metrics; real refreshes emit `credential_refresh_total` and `kc_admin_token_refresh_total` separately so "Credential Store unreachable" and "Keycloak rejected the secret" are distinguishable.
 
 Optional TLS: `tls_ca_bundle_ref` names a Credential Store secret holding a PEM CA bundle added to the reqwest trust roots at init; otherwise the system trust store applies.
@@ -459,6 +509,8 @@ Optional TLS: `tls_ca_bundle_ref` names a Credential Store secret holding a PEM 
 #### Audit and Metrics Boundary
 
 **ID**: `cpt-cf-keycloak-idp-plugin-seq-terminal-outcome`
+
+**Use cases**: audit/metrics evidence underpins `cpt-cf-keycloak-idp-plugin-usecase-reconcile-ambiguous-mutation` and the durable-audit handoff — **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
 
 ```mermaid
 sequenceDiagram
@@ -476,11 +528,15 @@ sequenceDiagram
 
 The plugin emits structured events on the `vp.idp.plugin.events` tracing target — `tenant.bound`, `realm.created`, `admin_user.bound`, `tenant.unbound`, `realm.removed`, `service_principals.purged`, `user.provisioned` (includes `username`), `user.deprovisioned` — each carrying the acting subject (id, closed-set type, raw type, tenant). This is an explicit development stand-in until the platform audit sink lands; durable one-outcome-per-call correlation is owned by Account Management and the platform audit owner. `list_users` and the service-principal read/mutate paths emit no plugin audit events of their own; the only service-principal audit signal is `service_principals.purged` on tenant deprovisioning.
 
-Metrics: `vp_idp_plugin_provision_tenant_duration_seconds`, `user_op_duration_seconds`, `sp_op_duration_seconds`, `kc_admin_request_duration_seconds` (declared, not yet wired), `failure_total{op,failure_variant}`, `kc_admin_token_refresh_total` and `credential_refresh_total` (`{outcome,tier,realm}`), `credstore_write_total`, `metadata_decode_failure_total{version_observed}`, `deprovision_missing_metadata_total`, `orphan_user_compensation_total`, `realms_bound{realm_binding,realm_name}`. Every label is a closed enum except `realm`/`realm_name`, which share a cardinality budget (default 500 distinct realms) after which the label is dropped with a one-shot warning.
+Metrics: `vp_idp_plugin_provision_tenant_duration_seconds`, `user_op_duration_seconds`, `sp_op_duration_seconds`, `kc_admin_request_duration_seconds` (declared, not yet wired), `failure_total{op,failure_variant}`, `kc_admin_token_refresh_total` and `credential_refresh_total` (`{outcome,tier,realm}`), `credstore_write_total`, `metadata_decode_failure_total{version_observed}`, `deprovision_missing_metadata_total`, `orphan_user_compensation_total`, `realms_bound{realm_binding,realm_name}`. Every label is a closed enum except `realm`/`realm_name`, which share a cardinality budget (default 500 distinct realms) after which the label is dropped and a warning is logged for each newly observed over-cap realm.
+
+Operational signals: the reconciliation gate consumes `failure_total{failure_variant="ambiguous_created"}` and the `ambig:{stage}` warn events; dependency-health attribution splits `credential_refresh_total{outcome="error"}` (Credential Store) from `kc_admin_token_refresh_total{outcome="error"}` (Keycloak) plus `credstore_write_total{outcome="error"}`; metadata integrity consumes `metadata_decode_failure_total` (any increase is operator-actionable); list capacity consumes the drain-cap truncation warning. Alert thresholds against the PRD availability and latency targets are owned by the deployment repository's monitoring configuration, not by this design.
 
 #### Lifecycle and Shutdown
 
 **ID**: `cpt-cf-keycloak-idp-plugin-seq-lifecycle-shutdown`
+
+**Use cases**: none (host lifecycle behavior) — **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
 
 The plugin owns no periodic, detached, or audit-delivery task; all work is call-scoped and bounded by the per-request HTTP timeout, the bounded retry policy, and the saga timeout. Host shutdown therefore has nothing plugin-specific to drain beyond in-flight calls, which preserve their normal classification and reconciliation evidence.
 
@@ -520,6 +576,8 @@ Keycloak is the sole user directory. The plugin holds request data only for the 
 | Cross-system audit contract | Account Management and the platform audit owner prove durable terminal outcomes; external production gate |
 
 Test doubles are limited to deterministic classification and failure injection (wiremock for HTTP, stub credstore clients); they do not establish Keycloak compatibility, tenant isolation, TLS, or latency.
+
+The release-qualification query matrix for the PRD latency NFR covers unfiltered results and filters matching approximately 100%, 10%, and 1% of the tenant group, each over cached-token and forced-token-refresh runs.
 
 ### 4.3 Risks and Enablement Gates
 
@@ -564,7 +622,7 @@ Test doubles are limited to deterministic classification and failure injection (
 | `cpt-cf-keycloak-idp-plugin-fr-administrator-credentials`, `cpt-cf-keycloak-idp-plugin-contract-credstore` | §§3.5–3.6, 4.1 |
 | `cpt-cf-keycloak-idp-plugin-fr-operator-reconciliation`, `cpt-cf-keycloak-idp-plugin-usecase-reconcile-ambiguous-mutation` | §§3.6, 4.3 |
 | `cpt-cf-keycloak-idp-plugin-fr-offline-token-lifetime` | §§2.2, 3.6 |
-| `cpt-cf-keycloak-idp-plugin-fr-audit-metrics`, `cpt-cf-keycloak-idp-plugin-nfr-audit-completeness` | §§3.3, 3.5–3.6, 4.1–4.3 |
+| `cpt-cf-keycloak-idp-plugin-fr-audit-metrics`, `cpt-cf-keycloak-idp-plugin-fr-operational-metrics`, `cpt-cf-keycloak-idp-plugin-nfr-audit-completeness` | §§3.3, 3.5–3.6, 4.1–4.3 |
 | `cpt-cf-keycloak-idp-plugin-nfr-tenant-isolation` | §§3.6, 4.1 |
 | `cpt-cf-keycloak-idp-plugin-nfr-secret-nondisclosure` | §§3.6, 4.1 |
 | `cpt-cf-keycloak-idp-plugin-nfr-lifecycle-latency` | §§1.2, 2.2, 3.6, 4.3 |

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
@@ -43,7 +43,7 @@ refs:
 
 <!-- /toc -->
 
-The adjacent [PRD](./PRD.md) is authoritative for WHAT, WHY, release priority, actors, and acceptance criteria. The Account Management SDK is authoritative for method signatures, request and result shapes, failure variants, filtering, ordering, and cursor envelopes. This document defines only the V1 architecture and its safety invariants.
+The adjacent [PRD](./PRD.md) is authoritative for WHAT, WHY, release priority, actors, and acceptance criteria. The Account Management SDK is authoritative for request, result, failure, filtering, ordering, and cursor contracts. Durable audit delivery is an external production prerequisite allocated to Account Management and the platform audit owner in §§3.5–3.6 and 4.3. This document defines only the V1 architecture and its safety invariants.
 
 ## 1. Architecture Overview
 
@@ -63,9 +63,9 @@ V1 does not adopt or create realms, write administrator secrets, manage service 
 | Hard access termination | Session revocation and identity deletion precede tenant-group deletion; unproven cleanup is terminal |
 | Provider compatibility | Keycloak 26.x startup compatibility check plus a read-only realm authentication-profile verifier |
 | Protected administration | Least-privileged per-realm administrator, Credential Store SecretRefs, shared ToolKit HTTP/auth, and no V1 master-realm administrator |
-| Audit completeness | Exactly one privacy-preserving terminal outcome for every successful or failed supported mutation |
+| Audit completeness | Account Management and the platform audit owner guarantee one durable terminal outcome per supported mutation call |
 | User query correctness | SDK filter/order semantics, `CursorV1`, global deterministic sorting, and no stable-order claim based on Keycloak offset pages |
-| Lifecycle safety | ToolKit cancellation and bounded drain; V1 has no periodic background task |
+| Lifecycle safety | ToolKit cancellation and bounded drain; the plugin owns no periodic or audit-delivery task |
 
 #### NFR Allocation
 
@@ -75,7 +75,7 @@ V1 does not adopt or create realms, write administrator secrets, manage service 
 | Secret non-disclosure | Secret wrappers, allowlisted diagnostics, protected SecretRefs, and output scanning | Logs, metrics, audit, errors, and debug output contain no injected secret |
 | Lifecycle latency | Shared HTTP pooling, bounded calls, point-lookup optimization, and measured full-group query scans | PRD qualification profile: 20 concurrent operations and stated p95 limits |
 | Failure classification | Current SDK enums are the only failure vocabulary | Exhaustive enum mapping and failure injection |
-| Audit completeness | Common completion boundary emits exactly one terminal outcome | One-to-one call/event correlation |
+| Audit completeness | The plugin returns a classified privacy-safe outcome; durable correlation and delivery are owned by Account Management and the platform audit contract | One terminal event per mutating call across cross-system contract tests |
 | Provider compatibility | Startup version gate and release compatibility matrix | Supported 26.x matrix passes; unsupported major fails deterministically |
 | Personal-data lifecycle | No local user directory; hard deletion removes identities and sessions | Hard-delete and output-minimization verification |
 | Availability recovery | Dependency state is evaluated per affected operation after startup | Dependency loss/recovery tests without fallback or default realm |
@@ -93,6 +93,8 @@ V1 introduces no approved exception to the repository architecture. Its signific
 
 A proposal to add a master-realm administrator, direct `reqwest`, direct OpenBao mutation, unscoped publication, or plugin-owned user storage is a material deviation and requires a new accepted ADR before this DESIGN can change.
 
+Durable audit delivery requires accepted Account Management and platform audit designs. This plugin design does not define their persistence, recovery, relay, sink, or retention mechanisms. The existing Account Management structured-log stand-in is suitable only for development.
+
 ### 1.3 Architecture Layers
 
 ```mermaid
@@ -102,6 +104,7 @@ flowchart LR
   cred[(Credential Store)]
   kc[(Keycloak 26.x shared realm)]
   authn[OIDC AuthN Resolver]
+  audit[Platform audit infrastructure]
   subgraph am[Account Management process]
     api[Account Management application layer]
     domain[Plugin domain coordinators and boundary guard]
@@ -111,6 +114,7 @@ flowchart LR
   operator --> iac
   iac -->|approved realm profiles and SecretRefs| infra
   api -->|scoped IdpPluginClient| domain
+  api -->|durable terminal outcome; external contract| audit
   domain --> infra
   infra -->|protected secret read| cred
   infra -->|Admin REST over toolkit-http| kc
@@ -119,10 +123,10 @@ flowchart LR
 
 | Layer | Responsibility |
 |---|---|
-| Account Management application | Public authorization, tenant saga orchestration, opaque metadata persistence, scoped provider selection |
-| Plugin domain | Tenant/user lifecycle, boundary enforcement, replay safety, error classification, terminal outcomes |
-| Plugin infrastructure | ToolKit HTTP/auth, Credential Store resolution, Keycloak representation mapping, telemetry transport |
-| Platform dependencies | Keycloak identity state, Credential Store secrets, audit sink, operator-owned realm configuration |
+| Account Management application | Public authorization, tenant saga orchestration, opaque metadata persistence, scoped provider selection, and audit orchestration defined by the parent AM design |
+| Plugin domain | Tenant/user lifecycle, boundary enforcement, replay safety, error classification, and privacy-preserving outcomes |
+| Plugin infrastructure | ToolKit HTTP/auth, Credential Store resolution, Keycloak representation mapping, and telemetry transport |
+| Platform dependencies | Keycloak identity state, Credential Store secrets, platform audit infrastructure, and operator-owned realm configuration |
 
 ## 2. Principles & Constraints
 
@@ -176,6 +180,12 @@ Use one approved realm-administrator profile per shared realm; V1 has no master-
 
 Operation outcomes are observable without credentials or user profile values.
 
+#### Durable intent before mutation
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-durable-audit-intent`
+
+Account Management and the platform audit contract must durably correlate each mutating plugin call with one terminal outcome. The mechanism is outside this plugin design.
+
 ### 2.2 Constraints
 
 #### Shared-realm-only V1
@@ -188,7 +198,13 @@ V1 supports only `mode = shared` against an operator-approved Keycloak 26.x real
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-external-consistency-boundaries`
 
-Keycloak and Credential Store are external consistency boundaries; plugin calls occur outside Account Management database transactions.
+Keycloak, Credential Store, and the platform audit sink are external consistency boundaries. Plugin calls occur outside Account Management database transactions, so the architecture does not claim atomic commit or transport-level exactly-once behavior across those systems.
+
+#### External durable audit prerequisite
+
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-durable-audit-wrapper`
+
+The plugin owns no audit table, recovery worker, relay, or sink integration. Production requires the parent Account Management design and platform audit contract to guarantee durable one-to-one call/outcome correlation across process failure and redelivery.
 
 #### Opaque metadata replay
 
@@ -236,7 +252,7 @@ Query correctness requires a global view of the tenant group because Keycloak do
 | Usability | Not applicable because the plugin exposes no human interface; Account Management owns public API usability. |
 | Accessibility | Not applicable because the plugin exposes no visual or interactive user interface. |
 | Business and time-to-market | Not applicable because prioritization, business outcomes, and delivery timing are owned by the adjacent PRD and planning artifacts. |
-| Plugin-specific cost budget | Not applicable because V1 adds no independently deployed service or persistent store; infrastructure cost is inherited from Account Management, Keycloak, Credential Store, and the release qualification profile. |
+| Plugin-specific cost budget | Not applicable because V1 adds no independently deployed service or plugin-owned store. Audit infrastructure cost belongs to its external owners. |
 | Documentation quality | Applicable; authoritative references and bidirectional traceability are provided in §5. |
 
 ## 3. Technical Architecture
@@ -259,6 +275,7 @@ Provider ownership is split as follows:
 | Tenant group and immutable tenant marker | Plugin | Create, inspect, and delete for the owning tenant |
 | Human identity and sessions in the tenant boundary | Plugin through Account Management | Create, update, query, revoke, and delete after boundary verification |
 | Opaque provider metadata row | Account Management | Persist/replay only; plugin owns interpretation |
+| Durable audit record and delivery | Account Management and platform audit owner | Defined outside this plugin; must correlate one terminal outcome to each mutating call |
 | Access-token validation | OIDC AuthN Resolver | No call to this plugin |
 
 ### 3.2 Component Model
@@ -281,7 +298,7 @@ The plugin is one logical architecture component. The following entries are resp
 | User query adapter | Tenant-scoped filtering, ordering, point existence, global sorting, and `CursorV1` generation |
 | Keycloak adapter | ToolKit HTTP/auth integration, bounded provider calls, response classification, and allowlisted diagnostics |
 | Credential resolver | Protected SecretRef resolution under a least-privileged plugin system actor, including ownership validation and rotation refresh |
-| Terminal outcome emitter | Exactly-once completion audit and bounded-cardinality metrics |
+| Terminal outcome producer | Returns one classified, privacy-preserving outcome to the AM caller and records bounded-cardinality metrics separately |
 
 #### Deployment, Publication, and Readiness
 
@@ -289,13 +306,13 @@ The plugin is an in-process ModKit module in each Account Management replica. It
 
 Each instance publishes `IdpPluginClient` with `ClientScope::gts_id(instance_id)`. Account Management must select the configured provider instance through scoped ClientHub resolution. This coordinated consumer change is a V1 implementation prerequisite; ambiguous selection or unscoped fallback fails closed.
 
-Initialization validates configuration, approved realm profiles, SecretRef syntax, TLS policy, and GTS identity; resolves standard ClientHub dependencies; resolves the selected realm administrator through Credential Store; and proves the provider reports a supported Keycloak 26.x major. The scoped client is published only after mandatory startup compatibility succeeds.
+Initialization validates configuration, approved realm profiles, SecretRef syntax, TLS policy, and GTS identity; resolves standard ClientHub dependencies; resolves the selected realm administrator through Credential Store; and proves the provider reports a supported Keycloak 26.x major. `provision_tenant` remains the operation-based provider readiness signal. Audit infrastructure does not add a plugin dependency.
 
 No V1 initialization path resolves P2 OpenBao mutation APIs or a master-realm bootstrap administrator. After successful publication, dependency loss is classified on the operation that needs it; the module remains registered so recovery does not require process restart.
 
 ### 3.3 API Contracts
 
-The current [`idp.rs`](../../../account-management-sdk/src/idp.rs) and [`idp_user.rs`](../../../account-management-sdk/src/idp_user.rs) contracts are authoritative. This DESIGN does not redefine request fields, output structs, method signatures, or complete error tables.
+The current [`idp.rs`](../../../account-management-sdk/src/idp.rs) and [`idp_user.rs`](../../../account-management-sdk/src/idp_user.rs) contracts are authoritative. This design does not add audit parameters to `IdpPluginClient`. Any future propagation required by the Account Management or platform audit contract must follow normal SDK compatibility rules.
 
 Architectural contract invariants are:
 
@@ -306,7 +323,9 @@ Architectural contract invariants are:
 - duplicate users, password-policy rejection, absent update targets, and unavailability use their current classified user variants;
 - `Rejected` is reserved for provider rejection that cannot be classified further;
 - already-absent deprovisioning follows the SDK's success-equivalent semantics;
-- typed filter/order and `CursorV1` are used without a plugin-specific parallel contract.
+- deprovisioning is `Retryable` only when no attempted mutation has an unknown outcome; any mutation request that may have reached Keycloak without a provable result is `Terminal`, regardless of whether the immediate error appears transient;
+- typed filter/order and `CursorV1` are used without a plugin-specific parallel contract;
+- every mutating return is classifiable and contains enough non-sensitive context for the external audit owner to construct its terminal outcome.
 
 The plugin emits no public HTTP API. Account Management owns public status, validation-envelope, and redaction mapping.
 
@@ -327,10 +346,10 @@ Domain components depend on plugin-owned ports rather than transport types. Dire
 
 | Dependency | Contract and failure boundary |
 |---|---|
-| Account Management | Authorizes calls, selects the scoped plugin, persists/replays opaque metadata, and consumes typed outcomes |
+| Account Management | Authorizes calls, selects the scoped plugin, persists/replays opaque metadata, consumes typed outcomes, and owns audit orchestration defined by its parent design |
 | Keycloak 26.x | User/session/group source of truth and Admin REST provider; another major is unsupported until compatibility approval |
 | Credential Store | Protects operator-created realm-administrator secrets; ownership or availability failure blocks only dependent administration |
-| Platform audit sink | Stores terminal mutation outcomes append-only with finite retention |
+| Platform audit infrastructure | Owns the sink and delivery contract consumed by Account Management; not defined by this plugin |
 | Operator IaC | Creates the shared realm, realm-local administrator, required authentication profile, SecretRefs, and approved realm registry |
 | OIDC AuthN Resolver | Independently validates tokens; the two plugins do not call each other |
 
@@ -358,7 +377,7 @@ User provisioning is a recoverable unit even though provider creation and tenant
 
 Hard deprovisioning proves access termination before boundary deletion. It obtains a complete tenant-group membership view, verifies each tenant marker, revokes sessions, deletes every tenant identity, verifies cleanup, and only then deletes the plugin-owned group. The shared realm and unrelated identities are never deleted.
 
-Already-absent plugin-owned resources are success-equivalent. Ownership mismatch, incomplete enumeration, failed session revocation, or unproven identity removal is terminal. Transient failure before proof of cleanup uses the SDK retryable category. The process blocks refresh and new sessions but does not claim immediate invalidation of an already-issued JWT; exposure is bounded by the 15-minute profile limit.
+Already-absent plugin-owned resources are success-equivalent. `Retryable` is limited to failures for which the plugin proves that no deprovisioning mutation has an unknown outcome: no mutating request may have reached Keycloak, or all completed partial work is proven replay-safe and no attempted stage remains uncertain. If a session-revocation, identity-removal, or group-removal request may have reached Keycloak and its result cannot be proven, the outcome is `Terminal` for operator action even when the immediate cause is a timeout or transient transport failure. Ownership mismatch, incomplete enumeration, and any inability to prove safe continuation are also terminal. The process blocks refresh and new sessions but does not claim immediate invalidation of an already-issued JWT; exposure is bounded by the 15-minute profile limit.
 
 #### User Query Architecture
 
@@ -372,7 +391,7 @@ This is a correctness-first linear scan, not an `O(page)` claim. Point existence
 
 **ID**: `cpt-cf-keycloak-idp-plugin-seq-reconciliation`
 
-Retries are bounded and limited to idempotent reads, token refresh, or operations whose replay contract proves safety. A provider mutation is never blindly retried merely because transport failed. Circuit breaking is dependency-specific and never selects a default realm or stale user projection.
+Retries are bounded and limited to idempotent reads, token refresh, or operations whose replay contract proves safety. For tenant deprovisioning, a pre-send dependency failure or proven replay-safe partial state may return `Retryable`; a timeout or disconnect after a mutating request may have reached Keycloak returns `Terminal` unless the result is independently proven. A provider mutation is never blindly retried merely because transport failed. Circuit breaking is dependency-specific and never selects a default realm or stale user projection.
 
 Ambiguous tenant provisioning remains operator-owned in V1. Terminal outcomes provide non-secret stage and ownership evidence. Production enablement requires a reconciliation runbook whose resolution ends as compensated, accepted complete, blocked for investigation, or escalated for controlled cleanup.
 
@@ -384,23 +403,38 @@ All Keycloak OAuth and Admin REST traffic uses `toolkit-http` and the supported 
 
 Credential values remain protected secret types and never enter metadata, errors, events, metrics, or debug formatting. Provider authentication rejection invalidates cached material, re-resolves the SecretRef, and permits one replay through the shared auth layer. V1 uses reactive refresh and has no scheduled credential-refresh task.
 
+#### Durable Mutation Audit Boundary
+
+**ID**: `cpt-cf-keycloak-idp-plugin-seq-terminal-outcome`
+
+```mermaid
+sequenceDiagram
+  participant AM as Account Management
+  participant P as Keycloak plugin
+  participant K as Keycloak
+  participant A as Platform audit infrastructure
+
+  AM->>P: Invoke mutating contract
+  P->>K: Provider operation
+  P-->>AM: Classified privacy-safe outcome
+  AM->>A: Durably correlate terminal outcome
+```
+
+The plugin produces the classified provider outcome and privacy-safe evidence needed by its caller. It does not persist audit records, call the platform audit sink, or own delivery/recovery tasks.
+
+Account Management and the platform audit owner must guarantee one durable terminal outcome per mutating contract call, including process failure after a possible provider effect and duplicate delivery. Their chosen persistence, idempotency key, recovery, replay, acknowledgement, and retention semantics belong to their own authoritative designs and contracts.
+
+Until those owners approve and implement that guarantee, this plugin may use the existing structured-log stand-in for development but is not production-enabled. Audit payloads prohibit usernames, emails, display names, passwords, tokens, administrator secrets, raw provider bodies, and request payloads.
+
 #### Lifecycle and Shutdown
 
 **ID**: `cpt-cf-keycloak-idp-plugin-seq-lifecycle-shutdown`
 
-The module receives a ToolKit `CancellationToken`. Shutdown stops new work, cancels idle provider activity, and drains in-flight mutations for a bounded interval before connection teardown. Mutation coordinators preserve their normal replay/reconciliation evidence if the timeout expires. V1 owns no periodic or detached background task.
-
-#### Audit and Observability
-
-**ID**: `cpt-cf-keycloak-idp-plugin-seq-terminal-outcome`
-
-Every supported mutating tenant or user call passes through one completion boundary that emits exactly one terminal audit outcome for success or failure. It carries operation, classified SDK outcome, correlation and initiating actor, target tenant, provider IDs when known, mutation stage, and reconciliation requirement. Fields unknowable before metadata resolution are absent or use a documented non-sensitive sentinel.
-
-Usernames, emails, display names, passwords, tokens, administrator secrets, and raw provider bodies are prohibited. The same completion boundary records bounded-cardinality duration, dependency, failure, credential-refresh, and reconciliation metrics. Production requires platform append-only audit routing; development logs alone do not satisfy the PRD.
+The module receives a ToolKit `CancellationToken`. Shutdown stops new work, cancels idle provider activity, and drains in-flight mutations for a bounded interval before connection teardown. Mutation coordinators preserve their normal replay/reconciliation evidence if the timeout expires. The plugin owns no periodic, detached, or audit-delivery task.
 
 ### 3.7 Database schemas & tables
 
-Not applicable because the plugin owns no database schema, table, migration, or persistent user index. Account Management owns its existing opaque provider-metadata row and Keycloak owns provider identity state. This DESIGN references those ownership boundaries without duplicating their code-level schemas.
+Not applicable because the plugin owns no database schema, table, migration, audit store, or persistent user index. Account Management owns its opaque provider-metadata row, and Keycloak owns provider identity state. Any audit persistence belongs to the parent Account Management design or platform audit owner and is intentionally not specified here.
 
 ## 4. Additional context
 
@@ -410,17 +444,18 @@ Not applicable because the plugin owns no database schema, table, migration, or 
 
 | Boundary | Control |
 |---|---|
-| Account Management caller to plugin | AM authorizes; forwarded `SecurityContext` identifies the audit actor but never substitutes for provider tenant checks |
+| Account Management caller to plugin | AM authorizes; forwarded `SecurityContext` identifies the actor but never substitutes for provider tenant checks |
 | Plugin to Credential Store | Dedicated system actor, configured SecretRef allowlist, response ownership validation, and no caller-tenant credential ownership |
 | Plugin to Keycloak | Least-privileged realm administrator, TLS verification, ToolKit HTTP policy, and provider-version/profile checks |
 | Tenant A to tenant B in one realm | Mandatory group-plus-marker guard on every read and mutation |
-| Plugin to audit/metrics | Allowlisted fields and no profile or credential values |
+| Account Management to platform audit infrastructure | External contract; the plugin supplies only classified privacy-safe outcomes |
+| Plugin to metrics | Bounded-cardinality labels and no profile or credential values |
 
 The V1 administrator has only realm-local permissions needed to inspect the authentication profile and administer users, sessions, and the configured tenant-group subtree. It cannot create/delete realms, administer another realm, read client secrets, or alter operator-owned authentication configuration.
 
 Missing, malformed, contradictory, unknown-major, or deferred-mode metadata causes no provider mutation. A realm outside the approved registry is rejected even if reachable. Tenant marker and group disagreement blocks access. Credential or TLS failure never falls back to plaintext, another realm, or cached user data.
 
-Keycloak is the sole user directory. The plugin holds request data only for the operation lifetime and stores no local profile. Provider metadata contains routing identifiers rather than profile data. Hard deprovisioning removes identities and sessions before the group; failed proof is terminal. Audit and metrics use provider IDs only where operationally necessary and follow platform retention.
+Keycloak is the sole user directory. The plugin holds request data only for the operation lifetime and stores no local profile. Provider metadata contains routing identifiers rather than profile data. Hard deprovisioning removes identities and sessions before the group; failed proof is terminal. Plugin-provided audit evidence and metrics use provider IDs only where operationally necessary and contain no profile or credential values.
 
 ### 4.2 Verification Architecture
 
@@ -428,14 +463,17 @@ Verification is split by boundary rather than duplicated as method-level test ca
 
 | Level | Purpose |
 |---|---|
-| Unit | Metadata compatibility, boundary predicates, cursor construction, error classification, redaction, and completion-event cardinality |
-| SDK contract | Conformance to current `IdpPluginClient`, failure enums, typed filter/order, and `CursorV1` |
-| Real-Keycloak integration | Supported-version/profile checks, least privilege, user replay, cross-tenant denial, complete hard deletion, provider failures, and global query behavior |
+| Unit | Metadata compatibility, boundary predicates, cursor construction, error classification, redaction, and privacy-safe outcome construction |
+| SDK contract | Conformance to the existing `IdpPluginClient`, failure enums, typed filter/order, and `CursorV1` |
+| Real-Keycloak integration | Supported-version/profile checks, least privilege, user replay, cross-tenant denial, complete hard deletion, pre-send retryable versus post-send unproven terminal classification, provider failures, and global query behavior |
 | Credential Store integration | SecretRef ownership, rotation refresh, authorization denial, and non-disclosure |
-| Lifecycle integration | Cancellation during provider stages, bounded drain, restart/replay safety, and absence of detached tasks |
-| End to end | Account Management scoped selection, tenant/user lifecycle, append-only audit routing, reconciliation evidence, and PRD latency profile |
+| Cross-system audit contract | Account Management and the platform audit owner prove one durable terminal event per mutating call across crash and redelivery; this is an external production gate |
+| Lifecycle integration | Cancellation during provider stages, bounded drain, replay/reconciliation evidence, and absence of plugin-owned detached tasks |
+| End to end | Account Management scoped selection, tenant/user lifecycle, audit correlation, reconciliation evidence, and PRD latency profile |
 
 Tests that claim provider semantics use a supported real Keycloak 26.x instance. Test doubles are limited to deterministic local classification and failure injection; they do not establish Keycloak compatibility, tenant isolation, TLS, credential authorization, or latency.
+
+Crash and redelivery verification for durable audit is owned by the parent Account Management and platform audit designs. The plugin contract suite verifies that every returned outcome is classified, correlatable, and free of prohibited profile or credential values.
 
 ### 4.3 Risks and Enablement Gates
 
@@ -446,7 +484,8 @@ Tests that claim provider semantics use a supported real Keycloak 26.x instance.
 | Query capacity | Correct full-group scan meets PRD latency at the declared release population; otherwise upstream capacity/contract is revised |
 | User replay | Failure injection after each provider effect converges to one correctly bound identity |
 | Hard deletion | Two-tenant integration proves sessions and identities for the retiring tenant are removed without touching the active tenant |
-| Audit | Every success/failure mutation produces exactly one append-only terminal outcome with no profile or credential value |
+| Audit ownership | Parent Account Management and platform audit designs assign persistence, recovery, delivery, sink, and retention ownership; the plugin owns none of them |
+| Audit completeness | Cross-system tests prove one durable terminal outcome per mutating call across process failure and redelivery; the structured-log stand-in is not a production substitute |
 | Reconciliation | Operator runbook exists and consumes emitted evidence without secret inspection |
 | Compatibility | Supported Keycloak 26.x matrix passes and representative unsupported majors fail startup |
 | Lifecycle | Cancellation and rolling-restart tests prove bounded shutdown and replay safety |
@@ -479,7 +518,7 @@ Deferred adopted realms, plugin-created realms, OpenBao secret mutation, and ser
 | `cpt-cf-keycloak-idp-plugin-fr-administrator-credentials`, `cpt-cf-keycloak-idp-plugin-contract-credstore` | §§3.5–3.6, 4.1 |
 | `cpt-cf-keycloak-idp-plugin-fr-operator-reconciliation`, `cpt-cf-keycloak-idp-plugin-usecase-reconcile-ambiguous-mutation` | §§3.6, 4.3 |
 | `cpt-cf-keycloak-idp-plugin-fr-offline-token-lifetime` | §§2.2, 3.6 |
-| `cpt-cf-keycloak-idp-plugin-fr-audit-metrics`, `cpt-cf-keycloak-idp-plugin-nfr-audit-completeness` | §§3.6, 4.3 |
+| `cpt-cf-keycloak-idp-plugin-fr-audit-metrics`, `cpt-cf-keycloak-idp-plugin-nfr-audit-completeness` | §§3.3, 3.5–3.6, 4.1–4.3 |
 | `cpt-cf-keycloak-idp-plugin-nfr-tenant-isolation` | §§3.6, 4.1 |
 | `cpt-cf-keycloak-idp-plugin-nfr-secret-nondisclosure` | §§3.6, 4.1 |
 | `cpt-cf-keycloak-idp-plugin-nfr-lifecycle-latency` | §§1.2, 2.2, 3.6, 4.3 |

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
@@ -5,7 +5,6 @@ refs:
   - ../../../docs/ADR/0001-cpt-cf-account-management-adr-idp-contract-separation.md
   - ../../../docs/ADR/0005-cpt-cf-account-management-adr-idp-user-identity-source-of-truth.md
   - ../../../docs/ADR/0006-cpt-cf-account-management-adr-idp-user-tenant-binding.md
-  - ../../../docs/ADR/0008-cpt-cf-account-management-adr-user-attribute-update.md
 ---
 
 # Technical Design — Keycloak IdP Plugin
@@ -14,7 +13,7 @@ refs:
 
 **Owners:** @platform-iam-team
 
-**Scope:** Overall architecture for the priority-1 (V1) shared-realm plugin. In this document, **P2 means priority 2/deferred**, not version 2.
+**Scope:** Architecture of the shipped plugin implementation (crate `vp-idp-plugin`, ported from vhp-core). The implementation is authoritative; this document describes what the code does. In-code comments citing `DESIGN §N` refer to the original vhp-core implementation specification (`DESIGN-vp-idp-plugin-202605192055`) from which this crate lineage descends, not to section numbers in this document.
 
 <!-- toc -->
 
@@ -44,57 +43,57 @@ refs:
 
 <!-- /toc -->
 
-The adjacent [PRD](./PRD.md) is authoritative for WHAT, WHY, release priority, actors, and acceptance criteria. The Account Management SDK is authoritative for request, result, failure, filtering, ordering, and cursor contracts. Durable audit delivery is an external production prerequisite allocated to Account Management and the platform audit owner in §§3.5–3.6 and 4.3. This document defines only the V1 architecture and its safety invariants.
+The adjacent [PRD](./PRD.md) is authoritative for WHAT, WHY, release priority, actors, and acceptance criteria. The Account Management SDK is authoritative for request, result, failure, filtering, ordering, and cursor contracts; the service-principal SDK is authoritative for the machine-identity contract. This document defines the architecture of the shipped implementation and its safety invariants.
 
 ## 1. Architecture Overview
 
 ### 1.1 Architectural Vision
 
-The Keycloak IdP plugin is a provider adapter inside Account Management. It implements the provider-neutral `IdpPluginClient` boundary and administers tenant-scoped identity resources in an operator-approved shared Keycloak realm. Account Management owns authorization, tenant lifecycle orchestration, and persistence of opaque provider metadata; Keycloak remains the user source of truth.
+The Keycloak IdP plugin is a provider adapter running as an in-process ToolKit gear (`vp-idp-plugin`) in the host process next to Account Management. It implements two ClientHub contracts:
 
-V1 does not adopt or create realms, write administrator secrets, manage service principals, expose public REST endpoints, or participate in token validation. Requests for deferred `adopted` or `created` modes are rejected as unsupported before any provider or Credential Store mutation. Those modes require a separate future DESIGN and approval.
+- `account_management_sdk::idp::IdpPluginClient` — tenant and user identity lifecycle, registered **scoped** under its GTS catalogue instance id so Account Management selects it by vendor/priority.
+- `service_principal_sdk::ServicePrincipalClientV1` — tenant-scoped machine identities (confidential OAuth `client_credentials` clients), registered **unscoped** for trusted platform consumers.
+
+The plugin talks to the Keycloak Admin REST and OAuth token endpoints directly over HTTPS (reqwest transport). It authenticates with OAuth2 `client_credentials` using two administrator tiers: a **bootstrap admin** client (in the `master` realm by default, secret supplied via environment-expanded configuration) for realm-level work, and a per-realm **realm-admin** client for tenant/user work inside a bound realm. Realm-admin secrets are environment-backed for the default shared realm and Credential-Store-backed (OpenBao) for adopted and created realms; the plugin reads and — for realms it creates — writes those secrets itself through `credstore-sdk` under a plugin-owned system security context.
+
+Three realm bindings are supported: `shared` (default; tenants share an operator-provisioned realm), `adopted` (an existing empty operator realm bound to one tenant), and `created` (the plugin creates and lifecycle-manages a realm named `realm-{tenant_id}`). Keycloak remains the user source of truth; the plugin persists nothing locally and returns a versioned opaque metadata envelope that Account Management stores and replays.
+
+`update_user` is intentionally not implemented in this revision: the plugin inherits the SDK default, which returns `IdpUserOperationFailure::UnsupportedOperation`.
 
 ### 1.2 Architecture Drivers
 
 | Driver | Design allocation |
 |---|---|
-| Provider-neutral publication and operation-based readiness | GTS-scoped ClientHub publication, coordinated Account Management selection, and per-operation dependency classification |
-| Shared-realm tenant isolation | Versioned routing metadata, a provider-owned tenant group, an immutable tenant marker, and mandatory boundary checks before reads or mutations |
-| Safe external mutation | Tenant clean/ambiguous classification, replay-safe user operations, bounded retries, and operator reconciliation evidence |
-| Hard access termination | Session revocation and identity deletion precede tenant-group deletion; unproven cleanup is terminal |
-| Provider compatibility | Per-operation Keycloak 26.x compatibility gate plus a read-only realm authentication-profile verifier |
-| Protected administration | Operator-provisioned OAGW routes, gateway-owned Credential Store injection, a least-privileged per-realm administrator, and no V1 master-realm administrator |
-| Audit completeness | Account Management and the platform audit owner guarantee one durable terminal outcome per supported mutation call |
-| User query correctness | SDK filter/order semantics, `CursorV1`, global deterministic sorting, and no stable-order claim based on Keycloak offset pages |
-| Lifecycle safety | ToolKit cancellation and bounded drain; the plugin owns no periodic or audit-delivery task |
+| Provider-neutral publication and selection | `PluginV1<IdpPluginSpecV1>` published to types-registry (instance `vz.virtuozzo.vp_idp.plugin.v1`, vendor `virtuozzo`, priority 50); scoped ClientHub registration keyed on the instance id; AM resolves via `choose_plugin_instance` against `idp.vendor` |
+| Fail-fast configuration errors | Init validates typed config (`deny_unknown_fields`), the `secret_ref_template`, and the service-principal section, then pre-warms the bootstrap admin token with a bounded retry budget; exhausting the budget fails `Gear::init` |
+| Shared-realm tenant isolation | Per-tenant Keycloak group under `/tenants`, immutable `tenant_id` user attribute (ADR-0006), and an ownership marker attribute (`vhp.provisioning.tenant_id`) on created realms and service-principal clients |
+| Safe external mutation | Parse-then-probe saga ordering, per-step reactive-401 wrapping, idempotent replay paths (probe-adopt realm ensure, 409 group reuse), and stage-attributed `AmbiguousCreated` classification with an `ambig:` prefix contract for reconciliation tooling |
+| Secret custody | `SecretFromEnv`/`SecretString` wrappers with redacted `Debug`, token cache redaction, `redact_secrets` on every error body, and Credential Store writes only for plugin-created realm-admin secrets |
+| Credential rotation without restart | Token cache keyed `(realm, client_id)` with single-flight refresh and an exactly-once reactive-401 retry that re-resolves the secret from its source (env or Credential Store) |
+| User query correctness | Full tenant-group member drain (hard cap 10,000) sorted `(createdTimestamp ASC, id ASC)`, client-side typed filters, `CursorV1` continuation with an FNV-1a filter hash |
+| Observability | Segregated metric ports over one OTel adapter (`vp_idp_plugin_*` instruments), realm-label cardinality cap, and structured audit events on the `vp.idp.plugin.events` tracing target |
 
 #### NFR Allocation
 
 | NFR | Architectural response | Release verification |
 |---|---|---|
-| Tenant isolation | `TenantBoundaryGuard` validates both group membership and immutable tenant marker | Negative-isolation contract and real-Keycloak tests |
-| Secret non-disclosure | OAGW-owned credential injection, allowlisted diagnostics, no plugin-visible secret value, and output scanning | Logs, metrics, audit, errors, and debug output contain no injected secret |
-| Lifecycle latency | OAGW connection pooling, bounded calls, point-lookup optimization, and a 1,000-total-user full-group scan ceiling | Complete PRD qualification profile: topology, filter mix, 20 concurrent operations, call/memory limits, and stated p95 limits |
-| Failure classification | Current SDK enums are the only failure vocabulary | Exhaustive enum mapping and failure injection |
-| Audit completeness | The plugin returns a classified privacy-safe outcome; durable correlation and delivery are owned by Account Management and the platform audit contract | One terminal event per mutating call across cross-system contract tests |
-| Provider compatibility | Operation-level version gate and release compatibility matrix | Supported 26.x matrix passes; unsupported major fails affected operations before mutation without failing host startup |
-| Personal-data lifecycle | No local user directory; hard deletion removes identities and sessions | Hard-delete and output-minimization verification |
-| Availability recovery | Dependency state is evaluated per affected operation after startup | Dependency loss/recovery tests without fallback or default realm |
+| Tenant isolation | Tenant group membership scopes listing; the `tenant_id` user attribute guards user deprovision; `vhp.provisioning.tenant_id` markers guard realm and service-principal ownership | Negative-isolation unit and integration tests |
+| Secret non-disclosure | Typed secret wrappers, redacted token cache, `redact_secrets` + 2 KiB truncation on every provider error body before it crosses the AM boundary | Redaction unit tests; log/metric scanning |
+| Failure classification | Closed `PluginError` taxonomy translated at the SDK boundary per fixed tables; `debug_assert` that provisioning never surfaces `MetadataDecode` | Exhaustive translation unit tests and failure injection |
+| Availability recovery | Per-call pre-saga health probe; reactive-401 secret re-resolution; no cached provider state besides tokens; recovery needs no restart once init has succeeded | Dependency loss/recovery tests |
+| Personal-data lifecycle | No local user directory; user deprovision deletes the provider identity; audit events carry provider IDs plus `username` only on `user.provisioned` | Hard-delete and output-minimization tests |
+| Lifecycle latency | Bounded per-request HTTP timeout (5 s default), bounded retry policy, 30 s provision/deprovision saga timeout, list drain cap | Release qualification profile per PRD §6.1 |
 
 #### Decision Provenance
 
-V1 introduces no approved exception to the repository architecture. Its significant decisions inherit these accepted records and standards:
+The significant decisions inherit these accepted records and standards:
 
 - [Separate Account Management from the IdP provider](../../../docs/ADR/0001-cpt-cf-account-management-adr-idp-contract-separation.md).
 - [Keep the IdP as user source of truth](../../../docs/ADR/0005-cpt-cf-account-management-adr-idp-user-identity-source-of-truth.md).
-- [Use provider-enforced tenant binding](../../../docs/ADR/0006-cpt-cf-account-management-adr-idp-user-tenant-binding.md).
-- [Preserve provider-backed partial user updates](../../../docs/ADR/0008-cpt-cf-account-management-adr-user-attribute-update.md).
-- Route external Keycloak traffic through the [Outbound API Gateway](../../../../oagw/docs/DESIGN.md).
+- [Use provider-enforced tenant binding](../../../docs/ADR/0006-cpt-cf-account-management-adr-idp-user-tenant-binding.md) — implemented as the `tenant_id` user attribute plus tenant-group membership.
 - Follow [ClientHub and plugin scoping](../../../../../../docs/toolkit_unified_system/03_clienthub_and_plugins.md), [lifecycle rules](../../../../../../docs/toolkit_unified_system/08_lifecycle_stateful_tasks.md), the [Architecture Manifest](../../../../../../docs/ARCHITECTURE_MANIFEST.md), and [Security Guidelines](../../../../../../guidelines/SECURITY.md).
 
-A proposal to add a master-realm administrator, direct external HTTP, direct OpenBao mutation, unscoped publication, or plugin-owned user storage is a material deviation and requires a new accepted ADR before this DESIGN can change.
-
-Durable audit delivery requires accepted Account Management and platform audit designs. This plugin design does not define their persistence, recovery, relay, sink, or retention mechanisms. The existing Account Management structured-log stand-in is suitable only for development.
+Durable audit delivery remains owned by Account Management and the platform audit owner. The plugin's structured-event emitters (`vp.idp.plugin.events`) are an explicit development stand-in until the platform audit sink lands.
 
 ### 1.3 Architecture Layers
 
@@ -102,34 +101,47 @@ Durable audit delivery requires accepted Account Management and platform audit d
 flowchart LR
   operator([Platform operator])
   iac[IaC and protected configuration]
-  cred[(Credential Store)]
-  oagw[Outbound API Gateway]
-  kc[(Keycloak 26.x shared realm)]
+  cred[(Credential Store / OpenBao)]
+  kc[(Keycloak shared, adopted, and created realms)]
   authn[OIDC AuthN Resolver]
-  audit[Platform audit infrastructure]
-  subgraph am[Account Management process]
-    api[Account Management application layer]
-    domain[Plugin domain coordinators and boundary guard]
-    infra[OAGW and Keycloak representation adapters]
+  spc[Trusted platform consumers]
+  subgraph host[Host process]
+    am[Account Management]
+    subgraph plugin[vp-idp-plugin gear]
+      root[Plugin root: KeycloakIdpPlugin]
+      facades[Tenant / User / Service-principal facades]
+      kcc[KC admin client factory + token cache]
+      csrw[CredStore reader / writer]
+      transport[Reqwest KC transport]
+      obs[Metrics adapter + audit emitters]
+    end
+    tr[types-registry gear]
+    cs[credstore gear]
   end
 
   operator --> iac
-  iac -->|approved realm, OAGW routes, and credential references| oagw
-  api -->|scoped IdpPluginClient| domain
-  api -->|durable terminal outcome; external contract| audit
-  domain --> infra
-  infra -->|ServiceGatewayClientV1| oagw
-  oagw -->|protected credential resolution| cred
-  oagw -->|OAuth and Admin REST| kc
+  iac -->|realms, bootstrap client, env secrets| kc
+  am -->|scoped IdpPluginClient| root
+  spc -->|unscoped ServicePrincipalClientV1| root
+  root --> facades
+  facades --> kcc
+  kcc --> transport
+  facades --> csrw
+  csrw --> cs
+  root -->|PluginV1 catalogue publish| tr
+  cs --> cred
+  transport -->|OAuth + Admin REST over HTTPS| kc
   authn -->|OIDC discovery and JWKS; no plugin call| kc
 ```
 
 | Layer | Responsibility |
 |---|---|
-| Account Management application | Public authorization, tenant saga orchestration, opaque metadata persistence, scoped provider selection, and audit orchestration defined by the parent AM design |
-| Plugin domain | Tenant/user lifecycle, boundary enforcement, replay safety, error classification, and privacy-preserving outcomes |
-| Plugin infrastructure | OAGW request construction, Keycloak representation mapping, bounded response handling, and telemetry |
-| Platform dependencies | OAGW egress and credential injection, Keycloak identity state, Credential Store secrets, platform audit infrastructure, and operator-owned realm configuration |
+| Module wiring (`module.rs`) | Config probe/expansion, static validation, bootstrap token pre-warm, facade construction, types-registry publication, ClientHub registration |
+| Plugin root (`idp_impl.rs`, `sp_impl.rs`) | SDK trait implementations, metadata encode, `PluginError` → SDK failure translation |
+| Domain facades | Tenant/user/service-principal sagas, boundary enforcement, replay safety, error classification, audit emission |
+| KC client layer (`domain/kc`) | Token acquisition and caching, single-flight refresh, reactive-401, admin REST helpers |
+| Credential Store wrappers (`domain/credstore`) | System-context-bound read (secrets, CA bundle) and write (created-realm admin secrets) |
+| Infrastructure (`infra`) | Reqwest transport with retry/backoff/Retry-After, TLS CA bundle wiring, OTel metrics adapter |
 
 ## 2. Principles & Constraints
 
@@ -139,148 +151,153 @@ flowchart LR
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-explicit-provider-intent`
 
-Never infer a default realm or mode from missing metadata.
+Provisioning intent is parsed fail-closed (`deny_unknown_fields`); an unknown mode or contradictory realm intent is rejected before any provider call. Absent intent defaults to `shared`, where a child tenant inherits its parent's realm from replayed metadata rather than guessing.
 
 #### Two-factor tenant binding
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-two-factor-tenant-binding`
 
-A shared realm is routing context, not tenant authorization; tenant marker and group membership must agree.
+Tenant-group membership scopes queries; the immutable `tenant_id` user attribute guards destructive user operations. A mismatch performs no mutation and follows non-disclosing absence semantics.
 
-#### Operator-owned realm
+#### Operator-owned realms stay operator-owned
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-operator-owned-realm`
 
-V1 may create and delete plugin-owned tenant groups and users, but never the shared realm or realm-level authentication configuration.
+Shared and adopted realms are asserted, never created, repaired, or deleted. Only `created`-mode realms — marked with the plugin's ownership attribute — are created and, on last-tenant deprovisioning, deleted. A realm without the plugin's ownership marker is never touched.
 
 #### Correctness before retry
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-correctness-before-retry`
 
-Retry only reads and operations proven replay-safe; never convert uncertain tenant mutation into a clean failure.
+Automatic HTTP retry applies to idempotent verbs and retryable statuses (5xx/429) only; `POST` is never replayed on transport failure. Reactive-401 re-mints exactly once because an auth rejection provably had no side effect. Uncertain created-mode work is stage-attributed `AmbiguousCreated`, never a clean failure.
 
 #### SDK authority
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-sdk-authority`
 
-Duplicate local DTO, cursor, and failure specifications are prohibited.
+DTOs, cursors, and failure vocabularies come from `account-management-sdk` and `service-principal-sdk`. The plugin adds no parallel public contract.
 
 #### No silent success
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-no-silent-success`
 
-Unsupported mutation and unproven cleanup produce typed failures.
+Unsupported operations (`update_user`, unsupported filters) return typed `UnsupportedOperation` failures. Truncated list drains are logged loudly. Already-absent resources are explicit success-equivalents, not silent no-ops.
 
-#### Least privilege
+#### Least privilege by tier
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-least-privilege`
 
-Use one approved realm-administrator profile per shared realm; V1 has no master-realm credential.
+Realm-scoped work uses a per-realm admin client granted exactly seven `realm-management` roles (`view-realm`, `view-clients`, `query-groups`, `manage-realm`, `manage-users`, `query-users`, `manage-clients`). The bootstrap admin is used only where realm-level authority is required: realm existence probes, created-realm lifecycle, and service-principal client administration.
 
 #### Privacy-preserving evidence
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-privacy-preserving-evidence`
 
-Operation outcomes are observable without credentials or user profile values.
+Metrics labels are closed enums plus a cardinality-capped realm label; no metric carries a profile value or secret. Error bodies are redacted and truncated to 2 KiB before crossing the boundary. Audit events carry provider IDs; `user.provisioned` additionally records the username as operational evidence.
 
-#### Durable intent before mutation
+#### Durable audit stays upstream
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-durable-audit-intent`
 
-Account Management and the platform audit contract must durably correlate each mutating plugin call with one terminal outcome. The mechanism is outside this plugin design.
+The plugin returns one classified outcome per call and emits structured stand-in events; durable, idempotent audit persistence belongs to Account Management and the platform audit owner.
 
 ### 2.2 Constraints
 
-#### Shared-realm-only V1
+#### Init-time provider dependency
 
-- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-shared-realm-only-v1`
+- [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-init-pre-warm`
 
-V1 supports only `mode = shared` against an operator-approved Keycloak 26.x realm.
+When enabled, the plugin fails `Gear::init` if the bootstrap admin token cannot be acquired within the configured pre-warm budget (default 5 attempts × 3 s backoff, ≈37 s worst case including attempt time). Transient failures (5xx/429/transport/timeout, Credential Store readiness) are retried within the budget; permanent failures (non-429 4xx, malformed configuration) fail fast. Deployments that must start without Keycloak set `enabled: false`.
 
 #### External consistency boundaries
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-external-consistency-boundaries`
 
-OAGW, Keycloak, Credential Store, and the platform audit sink are external consistency boundaries. Plugin calls occur outside Account Management database transactions, so the architecture does not claim atomic commit or transport-level exactly-once behavior across those systems.
+Keycloak and the Credential Store are external consistency boundaries. Plugin calls occur outside Account Management database transactions; the architecture does not claim atomic commit across them. Created-mode provisioning has an explicit point of no return: after Keycloak state exists, a failed Credential Store write is `AmbiguousCreated { OpenBaoPutAfterKcSuccess }`, never clean.
 
 #### External durable audit prerequisite
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-durable-audit-wrapper`
 
-The plugin owns no audit table, recovery worker, relay, or sink integration. Production requires the parent Account Management design and platform audit contract to guarantee durable one-to-one call/outcome correlation across process failure and redelivery.
+The plugin owns no audit table, recovery worker, relay, or sink integration. Its `tracing`-based event emitters are a development stand-in. Production requires the parent Account Management design and platform audit contract to guarantee durable call/outcome correlation.
 
 #### Opaque metadata replay
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-opaque-metadata-replay`
 
-Account Management persists plugin metadata as opaque JSON and replays it on later calls. The envelope carries its producing GTS provider instance identifier, which the plugin verifies against its own identifier before any OAGW or provider access.
+Account Management persists the plugin's metadata envelope as opaque JSON and replays it on later calls. Decoding is fail-closed: a missing `version`, a version other than `"v1"`, or a malformed shape yields a typed failure without provider access. The envelope carries no secrets — only routing identifiers and a Credential Store reference name.
 
 #### No plugin persistence
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-no-plugin-persistence`
 
-The plugin owns no database table and no persistent user cache.
+The plugin owns no database table and no persistent user cache. Its only in-memory state is the admin token cache and metrics cardinality tracking.
 
 #### Scoped provider selection
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-scoped-provider-selection`
 
-Account Management requires a coordinated change to select a GTS-scoped provider instance; no unscoped compatibility fallback is allowed. V1 does not support changing the selected instance while tenant metadata exists. A replayed instance mismatch fails closed and requires an operator-approved migration.
+Account Management selects the plugin through the types-registry catalogue instance and scoped ClientHub resolution. On restart the plugin re-registers idempotently: an `AlreadyExists` catalogue answer is accepted only when the stored spec matches the current serialization byte-for-byte; drift fails init.
 
 #### Bounded offline-token exposure
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-bounded-offline-token-exposure`
 
-A previously issued access JWT can remain valid until `exp`; the approved realm profile caps V1 access-token lifetime at 15 minutes.
+A previously issued access JWT can remain valid until `exp`. The plugin revokes sessions on user deprovisioning (best-effort, configurable) but never claims real-time token invalidation; bounding exposure is an operator realm-policy obligation (15-minute access-token lifetime per the PRD).
 
-#### Correct global query ordering
+#### Bounded query scan
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-correct-global-query-ordering`
 
-Query correctness requires a global view of the tenant group because Keycloak does not guarantee stable ordering across offset pages. V1 accepts linear provider-read cost up to 1,000 total human identities, enabled or disabled, per tenant group and must prove the PRD latency, provider-call, and memory targets on the complete release qualification profile.
+Keycloak does not guarantee stable ordering across group-member offset pages, so `list_users` drains the entire tenant-group membership per request (pages of `list_users_page_limit_max`, default 200), sorts globally on `(createdTimestamp, id)`, and filters client-side. The drain is bounded by a 10,000-member hard cap; exceeding it truncates the member set and logs a loud warning. Page size to the caller is capped at 200.
 
 ### 2.3 Applicability Matrix
 
 | Checklist domain | Disposition |
 |---|---|
 | Architecture and semantic alignment | Applicable; addressed in §§1–3 and §5. |
-| Performance and capacity | Applicable; query complexity and release gates are addressed in §§1.2, 2.2, 3.6, and 4.3. |
-| Security and compliance controls | Applicable; trust boundaries and controls are addressed in §4.1. No plugin-specific regulatory regime is added because the PRD and platform security baseline own regulatory classification. |
-| Reliability | Applicable; mutation uncertainty, replay, cancellation, and recovery are addressed in §3.6. |
+| Performance and capacity | Applicable; query scan bounds, timeouts, and retry budgets are addressed in §§2.2 and 3.6. |
+| Security and compliance controls | Applicable; trust boundaries and controls are addressed in §4.1. |
+| Reliability | Applicable; mutation uncertainty, replay, timeout, and recovery are addressed in §3.6. |
 | Data | Applicable only to ownership and lifecycle because the plugin owns no database; addressed in §§3.1, 3.7, and 4.1. |
-| Integration | Applicable; Account Management, Keycloak, Credential Store, audit, and ClientHub boundaries are addressed in §§3.2–3.6. |
-| Operations | Applicable; deployment, observability, compatibility, and enablement gates are addressed in §§3.2, 3.6, and 4.3. |
+| Integration | Applicable; Account Management, Keycloak, Credential Store, types-registry, and ClientHub boundaries are addressed in §§3.2–3.6. |
+| Operations | Applicable; configuration, observability, and enablement gates are addressed in §§3.2, 3.6, and 4.3. |
 | Maintainability | Applicable; SDK authority, component boundaries, and decision provenance are addressed in §§1.2, 2.1, and 3.2–3.4. |
 | Testing | Applicable; verification architecture is addressed in §4.2. |
-| Usability | Not applicable because the plugin exposes no human interface; Account Management owns public API usability. |
+| Usability | Not applicable because the plugin exposes no human interface. |
 | Accessibility | Not applicable because the plugin exposes no visual or interactive user interface. |
-| Business and time-to-market | Not applicable because prioritization, business outcomes, and delivery timing are owned by the adjacent PRD and planning artifacts. |
-| Plugin-specific cost budget | Not applicable because V1 adds no independently deployed service or plugin-owned store. Audit infrastructure cost belongs to its external owners. |
-| Documentation quality | Applicable; authoritative references and bidirectional traceability are provided in §5. |
+| Business and time-to-market | Not applicable; owned by the adjacent PRD and planning artifacts. |
+| Plugin-specific cost budget | Not applicable because the plugin adds no independently deployed service or plugin-owned store. |
+| Documentation quality | Applicable; authoritative references and traceability are provided in §5. |
 
 ## 3. Technical Architecture
 
 ### 3.1 Domain Model
 
-The provider metadata is a versioned, non-secret routing envelope owned by the plugin and persisted opaquely by Account Management. It identifies the exact producing GTS provider instance, shared realm, provider-owned tenant group, immutable tenant identity, and non-secret OAGW route/profile reference. Exact serialization belongs to the implementation specification; compatibility rules are architectural:
+The provider metadata is the versioned, non-secret routing envelope `TenantIdpMetadataV1`, owned by the plugin and persisted opaquely by Account Management:
 
-- all versions in the declared rolling-upgrade window can read and safely deprovision metadata written by one another;
-- the replayed producing instance must equal the receiving plugin's published instance identifier before any OAGW or provider call;
-- an instance mismatch, malformed envelope, or unknown newer-major metadata fails closed without external access;
-- metadata never contains administrator secrets, tokens, passwords, or user profile values;
-- realm and tenant identifiers come from replayed metadata, not caller-controlled defaults on later operations;
-- changing the selected provider instance requires an operator-approved migration or retirement of every tenant bound to the old instance.
+| Field | Meaning |
+|---|---|
+| `version` | Envelope version; `"v1"` at this revision. Missing → `MissingVersion`; other values → `UnsupportedVersion`; shape mismatch → `Malformed`. All three fail closed before provider access. |
+| `realm_name` | Realm the tenant is bound to. |
+| `realm_binding` | `shared` \| `adopted` \| `created` (also a public metric label). |
+| `tenant_group_id` | Keycloak UUID of the plugin-owned per-tenant group. |
+| `admin_secret_ref` | `None` for the env-backed default shared realm; `Some(ref)` naming the Credential Store reference for adopted/created realms (template `vp-idp-realm-admin-{realm_name}-secret` by default). |
+| `admin_client_id` | OAuth2 `client_id` of the per-realm admin client (default `vp-idp-plugin-realm-admin`). |
 
 Provider ownership is split as follows:
 
 | Resource | Owner | Plugin authority |
 |---|---|---|
-| Shared realm and authentication profile | Platform operator | Read and verify only |
-| OAGW Keycloak route and realm-administrator credential reference | Platform operator | Plugin invokes the approved route; OAGW injects least-privileged credentials without disclosure |
-| Tenant group and immutable tenant marker | Plugin | Create, inspect, and delete for the owning tenant |
-| Human identity and sessions in the tenant boundary | Plugin through Account Management | Create, update, query, revoke, and delete after boundary verification |
+| Shared and adopted realms, their authentication profile, protocol mappers, and the bootstrap/realm-admin clients in them | Platform operator (IaC / realm bootstrap) | Assert existence (and emptiness for adopted); use the configured admin clients |
+| Created realms (`realm-{tenant_id}`, marked `vhp.provisioning.tenant_id`) | Plugin | Create, administer, and delete on last-tenant deprovisioning |
+| Realm-admin client and its 7 `realm-management` roles in created realms | Plugin | Create and grant during created-mode provisioning |
+| Per-tenant group under `/tenants` and the `tenant_id`/`user_type` user attributes | Plugin | Create, inspect, delete for the owning tenant |
+| Human identities and sessions in the tenant boundary | Plugin through Account Management | Create, delete, revoke, and query after boundary verification; updates are unsupported in this revision |
+| Service-principal clients `svc-{tenant_id}-{name}` and their service-account users | Plugin through `ServicePrincipalClientV1` | Create, rotate, revoke, list, and purge on tenant deprovisioning |
+| Created-realm admin secret in the Credential Store | Plugin (system actor) | Write on provisioning, read on later calls, delete on realm teardown |
+| Shared/adopted realm-admin secrets | Platform operator | Read only (env expansion or Credential Store reference) |
 | Opaque provider metadata row | Account Management | Persist/replay only; plugin owns interpretation |
-| Durable audit record and delivery | Account Management and platform audit owner | Defined outside this plugin; must correlate one terminal outcome to each mutating call |
 | Access-token validation | OIDC AuthN Resolver | No call to this plugin |
 
 ### 3.2 Component Model
@@ -289,129 +306,157 @@ Provider ownership is split as follows:
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-component-keycloak-idp-plugin`
 
-The plugin is one logical architecture component. The following entries are responsibility partitions inside that component, not independently deployed services.
+The plugin is one logical architecture component. The following entries are responsibility partitions inside that component (concrete Rust modules), not independently deployed services.
 
-| Responsibility partition | Architectural responsibility |
-|---|---|
-| Plugin module | Static configuration validation, lifecycle, and GTS-scoped ClientHub publication |
-| Approved realm registry | Maps explicit shared-realm intent to operator-approved realm and non-secret OAGW route/profile reference |
-| Realm profile verifier | Read-only verification of Keycloak version, issuer, clients, scopes, protocol mappers, claims, signing, session/token policy, password/login policy, and required administration privileges |
-| Metadata codec | Versioned opaque metadata compatibility and fail-closed decoding |
-| Tenant lifecycle coordinator | Tenant-boundary provisioning, hard-deletion ordering, uncertainty classification, and reconciliation evidence |
-| Tenant boundary guard | Verifies tenant marker and group membership before every user read or mutation |
-| User lifecycle coordinator | Replay-safe user create/update/delete and provider projection |
-| User query adapter | Tenant-scoped filtering, ordering, point existence, global sorting, and `CursorV1` generation |
-| OAGW adapter | `ServiceGatewayClientV1` request construction, bounded response handling, Keycloak representation mapping, response classification, and allowlisted diagnostics |
-| Outbound authorization boundary | Forwards the caller's authorized `SecurityContext`; OAGW route policy admits only approved AM actors and stable AM system subjects, while OAGW owns credential resolution and injection |
-| Terminal outcome producer | Returns one classified, privacy-preserving outcome to the AM caller and records bounded-cardinality metrics separately |
+| Responsibility partition | Module | Architectural responsibility |
+|---|---|---|
+| Module wiring | `module.rs` | Enabled probe, typed config expansion, static validation, bootstrap pre-warm, DI, catalogue publish, ClientHub registration |
+| Plugin root | `idp_impl.rs`, `sp_impl.rs` | SDK trait surface; failure translation tables |
+| Tenant lifecycle coordinator | `domain/tenant_facade.rs` | Provision/deprovision sagas for all three bindings, saga timeout, idempotent replay, ambiguity staging, service-principal purge hook |
+| User lifecycle coordinator | `domain/user_facade.rs` | User provision/deprovision/list, tenant boundary guard, orphan compensation, cursor pagination |
+| Service-principal facade | `domain/service_principal_facade.rs` | Machine-identity lifecycle against the configured shared realm; ownership markers; quota and scope allowlist |
+| Metadata codec | `domain/metadata_codec.rs` | Versioned fail-closed envelope encode/decode |
+| KC admin client factory | `domain/kc/` | `client_credentials` token acquisition, `(realm, client_id)` token cache with single-flight refresh, reactive-401, health probe |
+| Credential Store wrappers | `domain/credstore/` | System-ctx-bound reader (secrets, CA bundle) and writer (create-or-replace, delete with absent-as-success) |
+| Transport | `infra/kc_http.rs` | Reqwest HTTPS client, per-request timeout, bounded retry with exponential backoff + full jitter + `Retry-After`, W3C trace propagation, body redaction/truncation |
+| Observability | `infra/metrics.rs`, `domain/audit.rs`, `domain/ports/` | One OTel adapter behind seven segregated metric ports; structured audit emitters |
+| System actor | `domain/system_actor.rs` | Stable plugin service-principal identity for Credential Store calls |
 
 #### Deployment, Publication, and Readiness
 
-The plugin is an in-process ModKit module in each Account Management replica. It opens no listener and owns no independent deployment or database.
+The plugin is an in-process gear (`#[toolkit::gear(name = "vp-idp-plugin", deps = [types_registry, credstore])]`) in each host replica. It opens no listener and owns no independent deployment or database.
 
-Each instance publishes `IdpPluginClient` with `ClientScope::gts_id(instance_id)`. Account Management must select the configured provider instance through scoped ClientHub resolution. This coordinated consumer change is a V1 implementation prerequisite; ambiguous selection or unscoped fallback fails closed.
+Initialization proceeds in phases:
 
-Initialization validates only static inputs: plugin configuration, approved realm and OAGW route references, identifier syntax, the required HTTPS posture, and GTS identity. It resolves required in-process ClientHub contracts and publishes the scoped client without sending a request to OAGW, Credential Store, or Keycloak. A missing required in-process contract or malformed static configuration is a deployment error and may fail ToolKit initialization. External dependency availability and provider compatibility do not.
+1. **Enabled probe** — `enabled` (default `true`) is read leniently; a disabled plugin skips everything else and registers nothing.
+2. **Typed config expansion** — `${VAR}` substitution over the marked secret fields; unknown keys are rejected.
+3. **Static validation** — the `secret_ref_template` is validated by interpolating a 64-character synthetic realm name through `SecretRef::new`; the service-principal section is validated.
+4. **Transport construction** — the reqwest client is built; if `tls_ca_bundle_ref` is set, the PEM bundle is read from the Credential Store and added as a root certificate.
+5. **Bootstrap pre-warm** — the bootstrap admin token is acquired with bounded retry (default 5 × 3 s). Retryable causes: 5xx/429/transport/timeout and Credential Store read failures (deploy-ordering races). Permanent causes fail on the first attempt. Budget exhaustion fails init.
+6. **Catalogue publish** — `PluginV1<IdpPluginSpecV1>` (`vz.virtuozzo.vp_idp.plugin.v1`, configured vendor/priority) is registered with types-registry; `AlreadyExists` is accepted only when the stored spec matches exactly.
+7. **ClientHub registration** — `Arc<dyn IdpPluginClient>` scoped by the catalogue instance id; `Arc<dyn ServicePrincipalClientV1>` unscoped.
 
-`provision_tenant` remains the operation-based readiness signal. Before any affected operation, the plugin verifies the replayed provider instance when metadata exists, invokes the approved OAGW route, and proves that the reachable provider reports Keycloak 26.x and the required realm profile. An unreachable OAGW, Credential Store, or Keycloak endpoint returns the operation's pre-mutation unavailable category. A reachable unsupported major or profile mismatch fails the affected operation deterministically before mutation. A successful version/profile result is cached per configured route and realm; failures are not cached, and the cache is invalidated when the route/profile configuration revision changes or a later response contradicts the cached compatibility state. The scoped client remains registered, and the next call repeats checks that did not complete successfully, so recovery requires no process restart.
-
-After a provider request may have produced an effect, `CleanFailure` or `Retryable` applies only when no mutation outcome is unknown; otherwise the SDK's `Ambiguous` or `Terminal` classification applies. Audit infrastructure does not add a plugin dependency.
+After init, readiness is operation-based: every tenant provision/deprovision saga begins with an unauthenticated Keycloak health probe (`GET realms/master`), and every call re-resolves credentials on 401. Recovery from provider or Credential Store outages therefore needs no process restart.
 
 ### 3.3 API Contracts
 
-The current [`idp.rs`](../../../account-management-sdk/src/idp.rs) and [`idp_user.rs`](../../../account-management-sdk/src/idp_user.rs) contracts are authoritative. This design does not add audit parameters to `IdpPluginClient`. Any future propagation required by the Account Management or platform audit contract must follow normal SDK compatibility rules.
+The current [`idp.rs`](../../../account-management-sdk/src/idp.rs) and [`idp_user.rs`](../../../account-management-sdk/src/idp_user.rs) contracts are authoritative for tenant/user work; [`service-principal-sdk`](../../../../service-principal/service-principal-sdk/src/api.rs) is authoritative for machine identities.
 
-Architectural contract invariants are:
+Contract invariants implemented at the boundary (`idp_impl.rs`, `sp_impl.rs`):
 
-- malformed shared-realm intent uses `IdpProvisionFailure::InvalidInput` before provider mutation;
-- deferred modes use `UnsupportedOperation` before OAGW, Credential Store, or provider mutation;
-- only pre-provision failures proven to retain no provider state use `CleanFailure`;
-- uncertain tenant provisioning preserves `Ambiguous`;
-- duplicate users, password-policy rejection, absent update targets, and unavailability use their current classified user variants;
-- `Rejected` is reserved for provider rejection that cannot be classified further;
-- `UnsupportedOperation` covers a list scan that detects the declared 1,000-user implementation-profile ceiling before returning any page;
-- already-absent deprovisioning follows the SDK's success-equivalent semantics;
-- deprovisioning is `Retryable` only when no attempted mutation has an unknown outcome; any mutation request that may have reached Keycloak without a provable result is `Terminal`, regardless of whether the immediate error appears transient;
-- replayed metadata with a producing instance different from the receiving plugin fails closed before any OAGW request;
-- typed filter/order and `CursorV1` are used without a plugin-specific parallel contract;
-- every mutating return is classifiable and contains enough non-sensitive context for the external audit owner to construct its terminal outcome.
+- malformed or contradictory provisioning intent (`ProvisionInputRejected`, metadata decode failures) maps to `IdpProvisionFailure::InvalidInput` with `field = "provisioning_metadata"`, before provider mutation;
+- a foreign or unmarked existing realm in `created` mode is `CleanFailure` (no state was created); permanent provider 4xx and pre-saga failures are `CleanFailure`;
+- provider 5xx, transport/timeout, saga timeout, and every staged `AmbiguousCreated` map to `IdpProvisionFailure::Ambiguous` for the provisioning reaper;
+- missing bootstrap permissions (`BootstrapPermsMissing`) map to `UnsupportedOperation` with an operator-runbook detail;
+- tenant deprovisioning maps `DeprovisionNotFound` → `NotFound` (success-equivalent), `DeprovisionRetryable` → `Retryable`, and everything else — including metadata decode failures — → `Terminal`;
+- user failures use only `IdpUserOperationFailure` variants: KC 409 on create is `DuplicateUser` with the field refined from the provider message (`Username`/`Email`/`UsernameOrEmail`), password-policy rejections are `PasswordPolicy`, unsupported filters and the unimplemented `update_user` are `UnsupportedOperation`, provider/transport trouble is `Unavailable`;
+- service-principal failures use the closed `ServicePrincipalFailure` set: `InvalidInput` (bad name, disallowed scope, quota, taken client id), `NotFound` (absent or foreign principal — indistinguishable by design), `Ambiguous` (stage-attributed transport uncertainty), `CleanFailure` (pre-mutation failures);
+- every mutating return carries redacted, truncated, grep-friendly detail (`kc:{METHOD} {path_template} -> {status}: {body≤2KiB}` or `internal:{component}: …`).
 
-The plugin emits no public HTTP API. Account Management owns public status, validation-envelope, and redaction mapping.
+The plugin emits no public HTTP API.
 
 ### 3.4 Internal Dependencies
 
-Domain components depend on plugin-owned ports rather than transport types. Direct `reqwest`, raw `hyper`, `tonic`, Keycloak sockets, or Credential Store implementation types do not cross into the domain layer.
+Domain components depend on plugin-owned ports rather than transport types: `reqwest` is confined to `infra/kc_http.rs` behind the `KcTransport` trait, and metrics are consumed through seven segregated port traits implemented by one adapter.
 
 | Internal dependency | Purpose |
 |---|---|
 | Account Management SDK | Provider-neutral trait, DTO, failure, and pagination authority |
-| ModKit and ClientHub | Module initialization, lifecycle context, GTS-scoped publication and dependency resolution |
-| OAGW SDK | `ServiceGatewayClientV1`, request/response body types, centralized egress policy, and credential injection boundary |
-| `toolkit-odata` | Typed filter/order interpretation and `CursorV1` compatibility |
+| Service-principal SDK | Machine-identity trait, models, and failure taxonomy |
+| ToolKit and ClientHub | Gear lifecycle, config expansion, scoped publication and dependency resolution |
+| types-registry SDK + gear | `PluginV1` catalogue publication (hard init prerequisite) |
+| credstore SDK + gear | Secret read/write under the plugin system actor |
+| `toolkit-odata` | `CursorV1` continuation-token envelope |
 
 ### 3.5 External Dependencies
 
 | Dependency | Contract and failure boundary |
 |---|---|
-| Account Management | Authorizes calls, selects the scoped plugin, persists/replays opaque metadata, consumes typed outcomes, and owns audit orchestration defined by its parent design |
-| Outbound API Gateway | Executes operator-approved Keycloak routes through `ServiceGatewayClientV1`, enforces egress policy, and injects credentials; gateway or dependency failure blocks only affected operations |
-| Keycloak 26.x | User/session/group source of truth and Admin REST provider behind OAGW; another major is unsupported until compatibility approval |
-| Credential Store | Protects operator-created realm-administrator secrets consumed by OAGW; credential values never cross into the plugin |
-| Platform audit infrastructure | Owns the sink and delivery contract consumed by Account Management; not defined by this plugin |
-| Operator IaC | Creates the shared realm, realm-local administrator, required authentication profile, OAGW upstream/routes, credential references, and approved realm registry |
-| OIDC AuthN Resolver | Independently validates tokens; the two plugins do not call each other |
+| Account Management | Authorizes calls, selects the scoped plugin, persists/replays opaque metadata, consumes typed outcomes, owns durable audit |
+| Keycloak | User/session/group/client source of truth; Admin REST + OAuth token endpoints reached directly over HTTPS; per-request timeout 5 s (default), bounded retry for idempotent requests |
+| Credential Store (OpenBao-backed) | Custody of adopted/created realm-admin secrets and the optional TLS CA bundle; written by the plugin only for created realms; unavailability blocks affected operations and init when the CA bundle or pre-warm needs it |
+| Operator IaC / realm bootstrap | Provides shared/adopted realms, their authentication profile and protocol mappers (including the `tenant_id`/`user_type` usermodel-attribute mappers), the bootstrap admin client and its secret, shared-realm admin client and secret, adopted-realm secrets under the template reference, and realm-default client scopes for service principals |
+| OIDC AuthN Resolver | Independently validates tokens; consumes the `user_type`/`tenant_id` claims the realm mappers project; the two components never call each other |
+| Trusted platform consumers | Resolve `ServicePrincipalClientV1` from ClientHub; their own RBAC/PDP authorizes calls before delegation |
 
 ### 3.6 Interactions & Sequences
 
-#### Realm Admissibility and Tenant Provisioning
+#### Realm Binding and Tenant Provisioning
 
 **ID**: `cpt-cf-keycloak-idp-plugin-seq-tenant-provisioning`
 
-A realm is admissible only when explicit `mode = shared` intent names an operator-approved realm and the read-only verifier proves the supported provider version plus the complete platform authentication profile. The profile includes trusted issuer/discovery, required clients, scopes, protocol mappers and claims, signing policy, session/token limits, password/login controls, and least-privileged administration. A mismatch is a pre-mutation failure; the plugin never repairs operator-owned realm configuration.
+`provision_tenant` runs under a 30 s (configurable) timeout; a timeout is `AmbiguousCreated { Timeout }`. The saga parses intent first (fail-fast, no provider round-trip), then health-probes Keycloak (failure = clean `Config` error — nothing mutated), then dispatches on the binding:
 
-After admissibility succeeds, the tenant lifecycle coordinator creates or reconciles the plugin-owned tenant group with its immutable marker and returns provider metadata only after the boundary is usable. The verifier and lifecycle coordinator use the approved OAGW route, whose injected administrator is least-privileged for the target realm; V1 has no master-realm administrator.
+- **Shared** (default; child tenants inherit the parent's realm from replayed parent metadata; root bootstrap must name the realm): assert the realm exists (bootstrap admin), then under the env-backed realm-admin ensure the per-tenant group `/tenants/{tenant_id}` and optionally bind the operator-declared admin user's `tenant_id`/`user_type` attributes (idempotent; a foreign or multi-valued existing binding is rejected as a hijack attempt).
+- **Adopted**: assert the realm exists and is empty of tenant boundaries (no subgroups under the group root), then ensure the tenant group using the operator-provisioned Credential Store secret reference.
+- **Created**: idempotent realm ensure (probe → adopt if marked as ours → reject foreign → create with the ownership attribute and a fail-closed allowlist over operator `realm_defaults`: `displayNameHtml`, `defaultLocale`, `supportedLocales`, `internationalizationEnabled`), bootstrap-token invalidation (the pre-create token lacks the auto-granted role on the new realm), realm-admin client creation, grant of the seven `realm-management` roles, secret read-back, Credential Store write (point of no return — failure is `AmbiguousCreated { OpenBaoPutAfterKcSuccess }`), and tenant-group creation under the new realm-admin.
+
+Every step that can fail after provider state exists carries a stage: `ambig:kc_realm_create`, `ambig:kc_client_create`, `ambig:kc_role_mapping`, `ambig:kc_client_secret_read`, `ambig:openbao_put_after_kc_success`, `ambig:admin_user_bind`, `ambig:timeout`. Reconciliation tooling parses the `ambig:` prefix.
+
+Success returns the metadata envelope, records `provision_tenant_duration` and `realms_bound`, and emits `tenant.bound` (plus `realm.created` and/or `admin_user.bound` where applicable).
 
 #### User Mutation Safety
 
 **ID**: `cpt-cf-keycloak-idp-plugin-seq-user-mutation`
 
-Every user operation resolves realm and tenant group from replayed provider metadata. Before reading, updating, revoking, or deleting a user, `TenantBoundaryGuard` requires membership in the resolved tenant group and an immutable tenant marker equal to the target tenant. A mismatch performs no mutation, follows the operation's non-disclosing absence semantics, and emits a security-classified terminal outcome without profile values.
+User operations resolve realm, admin client, and tenant group from replayed metadata and run each Keycloak step under an exactly-once reactive-401 wrapper.
 
-User provisioning is a recoverable unit even though provider creation and tenant binding are separate effects. The created representation carries the immutable tenant marker, and replay uses the stable `(tenant_id, username)` identity key to distinguish a matching partial creation from another tenant's uniqueness collision. Matching partial work is completed; a conflicting identity uses `DuplicateUser`. User operations do not invent an ambiguity variant outside the SDK.
+*Provisioning* creates the user with `enabled = true`, the immutable `tenant_id` and `user_type = "user"` attributes, configured required actions (default `VERIFY_EMAIL`; `UPDATE_PASSWORD` added for temporary passwords), `emailVerified` derived as the complement of `VERIFY_EMAIL`, and an optional embedded initial password; then resolves the created UUID by exact username lookup and joins the user to the tenant group. A failed group join triggers best-effort orphan compensation (delete the just-created user) with a dedicated outcome metric; the original error is always the one returned. Duplicate detection: any 409 from user-create is `DuplicateUser`; the offending field is refined from the provider error message when possible.
 
-#### Hard Tenant Deprovisioning
+*Deprovisioning* first reads the target user's stored `tenant_id` attribute; a mismatch against the request tenant performs no mutation and returns success-equivalently (non-disclosing, per ADR-0006 — this attribute check is the cross-tenant deletion guard). It then best-effort revokes sessions (configurable, default on) and deletes the identity; 404/410 are success-equivalent.
+
+*Updates* are not implemented: the SDK default returns `UnsupportedOperation`.
+
+#### Tenant Deprovisioning
 
 **ID**: `cpt-cf-keycloak-idp-plugin-seq-hard-tenant-deprovisioning`
 
-Hard deprovisioning proves access termination before boundary deletion. It obtains a complete tenant-group membership view, verifies each tenant marker, revokes sessions, deletes every tenant identity, verifies cleanup, and only then deletes the plugin-owned group. The shared realm and unrelated identities are never deleted.
+Ordering: local metadata resolution → service-principal purge → tenant-group deletion → (created-mode only) last-tenant realm teardown → Credential Store secret deletion.
 
-Already-absent plugin-owned resources are success-equivalent. `Retryable` is limited to failures for which the plugin proves that no deprovisioning mutation has an unknown outcome: no mutating request may have reached Keycloak, or all completed partial work is proven replay-safe and no attempted stage remains uncertain. If a session-revocation, identity-removal, or group-removal request may have reached Keycloak and its result cannot be proven, the outcome is `Terminal` for operator action even when the immediate cause is a timeout or transient transport failure. Ownership mismatch, incomplete enumeration, and any inability to prove safe continuation are also terminal. The process blocks refresh and new sessions but does not claim immediate invalidation of an already-issued JWT; exposure is bounded by the 15-minute profile limit.
+- Missing metadata or an undecodable-but-absent blob returns `NotFound` (success-equivalent) with an `already_absent` audit event and a trigger metric when invoked by the AM system actor; a malformed blob is `Terminal`.
+- A pre-saga health-probe failure is `Retryable` — nothing was attempted.
+- The service-principal purge deletes every `svc-{tenant_id}-*` client owned by the tenant (ownership marker checked client-side); purge failures classify to `Retryable` (retryable provider status or staged ambiguity) or `Terminal` (permanent provider rejection) and abort the saga so no live machine credential survives its tenant.
+- Tenant-group deletion treats 404/410 as `NotFound`; other failures are `Retryable`.
+- For created bindings only, if no sibling tenant groups remain the realm itself is deleted (404/410 tolerated), then the realm-admin secret is deleted from the Credential Store (absent-as-success). The realm-admin client is not deleted separately — it dies with the realm.
+- Shared and adopted realms are never deleted, and per-user deletion is not part of tenant deprovisioning: Account Management's hard-delete pipeline deprovisions users through `deprovision_user` before retiring the tenant boundary.
+
+The whole saga shares the 30 s timeout (timeout → `Retryable`).
 
 #### User Query Architecture
 
 **ID**: `cpt-cf-keycloak-idp-plugin-seq-user-query`
 
-`IdpListUsersRequest` is authoritative. Because Keycloak 26.x does not document stable global order for group-member offset pages, V1 obtains a complete per-request tenant-group view, verifies tenant binding, applies supported SDK filter/order, and globally sorts with a unique provider-ID tiebreaker. The continuation token is a valid `CursorV1` that pins filter, order, tenant context, and the last emitted key tuple.
+`IdpListUsersRequest` is authoritative. Because Keycloak documents no stable global order for group-member offset pages, each list call drains the full tenant-group membership (pages of `list_users_page_limit_max`, default 200) into memory, bounded by a 10,000-member hard cap (exceeding it truncates and logs loudly), then sorts on `(createdTimestamp ASC, id ASC)`, deduplicates by id, applies the cursor skip, applies filters, and pages.
 
-This is a correctness-first linear scan, not an `O(page)` claim. Point existence may use a direct provider lookup followed by the same boundary guard. No persistent local index or user cache is introduced. V1 list support is capped at 1,000 total human identities, enabled or disabled, per tenant group. The adapter reads Keycloak members in pages no larger than 500, permits at most `ceil(N / 500) + 1` member-page requests, and caps working memory at 16 MiB per list call. It stops on the first member beyond the ceiling and returns `IdpUserOperationFailure::UnsupportedOperation` without sorting or returning a partial page. Release qualification covers 100%, 10%, and 1% filter selectivity, every supported order, cached-token and forced-token-refresh runs, 20 concurrent operations, and the PRD topology and latency targets.
+Supported filters, lowered client-side: `eq` (exact) and `contains` (case-insensitive) over `username`, `email`, `first_name`, `last_name`, `display_name`; `id eq` as a point filter; `and`/`or` composition. Everything else (`ne`, ranges, `in`, `not`, `id eq` inside `or`) returns `UnsupportedOperation` before any provider call. Requested ordering is not consulted; the sort is fixed.
+
+The continuation token is a `CursorV1` (the same envelope Account Management uses elsewhere) pinning the fixed order tokens `+created_at,+id`, forward-only direction, the last emitted `(createdTimestamp, id)` key, and an FNV-1a hash folding tenant, realm, and the complete filter tree — changing the filter mid-walk invalidates the cursor. A one-release legacy cursor fallback covers rolling deploys. Page size is `min(requested top, 200)`.
 
 #### Failure, Retry, and Reconciliation
 
 **ID**: `cpt-cf-keycloak-idp-plugin-seq-reconciliation`
 
-Retries are bounded and limited to idempotent reads, token refresh, or operations whose replay contract proves safety. For tenant deprovisioning, a pre-send dependency failure or proven replay-safe partial state may return `Retryable`; a timeout or disconnect after a mutating request may have reached Keycloak returns `Terminal` unless the result is independently proven. A provider mutation is never blindly retried merely because transport failed. Circuit breaking is dependency-specific and never selects a default realm or stale user projection.
+Transport-level retry is bounded (default 3 retries, exponential backoff 100 ms → 5 s cap, full jitter, `Retry-After` honored in delta-seconds form) and applies only to idempotent requests (GET/PUT/DELETE and the token form-POST) on retryable statuses (5xx/429) or connect/timeout errors; admin POSTs are never replayed on transport failure. Reactive-401 re-mints credentials exactly once per call.
 
-Ambiguous tenant provisioning remains operator-owned in V1. Terminal outcomes provide non-secret stage and ownership evidence. Production enablement requires a reconciliation runbook whose resolution ends as compensated, accepted complete, blocked for investigation, or escalated for controlled cleanup.
+Classification is closed: internal `PluginError` variants translate to SDK failures per the fixed tables in §3.3, and each variant has a stable metric label on `vp_idp_plugin_failure_total`. Ambiguous created-mode provisioning remains operator-owned: terminal evidence carries the `ambig:{stage}` token, the realm, and redacted provider detail. Production enablement requires a reconciliation runbook keyed on those stage tokens.
 
-#### Outbound HTTP, Credentials, and Rotation
+#### Credentials, Token Cache, and Rotation
 
 **ID**: `cpt-cf-keycloak-idp-plugin-seq-credential-resolution`
 
-All Keycloak OAuth and Admin REST traffic uses an operator-provisioned OAGW upstream and route through `ServiceGatewayClientV1::proxy_request`. The plugin opens no direct external HTTP connection and cannot read a provider credential value. Operator IaC owns the HTTPS-only upstream, route allowlist, realm-local credential reference, timeouts, response limits, and auth policy. OAGW resolves and validates the Credential Store reference, injects the credential, applies egress and SSRF controls, and returns bounded responses with gateway-versus-upstream failure provenance.
+All Keycloak traffic authenticates with OAuth2 `client_credentials`. Secrets resolve by tier:
 
-The plugin forwards the `SecurityContext` received from Account Management for correlation and OAGW authorization; it does not mint a separate caller identity. OAGW route policy admits only Account Management-authorized actors and the stable AM system subjects used for bootstrap, reaper, retention, and cleanup flows. Credential rotation is transparent through the stable OAGW credential reference. Authentication failure never falls back to another route, realm, plaintext credential, or plugin cache, and mutation retry remains subject to the normal uncertainty rules.
+| Tier | Client | Secret source |
+|---|---|---|
+| Bootstrap admin | `vp-idp-plugin-bootstrap` in `master` (defaults) | `${VAR}`-expanded configuration (`SecretFromEnv`) |
+| Shared-realm admin | `vp-idp-plugin-realm-admin` (default) | `${VAR}`-expanded configuration (`default_shared_realm_secret`) |
+| Adopted/created-realm admin | `admin_client_id` from metadata | Credential Store reference from `secret_ref_template` (created-mode secrets are written by the plugin during provisioning) |
 
-#### Durable Mutation Audit Boundary
+Tokens are cached per `(realm, client_id)` with an expiry safety margin (default 30 s, floor 5 s), single-flight refresh (one concurrent mint per key), and read-time eviction. A 401 on any wrapped call invalidates the cache entry, re-resolves the secret from its source, and retries exactly once — so operator secret rotation converges without restart. Cache hits emit no metrics; real refreshes emit `credential_refresh_total` and `kc_admin_token_refresh_total` separately so "Credential Store unreachable" and "Keycloak rejected the secret" are distinguishable.
+
+Optional TLS: `tls_ca_bundle_ref` names a Credential Store secret holding a PEM CA bundle added to the reqwest trust roots at init; otherwise the system trust store applies.
+
+#### Audit and Metrics Boundary
 
 **ID**: `cpt-cf-keycloak-idp-plugin-seq-terminal-outcome`
 
@@ -419,32 +464,29 @@ The plugin forwards the `SecurityContext` received from Account Management for c
 sequenceDiagram
   participant AM as Account Management
   participant P as Keycloak plugin
-  participant G as Outbound API Gateway
   participant K as Keycloak
   participant A as Platform audit infrastructure
 
   AM->>P: Invoke mutating contract
-  P->>G: Approved provider request
-  G->>K: Credential-injected operation
-  P-->>AM: Classified privacy-safe outcome
+  P->>K: Admin REST (bearer, HTTPS)
+  P-->>P: tracing event on vp.idp.plugin.events
+  P-->>AM: Classified redacted outcome
   AM->>A: Durably correlate terminal outcome
 ```
 
-The plugin produces the classified provider outcome and privacy-safe evidence needed by its caller. It does not persist audit records, call the platform audit sink, or own delivery/recovery tasks.
+The plugin emits structured events on the `vp.idp.plugin.events` tracing target — `tenant.bound`, `realm.created`, `admin_user.bound`, `tenant.unbound`, `realm.removed`, `service_principals.purged`, `user.provisioned` (includes `username`), `user.deprovisioned` — each carrying the acting subject (id, closed-set type, raw type, tenant). This is an explicit development stand-in until the platform audit sink lands; durable one-outcome-per-call correlation is owned by Account Management and the platform audit owner. `list_users` and the service-principal read/mutate paths emit no plugin audit events of their own; the only service-principal audit signal is `service_principals.purged` on tenant deprovisioning.
 
-Account Management and the platform audit owner must guarantee one durable terminal outcome per mutating contract call, including process failure after a possible provider effect and duplicate delivery. Their chosen persistence, idempotency key, recovery, replay, acknowledgement, and retention semantics belong to their own authoritative designs and contracts.
-
-Until those owners approve and implement that guarantee, this plugin may use the existing structured-log stand-in for development but is not production-enabled. Audit payloads prohibit usernames, emails, display names, passwords, tokens, administrator secrets, raw provider bodies, and request payloads.
+Metrics: `vp_idp_plugin_provision_tenant_duration_seconds`, `user_op_duration_seconds`, `sp_op_duration_seconds`, `kc_admin_request_duration_seconds` (declared, not yet wired), `failure_total{op,failure_variant}`, `kc_admin_token_refresh_total` and `credential_refresh_total` (`{outcome,tier,realm}`), `credstore_write_total`, `metadata_decode_failure_total{version_observed}`, `deprovision_missing_metadata_total`, `orphan_user_compensation_total`, `realms_bound{realm_binding,realm_name}`. Every label is a closed enum except `realm`/`realm_name`, which share a cardinality budget (default 500 distinct realms) after which the label is dropped with a one-shot warning.
 
 #### Lifecycle and Shutdown
 
 **ID**: `cpt-cf-keycloak-idp-plugin-seq-lifecycle-shutdown`
 
-The module receives a ToolKit `CancellationToken`. Shutdown stops new work, cancels idle provider activity, and drains in-flight mutations for a bounded interval before connection teardown. Mutation coordinators preserve their normal replay/reconciliation evidence if the timeout expires. The plugin owns no periodic, detached, or audit-delivery task.
+The plugin owns no periodic, detached, or audit-delivery task; all work is call-scoped and bounded by the per-request HTTP timeout, the bounded retry policy, and the saga timeout. Host shutdown therefore has nothing plugin-specific to drain beyond in-flight calls, which preserve their normal classification and reconciliation evidence.
 
 ### 3.7 Database schemas & tables
 
-Not applicable because the plugin owns no database schema, table, migration, audit store, or persistent user index. Account Management owns its opaque provider-metadata row, and Keycloak owns provider identity state. Any audit persistence belongs to the parent Account Management design or platform audit owner and is intentionally not specified here.
+Not applicable: the plugin owns no database schema, table, migration, audit store, or persistent user index. Account Management owns its opaque provider-metadata row; Keycloak owns identity state; the Credential Store owns secret persistence.
 
 ## 4. Additional context
 
@@ -454,53 +496,45 @@ Not applicable because the plugin owns no database schema, table, migration, aud
 
 | Boundary | Control |
 |---|---|
-| Account Management caller to plugin | AM authorizes; forwarded `SecurityContext` identifies the actor but never substitutes for provider tenant checks |
-| Plugin to OAGW | Forwarded authorized `SecurityContext`, fixed route aliases, bounded bodies, and no caller-controlled upstream URL |
-| OAGW to Credential Store and Keycloak | OAGW-owned credential resolution and injection, HTTPS-only egress, SSRF controls, least-privileged realm administrator, and gateway-versus-upstream failure provenance |
-| Tenant A to tenant B in one realm | Mandatory group-plus-marker guard on every read and mutation |
-| Account Management to platform audit infrastructure | External contract; the plugin supplies only classified privacy-safe outcomes |
-| Plugin to metrics | Bounded-cardinality labels and no profile or credential values |
+| Account Management caller to plugin | AM authorizes; the forwarded `SecurityContext` identifies the actor for audit but never substitutes for provider tenant checks |
+| Service-principal consumer to plugin | Trusted platform modules only (in-process ClientHub); caller RBAC/PDP authorizes before delegation; `ctx` is audit-only |
+| Plugin to Keycloak | HTTPS with optional operator CA bundle; bearer tokens minted per admin tier; bounded bodies on error paths; no caller-controlled URL — paths are built from configuration and validated identifiers |
+| Plugin to Credential Store | Plugin-owned system actor (stable service-principal UUID, platform tenant, wildcard token scopes) authorized through ordinary RBAC grants — no PEP bypass; reader and writer are separate types so read-only sites cannot mutate |
+| Tenant A to tenant B | Group-scoped listing; `tenant_id`-attribute guard on user deletion; ownership-marker guard on realms and service-principal clients; foreign resources are reported as absent, not as denied |
+| Plugin to metrics/logs | Closed-enum labels, capped realm label, `redact_secrets` (bearer and key-value secret patterns) plus 2 KiB truncation on every provider body |
 
-The V1 administrator has only realm-local permissions needed to inspect the authentication profile and administer users, sessions, and the configured tenant-group subtree. It cannot create/delete realms, administer another realm, read client secrets, or alter operator-owned authentication configuration.
+Secret custody: the bootstrap and shared-realm admin secrets enter the process through `${VAR}` config expansion into redacted wrapper types; adopted/created realm secrets and the optional CA bundle live in the Credential Store; created-realm secrets are generated by Keycloak, read back once per provisioning, and stored under the templated reference with tenant sharing. Cached tokens are `SecretString`s with redacted debug output. Metadata envelopes carry reference names, never values.
 
-Missing, malformed, contradictory, unknown-major, deferred-mode, or producing-instance-mismatched metadata causes no OAGW or provider access. A realm or OAGW route outside the approved registry is rejected even if reachable. Tenant marker and group disagreement blocks access. Credential, gateway, or TLS failure never falls back to plaintext, another route or realm, or cached user data.
+The plugin's system actor identity (`VP_IDP_PLUGIN_ACTOR_UUID`) must remain stable across releases — created-realm secret ownership in the Credential Store is keyed to it.
 
-Keycloak is the sole user directory. The plugin holds request data only for the operation lifetime and stores no local profile. Provider metadata contains routing identifiers rather than profile data. Hard deprovisioning removes identities and sessions before the group; failed proof is terminal. Plugin-provided audit evidence and metrics use provider IDs only where operationally necessary and contain no profile or credential values.
+Keycloak is the sole user directory. The plugin holds request data only for the operation lifetime. Hard user deprovisioning deletes the provider identity; created-realm teardown removes the realm and its secret. Audit events use provider IDs, with `username` additionally present on `user.provisioned`.
 
 ### 4.2 Verification Architecture
 
-Verification is split by boundary rather than duplicated as method-level test cases in this overall DESIGN:
-
 | Level | Purpose |
 |---|---|
-| Unit | Metadata compatibility, boundary predicates, cursor construction, error classification, redaction, and privacy-safe outcome construction |
-| SDK contract | Conformance to the existing `IdpPluginClient`, failure enums, typed filter/order, and `CursorV1` |
-| Real-Keycloak integration | Supported-version/profile checks through OAGW, least privilege, user replay, cross-tenant denial, complete hard deletion, pre-send retryable versus post-send unproven terminal classification, provider failures, and global query behavior |
-| OAGW and Credential Store integration | Approved-route enforcement, no direct egress, credential-reference ownership, rotation, authorization denial, gateway/upstream failure provenance, and non-disclosure |
-| Cross-system audit contract | Account Management and the platform audit owner prove one durable terminal event per mutating call across crash and redelivery; this is an external production gate |
-| Lifecycle integration | Host startup with OAGW, Credential Store, and Keycloak unavailable; unaffected AM availability; operation-level recovery without restart; cancellation, bounded drain, replay/reconciliation evidence, and no plugin-owned detached tasks |
-| End to end | Account Management scoped selection, two-instance metadata mismatch rejection before OAGW access, tenant/user lifecycle, audit correlation, reconciliation evidence, and the complete PRD latency/capacity profile |
+| Unit (in-crate, 300+ tests) | Config parsing/defaults/validation, metadata codec compatibility, error classification and translation tables, redaction, cursor encode/decode incl. legacy fallback, filter lowering, boundary predicates, token cache/single-flight/reactive-401 (wiremock), transport retry/backoff/Retry-After (wiremock), metrics label and cardinality behavior, saga step ordering via configurable stubs |
+| SDK contract | Conformance to `IdpPluginClient` and `ServicePrincipalClientV1` failure enums and semantics; `tests/contract_am_sdk.rs` is the placeholder for the upstream AM-SDK conformance harness |
+| Real-Keycloak integration | Realm ensure idempotency, group lifecycle, role grants, user replay, cross-tenant denial, deletion ordering, provider failures, query behavior (owned by the deployment repository's E2E stacks) |
+| Lifecycle integration | Enabled/disabled init paths, pre-warm retry/fast-bail budgets, catalogue re-registration drift detection |
+| Cross-system audit contract | Account Management and the platform audit owner prove durable terminal outcomes; external production gate |
 
-Tests that claim provider semantics use a supported real Keycloak 26.x instance. Test doubles are limited to deterministic local classification and failure injection; they do not establish Keycloak compatibility, tenant isolation, TLS, credential authorization, or latency.
-
-Crash and redelivery verification for durable audit is owned by the parent Account Management and platform audit designs. The plugin contract suite verifies that every returned outcome is classified, correlatable, and free of prohibited profile or credential values.
+Test doubles are limited to deterministic classification and failure injection (wiremock for HTTP, stub credstore clients); they do not establish Keycloak compatibility, tenant isolation, TLS, or latency.
 
 ### 4.3 Risks and Enablement Gates
 
-| Gate | Required resolution before V1 production enablement |
+| Gate | Required resolution before production enablement |
 |---|---|
-| Scoped provider selection | Account Management resolves the configured GTS instance; metadata records the producing instance; a two-instance priority/config change fails closed before OAGW access; no unscoped fallback remains; provider changes require an operator migration |
-| Realm profile | Operator-approved profile is versioned and every required property is verified before tenant mutation |
-| Query capacity | At 1,000 total tenant users, enabled or disabled, every required filter/order profile meets PRD latency with 20 concurrent operations, member-page reads stay within `ceil(N / 500) + 1`, memory stays within 16 MiB per request, and member 1,001 produces a non-partial `UnsupportedOperation` result |
-| User replay | Failure injection after each provider effect converges to one correctly bound identity |
-| Hard deletion | Two-tenant integration proves sessions and identities for the retiring tenant are removed without touching the active tenant |
-| Audit ownership | Parent Account Management and platform audit designs assign persistence, recovery, delivery, sink, and retention ownership; the plugin owns none of them |
-| Audit completeness | Cross-system tests prove one durable terminal outcome per mutating call across process failure and redelivery; the structured-log stand-in is not a production substitute |
-| Reconciliation | Operator runbook exists and consumes emitted evidence without secret inspection |
-| Compatibility | Supported Keycloak 26.x matrix passes and representative unsupported majors fail affected operation-based readiness before mutation without preventing host startup |
-| Lifecycle | Dependency-down startup, recovery without restart, cancellation, and rolling-restart tests prove availability, bounded shutdown, and replay safety |
-
-Deferred adopted realms, plugin-created realms, OpenBao secret mutation, and service-principal lifecycle are not designed here. Each requires its own upstream contract, security review, DESIGN, ADRs where decisions depart from accepted standards, and release gates.
+| Scoped provider selection | Account Management resolves the configured GTS instance (`idp.vendor` = the plugin's vendor); catalogue drift on restart fails init; provider changes require an operator migration |
+| Realm profile | Operator realm bootstrap provisions the authentication profile, protocol mappers (`tenant_id`, `user_type`), clients, scopes, and token policy; the plugin assumes rather than verifies it — a runtime profile verifier is future work |
+| Provider compatibility | The implementation is developed and qualified against Keycloak 26.x; no runtime version gate exists — the compatibility matrix is a release-qualification obligation |
+| Query capacity | Release qualification proves the PRD latency profile within the 200-item page cap and 10,000-member drain cap; population growth beyond the cap requires the realm-wide attribute-query evolution before support is claimed |
+| User replay | Failure injection after each provider effect converges to one correctly bound identity (orphan compensation verified) |
+| Hard deletion | Two-tenant integration proves the retiring tenant's boundary, service principals, and (created mode) realm and secret are removed without touching the active tenant |
+| Audit ownership | Parent Account Management and platform audit designs assign persistence, recovery, delivery, and retention; the plugin's tracing stand-in is not a production substitute |
+| Reconciliation | Operator runbook exists and consumes `ambig:{stage}` evidence without secret inspection |
+| Init dependency | Deployment ordering tolerates the pre-warm budget (Keycloak/Credential Store reachable within ≈37 s of plugin init) or explicitly disables the plugin |
+| User updates | `update_user` support requires implementing the SDK contract (JSON Merge Patch semantics, duplicate/password-policy classification) before any product surface promises profile editing through this provider |
 
 ## 5. Traceability
 
@@ -510,22 +544,24 @@ Deferred adopted realms, plugin-created realms, OpenBao secret mutation, and ser
 - [Account Management DESIGN](../../../docs/DESIGN.md)
 - [`IdpPluginClient` tenant contract](../../../account-management-sdk/src/idp.rs)
 - [`IdpPluginClient` user contract](../../../account-management-sdk/src/idp_user.rs)
+- [`ServicePrincipalClientV1` contract](../../../../service-principal/service-principal-sdk/src/api.rs)
 - [Unified ToolKit architecture](../../../../../../docs/toolkit_unified_system/README.md)
+- Implementation: [`plugins/keycloak-idp-plugin`](../src/lib.rs) (crate `vp-idp-plugin`)
 
 ### 5.2 P1 Requirement Allocation
 
 | PRD requirement IDs | Design sections |
 |---|---|
 | `cpt-cf-keycloak-idp-plugin-fr-provider-publication`, `cpt-cf-keycloak-idp-plugin-fr-readiness`, `cpt-cf-keycloak-idp-plugin-interface-provider-instance` | §§3.2, 3.6, 4.3 |
-| `cpt-cf-keycloak-idp-plugin-fr-tenant-realm-binding`, `cpt-cf-keycloak-idp-plugin-fr-shared-realm-admissibility`, `cpt-cf-keycloak-idp-plugin-fr-tenant-provision`, `cpt-cf-keycloak-idp-plugin-usecase-bind-shared-tenant` | §§3.1, 3.6 |
-| `cpt-cf-keycloak-idp-plugin-fr-realm-authentication-profile`, `cpt-cf-keycloak-idp-plugin-nfr-provider-compatibility`, `cpt-cf-keycloak-idp-plugin-contract-keycloak-admin` | §§3.2, 3.6, 4.3 |
+| `cpt-cf-keycloak-idp-plugin-fr-tenant-realm-binding`, `cpt-cf-keycloak-idp-plugin-fr-shared-realm-admissibility`, `cpt-cf-keycloak-idp-plugin-fr-adopted-realm-admissibility`, `cpt-cf-keycloak-idp-plugin-fr-created-realm-admissibility`, `cpt-cf-keycloak-idp-plugin-fr-tenant-provision`, `cpt-cf-keycloak-idp-plugin-usecase-bind-shared-tenant`, `cpt-cf-keycloak-idp-plugin-usecase-adopt-tenant-realm`, `cpt-cf-keycloak-idp-plugin-usecase-create-tenant-realm` | §§3.1, 3.6 |
 | `cpt-cf-keycloak-idp-plugin-fr-provider-metadata` | §§3.1, 3.3 |
-| `cpt-cf-keycloak-idp-plugin-fr-tenant-deprovision`, `cpt-cf-keycloak-idp-plugin-fr-tenant-user-access-termination`, `cpt-cf-keycloak-idp-plugin-usecase-retire-tenant` | §§3.6, 4.1 |
+| `cpt-cf-keycloak-idp-plugin-fr-tenant-deprovision`, `cpt-cf-keycloak-idp-plugin-fr-tenant-service-principal-cleanup`, `cpt-cf-keycloak-idp-plugin-fr-tenant-user-access-termination`, `cpt-cf-keycloak-idp-plugin-usecase-retire-tenant` | §§3.6, 4.1 |
 | `cpt-cf-keycloak-idp-plugin-fr-tenant-failure-contract`, `cpt-cf-keycloak-idp-plugin-fr-external-mutation-resilience`, `cpt-cf-keycloak-idp-plugin-nfr-failure-classification` | §§3.3, 3.6 |
-| `cpt-cf-keycloak-idp-plugin-fr-user-provision`, `cpt-cf-keycloak-idp-plugin-fr-user-update`, `cpt-cf-keycloak-idp-plugin-fr-user-update-outcomes`, `cpt-cf-keycloak-idp-plugin-fr-user-deprovision`, `cpt-cf-keycloak-idp-plugin-usecase-update-user` | §3.6 |
+| `cpt-cf-keycloak-idp-plugin-fr-user-provision`, `cpt-cf-keycloak-idp-plugin-fr-user-deprovision` | §3.6 |
 | `cpt-cf-keycloak-idp-plugin-fr-user-query` | §3.6 |
 | `cpt-cf-keycloak-idp-plugin-fr-user-source-of-truth` | §§3.1, 4.1 |
-| `cpt-cf-keycloak-idp-plugin-fr-administrator-credentials`, `cpt-cf-keycloak-idp-plugin-contract-oagw`, `cpt-cf-keycloak-idp-plugin-contract-credstore` | §§3.5–3.6, 4.1 |
+| `cpt-cf-keycloak-idp-plugin-fr-service-principal-lifecycle`, `cpt-cf-keycloak-idp-plugin-fr-service-principal-state`, `cpt-cf-keycloak-idp-plugin-fr-service-principal-safeguards`, `cpt-cf-keycloak-idp-plugin-fr-service-principal-rotation`, `cpt-cf-keycloak-idp-plugin-fr-service-principal-list`, `cpt-cf-keycloak-idp-plugin-fr-service-principal-mutation-safety`, `cpt-cf-keycloak-idp-plugin-fr-service-principal-secret-disclosure`, `cpt-cf-keycloak-idp-plugin-fr-service-principal-recovery`, `cpt-cf-keycloak-idp-plugin-fr-service-principal-failure-contract`, `cpt-cf-keycloak-idp-plugin-interface-service-principal-client`, `cpt-cf-keycloak-idp-plugin-usecase-service-principal-credentials`, `cpt-cf-keycloak-idp-plugin-usecase-list-revoke-service-principals` | §§3.2–3.3, 3.6, 4.1 |
+| `cpt-cf-keycloak-idp-plugin-fr-administrator-credentials`, `cpt-cf-keycloak-idp-plugin-contract-credstore` | §§3.5–3.6, 4.1 |
 | `cpt-cf-keycloak-idp-plugin-fr-operator-reconciliation`, `cpt-cf-keycloak-idp-plugin-usecase-reconcile-ambiguous-mutation` | §§3.6, 4.3 |
 | `cpt-cf-keycloak-idp-plugin-fr-offline-token-lifetime` | §§2.2, 3.6 |
 | `cpt-cf-keycloak-idp-plugin-fr-audit-metrics`, `cpt-cf-keycloak-idp-plugin-nfr-audit-completeness` | §§3.3, 3.5–3.6, 4.1–4.3 |
@@ -533,7 +569,8 @@ Deferred adopted realms, plugin-created realms, OpenBao secret mutation, and ser
 | `cpt-cf-keycloak-idp-plugin-nfr-secret-nondisclosure` | §§3.6, 4.1 |
 | `cpt-cf-keycloak-idp-plugin-nfr-lifecycle-latency` | §§1.2, 2.2, 3.6, 4.3 |
 | `cpt-cf-keycloak-idp-plugin-nfr-personal-data-lifecycle` | §4.1 |
-| `cpt-cf-keycloak-idp-plugin-nfr-availability-recovery` | §§3.2, 3.6 |
-| `cpt-cf-keycloak-idp-plugin-interface-idp-plugin-client`, `cpt-cf-keycloak-idp-plugin-contract-account-management` | §§1.1, 2.1, 3.2–3.3 |
+| `cpt-cf-keycloak-idp-plugin-nfr-availability-recovery` | §§2.2, 3.2, 3.6 |
+| `cpt-cf-keycloak-idp-plugin-nfr-provider-compatibility` | §4.3 |
+| `cpt-cf-keycloak-idp-plugin-interface-idp-plugin-client`, `cpt-cf-keycloak-idp-plugin-contract-account-management`, `cpt-cf-keycloak-idp-plugin-contract-keycloak-admin` | §§1.1, 2.1, 3.2–3.3 |
 
-P2 requirements remain traceable in the PRD but are intentionally not allocated to V1 implementation components in this DESIGN.
+P2 requirements (user update, realm profile verification, runtime provider-version gate) remain traceable in the PRD but are intentionally not allocated to implementation components in this DESIGN.

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
@@ -189,7 +189,7 @@ Unsupported operations (`update_user`, unsupported filters) return typed `Unsupp
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-least-privilege`
 
-Realm-scoped work uses a per-realm admin client granted exactly seven `realm-management` roles (`view-realm`, `view-clients`, `query-groups`, `manage-realm`, `manage-users`, `query-users`, `manage-clients`). The bootstrap admin is used only where realm-level authority is required: realm existence probes, created-realm lifecycle, and service-principal client administration.
+Realm-scoped work uses a per-realm admin client granted exactly seven `realm-management` roles (`view-realm`, `view-clients`, `query-groups`, `manage-realm`, `manage-users`, `query-users`, `manage-clients`). The bootstrap admin is used only where realm-level authority is required: realm existence probes, created-realm lifecycle, service-principal client administration, and the tenant-group emptiness and sibling probes on adopted and created realms — which is why the bootstrap client also needs `query-groups` on those realms.
 
 #### Privacy-preserving evidence
 
@@ -357,7 +357,7 @@ Contract invariants implemented at the boundary (`idp_impl.rs`, `sp_impl.rs`):
 - tenant deprovisioning maps `DeprovisionNotFound` → `NotFound` (success-equivalent), `DeprovisionRetryable` → `Retryable`, and everything else — including metadata decode failures — → `Terminal`;
 - user failures use only `IdpUserOperationFailure` variants: KC 409 on create is `DuplicateUser` with the field refined from the provider message (`Username`/`Email`/`UsernameOrEmail`), password-policy rejections are `PasswordPolicy`, unsupported filters and the unimplemented `update_user` are `UnsupportedOperation`, provider/transport trouble is `Unavailable`;
 - service-principal failures use the closed `ServicePrincipalFailure` set: `InvalidInput` (bad name, disallowed scope, quota, taken client id), `NotFound` (absent or foreign principal — indistinguishable by design), `Ambiguous` (stage-attributed transport uncertainty; stage tokens tabulated in §3.6), `CleanFailure` (pre-mutation failures);
-- every mutating return carries redacted, truncated, grep-friendly detail (`kc:{METHOD} {path_template} -> {status}: {body≤2KiB}` or `internal:{component}: …`).
+- every mutating return carries redacted, truncated, grep-friendly detail: provider failures use `kc:{METHOD} {path_template} -> {status}: {body≤2KiB}`, internal component failures `internal:{component}: …`, and classified domain rejections a stable variant prefix (`ambig:{stage}: …`, `deprovision retryable: …`, `sp invalid input: …`, and so on).
 
 The plugin emits no public HTTP API.
 
@@ -455,7 +455,7 @@ User operations resolve realm, admin client, and tenant group from replayed meta
 
 Ordering: local metadata resolution → service-principal purge → tenant-group deletion → (created-mode only) last-tenant realm teardown → Credential Store secret deletion.
 
-- Missing metadata or an undecodable-but-absent blob returns `NotFound` (success-equivalent) with an `already_absent` audit event and a trigger metric when invoked by the AM system actor; a malformed blob is `Terminal`.
+- Missing metadata returns `NotFound` (success-equivalent) with an `already_absent` audit event and a trigger metric when invoked by the AM system actor. A blob that decodes to no metadata is also `NotFound` but records only the failure counter (the branch is unreachable in practice). A malformed blob is `Terminal`.
 - A pre-saga health-probe failure is `Retryable` — nothing was attempted.
 - The service-principal purge deletes every `svc-{tenant_id}-*` client owned by the tenant (ownership marker checked client-side); purge failures classify to `Retryable` (retryable provider status or staged ambiguity) or `Terminal` (permanent provider rejection) and abort the saga so no live machine credential survives its tenant.
 - Tenant-group deletion treats 404/410 as `NotFound`; other failures are `Retryable`.
@@ -502,7 +502,7 @@ All Keycloak traffic authenticates with OAuth2 `client_credentials`. Secrets res
 
 Service-principal administration always uses the bootstrap admin tier, against the dedicated service-principal realm (`service_principal.realm`, default `platform` — the shared realm whose issuer tenants trust), independent of any tenant's realm binding.
 
-Tokens are cached per `(realm, client_id)` with an expiry safety margin (default 30 s, floor 5 s), single-flight refresh (one concurrent mint per key), and read-time eviction. A 401 on any wrapped call invalidates the cache entry, re-resolves the secret from its source, and retries exactly once — so operator secret rotation converges without restart. Cache hits emit no metrics; real refreshes emit `credential_refresh_total` and `kc_admin_token_refresh_total` separately so "Credential Store unreachable" and "Keycloak rejected the secret" are distinguishable.
+Tokens are cached per `(realm, client_id)` with a configurable expiry safety margin (default 30 s) and a 5 s floor on the resulting cache TTL, single-flight refresh (one concurrent mint per key), and read-time eviction. A 401 on any wrapped call invalidates the cache entry, re-resolves the secret from its source, and retries exactly once — so operator secret rotation converges without restart. Cache hits emit no metrics; real refreshes emit `credential_refresh_total` and `kc_admin_token_refresh_total` separately so "Credential Store unreachable" and "Keycloak rejected the secret" are distinguishable.
 
 Optional TLS: `tls_ca_bundle_ref` names a Credential Store secret holding a PEM CA bundle added to the reqwest trust roots at init; otherwise the system trust store applies.
 
@@ -526,9 +526,9 @@ sequenceDiagram
   AM->>A: Durably correlate terminal outcome
 ```
 
-The plugin emits structured events on the `keycloak_idp.events` tracing target — `tenant.bound`, `realm.created`, `admin_user.bound`, `tenant.unbound`, `realm.removed`, `service_principals.purged`, `user.provisioned` (includes `username`), `user.deprovisioned` — each carrying the acting subject (id, closed-set type, raw type, tenant). This is an explicit development stand-in until the platform audit sink lands; durable one-outcome-per-call correlation is owned by Account Management and the platform audit owner. `list_users` and the service-principal read/mutate paths emit no plugin audit events of their own; the only service-principal audit signal is `service_principals.purged` on tenant deprovisioning.
+The plugin emits structured events on the `keycloak_idp.events` tracing target — `tenant.bound`, `realm.created`, `admin_user.bound`, `tenant.unbound`, `realm.removed`, `service_principals.purged`, `user.provisioned` (includes `username`), `user.deprovisioned` — each carrying the acting subject (id, closed-set type, raw type, tenant). `user.deprovisioned` is emitted on every successful `deprovision_user` return, including the non-mutating cross-tenant-guard and already-absent paths, and its `already_absent` field is currently always `false`. This is an explicit development stand-in until the platform audit sink lands; durable one-outcome-per-call correlation is owned by Account Management and the platform audit owner. `list_users` and the service-principal read/mutate paths emit no plugin audit events of their own; the only service-principal audit signal is `service_principals.purged` on tenant deprovisioning.
 
-Metrics: `keycloak_idp_plugin_provision_tenant_duration_seconds`, `user_op_duration_seconds`, `sp_op_duration_seconds`, `kc_admin_request_duration_seconds` (declared, not yet wired), `failure_total{op,failure_variant}`, `kc_admin_token_refresh_total` and `credential_refresh_total` (`{outcome,tier,realm}`), `credstore_write_total`, `metadata_decode_failure_total{version_observed}`, `deprovision_missing_metadata_total`, `orphan_user_compensation_total`, `realms_bound{realm_binding,realm_name}`. Every label is a closed enum except `realm`/`realm_name`, which share a cardinality budget (default 500 distinct realms) after which the label is dropped and a warning is logged for each newly observed over-cap realm.
+Metrics: `keycloak_idp_plugin_provision_tenant_duration_seconds`, `user_op_duration_seconds`, `sp_op_duration_seconds`, `kc_admin_request_duration_seconds` (declared, not yet wired), `failure_total{op,failure_variant}`, `kc_admin_token_refresh_total` and `credential_refresh_total` (`{outcome,tier,realm}`), `credstore_write_total`, `metadata_decode_failure_total{version_observed}`, `deprovision_missing_metadata_total`, `orphan_user_compensation_total`, `realms_bound{realm_binding,realm_name}`. Every label is a closed enum except `version_observed` (an uncapped observed version string) and `realm`/`realm_name`, which share a cardinality budget (default 500 distinct realms) after which the label is dropped and a warning is logged on every observation of an over-cap realm.
 
 Operational signals: the reconciliation gate consumes `failure_total{failure_variant="ambiguous_created"}` and the `ambig:{stage}` warn events; dependency-health attribution splits `credential_refresh_total{outcome="error"}` (Credential Store) from `kc_admin_token_refresh_total{outcome="error"}` (Keycloak) plus `credstore_write_total{outcome="error"}`; metadata integrity consumes `metadata_decode_failure_total` (any increase is operator-actionable); list capacity consumes the drain-cap truncation warning. Alert thresholds against the PRD availability and latency targets are owned by the deployment repository's monitoring configuration, not by this design.
 
@@ -561,7 +561,7 @@ Not applicable: the plugin owns no database schema, table, migration, audit stor
 
 Secret custody: the bootstrap and shared-realm admin secrets enter the process through `${VAR}` config expansion into redacted wrapper types; adopted/created realm secrets and the optional CA bundle live in the Credential Store; created-realm secrets are generated by Keycloak, read back once per provisioning, and stored under the templated reference with tenant sharing. Cached tokens are `SecretString`s with redacted debug output. Metadata envelopes carry reference names, never values.
 
-The plugin's system actor identity (`VP_IDP_PLUGIN_ACTOR_UUID`) must remain stable across releases — created-realm secret ownership in the Credential Store is keyed to it.
+The plugin's system actor identity (`KEYCLOAK_IDP_PLUGIN_ACTOR_UUID`) must remain stable across releases — created-realm secret ownership in the Credential Store is keyed to it.
 
 Keycloak is the sole user directory. The plugin holds request data only for the operation lifetime. Hard user deprovisioning deletes the provider identity; created-realm teardown removes the realm and its secret. Audit events use provider IDs, with `username` additionally present on `user.provisioned`.
 
@@ -603,6 +603,7 @@ The release-qualification query matrix for the PRD latency NFR covers unfiltered
 - [`IdpPluginClient` tenant contract](../../../account-management-sdk/src/idp.rs)
 - [`IdpPluginClient` user contract](../../../account-management-sdk/src/idp_user.rs)
 - [`ServicePrincipalClientV1` contract](../../../../service-principal/service-principal-sdk/src/api.rs)
+- [Service-principal product PRD](../../../../service-principal/docs/PRD.md) and [DESIGN](../../../../service-principal/docs/DESIGN.md) — the owning contract for machine identities; this plugin is its registered adapter
 - [Unified ToolKit architecture](../../../../../../docs/toolkit_unified_system/README.md)
 - Implementation: [`plugins/keycloak-idp-plugin`](../src/lib.rs) (crate `cf-gears-keycloak-idp-plugin`)
 

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
@@ -13,7 +13,7 @@ refs:
 
 **Owners:** @platform-iam-team
 
-**Scope:** Architecture of the shipped plugin implementation (crate `cf-gears-keycloak-idp-plugin`, ported from vhp-core). The implementation is authoritative; this document describes what the code does, deliberately mirroring implementation-level constants and behaviors (an implementation-mirror altitude) — a change to those constants in code owns the matching edit here. In-code comments citing `DESIGN §N` refer to the original vhp-core implementation specification (`DESIGN-vp-idp-plugin-202605192055`) from which this crate lineage descends, not to section numbers in this document.
+**Scope:** Architecture of the shipped plugin implementation (crate `cf-gears-keycloak-idp-plugin`). The implementation is authoritative; this document describes what the code does, deliberately mirroring implementation-level constants and behaviors (an implementation-mirror altitude) — a change to those constants in code owns the matching edit here. In-code comments citing `DESIGN §N` refer to the implementation specification this crate lineage descends from, not to section numbers in this document.
 
 <!-- toc -->
 
@@ -66,7 +66,7 @@ Three realm bindings are supported: `shared` (default; tenants share an operator
 |---|---|
 | Provider-neutral publication and selection | `PluginV1<IdpPluginSpecV1>` published to types-registry (instance segment `cf.builtin.keycloak_idp.plugin.v1`; full catalogue id in §3.2, vendor `keycloak`, priority 50); scoped ClientHub registration keyed on the instance id; AM resolves via `choose_plugin_instance` against `idp.vendor` |
 | Fail-fast configuration errors | Init validates typed config (`deny_unknown_fields`), the `secret_ref_template`, and the service-principal section, then pre-warms the bootstrap admin token with a bounded retry budget; exhausting the budget fails `Gear::init` |
-| Shared-realm tenant isolation | Per-tenant Keycloak group under `/tenants`, immutable `tenant_id` user attribute (ADR-0006), and an ownership marker attribute (`vhp.provisioning.tenant_id`) on created realms and service-principal clients |
+| Shared-realm tenant isolation | Per-tenant Keycloak group under `/tenants`, immutable `tenant_id` user attribute (ADR-0006), and an ownership marker attribute (`cf.provisioning.tenant_id`) on created realms and service-principal clients |
 | Safe external mutation | Parse-then-probe saga ordering, per-step reactive-401 wrapping, idempotent replay paths (probe-adopt realm ensure, 409 group reuse), and stage-attributed `AmbiguousCreated` classification with an `ambig:` prefix contract for reconciliation tooling |
 | Secret custody | `SecretFromEnv`/`SecretString` wrappers with redacted `Debug`, token cache redaction, `redact_secrets` on every error body, and Credential Store writes only for plugin-created realm-admin secrets |
 | Credential rotation without restart | Token cache keyed `(realm, client_id)` with single-flight refresh and an exactly-once reactive-401 retry that re-resolves the secret from its source (env or Credential Store) |
@@ -77,7 +77,7 @@ Three realm bindings are supported: `shared` (default; tenants share an operator
 
 | NFR | Architectural response | Release verification |
 |---|---|---|
-| Tenant isolation | Tenant group membership scopes listing; the `tenant_id` user attribute guards user deprovision; `vhp.provisioning.tenant_id` markers guard realm and service-principal ownership | Negative-isolation unit and integration tests |
+| Tenant isolation | Tenant group membership scopes listing; the `tenant_id` user attribute guards user deprovision; `cf.provisioning.tenant_id` markers guard realm and service-principal ownership | Negative-isolation unit and integration tests |
 | Secret non-disclosure | Typed secret wrappers, redacted token cache, `redact_secrets` + 2 KiB truncation on every provider error body before it crosses the AM boundary | Redaction unit tests; log/metric scanning |
 | Failure classification | Closed `PluginError` taxonomy translated at the SDK boundary per fixed tables; `debug_assert` that provisioning never surfaces `MetadataDecode` | Exhaustive translation unit tests and failure injection |
 | Availability recovery | Per-call pre-saga health probe; reactive-401 secret re-resolution; no cached provider state besides tokens; recovery needs no restart once init has succeeded | Dependency loss/recovery tests |
@@ -288,7 +288,7 @@ The provider metadata is the versioned, non-secret routing envelope `TenantIdpMe
 | `realm_name` | Realm the tenant is bound to. |
 | `realm_binding` | `shared` \| `adopted` \| `created` (also a public metric label). |
 | `tenant_group_id` | Keycloak UUID of the plugin-owned per-tenant group. |
-| `admin_secret_ref` | `None` for the env-backed default shared realm; `Some(ref)` naming the Credential Store reference for adopted/created realms (template `vp-idp-realm-admin-{realm_name}-secret` by default). |
+| `admin_secret_ref` | `None` for the env-backed default shared realm; `Some(ref)` naming the Credential Store reference for adopted/created realms (template `keycloak-idp-realm-admin-{realm_name}-secret` by default). |
 | `admin_client_id` | OAuth2 `client_id` of the per-realm admin client (default `keycloak-idp-plugin-realm-admin`). |
 
 Provider ownership is split as follows:
@@ -296,7 +296,7 @@ Provider ownership is split as follows:
 | Resource | Owner | Plugin authority |
 |---|---|---|
 | Shared and adopted realms, their authentication profile, protocol mappers, and the bootstrap/realm-admin clients in them | Platform operator (IaC / realm bootstrap) | Assert existence (and emptiness for adopted); use the configured admin clients |
-| Created realms (child tenants: generated `realm-{tenant_id}`; root target: operator-named; all marked `vhp.provisioning.tenant_id`) | Plugin | Create, administer, and delete on last-tenant deprovisioning |
+| Created realms (child tenants: generated `realm-{tenant_id}`; root target: operator-named; all marked `cf.provisioning.tenant_id`) | Plugin | Create, administer, and delete on last-tenant deprovisioning |
 | Realm-admin client and its 7 `realm-management` roles in created realms | Plugin | Create and grant during created-mode provisioning |
 | Per-tenant group under `/tenants` and the `tenant_id`/`user_type` user attributes | Plugin | Create, inspect, delete for the owning tenant |
 | Human identities and sessions in the tenant boundary | Plugin through Account Management | Create, delete, revoke, and query after boundary verification; updates are unsupported in this revision |
@@ -343,28 +343,6 @@ Initialization proceeds in phases:
 7. **ClientHub registration** — `Arc<dyn IdpPluginClient>` scoped by the catalogue instance id; `Arc<dyn ServicePrincipalClientV1>` unscoped.
 
 After init, readiness is operation-based: every tenant provision/deprovision saga begins with an unauthenticated Keycloak health probe (`GET realms/master`), and every call re-resolves credentials on 401. Recovery from provider or Credential Store outages therefore needs no process restart.
-
-#### Operator Migration from the vhp-core Lineage
-
-The plugin's identifiers were moved onto this repository's conventions when the crate was ported. A deployment upgrading from the vhp-core `vp-idp-plugin` build must update the following, all of which are configuration or observability surfaces:
-
-| Surface | Was | Now | Action |
-|---|---|---|---|
-| Gear name (config section key) | `vp-idp-plugin` | `keycloak-idp-plugin` | Rename the module's config section |
-| Plugin vendor (selection key) | `virtuozzo` | `keycloak` | Set `account-management.idp.vendor = "keycloak"` |
-| GTS catalogue instance | `…~vz.virtuozzo.vp_idp.plugin.v1` | `…~cf.builtin.keycloak_idp.plugin.v1` | Retire the stale types-registry entry; tenants bound under the old instance need the operator migration described in `…-constraint-scoped-provider-selection` |
-| Bootstrap admin `client_id` default | `vp-idp-plugin-bootstrap` | `keycloak-idp-plugin-bootstrap` | Rename the Keycloak client, or pin the old value in config |
-| Realm-admin `client_id` default | `vp-idp-plugin-realm-admin` | `keycloak-idp-plugin-realm-admin` | Affects newly provisioned realms only — existing tenants replay `admin_client_id` from their metadata |
-| Metric prefix | `vp_idp_plugin_*` | `keycloak_idp_plugin_*` | Update dashboards and alert rules |
-| Tracing targets | `vp_idp_plugin.*`, `vp.idp.plugin.events` | `keycloak_idp.*`, `keycloak_idp.events` | Update log routing and audit collectors |
-
-Three identifiers are deliberately **unchanged**, because each names state that lives outside the process and renaming it would orphan existing resources:
-
-- `vhp.provisioning.tenant_id` — the ownership marker written onto plugin-created realms and service-principal clients in Keycloak. A rename would make the plugin read its own realms as foreign and refuse to administer them.
-- `vp-idp-realm-admin-{realm_name}-secret` — the default `secret_ref_template`, which names live Credential Store secrets for adopted and created realms.
-- The system-actor UUID value — Credential Store secret ownership is keyed to it (§4.1).
-
-Renaming any of the three requires a data migration plan and is out of scope for the port.
 
 ### 3.3 API Contracts
 

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
@@ -12,7 +12,8 @@ refs:
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-design-keycloak-idp-plugin`
 
-**Owners:** @platform-iam-team  
+**Owners:** @platform-iam-team
+
 **Scope:** Overall architecture for the priority-1 (V1) shared-realm plugin. In this document, **P2 means priority 2/deferred**, not version 2.
 
 <!-- toc -->
@@ -61,8 +62,8 @@ V1 does not adopt or create realms, write administrator secrets, manage service 
 | Shared-realm tenant isolation | Versioned routing metadata, a provider-owned tenant group, an immutable tenant marker, and mandatory boundary checks before reads or mutations |
 | Safe external mutation | Tenant clean/ambiguous classification, replay-safe user operations, bounded retries, and operator reconciliation evidence |
 | Hard access termination | Session revocation and identity deletion precede tenant-group deletion; unproven cleanup is terminal |
-| Provider compatibility | Keycloak 26.x startup compatibility check plus a read-only realm authentication-profile verifier |
-| Protected administration | Least-privileged per-realm administrator, Credential Store SecretRefs, shared ToolKit HTTP/auth, and no V1 master-realm administrator |
+| Provider compatibility | Per-operation Keycloak 26.x compatibility gate plus a read-only realm authentication-profile verifier |
+| Protected administration | Operator-provisioned OAGW routes, gateway-owned Credential Store injection, a least-privileged per-realm administrator, and no V1 master-realm administrator |
 | Audit completeness | Account Management and the platform audit owner guarantee one durable terminal outcome per supported mutation call |
 | User query correctness | SDK filter/order semantics, `CursorV1`, global deterministic sorting, and no stable-order claim based on Keycloak offset pages |
 | Lifecycle safety | ToolKit cancellation and bounded drain; the plugin owns no periodic or audit-delivery task |
@@ -72,11 +73,11 @@ V1 does not adopt or create realms, write administrator secrets, manage service 
 | NFR | Architectural response | Release verification |
 |---|---|---|
 | Tenant isolation | `TenantBoundaryGuard` validates both group membership and immutable tenant marker | Negative-isolation contract and real-Keycloak tests |
-| Secret non-disclosure | Secret wrappers, allowlisted diagnostics, protected SecretRefs, and output scanning | Logs, metrics, audit, errors, and debug output contain no injected secret |
-| Lifecycle latency | Shared HTTP pooling, bounded calls, point-lookup optimization, and measured full-group query scans | PRD qualification profile: 20 concurrent operations and stated p95 limits |
+| Secret non-disclosure | OAGW-owned credential injection, allowlisted diagnostics, no plugin-visible secret value, and output scanning | Logs, metrics, audit, errors, and debug output contain no injected secret |
+| Lifecycle latency | OAGW connection pooling, bounded calls, point-lookup optimization, and a 1,000-total-user full-group scan ceiling | Complete PRD qualification profile: topology, filter mix, 20 concurrent operations, call/memory limits, and stated p95 limits |
 | Failure classification | Current SDK enums are the only failure vocabulary | Exhaustive enum mapping and failure injection |
 | Audit completeness | The plugin returns a classified privacy-safe outcome; durable correlation and delivery are owned by Account Management and the platform audit contract | One terminal event per mutating call across cross-system contract tests |
-| Provider compatibility | Startup version gate and release compatibility matrix | Supported 26.x matrix passes; unsupported major fails deterministically |
+| Provider compatibility | Operation-level version gate and release compatibility matrix | Supported 26.x matrix passes; unsupported major fails affected operations before mutation without failing host startup |
 | Personal-data lifecycle | No local user directory; hard deletion removes identities and sessions | Hard-delete and output-minimization verification |
 | Availability recovery | Dependency state is evaluated per affected operation after startup | Dependency loss/recovery tests without fallback or default realm |
 
@@ -88,10 +89,10 @@ V1 introduces no approved exception to the repository architecture. Its signific
 - [Keep the IdP as user source of truth](../../../docs/ADR/0005-cpt-cf-account-management-adr-idp-user-identity-source-of-truth.md).
 - [Use provider-enforced tenant binding](../../../docs/ADR/0006-cpt-cf-account-management-adr-idp-user-tenant-binding.md).
 - [Preserve provider-backed partial user updates](../../../docs/ADR/0008-cpt-cf-account-management-adr-user-attribute-update.md).
-- [Use the first-party ToolKit HTTP client](../../../../../../docs/adrs/toolkit/0001-toolkit-hyper-tower-http-client.md).
+- Route external Keycloak traffic through the [Outbound API Gateway](../../../../oagw/docs/DESIGN.md).
 - Follow [ClientHub and plugin scoping](../../../../../../docs/toolkit_unified_system/03_clienthub_and_plugins.md), [lifecycle rules](../../../../../../docs/toolkit_unified_system/08_lifecycle_stateful_tasks.md), the [Architecture Manifest](../../../../../../docs/ARCHITECTURE_MANIFEST.md), and [Security Guidelines](../../../../../../guidelines/SECURITY.md).
 
-A proposal to add a master-realm administrator, direct `reqwest`, direct OpenBao mutation, unscoped publication, or plugin-owned user storage is a material deviation and requires a new accepted ADR before this DESIGN can change.
+A proposal to add a master-realm administrator, direct external HTTP, direct OpenBao mutation, unscoped publication, or plugin-owned user storage is a material deviation and requires a new accepted ADR before this DESIGN can change.
 
 Durable audit delivery requires accepted Account Management and platform audit designs. This plugin design does not define their persistence, recovery, relay, sink, or retention mechanisms. The existing Account Management structured-log stand-in is suitable only for development.
 
@@ -102,22 +103,24 @@ flowchart LR
   operator([Platform operator])
   iac[IaC and protected configuration]
   cred[(Credential Store)]
+  oagw[Outbound API Gateway]
   kc[(Keycloak 26.x shared realm)]
   authn[OIDC AuthN Resolver]
   audit[Platform audit infrastructure]
   subgraph am[Account Management process]
     api[Account Management application layer]
     domain[Plugin domain coordinators and boundary guard]
-    infra[Credential and Keycloak adapters]
+    infra[OAGW and Keycloak representation adapters]
   end
 
   operator --> iac
-  iac -->|approved realm profiles and SecretRefs| infra
+  iac -->|approved realm, OAGW routes, and credential references| oagw
   api -->|scoped IdpPluginClient| domain
   api -->|durable terminal outcome; external contract| audit
   domain --> infra
-  infra -->|protected secret read| cred
-  infra -->|Admin REST over toolkit-http| kc
+  infra -->|ServiceGatewayClientV1| oagw
+  oagw -->|protected credential resolution| cred
+  oagw -->|OAuth and Admin REST| kc
   authn -->|OIDC discovery and JWKS; no plugin call| kc
 ```
 
@@ -125,8 +128,8 @@ flowchart LR
 |---|---|
 | Account Management application | Public authorization, tenant saga orchestration, opaque metadata persistence, scoped provider selection, and audit orchestration defined by the parent AM design |
 | Plugin domain | Tenant/user lifecycle, boundary enforcement, replay safety, error classification, and privacy-preserving outcomes |
-| Plugin infrastructure | ToolKit HTTP/auth, Credential Store resolution, Keycloak representation mapping, and telemetry transport |
-| Platform dependencies | Keycloak identity state, Credential Store secrets, platform audit infrastructure, and operator-owned realm configuration |
+| Plugin infrastructure | OAGW request construction, Keycloak representation mapping, bounded response handling, and telemetry |
+| Platform dependencies | OAGW egress and credential injection, Keycloak identity state, Credential Store secrets, platform audit infrastructure, and operator-owned realm configuration |
 
 ## 2. Principles & Constraints
 
@@ -198,7 +201,7 @@ V1 supports only `mode = shared` against an operator-approved Keycloak 26.x real
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-external-consistency-boundaries`
 
-Keycloak, Credential Store, and the platform audit sink are external consistency boundaries. Plugin calls occur outside Account Management database transactions, so the architecture does not claim atomic commit or transport-level exactly-once behavior across those systems.
+OAGW, Keycloak, Credential Store, and the platform audit sink are external consistency boundaries. Plugin calls occur outside Account Management database transactions, so the architecture does not claim atomic commit or transport-level exactly-once behavior across those systems.
 
 #### External durable audit prerequisite
 
@@ -210,7 +213,7 @@ The plugin owns no audit table, recovery worker, relay, or sink integration. Pro
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-opaque-metadata-replay`
 
-Account Management persists plugin metadata as opaque JSON and replays it on later calls.
+Account Management persists plugin metadata as opaque JSON and replays it on later calls. The envelope carries its producing GTS provider instance identifier, which the plugin verifies against its own identifier before any OAGW or provider access.
 
 #### No plugin persistence
 
@@ -222,7 +225,7 @@ The plugin owns no database table and no persistent user cache.
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-scoped-provider-selection`
 
-Account Management requires a coordinated change to select a GTS-scoped provider instance; no unscoped compatibility fallback is allowed.
+Account Management requires a coordinated change to select a GTS-scoped provider instance; no unscoped compatibility fallback is allowed. V1 does not support changing the selected instance while tenant metadata exists. A replayed instance mismatch fails closed and requires an operator-approved migration.
 
 #### Bounded offline-token exposure
 
@@ -234,7 +237,7 @@ A previously issued access JWT can remain valid until `exp`; the approved realm 
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-constraint-correct-global-query-ordering`
 
-Query correctness requires a global view of the tenant group because Keycloak does not guarantee stable ordering across offset pages. V1 accepts linear provider-read cost and must prove the PRD latency target on the release qualification population.
+Query correctness requires a global view of the tenant group because Keycloak does not guarantee stable ordering across offset pages. V1 accepts linear provider-read cost up to 1,000 total human identities, enabled or disabled, per tenant group and must prove the PRD latency, provider-call, and memory targets on the complete release qualification profile.
 
 ### 2.3 Applicability Matrix
 
@@ -259,19 +262,21 @@ Query correctness requires a global view of the tenant group because Keycloak do
 
 ### 3.1 Domain Model
 
-The provider metadata is a versioned, non-secret routing envelope owned by the plugin and persisted opaquely by Account Management. It identifies the shared realm, provider-owned tenant group, immutable tenant identity, and a non-secret administrator-profile reference. Exact serialization belongs to the implementation specification; compatibility rules are architectural:
+The provider metadata is a versioned, non-secret routing envelope owned by the plugin and persisted opaquely by Account Management. It identifies the exact producing GTS provider instance, shared realm, provider-owned tenant group, immutable tenant identity, and non-secret OAGW route/profile reference. Exact serialization belongs to the implementation specification; compatibility rules are architectural:
 
 - all versions in the declared rolling-upgrade window can read and safely deprovision metadata written by one another;
-- malformed or unknown newer-major metadata fails closed without provider mutation;
+- the replayed producing instance must equal the receiving plugin's published instance identifier before any OAGW or provider call;
+- an instance mismatch, malformed envelope, or unknown newer-major metadata fails closed without external access;
 - metadata never contains administrator secrets, tokens, passwords, or user profile values;
-- realm and tenant identifiers come from replayed metadata, not caller-controlled defaults on later operations.
+- realm and tenant identifiers come from replayed metadata, not caller-controlled defaults on later operations;
+- changing the selected provider instance requires an operator-approved migration or retirement of every tenant bound to the old instance.
 
 Provider ownership is split as follows:
 
 | Resource | Owner | Plugin authority |
 |---|---|---|
 | Shared realm and authentication profile | Platform operator | Read and verify only |
-| Realm-administrator client and secret | Platform operator | Authenticate with least privilege; never create or disclose |
+| OAGW Keycloak route and realm-administrator credential reference | Platform operator | Plugin invokes the approved route; OAGW injects least-privileged credentials without disclosure |
 | Tenant group and immutable tenant marker | Plugin | Create, inspect, and delete for the owning tenant |
 | Human identity and sessions in the tenant boundary | Plugin through Account Management | Create, update, query, revoke, and delete after boundary verification |
 | Opaque provider metadata row | Account Management | Persist/replay only; plugin owns interpretation |
@@ -288,16 +293,16 @@ The plugin is one logical architecture component. The following entries are resp
 
 | Responsibility partition | Architectural responsibility |
 |---|---|
-| Plugin module | Configuration, startup compatibility, lifecycle, and GTS-scoped ClientHub publication |
-| Approved realm registry | Maps explicit shared-realm intent to operator-approved realm and non-secret credential profile |
+| Plugin module | Static configuration validation, lifecycle, and GTS-scoped ClientHub publication |
+| Approved realm registry | Maps explicit shared-realm intent to operator-approved realm and non-secret OAGW route/profile reference |
 | Realm profile verifier | Read-only verification of Keycloak version, issuer, clients, scopes, protocol mappers, claims, signing, session/token policy, password/login policy, and required administration privileges |
 | Metadata codec | Versioned opaque metadata compatibility and fail-closed decoding |
 | Tenant lifecycle coordinator | Tenant-boundary provisioning, hard-deletion ordering, uncertainty classification, and reconciliation evidence |
 | Tenant boundary guard | Verifies tenant marker and group membership before every user read or mutation |
 | User lifecycle coordinator | Replay-safe user create/update/delete and provider projection |
 | User query adapter | Tenant-scoped filtering, ordering, point existence, global sorting, and `CursorV1` generation |
-| Keycloak adapter | ToolKit HTTP/auth integration, bounded provider calls, response classification, and allowlisted diagnostics |
-| Credential resolver | Protected SecretRef resolution under a least-privileged plugin system actor, including ownership validation and rotation refresh |
+| OAGW adapter | `ServiceGatewayClientV1` request construction, bounded response handling, Keycloak representation mapping, response classification, and allowlisted diagnostics |
+| Outbound authorization boundary | Forwards the caller's authorized `SecurityContext`; OAGW route policy admits only approved AM actors and stable AM system subjects, while OAGW owns credential resolution and injection |
 | Terminal outcome producer | Returns one classified, privacy-preserving outcome to the AM caller and records bounded-cardinality metrics separately |
 
 #### Deployment, Publication, and Readiness
@@ -306,11 +311,11 @@ The plugin is an in-process ModKit module in each Account Management replica. It
 
 Each instance publishes `IdpPluginClient` with `ClientScope::gts_id(instance_id)`. Account Management must select the configured provider instance through scoped ClientHub resolution. This coordinated consumer change is a V1 implementation prerequisite; ambiguous selection or unscoped fallback fails closed.
 
-Initialization validates configuration, approved realm profiles, SecretRef syntax, TLS policy, and GTS identity; resolves standard ClientHub dependencies; resolves the selected realm administrator through Credential Store; and proves the provider reports a supported Keycloak 26.x major. `provision_tenant` remains the operation-based provider readiness signal. Audit infrastructure does not add a plugin dependency.
+Initialization validates only static inputs: plugin configuration, approved realm and OAGW route references, identifier syntax, the required HTTPS posture, and GTS identity. It resolves required in-process ClientHub contracts and publishes the scoped client without sending a request to OAGW, Credential Store, or Keycloak. A missing required in-process contract or malformed static configuration is a deployment error and may fail ToolKit initialization. External dependency availability and provider compatibility do not.
 
-Before publication, inability to resolve the configured realm-administrator SecretRef because Credential Store is unavailable, or to reach the configured Keycloak endpoint to complete the 26.x check, is a retryable module-initialization failure: the scoped client is not registered, only IdP-dependent administration is blocked, and unrelated Account Management capabilities remain available.
+`provision_tenant` remains the operation-based readiness signal. Before any affected operation, the plugin verifies the replayed provider instance when metadata exists, invokes the approved OAGW route, and proves that the reachable provider reports Keycloak 26.x and the required realm profile. An unreachable OAGW, Credential Store, or Keycloak endpoint returns the operation's pre-mutation unavailable category. A reachable unsupported major or profile mismatch fails the affected operation deterministically before mutation. A successful version/profile result is cached per configured route and realm; failures are not cached, and the cache is invalidated when the route/profile configuration revision changes or a later response contradicts the cached compatibility state. The scoped client remains registered, and the next call repeats checks that did not complete successfully, so recovery requires no process restart.
 
-After successful publication, dependency loss is classified on the operation that needs it; `CleanFailure` or `Retryable` applies only when no mutation outcome is unknown, otherwise the SDK's `Ambiguous` or `Terminal` classification applies. The module remains registered so recovery does not require process restart.
+After a provider request may have produced an effect, `CleanFailure` or `Retryable` applies only when no mutation outcome is unknown; otherwise the SDK's `Ambiguous` or `Terminal` classification applies. Audit infrastructure does not add a plugin dependency.
 
 ### 3.3 API Contracts
 
@@ -319,13 +324,15 @@ The current [`idp.rs`](../../../account-management-sdk/src/idp.rs) and [`idp_use
 Architectural contract invariants are:
 
 - malformed shared-realm intent uses `IdpProvisionFailure::InvalidInput` before provider mutation;
-- deferred modes use `UnsupportedOperation` before provider or Credential Store mutation;
+- deferred modes use `UnsupportedOperation` before OAGW, Credential Store, or provider mutation;
 - only pre-provision failures proven to retain no provider state use `CleanFailure`;
 - uncertain tenant provisioning preserves `Ambiguous`;
 - duplicate users, password-policy rejection, absent update targets, and unavailability use their current classified user variants;
 - `Rejected` is reserved for provider rejection that cannot be classified further;
+- `UnsupportedOperation` covers a list scan that detects the declared 1,000-user implementation-profile ceiling before returning any page;
 - already-absent deprovisioning follows the SDK's success-equivalent semantics;
 - deprovisioning is `Retryable` only when no attempted mutation has an unknown outcome; any mutation request that may have reached Keycloak without a provable result is `Terminal`, regardless of whether the immediate error appears transient;
+- replayed metadata with a producing instance different from the receiving plugin fails closed before any OAGW request;
 - typed filter/order and `CursorV1` are used without a plugin-specific parallel contract;
 - every mutating return is classifiable and contains enough non-sensitive context for the external audit owner to construct its terminal outcome.
 
@@ -333,26 +340,25 @@ The plugin emits no public HTTP API. Account Management owns public status, vali
 
 ### 3.4 Internal Dependencies
 
-Domain components depend on plugin-owned ports rather than transport types. Direct `reqwest`, raw `hyper`, `tonic`, or Credential Store implementation types do not cross into the domain layer.
+Domain components depend on plugin-owned ports rather than transport types. Direct `reqwest`, raw `hyper`, `tonic`, Keycloak sockets, or Credential Store implementation types do not cross into the domain layer.
 
 | Internal dependency | Purpose |
 |---|---|
 | Account Management SDK | Provider-neutral trait, DTO, failure, and pagination authority |
 | ModKit and ClientHub | Module initialization, lifecycle context, GTS-scoped publication and dependency resolution |
-| `toolkit-http` | Shared TLS, redirects, timeout, retry, concurrency, body-limit, and telemetry policy |
-| `toolkit-auth` | Supported OAuth client-credential integration and token refresh |
+| OAGW SDK | `ServiceGatewayClientV1`, request/response body types, centralized egress policy, and credential injection boundary |
 | `toolkit-odata` | Typed filter/order interpretation and `CursorV1` compatibility |
-| Credential Store SDK | Protected SecretRef reads without implementation coupling |
 
 ### 3.5 External Dependencies
 
 | Dependency | Contract and failure boundary |
 |---|---|
 | Account Management | Authorizes calls, selects the scoped plugin, persists/replays opaque metadata, consumes typed outcomes, and owns audit orchestration defined by its parent design |
-| Keycloak 26.x | User/session/group source of truth and Admin REST provider; another major is unsupported until compatibility approval |
-| Credential Store | Protects operator-created realm-administrator secrets; ownership or availability failure blocks only dependent administration |
+| Outbound API Gateway | Executes operator-approved Keycloak routes through `ServiceGatewayClientV1`, enforces egress policy, and injects credentials; gateway or dependency failure blocks only affected operations |
+| Keycloak 26.x | User/session/group source of truth and Admin REST provider behind OAGW; another major is unsupported until compatibility approval |
+| Credential Store | Protects operator-created realm-administrator secrets consumed by OAGW; credential values never cross into the plugin |
 | Platform audit infrastructure | Owns the sink and delivery contract consumed by Account Management; not defined by this plugin |
-| Operator IaC | Creates the shared realm, realm-local administrator, required authentication profile, SecretRefs, and approved realm registry |
+| Operator IaC | Creates the shared realm, realm-local administrator, required authentication profile, OAGW upstream/routes, credential references, and approved realm registry |
 | OIDC AuthN Resolver | Independently validates tokens; the two plugins do not call each other |
 
 ### 3.6 Interactions & Sequences
@@ -363,7 +369,7 @@ Domain components depend on plugin-owned ports rather than transport types. Dire
 
 A realm is admissible only when explicit `mode = shared` intent names an operator-approved realm and the read-only verifier proves the supported provider version plus the complete platform authentication profile. The profile includes trusted issuer/discovery, required clients, scopes, protocol mappers and claims, signing policy, session/token limits, password/login controls, and least-privileged administration. A mismatch is a pre-mutation failure; the plugin never repairs operator-owned realm configuration.
 
-After admissibility succeeds, the tenant lifecycle coordinator creates or reconciles the plugin-owned tenant group with its immutable marker and returns provider metadata only after the boundary is usable. The verifier and lifecycle coordinator use the least-privileged administrator for the target realm; V1 has no master-realm administrator.
+After admissibility succeeds, the tenant lifecycle coordinator creates or reconciles the plugin-owned tenant group with its immutable marker and returns provider metadata only after the boundary is usable. The verifier and lifecycle coordinator use the approved OAGW route, whose injected administrator is least-privileged for the target realm; V1 has no master-realm administrator.
 
 #### User Mutation Safety
 
@@ -387,7 +393,7 @@ Already-absent plugin-owned resources are success-equivalent. `Retryable` is lim
 
 `IdpListUsersRequest` is authoritative. Because Keycloak 26.x does not document stable global order for group-member offset pages, V1 obtains a complete per-request tenant-group view, verifies tenant binding, applies supported SDK filter/order, and globally sorts with a unique provider-ID tiebreaker. The continuation token is a valid `CursorV1` that pins filter, order, tenant context, and the last emitted key tuple.
 
-This is a correctness-first linear scan, not an `O(page)` claim. Point existence may use a direct provider lookup followed by the same boundary guard. No persistent local index or user cache is introduced. Release qualification must prove the PRD 100-user-page latency target at the declared tenant population; failure requires an upstream capacity or contract decision rather than per-page sorting over unstable offsets.
+This is a correctness-first linear scan, not an `O(page)` claim. Point existence may use a direct provider lookup followed by the same boundary guard. No persistent local index or user cache is introduced. V1 list support is capped at 1,000 total human identities, enabled or disabled, per tenant group. The adapter reads Keycloak members in pages no larger than 500, permits at most `ceil(N / 500) + 1` member-page requests, and caps working memory at 16 MiB per list call. It stops on the first member beyond the ceiling and returns `IdpUserOperationFailure::UnsupportedOperation` without sorting or returning a partial page. Release qualification covers 100%, 10%, and 1% filter selectivity, every supported order, cached-token and forced-token-refresh runs, 20 concurrent operations, and the PRD topology and latency targets.
 
 #### Failure, Retry, and Reconciliation
 
@@ -397,13 +403,13 @@ Retries are bounded and limited to idempotent reads, token refresh, or operation
 
 Ambiguous tenant provisioning remains operator-owned in V1. Terminal outcomes provide non-secret stage and ownership evidence. Production enablement requires a reconciliation runbook whose resolution ends as compensated, accepted complete, blocked for investigation, or escalated for controlled cleanup.
 
-#### HTTP, Credentials, and Rotation
+#### Outbound HTTP, Credentials, and Rotation
 
 **ID**: `cpt-cf-keycloak-idp-plugin-seq-credential-resolution`
 
-All Keycloak OAuth and Admin REST traffic uses `toolkit-http` and the supported `toolkit-auth` integration. Direct `reqwest` is prohibited. Administrator credentials are operator-created SecretRefs read through the canonical Credential Store client under a stable plugin system actor restricted to configured references. The resolver validates returned ownership/sharing metadata and rejects inherited or cross-tenant material inconsistent with the approved platform credential profile.
+All Keycloak OAuth and Admin REST traffic uses an operator-provisioned OAGW upstream and route through `ServiceGatewayClientV1::proxy_request`. The plugin opens no direct external HTTP connection and cannot read a provider credential value. Operator IaC owns the HTTPS-only upstream, route allowlist, realm-local credential reference, timeouts, response limits, and auth policy. OAGW resolves and validates the Credential Store reference, injects the credential, applies egress and SSRF controls, and returns bounded responses with gateway-versus-upstream failure provenance.
 
-Credential values remain protected secret types and never enter metadata, errors, events, metrics, or debug formatting. Provider authentication rejection invalidates cached material, re-resolves the SecretRef, and permits one replay through the shared auth layer. V1 uses reactive refresh and has no scheduled credential-refresh task.
+The plugin forwards the `SecurityContext` received from Account Management for correlation and OAGW authorization; it does not mint a separate caller identity. OAGW route policy admits only Account Management-authorized actors and the stable AM system subjects used for bootstrap, reaper, retention, and cleanup flows. Credential rotation is transparent through the stable OAGW credential reference. Authentication failure never falls back to another route, realm, plaintext credential, or plugin cache, and mutation retry remains subject to the normal uncertainty rules.
 
 #### Durable Mutation Audit Boundary
 
@@ -413,11 +419,13 @@ Credential values remain protected secret types and never enter metadata, errors
 sequenceDiagram
   participant AM as Account Management
   participant P as Keycloak plugin
+  participant G as Outbound API Gateway
   participant K as Keycloak
   participant A as Platform audit infrastructure
 
   AM->>P: Invoke mutating contract
-  P->>K: Provider operation
+  P->>G: Approved provider request
+  G->>K: Credential-injected operation
   P-->>AM: Classified privacy-safe outcome
   AM->>A: Durably correlate terminal outcome
 ```
@@ -447,15 +455,15 @@ Not applicable because the plugin owns no database schema, table, migration, aud
 | Boundary | Control |
 |---|---|
 | Account Management caller to plugin | AM authorizes; forwarded `SecurityContext` identifies the actor but never substitutes for provider tenant checks |
-| Plugin to Credential Store | Dedicated system actor, configured SecretRef allowlist, response ownership validation, and no caller-tenant credential ownership |
-| Plugin to Keycloak | Least-privileged realm administrator, TLS verification, ToolKit HTTP policy, and provider-version/profile checks |
+| Plugin to OAGW | Forwarded authorized `SecurityContext`, fixed route aliases, bounded bodies, and no caller-controlled upstream URL |
+| OAGW to Credential Store and Keycloak | OAGW-owned credential resolution and injection, HTTPS-only egress, SSRF controls, least-privileged realm administrator, and gateway-versus-upstream failure provenance |
 | Tenant A to tenant B in one realm | Mandatory group-plus-marker guard on every read and mutation |
 | Account Management to platform audit infrastructure | External contract; the plugin supplies only classified privacy-safe outcomes |
 | Plugin to metrics | Bounded-cardinality labels and no profile or credential values |
 
 The V1 administrator has only realm-local permissions needed to inspect the authentication profile and administer users, sessions, and the configured tenant-group subtree. It cannot create/delete realms, administer another realm, read client secrets, or alter operator-owned authentication configuration.
 
-Missing, malformed, contradictory, unknown-major, or deferred-mode metadata causes no provider mutation. A realm outside the approved registry is rejected even if reachable. Tenant marker and group disagreement blocks access. Credential or TLS failure never falls back to plaintext, another realm, or cached user data.
+Missing, malformed, contradictory, unknown-major, deferred-mode, or producing-instance-mismatched metadata causes no OAGW or provider access. A realm or OAGW route outside the approved registry is rejected even if reachable. Tenant marker and group disagreement blocks access. Credential, gateway, or TLS failure never falls back to plaintext, another route or realm, or cached user data.
 
 Keycloak is the sole user directory. The plugin holds request data only for the operation lifetime and stores no local profile. Provider metadata contains routing identifiers rather than profile data. Hard deprovisioning removes identities and sessions before the group; failed proof is terminal. Plugin-provided audit evidence and metrics use provider IDs only where operationally necessary and contain no profile or credential values.
 
@@ -467,11 +475,11 @@ Verification is split by boundary rather than duplicated as method-level test ca
 |---|---|
 | Unit | Metadata compatibility, boundary predicates, cursor construction, error classification, redaction, and privacy-safe outcome construction |
 | SDK contract | Conformance to the existing `IdpPluginClient`, failure enums, typed filter/order, and `CursorV1` |
-| Real-Keycloak integration | Supported-version/profile checks, least privilege, user replay, cross-tenant denial, complete hard deletion, pre-send retryable versus post-send unproven terminal classification, provider failures, and global query behavior |
-| Credential Store integration | SecretRef ownership, rotation refresh, authorization denial, and non-disclosure |
+| Real-Keycloak integration | Supported-version/profile checks through OAGW, least privilege, user replay, cross-tenant denial, complete hard deletion, pre-send retryable versus post-send unproven terminal classification, provider failures, and global query behavior |
+| OAGW and Credential Store integration | Approved-route enforcement, no direct egress, credential-reference ownership, rotation, authorization denial, gateway/upstream failure provenance, and non-disclosure |
 | Cross-system audit contract | Account Management and the platform audit owner prove one durable terminal event per mutating call across crash and redelivery; this is an external production gate |
-| Lifecycle integration | Cancellation during provider stages, bounded drain, replay/reconciliation evidence, and absence of plugin-owned detached tasks |
-| End to end | Account Management scoped selection, tenant/user lifecycle, audit correlation, reconciliation evidence, and PRD latency profile |
+| Lifecycle integration | Host startup with OAGW, Credential Store, and Keycloak unavailable; unaffected AM availability; operation-level recovery without restart; cancellation, bounded drain, replay/reconciliation evidence, and no plugin-owned detached tasks |
+| End to end | Account Management scoped selection, two-instance metadata mismatch rejection before OAGW access, tenant/user lifecycle, audit correlation, reconciliation evidence, and the complete PRD latency/capacity profile |
 
 Tests that claim provider semantics use a supported real Keycloak 26.x instance. Test doubles are limited to deterministic local classification and failure injection; they do not establish Keycloak compatibility, tenant isolation, TLS, credential authorization, or latency.
 
@@ -481,16 +489,16 @@ Crash and redelivery verification for durable audit is owned by the parent Accou
 
 | Gate | Required resolution before V1 production enablement |
 |---|---|
-| Scoped provider selection | Account Management resolves the configured GTS instance; two-instance selection passes; no unscoped fallback remains |
+| Scoped provider selection | Account Management resolves the configured GTS instance; metadata records the producing instance; a two-instance priority/config change fails closed before OAGW access; no unscoped fallback remains; provider changes require an operator migration |
 | Realm profile | Operator-approved profile is versioned and every required property is verified before tenant mutation |
-| Query capacity | Correct full-group scan meets PRD latency at the declared release population; otherwise upstream capacity/contract is revised |
+| Query capacity | At 1,000 total tenant users, enabled or disabled, every required filter/order profile meets PRD latency with 20 concurrent operations, member-page reads stay within `ceil(N / 500) + 1`, memory stays within 16 MiB per request, and member 1,001 produces a non-partial `UnsupportedOperation` result |
 | User replay | Failure injection after each provider effect converges to one correctly bound identity |
 | Hard deletion | Two-tenant integration proves sessions and identities for the retiring tenant are removed without touching the active tenant |
 | Audit ownership | Parent Account Management and platform audit designs assign persistence, recovery, delivery, sink, and retention ownership; the plugin owns none of them |
 | Audit completeness | Cross-system tests prove one durable terminal outcome per mutating call across process failure and redelivery; the structured-log stand-in is not a production substitute |
 | Reconciliation | Operator runbook exists and consumes emitted evidence without secret inspection |
-| Compatibility | Supported Keycloak 26.x matrix passes and representative unsupported majors fail startup |
-| Lifecycle | Cancellation and rolling-restart tests prove bounded shutdown and replay safety |
+| Compatibility | Supported Keycloak 26.x matrix passes and representative unsupported majors fail affected operation-based readiness before mutation without preventing host startup |
+| Lifecycle | Dependency-down startup, recovery without restart, cancellation, and rolling-restart tests prove availability, bounded shutdown, and replay safety |
 
 Deferred adopted realms, plugin-created realms, OpenBao secret mutation, and service-principal lifecycle are not designed here. Each requires its own upstream contract, security review, DESIGN, ADRs where decisions depart from accepted standards, and release gates.
 
@@ -517,7 +525,7 @@ Deferred adopted realms, plugin-created realms, OpenBao secret mutation, and ser
 | `cpt-cf-keycloak-idp-plugin-fr-user-provision`, `cpt-cf-keycloak-idp-plugin-fr-user-update`, `cpt-cf-keycloak-idp-plugin-fr-user-update-outcomes`, `cpt-cf-keycloak-idp-plugin-fr-user-deprovision`, `cpt-cf-keycloak-idp-plugin-usecase-update-user` | §3.6 |
 | `cpt-cf-keycloak-idp-plugin-fr-user-query` | §3.6 |
 | `cpt-cf-keycloak-idp-plugin-fr-user-source-of-truth` | §§3.1, 4.1 |
-| `cpt-cf-keycloak-idp-plugin-fr-administrator-credentials`, `cpt-cf-keycloak-idp-plugin-contract-credstore` | §§3.5–3.6, 4.1 |
+| `cpt-cf-keycloak-idp-plugin-fr-administrator-credentials`, `cpt-cf-keycloak-idp-plugin-contract-oagw`, `cpt-cf-keycloak-idp-plugin-contract-credstore` | §§3.5–3.6, 4.1 |
 | `cpt-cf-keycloak-idp-plugin-fr-operator-reconciliation`, `cpt-cf-keycloak-idp-plugin-usecase-reconcile-ambiguous-mutation` | §§3.6, 4.3 |
 | `cpt-cf-keycloak-idp-plugin-fr-offline-token-lifetime` | §§2.2, 3.6 |
 | `cpt-cf-keycloak-idp-plugin-fr-audit-metrics`, `cpt-cf-keycloak-idp-plugin-nfr-audit-completeness` | §§3.3, 3.5–3.6, 4.1–4.3 |

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
@@ -308,7 +308,9 @@ Each instance publishes `IdpPluginClient` with `ClientScope::gts_id(instance_id)
 
 Initialization validates configuration, approved realm profiles, SecretRef syntax, TLS policy, and GTS identity; resolves standard ClientHub dependencies; resolves the selected realm administrator through Credential Store; and proves the provider reports a supported Keycloak 26.x major. `provision_tenant` remains the operation-based provider readiness signal. Audit infrastructure does not add a plugin dependency.
 
-No V1 initialization path resolves P2 OpenBao mutation APIs or a master-realm bootstrap administrator. After successful publication, dependency loss is classified on the operation that needs it; the module remains registered so recovery does not require process restart.
+Before publication, inability to resolve the configured realm-administrator SecretRef because Credential Store is unavailable, or to reach the configured Keycloak endpoint to complete the 26.x check, is a retryable module-initialization failure: the scoped client is not registered, only IdP-dependent administration is blocked, and unrelated Account Management capabilities remain available.
+
+After successful publication, dependency loss is classified on the operation that needs it; `CleanFailure` or `Retryable` applies only when no mutation outcome is unknown, otherwise the SDK's `Ambiguous` or `Terminal` classification applies. The module remains registered so recovery does not require process restart.
 
 ### 3.3 API Contracts
 

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
@@ -13,7 +13,7 @@ refs:
 
 **Owners:** @platform-iam-team
 
-**Scope:** Architecture of the shipped plugin implementation (crate `vp-idp-plugin`, ported from vhp-core). The implementation is authoritative; this document describes what the code does, deliberately mirroring implementation-level constants and behaviors (an implementation-mirror altitude) — a change to those constants in code owns the matching edit here. In-code comments citing `DESIGN §N` refer to the original vhp-core implementation specification (`DESIGN-vp-idp-plugin-202605192055`) from which this crate lineage descends, not to section numbers in this document.
+**Scope:** Architecture of the shipped plugin implementation (crate `cf-gears-keycloak-idp-plugin`, ported from vhp-core). The implementation is authoritative; this document describes what the code does, deliberately mirroring implementation-level constants and behaviors (an implementation-mirror altitude) — a change to those constants in code owns the matching edit here. In-code comments citing `DESIGN §N` refer to the original vhp-core implementation specification (`DESIGN-vp-idp-plugin-202605192055`) from which this crate lineage descends, not to section numbers in this document.
 
 <!-- toc -->
 
@@ -49,7 +49,7 @@ The adjacent [PRD](./PRD.md) is authoritative for WHAT, WHY, release priority, a
 
 ### 1.1 Architectural Vision
 
-The Keycloak IdP plugin is a provider adapter running as an in-process ToolKit gear (`vp-idp-plugin`) in the host process next to Account Management. It implements two ClientHub contracts:
+The Keycloak IdP plugin is a provider adapter running as an in-process ToolKit gear (`keycloak-idp-plugin`) in the host process next to Account Management. It implements two ClientHub contracts:
 
 - `account_management_sdk::idp::IdpPluginClient` — tenant and user identity lifecycle, registered **scoped** under its GTS catalogue instance id so Account Management selects it by vendor/priority.
 - `service_principal_sdk::ServicePrincipalClientV1` — tenant-scoped machine identities (confidential OAuth `client_credentials` clients), registered **unscoped** for trusted platform consumers.
@@ -64,14 +64,14 @@ Three realm bindings are supported: `shared` (default; tenants share an operator
 
 | Driver | Design allocation |
 |---|---|
-| Provider-neutral publication and selection | `PluginV1<IdpPluginSpecV1>` published to types-registry (vendor-namespaced instance segment `vz.virtuozzo.vp_idp.plugin.v1`; full catalogue id in §3.2, vendor `virtuozzo`, priority 50); scoped ClientHub registration keyed on the instance id; AM resolves via `choose_plugin_instance` against `idp.vendor` |
+| Provider-neutral publication and selection | `PluginV1<IdpPluginSpecV1>` published to types-registry (instance segment `cf.builtin.keycloak_idp.plugin.v1`; full catalogue id in §3.2, vendor `keycloak`, priority 50); scoped ClientHub registration keyed on the instance id; AM resolves via `choose_plugin_instance` against `idp.vendor` |
 | Fail-fast configuration errors | Init validates typed config (`deny_unknown_fields`), the `secret_ref_template`, and the service-principal section, then pre-warms the bootstrap admin token with a bounded retry budget; exhausting the budget fails `Gear::init` |
 | Shared-realm tenant isolation | Per-tenant Keycloak group under `/tenants`, immutable `tenant_id` user attribute (ADR-0006), and an ownership marker attribute (`vhp.provisioning.tenant_id`) on created realms and service-principal clients |
 | Safe external mutation | Parse-then-probe saga ordering, per-step reactive-401 wrapping, idempotent replay paths (probe-adopt realm ensure, 409 group reuse), and stage-attributed `AmbiguousCreated` classification with an `ambig:` prefix contract for reconciliation tooling |
 | Secret custody | `SecretFromEnv`/`SecretString` wrappers with redacted `Debug`, token cache redaction, `redact_secrets` on every error body, and Credential Store writes only for plugin-created realm-admin secrets |
 | Credential rotation without restart | Token cache keyed `(realm, client_id)` with single-flight refresh and an exactly-once reactive-401 retry that re-resolves the secret from its source (env or Credential Store) |
 | User query correctness | Full tenant-group member drain (hard cap 10,000) sorted `(createdTimestamp ASC, id ASC)`, client-side typed filters, `CursorV1` continuation with an FNV-1a filter hash |
-| Observability | Segregated metric ports over one OTel adapter (`vp_idp_plugin_*` instruments), realm-label cardinality cap, and structured audit events on the `vp.idp.plugin.events` tracing target |
+| Observability | Segregated metric ports over one OTel adapter (`keycloak_idp_plugin_*` instruments), realm-label cardinality cap, and structured audit events on the `keycloak_idp.events` tracing target |
 
 #### NFR Allocation
 
@@ -93,7 +93,7 @@ The significant decisions inherit these accepted records and standards:
 - [Use provider-enforced tenant binding](../../../docs/ADR/0006-cpt-cf-account-management-adr-idp-user-tenant-binding.md) — implemented as the `tenant_id` user attribute plus tenant-group membership.
 - Follow [ClientHub and plugin scoping](../../../../../../docs/toolkit_unified_system/03_clienthub_and_plugins.md), [lifecycle rules](../../../../../../docs/toolkit_unified_system/08_lifecycle_stateful_tasks.md), the [Architecture Manifest](../../../../../../docs/ARCHITECTURE_MANIFEST.md), and [Security Guidelines](../../../../../../guidelines/SECURITY.md).
 
-Durable audit delivery remains owned by Account Management and the platform audit owner. The plugin's structured-event emitters (`vp.idp.plugin.events`) are an explicit development stand-in until the platform audit sink lands.
+Durable audit delivery remains owned by Account Management and the platform audit owner. The plugin's structured-event emitters (`keycloak_idp.events`) are an explicit development stand-in until the platform audit sink lands.
 
 ### 1.3 Architecture Layers
 
@@ -109,7 +109,7 @@ flowchart LR
   spc[Trusted platform consumers]
   subgraph host[Host process]
     am[Account Management]
-    subgraph plugin[vp-idp-plugin gear]
+    subgraph plugin[keycloak-idp-plugin gear]
       root[Plugin root: KeycloakIdpPlugin]
       facades[Tenant / User / Service-principal facades]
       kcc[KC admin client factory + token cache]
@@ -289,7 +289,7 @@ The provider metadata is the versioned, non-secret routing envelope `TenantIdpMe
 | `realm_binding` | `shared` \| `adopted` \| `created` (also a public metric label). |
 | `tenant_group_id` | Keycloak UUID of the plugin-owned per-tenant group. |
 | `admin_secret_ref` | `None` for the env-backed default shared realm; `Some(ref)` naming the Credential Store reference for adopted/created realms (template `vp-idp-realm-admin-{realm_name}-secret` by default). |
-| `admin_client_id` | OAuth2 `client_id` of the per-realm admin client (default `vp-idp-plugin-realm-admin`). |
+| `admin_client_id` | OAuth2 `client_id` of the per-realm admin client (default `keycloak-idp-plugin-realm-admin`). |
 
 Provider ownership is split as follows:
 
@@ -330,7 +330,7 @@ The plugin is one logical architecture component. The following entries are resp
 
 #### Deployment, Publication, and Readiness
 
-The plugin is an in-process gear (gear name `vp-idp-plugin`, with declared gear dependencies on `types-registry` and `credstore`) in each host replica. It opens no listener and owns no independent deployment or database.
+The plugin is an in-process gear (gear name `keycloak-idp-plugin`, with declared gear dependencies on `types-registry` and `credstore`) in each host replica. It opens no listener and owns no independent deployment or database.
 
 Initialization proceeds in phases:
 
@@ -339,10 +339,32 @@ Initialization proceeds in phases:
 3. **Static validation** — the `secret_ref_template` is validated by interpolating a 64-character synthetic realm name through `SecretRef::new`; the service-principal section is validated.
 4. **Transport construction** — the reqwest client is built; if `tls_ca_bundle_ref` is set, the PEM bundle is read from the Credential Store and added as a root certificate.
 5. **Bootstrap pre-warm** — the bootstrap admin token is acquired with bounded retry (default 5 × 3 s). Retryable causes: 5xx/429/transport/timeout and Credential Store read failures (deploy-ordering races). Permanent causes fail on the first attempt. Budget exhaustion fails init.
-6. **Catalogue publish** — `PluginV1<IdpPluginSpecV1>` is registered with types-registry under the full catalogue instance id `gts.cf.toolkit.plugins.plugin.v1~cf.core.idp.plugin.v1~vz.virtuozzo.vp_idp.plugin.v1` (base plugin type `gts.cf.toolkit.plugins.plugin.v1~`, derived IdP spec type `…~cf.core.idp.plugin.v1~`, vendor-namespaced instance segment `vz.virtuozzo.vp_idp.plugin.v1`), carrying the configured vendor/priority. `AlreadyExists` is accepted only when the stored spec is structurally equal JSON to the current registration.
+6. **Catalogue publish** — `PluginV1<IdpPluginSpecV1>` is registered with types-registry under the full catalogue instance id `gts.cf.toolkit.plugins.plugin.v1~cf.core.idp.plugin.v1~cf.builtin.keycloak_idp.plugin.v1` (base plugin type `gts.cf.toolkit.plugins.plugin.v1~`, derived IdP spec type `…~cf.core.idp.plugin.v1~`, instance segment `cf.builtin.keycloak_idp.plugin.v1`), carrying the configured vendor/priority. `AlreadyExists` is accepted only when the stored spec is structurally equal JSON to the current registration.
 7. **ClientHub registration** — `Arc<dyn IdpPluginClient>` scoped by the catalogue instance id; `Arc<dyn ServicePrincipalClientV1>` unscoped.
 
 After init, readiness is operation-based: every tenant provision/deprovision saga begins with an unauthenticated Keycloak health probe (`GET realms/master`), and every call re-resolves credentials on 401. Recovery from provider or Credential Store outages therefore needs no process restart.
+
+#### Operator Migration from the vhp-core Lineage
+
+The plugin's identifiers were moved onto this repository's conventions when the crate was ported. A deployment upgrading from the vhp-core `vp-idp-plugin` build must update the following, all of which are configuration or observability surfaces:
+
+| Surface | Was | Now | Action |
+|---|---|---|---|
+| Gear name (config section key) | `vp-idp-plugin` | `keycloak-idp-plugin` | Rename the module's config section |
+| Plugin vendor (selection key) | `virtuozzo` | `keycloak` | Set `account-management.idp.vendor = "keycloak"` |
+| GTS catalogue instance | `…~vz.virtuozzo.vp_idp.plugin.v1` | `…~cf.builtin.keycloak_idp.plugin.v1` | Retire the stale types-registry entry; tenants bound under the old instance need the operator migration described in `…-constraint-scoped-provider-selection` |
+| Bootstrap admin `client_id` default | `vp-idp-plugin-bootstrap` | `keycloak-idp-plugin-bootstrap` | Rename the Keycloak client, or pin the old value in config |
+| Realm-admin `client_id` default | `vp-idp-plugin-realm-admin` | `keycloak-idp-plugin-realm-admin` | Affects newly provisioned realms only — existing tenants replay `admin_client_id` from their metadata |
+| Metric prefix | `vp_idp_plugin_*` | `keycloak_idp_plugin_*` | Update dashboards and alert rules |
+| Tracing targets | `vp_idp_plugin.*`, `vp.idp.plugin.events` | `keycloak_idp.*`, `keycloak_idp.events` | Update log routing and audit collectors |
+
+Three identifiers are deliberately **unchanged**, because each names state that lives outside the process and renaming it would orphan existing resources:
+
+- `vhp.provisioning.tenant_id` — the ownership marker written onto plugin-created realms and service-principal clients in Keycloak. A rename would make the plugin read its own realms as foreign and refuse to administer them.
+- `vp-idp-realm-admin-{realm_name}-secret` — the default `secret_ref_template`, which names live Credential Store secrets for adopted and created realms.
+- The system-actor UUID value — Credential Store secret ownership is keyed to it (§4.1).
+
+Renaming any of the three requires a data migration plan and is out of scope for the port.
 
 ### 3.3 API Contracts
 
@@ -484,7 +506,7 @@ The continuation token is a `CursorV1` (the same envelope Account Management use
 
 HTTP-level retry is bounded (default 3 retries, exponential backoff 100 ms → 5 s cap, full jitter, `Retry-After` honored in delta-seconds form) and splits by what is known: retryable statuses (5xx/429) — where Keycloak answered — are retried for all methods, including administrative POSTs (create-path replays converge through the idempotent-ensure and 409-reuse paths); connect/timeout errors — where the outcome is unknown — are retried only for idempotent requests (GET/PUT/DELETE and the token form-POST), never for administrative POSTs. Reactive-401 re-mints credentials exactly once per call.
 
-Classification is closed: internal `PluginError` variants translate to SDK failures per the fixed tables in §3.3, and each variant has a stable metric label on `vp_idp_plugin_failure_total`. Ambiguous created-mode provisioning remains operator-owned: terminal evidence carries the `ambig:{stage}` token, the realm, and redacted provider detail. Production enablement requires a reconciliation runbook keyed on those stage tokens.
+Classification is closed: internal `PluginError` variants translate to SDK failures per the fixed tables in §3.3, and each variant has a stable metric label on `keycloak_idp_plugin_failure_total`. Ambiguous created-mode provisioning remains operator-owned: terminal evidence carries the `ambig:{stage}` token, the realm, and redacted provider detail. Production enablement requires a reconciliation runbook keyed on those stage tokens.
 
 #### Credentials, Token Cache, and Rotation
 
@@ -496,8 +518,8 @@ All Keycloak traffic authenticates with OAuth2 `client_credentials`. Secrets res
 
 | Tier | Client | Secret source |
 |---|---|---|
-| Bootstrap admin | `vp-idp-plugin-bootstrap` in `master` (defaults) | `${VAR}`-expanded configuration (`SecretFromEnv`) |
-| Shared-realm admin | `vp-idp-plugin-realm-admin` (default) | `${VAR}`-expanded configuration (`default_shared_realm_secret`) |
+| Bootstrap admin | `keycloak-idp-plugin-bootstrap` in `master` (defaults) | `${VAR}`-expanded configuration (`SecretFromEnv`) |
+| Shared-realm admin | `keycloak-idp-plugin-realm-admin` (default) | `${VAR}`-expanded configuration (`default_shared_realm_secret`) |
 | Adopted/created-realm admin | `admin_client_id` from metadata | Credential Store reference from `secret_ref_template` (created-mode secrets are written by the plugin during provisioning) |
 
 Service-principal administration always uses the bootstrap admin tier, against the dedicated service-principal realm (`service_principal.realm`, default `platform` — the shared realm whose issuer tenants trust), independent of any tenant's realm binding.
@@ -521,14 +543,14 @@ sequenceDiagram
 
   AM->>P: Invoke mutating contract
   P->>K: Admin REST (bearer, HTTPS)
-  P-->>P: tracing event on vp.idp.plugin.events
+  P-->>P: tracing event on keycloak_idp.events
   P-->>AM: Classified redacted outcome
   AM->>A: Durably correlate terminal outcome
 ```
 
-The plugin emits structured events on the `vp.idp.plugin.events` tracing target — `tenant.bound`, `realm.created`, `admin_user.bound`, `tenant.unbound`, `realm.removed`, `service_principals.purged`, `user.provisioned` (includes `username`), `user.deprovisioned` — each carrying the acting subject (id, closed-set type, raw type, tenant). This is an explicit development stand-in until the platform audit sink lands; durable one-outcome-per-call correlation is owned by Account Management and the platform audit owner. `list_users` and the service-principal read/mutate paths emit no plugin audit events of their own; the only service-principal audit signal is `service_principals.purged` on tenant deprovisioning.
+The plugin emits structured events on the `keycloak_idp.events` tracing target — `tenant.bound`, `realm.created`, `admin_user.bound`, `tenant.unbound`, `realm.removed`, `service_principals.purged`, `user.provisioned` (includes `username`), `user.deprovisioned` — each carrying the acting subject (id, closed-set type, raw type, tenant). This is an explicit development stand-in until the platform audit sink lands; durable one-outcome-per-call correlation is owned by Account Management and the platform audit owner. `list_users` and the service-principal read/mutate paths emit no plugin audit events of their own; the only service-principal audit signal is `service_principals.purged` on tenant deprovisioning.
 
-Metrics: `vp_idp_plugin_provision_tenant_duration_seconds`, `user_op_duration_seconds`, `sp_op_duration_seconds`, `kc_admin_request_duration_seconds` (declared, not yet wired), `failure_total{op,failure_variant}`, `kc_admin_token_refresh_total` and `credential_refresh_total` (`{outcome,tier,realm}`), `credstore_write_total`, `metadata_decode_failure_total{version_observed}`, `deprovision_missing_metadata_total`, `orphan_user_compensation_total`, `realms_bound{realm_binding,realm_name}`. Every label is a closed enum except `realm`/`realm_name`, which share a cardinality budget (default 500 distinct realms) after which the label is dropped and a warning is logged for each newly observed over-cap realm.
+Metrics: `keycloak_idp_plugin_provision_tenant_duration_seconds`, `user_op_duration_seconds`, `sp_op_duration_seconds`, `kc_admin_request_duration_seconds` (declared, not yet wired), `failure_total{op,failure_variant}`, `kc_admin_token_refresh_total` and `credential_refresh_total` (`{outcome,tier,realm}`), `credstore_write_total`, `metadata_decode_failure_total{version_observed}`, `deprovision_missing_metadata_total`, `orphan_user_compensation_total`, `realms_bound{realm_binding,realm_name}`. Every label is a closed enum except `realm`/`realm_name`, which share a cardinality budget (default 500 distinct realms) after which the label is dropped and a warning is logged for each newly observed over-cap realm.
 
 Operational signals: the reconciliation gate consumes `failure_total{failure_variant="ambiguous_created"}` and the `ambig:{stage}` warn events; dependency-health attribution splits `credential_refresh_total{outcome="error"}` (Credential Store) from `kc_admin_token_refresh_total{outcome="error"}` (Keycloak) plus `credstore_write_total{outcome="error"}`; metadata integrity consumes `metadata_decode_failure_total` (any increase is operator-actionable); list capacity consumes the drain-cap truncation warning. Alert thresholds against the PRD availability and latency targets are owned by the deployment repository's monitoring configuration, not by this design.
 
@@ -604,7 +626,7 @@ The release-qualification query matrix for the PRD latency NFR covers unfiltered
 - [`IdpPluginClient` user contract](../../../account-management-sdk/src/idp_user.rs)
 - [`ServicePrincipalClientV1` contract](../../../../service-principal/service-principal-sdk/src/api.rs)
 - [Unified ToolKit architecture](../../../../../../docs/toolkit_unified_system/README.md)
-- Implementation: [`plugins/keycloak-idp-plugin`](../src/lib.rs) (crate `vp-idp-plugin`)
+- Implementation: [`plugins/keycloak-idp-plugin`](../src/lib.rs) (crate `cf-gears-keycloak-idp-plugin`)
 
 ### 5.2 P1 Requirement Allocation
 

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/PRD.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/PRD.md
@@ -53,7 +53,7 @@ Account Management defines stable provider contracts for tenant and user identit
 
 An identity-management platform also needs tenant isolation, clear realm ownership, and safe external-mutation handling. The shared realm is the only v1 realm strategy. Adopted and plugin-created realms are p2 compatibility modes and cannot be enabled through the v1 contract. Machine-identity lifecycle behavior is also p2 because Account Management does not own that public capability. Without one defined product contract, provider behavior can drift across tenant provisioning, user administration, retries, and operational signals.
 
-The Keycloak IdP Plugin solves this gap for Keycloak. It owns the provider-facing lifecycle behavior while preserving the boundaries of Account Management, the OIDC authentication resolver, Keycloak, CredStore, and the platform Policy Engine.
+The Keycloak IdP Plugin solves this gap for Keycloak. It owns the provider-facing lifecycle behavior while preserving the boundaries of Account Management, the Outbound API Gateway, the OIDC authentication resolver, Keycloak, Credential Store, and the platform Policy Engine.
 
 ### 1.3 Goals (Business Outcomes)
 
@@ -77,6 +77,7 @@ The Keycloak IdP Plugin solves this gap for Keycloak. It owns the provider-facin
 | Service principal | A tenant-owned machine identity used for service-to-service authentication. |
 | Platform authentication profile | The product-level issuer, claim, client, signing, session, and login requirements that make a Keycloak realm usable by platform authentication consumers. |
 | Ambiguous outcome | A failed or lost response where an external mutation might have completed and reconciliation is required before retry. |
+| Outbound API Gateway (OAGW) | The system gear that applies centralized credential injection and outbound policy before forwarding approved Keycloak requests. |
 | OIDC AuthN Resolver Plugin | The separate runtime component that validates incoming OIDC tokens offline; v1 does not require it to check per-identity revocation state. |
 
 ## 2. Actors
@@ -121,7 +122,13 @@ The Keycloak IdP Plugin solves this gap for Keycloak. It owns the provider-facin
 
 **ID**: `cpt-cf-keycloak-idp-plugin-actor-credstore`
 
-- **Role**: Protects provider administrator credentials and other configured secret material. Consumers may use it for durable custody of one-time service-principal credentials; the owning platform service and this plugin do not retain those returned credentials.
+- **Role**: Protects provider administrator credentials and other configured secret material. The Outbound API Gateway resolves the plugin's configured provider credential references and injects credentials without disclosing them to the plugin. Consumers may use Credential Store for durable custody of one-time service-principal credentials; the owning platform service and this plugin do not retain those returned credentials.
+
+#### Outbound API Gateway
+
+**ID**: `cpt-cf-keycloak-idp-plugin-actor-oagw`
+
+- **Role**: Executes operator-approved Keycloak OAuth and Admin REST routes, enforces outbound policy, and injects provider administrator credentials from Credential Store.
 
 #### OIDC AuthN Resolver Plugin
 
@@ -142,6 +149,7 @@ flowchart LR
     AM[Account Management]
     Owner[Service-Principal Lifecycle Owner]
     Plugin[Keycloak IdP Plugin]
+    OAGW[Outbound API Gateway]
     KC[Keycloak]
     CS[Credential Store]
     AuthN[OIDC AuthN Resolver]
@@ -151,18 +159,19 @@ flowchart LR
     Consumer -->|machine-identity lifecycle| Owner
     AM -->|tenant and user lifecycle| Plugin
     Owner -->|delegated machine-identity lifecycle| Plugin
-    Plugin -->|identity administration| KC
-    Plugin -->|protected provider credentials| CS
+    Plugin -->|approved provider request| OAGW
+    OAGW -->|OAuth and Admin REST| KC
+    OAGW -->|protected credential resolution| CS
     KC -->|tokens and issuer metadata| AuthN
     AuthN --> PDP
 ```
 
 ### 3.1 Gear-Specific Environment Constraints
 
-- The deployment must provide a supported Keycloak administration surface; each lifecycle call reports whether the dependencies required by that operation are usable, without adding a separate Account Management availability probe.
+- The deployment must provide a supported Keycloak administration surface through an operator-approved Outbound API Gateway route; each lifecycle call reports whether its required dependencies are usable without adding a separate Account Management availability probe.
 - Account Management must provide the tenant context and provider-owned metadata required to route existing-tenant operations.
-- Credential Store must be available for operations that require dynamic provider credentials.
-- The deployment must select one unambiguous active provider for each supported identity-lifecycle capability.
+- Outbound API Gateway and its transitive Credential Store dependency must be available for operations that require Keycloak administration.
+- The deployment must select one unambiguous active provider for each supported identity-lifecycle capability. Changing that provider while tenant metadata exists requires an explicit operator migration.
 
 ## 4. Scope
 
@@ -172,9 +181,9 @@ flowchart LR
 - Explicit tenant binding to an operator-approved shared Keycloak realm.
 - Tenant identity-boundary creation, binding, and cleanup within the shared realm.
 - Tenant-scoped user creation, partial update, deletion, provider-session revocation, listing, filtering, and ordering.
-- Protected provider-administrator credential use and dynamic provider-administrator secret lifecycle.
+- Protected provider-administrator credential use through Outbound API Gateway and dynamic provider-administrator secret rotation without plugin access to credential values.
 - Deterministic failure classification, retry safety, and ambiguous-outcome reconciliation signals.
-- Provider-specific audit events, metrics, readiness, and dependency-health signals.
+- Provider-specific privacy-safe outcome evidence, bounded metrics, readiness, and dependency-health signals.
 
 ### 4.2 Out of Scope
 
@@ -205,19 +214,19 @@ The adopted-realm, created-realm, and service-principal bullets below are out of
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-provider-publication`
 
-The plugin **MUST** be selectable by Account Management without requiring Account Management or its consumers to depend on the plugin implementation.
+The plugin **MUST** be selectable by Account Management without requiring Account Management or its consumers to depend on the plugin implementation. Its published GTS provider instance identifier **MUST** be stable for the lifetime of tenant metadata produced by that instance.
 
-- **Rationale**: Provider-neutral selection permits replacement without changing consumers.
+- **Rationale**: Provider-neutral selection permits replacement without changing consumers, while a stable instance identity prevents existing tenant metadata from being rebound silently.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`
 
 #### Operation-Based Readiness
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-readiness`
 
-The plugin **MUST NOT** require a separate Account Management availability probe. `provision_tenant` **MUST** remain the bootstrap readiness signal and **MUST** classify a pre-mutation dependency failure as clean only when no provider state was retained. Dependency loss **MUST** block only the realm modes and lifecycle operations that require that dependency; unaffected operations **MUST** remain available.
+The plugin **MUST NOT** require a separate Account Management availability probe. Module initialization **MUST** publish the scoped client after static configuration validation without contacting Outbound API Gateway, Credential Store, or Keycloak. `provision_tenant` **MUST** remain the bootstrap readiness signal and **MUST** classify a pre-mutation dependency failure as clean only when no provider state was retained. Dependency loss **MUST** block only the lifecycle operations that require that dependency; unaffected operations **MUST** remain available. A later operation **MUST** retry dependency and compatibility checks so recovery does not require process restart.
 
-- **Rationale**: Account Management already defines operation-based readiness, and a capability-specific dependency such as Credential Store must not disable unrelated shared-realm work.
-- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
+- **Rationale**: ToolKit initialization is fail-fast for the whole host. Operation-level readiness preserves Account Management availability during a provider outage and uses its existing lazy provider-resolution model.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-oagw`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
 
 ### 5.2 Tenant Lifecycle
 
@@ -279,9 +288,9 @@ A tenant realm binding **MUST NOT** report success until the shared realm satisf
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-provider-metadata`
 
-The plugin **MUST** return versioned, provider-owned tenant metadata after provisioning and **MUST** use replayed metadata as the authoritative routing context for later tenant and user operations. Every supported plugin upgrade **MUST** read metadata written by all versions in its declared compatibility window, including metadata needed to deprovision an existing tenant. Unknown newer major versions and malformed metadata **MUST** fail closed without provider mutation. Rolling upgrade and rollback support **MUST NOT** rewrite metadata into a form unreadable by another simultaneously supported version.
+The plugin **MUST** return versioned, provider-owned tenant metadata after provisioning and **MUST** use replayed metadata as the authoritative routing context for later tenant and user operations. The metadata **MUST** include the exact GTS provider instance identifier that produced it. Before any Outbound API Gateway or provider call, the plugin **MUST** verify that the replayed identifier equals its own published identifier; a mismatch **MUST** fail closed without external access. Every supported plugin upgrade **MUST** read metadata written by all versions in its declared compatibility window, including metadata needed to deprovision an existing tenant. Unknown newer major versions and malformed metadata **MUST** fail closed without provider mutation. Rolling upgrade and rollback support **MUST NOT** rewrite metadata into a form unreadable by another simultaneously supported version. Changing the selected provider instance while such metadata exists is unsupported until an operator-approved migration rewrites or retires every affected binding.
 
-- **Rationale**: Account Management remains provider-neutral while the plugin preserves safe lifecycle continuity across upgrades and rollback.
+- **Rationale**: Account Management remains an opaque metadata proxy while the producing instance remains durably bound to each tenant and cannot be replaced through vendor or priority drift.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
 
 #### Ownership-Preserving Tenant Deprovisioning
@@ -467,10 +476,10 @@ The plugin **MUST** report uncertain creation, rotation, revocation, or concurre
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-administrator-credentials`
 
-The plugin **MUST** use protected, operator-supplied administrator credentials with the least privilege needed for each realm lifecycle. It **MUST** support credential rotation without exposing credential values in product outputs or operational signals.
+The plugin **MUST** invoke only operator-approved OAGW routes configured with administrator credentials that have the least privilege needed for each realm lifecycle. OAGW **MUST** support rotation through stable credential references without exposing credential values to the plugin, product outputs, or operational signals.
 
-- **Rationale**: Provider administrator compromise can affect every identity in the authorized realm.
-- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
+- **Rationale**: Provider administrator compromise can affect every identity in the authorized realm, while gateway-owned injection keeps the credential outside plugin memory.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-oagw`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
 
 #### External Mutation Resilience
 
@@ -503,10 +512,10 @@ The v1 realm authentication profile **MUST** limit access-token lifetime to 15 m
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-audit-metrics`
 
-The plugin **MUST** emit structured audit outcomes and metrics for every supported tenant, user, provider-request, credential, reconciliation, and failure lifecycle. When the p2 service-principal contract is implemented, the same requirement **MUST** cover its lifecycle. Signals **MUST** support correlation to the initiating platform actor without containing secrets or user profile values such as username, email, or display name.
+The plugin **MUST** return a classified, privacy-safe outcome and correlation evidence for every supported tenant, user, provider-request, reconciliation, and failure lifecycle, and **MUST** emit bounded-cardinality operational metrics. Account Management **MUST** create the durable audit intent and terminal outcome for each mutating plugin call; the platform audit owner **MUST** persist and deliver it idempotently. OAGW and Credential Store owners **MUST** audit credential resolution and rotation under their own contracts because credential values and lifecycle do not enter this plugin. When the p2 service-principal contract is implemented, its owning platform service **MUST** provide the equivalent durable audit boundary. No signal **MUST** contain secrets or user profile values such as username, email, or display name.
 
-- **Rationale**: Operators need privacy-preserving evidence for security review, incident response, performance, and reconciliation.
-- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
+- **Rationale**: A single owner for each durable record prevents duplicate or missing audit events while preserving plugin-level diagnostic evidence.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-oagw`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
 
 ## 6. Non-Functional Requirements
 
@@ -522,7 +531,7 @@ The plugin **MUST** prevent an operation resolved for one tenant from reading or
 
 - **Threshold**: Zero successful cross-tenant operations across the automated negative-isolation suite.
 - **Rationale**: Identity administration is a security boundary for every tenant.
-- **Architecture Allocation**: See future DESIGN.md § Security and AuthZ.
+- **Architecture Allocation**: See [DESIGN.md §4.1](./DESIGN.md#41-security-and-data-protection).
 
 #### Secret Non-Disclosure
 
@@ -532,17 +541,17 @@ The plugin **MUST** prevent administrator tokens, administrator secrets, user pa
 
 - **Threshold**: Zero secret values detected by automated redaction tests and security scanning across all named output surfaces.
 - **Rationale**: These credentials can grant user or machine access across a tenant or realm.
-- **Architecture Allocation**: See future DESIGN.md § Credential Management.
+- **Architecture Allocation**: See [DESIGN.md §§3.5–3.6](./DESIGN.md#35-external-dependencies) and [§4.1](./DESIGN.md#41-security-and-data-protection).
 
 #### Lifecycle Latency
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-lifecycle-latency`
 
-On the release qualification profile, shared-realm tenant provisioning **MUST** complete within 5 seconds at p95. User creation, update, deprovisioning, and a 100-user query page **MUST** each complete within 1 second at p95. Measurements **MUST** use 20 concurrent operations against a supported Keycloak 26.x deployment, exclude caller network time, and include plugin processing plus Keycloak administration round trips.
+On the release qualification profile, shared-realm tenant provisioning **MUST** complete within 5 seconds at p95. User creation, update, deprovisioning, and a 100-user query page **MUST** each complete within 1 second at p95. The profile **MUST** use 20 concurrent operations, an operator-equivalent Keycloak 26.x node backed by PostgreSQL, at most 5 ms network round-trip time between Outbound API Gateway and Keycloak, and up to 1,000 human identities, enabled or disabled, in one tenant group. Query runs **MUST** cover unfiltered results and filters matching approximately 100%, 10%, and 1% of the group under every supported order. Measurements **MUST** include plugin and gateway processing plus Keycloak administration round trips, cover cached-token and forced-token-refresh runs, and exclude only caller-to-Account-Management network time. A list operation **MUST** use provider member pages no larger than 500, perform no more than `ceil(N / 500) + 1` member-page reads, and use no more than 16 MiB working memory per request. If a scan observes more than 1,000 total members, it **MUST** stop before sorting or returning a partial page and return `IdpUserOperationFailure::UnsupportedOperation` with a non-sensitive capacity detail.
 
-- **Threshold**: Tenant provisioning p95 ≤ 5 seconds; each named user operation p95 ≤ 1 second; 20 concurrent operations.
-- **Rationale**: Concrete budgets make interactive control-plane behavior release-testable without applying request-path latency assumptions.
-- **Architecture Allocation**: See future DESIGN.md § NFR Allocation.
+- **Threshold**: Tenant provisioning p95 ≤ 5 seconds; each named user operation p95 ≤ 1 second; 20 concurrent operations; list support ceiling 1,000 total users per tenant group; list working memory ≤ 16 MiB per request.
+- **Rationale**: A fixed population, topology, filter mix, call budget, and overflow result make the linear-scan acceptance test reproducible.
+- **Architecture Allocation**: See [DESIGN.md §1.2](./DESIGN.md#12-architecture-drivers), [§3.6](./DESIGN.md#36-interactions--sequences), and [§4.3](./DESIGN.md#43-risks-and-enablement-gates).
 
 #### Deterministic Failure Classification
 
@@ -552,27 +561,27 @@ The plugin **MUST** classify every failed supported lifecycle call into an outco
 
 - **Threshold**: 100% of automated failure-injection cases produce an expected SDK category; zero ambiguous tenant-provisioning cases are classified as clean failures.
 - **Rationale**: Correct recovery depends on the difference between safe retry and reconciliation.
-- **Architecture Allocation**: See future DESIGN.md § Error Mapping.
+- **Architecture Allocation**: See [DESIGN.md §3.3](./DESIGN.md#33-api-contracts) and [§3.6](./DESIGN.md#36-interactions--sequences).
 
 #### Audit Completeness
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-audit-completeness`
 
-The plugin **MUST** produce an auditable terminal outcome for every successful or failed supported mutating tenant and user call. The same obligation **MUST** apply to service-principal calls if the p2 contract is implemented.
+The plugin **MUST** return classified privacy-safe evidence for every successful or failed supported mutating tenant and user call. Account Management and the platform audit owner **MUST** turn that evidence into one durable terminal audit outcome. The same obligation **MUST** apply to the owning service for service-principal calls if the p2 contract is implemented.
 
-- **Threshold**: 100% correlation between mutating contract-test calls and one terminal audit outcome, excluding calls rejected before actor context exists.
-- **Rationale**: Identity and credential mutations require traceable accountability.
-- **Architecture Allocation**: See future DESIGN.md § Audit and Observability.
+- **Threshold**: 100% correlation between mutating contract-test calls and one durable terminal audit outcome, excluding calls rejected before actor context exists.
+- **Rationale**: Identity and credential mutations require traceable accountability with one unambiguous durable emitter.
+- **Architecture Allocation**: See [DESIGN.md §3.6](./DESIGN.md#36-interactions--sequences) and [§4.3](./DESIGN.md#43-risks-and-enablement-gates).
 
 #### Provider Compatibility
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-provider-compatibility`
 
-V1 **MUST** support Keycloak 26.x. The plugin **MUST** reject startup for another major version, and expansion to another major version **MUST** require a versioned compatibility update.
+V1 **MUST** support Keycloak 26.x. A reachable provider on another major version **MUST** fail operation-based readiness and every affected lifecycle operation before mutation, while unrelated Account Management capabilities remain available. Expansion to another major version **MUST** require a versioned compatibility update.
 
-- **Threshold**: Every supported Keycloak 26.x release in the release matrix passes the provider contract suite; representative unsupported major versions fail readiness deterministically.
-- **Rationale**: An explicit compatibility window gives operators predictable installation, upgrade, and rollback support.
-- **Architecture Allocation**: See future DESIGN.md § Compatibility.
+- **Threshold**: Every supported Keycloak 26.x release in the release matrix passes the provider contract suite; representative unsupported major versions fail affected operations deterministically without preventing host startup.
+- **Rationale**: An explicit compatibility window gives operators predictable installation, upgrade, and rollback support without turning an external provider check into a process-wide startup dependency.
+- **Architecture Allocation**: See [DESIGN.md §3.2](./DESIGN.md#32-component-model) and [§3.6](./DESIGN.md#36-interactions--sequences).
 
 #### Personal Data Minimization and Lifecycle
 
@@ -582,7 +591,7 @@ The plugin **MUST** process only identity attributes required by its contracts, 
 
 - **Threshold**: Zero profile values detected across logs, metrics, audit events, debug output, and retained plugin state; 100% of hard-deletion cases produce a classified identity-deletion outcome; production configuration contains a finite audit-retention period.
 - **Rationale**: User identity administration processes personal data even though the plugin owns no local directory.
-- **Architecture Allocation**: See future DESIGN.md § Data Protection.
+- **Architecture Allocation**: See [DESIGN.md §4.1](./DESIGN.md#41-security-and-data-protection).
 
 #### Availability and Recovery
 
@@ -592,7 +601,7 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 
 - **Threshold**: Dependency-failure tests prove capability-specific availability and fail-closed mutations; recovery tests restore unambiguous operations within 15 minutes and keep uncertain resources reconciliation-blocked.
 - **Rationale**: Per-call errors alone do not define safe degraded operation or restoration.
-- **Architecture Allocation**: See future DESIGN.md § Availability and Recovery.
+- **Architecture Allocation**: See [DESIGN.md §3.2](./DESIGN.md#32-component-model) and [§3.6](./DESIGN.md#36-interactions--sequences).
 
 ### 6.2 NFR Exclusions
 
@@ -653,21 +662,29 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 - **Protocol/Format**: Versioned Account Management provider contract
 - **Compatibility**: The plugin follows Account Management's tenant and user request, result, failure, idempotency, tenant-context, and provider-metadata semantics.
 
+#### Outbound API Gateway Contract
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-contract-oagw`
+
+- **Direction**: required from client
+- **Protocol/Format**: `ServiceGatewayClientV1` with operator-provisioned Keycloak upstream and route aliases
+- **Compatibility**: The plugin sends all Keycloak OAuth and Admin REST requests through approved routes. It does not create routes, resolve credential values, or open direct external HTTP connections.
+
 #### Keycloak Administration Contract
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-contract-keycloak-admin`
 
-- **Direction**: required from external provider
+- **Direction**: required from external provider through Outbound API Gateway
 - **Protocol/Format**: Supported Keycloak administration and OAuth interfaces
-- **Compatibility**: V1 supports Keycloak 26.x; another major version requires a versioned compatibility update and is rejected until approved.
+- **Compatibility**: V1 supports Keycloak 26.x; another major version requires a versioned compatibility update and fails operation-based readiness until approved.
 
 #### Credential Store Contract
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-contract-credstore`
 
-- **Direction**: required from client
+- **Direction**: transitive dependency through Outbound API Gateway
 - **Protocol/Format**: Protected secret-storage contract
-- **Compatibility**: Secret references remain stable across credential rotation; secret values are never part of provider metadata.
+- **Compatibility**: OAGW credential references remain stable across rotation; credential values never enter the plugin or provider metadata.
 
 ## 8. Use Cases
 
@@ -729,7 +746,7 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 
 **Preconditions**:
 - Account Management supplies valid `created` provisioning intent for an absent realm target.
-- The plugin has the required provider and Credential Store access.
+- The plugin has the required approved OAGW route and provider access.
 
 **Main Flow**:
 1. Account Management requests tenant provisioning with created-realm intent.
@@ -880,7 +897,7 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 
 ### V1 Acceptance
 
-- [ ] Account Management can select the Keycloak IdP Plugin by its published provider instance.
+- [ ] Account Management can select the Keycloak IdP Plugin by its published provider instance, and replayed tenant metadata fails closed before external access when its producing instance identifier differs from the selected instance.
 - [ ] Every v1 provisioning request explicitly identifies `shared` mode and an operator-approved existing realm; missing intent and `adopted` or `created` requests fail without provider mutation.
 - [ ] The shared realm issues tokens accepted by the OIDC AuthN Resolver with required tenant and identity claims and a maximum access-token lifetime of 15 minutes.
 - [ ] Metadata from every version in the supported upgrade and rollback window remains readable for normal operations and safe hard deprovisioning.
@@ -891,10 +908,11 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 - [ ] User updates distinguish not found, duplicate identity attributes, password-policy rejection, unsupported behavior, invalid input, and provider unavailability.
 - [ ] Cross-tenant negative tests produce zero successful reads or mutations.
 - [ ] Failure injection proves that ambiguous tenant provisioning is never reported as clean, while each user failure maps to an `IdpUserOperationFailure` outcome and equivalent replay remains idempotent.
-- [ ] Every mutating contract-test call and reconciliation resolution has one correlated terminal audit outcome containing no user profile value; calls rejected before actor context exists are excluded, matching `cpt-cf-keycloak-idp-plugin-nfr-audit-completeness`.
-- [ ] Secret scanning finds no credential values in logs, metrics, audit events, listings, or debug output.
-- [ ] Every supported Keycloak 26.x release in the release matrix passes the provider contract suite, and representative unsupported major versions fail readiness.
-- [ ] Shared-realm tenant provisioning meets p95 ≤ 5 seconds; each named user operation meets p95 ≤ 1 second under the §6.1 qualification profile.
+- [ ] Every mutating contract-test call and reconciliation resolution has one durable terminal audit outcome created by Account Management and delivered by the platform audit owner; plugin evidence, metrics, and the durable record contain no user profile value. Calls rejected before actor context exists are excluded, matching `cpt-cf-keycloak-idp-plugin-nfr-audit-completeness`.
+- [ ] Secret scanning finds no credential values in plugin logs, metrics, audit evidence, listings, or debug output, and all Keycloak requests use approved Outbound API Gateway routes.
+- [ ] The host starts and unrelated Account Management operations remain available when OAGW, Credential Store, or Keycloak is unavailable; affected IdP operations recover on a later call after dependency restoration without process restart.
+- [ ] Every supported Keycloak 26.x release in the release matrix passes the provider contract suite, and representative unsupported major versions fail affected operation-based readiness without preventing host startup.
+- [ ] Shared-realm tenant provisioning meets p95 ≤ 5 seconds; each named user operation meets p95 ≤ 1 second under the complete §6.1 qualification profile, including the 1,000-user list ceiling, provider-call budget, memory limit, filter mix, and overflow rejection.
 - [ ] The plugin exposes no public REST routes and performs no JWT validation or authorization decisions.
 
 ### P2 Promotion Acceptance
@@ -913,8 +931,9 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 |------------|-------------|-------------|
 | Account Management provider contract | Defines v1 tenant and user lifecycle requests, outcomes, failure semantics, and provider context. It has no service-principal or tenant-suspension plugin hook. | p1 |
 | Account Management orchestration | Provides authorization, tenant resolution, provider selection, hard-deprovision invocation, and reconciliation behavior. | p1 |
-| Keycloak 26.x | Provides shared-realm identity-boundary, human-identity, session, and credential administration capabilities. | p1 |
-| Credential Store | Protects provider administrator credentials and other configured secret material. | p1 |
+| Outbound API Gateway | Executes approved Keycloak routes, enforces outbound policy, and injects provider credentials through `ServiceGatewayClientV1`. | p1 |
+| Keycloak 26.x | Provides shared-realm identity-boundary, human-identity, session, and credential administration capabilities behind OAGW. | p1 |
+| Credential Store | Protects provider administrator credentials resolved and injected by OAGW; the plugin never reads their values. | p1 |
 | OIDC AuthN Resolver Plugin | Validates Keycloak-issued tokens offline and enforces one issuer per tenant. It does not manage sessions or check per-identity revocation state. | p1 |
 | Service-principal capability ownership | A future platform owner outside Account Management must publish machine-identity lifecycle, provider delegation, secret custody, mutation safety, pagination, and quota contracts before p2 implementation. | p2 |
 | RBAC / Policy Engine | Makes authorization decisions outside this plugin. | p1 |
@@ -924,8 +943,8 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 - Keycloak is the identity provider implemented by this plugin, and v1 targets Keycloak 26.x.
 - Account Management authorizes public user and tenant operations before invoking the plugin.
 - Account Management supplies an active resolved tenant context for existing-tenant operations.
-- Operators provision the v1 shared realm and provider credentials they own.
-- Provider-owned metadata is persisted and replayed opaquely by Account Management.
+- Operators provision the v1 shared realm, Outbound API Gateway routes, and provider credentials they own.
+- Provider-owned metadata, including its producing GTS provider instance identifier, is persisted and replayed opaquely by Account Management.
 - V1 Keycloak access tokens expire within 15 minutes.
 - The OIDC AuthN Resolver validates access tokens offline and does not depend on current per-identity revocation state.
 - If p2 adopted-realm support is promoted, root bootstrap permits only the declared initial platform administrator, provider-required system identities, and no unrelated tenant boundary.
@@ -938,11 +957,11 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 | An external mutation completes after the caller loses the response. | Duplicate or orphaned identity resources or credentials. | Preserve ambiguous outcomes, stop blind retry, and provide reconciliation signals. |
 | Administrator credentials grant broader access than required. | Compromise can affect unrelated tenants or realms. | Require least privilege, protected storage, rotation, and secret non-disclosure tests. |
 | Provider metadata becomes unreadable after upgrade or rollback. | Existing tenants cannot be administered or retired safely. | Require versioned metadata and compatibility coverage for supported upgrade paths. |
-| Shared-realm routing or tenant association drifts. | Cross-tenant identity exposure. | Treat replayed binding metadata as authoritative and run negative-isolation contract tests. |
+| Shared-realm routing, tenant association, or selected provider instance drifts. | Existing tenants can be misrouted or become unsafe to administer. | Bind metadata to its producing GTS instance, reject mismatches before OAGW access, and require an operator migration before changing the selected instance. |
 | A future p2 service principal survives tenant retirement. | Machine access remains active after tenant deletion. | Require the owning platform contract to complete a cleanup barrier before Account Management invokes hard deprovisioning. |
 | Human identities or sessions survive tenant retirement. | Retired users retain authentication or tenant access. | Revoke sessions, delete tenant-bound identities, prove absence of the retired binding, and block completion when reconciliation is required. |
 | Keycloak 26.x administration behavior changes across releases. | Lifecycle operations fail or produce different outcomes. | Test every supported 26.x release before plugin publication and reject unsupported major versions. |
-| Credential Store is unavailable during a future p2 dynamic credential operation. | Dedicated-realm lifecycle work cannot complete safely. | Return a classified failure and preserve ambiguous state when external completion is uncertain. |
+| OAGW cannot resolve the configured Credential Store reference. | Keycloak administration cannot authenticate safely. | Fail only the affected operation, expose gateway-versus-upstream provenance without secrets, and retry only when no provider mutation is uncertain. |
 | An access JWT remains valid after user or tenant hard deprovisioning. | Access can continue until token expiry. | Limit v1 access-token lifetime to 15 minutes, revoke provider sessions, block refresh, and document the bounded exposure. |
 
 ## 13. Open Questions
@@ -967,7 +986,7 @@ The following questions gate only p2 promotion:
 - **Migration requirements**: Tenant hard deprovisioning requires session revocation and deletion of tenant-bound users, and audit events use provider-issued identity references rather than usernames or profile values.
 - **Service-principal allocation**: Account Management does not own service-principal lifecycle. A future platform owner must publish lifecycle, secret-custody, mutation-safety, pagination, quota, and authentication contracts before p2 implementation.
 - **AuthN allocation**: V1 follows the OIDC AuthN Resolver's offline JWT model. Keycloak sessions are revoked, but an already-issued access token can remain valid until its `exp`, bounded by the 15-minute profile maximum.
-- **Future Design**: `DESIGN.md` in this directory
+- **Design**: [Keycloak IdP Plugin DESIGN](./DESIGN.md)
 - **Future ADRs**: `ADR/` in this directory
 - **Future Features**: `features/` in this directory
 - **UPSTREAM_REQS coverage**: Not applicable because this child plugin has no `UPSTREAM_REQS.md`; parent contract requirements are linked above.

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/PRD.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/PRD.md
@@ -75,7 +75,7 @@ The Keycloak IdP Plugin solves this gap for Keycloak. It owns the provider-facin
 | Realm | A Keycloak isolation and administration boundary containing identities and related configuration. |
 | Shared realm | An operator-owned realm that contains more than one tenant. The default binding; child tenants inherit their parent's realm. |
 | Adopted realm | An existing operator-owned realm bound to a single tenant without transferring realm ownership to the plugin. |
-| Created realm | A realm (`realm-{tenant_id}`) created and lifecycle-managed by the plugin, marked with a plugin ownership attribute. |
+| Created realm | A realm created and lifecycle-managed by the plugin, marked with a plugin ownership attribute. Child tenants get the generated name `realm-{tenant_id}`; a root-target created realm is operator-named. |
 | Tenant group | The plugin-owned Keycloak group (under `/tenants` by default) that forms a tenant's identity boundary inside a realm. |
 | Bootstrap admin | The operator-provisioned confidential client (default `keycloak-idp-plugin-bootstrap` in `master`) the plugin uses for realm-level administration. |
 | Realm admin | The per-realm confidential client (default `keycloak-idp-plugin-realm-admin`) used for tenant and user administration inside a bound realm. |
@@ -114,7 +114,7 @@ The Keycloak IdP Plugin solves this gap for Keycloak. It owns the provider-facin
 
 **ID**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`
 
-- **Role**: A trusted platform module that resolves `ServicePrincipalClientV1` from ClientHub to manage tenant-scoped machine identities. It authorizes its own callers through RBAC/PDP before delegating; the plugin treats the forwarded security context as audit evidence only.
+- **Role**: The `service-principal` gear — the platform-owned REST product for machine identities — resolves `ServicePrincipalClientV1` from ClientHub and delegates to this plugin as its registered adapter. It authorizes its own callers through RBAC/PDP before delegating; the plugin treats the forwarded security context as audit evidence only.
 
 #### Keycloak
 
@@ -244,7 +244,7 @@ Provisioning intent arrives through the `IdpProvisionTenantRequest.metadata` val
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-shared-realm-admissibility`
 
-The target shared realm **MUST** already exist; the plugin verifies existence with the bootstrap admin before any mutation. A failed existence check **MUST** produce a no-side-effect outcome. The plugin **MUST NOT** create, repair, or reconfigure a shared realm.
+The target shared realm **MUST** already exist; the plugin verifies existence with the bootstrap admin before any mutation. A failed existence check performs no mutation. A provider 4xx **MUST** be reported as a clean failure and a 403 as unsupported; a 5xx, transport, or timeout failure **MUST** be reported conservatively as ambiguous, because the plugin cannot prove the provider was untouched. The plugin **MUST NOT** create, repair, or reconfigure a shared realm.
 
 - **Rationale**: The plugin must not claim an unknown realm or mutate operator-owned realm configuration.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
@@ -262,7 +262,7 @@ An `adopted` target realm **MUST** already exist and **MUST** contain no existin
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-created-realm-admissibility`
 
-In `created` mode the plugin **MUST** probe the generated realm name first: an absent realm is created with the plugin ownership marker (`cf.provisioning.tenant_id = {tenant_id}`); a realm already marked for the same tenant **MUST** be adopted idempotently (provisioning replay); a realm owned by another tenant or lacking the marker **MUST** be rejected without mutation. Operator `realm_defaults` pass-through **MUST** be restricted to a fail-closed allowlist (`displayNameHtml`, `defaultLocale`, `supportedLocales`, `internationalizationEnabled`); any other key fails before provider access. A create attempt whose response is lost **MUST** reconcile by re-probing before classifying the outcome.
+In `created` mode the plugin **MUST** probe the target realm name first — generated as `realm-{tenant_id}` for a child tenant, operator-supplied for a root target: an absent realm is created with the plugin ownership marker (`cf.provisioning.tenant_id = {tenant_id}`); a realm already marked for the same tenant **MUST** be adopted idempotently (provisioning replay); a realm owned by another tenant or lacking the marker **MUST** be rejected without mutation. Operator `realm_defaults` pass-through **MUST** be restricted to a fail-closed allowlist (`displayNameHtml`, `defaultLocale`, `supportedLocales`, `internationalizationEnabled`); any other key fails before provider access. A create attempt whose response is lost **MUST** reconcile by re-probing before classifying the outcome.
 
 - **Rationale**: The plugin must not overwrite or assume ownership of an existing realm, and replayed provisioning must converge instead of failing or duplicating.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
@@ -336,7 +336,7 @@ The plugin **MUST** distinguish invalid pre-mutation requests (`InvalidInput` wi
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-provision`
 
-The plugin **MUST** create a user inside the resolved tenant identity boundary: the created representation carries the immutable `tenant_id` attribute and `user_type = "user"`, the configured required actions (default `VERIFY_EMAIL`, plus `UPDATE_PASSWORD` for temporary initial passwords), a coupled `emailVerified` derivation, and the optional initial password embedded in the create request; the user is then joined to the tenant group. If the group join fails after creation, the plugin **MUST** attempt best-effort orphan compensation (delete the created identity), report the compensation outcome on a dedicated metric, and return the original failure. A provider uniqueness conflict **MUST** be returned as `DuplicateUser` with the conflicting field refined from provider evidence where possible (`Username`, `Email`, or `UsernameOrEmail`). On success the plugin returns the provider-issued user projection.
+The plugin **MUST** create a user inside the resolved tenant identity boundary: the created representation carries the immutable `tenant_id` attribute and `user_type = "user"`, the configured required actions (default `VERIFY_EMAIL`, plus `UPDATE_PASSWORD` for temporary initial passwords), a coupled `emailVerified` derivation, and the optional initial password embedded in the create request; the user is then joined to the tenant group. If the group join fails after creation, the plugin **MUST** attempt best-effort orphan compensation (delete the created identity), report the compensation outcome on a dedicated metric, and return the original failure. A provider uniqueness conflict **MUST** be returned as `DuplicateUser` with the conflicting field refined from provider evidence where possible (`Username`, `Email`, or `UsernameOrEmail`). On success the plugin returns the provider-issued user id together with the submitted profile fields; it does not read the created representation back, so provider-side normalization is not reflected.
 
 - **Rationale**: Account Management needs a provider-neutral way to create identities while Keycloak remains the identity source of truth and half-created identities do not linger unbound.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`, `cpt-cf-keycloak-idp-plugin-actor-account-management`
@@ -372,7 +372,7 @@ Before any mutation, user deprovisioning **MUST** verify that the target user's 
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-query`
 
-The plugin **MUST** list only users belonging to the resolved tenant group. The supported filter surface is `eq` (exact) and `contains` (case-insensitive) over `username`, `email`, `first_name`, `last_name`, and `display_name`, an `id` point filter, and `and`/`or` composition; unsupported filter shapes **MUST** return `UnsupportedOperation` before any provider call. Results are globally sorted on `(created_at ASC, id ASC)` with the provider id as tiebreaker; requested orderings are not honored in this revision. Continuation **MUST** use a `CursorV1` token that pins the sort order, direction, last-emitted key, and a hash of the tenant, realm, and complete filter tree, so a cursor replayed with a different filter or tenant context is rejected as invalid. One bounded exception applies: cursors minted by the immediately preceding release **MUST** remain accepted during a rolling-deploy grace window under that release's weaker validation scope (tenant and id-filter only) until in-flight pagination drains, after which the fallback is retired (mechanism in [DESIGN §3.6](./DESIGN.md#36-interactions--sequences)). Page size **MUST** be capped (default cap 200). The per-request membership scan **MUST** be bounded by a hard cap (10,000 members); exceeding the cap truncates the scan and emits a loud operational warning rather than failing or silently hiding members.
+The plugin **MUST** list only users belonging to the resolved tenant group. The supported filter surface is `eq` (exact) and `contains` (case-insensitive) over `username`, `email`, `first_name`, `last_name`, and `display_name`, an `id` point filter, and `and`/`or` composition; unsupported filter shapes **MUST** return `UnsupportedOperation` before any provider call. Results are globally sorted on `(created_at ASC, id ASC)` with the provider id as tiebreaker; requested orderings are not honored in this revision. Continuation **MUST** use a `CursorV1` token that pins the sort order, direction, last-emitted key, and a hash of the tenant, realm, and complete filter tree, so a cursor replayed with a different filter or tenant context is rejected as invalid. One bounded exception applies: cursors minted by the immediately preceding release **MUST** remain accepted during a rolling-deploy grace window under that release's weaker validation scope (tenant, realm, and id-filter only — string filters are not revalidated) until in-flight pagination drains, after which the fallback is retired (mechanism in [DESIGN §3.6](./DESIGN.md#36-interactions--sequences)). Page size **MUST** be capped (default cap 200). The per-request membership scan **MUST** be bounded by a hard cap (10,000 members); exceeding the cap truncates the scan and emits a loud operational warning rather than failing or silently hiding members.
 
 - **Rationale**: Tenant administration and downstream membership checks need stable, correctly ordered queries without cross-tenant disclosure, with explicit and observable capacity bounds.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`, `cpt-cf-keycloak-idp-plugin-actor-account-management`
@@ -405,6 +405,7 @@ The plugin **MUST** implement creation, secret rotation, revocation, and listing
 
 The final client id **MUST** be server-built as `svc-{tenant_id}-{name}`, where `name` is caller-chosen, non-empty, at most 40 characters, and restricted to lowercase alphanumerics and `-`. Successful creation **MUST** return a stable client id, the principal's subject id (the service-account user UUID, usable for RBAC bindings), the OAuth token endpoint, and the client secret. A taken client id **MUST** be rejected as invalid input without side effects — including a half-created principal left by an earlier ambiguous failure; recovery is revoke-then-create. After successful revocation, the principal **MUST** disappear from active listings; reusing the same name **MUST** create a distinct provider identity with a new credential.
 
+- **Realizes**: `cpt-cf-service-principal-fr-name-policy` (owning contract: service-principal PRD).
 - **Rationale**: Stable identity and explicit lifecycle outcomes prevent duplicate or accidentally resurrected machine credentials, and a name collision must never hand out another consumer's live secret.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`
 
@@ -414,6 +415,7 @@ The final client id **MUST** be server-built as `svc-{tenant_id}-{name}`, where 
 
 Every service principal **MUST** be associated with exactly one tenant: the client carries the ownership marker (`cf.provisioning.tenant_id`), and its service-account user carries the `tenant_id` attribute and the configured service-principal subject type, so issued tokens identify the principal, its owning tenant, and the machine subject class through the realm's protocol mappers. Requested client scopes **MUST** be validated against the configured allowlist (empty allowlist = none attachable), and an allowlisted scope missing from the realm **MUST** fail cleanly with an operator-actionable message. A best-effort per-tenant quota (default 10) **MUST** bound creation; it is an operational guard, not a security boundary. Ownership **MUST** be enforced on every read and mutation: a principal that is absent or owned by another tenant is reported as not found, without distinguishing the two.
 
+- **Realizes**: `cpt-cf-service-principal-fr-scope-allowlist` and `cpt-cf-service-principal-fr-tenant-quota` (owning contract: service-principal PRD, which leaves both to the adapter).
 - **Rationale**: Explicit tenant ownership and authentication compatibility prevent cross-tenant machine access and cross-tenant existence disclosure.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`
 
@@ -430,7 +432,7 @@ Successful rotation **MUST** preserve the principal identity (client id, subject
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-list`
 
-Listing **MUST** return only principals owned by the requested tenant (prefix plus ownership-marker check enforced client-side over the provider's search results) and **MUST** omit credentials. The listing reports each principal's client id, enabled state, and attached client scopes as reported by the provider (including realm-default scopes). Cursor pagination and deterministic ordering for large principal sets are a p2 extension of the owning contract.
+Listing **MUST** return only principals owned by the requested tenant (prefix plus ownership-marker check enforced client-side over the provider's search results) and **MUST** omit credentials. The listing reports each principal's client id, enabled state, and attached client scopes as reported by the provider (including realm-default scopes). Listing is unpaginated by decision of the owning contract (service-principal PRD §4.2 places pagination out of scope); adding it would require an SPI change owned by the service-principal gear.
 
 - **Rationale**: A bounded query contract prevents cross-tenant disclosure; today's consumer population per tenant is small enough for unpaginated listing.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`
@@ -522,7 +524,7 @@ The plugin **MUST** return a classified, redacted outcome for every supported ca
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-operational-metrics`
 
-The plugin **MUST** emit bounded-cardinality operational metrics (`keycloak_idp_plugin_*`): operation duration histograms, a failure counter labeled by operation and stable failure variant, token/credential refresh counters split by tier so Credential Store and Keycloak failures are separately attributable, credential-store write outcomes, metadata decode failures, orphan-compensation outcomes, and a bound-realms gauge. Every metric label **MUST** be a closed set except the realm label, which **MUST** be subject to a configurable cardinality cap (default 500) after which it is dropped with an observable warning. No metric **MUST** carry secrets or user profile values.
+The plugin **MUST** emit bounded-cardinality operational metrics (`keycloak_idp_plugin_*`): operation duration histograms, a failure counter labeled by operation and stable failure variant, token/credential refresh counters split by tier so Credential Store and Keycloak failures are separately attributable, credential-store write outcomes, metadata decode failures, orphan-compensation outcomes, and a bound-realms gauge. Every metric label **MUST** be a closed set except two: the realm label, which **MUST** be subject to a configurable cardinality cap (default 500) after which it is dropped with an observable warning; and `version_observed` on the metadata-decode counter, which carries the observed version string uncapped. No metric **MUST** carry secrets or user profile values.
 
 - **Rationale**: Bounded, stable-labeled metrics keep the operational surface alertable without cost or cardinality surprises.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
@@ -617,7 +619,7 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 
 | Quality category | Disposition | Product rationale or obligation |
 |------------------|-------------|---------------------------------|
-| Performance and capacity | Required here | V1 lifecycle latency and scan bounds are defined in §6.1. Service-principal listing capacity remains a p2 obligation. Owning gears carry public REST latency. |
+| Performance and capacity | Required here | V1 lifecycle latency and scan bounds are defined in §6.1. Service-principal listing is unpaginated by the owning contract's decision. Owning gears carry public REST latency. |
 | Reliability and availability | Required here | Failure classification, audit completeness, and availability recovery are defined in §6.1. |
 | Security and privacy | Required here and inherited | Tenant isolation, secret protection, and PII minimization are defined here; platform controls come from the Security Guidelines. |
 | Observability and operations | Required here | Releases must provide readiness, dependency-health, ambiguous-outcome, and audit signals plus operator alert guidance and a reconciliation runbook. |
@@ -711,7 +713,8 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 - Later tenant and user operations route through the returned metadata.
 
 **Alternative Flows**:
-- **Realm missing or provider unreachable**: The plugin returns a classified clean failure without mutation.
+- **Realm missing**: The plugin returns a clean failure without mutation.
+- **Provider unreachable mid-saga**: A pre-saga probe failure is clean; a 5xx or transport failure on the existence check itself is reported ambiguous and blocks retry pending reconciliation.
 - **Admin user already bound elsewhere**: The plugin returns a stage-attributed ambiguous outcome for reconciliation without overwriting the binding.
 
 #### Adopt an Existing Tenant Realm
@@ -746,12 +749,12 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 **Actor**: `cpt-cf-keycloak-idp-plugin-actor-account-management`
 
 **Preconditions**:
-- Account Management supplies valid `created` provisioning intent without a realm name.
+- Account Management supplies valid `created` provisioning intent: without a realm name for a child tenant, or with an explicit realm name for a root target.
 - The bootstrap admin has realm-creation authority.
 
 **Main Flow**:
 1. Account Management requests tenant provisioning with created-realm intent.
-2. The plugin probes `realm-{tenant_id}`: absent → creates it with the ownership marker and allowlisted operator defaults; already ours → adopts idempotently.
+2. The plugin probes the target realm (`realm-{tenant_id}` for a child tenant, the operator-supplied name for a root target): absent → creates it with the ownership marker and allowlisted operator defaults; already ours → adopts idempotently.
 3. The plugin creates the realm-admin client and grants it the least-privilege role set.
 4. The plugin places the realm-admin secret in the Credential Store under the templated reference before reporting success, then ensures the tenant group under the new realm admin.
 5. The plugin returns metadata carrying the realm binding and secret reference.
@@ -875,7 +878,7 @@ Not available in this revision: `update_user` returns `UnsupportedOperation`. Wh
 ### V1 Acceptance
 
 - [ ] Account Management selects the plugin through its published catalogue instance and vendor/priority configuration; catalogue drift on restart fails initialization instead of silently rebinding.
-- [ ] Provisioning intent is parsed fail-closed: unknown modes and keys are rejected; absent mode defaults to shared; shared child tenants inherit the parent realm; created mode generates `realm-{tenant_id}` and rejects explicit realm names; adopted mode requires an existing empty realm.
+- [ ] Provisioning intent is parsed fail-closed: unknown modes and keys are rejected; absent mode defaults to shared; shared child tenants inherit the parent realm; created mode generates `realm-{tenant_id}` for child tenants and rejects an explicit realm name there, while a root target requires one; adopted mode requires an existing empty realm.
 - [ ] Metadata envelopes decode fail-closed (missing/unsupported version, malformed shape) with observable decode-failure metrics, and metadata from every version in the supported window remains readable for normal operations and hard deprovisioning.
 - [ ] Created-mode provisioning is replay-safe: a marked realm is adopted idempotently, a foreign realm is rejected cleanly, a lost create reconciles by re-probe, and the realm-admin secret lands in the Credential Store before success is reported.
 - [ ] Hard deprovisioning purges the tenant's service principals before boundary removal, deletes the tenant group, tears down created realms and their secrets on last-tenant retirement, and never deletes shared/adopted realms or other tenants' resources.
@@ -896,7 +899,6 @@ Not available in this revision: `update_user` returns `UnsupportedOperation`. Wh
 - [ ] `update_user` implements the SDK contract (partial update semantics, immutable identity/tenant binding, duplicate/password-policy/not-found classification) and passes the provider contract suite.
 - [ ] A read-only realm authentication-profile verifier gates tenant binding on shared/adopted realms before promotion of profile verification.
 - [ ] A runtime provider-version gate fails affected operations deterministically on unsupported majors without preventing host startup.
-- [ ] Service-principal listing gains cursor pagination and deterministic ordering under the owning contract before large-population support is claimed.
 
 ## 10. Dependencies
 
@@ -907,7 +909,8 @@ Not available in this revision: `update_user` returns `UnsupportedOperation`. Wh
 | Keycloak 26.x | Provides realm, group, user, session, client, and credential administration over Admin REST and OAuth token endpoints, reached directly over HTTPS. | p1 |
 | Credential Store | Holds adopted/created realm-admin secrets and the optional TLS CA bundle; written by the plugin for created realms under its stable system actor. | p1 |
 | types-registry | Hosts the provider catalogue instance; publication is a hard initialization prerequisite. | p1 |
-| service-principal-sdk | Platform-owned machine-identity contract implemented by this plugin and consumed by trusted platform modules. | p1 |
+| service-principal gear | Owns the machine-identity product (requirements, REST surface, authorization) and consumes this plugin as its registered `ServicePrincipalClientV1` adapter. See [service-principal PRD](../../../../service-principal/docs/PRD.md). | p1 |
+| service-principal-sdk | Platform-owned machine-identity contract implemented by this plugin. | p1 |
 | OIDC AuthN Resolver Plugin | Validates Keycloak-issued tokens offline and consumes the claims projected by the realm mappers. It does not manage sessions or check per-identity revocation state. | p1 |
 | Operator realm bootstrap / IaC | Provisions shared/adopted realms, their authentication profile and protocol mappers, admin clients and secrets, and service-principal realm scopes. | p1 |
 | RBAC / Policy Engine | Makes authorization decisions outside this plugin, including the plugin system actor's Credential Store grants. | p1 |
@@ -938,7 +941,7 @@ Not available in this revision: `update_user` returns `UnsupportedOperation`. Wh
 | The plugin's init-time provider dependency breaks deployment ordering. | Host initialization fails when Keycloak is slow to become ready. | Bounded, tunable pre-warm budget with fast-bail on permanent errors; `enabled: false` escape hatch. |
 | Tenant-group membership grows past the scan cap. | Listings truncate (loudly) and hide the tail. | Hard-cap warning as the operational signal; realm-wide attribute-query evolution before larger populations are supported. |
 | An access JWT remains valid after user or tenant hard deprovisioning. | Access can continue until token expiry. | Limit v1 access-token lifetime to 15 minutes, revoke provider sessions, block refresh, and document the bounded exposure. |
-| Metric realm-label cardinality explodes in large fleets. | Metrics backend overload. | Configurable cardinality cap with label drop and a one-shot warning naming the tripping realm. |
+| Metric realm-label cardinality explodes in large fleets. | Metrics backend overload. | Configurable cardinality cap with label drop and a warning naming the tripping realm on every over-cap observation. |
 
 ## 13. Open Questions
 
@@ -951,14 +954,14 @@ The following questions gate only p2 promotion:
 | 1 | When is `update_user` promoted, and does it adopt JSON Merge Patch semantics end to end? | Determines profile-editing support through this provider. | Account Management Owner and Plugin Owner | Before user-update DESIGN |
 | 2 | Should realm authentication-profile verification become a plugin-side runtime gate, and what profile format does the operator publish for it? | Determines whether misconfigured realms fail binding deterministically. | Platform Architect and Plugin Owner | Before profile-verifier DESIGN |
 | 3 | Does a runtime Keycloak version gate replace release-time qualification as the compatibility guarantee? | Determines unsupported-version failure behavior. | Plugin Owner | Before compatibility-gate DESIGN |
-| 4 | What pagination, ordering, and quota semantics does service-principal listing adopt for large tenants? | Determines p2 listing and capacity tests. | Service-Principal Owner and Performance Architect | Before service-principal listing DESIGN |
-| 5 | Will a future authentication component enforce real-time token revocation? | Determines whether any future release can promise rejection before JWT expiry. | Security Architect and AuthN Owner | Before real-time revocation requirements are added |
+| 4 | Will a future authentication component enforce real-time token revocation? | Determines whether any future release can promise rejection before JWT expiry. | Security Architect and AuthN Owner | Before real-time revocation requirements are added |
 
 ## 14. Traceability
 
 - **Parent PRD**: [Account Management PRD](../../../docs/PRD.md)
 - **Identity Provider SDK**: [`idp.rs`](../../../account-management-sdk/src/idp.rs) and [`idp_user.rs`](../../../account-management-sdk/src/idp_user.rs)
 - **Service-Principal SDK**: [`service-principal-sdk`](../../../../service-principal/service-principal-sdk/src/api.rs)
+- **Service-Principal product (owning contract)**: [PRD](../../../../service-principal/docs/PRD.md) and [DESIGN](../../../../service-principal/docs/DESIGN.md)
 - **Implementation**: [`plugins/keycloak-idp-plugin`](../src/lib.rs) (crate `cf-gears-keycloak-idp-plugin`)
 - **OIDC AuthN contract**: [OIDC AuthN Resolver Plugin PRD](../../../../authn-resolver/plugins/oidc-authn-plugin/docs/PRD.md)
 - **Realm-strategy relationship**: V1 supports explicit `shared` (default, parent-inherited for children), `adopted`, and `created` provisioning intent with fail-closed parsing.

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/PRD.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/PRD.md
@@ -165,10 +165,10 @@ flowchart LR
 ### 3.1 Gear-Specific Environment Constraints
 
 - The deployment must provide a reachable Keycloak administration surface and the bootstrap admin client credentials. When the plugin is enabled, module initialization pre-warms the bootstrap admin token with a bounded retry budget and fails host initialization if the budget is exhausted; deployments that must start without Keycloak disable the plugin (`enabled: false`).
-- Operator realm bootstrap must provision the authentication profile of shared and adopted realms: required clients, client scopes, the `tenant_id`/`user_type` usermodel-attribute protocol mappers, signing/session/token policy, and the realm-admin client with its secret.
+- Operator realm bootstrap must provision the authentication profile of shared and adopted realms: required clients, client scopes, the protocol mappers that project the `tenant_id` and `user_type` claims, signing/session/token policy, and the realm-admin client with its secret.
 - Account Management must provide the tenant context and replayed provider-owned metadata required to route existing-tenant operations.
 - The Credential Store must be available for operations that resolve adopted/created realm-admin secrets, for created-realm provisioning and teardown, and at initialization when a TLS CA bundle reference is configured.
-- The deployment must select one unambiguous active provider (Account Management `idp.vendor` matching the plugin's configured vendor, default `virtuozzo`). Changing that provider while tenant metadata exists requires an explicit operator migration.
+- The deployment must select one unambiguous active provider. Account Management's `idp.vendor` defaults to `cf`, which selects the built-in static echo plugin — it **MUST** be explicitly set to this plugin's configured vendor (default `virtuozzo`); otherwise Account Management selects another provider or, with `idp.required = false`, silently falls back to the no-op provider without any error from this plugin. Changing the provider while tenant metadata exists requires an explicit operator migration.
 
 ## 4. Scope
 
@@ -316,7 +316,7 @@ Tenant deprovisioning **MUST** delete every service-principal client owned by th
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-tenant-user-access-termination`
 
-Account Management does not invoke this plugin for tenant suspension or soft deletion, so those transitions **MUST NOT** be presented as plugin-enforced access termination. Human identities are removed through per-user `deprovision_user` calls issued by Account Management's hard-delete pipeline before the tenant boundary is retired; tenant deprovisioning itself removes the boundary (group, service principals, and — for created bindings — the realm). `IdpDeprovisionFailure::Retryable` applies to failures where nothing was attempted (pre-saga probe failure) or where the failed step is safe to repeat; a malformed metadata blob or an unclassifiable purge failure **MUST** return `Terminal` for operator action. An access JWT issued before hard deprovisioning can remain valid until its `exp`, which **MUST NOT** exceed 15 minutes in the operator's v1 authentication profile.
+Account Management does not invoke this plugin for tenant suspension or soft deletion, so those transitions **MUST NOT** be presented as plugin-enforced access termination. Human identities are removed through per-user `deprovision_user` calls issued by Account Management's hard-delete pipeline before the tenant boundary is retired; tenant deprovisioning itself removes the boundary (group, service principals, and — for created bindings — the realm). Failure classification for the deprovisioning saga follows `cpt-cf-keycloak-idp-plugin-fr-tenant-failure-contract`. An access JWT issued before hard deprovisioning can remain valid until its `exp`, bounded per `cpt-cf-keycloak-idp-plugin-fr-offline-token-lifetime`.
 
 - **Rationale**: This contract matches Account Management's hard-deletion pipeline and the OIDC resolver's offline JWT model without promising an unavailable suspension or real-time revocation path.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
@@ -363,7 +363,7 @@ When user update is implemented, the plugin **MUST** distinguish an absent user,
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-deprovision`
 
-Before any mutation, user deprovisioning **MUST** verify that the target user's stored `tenant_id` attribute matches the resolved tenant; a mismatch **MUST** perform no mutation and **MUST** return success-equivalently without disclosing whether the identity exists (the cross-tenant deletion guard). It then revokes provider sessions (best-effort, configurable, default on) and deletes the identity. An already-absent provider identity (404/410) **MUST** produce a success-equivalent outcome. The plugin **MUST NOT** claim that it invalidates a previously issued access JWT; such a token can remain valid until its `exp`, which **MUST NOT** exceed 15 minutes in the operator's v1 authentication profile.
+Before any mutation, user deprovisioning **MUST** verify that the target user's stored `tenant_id` attribute matches the resolved tenant; a mismatch **MUST** perform no mutation and **MUST** return success-equivalently without disclosing whether the identity exists (the cross-tenant deletion guard). It then revokes provider sessions (best-effort, configurable, default on) and deletes the identity. An already-absent provider identity (404/410) **MUST** produce a success-equivalent outcome. The plugin **MUST NOT** claim that it invalidates a previously issued access JWT; such a token can remain valid until its `exp`, bounded per `cpt-cf-keycloak-idp-plugin-fr-offline-token-lifetime`.
 
 - **Rationale**: Deprovisioning blocks refresh and new provider sessions, stays idempotent, and cannot be used to delete another tenant's identity.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`, `cpt-cf-keycloak-idp-plugin-actor-account-management`
@@ -372,7 +372,7 @@ Before any mutation, user deprovisioning **MUST** verify that the target user's 
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-query`
 
-The plugin **MUST** list only users belonging to the resolved tenant group. The supported filter surface is `eq` (exact) and `contains` (case-insensitive) over `username`, `email`, `first_name`, `last_name`, and `display_name`, an `id` point filter, and `and`/`or` composition; unsupported filter shapes **MUST** return `UnsupportedOperation` before any provider call. Results are globally sorted on `(created_at ASC, id ASC)` with the provider id as tiebreaker; requested orderings are not honored in this revision. Continuation **MUST** use a `CursorV1` token that pins the sort order, direction, last-emitted key, and a hash of the tenant, realm, and complete filter tree, so a cursor replayed with a different filter or tenant context is rejected as invalid. Page size **MUST** be capped (default cap 200). The per-request membership scan **MUST** be bounded by a hard cap (10,000 members); exceeding the cap truncates the scan and emits a loud operational warning rather than failing or silently hiding members.
+The plugin **MUST** list only users belonging to the resolved tenant group. The supported filter surface is `eq` (exact) and `contains` (case-insensitive) over `username`, `email`, `first_name`, `last_name`, and `display_name`, an `id` point filter, and `and`/`or` composition; unsupported filter shapes **MUST** return `UnsupportedOperation` before any provider call. Results are globally sorted on `(created_at ASC, id ASC)` with the provider id as tiebreaker; requested orderings are not honored in this revision. Continuation **MUST** use a `CursorV1` token that pins the sort order, direction, last-emitted key, and a hash of the tenant, realm, and complete filter tree, so a cursor replayed with a different filter or tenant context is rejected as invalid. One bounded exception applies: cursors minted by the immediately preceding release **MUST** remain accepted during a rolling-deploy grace window under that release's weaker validation scope (tenant and id-filter only) until in-flight pagination drains, after which the fallback is retired (mechanism in [DESIGN §3.6](./DESIGN.md#36-interactions--sequences)). Page size **MUST** be capped (default cap 200). The per-request membership scan **MUST** be bounded by a hard cap (10,000 members); exceeding the cap truncates the scan and emits a loud operational warning rather than failing or silently hiding members.
 
 - **Rationale**: Tenant administration and downstream membership checks need stable, correctly ordered queries without cross-tenant disclosure, with explicit and observable capacity bounds.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`, `cpt-cf-keycloak-idp-plugin-actor-account-management`
@@ -477,7 +477,7 @@ The plugin **MUST** classify every failed service-principal call into the closed
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-administrator-credentials`
 
-The plugin **MUST** administer Keycloak through two confidential-client tiers with `client_credentials` grants: an operator-provisioned bootstrap admin (default `vp-idp-plugin-bootstrap` in `master`) for realm-level work, and a per-realm realm admin (default `vp-idp-plugin-realm-admin`) for tenant/user work. Realm-admin clients created by the plugin (created mode) **MUST** be granted exactly the least-privilege role set (`view-realm`, `view-clients`, `query-groups`, `manage-realm`, `manage-users`, `query-users`, `manage-clients`). Secrets **MUST** enter the process only through environment-expanded configuration (bootstrap, default shared realm) or the Credential Store (adopted/created realms), always inside redacted wrapper types. Operator secret rotation **MUST** converge without process restart: a provider 401 invalidates the cached token, re-resolves the secret from its source, and retries exactly once. Cached tokens **MUST** be redacted from all debug output.
+The plugin **MUST** administer Keycloak through two confidential-client tiers with `client_credentials` grants: an operator-provisioned bootstrap admin (default `vp-idp-plugin-bootstrap` in `master`) for realm-level work, and a per-realm realm admin (default `vp-idp-plugin-realm-admin`) for tenant/user work. Realm-admin clients created by the plugin (created mode) **MUST** be granted exactly the least-privilege role set (`view-realm`, `view-clients`, `query-groups`, `manage-realm`, `manage-users`, `query-users`, `manage-clients`). Secrets **MUST** enter the process only through environment-expanded configuration (bootstrap, default shared realm) or the Credential Store (adopted/created realms). Operator secret rotation **MUST** converge without process restart. Administrator secrets and cached tokens **MUST NOT** appear in any log, metric, or debug output (mechanism in [DESIGN §3.6](./DESIGN.md#36-interactions--sequences)).
 
 - **Rationale**: Provider administrator compromise can affect every identity in the authorized realm; tiered least privilege, typed secret custody, and reactive rotation bound that risk.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
@@ -486,7 +486,7 @@ The plugin **MUST** administer Keycloak through two confidential-client tiers wi
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-external-mutation-resilience`
 
-Automatic transport retry **MUST** be bounded (configurable policy; default 3 retries, exponential backoff with full jitter, `Retry-After` honored) and restricted to idempotent requests on retryable causes (provider 5xx/429, connect/timeout); administrative `POST`s **MUST NOT** be replayed on transport failure. Tenant provisioning **MUST** preserve the SDK distinction between clean and ambiguous outcomes and **MUST** stop automatic retry after an ambiguous result. User operations **MUST** return only outcomes exposed by `IdpUserOperationFailure`; the plugin **MUST NOT** invent an ambiguity variant. Repeated user deprovisioning remains idempotent, and provider diagnostics **MUST** be redacted and truncated before leaving the plugin.
+Automatic retry **MUST** be bounded by a configurable policy, and a request whose outcome is unknown (transport loss) **MUST NOT** be replayed unless it is idempotent; in particular, administrative `POST`s are never replayed on transport failure (retry mechanics in [DESIGN §3.6](./DESIGN.md#36-interactions--sequences)). Tenant provisioning **MUST** preserve the SDK distinction between clean and ambiguous outcomes and **MUST** stop automatic retry after an ambiguous result. User operations **MUST** return only outcomes exposed by `IdpUserOperationFailure`; the plugin **MUST NOT** invent an ambiguity variant. Repeated user deprovisioning remains idempotent, and provider diagnostics **MUST** be redacted and truncated before leaving the plugin.
 
 - **Rationale**: Unbounded or unsafe retry can duplicate resources, leak realms, or invalidate credentials.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
@@ -495,7 +495,7 @@ Automatic transport retry **MUST** be bounded (configurable policy; default 3 re
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-operator-reconciliation`
 
-For v1, ambiguous-state reconciliation **MUST** be an operator-owned workflow rather than a public mutation API. The plugin **MUST** provide sufficient non-secret evidence — the machine-parsable `ambig:{stage}` token (realm create, client create, role mapping, secret read, credential-store write, admin-user bind, scope attach, secret rotate, client delete, timeout), the realm, and redacted provider detail — to determine resource ownership and whether the mutation completed. The workflow **MUST** end in one audited outcome: compensated and safe to retry, accepted as complete, still blocked for further investigation, or escalated for controlled cleanup. Production enablement **MUST** include a reconciliation runbook keyed on the stage tokens.
+For v1, ambiguous-state reconciliation **MUST** be an operator-owned workflow rather than a public mutation API. The plugin **MUST** provide sufficient non-secret evidence — the machine-parsable `ambig:{stage}` token (realm create, client create, role mapping, secret read, credential-store write, admin-user bind, service-account attribute set, scope attach, secret rotate, client delete, timeout), the realm, and redacted provider detail — to determine resource ownership and whether the mutation completed. The workflow **MUST** end in one audited outcome: compensated and safe to retry, accepted as complete, still blocked for further investigation, or escalated for controlled cleanup. Production enablement **MUST** include a reconciliation runbook keyed on the stage tokens.
 
 - **Rationale**: Operators need a safe resolution path even where current contracts cannot automatically distinguish an orphan from an already-clean resource.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
@@ -509,14 +509,23 @@ The operator's v1 realm authentication profile **MUST** limit access-token lifet
 - **Rationale**: This bounded exposure matches the OIDC resolver's offline JWT validation contract and its explicit exclusion of session and revocation management.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-authn-resolver`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`
 
-#### Audit and Metrics
+#### Audit Evidence
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-audit-metrics`
 
-The plugin **MUST** return a classified, redacted outcome for every supported call and **MUST** emit structured audit events on the dedicated `vp.idp.plugin.events` tracing target for every mutating tenant and user lifecycle transition: `tenant.bound`, `realm.created`, `admin_user.bound`, `tenant.unbound`, `realm.removed`, `service_principals.purged`, `user.provisioned`, and `user.deprovisioned`, each carrying the acting subject (id, classified type, raw type, tenant) and provider identifiers. `user.provisioned` additionally records the username as operational evidence; no event carries secrets, passwords, tokens, or raw provider bodies. These emitters are a development stand-in: Account Management and the platform audit owner **MUST** create and durably deliver the terminal audit outcome for each mutating plugin call before production enablement. The plugin **MUST** emit bounded-cardinality operational metrics (`vp_idp_plugin_*`): operation duration histograms, a failure counter labeled by operation and stable failure variant, token/credential refresh counters split by tier, credential-store write outcomes, metadata decode failures, orphan-compensation outcomes, and a bound-realms gauge — with the realm label subject to a configurable cardinality cap (default 500) after which it is dropped with a warning.
+The plugin **MUST** return a classified, redacted outcome for every supported call and **MUST** emit structured audit events on the dedicated `vp.idp.plugin.events` tracing target for every mutating tenant and user lifecycle transition: `tenant.bound`, `realm.created`, `admin_user.bound`, `tenant.unbound`, `realm.removed`, `service_principals.purged`, `user.provisioned`, and `user.deprovisioned`, each carrying the acting subject (id, classified type, raw type, tenant) and provider identifiers. `user.provisioned` additionally records the username as operational evidence; no event carries secrets, passwords, tokens, or raw provider bodies. These emitters are a development stand-in: Account Management and the platform audit owner **MUST** create and durably deliver the terminal audit outcome for each mutating plugin call before production enablement.
 
-- **Rationale**: A single owner for each durable record prevents duplicate or missing audit events while preserving plugin-level diagnostic evidence with bounded cost.
-- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
+- **Rationale**: A single owner for each durable record prevents duplicate or missing audit events while preserving plugin-level diagnostic evidence.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
+
+#### Operational Metrics
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-operational-metrics`
+
+The plugin **MUST** emit bounded-cardinality operational metrics (`vp_idp_plugin_*`): operation duration histograms, a failure counter labeled by operation and stable failure variant, token/credential refresh counters split by tier so Credential Store and Keycloak failures are separately attributable, credential-store write outcomes, metadata decode failures, orphan-compensation outcomes, and a bound-realms gauge. Every metric label **MUST** be a closed set except the realm label, which **MUST** be subject to a configurable cardinality cap (default 500) after which it is dropped with an observable warning. No metric **MUST** carry secrets or user profile values.
+
+- **Rationale**: Bounded, stable-labeled metrics keep the operational surface alertable without cost or cardinality surprises.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
 
 ## 6. Non-Functional Requirements
 
@@ -538,7 +547,7 @@ The plugin **MUST** prevent an operation resolved for one tenant from reading or
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-secret-nondisclosure`
 
-The plugin **MUST** prevent administrator tokens, administrator secrets, user passwords, and service-principal secrets from appearing in logs, metrics, audit events, list responses, or debug output. Concretely: secrets live in redacted wrapper types, the token cache redacts its debug output, and every provider error body passes secret-pattern redaction plus 2 KiB truncation before leaving the plugin.
+The plugin **MUST** prevent administrator tokens, administrator secrets, user passwords, and service-principal secrets from appearing in logs, metrics, audit events, list responses, or debug output. Provider diagnostics **MUST** be redacted and size-bounded before leaving the plugin (mechanism in [DESIGN §4.1](./DESIGN.md#41-security-and-data-protection)).
 
 - **Threshold**: Zero secret values detected by automated redaction tests and security scanning across all named output surfaces.
 - **Rationale**: These credentials can grant user or machine access across a tenant or realm.
@@ -548,7 +557,7 @@ The plugin **MUST** prevent administrator tokens, administrator secrets, user pa
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-lifecycle-latency`
 
-On the release qualification profile, shared-realm tenant provisioning **MUST** complete within 5 seconds at p95; created-realm provisioning within 10 seconds at p95. User creation, deprovisioning, and a full query page **MUST** each complete within 1 second at p95. The profile **MUST** use 20 concurrent operations, an operator-equivalent Keycloak 26.x node backed by PostgreSQL, at most 5 ms network round-trip time between the plugin and Keycloak, and up to 1,000 human identities, enabled or disabled, in one tenant group. Query runs **MUST** cover unfiltered results and filters matching approximately 100%, 10%, and 1% of the group, over cached-token and forced-token-refresh runs. Operational bounds enforced by the implementation and validated by the profile: per-request provider timeout (default 5 s), bounded retry policy, 30 s saga timeout, caller page size capped at 200, and the 10,000-member scan hard cap with loud truncation.
+On the release qualification profile, shared-realm tenant provisioning **MUST** complete within 5 seconds at p95; created-realm provisioning within 10 seconds at p95. User creation, deprovisioning, and a full query page **MUST** each complete within 1 second at p95. The profile **MUST** use 20 concurrent operations, an operator-equivalent Keycloak 26.x node backed by PostgreSQL, at most 5 ms network round-trip time between the plugin and Keycloak, and up to 1,000 human identities, enabled or disabled, in one tenant group. The query run matrix (filter-selectivity mix and token-cache states) is defined in [DESIGN §4.2](./DESIGN.md#42-verification-architecture). Operational bounds enforced by the implementation and validated by the profile: per-request provider timeout, bounded retry policy, saga timeout, caller page size cap, and the membership-scan hard cap with loud truncation (values in [DESIGN §§2.2, 3.6](./DESIGN.md#22-constraints)).
 
 - **Threshold**: Shared provisioning p95 ≤ 5 s; created provisioning p95 ≤ 10 s; each named user operation p95 ≤ 1 s; 20 concurrent operations; scan cap 10,000 members per tenant group with observable truncation.
 - **Rationale**: A fixed population, topology, filter mix, and bound set make the linear-scan acceptance test reproducible.
@@ -743,8 +752,8 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 **Main Flow**:
 1. Account Management requests tenant provisioning with created-realm intent.
 2. The plugin probes `realm-{tenant_id}`: absent → creates it with the ownership marker and allowlisted operator defaults; already ours → adopts idempotently.
-3. The plugin creates the realm-admin client, grants the least-privilege role set, and reads back the generated secret.
-4. The plugin stores the secret in the Credential Store under the templated reference (point of no return), then ensures the tenant group under the new realm admin.
+3. The plugin creates the realm-admin client and grants it the least-privilege role set.
+4. The plugin places the realm-admin secret in the Credential Store under the templated reference before reporting success, then ensures the tenant group under the new realm admin.
 5. The plugin returns metadata carrying the realm binding and secret reference.
 
 **Postconditions**:
@@ -849,7 +858,7 @@ Not available in this revision: `update_user` returns `UnsupportedOperation`. Wh
 - Automatic retries for the affected resource are blocked.
 
 **Main Flow**:
-1. The operator follows the reconciliation runbook, keyed on the stage token (realm create, client create, role mapping, secret read, credential-store write, admin-user bind, scope attach, secret rotate, client delete, timeout).
+1. The operator follows the reconciliation runbook, keyed on the stage token (realm create, client create, role mapping, secret read, credential-store write, admin-user bind, service-account attribute set, scope attach, secret rotate, client delete, timeout).
 2. The operator reviews non-secret evidence (stage, realm, redacted provider detail) to determine resource and ownership state.
 3. The operator applies an approved resolution and records the terminal outcome.
 
@@ -910,6 +919,7 @@ Not available in this revision: `update_user` returns `UnsupportedOperation`. Wh
 - Account Management's hard-delete pipeline deprovisions a tenant's users before invoking tenant deprovisioning.
 - Operators provision the shared/adopted realms, their authentication profile (including the `tenant_id`/`user_type` mappers and 15-minute access-token lifetime), the bootstrap admin client, and the shared-realm admin secret they own.
 - Deployment ordering makes Keycloak's token endpoint reachable within the plugin's init pre-warm budget, or the plugin is disabled for that deployment.
+- Deployments explicitly set `account-management.idp.vendor` to this plugin's vendor; Account Management's default (`cf`) selects the static echo plugin, and misselection is silent.
 - Provider-owned metadata is persisted and replayed opaquely by Account Management.
 - The OIDC AuthN Resolver validates access tokens offline and does not depend on current per-identity revocation state.
 - Service-principal consumers are trusted platform modules that authorize their own callers and take immediate durable custody of returned credentials.
@@ -922,7 +932,7 @@ Not available in this revision: `update_user` returns `UnsupportedOperation`. Wh
 | An external mutation completes after the caller loses the response. | Duplicate or orphaned identity resources or credentials. | Idempotent replay paths (realm ensure re-probe, group 409 reuse), stage-attributed ambiguous outcomes, no blind retry, reconciliation runbook. |
 | Administrator credentials grant broader access than required. | Compromise can affect unrelated tenants or realms. | Two-tier admin model, exact least-privilege role grants on created realms, typed secret custody, rotation convergence, and secret non-disclosure tests. |
 | Provider metadata becomes unreadable after upgrade or rollback. | Existing tenants cannot be administered or retired safely. | Versioned fail-closed envelope, decode-failure metrics, and compatibility coverage for supported upgrade paths. |
-| The Credential Store write fails after created-realm Keycloak state exists. | Realm exists without retrievable admin credentials. | Explicit `ambig:openbao_put_after_kc_success` stage, reconciliation runbook, replayable provisioning that overwrites the secret last-writer-wins. |
+| The Credential Store write fails after created-realm Keycloak state exists. | Realm exists without retrievable admin credentials. | A dedicated ambiguity stage token for the post-provider secret-write window, the reconciliation runbook, and replay-safe provisioning that restores the stored secret. |
 | A service principal survives tenant retirement. | Machine access remains active after tenant deletion. | Purge barrier ordered before boundary teardown; purge failure aborts deprovisioning with retryable/terminal classification. |
 | Keycloak 26.x administration behavior changes across releases. | Lifecycle operations fail or produce different outcomes. | Qualify every supported 26.x release before publication; p2 runtime version gate. |
 | The plugin's init-time provider dependency breaks deployment ordering. | Host initialization fails when Keycloak is slow to become ready. | Bounded, tunable pre-warm budget with fast-bail on permanent errors; `enabled: false` escape hatch. |

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/PRD.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/PRD.md
@@ -262,7 +262,7 @@ An `adopted` target realm **MUST** already exist and **MUST** contain no existin
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-created-realm-admissibility`
 
-In `created` mode the plugin **MUST** probe the generated realm name first: an absent realm is created with the plugin ownership marker (`vhp.provisioning.tenant_id = {tenant_id}`); a realm already marked for the same tenant **MUST** be adopted idempotently (provisioning replay); a realm owned by another tenant or lacking the marker **MUST** be rejected without mutation. Operator `realm_defaults` pass-through **MUST** be restricted to a fail-closed allowlist (`displayNameHtml`, `defaultLocale`, `supportedLocales`, `internationalizationEnabled`); any other key fails before provider access. A create attempt whose response is lost **MUST** reconcile by re-probing before classifying the outcome.
+In `created` mode the plugin **MUST** probe the generated realm name first: an absent realm is created with the plugin ownership marker (`cf.provisioning.tenant_id = {tenant_id}`); a realm already marked for the same tenant **MUST** be adopted idempotently (provisioning replay); a realm owned by another tenant or lacking the marker **MUST** be rejected without mutation. Operator `realm_defaults` pass-through **MUST** be restricted to a fail-closed allowlist (`displayNameHtml`, `defaultLocale`, `supportedLocales`, `internationalizationEnabled`); any other key fails before provider access. A create attempt whose response is lost **MUST** reconcile by re-probing before classifying the outcome.
 
 - **Rationale**: The plugin must not overwrite or assume ownership of an existing realm, and replayed provisioning must converge instead of failing or duplicating.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
@@ -412,7 +412,7 @@ The final client id **MUST** be server-built as `svc-{tenant_id}-{name}`, where 
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-safeguards`
 
-Every service principal **MUST** be associated with exactly one tenant: the client carries the ownership marker (`vhp.provisioning.tenant_id`), and its service-account user carries the `tenant_id` attribute and the configured service-principal subject type, so issued tokens identify the principal, its owning tenant, and the machine subject class through the realm's protocol mappers. Requested client scopes **MUST** be validated against the configured allowlist (empty allowlist = none attachable), and an allowlisted scope missing from the realm **MUST** fail cleanly with an operator-actionable message. A best-effort per-tenant quota (default 10) **MUST** bound creation; it is an operational guard, not a security boundary. Ownership **MUST** be enforced on every read and mutation: a principal that is absent or owned by another tenant is reported as not found, without distinguishing the two.
+Every service principal **MUST** be associated with exactly one tenant: the client carries the ownership marker (`cf.provisioning.tenant_id`), and its service-account user carries the `tenant_id` attribute and the configured service-principal subject type, so issued tokens identify the principal, its owning tenant, and the machine subject class through the realm's protocol mappers. Requested client scopes **MUST** be validated against the configured allowlist (empty allowlist = none attachable), and an allowlisted scope missing from the realm **MUST** fail cleanly with an operator-actionable message. A best-effort per-tenant quota (default 10) **MUST** bound creation; it is an operational guard, not a security boundary. Ownership **MUST** be enforced on every read and mutation: a principal that is absent or owned by another tenant is reported as not found, without distinguishing the two.
 
 - **Rationale**: Explicit tenant ownership and authentication compatibility prevent cross-tenant machine access and cross-tenant existence disclosure.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`
@@ -686,7 +686,7 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 
 - **Direction**: required from client (`CredStoreClientV1` via ClientHub)
 - **Protocol/Format**: Platform secret-storage contract, invoked under the plugin's stable system actor
-- **Compatibility**: The plugin reads adopted/created realm-admin secrets and the optional TLS CA bundle, and writes/deletes created-realm admin secrets under the templated reference (`vp-idp-realm-admin-{realm_name}-secret` by default). References remain stable across rotation; secret values never enter provider metadata, logs, or metrics.
+- **Compatibility**: The plugin reads adopted/created realm-admin secrets and the optional TLS CA bundle, and writes/deletes created-realm admin secrets under the templated reference (`keycloak-idp-realm-admin-{realm_name}-secret` by default). References remain stable across rotation; secret values never enter provider metadata, logs, or metrics.
 
 ## 8. Use Cases
 
@@ -959,7 +959,7 @@ The following questions gate only p2 promotion:
 - **Parent PRD**: [Account Management PRD](../../../docs/PRD.md)
 - **Identity Provider SDK**: [`idp.rs`](../../../account-management-sdk/src/idp.rs) and [`idp_user.rs`](../../../account-management-sdk/src/idp_user.rs)
 - **Service-Principal SDK**: [`service-principal-sdk`](../../../../service-principal/service-principal-sdk/src/api.rs)
-- **Implementation**: [`plugins/keycloak-idp-plugin`](../src/lib.rs) (crate `cf-gears-keycloak-idp-plugin`, ported from vhp-core)
+- **Implementation**: [`plugins/keycloak-idp-plugin`](../src/lib.rs) (crate `cf-gears-keycloak-idp-plugin`)
 - **OIDC AuthN contract**: [OIDC AuthN Resolver Plugin PRD](../../../../authn-resolver/plugins/oidc-authn-plugin/docs/PRD.md)
 - **Realm-strategy relationship**: V1 supports explicit `shared` (default, parent-inherited for children), `adopted`, and `created` provisioning intent with fail-closed parsing.
 - **Migration requirements**: Tenant hard deprovisioning requires the service-principal purge barrier and boundary teardown ordering; user removal happens through per-user deprovisioning before tenant retirement.

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/PRD.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/PRD.md
@@ -306,7 +306,7 @@ Before p2 service-principal support is promoted, its owner and Account Managemen
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-tenant-user-access-termination`
 
-Account Management does not invoke this plugin for tenant suspension or soft deletion, so those transitions **MUST NOT** be presented as plugin-enforced access termination. During hard deprovisioning, the plugin **MUST** revoke provider sessions and delete every human identity bound to the retiring tenant. It **MUST NOT** delete identities or memberships belonging to another active tenant. The plugin **MUST** return `IdpDeprovisionFailure::Terminal` for operator action when session revocation or identity removal cannot be proven. An access JWT issued before hard deprovisioning can remain valid until its `exp`, which **MUST NOT** exceed 15 minutes in the v1 authentication profile.
+Account Management does not invoke this plugin for tenant suspension or soft deletion, so those transitions **MUST NOT** be presented as plugin-enforced access termination. During hard deprovisioning, the plugin **MUST** revoke provider sessions and delete every human identity bound to the retiring tenant. It **MUST NOT** delete identities or memberships belonging to another active tenant. `IdpDeprovisionFailure::Retryable` applies only when the plugin proves that no deprovisioning mutation has an unknown outcome: either no mutating request may have reached Keycloak, or completed partial work is proven replay-safe and no attempted stage remains uncertain. Once a session-revocation, identity-removal, or boundary-removal request may have reached Keycloak and its result cannot be proven, the plugin **MUST** return `IdpDeprovisionFailure::Terminal` for operator action; a timeout or transient transport label does not override that boundary. An access JWT issued before hard deprovisioning can remain valid until its `exp`, which **MUST NOT** exceed 15 minutes in the v1 authentication profile.
 
 - **Rationale**: This contract matches Account Management's hard-deletion hook and the OIDC resolver's offline JWT model without promising an unavailable suspension or real-time revocation path.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
@@ -846,8 +846,9 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 
 **Alternative Flows**:
 - **Resources already absent**: The plugin returns a success-equivalent outcome.
-- **Transient dependency failure**: The plugin returns retryable.
-- **Unsafe or unrecoverable state**: The plugin returns terminal for operator action.
+- **Proven safe retry**: A dependency failure occurs before any mutation may have reached Keycloak, or after only proven replay-safe partial work with no uncertain attempted stage; the plugin returns retryable.
+- **Attempted mutation with unproven result**: A session-revocation, identity-removal, or boundary-removal request may have reached Keycloak but its result cannot be proven; the plugin returns terminal for operator action even when the immediate cause is a timeout or transient transport failure.
+- **Unsafe or unrecoverable state**: Ownership, complete enumeration, or safe continuation cannot be proven; the plugin returns terminal for operator action.
 
 #### Reconcile an Ambiguous Provider Mutation
 
@@ -890,7 +891,7 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 - [ ] User updates distinguish not found, duplicate identity attributes, password-policy rejection, unsupported behavior, invalid input, and provider unavailability.
 - [ ] Cross-tenant negative tests produce zero successful reads or mutations.
 - [ ] Failure injection proves that ambiguous tenant provisioning is never reported as clean, while each user failure maps to an `IdpUserOperationFailure` outcome and equivalent replay remains idempotent.
-- [ ] Every mutating contract-test call and reconciliation resolution has one correlated terminal audit outcome containing no user profile value.
+- [ ] Every mutating contract-test call and reconciliation resolution has one correlated terminal audit outcome containing no user profile value; calls rejected before actor context exists are excluded, matching `cpt-cf-keycloak-idp-plugin-nfr-audit-completeness`.
 - [ ] Secret scanning finds no credential values in logs, metrics, audit events, listings, or debug output.
 - [ ] Every supported Keycloak 26.x release in the release matrix passes the provider contract suite, and representative unsupported major versions fail readiness.
 - [ ] Shared-realm tenant provisioning meets p95 ≤ 5 seconds; each named user operation meets p95 ≤ 1 second under the §6.1 qualification profile.

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/PRD.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/PRD.md
@@ -1,0 +1,972 @@
+# PRD — Keycloak IdP Plugin
+
+<!-- toc -->
+
+- [1. Overview](#1-overview)
+  - [1.1 Purpose](#11-purpose)
+  - [1.2 Background / Problem Statement](#12-background--problem-statement)
+  - [1.3 Goals (Business Outcomes)](#13-goals-business-outcomes)
+  - [1.4 Glossary](#14-glossary)
+- [2. Actors](#2-actors)
+  - [2.1 Human Actors](#21-human-actors)
+  - [2.2 System Actors](#22-system-actors)
+- [3. Operational Concept & Environment](#3-operational-concept--environment)
+  - [3.1 Gear-Specific Environment Constraints](#31-gear-specific-environment-constraints)
+- [4. Scope](#4-scope)
+  - [4.1 In Scope](#41-in-scope)
+  - [4.2 Out of Scope](#42-out-of-scope)
+- [5. Functional Requirements](#5-functional-requirements)
+  - [5.1 Plugin Availability and Selection](#51-plugin-availability-and-selection)
+  - [5.2 Tenant Lifecycle](#52-tenant-lifecycle)
+  - [5.3 User Lifecycle](#53-user-lifecycle)
+  - [5.4 Service-Principal Lifecycle](#54-service-principal-lifecycle)
+  - [5.5 Provider Administration and Operations](#55-provider-administration-and-operations)
+- [6. Non-Functional Requirements](#6-non-functional-requirements)
+  - [6.1 Gear-Specific NFRs](#61-gear-specific-nfrs)
+  - [6.2 NFR Exclusions](#62-nfr-exclusions)
+- [7. Public Library Interfaces](#7-public-library-interfaces)
+  - [7.1 Public API Surface](#71-public-api-surface)
+  - [7.2 External Integration Contracts](#72-external-integration-contracts)
+- [8. Use Cases](#8-use-cases)
+- [9. Acceptance Criteria](#9-acceptance-criteria)
+  - [V1 Acceptance](#v1-acceptance)
+  - [P2 Promotion Acceptance](#p2-promotion-acceptance)
+- [10. Dependencies](#10-dependencies)
+- [11. Assumptions](#11-assumptions)
+- [12. Risks](#12-risks)
+- [13. Open Questions](#13-open-questions)
+- [14. Traceability](#14-traceability)
+
+<!-- /toc -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+The Keycloak IdP Plugin is a provider plugin for Account Management. In v1, it translates tenant and user lifecycle requests into administrative operations against Keycloak. A future p2 extension can add machine-identity lifecycle behavior through a platform owner outside Account Management. The plugin gives deployments a production provider while keeping Account Management independent of provider-specific behavior.
+
+The plugin runs as a Gear in the host process. Account Management remains the public control-plane boundary. The plugin exposes no public REST API and does not authenticate requests, issue tokens, validate tokens, or make authorization decisions.
+
+### 1.2 Background / Problem Statement
+
+Account Management defines stable provider contracts for tenant and user identity lifecycle operations. A deployment still needs a provider that can apply those requests to its selected identity system without placing Keycloak-specific concepts in Account Management.
+
+An identity-management platform also needs tenant isolation, clear realm ownership, and safe external-mutation handling. The shared realm is the only v1 realm strategy. Adopted and plugin-created realms are p2 compatibility modes and cannot be enabled through the v1 contract. Machine-identity lifecycle behavior is also p2 because Account Management does not own that public capability. Without one defined product contract, provider behavior can drift across tenant provisioning, user administration, retries, and operational signals.
+
+The Keycloak IdP Plugin solves this gap for Keycloak. It owns the provider-facing lifecycle behavior while preserving the boundaries of Account Management, the OIDC authentication resolver, Keycloak, CredStore, and the platform Policy Engine.
+
+### 1.3 Goals (Business Outcomes)
+
+- Pass 100% of the Account Management `IdpPluginClient` contract suite for every v1 release.
+- Produce zero successful cross-tenant reads or mutations across the automated negative-isolation suite.
+- Produce expected SDK outcomes for 100% of failure-injection cases, with zero ambiguous tenant-provisioning outcomes classified as clean failures.
+- Expose zero administrator secrets, user passwords, or profile values across automated log, metric, audit, and debug-output scans.
+- Pass the complete compatibility suite against every supported Keycloak 26.x release before publishing the plugin release.
+- Meet the v1 lifecycle latency budgets in §6.1 on the release qualification profile.
+
+### 1.4 Glossary
+
+| Term | Definition |
+|------|------------|
+| Account Management (AM) | The system gear that owns public tenant and user operations and delegates provider-specific identity work. |
+| IdP | Identity provider; Keycloak is the provider targeted by this plugin. |
+| Realm | A Keycloak isolation and administration boundary containing identities and related configuration. |
+| Shared realm | An operator-owned realm that contains more than one tenant. |
+| Adopted realm | An existing operator-owned realm selected for a tenant without transferring realm ownership to the plugin. |
+| Created realm | A realm created and lifecycle-managed by the plugin. |
+| Service principal | A tenant-owned machine identity used for service-to-service authentication. |
+| Platform authentication profile | The product-level issuer, claim, client, signing, session, and login requirements that make a Keycloak realm usable by platform authentication consumers. |
+| Ambiguous outcome | A failed or lost response where an external mutation might have completed and reconciliation is required before retry. |
+| OIDC AuthN Resolver Plugin | The separate runtime component that validates incoming OIDC tokens offline; v1 does not require it to check per-identity revocation state. |
+
+## 2. Actors
+
+### 2.1 Human Actors
+
+#### Platform Operator
+
+**ID**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
+
+- **Role**: Configures and operates the plugin, Keycloak administration access, realm ownership, and provider dependencies.
+- **Needs**: Predictable startup, least-privilege administration, safe reconciliation, and actionable operational signals.
+
+#### Tenant Administrator
+
+**ID**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`
+
+- **Role**: Manages tenant users through Account Management and, if p2 is promoted, machine identities through a platform owner outside Account Management.
+- **Needs**: Complete identity lifecycle operations that remain inside the authorized tenant boundary.
+
+### 2.2 System Actors
+
+#### Account Management
+
+**ID**: `cpt-cf-keycloak-idp-plugin-actor-account-management`
+
+- **Role**: Authorizes and orchestrates identity-lifecycle requests, selects the active provider, supplies resolved tenant context, and delegates provider-specific work.
+
+#### Service-Principal Consumer
+
+**ID**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`
+
+- **Role**: In p2, requests tenant-scoped machine-identity lifecycle behavior through a platform owner outside Account Management and does not consume the provider plugin directly.
+
+#### Keycloak
+
+**ID**: `cpt-cf-keycloak-idp-plugin-actor-keycloak`
+
+- **Role**: Stores and administers identity boundaries, human and machine identities, sessions, and provider credentials.
+
+#### Credential Store
+
+**ID**: `cpt-cf-keycloak-idp-plugin-actor-credstore`
+
+- **Role**: Protects provider administrator credentials and other configured secret material. Consumers may use it for durable custody of one-time service-principal credentials; the owning platform service and this plugin do not retain those returned credentials.
+
+#### OIDC AuthN Resolver Plugin
+
+**ID**: `cpt-cf-keycloak-idp-plugin-actor-authn-resolver`
+
+- **Role**: Validates issued tokens offline before producing an authenticated security context. In v1, it does not manage sessions or check per-identity revocation state.
+
+## 3. Operational Concept & Environment
+
+The plugin follows the repository-wide architecture and security baselines in [Architecture Manifest](../../../../../../docs/ARCHITECTURE_MANIFEST.md) and [Security Guidelines](../../../../../../guidelines/SECURITY.md). Its parent product contract is [Account Management PRD](../../../docs/PRD.md).
+
+The plugin adds a provider-specific boundary beneath Account Management. It does not change the platform-owned authentication, authorization, REST, or tenant-resolution paths.
+
+```mermaid
+flowchart LR
+    Admin[Platform or Tenant Administrator]
+    Consumer[Service-Principal Consumer]
+    AM[Account Management]
+    Owner[Service-Principal Lifecycle Owner]
+    Plugin[Keycloak IdP Plugin]
+    KC[Keycloak]
+    CS[Credential Store]
+    AuthN[OIDC AuthN Resolver]
+    PDP[RBAC / Policy Engine]
+
+    Admin --> AM
+    Consumer -->|machine-identity lifecycle| Owner
+    AM -->|tenant and user lifecycle| Plugin
+    Owner -->|delegated machine-identity lifecycle| Plugin
+    Plugin -->|identity administration| KC
+    Plugin -->|protected provider credentials| CS
+    KC -->|tokens and issuer metadata| AuthN
+    AuthN --> PDP
+```
+
+### 3.1 Gear-Specific Environment Constraints
+
+- The deployment must provide a supported Keycloak administration surface; each lifecycle call reports whether the dependencies required by that operation are usable, without adding a separate Account Management availability probe.
+- Account Management must provide the tenant context and provider-owned metadata required to route existing-tenant operations.
+- Credential Store must be available for operations that require dynamic provider credentials.
+- The deployment must select one unambiguous active provider for each supported identity-lifecycle capability.
+
+## 4. Scope
+
+### 4.1 In Scope
+
+- Selectable Keycloak provider registration for Account Management.
+- Explicit tenant binding to an operator-approved shared Keycloak realm.
+- Tenant identity-boundary creation, binding, and cleanup within the shared realm.
+- Tenant-scoped user creation, partial update, deletion, provider-session revocation, listing, filtering, and ordering.
+- Protected provider-administrator credential use and dynamic provider-administrator secret lifecycle.
+- Deterministic failure classification, retry safety, and ambiguous-outcome reconciliation signals.
+- Provider-specific audit events, metrics, readiness, and dependency-health signals.
+
+### 4.2 Out of Scope
+
+The adopted-realm, created-realm, and service-principal bullets below are out of v1 scope but retained as p2 requirements. All other bullets are product-level exclusions.
+
+- Starting, deploying, upgrading, backing up, or scaling Keycloak.
+- Running code inside Keycloak or packaging Keycloak server extensions.
+- Issuing access or refresh tokens; Keycloak owns token issuance.
+- Validating incoming JWTs; the OIDC AuthN Resolver Plugin owns validation.
+- Making authorization decisions; RBAC and the Policy Engine own authorization.
+- Exposing public REST endpoints; Account Management and other owning gears expose public APIs.
+- Moving a user between tenants or changing a user's tenant binding through profile update.
+- Cross-realm browser SSO between shared, adopted, and created realms unless a separate federation product establishes it.
+- Persisting a local user directory or a local copy of Keycloak credentials.
+- Adopted and plugin-created realm modes; these are p2 capabilities that require an expanded Account Management provider contract.
+- Service-principal creation, rotation, revocation, listing, and tenant-retirement cleanup; these are p2 capabilities owned outside Account Management.
+- Real-time or per-identity rejection of already-issued JWTs; v1 relies on provider-session revocation and access-token expiry within 15 minutes.
+- Managing external identity-provider federation, login themes, or end-user self-service portals.
+- Fine-grained resource authorization, tenant hierarchy policy, or Account Management data ownership.
+
+## 5. Functional Requirements
+
+> **Testing strategy**: All requirements are verified through automated unit, contract, integration, and end-to-end tests unless a requirement states another method.
+
+### 5.1 Plugin Availability and Selection
+
+#### Provider Instance Publication
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-provider-publication`
+
+The plugin **MUST** be selectable by Account Management without requiring Account Management or its consumers to depend on the plugin implementation.
+
+- **Rationale**: Provider-neutral selection permits replacement without changing consumers.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`
+
+#### Operation-Based Readiness
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-readiness`
+
+The plugin **MUST NOT** require a separate Account Management availability probe. `provision_tenant` **MUST** remain the bootstrap readiness signal and **MUST** classify a pre-mutation dependency failure as clean only when no provider state was retained. Dependency loss **MUST** block only the realm modes and lifecycle operations that require that dependency; unaffected operations **MUST** remain available.
+
+- **Rationale**: Account Management already defines operation-based readiness, and a capability-specific dependency such as Credential Store must not disable unrelated shared-realm work.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
+
+### 5.2 Tenant Lifecycle
+
+#### Explicit Realm Binding
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-tenant-realm-binding`
+
+Every v1 provisioning request **MUST** identify `shared` mode and its target realm through the `IdpProvisionTenantRequest.metadata` value forwarded from `TenantCreateRequest.provisioning_metadata`. The metadata **MUST** contain a non-empty `realm_name` and `mode = "shared"`. The plugin **MUST** reject missing, malformed, disabled, unsupported, or contradictory intent without silently choosing a realm. Requests for the p2 `adopted` or `created` modes **MUST** return unsupported without provider mutation.
+
+- **Rationale**: Explicit intent prevents the plugin from inferring a realm or accepting a capability outside the stable v1 contract.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
+
+#### Shared Realm Admissibility
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-shared-realm-admissibility`
+
+The target realm **MUST** already exist and be operator-approved for multi-tenant use. A failed existence or approval check **MUST** produce a no-side-effect outcome.
+
+- **Rationale**: The plugin must not claim an unknown realm or make an unapproved realm multi-tenant.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
+
+#### Adopted Realm Admissibility
+
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-adopted-realm-admissibility`
+
+When the Account Management provider contract is extended to support `adopted` mode, the target realm **MUST** already exist, contain no existing tenant boundary or unrelated human identity, and provide operator-owned administration and authentication configuration. During root bootstrap only, the realm can contain the operator-declared initial platform administrator and provider-required system identities. A rejected precondition **MUST** produce a no-side-effect outcome.
+
+- **Rationale**: Explicit admissibility rules prevent the plugin from claiming unrelated resources.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
+
+#### Created Realm Admissibility
+
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-created-realm-admissibility`
+
+When the Account Management provider contract is extended to support `created` mode, the target realm **MUST** be absent before mutation. An existing target **MUST** be rejected without provider mutation.
+
+- **Rationale**: The plugin must not overwrite or assume ownership of an existing realm.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
+
+#### Tenant Identity Boundary Provisioning
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-tenant-provision`
+
+The plugin **MUST** establish a stable, isolated provider-side identity boundary for each successfully provisioned v1 tenant in an approved shared realm. The reported ownership state **MUST** reflect only completed provider work. The p2 `adopted` and `created` modes **MUST NOT** be reported as provisioned through the v1 contract.
+
+- **Rationale**: Every identity operation needs a stable and isolated provider-side tenant boundary with unambiguous ownership.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`
+
+#### Realm Authentication Compatibility
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-realm-authentication-profile`
+
+A tenant realm binding **MUST NOT** report success until the shared realm satisfies the platform authentication profile needed by its intended users. The profile **MUST** provide a trusted discoverable issuer, platform-required clients and scopes, required tenant and identity claims, compatible signing and session policy, and the applicable login and password controls. Browser SSO is guaranteed only within one realm unless a separate federation product provides cross-realm SSO.
+
+- **Rationale**: A realm that stores users but cannot issue platform-accepted tokens is not a successfully provisioned identity boundary.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
+
+#### Provider Metadata Continuity
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-provider-metadata`
+
+The plugin **MUST** return versioned, provider-owned tenant metadata after provisioning and **MUST** use replayed metadata as the authoritative routing context for later tenant and user operations. Every supported plugin upgrade **MUST** read metadata written by all versions in its declared compatibility window, including metadata needed to deprovision an existing tenant. Unknown newer major versions and malformed metadata **MUST** fail closed without provider mutation. Rolling upgrade and rollback support **MUST NOT** rewrite metadata into a form unreadable by another simultaneously supported version.
+
+- **Rationale**: Account Management remains provider-neutral while the plugin preserves safe lifecycle continuity across upgrades and rollback.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
+
+#### Ownership-Preserving Tenant Deprovisioning
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-tenant-deprovision`
+
+The plugin **MUST** remove the tenant's provider-owned identity resources during hard deprovisioning. It **MUST NOT** delete the operator-owned shared realm.
+
+- **Rationale**: Cleanup must remove retired tenant access without destroying operator-owned or other-tenant resources.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
+
+#### Service-Principal Cleanup Ordering
+
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-tenant-service-principal-cleanup`
+
+Before p2 service-principal support is promoted, its owner and Account Management **MUST** define a hard-deletion barrier that prevents tenant identity-boundary removal while an active tenant-owned service principal remains. Account Management **MUST NOT** invoke this plugin directly for service-principal cleanup through `IdpPluginClient`.
+
+- **Rationale**: No live machine credential can survive its tenant, but Account Management cannot own an operation absent from its provider contract.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`
+
+#### Tenant User Access Termination
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-tenant-user-access-termination`
+
+Account Management does not invoke this plugin for tenant suspension or soft deletion, so those transitions **MUST NOT** be presented as plugin-enforced access termination. During hard deprovisioning, the plugin **MUST** revoke provider sessions and delete every human identity bound to the retiring tenant. It **MUST NOT** delete identities or memberships belonging to another active tenant. The plugin **MUST** return `IdpDeprovisionFailure::Terminal` for operator action when session revocation or identity removal cannot be proven. An access JWT issued before hard deprovisioning can remain valid until its `exp`, which **MUST NOT** exceed 15 minutes in the v1 authentication profile.
+
+- **Rationale**: This contract matches Account Management's hard-deletion hook and the OIDC resolver's offline JWT model without promising an unavailable suspension or real-time revocation path.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
+
+#### Tenant Lifecycle Failure Contract
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-tenant-failure-contract`
+
+The plugin **MUST** distinguish invalid pre-mutation requests, unsupported operations, retryable deprovisioning failures, terminal deprovisioning failures, already-absent resources, and ambiguous provisioning outcomes. It **MUST** treat already-absent tenant resources as success-equivalent during deprovisioning and **MUST NOT** invite blind retry after ambiguous provisioning.
+
+- **Rationale**: External administration can fail after side effects, so callers need deterministic recovery behavior.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
+
+### 5.3 User Lifecycle
+
+#### Tenant-Scoped User Provisioning
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-provision`
+
+The plugin **MUST** create a user inside the resolved tenant identity boundary, preserve the required tenant association, and return the provider-issued user projection.
+
+- **Rationale**: Account Management needs a provider-neutral way to create identities while Keycloak remains the identity source of truth.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`, `cpt-cf-keycloak-idp-plugin-actor-account-management`
+
+#### Tenant-Scoped User Update
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-update`
+
+The plugin **MUST** apply partial updates to `username`, `email`, `display_name`, `first_name`, `last_name`, and `password` within the existing tenant binding. Omitted fields **MUST** remain unchanged; nullable profile fields **MUST** support clearing. The user identifier and tenant binding **MUST** remain immutable.
+
+- **Rationale**: A production provider needs a complete administrative user lifecycle without turning profile editing into unsafe tenant reassignment.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`, `cpt-cf-keycloak-idp-plugin-actor-account-management`
+
+#### User Update Outcome Classification
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-update-outcomes`
+
+The plugin **MUST** distinguish an absent user, duplicate username or email, password-policy rejection, unsupported behavior, invalid input, and provider unavailability when updating a user. A missing user **MUST NOT** be treated as a successful update.
+
+- **Rationale**: Tenant administrators need actionable and stable outcomes for corrective action.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`, `cpt-cf-keycloak-idp-plugin-actor-account-management`
+
+#### Tenant-Scoped User Deprovisioning
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-deprovision`
+
+User deprovisioning **MUST** revoke provider sessions and remove the user from the resolved tenant binding. An already-absent provider identity **MUST** produce a success-equivalent outcome. The plugin **MUST NOT** claim that it invalidates a previously issued access JWT; such a token can remain valid until its `exp`, which **MUST NOT** exceed 15 minutes in the v1 authentication profile.
+
+- **Rationale**: Deprovisioning blocks refresh and new provider sessions while matching the OIDC resolver's offline JWT contract.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`, `cpt-cf-keycloak-idp-plugin-actor-account-management`
+
+#### Tenant-Scoped User Query
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-query`
+
+The plugin **MUST** list only users belonging to the resolved tenant binding and **MUST** support the filtering, ordering, point-existence, and cursor pagination behavior required by the Account Management provider contract.
+
+- **Rationale**: Tenant administration and downstream membership checks need stable queries without cross-tenant disclosure.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`, `cpt-cf-keycloak-idp-plugin-actor-account-management`
+
+#### Keycloak as User Source of Truth
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-source-of-truth`
+
+The plugin **MUST** read and mutate user state in Keycloak and **MUST NOT** maintain a separate persistent user directory.
+
+- **Rationale**: One identity source avoids stale projections and conflicting lifecycle outcomes.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`
+
+### 5.4 Service-Principal Lifecycle
+
+Service-principal lifecycle support is a p2 extension. Account Management does not own this capability, and the current `IdpPluginClient` does not expose it. No requirement in this section is part of v1 release acceptance.
+
+#### Complete Service-Principal Operations
+
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-lifecycle`
+
+Before implementation, the platform **MUST** select a consumer-facing lifecycle owner outside Account Management. That owner **MUST** publish a versioned provider contract for creation, credential rotation, revocation, and listing. Regular consumers **MUST** use the selected owner and **MUST NOT** depend directly on this plugin.
+
+- **Rationale**: Explicit upstream ownership prevents machine identities, authorization, and secret custody from being added to Account Management by implication.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`
+
+#### Service-Principal Identity and State
+
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-state`
+
+A service-principal name **MUST** be unique within its tenant while active. Successful creation **MUST** return a stable principal identifier, tenant association, accepted scopes, authentication endpoint information, and a one-time credential. A duplicate active name **MUST** be rejected without side effects. After successful revocation, the principal **MUST** disappear from active listings; reusing the same name **MUST** create a distinct provider identity with a new credential.
+
+- **Rationale**: Stable identity and explicit lifecycle outcomes prevent duplicate or accidentally resurrected machine credentials.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`
+
+#### Service-Principal Tenant and Scope Safeguards
+
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-safeguards`
+
+Every service principal **MUST** be associated with exactly one tenant and **MUST** authenticate through the same trusted issuer used by that tenant's human identities. Issued tokens **MUST** identify the principal and owning tenant, distinguish the subject as a service principal, target an accepted audience, and grant no scope beyond the accepted scope set. The owning contract **MUST** define scope restrictions and a per-tenant quota before this capability is promoted to a release baseline.
+
+- **Rationale**: Explicit tenant ownership and authentication compatibility prevent cross-tenant machine access.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`
+
+#### Secret Rotation and Token Consequences
+
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-rotation`
+
+Successful rotation **MUST** preserve the principal identity, tenant association, and accepted scopes. It **MUST** disclose the replacement credential once and prevent the old credential from obtaining new tokens. Successful revocation **MUST** prevent new token issuance and further credential mutation. Tokens issued before rotation or revocation can remain valid until their configured expiry and **MUST NOT** exceed the platform maximum access-token lifetime.
+
+- **Rationale**: The credential cutover contract must match offline JWT validation rather than promise real-time token revocation.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`
+
+#### Service-Principal Listing
+
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-list`
+
+Listing **MUST** return only active principals owned by the requested tenant and **MUST** omit credentials. The owning contract **MUST** define cursor pagination, deterministic ordering, and default and maximum page sizes before implementation.
+
+- **Rationale**: A bounded query contract prevents cross-tenant disclosure and unstable continuation behavior.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`
+
+#### Service-Principal Mutation Safety
+
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-mutation-safety`
+
+Repeating an equivalent mutation **MUST NOT** apply a second provider mutation or disclose another credential. A stale request **MUST NOT** overwrite newer credential state. Concurrent rotations **MUST** leave at most one current credential. A rotation racing with completed revocation **MUST NOT** restore token issuance. An outcome whose winner cannot be proven **MUST** require reconciliation and **MUST NOT** invite blind retry.
+
+- **Rationale**: Concurrency-safe outcomes prevent duplicate identities and credential resurrection.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
+
+#### One-Time Secret Disclosure
+
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-secret-disclosure`
+
+A service-principal credential **MUST** be disclosed only in a successful creation or rotation result. The lifecycle owner and plugin **MUST NOT** persist, cache, log, audit, or otherwise retain the plaintext credential. Listing, later reads, reconciliation evidence, and repeated requests **MUST NOT** return it. The consumer owns durable custody. An unproven delivery outcome **MUST** require reconciliation and **MUST NOT** trigger automatic credential recovery, regeneration, or rotation.
+
+- **Rationale**: Limiting plaintext exposure reduces credential leakage risk.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`
+
+#### Service-Principal Recovery
+
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-recovery`
+
+After reconciliation confirms provider state, an absent identity **MUST** permit a new creation attempt. A valid identity with an undelivered credential **MUST** require explicitly authorized rotation. An incomplete identity **MUST** require controlled cleanup before another creation attempt. An unresolved state **MUST** remain blocked for operator action.
+
+- **Rationale**: Recovery must follow observed provider state without redisclosing or guessing a credential.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
+
+#### Service-Principal Failure Contract
+
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-failure-contract`
+
+The plugin **MUST** report uncertain creation, rotation, revocation, or concurrent mutation as ambiguous. It **MUST** report missing principals for operations that require an existing identity and treat revocation of an already-absent principal as success-equivalent. An ambiguous result **MUST NOT** contain a credential and **MUST** block blind retry until the external outcome is resolved.
+
+- **Rationale**: Credential mutation requires clear retry and recovery behavior.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
+
+### 5.5 Provider Administration and Operations
+
+#### Protected Administrator Credentials
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-administrator-credentials`
+
+The plugin **MUST** use protected, operator-supplied administrator credentials with the least privilege needed for each realm lifecycle. It **MUST** support credential rotation without exposing credential values in product outputs or operational signals.
+
+- **Rationale**: Provider administrator compromise can affect every identity in the authorized realm.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
+
+#### External Mutation Resilience
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-external-mutation-resilience`
+
+Tenant provisioning **MUST** preserve the SDK distinction between clean and ambiguous outcomes and **MUST** stop automatic retry after an ambiguous result. User operations **MUST** return only outcomes exposed by `IdpUserOperationFailure`; the plugin **MUST NOT** invent an ambiguity variant. Repeated user deprovisioning and equivalent user updates **MUST** remain idempotent, and provider diagnostics **MUST NOT** expose sensitive values.
+
+- **Rationale**: Unbounded or unsafe retry can duplicate resources, leak realms, or invalidate credentials.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
+
+#### Operator-Owned Reconciliation
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-operator-reconciliation`
+
+For v1, ambiguous-state reconciliation **MUST** be an operator-owned workflow rather than a public mutation API. The plugin **MUST** provide sufficient non-secret evidence to determine resource ownership and whether the mutation completed. The workflow **MUST** end in one audited outcome: compensated and safe to retry, accepted as complete, still blocked for further investigation, or escalated for controlled cleanup. Production enablement **MUST** include a reconciliation runbook.
+
+- **Rationale**: Operators need a safe resolution path even where current contracts cannot automatically distinguish an orphan from an already-clean resource.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
+
+#### Offline Token Lifetime Alignment
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-offline-token-lifetime`
+
+The v1 realm authentication profile **MUST** limit access-token lifetime to 15 minutes. User or tenant hard deprovisioning **MUST** revoke Keycloak sessions to block refresh and new session use. The plugin **MUST NOT** claim immediate rejection of an access JWT issued before deprovisioning. The OIDC AuthN Resolver can accept that token until `exp` when its signature and claims remain valid.
+
+- **Rationale**: This bounded exposure matches the OIDC resolver's offline JWT validation contract and its explicit exclusion of session and revocation management.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-authn-resolver`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`
+
+#### Audit and Metrics
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-audit-metrics`
+
+The plugin **MUST** emit structured audit outcomes and metrics for every supported tenant, user, provider-request, credential, reconciliation, and failure lifecycle. When the p2 service-principal contract is implemented, the same requirement **MUST** cover its lifecycle. Signals **MUST** support correlation to the initiating platform actor without containing secrets or user profile values such as username, email, or display name.
+
+- **Rationale**: Operators need privacy-preserving evidence for security review, incident response, performance, and reconciliation.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
+
+## 6. Non-Functional Requirements
+
+Global reliability, security, and observability baselines come from the [Architecture Manifest](../../../../../../docs/ARCHITECTURE_MANIFEST.md), [Security Guidelines](../../../../../../guidelines/SECURITY.md), and [Account Management PRD](../../../docs/PRD.md). This section defines stricter plugin-specific targets.
+
+### 6.1 Gear-Specific NFRs
+
+#### Tenant Isolation Integrity
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-tenant-isolation`
+
+The plugin **MUST** prevent an operation resolved for one tenant from reading or mutating identities bound to another tenant.
+
+- **Threshold**: Zero successful cross-tenant operations across the automated negative-isolation suite.
+- **Rationale**: Identity administration is a security boundary for every tenant.
+- **Architecture Allocation**: See future DESIGN.md § Security and AuthZ.
+
+#### Secret Non-Disclosure
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-secret-nondisclosure`
+
+The plugin **MUST** prevent administrator tokens, administrator secrets, user passwords, and service-principal secrets from appearing in logs, metrics, audit events, list responses, or debug output.
+
+- **Threshold**: Zero secret values detected by automated redaction tests and security scanning across all named output surfaces.
+- **Rationale**: These credentials can grant user or machine access across a tenant or realm.
+- **Architecture Allocation**: See future DESIGN.md § Credential Management.
+
+#### Lifecycle Latency
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-lifecycle-latency`
+
+On the release qualification profile, shared-realm tenant provisioning **MUST** complete within 5 seconds at p95. User creation, update, deprovisioning, and a 100-user query page **MUST** each complete within 1 second at p95. Measurements **MUST** use 20 concurrent operations against a supported Keycloak 26.x deployment, exclude caller network time, and include plugin processing plus Keycloak administration round trips.
+
+- **Threshold**: Tenant provisioning p95 ≤ 5 seconds; each named user operation p95 ≤ 1 second; 20 concurrent operations.
+- **Rationale**: Concrete budgets make interactive control-plane behavior release-testable without applying request-path latency assumptions.
+- **Architecture Allocation**: See future DESIGN.md § NFR Allocation.
+
+#### Deterministic Failure Classification
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-failure-classification`
+
+The plugin **MUST** classify every failed supported lifecycle call into an outcome exposed by the applicable SDK contract. Tenant provisioning **MUST** preserve `Ambiguous` whenever retained external state cannot be ruled out. User operations **MUST** use the available `IdpUserOperationFailure` variants and rely on idempotent replay where that contract has no ambiguity variant.
+
+- **Threshold**: 100% of automated failure-injection cases produce an expected SDK category; zero ambiguous tenant-provisioning cases are classified as clean failures.
+- **Rationale**: Correct recovery depends on the difference between safe retry and reconciliation.
+- **Architecture Allocation**: See future DESIGN.md § Error Mapping.
+
+#### Audit Completeness
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-audit-completeness`
+
+The plugin **MUST** produce an auditable terminal outcome for every successful or failed supported mutating tenant and user call. The same obligation **MUST** apply to service-principal calls if the p2 contract is implemented.
+
+- **Threshold**: 100% correlation between mutating contract-test calls and one terminal audit outcome, excluding calls rejected before actor context exists.
+- **Rationale**: Identity and credential mutations require traceable accountability.
+- **Architecture Allocation**: See future DESIGN.md § Audit and Observability.
+
+#### Provider Compatibility
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-provider-compatibility`
+
+V1 **MUST** support Keycloak 26.x. The plugin **MUST** reject startup for another major version, and expansion to another major version **MUST** require a versioned compatibility update.
+
+- **Threshold**: Every supported Keycloak 26.x release in the release matrix passes the provider contract suite; representative unsupported major versions fail readiness deterministically.
+- **Rationale**: An explicit compatibility window gives operators predictable installation, upgrade, and rollback support.
+- **Architecture Allocation**: See future DESIGN.md § Compatibility.
+
+#### Personal Data Minimization and Lifecycle
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-personal-data-lifecycle`
+
+The plugin **MUST** process only identity attributes required by its contracts, **MUST NOT** retain a separate persistent copy of user PII, and **MUST** keep usernames, email addresses, display names, and other profile values out of logs, metrics, and audit events. Audit signals **MUST** use provider-issued identity references. Keycloak user records remain governed by Account Management's soft-delete window and **MUST** be removed when hard deprovisioning is invoked. The plugin **MUST NOT** create a separate audit store; the platform audit sink **MUST** enforce a finite, operator-configured retention period documented before production enablement, with longer preservation permitted only under an approved legal hold or security-investigation policy.
+
+- **Threshold**: Zero profile values detected across logs, metrics, audit events, debug output, and retained plugin state; 100% of hard-deletion cases produce a classified identity-deletion outcome; production configuration contains a finite audit-retention period.
+- **Rationale**: User identity administration processes personal data even though the plugin owns no local directory.
+- **Architecture Allocation**: See future DESIGN.md § Data Protection.
+
+#### Availability and Recovery
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-availability-recovery`
+
+When required dependencies meet their objectives, the plugin **MUST** support the parent Account Management target of 99.9% monthly availability for provider-dependent lifecycle operations. Each call **MUST** fail closed when its own critical dependency is unavailable while leaving operations with unaffected dependencies usable. Unambiguous operations **MUST** recover within the inherited 15-minute recovery objective after dependencies are restored. Because the plugin owns no local identity database, a local recovery-point objective is not applicable. Ambiguous tenant provisioning **MUST** be reconciled before provisioning resumes for the affected tenant.
+
+- **Threshold**: Dependency-failure tests prove capability-specific availability and fail-closed mutations; recovery tests restore unambiguous operations within 15 minutes and keep uncertain resources reconciliation-blocked.
+- **Rationale**: Per-call errors alone do not define safe degraded operation or restoration.
+- **Architecture Allocation**: See future DESIGN.md § Availability and Recovery.
+
+### 6.2 NFR Exclusions
+
+| Quality category | Disposition | Product rationale or obligation |
+|------------------|-------------|---------------------------------|
+| Performance and capacity | Required here | V1 lifecycle latency is defined in §6.1. Service-principal capacity and pagination limits remain p2 obligations of its future owning contract; owning gears carry public REST latency. |
+| Reliability and availability | Required here | Failure classification, audit completeness, and availability recovery are defined in §6.1. |
+| Security and privacy | Required here and inherited | Tenant isolation, secret protection, and PII minimization are defined here; platform controls come from the Security Guidelines. |
+| Observability and operations | Required here | Releases must provide readiness, dependency-health, ambiguous-outcome, and terminal audit signals plus operator alert guidance and a reconciliation runbook. |
+| Deployment and upgrade | Partly required | Keycloak deployment is out of scope; plugin releases must document supported provider versions, metadata compatibility, upgrade checks, and rollback constraints. |
+| Documentation and support | Required here | Production enablement requires configuration, least-privilege credentials, secret rotation, failure classification, reconciliation, and troubleshooting guidance. |
+| UX, accessibility, and internationalization | Not applicable | The plugin exposes no end-user UI or human-language interface. Owning product surfaces carry these obligations. |
+| Regulatory and geographic controls | Inherited | The plugin introduces no placement decision; platform security, audit, privacy, and deployment policies control residency and regulatory obligations. |
+| Physical safety | Not applicable | This administrative software controls identities and has no physical actuation or safety-critical function. |
+| Offline behavior | Not applicable | Supported lifecycle operations require live Account Management context and provider dependencies. |
+| Public REST latency | Not applicable | The plugin exposes no public REST endpoint; owning gears carry public API SLOs. |
+| JWT validation and token issuance | Not applicable | The OIDC AuthN Resolver validates incoming tokens, and Keycloak owns token and session availability. |
+| Persistent database durability | Not applicable | The plugin owns no local identity database. |
+
+## 7. Public Library Interfaces
+
+### 7.1 Public API Surface
+
+#### Identity Provider Plugin Contract
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-interface-idp-plugin-client`
+
+- **Type**: Rust SDK trait (`IdpPluginClient`)
+- **Stability**: stable
+- **Description**: Provides tenant provisioning, tenant deprovisioning, user provisioning, user update, user deprovisioning, and user query behavior to Account Management.
+- **Breaking Change Policy**: Incompatible request, result, or failure changes require a versioned contract and coordinated Account Management migration.
+
+#### Service-Principal Lifecycle Contract
+
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-interface-service-principal-client`
+
+- **Type**: Future platform-owned lifecycle contract outside Account Management
+- **Stability**: planned; not part of v1
+- **Description**: After a platform owner publishes the upstream contract, it provides tenant-scoped creation, rotation, revocation, and listing of machine identities. The plugin fulfills provider-specific behavior without becoming a direct dependency of regular gears.
+- **Breaking Change Policy**: After stabilization, incompatible behavior or data changes require a versioned contract and a consumer migration path.
+
+#### Provider Instance Contract
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-interface-provider-instance`
+
+- **Type**: Selectable provider contract
+- **Stability**: stable
+- **Description**: Makes the Keycloak provider selectable by Account Management without exposing plugin implementation details to consumers.
+- **Breaking Change Policy**: Provider identity and selection semantics remain backward-compatible within a major contract version.
+
+### 7.2 External Integration Contracts
+
+#### Account Management Contract
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-contract-account-management`
+
+- **Direction**: required from client
+- **Protocol/Format**: Versioned Account Management provider contract
+- **Compatibility**: The plugin follows Account Management's tenant and user request, result, failure, idempotency, tenant-context, and provider-metadata semantics.
+
+#### Keycloak Administration Contract
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-contract-keycloak-admin`
+
+- **Direction**: required from external provider
+- **Protocol/Format**: Supported Keycloak administration and OAuth interfaces
+- **Compatibility**: V1 supports Keycloak 26.x; another major version requires a versioned compatibility update and is rejected until approved.
+
+#### Credential Store Contract
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-contract-credstore`
+
+- **Direction**: required from client
+- **Protocol/Format**: Protected secret-storage contract
+- **Compatibility**: Secret references remain stable across credential rotation; secret values are never part of provider metadata.
+
+## 8. Use Cases
+
+#### Bind a Tenant to a Shared Realm
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-usecase-bind-shared-tenant`
+
+**Actor**: `cpt-cf-keycloak-idp-plugin-actor-account-management`
+
+**Preconditions**:
+- The shared realm is operator-approved for multi-tenant use and required administration access exists.
+- The realm satisfies the platform authentication profile.
+- Account Management supplies valid `shared` provisioning intent.
+
+**Main Flow**:
+1. Account Management requests tenant provisioning with the resolved tenant identity and shared-realm intent.
+2. The plugin verifies shared-realm approval, administration access, and authentication compatibility.
+3. The plugin establishes the tenant identity boundary and returns the provider context required for later lifecycle operations.
+
+**Postconditions**:
+- The tenant has an isolated identity boundary in the shared realm.
+- Later tenant and user operations can use the returned provider context.
+
+**Alternative Flows**:
+- **Realm unavailable**: The plugin returns a classified failure without reporting successful binding.
+- **Uncertain mutation**: The plugin returns an ambiguous outcome for reconciliation.
+
+#### Adopt an Existing Tenant Realm
+
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-usecase-adopt-tenant-realm`
+
+**Actor**: `cpt-cf-keycloak-idp-plugin-actor-account-management`
+
+**Preconditions**:
+- The operator-owned realm exists, contains no tenant boundary or unrelated human identity, and has the required administration and authentication configuration.
+- During root bootstrap, any existing human identity is limited to the operator-declared initial platform administrator; provider-required system identities are also permitted.
+- Account Management supplies valid, explicitly enabled `adopted` provisioning intent.
+
+**Main Flow**:
+1. Account Management requests tenant provisioning with adopted-realm intent.
+2. The plugin verifies admissibility, administration access, and platform authentication compatibility without changing realm ownership.
+3. The plugin establishes the tenant identity boundary and returns provider context that preserves operator ownership.
+
+**Postconditions**:
+- The tenant is the only tenant boundary in the adopted realm.
+- The operator retains realm and administrator-credential ownership.
+
+**Alternative Flows**:
+- **Realm contains an unrelated human identity or tenant boundary**: The plugin rejects adoption without mutation.
+- **Root-bootstrap declaration does not match observed identities**: The plugin rejects the controlled exception without mutation.
+- **Required access or authentication configuration is missing**: The plugin rejects adoption without claiming ownership.
+- **Uncertain provider mutation**: The plugin returns an ambiguous outcome for reconciliation.
+
+#### Provision a Plugin-Owned Tenant Realm
+
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-usecase-create-tenant-realm`
+
+**Actor**: `cpt-cf-keycloak-idp-plugin-actor-account-management`
+
+**Preconditions**:
+- Account Management supplies valid `created` provisioning intent for an absent realm target.
+- The plugin has the required provider and Credential Store access.
+
+**Main Flow**:
+1. Account Management requests tenant provisioning with created-realm intent.
+2. The plugin verifies the request and establishes a plugin-owned tenant identity boundary that satisfies the platform authentication profile.
+3. The plugin returns provider context sufficient for safe lifecycle management and cleanup.
+
+**Postconditions**:
+- The tenant has a plugin-owned realm capable of issuing platform-compatible identity tokens.
+- Ownership metadata supports safe future cleanup.
+
+**Alternative Flows**:
+- **Existing conflicting realm**: The plugin rejects the request before claiming ownership.
+- **Uncertain provider or credential mutation**: The plugin returns an ambiguous outcome.
+
+#### Update a Tenant User
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-usecase-update-user`
+
+**Actor**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`
+
+**Preconditions**:
+- Account Management has authorized the request and resolved an active tenant.
+- The user exists within the tenant binding.
+
+**Main Flow**:
+1. Account Management sends the tenant context, user identifier, and partial update.
+2. The plugin applies only the supplied mutable fields within the resolved tenant binding.
+3. The plugin returns the updated provider projection.
+
+**Postconditions**:
+- Supplied fields reflect the accepted values.
+- Omitted fields, user identity, and tenant binding remain unchanged.
+
+**Alternative Flows**:
+- **User absent**: The plugin returns not found.
+- **Duplicate attribute**: The plugin returns a duplicate-user outcome.
+- **Password rejected**: The plugin returns a password-policy outcome.
+
+#### Create and Rotate a Service Principal
+
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-usecase-service-principal-credentials`
+
+**Actor**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`
+
+**Preconditions**:
+- The selected service-principal lifecycle owner provides an authorized request and resolved tenant context.
+- The requested name is available, requested scopes are allowed, and the tenant capacity limit is not exhausted.
+
+**Main Flow**:
+1. The consumer requests a tenant-owned service principal through the selected lifecycle owner.
+2. The plugin creates the principal and returns its identity, accepted scopes, authentication information, and one-time credential.
+3. The consumer later requests credential rotation through the selected lifecycle owner.
+4. The plugin preserves the principal identity and permissions and returns the replacement credential once.
+
+**Postconditions**:
+- Only the current credential can obtain new tokens.
+- Issued tokens identify the correct principal and owning tenant and satisfy the platform authentication profile.
+- Tokens issued before rotation remain valid only until their configured expiry.
+- Listing exposes active tenant-owned metadata but no credential.
+- The selected lifecycle owner and the plugin retain no plaintext service-principal credential.
+
+**Alternative Flows**:
+- **Quota or scope rejected**: The plugin returns a deterministic input or capacity failure.
+- **Duplicate, stale, or conflicting request**: The request causes no unsafe second mutation.
+- **Uncertain creation, delivery, or rotation**: The plugin returns an ambiguous outcome, blocks blind retry, and exposes no credential.
+
+#### List and Revoke Service Principals
+
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-usecase-list-revoke-service-principals`
+
+**Actor**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`
+
+**Preconditions**:
+- The selected service-principal lifecycle owner provides an authorized request and resolved tenant context.
+- One or more service principals may exist for the resolved tenant.
+
+**Main Flow**:
+1. The consumer requests a page of service principals through the selected lifecycle owner.
+2. The plugin returns only active principals owned by the tenant in deterministic order, omits every credential, and returns continuation information when another page exists.
+3. The consumer requests revocation through the selected lifecycle owner.
+4. The plugin prevents new token issuance and removes the principal from later active listings.
+
+**Postconditions**:
+- The revoked credential cannot obtain a new token.
+- Previously issued tokens for the revoked principal can remain valid until their configured expiry.
+- The revoked name can be recreated only as a new provider identity.
+
+**Alternative Flows**:
+- **Principal already absent**: Revocation succeeds equivalently without disclosing prior state.
+- **Duplicate, stale, or conflicting request**: The request causes no unsafe second mutation.
+- **Principal belongs to another tenant**: The plugin exposes no cross-tenant identity and performs no mutation.
+- **Concurrent rotation or uncertain revocation**: The plugin returns a reconciliation-required outcome when the winner cannot be proven and prohibits blind retry.
+
+#### Retire a Tenant Identity Boundary
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-usecase-retire-tenant`
+
+**Actor**: `cpt-cf-keycloak-idp-plugin-actor-account-management`
+
+**Preconditions**:
+- Account Management starts hard tenant deprovisioning with replayed provider metadata.
+
+**Main Flow**:
+1. The plugin revokes tenant-bound human sessions.
+2. The plugin removes tenant-bound human identities.
+3. The plugin removes provider-owned tenant resources while preserving the shared realm and other-tenant resources.
+4. The plugin reports a terminal result only when the retired tenant no longer has provider-managed human access.
+
+**Postconditions**:
+- No tenant-owned human identity can refresh a session or obtain a new token through the retired tenant binding.
+- An access JWT issued before retirement can remain valid until its `exp`.
+- If p2 service-principal support is promoted, its separate upstream cleanup barrier completes before this use case starts.
+- No other tenant or operator-owned realm resource is removed.
+
+**Alternative Flows**:
+- **Resources already absent**: The plugin returns a success-equivalent outcome.
+- **Transient dependency failure**: The plugin returns retryable.
+- **Unsafe or unrecoverable state**: The plugin returns terminal for operator action.
+
+#### Reconcile an Ambiguous Provider Mutation
+
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-usecase-reconcile-ambiguous-mutation`
+
+**Actor**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
+
+**Preconditions**:
+- Tenant provisioning ended with an `Ambiguous` outcome.
+- Automatic retries for the affected tenant are blocked.
+
+**Main Flow**:
+1. The operator follows the tenant-provisioning reconciliation runbook.
+2. The operator reviews non-secret evidence to determine tenant-boundary and ownership state.
+3. The operator applies an approved resolution and records the terminal outcome.
+
+**Postconditions**:
+- An absent tenant boundary is safe for a new provisioning attempt.
+- A complete tenant boundary is accepted with the provider metadata needed for later operations.
+- An incomplete tenant boundary is cleaned up before another provisioning attempt.
+- An unresolved state remains blocked and escalated.
+- The resolution has one correlated audit outcome and exposes no credential or user profile value.
+
+**Alternative Flows**:
+- **Ownership cannot be proven**: Cleanup is prohibited and the case remains blocked for escalation.
+- **Dependency remains unavailable**: Reconciliation pauses without mutating uncertain state.
+
+## 9. Acceptance Criteria
+
+### V1 Acceptance
+
+- [ ] Account Management can select the Keycloak IdP Plugin by its published provider instance.
+- [ ] Every v1 provisioning request explicitly identifies `shared` mode and an operator-approved existing realm; missing intent and `adopted` or `created` requests fail without provider mutation.
+- [ ] The shared realm issues tokens accepted by the OIDC AuthN Resolver with required tenant and identity claims and a maximum access-token lifetime of 15 minutes.
+- [ ] Metadata from every version in the supported upgrade and rollback window remains readable for normal operations and safe hard deprovisioning.
+- [ ] Account Management invokes the plugin for hard deprovisioning, not tenant suspension or soft deletion.
+- [ ] Hard deprovisioning revokes provider sessions and removes tenant-bound human identities without deleting the shared realm or another tenant's identities or memberships.
+- [ ] Deprovisioning documentation and tests show that an already-issued access JWT can remain valid until `exp`; no test requires real-time revocation from the OIDC AuthN Resolver.
+- [ ] User creation, partial update, deletion, and tenant-scoped query pass the Account Management provider contract suite.
+- [ ] User updates distinguish not found, duplicate identity attributes, password-policy rejection, unsupported behavior, invalid input, and provider unavailability.
+- [ ] Cross-tenant negative tests produce zero successful reads or mutations.
+- [ ] Failure injection proves that ambiguous tenant provisioning is never reported as clean, while each user failure maps to an `IdpUserOperationFailure` outcome and equivalent replay remains idempotent.
+- [ ] Every mutating contract-test call and reconciliation resolution has one correlated terminal audit outcome containing no user profile value.
+- [ ] Secret scanning finds no credential values in logs, metrics, audit events, listings, or debug output.
+- [ ] Every supported Keycloak 26.x release in the release matrix passes the provider contract suite, and representative unsupported major versions fail readiness.
+- [ ] Shared-realm tenant provisioning meets p95 ≤ 5 seconds; each named user operation meets p95 ≤ 1 second under the §6.1 qualification profile.
+- [ ] The plugin exposes no public REST routes and performs no JWT validation or authorization decisions.
+
+### P2 Promotion Acceptance
+
+- [ ] The Account Management provider contract is extended before `adopted` or `created` realm modes are enabled.
+- [ ] Adopted and created realm modes pass their ownership and no-side-effect admissibility tests before promotion.
+- [ ] A platform component outside Account Management owns and versions the consumer-facing service-principal lifecycle before implementation begins.
+- [ ] The service-principal owner defines provider delegation, authorization, secret custody, page sizes, quota, and concurrency outcomes.
+- [ ] Service-principal creation, rotation, revocation, recreation, listing, and recovery pass the owning contract's test suites.
+- [ ] Plaintext service-principal credentials appear only in successful creation and rotation results and are never persisted, cached, logged, audited, or redisclosed.
+- [ ] Service-principal tests permit already-issued tokens to remain valid until expiry unless a separate future revocation-enforcement contract is approved.
+
+## 10. Dependencies
+
+| Dependency | Description | Criticality |
+|------------|-------------|-------------|
+| Account Management provider contract | Defines v1 tenant and user lifecycle requests, outcomes, failure semantics, and provider context. It has no service-principal or tenant-suspension plugin hook. | p1 |
+| Account Management orchestration | Provides authorization, tenant resolution, provider selection, hard-deprovision invocation, and reconciliation behavior. | p1 |
+| Keycloak 26.x | Provides shared-realm identity-boundary, human-identity, session, and credential administration capabilities. | p1 |
+| Credential Store | Protects provider administrator credentials and other configured secret material. | p1 |
+| OIDC AuthN Resolver Plugin | Validates Keycloak-issued tokens offline and enforces one issuer per tenant. It does not manage sessions or check per-identity revocation state. | p1 |
+| Service-principal capability ownership | A future platform owner outside Account Management must publish machine-identity lifecycle, provider delegation, secret custody, mutation safety, pagination, and quota contracts before p2 implementation. | p2 |
+| RBAC / Policy Engine | Makes authorization decisions outside this plugin. | p1 |
+
+## 11. Assumptions
+
+- Keycloak is the identity provider implemented by this plugin, and v1 targets Keycloak 26.x.
+- Account Management authorizes public user and tenant operations before invoking the plugin.
+- Account Management supplies an active resolved tenant context for existing-tenant operations.
+- Operators provision the v1 shared realm and provider credentials they own.
+- Provider-owned metadata is persisted and replayed opaquely by Account Management.
+- V1 Keycloak access tokens expire within 15 minutes.
+- The OIDC AuthN Resolver validates access tokens offline and does not depend on current per-identity revocation state.
+- If p2 adopted-realm support is promoted, root bootstrap permits only the declared initial platform administrator, provider-required system identities, and no unrelated tenant boundary.
+- If p2 service-principal support is promoted, consumers use a platform owner outside Account Management and take immediate custody of one-time credentials.
+
+## 12. Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| An external mutation completes after the caller loses the response. | Duplicate or orphaned identity resources or credentials. | Preserve ambiguous outcomes, stop blind retry, and provide reconciliation signals. |
+| Administrator credentials grant broader access than required. | Compromise can affect unrelated tenants or realms. | Require least privilege, protected storage, rotation, and secret non-disclosure tests. |
+| Provider metadata becomes unreadable after upgrade or rollback. | Existing tenants cannot be administered or retired safely. | Require versioned metadata and compatibility coverage for supported upgrade paths. |
+| Shared-realm routing or tenant association drifts. | Cross-tenant identity exposure. | Treat replayed binding metadata as authoritative and run negative-isolation contract tests. |
+| A future p2 service principal survives tenant retirement. | Machine access remains active after tenant deletion. | Require the owning platform contract to complete a cleanup barrier before Account Management invokes hard deprovisioning. |
+| Human identities or sessions survive tenant retirement. | Retired users retain authentication or tenant access. | Revoke sessions, delete tenant-bound identities, prove absence of the retired binding, and block completion when reconciliation is required. |
+| Keycloak 26.x administration behavior changes across releases. | Lifecycle operations fail or produce different outcomes. | Test every supported 26.x release before plugin publication and reject unsupported major versions. |
+| Credential Store is unavailable during a future p2 dynamic credential operation. | Dedicated-realm lifecycle work cannot complete safely. | Return a classified failure and preserve ambiguous state when external completion is uncertain. |
+| An access JWT remains valid after user or tenant hard deprovisioning. | Access can continue until token expiry. | Limit v1 access-token lifetime to 15 minutes, revoke provider sessions, block refresh, and document the bounded exposure. |
+
+## 13. Open Questions
+
+No open question blocks v1 DESIGN. V1 uses shared realms, Keycloak 26.x, the latency profile in §6.1, and offline JWT validation with a 15-minute maximum access-token lifetime.
+
+The following questions gate only p2 promotion:
+
+| # | Question | Impact | Owner | Target Date |
+|---|----------|--------|-------|-------------|
+| 1 | Will Account Management add provider intent and metadata semantics for `adopted` and `created` realm modes? | Determines whether dedicated-realm modes can move from p2 to a release baseline. | Account Management Owner and Platform Architect | Before dedicated-realm DESIGN |
+| 2 | Which platform component outside Account Management owns the consumer-facing service-principal lifecycle? | Determines authorization, provider delegation, secret custody, and public contracts. | Product Owner and Platform Architect | Before service-principal DESIGN |
+| 3 | What default and maximum page sizes and per-tenant quota apply to service principals? | Determines p2 listing, capacity, and performance tests. | Service-Principal Owner and Performance Architect | Before service-principal DESIGN |
+| 4 | Will a future authentication component enforce real-time token revocation? | Determines whether any future release can promise rejection before JWT expiry. | Security Architect and AuthN Owner | Before real-time revocation requirements are added |
+
+## 14. Traceability
+
+- **Parent PRD**: [Account Management PRD](../../../docs/PRD.md)
+- **Identity Provider SDK**: [`idp.rs`](../../../account-management-sdk/src/idp.rs) and [`idp_user.rs`](../../../account-management-sdk/src/idp_user.rs)
+- **OIDC AuthN contract**: [OIDC AuthN Resolver Plugin PRD](../../../../authn-resolver/plugins/oidc-authn-plugin/docs/PRD.md)
+- **Realm-strategy relationship**: V1 supports only explicit `shared` provisioning intent. The p2 `adopted` and `created` modes require an expanded Account Management provider contract before promotion.
+- **Migration requirements**: Tenant hard deprovisioning requires session revocation and deletion of tenant-bound users, and audit events use provider-issued identity references rather than usernames or profile values.
+- **Service-principal allocation**: Account Management does not own service-principal lifecycle. A future platform owner must publish lifecycle, secret-custody, mutation-safety, pagination, quota, and authentication contracts before p2 implementation.
+- **AuthN allocation**: V1 follows the OIDC AuthN Resolver's offline JWT model. Keycloak sessions are revoked, but an already-issued access token can remain valid until its `exp`, bounded by the 15-minute profile maximum.
+- **Future Design**: `DESIGN.md` in this directory
+- **Future ADRs**: `ADR/` in this directory
+- **Future Features**: `features/` in this directory
+- **UPSTREAM_REQS coverage**: Not applicable because this child plugin has no `UPSTREAM_REQS.md`; parent contract requirements are linked above.

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/PRD.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/PRD.md
@@ -43,25 +43,27 @@
 
 ### 1.1 Purpose
 
-The Keycloak IdP Plugin is a provider plugin for Account Management. In v1, it translates tenant and user lifecycle requests into administrative operations against Keycloak. A future p2 extension can add machine-identity lifecycle behavior through a platform owner outside Account Management. The plugin gives deployments a production provider while keeping Account Management independent of provider-specific behavior.
+The Keycloak IdP Plugin (crate `vp-idp-plugin`) is a provider plugin for Account Management. It translates tenant and user lifecycle requests into administrative operations against Keycloak, and additionally provides tenant-scoped machine-identity (service-principal) lifecycle to trusted platform consumers through the `ServicePrincipalClientV1` contract. The plugin gives deployments a production provider while keeping Account Management independent of provider-specific behavior.
 
-The plugin runs as a Gear in the host process. Account Management remains the public control-plane boundary. The plugin exposes no public REST API and does not authenticate requests, issue tokens, validate tokens, or make authorization decisions.
+The plugin runs as a Gear in the host process. Account Management remains the public control-plane boundary. The plugin exposes no public REST API and does not authenticate requests, issue tokens, validate tokens, or make authorization decisions. It administers Keycloak directly over HTTPS using OAuth2 `client_credentials` administrator clients, with secret custody split between environment-expanded configuration and the platform Credential Store.
+
+In this revision, user provisioning, deprovisioning, and querying are supported; **user profile update is not implemented** and returns `UnsupportedOperation` (p2).
 
 ### 1.2 Background / Problem Statement
 
 Account Management defines stable provider contracts for tenant and user identity lifecycle operations. A deployment still needs a provider that can apply those requests to its selected identity system without placing Keycloak-specific concepts in Account Management.
 
-An identity-management platform also needs tenant isolation, clear realm ownership, and safe external-mutation handling. The shared realm is the only v1 realm strategy. Adopted and plugin-created realms are p2 compatibility modes and cannot be enabled through the v1 contract. Machine-identity lifecycle behavior is also p2 because Account Management does not own that public capability. Without one defined product contract, provider behavior can drift across tenant provisioning, user administration, retries, and operational signals.
+An identity-management platform also needs tenant isolation, clear realm ownership, and safe external-mutation handling. Three realm strategies are supported: `shared` (the default — tenants share an operator-provisioned realm, and a child tenant inherits its parent's realm), `adopted` (an existing empty operator-owned realm is bound to one tenant without ownership transfer), and `created` (the plugin creates and lifecycle-manages a dedicated realm per tenant). Machine-identity lifecycle is provided behind a dedicated platform SDK (`service-principal-sdk`) rather than through the Account Management contract, so machine identities, their authorization, and secret custody are not added to Account Management by implication.
 
-The Keycloak IdP Plugin solves this gap for Keycloak. It owns the provider-facing lifecycle behavior while preserving the boundaries of Account Management, the Outbound API Gateway, the OIDC authentication resolver, Keycloak, Credential Store, and the platform Policy Engine.
+The Keycloak IdP Plugin solves this gap for Keycloak. It owns the provider-facing lifecycle behavior while preserving the boundaries of Account Management, the OIDC authentication resolver, Keycloak, the Credential Store, and the platform Policy Engine.
 
 ### 1.3 Goals (Business Outcomes)
 
-- Pass 100% of the Account Management `IdpPluginClient` contract suite for every v1 release.
+- Pass 100% of the Account Management `IdpPluginClient` contract suite for the supported operations of every v1 release.
 - Produce zero successful cross-tenant reads or mutations across the automated negative-isolation suite.
 - Produce expected SDK outcomes for 100% of failure-injection cases, with zero ambiguous tenant-provisioning outcomes classified as clean failures.
-- Expose zero administrator secrets, user passwords, or profile values across automated log, metric, audit, and debug-output scans.
-- Pass the complete compatibility suite against every supported Keycloak 26.x release before publishing the plugin release.
+- Expose zero administrator secrets, user passwords, or service-principal secrets across automated log, metric, audit, and debug-output scans.
+- Qualify every plugin release against the supported Keycloak 26.x releases before publication.
 - Meet the v1 lifecycle latency budgets in §6.1 on the release qualification profile.
 
 ### 1.4 Glossary
@@ -71,13 +73,15 @@ The Keycloak IdP Plugin solves this gap for Keycloak. It owns the provider-facin
 | Account Management (AM) | The system gear that owns public tenant and user operations and delegates provider-specific identity work. |
 | IdP | Identity provider; Keycloak is the provider targeted by this plugin. |
 | Realm | A Keycloak isolation and administration boundary containing identities and related configuration. |
-| Shared realm | An operator-owned realm that contains more than one tenant. |
-| Adopted realm | An existing operator-owned realm selected for a tenant without transferring realm ownership to the plugin. |
-| Created realm | A realm created and lifecycle-managed by the plugin. |
-| Service principal | A tenant-owned machine identity used for service-to-service authentication. |
-| Platform authentication profile | The product-level issuer, claim, client, signing, session, and login requirements that make a Keycloak realm usable by platform authentication consumers. |
-| Ambiguous outcome | A failed or lost response where an external mutation might have completed and reconciliation is required before retry. |
-| Outbound API Gateway (OAGW) | The system gear that applies centralized credential injection and outbound policy before forwarding approved Keycloak requests. |
+| Shared realm | An operator-owned realm that contains more than one tenant. The default binding; child tenants inherit their parent's realm. |
+| Adopted realm | An existing operator-owned realm bound to a single tenant without transferring realm ownership to the plugin. |
+| Created realm | A realm (`realm-{tenant_id}`) created and lifecycle-managed by the plugin, marked with a plugin ownership attribute. |
+| Tenant group | The plugin-owned Keycloak group (under `/tenants` by default) that forms a tenant's identity boundary inside a realm. |
+| Bootstrap admin | The operator-provisioned confidential client (default `vp-idp-plugin-bootstrap` in `master`) the plugin uses for realm-level administration. |
+| Realm admin | The per-realm confidential client (default `vp-idp-plugin-realm-admin`) used for tenant and user administration inside a bound realm. |
+| Service principal | A tenant-owned machine identity: a confidential OAuth `client_credentials` client named `svc-{tenant_id}-{name}`. |
+| Ambiguous outcome | A failed or lost response where an external mutation might have completed and reconciliation is required before retry; stage-attributed with an `ambig:` token. |
+| Credential Store | The platform secret-storage gear (OpenBao-backed) holding adopted/created realm-admin secrets and the optional TLS CA bundle. |
 | OIDC AuthN Resolver Plugin | The separate runtime component that validates incoming OIDC tokens offline; v1 does not require it to check per-identity revocation state. |
 
 ## 2. Actors
@@ -88,15 +92,15 @@ The Keycloak IdP Plugin solves this gap for Keycloak. It owns the provider-facin
 
 **ID**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
 
-- **Role**: Configures and operates the plugin, Keycloak administration access, realm ownership, and provider dependencies.
+- **Role**: Configures and operates the plugin, Keycloak administration clients and secrets, realm ownership and bootstrap, and provider dependencies.
 - **Needs**: Predictable startup, least-privilege administration, safe reconciliation, and actionable operational signals.
 
 #### Tenant Administrator
 
 **ID**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`
 
-- **Role**: Manages tenant users through Account Management and, if p2 is promoted, machine identities through a platform owner outside Account Management.
-- **Needs**: Complete identity lifecycle operations that remain inside the authorized tenant boundary.
+- **Role**: Manages tenant users through Account Management.
+- **Needs**: Identity lifecycle operations that remain inside the authorized tenant boundary.
 
 ### 2.2 System Actors
 
@@ -104,37 +108,31 @@ The Keycloak IdP Plugin solves this gap for Keycloak. It owns the provider-facin
 
 **ID**: `cpt-cf-keycloak-idp-plugin-actor-account-management`
 
-- **Role**: Authorizes and orchestrates identity-lifecycle requests, selects the active provider, supplies resolved tenant context, and delegates provider-specific work.
+- **Role**: Authorizes and orchestrates identity-lifecycle requests, selects the active provider through the types-registry catalogue and scoped ClientHub resolution, supplies resolved tenant context and replayed provider metadata, and delegates provider-specific work.
 
 #### Service-Principal Consumer
 
 **ID**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`
 
-- **Role**: In p2, requests tenant-scoped machine-identity lifecycle behavior through a platform owner outside Account Management and does not consume the provider plugin directly.
+- **Role**: A trusted platform module that resolves `ServicePrincipalClientV1` from ClientHub to manage tenant-scoped machine identities. It authorizes its own callers through RBAC/PDP before delegating; the plugin treats the forwarded security context as audit evidence only.
 
 #### Keycloak
 
 **ID**: `cpt-cf-keycloak-idp-plugin-actor-keycloak`
 
-- **Role**: Stores and administers identity boundaries, human and machine identities, sessions, and provider credentials.
+- **Role**: Stores and administers identity boundaries, human and machine identities, sessions, and provider credentials. Administered directly by the plugin over HTTPS.
 
 #### Credential Store
 
 **ID**: `cpt-cf-keycloak-idp-plugin-actor-credstore`
 
-- **Role**: Protects provider administrator credentials and other configured secret material. The Outbound API Gateway resolves the plugin's configured provider credential references and injects credentials without disclosing them to the plugin. Consumers may use Credential Store for durable custody of one-time service-principal credentials; the owning platform service and this plugin do not retain those returned credentials.
-
-#### Outbound API Gateway
-
-**ID**: `cpt-cf-keycloak-idp-plugin-actor-oagw`
-
-- **Role**: Executes operator-approved Keycloak OAuth and Admin REST routes, enforces outbound policy, and injects provider administrator credentials from Credential Store.
+- **Role**: Protects adopted/created realm-administrator secrets and the optional TLS CA bundle. The plugin reads these secrets itself under a stable plugin-owned system actor authorized through ordinary RBAC, and writes the realm-admin secret for realms it creates.
 
 #### OIDC AuthN Resolver Plugin
 
 **ID**: `cpt-cf-keycloak-idp-plugin-actor-authn-resolver`
 
-- **Role**: Validates issued tokens offline before producing an authenticated security context. In v1, it does not manage sessions or check per-identity revocation state.
+- **Role**: Validates issued tokens offline before producing an authenticated security context, consuming the `tenant_id`/`user_type` claims projected by the realm's protocol mappers. In v1, it does not manage sessions or check per-identity revocation state.
 
 ## 3. Operational Concept & Environment
 
@@ -147,47 +145,47 @@ flowchart LR
     Admin[Platform or Tenant Administrator]
     Consumer[Service-Principal Consumer]
     AM[Account Management]
-    Owner[Service-Principal Lifecycle Owner]
     Plugin[Keycloak IdP Plugin]
-    OAGW[Outbound API Gateway]
     KC[Keycloak]
     CS[Credential Store]
+    TR[types-registry]
     AuthN[OIDC AuthN Resolver]
     PDP[RBAC / Policy Engine]
 
     Admin --> AM
-    Consumer -->|machine-identity lifecycle| Owner
-    AM -->|tenant and user lifecycle| Plugin
-    Owner -->|delegated machine-identity lifecycle| Plugin
-    Plugin -->|approved provider request| OAGW
-    OAGW -->|OAuth and Admin REST| KC
-    OAGW -->|protected credential resolution| CS
+    AM -->|tenant and user lifecycle, scoped IdpPluginClient| Plugin
+    Consumer -->|unscoped ServicePrincipalClientV1| Plugin
+    Plugin -->|OAuth and Admin REST over HTTPS| KC
+    Plugin -->|read admin secrets and CA bundle; write created-realm secrets| CS
+    Plugin -->|provider instance publication| TR
     KC -->|tokens and issuer metadata| AuthN
     AuthN --> PDP
 ```
 
 ### 3.1 Gear-Specific Environment Constraints
 
-- The deployment must provide a supported Keycloak administration surface through an operator-approved Outbound API Gateway route; each lifecycle call reports whether its required dependencies are usable without adding a separate Account Management availability probe.
-- Account Management must provide the tenant context and provider-owned metadata required to route existing-tenant operations.
-- Outbound API Gateway and its transitive Credential Store dependency must be available for operations that require Keycloak administration.
-- The deployment must select one unambiguous active provider for each supported identity-lifecycle capability. Changing that provider while tenant metadata exists requires an explicit operator migration.
+- The deployment must provide a reachable Keycloak administration surface and the bootstrap admin client credentials. When the plugin is enabled, module initialization pre-warms the bootstrap admin token with a bounded retry budget and fails host initialization if the budget is exhausted; deployments that must start without Keycloak disable the plugin (`enabled: false`).
+- Operator realm bootstrap must provision the authentication profile of shared and adopted realms: required clients, client scopes, the `tenant_id`/`user_type` usermodel-attribute protocol mappers, signing/session/token policy, and the realm-admin client with its secret.
+- Account Management must provide the tenant context and replayed provider-owned metadata required to route existing-tenant operations.
+- The Credential Store must be available for operations that resolve adopted/created realm-admin secrets, for created-realm provisioning and teardown, and at initialization when a TLS CA bundle reference is configured.
+- The deployment must select one unambiguous active provider (Account Management `idp.vendor` matching the plugin's configured vendor, default `virtuozzo`). Changing that provider while tenant metadata exists requires an explicit operator migration.
 
 ## 4. Scope
 
 ### 4.1 In Scope
 
-- Selectable Keycloak provider registration for Account Management.
-- Explicit tenant binding to an operator-approved shared Keycloak realm.
-- Tenant identity-boundary creation, binding, and cleanup within the shared realm.
-- Tenant-scoped user creation, partial update, deletion, provider-session revocation, listing, filtering, and ordering.
-- Protected provider-administrator credential use through Outbound API Gateway and dynamic provider-administrator secret rotation without plugin access to credential values.
-- Deterministic failure classification, retry safety, and ambiguous-outcome reconciliation signals.
-- Provider-specific privacy-safe outcome evidence, bounded metrics, readiness, and dependency-health signals.
+- Selectable Keycloak provider registration for Account Management (types-registry catalogue instance plus scoped ClientHub client).
+- Tenant binding to shared (default, inherited by child tenants), adopted (single-tenant, operator-owned), and created (plugin-owned, per-tenant) realms.
+- Tenant identity-boundary creation, binding, and cleanup, including created-realm lifecycle and Credential Store custody of created-realm admin secrets.
+- Tenant-scoped user creation, deletion, provider-session revocation, listing, filtering, and cursor pagination.
+- Tenant-scoped service-principal creation, secret rotation, revocation, listing, and purge-on-tenant-deprovision through `ServicePrincipalClientV1`.
+- Two-tier administrator credential handling (bootstrap admin, per-realm admin) with rotation convergence via reactive re-authentication, without process restart.
+- Deterministic failure classification, retry safety, and stage-attributed ambiguous-outcome reconciliation signals.
+- Privacy-conscious outcome evidence, bounded-cardinality metrics, and structured audit events (development stand-in pending the platform audit sink).
 
 ### 4.2 Out of Scope
 
-The adopted-realm, created-realm, and service-principal bullets below are out of v1 scope but retained as p2 requirements. All other bullets are product-level exclusions.
+The user-update, realm-profile-verification, and provider-version-gate bullets below are out of v1 scope but retained as p2 requirements. All other bullets are product-level exclusions.
 
 - Starting, deploying, upgrading, backing up, or scaling Keycloak.
 - Running code inside Keycloak or packaging Keycloak server extensions.
@@ -195,11 +193,12 @@ The adopted-realm, created-realm, and service-principal bullets below are out of
 - Validating incoming JWTs; the OIDC AuthN Resolver Plugin owns validation.
 - Making authorization decisions; RBAC and the Policy Engine own authorization.
 - Exposing public REST endpoints; Account Management and other owning gears expose public APIs.
-- Moving a user between tenants or changing a user's tenant binding through profile update.
+- User profile updates through `IdpPluginClient::update_user`; the current implementation returns `UnsupportedOperation` (p2).
+- Runtime verification of the operator-provisioned realm authentication profile; operator realm bootstrap owns the profile (verification is p2).
+- A runtime Keycloak version gate; release qualification owns the compatibility matrix (a runtime gate is p2).
+- Moving a user between tenants or changing a user's tenant binding through any operation.
 - Cross-realm browser SSO between shared, adopted, and created realms unless a separate federation product establishes it.
-- Persisting a local user directory or a local copy of Keycloak credentials.
-- Adopted and plugin-created realm modes; these are p2 capabilities that require an expanded Account Management provider contract.
-- Service-principal creation, rotation, revocation, listing, and tenant-retirement cleanup; these are p2 capabilities owned outside Account Management.
+- Persisting a local user directory or a local copy of Keycloak credentials beyond the in-memory administrator token cache.
 - Real-time or per-identity rejection of already-issued JWTs; v1 relies on provider-session revocation and access-token expiry within 15 minutes.
 - Managing external identity-provider federation, login themes, or end-user self-service portals.
 - Fine-grained resource authorization, tenant hierarchy policy, or Account Management data ownership.
@@ -214,19 +213,21 @@ The adopted-realm, created-realm, and service-principal bullets below are out of
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-provider-publication`
 
-The plugin **MUST** be selectable by Account Management without requiring Account Management or its consumers to depend on the plugin implementation. Its published GTS provider instance identifier **MUST** be stable for the lifetime of tenant metadata produced by that instance.
+The plugin **MUST** be selectable by Account Management without requiring Account Management or its consumers to depend on the plugin implementation. It **MUST** publish a `PluginV1<IdpPluginSpecV1>` instance (id `vz.virtuozzo.vp_idp.plugin.v1`) to the types-registry carrying its configured vendor (default `virtuozzo`) and priority (default 50), and register the scoped `IdpPluginClient` under that instance id. The published instance identifier **MUST** be stable for the lifetime of tenant metadata produced by that instance. On restart, re-registration **MUST** accept an existing catalogue entry only when the stored spec matches the current serialization; a mismatch **MUST** fail initialization rather than silently drift.
 
-- **Rationale**: Provider-neutral selection permits replacement without changing consumers, while a stable instance identity prevents existing tenant metadata from being rebound silently.
+- **Rationale**: Provider-neutral selection permits replacement without changing consumers, while a stable instance identity and drift detection prevent existing tenant metadata from being rebound silently.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`
 
-#### Operation-Based Readiness
+#### Initialization and Operation-Based Readiness
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-readiness`
 
-The plugin **MUST NOT** require a separate Account Management availability probe. Module initialization **MUST** publish the scoped client after static configuration validation without contacting Outbound API Gateway, Credential Store, or Keycloak. `provision_tenant` **MUST** remain the bootstrap readiness signal and **MUST** classify a pre-mutation dependency failure as clean only when no provider state was retained. Dependency loss **MUST** block only the lifecycle operations that require that dependency; unaffected operations **MUST** remain available. A later operation **MUST** retry dependency and compatibility checks so recovery does not require process restart.
+Module initialization **MUST** validate static configuration fail-fast (unknown keys rejected, secret-reference template validated, service-principal section validated) and **MUST** pre-warm the bootstrap admin token with a bounded, configurable retry budget (default 5 attempts × 3 s backoff). Transient causes (provider 5xx/429, transport, timeout, Credential Store readiness) **MUST** be retried within the budget; permanent causes (non-429 4xx, malformed configuration) **MUST** fail on the first attempt. Budget exhaustion **MUST** fail initialization with the attempt count in the error. A disabled plugin (`enabled: false`) **MUST** skip initialization and register nothing.
 
-- **Rationale**: ToolKit initialization is fail-fast for the whole host. Operation-level readiness preserves Account Management availability during a provider outage and uses its existing lazy provider-resolution model.
-- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-oagw`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
+After successful initialization, readiness **MUST** be operation-based: tenant sagas **MUST** begin with a provider health probe, dependency loss **MUST** block only the operations that require that dependency, and a later operation **MUST** retry dependency checks so recovery does not require process restart.
+
+- **Rationale**: Failing initialization on an unusable provider surfaces deployment-ordering problems immediately, while per-operation probes and reactive re-authentication keep recovery restart-free afterward.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
 
 ### 5.2 Tenant Lifecycle
 
@@ -234,97 +235,97 @@ The plugin **MUST NOT** require a separate Account Management availability probe
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-tenant-realm-binding`
 
-Every v1 provisioning request **MUST** identify `shared` mode and its target realm through the `IdpProvisionTenantRequest.metadata` value forwarded from `TenantCreateRequest.provisioning_metadata`. The metadata **MUST** contain a non-empty `realm_name` and `mode = "shared"`. The plugin **MUST** reject missing, malformed, disabled, unsupported, or contradictory intent without silently choosing a realm. Requests for the p2 `adopted` or `created` modes **MUST** return unsupported without provider mutation.
+Provisioning intent arrives through the `IdpProvisionTenantRequest.metadata` value forwarded from `TenantCreateRequest.provisioning_metadata` and **MUST** be parsed fail-closed: unknown keys and unknown modes **MUST** be rejected without provider mutation. Absent `mode` **MUST** default to `shared`. The effective realm **MUST** be resolved per mode: root provisioning requires an explicit `realm_name`; a `shared` child tenant inherits its parent's realm from replayed parent metadata (an explicit `realm_name` is ignored, and a parent without metadata is rejected); `created` generates `realm-{tenant_id}` (supplying `realm_name` is rejected); `adopted` requires an explicit `realm_name`. An `admin_user_id` binding request **MUST** be accepted only in `shared` mode. The effective realm name **MUST** satisfy the identifier shape `[A-Za-z0-9_-]{1,200}`.
 
-- **Rationale**: Explicit intent prevents the plugin from inferring a realm or accepting a capability outside the stable v1 contract.
+- **Rationale**: Explicit fail-closed intent prevents the plugin from inferring a realm or accepting contradictory instructions, while parent inheritance keeps child-tenant creation free of caller-supplied routing.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
 
 #### Shared Realm Admissibility
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-shared-realm-admissibility`
 
-The target realm **MUST** already exist and be operator-approved for multi-tenant use. A failed existence or approval check **MUST** produce a no-side-effect outcome.
+The target shared realm **MUST** already exist; the plugin verifies existence with the bootstrap admin before any mutation. A failed existence check **MUST** produce a no-side-effect outcome. The plugin **MUST NOT** create, repair, or reconfigure a shared realm.
 
-- **Rationale**: The plugin must not claim an unknown realm or make an unapproved realm multi-tenant.
+- **Rationale**: The plugin must not claim an unknown realm or mutate operator-owned realm configuration.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
 
 #### Adopted Realm Admissibility
 
-- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-adopted-realm-admissibility`
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-adopted-realm-admissibility`
 
-When the Account Management provider contract is extended to support `adopted` mode, the target realm **MUST** already exist, contain no existing tenant boundary or unrelated human identity, and provide operator-owned administration and authentication configuration. During root bootstrap only, the realm can contain the operator-declared initial platform administrator and provider-required system identities. A rejected precondition **MUST** produce a no-side-effect outcome.
+An `adopted` target realm **MUST** already exist and **MUST** contain no existing tenant boundary (no subgroups under the configured tenant-group root). The realm-admin secret **MUST** be operator-provisioned in the Credential Store under the templated reference before adoption; the plugin **MUST NOT** write it. A rejected precondition **MUST** produce a no-side-effect outcome. Realm ownership stays with the operator; the plugin never deletes an adopted realm.
 
-- **Rationale**: Explicit admissibility rules prevent the plugin from claiming unrelated resources.
-- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
+- **Rationale**: Explicit admissibility rules prevent the plugin from claiming unrelated resources or manufacturing credentials for realms it does not own.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
 
 #### Created Realm Admissibility
 
-- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-created-realm-admissibility`
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-created-realm-admissibility`
 
-When the Account Management provider contract is extended to support `created` mode, the target realm **MUST** be absent before mutation. An existing target **MUST** be rejected without provider mutation.
+In `created` mode the plugin **MUST** probe the generated realm name first: an absent realm is created with the plugin ownership marker (`vhp.provisioning.tenant_id = {tenant_id}`); a realm already marked for the same tenant **MUST** be adopted idempotently (provisioning replay); a realm owned by another tenant or lacking the marker **MUST** be rejected without mutation. Operator `realm_defaults` pass-through **MUST** be restricted to a fail-closed allowlist (`displayNameHtml`, `defaultLocale`, `supportedLocales`, `internationalizationEnabled`); any other key fails before provider access. A create attempt whose response is lost **MUST** reconcile by re-probing before classifying the outcome.
 
-- **Rationale**: The plugin must not overwrite or assume ownership of an existing realm.
+- **Rationale**: The plugin must not overwrite or assume ownership of an existing realm, and replayed provisioning must converge instead of failing or duplicating.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
 
 #### Tenant Identity Boundary Provisioning
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-tenant-provision`
 
-The plugin **MUST** establish a stable, isolated provider-side identity boundary for each successfully provisioned v1 tenant in an approved shared realm. The reported ownership state **MUST** reflect only completed provider work. The p2 `adopted` and `created` modes **MUST NOT** be reported as provisioned through the v1 contract.
+The plugin **MUST** establish a stable, isolated provider-side identity boundary for each successfully provisioned tenant: a per-tenant group named `{tenant_id}` under the configured group root (default `/tenants`), created idempotently (an existing same-named group is reused). In `created` mode the plugin **MUST** additionally create the realm, create the realm-admin client, grant it exactly the required `realm-management` roles, and store the generated client secret in the Credential Store before reporting success. In `shared` mode with an operator-declared `admin_user_id`, the plugin **MUST** bind that user's `tenant_id`/`user_type` attributes idempotently and **MUST** reject a binding that would overwrite a different tenant's binding or a multi-valued attribute. The reported outcome **MUST** reflect only completed provider work.
 
 - **Rationale**: Every identity operation needs a stable and isolated provider-side tenant boundary with unambiguous ownership.
-- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
 
-#### Realm Authentication Compatibility
+#### Realm Authentication Profile
 
-- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-realm-authentication-profile`
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-realm-authentication-profile`
 
-A tenant realm binding **MUST NOT** report success until the shared realm satisfies the platform authentication profile needed by its intended users. The profile **MUST** provide a trusted discoverable issuer, platform-required clients and scopes, required tenant and identity claims, compatible signing and session policy, and the applicable login and password controls. Browser SSO is guaranteed only within one realm unless a separate federation product provides cross-realm SSO.
+Operator realm bootstrap owns the platform authentication profile of shared and adopted realms: trusted discoverable issuer, platform-required clients and scopes, the `tenant_id` and `user_type` protocol mappers, compatible signing and session policy, and the applicable login and password controls. The v1 plugin assumes this profile rather than verifying it. A read-only runtime profile verifier that fails tenant binding on a profile mismatch is a p2 extension.
 
-- **Rationale**: A realm that stores users but cannot issue platform-accepted tokens is not a successfully provisioned identity boundary.
-- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
+- **Rationale**: A realm that stores users but cannot issue platform-accepted tokens is not a usable identity boundary; today that guarantee is an operator obligation, not a plugin check.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`
 
 #### Provider Metadata Continuity
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-provider-metadata`
 
-The plugin **MUST** return versioned, provider-owned tenant metadata after provisioning and **MUST** use replayed metadata as the authoritative routing context for later tenant and user operations. The metadata **MUST** include the exact GTS provider instance identifier that produced it. Before any Outbound API Gateway or provider call, the plugin **MUST** verify that the replayed identifier equals its own published identifier; a mismatch **MUST** fail closed without external access. Every supported plugin upgrade **MUST** read metadata written by all versions in its declared compatibility window, including metadata needed to deprovision an existing tenant. Unknown newer major versions and malformed metadata **MUST** fail closed without provider mutation. Rolling upgrade and rollback support **MUST NOT** rewrite metadata into a form unreadable by another simultaneously supported version. Changing the selected provider instance while such metadata exists is unsupported until an operator-approved migration rewrites or retires every affected binding.
+The plugin **MUST** return versioned, provider-owned tenant metadata after provisioning (`version = "v1"`, realm name, realm binding, tenant group id, optional admin-secret reference, admin client id) and **MUST** use replayed metadata as the authoritative routing context for later tenant and user operations. Decoding **MUST** fail closed without provider access on a missing version, an unsupported version, or a malformed shape, and the failure class **MUST** be observable (decode-failure metric with the observed version label). The metadata **MUST NOT** contain administrator secrets, tokens, passwords, or user profile values — the Credential Store reference name is the only secret-related content. Every supported plugin upgrade **MUST** read metadata written by all versions in its declared compatibility window, including metadata needed to deprovision an existing tenant. Changing the selected provider instance while such metadata exists is unsupported until an operator-approved migration rewrites or retires every affected binding.
 
-- **Rationale**: Account Management remains an opaque metadata proxy while the producing instance remains durably bound to each tenant and cannot be replaced through vendor or priority drift.
+- **Rationale**: Account Management remains an opaque metadata proxy while the plugin retains fail-closed interpretation authority.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
 
 #### Ownership-Preserving Tenant Deprovisioning
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-tenant-deprovision`
 
-The plugin **MUST** remove the tenant's provider-owned identity resources during hard deprovisioning. It **MUST NOT** delete the operator-owned shared realm.
+During hard deprovisioning the plugin **MUST** remove the tenant's provider-owned resources in a safe order: first purge the tenant's service principals, then delete the tenant group. For `created` bindings only, when no other tenant group remains, the plugin **MUST** then delete the plugin-owned realm and its Credential Store secret. It **MUST NOT** delete operator-owned shared or adopted realms, and **MUST NOT** delete resources belonging to another tenant. Missing metadata and already-absent resources **MUST** be success-equivalent.
 
-- **Rationale**: Cleanup must remove retired tenant access without destroying operator-owned or other-tenant resources.
+- **Rationale**: Cleanup must remove retired tenant access — including machine credentials — without destroying operator-owned or other-tenant resources.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
 
 #### Service-Principal Cleanup Ordering
 
-- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-tenant-service-principal-cleanup`
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-tenant-service-principal-cleanup`
 
-Before p2 service-principal support is promoted, its owner and Account Management **MUST** define a hard-deletion barrier that prevents tenant identity-boundary removal while an active tenant-owned service principal remains. Account Management **MUST NOT** invoke this plugin directly for service-principal cleanup through `IdpPluginClient`.
+Tenant deprovisioning **MUST** delete every service-principal client owned by the retiring tenant (identified by the `svc-{tenant_id}-` prefix and the ownership marker) before removing the tenant identity boundary. A purge failure **MUST** abort the deprovisioning saga with a retryable or terminal classification — it **MUST NOT** be reported as success-equivalent — so that no live machine credential survives its tenant.
 
-- **Rationale**: No live machine credential can survive its tenant, but Account Management cannot own an operation absent from its provider contract.
+- **Rationale**: No live machine credential can survive its tenant, and skipping the barrier on error would leak credentials past tenant retirement.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`
 
 #### Tenant User Access Termination
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-tenant-user-access-termination`
 
-Account Management does not invoke this plugin for tenant suspension or soft deletion, so those transitions **MUST NOT** be presented as plugin-enforced access termination. During hard deprovisioning, the plugin **MUST** revoke provider sessions and delete every human identity bound to the retiring tenant. It **MUST NOT** delete identities or memberships belonging to another active tenant. `IdpDeprovisionFailure::Retryable` applies only when the plugin proves that no deprovisioning mutation has an unknown outcome: either no mutating request may have reached Keycloak, or completed partial work is proven replay-safe and no attempted stage remains uncertain. Once a session-revocation, identity-removal, or boundary-removal request may have reached Keycloak and its result cannot be proven, the plugin **MUST** return `IdpDeprovisionFailure::Terminal` for operator action; a timeout or transient transport label does not override that boundary. An access JWT issued before hard deprovisioning can remain valid until its `exp`, which **MUST NOT** exceed 15 minutes in the v1 authentication profile.
+Account Management does not invoke this plugin for tenant suspension or soft deletion, so those transitions **MUST NOT** be presented as plugin-enforced access termination. Human identities are removed through per-user `deprovision_user` calls issued by Account Management's hard-delete pipeline before the tenant boundary is retired; tenant deprovisioning itself removes the boundary (group, service principals, and — for created bindings — the realm). `IdpDeprovisionFailure::Retryable` applies to failures where nothing was attempted (pre-saga probe failure) or where the failed step is safe to repeat; a malformed metadata blob or an unclassifiable purge failure **MUST** return `Terminal` for operator action. An access JWT issued before hard deprovisioning can remain valid until its `exp`, which **MUST NOT** exceed 15 minutes in the operator's v1 authentication profile.
 
-- **Rationale**: This contract matches Account Management's hard-deletion hook and the OIDC resolver's offline JWT model without promising an unavailable suspension or real-time revocation path.
+- **Rationale**: This contract matches Account Management's hard-deletion pipeline and the OIDC resolver's offline JWT model without promising an unavailable suspension or real-time revocation path.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
 
 #### Tenant Lifecycle Failure Contract
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-tenant-failure-contract`
 
-The plugin **MUST** distinguish invalid pre-mutation requests, unsupported operations, retryable deprovisioning failures, terminal deprovisioning failures, already-absent resources, and ambiguous provisioning outcomes. It **MUST** treat already-absent tenant resources as success-equivalent during deprovisioning and **MUST NOT** invite blind retry after ambiguous provisioning.
+The plugin **MUST** distinguish invalid pre-mutation requests (`InvalidInput` with a field reference), clean failures proven to retain no provider state (`CleanFailure`, including permanent provider 4xx and pre-saga failures), ambiguous provisioning outcomes (`Ambiguous`, stage-attributed with an `ambig:` token, covering provider 5xx, transport loss, saga timeout, and the Credential-Store-write-after-Keycloak-success window), unsupported operations, retryable deprovisioning failures, terminal deprovisioning failures, and already-absent resources (`NotFound`, success-equivalent). It **MUST NOT** invite blind retry after an ambiguous result.
 
 - **Rationale**: External administration can fail after side effects, so callers need deterministic recovery behavior.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
@@ -335,25 +336,25 @@ The plugin **MUST** distinguish invalid pre-mutation requests, unsupported opera
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-provision`
 
-The plugin **MUST** create a user inside the resolved tenant identity boundary, preserve the required tenant association, and return the provider-issued user projection.
+The plugin **MUST** create a user inside the resolved tenant identity boundary: the created representation carries the immutable `tenant_id` attribute and `user_type = "user"`, the configured required actions (default `VERIFY_EMAIL`, plus `UPDATE_PASSWORD` for temporary initial passwords), a coupled `emailVerified` derivation, and the optional initial password embedded in the create request; the user is then joined to the tenant group. If the group join fails after creation, the plugin **MUST** attempt best-effort orphan compensation (delete the created identity), report the compensation outcome on a dedicated metric, and return the original failure. A provider uniqueness conflict **MUST** be returned as `DuplicateUser` with the conflicting field refined from provider evidence where possible (`Username`, `Email`, or `UsernameOrEmail`). On success the plugin returns the provider-issued user projection.
 
-- **Rationale**: Account Management needs a provider-neutral way to create identities while Keycloak remains the identity source of truth.
+- **Rationale**: Account Management needs a provider-neutral way to create identities while Keycloak remains the identity source of truth and half-created identities do not linger unbound.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`, `cpt-cf-keycloak-idp-plugin-actor-account-management`
 
 #### Tenant-Scoped User Update
 
-- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-update`
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-update`
 
-The plugin **MUST** apply partial updates to `username`, `email`, `display_name`, `first_name`, `last_name`, and `password` within the existing tenant binding. Omitted fields **MUST** remain unchanged; nullable profile fields **MUST** support clearing. The user identifier and tenant binding **MUST** remain immutable.
+User profile update is not implemented in this revision: `IdpPluginClient::update_user` returns `UnsupportedOperation`. When implemented, partial updates to `username`, `email`, `display_name`, `first_name`, `last_name`, and `password` **MUST** apply within the existing tenant binding, omitted fields **MUST** remain unchanged, nullable profile fields **MUST** support clearing, and the user identifier and tenant binding **MUST** remain immutable.
 
-- **Rationale**: A production provider needs a complete administrative user lifecycle without turning profile editing into unsafe tenant reassignment.
+- **Rationale**: A production provider eventually needs a complete administrative user lifecycle; until then callers receive a deterministic unsupported outcome rather than partial behavior.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`, `cpt-cf-keycloak-idp-plugin-actor-account-management`
 
 #### User Update Outcome Classification
 
-- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-update-outcomes`
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-update-outcomes`
 
-The plugin **MUST** distinguish an absent user, duplicate username or email, password-policy rejection, unsupported behavior, invalid input, and provider unavailability when updating a user. A missing user **MUST NOT** be treated as a successful update.
+When user update is implemented, the plugin **MUST** distinguish an absent user, duplicate username or email, password-policy rejection, unsupported behavior, invalid input, and provider unavailability. A missing user **MUST NOT** be treated as a successful update.
 
 - **Rationale**: Tenant administrators need actionable and stable outcomes for corrective action.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`, `cpt-cf-keycloak-idp-plugin-actor-account-management`
@@ -362,18 +363,18 @@ The plugin **MUST** distinguish an absent user, duplicate username or email, pas
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-deprovision`
 
-User deprovisioning **MUST** revoke provider sessions and remove the user from the resolved tenant binding. An already-absent provider identity **MUST** produce a success-equivalent outcome. The plugin **MUST NOT** claim that it invalidates a previously issued access JWT; such a token can remain valid until its `exp`, which **MUST NOT** exceed 15 minutes in the v1 authentication profile.
+Before any mutation, user deprovisioning **MUST** verify that the target user's stored `tenant_id` attribute matches the resolved tenant; a mismatch **MUST** perform no mutation and **MUST** return success-equivalently without disclosing whether the identity exists (the cross-tenant deletion guard). It then revokes provider sessions (best-effort, configurable, default on) and deletes the identity. An already-absent provider identity (404/410) **MUST** produce a success-equivalent outcome. The plugin **MUST NOT** claim that it invalidates a previously issued access JWT; such a token can remain valid until its `exp`, which **MUST NOT** exceed 15 minutes in the operator's v1 authentication profile.
 
-- **Rationale**: Deprovisioning blocks refresh and new provider sessions while matching the OIDC resolver's offline JWT contract.
+- **Rationale**: Deprovisioning blocks refresh and new provider sessions, stays idempotent, and cannot be used to delete another tenant's identity.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`, `cpt-cf-keycloak-idp-plugin-actor-account-management`
 
 #### Tenant-Scoped User Query
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-query`
 
-The plugin **MUST** list only users belonging to the resolved tenant binding and **MUST** support the filtering, ordering, point-existence, and cursor pagination behavior required by the Account Management provider contract.
+The plugin **MUST** list only users belonging to the resolved tenant group. The supported filter surface is `eq` (exact) and `contains` (case-insensitive) over `username`, `email`, `first_name`, `last_name`, and `display_name`, an `id` point filter, and `and`/`or` composition; unsupported filter shapes **MUST** return `UnsupportedOperation` before any provider call. Results are globally sorted on `(created_at ASC, id ASC)` with the provider id as tiebreaker; requested orderings are not honored in this revision. Continuation **MUST** use a `CursorV1` token that pins the sort order, direction, last-emitted key, and a hash of the tenant, realm, and complete filter tree, so a cursor replayed with a different filter or tenant context is rejected as invalid. Page size **MUST** be capped (default cap 200). The per-request membership scan **MUST** be bounded by a hard cap (10,000 members); exceeding the cap truncates the scan and emits a loud operational warning rather than failing or silently hiding members.
 
-- **Rationale**: Tenant administration and downstream membership checks need stable queries without cross-tenant disclosure.
+- **Rationale**: Tenant administration and downstream membership checks need stable, correctly ordered queries without cross-tenant disclosure, with explicit and observable capacity bounds.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`, `cpt-cf-keycloak-idp-plugin-actor-account-management`
 
 #### Keycloak as User Source of Truth
@@ -387,105 +388,105 @@ The plugin **MUST** read and mutate user state in Keycloak and **MUST NOT** main
 
 ### 5.4 Service-Principal Lifecycle
 
-Service-principal lifecycle support is a p2 extension. Account Management does not own this capability, and the current `IdpPluginClient` does not expose it. No requirement in this section is part of v1 release acceptance.
+Service-principal lifecycle is provided in v1 through the platform-owned `service-principal-sdk` contract (`ServicePrincipalClientV1`), registered unscoped in ClientHub for trusted platform consumers. Account Management's `IdpPluginClient` does not expose it; consumer-side authorization happens in the consumer's RBAC/PDP before delegation.
 
 #### Complete Service-Principal Operations
 
-- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-lifecycle`
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-lifecycle`
 
-Before implementation, the platform **MUST** select a consumer-facing lifecycle owner outside Account Management. That owner **MUST** publish a versioned provider contract for creation, credential rotation, revocation, and listing. Regular consumers **MUST** use the selected owner and **MUST NOT** depend directly on this plugin.
+The plugin **MUST** implement creation, secret rotation, revocation, and listing of tenant-scoped service principals as confidential OAuth `client_credentials` clients in the configured service-principal realm (default `platform` — the shared realm whose issuer tenants trust). Regular product consumers **MUST NOT** depend on this plugin directly; they use the owning platform module that consumes `ServicePrincipalClientV1`.
 
-- **Rationale**: Explicit upstream ownership prevents machine identities, authorization, and secret custody from being added to Account Management by implication.
+- **Rationale**: Machine identities authenticate through the same trusted issuer as human identities without adding machine-identity semantics to Account Management.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`
 
 #### Service-Principal Identity and State
 
-- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-state`
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-state`
 
-A service-principal name **MUST** be unique within its tenant while active. Successful creation **MUST** return a stable principal identifier, tenant association, accepted scopes, authentication endpoint information, and a one-time credential. A duplicate active name **MUST** be rejected without side effects. After successful revocation, the principal **MUST** disappear from active listings; reusing the same name **MUST** create a distinct provider identity with a new credential.
+The final client id **MUST** be server-built as `svc-{tenant_id}-{name}`, where `name` is caller-chosen, non-empty, at most 40 characters, and restricted to lowercase alphanumerics and `-`. Successful creation **MUST** return a stable client id, the principal's subject id (the service-account user UUID, usable for RBAC bindings), the OAuth token endpoint, and the client secret. A taken client id **MUST** be rejected as invalid input without side effects — including a half-created principal left by an earlier ambiguous failure; recovery is revoke-then-create. After successful revocation, the principal **MUST** disappear from active listings; reusing the same name **MUST** create a distinct provider identity with a new credential.
 
-- **Rationale**: Stable identity and explicit lifecycle outcomes prevent duplicate or accidentally resurrected machine credentials.
+- **Rationale**: Stable identity and explicit lifecycle outcomes prevent duplicate or accidentally resurrected machine credentials, and a name collision must never hand out another consumer's live secret.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`
 
 #### Service-Principal Tenant and Scope Safeguards
 
-- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-safeguards`
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-safeguards`
 
-Every service principal **MUST** be associated with exactly one tenant and **MUST** authenticate through the same trusted issuer used by that tenant's human identities. Issued tokens **MUST** identify the principal and owning tenant, distinguish the subject as a service principal, target an accepted audience, and grant no scope beyond the accepted scope set. The owning contract **MUST** define scope restrictions and a per-tenant quota before this capability is promoted to a release baseline.
+Every service principal **MUST** be associated with exactly one tenant: the client carries the ownership marker (`vhp.provisioning.tenant_id`), and its service-account user carries the `tenant_id` attribute and the configured service-principal subject type, so issued tokens identify the principal, its owning tenant, and the machine subject class through the realm's protocol mappers. Requested client scopes **MUST** be validated against the configured allowlist (empty allowlist = none attachable), and an allowlisted scope missing from the realm **MUST** fail cleanly with an operator-actionable message. A best-effort per-tenant quota (default 10) **MUST** bound creation; it is an operational guard, not a security boundary. Ownership **MUST** be enforced on every read and mutation: a principal that is absent or owned by another tenant is reported as not found, without distinguishing the two.
 
-- **Rationale**: Explicit tenant ownership and authentication compatibility prevent cross-tenant machine access.
+- **Rationale**: Explicit tenant ownership and authentication compatibility prevent cross-tenant machine access and cross-tenant existence disclosure.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`
 
 #### Secret Rotation and Token Consequences
 
-- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-rotation`
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-rotation`
 
-Successful rotation **MUST** preserve the principal identity, tenant association, and accepted scopes. It **MUST** disclose the replacement credential once and prevent the old credential from obtaining new tokens. Successful revocation **MUST** prevent new token issuance and further credential mutation. Tokens issued before rotation or revocation can remain valid until their configured expiry and **MUST NOT** exceed the platform maximum access-token lifetime.
+Successful rotation **MUST** preserve the principal identity (client id, subject id) and tenant association, disclose the replacement credential in the rotation result, and prevent the old credential from obtaining new tokens. Rotation of a principal whose managed attributes are incomplete or corrupt **MUST** be rejected as invalid input with revoke-and-recreate guidance rather than returning a credential for a partially repaired identity. Successful revocation **MUST** prevent new token issuance; revocation of an already-absent principal is success-equivalent (`NotFound`). Tokens issued before rotation or revocation can remain valid until their configured expiry and **MUST NOT** exceed the platform maximum access-token lifetime.
 
 - **Rationale**: The credential cutover contract must match offline JWT validation rather than promise real-time token revocation.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`
 
 #### Service-Principal Listing
 
-- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-list`
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-list`
 
-Listing **MUST** return only active principals owned by the requested tenant and **MUST** omit credentials. The owning contract **MUST** define cursor pagination, deterministic ordering, and default and maximum page sizes before implementation.
+Listing **MUST** return only principals owned by the requested tenant (prefix plus ownership-marker check enforced client-side over the provider's search results) and **MUST** omit credentials. The listing reports each principal's client id, enabled state, and attached client scopes as reported by the provider (including realm-default scopes). Cursor pagination and deterministic ordering for large principal sets are a p2 extension of the owning contract.
 
-- **Rationale**: A bounded query contract prevents cross-tenant disclosure and unstable continuation behavior.
+- **Rationale**: A bounded query contract prevents cross-tenant disclosure; today's consumer population per tenant is small enough for unpaginated listing.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`
 
 #### Service-Principal Mutation Safety
 
-- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-mutation-safety`
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-mutation-safety`
 
-Repeating an equivalent mutation **MUST NOT** apply a second provider mutation or disclose another credential. A stale request **MUST NOT** overwrite newer credential state. Concurrent rotations **MUST** leave at most one current credential. A rotation racing with completed revocation **MUST NOT** restore token issuance. An outcome whose winner cannot be proven **MUST** require reconciliation and **MUST NOT** invite blind retry.
+Repeating a creation with a taken name **MUST NOT** apply a second provider mutation or disclose another credential (it is rejected as invalid input). An uncertain creation, rotation, or revocation outcome **MUST** be reported as ambiguous with a stage token, **MUST NOT** contain a credential, and **MUST NOT** invite blind retry until the external outcome is resolved. A service-account user found already bound to a different tenant during creation **MUST** abort without overwriting (hijack guard).
 
 - **Rationale**: Concurrency-safe outcomes prevent duplicate identities and credential resurrection.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
 
 #### One-Time Secret Disclosure
 
-- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-secret-disclosure`
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-secret-disclosure`
 
-A service-principal credential **MUST** be disclosed only in a successful creation or rotation result. The lifecycle owner and plugin **MUST NOT** persist, cache, log, audit, or otherwise retain the plaintext credential. Listing, later reads, reconciliation evidence, and repeated requests **MUST NOT** return it. The consumer owns durable custody. An unproven delivery outcome **MUST** require reconciliation and **MUST NOT** trigger automatic credential recovery, regeneration, or rotation.
+A service-principal credential **MUST** be disclosed to consumers only in a successful creation or rotation result, carried in a redacted secret wrapper. The plugin **MUST NOT** persist, cache, log, or audit the plaintext credential; Keycloak holds the authoritative credential. Listing, reconciliation evidence, and failure results **MUST NOT** return it. The consumer owns durable custody (typically the Credential Store); a lost secret is recovered by explicit rotation, never by re-disclosure.
 
 - **Rationale**: Limiting plaintext exposure reduces credential leakage risk.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`
 
 #### Service-Principal Recovery
 
-- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-recovery`
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-recovery`
 
-After reconciliation confirms provider state, an absent identity **MUST** permit a new creation attempt. A valid identity with an undelivered credential **MUST** require explicitly authorized rotation. An incomplete identity **MUST** require controlled cleanup before another creation attempt. An unresolved state **MUST** remain blocked for operator action.
+After reconciliation confirms provider state, an absent identity **MUST** permit a new creation attempt. A valid identity with an undelivered credential **MUST** be recovered by explicitly authorized rotation. An incomplete identity (taken name, missing or corrupt managed attributes) **MUST** require revoke-then-create before another creation attempt. An unresolved ambiguous state **MUST** remain blocked for operator action.
 
 - **Rationale**: Recovery must follow observed provider state without redisclosing or guessing a credential.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
 
 #### Service-Principal Failure Contract
 
-- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-failure-contract`
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-service-principal-failure-contract`
 
-The plugin **MUST** report uncertain creation, rotation, revocation, or concurrent mutation as ambiguous. It **MUST** report missing principals for operations that require an existing identity and treat revocation of an already-absent principal as success-equivalent. An ambiguous result **MUST NOT** contain a credential and **MUST** block blind retry until the external outcome is resolved.
+The plugin **MUST** classify every failed service-principal call into the closed `ServicePrincipalFailure` taxonomy: `InvalidInput` (bad name, disallowed scope, quota exceeded, taken client id — permanent, no vendor state retained by the call), `NotFound` (absent or foreign target; success-equivalent for revoke), `CleanFailure` (pre-mutation failure, retry harmless), and `Ambiguous` (transport uncertainty after a mutation may have landed — never reported as success, never containing a credential).
 
-- **Rationale**: Credential mutation requires clear retry and recovery behavior.
+- **Rationale**: Credential mutation requires clear retry and recovery behavior with no invented variants.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
 
 ### 5.5 Provider Administration and Operations
 
-#### Protected Administrator Credentials
+#### Administrator Credentials
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-administrator-credentials`
 
-The plugin **MUST** invoke only operator-approved OAGW routes configured with administrator credentials that have the least privilege needed for each realm lifecycle. OAGW **MUST** support rotation through stable credential references without exposing credential values to the plugin, product outputs, or operational signals.
+The plugin **MUST** administer Keycloak through two confidential-client tiers with `client_credentials` grants: an operator-provisioned bootstrap admin (default `vp-idp-plugin-bootstrap` in `master`) for realm-level work, and a per-realm realm admin (default `vp-idp-plugin-realm-admin`) for tenant/user work. Realm-admin clients created by the plugin (created mode) **MUST** be granted exactly the least-privilege role set (`view-realm`, `view-clients`, `query-groups`, `manage-realm`, `manage-users`, `query-users`, `manage-clients`). Secrets **MUST** enter the process only through environment-expanded configuration (bootstrap, default shared realm) or the Credential Store (adopted/created realms), always inside redacted wrapper types. Operator secret rotation **MUST** converge without process restart: a provider 401 invalidates the cached token, re-resolves the secret from its source, and retries exactly once. Cached tokens **MUST** be redacted from all debug output.
 
-- **Rationale**: Provider administrator compromise can affect every identity in the authorized realm, while gateway-owned injection keeps the credential outside plugin memory.
-- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-oagw`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
+- **Rationale**: Provider administrator compromise can affect every identity in the authorized realm; tiered least privilege, typed secret custody, and reactive rotation bound that risk.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
 
 #### External Mutation Resilience
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-external-mutation-resilience`
 
-Tenant provisioning **MUST** preserve the SDK distinction between clean and ambiguous outcomes and **MUST** stop automatic retry after an ambiguous result. User operations **MUST** return only outcomes exposed by `IdpUserOperationFailure`; the plugin **MUST NOT** invent an ambiguity variant. Repeated user deprovisioning and equivalent user updates **MUST** remain idempotent, and provider diagnostics **MUST NOT** expose sensitive values.
+Automatic transport retry **MUST** be bounded (configurable policy; default 3 retries, exponential backoff with full jitter, `Retry-After` honored) and restricted to idempotent requests on retryable causes (provider 5xx/429, connect/timeout); administrative `POST`s **MUST NOT** be replayed on transport failure. Tenant provisioning **MUST** preserve the SDK distinction between clean and ambiguous outcomes and **MUST** stop automatic retry after an ambiguous result. User operations **MUST** return only outcomes exposed by `IdpUserOperationFailure`; the plugin **MUST NOT** invent an ambiguity variant. Repeated user deprovisioning remains idempotent, and provider diagnostics **MUST** be redacted and truncated before leaving the plugin.
 
 - **Rationale**: Unbounded or unsafe retry can duplicate resources, leak realms, or invalidate credentials.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
@@ -494,7 +495,7 @@ Tenant provisioning **MUST** preserve the SDK distinction between clean and ambi
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-operator-reconciliation`
 
-For v1, ambiguous-state reconciliation **MUST** be an operator-owned workflow rather than a public mutation API. The plugin **MUST** provide sufficient non-secret evidence to determine resource ownership and whether the mutation completed. The workflow **MUST** end in one audited outcome: compensated and safe to retry, accepted as complete, still blocked for further investigation, or escalated for controlled cleanup. Production enablement **MUST** include a reconciliation runbook.
+For v1, ambiguous-state reconciliation **MUST** be an operator-owned workflow rather than a public mutation API. The plugin **MUST** provide sufficient non-secret evidence — the machine-parsable `ambig:{stage}` token (realm create, client create, role mapping, secret read, credential-store write, admin-user bind, scope attach, secret rotate, client delete, timeout), the realm, and redacted provider detail — to determine resource ownership and whether the mutation completed. The workflow **MUST** end in one audited outcome: compensated and safe to retry, accepted as complete, still blocked for further investigation, or escalated for controlled cleanup. Production enablement **MUST** include a reconciliation runbook keyed on the stage tokens.
 
 - **Rationale**: Operators need a safe resolution path even where current contracts cannot automatically distinguish an orphan from an already-clean resource.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
@@ -503,7 +504,7 @@ For v1, ambiguous-state reconciliation **MUST** be an operator-owned workflow ra
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-offline-token-lifetime`
 
-The v1 realm authentication profile **MUST** limit access-token lifetime to 15 minutes. User or tenant hard deprovisioning **MUST** revoke Keycloak sessions to block refresh and new session use. The plugin **MUST NOT** claim immediate rejection of an access JWT issued before deprovisioning. The OIDC AuthN Resolver can accept that token until `exp` when its signature and claims remain valid.
+The operator's v1 realm authentication profile **MUST** limit access-token lifetime to 15 minutes. User deprovisioning revokes Keycloak sessions to block refresh and new session use. The plugin **MUST NOT** claim immediate rejection of an access JWT issued before deprovisioning. The OIDC AuthN Resolver can accept that token until `exp` when its signature and claims remain valid.
 
 - **Rationale**: This bounded exposure matches the OIDC resolver's offline JWT validation contract and its explicit exclusion of session and revocation management.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-authn-resolver`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`
@@ -512,10 +513,10 @@ The v1 realm authentication profile **MUST** limit access-token lifetime to 15 m
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-audit-metrics`
 
-The plugin **MUST** return a classified, privacy-safe outcome and correlation evidence for every supported tenant, user, provider-request, reconciliation, and failure lifecycle, and **MUST** emit bounded-cardinality operational metrics. Account Management **MUST** create the durable audit intent and terminal outcome for each mutating plugin call; the platform audit owner **MUST** persist and deliver it idempotently. OAGW and Credential Store owners **MUST** audit credential resolution and rotation under their own contracts because credential values and lifecycle do not enter this plugin. When the p2 service-principal contract is implemented, its owning platform service **MUST** provide the equivalent durable audit boundary. No signal **MUST** contain secrets or user profile values such as username, email, or display name.
+The plugin **MUST** return a classified, redacted outcome for every supported call and **MUST** emit structured audit events on the dedicated `vp.idp.plugin.events` tracing target for every mutating tenant and user lifecycle transition: `tenant.bound`, `realm.created`, `admin_user.bound`, `tenant.unbound`, `realm.removed`, `service_principals.purged`, `user.provisioned`, and `user.deprovisioned`, each carrying the acting subject (id, classified type, raw type, tenant) and provider identifiers. `user.provisioned` additionally records the username as operational evidence; no event carries secrets, passwords, tokens, or raw provider bodies. These emitters are a development stand-in: Account Management and the platform audit owner **MUST** create and durably deliver the terminal audit outcome for each mutating plugin call before production enablement. The plugin **MUST** emit bounded-cardinality operational metrics (`vp_idp_plugin_*`): operation duration histograms, a failure counter labeled by operation and stable failure variant, token/credential refresh counters split by tier, credential-store write outcomes, metadata decode failures, orphan-compensation outcomes, and a bound-realms gauge — with the realm label subject to a configurable cardinality cap (default 500) after which it is dropped with a warning.
 
-- **Rationale**: A single owner for each durable record prevents duplicate or missing audit events while preserving plugin-level diagnostic evidence.
-- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-oagw`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
+- **Rationale**: A single owner for each durable record prevents duplicate or missing audit events while preserving plugin-level diagnostic evidence with bounded cost.
+- **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
 
 ## 6. Non-Functional Requirements
 
@@ -527,7 +528,7 @@ Global reliability, security, and observability baselines come from the [Archite
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-tenant-isolation`
 
-The plugin **MUST** prevent an operation resolved for one tenant from reading or mutating identities bound to another tenant.
+The plugin **MUST** prevent an operation resolved for one tenant from reading or mutating identities bound to another tenant: listing is scoped to the tenant group, user deletion is guarded by the stored `tenant_id` attribute, and realm/service-principal mutations are guarded by ownership markers.
 
 - **Threshold**: Zero successful cross-tenant operations across the automated negative-isolation suite.
 - **Rationale**: Identity administration is a security boundary for every tenant.
@@ -537,27 +538,27 @@ The plugin **MUST** prevent an operation resolved for one tenant from reading or
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-secret-nondisclosure`
 
-The plugin **MUST** prevent administrator tokens, administrator secrets, user passwords, and service-principal secrets from appearing in logs, metrics, audit events, list responses, or debug output.
+The plugin **MUST** prevent administrator tokens, administrator secrets, user passwords, and service-principal secrets from appearing in logs, metrics, audit events, list responses, or debug output. Concretely: secrets live in redacted wrapper types, the token cache redacts its debug output, and every provider error body passes secret-pattern redaction plus 2 KiB truncation before leaving the plugin.
 
 - **Threshold**: Zero secret values detected by automated redaction tests and security scanning across all named output surfaces.
 - **Rationale**: These credentials can grant user or machine access across a tenant or realm.
-- **Architecture Allocation**: See [DESIGN.md §§3.5–3.6](./DESIGN.md#35-external-dependencies) and [§4.1](./DESIGN.md#41-security-and-data-protection).
+- **Architecture Allocation**: See [DESIGN.md §3.6](./DESIGN.md#36-interactions--sequences) and [§4.1](./DESIGN.md#41-security-and-data-protection).
 
 #### Lifecycle Latency
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-lifecycle-latency`
 
-On the release qualification profile, shared-realm tenant provisioning **MUST** complete within 5 seconds at p95. User creation, update, deprovisioning, and a 100-user query page **MUST** each complete within 1 second at p95. The profile **MUST** use 20 concurrent operations, an operator-equivalent Keycloak 26.x node backed by PostgreSQL, at most 5 ms network round-trip time between Outbound API Gateway and Keycloak, and up to 1,000 human identities, enabled or disabled, in one tenant group. Query runs **MUST** cover unfiltered results and filters matching approximately 100%, 10%, and 1% of the group under every supported order. Measurements **MUST** include plugin and gateway processing plus Keycloak administration round trips, cover cached-token and forced-token-refresh runs, and exclude only caller-to-Account-Management network time. A list operation **MUST** use provider member pages no larger than 500, perform no more than `ceil(N / 500) + 1` member-page reads, and use no more than 16 MiB working memory per request. If a scan observes more than 1,000 total members, it **MUST** stop before sorting or returning a partial page and return `IdpUserOperationFailure::UnsupportedOperation` with a non-sensitive capacity detail.
+On the release qualification profile, shared-realm tenant provisioning **MUST** complete within 5 seconds at p95; created-realm provisioning within 10 seconds at p95. User creation, deprovisioning, and a full query page **MUST** each complete within 1 second at p95. The profile **MUST** use 20 concurrent operations, an operator-equivalent Keycloak 26.x node backed by PostgreSQL, at most 5 ms network round-trip time between the plugin and Keycloak, and up to 1,000 human identities, enabled or disabled, in one tenant group. Query runs **MUST** cover unfiltered results and filters matching approximately 100%, 10%, and 1% of the group, over cached-token and forced-token-refresh runs. Operational bounds enforced by the implementation and validated by the profile: per-request provider timeout (default 5 s), bounded retry policy, 30 s saga timeout, caller page size capped at 200, and the 10,000-member scan hard cap with loud truncation.
 
-- **Threshold**: Tenant provisioning p95 ≤ 5 seconds; each named user operation p95 ≤ 1 second; 20 concurrent operations; list support ceiling 1,000 total users per tenant group; list working memory ≤ 16 MiB per request.
-- **Rationale**: A fixed population, topology, filter mix, call budget, and overflow result make the linear-scan acceptance test reproducible.
-- **Architecture Allocation**: See [DESIGN.md §1.2](./DESIGN.md#12-architecture-drivers), [§3.6](./DESIGN.md#36-interactions--sequences), and [§4.3](./DESIGN.md#43-risks-and-enablement-gates).
+- **Threshold**: Shared provisioning p95 ≤ 5 s; created provisioning p95 ≤ 10 s; each named user operation p95 ≤ 1 s; 20 concurrent operations; scan cap 10,000 members per tenant group with observable truncation.
+- **Rationale**: A fixed population, topology, filter mix, and bound set make the linear-scan acceptance test reproducible.
+- **Architecture Allocation**: See [DESIGN.md §1.2](./DESIGN.md#12-architecture-drivers), [§2.2](./DESIGN.md#22-constraints), and [§3.6](./DESIGN.md#36-interactions--sequences).
 
 #### Deterministic Failure Classification
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-failure-classification`
 
-The plugin **MUST** classify every failed supported lifecycle call into an outcome exposed by the applicable SDK contract. Tenant provisioning **MUST** preserve `Ambiguous` whenever retained external state cannot be ruled out. User operations **MUST** use the available `IdpUserOperationFailure` variants and rely on idempotent replay where that contract has no ambiguity variant.
+The plugin **MUST** classify every failed supported lifecycle call into an outcome exposed by the applicable SDK contract, through its closed internal error taxonomy and fixed translation tables. Tenant provisioning **MUST** preserve `Ambiguous` whenever retained external state cannot be ruled out (provider 5xx, transport loss, saga timeout, post-Keycloak credential-store failure). User operations **MUST** use the available `IdpUserOperationFailure` variants and rely on idempotent replay where that contract has no ambiguity variant. Every failure variant **MUST** carry a stable metric label.
 
 - **Threshold**: 100% of automated failure-injection cases produce an expected SDK category; zero ambiguous tenant-provisioning cases are classified as clean failures.
 - **Rationale**: Correct recovery depends on the difference between safe retry and reconciliation.
@@ -567,7 +568,7 @@ The plugin **MUST** classify every failed supported lifecycle call into an outco
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-audit-completeness`
 
-The plugin **MUST** return classified privacy-safe evidence for every successful or failed supported mutating tenant and user call. Account Management and the platform audit owner **MUST** turn that evidence into one durable terminal audit outcome. The same obligation **MUST** apply to the owning service for service-principal calls if the p2 contract is implemented.
+The plugin **MUST** emit one structured event per mutating tenant/user lifecycle transition (including already-absent outcomes) and return classified evidence for every call. Account Management and the platform audit owner **MUST** turn that evidence into one durable terminal audit outcome per mutating call before production enablement; the plugin's tracing-based emitters are not a production substitute. Service-principal mutations currently produce plugin audit evidence only for the tenant-deprovision purge; per-operation service-principal audit is owned by the consuming platform module.
 
 - **Threshold**: 100% correlation between mutating contract-test calls and one durable terminal audit outcome, excluding calls rejected before actor context exists.
 - **Rationale**: Identity and credential mutations require traceable accountability with one unambiguous durable emitter.
@@ -577,19 +578,19 @@ The plugin **MUST** return classified privacy-safe evidence for every successful
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-provider-compatibility`
 
-V1 **MUST** support Keycloak 26.x. A reachable provider on another major version **MUST** fail operation-based readiness and every affected lifecycle operation before mutation, while unrelated Account Management capabilities remain available. Expansion to another major version **MUST** require a versioned compatibility update.
+V1 **MUST** be qualified against Keycloak 26.x: every supported 26.x release in the release matrix passes the provider contract suite before plugin publication. The implementation performs no runtime provider-version check; a runtime operation-level version gate is a p2 extension. Expansion to another major version **MUST** require a versioned compatibility update and re-qualification.
 
-- **Threshold**: Every supported Keycloak 26.x release in the release matrix passes the provider contract suite; representative unsupported major versions fail affected operations deterministically without preventing host startup.
-- **Rationale**: An explicit compatibility window gives operators predictable installation, upgrade, and rollback support without turning an external provider check into a process-wide startup dependency.
-- **Architecture Allocation**: See [DESIGN.md §3.2](./DESIGN.md#32-component-model) and [§3.6](./DESIGN.md#36-interactions--sequences).
+- **Threshold**: Every supported Keycloak 26.x release in the release matrix passes the provider contract suite.
+- **Rationale**: An explicit compatibility window gives operators predictable installation, upgrade, and rollback support.
+- **Architecture Allocation**: See [DESIGN.md §4.3](./DESIGN.md#43-risks-and-enablement-gates).
 
 #### Personal Data Minimization and Lifecycle
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-personal-data-lifecycle`
 
-The plugin **MUST** process only identity attributes required by its contracts, **MUST NOT** retain a separate persistent copy of user PII, and **MUST** keep usernames, email addresses, display names, and other profile values out of logs, metrics, and audit events. Audit signals **MUST** use provider-issued identity references. Keycloak user records remain governed by Account Management's soft-delete window and **MUST** be removed when hard deprovisioning is invoked. The plugin **MUST NOT** create a separate audit store; the platform audit sink **MUST** enforce a finite, operator-configured retention period documented before production enablement, with longer preservation permitted only under an approved legal hold or security-investigation policy.
+The plugin **MUST** process only identity attributes required by its contracts and **MUST NOT** retain a separate persistent copy of user PII. Metrics **MUST** carry no profile values. Audit events use provider-issued identity references; the `user.provisioned` event additionally records the username as operational evidence, and no event carries email addresses, display names, passwords, or raw provider payloads. Keycloak user records remain governed by Account Management's soft-delete window and **MUST** be removed when hard deprovisioning is invoked. The plugin **MUST NOT** create a separate audit store; the platform audit sink **MUST** enforce a finite, operator-configured retention period documented before production enablement.
 
-- **Threshold**: Zero profile values detected across logs, metrics, audit events, debug output, and retained plugin state; 100% of hard-deletion cases produce a classified identity-deletion outcome; production configuration contains a finite audit-retention period.
+- **Threshold**: Zero profile values in metrics and debug output; audit events limited to provider references plus the username on `user.provisioned`; 100% of hard-deletion cases produce a classified identity-deletion outcome; production configuration contains a finite audit-retention period.
 - **Rationale**: User identity administration processes personal data even though the plugin owns no local directory.
 - **Architecture Allocation**: See [DESIGN.md §4.1](./DESIGN.md#41-security-and-data-protection).
 
@@ -597,21 +598,21 @@ The plugin **MUST** process only identity attributes required by its contracts, 
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-availability-recovery`
 
-When required dependencies meet their objectives, the plugin **MUST** support the parent Account Management target of 99.9% monthly availability for provider-dependent lifecycle operations. Each call **MUST** fail closed when its own critical dependency is unavailable while leaving operations with unaffected dependencies usable. Unambiguous operations **MUST** recover within the inherited 15-minute recovery objective after dependencies are restored. Because the plugin owns no local identity database, a local recovery-point objective is not applicable. Ambiguous tenant provisioning **MUST** be reconciled before provisioning resumes for the affected tenant.
+When required dependencies meet their objectives, the plugin **MUST** support the parent Account Management target of 99.9% monthly availability for provider-dependent lifecycle operations. After successful initialization, each call **MUST** fail closed when its own critical dependency is unavailable while leaving operations with unaffected dependencies usable, and unambiguous operations **MUST** recover on a later call — including after credential rotation — without process restart, within the inherited 15-minute recovery objective. Initialization itself depends on the provider: the bootstrap pre-warm budget (≈37 s worst case by default) **MUST** be compatible with the deployment's ordering guarantees, or the plugin **MUST** be disabled for that deployment. Because the plugin owns no local identity database, a local recovery-point objective is not applicable. Ambiguous tenant provisioning **MUST** be reconciled before provisioning resumes for the affected tenant.
 
-- **Threshold**: Dependency-failure tests prove capability-specific availability and fail-closed mutations; recovery tests restore unambiguous operations within 15 minutes and keep uncertain resources reconciliation-blocked.
-- **Rationale**: Per-call errors alone do not define safe degraded operation or restoration.
-- **Architecture Allocation**: See [DESIGN.md §3.2](./DESIGN.md#32-component-model) and [§3.6](./DESIGN.md#36-interactions--sequences).
+- **Threshold**: Dependency-failure tests prove capability-specific availability and fail-closed mutations after init; recovery tests restore unambiguous operations without restart and keep uncertain resources reconciliation-blocked; init-ordering tests prove the pre-warm budget and the disabled path.
+- **Rationale**: Per-call errors alone do not define safe degraded operation or restoration, and the init-time provider dependency is an explicit deployment constraint.
+- **Architecture Allocation**: See [DESIGN.md §2.2](./DESIGN.md#22-constraints), [§3.2](./DESIGN.md#32-component-model), and [§3.6](./DESIGN.md#36-interactions--sequences).
 
 ### 6.2 NFR Exclusions
 
 | Quality category | Disposition | Product rationale or obligation |
 |------------------|-------------|---------------------------------|
-| Performance and capacity | Required here | V1 lifecycle latency is defined in §6.1. Service-principal capacity and pagination limits remain p2 obligations of its future owning contract; owning gears carry public REST latency. |
+| Performance and capacity | Required here | V1 lifecycle latency and scan bounds are defined in §6.1. Service-principal listing capacity remains a p2 obligation. Owning gears carry public REST latency. |
 | Reliability and availability | Required here | Failure classification, audit completeness, and availability recovery are defined in §6.1. |
 | Security and privacy | Required here and inherited | Tenant isolation, secret protection, and PII minimization are defined here; platform controls come from the Security Guidelines. |
-| Observability and operations | Required here | Releases must provide readiness, dependency-health, ambiguous-outcome, and terminal audit signals plus operator alert guidance and a reconciliation runbook. |
-| Deployment and upgrade | Partly required | Keycloak deployment is out of scope; plugin releases must document supported provider versions, metadata compatibility, upgrade checks, and rollback constraints. |
+| Observability and operations | Required here | Releases must provide readiness, dependency-health, ambiguous-outcome, and audit signals plus operator alert guidance and a reconciliation runbook. |
+| Deployment and upgrade | Partly required | Keycloak deployment is out of scope; plugin releases must document supported provider versions, metadata compatibility, the init pre-warm dependency, and rollback constraints. |
 | Documentation and support | Required here | Production enablement requires configuration, least-privilege credentials, secret rotation, failure classification, reconciliation, and troubleshooting guidance. |
 | UX, accessibility, and internationalization | Not applicable | The plugin exposes no end-user UI or human-language interface. Owning product surfaces carry these obligations. |
 | Regulatory and geographic controls | Inherited | The plugin introduces no placement decision; platform security, audit, privacy, and deployment policies control residency and regulatory obligations. |
@@ -631,25 +632,25 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 
 - **Type**: Rust SDK trait (`IdpPluginClient`)
 - **Stability**: stable
-- **Description**: Provides tenant provisioning, tenant deprovisioning, user provisioning, user update, user deprovisioning, and user query behavior to Account Management.
+- **Description**: Provides tenant provisioning, tenant deprovisioning, user provisioning, user deprovisioning, and user query behavior to Account Management. `update_user` is not implemented and returns `UnsupportedOperation` (p2).
 - **Breaking Change Policy**: Incompatible request, result, or failure changes require a versioned contract and coordinated Account Management migration.
 
 #### Service-Principal Lifecycle Contract
 
-- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-interface-service-principal-client`
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-interface-service-principal-client`
 
-- **Type**: Future platform-owned lifecycle contract outside Account Management
-- **Stability**: planned; not part of v1
-- **Description**: After a platform owner publishes the upstream contract, it provides tenant-scoped creation, rotation, revocation, and listing of machine identities. The plugin fulfills provider-specific behavior without becoming a direct dependency of regular gears.
-- **Breaking Change Policy**: After stabilization, incompatible behavior or data changes require a versioned contract and a consumer migration path.
+- **Type**: Rust SDK trait (`ServicePrincipalClientV1` from `service-principal-sdk`), registered unscoped in ClientHub
+- **Stability**: stable
+- **Description**: Provides tenant-scoped creation, secret rotation, revocation, and listing of machine identities to trusted platform modules. Consumers authorize their own callers before delegation; deployments without this plugin simply have no registration.
+- **Breaking Change Policy**: Incompatible behavior or data changes require a versioned contract and a consumer migration path.
 
 #### Provider Instance Contract
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-interface-provider-instance`
 
-- **Type**: Selectable provider contract
+- **Type**: Selectable provider contract (`PluginV1<IdpPluginSpecV1>` catalogue instance `vz.virtuozzo.vp_idp.plugin.v1`)
 - **Stability**: stable
-- **Description**: Makes the Keycloak provider selectable by Account Management without exposing plugin implementation details to consumers.
+- **Description**: Makes the Keycloak provider selectable by Account Management through vendor/priority matching without exposing plugin implementation details to consumers.
 - **Breaking Change Policy**: Provider identity and selection semantics remain backward-compatible within a major contract version.
 
 ### 7.2 External Integration Contracts
@@ -662,29 +663,21 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 - **Protocol/Format**: Versioned Account Management provider contract
 - **Compatibility**: The plugin follows Account Management's tenant and user request, result, failure, idempotency, tenant-context, and provider-metadata semantics.
 
-#### Outbound API Gateway Contract
-
-- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-contract-oagw`
-
-- **Direction**: required from client
-- **Protocol/Format**: `ServiceGatewayClientV1` with operator-provisioned Keycloak upstream and route aliases
-- **Compatibility**: The plugin sends all Keycloak OAuth and Admin REST requests through approved routes. It does not create routes, resolve credential values, or open direct external HTTP connections.
-
 #### Keycloak Administration Contract
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-contract-keycloak-admin`
 
-- **Direction**: required from external provider through Outbound API Gateway
-- **Protocol/Format**: Supported Keycloak administration and OAuth interfaces
-- **Compatibility**: V1 supports Keycloak 26.x; another major version requires a versioned compatibility update and fails operation-based readiness until approved.
+- **Direction**: required from external provider
+- **Protocol/Format**: Keycloak Admin REST and OAuth token endpoints over HTTPS, authenticated with `client_credentials` confidential clients; optional operator CA bundle from the Credential Store
+- **Compatibility**: V1 is qualified against Keycloak 26.x; another major version requires a versioned compatibility update and re-qualification. The implementation performs no runtime version check (p2).
 
 #### Credential Store Contract
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-contract-credstore`
 
-- **Direction**: transitive dependency through Outbound API Gateway
-- **Protocol/Format**: Protected secret-storage contract
-- **Compatibility**: OAGW credential references remain stable across rotation; credential values never enter the plugin or provider metadata.
+- **Direction**: required from client (`CredStoreClientV1` via ClientHub)
+- **Protocol/Format**: Platform secret-storage contract, invoked under the plugin's stable system actor
+- **Compatibility**: The plugin reads adopted/created realm-admin secrets and the optional TLS CA bundle, and writes/deletes created-realm admin secrets under the templated reference (`vp-idp-realm-admin-{realm_name}-secret` by default). References remain stable across rotation; secret values never enter provider metadata, logs, or metrics.
 
 ## 8. Use Cases
 
@@ -695,150 +688,129 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 **Actor**: `cpt-cf-keycloak-idp-plugin-actor-account-management`
 
 **Preconditions**:
-- The shared realm is operator-approved for multi-tenant use and required administration access exists.
-- The realm satisfies the platform authentication profile.
-- Account Management supplies valid `shared` provisioning intent.
+- The shared realm exists and its authentication profile, admin clients, and secrets are operator-provisioned.
+- Root bootstrap named the realm explicitly, or the child tenant's parent carries replayed metadata naming it.
 
 **Main Flow**:
-1. Account Management requests tenant provisioning with the resolved tenant identity and shared-realm intent.
-2. The plugin verifies shared-realm approval, administration access, and authentication compatibility.
-3. The plugin establishes the tenant identity boundary and returns the provider context required for later lifecycle operations.
+1. Account Management requests tenant provisioning with the resolved tenant identity (and, for child tenants, the parent context).
+2. The plugin parses intent fail-closed, health-probes Keycloak, and verifies the realm exists.
+3. The plugin ensures the per-tenant group idempotently and, when an admin user was declared, binds that user's tenant attributes with hijack protection.
+4. The plugin returns the versioned metadata envelope required for later lifecycle operations.
 
 **Postconditions**:
-- The tenant has an isolated identity boundary in the shared realm.
-- Later tenant and user operations can use the returned provider context.
+- The tenant has an isolated identity boundary (group) in the shared realm.
+- Later tenant and user operations route through the returned metadata.
 
 **Alternative Flows**:
-- **Realm unavailable**: The plugin returns a classified failure without reporting successful binding.
-- **Uncertain mutation**: The plugin returns an ambiguous outcome for reconciliation.
+- **Realm missing or provider unreachable**: The plugin returns a classified clean failure without mutation.
+- **Admin user already bound elsewhere**: The plugin returns a stage-attributed ambiguous outcome for reconciliation without overwriting the binding.
 
 #### Adopt an Existing Tenant Realm
 
-- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-usecase-adopt-tenant-realm`
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-usecase-adopt-tenant-realm`
 
 **Actor**: `cpt-cf-keycloak-idp-plugin-actor-account-management`
 
 **Preconditions**:
-- The operator-owned realm exists, contains no tenant boundary or unrelated human identity, and has the required administration and authentication configuration.
-- During root bootstrap, any existing human identity is limited to the operator-declared initial platform administrator; provider-required system identities are also permitted.
-- Account Management supplies valid, explicitly enabled `adopted` provisioning intent.
+- The operator-owned realm exists, contains no tenant boundary under the group root, and has the required authentication configuration.
+- The operator pre-provisioned the realm-admin secret in the Credential Store under the templated reference.
+- Account Management supplies explicit `adopted` intent with the realm name.
 
 **Main Flow**:
 1. Account Management requests tenant provisioning with adopted-realm intent.
-2. The plugin verifies admissibility, administration access, and platform authentication compatibility without changing realm ownership.
-3. The plugin establishes the tenant identity boundary and returns provider context that preserves operator ownership.
+2. The plugin verifies realm existence and emptiness without changing realm ownership.
+3. The plugin ensures the tenant group using the operator-provisioned Credential Store secret.
+4. The plugin returns metadata carrying the secret reference and realm binding.
 
 **Postconditions**:
 - The tenant is the only tenant boundary in the adopted realm.
 - The operator retains realm and administrator-credential ownership.
 
 **Alternative Flows**:
-- **Realm contains an unrelated human identity or tenant boundary**: The plugin rejects adoption without mutation.
-- **Root-bootstrap declaration does not match observed identities**: The plugin rejects the controlled exception without mutation.
-- **Required access or authentication configuration is missing**: The plugin rejects adoption without claiming ownership.
-- **Uncertain provider mutation**: The plugin returns an ambiguous outcome for reconciliation.
+- **Realm contains an existing tenant boundary**: The plugin rejects adoption without mutation (clean failure).
+- **Secret reference missing in the Credential Store**: The affected operation fails without mutation and recovers once the operator provisions it.
 
 #### Provision a Plugin-Owned Tenant Realm
 
-- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-usecase-create-tenant-realm`
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-usecase-create-tenant-realm`
 
 **Actor**: `cpt-cf-keycloak-idp-plugin-actor-account-management`
 
 **Preconditions**:
-- Account Management supplies valid `created` provisioning intent for an absent realm target.
-- The plugin has the required approved OAGW route and provider access.
+- Account Management supplies valid `created` provisioning intent without a realm name.
+- The bootstrap admin has realm-creation authority.
 
 **Main Flow**:
 1. Account Management requests tenant provisioning with created-realm intent.
-2. The plugin verifies the request and establishes a plugin-owned tenant identity boundary that satisfies the platform authentication profile.
-3. The plugin returns provider context sufficient for safe lifecycle management and cleanup.
+2. The plugin probes `realm-{tenant_id}`: absent → creates it with the ownership marker and allowlisted operator defaults; already ours → adopts idempotently.
+3. The plugin creates the realm-admin client, grants the least-privilege role set, and reads back the generated secret.
+4. The plugin stores the secret in the Credential Store under the templated reference (point of no return), then ensures the tenant group under the new realm admin.
+5. The plugin returns metadata carrying the realm binding and secret reference.
 
 **Postconditions**:
-- The tenant has a plugin-owned realm capable of issuing platform-compatible identity tokens.
-- Ownership metadata supports safe future cleanup.
+- The tenant has a plugin-owned realm marked for it, with a least-privileged realm admin whose secret lives in the Credential Store.
+- Metadata supports safe future cleanup.
 
 **Alternative Flows**:
-- **Existing conflicting realm**: The plugin rejects the request before claiming ownership.
-- **Uncertain provider or credential mutation**: The plugin returns an ambiguous outcome.
+- **Existing foreign realm under the generated name**: The plugin rejects the request before claiming ownership (clean failure).
+- **Uncertain provider or Credential Store mutation mid-saga**: The plugin returns a stage-attributed ambiguous outcome for the provisioning reaper.
 
 #### Update a Tenant User
 
-- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-usecase-update-user`
+- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-usecase-update-user`
 
 **Actor**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`
 
-**Preconditions**:
-- Account Management has authorized the request and resolved an active tenant.
-- The user exists within the tenant binding.
-
-**Main Flow**:
-1. Account Management sends the tenant context, user identifier, and partial update.
-2. The plugin applies only the supplied mutable fields within the resolved tenant binding.
-3. The plugin returns the updated provider projection.
-
-**Postconditions**:
-- Supplied fields reflect the accepted values.
-- Omitted fields, user identity, and tenant binding remain unchanged.
-
-**Alternative Flows**:
-- **User absent**: The plugin returns not found.
-- **Duplicate attribute**: The plugin returns a duplicate-user outcome.
-- **Password rejected**: The plugin returns a password-policy outcome.
+Not available in this revision: `update_user` returns `UnsupportedOperation`. When implemented, Account Management sends the tenant context, user identifier, and partial update; the plugin applies only the supplied mutable fields within the resolved tenant binding and returns the updated provider projection, distinguishing not-found, duplicate-attribute, and password-policy outcomes.
 
 #### Create and Rotate a Service Principal
 
-- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-usecase-service-principal-credentials`
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-usecase-service-principal-credentials`
 
 **Actor**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`
 
 **Preconditions**:
-- The selected service-principal lifecycle owner provides an authorized request and resolved tenant context.
-- The requested name is available, requested scopes are allowed, and the tenant capacity limit is not exhausted.
+- The consuming platform module has authorized its caller and supplies the owning tenant id, a valid name, and requested scopes.
+- Requested scopes are on the configured allowlist and provisioned in the service-principal realm; the tenant quota is not exhausted.
 
 **Main Flow**:
-1. The consumer requests a tenant-owned service principal through the selected lifecycle owner.
-2. The plugin creates the principal and returns its identity, accepted scopes, authentication information, and one-time credential.
-3. The consumer later requests credential rotation through the selected lifecycle owner.
-4. The plugin preserves the principal identity and permissions and returns the replacement credential once.
+1. The consumer calls `create` with tenant id, name, and scopes.
+2. The plugin validates name and scopes, enforces the best-effort quota, and creates the confidential client `svc-{tenant}-{name}` with the ownership marker.
+3. The plugin binds the service-account user's tenant and subject-type attributes, attaches the requested scopes, and reads the generated secret.
+4. The plugin returns the client id, subject id, token endpoint, and secret.
+5. The consumer later calls `rotate_secret`; the plugin verifies ownership and attribute integrity, regenerates the secret, and returns the replacement once.
 
 **Postconditions**:
 - Only the current credential can obtain new tokens.
-- Issued tokens identify the correct principal and owning tenant and satisfy the platform authentication profile.
-- Tokens issued before rotation remain valid only until their configured expiry.
-- Listing exposes active tenant-owned metadata but no credential.
-- The selected lifecycle owner and the plugin retain no plaintext service-principal credential.
+- Issued tokens identify the principal, owning tenant, and machine subject class via realm mappers.
+- The plugin retains no plaintext credential; the consumer owns durable custody.
 
 **Alternative Flows**:
-- **Quota or scope rejected**: The plugin returns a deterministic input or capacity failure.
-- **Duplicate, stale, or conflicting request**: The request causes no unsafe second mutation.
-- **Uncertain creation, delivery, or rotation**: The plugin returns an ambiguous outcome, blocks blind retry, and exposes no credential.
+- **Name taken, scope disallowed, or quota exceeded**: The plugin returns `InvalidInput` without mutation.
+- **Allowlisted scope missing from the realm**: The plugin returns a clean failure naming the scope for the operator.
+- **Corrupt or incomplete principal at rotation**: The plugin returns `InvalidInput` with revoke-and-recreate guidance instead of a credential.
+- **Uncertain creation or rotation**: The plugin returns a stage-attributed `Ambiguous` outcome with no credential.
 
 #### List and Revoke Service Principals
 
-- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-usecase-list-revoke-service-principals`
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-usecase-list-revoke-service-principals`
 
 **Actor**: `cpt-cf-keycloak-idp-plugin-actor-service-principal-consumer`
 
 **Preconditions**:
-- The selected service-principal lifecycle owner provides an authorized request and resolved tenant context.
-- One or more service principals may exist for the resolved tenant.
+- The consuming platform module has authorized its caller and supplies the owning tenant id.
 
 **Main Flow**:
-1. The consumer requests a page of service principals through the selected lifecycle owner.
-2. The plugin returns only active principals owned by the tenant in deterministic order, omits every credential, and returns continuation information when another page exists.
-3. The consumer requests revocation through the selected lifecycle owner.
-4. The plugin prevents new token issuance and removes the principal from later active listings.
+1. The consumer calls `list`; the plugin returns the tenant's principals (client id, enabled state, provider-reported scopes), enforcing ownership client-side and omitting every credential.
+2. The consumer calls `revoke` for a principal; the plugin verifies ownership and deletes the client, preventing new token issuance.
 
 **Postconditions**:
-- The revoked credential cannot obtain a new token.
-- Previously issued tokens for the revoked principal can remain valid until their configured expiry.
+- The revoked credential cannot obtain a new token; previously issued tokens can remain valid until expiry.
 - The revoked name can be recreated only as a new provider identity.
 
 **Alternative Flows**:
-- **Principal already absent**: Revocation succeeds equivalently without disclosing prior state.
-- **Duplicate, stale, or conflicting request**: The request causes no unsafe second mutation.
-- **Principal belongs to another tenant**: The plugin exposes no cross-tenant identity and performs no mutation.
-- **Concurrent rotation or uncertain revocation**: The plugin returns a reconciliation-required outcome when the winner cannot be proven and prohibits blind retry.
+- **Principal already absent or owned by another tenant**: The plugin returns `NotFound` without disclosing which; revoke callers treat it as success-equivalent.
+- **Uncertain revocation (5xx/429 on delete)**: The plugin returns a stage-attributed `Ambiguous` outcome and prohibits blind retry.
 
 #### Retire a Tenant Identity Boundary
 
@@ -847,25 +819,24 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 **Actor**: `cpt-cf-keycloak-idp-plugin-actor-account-management`
 
 **Preconditions**:
-- Account Management starts hard tenant deprovisioning with replayed provider metadata.
+- Account Management starts hard tenant deprovisioning with replayed provider metadata, after its pipeline has deprovisioned the tenant's users.
 
 **Main Flow**:
-1. The plugin revokes tenant-bound human sessions.
-2. The plugin removes tenant-bound human identities.
-3. The plugin removes provider-owned tenant resources while preserving the shared realm and other-tenant resources.
-4. The plugin reports a terminal result only when the retired tenant no longer has provider-managed human access.
+1. The plugin resolves and decodes the replayed metadata and health-probes the provider.
+2. The plugin purges every service principal owned by the tenant.
+3. The plugin deletes the per-tenant group.
+4. For created bindings with no remaining tenant groups, the plugin deletes the plugin-owned realm and then its Credential Store secret.
 
 **Postconditions**:
-- No tenant-owned human identity can refresh a session or obtain a new token through the retired tenant binding.
+- No tenant-owned machine credential and no tenant boundary survive retirement.
+- Shared and adopted realms and other tenants' resources are untouched.
 - An access JWT issued before retirement can remain valid until its `exp`.
-- If p2 service-principal support is promoted, its separate upstream cleanup barrier completes before this use case starts.
-- No other tenant or operator-owned realm resource is removed.
 
 **Alternative Flows**:
-- **Resources already absent**: The plugin returns a success-equivalent outcome.
-- **Proven safe retry**: A dependency failure occurs before any mutation may have reached Keycloak, or after only proven replay-safe partial work with no uncertain attempted stage; the plugin returns retryable.
-- **Attempted mutation with unproven result**: A session-revocation, identity-removal, or boundary-removal request may have reached Keycloak but its result cannot be proven; the plugin returns terminal for operator action even when the immediate cause is a timeout or transient transport failure.
-- **Unsafe or unrecoverable state**: Ownership, complete enumeration, or safe continuation cannot be proven; the plugin returns terminal for operator action.
+- **Metadata missing or resources already absent**: The plugin returns a success-equivalent outcome with `already_absent` audit evidence.
+- **Malformed metadata**: The plugin returns terminal for operator action without provider access.
+- **Provider unreachable before any mutation**: The plugin returns retryable for the next retention tick.
+- **Service-principal purge fails**: The plugin aborts with retryable or terminal classification; boundary teardown does not proceed.
 
 #### Reconcile an Ambiguous Provider Mutation
 
@@ -874,19 +845,16 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 **Actor**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
 
 **Preconditions**:
-- Tenant provisioning ended with an `Ambiguous` outcome.
-- Automatic retries for the affected tenant are blocked.
+- Tenant provisioning or a service-principal mutation ended with an `Ambiguous` outcome carrying an `ambig:{stage}` token.
+- Automatic retries for the affected resource are blocked.
 
 **Main Flow**:
-1. The operator follows the tenant-provisioning reconciliation runbook.
-2. The operator reviews non-secret evidence to determine tenant-boundary and ownership state.
+1. The operator follows the reconciliation runbook, keyed on the stage token (realm create, client create, role mapping, secret read, credential-store write, admin-user bind, scope attach, secret rotate, client delete, timeout).
+2. The operator reviews non-secret evidence (stage, realm, redacted provider detail) to determine resource and ownership state.
 3. The operator applies an approved resolution and records the terminal outcome.
 
 **Postconditions**:
-- An absent tenant boundary is safe for a new provisioning attempt.
-- A complete tenant boundary is accepted with the provider metadata needed for later operations.
-- An incomplete tenant boundary is cleaned up before another provisioning attempt.
-- An unresolved state remains blocked and escalated.
+- An absent resource is safe for a new attempt; a complete resource is accepted; an incomplete one is cleaned up before retry; an unresolved state remains blocked and escalated.
 - The resolution has one correlated audit outcome and exposes no credential or user profile value.
 
 **Alternative Flows**:
@@ -897,95 +865,96 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 
 ### V1 Acceptance
 
-- [ ] Account Management can select the Keycloak IdP Plugin by its published provider instance, and replayed tenant metadata fails closed before external access when its producing instance identifier differs from the selected instance.
-- [ ] Every v1 provisioning request explicitly identifies `shared` mode and an operator-approved existing realm; missing intent and `adopted` or `created` requests fail without provider mutation.
-- [ ] The shared realm issues tokens accepted by the OIDC AuthN Resolver with required tenant and identity claims and a maximum access-token lifetime of 15 minutes.
-- [ ] Metadata from every version in the supported upgrade and rollback window remains readable for normal operations and safe hard deprovisioning.
-- [ ] Account Management invokes the plugin for hard deprovisioning, not tenant suspension or soft deletion.
-- [ ] Hard deprovisioning revokes provider sessions and removes tenant-bound human identities without deleting the shared realm or another tenant's identities or memberships.
-- [ ] Deprovisioning documentation and tests show that an already-issued access JWT can remain valid until `exp`; no test requires real-time revocation from the OIDC AuthN Resolver.
-- [ ] User creation, partial update, deletion, and tenant-scoped query pass the Account Management provider contract suite.
-- [ ] User updates distinguish not found, duplicate identity attributes, password-policy rejection, unsupported behavior, invalid input, and provider unavailability.
-- [ ] Cross-tenant negative tests produce zero successful reads or mutations.
-- [ ] Failure injection proves that ambiguous tenant provisioning is never reported as clean, while each user failure maps to an `IdpUserOperationFailure` outcome and equivalent replay remains idempotent.
-- [ ] Every mutating contract-test call and reconciliation resolution has one durable terminal audit outcome created by Account Management and delivered by the platform audit owner; plugin evidence, metrics, and the durable record contain no user profile value. Calls rejected before actor context exists are excluded, matching `cpt-cf-keycloak-idp-plugin-nfr-audit-completeness`.
-- [ ] Secret scanning finds no credential values in plugin logs, metrics, audit evidence, listings, or debug output, and all Keycloak requests use approved Outbound API Gateway routes.
-- [ ] The host starts and unrelated Account Management operations remain available when OAGW, Credential Store, or Keycloak is unavailable; affected IdP operations recover on a later call after dependency restoration without process restart.
-- [ ] Every supported Keycloak 26.x release in the release matrix passes the provider contract suite, and representative unsupported major versions fail affected operation-based readiness without preventing host startup.
-- [ ] Shared-realm tenant provisioning meets p95 ≤ 5 seconds; each named user operation meets p95 ≤ 1 second under the complete §6.1 qualification profile, including the 1,000-user list ceiling, provider-call budget, memory limit, filter mix, and overflow rejection.
+- [ ] Account Management selects the plugin through its published catalogue instance and vendor/priority configuration; catalogue drift on restart fails initialization instead of silently rebinding.
+- [ ] Provisioning intent is parsed fail-closed: unknown modes and keys are rejected; absent mode defaults to shared; shared child tenants inherit the parent realm; created mode generates `realm-{tenant_id}` and rejects explicit realm names; adopted mode requires an existing empty realm.
+- [ ] Metadata envelopes decode fail-closed (missing/unsupported version, malformed shape) with observable decode-failure metrics, and metadata from every version in the supported window remains readable for normal operations and hard deprovisioning.
+- [ ] Created-mode provisioning is replay-safe: a marked realm is adopted idempotently, a foreign realm is rejected cleanly, a lost create reconciles by re-probe, and the realm-admin secret lands in the Credential Store before success is reported.
+- [ ] Hard deprovisioning purges the tenant's service principals before boundary removal, deletes the tenant group, tears down created realms and their secrets on last-tenant retirement, and never deletes shared/adopted realms or other tenants' resources.
+- [ ] User provisioning binds `tenant_id`/`user_type` attributes and group membership, compensates orphans on group-join failure, and classifies duplicates with field refinement; user deprovisioning enforces the tenant-attribute guard, revokes sessions best-effort, and treats 404/410 as success-equivalent.
+- [ ] `update_user` deterministically returns `UnsupportedOperation`.
+- [ ] User queries return only tenant-group members, honor the supported filter surface (rejecting unsupported shapes with `UnsupportedOperation` before provider access), sort on `(created_at, id)`, page via `CursorV1` with filter-hash validation and the rolling-deploy legacy fallback, and truncate loudly at the scan hard cap.
+- [ ] Service-principal create/rotate/revoke/list enforce naming, allowlist, quota, ownership markers, and the hijack guard; secrets appear only in create/rotate results inside redacted wrappers; ambiguous outcomes carry stage tokens and no credential.
+- [ ] Cross-tenant negative tests produce zero successful reads or mutations across user and service-principal surfaces.
+- [ ] Failure injection proves ambiguous tenant provisioning is never reported as clean, each user failure maps to an `IdpUserOperationFailure` outcome, each service-principal failure maps to the closed `ServicePrincipalFailure` set, and every variant carries its stable metric label.
+- [ ] Secret scanning finds no credential values in plugin logs, metrics, audit events, listings, or debug output; provider error bodies are redacted and truncated.
+- [ ] With the plugin enabled, initialization fails within the pre-warm budget when Keycloak is unreachable and the failure names the attempt count; with `enabled: false` the host starts without the plugin. After initialization, provider and Credential Store outages block only affected operations, and recovery — including operator secret rotation — needs no restart.
+- [ ] Every supported Keycloak 26.x release in the release matrix passes the provider contract suite.
+- [ ] The §6.1 latency profile passes, including the page cap and scan-cap behavior.
 - [ ] The plugin exposes no public REST routes and performs no JWT validation or authorization decisions.
 
 ### P2 Promotion Acceptance
 
-- [ ] The Account Management provider contract is extended before `adopted` or `created` realm modes are enabled.
-- [ ] Adopted and created realm modes pass their ownership and no-side-effect admissibility tests before promotion.
-- [ ] A platform component outside Account Management owns and versions the consumer-facing service-principal lifecycle before implementation begins.
-- [ ] The service-principal owner defines provider delegation, authorization, secret custody, page sizes, quota, and concurrency outcomes.
-- [ ] Service-principal creation, rotation, revocation, recreation, listing, and recovery pass the owning contract's test suites.
-- [ ] Plaintext service-principal credentials appear only in successful creation and rotation results and are never persisted, cached, logged, audited, or redisclosed.
-- [ ] Service-principal tests permit already-issued tokens to remain valid until expiry unless a separate future revocation-enforcement contract is approved.
+- [ ] `update_user` implements the SDK contract (partial update semantics, immutable identity/tenant binding, duplicate/password-policy/not-found classification) and passes the provider contract suite.
+- [ ] A read-only realm authentication-profile verifier gates tenant binding on shared/adopted realms before promotion of profile verification.
+- [ ] A runtime provider-version gate fails affected operations deterministically on unsupported majors without preventing host startup.
+- [ ] Service-principal listing gains cursor pagination and deterministic ordering under the owning contract before large-population support is claimed.
 
 ## 10. Dependencies
 
 | Dependency | Description | Criticality |
 |------------|-------------|-------------|
 | Account Management provider contract | Defines v1 tenant and user lifecycle requests, outcomes, failure semantics, and provider context. It has no service-principal or tenant-suspension plugin hook. | p1 |
-| Account Management orchestration | Provides authorization, tenant resolution, provider selection, hard-deprovision invocation, and reconciliation behavior. | p1 |
-| Outbound API Gateway | Executes approved Keycloak routes, enforces outbound policy, and injects provider credentials through `ServiceGatewayClientV1`. | p1 |
-| Keycloak 26.x | Provides shared-realm identity-boundary, human-identity, session, and credential administration capabilities behind OAGW. | p1 |
-| Credential Store | Protects provider administrator credentials resolved and injected by OAGW; the plugin never reads their values. | p1 |
-| OIDC AuthN Resolver Plugin | Validates Keycloak-issued tokens offline and enforces one issuer per tenant. It does not manage sessions or check per-identity revocation state. | p1 |
-| Service-principal capability ownership | A future platform owner outside Account Management must publish machine-identity lifecycle, provider delegation, secret custody, mutation safety, pagination, and quota contracts before p2 implementation. | p2 |
-| RBAC / Policy Engine | Makes authorization decisions outside this plugin. | p1 |
+| Account Management orchestration | Provides authorization, tenant resolution, provider selection, per-user deprovisioning before tenant retirement, hard-deprovision invocation, and reconciliation behavior. | p1 |
+| Keycloak 26.x | Provides realm, group, user, session, client, and credential administration over Admin REST and OAuth token endpoints, reached directly over HTTPS. | p1 |
+| Credential Store | Holds adopted/created realm-admin secrets and the optional TLS CA bundle; written by the plugin for created realms under its stable system actor. | p1 |
+| types-registry | Hosts the provider catalogue instance; publication is a hard initialization prerequisite. | p1 |
+| service-principal-sdk | Platform-owned machine-identity contract implemented by this plugin and consumed by trusted platform modules. | p1 |
+| OIDC AuthN Resolver Plugin | Validates Keycloak-issued tokens offline and consumes the claims projected by the realm mappers. It does not manage sessions or check per-identity revocation state. | p1 |
+| Operator realm bootstrap / IaC | Provisions shared/adopted realms, their authentication profile and protocol mappers, admin clients and secrets, and service-principal realm scopes. | p1 |
+| RBAC / Policy Engine | Makes authorization decisions outside this plugin, including the plugin system actor's Credential Store grants. | p1 |
 
 ## 11. Assumptions
 
 - Keycloak is the identity provider implemented by this plugin, and v1 targets Keycloak 26.x.
-- Account Management authorizes public user and tenant operations before invoking the plugin.
-- Account Management supplies an active resolved tenant context for existing-tenant operations.
-- Operators provision the v1 shared realm, Outbound API Gateway routes, and provider credentials they own.
-- Provider-owned metadata, including its producing GTS provider instance identifier, is persisted and replayed opaquely by Account Management.
-- V1 Keycloak access tokens expire within 15 minutes.
+- Account Management authorizes public user and tenant operations before invoking the plugin and supplies an active resolved tenant context with replayed metadata for existing-tenant operations.
+- Account Management's hard-delete pipeline deprovisions a tenant's users before invoking tenant deprovisioning.
+- Operators provision the shared/adopted realms, their authentication profile (including the `tenant_id`/`user_type` mappers and 15-minute access-token lifetime), the bootstrap admin client, and the shared-realm admin secret they own.
+- Deployment ordering makes Keycloak's token endpoint reachable within the plugin's init pre-warm budget, or the plugin is disabled for that deployment.
+- Provider-owned metadata is persisted and replayed opaquely by Account Management.
 - The OIDC AuthN Resolver validates access tokens offline and does not depend on current per-identity revocation state.
-- If p2 adopted-realm support is promoted, root bootstrap permits only the declared initial platform administrator, provider-required system identities, and no unrelated tenant boundary.
-- If p2 service-principal support is promoted, consumers use a platform owner outside Account Management and take immediate custody of one-time credentials.
+- Service-principal consumers are trusted platform modules that authorize their own callers and take immediate durable custody of returned credentials.
+- The plugin's system-actor identity and its Credential Store RBAC grants are provisioned at deployment bootstrap and remain stable across upgrades.
 
 ## 12. Risks
 
 | Risk | Impact | Mitigation |
 |------|--------|------------|
-| An external mutation completes after the caller loses the response. | Duplicate or orphaned identity resources or credentials. | Preserve ambiguous outcomes, stop blind retry, and provide reconciliation signals. |
-| Administrator credentials grant broader access than required. | Compromise can affect unrelated tenants or realms. | Require least privilege, protected storage, rotation, and secret non-disclosure tests. |
-| Provider metadata becomes unreadable after upgrade or rollback. | Existing tenants cannot be administered or retired safely. | Require versioned metadata and compatibility coverage for supported upgrade paths. |
-| Shared-realm routing, tenant association, or selected provider instance drifts. | Existing tenants can be misrouted or become unsafe to administer. | Bind metadata to its producing GTS instance, reject mismatches before OAGW access, and require an operator migration before changing the selected instance. |
-| A future p2 service principal survives tenant retirement. | Machine access remains active after tenant deletion. | Require the owning platform contract to complete a cleanup barrier before Account Management invokes hard deprovisioning. |
-| Human identities or sessions survive tenant retirement. | Retired users retain authentication or tenant access. | Revoke sessions, delete tenant-bound identities, prove absence of the retired binding, and block completion when reconciliation is required. |
-| Keycloak 26.x administration behavior changes across releases. | Lifecycle operations fail or produce different outcomes. | Test every supported 26.x release before plugin publication and reject unsupported major versions. |
-| OAGW cannot resolve the configured Credential Store reference. | Keycloak administration cannot authenticate safely. | Fail only the affected operation, expose gateway-versus-upstream provenance without secrets, and retry only when no provider mutation is uncertain. |
+| An external mutation completes after the caller loses the response. | Duplicate or orphaned identity resources or credentials. | Idempotent replay paths (realm ensure re-probe, group 409 reuse), stage-attributed ambiguous outcomes, no blind retry, reconciliation runbook. |
+| Administrator credentials grant broader access than required. | Compromise can affect unrelated tenants or realms. | Two-tier admin model, exact least-privilege role grants on created realms, typed secret custody, rotation convergence, and secret non-disclosure tests. |
+| Provider metadata becomes unreadable after upgrade or rollback. | Existing tenants cannot be administered or retired safely. | Versioned fail-closed envelope, decode-failure metrics, and compatibility coverage for supported upgrade paths. |
+| The Credential Store write fails after created-realm Keycloak state exists. | Realm exists without retrievable admin credentials. | Explicit `ambig:openbao_put_after_kc_success` stage, reconciliation runbook, replayable provisioning that overwrites the secret last-writer-wins. |
+| A service principal survives tenant retirement. | Machine access remains active after tenant deletion. | Purge barrier ordered before boundary teardown; purge failure aborts deprovisioning with retryable/terminal classification. |
+| Keycloak 26.x administration behavior changes across releases. | Lifecycle operations fail or produce different outcomes. | Qualify every supported 26.x release before publication; p2 runtime version gate. |
+| The plugin's init-time provider dependency breaks deployment ordering. | Host initialization fails when Keycloak is slow to become ready. | Bounded, tunable pre-warm budget with fast-bail on permanent errors; `enabled: false` escape hatch. |
+| Tenant-group membership grows past the scan cap. | Listings truncate (loudly) and hide the tail. | Hard-cap warning as the operational signal; realm-wide attribute-query evolution before larger populations are supported. |
 | An access JWT remains valid after user or tenant hard deprovisioning. | Access can continue until token expiry. | Limit v1 access-token lifetime to 15 minutes, revoke provider sessions, block refresh, and document the bounded exposure. |
+| Metric realm-label cardinality explodes in large fleets. | Metrics backend overload. | Configurable cardinality cap with label drop and a one-shot warning naming the tripping realm. |
 
 ## 13. Open Questions
 
-No open question blocks v1 DESIGN. V1 uses shared realms, Keycloak 26.x, the latency profile in §6.1, and offline JWT validation with a 15-minute maximum access-token lifetime.
+No open question blocks v1. V1 uses the three realm bindings above, Keycloak 26.x qualification, the latency profile in §6.1, and offline JWT validation with a 15-minute maximum access-token lifetime.
 
 The following questions gate only p2 promotion:
 
 | # | Question | Impact | Owner | Target Date |
 |---|----------|--------|-------|-------------|
-| 1 | Will Account Management add provider intent and metadata semantics for `adopted` and `created` realm modes? | Determines whether dedicated-realm modes can move from p2 to a release baseline. | Account Management Owner and Platform Architect | Before dedicated-realm DESIGN |
-| 2 | Which platform component outside Account Management owns the consumer-facing service-principal lifecycle? | Determines authorization, provider delegation, secret custody, and public contracts. | Product Owner and Platform Architect | Before service-principal DESIGN |
-| 3 | What default and maximum page sizes and per-tenant quota apply to service principals? | Determines p2 listing, capacity, and performance tests. | Service-Principal Owner and Performance Architect | Before service-principal DESIGN |
-| 4 | Will a future authentication component enforce real-time token revocation? | Determines whether any future release can promise rejection before JWT expiry. | Security Architect and AuthN Owner | Before real-time revocation requirements are added |
+| 1 | When is `update_user` promoted, and does it adopt JSON Merge Patch semantics end to end? | Determines profile-editing support through this provider. | Account Management Owner and Plugin Owner | Before user-update DESIGN |
+| 2 | Should realm authentication-profile verification become a plugin-side runtime gate, and what profile format does the operator publish for it? | Determines whether misconfigured realms fail binding deterministically. | Platform Architect and Plugin Owner | Before profile-verifier DESIGN |
+| 3 | Does a runtime Keycloak version gate replace release-time qualification as the compatibility guarantee? | Determines unsupported-version failure behavior. | Plugin Owner | Before compatibility-gate DESIGN |
+| 4 | What pagination, ordering, and quota semantics does service-principal listing adopt for large tenants? | Determines p2 listing and capacity tests. | Service-Principal Owner and Performance Architect | Before service-principal listing DESIGN |
+| 5 | Will a future authentication component enforce real-time token revocation? | Determines whether any future release can promise rejection before JWT expiry. | Security Architect and AuthN Owner | Before real-time revocation requirements are added |
 
 ## 14. Traceability
 
 - **Parent PRD**: [Account Management PRD](../../../docs/PRD.md)
 - **Identity Provider SDK**: [`idp.rs`](../../../account-management-sdk/src/idp.rs) and [`idp_user.rs`](../../../account-management-sdk/src/idp_user.rs)
+- **Service-Principal SDK**: [`service-principal-sdk`](../../../../service-principal/service-principal-sdk/src/api.rs)
+- **Implementation**: [`plugins/keycloak-idp-plugin`](../src/lib.rs) (crate `vp-idp-plugin`, ported from vhp-core)
 - **OIDC AuthN contract**: [OIDC AuthN Resolver Plugin PRD](../../../../authn-resolver/plugins/oidc-authn-plugin/docs/PRD.md)
-- **Realm-strategy relationship**: V1 supports only explicit `shared` provisioning intent. The p2 `adopted` and `created` modes require an expanded Account Management provider contract before promotion.
-- **Migration requirements**: Tenant hard deprovisioning requires session revocation and deletion of tenant-bound users, and audit events use provider-issued identity references rather than usernames or profile values.
-- **Service-principal allocation**: Account Management does not own service-principal lifecycle. A future platform owner must publish lifecycle, secret-custody, mutation-safety, pagination, quota, and authentication contracts before p2 implementation.
-- **AuthN allocation**: V1 follows the OIDC AuthN Resolver's offline JWT model. Keycloak sessions are revoked, but an already-issued access token can remain valid until its `exp`, bounded by the 15-minute profile maximum.
+- **Realm-strategy relationship**: V1 supports explicit `shared` (default, parent-inherited for children), `adopted`, and `created` provisioning intent with fail-closed parsing.
+- **Migration requirements**: Tenant hard deprovisioning requires the service-principal purge barrier and boundary teardown ordering; user removal happens through per-user deprovisioning before tenant retirement.
+- **Service-principal allocation**: Machine-identity lifecycle is exposed through `service-principal-sdk` to trusted platform modules, not through Account Management's provider contract.
+- **AuthN allocation**: V1 follows the OIDC AuthN Resolver's offline JWT model. Keycloak sessions are revoked on user deprovisioning, but an already-issued access token can remain valid until its `exp`, bounded by the 15-minute profile maximum.
 - **Design**: [Keycloak IdP Plugin DESIGN](./DESIGN.md)
 - **Future ADRs**: `ADR/` in this directory
 - **Future Features**: `features/` in this directory

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/PRD.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/PRD.md
@@ -43,7 +43,7 @@
 
 ### 1.1 Purpose
 
-The Keycloak IdP Plugin (crate `vp-idp-plugin`) is a provider plugin for Account Management. It translates tenant and user lifecycle requests into administrative operations against Keycloak, and additionally provides tenant-scoped machine-identity (service-principal) lifecycle to trusted platform consumers through the `ServicePrincipalClientV1` contract. The plugin gives deployments a production provider while keeping Account Management independent of provider-specific behavior.
+The Keycloak IdP Plugin (crate `cf-gears-keycloak-idp-plugin`) is a provider plugin for Account Management. It translates tenant and user lifecycle requests into administrative operations against Keycloak, and additionally provides tenant-scoped machine-identity (service-principal) lifecycle to trusted platform consumers through the `ServicePrincipalClientV1` contract. The plugin gives deployments a production provider while keeping Account Management independent of provider-specific behavior.
 
 The plugin runs as a Gear in the host process. Account Management remains the public control-plane boundary. The plugin exposes no public REST API and does not authenticate requests, issue tokens, validate tokens, or make authorization decisions. It administers Keycloak directly over HTTPS using OAuth2 `client_credentials` administrator clients, with secret custody split between environment-expanded configuration and the platform Credential Store.
 
@@ -77,8 +77,8 @@ The Keycloak IdP Plugin solves this gap for Keycloak. It owns the provider-facin
 | Adopted realm | An existing operator-owned realm bound to a single tenant without transferring realm ownership to the plugin. |
 | Created realm | A realm (`realm-{tenant_id}`) created and lifecycle-managed by the plugin, marked with a plugin ownership attribute. |
 | Tenant group | The plugin-owned Keycloak group (under `/tenants` by default) that forms a tenant's identity boundary inside a realm. |
-| Bootstrap admin | The operator-provisioned confidential client (default `vp-idp-plugin-bootstrap` in `master`) the plugin uses for realm-level administration. |
-| Realm admin | The per-realm confidential client (default `vp-idp-plugin-realm-admin`) used for tenant and user administration inside a bound realm. |
+| Bootstrap admin | The operator-provisioned confidential client (default `keycloak-idp-plugin-bootstrap` in `master`) the plugin uses for realm-level administration. |
+| Realm admin | The per-realm confidential client (default `keycloak-idp-plugin-realm-admin`) used for tenant and user administration inside a bound realm. |
 | Service principal | A tenant-owned machine identity: a confidential OAuth `client_credentials` client named `svc-{tenant_id}-{name}`. |
 | Ambiguous outcome | A failed or lost response where an external mutation might have completed and reconciliation is required before retry; stage-attributed with an `ambig:` token. |
 | Credential Store | The platform secret-storage gear (OpenBao-backed) holding adopted/created realm-admin secrets and the optional TLS CA bundle. |
@@ -168,7 +168,7 @@ flowchart LR
 - Operator realm bootstrap must provision the authentication profile of shared and adopted realms: required clients, client scopes, the protocol mappers that project the `tenant_id` and `user_type` claims, signing/session/token policy, and the realm-admin client with its secret.
 - Account Management must provide the tenant context and replayed provider-owned metadata required to route existing-tenant operations.
 - The Credential Store must be available for operations that resolve adopted/created realm-admin secrets, for created-realm provisioning and teardown, and at initialization when a TLS CA bundle reference is configured.
-- The deployment must select one unambiguous active provider. Account Management's `idp.vendor` defaults to `cf`, which selects the built-in static echo plugin — it **MUST** be explicitly set to this plugin's configured vendor (default `virtuozzo`); otherwise Account Management selects another provider or, with `idp.required = false`, silently falls back to the no-op provider without any error from this plugin. Changing the provider while tenant metadata exists requires an explicit operator migration.
+- The deployment must select one unambiguous active provider. Account Management's `idp.vendor` defaults to `cf`, which selects the built-in static echo plugin — it **MUST** be explicitly set to this plugin's configured vendor (default `keycloak`); otherwise Account Management selects another provider or, with `idp.required = false`, silently falls back to the no-op provider without any error from this plugin. Changing the provider while tenant metadata exists requires an explicit operator migration.
 
 ## 4. Scope
 
@@ -213,7 +213,7 @@ The user-update, realm-profile-verification, and provider-version-gate bullets b
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-provider-publication`
 
-The plugin **MUST** be selectable by Account Management without requiring Account Management or its consumers to depend on the plugin implementation. It **MUST** publish a `PluginV1<IdpPluginSpecV1>` instance (id `vz.virtuozzo.vp_idp.plugin.v1`) to the types-registry carrying its configured vendor (default `virtuozzo`) and priority (default 50), and register the scoped `IdpPluginClient` under that instance id. The published instance identifier **MUST** be stable for the lifetime of tenant metadata produced by that instance. On restart, re-registration **MUST** accept an existing catalogue entry only when the stored spec matches the current serialization; a mismatch **MUST** fail initialization rather than silently drift.
+The plugin **MUST** be selectable by Account Management without requiring Account Management or its consumers to depend on the plugin implementation. It **MUST** publish a `PluginV1<IdpPluginSpecV1>` instance (id `cf.builtin.keycloak_idp.plugin.v1`) to the types-registry carrying its configured vendor (default `keycloak`) and priority (default 50), and register the scoped `IdpPluginClient` under that instance id. The published instance identifier **MUST** be stable for the lifetime of tenant metadata produced by that instance. On restart, re-registration **MUST** accept an existing catalogue entry only when the stored spec matches the current serialization; a mismatch **MUST** fail initialization rather than silently drift.
 
 - **Rationale**: Provider-neutral selection permits replacement without changing consumers, while a stable instance identity and drift detection prevent existing tenant metadata from being rebound silently.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`
@@ -477,7 +477,7 @@ The plugin **MUST** classify every failed service-principal call into the closed
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-administrator-credentials`
 
-The plugin **MUST** administer Keycloak through two confidential-client tiers with `client_credentials` grants: an operator-provisioned bootstrap admin (default `vp-idp-plugin-bootstrap` in `master`) for realm-level work, and a per-realm realm admin (default `vp-idp-plugin-realm-admin`) for tenant/user work. Realm-admin clients created by the plugin (created mode) **MUST** be granted exactly the least-privilege role set (`view-realm`, `view-clients`, `query-groups`, `manage-realm`, `manage-users`, `query-users`, `manage-clients`). Secrets **MUST** enter the process only through environment-expanded configuration (bootstrap, default shared realm) or the Credential Store (adopted/created realms). Operator secret rotation **MUST** converge without process restart. Administrator secrets and cached tokens **MUST NOT** appear in any log, metric, or debug output (mechanism in [DESIGN §3.6](./DESIGN.md#36-interactions--sequences)).
+The plugin **MUST** administer Keycloak through two confidential-client tiers with `client_credentials` grants: an operator-provisioned bootstrap admin (default `keycloak-idp-plugin-bootstrap` in `master`) for realm-level work, and a per-realm realm admin (default `keycloak-idp-plugin-realm-admin`) for tenant/user work. Realm-admin clients created by the plugin (created mode) **MUST** be granted exactly the least-privilege role set (`view-realm`, `view-clients`, `query-groups`, `manage-realm`, `manage-users`, `query-users`, `manage-clients`). Secrets **MUST** enter the process only through environment-expanded configuration (bootstrap, default shared realm) or the Credential Store (adopted/created realms). Operator secret rotation **MUST** converge without process restart. Administrator secrets and cached tokens **MUST NOT** appear in any log, metric, or debug output (mechanism in [DESIGN §3.6](./DESIGN.md#36-interactions--sequences)).
 
 - **Rationale**: Provider administrator compromise can affect every identity in the authorized realm; tiered least privilege, typed secret custody, and reactive rotation bound that risk.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
@@ -513,7 +513,7 @@ The operator's v1 realm authentication profile **MUST** limit access-token lifet
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-audit-metrics`
 
-The plugin **MUST** return a classified, redacted outcome for every supported call and **MUST** emit structured audit events on the dedicated `vp.idp.plugin.events` tracing target for every mutating tenant and user lifecycle transition: `tenant.bound`, `realm.created`, `admin_user.bound`, `tenant.unbound`, `realm.removed`, `service_principals.purged`, `user.provisioned`, and `user.deprovisioned`, each carrying the acting subject (id, classified type, raw type, tenant) and provider identifiers. `user.provisioned` additionally records the username as operational evidence; no event carries secrets, passwords, tokens, or raw provider bodies. These emitters are a development stand-in: Account Management and the platform audit owner **MUST** create and durably deliver the terminal audit outcome for each mutating plugin call before production enablement.
+The plugin **MUST** return a classified, redacted outcome for every supported call and **MUST** emit structured audit events on the dedicated `keycloak_idp.events` tracing target for every mutating tenant and user lifecycle transition: `tenant.bound`, `realm.created`, `admin_user.bound`, `tenant.unbound`, `realm.removed`, `service_principals.purged`, `user.provisioned`, and `user.deprovisioned`, each carrying the acting subject (id, classified type, raw type, tenant) and provider identifiers. `user.provisioned` additionally records the username as operational evidence; no event carries secrets, passwords, tokens, or raw provider bodies. These emitters are a development stand-in: Account Management and the platform audit owner **MUST** create and durably deliver the terminal audit outcome for each mutating plugin call before production enablement.
 
 - **Rationale**: A single owner for each durable record prevents duplicate or missing audit events while preserving plugin-level diagnostic evidence.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
@@ -522,7 +522,7 @@ The plugin **MUST** return a classified, redacted outcome for every supported ca
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-operational-metrics`
 
-The plugin **MUST** emit bounded-cardinality operational metrics (`vp_idp_plugin_*`): operation duration histograms, a failure counter labeled by operation and stable failure variant, token/credential refresh counters split by tier so Credential Store and Keycloak failures are separately attributable, credential-store write outcomes, metadata decode failures, orphan-compensation outcomes, and a bound-realms gauge. Every metric label **MUST** be a closed set except the realm label, which **MUST** be subject to a configurable cardinality cap (default 500) after which it is dropped with an observable warning. No metric **MUST** carry secrets or user profile values.
+The plugin **MUST** emit bounded-cardinality operational metrics (`keycloak_idp_plugin_*`): operation duration histograms, a failure counter labeled by operation and stable failure variant, token/credential refresh counters split by tier so Credential Store and Keycloak failures are separately attributable, credential-store write outcomes, metadata decode failures, orphan-compensation outcomes, and a bound-realms gauge. Every metric label **MUST** be a closed set except the realm label, which **MUST** be subject to a configurable cardinality cap (default 500) after which it is dropped with an observable warning. No metric **MUST** carry secrets or user profile values.
 
 - **Rationale**: Bounded, stable-labeled metrics keep the operational surface alertable without cost or cardinality surprises.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-platform-operator`, `cpt-cf-keycloak-idp-plugin-actor-credstore`
@@ -657,7 +657,7 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-interface-provider-instance`
 
-- **Type**: Selectable provider contract (`PluginV1<IdpPluginSpecV1>` catalogue instance `vz.virtuozzo.vp_idp.plugin.v1`)
+- **Type**: Selectable provider contract (`PluginV1<IdpPluginSpecV1>` catalogue instance `cf.builtin.keycloak_idp.plugin.v1`)
 - **Stability**: stable
 - **Description**: Makes the Keycloak provider selectable by Account Management through vendor/priority matching without exposing plugin implementation details to consumers.
 - **Breaking Change Policy**: Provider identity and selection semantics remain backward-compatible within a major contract version.
@@ -959,7 +959,7 @@ The following questions gate only p2 promotion:
 - **Parent PRD**: [Account Management PRD](../../../docs/PRD.md)
 - **Identity Provider SDK**: [`idp.rs`](../../../account-management-sdk/src/idp.rs) and [`idp_user.rs`](../../../account-management-sdk/src/idp_user.rs)
 - **Service-Principal SDK**: [`service-principal-sdk`](../../../../service-principal/service-principal-sdk/src/api.rs)
-- **Implementation**: [`plugins/keycloak-idp-plugin`](../src/lib.rs) (crate `vp-idp-plugin`, ported from vhp-core)
+- **Implementation**: [`plugins/keycloak-idp-plugin`](../src/lib.rs) (crate `cf-gears-keycloak-idp-plugin`, ported from vhp-core)
 - **OIDC AuthN contract**: [OIDC AuthN Resolver Plugin PRD](../../../../authn-resolver/plugins/oidc-authn-plugin/docs/PRD.md)
 - **Realm-strategy relationship**: V1 supports explicit `shared` (default, parent-inherited for children), `adopted`, and `created` provisioning intent with fail-closed parsing.
 - **Migration requirements**: Tenant hard deprovisioning requires the service-principal purge barrier and boundary teardown ordering; user removal happens through per-user deprovisioning before tenant retirement.

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/config.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/config.rs
@@ -375,7 +375,7 @@ fn default_realm_admin_client_id() -> String {
     "keycloak-idp-plugin-realm-admin".into()
 }
 fn default_secret_ref_template() -> String {
-    "vp-idp-realm-admin-{realm_name}-secret".into()
+    "keycloak-idp-realm-admin-{realm_name}-secret".into()
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/config.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/config.rs
@@ -1,7 +1,7 @@
 //! Plugin configuration.
 //!
 //! Mirrors the worked example at
-//! `docs/design/DESIGN-vp-idp-plugin-202605192055/vp-idp-plugin.config.example.yaml`.
+//! `docs/design/DESIGN-keycloak-idp-plugin-202605192055/keycloak-idp-plugin.config.example.yaml`.
 //! Per the ADDENDUM, static admin creds (`bootstrap_admin.client_secret`,
 //! `realm_admin.default_shared_realm_secret`) are templated `${VAR}` strings
 //! resolved at config-load time via toolkit's `ExpandVars` (symmetric with the
@@ -150,13 +150,13 @@ impl Default for HttpRetryPolicy {
 
 /// Lightweight probe struct used to read the `enabled` flag without requiring
 /// all mandatory Keycloak fields to be present. Deserialization of
-/// [`VpIdpPluginConfig`] is only attempted when the flag is `true` (default).
+/// [`KeycloakIdpPluginConfig`] is only attempted when the flag is `true` (default).
 ///
 /// This mirrors the pattern used by `temporal-workflow-executor-plugin`: read
-/// `enabled` via `ctx.config_or_default::<VpIdpPluginEnabledProbe>()`, then
+/// `enabled` via `ctx.config_or_default::<KeycloakIdpPluginEnabledProbe>()`, then
 /// proceed with the full config parse only when enabled.
 #[derive(Debug, Default, Deserialize)]
-pub struct VpIdpPluginEnabledProbe {
+pub struct KeycloakIdpPluginEnabledProbe {
     /// When `false` the module skips full init. Defaults to `true`.
     #[serde(default = "default_enabled")]
     pub enabled: bool,
@@ -168,7 +168,7 @@ fn default_enabled() -> bool {
 
 #[derive(Debug, Clone, Deserialize, ExpandVars)]
 #[serde(deny_unknown_fields)]
-pub struct VpIdpPluginConfig {
+pub struct KeycloakIdpPluginConfig {
     pub security_context: SecurityContextConfig,
     #[expand_vars]
     pub keycloak: KeycloakConfig,
@@ -182,8 +182,8 @@ pub struct VpIdpPluginConfig {
     /// instance this module publishes to types-registry, and the key
     /// AM's `choose_plugin_instance` filter matches against
     /// `cfg.idp.vendor` to pick a candidate. Defaults to
-    /// `"virtuozzo"` — deploys that want this plugin to win
-    /// selection MUST set `account-management.idp.vendor = "virtuozzo"`
+    /// `"keycloak"` — deploys that want this plugin to win
+    /// selection MUST set `account-management.idp.vendor = "keycloak"`
     /// to align, otherwise AM falls back per `idp.required`.
     #[serde(default = "default_vendor")]
     pub vendor: String,
@@ -191,8 +191,8 @@ pub struct VpIdpPluginConfig {
     /// Plugin selection priority — lower wins on tie-breaks within
     /// the same vendor. Defaults to `50` (lower than
     /// `static-idp-plugin`'s `100`) so an environment that publishes
-    /// both under `vendor = "virtuozzo"` (e.g. a transitional canary
-    /// with two vp-idp-plugin versions) deterministically picks the
+    /// both under `vendor = "keycloak"` (e.g. a transitional canary
+    /// with two keycloak-idp-plugin versions) deterministically picks the
     /// newer one if it pins a lower number, while leaving headroom
     /// for emergency "force this plugin to win" overrides via
     /// `i16::MIN`.
@@ -201,7 +201,7 @@ pub struct VpIdpPluginConfig {
 }
 
 fn default_vendor() -> String {
-    "virtuozzo".to_owned()
+    "keycloak".to_owned()
 }
 
 const fn default_priority() -> i16 {
@@ -349,7 +349,7 @@ fn default_master_realm() -> String {
     "master".into()
 }
 fn default_bootstrap_client_id() -> String {
-    "vp-idp-plugin-bootstrap".into()
+    "keycloak-idp-plugin-bootstrap".into()
 }
 
 #[derive(Debug, Clone, Deserialize, ExpandVars)]
@@ -372,7 +372,7 @@ pub struct RealmAdminConfig {
 }
 
 fn default_realm_admin_client_id() -> String {
-    "vp-idp-plugin-realm-admin".into()
+    "keycloak-idp-plugin-realm-admin".into()
 }
 fn default_secret_ref_template() -> String {
     "vp-idp-realm-admin-{realm_name}-secret".into()
@@ -464,7 +464,7 @@ impl ServicePrincipalConfig {
     /// `realm` cannot be cross-validated against AM's shared realm here — that
     /// value lives in account-management's bootstrap config, not this plugin's.
     /// The field defaults to `platform` when the section is omitted (see the
-    /// `#[serde(default)]` on `VpIdpPluginConfig::service_principal`), so a
+    /// `#[serde(default)]` on `KeycloakIdpPluginConfig::service_principal`), so a
     /// deployment on a non-`platform` shared realm MUST set `realm` explicitly
     /// or principals are created/purged against the wrong realm. The check
     /// below only rejects an explicitly blank value.

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/config.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/config.rs
@@ -1,0 +1,498 @@
+//! Plugin configuration.
+//!
+//! Mirrors the worked example at
+//! `docs/design/DESIGN-vp-idp-plugin-202605192055/vp-idp-plugin.config.example.yaml`.
+//! Per the ADDENDUM, static admin creds (`bootstrap_admin.client_secret`,
+//! `realm_admin.default_shared_realm_secret`) are templated `${VAR}` strings
+//! resolved at config-load time via toolkit's `ExpandVars` (symmetric with the
+//! AM DB DSN's `${PGPASSWORD}` substitution). Operators may also inline a
+//! literal value. Per-realm dynamic secrets for `Adopted` / `Created` use the
+//! `realm_admin.secret_ref_template`.
+
+use std::time::Duration;
+
+use secrecy::SecretString;
+use serde::{Deserialize, Serialize};
+use toolkit::var_expand::{ExpandVars as ExpandVarsTrait, ExpandVarsError};
+use toolkit_gts::gts_id;
+use toolkit_macros::ExpandVars;
+use url::Url;
+use uuid::Uuid;
+
+/// Wrapper around a config string whose final value is a secret.
+///
+/// Holds a plain `String` for `Deserialize` + `ExpandVars` compatibility
+/// (toolkit's macro derives env-var substitution on `String` fields and
+/// teaching it about `secrecy::SecretString` is out of scope), but
+/// suppresses every accidental leak surface around it:
+///
+/// * No `Display` impl — `format!("{}", secret)` won't compile.
+/// * `Debug` emits `<redacted>`, so `anyhow!("{:?}", config)` /
+///   panic-formatter dumps don't print the resolved value.
+/// * No `Serialize`, no `PartialEq` — secret bytes never leak through a
+///   `to_yaml()` / config-snapshot path or an assertion message.
+/// * The only read accessor is [`Self::expose`] (deliberately verbose
+///   so every leak site is grep-able) plus
+///   [`Self::clone_into_secret_string`] which moves the value behind
+///   the `secrecy` opaque-debug guarantee at the factory boundary.
+///
+/// The newtype implements [`ExpandVarsTrait`] manually so the
+/// `#[expand_vars]` derive on its parent struct keeps working —
+/// substitution happens on the inner `String` before any consumer
+/// sees the value.
+#[derive(Clone, Deserialize)]
+#[serde(transparent)]
+pub struct SecretFromEnv(String);
+
+impl SecretFromEnv {
+    /// Read the resolved secret bytes. Use **only** at boundaries that
+    /// hand the value to a `secrecy`-protected sink — typically
+    /// [`Self::clone_into_secret_string`] is what you want.
+    #[must_use]
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+
+    /// Clone the resolved secret into a [`SecretString`] for downstream
+    /// `secrecy`-tracked usage (factory caches, token POST bodies,
+    /// realm-admin source enum). The intermediate `String` lives only
+    /// on this function's stack.
+    #[must_use]
+    pub fn clone_into_secret_string(&self) -> SecretString {
+        SecretString::from(self.0.clone())
+    }
+
+    /// Construct from an unexpanded literal. Crate-private and named to
+    /// stand out at call sites — production code MUST go through
+    /// `Deserialize` + `ExpandVars` so `${VAR}` placeholders are
+    /// substituted before any consumer sees the value. The only legitimate
+    /// callers today are unit-test fixtures + `domain::test_support`.
+    ///
+    /// The `#[cfg_attr(not(test), allow(dead_code))]` keeps the function
+    /// callable from `#[cfg(test)]` modules (where it's the test-fixture
+    /// entry point) without tripping `dead_code` in production builds.
+    /// The function itself is NOT `#[cfg(test)]`-gated so DE1101
+    /// (tests-in-separate-files) doesn't see it as inline test code
+    /// alongside the companion `config_tests.rs`.
+    #[doc(hidden)]
+    #[cfg_attr(not(test), allow(dead_code))]
+    #[must_use]
+    pub(crate) fn from_literal_unchecked(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+}
+
+impl std::fmt::Debug for SecretFromEnv {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("<redacted>")
+    }
+}
+
+impl ExpandVarsTrait for SecretFromEnv {
+    fn expand_vars(&mut self) -> Result<(), ExpandVarsError> {
+        self.0.expand_vars()
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BackoffKind {
+    #[default]
+    Exponential,
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum JitterKind {
+    #[default]
+    Full,
+    None,
+}
+
+/// HTTP retry policy for Keycloak Admin REST. Applied to 5xx / 429 / transport
+/// errors only — 4xx (other than 429) and 2xx return immediately. Per DESIGN §4.4.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct HttpRetryPolicy {
+    #[serde(default = "default_max_retries")]
+    pub max_retries: u32,
+    #[serde(default)]
+    pub backoff: BackoffKind,
+    #[serde(default)]
+    pub jitter: JitterKind,
+    #[serde(default = "default_initial_backoff_ms")]
+    pub initial_backoff_ms: u64,
+    #[serde(default = "default_max_backoff_ms")]
+    pub max_backoff_ms: u64,
+}
+
+fn default_max_retries() -> u32 {
+    3
+}
+fn default_initial_backoff_ms() -> u64 {
+    100
+}
+fn default_max_backoff_ms() -> u64 {
+    5_000
+}
+
+impl Default for HttpRetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_retries: default_max_retries(),
+            backoff: BackoffKind::default(),
+            jitter: JitterKind::default(),
+            initial_backoff_ms: default_initial_backoff_ms(),
+            max_backoff_ms: default_max_backoff_ms(),
+        }
+    }
+}
+
+/// Lightweight probe struct used to read the `enabled` flag without requiring
+/// all mandatory Keycloak fields to be present. Deserialization of
+/// [`VpIdpPluginConfig`] is only attempted when the flag is `true` (default).
+///
+/// This mirrors the pattern used by `temporal-workflow-executor-plugin`: read
+/// `enabled` via `ctx.config_or_default::<VpIdpPluginEnabledProbe>()`, then
+/// proceed with the full config parse only when enabled.
+#[derive(Debug, Default, Deserialize)]
+pub struct VpIdpPluginEnabledProbe {
+    /// When `false` the module skips full init. Defaults to `true`.
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Deserialize, ExpandVars)]
+#[serde(deny_unknown_fields)]
+pub struct VpIdpPluginConfig {
+    pub security_context: SecurityContextConfig,
+    #[expand_vars]
+    pub keycloak: KeycloakConfig,
+    pub tenant_facade: TenantFacadeConfig,
+    pub user_facade: UserFacadeConfig,
+    /// Machine-identity lifecycle configuration (confidential OIDC clients).
+    #[serde(default)]
+    pub service_principal: ServicePrincipalConfig,
+
+    /// Vendor name advertised on the `PluginV1<IdpPluginSpecV1>`
+    /// instance this module publishes to types-registry, and the key
+    /// AM's `choose_plugin_instance` filter matches against
+    /// `cfg.idp.vendor` to pick a candidate. Defaults to
+    /// `"virtuozzo"` — deploys that want this plugin to win
+    /// selection MUST set `account-management.idp.vendor = "virtuozzo"`
+    /// to align, otherwise AM falls back per `idp.required`.
+    #[serde(default = "default_vendor")]
+    pub vendor: String,
+
+    /// Plugin selection priority — lower wins on tie-breaks within
+    /// the same vendor. Defaults to `50` (lower than
+    /// `static-idp-plugin`'s `100`) so an environment that publishes
+    /// both under `vendor = "virtuozzo"` (e.g. a transitional canary
+    /// with two vp-idp-plugin versions) deterministically picks the
+    /// newer one if it pins a lower number, while leaving headroom
+    /// for emergency "force this plugin to win" overrides via
+    /// `i16::MIN`.
+    #[serde(default = "default_priority")]
+    pub priority: i16,
+}
+
+fn default_vendor() -> String {
+    "virtuozzo".to_owned()
+}
+
+const fn default_priority() -> i16 {
+    50
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SecurityContextConfig {
+    /// Tenant under which the plugin owns its infrastructure secrets.
+    ///
+    /// Defaults to the platform **root** tenant (`…0001`, AM bootstrap's
+    /// "Platform" tenant). This MUST be a REAL tenant: credstore's own-tenant
+    /// gate (`scope_includes_tenant`) checks that the secret's owning tenant
+    /// falls inside the plugin's RBAC-granted scope. The nil UUID is not a real
+    /// tenant — it is in no grant's materialized subtree — so it fails the gate
+    /// (`AccessDenied` on every dedicated-realm secret write). The root tenant
+    /// is the correct platform-scope home and is covered by the plugin's
+    /// Credstore Secret Operator grant.
+    #[serde(default = "default_platform_tenant_id")]
+    pub platform_tenant_id: Uuid,
+}
+
+/// Platform root tenant id — AM bootstrap's stable root ("Platform") tenant.
+/// The plugin's infrastructure secrets are owned here so the credstore
+/// own-tenant gate passes under the plugin's Credstore Secret Operator grant.
+fn default_platform_tenant_id() -> Uuid {
+    Uuid::from_u128(1)
+}
+
+#[derive(Debug, Clone, Deserialize, ExpandVars)]
+#[serde(deny_unknown_fields)]
+pub struct KeycloakConfig {
+    pub base_url: Url,
+    #[expand_vars]
+    pub bootstrap_admin: BootstrapAdminConfig,
+    #[expand_vars]
+    pub realm_admin: RealmAdminConfig,
+    #[serde(default)]
+    pub tls_ca_bundle_ref: Option<String>,
+    #[serde(default = "default_token_safety_ms")]
+    pub admin_token_lifetime_safety_ms: u64,
+    #[serde(default = "default_http_timeout_ms")]
+    pub http_request_timeout_ms: u64,
+    /// Humantime string (e.g. `"30m"`) or `null` to disable. Reactive-401 is always on.
+    #[serde(default, with = "humantime_serde")]
+    pub credential_refresh_interval: Option<Duration>,
+    /// HTTP retry policy applied to 5xx / 429 / transport errors (DESIGN §4.4).
+    #[serde(default)]
+    pub http_retry_policy: HttpRetryPolicy,
+    /// Metrics cardinality controls (DESIGN §4.4, §9).
+    #[serde(default)]
+    pub metrics: KeycloakMetricsConfig,
+    /// Init-time bootstrap-admin pre-warm retry budget (DESIGN §4.0 init
+    /// lifecycle / §4.4 line 197). Operators with slow-starting KC pods
+    /// can extend this without a code change; the defaults match the
+    /// `~12s of backoff + per-attempt timeout` budget the runbook documents.
+    #[serde(default)]
+    pub bootstrap_pre_warm: BootstrapPreWarmConfig,
+}
+
+/// Bootstrap-admin pre-warm retry budget. `MAX_ATTEMPTS - 1` backoffs
+/// apply BETWEEN attempts — the last attempt's failure is propagated
+/// without an extra sleep.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BootstrapPreWarmConfig {
+    /// Max attempts before init bails. Default `5`.
+    #[serde(default = "default_pre_warm_max_attempts")]
+    pub max_attempts: u32,
+    /// Linear backoff between attempts. Humantime string (e.g. `"3s"`).
+    /// Default `"3s"`.
+    #[serde(default = "default_pre_warm_backoff", with = "humantime_serde")]
+    pub backoff: Duration,
+}
+
+fn default_pre_warm_max_attempts() -> u32 {
+    5
+}
+fn default_pre_warm_backoff() -> Duration {
+    Duration::from_secs(3)
+}
+
+impl Default for BootstrapPreWarmConfig {
+    fn default() -> Self {
+        Self {
+            max_attempts: default_pre_warm_max_attempts(),
+            backoff: default_pre_warm_backoff(),
+        }
+    }
+}
+
+/// Metrics-specific configuration nested under `keycloak:` (DESIGN §4.4, §9).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct KeycloakMetricsConfig {
+    /// Maximum number of distinct `realm_name` values that may appear as a
+    /// metric label before the plugin drops the label and falls back to a
+    /// tracing-span attribute. Default `500`. Set to `0` to disable (never
+    /// drop).
+    #[serde(default = "default_realm_label_cap")]
+    pub drop_realm_label_at_cardinality: u32,
+}
+
+fn default_realm_label_cap() -> u32 {
+    500
+}
+
+impl Default for KeycloakMetricsConfig {
+    fn default() -> Self {
+        Self {
+            drop_realm_label_at_cardinality: default_realm_label_cap(),
+        }
+    }
+}
+
+fn default_token_safety_ms() -> u64 {
+    30_000
+}
+fn default_http_timeout_ms() -> u64 {
+    5_000
+}
+
+#[derive(Debug, Clone, Deserialize, ExpandVars)]
+#[serde(deny_unknown_fields)]
+pub struct BootstrapAdminConfig {
+    #[serde(default = "default_master_realm")]
+    pub realm: String,
+    #[serde(default = "default_bootstrap_client_id")]
+    pub client_id: String,
+    /// Bootstrap admin client secret. Supports `${VAR}` templating expanded at
+    /// config-load time via toolkit's `ExpandVars` (ADDENDUM §3.1) — symmetric
+    /// with how the AM DB DSN handles `${PGPASSWORD}`. Operators may also
+    /// inline a literal value.
+    ///
+    /// Wrapped in [`SecretFromEnv`] so `{:?}` / `Display` / `Serialize`
+    /// surfaces don't leak the resolved value. The wrapper implements
+    /// the workspace `ExpandVarsTrait` manually, so the `#[expand_vars]`
+    /// derive on this struct keeps substituting `${VAR}` placeholders.
+    #[expand_vars]
+    pub client_secret: SecretFromEnv,
+}
+
+fn default_master_realm() -> String {
+    "master".into()
+}
+fn default_bootstrap_client_id() -> String {
+    "vp-idp-plugin-bootstrap".into()
+}
+
+#[derive(Debug, Clone, Deserialize, ExpandVars)]
+#[serde(deny_unknown_fields)]
+pub struct RealmAdminConfig {
+    #[serde(default = "default_realm_admin_client_id")]
+    pub client_id_default: String,
+    /// Default-shared-realm admin client secret. Supports `${VAR}` templating
+    /// expanded at config-load time via toolkit's `ExpandVars` (ADDENDUM §3.2).
+    /// Operators may also inline a literal value.
+    ///
+    /// Wrapped in [`SecretFromEnv`] — see [`BootstrapAdminConfig::client_secret`]
+    /// for the rationale (Debug-redacted, no Display / Serialize surface).
+    #[expand_vars]
+    pub default_shared_realm_secret: SecretFromEnv,
+    /// `SecretRef` ID template for non-default-shared realms (Adopted / Created).
+    /// Must yield a valid `SecretRef` (≤255 chars, `[A-Za-z0-9_-]+`).
+    #[serde(default = "default_secret_ref_template")]
+    pub secret_ref_template: String,
+}
+
+fn default_realm_admin_client_id() -> String {
+    "vp-idp-plugin-realm-admin".into()
+}
+fn default_secret_ref_template() -> String {
+    "vp-idp-realm-admin-{realm_name}-secret".into()
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TenantFacadeConfig {
+    /// Pass-through into Keycloak `RealmRepresentation` at `Created` provision time.
+    #[serde(default)]
+    pub realm_defaults: serde_json::Value,
+    #[serde(default = "default_tenant_group_root")]
+    pub tenant_group_root: String,
+    /// Per-call upper bound on Keycloak Admin REST work (transport + retries) before
+    /// returning `Ambiguous`. Per DESIGN §4.2.
+    #[serde(default = "default_provision_timeout_ms")]
+    pub provision_timeout_ms: u64,
+}
+
+fn default_tenant_group_root() -> String {
+    "/tenants".into()
+}
+
+fn default_provision_timeout_ms() -> u64 {
+    30_000
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UserFacadeConfig {
+    #[serde(default = "default_user_required_actions")]
+    pub default_user_required_actions: Vec<String>,
+    #[serde(default = "default_list_limit")]
+    pub list_users_page_limit_default: u32,
+    #[serde(default = "default_list_limit_max")]
+    pub list_users_page_limit_max: u32,
+    #[serde(default = "default_session_revoke")]
+    pub session_revoke_on_deprovision: bool,
+}
+
+fn default_user_required_actions() -> Vec<String> {
+    vec!["VERIFY_EMAIL".into()]
+}
+fn default_list_limit() -> u32 {
+    50
+}
+fn default_list_limit_max() -> u32 {
+    200
+}
+fn default_session_revoke() -> bool {
+    true
+}
+
+/// `service_principal` — tenant-scoped machine-identity lifecycle
+/// (confidential `client_credentials` clients in the platform realm).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct ServicePrincipalConfig {
+    /// Realm hosting service-principal clients. MUST name the shared
+    /// realm whose issuer tenants trust (the same realm configured at
+    /// AM bootstrap as `root_tenant_metadata.realm_name`) — the two
+    /// keys have no cross-validation, keep them in sync.
+    pub realm: String,
+    /// Client scopes a caller may request. Empty = none attachable.
+    pub scope_allowlist: Vec<String>,
+    /// Max service-principal clients per tenant. Best-effort cap (no
+    /// cross-replica serialization): concurrent creates may briefly
+    /// overshoot; not a security boundary.
+    pub per_tenant_quota: u32,
+    /// `user_type` attribute value for service-account users. Must
+    /// contain `subject_service` (RBAC principal-resolver pattern).
+    pub subject_type: String,
+}
+
+impl Default for ServicePrincipalConfig {
+    fn default() -> Self {
+        Self {
+            realm: "platform".into(),
+            scope_allowlist: Vec::new(),
+            per_tenant_quota: 10,
+            subject_type: gts_id!("cf.core.security.subject_service_principal.v1~").into(),
+        }
+    }
+}
+
+impl ServicePrincipalConfig {
+    /// Init-time validation; called from module init.
+    ///
+    /// `realm` cannot be cross-validated against AM's shared realm here — that
+    /// value lives in account-management's bootstrap config, not this plugin's.
+    /// The field defaults to `platform` when the section is omitted (see the
+    /// `#[serde(default)]` on `VpIdpPluginConfig::service_principal`), so a
+    /// deployment on a non-`platform` shared realm MUST set `realm` explicitly
+    /// or principals are created/purged against the wrong realm. The check
+    /// below only rejects an explicitly blank value.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if `realm` is blank, or if `subject_type` does not
+    /// contain `"subject_service"`.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.realm.trim().is_empty() {
+            return Err(
+                "service_principal.realm must be a non-empty realm name (the shared realm \
+                 whose issuer tenants trust — keep in sync with account-management \
+                 bootstrap.root_tenant_metadata.realm_name)"
+                    .to_string(),
+            );
+        }
+        if !self.subject_type.contains("subject_service") {
+            return Err(format!(
+                "service_principal.subject_type '{}' must contain 'subject_service' \
+                 (RBAC principal-resolver classification pattern)",
+                self.subject_type,
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "config_tests.rs"]
+mod config_tests;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/config_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/config_tests.rs
@@ -52,7 +52,7 @@ keycloak:
   realm_admin:
     client_id_default: keycloak-idp-plugin-realm-admin
     default_shared_realm_secret: "${VP_IDP_REALM_ADMIN_PLATFORM_CLIENT_SECRET}"
-    secret_ref_template: vp-idp-realm-admin-{realm_name}-secret
+    secret_ref_template: keycloak-idp-realm-admin-{realm_name}-secret
 tenant_facade:
   realm_defaults: {}
   tenant_group_root: /tenants
@@ -75,7 +75,7 @@ user_facade:
 #[test]
 fn template_with_invalid_chars_is_rejected_via_secret_ref_validation() {
     // This template contains a colon, which SecretRef forbids.
-    let bad_template = "vhp:realm:{realm_name}";
+    let bad_template = "bad:template:{realm_name}";
     let synthetic = "a".repeat(64);
     let probe = bad_template.replace("{realm_name}", &synthetic);
     assert!(
@@ -221,7 +221,7 @@ fn realm_admin_debug_redacts_default_shared_realm_secret() {
     let cfg = RealmAdminConfig {
         client_id_default: "keycloak-idp-plugin-realm-admin".into(),
         default_shared_realm_secret: SecretFromEnv::from_literal_unchecked("rotated-on-tuesdays"),
-        secret_ref_template: "vp-idp-realm-admin-{realm_name}-secret".into(),
+        secret_ref_template: "keycloak-idp-realm-admin-{realm_name}-secret".into(),
     };
     let dump = format!("{cfg:?}");
     assert!(

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/config_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/config_tests.rs
@@ -47,10 +47,10 @@ keycloak:
   base_url: https://keycloak.example
   bootstrap_admin:
     realm: master
-    client_id: vp-idp-plugin-bootstrap
+    client_id: keycloak-idp-plugin-bootstrap
     client_secret: "${VP_IDP_BOOTSTRAP_CLIENT_SECRET}"
   realm_admin:
-    client_id_default: vp-idp-plugin-realm-admin
+    client_id_default: keycloak-idp-plugin-realm-admin
     default_shared_realm_secret: "${VP_IDP_REALM_ADMIN_PLATFORM_CLIENT_SECRET}"
     secret_ref_template: vp-idp-realm-admin-{realm_name}-secret
 tenant_facade:
@@ -62,7 +62,7 @@ user_facade:
   list_users_page_limit_max: 200
   session_revoke_on_deprovision: true
 "#;
-    let cfg: VpIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
+    let cfg: KeycloakIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
     // Pre-expansion: the `${VAR}` placeholder is verbatim on the parsed
     // struct. Expansion happens via `ctx.config_expanded::<T>()` at module
     // init; this test doesn't exercise that path.
@@ -96,7 +96,7 @@ keycloak:
 tenant_facade: {}
 user_facade: {}
 "#;
-    let cfg: VpIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
+    let cfg: KeycloakIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
     assert_eq!(
         cfg.keycloak.credential_refresh_interval,
         Some(std::time::Duration::from_mins(30))
@@ -115,7 +115,7 @@ keycloak:
 tenant_facade: {}
 user_facade: {}
 ";
-    let cfg: VpIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
+    let cfg: KeycloakIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
     assert_eq!(
         cfg.keycloak.metrics.drop_realm_label_at_cardinality, 500,
         "default cap must be 500"
@@ -135,7 +135,7 @@ keycloak:
 tenant_facade: {}
 user_facade: {}
 ";
-    let cfg: VpIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
+    let cfg: KeycloakIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
     assert_eq!(
         cfg.keycloak.metrics.drop_realm_label_at_cardinality, 0,
         "explicit 0 must be preserved"
@@ -155,7 +155,7 @@ keycloak:
 tenant_facade: {}
 user_facade: {}
 ";
-    let cfg: VpIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
+    let cfg: KeycloakIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
     assert_eq!(
         cfg.keycloak.http_retry_policy.max_retries, 3,
         "default max_retries must be 3"
@@ -189,7 +189,7 @@ keycloak:
 tenant_facade: {}
 user_facade: {}
 ";
-    let cfg: VpIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
+    let cfg: KeycloakIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
     let p = &cfg.keycloak.http_retry_policy;
     assert_eq!(p.max_retries, 5);
     assert_eq!(p.backoff, BackoffKind::Exponential);
@@ -202,7 +202,7 @@ user_facade: {}
 fn bootstrap_admin_debug_redacts_client_secret() {
     let cfg = BootstrapAdminConfig {
         realm: "master".into(),
-        client_id: "vp-idp-plugin-bootstrap".into(),
+        client_id: "keycloak-idp-plugin-bootstrap".into(),
         client_secret: SecretFromEnv::from_literal_unchecked("super-secret-hunter2"),
     };
     let dump = format!("{cfg:?}");
@@ -219,7 +219,7 @@ fn bootstrap_admin_debug_redacts_client_secret() {
 #[test]
 fn realm_admin_debug_redacts_default_shared_realm_secret() {
     let cfg = RealmAdminConfig {
-        client_id_default: "vp-idp-plugin-realm-admin".into(),
+        client_id_default: "keycloak-idp-plugin-realm-admin".into(),
         default_shared_realm_secret: SecretFromEnv::from_literal_unchecked("rotated-on-tuesdays"),
         secret_ref_template: "vp-idp-realm-admin-{realm_name}-secret".into(),
     };
@@ -270,7 +270,7 @@ keycloak:
 tenant_facade: {}
 user_facade: {}
 ";
-    let cfg: VpIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
+    let cfg: KeycloakIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
     assert_eq!(
         cfg.tenant_facade.provision_timeout_ms, 30_000,
         "default provision_timeout_ms must be 30000"
@@ -289,7 +289,7 @@ keycloak:
 tenant_facade: {}
 user_facade: {}
 ";
-    let cfg: VpIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
+    let cfg: KeycloakIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
     assert_eq!(cfg.service_principal.realm, "platform");
     assert!(cfg.service_principal.scope_allowlist.is_empty());
     assert_eq!(cfg.service_principal.per_tenant_quota, 10);

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/config_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/config_tests.rs
@@ -1,0 +1,324 @@
+use super::*;
+use crate::config::{
+    BackoffKind, BootstrapAdminConfig, JitterKind, RealmAdminConfig, SecretFromEnv,
+    ServicePrincipalConfig,
+};
+
+#[test]
+fn template_yields_valid_secret_ref_for_simple_realm_name() {
+    let template = default_secret_ref_template();
+    let resolved = template.replace("{realm_name}", "partner-acme");
+    assert!(
+        resolved
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+        "resolved SecretRef must satisfy canonical SDK charset: {resolved}"
+    );
+    assert!(
+        resolved.len() <= 255,
+        "resolved SecretRef must be ≤255 chars: {resolved}"
+    );
+}
+
+#[test]
+fn platform_tenant_id_defaults_to_platform_root_not_nil() {
+    // Load-bearing: credstore's own-tenant gate rejects a secret whose owning
+    // tenant falls outside the plugin's RBAC-granted scope, and the nil UUID is
+    // not a real tenant (in no grant's materialised subtree). The default MUST
+    // be the platform root tenant (…0001), covered by the plugin's Credstore
+    // Secret Operator grant.
+    assert_eq!(
+        default_platform_tenant_id(),
+        Uuid::from_u128(1),
+        "platform_tenant_id default MUST be the platform root tenant (…0001)"
+    );
+    assert!(
+        !default_platform_tenant_id().is_nil(),
+        "platform_tenant_id default MUST NOT be nil — it fails the credstore own-tenant gate"
+    );
+}
+
+#[test]
+fn deserialises_full_example_shape() {
+    let yaml = r#"
+security_context:
+  platform_tenant_id: 00000000-0000-0000-0000-000000000000
+keycloak:
+  base_url: https://keycloak.example
+  bootstrap_admin:
+    realm: master
+    client_id: vp-idp-plugin-bootstrap
+    client_secret: "${VP_IDP_BOOTSTRAP_CLIENT_SECRET}"
+  realm_admin:
+    client_id_default: vp-idp-plugin-realm-admin
+    default_shared_realm_secret: "${VP_IDP_REALM_ADMIN_PLATFORM_CLIENT_SECRET}"
+    secret_ref_template: vp-idp-realm-admin-{realm_name}-secret
+tenant_facade:
+  realm_defaults: {}
+  tenant_group_root: /tenants
+user_facade:
+  default_user_required_actions: [VERIFY_EMAIL]
+  list_users_page_limit_default: 50
+  list_users_page_limit_max: 200
+  session_revoke_on_deprovision: true
+"#;
+    let cfg: VpIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
+    // Pre-expansion: the `${VAR}` placeholder is verbatim on the parsed
+    // struct. Expansion happens via `ctx.config_expanded::<T>()` at module
+    // init; this test doesn't exercise that path.
+    assert_eq!(
+        cfg.keycloak.bootstrap_admin.client_secret.expose(),
+        "${VP_IDP_BOOTSTRAP_CLIENT_SECRET}"
+    );
+}
+
+#[test]
+fn template_with_invalid_chars_is_rejected_via_secret_ref_validation() {
+    // This template contains a colon, which SecretRef forbids.
+    let bad_template = "vhp:realm:{realm_name}";
+    let synthetic = "a".repeat(64);
+    let probe = bad_template.replace("{realm_name}", &synthetic);
+    assert!(
+        credstore_sdk::SecretRef::new(&probe).is_err(),
+        "SecretRef::new should reject colons in the ID"
+    );
+}
+
+#[test]
+fn humantime_credential_refresh_parsed() {
+    let yaml = r#"
+security_context: { platform_tenant_id: "00000000-0000-0000-0000-000000000000" }
+keycloak:
+  base_url: https://k
+  bootstrap_admin: { client_secret: X }
+  realm_admin: { default_shared_realm_secret: Y }
+  credential_refresh_interval: 30m
+tenant_facade: {}
+user_facade: {}
+"#;
+    let cfg: VpIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
+    assert_eq!(
+        cfg.keycloak.credential_refresh_interval,
+        Some(std::time::Duration::from_mins(30))
+    );
+}
+
+#[test]
+fn keycloak_metrics_config_defaults_cap_to_500() {
+    // `metrics:` block is intentionally absent — must default to 500.
+    let yaml = r"
+security_context: { platform_tenant_id: '00000000-0000-0000-0000-000000000000' }
+keycloak:
+  base_url: https://k
+  bootstrap_admin: { client_secret: X }
+  realm_admin: { default_shared_realm_secret: Y }
+tenant_facade: {}
+user_facade: {}
+";
+    let cfg: VpIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
+    assert_eq!(
+        cfg.keycloak.metrics.drop_realm_label_at_cardinality, 500,
+        "default cap must be 500"
+    );
+}
+
+#[test]
+fn keycloak_metrics_config_explicit_zero_disables_drop() {
+    let yaml = r"
+security_context: { platform_tenant_id: '00000000-0000-0000-0000-000000000000' }
+keycloak:
+  base_url: https://k
+  bootstrap_admin: { client_secret: X }
+  realm_admin: { default_shared_realm_secret: Y }
+  metrics:
+    drop_realm_label_at_cardinality: 0
+tenant_facade: {}
+user_facade: {}
+";
+    let cfg: VpIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
+    assert_eq!(
+        cfg.keycloak.metrics.drop_realm_label_at_cardinality, 0,
+        "explicit 0 must be preserved"
+    );
+}
+
+#[test]
+fn http_retry_policy_defaults_when_block_absent() {
+    // `http_retry_policy:` block is intentionally absent — must default to
+    // max_retries=3, exponential backoff, full jitter.
+    let yaml = r"
+security_context: { platform_tenant_id: '00000000-0000-0000-0000-000000000000' }
+keycloak:
+  base_url: https://k
+  bootstrap_admin: { client_secret: X }
+  realm_admin: { default_shared_realm_secret: Y }
+tenant_facade: {}
+user_facade: {}
+";
+    let cfg: VpIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
+    assert_eq!(
+        cfg.keycloak.http_retry_policy.max_retries, 3,
+        "default max_retries must be 3"
+    );
+    assert_eq!(
+        cfg.keycloak.http_retry_policy.backoff,
+        BackoffKind::Exponential,
+        "default backoff must be exponential"
+    );
+    assert_eq!(
+        cfg.keycloak.http_retry_policy.jitter,
+        JitterKind::Full,
+        "default jitter must be full"
+    );
+}
+
+#[test]
+fn http_retry_policy_custom_values_parsed() {
+    let yaml = r"
+security_context: { platform_tenant_id: '00000000-0000-0000-0000-000000000000' }
+keycloak:
+  base_url: https://k
+  bootstrap_admin: { client_secret: X }
+  realm_admin: { default_shared_realm_secret: Y }
+  http_retry_policy:
+    max_retries: 5
+    backoff: exponential
+    jitter: none
+    initial_backoff_ms: 50
+    max_backoff_ms: 2000
+tenant_facade: {}
+user_facade: {}
+";
+    let cfg: VpIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
+    let p = &cfg.keycloak.http_retry_policy;
+    assert_eq!(p.max_retries, 5);
+    assert_eq!(p.backoff, BackoffKind::Exponential);
+    assert_eq!(p.jitter, JitterKind::None);
+    assert_eq!(p.initial_backoff_ms, 50);
+    assert_eq!(p.max_backoff_ms, 2000);
+}
+
+#[test]
+fn bootstrap_admin_debug_redacts_client_secret() {
+    let cfg = BootstrapAdminConfig {
+        realm: "master".into(),
+        client_id: "vp-idp-plugin-bootstrap".into(),
+        client_secret: SecretFromEnv::from_literal_unchecked("super-secret-hunter2"),
+    };
+    let dump = format!("{cfg:?}");
+    assert!(
+        !dump.contains("hunter2"),
+        "client_secret leaked into Debug: {dump}"
+    );
+    assert!(
+        dump.contains("<redacted>"),
+        "expected redaction marker in Debug: {dump}"
+    );
+}
+
+#[test]
+fn realm_admin_debug_redacts_default_shared_realm_secret() {
+    let cfg = RealmAdminConfig {
+        client_id_default: "vp-idp-plugin-realm-admin".into(),
+        default_shared_realm_secret: SecretFromEnv::from_literal_unchecked("rotated-on-tuesdays"),
+        secret_ref_template: "vp-idp-realm-admin-{realm_name}-secret".into(),
+    };
+    let dump = format!("{cfg:?}");
+    assert!(
+        !dump.contains("rotated-on-tuesdays"),
+        "default_shared_realm_secret leaked into Debug: {dump}"
+    );
+    assert!(
+        dump.contains("<redacted>"),
+        "expected redaction marker in Debug: {dump}"
+    );
+}
+
+/// `SecretFromEnv` MUST NOT implement `Display`. If a future refactor
+/// adds one accidentally, every `format!("{}", secret)` site becomes a
+/// silent leak — so this pin is structural, asserted via `static_assertions`
+/// rather than at runtime.
+#[test]
+fn secret_from_env_has_no_display_impl() {
+    // Compile-time assertion: `SecretFromEnv: !Display`.
+    fn assert_not_display<T: ?Sized>()
+    where
+        for<'a> &'a T: std::fmt::Debug, // anchor — leave Debug bound free of Display
+    {
+    }
+    // The actual structural guarantee: if SecretFromEnv implemented
+    // Display, `format!("{}", …)` would compile in the line below.
+    // Demonstrate via a runtime check that Debug ≠ Display by reading
+    // the redaction marker.
+    let s = SecretFromEnv::from_literal_unchecked("never-printed");
+    let dbg = format!("{s:?}");
+    assert_eq!(dbg, "<redacted>");
+    // Sanity: expose() returns the bytes (covered elsewhere too).
+    assert_eq!(s.expose(), "never-printed");
+    // Marker call so the assert helper isn't dead in -Awarnings runs.
+    assert_not_display::<SecretFromEnv>();
+}
+
+#[test]
+fn provision_timeout_ms_defaults_to_30000_when_absent() {
+    let yaml = r"
+security_context: { platform_tenant_id: '00000000-0000-0000-0000-000000000000' }
+keycloak:
+  base_url: https://k
+  bootstrap_admin: { client_secret: X }
+  realm_admin: { default_shared_realm_secret: Y }
+tenant_facade: {}
+user_facade: {}
+";
+    let cfg: VpIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
+    assert_eq!(
+        cfg.tenant_facade.provision_timeout_ms, 30_000,
+        "default provision_timeout_ms must be 30000"
+    );
+}
+
+#[test]
+fn service_principal_defaults_apply_when_section_absent() {
+    // `service_principal:` key is intentionally absent — exercises #[serde(default)] wiring.
+    let yaml = r"
+security_context: { platform_tenant_id: '00000000-0000-0000-0000-000000000000' }
+keycloak:
+  base_url: https://k
+  bootstrap_admin: { client_secret: X }
+  realm_admin: { default_shared_realm_secret: Y }
+tenant_facade: {}
+user_facade: {}
+";
+    let cfg: VpIdpPluginConfig = serde_yaml::from_str(yaml).expect("valid yaml");
+    assert_eq!(cfg.service_principal.realm, "platform");
+    assert!(cfg.service_principal.scope_allowlist.is_empty());
+    assert_eq!(cfg.service_principal.per_tenant_quota, 10);
+    assert!(
+        cfg.service_principal
+            .subject_type
+            .contains("subject_service")
+    );
+    assert!(cfg.service_principal.validate().is_ok());
+}
+
+#[test]
+fn service_principal_subject_type_must_contain_subject_service() {
+    let cfg = ServicePrincipalConfig {
+        subject_type: "gts.cf.core.security.subject_user.v1~".into(),
+        ..Default::default()
+    };
+    let err = cfg
+        .validate()
+        .expect_err("must reject non-service subject type");
+    assert!(err.contains("subject_service"));
+}
+
+#[test]
+fn service_principal_realm_must_not_be_blank() {
+    let cfg = ServicePrincipalConfig {
+        realm: "   ".into(),
+        ..Default::default()
+    };
+    let err = cfg.validate().expect_err("must reject blank realm");
+    assert!(err.contains("service_principal.realm"));
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/config_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/config_tests.rs
@@ -48,10 +48,10 @@ keycloak:
   bootstrap_admin:
     realm: master
     client_id: keycloak-idp-plugin-bootstrap
-    client_secret: "${VP_IDP_BOOTSTRAP_CLIENT_SECRET}"
+    client_secret: "${KEYCLOAK_IDP_BOOTSTRAP_CLIENT_SECRET}"
   realm_admin:
     client_id_default: keycloak-idp-plugin-realm-admin
-    default_shared_realm_secret: "${VP_IDP_REALM_ADMIN_PLATFORM_CLIENT_SECRET}"
+    default_shared_realm_secret: "${KEYCLOAK_IDP_REALM_ADMIN_PLATFORM_CLIENT_SECRET}"
     secret_ref_template: keycloak-idp-realm-admin-{realm_name}-secret
 tenant_facade:
   realm_defaults: {}
@@ -68,7 +68,7 @@ user_facade:
     // init; this test doesn't exercise that path.
     assert_eq!(
         cfg.keycloak.bootstrap_admin.client_secret.expose(),
-        "${VP_IDP_BOOTSTRAP_CLIENT_SECRET}"
+        "${KEYCLOAK_IDP_BOOTSTRAP_CLIENT_SECRET}"
     );
 }
 

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain.rs
@@ -1,4 +1,4 @@
-//! Domain layer for the VHP `IdP` Plugin.
+//! Domain layer for the Keycloak `IdP` plugin.
 //!
 //! Contains the plugin-owned system
 //! [`SecurityContext`](toolkit_security::SecurityContext) ([`system_actor`])

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain.rs
@@ -1,0 +1,20 @@
+//! Domain layer for the VHP `IdP` Plugin.
+//!
+//! Contains the plugin-owned system
+//! [`SecurityContext`](toolkit_security::SecurityContext) ([`system_actor`])
+//! and the ctx-baked-in `CredStore` seams ([`credstore`]).
+
+pub mod audit;
+pub mod credstore;
+pub mod error;
+pub mod kc;
+pub mod metadata_codec;
+pub mod metrics;
+pub mod ports;
+pub mod service_principal_facade;
+pub mod system_actor;
+pub mod tenant_facade;
+pub mod user_facade;
+
+#[cfg(test)]
+pub(crate) mod test_support;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/audit.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/audit.rs
@@ -1,4 +1,4 @@
-//! Structured audit-event emitters for `vp.idp.plugin.events`.
+//! Structured audit-event emitters for `keycloak_idp.events`.
 //!
 //! Until the platform audit sink lands these emit as plain `tracing::info!`
 //! records on the dedicated target (DESIGN §6.3 deferred wiring). The
@@ -25,8 +25,8 @@ use crate::domain::metadata_codec::RealmBinding;
 ///
 /// * `"am.system"` — AM-internal system actor (the `for_module_init` /
 ///   `for_bootstrap` shape).
-/// * `"vp.idp.plugin"` — this plugin's own system actor, identified by its
-///   stable [`VP_IDP_PLUGIN_ACTOR_UUID`] — NOT by its `subject_type` string.
+/// * `"keycloak_idp.plugin"` — this plugin's own system actor, identified by its
+///   stable [`KEYCLOAK_IDP_PLUGIN_ACTOR_UUID`] — NOT by its `subject_type` string.
 ///   The authz `subject_type` is now the canonical service-principal GTS (so
 ///   the resolver classifies + RBAC-authorizes it), which would otherwise
 ///   collapse this actor into the `"rest"` bucket; keying the audit class on
@@ -37,7 +37,7 @@ use crate::domain::metadata_codec::RealmBinding;
 ///
 /// `subject_type_raw` is the verbatim string from `SecurityContext::
 /// subject_type()` (or `"anonymous"` when none) so a future actor
-/// (e.g. `"vp.workflow.plugin"`) is still distinguishable in the
+/// (e.g. a future `"workflow.plugin"` actor) is still distinguishable in the
 /// operator audit stream — without that field, every new actor type
 /// silently collapses into the `"rest"` bucket and gets mis-attributed
 /// as REST-forwarded.
@@ -48,8 +48,8 @@ fn common_fields(actor: &SecurityContext) -> (Uuid, &'static str, String, Uuid) 
     // UUID rather than its `subject_type` string: the authz subject_type is
     // the canonical service-principal GTS now, so a string match would drop
     // it into `"rest"`. Check the UUID first; fall back to the string buckets.
-    let class: &'static str = if id == crate::domain::system_actor::VP_IDP_PLUGIN_ACTOR_UUID {
-        "vp.idp.plugin"
+    let class: &'static str = if id == crate::domain::system_actor::KEYCLOAK_IDP_PLUGIN_ACTOR_UUID {
+        "keycloak_idp.plugin"
     } else {
         match actor.subject_type() {
             Some("am.system") => "am.system",
@@ -85,7 +85,7 @@ pub(crate) fn emit_tenant_bound(
     let realm_binding_str = realm_binding_str(realm_binding);
     let created_realm = matches!(realm_binding, RealmBinding::Created);
     tracing::info!(
-        target: "vp.idp.plugin.events",
+        target: "keycloak_idp.events",
         kind = "tenant.bound",
         %actor_subject_id,
         actor_subject_type,
@@ -126,7 +126,7 @@ pub(crate) fn emit_tenant_unbound(
         realm_name
     };
     tracing::info!(
-        target: "vp.idp.plugin.events",
+        target: "keycloak_idp.events",
         kind = "tenant.unbound",
         %actor_subject_id,
         actor_subject_type,
@@ -156,7 +156,7 @@ pub(crate) fn emit_admin_user_bound(
     let (actor_subject_id, actor_subject_type, actor_subject_type_raw, actor_tenant_id) =
         common_fields(actor);
     tracing::info!(
-        target: "vp.idp.plugin.events",
+        target: "keycloak_idp.events",
         kind = "admin_user.bound",
         %actor_subject_id,
         actor_subject_type,
@@ -176,7 +176,7 @@ pub(crate) fn emit_realm_created(actor: &SecurityContext, tenant_id: Uuid, realm
     let (actor_subject_id, actor_subject_type, actor_subject_type_raw, actor_tenant_id) =
         common_fields(actor);
     tracing::info!(
-        target: "vp.idp.plugin.events",
+        target: "keycloak_idp.events",
         kind = "realm.created",
         %actor_subject_id,
         actor_subject_type,
@@ -195,7 +195,7 @@ pub(crate) fn emit_realm_removed(actor: &SecurityContext, tenant_id: Uuid, realm
     let (actor_subject_id, actor_subject_type, actor_subject_type_raw, actor_tenant_id) =
         common_fields(actor);
     tracing::info!(
-        target: "vp.idp.plugin.events",
+        target: "keycloak_idp.events",
         kind = "realm.removed",
         %actor_subject_id,
         actor_subject_type,
@@ -221,7 +221,7 @@ pub(crate) fn emit_user_provisioned(
         common_fields(actor);
     let realm_binding_str = realm_binding_str(realm_binding);
     tracing::info!(
-        target: "vp.idp.plugin.events",
+        target: "keycloak_idp.events",
         kind = "user.provisioned",
         %actor_subject_id,
         actor_subject_type,
@@ -251,7 +251,7 @@ pub(crate) fn emit_user_deprovisioned(
         common_fields(actor);
     let realm_binding_str = realm_binding_str(realm_binding);
     tracing::info!(
-        target: "vp.idp.plugin.events",
+        target: "keycloak_idp.events",
         kind = "user.deprovisioned",
         %actor_subject_id,
         actor_subject_type,
@@ -277,7 +277,7 @@ pub(crate) fn emit_service_principals_purged(
     let (actor_subject_id, actor_subject_type, actor_subject_type_raw, actor_tenant_id) =
         common_fields(actor);
     tracing::info!(
-        target: "vp.idp.plugin.events",
+        target: "keycloak_idp.events",
         kind = "service_principals.purged",
         %actor_subject_id,
         actor_subject_type,

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/audit.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/audit.rs
@@ -1,0 +1,290 @@
+//! Structured audit-event emitters for `vp.idp.plugin.events`.
+//!
+//! Until the platform audit sink lands these emit as plain `tracing::info!`
+//! records on the dedicated target (DESIGN §6.3 deferred wiring). The
+//! per-`kind` field set follows DESIGN §6.1 (common fields) + §6.2
+//! (event-kinds table).
+//!
+//! Each emitter is `#[inline]` and side-effect-free aside from the
+//! `tracing::info!` call; the production hot-paths in [`TenantFacade`] and
+//! [`UserFacade`] invoke these directly at success / failure sites.
+//!
+//! [`TenantFacade`]: crate::domain::tenant_facade::TenantFacade
+//! [`UserFacade`]: crate::domain::user_facade::UserFacade
+
+use toolkit_security::SecurityContext;
+use uuid::Uuid;
+
+use crate::domain::metadata_codec::RealmBinding;
+
+/// Resolve the common `actor_*` fields per DESIGN §6.1.
+///
+/// Returns `(subject_id, subject_type_class, subject_type_raw, subject_tenant_id)`.
+///
+/// `subject_type_class` is the dashboard-stable bucket (closed set):
+///
+/// * `"am.system"` — AM-internal system actor (the `for_module_init` /
+///   `for_bootstrap` shape).
+/// * `"vp.idp.plugin"` — this plugin's own system actor, identified by its
+///   stable [`VP_IDP_PLUGIN_ACTOR_UUID`] — NOT by its `subject_type` string.
+///   The authz `subject_type` is now the canonical service-principal GTS (so
+///   the resolver classifies + RBAC-authorizes it), which would otherwise
+///   collapse this actor into the `"rest"` bucket; keying the audit class on
+///   the unforgeable UUID preserves the attribution.
+/// * `"rest"` — any other non-system actor with a `subject_type` set on
+///   the [`SecurityContext`].
+/// * `"anonymous"` — no `subject_type` recorded on the context.
+///
+/// `subject_type_raw` is the verbatim string from `SecurityContext::
+/// subject_type()` (or `"anonymous"` when none) so a future actor
+/// (e.g. `"vp.workflow.plugin"`) is still distinguishable in the
+/// operator audit stream — without that field, every new actor type
+/// silently collapses into the `"rest"` bucket and gets mis-attributed
+/// as REST-forwarded.
+fn common_fields(actor: &SecurityContext) -> (Uuid, &'static str, String, Uuid) {
+    let id = actor.subject_id();
+    let raw = actor.subject_type().unwrap_or("anonymous").to_owned();
+    // Attribute this plugin's own system actor by its stable, unforgeable
+    // UUID rather than its `subject_type` string: the authz subject_type is
+    // the canonical service-principal GTS now, so a string match would drop
+    // it into `"rest"`. Check the UUID first; fall back to the string buckets.
+    let class: &'static str = if id == crate::domain::system_actor::VP_IDP_PLUGIN_ACTOR_UUID {
+        "vp.idp.plugin"
+    } else {
+        match actor.subject_type() {
+            Some("am.system") => "am.system",
+            Some(_) => "rest",
+            None => "anonymous",
+        }
+    };
+    (id, class, raw, actor.subject_tenant_id())
+}
+
+/// Stringify a [`RealmBinding`] for the `realm_binding` field. Matches the
+/// snake-case wire shape persisted on the metadata blob.
+fn realm_binding_str(b: RealmBinding) -> &'static str {
+    match b {
+        RealmBinding::Shared => "shared",
+        RealmBinding::Adopted => "adopted",
+        RealmBinding::Created => "created",
+    }
+}
+
+/// `kind = "tenant.bound"` — fired on every `provision_tenant` success.
+/// `created_realm` is `true` iff the binding mode is [`RealmBinding::Created`]
+/// (in which case the realm itself was provisioned by this run).
+pub(crate) fn emit_tenant_bound(
+    actor: &SecurityContext,
+    tenant_id: Uuid,
+    realm_name: &str,
+    realm_binding: RealmBinding,
+    admin_secret_ref: Option<&str>,
+) {
+    let (actor_subject_id, actor_subject_type, actor_subject_type_raw, actor_tenant_id) =
+        common_fields(actor);
+    let realm_binding_str = realm_binding_str(realm_binding);
+    let created_realm = matches!(realm_binding, RealmBinding::Created);
+    tracing::info!(
+        target: "vp.idp.plugin.events",
+        kind = "tenant.bound",
+        %actor_subject_id,
+        actor_subject_type,
+        actor_subject_type_raw,
+        %actor_tenant_id,
+        %tenant_id,
+        realm_name,
+        realm_binding = realm_binding_str,
+        created_realm,
+        admin_secret_ref = admin_secret_ref.unwrap_or("<env-backed>"),
+        "tenant bound"
+    );
+}
+
+/// `kind = "tenant.unbound"` — fired on every `deprovision_tenant` success
+/// (including 404/410 "already gone" branches). `already_absent = true` when
+/// the deprovision short-circuited because metadata was `None` (the
+/// `am.system` missing-metadata branch) or the tenant group came back
+/// 404/410. `removed_realm = true` when Created-mode last-tenant teardown
+/// also `DELETE`d the realm.
+pub(crate) fn emit_tenant_unbound(
+    actor: &SecurityContext,
+    tenant_id: Uuid,
+    realm_name: &str,
+    realm_binding: Option<RealmBinding>,
+    already_absent: bool,
+    removed_realm: bool,
+) {
+    let (actor_subject_id, actor_subject_type, actor_subject_type_raw, actor_tenant_id) =
+        common_fields(actor);
+    let realm_binding_str = match realm_binding {
+        Some(b) => realm_binding_str(b),
+        None => "unknown",
+    };
+    let realm_name_str = if realm_name.is_empty() {
+        "unknown"
+    } else {
+        realm_name
+    };
+    tracing::info!(
+        target: "vp.idp.plugin.events",
+        kind = "tenant.unbound",
+        %actor_subject_id,
+        actor_subject_type,
+        actor_subject_type_raw,
+        %actor_tenant_id,
+        %tenant_id,
+        realm_name = realm_name_str,
+        realm_binding = realm_binding_str,
+        already_absent,
+        removed_realm,
+        "tenant unbound"
+    );
+}
+
+/// `kind = "admin_user.bound"` — fired when `provision_shared` writes
+/// `tenant_id` + `user_type` attributes onto a Phase-0-provisioned KC
+/// user (the optional `admin_user_id` metadata branch). Security-relevant:
+/// the bind mutates KC-side attributes that downstream authz consumes,
+/// so the operator audit log must carry this event distinct from the
+/// generic `tenant.bound`.
+pub(crate) fn emit_admin_user_bound(
+    actor: &SecurityContext,
+    tenant_id: Uuid,
+    realm_name: &str,
+    admin_user_id: Uuid,
+) {
+    let (actor_subject_id, actor_subject_type, actor_subject_type_raw, actor_tenant_id) =
+        common_fields(actor);
+    tracing::info!(
+        target: "vp.idp.plugin.events",
+        kind = "admin_user.bound",
+        %actor_subject_id,
+        actor_subject_type,
+        actor_subject_type_raw,
+        %actor_tenant_id,
+        %tenant_id,
+        realm_name,
+        realm_binding = "shared",
+        %admin_user_id,
+        "admin user bound to tenant"
+    );
+}
+
+/// `kind = "realm.created"` — emitted alongside `tenant.bound` on a
+/// successful Created-mode provision (the realm itself was provisioned).
+pub(crate) fn emit_realm_created(actor: &SecurityContext, tenant_id: Uuid, realm_name: &str) {
+    let (actor_subject_id, actor_subject_type, actor_subject_type_raw, actor_tenant_id) =
+        common_fields(actor);
+    tracing::info!(
+        target: "vp.idp.plugin.events",
+        kind = "realm.created",
+        %actor_subject_id,
+        actor_subject_type,
+        actor_subject_type_raw,
+        %actor_tenant_id,
+        %tenant_id,
+        realm_name,
+        realm_binding = "created",
+        "realm created"
+    );
+}
+
+/// `kind = "realm.removed"` — emitted alongside `tenant.unbound` when a
+/// Created-mode last-tenant teardown also `DELETE`s the realm.
+pub(crate) fn emit_realm_removed(actor: &SecurityContext, tenant_id: Uuid, realm_name: &str) {
+    let (actor_subject_id, actor_subject_type, actor_subject_type_raw, actor_tenant_id) =
+        common_fields(actor);
+    tracing::info!(
+        target: "vp.idp.plugin.events",
+        kind = "realm.removed",
+        %actor_subject_id,
+        actor_subject_type,
+        actor_subject_type_raw,
+        %actor_tenant_id,
+        %tenant_id,
+        realm_name,
+        realm_binding = "created",
+        "realm removed"
+    );
+}
+
+/// `kind = "user.provisioned"` — fired on every `provision_user` success.
+pub(crate) fn emit_user_provisioned(
+    actor: &SecurityContext,
+    tenant_id: Uuid,
+    realm_name: &str,
+    realm_binding: RealmBinding,
+    user_id: Uuid,
+    username: &str,
+) {
+    let (actor_subject_id, actor_subject_type, actor_subject_type_raw, actor_tenant_id) =
+        common_fields(actor);
+    let realm_binding_str = realm_binding_str(realm_binding);
+    tracing::info!(
+        target: "vp.idp.plugin.events",
+        kind = "user.provisioned",
+        %actor_subject_id,
+        actor_subject_type,
+        actor_subject_type_raw,
+        %actor_tenant_id,
+        %tenant_id,
+        realm_name,
+        realm_binding = realm_binding_str,
+        %user_id,
+        username,
+        "user provisioned"
+    );
+}
+
+/// `kind = "user.deprovisioned"` — fired on every `deprovision_user`
+/// success (including the 404/410 idempotency branches; `already_absent`
+/// distinguishes them).
+pub(crate) fn emit_user_deprovisioned(
+    actor: &SecurityContext,
+    tenant_id: Uuid,
+    realm_name: &str,
+    realm_binding: RealmBinding,
+    user_id: Uuid,
+    already_absent: bool,
+) {
+    let (actor_subject_id, actor_subject_type, actor_subject_type_raw, actor_tenant_id) =
+        common_fields(actor);
+    let realm_binding_str = realm_binding_str(realm_binding);
+    tracing::info!(
+        target: "vp.idp.plugin.events",
+        kind = "user.deprovisioned",
+        %actor_subject_id,
+        actor_subject_type,
+        actor_subject_type_raw,
+        %actor_tenant_id,
+        %tenant_id,
+        realm_name,
+        realm_binding = realm_binding_str,
+        %user_id,
+        already_absent,
+        "user deprovisioned"
+    );
+}
+
+/// `kind = "service_principals.purged"` — fired during tenant
+/// deprovisioning after live service-principal clients owned by the tenant
+/// are deleted from the shared service-principal realm.
+pub(crate) fn emit_service_principals_purged(
+    actor: &SecurityContext,
+    tenant_id: Uuid,
+    deleted_count: usize,
+) {
+    let (actor_subject_id, actor_subject_type, actor_subject_type_raw, actor_tenant_id) =
+        common_fields(actor);
+    tracing::info!(
+        target: "vp.idp.plugin.events",
+        kind = "service_principals.purged",
+        %actor_subject_id,
+        actor_subject_type,
+        actor_subject_type_raw,
+        %actor_tenant_id,
+        %tenant_id,
+        deleted_count,
+        "service principals purged for tenant"
+    );
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/credstore.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/credstore.rs
@@ -1,0 +1,16 @@
+//! `CredStore` seams — ctx-baked-in wrappers ensuring call sites cannot
+//! accidentally pass AM-forwarded ctx to `CredStore`.
+//!
+//! [`CredStoreReader`] is the canonical read-only path (DESIGN §4.6).
+//! [`CredStoreWriter`] wraps the unified `credstore_sdk::CredStoreClientV1`
+//! (the gateway client resolved from the `ClientHub`) for `put`/`delete`.
+//!
+//! Reader and writer are deliberately separate types — not one `CredStore` —
+//! so that read-only call sites cannot accidentally reach a mutation method
+//! (DESIGN §4.7).
+
+pub mod reader;
+pub mod writer;
+
+pub use reader::CredStoreReader;
+pub use writer::CredStoreWriter;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/credstore/reader.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/credstore/reader.rs
@@ -1,0 +1,58 @@
+//! Read wrapper over `dyn CredStoreClientV1`.
+//!
+//! The plugin's system [`SecurityContext`] is baked in at construction so call
+//! sites cannot accidentally pass an AM-forwarded ctx to `inner.get`
+//! (DESIGN §4.6, §8.1). The wrapper exposes a minimal `get` surface that
+//! drops the response metadata (`owner_tenant_id`, `sharing`, `is_inherited`)
+//! per DESIGN §4.6 — the plugin only consumes `r.value`.
+
+use std::sync::Arc;
+
+use credstore_sdk::{CredStoreClientV1, CredStoreError, SecretRef};
+use secrecy::SecretString;
+use toolkit_macros::domain_model;
+use toolkit_security::SecurityContext;
+
+/// Ctx-baked-in read wrapper over [`CredStoreClientV1`].
+#[domain_model]
+#[derive(Clone)]
+pub struct CredStoreReader {
+    inner: Arc<dyn CredStoreClientV1>,
+    system_ctx: Arc<SecurityContext>,
+}
+
+impl CredStoreReader {
+    /// Wrap a [`CredStoreClientV1`] with the plugin-owned system ctx.
+    #[must_use]
+    pub fn new(inner: Arc<dyn CredStoreClientV1>, system_ctx: Arc<SecurityContext>) -> Self {
+        Self { inner, system_ctx }
+    }
+
+    /// Fetch a secret by reference.
+    ///
+    /// Returns `Ok(None)` if the secret does not exist or is inaccessible
+    /// (matching the underlying `CredStoreClientV1::get` contract — access
+    /// denial is expressed as `Ok(None)`, not as an error, to prevent
+    /// enumeration). `Ok(Some(SecretString))` on success. Transport / auth
+    /// failures bubble up as [`CredStoreError`].
+    ///
+    /// # Errors
+    ///
+    /// * Any infrastructure failure surfaced by the underlying client.
+    /// * [`CredStoreError::Internal`] if the stored value is not valid UTF-8
+    ///   (the plugin only stores UTF-8 client secrets — non-UTF-8 indicates
+    ///   storage corruption or a key collision with another consumer).
+    pub async fn get(&self, key: &SecretRef) -> Result<Option<SecretString>, CredStoreError> {
+        let response = self.inner.get(&self.system_ctx, key).await?;
+        let Some(response) = response else {
+            return Ok(None);
+        };
+        let value = std::str::from_utf8(response.value.as_bytes())
+            .map_err(|e| CredStoreError::internal(format!("invalid UTF-8 in secret value: {e}")))?;
+        Ok(Some(SecretString::from(value.to_owned())))
+    }
+}
+
+#[cfg(test)]
+#[path = "reader_tests.rs"]
+mod reader_tests;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/credstore/reader_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/credstore/reader_tests.rs
@@ -1,0 +1,118 @@
+use super::*;
+use crate::domain::system_actor::build_system_ctx;
+use async_trait::async_trait;
+use credstore_sdk::{GetSecretResponse, SecretValue, SharingMode, TenantId, WritePrecondition};
+use secrecy::ExposeSecret;
+use std::sync::Mutex;
+use uuid::Uuid;
+
+/// Stub serving one canned response (`GetSecretResponse` is not `Clone`
+/// because `SecretValue` isn't; we `take()` on first call).
+#[domain_model]
+#[derive(Default)]
+struct StubClient {
+    response: Mutex<Option<GetSecretResponse>>,
+}
+
+#[async_trait]
+impl CredStoreClientV1 for StubClient {
+    async fn create(
+        &self,
+        ctx: &SecurityContext,
+        key: &SecretRef,
+        value: SecretValue,
+        sharing: SharingMode,
+    ) -> Result<(), CredStoreError> {
+        self.put(ctx, key, value, sharing, WritePrecondition::Exists)
+            .await
+    }
+
+    async fn get(
+        &self,
+        _ctx: &SecurityContext,
+        _key: &SecretRef,
+    ) -> Result<Option<GetSecretResponse>, CredStoreError> {
+        Ok(self.response.lock().expect("stub lock poisoned").take())
+    }
+
+    async fn put(
+        &self,
+        _ctx: &SecurityContext,
+        _key: &SecretRef,
+        _value: SecretValue,
+        _sharing: SharingMode,
+        _precondition: WritePrecondition,
+    ) -> Result<(), CredStoreError> {
+        Ok(())
+    }
+
+    async fn delete(
+        &self,
+        _ctx: &SecurityContext,
+        _key: &SecretRef,
+        _precondition: WritePrecondition,
+    ) -> Result<(), CredStoreError> {
+        Ok(())
+    }
+}
+
+fn make_response(value: &str) -> GetSecretResponse {
+    GetSecretResponse {
+        value: SecretValue::from(value),
+        owner_tenant_id: TenantId::nil(),
+        sharing: SharingMode::Tenant,
+        is_inherited: false,
+        version: 1,
+        id: Uuid::nil(),
+        secret_type: "gts.x.core.secret.type.v1~x.core.secret.generic.v1".to_owned(),
+        expires_at: None,
+    }
+}
+
+#[tokio::test]
+async fn get_extracts_value_from_response() {
+    let stub = Arc::new(StubClient {
+        response: Mutex::new(Some(make_response("my-secret"))),
+    });
+    let ctx = build_system_ctx(Uuid::nil());
+    let reader = CredStoreReader::new(stub, ctx);
+    let key = SecretRef::new("k").expect("valid SecretRef");
+    let got = reader.get(&key).await.expect("read ok");
+    assert_eq!(
+        got.as_ref().map(ExposeSecret::expose_secret),
+        Some("my-secret"),
+    );
+}
+
+#[tokio::test]
+async fn missing_returns_none() {
+    let stub = Arc::new(StubClient {
+        response: Mutex::new(None),
+    });
+    let ctx = build_system_ctx(Uuid::nil());
+    let reader = CredStoreReader::new(stub, ctx);
+    let key = SecretRef::new("k").expect("valid SecretRef");
+    assert!(reader.get(&key).await.expect("read ok").is_none());
+}
+
+#[tokio::test]
+async fn non_utf8_value_surfaces_as_internal_error() {
+    // 0xFF is not valid UTF-8 in any position.
+    let stub = Arc::new(StubClient {
+        response: Mutex::new(Some(GetSecretResponse {
+            value: SecretValue::new(vec![0xFF, 0xFE, 0xFD]),
+            owner_tenant_id: TenantId::nil(),
+            sharing: SharingMode::Tenant,
+            is_inherited: false,
+            version: 1,
+            id: Uuid::nil(),
+            secret_type: "gts.x.core.secret.type.v1~x.core.secret.generic.v1".to_owned(),
+            expires_at: None,
+        })),
+    });
+    let ctx = build_system_ctx(Uuid::nil());
+    let reader = CredStoreReader::new(stub, ctx);
+    let key = SecretRef::new("k").expect("valid SecretRef");
+    let err = reader.get(&key).await.expect_err("must reject non-UTF-8");
+    assert!(matches!(err, CredStoreError::Internal(_)));
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/credstore/writer.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/credstore/writer.rs
@@ -1,0 +1,90 @@
+//! Write wrapper over [`credstore_sdk::CredStoreClientV1`].
+//!
+//! The plugin's system [`SecurityContext`] is baked in at construction so call
+//! sites cannot accidentally pass an AM-forwarded ctx to mutation paths
+//! (DESIGN §4.7, §8.1). Vendor 404 on `delete` is mapped to `Ok(())` —
+//! "already absent" is success-equivalent (DESIGN §4.7 last paragraph).
+
+use std::sync::Arc;
+
+use credstore_sdk::{
+    CredStoreClientV1, CredStoreError, SecretRef, SecretValue, SharingMode, WritePrecondition,
+};
+use toolkit_macros::domain_model;
+use toolkit_security::SecurityContext;
+
+/// Ctx-baked-in write wrapper over [`CredStoreClientV1`].
+#[domain_model]
+#[derive(Clone)]
+pub struct CredStoreWriter {
+    inner: Arc<dyn CredStoreClientV1>,
+    system_ctx: Arc<SecurityContext>,
+}
+
+impl CredStoreWriter {
+    /// Wrap a [`CredStoreClientV1`] with the plugin-owned system ctx.
+    #[must_use]
+    pub fn new(inner: Arc<dyn CredStoreClientV1>, system_ctx: Arc<SecurityContext>) -> Self {
+        Self { inner, system_ctx }
+    }
+
+    /// Create or update one secret.
+    ///
+    /// # Errors
+    ///
+    /// Any [`CredStoreError`] surfaced by the underlying client (transport,
+    /// auth, validation).
+    pub async fn put(
+        &self,
+        key: &SecretRef,
+        value: SecretValue,
+        sharing: SharingMode,
+    ) -> Result<(), CredStoreError> {
+        // `create` is the SDK's only preconditionless write; `Conflict` means
+        // the reference already exists (provisioning replay), so overwrite it
+        // wholesale — the plugin owns its templated references outright, which
+        // is exactly the `WritePrecondition::Exists` last-writer-wins case.
+        let replay_value = SecretValue::new(value.as_bytes().to_vec());
+        match self
+            .inner
+            .create(&self.system_ctx, key, value, sharing)
+            .await
+        {
+            Err(CredStoreError::Conflict) => {
+                self.inner
+                    .put(
+                        &self.system_ctx,
+                        key,
+                        replay_value,
+                        sharing,
+                        WritePrecondition::Exists,
+                    )
+                    .await
+            }
+            other => other,
+        }
+    }
+
+    /// Delete one plugin-owned secret. Vendor 404
+    /// ([`CredStoreError::NotFound`]) is mapped to `Ok(())` — "already
+    /// absent" is success-equivalent on the deprovision path (DESIGN §4.7).
+    ///
+    /// # Errors
+    ///
+    /// Any non-`NotFound` [`CredStoreError`] surfaced by the underlying
+    /// client.
+    pub async fn delete(&self, key: &SecretRef) -> Result<(), CredStoreError> {
+        match self
+            .inner
+            .delete(&self.system_ctx, key, WritePrecondition::Exists)
+            .await
+        {
+            Ok(()) | Err(CredStoreError::NotFound) => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "writer_tests.rs"]
+mod writer_tests;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/credstore/writer_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/credstore/writer_tests.rs
@@ -1,0 +1,126 @@
+use super::*;
+use crate::domain::system_actor::build_system_ctx;
+use async_trait::async_trait;
+use credstore_sdk::GetSecretResponse;
+use std::sync::Mutex;
+use uuid::Uuid;
+
+/// One recorded `put` invocation — `(key_str, value_bytes, sharing)`.
+type PutCall = (String, Vec<u8>, SharingMode);
+
+/// Stub unified client capturing `put` calls and serving one canned
+/// `delete` response.
+#[domain_model]
+#[derive(Default)]
+struct StubMutator {
+    /// All recorded `put` invocations.
+    put_calls: Mutex<Vec<PutCall>>,
+    /// One-shot response for the next `delete` call; defaults to `Ok(())`.
+    delete_response: Mutex<Option<Result<(), CredStoreError>>>,
+}
+
+#[async_trait]
+impl CredStoreClientV1 for StubMutator {
+    async fn create(
+        &self,
+        ctx: &SecurityContext,
+        key: &SecretRef,
+        value: SecretValue,
+        sharing: SharingMode,
+    ) -> Result<(), CredStoreError> {
+        self.put(ctx, key, value, sharing, WritePrecondition::Exists)
+            .await
+    }
+
+    async fn get(
+        &self,
+        _ctx: &SecurityContext,
+        _key: &SecretRef,
+    ) -> Result<Option<GetSecretResponse>, CredStoreError> {
+        Ok(None)
+    }
+
+    async fn put(
+        &self,
+        _ctx: &SecurityContext,
+        key: &SecretRef,
+        value: SecretValue,
+        sharing: SharingMode,
+        _precondition: WritePrecondition,
+    ) -> Result<(), CredStoreError> {
+        self.put_calls.lock().expect("stub lock poisoned").push((
+            key.as_ref().to_owned(),
+            value.as_bytes().to_vec(),
+            sharing,
+        ));
+        Ok(())
+    }
+
+    async fn delete(
+        &self,
+        _ctx: &SecurityContext,
+        _key: &SecretRef,
+        _precondition: WritePrecondition,
+    ) -> Result<(), CredStoreError> {
+        self.delete_response
+            .lock()
+            .expect("stub lock poisoned")
+            .take()
+            .unwrap_or(Ok(()))
+    }
+}
+
+#[tokio::test]
+async fn put_forwards_with_system_ctx() {
+    let stub = Arc::new(StubMutator::default());
+    let ctx = build_system_ctx(Uuid::nil());
+    let writer = CredStoreWriter::new(stub.clone(), ctx);
+    let key = SecretRef::new("k").expect("valid SecretRef");
+    let val = SecretValue::from("v");
+    writer
+        .put(&key, val, SharingMode::Tenant)
+        .await
+        .expect("put ok");
+    let calls = stub.put_calls.lock().expect("stub lock poisoned");
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].0, "k");
+    assert_eq!(calls[0].1, b"v");
+    assert_eq!(calls[0].2, SharingMode::Tenant);
+}
+
+#[tokio::test]
+async fn delete_maps_not_found_to_ok() {
+    let stub = Arc::new(StubMutator::default());
+    *stub.delete_response.lock().expect("stub lock poisoned") = Some(Err(CredStoreError::NotFound));
+    let ctx = build_system_ctx(Uuid::nil());
+    let writer = CredStoreWriter::new(stub, ctx);
+    let key = SecretRef::new("k").expect("valid SecretRef");
+    writer
+        .delete(&key)
+        .await
+        .expect("NotFound MUST be mapped to Ok");
+}
+
+#[tokio::test]
+async fn delete_passes_other_errors_through() {
+    let stub = Arc::new(StubMutator::default());
+    *stub.delete_response.lock().expect("stub lock poisoned") =
+        Some(Err(CredStoreError::service_unavailable("nope")));
+    let ctx = build_system_ctx(Uuid::nil());
+    let writer = CredStoreWriter::new(stub, ctx);
+    let key = SecretRef::new("k").expect("valid SecretRef");
+    let err = writer
+        .delete(&key)
+        .await
+        .expect_err("non-NotFound MUST surface");
+    assert!(matches!(err, CredStoreError::ServiceUnavailable { .. }));
+}
+
+#[tokio::test]
+async fn delete_ok_stays_ok() {
+    let stub = Arc::new(StubMutator::default());
+    let ctx = build_system_ctx(Uuid::nil());
+    let writer = CredStoreWriter::new(stub, ctx);
+    let key = SecretRef::new("k").expect("valid SecretRef");
+    writer.delete(&key).await.expect("Ok MUST stay Ok");
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/error.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/error.rs
@@ -222,7 +222,7 @@ pub enum PluginError {
     SpNotFound { detail: String },
 }
 
-/// Stable `failure_variant` label string for the `vp_idp_plugin_failure_total`
+/// Stable `failure_variant` label string for the `keycloak_idp_plugin_failure_total`
 /// metric (DESIGN §9). Must stay 1:1 with [`PluginError`] variants so dashboards
 /// and alerts don't drift when a new variant is added — every new variant adds
 /// one branch here.

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/error.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/error.rs
@@ -167,7 +167,7 @@ pub enum PluginError {
     /// 15 boundary maps this to [`IdpUserOperationFailure::Rejected`]
     /// per DESIGN §5.5 — AM surfaces a generic validation envelope.
     /// Uniqueness conflicts never land here: every KC 409 rides
-    /// [`Self::UserOpDuplicate`] (VHP-2158).
+    /// [`Self::UserOpDuplicate`].
     #[error("user op rejected: {detail}")]
     UserOpRejected { detail: String },
 
@@ -177,7 +177,7 @@ pub enum PluginError {
     /// `errorMessage` when attributable, `UsernameOrEmail` otherwise
     /// (KC 26's combined constant, unparseable bodies). Boundary maps
     /// this to [`IdpUserOperationFailure::DuplicateUser`] so AM
-    /// surfaces HTTP 409 `already_exists` (VHP-2158) — wording drift
+    /// surfaces HTTP 409 `already_exists` — wording drift
     /// in KC can degrade the field token, never the status.
     #[error("user op duplicate {field:?}: {detail}")]
     UserOpDuplicate {
@@ -189,7 +189,7 @@ pub enum PluginError {
     /// recognised policy `errorMessage`). Boundary maps this to
     /// [`IdpUserOperationFailure::PasswordPolicy`] so AM can surface
     /// the structured `password` / `PASSWORD_POLICY` field violation
-    /// (VHP-2158). Previously this fell through the non-409 catch-all
+    ///. Previously this fell through the non-409 catch-all
     /// into `UserOpUnavailable` and mis-surfaced as a retryable 503.
     #[error("user op password policy: {detail}")]
     UserOpPasswordPolicy { detail: String },

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/error.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/error.rs
@@ -1,0 +1,356 @@
+//! Internal plugin error.
+//!
+//! Boundaries (`idp_impl.rs` in Phase 15) translate `PluginError` into the
+//! typed SDK failure variants per DESIGN §5.5. Inside the plugin we deal in
+//! `PluginError` exclusively so call sites don't sprinkle SDK-type construction
+//! around the codebase.
+//!
+//! `detail` format per DESIGN §5.5:
+//!   `kc:{METHOD} {path_template} -> {status}: {body_first_2KB}`
+//! for KC REST failures; `internal:{component}: {short message}` otherwise.
+
+use std::sync::OnceLock;
+
+use thiserror::Error;
+use toolkit_macros::domain_model;
+
+/// DESIGN §8.2 defence-in-depth: regex-redact obvious credential leaks in any
+/// `body_first_2KB` we emit, before the value crosses the AM boundary. AM owns
+/// the authoritative redaction; this is a belt-and-braces layer.
+///
+/// Two compiled patterns with explicit role split (so they don't fight each
+/// other on the same input):
+///
+/// 1. `BEARER_RE` — matches `Bearer <token>` anywhere (HTTP-header echo,
+///    JSON-wrapped `"Bearer X"`, form-body fragments). Covers every
+///    `Authorization`-header echo we've seen from KC.
+/// 2. `KV_RE` — matches `key[:=]value` for `client_secret` and `password`
+///    only. `authorization` is deliberately NOT here — `kv_re`'s `\S+`
+///    value capture is too greedy for the `Authorization: Bearer X`
+///    shape (it would consume `Bearer` while leaving the token), and
+///    `bearer_re` already covers that case.
+#[allow(clippy::expect_used)] // regex literals are compile-time constants; cannot fail at runtime
+fn bearer_re() -> &'static regex::Regex {
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        regex::Regex::new(r"(?i)(bearer)\s+([A-Za-z0-9._~+/\-]+=*)").expect("valid regex")
+    })
+}
+
+#[allow(clippy::expect_used)] // regex literals are compile-time constants; cannot fail at runtime
+fn kv_re() -> &'static regex::Regex {
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        // Value-bound: stop at JSON / form / shell delimiters so we
+        // don't swallow trailing fields of a multi-field body (see the
+        // regression test pinning the JSON-after-secret shape).
+        //
+        // Key set covers both snake_case (form bodies, our own
+        // request/response shapes) and the camelCase variants Keycloak
+        // emits on certain error / discovery responses
+        // (`ClientRepresentation.secret`, `clientSecret`, `refreshToken`,
+        // …). `(?i)` does NOT bridge snake_case↔camelCase, so each
+        // shape is enumerated explicitly. `\bsecret\b` is anchored
+        // with word boundaries so it doesn't false-positive on
+        // `client_secrets` / `secretarial`.
+        regex::Regex::new(
+            r#"(?ix)
+              ( client_secret
+              | clientSecret
+              | password
+              | refresh_token
+              | refreshToken
+              | access_token
+              | accessToken
+              | id_token
+              | idToken
+              | \bsecret\b
+              )
+              ["'\s]*[:=]["'\s]*
+              [^"',&\s}]+
+            "#,
+        )
+        .expect("valid regex")
+    })
+}
+
+/// Redact obvious credential patterns from a response body string.
+///
+/// Implements DESIGN §8.2 defence-in-depth before the value is stored in
+/// `body_first_2kb` of a [`PluginError::KcRest`]:
+///
+/// - `Bearer <token>` → `Bearer <redacted>` (space separator, matching the
+///   HTTP-header echo shape that the dedicated `BEARER_RE` pattern targets).
+/// - `key[:=]value` for `client_secret` / `password` / `authorization`
+///   → `key=<redacted>` (preserves the `=` form because that's how the
+///   surrounding form-body or JSON serialises the original).
+#[must_use]
+pub fn redact_secrets(body: &str) -> String {
+    let s = bearer_re().replace_all(body, "$1 <redacted>");
+    kv_re().replace_all(&s, "$1=<redacted>").into_owned()
+}
+
+#[domain_model]
+#[derive(Debug, Error)]
+pub enum PluginError {
+    /// Keycloak Admin REST failure. `path_template` keeps literal
+    /// `{realm}` / `{tenant_id}` / `{client_uuid}` placeholders to stay
+    /// grep-friendly; concrete IDs ride on adjacent structured fields.
+    /// `body_first_2kb` is verbatim-truncated.
+    #[error("kc:{method} {path_template} -> {status}: {body_first_2kb}")]
+    KcRest {
+        method: &'static str,
+        path_template: String,
+        status: KcStatusKind,
+        body_first_2kb: String,
+    },
+    #[error("internal:CredStoreReader: {detail}")]
+    CredStoreRead { detail: String },
+    #[error("internal:MetadataCodec: {0}")]
+    MetadataDecode(#[from] crate::domain::metadata_codec::DecodeError),
+    #[error("internal:Config: {detail}")]
+    Config { detail: String },
+    /// Caller-supplied `provisioning_metadata` rejected by `parse_input`
+    /// BEFORE any KC call (e.g. created+explicit-realm, shared with no
+    /// parent metadata, bad mode/realm shape). Distinct from `Config` —
+    /// which is also emitted post-KC — so it can map to a clean 400.
+    #[error("provisioning input rejected: {detail}")]
+    ProvisionInputRejected { detail: String },
+    /// Bootstrap admin lacks `view-realm` / `query-groups` on the target realm.
+    /// Phase 15 boundary translates this to `IdpProvisionFailure::UnsupportedOperation`
+    /// per DESIGN §5.2 (line 432). The detail string is the runbook key the
+    /// operator searches for.
+    #[error("bootstrap admin lacks view-realm/query-groups in {realm} — see Phase 0 IaC checklist")]
+    BootstrapPermsMissing { realm: String },
+
+    /// `mode = created` requested but the target realm already exists in
+    /// Keycloak. Validation rejection — NO IdP-side state was created.
+    /// Phase 15 boundary maps this to
+    /// [`IdpProvisionFailure::CleanFailure`] per DESIGN §5.2.
+    #[error("mode = created but realm '{realm}' already exists")]
+    CreatedRealmExists { realm: String },
+
+    /// Ambiguous Created-mode failure — Keycloak (or `OpenBao`) side effects
+    /// may or may not be in place. Phase 15 boundary maps this to
+    /// [`IdpProvisionFailure::Ambiguous { detail }`] per DESIGN §4.2 / §5.5
+    /// (line 482): `detail = format!("ambig:{stage}: {body}")`. `stage`
+    /// pinpoints which step failed so the operator reconciliation runbook
+    /// (§12 risk #9) can prioritise cleanup.
+    #[error("{stage}: {detail}")]
+    AmbiguousCreated {
+        stage: AmbiguousStage,
+        detail: String,
+    },
+
+    /// Deprovision target was already absent (vendor 404/410, or the
+    /// missing-metadata branch — DESIGN §6.2). Phase 15 boundary maps to
+    /// [`IdpDeprovisionFailure::NotFound`] which AM treats as a
+    /// success-equivalent on the hard-delete pipeline.
+    #[error("deprovision target not found in realm '{realm_name}'")]
+    DeprovisionNotFound { realm_name: String },
+
+    /// Transient failure during deprovision (5xx / transport / timeout).
+    /// Phase 15 boundary maps to [`IdpDeprovisionFailure::Retryable`]; the
+    /// row is deferred to the next reaper / retention tick.
+    #[error("deprovision retryable: {detail}")]
+    DeprovisionRetryable { detail: String },
+
+    /// Operator-must-intervene deprovision failure — e.g. malformed
+    /// persisted metadata or other irrecoverable state. Phase 15 boundary
+    /// maps to [`IdpDeprovisionFailure::Terminal`].
+    #[error("deprovision terminal: {detail}")]
+    DeprovisionTerminal { detail: String },
+
+    /// User-op payload was rejected by KC (400/422 that is not a
+    /// recognised password-policy reject: invalid email format,
+    /// user-profile attribute validation, malformed metadata). Phase
+    /// 15 boundary maps this to [`IdpUserOperationFailure::Rejected`]
+    /// per DESIGN §5.5 — AM surfaces a generic validation envelope.
+    /// Uniqueness conflicts never land here: every KC 409 rides
+    /// [`Self::UserOpDuplicate`] (VHP-2158).
+    #[error("user op rejected: {detail}")]
+    UserOpRejected { detail: String },
+
+    /// User-op hit a KC uniqueness collision — ANY 409 from
+    /// user-create (the status is the machine signal; on that endpoint
+    /// it has no other cause). `field` is refined from KC's
+    /// `errorMessage` when attributable, `UsernameOrEmail` otherwise
+    /// (KC 26's combined constant, unparseable bodies). Boundary maps
+    /// this to [`IdpUserOperationFailure::DuplicateUser`] so AM
+    /// surfaces HTTP 409 `already_exists` (VHP-2158) — wording drift
+    /// in KC can degrade the field token, never the status.
+    #[error("user op duplicate {field:?}: {detail}")]
+    UserOpDuplicate {
+        field: account_management_sdk::IdpUserDuplicateField,
+        detail: String,
+    },
+
+    /// User-op was rejected by KC's password policy (400/422 with a
+    /// recognised policy `errorMessage`). Boundary maps this to
+    /// [`IdpUserOperationFailure::PasswordPolicy`] so AM can surface
+    /// the structured `password` / `PASSWORD_POLICY` field violation
+    /// (VHP-2158). Previously this fell through the non-409 catch-all
+    /// into `UserOpUnavailable` and mis-surfaced as a retryable 503.
+    #[error("user op password policy: {detail}")]
+    UserOpPasswordPolicy { detail: String },
+
+    /// User-op failed at transport / 5xx / timeout. Phase 15 boundary
+    /// maps to [`IdpUserOperationFailure::Unavailable`] per DESIGN §5.5
+    /// — AM surfaces `idp_unavailable` and does NOT serve a fallback
+    /// projection.
+    #[error("user op unavailable: {detail}")]
+    UserOpUnavailable { detail: String },
+
+    /// User-op was explicitly declined by the provider (read-only /
+    /// legacy profile). Phase 15 boundary maps to
+    /// [`IdpUserOperationFailure::UnsupportedOperation`] per DESIGN §5.5.
+    #[error("user op unsupported: {detail}")]
+    UserOpUnsupported { detail: String },
+
+    /// Service-principal request rejected before any KC call
+    /// (name/scope/quota/conflict). Permanent client error.
+    /// Boundary maps this to service-principal-sdk's `InvalidInput`.
+    #[error("sp invalid input: {detail}")]
+    SpInvalidInput {
+        detail: String,
+        field: Option<String>,
+    },
+    /// Service-principal client absent, or not owned by the addressed
+    /// tenant (ownership-attribute mismatch is NOT revealed separately).
+    /// Boundary maps this to service-principal-sdk's `NotFound`.
+    #[error("sp not found: {detail}")]
+    SpNotFound { detail: String },
+}
+
+/// Stable `failure_variant` label string for the `vp_idp_plugin_failure_total`
+/// metric (DESIGN §9). Must stay 1:1 with [`PluginError`] variants so dashboards
+/// and alerts don't drift when a new variant is added — every new variant adds
+/// one branch here.
+#[must_use]
+pub fn failure_variant_label(e: &PluginError) -> &'static str {
+    match e {
+        PluginError::Config { .. } => "config",
+        PluginError::ProvisionInputRejected { .. } => "provision_input_rejected",
+        PluginError::CredStoreRead { .. } => "credstore_read",
+        PluginError::MetadataDecode(_) => "metadata_decode",
+        PluginError::KcRest { .. } => "kc_rest",
+        PluginError::AmbiguousCreated { .. } => "ambiguous_created",
+        PluginError::CreatedRealmExists { .. } => "created_realm_exists",
+        PluginError::BootstrapPermsMissing { .. } => "bootstrap_perms_missing",
+        PluginError::DeprovisionNotFound { .. } => "deprovision_not_found",
+        PluginError::DeprovisionRetryable { .. } => "deprovision_retryable",
+        PluginError::DeprovisionTerminal { .. } => "deprovision_terminal",
+        PluginError::UserOpRejected { .. } => "user_op_rejected",
+        PluginError::UserOpDuplicate { .. } => "user_op_duplicate",
+        PluginError::UserOpPasswordPolicy { .. } => "user_op_password_policy",
+        PluginError::UserOpUnavailable { .. } => "user_op_unavailable",
+        PluginError::UserOpUnsupported { .. } => "user_op_unsupported",
+        PluginError::SpInvalidInput { .. } => "sp_invalid_input",
+        PluginError::SpNotFound { .. } => "sp_not_found",
+    }
+}
+
+/// Wire prefix on every `IdpProvisionFailure::Ambiguous::detail` produced by
+/// the plugin (DESIGN §4.2.1). Operator reconciliation tooling parses this
+/// prefix to bucket failures by saga stage.
+pub(crate) const AMBIG_PREFIX: &str = "ambig:";
+
+/// Which Created-mode saga step produced an
+/// [`PluginError::AmbiguousCreated`]. Stable strings — these are part of the
+/// `detail` prefix emitted to AM (DESIGN §5.5: `ambig:kc_realm_create`,
+/// `ambig:kc_client_create`, `ambig:kc_role_mapping`,
+/// `ambig:kc_client_secret_read`, `ambig:openbao_put_after_kc_success`).
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AmbiguousStage {
+    KcRealmCreate,
+    KcClientCreate,
+    KcRoleMapping,
+    KcClientSecretRead,
+    OpenBaoPutAfterKcSuccess,
+    /// Saga exceeded `provision_timeout_ms`. Wire detail: `ambig:timeout`.
+    Timeout,
+    /// Shared-mode admin-user bind (GET-modify-PUT on `/users/{id}`)
+    /// failed AFTER the tenant group was already created. Operator
+    /// runbook: the tenant group exists in KC but the admin user is
+    /// not bound — re-run provisioning is safe (idempotent), or
+    /// operator can manually set `tenant_id` + `user_type` attributes
+    /// on the admin user. Wire detail: `ambig:admin_user_bind`.
+    AdminUserBind,
+    /// SA-user attribute GET-modify-PUT failed after client create.
+    /// Wire detail: `ambig:kc_sa_attr_set`.
+    KcSaAttrSet,
+    /// Client-scope attach failed after client create.
+    /// Wire detail: `ambig:kc_client_scope_attach`.
+    KcClientScopeAttach,
+    /// Secret regeneration POST outcome unknown.
+    /// Wire detail: `ambig:kc_client_secret_rotate`.
+    KcClientSecretRotate,
+    /// Client DELETE outcome unknown.
+    /// Wire detail: `ambig:kc_client_delete`.
+    KcClientDelete,
+}
+
+impl std::fmt::Display for AmbiguousStage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Self::KcRealmCreate => "kc_realm_create",
+            Self::KcClientCreate => "kc_client_create",
+            Self::KcRoleMapping => "kc_role_mapping",
+            Self::KcClientSecretRead => "kc_client_secret_read",
+            Self::OpenBaoPutAfterKcSuccess => "openbao_put_after_kc_success",
+            Self::Timeout => "timeout",
+            Self::AdminUserBind => "admin_user_bind",
+            Self::KcSaAttrSet => "kc_sa_attr_set",
+            Self::KcClientScopeAttach => "kc_client_scope_attach",
+            Self::KcClientSecretRotate => "kc_client_secret_rotate",
+            Self::KcClientDelete => "kc_client_delete",
+        };
+        write!(f, "{AMBIG_PREFIX}{name}")
+    }
+}
+
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KcStatusKind {
+    Http(u16),
+    Transport,
+    Timeout,
+}
+
+impl KcStatusKind {
+    /// `true` when this outcome is worth retrying. Transport- and
+    /// timeout-class failures are always transient; HTTP responses defer to
+    /// [`is_retryable_status`] (5xx / 429 retry, the rest fast-bail).
+    #[must_use]
+    pub fn is_retryable(self) -> bool {
+        match self {
+            Self::Http(s) => is_retryable_status(s),
+            Self::Transport | Self::Timeout => true,
+        }
+    }
+}
+
+/// HTTP-status retry policy shared between the low-level transport
+/// (`infra::kc_http`) and bootstrap-init pre-warm (`module`). 5xx and 429
+/// are treated as transient; everything else in 4xx is permanent so callers
+/// fast-bail instead of burning their retry budget on guaranteed-permanent
+/// failures (`invalid_client`, missing realm, missing role mapping).
+#[must_use]
+pub(crate) fn is_retryable_status(status: u16) -> bool {
+    status >= 500 || status == 429
+}
+
+impl std::fmt::Display for KcStatusKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Http(s) => write!(f, "{s}"),
+            Self::Transport => write!(f, "transport"),
+            Self::Timeout => write!(f, "timeout"),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "error_tests.rs"]
+mod error_tests;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/error_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/error_tests.rs
@@ -1,0 +1,368 @@
+use super::*;
+
+#[test]
+fn kc_rest_detail_format_matches_design() {
+    let e = PluginError::KcRest {
+        method: "GET",
+        path_template: "/admin/realms/{realm}".into(),
+        status: KcStatusKind::Http(403),
+        body_first_2kb: "forbidden".into(),
+    };
+    assert_eq!(
+        format!("{e}"),
+        "kc:GET /admin/realms/{realm} -> 403: forbidden"
+    );
+}
+
+#[test]
+fn kc_rest_with_transport_status() {
+    let e = PluginError::KcRest {
+        method: "POST",
+        path_template: "/admin/realms".into(),
+        status: KcStatusKind::Transport,
+        body_first_2kb: "connection refused".into(),
+    };
+    assert_eq!(
+        format!("{e}"),
+        "kc:POST /admin/realms -> transport: connection refused"
+    );
+}
+
+#[test]
+fn kc_rest_with_timeout_status() {
+    let e = PluginError::KcRest {
+        method: "PUT",
+        path_template: "/admin/realms/{realm}".into(),
+        status: KcStatusKind::Timeout,
+        body_first_2kb: "deadline exceeded".into(),
+    };
+    assert_eq!(
+        format!("{e}"),
+        "kc:PUT /admin/realms/{realm} -> timeout: deadline exceeded"
+    );
+}
+
+#[test]
+fn credstore_read_detail_format() {
+    let e = PluginError::CredStoreRead {
+        detail: "timeout reading vp-idp-bootstrap-admin-secret".into(),
+    };
+    assert_eq!(
+        format!("{e}"),
+        "internal:CredStoreReader: timeout reading vp-idp-bootstrap-admin-secret"
+    );
+}
+
+#[test]
+fn metadata_decode_propagates_via_from() {
+    use crate::domain::metadata_codec::DecodeError;
+    let dec_err = DecodeError::MissingVersion;
+    let plugin_err: PluginError = dec_err.into();
+    assert!(matches!(plugin_err, PluginError::MetadataDecode(_)));
+    assert!(format!("{plugin_err}").contains("internal:MetadataCodec:"));
+}
+
+#[test]
+fn bootstrap_perms_missing_detail_format() {
+    let e = PluginError::BootstrapPermsMissing {
+        realm: "partner-acme".into(),
+    };
+    assert_eq!(
+        format!("{e}"),
+        "bootstrap admin lacks view-realm/query-groups in partner-acme — see Phase 0 IaC checklist"
+    );
+}
+
+#[test]
+fn created_realm_exists_detail_format() {
+    let e = PluginError::CreatedRealmExists {
+        realm: "partner-acme".into(),
+    };
+    assert_eq!(
+        format!("{e}"),
+        "mode = created but realm 'partner-acme' already exists"
+    );
+}
+
+#[test]
+fn ambiguous_created_kc_realm_create_format() {
+    let e = PluginError::AmbiguousCreated {
+        stage: AmbiguousStage::KcRealmCreate,
+        detail: "kc:POST /admin/realms -> 500: boom".into(),
+    };
+    assert_eq!(
+        format!("{e}"),
+        "ambig:kc_realm_create: kc:POST /admin/realms -> 500: boom"
+    );
+}
+
+#[test]
+fn ambiguous_created_openbao_format() {
+    let e = PluginError::AmbiguousCreated {
+        stage: AmbiguousStage::OpenBaoPutAfterKcSuccess,
+        detail: "credstore: ServiceUnavailable(nope)".into(),
+    };
+    assert_eq!(
+        format!("{e}"),
+        "ambig:openbao_put_after_kc_success: credstore: ServiceUnavailable(nope)"
+    );
+}
+
+#[test]
+fn deprovision_not_found_detail_format() {
+    let e = PluginError::DeprovisionNotFound {
+        realm_name: "partner-acme".into(),
+    };
+    assert_eq!(
+        format!("{e}"),
+        "deprovision target not found in realm 'partner-acme'"
+    );
+}
+
+#[test]
+fn deprovision_retryable_detail_format() {
+    let e = PluginError::DeprovisionRetryable {
+        detail: "kc:DELETE /admin/realms/{realm}/groups/{tenant_group_id} -> 503: boom".into(),
+    };
+    assert_eq!(
+        format!("{e}"),
+        "deprovision retryable: kc:DELETE /admin/realms/{realm}/groups/{tenant_group_id} -> 503: boom"
+    );
+}
+
+#[test]
+fn deprovision_terminal_detail_format() {
+    let e = PluginError::DeprovisionTerminal {
+        detail: "metadata corrupt".into(),
+    };
+    assert_eq!(format!("{e}"), "deprovision terminal: metadata corrupt");
+}
+
+#[test]
+fn user_op_rejected_detail_format() {
+    let e = PluginError::UserOpRejected {
+        detail: "user already exists".into(),
+    };
+    assert_eq!(format!("{e}"), "user op rejected: user already exists");
+}
+
+#[test]
+fn user_op_unavailable_detail_format() {
+    let e = PluginError::UserOpUnavailable {
+        detail: "kc:POST /admin/realms/{realm}/users -> 503: boom".into(),
+    };
+    assert_eq!(
+        format!("{e}"),
+        "user op unavailable: kc:POST /admin/realms/{realm}/users -> 503: boom"
+    );
+}
+
+#[test]
+fn user_op_unsupported_detail_format() {
+    let e = PluginError::UserOpUnsupported {
+        detail: "provider is read-only".into(),
+    };
+    assert_eq!(format!("{e}"), "user op unsupported: provider is read-only");
+}
+
+#[test]
+fn redact_secrets_masks_client_secret_kv() {
+    let body = r#"{"error":"invalid_request","client_secret":"sensitive-value-123"}"#;
+    let out = crate::domain::error::redact_secrets(body);
+    assert!(!out.contains("sensitive-value-123"), "secret leaked: {out}");
+    assert!(out.contains("<redacted>"), "redaction marker absent: {out}");
+}
+
+#[test]
+fn redact_secrets_masks_password_kv() {
+    let body = "password=hunter2&grant_type=password";
+    let out = crate::domain::error::redact_secrets(body);
+    assert!(!out.contains("hunter2"), "password leaked: {out}");
+}
+
+#[test]
+fn redact_secrets_masks_authorization_header_echo() {
+    let body = "received Authorization: Bearer eyJhbGciOi...";
+    let out = crate::domain::error::redact_secrets(body);
+    assert!(!out.contains("eyJhbGciOi"), "bearer token leaked: {out}");
+    assert!(out.contains("<redacted>"));
+    // Pin the HTTP-header echo shape — no `=` injected (which would
+    // produce the malformed `Bearer=<redacted>` form).
+    assert!(
+        out.contains("Bearer <redacted>"),
+        "expected `Bearer <redacted>` (space separator); got: {out}"
+    );
+}
+
+#[test]
+fn redact_secrets_passes_through_non_matching_body() {
+    let body = r#"{"error":"not_found","message":"realm not found"}"#;
+    let out = crate::domain::error::redact_secrets(body);
+    assert_eq!(out, body);
+}
+
+#[test]
+fn redact_secrets_preserves_trailing_json_fields_after_client_secret() {
+    // Regression: a greedy `\S+` value bound on `kv_re` previously
+    // consumed `"abc","other":"y"}` in one match, so every diagnostic
+    // field after the secret was lost from `body_first_2kb`. The bound
+    // must stop at the JSON closing quote so the rest of the body
+    // round-trips.
+    let body = r#"{"error":"x","client_secret":"abc","other":"y"}"#;
+    let out = crate::domain::error::redact_secrets(body);
+    assert!(!out.contains("\"abc\""), "client_secret leaked: {out}");
+    assert!(out.contains("<redacted>"), "redaction marker absent: {out}");
+    assert!(
+        out.contains("\"other\":\"y\""),
+        "trailing JSON field after client_secret was clobbered by greedy regex: {out}"
+    );
+    assert!(
+        out.ends_with("\"other\":\"y\"}"),
+        "JSON closing brace clobbered: {out}"
+    );
+}
+
+#[test]
+fn redact_secrets_preserves_trailing_query_params_after_password() {
+    // Form-body shape: `password=...&grant_type=...&...`. The value
+    // bound must stop at `&` so the remaining query params survive.
+    let body = "grant_type=password&password=hunter2&client_id=foo";
+    let out = crate::domain::error::redact_secrets(body);
+    assert!(!out.contains("hunter2"), "password leaked: {out}");
+    assert!(out.contains("<redacted>"), "redaction marker absent: {out}");
+    assert!(
+        out.contains("client_id=foo"),
+        "trailing form param after password was clobbered: {out}"
+    );
+}
+
+#[test]
+fn redact_secrets_masks_kc_camel_case_keys() {
+    // KC error / discovery responses use camelCase: `clientSecret`,
+    // `refreshToken`, `idToken`, plus the bare `secret` field on
+    // `ClientRepresentation`. snake_case-only matching let these slip
+    // through the defence-in-depth layer.
+    let body = r#"{"clientId":"foo","clientSecret":"hunter2","refreshToken":"rt-x"}"#;
+    let out = crate::domain::error::redact_secrets(body);
+    assert!(!out.contains("hunter2"), "clientSecret leaked: {out}");
+    assert!(!out.contains("rt-x"), "refreshToken leaked: {out}");
+    assert!(out.contains("<redacted>"));
+}
+
+#[test]
+fn redact_secrets_masks_kc_bare_secret_key() {
+    let body = r#"{"clientId":"foo","secret":"shh"}"#;
+    let out = crate::domain::error::redact_secrets(body);
+    assert!(!out.contains("\"shh\""), "bare `secret` key leaked: {out}");
+    assert!(out.contains("<redacted>"));
+}
+
+#[test]
+fn redact_secrets_does_not_match_secret_inside_compound_key() {
+    // `client_secrets` (plural) and `secretary` MUST NOT trigger the
+    // `\bsecret\b` arm — otherwise we redact unrelated harmless fields.
+    let body = r#"{"client_secrets_managed":true,"secretary":"alice"}"#;
+    let out = crate::domain::error::redact_secrets(body);
+    // `client_secrets_managed` is NOT one of the redacted keys; the
+    // `client_secret` arm has no `:` immediately after `_secret`, so no
+    // false-positive. `secretary` likewise shouldn't trigger.
+    assert!(
+        out.contains("\"client_secrets_managed\":true") && out.contains("\"secretary\":\"alice\""),
+        "compound key false-positive: {out}"
+    );
+}
+
+#[test]
+fn redact_secrets_is_case_insensitive() {
+    let body = r#"Client_Secret = "x""#;
+    let out = crate::domain::error::redact_secrets(body);
+    assert!(
+        !out.contains("\"x\""),
+        "case-insensitive match failed: {out}"
+    );
+}
+
+#[test]
+fn ambiguous_stage_display_strings_are_stable() {
+    // These strings are part of the `ambig:{stage}:` prefix contract
+    // (DESIGN §4.2 / §5.5 line 482) and MUST NOT silently change — Phase
+    // 15 boundary + operator runbooks key on them.
+    assert_eq!(
+        AmbiguousStage::KcRealmCreate.to_string(),
+        "ambig:kc_realm_create"
+    );
+    assert_eq!(
+        AmbiguousStage::KcClientCreate.to_string(),
+        "ambig:kc_client_create"
+    );
+    assert_eq!(
+        AmbiguousStage::KcRoleMapping.to_string(),
+        "ambig:kc_role_mapping"
+    );
+    assert_eq!(
+        AmbiguousStage::KcClientSecretRead.to_string(),
+        "ambig:kc_client_secret_read"
+    );
+    assert_eq!(
+        AmbiguousStage::AdminUserBind.to_string(),
+        "ambig:admin_user_bind"
+    );
+    assert_eq!(
+        AmbiguousStage::OpenBaoPutAfterKcSuccess.to_string(),
+        "ambig:openbao_put_after_kc_success"
+    );
+}
+
+#[test]
+fn ambiguous_stage_timeout_displays_with_ambig_prefix() {
+    assert_eq!(AmbiguousStage::Timeout.to_string(), "ambig:timeout");
+}
+
+#[test]
+fn sp_error_variants_have_stable_labels() {
+    let invalid = PluginError::SpInvalidInput {
+        detail: "d".into(),
+        field: Some("name".into()),
+    };
+    let not_found = PluginError::SpNotFound { detail: "d".into() };
+    assert_eq!(failure_variant_label(&invalid), "sp_invalid_input");
+    assert_eq!(failure_variant_label(&not_found), "sp_not_found");
+}
+
+// SP-saga wire detail strings: part of the ambig:{stage} prefix contract; must not change silently.
+#[test]
+fn sp_ambiguous_stages_display() {
+    assert_eq!(
+        AmbiguousStage::KcSaAttrSet.to_string(),
+        "ambig:kc_sa_attr_set"
+    );
+    assert_eq!(
+        AmbiguousStage::KcClientScopeAttach.to_string(),
+        "ambig:kc_client_scope_attach"
+    );
+    assert_eq!(
+        AmbiguousStage::KcClientSecretRotate.to_string(),
+        "ambig:kc_client_secret_rotate"
+    );
+    assert_eq!(
+        AmbiguousStage::KcClientDelete.to_string(),
+        "ambig:kc_client_delete"
+    );
+}
+
+#[test]
+fn sp_invalid_input_detail_format() {
+    let e = PluginError::SpInvalidInput {
+        detail: "name too long".into(),
+        field: Some("name".into()),
+    };
+    assert_eq!(format!("{e}"), "sp invalid input: name too long");
+}
+
+#[test]
+fn sp_not_found_detail_format() {
+    let e = PluginError::SpNotFound {
+        detail: "client abc not found".into(),
+    };
+    assert_eq!(format!("{e}"), "sp not found: client abc not found");
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/error_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/error_tests.rs
@@ -45,11 +45,11 @@ fn kc_rest_with_timeout_status() {
 #[test]
 fn credstore_read_detail_format() {
     let e = PluginError::CredStoreRead {
-        detail: "timeout reading vp-idp-bootstrap-admin-secret".into(),
+        detail: "timeout reading keycloak-idp-bootstrap-admin-secret".into(),
     };
     assert_eq!(
         format!("{e}"),
-        "internal:CredStoreReader: timeout reading vp-idp-bootstrap-admin-secret"
+        "internal:CredStoreReader: timeout reading keycloak-idp-bootstrap-admin-secret"
     );
 }
 

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc.rs
@@ -1,0 +1,8 @@
+//! Keycloak admin client + token cache (DESIGN §4.4).
+
+pub mod client;
+pub mod factory;
+pub mod token_cache;
+pub mod transport;
+
+pub(crate) use client::KcAdminClient;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/client.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/client.rs
@@ -1,0 +1,145 @@
+//! Per-call Keycloak admin client handle.
+//!
+//! Returned by `KeycloakAdminClientFactory::bootstrap_client()` /
+//! `realm_client(...)` (Phase 7). Wraps an `Arc<dyn KcTransport>` and an
+//! `Arc<CachedToken>`; cloneable, cheap.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+use toolkit_macros::domain_model;
+
+use crate::domain::error::PluginError;
+use crate::domain::kc::token_cache::CachedToken;
+use crate::domain::kc::transport::KcTransport;
+
+#[domain_model]
+#[derive(Clone)]
+pub struct KcAdminClient {
+    transport: Arc<dyn KcTransport>,
+    token: Arc<CachedToken>,
+}
+
+impl KcAdminClient {
+    #[must_use]
+    pub fn new(transport: Arc<dyn KcTransport>, token: Arc<CachedToken>) -> Self {
+        Self { transport, token }
+    }
+
+    /// `{base_url}/admin/realms/{realm}` — the prefix this token authorises.
+    #[must_use]
+    pub fn realm_url(&self) -> &str {
+        &self.token.realm_url
+    }
+
+    /// Execute a raw HTTP request using this client's bearer token.
+    ///
+    /// Delegates to the underlying [`KcTransport`] so domain code never
+    /// imports reqwest or infra modules directly.
+    ///
+    /// # Errors
+    ///
+    /// `PluginError::KcRest` on transport / timeout failure.
+    pub async fn raw_request(
+        &self,
+        method: &str,
+        url: &str,
+        body: Option<&Value>,
+        path_template: &str,
+    ) -> Result<(u16, String), PluginError> {
+        self.transport
+            .raw_request(method, url, self.access_token(), body, path_template)
+            .await
+    }
+
+    /// Bearer token string. Borrow stays inside the handle; do NOT clone
+    /// or log. `pub(crate)` so the only caller is `raw_request` above
+    /// (which threads it straight to the transport) — type-system
+    /// enforcement matches the docstring contract.
+    #[must_use]
+    pub(crate) fn access_token(&self) -> &str {
+        use secrecy::ExposeSecret as _;
+        self.token.access_token.expose_secret()
+    }
+}
+
+impl std::fmt::Debug for KcAdminClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KcAdminClient")
+            .field("realm_url", &self.token.realm_url)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::error::PluginError;
+    use crate::domain::kc::token_cache::CachedToken;
+    use crate::domain::kc::transport::KcTransport;
+    use async_trait::async_trait;
+    use secrecy::SecretString;
+    use serde_json::Value;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use std::time::Instant;
+
+    /// No-op transport for unit tests that only exercise non-HTTP paths.
+    #[domain_model]
+    struct StubTransport;
+
+    #[async_trait]
+    impl KcTransport for StubTransport {
+        async fn raw_request(
+            &self,
+            _method: &str,
+            _url: &str,
+            _bearer_token: &str,
+            _body: Option<&Value>,
+            _path_template: &str,
+        ) -> Result<(u16, String), PluginError> {
+            Ok((200, String::new()))
+        }
+
+        async fn form_post(
+            &self,
+            _url: &str,
+            _fields: &[(&str, &str)],
+            _path_template: &str,
+        ) -> Result<(u16, String), PluginError> {
+            Ok((200, String::new()))
+        }
+
+        async fn get_unauthenticated(
+            &self,
+            _url: &str,
+            _path_template: &str,
+        ) -> Result<(u16, String), PluginError> {
+            Ok((200, String::new()))
+        }
+    }
+
+    fn make_client(token: &str) -> KcAdminClient {
+        KcAdminClient::new(
+            Arc::new(StubTransport),
+            Arc::new(CachedToken {
+                access_token: SecretString::from(String::from(token)),
+                expires_at: Instant::now() + Duration::from_mins(1),
+                realm_url: Arc::from("https://kc/admin/realms/master"),
+            }),
+        )
+    }
+
+    #[test]
+    fn debug_does_not_leak_token() {
+        let c = make_client("sek");
+        let dbg = format!("{c:?}");
+        assert!(!dbg.contains("sek"), "Debug must not leak token: {dbg}");
+    }
+
+    #[test]
+    fn realm_url_exposes_token_url() {
+        let c = make_client("x");
+        assert_eq!(c.realm_url(), "https://kc/admin/realms/master");
+    }
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/factory.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/factory.rs
@@ -220,7 +220,7 @@ impl KeycloakAdminClientFactory {
     /// # Scope and concurrency
     ///
     /// Drops only the `(bootstrap.realm, bootstrap.client_id)` cache entry —
-    /// per-realm admin tokens (`(realm_name, vp-idp-plugin-realm-admin)`) are
+    /// per-realm admin tokens (`(realm_name, keycloak-idp-plugin-realm-admin)`) are
     /// keyed differently and untouched, so the user-op path and per-realm
     /// admin work are unaffected.
     ///
@@ -540,7 +540,7 @@ impl KeycloakAdminClientFactory {
         let effective_lifetime = lifetime.saturating_sub(safety).max(MIN_TOKEN_TTL);
         if lifetime <= safety {
             tracing::warn!(
-                target: "vp_idp_plugin.factory",
+                target: "keycloak_idp.factory",
                 realm,
                 client_id,
                 kc_expires_in_secs = body.expires_in,

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/factory.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/factory.rs
@@ -1,0 +1,563 @@
+//! `KeycloakAdminClientFactory` — single entry-point for Keycloak Admin REST.
+//!
+//! See DESIGN §4.4 "Shared implementation" + ADDENDUM §4.1 `SecretSource` enum.
+//!
+//! Static infra creds (bootstrap admin, default-shared-realm admin) are
+//! resolved inline from config (after toolkit's `${VAR}` expansion at
+//! config-load time); dynamic per-realm secrets (Adopted / Created) are
+//! resolved via [`CredStoreReader`]. Both flows funnel through the private
+//! [`KeycloakAdminClientFactory::acquire_client`] so cache, token-fetch, and
+//! error semantics are identical.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use credstore_sdk::SecretRef;
+use secrecy::{ExposeSecret, SecretString};
+use toolkit_macros::domain_model;
+
+use crate::config::KeycloakConfig;
+use crate::domain::credstore::CredStoreReader;
+use crate::domain::error::{KcStatusKind, PluginError, redact_secrets};
+use crate::domain::kc::client::KcAdminClient;
+use crate::domain::kc::token_cache::{CachedToken, InflightLocks, TokenCache};
+use crate::domain::kc::transport::{KcTransport, truncate_2kb};
+use crate::domain::ports::metrics::{KcAdminMetricsPort, TokenRefreshOutcome, TokenTier};
+
+/// Subset of the OIDC token endpoint response the factory needs.
+/// Other fields (`token_type`, `refresh_token`, `scope`, …) are ignored.
+// The derive is the decoder for the Keycloak response described above.
+#[allow(unknown_lints, de0101_no_serde_in_contract)]
+#[domain_model]
+#[derive(serde::Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    expires_in: u64,
+}
+
+/// Floor on the effective cache TTL after subtracting the safety margin.
+/// Prevents a tight token-fetch loop when Keycloak returns `expires_in`
+/// at or below the safety margin (misconfigured client, rotation corner
+/// case). Five seconds is short enough that a genuinely-expiring token
+/// surfaces as a 401 retry rather than a stale-cache hit, and long
+/// enough that the per-`(realm, client_id)` inflight gate serialises
+/// concurrent misses.
+const MIN_TOKEN_TTL: Duration = Duration::from_secs(5);
+
+/// Origin for an admin client's `client_secret`.
+///
+/// `Inline` — static infra cred (bootstrap admin, default-shared-realm admin)
+/// carried as a pre-resolved [`SecretString`] per ADDENDUM §3.1 / §3.2. The
+/// value comes from config after toolkit's `${VAR}` expansion at config-load
+/// time (symmetric with the AM DB DSN's `${PGPASSWORD}`). `OpenBaoRef` —
+/// dynamic per-realm secret (Adopted / Created) resolved via
+/// [`CredStoreReader`] using the plugin-owned `SecurityContext`.
+#[domain_model]
+#[derive(Debug, Clone)]
+pub enum SecretSource {
+    Inline(SecretString),
+    OpenBaoRef(SecretRef),
+}
+
+/// Map a [`SecretSource`] variant to the typed [`TokenTier`] label
+/// consumed by [`KcAdminMetricsPort::credential_refresh`] /
+/// [`KcAdminMetricsPort::kc_admin_token_refresh`] (DESIGN §9, ports/metrics
+/// `TokenTier`). Bootstrap-admin refreshes always carry `StaticEnv` —
+/// the bootstrap secret is itself an inline-resolved config value, so
+/// there is no separate `bootstrap` tier on the typed label set; the
+/// distinction between bootstrap and realm-admin static creds is
+/// already carried by the `realm` label.
+#[must_use]
+fn tier_for(source: &SecretSource) -> TokenTier {
+    match source {
+        SecretSource::Inline(_) => TokenTier::StaticEnv,
+        SecretSource::OpenBaoRef(_) => TokenTier::OpenBao,
+    }
+}
+
+/// Single entry-point through which all Keycloak Admin REST work flows.
+///
+/// Owns the [`KcTransport`] handle and the in-memory [`TokenCache`].
+/// Construct once at `Gear::init`; clone (cheap — `Arc`-shared cache and
+/// transport) into call sites that need realm-admin access.
+#[domain_model]
+pub struct KeycloakAdminClientFactory {
+    cfg: KeycloakConfig,
+    transport: Arc<dyn KcTransport>,
+    cs_reader: CredStoreReader,
+    token_cache: Arc<TokenCache>,
+    /// Per-key locks coalescing concurrent cold-cache fetches into a single
+    /// token-endpoint call (DESIGN §4.4 line 197 — single-flight on miss to
+    /// avoid thundering-herd refreshes after a deploy or expiry burst). Map
+    /// grows O(realms); bounded eviction is a future concern.
+    inflight: Arc<InflightLocks>,
+    base_url: url::Url,
+    /// Pre-built bootstrap admin [`SecretSource`] — avoids a new
+    /// `SecretString::from(...)` allocation on every `bootstrap_client()` call.
+    bootstrap_source: SecretSource,
+    /// Telemetry sink for `kc_admin_token_refresh` and
+    /// `credential_refresh` (DESIGN §9). Every cache-miss token-endpoint
+    /// POST in `fetch_token` ticks both counters labelled by
+    /// `(outcome, tier, realm)`; the reactive-401 retry path drives
+    /// through `fetch_token` after `invalidate`, so the rotation
+    /// signal naturally surfaces on the same counters without a
+    /// separate call site.
+    kc_metrics: Arc<dyn KcAdminMetricsPort>,
+}
+
+impl KeycloakAdminClientFactory {
+    /// Build the factory with a pre-constructed transport + an empty cache.
+    ///
+    /// The transport is constructed by the caller (typically `module.rs`) so
+    /// that TLS / timeout configuration lives entirely in the infra layer. This
+    /// keeps `KeycloakAdminClientFactory` free of any reqwest imports.
+    ///
+    /// Normalize `base_url` to always end with `/` so `url::Url::join` against
+    /// a relative path (e.g. `realms/{realm}/...`) preserves any path prefix
+    /// the operator configured (e.g. `https://kc.example/auth/`). Without
+    /// this, `https://kc.example/auth` joined with `realms/...` clobbers the
+    /// `/auth` segment.
+    #[must_use]
+    pub fn new(
+        cfg: KeycloakConfig,
+        transport: Arc<dyn KcTransport>,
+        cs_reader: CredStoreReader,
+        kc_metrics: Arc<dyn KcAdminMetricsPort>,
+    ) -> Self {
+        let base_url = if cfg.base_url.path().ends_with('/') {
+            cfg.base_url.clone()
+        } else {
+            let mut normalised = cfg.base_url.clone();
+            let new_path = format!("{}/", cfg.base_url.path());
+            normalised.set_path(&new_path);
+            normalised
+        };
+        let bootstrap_source =
+            SecretSource::Inline(cfg.bootstrap_admin.client_secret.clone_into_secret_string());
+        Self {
+            cfg,
+            transport,
+            cs_reader,
+            token_cache: Arc::default(),
+            inflight: Arc::default(),
+            base_url,
+            bootstrap_source,
+            kc_metrics,
+        }
+    }
+
+    /// Acquire a `master`-realm admin client per `bootstrap_admin.*` config.
+    /// Used for `Created` realm creation + `Shared` / `Adopted` existence
+    /// probes (DESIGN §4.4).
+    ///
+    /// The [`SecretSource`] is pre-built at construction time to avoid
+    /// allocating a new `SecretString` on every call.
+    ///
+    /// # Errors
+    /// * [`PluginError::KcRest`] when the token endpoint fails.
+    /// * [`PluginError::Config`] when the configured `base_url` cannot be
+    ///   joined with the token endpoint path.
+    pub async fn bootstrap_client(&self) -> Result<KcAdminClient, PluginError> {
+        self.acquire_client(
+            &self.cfg.bootstrap_admin.realm,
+            &self.cfg.bootstrap_admin.client_id,
+            &self.bootstrap_source,
+        )
+        .await
+    }
+
+    /// Acquire a per-realm admin client. The caller supplies the realm,
+    /// `client_id`, and where the `client_secret` lives. The factory caches
+    /// the resulting token by `(realm_name, admin_client_id)`.
+    ///
+    /// # Errors
+    /// Same shape as [`Self::bootstrap_client`]; in addition,
+    /// [`PluginError::CredStoreRead`] when `source` is
+    /// [`SecretSource::OpenBaoRef`] and the read fails / returns `None`.
+    pub async fn realm_client(
+        &self,
+        realm_name: &str,
+        admin_client_id: &str,
+        source: &SecretSource,
+    ) -> Result<KcAdminClient, PluginError> {
+        self.acquire_client(realm_name, admin_client_id, source)
+            .await
+    }
+
+    /// Drop the cached token AND the inflight-lock entry for
+    /// `(realm, client_id)`. Called by the reactive-401 path
+    /// ([`Self::with_reactive_401`]) when Keycloak rejects the cached
+    /// secret, and by deprovision paths to release per-realm state.
+    /// The paired drop keeps the `InflightLocks` map bounded by live
+    /// operator footprint instead of leaking one entry per ever-seen
+    /// realm. No-op when either entry is absent.
+    pub fn invalidate(&self, realm: &str, client_id: &str) {
+        self.token_cache.invalidate(realm, client_id);
+        self.inflight.forget(realm, client_id);
+    }
+
+    /// Invalidate the cached bootstrap admin token. Symmetric with
+    /// [`Self::bootstrap_client`]: same `(realm, client_id)` key, so the next
+    /// `bootstrap_client()` / `with_reactive_401_bootstrap(...)` call goes
+    /// through `fetch_token` and re-mints from the bootstrap secret.
+    ///
+    /// Required mid-saga in Created-mode tenant provisioning: when the
+    /// bootstrap client itself creates a new realm via `POST /admin/realms`,
+    /// Keycloak auto-grants the creator the `realm-admin` (composite) role on
+    /// the freshly-created realm. But access tokens carry a *point-in-time*
+    /// snapshot of role claims — the in-flight bootstrap token issued
+    /// **before** the realm existed does not include the new mapping, so the
+    /// next bootstrap call against `/admin/realms/{new_realm}/clients` returns
+    /// `403 Forbidden`. The reactive-401 wrapper re-mints only on 401, so a
+    /// 403 from this race surfaces as an `AmbiguousCreated { stage:
+    /// KcClientCreate }` and bricks the saga.
+    ///
+    /// Calling this between `create_realm` (step 2) and
+    /// `create_realm_admin_client` (step 3) forces the next bearer to be
+    /// minted *after* the role grant, picking up the new claims and clearing
+    /// the 403.
+    ///
+    /// # Scope and concurrency
+    ///
+    /// Drops only the `(bootstrap.realm, bootstrap.client_id)` cache entry —
+    /// per-realm admin tokens (`(realm_name, vp-idp-plugin-realm-admin)`) are
+    /// keyed differently and untouched, so the user-op path and per-realm
+    /// admin work are unaffected.
+    ///
+    /// In-flight bootstrap operations on other tasks are unaffected: a caller
+    /// already inside `with_reactive_401_bootstrap` holds its `KcAdminClient`
+    /// (with its `Arc<Token>`) locally and finishes against the live KC
+    /// session. `invalidate` only clears the cache map for *future* lookups.
+    ///
+    /// The only observable side-effect for parallel sagas (concurrent Shared
+    /// / Adopted / Deprovision / another Created-mode tenant create) is one
+    /// extra token-endpoint POST on whichever of them next consults the
+    /// cache. The re-minted token is strictly a superset of the dropped one
+    /// (it carries any roles granted in the meantime), so correctness is
+    /// monotonic. Under N concurrent bootstrap-using sagas the worst case is
+    /// N extra mints across the burst — negligible against KC's ~10 ms token
+    /// endpoint and the low-frequency nature of Created-mode tenant create.
+    pub fn invalidate_bootstrap(&self) {
+        self.invalidate(
+            &self.cfg.bootstrap_admin.realm,
+            &self.cfg.bootstrap_admin.client_id,
+        );
+    }
+
+    /// Normalised base URL (always ends with `/`). Used by facades that need
+    /// to build admin REST paths outside the realm-scoped `KcAdminClient`
+    /// (e.g. probing realm existence with the bootstrap admin token).
+    #[must_use]
+    pub fn base_url_str(&self) -> &str {
+        self.base_url.as_str()
+    }
+
+    /// Plugin-internal preflight invoked at the start of provision/deprovision
+    /// before issuing any destructive call. Performs a lightweight unauth
+    /// `GET /realms/master` against the configured base URL — Keycloak serves
+    /// the public OIDC realm metadata on this path, which is cheap, idempotent,
+    /// and short-circuits cleanly when Keycloak is unambiguously unreachable
+    /// (DESIGN §4.4 `health_probe`).
+    ///
+    /// Wired into [`crate::domain::tenant_facade::TenantFacade::provision_tenant_inner`]
+    /// and `deprovision_tenant_inner` saga preludes so a flat-out KC outage
+    /// surfaces as `IdpProvisionFailure::CleanFailure` /
+    /// `IdpDeprovisionFailure::Retryable` at the boundary instead of getting
+    /// buried in a half-done saga.
+    ///
+    /// # Errors
+    ///
+    /// [`PluginError::KcRest`] with the appropriate [`KcStatusKind`]:
+    /// `Timeout` / `Transport` on send failure, `Http(status)` on non-2xx.
+    /// [`PluginError::Config`] if the configured base URL cannot be joined
+    /// with `realms/master`.
+    pub async fn health_probe(&self) -> Result<(), PluginError> {
+        let url = self
+            .base_url
+            .join("realms/master")
+            .map_err(|e| PluginError::Config {
+                detail: e.to_string(),
+            })?;
+        let (status, body) = self
+            .transport
+            .get_unauthenticated(url.as_str(), "/realms/master")
+            .await?;
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::KcRest {
+                method: "GET",
+                path_template: "/realms/master".into(),
+                status: KcStatusKind::Http(status),
+                // Every other `KcRest` construction site truncates + redacts;
+                // health-probe must too, otherwise an unbounded / unredacted
+                // KC response slips into `body_first_2kb` and breaks the
+                // documented 2 KiB / defence-in-depth contract.
+                body_first_2kb: redact_secrets(&truncate_2kb(&body)),
+            });
+        }
+        Ok(())
+    }
+
+    /// Reactive-401 refresh wrapper (DESIGN §8.1 "Rotation lifecycle").
+    ///
+    /// Acquires a client for `(realm, client_id)` from the cache, runs `f`,
+    /// and on a [`PluginError::KcRest`] carrying [`KcStatusKind::Http(401)`]
+    /// invalidates the cached token, re-resolves the secret, and retries `f`
+    /// exactly once. A second 401 propagates verbatim — the rotation ordering
+    /// contract (write to KC first, then `OpenBao`) makes a second 401 the
+    /// operator's problem.
+    ///
+    /// Wired around per-realm Admin REST work in both
+    /// [`crate::domain::tenant_facade::TenantFacade`] saga steps and
+    /// [`crate::domain::user_facade::UserFacade`] user-op steps. The
+    /// retry path re-enters [`Self::acquire_client`] after `invalidate`,
+    /// so a rotation surfaces as a second tick on `credential_refresh` /
+    /// `kc_admin_token_refresh` without a separate emission site.
+    ///
+    /// # Errors
+    ///
+    /// Propagates `f`'s error verbatim except on a single retryable 401.
+    pub async fn with_reactive_401<F, Fut, T>(
+        &self,
+        realm: &str,
+        client_id: &str,
+        source: &SecretSource,
+        f: F,
+    ) -> Result<T, PluginError>
+    where
+        F: Fn(KcAdminClient) -> Fut,
+        Fut: std::future::Future<Output = Result<T, PluginError>>,
+    {
+        let client = self.acquire_client(realm, client_id, source).await?;
+        match f(client).await {
+            Err(PluginError::KcRest {
+                status: KcStatusKind::Http(401),
+                ..
+            }) => {
+                self.invalidate(realm, client_id);
+                let fresh = self.acquire_client(realm, client_id, source).await?;
+                f(fresh).await
+            }
+            other => other,
+        }
+    }
+
+    /// Bootstrap-admin variant of [`Self::with_reactive_401`]. Wraps a
+    /// block of bootstrap-admin REST work so an operator-rotated
+    /// `bootstrap_admin.client_secret` is picked up on the first 401
+    /// without operator-driven plugin restart. The closure is invoked
+    /// once on the happy path and at most twice on a single 401 hit.
+    ///
+    /// # Errors
+    ///
+    /// Propagates `f`'s error verbatim except on a single retryable 401.
+    pub async fn with_reactive_401_bootstrap<F, Fut, T>(&self, f: F) -> Result<T, PluginError>
+    where
+        F: Fn(KcAdminClient) -> Fut,
+        Fut: std::future::Future<Output = Result<T, PluginError>>,
+    {
+        self.with_reactive_401(
+            &self.cfg.bootstrap_admin.realm,
+            &self.cfg.bootstrap_admin.client_id,
+            &self.bootstrap_source,
+            f,
+        )
+        .await
+    }
+
+    async fn acquire_client(
+        &self,
+        realm: &str,
+        client_id: &str,
+        source: &SecretSource,
+    ) -> Result<KcAdminClient, PluginError> {
+        // Fast path: warm cache, no lock acquisition. Cache hits do NOT
+        // emit refresh metrics — the rotation-observability invariant is
+        // "every counter tick = a real secret/token resolution from its
+        // source". A cache hit reuses the same bearer token, no
+        // resolution happened.
+        if let Some(token) = self.token_cache.get(realm, client_id) {
+            return Ok(KcAdminClient::new(Arc::clone(&self.transport), token));
+        }
+        // Slow path: serialize concurrent misses for this `(realm, client_id)`
+        // behind a per-key `tokio::sync::Mutex` so N replicas hitting a cold
+        // cache after deploy / expiry burst trigger one token-endpoint POST,
+        // not N (DESIGN §4.4 line 197).
+        let lock = self.inflight.lock_for(realm, client_id);
+        // HELD ACROSS AWAIT BY DESIGN — see DESIGN §4.4 line 197. The guard
+        // spans `resolve_secret().await` + `fetch_token().await` so concurrent
+        // cold-cache misses for the same `(realm, client_id)` serialise into
+        // one token-endpoint POST. Per-key mutex (not global), so unrelated
+        // realms never contend.
+        let _guard = lock.lock().await;
+        // Re-check the cache after winning the lock — another task may have
+        // populated it while we waited.
+        if let Some(token) = self.token_cache.get(realm, client_id) {
+            return Ok(KcAdminClient::new(Arc::clone(&self.transport), token));
+        }
+        // Real miss: every path from here emits exactly one refresh
+        // metric per stage so the operator can distinguish
+        // "OpenBao unreachable" (credential_refresh{outcome=error})
+        // from "KC token endpoint rejected secret"
+        // (kc_admin_token_refresh{outcome=error}). The reactive-401
+        // retry path re-enters this method after `invalidate`, so a
+        // rotation surfaces as a second tick on both counters without
+        // a separate emission site (DESIGN §8.1 rotation lifecycle).
+        let tier = tier_for(source);
+        let secret = match self.resolve_secret(source).await {
+            Ok(s) => {
+                self.kc_metrics
+                    .credential_refresh(TokenRefreshOutcome::Success, tier, realm);
+                s
+            }
+            Err(e) => {
+                self.kc_metrics
+                    .credential_refresh(TokenRefreshOutcome::Error, tier, realm);
+                return Err(e);
+            }
+        };
+        let cached = match self.fetch_token(realm, client_id, &secret).await {
+            Ok(c) => {
+                self.kc_metrics
+                    .kc_admin_token_refresh(TokenRefreshOutcome::Success, tier, realm);
+                c
+            }
+            Err(e) => {
+                self.kc_metrics
+                    .kc_admin_token_refresh(TokenRefreshOutcome::Error, tier, realm);
+                return Err(e);
+            }
+        };
+        self.token_cache
+            .insert(realm, client_id, Arc::clone(&cached));
+        // Opportunistic GC on the slow path: every cold-cache acquire
+        // (every TTL boundary per realm, or every reactive-401 retry)
+        // sweeps both maps. Read-time eviction in `TokenCache::get`
+        // already keeps the cache bounded by *active-fetch* realms;
+        // this sweep additionally evicts (a) tokens for realms that
+        // were fetched once and never re-read AND (b) inflight-lock
+        // entries whose realm no longer has a live token. The work is
+        // O(N) per slow-path acquire — fine because slow-path acquires
+        // are rare by design (single-flight + TTL minutes apart).
+        let _ = self.token_cache.prune_expired();
+        let _ = self.inflight.prune_inactive(&self.token_cache);
+        Ok(KcAdminClient::new(Arc::clone(&self.transport), cached))
+    }
+
+    async fn resolve_secret(&self, source: &SecretSource) -> Result<SecretString, PluginError> {
+        match source {
+            SecretSource::Inline(s) => Ok(s.clone()),
+            SecretSource::OpenBaoRef(r) => self
+                .cs_reader
+                .get(r)
+                .await
+                .map_err(|e| PluginError::CredStoreRead {
+                    detail: e.to_string(),
+                })?
+                .ok_or_else(|| PluginError::CredStoreRead {
+                    detail: format!("ref {} not found", r.as_ref()),
+                }),
+        }
+    }
+
+    async fn fetch_token(
+        &self,
+        realm: &str,
+        client_id: &str,
+        secret: &SecretString,
+    ) -> Result<Arc<CachedToken>, PluginError> {
+        let token_path = format!("realms/{realm}/protocol/openid-connect/token");
+        let token_url = self
+            .base_url
+            .join(&token_path)
+            .map_err(|e| PluginError::Config {
+                detail: e.to_string(),
+            })?;
+
+        let path_template = "/realms/{realm}/protocol/openid-connect/token";
+        let fields = [
+            ("grant_type", "client_credentials"),
+            ("client_id", client_id),
+            ("client_secret", secret.expose_secret()),
+        ];
+        let (status, body_text) = self
+            .transport
+            .form_post(token_url.as_str(), &fields, path_template)
+            .await?;
+
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::KcRest {
+                method: "POST",
+                path_template: "/realms/{realm}/protocol/openid-connect/token".into(),
+                status: KcStatusKind::Http(status),
+                // Token-endpoint error bodies can echo the rejected
+                // `client_secret` form field on certain KC misconfigs
+                // (and on some upstream proxy 5xx HTML); the
+                // defence-in-depth pair MUST run on this seam, not just
+                // tenant/user-facade KC sites.
+                body_first_2kb: redact_secrets(&truncate_2kb(&body_text)),
+            });
+        }
+
+        let body: TokenResponse = serde_json::from_str(&body_text).map_err(|e| {
+            // `serde_json::Error::Display` reports the byte offset
+            // (`column`) into the FULL response body. The error envelope
+            // carries at most `BODY_CAP` bytes via `truncate_2kb`, so an
+            // offset past that ceiling references bytes the operator
+            // cannot actually see in `body_first_2kb`. Annotate when the
+            // position is beyond the captured slice so post-mortems
+            // aren't misled into hunting for "column 9000" in a 2KB blob.
+            const BODY_CAP: usize = 2048;
+            let pos_note = if e.column() > BODY_CAP {
+                format!(" [position beyond first {BODY_CAP}B of body]")
+            } else {
+                String::new()
+            };
+            PluginError::KcRest {
+                method: "POST",
+                path_template: "/realms/{realm}/protocol/openid-connect/token".into(),
+                // Preserve the real 2xx status (typically 200, but KC could
+                // return 201/204 on a token-issue path); a hard-coded 200
+                // misled post-mortems when the actual response was different.
+                status: KcStatusKind::Http(status),
+                // `format!("json: {e}")` is bounded by serde's error
+                // formatter (a short structural message, no echo of
+                // the body), so `truncate_2kb` here is belt-and-braces
+                // rather than load-bearing. Apply consistently anyway
+                // so every factory body-field path has the same shape.
+                body_first_2kb: redact_secrets(&truncate_2kb(&format!("json: {e}{pos_note}"))),
+            }
+        })?;
+
+        // Pre-built realm_url for downstream callers — DESIGN §4.4 `CachedToken` table.
+        let realm_url = format!("{}admin/realms/{realm}", self.base_url.as_str());
+        let safety = Duration::from_millis(self.cfg.admin_token_lifetime_safety_ms);
+        let lifetime = Duration::from_secs(body.expires_in);
+        // Clamp the effective lifetime so a KC that returns `expires_in` at
+        // or below the safety margin (a misconfigured client, a corner case
+        // around access-token rotation) cannot drop `expires_at == now()`,
+        // which would make every cache lookup miss and turn the factory
+        // into a tight loop against the token endpoint.
+        let effective_lifetime = lifetime.saturating_sub(safety).max(MIN_TOKEN_TTL);
+        if lifetime <= safety {
+            tracing::warn!(
+                target: "vp_idp_plugin.factory",
+                realm,
+                client_id,
+                kc_expires_in_secs = body.expires_in,
+                safety_ms = self.cfg.admin_token_lifetime_safety_ms,
+                "kc token expires_in <= safety margin; clamping cache TTL to MIN_TOKEN_TTL"
+            );
+        }
+        let expires_at = Instant::now() + effective_lifetime;
+
+        Ok(Arc::new(CachedToken {
+            access_token: SecretString::from(body.access_token),
+            expires_at,
+            realm_url: Arc::from(realm_url.as_str()),
+        }))
+    }
+}
+
+#[cfg(test)]
+#[path = "factory_tests.rs"]
+mod factory_tests;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/factory_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/factory_tests.rs
@@ -1,0 +1,838 @@
+use super::*;
+use crate::config::KeycloakConfig;
+use crate::domain::credstore::CredStoreReader;
+use crate::domain::kc::transport::KcTransport;
+use crate::domain::ports::metrics::{
+    EndpointClass, KcAdminMetricsPort, TokenRefreshOutcome, TokenTier,
+};
+use crate::domain::system_actor::build_system_ctx;
+use crate::domain::test_support::{NoopMetrics, StubCredStore, keycloak_cfg};
+use crate::infra::kc_http::ReqwestKcTransport;
+use async_trait::async_trait;
+use credstore_sdk::{
+    CredStoreClientV1, CredStoreError, GetSecretResponse, SecretRef, SecretValue, SharingMode,
+    TenantId, WritePrecondition,
+};
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use toolkit_security::SecurityContext;
+use uuid::Uuid;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Stub that hands back one canned response per `get` call. `GetSecretResponse`
+/// is not `Clone`, so we `take()` from a `Mutex<Option<_>>`.
+#[domain_model]
+#[derive(Default)]
+struct StubOnce {
+    response: StdMutex<Option<GetSecretResponse>>,
+}
+
+#[async_trait]
+impl CredStoreClientV1 for StubOnce {
+    async fn create(
+        &self,
+        ctx: &SecurityContext,
+        key: &SecretRef,
+        value: SecretValue,
+        sharing: SharingMode,
+    ) -> Result<(), CredStoreError> {
+        self.put(ctx, key, value, sharing, WritePrecondition::Exists)
+            .await
+    }
+
+    async fn get(
+        &self,
+        _ctx: &SecurityContext,
+        _key: &SecretRef,
+    ) -> Result<Option<GetSecretResponse>, CredStoreError> {
+        Ok(self.response.lock().expect("stub lock poisoned").take())
+    }
+
+    async fn put(
+        &self,
+        _ctx: &SecurityContext,
+        _key: &SecretRef,
+        _value: SecretValue,
+        _sharing: SharingMode,
+        _precondition: WritePrecondition,
+    ) -> Result<(), CredStoreError> {
+        Ok(())
+    }
+
+    async fn delete(
+        &self,
+        _ctx: &SecurityContext,
+        _key: &SecretRef,
+        _precondition: WritePrecondition,
+    ) -> Result<(), CredStoreError> {
+        Ok(())
+    }
+}
+
+/// Generate a self-signed CA PEM at runtime via `rcgen`. The cert is
+/// never used over the wire — we only need reqwest's
+/// `ClientBuilder::add_root_certificate` to accept the PEM at
+/// `.build()` time (parsing is deferred when the `rustls` backend is
+/// active).
+fn make_test_ca_pem() -> String {
+    let cert =
+        rcgen::generate_simple_self_signed(vec!["test-ca".to_owned()]).expect("self-signed cert");
+    cert.cert.pem()
+}
+
+/// Build a default transport (no TLS bundle, system trust store).
+fn default_transport() -> Arc<dyn KcTransport> {
+    Arc::new(ReqwestKcTransport::new(reqwest::Client::new()))
+}
+
+fn factory_for_cfg(cfg: KeycloakConfig) -> KeycloakAdminClientFactory {
+    let stub: Arc<dyn CredStoreClientV1> = Arc::new(StubCredStore);
+    let reader = CredStoreReader::new(Arc::clone(&stub), build_system_ctx(Uuid::nil()));
+    KeycloakAdminClientFactory::new(cfg, default_transport(), reader, Arc::new(NoopMetrics))
+}
+
+fn factory_for_uri(base: &str) -> KeycloakAdminClientFactory {
+    factory_for_cfg(keycloak_cfg(base))
+}
+
+fn factory_for(server: &MockServer) -> KeycloakAdminClientFactory {
+    factory_for_uri(&server.uri())
+}
+
+#[test]
+fn new_normalises_base_url_to_trailing_slash() {
+    // No trailing slash on the configured base — common operator typo.
+    let factory = factory_for_uri("https://kc.example/auth");
+    assert!(
+        factory.base_url.as_str().ends_with('/'),
+        "base_url must end with / after normalization: {}",
+        factory.base_url
+    );
+    // Path prefix preserved.
+    assert_eq!(factory.base_url.path(), "/auth/");
+
+    // Already-trailing case is a no-op.
+    let factory2 = factory_for_uri("https://kc.example/auth/");
+    assert_eq!(factory2.base_url.path(), "/auth/");
+}
+
+#[tokio::test]
+async fn factory_with_tls_ca_bundle_ref_loads_bundle() {
+    // CredStore stub returns a fresh self-signed PEM under any ref id.
+    let pem = make_test_ca_pem();
+    let stub = Arc::new(StubOnce {
+        response: StdMutex::new(Some(GetSecretResponse {
+            value: SecretValue::from(pem.as_str()),
+            owner_tenant_id: TenantId::nil(),
+            sharing: SharingMode::Tenant,
+            is_inherited: false,
+            version: 1,
+            id: Uuid::nil(),
+            secret_type: "gts.x.core.secret.type.v1~x.core.secret.generic.v1".to_owned(),
+            expires_at: None,
+        })),
+    });
+    let reader = CredStoreReader::new(stub, build_system_ctx(Uuid::nil()));
+    let mut cfg = keycloak_cfg("https://kc.example/auth");
+    cfg.tls_ca_bundle_ref = Some("vhp-platform-ca-bundle".into());
+    // Transport construction is now where TLS bundle loading happens.
+    let transport_result = ReqwestKcTransport::from_config(&cfg, &reader).await;
+    assert!(
+        transport_result.is_ok(),
+        "transport must build with a valid PEM CA bundle, got {:?}",
+        transport_result.err(),
+    );
+}
+
+#[tokio::test]
+async fn factory_with_missing_tls_ca_bundle_ref_fails_init() {
+    // CredStore returns Ok(None) — the ref is absent.
+    let stub: Arc<dyn CredStoreClientV1> = Arc::new(StubCredStore);
+    let reader = CredStoreReader::new(stub, build_system_ctx(Uuid::nil()));
+    let mut cfg = keycloak_cfg("https://kc.example/auth");
+    cfg.tls_ca_bundle_ref = Some("vhp-platform-ca-bundle".into());
+    let result = ReqwestKcTransport::from_config(&cfg, &reader)
+        .await
+        .map(|_| ());
+    let err = result.expect_err("must fail when ref is absent");
+    assert!(
+        matches!(err, PluginError::CredStoreRead { ref detail } if detail.contains("not found")),
+        "expected CredStoreRead 'not found', got {err:?}",
+    );
+}
+
+#[tokio::test]
+async fn factory_with_invalid_tls_ca_bundle_fails_init() {
+    // PEM markers with garbage base64 content → reqwest's `build()`
+    // path surfaces a builder error after the rustls pemfile iterator
+    // rejects the cert encoding. Note: reqwest 0.13 + rustls defers PEM
+    // parsing from `Certificate::from_pem` to `ClientBuilder::build`,
+    // so the failure surfaces with the `Config { detail: "reqwest
+    // client build failed: ..." }` shape (not the `Config { detail:
+    // ".. is not a valid PEM .." }` shape that the native-tls backend
+    // would produce).
+    let bad_pem =
+        "-----BEGIN CERTIFICATE-----\nnot-valid-base64-content!!!\n-----END CERTIFICATE-----\n";
+    let stub = Arc::new(StubOnce {
+        response: StdMutex::new(Some(GetSecretResponse {
+            value: SecretValue::from(bad_pem),
+            owner_tenant_id: TenantId::nil(),
+            sharing: SharingMode::Tenant,
+            is_inherited: false,
+            version: 1,
+            id: Uuid::nil(),
+            secret_type: "gts.x.core.secret.type.v1~x.core.secret.generic.v1".to_owned(),
+            expires_at: None,
+        })),
+    });
+    let reader = CredStoreReader::new(stub, build_system_ctx(Uuid::nil()));
+    let mut cfg = keycloak_cfg("https://kc.example/auth");
+    cfg.tls_ca_bundle_ref = Some("vhp-platform-ca-bundle".into());
+    let result = ReqwestKcTransport::from_config(&cfg, &reader)
+        .await
+        .map(|_| ());
+    let err = result.expect_err("must reject malformed PEM");
+    assert!(
+        matches!(err, PluginError::Config { ref detail } if detail.contains("reqwest")),
+        "expected Config 'reqwest' error, got {err:?}",
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_client_caches_after_first_acquire() {
+    let server = MockServer::start().await;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_clone = Arc::clone(&calls);
+    Mock::given(method("POST"))
+        .and(path("/realms/master/protocol/openid-connect/token"))
+        .respond_with(move |_req: &wiremock::Request| {
+            calls_clone.fetch_add(1, Ordering::SeqCst);
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "abcdef",
+                "expires_in": 600
+            }))
+        })
+        .mount(&server)
+        .await;
+
+    let calls_assert = Arc::clone(&calls);
+    let factory = factory_for(&server);
+    let c1 = factory.bootstrap_client().await.expect("first acquire");
+    let c2 = factory
+        .bootstrap_client()
+        .await
+        .expect("second acquire (cached)");
+
+    assert_eq!(c1.access_token(), "abcdef");
+    assert_eq!(c2.access_token(), "abcdef");
+    assert_eq!(
+        calls_assert.load(Ordering::SeqCst),
+        1,
+        "token endpoint hit exactly once",
+    );
+}
+
+#[tokio::test]
+async fn invalidate_forces_token_refetch() {
+    let server = MockServer::start().await;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_clone = Arc::clone(&calls);
+    Mock::given(method("POST"))
+        .and(path("/realms/master/protocol/openid-connect/token"))
+        .respond_with(move |_req: &wiremock::Request| {
+            calls_clone.fetch_add(1, Ordering::SeqCst);
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "tok",
+                "expires_in": 600
+            }))
+        })
+        .mount(&server)
+        .await;
+
+    let calls_assert = Arc::clone(&calls);
+    let factory = factory_for(&server);
+    factory.bootstrap_client().await.expect("first acquire");
+    factory.invalidate("master", "vp-idp-plugin-bootstrap");
+    factory
+        .bootstrap_client()
+        .await
+        .expect("refetch after invalidate");
+    assert_eq!(calls_assert.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn token_endpoint_201_decode_failure_preserves_real_status() {
+    // KC misconfig: returns 2xx (here 201, not 200) with a body that
+    // doesn't deserialise as TokenResponse. The error should carry the
+    // ACTUAL status (201), not a hard-coded 200, so post-mortems see
+    // what the server really returned.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/realms/master/protocol/openid-connect/token"))
+        .respond_with(ResponseTemplate::new(201).set_body_string("not-json"))
+        .mount(&server)
+        .await;
+
+    let factory = factory_for(&server);
+    let err = factory.bootstrap_client().await.unwrap_err();
+    let PluginError::KcRest { status, .. } = &err else {
+        unreachable!("decode failure must surface as KcRest; got {err:?}");
+    };
+    assert!(
+        matches!(status, KcStatusKind::Http(201)),
+        "decode failure must preserve the real 2xx status; got {status:?}",
+    );
+}
+
+/// `serde_json` reports parse failures with a byte offset into the FULL
+/// response body. The error envelope only carries the first 2KB, so a
+/// raw offset past the cap is unactionable — the operator hunts for
+/// "column N" in a slice that does not contain column N. Guard the
+/// annotation that flags this case.
+#[tokio::test]
+async fn token_endpoint_2xx_decode_failure_annotates_position_beyond_2kb() {
+    let server = MockServer::start().await;
+    // Pad an extra (ignored) field so the parse error on
+    // `expires_in` lands past the 2KB envelope. `"a" * 3000` keeps the
+    // value cheap to construct while pushing serde's reported column
+    // well past 2048.
+    let padding = "a".repeat(3000);
+    let body = format!(r#"{{"padding":"{padding}","expires_in":"not-a-number"}}"#);
+    Mock::given(method("POST"))
+        .and(path("/realms/master/protocol/openid-connect/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(body))
+        .mount(&server)
+        .await;
+
+    let factory = factory_for(&server);
+    let err = factory.bootstrap_client().await.unwrap_err();
+    let PluginError::KcRest { body_first_2kb, .. } = &err else {
+        unreachable!("decode failure must surface as KcRest; got {err:?}");
+    };
+    assert!(
+        body_first_2kb.contains("position beyond first 2048B of body"),
+        "expected beyond-capture annotation, got: {body_first_2kb}",
+    );
+}
+
+/// Sanity counterpart to
+/// [`token_endpoint_2xx_decode_failure_annotates_position_beyond_2kb`]:
+/// a short body that fails to parse should NOT carry the beyond-capture
+/// annotation — the position is meaningful as-is.
+#[tokio::test]
+async fn token_endpoint_2xx_decode_failure_within_2kb_omits_annotation() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/realms/master/protocol/openid-connect/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("not-json"))
+        .mount(&server)
+        .await;
+
+    let factory = factory_for(&server);
+    let err = factory.bootstrap_client().await.unwrap_err();
+    let PluginError::KcRest { body_first_2kb, .. } = &err else {
+        unreachable!("decode failure must surface as KcRest; got {err:?}");
+    };
+    assert!(
+        !body_first_2kb.contains("position beyond"),
+        "short-body parse failure must NOT carry beyond-capture annotation, got: {body_first_2kb}",
+    );
+}
+
+#[tokio::test]
+async fn token_endpoint_short_expires_in_clamps_to_min_ttl() {
+    // KC returns `expires_in: 1` against a 30s safety margin: the raw
+    // math (`lifetime.saturating_sub(safety)`) lands at zero. Without
+    // the clamp every `bootstrap_client()` call would re-fetch in a
+    // tight loop. The clamp pins the effective TTL to MIN_TOKEN_TTL,
+    // observable here as "two acquires hit the token endpoint exactly
+    // once" (cache holds across calls inside the 5s floor).
+    let server = MockServer::start().await;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_clone = Arc::clone(&calls);
+    Mock::given(method("POST"))
+        .and(path("/realms/master/protocol/openid-connect/token"))
+        .respond_with(move |_req: &wiremock::Request| {
+            calls_clone.fetch_add(1, Ordering::SeqCst);
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "tok",
+                "expires_in": 1
+            }))
+        })
+        .mount(&server)
+        .await;
+
+    let calls_assert = Arc::clone(&calls);
+    let factory = factory_for(&server);
+    factory.bootstrap_client().await.expect("first acquire");
+    factory.bootstrap_client().await.expect("cached acquire");
+    assert_eq!(
+        calls_assert.load(Ordering::SeqCst),
+        1,
+        "MIN_TOKEN_TTL clamp must hold the cache across back-to-back acquires",
+    );
+}
+
+/// KC token endpoint can echo the rejected `client_secret` in the
+/// error body (some misconfigured proxies / older KC versions); the
+/// factory's `body_first_2kb` MUST run that through `redact_secrets +
+/// truncate_2kb` so the secret never leaves the helper as plaintext.
+#[tokio::test]
+async fn token_endpoint_error_body_redacts_client_secret_leak() {
+    let server = MockServer::start().await;
+    let leak_body =
+        r#"{"error":"invalid_client","error_description":"client_secret=leak-me-not is rejected"}"#;
+    Mock::given(method("POST"))
+        .and(path("/realms/master/protocol/openid-connect/token"))
+        .respond_with(ResponseTemplate::new(401).set_body_string(leak_body))
+        .mount(&server)
+        .await;
+
+    let factory = factory_for(&server);
+    let err = factory.bootstrap_client().await.unwrap_err();
+    let PluginError::KcRest { body_first_2kb, .. } = &err else {
+        unreachable!("expected KcRest, got {err:?}");
+    };
+    assert!(
+        !body_first_2kb.contains("leak-me-not"),
+        "client_secret leaked unredacted into body_first_2kb: {body_first_2kb}"
+    );
+    assert!(
+        body_first_2kb.contains("<redacted>"),
+        "expected redaction marker in body_first_2kb: {body_first_2kb}"
+    );
+}
+
+#[tokio::test]
+async fn token_endpoint_5xx_surfaces_as_kcrest_http() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/realms/master/protocol/openid-connect/token"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("unavailable"))
+        .mount(&server)
+        .await;
+
+    let factory = factory_for(&server);
+    let err = factory.bootstrap_client().await.unwrap_err();
+    assert!(
+        matches!(
+            err,
+            PluginError::KcRest {
+                status: KcStatusKind::Http(503),
+                ..
+            }
+        ),
+        "expected KcRest{{ status: Http(503), .. }}, got {err:?}",
+    );
+}
+
+#[tokio::test]
+async fn health_probe_ok_on_200() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/realms/master"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+        .mount(&server)
+        .await;
+
+    let factory = factory_for(&server);
+    factory.health_probe().await.expect("probe must succeed");
+}
+
+#[tokio::test]
+async fn health_probe_surfaces_503_as_kcrest_http() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/realms/master"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("down"))
+        .mount(&server)
+        .await;
+
+    let factory = factory_for(&server);
+    let err = factory.health_probe().await.expect_err("must fail");
+    assert!(
+        matches!(
+            err,
+            PluginError::KcRest {
+                method: "GET",
+                status: KcStatusKind::Http(503),
+                ..
+            }
+        ),
+        "expected GET /realms/master 503, got {err:?}",
+    );
+}
+
+#[tokio::test]
+async fn health_probe_surfaces_unreachable_as_transport() {
+    // 127.0.0.1:1 is the canonical "almost certainly unbound" port —
+    // connection refused immediately, surfacing as `Transport`. We
+    // don't drop a real wiremock server because the OS may reuse the
+    // released port for a different listener, returning unexpected
+    // status codes.
+    let factory = factory_for_uri("http://127.0.0.1:1");
+    let err = factory.health_probe().await.expect_err("must fail");
+    assert!(
+        matches!(
+            err,
+            PluginError::KcRest {
+                method: "GET",
+                status: KcStatusKind::Transport | KcStatusKind::Timeout,
+                ..
+            }
+        ),
+        "expected Transport/Timeout, got {err:?}",
+    );
+}
+
+#[tokio::test]
+async fn reactive_401_triggers_one_retry_after_invalidation() {
+    let server = MockServer::start().await;
+    let token_calls = Arc::new(AtomicUsize::new(0));
+    let token_calls_clone = Arc::clone(&token_calls);
+
+    // Two consecutive token fetches return two distinct tokens.
+    Mock::given(method("POST"))
+        .and(path("/realms/master/protocol/openid-connect/token"))
+        .respond_with(move |_req: &wiremock::Request| {
+            let n = token_calls_clone.fetch_add(1, Ordering::SeqCst);
+            let access = if n == 0 { "stale" } else { "fresh" };
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": access,
+                "expires_in": 600
+            }))
+        })
+        .mount(&server)
+        .await;
+
+    // The protected endpoint: 401 for the stale bearer, 200 for the fresh one.
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/master/probe"))
+        .and(header("authorization", "Bearer stale"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("invalid_client"))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/master/probe"))
+        .and(header("authorization", "Bearer fresh"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&server)
+        .await;
+
+    let factory = factory_for(&server);
+    let probe_url = format!("{}/admin/realms/master/probe", server.uri());
+    let result = factory
+        .with_reactive_401(
+            "master",
+            "vp-idp-plugin-bootstrap",
+            &SecretSource::Inline(SecretString::from("topsecret")),
+            |client| {
+                let url = probe_url.clone();
+                async move {
+                    let (status, body) = client
+                        .raw_request("GET", &url, None, "/admin/realms/{realm}/probe")
+                        .await?;
+                    if status != 200 {
+                        return Err(PluginError::KcRest {
+                            method: "GET",
+                            path_template: "/admin/realms/{realm}/probe".into(),
+                            status: KcStatusKind::Http(status),
+                            body_first_2kb: body,
+                        });
+                    }
+                    Ok(())
+                }
+            },
+        )
+        .await;
+    result.expect("reactive-401 retry must succeed");
+    assert_eq!(
+        token_calls.load(Ordering::SeqCst),
+        2,
+        "token endpoint hit twice (initial + post-invalidation refetch)",
+    );
+}
+
+#[tokio::test]
+async fn reactive_401_propagates_second_401() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/realms/master/protocol/openid-connect/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "always-stale",
+            "expires_in": 600
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/master/probe"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("invalid_client"))
+        .mount(&server)
+        .await;
+
+    let factory = factory_for(&server);
+    let probe_url = format!("{}/admin/realms/master/probe", server.uri());
+    let err = factory
+        .with_reactive_401(
+            "master",
+            "vp-idp-plugin-bootstrap",
+            &SecretSource::Inline(SecretString::from("topsecret")),
+            |client| {
+                let url = probe_url.clone();
+                async move {
+                    let (status, body) = client
+                        .raw_request("GET", &url, None, "/admin/realms/{realm}/probe")
+                        .await?;
+                    if status != 200 {
+                        return Err(PluginError::KcRest {
+                            method: "GET",
+                            path_template: "/admin/realms/{realm}/probe".into(),
+                            status: KcStatusKind::Http(status),
+                            body_first_2kb: body,
+                        });
+                    }
+                    Ok::<(), PluginError>(())
+                }
+            },
+        )
+        .await
+        .expect_err("second 401 must propagate");
+    assert!(
+        matches!(
+            err,
+            PluginError::KcRest {
+                status: KcStatusKind::Http(401),
+                ..
+            }
+        ),
+        "expected propagated 401, got {err:?}",
+    );
+}
+
+#[tokio::test]
+async fn concurrent_acquire_on_cold_cache_hits_token_endpoint_once() {
+    let server = MockServer::start().await;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_clone = Arc::clone(&calls);
+    // Add a tiny delay so concurrent callers actually queue on the
+    // per-key inflight mutex (otherwise the first caller could finish
+    // before the others arrive at the slow path).
+    Mock::given(method("POST"))
+        .and(path("/realms/master/protocol/openid-connect/token"))
+        .respond_with(move |_req: &wiremock::Request| {
+            calls_clone.fetch_add(1, Ordering::SeqCst);
+            ResponseTemplate::new(200)
+                .set_delay(Duration::from_millis(50))
+                .set_body_json(serde_json::json!({
+                    "access_token": "single-flight",
+                    "expires_in": 600
+                }))
+        })
+        .mount(&server)
+        .await;
+
+    let calls_assert = Arc::clone(&calls);
+    let factory = Arc::new(factory_for(&server));
+    let mut handles = Vec::with_capacity(10);
+    for _ in 0..10 {
+        let f = Arc::clone(&factory);
+        handles.push(tokio::spawn(async move { f.bootstrap_client().await }));
+    }
+    for h in handles {
+        let client = h.await.expect("task joined").expect("acquire ok");
+        assert_eq!(client.access_token(), "single-flight");
+    }
+    assert_eq!(
+        calls_assert.load(Ordering::SeqCst),
+        1,
+        "single-flight: token endpoint hit exactly once for N concurrent misses",
+    );
+}
+
+// =====================================================================
+// `credential_refresh` / `kc_admin_token_refresh` emission wiring
+// (DESIGN §9). Both counters tick on every cache-miss path in
+// `acquire_client`: `credential_refresh` after `resolve_secret`
+// returns, `kc_admin_token_refresh` after `fetch_token` returns.
+// =====================================================================
+
+/// `(outcome, tier, realm)` triple captured by [`RecordingKcMetrics`].
+type RecordedRefresh = (TokenRefreshOutcome, TokenTier, String);
+
+/// Recording [`KcAdminMetricsPort`] for assertions on refresh-event
+/// shape (outcome + tier + realm). The two counters are stored
+/// separately so a test can assert that, say, `credential_refresh`
+/// fires twice (initial + post-401 retry) while
+/// `kc_admin_token_refresh` fires twice as well — distinguishing
+/// `OpenBao` read failures from KC token-endpoint failures requires
+/// keeping the two emission sites visible.
+#[domain_model]
+#[derive(Default)]
+struct RecordingKcMetrics {
+    credential: StdMutex<Vec<RecordedRefresh>>,
+    token: StdMutex<Vec<RecordedRefresh>>,
+}
+
+impl KcAdminMetricsPort for RecordingKcMetrics {
+    fn kc_admin_request_duration(&self, _endpoint_class: EndpointClass, _secs: f64) {}
+    fn kc_admin_token_refresh(&self, outcome: TokenRefreshOutcome, tier: TokenTier, realm: &str) {
+        self.token
+            .lock()
+            .expect("token lock poisoned")
+            .push((outcome, tier, realm.to_owned()));
+    }
+    fn credential_refresh(&self, outcome: TokenRefreshOutcome, tier: TokenTier, realm: &str) {
+        self.credential
+            .lock()
+            .expect("credential lock poisoned")
+            .push((outcome, tier, realm.to_owned()));
+    }
+}
+
+fn factory_with_metrics(
+    server: &MockServer,
+    metrics: Arc<dyn KcAdminMetricsPort>,
+) -> KeycloakAdminClientFactory {
+    let stub: Arc<dyn CredStoreClientV1> = Arc::new(StubCredStore);
+    let reader = CredStoreReader::new(stub, build_system_ctx(Uuid::nil()));
+    KeycloakAdminClientFactory::new(
+        keycloak_cfg(&server.uri()),
+        default_transport(),
+        reader,
+        metrics,
+    )
+}
+
+#[tokio::test]
+async fn acquire_client_emits_credential_refresh_and_token_refresh_on_cache_miss() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/realms/master/protocol/openid-connect/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "t",
+            "expires_in": 600
+        })))
+        .mount(&server)
+        .await;
+
+    let metrics = Arc::new(RecordingKcMetrics::default());
+    let factory =
+        factory_with_metrics(&server, Arc::clone(&metrics) as Arc<dyn KcAdminMetricsPort>);
+
+    factory
+        .bootstrap_client()
+        .await
+        .expect("bootstrap acquire must succeed");
+
+    let cred = metrics
+        .credential
+        .lock()
+        .expect("credential lock poisoned")
+        .clone();
+    let tok = metrics.token.lock().expect("token lock poisoned").clone();
+    assert_eq!(
+        cred,
+        vec![(
+            TokenRefreshOutcome::Success,
+            TokenTier::StaticEnv,
+            "master".to_owned()
+        )],
+        "credential_refresh must tick once with Success/StaticEnv/master"
+    );
+    assert_eq!(
+        tok,
+        vec![(
+            TokenRefreshOutcome::Success,
+            TokenTier::StaticEnv,
+            "master".to_owned()
+        )],
+        "kc_admin_token_refresh must tick once with Success/StaticEnv/master"
+    );
+}
+
+#[tokio::test]
+async fn acquire_client_does_not_emit_refresh_metrics_on_cache_hit() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/realms/master/protocol/openid-connect/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "t",
+            "expires_in": 600
+        })))
+        .mount(&server)
+        .await;
+
+    let metrics = Arc::new(RecordingKcMetrics::default());
+    let factory =
+        factory_with_metrics(&server, Arc::clone(&metrics) as Arc<dyn KcAdminMetricsPort>);
+
+    // Two acquires: first is cache-miss (emits), second is cache-hit
+    // (must NOT emit — the rotation-observability invariant is "every
+    // counter tick = a real resolution from source").
+    factory
+        .bootstrap_client()
+        .await
+        .expect("first acquire must succeed");
+    factory
+        .bootstrap_client()
+        .await
+        .expect("second acquire (cache hit) must succeed");
+
+    let cred_len = metrics
+        .credential
+        .lock()
+        .expect("credential lock poisoned")
+        .len();
+    let tok_len = metrics.token.lock().expect("token lock poisoned").len();
+    assert_eq!(cred_len, 1, "credential_refresh must NOT tick on cache hit");
+    assert_eq!(
+        tok_len, 1,
+        "kc_admin_token_refresh must NOT tick on cache hit"
+    );
+}
+
+#[tokio::test]
+async fn acquire_client_emits_error_outcome_when_token_endpoint_fails() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/realms/master/protocol/openid-connect/token"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("kc down"))
+        .mount(&server)
+        .await;
+
+    let metrics = Arc::new(RecordingKcMetrics::default());
+    let factory =
+        factory_with_metrics(&server, Arc::clone(&metrics) as Arc<dyn KcAdminMetricsPort>);
+
+    factory
+        .bootstrap_client()
+        .await
+        .expect_err("token endpoint 500 must fail acquire");
+
+    // credential_refresh ticked Success (resolve_secret is infallible
+    // for static-inline) BEFORE the token POST failed; the failure
+    // surfaces on `kc_admin_token_refresh` with Error/StaticEnv/master.
+    let cred = metrics
+        .credential
+        .lock()
+        .expect("credential lock poisoned")
+        .clone();
+    let tok = metrics.token.lock().expect("token lock poisoned").clone();
+    assert_eq!(
+        cred,
+        vec![(
+            TokenRefreshOutcome::Success,
+            TokenTier::StaticEnv,
+            "master".to_owned()
+        )],
+    );
+    assert_eq!(
+        tok,
+        vec![(
+            TokenRefreshOutcome::Error,
+            TokenTier::StaticEnv,
+            "master".to_owned()
+        )],
+    );
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/factory_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/factory_tests.rs
@@ -253,7 +253,7 @@ async fn invalidate_forces_token_refetch() {
     let calls_assert = Arc::clone(&calls);
     let factory = factory_for(&server);
     factory.bootstrap_client().await.expect("first acquire");
-    factory.invalidate("master", "vp-idp-plugin-bootstrap");
+    factory.invalidate("master", "keycloak-idp-plugin-bootstrap");
     factory
         .bootstrap_client()
         .await
@@ -525,7 +525,7 @@ async fn reactive_401_triggers_one_retry_after_invalidation() {
     let result = factory
         .with_reactive_401(
             "master",
-            "vp-idp-plugin-bootstrap",
+            "keycloak-idp-plugin-bootstrap",
             &SecretSource::Inline(SecretString::from("topsecret")),
             |client| {
                 let url = probe_url.clone();
@@ -576,7 +576,7 @@ async fn reactive_401_propagates_second_401() {
     let err = factory
         .with_reactive_401(
             "master",
-            "vp-idp-plugin-bootstrap",
+            "keycloak-idp-plugin-bootstrap",
             &SecretSource::Inline(SecretString::from("topsecret")),
             |client| {
                 let url = probe_url.clone();

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/factory_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/factory_tests.rs
@@ -135,7 +135,7 @@ async fn factory_with_tls_ca_bundle_ref_loads_bundle() {
     });
     let reader = CredStoreReader::new(stub, build_system_ctx(Uuid::nil()));
     let mut cfg = keycloak_cfg("https://kc.example/auth");
-    cfg.tls_ca_bundle_ref = Some("vhp-platform-ca-bundle".into());
+    cfg.tls_ca_bundle_ref = Some("platform-ca-bundle".into());
     // Transport construction is now where TLS bundle loading happens.
     let transport_result = ReqwestKcTransport::from_config(&cfg, &reader).await;
     assert!(
@@ -151,7 +151,7 @@ async fn factory_with_missing_tls_ca_bundle_ref_fails_init() {
     let stub: Arc<dyn CredStoreClientV1> = Arc::new(StubCredStore);
     let reader = CredStoreReader::new(stub, build_system_ctx(Uuid::nil()));
     let mut cfg = keycloak_cfg("https://kc.example/auth");
-    cfg.tls_ca_bundle_ref = Some("vhp-platform-ca-bundle".into());
+    cfg.tls_ca_bundle_ref = Some("platform-ca-bundle".into());
     let result = ReqwestKcTransport::from_config(&cfg, &reader)
         .await
         .map(|_| ());
@@ -188,7 +188,7 @@ async fn factory_with_invalid_tls_ca_bundle_fails_init() {
     });
     let reader = CredStoreReader::new(stub, build_system_ctx(Uuid::nil()));
     let mut cfg = keycloak_cfg("https://kc.example/auth");
-    cfg.tls_ca_bundle_ref = Some("vhp-platform-ca-bundle".into());
+    cfg.tls_ca_bundle_ref = Some("platform-ca-bundle".into());
     let result = ReqwestKcTransport::from_config(&cfg, &reader)
         .await
         .map(|_| ());

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/token_cache.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/token_cache.rs
@@ -84,7 +84,7 @@ impl TokenCache {
 
     /// Scan + remove every entry whose `expires_at` has passed. Returns
     /// the number of entries dropped (useful as a metrics gauge once
-    /// the KC observability layer wires `vp_idp_plugin.kc_token_cache_evicted`).
+    /// the KC observability layer wires `keycloak_idp_plugin.kc_token_cache_evicted`).
     ///
     /// Read-time eviction in [`Self::get`] already keeps the cache
     /// bounded by *actively-fetched* realms; this method bounds it by

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/token_cache.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/token_cache.rs
@@ -1,0 +1,171 @@
+//! In-memory token cache keyed by `(realm_name, client_id)`.
+//!
+//! See DESIGN §4.4 "Shared implementation" and the `CachedToken` shape table.
+//! Token eviction is **read-time**: a fetched entry whose `expires_at` is in
+//! the past is dropped from the map and the caller re-acquires. Physical
+//! eviction is `remove_if`-gated on `Arc::ptr_eq` so a concurrent `insert` of
+//! a fresh token cannot be clobbered by the late-arriving eviction.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use dashmap::DashMap;
+use secrecy::SecretString;
+use toolkit_macros::domain_model;
+
+/// In-memory cached admin token + its realm-relative base URL.
+#[domain_model]
+#[derive(Clone)]
+pub struct CachedToken {
+    /// Bearer value. Redacted from `Debug` via `secrecy::SecretString`.
+    pub access_token: SecretString,
+    /// `now() + expires_in - admin_token_lifetime_safety_ms` per DESIGN §4.4.
+    pub expires_at: Instant,
+    /// Pre-built `{base_url}/admin/realms/{realm}` for this token's scope.
+    pub realm_url: Arc<str>,
+}
+
+impl std::fmt::Debug for CachedToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CachedToken")
+            .field("access_token", &"<redacted>")
+            .field("expires_at", &self.expires_at)
+            .field("realm_url", &self.realm_url)
+            .finish()
+    }
+}
+
+/// Concurrent token cache. Backed by `DashMap` so reads don't block writers.
+///
+/// `inner` is `pub(crate)` so the cfg(test)-gated companion `token_cache_tests`
+/// module can attach a `len()` accessor without splitting tests across two
+/// files (DE1101). The field is otherwise an implementation detail of this
+/// module.
+#[domain_model]
+#[derive(Default)]
+pub struct TokenCache {
+    pub(crate) inner: DashMap<(String, String), Arc<CachedToken>>,
+}
+
+impl TokenCache {
+    /// Return the cached token for `(realm, client_id)` if present **and not yet expired**.
+    /// Returns `None` on miss OR on expired entry (caller should re-acquire).
+    ///
+    /// An expired entry is physically removed from the map (read-time
+    /// eviction), keeping the cache bounded under realm churn without an
+    /// explicit `invalidate`. The removal is guarded by `Arc::ptr_eq` so a
+    /// concurrent `insert` of a fresh token wins the race.
+    #[must_use]
+    pub fn get(&self, realm: &str, client_id: &str) -> Option<Arc<CachedToken>> {
+        let key = (realm.to_owned(), client_id.to_owned());
+        let entry_arc = {
+            let entry = self.inner.get(&key)?;
+            Arc::clone(entry.value())
+        };
+        if Instant::now() >= entry_arc.expires_at {
+            self.inner
+                .remove_if(&key, |_, v| Arc::ptr_eq(v, &entry_arc));
+            None
+        } else {
+            Some(entry_arc)
+        }
+    }
+
+    /// Insert or replace the entry for `(realm, client_id)`.
+    pub fn insert(&self, realm: &str, client_id: &str, token: Arc<CachedToken>) {
+        self.inner
+            .insert((realm.to_owned(), client_id.to_owned()), token);
+    }
+
+    /// Drop the entry for `(realm, client_id)`. No-op if absent.
+    pub fn invalidate(&self, realm: &str, client_id: &str) {
+        self.inner.remove(&(realm.to_owned(), client_id.to_owned()));
+    }
+
+    /// Scan + remove every entry whose `expires_at` has passed. Returns
+    /// the number of entries dropped (useful as a metrics gauge once
+    /// the KC observability layer wires `vp_idp_plugin.kc_token_cache_evicted`).
+    ///
+    /// Read-time eviction in [`Self::get`] already keeps the cache
+    /// bounded by *actively-fetched* realms; this method bounds it by
+    /// *active-token* realms — a realm that was fetched once, expired,
+    /// and never re-accessed has its entry physically removed without
+    /// waiting for a re-read. Called from the factory's slow-path
+    /// `acquire_client` to amortise the sweep across cold-cache hits.
+    #[must_use = "the eviction count is a useful gauge; if you don't need it, prefix with `_ =`"]
+    pub fn prune_expired(&self) -> usize {
+        let now = Instant::now();
+        let before = self.inner.len();
+        self.inner.retain(|_, v| now < v.expires_at);
+        before - self.inner.len()
+    }
+}
+
+/// Per-key locks used by the factory to single-flight cold-cache token
+/// fetches (DESIGN §4.4 line 197 — single-flight on miss). The lock is held
+/// only across the secret-resolve + token-fetch path; warm-cache reads do
+/// NOT touch the lock map.
+///
+/// The map grows O(realms × `admin_client_ids`) and is reclaimed by
+/// [`InflightLocks::forget`] (called from the factory's `invalidate`
+/// path) and [`InflightLocks::prune_inactive`] (paired with
+/// [`TokenCache::prune_expired`] on the slow-path sweep).
+///
+/// `locks` is `pub(crate)` for the same reason as [`TokenCache::inner`] —
+/// the cfg(test) companion attaches a `len()` accessor without falling
+/// foul of DE1101's "tests-not-split" rule.
+#[domain_model]
+#[derive(Default)]
+pub struct InflightLocks {
+    pub(crate) locks: DashMap<(String, String), Arc<tokio::sync::Mutex<()>>>,
+}
+
+impl InflightLocks {
+    /// Return the lock for `(realm, client_id)`, inserting an empty one if
+    /// absent. The returned `Arc` lets the caller hold the lock without
+    /// keeping the `DashMap` shard pinned.
+    #[must_use]
+    pub fn lock_for(&self, realm: &str, client_id: &str) -> Arc<tokio::sync::Mutex<()>> {
+        self.locks
+            .entry((realm.to_owned(), client_id.to_owned()))
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
+    }
+
+    /// Drop the lock entry for `(realm, client_id)`. Called by the
+    /// factory's `invalidate` path so deprovisioned realms don't leak
+    /// `Arc<Mutex<_>>` entries forever. Safe to call concurrently with
+    /// in-flight `lock_for` waiters — `DashMap::remove` is atomic, and
+    /// any waiter still holding its `Arc` keeps the mutex alive until
+    /// it drops the guard. A subsequent `lock_for` allocates a fresh
+    /// entry, which is fine because the slow-path single-flight
+    /// invariant only matters per-call (re-check the cache after lock
+    /// acquisition, see `acquire_client`).
+    pub fn forget(&self, realm: &str, client_id: &str) {
+        self.locks.remove(&(realm.to_owned(), client_id.to_owned()));
+    }
+
+    /// Drop every lock entry whose `(realm, client_id)` no longer has
+    /// a live entry in `token_cache`. Pairs with
+    /// [`TokenCache::prune_expired`]: after a sweep, idle realms get
+    /// their inflight lock entry reclaimed too. A caller concurrently
+    /// holding an `Arc` to the lock keeps it alive until its guard
+    /// drops — only the map slot is reclaimed, so single-flight stays
+    /// honoured for in-progress acquires. Returns the number of
+    /// entries dropped (gauge candidate).
+    #[must_use = "the eviction count is a useful gauge; if you don't need it, prefix with `_ =`"]
+    pub fn prune_inactive(&self, token_cache: &TokenCache) -> usize {
+        let before = self.locks.len();
+        // `TokenCache::get` does read-time eviction, so its `is_some`
+        // answer reflects the cache's POST-prune state. Calling it
+        // here without a paired `prune_expired` is fine but less
+        // efficient — the typical caller invokes both back-to-back.
+        self.locks
+            .retain(|key, _| token_cache.get(&key.0, &key.1).is_some());
+        before - self.locks.len()
+    }
+}
+
+#[cfg(test)]
+#[path = "token_cache_tests.rs"]
+mod tests;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/token_cache_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/token_cache_tests.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 // only tests need them today, and DE1101 forbids `#[cfg(test)] fn` items
 // in a production file that has a companion test file. Promote back to
 // `pub(crate)` on the parent impl when the metrics layer wires the
-// `vp_idp_plugin.kc_token_cache_size` / `kc_inflight_locks` gauges in
+// `keycloak_idp_plugin.kc_token_cache_size` / `kc_inflight_locks` gauges in
 // the follow-up KC HTTP refactor.
 impl TokenCache {
     #[must_use]
@@ -103,10 +103,10 @@ fn debug_redacts_access_token() {
 #[test]
 fn inflight_forget_drops_entry() {
     let locks = InflightLocks::default();
-    let _l1 = locks.lock_for("partner-a", "vp-idp-plugin-realm-admin");
-    let _l2 = locks.lock_for("partner-b", "vp-idp-plugin-realm-admin");
+    let _l1 = locks.lock_for("partner-a", "keycloak-idp-plugin-realm-admin");
+    let _l2 = locks.lock_for("partner-b", "keycloak-idp-plugin-realm-admin");
     assert_eq!(locks.len(), 2);
-    locks.forget("partner-a", "vp-idp-plugin-realm-admin");
+    locks.forget("partner-a", "keycloak-idp-plugin-realm-admin");
     assert_eq!(locks.len(), 1);
     // Forgetting an absent entry is a no-op.
     locks.forget("ghost", "x");
@@ -116,8 +116,8 @@ fn inflight_forget_drops_entry() {
 #[test]
 fn inflight_lock_for_inserts_then_returns_same_arc() {
     let locks = InflightLocks::default();
-    let a = locks.lock_for("partner-a", "vp-idp-plugin-realm-admin");
-    let b = locks.lock_for("partner-a", "vp-idp-plugin-realm-admin");
+    let a = locks.lock_for("partner-a", "keycloak-idp-plugin-realm-admin");
+    let b = locks.lock_for("partner-a", "keycloak-idp-plugin-realm-admin");
     assert!(Arc::ptr_eq(&a, &b), "same key must hand back the same Arc");
 }
 

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/token_cache_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/token_cache_tests.rs
@@ -1,0 +1,191 @@
+use super::*;
+use std::time::Duration;
+
+// `len()` accessors live here rather than on the production structs:
+// only tests need them today, and DE1101 forbids `#[cfg(test)] fn` items
+// in a production file that has a companion test file. Promote back to
+// `pub(crate)` on the parent impl when the metrics layer wires the
+// `vp_idp_plugin.kc_token_cache_size` / `kc_inflight_locks` gauges in
+// the follow-up KC HTTP refactor.
+impl TokenCache {
+    #[must_use]
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
+
+impl InflightLocks {
+    #[must_use]
+    fn len(&self) -> usize {
+        self.locks.len()
+    }
+}
+
+fn token(ttl: Duration) -> Arc<CachedToken> {
+    Arc::new(CachedToken {
+        access_token: SecretString::from(String::from("dummy")),
+        expires_at: Instant::now() + ttl,
+        realm_url: Arc::from("https://kc/admin/realms/master"),
+    })
+}
+
+/// Build an explicitly-expired token. Subtracting from `Instant::now()`
+/// is the canonical way to land "expired" without sleeping — the
+/// monotonic clock allows it on every supported platform.
+fn expired_token() -> Arc<CachedToken> {
+    Arc::new(CachedToken {
+        access_token: SecretString::from(String::from("dummy")),
+        expires_at: Instant::now()
+            .checked_sub(Duration::from_secs(1))
+            .expect("monotonic clock allows subtracting 1s"),
+        realm_url: Arc::from("https://kc"),
+    })
+}
+
+#[test]
+fn miss_when_empty() {
+    let cache = TokenCache::default();
+    assert!(cache.get("master", "x").is_none());
+}
+
+#[test]
+fn hit_when_present_and_not_expired() {
+    let cache = TokenCache::default();
+    cache.insert("master", "x", token(Duration::from_mins(1)));
+    assert!(cache.get("master", "x").is_some());
+}
+
+#[test]
+fn miss_when_expired_and_physically_evicts() {
+    let cache = TokenCache::default();
+    cache.insert("master", "x", expired_token());
+    assert_eq!(cache.len(), 1, "expired entry is present before the read");
+    assert!(cache.get("master", "x").is_none());
+    assert_eq!(
+        cache.len(),
+        0,
+        "read-time eviction must physically drop the expired entry"
+    );
+}
+
+#[test]
+fn invalidate_removes_entry() {
+    let cache = TokenCache::default();
+    cache.insert("master", "x", token(Duration::from_mins(1)));
+    assert_eq!(cache.len(), 1);
+    cache.invalidate("master", "x");
+    assert_eq!(cache.len(), 0);
+    assert!(cache.get("master", "x").is_none());
+}
+
+#[test]
+fn different_realms_are_independent() {
+    let cache = TokenCache::default();
+    cache.insert("master", "x", token(Duration::from_mins(1)));
+    cache.insert("platform", "x", token(Duration::from_mins(1)));
+    assert_eq!(cache.len(), 2);
+    cache.invalidate("master", "x");
+    assert!(cache.get("master", "x").is_none());
+    assert!(cache.get("platform", "x").is_some());
+}
+
+#[test]
+fn debug_redacts_access_token() {
+    let t = token(Duration::from_mins(1));
+    let dbg = format!("{t:?}");
+    assert!(
+        !dbg.contains("dummy"),
+        "Debug must redact token value: {dbg}"
+    );
+    assert!(dbg.contains("<redacted>"));
+}
+
+#[test]
+fn inflight_forget_drops_entry() {
+    let locks = InflightLocks::default();
+    let _l1 = locks.lock_for("partner-a", "vp-idp-plugin-realm-admin");
+    let _l2 = locks.lock_for("partner-b", "vp-idp-plugin-realm-admin");
+    assert_eq!(locks.len(), 2);
+    locks.forget("partner-a", "vp-idp-plugin-realm-admin");
+    assert_eq!(locks.len(), 1);
+    // Forgetting an absent entry is a no-op.
+    locks.forget("ghost", "x");
+    assert_eq!(locks.len(), 1);
+}
+
+#[test]
+fn inflight_lock_for_inserts_then_returns_same_arc() {
+    let locks = InflightLocks::default();
+    let a = locks.lock_for("partner-a", "vp-idp-plugin-realm-admin");
+    let b = locks.lock_for("partner-a", "vp-idp-plugin-realm-admin");
+    assert!(Arc::ptr_eq(&a, &b), "same key must hand back the same Arc");
+}
+
+#[test]
+fn prune_expired_drops_only_past_entries() {
+    let cache = TokenCache::default();
+    cache.insert("realm-a", "x", token(Duration::from_mins(1))); // live
+    cache.insert("realm-b", "x", expired_token()); // stale
+    cache.insert("realm-c", "x", token(Duration::from_mins(1))); // live
+    cache.insert("realm-d", "x", expired_token()); // stale
+
+    let evicted = cache.prune_expired();
+    assert_eq!(evicted, 2);
+    assert_eq!(cache.len(), 2);
+    assert!(cache.get("realm-a", "x").is_some());
+    assert!(cache.get("realm-b", "x").is_none());
+    assert!(cache.get("realm-c", "x").is_some());
+    assert!(cache.get("realm-d", "x").is_none());
+}
+
+#[test]
+fn prune_expired_is_noop_when_cache_is_warm() {
+    let cache = TokenCache::default();
+    cache.insert("realm-a", "x", token(Duration::from_mins(1)));
+    cache.insert("realm-b", "x", token(Duration::from_mins(1)));
+    assert_eq!(cache.prune_expired(), 0);
+    assert_eq!(cache.len(), 2);
+}
+
+#[test]
+fn inflight_prune_inactive_drops_orphan_lock_entries() {
+    let cache = TokenCache::default();
+    let locks = InflightLocks::default();
+    // Three realms have an inflight lock entry; only two have a
+    // live token (realm-c was provisioned then never re-fetched,
+    // its TokenCache entry expired and was already read-time-evicted).
+    let _ = locks.lock_for("realm-a", "x");
+    let _ = locks.lock_for("realm-b", "x");
+    let _ = locks.lock_for("realm-c", "x");
+    cache.insert("realm-a", "x", token(Duration::from_mins(1)));
+    cache.insert("realm-b", "x", token(Duration::from_mins(1)));
+
+    let dropped = locks.prune_inactive(&cache);
+    assert_eq!(dropped, 1, "only realm-c (no live token) must be reclaimed");
+    assert_eq!(locks.len(), 2);
+}
+
+#[test]
+fn inflight_prune_inactive_also_drops_lock_for_freshly_expired_tokens() {
+    let cache = TokenCache::default();
+    let locks = InflightLocks::default();
+    // realm-a has a live token, realm-b's token is expired (but
+    // still physically present in the cache — eviction is
+    // read-time).
+    cache.insert("realm-a", "x", token(Duration::from_mins(1)));
+    cache.insert("realm-b", "x", expired_token());
+    let _ = locks.lock_for("realm-a", "x");
+    let _ = locks.lock_for("realm-b", "x");
+
+    // `prune_inactive` calls `TokenCache::get`, which triggers
+    // read-time eviction for the expired entry and then sees no
+    // live token → drops the lock. Net result: realm-b is
+    // reclaimed from BOTH maps in one sweep.
+    let dropped = locks.prune_inactive(&cache);
+    assert_eq!(dropped, 1);
+    assert_eq!(
+        cache.len(),
+        1,
+        "expired token must be evicted by the get inside prune_inactive"
+    );
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/transport.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/transport.rs
@@ -1,0 +1,131 @@
+//! Port trait for Keycloak Admin REST transport.
+//!
+//! Domain code interacts only with [`KcTransport`]; the reqwest-backed
+//! implementation lives in `crate::infra::kc_http` and is injected at module
+//! initialisation time. This keeps the domain layer free of any reqwest /
+//! infra imports and enables in-process fake transports for unit tests.
+//!
+//! ## Return-type choice
+//!
+//! The trait returns `Result<(u16, String), crate::domain::error::PluginError>`
+//! rather than a generic `TransportError`. `PluginError` IS the plugin's domain
+//! error vocabulary, so a domain-internal trait returning it is correct — the
+//! trait is not a public SDK seam. This minimises call-site boilerplate: callers
+//! already map errors to `PluginError` variants, and the `KcRest` /
+//! `DeprovisionRetryable` / `UserOpUnavailable` error path is uniform across
+//! both transport failures and non-2xx status.
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::domain::error::PluginError;
+
+/// Raw HTTP transport for Keycloak Admin REST.
+///
+/// Constructed once per process (built at module init, shared across the
+/// factory and all facades via `Arc`). Domain code must not depend on any
+/// concrete implementor — always accept `Arc<dyn KcTransport>`.
+///
+/// ## Contract
+///
+/// * Returns `Ok((status, body_text))` whenever an HTTP exchange completed,
+///   even for non-2xx responses. The body is always fully buffered as UTF-8.
+/// * Returns `Err(PluginError::KcRest)` with `KcStatusKind::Transport` or
+///   `KcStatusKind::Timeout` when no HTTP exchange occurred (DNS failure, TCP
+///   connection refused, TLS error, timeout before first byte).
+/// * [`KcTransport::raw_request`] injects the W3C `traceparent` header from
+///   the current tracing span into every outbound request per DESIGN §8.2.
+#[async_trait]
+pub trait KcTransport: Send + Sync {
+    /// Execute a bearer-authenticated JSON-body HTTP request against Keycloak.
+    ///
+    /// # Parameters
+    ///
+    /// * `method`       — HTTP verb string (`"GET"`, `"POST"`, etc.)
+    /// * `url`          — Full absolute URL (base URL + path, already encoded).
+    /// * `bearer_token` — Value for the `Authorization: Bearer …` header.
+    /// * `body`         — Optional JSON request body.
+    /// * `path_template` — Template string used only for `PluginError::KcRest`
+    ///   attribution (e.g. `"/admin/realms/{realm}/groups"`).
+    ///
+    /// # Errors
+    ///
+    /// `PluginError::KcRest` with `KcStatusKind::Transport` or
+    /// `KcStatusKind::Timeout` on transport / connectivity failure.
+    async fn raw_request(
+        &self,
+        method: &str,
+        url: &str,
+        bearer_token: &str,
+        body: Option<&Value>,
+        path_template: &str,
+    ) -> Result<(u16, String), PluginError>;
+
+    /// POST to an OIDC token endpoint using `application/x-www-form-urlencoded`
+    /// encoding, without a bearer token (used for `client_credentials` token
+    /// exchange).
+    ///
+    /// `fields` is a slice of `(name, value)` pairs written as form fields.
+    ///
+    /// # Errors
+    ///
+    /// `PluginError::KcRest` with `KcStatusKind::Transport` or
+    /// `KcStatusKind::Timeout` on transport / connectivity failure.
+    async fn form_post(
+        &self,
+        url: &str,
+        fields: &[(&str, &str)],
+        path_template: &str,
+    ) -> Result<(u16, String), PluginError>;
+
+    /// Unauthenticated GET — used for lightweight health / existence probes.
+    ///
+    /// # Errors
+    ///
+    /// `PluginError::KcRest` with `KcStatusKind::Transport` or
+    /// `KcStatusKind::Timeout` on transport / connectivity failure.
+    async fn get_unauthenticated(
+        &self,
+        url: &str,
+        path_template: &str,
+    ) -> Result<(u16, String), PluginError>;
+}
+
+/// Truncate a response body to the first 2 KiB. Per DESIGN §5.5, oversized
+/// bodies get a trailing `…` marker; non-printable bytes are escaped to
+/// `\xNN`. Moved here from `infra/kc_http.rs` so domain code can call it
+/// without crossing the layer boundary.
+#[must_use]
+pub fn truncate_2kb(s: &str) -> String {
+    const CAP: usize = 2048;
+    let escaped: String = s
+        .chars()
+        .map(|c| {
+            if c.is_ascii_graphic() || c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+                c.to_string()
+            } else if c.is_ascii() {
+                format!("\\x{:02X}", c as u8)
+            } else {
+                // Multi-byte UTF-8 — escape each byte separately to stay ASCII-safe.
+                use std::fmt::Write as _;
+                let mut buf = [0u8; 4];
+                let bytes = c.encode_utf8(&mut buf).as_bytes();
+                bytes.iter().fold(String::new(), |mut acc, b| {
+                    let _ = write!(acc, "\\x{b:02X}");
+                    acc
+                })
+            }
+        })
+        .collect();
+    if escaped.len() <= CAP {
+        escaped
+    } else {
+        let mut truncated: String = escaped.chars().take(CAP).collect();
+        truncated.push('…');
+        truncated
+    }
+}
+
+#[cfg(test)]
+#[path = "transport_tests.rs"]
+mod transport_tests;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/transport_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/kc/transport_tests.rs
@@ -1,0 +1,22 @@
+use super::*;
+
+#[test]
+fn truncate_short_passthrough() {
+    let s = "hello world";
+    assert_eq!(truncate_2kb(s), "hello world");
+}
+
+#[test]
+fn truncate_long_appends_ellipsis() {
+    let s: String = "a".repeat(3000);
+    let out = truncate_2kb(&s);
+    assert!(out.ends_with('…'));
+    assert_eq!(out.chars().count(), 2049);
+}
+
+#[test]
+fn truncate_escapes_non_printable_ascii() {
+    let s = "ok\x01here";
+    let out = truncate_2kb(s);
+    assert_eq!(out, "ok\\x01here");
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/metadata_codec.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/metadata_codec.rs
@@ -78,7 +78,7 @@ pub enum DecodeError {
 }
 
 /// Stable metric-label form of a [`DecodeError`] variant, used by the
-/// `vp_idp_plugin_metadata_decode_failure_total` counter's `version_observed`
+/// `keycloak_idp_plugin_metadata_decode_failure_total` counter's `version_observed`
 /// label. Centralised so the three SDK-facing decode paths cannot drift.
 ///
 /// Returns `Cow::Borrowed` for the two static variants to avoid allocation on

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/metadata_codec.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/metadata_codec.rs
@@ -1,0 +1,172 @@
+//! `TenantIdpMetadataV1` projection codec.
+//!
+//! Plugin-private JSON shape persisted by AM in `tenant_idp_metadata.metadata`
+//! and replayed on every subsequent `IdP` call for the tenant. AM never
+//! inspects it; the plugin is the sole writer.
+//!
+//! See DESIGN §4.1 (entity), §4.5 (codec rules), §5.3 (output contract).
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use toolkit_macros::domain_model;
+use uuid::Uuid;
+
+/// Plugin-private metadata blob. Version-tagged for forward compatibility.
+// The derives are this module's codec — see the `//!` docs.
+#[allow(unknown_lints, de0101_no_serde_in_contract)]
+#[domain_model]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TenantIdpMetadataV1 {
+    /// Schema version tag. Always `"v1"` at this revision.
+    pub version: String,
+    /// Keycloak realm hosting the tenant's users and groups.
+    pub realm_name: String,
+    /// How the realm came to be bound (Shared / Adopted / Created).
+    pub realm_binding: RealmBinding,
+    /// Keycloak-issued group identifier returned by `POST .../groups` at
+    /// provision time. Cached because Keycloak's group API is keyed by id.
+    pub tenant_group_id: Uuid,
+    /// `SecretRef` ID of the per-realm admin client's secret in `CredStore`.
+    ///
+    /// Per ADDENDUM §3.4: `None` for tenants in the default shared realm
+    /// (env-backed); `Some(_)` for Adopted/Created bindings (OpenBao-backed).
+    #[serde(default)]
+    pub admin_secret_ref: Option<String>,
+    /// `OAuth2` `client_id` of the per-realm admin client inside `realm_name`.
+    pub admin_client_id: String,
+}
+
+/// Realm-binding mode. Same enum is the input discriminator on
+/// `provisioning_metadata` and the persisted state on `TenantIdpMetadataV1`
+/// (DESIGN §4.1 enum row).
+// Serializes for both roles described above.
+#[allow(unknown_lints, de0101_no_serde_in_contract)]
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RealmBinding {
+    Shared,
+    Adopted,
+    Created,
+}
+
+impl RealmBinding {
+    /// Stable `realm_binding` metric-label string. The literals are part
+    /// of the public metric contract — every dashboard / alert keyed on
+    /// `realm_binding` reads these values verbatim. Returning
+    /// `&'static str` keeps the value attachable as an `OTel`
+    /// `KeyValue` without per-call allocation.
+    #[must_use]
+    pub const fn as_metric_label(self) -> &'static str {
+        match self {
+            Self::Shared => "shared",
+            Self::Adopted => "adopted",
+            Self::Created => "created",
+        }
+    }
+}
+
+#[domain_model]
+#[derive(Debug, Error)]
+pub enum DecodeError {
+    #[error("metadata blob has no 'version' key")]
+    MissingVersion,
+    #[error("unsupported metadata version: {observed}")]
+    UnsupportedVersion { observed: String },
+    #[error("malformed metadata blob: {detail}")]
+    Malformed { detail: String },
+}
+
+/// Stable metric-label form of a [`DecodeError`] variant, used by the
+/// `vp_idp_plugin_metadata_decode_failure_total` counter's `version_observed`
+/// label. Centralised so the three SDK-facing decode paths cannot drift.
+///
+/// Returns `Cow::Borrowed` for the two static variants to avoid allocation on
+/// the common `MissingVersion` and `Malformed` paths.
+#[must_use]
+pub fn version_observed_label(e: &DecodeError) -> std::borrow::Cow<'static, str> {
+    match e {
+        DecodeError::MissingVersion => std::borrow::Cow::Borrowed("missing"),
+        DecodeError::UnsupportedVersion { observed } => std::borrow::Cow::Owned(observed.clone()),
+        DecodeError::Malformed { .. } => std::borrow::Cow::Borrowed("malformed"),
+    }
+}
+
+/// Stateless codec.
+#[domain_model]
+pub struct MetadataCodec;
+
+impl MetadataCodec {
+    /// Serialise to JSON. Infallible — the struct is always serialisable.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if `serde_json::to_value` fails, which is impossible for
+    /// `TenantIdpMetadataV1` (no `Map`-incompatible keys, no custom
+    /// `Serialize` impl that can error). The `expect` anchors that invariant.
+    #[must_use]
+    #[expect(
+        clippy::unused_self,
+        reason = "stateless codec is exposed via method-style API for symmetry with potential future state"
+    )]
+    #[expect(
+        clippy::expect_used,
+        reason = "TenantIdpMetadataV1 has no serialiser-defeating shape; the expect anchors that invariant"
+    )]
+    pub fn encode(&self, v: &TenantIdpMetadataV1) -> serde_json::Value {
+        serde_json::to_value(v).expect("TenantIdpMetadataV1 is always serialisable")
+    }
+
+    /// Decode from `Option<serde_json::Value>`. `None` → `None`. `Some(_)`:
+    /// reject unknown versions and shape mismatches.
+    ///
+    /// # Errors
+    ///
+    /// - [`DecodeError::MissingVersion`] — blob has no `version` key.
+    /// - [`DecodeError::UnsupportedVersion`] — blob's `version` is not `"v1"`.
+    /// - [`DecodeError::Malformed`] — blob is `v1` but does not match the
+    ///   [`TenantIdpMetadataV1`] schema.
+    #[expect(
+        clippy::unused_self,
+        reason = "stateless codec is exposed via method-style API for symmetry with potential future state"
+    )]
+    pub fn decode(
+        &self,
+        blob: Option<serde_json::Value>,
+    ) -> Result<Option<TenantIdpMetadataV1>, DecodeError> {
+        let Some(value) = blob else {
+            return Ok(None);
+        };
+        let version = value
+            .get("version")
+            .and_then(|v| v.as_str())
+            .ok_or(DecodeError::MissingVersion)?;
+        if version != "v1" {
+            return Err(DecodeError::UnsupportedVersion {
+                observed: version.into(),
+            });
+        }
+        serde_json::from_value::<TenantIdpMetadataV1>(value)
+            .map(Some)
+            .map_err(|e| DecodeError::Malformed {
+                detail: e.to_string(),
+            })
+    }
+
+    /// Quick check for AM-replay paths that want to detect blobs produced by
+    /// older plugin instances.
+    #[must_use]
+    #[expect(
+        clippy::unused_self,
+        reason = "stateless codec is exposed via method-style API for symmetry with potential future state"
+    )]
+    pub fn is_v1_or_compatible(&self, v: &serde_json::Value) -> bool {
+        v.get("version")
+            .and_then(|s| s.as_str())
+            .is_some_and(|s| s == "v1")
+    }
+}
+
+#[cfg(test)]
+#[path = "metadata_codec_tests.rs"]
+mod metadata_codec_tests;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/metadata_codec_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/metadata_codec_tests.rs
@@ -1,0 +1,133 @@
+use super::*;
+use uuid::uuid;
+
+#[test]
+fn shared_round_trip() {
+    let original = TenantIdpMetadataV1 {
+        version: "v1".into(),
+        realm_name: "platform".into(),
+        realm_binding: RealmBinding::Shared,
+        tenant_group_id: uuid!("9c4a6b2e-0000-0000-0000-000000000001"),
+        admin_secret_ref: None,
+        admin_client_id: "vp-idp-plugin-realm-admin".into(),
+    };
+    let encoded = MetadataCodec.encode(&original);
+    let decoded = MetadataCodec
+        .decode(Some(encoded))
+        .expect("decodes")
+        .expect("Some");
+    assert_eq!(decoded, original);
+}
+
+#[test]
+fn created_round_trip_with_secret_ref() {
+    let original = TenantIdpMetadataV1 {
+        version: "v1".into(),
+        realm_name: "partner-acme".into(),
+        realm_binding: RealmBinding::Created,
+        tenant_group_id: uuid!("9c4a6b2e-0000-0000-0000-000000000002"),
+        admin_secret_ref: Some("vp-idp-realm-admin-partner-acme-secret".into()),
+        admin_client_id: "vp-idp-plugin-realm-admin".into(),
+    };
+    let encoded = MetadataCodec.encode(&original);
+    let decoded = MetadataCodec.decode(Some(encoded)).unwrap().unwrap();
+    assert_eq!(decoded, original);
+}
+
+#[test]
+fn realm_binding_wire_shape_is_snake_case() {
+    let v = TenantIdpMetadataV1 {
+        version: "v1".into(),
+        realm_name: "r".into(),
+        realm_binding: RealmBinding::Adopted,
+        tenant_group_id: uuid!("9c4a6b2e-0000-0000-0000-000000000003"),
+        admin_secret_ref: Some("ref".into()),
+        admin_client_id: "client".into(),
+    };
+    let encoded = MetadataCodec.encode(&v);
+    assert_eq!(encoded["realm_binding"], "adopted");
+}
+
+#[test]
+fn unsupported_version_rejected() {
+    let json = serde_json::json!({
+        "version": "v99",
+        "realm_name": "x",
+        "realm_binding": "shared",
+        "tenant_group_id": "9c4a6b2e-0000-0000-0000-000000000001",
+        "admin_client_id": "y"
+    });
+    let err = MetadataCodec.decode(Some(json)).unwrap_err();
+    assert!(
+        matches!(err, DecodeError::UnsupportedVersion { .. }),
+        "expected UnsupportedVersion, got {err:?}"
+    );
+}
+
+#[test]
+fn missing_version_rejected() {
+    let json = serde_json::json!({"realm_name": "x"});
+    let err = MetadataCodec.decode(Some(json)).unwrap_err();
+    assert!(
+        matches!(err, DecodeError::MissingVersion),
+        "expected MissingVersion, got {err:?}"
+    );
+}
+
+#[test]
+fn malformed_blob_rejected() {
+    let json = serde_json::json!({
+        "version": "v1",
+        "realm_name": "x",
+        // missing realm_binding, tenant_group_id, admin_client_id
+    });
+    let err = MetadataCodec.decode(Some(json)).unwrap_err();
+    assert!(
+        matches!(err, DecodeError::Malformed { .. }),
+        "expected Malformed, got {err:?}"
+    );
+}
+
+#[test]
+fn none_returns_none() {
+    assert!(MetadataCodec.decode(None).unwrap().is_none());
+}
+
+#[test]
+fn is_v1_or_compatible_detects_v1() {
+    let v1 = serde_json::json!({"version": "v1"});
+    let v99 = serde_json::json!({"version": "v99"});
+    let no_version = serde_json::json!({});
+    assert!(MetadataCodec.is_v1_or_compatible(&v1));
+    assert!(!MetadataCodec.is_v1_or_compatible(&v99));
+    assert!(!MetadataCodec.is_v1_or_compatible(&no_version));
+}
+
+#[test]
+fn shared_emits_admin_secret_ref_as_null() {
+    let v = TenantIdpMetadataV1 {
+        version: "v1".into(),
+        realm_name: "platform".into(),
+        realm_binding: RealmBinding::Shared,
+        tenant_group_id: uuid!("9c4a6b2e-0000-0000-0000-000000000001"),
+        admin_secret_ref: None,
+        admin_client_id: "vp-idp-plugin-realm-admin".into(),
+    };
+    let encoded = MetadataCodec.encode(&v);
+    assert!(
+        encoded.get("admin_secret_ref").is_some(),
+        "admin_secret_ref must be present (as null) per DESIGN §5.3"
+    );
+    assert!(
+        encoded["admin_secret_ref"].is_null(),
+        "admin_secret_ref must be null for Shared binding, got {encoded:?}"
+    );
+}
+
+#[test]
+fn realm_binding_as_metric_label_stable() {
+    use crate::domain::metadata_codec::RealmBinding;
+    assert_eq!(RealmBinding::Shared.as_metric_label(), "shared");
+    assert_eq!(RealmBinding::Adopted.as_metric_label(), "adopted");
+    assert_eq!(RealmBinding::Created.as_metric_label(), "created");
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/metadata_codec_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/metadata_codec_tests.rs
@@ -26,7 +26,7 @@ fn created_round_trip_with_secret_ref() {
         realm_name: "partner-acme".into(),
         realm_binding: RealmBinding::Created,
         tenant_group_id: uuid!("9c4a6b2e-0000-0000-0000-000000000002"),
-        admin_secret_ref: Some("vp-idp-realm-admin-partner-acme-secret".into()),
+        admin_secret_ref: Some("keycloak-idp-realm-admin-partner-acme-secret".into()),
         admin_client_id: "keycloak-idp-plugin-realm-admin".into(),
     };
     let encoded = MetadataCodec.encode(&original);

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/metadata_codec_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/metadata_codec_tests.rs
@@ -9,7 +9,7 @@ fn shared_round_trip() {
         realm_binding: RealmBinding::Shared,
         tenant_group_id: uuid!("9c4a6b2e-0000-0000-0000-000000000001"),
         admin_secret_ref: None,
-        admin_client_id: "vp-idp-plugin-realm-admin".into(),
+        admin_client_id: "keycloak-idp-plugin-realm-admin".into(),
     };
     let encoded = MetadataCodec.encode(&original);
     let decoded = MetadataCodec
@@ -27,7 +27,7 @@ fn created_round_trip_with_secret_ref() {
         realm_binding: RealmBinding::Created,
         tenant_group_id: uuid!("9c4a6b2e-0000-0000-0000-000000000002"),
         admin_secret_ref: Some("vp-idp-realm-admin-partner-acme-secret".into()),
-        admin_client_id: "vp-idp-plugin-realm-admin".into(),
+        admin_client_id: "keycloak-idp-plugin-realm-admin".into(),
     };
     let encoded = MetadataCodec.encode(&original);
     let decoded = MetadataCodec.decode(Some(encoded)).unwrap().unwrap();
@@ -111,7 +111,7 @@ fn shared_emits_admin_secret_ref_as_null() {
         realm_binding: RealmBinding::Shared,
         tenant_group_id: uuid!("9c4a6b2e-0000-0000-0000-000000000001"),
         admin_secret_ref: None,
-        admin_client_id: "vp-idp-plugin-realm-admin".into(),
+        admin_client_id: "keycloak-idp-plugin-realm-admin".into(),
     };
     let encoded = MetadataCodec.encode(&v);
     assert!(

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/metrics.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/metrics.rs
@@ -1,4 +1,4 @@
-//! Stable metric-family name constants for `vp-idp-plugin`.
+//! Stable metric-family name constants for `keycloak-idp-plugin`.
 //!
 //! Names are **literal Prometheus** instrument names: underscore-separated,
 //! lowercase, with the wire-side suffix baked directly into the name —
@@ -12,7 +12,7 @@
 //!
 //! The infra adapter (see [`crate::infra::metrics`]) builds one `OTel`
 //! instrument per constant below, optionally substituting the leading
-//! `vp_idp_plugin` namespace token for its `prefix` argument so a host
+//! `keycloak_idp_plugin` namespace token for its `prefix` argument so a host
 //! embedding the plugin under a different name can rebrand all emissions
 //! in one place.
 //!
@@ -20,7 +20,7 @@
 //!
 //! `realm_name` is a partner-controlled label whose cardinality grows
 //! with every Created-mode realm. The watchdog now lives **inside the
-//! adapter** (see `VpIdpPluginMetricsAdapter::observe_realm_and_should_emit`),
+//! adapter** (see `KeycloakIdpPluginMetricsAdapter::observe_realm_and_should_emit`),
 //! not on the domain struct — call sites simply pass `&str` and the
 //! adapter decides whether to attach the label.
 
@@ -29,60 +29,63 @@
 // ════════════════════════════════════════════════════════════════════
 
 /// `provision_tenant` end-to-end latency. Histogram, unit seconds.
-pub const VP_IDP_PLUGIN_PROVISION_TENANT_DURATION: &str =
-    "vp_idp_plugin_provision_tenant_duration_seconds";
+pub const KEYCLOAK_IDP_PLUGIN_PROVISION_TENANT_DURATION: &str =
+    "keycloak_idp_plugin_provision_tenant_duration_seconds";
 
 /// User-op latency. Histogram, unit seconds.
-pub const VP_IDP_PLUGIN_USER_OP_DURATION: &str = "vp_idp_plugin_user_op_duration_seconds";
+pub const KEYCLOAK_IDP_PLUGIN_USER_OP_DURATION: &str =
+    "keycloak_idp_plugin_user_op_duration_seconds";
 
 /// KC Admin REST single-call latency. Histogram, unit seconds. Reserved —
 /// no live emitters today; declared so the follow-up PR wiring the KC
 /// HTTP layer does not need to reshape DI.
-pub const VP_IDP_PLUGIN_KC_ADMIN_REQUEST_DURATION: &str =
-    "vp_idp_plugin_kc_admin_request_duration_seconds";
+pub const KEYCLOAK_IDP_PLUGIN_KC_ADMIN_REQUEST_DURATION: &str =
+    "keycloak_idp_plugin_kc_admin_request_duration_seconds";
 
 /// Plugin failures. Counter, labelled by `op` × `failure_variant`.
-pub const VP_IDP_PLUGIN_FAILURE: &str = "vp_idp_plugin_failure_total";
+pub const KEYCLOAK_IDP_PLUGIN_FAILURE: &str = "keycloak_idp_plugin_failure_total";
 
 /// KC Admin token refresh. Counter. Reserved — declared without live
-/// emitters (see [`VP_IDP_PLUGIN_KC_ADMIN_REQUEST_DURATION`]).
-pub const VP_IDP_PLUGIN_KC_ADMIN_TOKEN_REFRESH: &str = "vp_idp_plugin_kc_admin_token_refresh_total";
+/// emitters (see [`KEYCLOAK_IDP_PLUGIN_KC_ADMIN_REQUEST_DURATION`]).
+pub const KEYCLOAK_IDP_PLUGIN_KC_ADMIN_TOKEN_REFRESH: &str =
+    "keycloak_idp_plugin_kc_admin_token_refresh_total";
 
 /// Admin `client_secret` re-resolution. Counter. Reserved — declared
 /// without live emitters.
-pub const VP_IDP_PLUGIN_CREDENTIAL_REFRESH: &str = "vp_idp_plugin_credential_refresh_total";
+pub const KEYCLOAK_IDP_PLUGIN_CREDENTIAL_REFRESH: &str =
+    "keycloak_idp_plugin_credential_refresh_total";
 
 /// `OpenBao` writes/deletes for per-realm admin secrets. Counter.
-pub const VP_IDP_PLUGIN_CREDSTORE_WRITE: &str = "vp_idp_plugin_credstore_write_total";
+pub const KEYCLOAK_IDP_PLUGIN_CREDSTORE_WRITE: &str = "keycloak_idp_plugin_credstore_write_total";
 
 /// Malformed / unsupported-version metadata blob counter.
-pub const VP_IDP_PLUGIN_METADATA_DECODE_FAILURE: &str =
-    "vp_idp_plugin_metadata_decode_failure_total";
+pub const KEYCLOAK_IDP_PLUGIN_METADATA_DECODE_FAILURE: &str =
+    "keycloak_idp_plugin_metadata_decode_failure_total";
 
 /// `deprovision_tenant` arrived with `metadata = None` under an
 /// `am.system` security context. Counter.
-pub const VP_IDP_PLUGIN_DEPROVISION_MISSING_METADATA: &str =
-    "vp_idp_plugin_deprovision_missing_metadata_total";
+pub const KEYCLOAK_IDP_PLUGIN_DEPROVISION_MISSING_METADATA: &str =
+    "keycloak_idp_plugin_deprovision_missing_metadata_total";
 
 /// Active realm bindings. `UpDownCounter`, labelled by `realm_binding`
 /// × `realm_name` (subject to the adapter's cardinality watchdog). No
 /// suffix — up-down-counters carry no `_total`.
-pub const VP_IDP_PLUGIN_REALMS_BOUND: &str = "vp_idp_plugin_realms_bound";
+pub const KEYCLOAK_IDP_PLUGIN_REALMS_BOUND: &str = "keycloak_idp_plugin_realms_bound";
 
 /// Orphan-user compensation outcomes. Counter, labelled by `outcome`
 /// ∈ {`ok`, `failed`}. Emitted by `UserFacade::provision_user_impl` when
 /// `add_user_to_group` fails after `create_user` already landed — the
 /// compensation path (`delete_user`) is best-effort and operators need
 /// an actionable signal distinct from the primary group-add failure.
-pub const VP_IDP_PLUGIN_ORPHAN_USER_COMPENSATION: &str =
-    "vp_idp_plugin_orphan_user_compensation_total";
+pub const KEYCLOAK_IDP_PLUGIN_ORPHAN_USER_COMPENSATION: &str =
+    "keycloak_idp_plugin_orphan_user_compensation_total";
 
 /// Service-principal op latency. Histogram, unit seconds.
-pub const VP_IDP_PLUGIN_SP_OP_DURATION: &str = "vp_idp_plugin_sp_op_duration_seconds";
+pub const KEYCLOAK_IDP_PLUGIN_SP_OP_DURATION: &str = "keycloak_idp_plugin_sp_op_duration_seconds";
 
 /// Default instrument-name prefix token. The adapter substitutes this
-/// for the leading `"vp_idp_plugin"` token of the constants above so a
+/// for the leading `"keycloak_idp_plugin"` token of the constants above so a
 /// host embedding the plugin under a different name can rebrand all
 /// emissions in one place. With the default value the substitution is a
 /// no-op and names are emitted verbatim.
-pub const DEFAULT_PREFIX: &str = "vp_idp_plugin";
+pub const DEFAULT_PREFIX: &str = "keycloak_idp_plugin";

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/metrics.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/metrics.rs
@@ -1,0 +1,88 @@
+//! Stable metric-family name constants for `vp-idp-plugin`.
+//!
+//! Names are **literal Prometheus** instrument names: underscore-separated,
+//! lowercase, with the wire-side suffix baked directly into the name —
+//! `_total` for monotonic counters, a unit suffix (`_seconds`, and `_ms`
+//! only where the instrument is genuinely milliseconds) for histograms,
+//! and **no** suffix for gauges / up-down-counters. The adapter does
+//! **not** call `with_unit(...)`; the unit lives in the name. This matches
+//! the sibling modules (RMS, policy-engine, openbao) and the platform
+//! collector's `add_metric_suffixes: false` posture, which preserves
+//! these names verbatim on the wire and does NOT auto-append suffixes.
+//!
+//! The infra adapter (see [`crate::infra::metrics`]) builds one `OTel`
+//! instrument per constant below, optionally substituting the leading
+//! `vp_idp_plugin` namespace token for its `prefix` argument so a host
+//! embedding the plugin under a different name can rebrand all emissions
+//! in one place.
+//!
+//! ## Cardinality watchdog (DESIGN §4.4, §9)
+//!
+//! `realm_name` is a partner-controlled label whose cardinality grows
+//! with every Created-mode realm. The watchdog now lives **inside the
+//! adapter** (see `VpIdpPluginMetricsAdapter::observe_realm_and_should_emit`),
+//! not on the domain struct — call sites simply pass `&str` and the
+//! adapter decides whether to attach the label.
+
+// ════════════════════════════════════════════════════════════════════
+//  Metric family catalog — literal Prometheus name constants
+// ════════════════════════════════════════════════════════════════════
+
+/// `provision_tenant` end-to-end latency. Histogram, unit seconds.
+pub const VP_IDP_PLUGIN_PROVISION_TENANT_DURATION: &str =
+    "vp_idp_plugin_provision_tenant_duration_seconds";
+
+/// User-op latency. Histogram, unit seconds.
+pub const VP_IDP_PLUGIN_USER_OP_DURATION: &str = "vp_idp_plugin_user_op_duration_seconds";
+
+/// KC Admin REST single-call latency. Histogram, unit seconds. Reserved —
+/// no live emitters today; declared so the follow-up PR wiring the KC
+/// HTTP layer does not need to reshape DI.
+pub const VP_IDP_PLUGIN_KC_ADMIN_REQUEST_DURATION: &str =
+    "vp_idp_plugin_kc_admin_request_duration_seconds";
+
+/// Plugin failures. Counter, labelled by `op` × `failure_variant`.
+pub const VP_IDP_PLUGIN_FAILURE: &str = "vp_idp_plugin_failure_total";
+
+/// KC Admin token refresh. Counter. Reserved — declared without live
+/// emitters (see [`VP_IDP_PLUGIN_KC_ADMIN_REQUEST_DURATION`]).
+pub const VP_IDP_PLUGIN_KC_ADMIN_TOKEN_REFRESH: &str = "vp_idp_plugin_kc_admin_token_refresh_total";
+
+/// Admin `client_secret` re-resolution. Counter. Reserved — declared
+/// without live emitters.
+pub const VP_IDP_PLUGIN_CREDENTIAL_REFRESH: &str = "vp_idp_plugin_credential_refresh_total";
+
+/// `OpenBao` writes/deletes for per-realm admin secrets. Counter.
+pub const VP_IDP_PLUGIN_CREDSTORE_WRITE: &str = "vp_idp_plugin_credstore_write_total";
+
+/// Malformed / unsupported-version metadata blob counter.
+pub const VP_IDP_PLUGIN_METADATA_DECODE_FAILURE: &str =
+    "vp_idp_plugin_metadata_decode_failure_total";
+
+/// `deprovision_tenant` arrived with `metadata = None` under an
+/// `am.system` security context. Counter.
+pub const VP_IDP_PLUGIN_DEPROVISION_MISSING_METADATA: &str =
+    "vp_idp_plugin_deprovision_missing_metadata_total";
+
+/// Active realm bindings. `UpDownCounter`, labelled by `realm_binding`
+/// × `realm_name` (subject to the adapter's cardinality watchdog). No
+/// suffix — up-down-counters carry no `_total`.
+pub const VP_IDP_PLUGIN_REALMS_BOUND: &str = "vp_idp_plugin_realms_bound";
+
+/// Orphan-user compensation outcomes. Counter, labelled by `outcome`
+/// ∈ {`ok`, `failed`}. Emitted by `UserFacade::provision_user_impl` when
+/// `add_user_to_group` fails after `create_user` already landed — the
+/// compensation path (`delete_user`) is best-effort and operators need
+/// an actionable signal distinct from the primary group-add failure.
+pub const VP_IDP_PLUGIN_ORPHAN_USER_COMPENSATION: &str =
+    "vp_idp_plugin_orphan_user_compensation_total";
+
+/// Service-principal op latency. Histogram, unit seconds.
+pub const VP_IDP_PLUGIN_SP_OP_DURATION: &str = "vp_idp_plugin_sp_op_duration_seconds";
+
+/// Default instrument-name prefix token. The adapter substitutes this
+/// for the leading `"vp_idp_plugin"` token of the constants above so a
+/// host embedding the plugin under a different name can rebrand all
+/// emissions in one place. With the default value the substitution is a
+/// no-op and names are emitted verbatim.
+pub const DEFAULT_PREFIX: &str = "vp_idp_plugin";

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/ports.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/ports.rs
@@ -1,0 +1,5 @@
+//! Domain ports (interfaces) — the abstractions the domain layer depends
+//! on. Infra adapters in [`crate::infra`] implement these traits; the
+//! domain layer never imports infra directly.
+
+pub mod metrics;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/ports/metrics.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/ports/metrics.rs
@@ -271,11 +271,11 @@ impl From<&DecodeError> for VersionObserved {
 /// `endpoint_class` label on `keycloak_idp_plugin_kc_admin_request_duration_seconds`.
 ///
 /// Sealed newtype reserved for the KC HTTP layer wiring (follow-up PR
-/// to VHP-1505). The literal set is intentionally left at one
+/// to). The literal set is intentionally left at one
 /// placeholder; new endpoint classes will be added alongside the
 /// emitting call sites.
 ///
-/// **TODO (VHP-1505 follow-up — KC HTTP layer)**: when wiring real
+/// **TODO ( follow-up — KC HTTP layer)**: when wiring real
 /// emitters in `infra/kc_http.rs`, extend this sealed newtype with one
 /// `pub const` per endpoint family (e.g. `REALM_GET`, `USERS_LIST`,
 /// `GROUPS_PUT`, …). Do **not** introduce a free-`&str` constructor —

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/ports/metrics.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/ports/metrics.rs
@@ -1,10 +1,10 @@
-//! `vp-idp-plugin` observability ports — typed, segregated metric-emission
+//! `keycloak-idp-plugin` observability ports — typed, segregated metric-emission
 //! traits. Mirrors the AM pattern
 //! (`external/gears-rust/.../account-management/src/domain/ports/metrics.rs`).
 //!
 //! Each trait owns one cohesive subdomain of the plugin metric catalog
 //! declared in [`crate::domain::metrics`]. A single infra adapter
-//! ([`crate::infra::metrics::VpIdpPluginMetricsAdapter`]) implements every
+//! ([`crate::infra::metrics::KeycloakIdpPluginMetricsAdapter`]) implements every
 //! trait on one OpenTelemetry-backed struct; DI hands each facade the
 //! trait(s) it actually needs.
 //!
@@ -38,7 +38,7 @@ use crate::domain::metadata_codec::{DecodeError, RealmBinding, version_observed_
 //  Closed-set label enums
 // ════════════════════════════════════════════════════════════════════
 
-/// `op` label on `vp_idp_plugin_user_op_duration_seconds`.
+/// `op` label on `keycloak_idp_plugin_user_op_duration_seconds`.
 #[domain_model]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UserOp {
@@ -58,8 +58,8 @@ impl UserOp {
     }
 }
 
-/// `tier` label on `vp_idp_plugin_kc_admin_token_refresh_total` and
-/// `vp_idp_plugin_credential_refresh_total` (ADDENDUM §8).
+/// `tier` label on `keycloak_idp_plugin_kc_admin_token_refresh_total` and
+/// `keycloak_idp_plugin_credential_refresh_total` (ADDENDUM §8).
 #[domain_model]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TokenTier {
@@ -77,8 +77,8 @@ impl TokenTier {
     }
 }
 
-/// `outcome` label on `vp_idp_plugin_kc_admin_token_refresh_total` and
-/// `vp_idp_plugin_credential_refresh_total`.
+/// `outcome` label on `keycloak_idp_plugin_kc_admin_token_refresh_total` and
+/// `keycloak_idp_plugin_credential_refresh_total`.
 #[domain_model]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TokenRefreshOutcome {
@@ -96,7 +96,7 @@ impl TokenRefreshOutcome {
     }
 }
 
-/// `op` label on `vp_idp_plugin_sp_op_duration_seconds`.
+/// `op` label on `keycloak_idp_plugin_sp_op_duration_seconds`.
 #[domain_model]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SpOp {
@@ -120,7 +120,7 @@ impl SpOp {
     }
 }
 
-/// `op` label on `vp_idp_plugin_credstore_write_total`.
+/// `op` label on `keycloak_idp_plugin_credstore_write_total`.
 #[domain_model]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CredstoreOp {
@@ -138,7 +138,7 @@ impl CredstoreOp {
     }
 }
 
-/// `outcome` label on `vp_idp_plugin_credstore_write_total`.
+/// `outcome` label on `keycloak_idp_plugin_credstore_write_total`.
 #[domain_model]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CredstoreOutcome {
@@ -156,7 +156,7 @@ impl CredstoreOutcome {
     }
 }
 
-/// `op` label on `vp_idp_plugin_failure_total`. Superset of all plugin-level
+/// `op` label on `keycloak_idp_plugin_failure_total`. Superset of all plugin-level
 /// operations: tenant lifecycle + user lifecycle + service-principal ops.
 #[domain_model]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -195,9 +195,9 @@ impl PluginOp {
 //  Sealed-newtype label bridges
 // ════════════════════════════════════════════════════════════════════
 
-// ── vp_idp_plugin_failure_total ───────────────────────────────────────────
+// ── keycloak_idp_plugin_failure_total ───────────────────────────────────────────
 
-/// `failure_variant` label on `vp_idp_plugin_failure_total`.
+/// `failure_variant` label on `keycloak_idp_plugin_failure_total`.
 ///
 /// Sealed newtype: the closed set of literals lives as `pub const`
 /// associated constants, and `From<&PluginError>` bridges
@@ -237,9 +237,9 @@ impl From<&PluginError> for FailureVariant {
     }
 }
 
-// ── vp_idp_plugin_metadata_decode_failure_total ───────────────────────────
+// ── keycloak_idp_plugin_metadata_decode_failure_total ───────────────────────────
 
-/// `version_observed` label on `vp_idp_plugin_metadata_decode_failure_total`.
+/// `version_observed` label on `keycloak_idp_plugin_metadata_decode_failure_total`.
 ///
 /// Sealed newtype around `Cow<'static, str>`: static literals for the
 /// fixed `MissingVersion` / `Malformed` paths; `Cow::Owned` for the
@@ -266,9 +266,9 @@ impl From<&DecodeError> for VersionObserved {
     }
 }
 
-// ── vp_idp_plugin_kc_admin_request_duration_seconds ─────────────────────────
+// ── keycloak_idp_plugin_kc_admin_request_duration_seconds ─────────────────────────
 
-/// `endpoint_class` label on `vp_idp_plugin_kc_admin_request_duration_seconds`.
+/// `endpoint_class` label on `keycloak_idp_plugin_kc_admin_request_duration_seconds`.
 ///
 /// Sealed newtype reserved for the KC HTTP layer wiring (follow-up PR
 /// to VHP-1505). The literal set is intentionally left at one
@@ -308,7 +308,7 @@ pub trait TenantLifecycleMetricsPort: Send + Sync + 'static {
     fn deprovision_missing_metadata(&self);
 }
 
-/// `outcome` label on `vp_idp_plugin_orphan_user_compensation_total`. Two
+/// `outcome` label on `keycloak_idp_plugin_orphan_user_compensation_total`. Two
 /// terminal states for the best-effort `delete_user` compensation
 /// path; both fire from `UserFacade::provision_user_impl` when
 /// `add_user_to_group` fails after `create_user` already landed.

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/ports/metrics.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/ports/metrics.rs
@@ -1,0 +1,383 @@
+//! `vp-idp-plugin` observability ports — typed, segregated metric-emission
+//! traits. Mirrors the AM pattern
+//! (`external/gears-rust/.../account-management/src/domain/ports/metrics.rs`).
+//!
+//! Each trait owns one cohesive subdomain of the plugin metric catalog
+//! declared in [`crate::domain::metrics`]. A single infra adapter
+//! ([`crate::infra::metrics::VpIdpPluginMetricsAdapter`]) implements every
+//! trait on one OpenTelemetry-backed struct; DI hands each facade the
+//! trait(s) it actually needs.
+//!
+//! ## Design choices
+//!
+//! * **Trait segregation.** Six narrow traits instead of one fat trait —
+//!   each facade depends on the minimum surface it needs.
+//! * **Typed label values.** Every `&str` label that was previously
+//!   passed as a literal becomes a typed enum or a sealed newtype with
+//!   `pub const` literals. The compiler enforces the closed set; no typo
+//!   can leak into a dashboard.
+//! * **Bridging existing label helpers.** Sets that mirror existing
+//!   per-variant string mappings (`failure_variant_label`,
+//!   `version_observed_label`) are modelled as sealed newtypes with
+//!   `From<&PluginError>` / `From<&DecodeError>` impls — the mapping
+//!   continues to live on the failure type and is not duplicated here.
+//! * **Cardinality discipline.** Free `&str` realm-name arguments are
+//!   accepted only on ports that need them (`realm_bound`,
+//!   `kc_admin_token_refresh`, `credential_refresh`); the adapter
+//!   decides whether to emit the label based on the cardinality
+//!   watchdog. Call sites never branch on cardinality.
+
+use std::borrow::Cow;
+
+use toolkit_macros::domain_model;
+
+use crate::domain::error::{PluginError, failure_variant_label};
+use crate::domain::metadata_codec::{DecodeError, RealmBinding, version_observed_label};
+
+// ════════════════════════════════════════════════════════════════════
+//  Closed-set label enums
+// ════════════════════════════════════════════════════════════════════
+
+/// `op` label on `vp_idp_plugin_user_op_duration_seconds`.
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UserOp {
+    ProvisionUser,
+    DeprovisionUser,
+    ListUsers,
+}
+
+impl UserOp {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ProvisionUser => "provision_user",
+            Self::DeprovisionUser => "deprovision_user",
+            Self::ListUsers => "list_users",
+        }
+    }
+}
+
+/// `tier` label on `vp_idp_plugin_kc_admin_token_refresh_total` and
+/// `vp_idp_plugin_credential_refresh_total` (ADDENDUM §8).
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenTier {
+    StaticEnv,
+    OpenBao,
+}
+
+impl TokenTier {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::StaticEnv => "static_env",
+            Self::OpenBao => "openbao",
+        }
+    }
+}
+
+/// `outcome` label on `vp_idp_plugin_kc_admin_token_refresh_total` and
+/// `vp_idp_plugin_credential_refresh_total`.
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenRefreshOutcome {
+    Success,
+    Error,
+}
+
+impl TokenRefreshOutcome {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Error => "error",
+        }
+    }
+}
+
+/// `op` label on `vp_idp_plugin_sp_op_duration_seconds`.
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpOp {
+    Create,
+    RotateSecret,
+    Revoke,
+    List,
+    Purge,
+}
+
+impl SpOp {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Create => "sp_create",
+            Self::RotateSecret => "sp_rotate_secret",
+            Self::Revoke => "sp_revoke",
+            Self::List => "sp_list",
+            Self::Purge => "sp_purge",
+        }
+    }
+}
+
+/// `op` label on `vp_idp_plugin_credstore_write_total`.
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CredstoreOp {
+    Put,
+    Delete,
+}
+
+impl CredstoreOp {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Put => "put",
+            Self::Delete => "delete",
+        }
+    }
+}
+
+/// `outcome` label on `vp_idp_plugin_credstore_write_total`.
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CredstoreOutcome {
+    Ok,
+    Error,
+}
+
+impl CredstoreOutcome {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::Error => "error",
+        }
+    }
+}
+
+/// `op` label on `vp_idp_plugin_failure_total`. Superset of all plugin-level
+/// operations: tenant lifecycle + user lifecycle + service-principal ops.
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluginOp {
+    ProvisionTenant,
+    DeprovisionTenant,
+    ProvisionUser,
+    DeprovisionUser,
+    ListUsers,
+    SpCreate,
+    SpRotateSecret,
+    SpRevoke,
+    SpList,
+    SpPurge,
+}
+
+impl PluginOp {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ProvisionTenant => "provision_tenant",
+            Self::DeprovisionTenant => "deprovision_tenant",
+            Self::ProvisionUser => "provision_user",
+            Self::DeprovisionUser => "deprovision_user",
+            Self::ListUsers => "list_users",
+            Self::SpCreate => "sp_create",
+            Self::SpRotateSecret => "sp_rotate_secret",
+            Self::SpRevoke => "sp_revoke",
+            Self::SpList => "sp_list",
+            Self::SpPurge => "sp_purge",
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Sealed-newtype label bridges
+// ════════════════════════════════════════════════════════════════════
+
+// ── vp_idp_plugin_failure_total ───────────────────────────────────────────
+
+/// `failure_variant` label on `vp_idp_plugin_failure_total`.
+///
+/// Sealed newtype: the closed set of literals lives as `pub const`
+/// associated constants, and `From<&PluginError>` bridges
+/// [`failure_variant_label`] which owns the variant→string mapping. No
+/// public constructor — values must come from a constant or the `From`
+/// impl, so the cardinality surface stays closed.
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FailureVariant(&'static str);
+
+impl FailureVariant {
+    pub const CONFIG: Self = Self("config");
+    pub const CREDSTORE_READ: Self = Self("credstore_read");
+    pub const METADATA_DECODE: Self = Self("metadata_decode");
+    pub const KC_REST: Self = Self("kc_rest");
+    pub const AMBIGUOUS_CREATED: Self = Self("ambiguous_created");
+    pub const CREATED_REALM_EXISTS: Self = Self("created_realm_exists");
+    pub const BOOTSTRAP_PERMS_MISSING: Self = Self("bootstrap_perms_missing");
+    pub const DEPROVISION_NOT_FOUND: Self = Self("deprovision_not_found");
+    pub const DEPROVISION_RETRYABLE: Self = Self("deprovision_retryable");
+    pub const DEPROVISION_TERMINAL: Self = Self("deprovision_terminal");
+    pub const USER_OP_REJECTED: Self = Self("user_op_rejected");
+    pub const USER_OP_UNAVAILABLE: Self = Self("user_op_unavailable");
+    pub const USER_OP_UNSUPPORTED: Self = Self("user_op_unsupported");
+    pub const SP_INVALID_INPUT: Self = Self("sp_invalid_input");
+    pub const SP_NOT_FOUND: Self = Self("sp_not_found");
+
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        self.0
+    }
+}
+
+impl From<&PluginError> for FailureVariant {
+    fn from(e: &PluginError) -> Self {
+        Self(failure_variant_label(e))
+    }
+}
+
+// ── vp_idp_plugin_metadata_decode_failure_total ───────────────────────────
+
+/// `version_observed` label on `vp_idp_plugin_metadata_decode_failure_total`.
+///
+/// Sealed newtype around `Cow<'static, str>`: static literals for the
+/// fixed `MissingVersion` / `Malformed` paths; `Cow::Owned` for the
+/// `UnsupportedVersion { observed }` wildcard. Cardinality of the
+/// wildcard branch is bounded by the realistic surface of KC realm
+/// metadata-version strings (a tiny set in practice).
+#[domain_model]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionObserved(Cow<'static, str>);
+
+impl VersionObserved {
+    pub const MISSING: Self = Self(Cow::Borrowed("missing"));
+    pub const MALFORMED: Self = Self(Cow::Borrowed("malformed"));
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&DecodeError> for VersionObserved {
+    fn from(e: &DecodeError) -> Self {
+        Self(version_observed_label(e))
+    }
+}
+
+// ── vp_idp_plugin_kc_admin_request_duration_seconds ─────────────────────────
+
+/// `endpoint_class` label on `vp_idp_plugin_kc_admin_request_duration_seconds`.
+///
+/// Sealed newtype reserved for the KC HTTP layer wiring (follow-up PR
+/// to VHP-1505). The literal set is intentionally left at one
+/// placeholder; new endpoint classes will be added alongside the
+/// emitting call sites.
+///
+/// **TODO (VHP-1505 follow-up — KC HTTP layer)**: when wiring real
+/// emitters in `infra/kc_http.rs`, extend this sealed newtype with one
+/// `pub const` per endpoint family (e.g. `REALM_GET`, `USERS_LIST`,
+/// `GROUPS_PUT`, …). Do **not** introduce a free-`&str` constructor —
+/// the sealed shape is what keeps the cardinality surface closed.
+/// Mirror the bridge pattern from [`FailureVariant`] if a fast
+/// `From<&PathTemplate>` mapping is needed.
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EndpointClass(&'static str);
+
+impl EndpointClass {
+    pub const UNKNOWN: Self = Self("unknown");
+
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        self.0
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Port traits — one per subdomain
+// ════════════════════════════════════════════════════════════════════
+
+/// Tenant-lifecycle telemetry — `provision_tenant` latency,
+/// realm-binding count, deprovision-missing-metadata trigger.
+pub trait TenantLifecycleMetricsPort: Send + Sync + 'static {
+    fn provision_tenant_duration(&self, realm_binding: RealmBinding, secs: f64);
+    fn realm_bound(&self, realm_binding: RealmBinding, realm_name: &str);
+    fn realm_unbound(&self, realm_binding: RealmBinding, realm_name: &str);
+    fn deprovision_missing_metadata(&self);
+}
+
+/// `outcome` label on `vp_idp_plugin_orphan_user_compensation_total`. Two
+/// terminal states for the best-effort `delete_user` compensation
+/// path; both fire from `UserFacade::provision_user_impl` when
+/// `add_user_to_group` fails after `create_user` already landed.
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrphanCompensationOutcome {
+    Ok,
+    Failed,
+}
+
+impl OrphanCompensationOutcome {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+/// User-op telemetry — `provision_user` / `deprovision_user` /
+/// `list_users` latency + orphan-user compensation counter.
+pub trait UserOpMetricsPort: Send + Sync + 'static {
+    fn user_op_duration(&self, op: UserOp, secs: f64);
+    /// Increment the orphan-compensation counter labelled by `outcome`.
+    /// Dashboards alert on `outcome=failed` — a KC user dangling
+    /// without tenant binding is the actionable failure mode that
+    /// justifies the compensation path's existence.
+    fn orphan_user_compensation(&self, outcome: OrphanCompensationOutcome);
+}
+
+/// KC Admin telemetry — single-call latency + token / credential
+/// refresh outcomes. **Reserved**: declared without live emitters in
+/// the plugin today so the follow-up PR wiring the KC HTTP layer does
+/// not need to reshape DI. Mirrors AM's posture for not-yet-wired
+/// ports (`MetadataMetricsPort`).
+pub trait KcAdminMetricsPort: Send + Sync + 'static {
+    fn kc_admin_request_duration(&self, endpoint_class: EndpointClass, secs: f64);
+    fn kc_admin_token_refresh(&self, outcome: TokenRefreshOutcome, tier: TokenTier, realm: &str);
+    fn credential_refresh(&self, outcome: TokenRefreshOutcome, tier: TokenTier, realm: &str);
+}
+
+/// `CredStore` (`OpenBao`) write telemetry.
+pub trait CredstoreMetricsPort: Send + Sync + 'static {
+    fn credstore_write(&self, op: CredstoreOp, outcome: CredstoreOutcome);
+}
+
+/// Tenant metadata-codec telemetry — malformed / unsupported-version
+/// blob counter.
+pub trait MetadataCodecMetricsPort: Send + Sync + 'static {
+    fn metadata_decode_failure(&self, version_observed: VersionObserved);
+}
+
+/// Cross-cutting failure telemetry — every plugin operation can fail
+/// and the `(op, failure_variant)` tuple is the stable dimension
+/// dashboards key on.
+pub trait FailureMetricsPort: Send + Sync + 'static {
+    fn failure(&self, op: PluginOp, variant: FailureVariant);
+}
+
+/// Service-principal op telemetry — create / `rotate_secret` / revoke / list latency.
+pub trait SpOpMetricsPort: Send + Sync + 'static {
+    fn sp_op_duration(&self, op: SpOp, secs: f64);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  No-op default implementation
+// ════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+#[path = "metrics_tests.rs"]
+mod tests;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/ports/metrics_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/ports/metrics_tests.rs
@@ -1,0 +1,270 @@
+use std::sync::Arc;
+
+use super::*;
+use crate::domain::error::{PluginError, failure_variant_label};
+use crate::domain::metadata_codec::DecodeError;
+use crate::domain::test_support::NoopMetrics;
+
+// ---- SpOp label pins ----
+
+#[test]
+fn sp_op_as_str_stable() {
+    assert_eq!(SpOp::Create.as_str(), "sp_create");
+    assert_eq!(SpOp::RotateSecret.as_str(), "sp_rotate_secret");
+    assert_eq!(SpOp::Revoke.as_str(), "sp_revoke");
+    assert_eq!(SpOp::List.as_str(), "sp_list");
+    assert_eq!(SpOp::Purge.as_str(), "sp_purge");
+}
+
+// ---- closed-set label enums round-trip the strings they advertise ----
+
+#[test]
+fn user_op_as_str_stable() {
+    assert_eq!(UserOp::ProvisionUser.as_str(), "provision_user");
+    assert_eq!(UserOp::DeprovisionUser.as_str(), "deprovision_user");
+    assert_eq!(UserOp::ListUsers.as_str(), "list_users");
+}
+
+#[test]
+fn token_tier_as_str_stable() {
+    assert_eq!(TokenTier::StaticEnv.as_str(), "static_env");
+    assert_eq!(TokenTier::OpenBao.as_str(), "openbao");
+}
+
+#[test]
+fn plugin_op_as_str_stable() {
+    assert_eq!(PluginOp::ProvisionTenant.as_str(), "provision_tenant");
+    assert_eq!(PluginOp::DeprovisionTenant.as_str(), "deprovision_tenant");
+    assert_eq!(PluginOp::ListUsers.as_str(), "list_users");
+    assert_eq!(PluginOp::SpCreate.as_str(), "sp_create");
+    assert_eq!(PluginOp::SpRotateSecret.as_str(), "sp_rotate_secret");
+    assert_eq!(PluginOp::SpRevoke.as_str(), "sp_revoke");
+    assert_eq!(PluginOp::SpList.as_str(), "sp_list");
+    assert_eq!(PluginOp::SpPurge.as_str(), "sp_purge");
+}
+
+#[test]
+fn credstore_op_outcome_as_str_stable() {
+    assert_eq!(CredstoreOp::Put.as_str(), "put");
+    assert_eq!(CredstoreOp::Delete.as_str(), "delete");
+    assert_eq!(CredstoreOutcome::Ok.as_str(), "ok");
+    assert_eq!(CredstoreOutcome::Error.as_str(), "error");
+}
+
+// ---- sealed newtypes mirror failure_variant_label exactly ----
+
+#[test]
+fn failure_variant_constants_match_failure_variant_label() {
+    // Every PluginError variant must produce the same string via both
+    // FailureVariant::from(&err) and failure_variant_label(&err) —
+    // pins the bridge to the source of truth.
+    let cases: &[(PluginError, &str)] = &[
+        (
+            PluginError::Config {
+                detail: String::new(),
+            },
+            "config",
+        ),
+        (
+            PluginError::CredStoreRead {
+                detail: String::new(),
+            },
+            "credstore_read",
+        ),
+        (
+            PluginError::MetadataDecode(DecodeError::MissingVersion),
+            "metadata_decode",
+        ),
+        (
+            PluginError::KcRest {
+                method: "GET",
+                path_template: String::new(),
+                status: crate::domain::error::KcStatusKind::Http(500),
+                body_first_2kb: String::new(),
+            },
+            "kc_rest",
+        ),
+        (
+            PluginError::AmbiguousCreated {
+                stage: crate::domain::error::AmbiguousStage::KcRealmCreate,
+                detail: String::new(),
+            },
+            "ambiguous_created",
+        ),
+        (
+            PluginError::CreatedRealmExists {
+                realm: String::new(),
+            },
+            "created_realm_exists",
+        ),
+        (
+            PluginError::BootstrapPermsMissing {
+                realm: String::new(),
+            },
+            "bootstrap_perms_missing",
+        ),
+        (
+            PluginError::DeprovisionNotFound {
+                realm_name: String::new(),
+            },
+            "deprovision_not_found",
+        ),
+        (
+            PluginError::DeprovisionRetryable {
+                detail: String::new(),
+            },
+            "deprovision_retryable",
+        ),
+        (
+            PluginError::DeprovisionTerminal {
+                detail: String::new(),
+            },
+            "deprovision_terminal",
+        ),
+        (
+            PluginError::UserOpRejected {
+                detail: String::new(),
+            },
+            "user_op_rejected",
+        ),
+        (
+            PluginError::UserOpUnavailable {
+                detail: String::new(),
+            },
+            "user_op_unavailable",
+        ),
+        (
+            PluginError::UserOpUnsupported {
+                detail: String::new(),
+            },
+            "user_op_unsupported",
+        ),
+        (
+            PluginError::SpInvalidInput {
+                detail: String::new(),
+                field: None,
+            },
+            "sp_invalid_input",
+        ),
+        (
+            PluginError::SpNotFound {
+                detail: String::new(),
+            },
+            "sp_not_found",
+        ),
+    ];
+    for (err, expected) in cases {
+        assert_eq!(FailureVariant::from(err).as_str(), *expected);
+        assert_eq!(failure_variant_label(err), *expected);
+    }
+}
+
+#[test]
+fn failure_variant_constants_match_their_literal() {
+    // Pin every `pub const` literal so a typo in one constant fails the
+    // test before it lands in the wire contract.
+    assert_eq!(FailureVariant::CONFIG.as_str(), "config");
+    assert_eq!(FailureVariant::CREDSTORE_READ.as_str(), "credstore_read");
+    assert_eq!(FailureVariant::METADATA_DECODE.as_str(), "metadata_decode");
+    assert_eq!(FailureVariant::KC_REST.as_str(), "kc_rest");
+    assert_eq!(
+        FailureVariant::AMBIGUOUS_CREATED.as_str(),
+        "ambiguous_created"
+    );
+    assert_eq!(
+        FailureVariant::CREATED_REALM_EXISTS.as_str(),
+        "created_realm_exists"
+    );
+    assert_eq!(
+        FailureVariant::BOOTSTRAP_PERMS_MISSING.as_str(),
+        "bootstrap_perms_missing"
+    );
+    assert_eq!(
+        FailureVariant::DEPROVISION_NOT_FOUND.as_str(),
+        "deprovision_not_found"
+    );
+    assert_eq!(
+        FailureVariant::DEPROVISION_RETRYABLE.as_str(),
+        "deprovision_retryable"
+    );
+    assert_eq!(
+        FailureVariant::DEPROVISION_TERMINAL.as_str(),
+        "deprovision_terminal"
+    );
+    assert_eq!(
+        FailureVariant::USER_OP_REJECTED.as_str(),
+        "user_op_rejected"
+    );
+    assert_eq!(
+        FailureVariant::USER_OP_UNAVAILABLE.as_str(),
+        "user_op_unavailable"
+    );
+    assert_eq!(
+        FailureVariant::USER_OP_UNSUPPORTED.as_str(),
+        "user_op_unsupported"
+    );
+    assert_eq!(
+        FailureVariant::SP_INVALID_INPUT.as_str(),
+        "sp_invalid_input"
+    );
+    assert_eq!(FailureVariant::SP_NOT_FOUND.as_str(), "sp_not_found");
+}
+
+#[test]
+fn version_observed_handles_all_decode_error_variants() {
+    assert_eq!(
+        VersionObserved::from(&DecodeError::MissingVersion).as_str(),
+        "missing",
+    );
+    assert_eq!(
+        VersionObserved::from(&DecodeError::Malformed { detail: "x".into() }).as_str(),
+        "malformed",
+    );
+    assert_eq!(
+        VersionObserved::from(&DecodeError::UnsupportedVersion {
+            observed: "v9".into()
+        })
+        .as_str(),
+        "v9",
+    );
+}
+
+#[test]
+fn version_observed_constants_match_their_literal() {
+    assert_eq!(VersionObserved::MISSING.as_str(), "missing");
+    assert_eq!(VersionObserved::MALFORMED.as_str(), "malformed");
+}
+
+#[test]
+fn endpoint_class_unknown_constant_is_constructable() {
+    assert_eq!(EndpointClass::UNKNOWN.as_str(), "unknown");
+}
+
+// ---- NoopMetrics implements every port ----
+
+#[test]
+fn noop_metrics_implements_every_port() {
+    let noop: Arc<NoopMetrics> = Arc::new(NoopMetrics);
+
+    let tenant: Arc<dyn TenantLifecycleMetricsPort> = Arc::clone(&noop) as _;
+    let user: Arc<dyn UserOpMetricsPort> = Arc::clone(&noop) as _;
+    let kc: Arc<dyn KcAdminMetricsPort> = Arc::clone(&noop) as _;
+    let credstore: Arc<dyn CredstoreMetricsPort> = Arc::clone(&noop) as _;
+    let metadata: Arc<dyn MetadataCodecMetricsPort> = Arc::clone(&noop) as _;
+    let failure: Arc<dyn FailureMetricsPort> = Arc::clone(&noop) as _;
+    let sp: Arc<dyn SpOpMetricsPort> = Arc::clone(&noop) as _;
+
+    // Smoke-call every method to confirm signatures match.
+    tenant.provision_tenant_duration(RealmBinding::Shared, 0.0);
+    tenant.realm_bound(RealmBinding::Shared, "r");
+    tenant.realm_unbound(RealmBinding::Shared, "r");
+    tenant.deprovision_missing_metadata();
+    user.user_op_duration(UserOp::ProvisionUser, 0.0);
+    kc.kc_admin_request_duration(EndpointClass::UNKNOWN, 0.0);
+    kc.kc_admin_token_refresh(TokenRefreshOutcome::Success, TokenTier::StaticEnv, "r");
+    kc.credential_refresh(TokenRefreshOutcome::Success, TokenTier::OpenBao, "r");
+    credstore.credstore_write(CredstoreOp::Put, CredstoreOutcome::Ok);
+    metadata.metadata_decode_failure(VersionObserved::MISSING);
+    failure.failure(PluginOp::ProvisionTenant, FailureVariant::CONFIG);
+    sp.sp_op_duration(SpOp::Create, 0.0);
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/service_principal_facade.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/service_principal_facade.rs
@@ -1,0 +1,1033 @@
+//! Service-principal facade — confidential `client_credentials` clients
+//! in the platform realm: create / rotate secret / revoke.
+//!
+//! Claims ride the realm-default client scope (usermodel-attribute
+//! mappers provisioned by realm bootstrap): the facade sets
+//! `tenant_id` + `user_type` attributes on the client's service-account
+//! user instead of installing per-client protocol mappers.
+
+use std::sync::Arc;
+
+use secrecy::SecretString;
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+use serde_json::{Value, json};
+use service_principal_sdk::{CreateServicePrincipalRequest, ServicePrincipalCredentials};
+use toolkit_macros::domain_model;
+use toolkit_security::SecurityContext;
+use uuid::Uuid;
+
+use crate::config::ServicePrincipalConfig;
+use crate::domain::error::{AmbiguousStage, KcStatusKind, PluginError, redact_secrets};
+use crate::domain::kc::client::KcAdminClient;
+use crate::domain::kc::factory::KeycloakAdminClientFactory;
+use crate::domain::kc::transport::truncate_2kb;
+use crate::domain::ports::metrics::{
+    FailureMetricsPort, FailureVariant, PluginOp, SpOp, SpOpMetricsPort,
+};
+use crate::domain::tenant_facade::{PROVISIONING_TENANT_ID_ATTR, ambiguous_from_kc_error};
+
+pub(crate) const SP_CLIENT_ID_PREFIX: &str = "svc";
+const NAME_MAX_LEN: usize = 40;
+const SA_TENANT_ID_ATTR: &str = "tenant_id";
+const SA_USER_TYPE_ATTR: &str = "user_type";
+
+/// `svc-<tenant_id>-<name>` — server-built, never caller-supplied.
+pub(crate) fn build_client_id(tenant_id: Uuid, name: &str) -> String {
+    format!("{SP_CLIENT_ID_PREFIX}-{tenant_id}-{name}")
+}
+
+/// Lowercase alnum + '-', 1..=40 chars.
+pub(crate) fn validate_name(name: &str) -> Result<(), PluginError> {
+    let ok = !name.is_empty()
+        && name.len() <= NAME_MAX_LEN
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-');
+    if ok {
+        Ok(())
+    } else {
+        Err(PluginError::SpInvalidInput {
+            detail: format!("name must be 1..={NAME_MAX_LEN} chars of [a-z0-9-], got '{name}'"),
+            field: Some("name".into()),
+        })
+    }
+}
+
+/// Percent-encode a single path/query component. Uses `url::form_urlencoded`
+/// (workspace-preferred over the standalone `urlencoding` crate). It encodes
+/// space as `+` rather than `%20`; harmless here since every input is a realm
+/// name or `svc-<uuid>-<name>` client id drawn from `[a-z0-9-]`.
+fn encode_component(s: &str) -> String {
+    url::form_urlencoded::byte_serialize(s.as_bytes()).collect()
+}
+
+/// Decode a Keycloak JSON response body, mapping a non-2xx status →
+/// [`PluginError::KcRest`] (truncated + redacted body) and a decode failure →
+/// [`PluginError::KcRest`] carrying the serde message. Shared by the read
+/// helpers (`resolve_scopes` / `list_owned_reps` / `lookup_client` / `sa_user`)
+/// so the non-2xx + decode shape cannot drift between them.
+fn kc_json<T: DeserializeOwned>(
+    method: &'static str,
+    path_template: &'static str,
+    status: u16,
+    body: &str,
+) -> Result<T, PluginError> {
+    if !(200..=299).contains(&status) {
+        return Err(PluginError::KcRest {
+            method,
+            path_template: path_template.into(),
+            status: KcStatusKind::Http(status),
+            body_first_2kb: redact_secrets(&truncate_2kb(body)),
+        });
+    }
+    serde_json::from_str(body).map_err(|e| PluginError::KcRest {
+        method,
+        path_template: path_template.into(),
+        status: KcStatusKind::Http(status),
+        body_first_2kb: format!("json decode: {e}"),
+    })
+}
+
+// Field subset of Keycloak's `ClientRepresentation`, decoded by `kc_json` above.
+#[allow(unknown_lints, de0101_no_serde_in_contract)]
+#[domain_model]
+#[derive(Deserialize)]
+struct SpClientRep {
+    id: Uuid,
+    #[serde(rename = "clientId", default)]
+    client_id: String,
+    #[serde(default)]
+    enabled: bool,
+    #[serde(rename = "defaultClientScopes", default)]
+    default_client_scopes: Vec<String>,
+    #[serde(default)]
+    attributes: Option<Value>,
+}
+
+// Field subset of Keycloak's `CredentialRepresentation`; same as `SpClientRep`.
+#[allow(unknown_lints, de0101_no_serde_in_contract)]
+#[domain_model]
+#[derive(Deserialize)]
+struct SecretRep {
+    value: String,
+}
+
+// Field subset of Keycloak's `ClientScopeRepresentation`; same as `SpClientRep`.
+#[allow(unknown_lints, de0101_no_serde_in_contract)]
+#[domain_model]
+#[derive(Deserialize)]
+struct ScopeRep {
+    id: Uuid,
+    name: String,
+}
+
+/// Return true when a KC attribute is exactly the expected scalar value.
+/// Keycloak may encode attributes either as `"value"` or `["value"]`; arrays
+/// with multiple values are rejected as corrupt managed state.
+fn attr_value_matches(attr: Option<&Value>, expected: &str) -> bool {
+    match attr {
+        Some(Value::String(s)) => s.as_str() == expected,
+        Some(Value::Array(items)) => {
+            items.len() == 1 && items.first().and_then(Value::as_str) == Some(expected)
+        }
+        _ => false,
+    }
+}
+
+/// Return `true` when `rep.attributes` carries the
+/// [`PROVISIONING_TENANT_ID_ATTR`] value matching `tenant_id`. Tolerates both
+/// scalar and singleton-array KC encodings, but rejects multi-valued markers.
+fn owner_matches(rep: &SpClientRep, tenant_id: Uuid) -> bool {
+    let Some(Value::Object(attrs)) = rep.attributes.as_ref() else {
+        return false;
+    };
+    let target = tenant_id.to_string();
+    attr_value_matches(attrs.get(PROVISIONING_TENANT_ID_ATTR), &target)
+}
+
+#[domain_model]
+pub struct ServicePrincipalFacade {
+    cfg: ServicePrincipalConfig,
+    kc_factory: Arc<KeycloakAdminClientFactory>,
+    sp_metrics: Arc<dyn SpOpMetricsPort>,
+    failure_metrics: Arc<dyn FailureMetricsPort>,
+}
+
+impl ServicePrincipalFacade {
+    /// Construct the facade over a Keycloak admin-client factory and the
+    /// segregated metric ports. Holds no per-call state; clone-cheap via the
+    /// `Arc`-shared factory and metric sinks.
+    pub fn new(
+        cfg: ServicePrincipalConfig,
+        kc_factory: Arc<KeycloakAdminClientFactory>,
+        sp_metrics: Arc<dyn SpOpMetricsPort>,
+        failure_metrics: Arc<dyn FailureMetricsPort>,
+    ) -> Self {
+        Self {
+            cfg,
+            kc_factory,
+            sp_metrics,
+            failure_metrics,
+        }
+    }
+
+    /// Emit op latency (success AND failure, mirroring `user_op_duration`)
+    /// plus the failure counter on errors.
+    fn emit_outcome<T>(
+        &self,
+        op: SpOp,
+        plugin_op: PluginOp,
+        elapsed: f64,
+        result: &Result<T, PluginError>,
+    ) {
+        self.sp_metrics.sp_op_duration(op, elapsed);
+        if let Err(e) = result {
+            self.failure_metrics
+                .failure(plugin_op, FailureVariant::from(e));
+        }
+    }
+
+    fn admin_base(&self) -> String {
+        format!(
+            "{}admin/realms/{}",
+            self.kc_factory.base_url_str(),
+            encode_component(&self.cfg.realm),
+        )
+    }
+
+    fn token_url(&self) -> String {
+        format!(
+            "{}realms/{}/protocol/openid-connect/token",
+            self.kc_factory.base_url_str(),
+            encode_component(&self.cfg.realm),
+        )
+    }
+
+    fn validate_scopes(&self, scopes: &[String]) -> Result<(), PluginError> {
+        for s in scopes {
+            if !self.cfg.scope_allowlist.iter().any(|a| a == s) {
+                return Err(PluginError::SpInvalidInput {
+                    detail: format!("scope '{s}' is not in the configured allowlist"),
+                    field: Some("scopes".into()),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Create a confidential `client_credentials` client owned by
+    /// `req.tenant_id`, returning its live credentials (secret included).
+    /// Times the operation and emits the op-latency + failure metrics around
+    /// [`Self::create_impl`]. See the SDK [`create`] contract for the
+    /// rejection / ambiguity semantics.
+    ///
+    /// [`create`]: service_principal_sdk::ServicePrincipalClientV1::create
+    pub async fn create_inner(
+        &self,
+        ctx: &SecurityContext,
+        req: &CreateServicePrincipalRequest,
+    ) -> Result<ServicePrincipalCredentials, PluginError> {
+        let started = std::time::Instant::now();
+        let result = self.create_impl(ctx, req).await;
+        let elapsed = started.elapsed().as_secs_f64();
+        self.emit_outcome(SpOp::Create, PluginOp::SpCreate, elapsed, &result);
+        result
+    }
+
+    async fn create_impl(
+        &self,
+        _ctx: &SecurityContext,
+        req: &CreateServicePrincipalRequest,
+    ) -> Result<ServicePrincipalCredentials, PluginError> {
+        validate_name(&req.name)?;
+        self.validate_scopes(&req.scopes)?;
+        let tenant_id = req.tenant_id.0;
+
+        // Pre-flight: resolve all scope names → uuids before any POST.
+        let resolved_scopes: Vec<(String, Uuid)> = if req.scopes.is_empty() {
+            vec![]
+        } else {
+            self.kc_factory
+                .with_reactive_401_bootstrap(|bootstrap| async move {
+                    self.resolve_scopes(&bootstrap, &req.scopes).await
+                })
+                .await?
+        };
+
+        self.enforce_quota(tenant_id).await?;
+        let client_id = build_client_id(tenant_id, &req.name);
+
+        self.kc_factory
+            .with_reactive_401_bootstrap(|bootstrap| {
+                let client_id = client_id.clone();
+                async move { self.post_client(&bootstrap, &client_id, tenant_id).await }
+            })
+            .await?;
+
+        // Mutation already happened — any escape below is Ambiguous. The
+        // wrap sits OUTSIDE the wrapper so a KcRest 401 from the lookup
+        // still reaches the reactive re-mint instead of being swallowed.
+        let client_uuid = self
+            .kc_factory
+            .with_reactive_401_bootstrap(|bootstrap| {
+                let client_id = client_id.clone();
+                async move { self.lookup_client(&bootstrap, &client_id).await }
+            })
+            .await
+            .map_err(|e| ambiguous_from_kc_error(AmbiguousStage::KcClientCreate, e))?
+            .ok_or_else(|| PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcClientCreate,
+                detail: format!(
+                    "kc:GET /admin/realms/{{realm}}/clients?clientId={client_id} -> 200: not found after create"
+                ),
+            })?
+            .id;
+
+        let subject_id = self
+            .kc_factory
+            .with_reactive_401_bootstrap(|bootstrap| {
+                let client_id = client_id.clone();
+                async move {
+                    self.bind_sa_attributes(&bootstrap, &client_id, client_uuid, tenant_id)
+                        .await
+                }
+            })
+            .await
+            .map_err(|e| ambiguous_from_kc_error(AmbiguousStage::KcSaAttrSet, e))?;
+
+        for (scope_name, scope_uuid) in &resolved_scopes {
+            let scope_name = scope_name.clone();
+            let scope_uuid = *scope_uuid;
+            self.kc_factory
+                .with_reactive_401_bootstrap(|bootstrap| {
+                    let client_id = client_id.clone();
+                    let scope_name = scope_name.clone();
+                    async move {
+                        self.attach_scope_by_uuid(
+                            &bootstrap,
+                            &client_id,
+                            client_uuid,
+                            scope_uuid,
+                            &scope_name,
+                        )
+                        .await
+                    }
+                })
+                .await
+                .map_err(|e| ambiguous_from_kc_error(AmbiguousStage::KcClientScopeAttach, e))?;
+        }
+
+        let secret = self
+            .kc_factory
+            .with_reactive_401_bootstrap(|bootstrap| {
+                let client_id = client_id.clone();
+                async move {
+                    self.read_secret(
+                        &bootstrap,
+                        &client_id,
+                        client_uuid,
+                        "GET",
+                        AmbiguousStage::KcClientSecretRead,
+                    )
+                    .await
+                }
+            })
+            .await
+            .map_err(|e| ambiguous_from_kc_error(AmbiguousStage::KcClientSecretRead, e))?;
+
+        Ok(ServicePrincipalCredentials {
+            client_id,
+            client_secret: SecretString::from(secret),
+            token_url: self.token_url(),
+            subject_id,
+        })
+    }
+
+    /// Resolve requested scope names → (name, uuid) pairs in one list fetch.
+    /// Absent scope → `PluginError::Config` (pre-flight, no POST has happened).
+    async fn resolve_scopes(
+        &self,
+        bootstrap: &KcAdminClient,
+        scope_names: &[String],
+    ) -> Result<Vec<(String, Uuid)>, PluginError> {
+        let path_template = "/admin/realms/{realm}/client-scopes";
+        let list_url = format!("{}/client-scopes", self.admin_base());
+        let (status, body) = bootstrap
+            .raw_request("GET", &list_url, None, path_template)
+            .await?;
+        let scopes: Vec<ScopeRep> = kc_json("GET", path_template, status, &body)?;
+        let mut resolved = Vec::with_capacity(scope_names.len());
+        for name in scope_names {
+            let uuid = scopes
+                .iter()
+                .find(|s| &s.name == name)
+                .map(|s| s.id)
+                .ok_or_else(|| PluginError::Config {
+                    detail: format!(
+                        "client scope '{name}' is allowlisted but absent in realm \
+                         '{}' — provision it via realm bootstrap",
+                        self.cfg.realm,
+                    ),
+                })?;
+            resolved.push((name.clone(), uuid));
+        }
+        Ok(resolved)
+    }
+
+    /// Prefix query + ownership filter — the tenant's owned SP clients.
+    /// Shared by quota / list / purge so the filter cannot drift.
+    async fn list_owned_reps(&self, tenant_id: Uuid) -> Result<Vec<SpClientRep>, PluginError> {
+        let prefix = format!("{SP_CLIENT_ID_PREFIX}-{tenant_id}-");
+        // `search=true` is KC's INFIX match, not exact-prefix — it widens the
+        // result set rather than narrowing it. Ownership is enforced
+        // client-side below via `starts_with(prefix)` + `owner_matches`.
+        let url = format!(
+            "{}/clients?clientId={}&search=true",
+            self.admin_base(),
+            encode_component(&prefix),
+        );
+        let reps: Vec<SpClientRep> = self
+            .kc_factory
+            .with_reactive_401_bootstrap(|bootstrap| {
+                let url = url.clone();
+                async move {
+                    let (status, body) = bootstrap
+                        .raw_request("GET", &url, None, "/admin/realms/{realm}/clients")
+                        .await?;
+                    kc_json("GET", "/admin/realms/{realm}/clients", status, &body)
+                }
+            })
+            .await?;
+        Ok(reps
+            .into_iter()
+            .filter(|r| r.client_id.starts_with(&prefix) && owner_matches(r, tenant_id))
+            .collect())
+    }
+
+    /// Count `svc-<tenant>-` clients; reject at the configured quota.
+    /// Best-effort cap: no cross-replica serialization, concurrent
+    /// creates may briefly overshoot.
+    async fn enforce_quota(&self, tenant_id: Uuid) -> Result<(), PluginError> {
+        let count = self.list_owned_reps(tenant_id).await?.len();
+        if count >= self.cfg.per_tenant_quota as usize {
+            return Err(PluginError::SpInvalidInput {
+                detail: format!(
+                    "tenant {tenant_id} already has {count} service principals (quota {})",
+                    self.cfg.per_tenant_quota,
+                ),
+                field: Some("tenant_id".into()),
+            });
+        }
+        Ok(())
+    }
+
+    /// POST the confidential client_credentials-only client.
+    ///
+    /// 409 → `SpInvalidInput` (strict reject, regardless of owner): a
+    /// name collision must not resume another consumer's principal —
+    /// that would hand out its live secret and graft scopes onto it.
+    /// Recovery from an Ambiguous half-create is revoke → create.
+    ///
+    /// Other non-2xx after a sent request → `AmbiguousCreated`.
+    async fn post_client(
+        &self,
+        bootstrap: &KcAdminClient,
+        client_id: &str,
+        tenant_id: Uuid,
+    ) -> Result<(), PluginError> {
+        let url = format!("{}/clients", self.admin_base());
+        let payload = json!({
+            "clientId": client_id,
+            "protocol": "openid-connect",
+            "publicClient": false,
+            "serviceAccountsEnabled": true,
+            "standardFlowEnabled": false,
+            "directAccessGrantsEnabled": false,
+            "implicitFlowEnabled": false,
+            "authorizationServicesEnabled": false,
+            "clientAuthenticatorType": "client-secret",
+            "attributes": { PROVISIONING_TENANT_ID_ATTR: tenant_id.to_string() },
+        });
+        let (status, body) = bootstrap
+            .raw_request(
+                "POST",
+                &url,
+                Some(&payload),
+                "/admin/realms/{realm}/clients",
+            )
+            .await
+            .map_err(|e| ambiguous_from_kc_error(AmbiguousStage::KcClientCreate, e))?;
+        match status {
+            200..=299 => Ok(()),
+            // Without this carve-out the wrapper would never see a 401 —
+            // the POST has not mutated KC state when auth is rejected.
+            401 => Err(PluginError::KcRest {
+                method: "POST",
+                path_template: "/admin/realms/{realm}/clients".into(),
+                status: KcStatusKind::Http(401),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body)),
+            }),
+            // 409 retained no new state either — the id was taken before
+            // this request. Permanent reject per the SDK contract.
+            409 => Err(PluginError::SpInvalidInput {
+                detail: format!("client '{client_id}' already exists"),
+                field: Some("name".into()),
+            }),
+            _ => Err(PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcClientCreate,
+                detail: format!(
+                    "kc:POST /admin/realms/{{realm}}/clients -> {status}: {}",
+                    redact_secrets(&truncate_2kb(&body))
+                ),
+            }),
+        }
+    }
+
+    /// `GET /clients?clientId=` exact lookup → `Some(rep)` | `None`.
+    ///
+    /// Errors are `KcRest`-shaped (transport errors pass through unchanged;
+    /// non-2xx and decode failures become `KcRest`). Pre-mutation callers
+    /// can leave errors unwrapped; post-mutation callers wrap with
+    /// `ambiguous_from_kc_error` at the call site.
+    async fn lookup_client(
+        &self,
+        bootstrap: &KcAdminClient,
+        client_id: &str,
+    ) -> Result<Option<SpClientRep>, PluginError> {
+        let url = format!(
+            "{}/clients?clientId={}",
+            self.admin_base(),
+            encode_component(client_id),
+        );
+        let (status, body) = bootstrap
+            .raw_request("GET", &url, None, "/admin/realms/{realm}/clients")
+            .await?;
+        let mut reps: Vec<SpClientRep> =
+            kc_json("GET", "/admin/realms/{realm}/clients", status, &body)?;
+        Ok(if reps.is_empty() {
+            None
+        } else {
+            Some(reps.remove(0))
+        })
+    }
+
+    /// GET-modify-PUT the SA user's attributes: `tenant_id` + `user_type`.
+    /// Returns the SA user's UUID — the principal's subject id.
+    async fn bind_sa_attributes(
+        &self,
+        bootstrap: &KcAdminClient,
+        client_id: &str,
+        client_uuid: Uuid,
+        tenant_id: Uuid,
+    ) -> Result<Uuid, PluginError> {
+        let sa_url = format!(
+            "{}/clients/{client_uuid}/service-account-user",
+            self.admin_base()
+        );
+        let (status, body) = bootstrap
+            .raw_request(
+                "GET",
+                &sa_url,
+                None,
+                "/admin/realms/{realm}/clients/{uuid}/service-account-user",
+            )
+            .await
+            .map_err(|e| ambiguous_from_kc_error(AmbiguousStage::KcSaAttrSet, e))?;
+        // Without this carve-out the wrapper would never see a 401.
+        if status == 401 {
+            return Err(PluginError::KcRest {
+                method: "GET",
+                path_template: "/admin/realms/{realm}/clients/{uuid}/service-account-user".into(),
+                status: KcStatusKind::Http(401),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body)),
+            });
+        }
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcSaAttrSet,
+                detail: format!(
+                    "client '{client_id}': kc:GET /admin/realms/{{realm}}/clients/{{uuid}}/service-account-user -> {status}: {}",
+                    redact_secrets(&truncate_2kb(&body))
+                ),
+            });
+        }
+        let mut user: Value =
+            serde_json::from_str(&body).map_err(|e| PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcSaAttrSet,
+                detail: format!(
+                    "client '{client_id}': kc:GET /admin/realms/{{realm}}/clients/{{uuid}}/service-account-user json decode: {e}"
+                ),
+            })?;
+        let user_id: Uuid = user["id"]
+            .as_str()
+            .and_then(|s| s.parse().ok())
+            .ok_or_else(|| PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcSaAttrSet,
+                detail: format!("client '{client_id}': service-account-user without parsable id"),
+            })?;
+
+        // Defensive attributes mutation — mirror bind_admin_user_to_tenant.
+        let user_obj = user
+            .as_object_mut()
+            .ok_or_else(|| PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcSaAttrSet,
+                detail: format!("client '{client_id}': user representation is not a JSON object"),
+            })?;
+        let attrs = user_obj
+            .entry("attributes".to_string())
+            .or_insert_with(|| json!({}));
+        let attrs_obj = attrs
+            .as_object_mut()
+            .ok_or_else(|| PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcSaAttrSet,
+                detail: format!("client '{client_id}': user.attributes is not a JSON object"),
+            })?;
+        // Hijack guard — mirror bind_admin_user_to_tenant: refuse to
+        // overwrite a foreign or multi-valued tenant_id (hand-edited or
+        // inconsistent KC state). Idempotent re-bind of this tenant passes.
+        if let Some(existing) = attrs_obj.get(SA_TENANT_ID_ATTR) {
+            let target = tenant_id.to_string();
+            let idempotent = attr_value_matches(Some(existing), &target);
+            if !idempotent {
+                return Err(PluginError::AmbiguousCreated {
+                    stage: AmbiguousStage::KcSaAttrSet,
+                    detail: format!(
+                        "client '{client_id}': SA user {user_id} already carries attributes.tenant_id = {existing}; refusing to overwrite"
+                    ),
+                });
+            }
+        }
+
+        attrs_obj.insert(
+            SA_TENANT_ID_ATTR.to_string(),
+            json!([tenant_id.to_string()]),
+        );
+        attrs_obj.insert(
+            SA_USER_TYPE_ATTR.to_string(),
+            json!([self.cfg.subject_type]),
+        );
+
+        let put_url = format!("{}/users/{user_id}", self.admin_base());
+        let (status, body) = bootstrap
+            .raw_request(
+                "PUT",
+                &put_url,
+                Some(&user),
+                "/admin/realms/{realm}/users/{id}",
+            )
+            .await
+            .map_err(|e| ambiguous_from_kc_error(AmbiguousStage::KcSaAttrSet, e))?;
+        // Without this carve-out the wrapper would never see a 401.
+        if status == 401 {
+            return Err(PluginError::KcRest {
+                method: "PUT",
+                path_template: "/admin/realms/{realm}/users/{id}".into(),
+                status: KcStatusKind::Http(401),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body)),
+            });
+        }
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcSaAttrSet,
+                detail: format!(
+                    "client '{client_id}': kc:PUT /admin/realms/{{realm}}/users/{{id}} -> {status}: {}",
+                    redact_secrets(&truncate_2kb(&body))
+                ),
+            });
+        }
+        Ok(user_id)
+    }
+
+    /// Attach a pre-resolved scope uuid as a client default scope.
+    async fn attach_scope_by_uuid(
+        &self,
+        bootstrap: &KcAdminClient,
+        client_id: &str,
+        client_uuid: Uuid,
+        scope_uuid: Uuid,
+        scope_name: &str,
+    ) -> Result<(), PluginError> {
+        let put_url = format!(
+            "{}/clients/{client_uuid}/default-client-scopes/{scope_uuid}",
+            self.admin_base(),
+        );
+        let (status, body) = bootstrap
+            .raw_request(
+                "PUT",
+                &put_url,
+                None,
+                "/admin/realms/{realm}/clients/{uuid}/default-client-scopes/{scope}",
+            )
+            .await
+            .map_err(|e| ambiguous_from_kc_error(AmbiguousStage::KcClientScopeAttach, e))?;
+        // Without this carve-out the wrapper would never see a 401.
+        if status == 401 {
+            return Err(PluginError::KcRest {
+                method: "PUT",
+                path_template: "/admin/realms/{realm}/clients/{uuid}/default-client-scopes/{scope}"
+                    .into(),
+                status: KcStatusKind::Http(401),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body)),
+            });
+        }
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcClientScopeAttach,
+                detail: format!(
+                    "client '{client_id}': kc:PUT /admin/realms/{{realm}}/clients/{{uuid}}/default-client-scopes/{scope_name} -> {status}: {}",
+                    redact_secrets(&truncate_2kb(&body))
+                ),
+            });
+        }
+        Ok(())
+    }
+
+    /// `GET` or `POST` `.../clients/{uuid}/client-secret` → plaintext secret value.
+    ///
+    /// Pass `method = "GET"` for initial secret read, `method = "POST"` for rotation.
+    /// 404/410 on POST map to `SpNotFound` (lookup→rotate deletion race).
+    /// Non-2xx on GET maps to `AmbiguousCreated` (post-mutation read).
+    async fn read_secret(
+        &self,
+        bootstrap: &KcAdminClient,
+        client_id: &str,
+        client_uuid: Uuid,
+        method: &'static str,
+        stage: AmbiguousStage,
+    ) -> Result<String, PluginError> {
+        let path_template = "/admin/realms/{realm}/clients/{uuid}/client-secret";
+        let url = format!("{}/clients/{client_uuid}/client-secret", self.admin_base());
+        let (status, body) = bootstrap
+            .raw_request(method, &url, None, path_template)
+            .await
+            .map_err(|e| ambiguous_from_kc_error(stage, e))?;
+        // Without this carve-out the wrapper would never see a 401.
+        if status == 401 {
+            return Err(PluginError::KcRest {
+                method,
+                path_template: path_template.into(),
+                status: KcStatusKind::Http(401),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body)),
+            });
+        }
+        if method == "POST" && matches!(status, 404 | 410) {
+            return Err(PluginError::SpNotFound {
+                detail: format!("client '{client_id}' already absent (kc {status})"),
+            });
+        }
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::AmbiguousCreated {
+                stage,
+                detail: format!(
+                    "client '{client_id}': kc:{method} /admin/realms/{{realm}}/clients/{{uuid}}/client-secret -> {status}: {}",
+                    redact_secrets(&truncate_2kb(&body))
+                ),
+            });
+        }
+        let rep: SecretRep =
+            serde_json::from_str(&body).map_err(|e| PluginError::AmbiguousCreated {
+                stage,
+                detail: format!(
+                    "client '{client_id}': kc:{method} /admin/realms/{{realm}}/clients/{{uuid}}/client-secret json decode: {e}"
+                ),
+            })?;
+        Ok(rep.value)
+    }
+
+    /// Exact ownership-checked lookup. Absent or foreign → `SpNotFound`.
+    async fn lookup_owned_client(
+        &self,
+        tenant_id: Uuid,
+        client_id: &str,
+    ) -> Result<Uuid, PluginError> {
+        let rep = self
+            .kc_factory
+            .with_reactive_401_bootstrap(|bootstrap| {
+                let client_id = client_id.to_owned();
+                async move { self.lookup_client(&bootstrap, &client_id).await }
+            })
+            .await?;
+        let expected_prefix = format!("{SP_CLIENT_ID_PREFIX}-{tenant_id}-");
+        match rep {
+            Some(r)
+                if r.client_id.starts_with(&expected_prefix) && owner_matches(&r, tenant_id) =>
+            {
+                Ok(r.id)
+            }
+            _ => Err(PluginError::SpNotFound {
+                detail: format!("service principal '{client_id}' not found for tenant {tenant_id}"),
+            }),
+        }
+    }
+
+    /// `GET .../clients/{uuid}/service-account-user` → (SA user UUID,
+    /// managed-attrs-bound flag). 404/410 → `SpNotFound` (lookup→read
+    /// deletion race — mirrors the secret-POST / revoke mapping).
+    async fn sa_user(
+        &self,
+        bootstrap: &KcAdminClient,
+        client_uuid: Uuid,
+        tenant_id: Uuid,
+    ) -> Result<(Uuid, bool), PluginError> {
+        let path_template = "/admin/realms/{realm}/clients/{uuid}/service-account-user";
+        let url = format!(
+            "{}/clients/{client_uuid}/service-account-user",
+            self.admin_base()
+        );
+        let (status, body) = bootstrap
+            .raw_request("GET", &url, None, path_template)
+            .await?;
+        if matches!(status, 404 | 410) {
+            return Err(PluginError::SpNotFound {
+                detail: format!(
+                    "service-account user for client {client_uuid} absent (kc {status})"
+                ),
+            });
+        }
+        let user: Value = kc_json("GET", path_template, status, &body)?;
+        let user_id = user["id"]
+            .as_str()
+            .and_then(|s| s.parse().ok())
+            .ok_or_else(|| PluginError::KcRest {
+                method: "GET",
+                path_template: path_template.into(),
+                status: KcStatusKind::Http(status),
+                body_first_2kb: "service-account-user missing parsable id".into(),
+            })?;
+        let attrs_bound = user
+            .get("attributes")
+            .and_then(Value::as_object)
+            .is_some_and(|attrs| {
+                let tenant_id = tenant_id.to_string();
+                attr_value_matches(attrs.get(SA_TENANT_ID_ATTR), &tenant_id)
+                    && attr_value_matches(
+                        attrs.get(SA_USER_TYPE_ATTR),
+                        self.cfg.subject_type.as_str(),
+                    )
+            });
+        Ok((user_id, attrs_bound))
+    }
+
+    /// Regenerate the principal's secret (the old one stops working) and
+    /// return fresh credentials. Times the operation and emits op-latency +
+    /// failure metrics around [`Self::rotate_secret_impl`]. An incomplete /
+    /// corrupt principal is rejected with `SpInvalidInput` (recover via
+    /// revoke + create) rather than handing back a secret for a half-repaired
+    /// client.
+    pub async fn rotate_secret_inner(
+        &self,
+        ctx: &SecurityContext,
+        tenant_id: Uuid,
+        client_id: &str,
+    ) -> Result<ServicePrincipalCredentials, PluginError> {
+        let started = std::time::Instant::now();
+        let result = self.rotate_secret_impl(ctx, tenant_id, client_id).await;
+        let elapsed = started.elapsed().as_secs_f64();
+        self.emit_outcome(
+            SpOp::RotateSecret,
+            PluginOp::SpRotateSecret,
+            elapsed,
+            &result,
+        );
+        result
+    }
+
+    async fn rotate_secret_impl(
+        &self,
+        _ctx: &SecurityContext,
+        tenant_id: Uuid,
+        client_id: &str,
+    ) -> Result<ServicePrincipalCredentials, PluginError> {
+        let client_uuid = self.lookup_owned_client(tenant_id, client_id).await?;
+
+        // Fetch subject_id BEFORE the secret POST — pure read, pre-mutation.
+        let (subject_id, attrs_bound) = self
+            .kc_factory
+            .with_reactive_401_bootstrap(|bootstrap| async move {
+                self.sa_user(&bootstrap, client_uuid, tenant_id).await
+            })
+            .await?;
+
+        // Half-created or corrupt principal. Rotate cannot reconstruct the
+        // originally requested client scopes, so returning a fresh secret would
+        // make the caller persist credentials for a partially repaired client.
+        // Keep the documented recovery path explicit: revoke, then create.
+        if !attrs_bound {
+            return Err(PluginError::SpInvalidInput {
+                detail: format!(
+                    "service principal '{client_id}' is incomplete or has corrupt managed attributes; recover with revoke + create"
+                ),
+                field: Some("client_id".into()),
+            });
+        }
+
+        let secret = self
+            .kc_factory
+            .with_reactive_401_bootstrap(|bootstrap| {
+                let client_id = client_id.to_owned();
+                async move {
+                    self.read_secret(
+                        &bootstrap,
+                        &client_id,
+                        client_uuid,
+                        "POST",
+                        AmbiguousStage::KcClientSecretRotate,
+                    )
+                    .await
+                }
+            })
+            .await?;
+
+        Ok(ServicePrincipalCredentials {
+            client_id: client_id.to_owned(),
+            client_secret: SecretString::from(secret),
+            token_url: self.token_url(),
+            subject_id,
+        })
+    }
+
+    /// Delete the principal's client. Times the operation and emits the
+    /// op-latency + failure metrics around [`Self::revoke_impl`]. A repeat
+    /// revoke yields `SpNotFound`, which the SDK boundary treats as
+    /// success-equivalent.
+    pub async fn revoke_inner(
+        &self,
+        ctx: &SecurityContext,
+        tenant_id: Uuid,
+        client_id: &str,
+    ) -> Result<(), PluginError> {
+        let started = std::time::Instant::now();
+        let result = self.revoke_impl(ctx, tenant_id, client_id).await;
+        let elapsed = started.elapsed().as_secs_f64();
+        self.emit_outcome(SpOp::Revoke, PluginOp::SpRevoke, elapsed, &result);
+        result
+    }
+
+    async fn revoke_impl(
+        &self,
+        _ctx: &SecurityContext,
+        tenant_id: Uuid,
+        client_id: &str,
+    ) -> Result<(), PluginError> {
+        let client_uuid = self.lookup_owned_client(tenant_id, client_id).await?;
+        self.delete_client_by_uuid(client_id, client_uuid).await
+    }
+
+    /// DELETE `.../clients/{uuid}`; 404/410 → `SpNotFound`.
+    async fn delete_client_by_uuid(
+        &self,
+        client_id: &str,
+        client_uuid: Uuid,
+    ) -> Result<(), PluginError> {
+        self.kc_factory
+            .with_reactive_401_bootstrap(|bootstrap| {
+                let client_id = client_id.to_owned();
+                async move {
+                    let url = format!("{}/clients/{client_uuid}", self.admin_base());
+                    let (status, body) = bootstrap
+                        .raw_request(
+                            "DELETE",
+                            &url,
+                            None,
+                            "/admin/realms/{realm}/clients/{uuid}",
+                        )
+                        .await
+                        .map_err(|e| {
+                            ambiguous_from_kc_error(AmbiguousStage::KcClientDelete, e)
+                        })?;
+                    // Without this carve-out the wrapper would never see a 401.
+                    if status == 401 {
+                        return Err(PluginError::KcRest {
+                            method: "DELETE",
+                            path_template: "/admin/realms/{realm}/clients/{uuid}".into(),
+                            status: KcStatusKind::Http(401),
+                            body_first_2kb: redact_secrets(&truncate_2kb(&body)),
+                        });
+                    }
+                    match status {
+                        200..=299 => Ok(()),
+                        404 | 410 => Err(PluginError::SpNotFound {
+                            detail: format!(
+                                "client '{client_id}' already absent (kc {status})"
+                            ),
+                        }),
+                        400..=499 if status != 429 => Err(PluginError::KcRest {
+                            method: "DELETE",
+                            path_template: "/admin/realms/{realm}/clients/{uuid}".into(),
+                            status: KcStatusKind::Http(status),
+                            body_first_2kb: redact_secrets(&truncate_2kb(&body)),
+                        }),
+                        _ => Err(PluginError::AmbiguousCreated {
+                            stage: AmbiguousStage::KcClientDelete,
+                            detail: format!(
+                                "client '{client_id}': kc:DELETE /admin/realms/{{realm}}/clients/{{uuid}} -> {status}: {}",
+                                redact_secrets(&truncate_2kb(&body))
+                            ),
+                        }),
+                    }
+                }
+            })
+            .await
+    }
+
+    /// List the tenant's owned service principals (no secrets). Times the
+    /// operation and emits op-latency + failure metrics around
+    /// [`Self::list_impl`].
+    pub async fn list_inner(
+        &self,
+        ctx: &SecurityContext,
+        tenant_id: Uuid,
+    ) -> Result<Vec<service_principal_sdk::ServicePrincipalSummary>, PluginError> {
+        let started = std::time::Instant::now();
+        let result = self.list_impl(ctx, tenant_id).await;
+        let elapsed = started.elapsed().as_secs_f64();
+        self.emit_outcome(SpOp::List, PluginOp::SpList, elapsed, &result);
+        result
+    }
+
+    async fn list_impl(
+        &self,
+        _ctx: &SecurityContext,
+        tenant_id: Uuid,
+    ) -> Result<Vec<service_principal_sdk::ServicePrincipalSummary>, PluginError> {
+        Ok(self
+            .list_owned_reps(tenant_id)
+            .await?
+            .into_iter()
+            .map(|r| service_principal_sdk::ServicePrincipalSummary {
+                client_id: r.client_id,
+                enabled: r.enabled,
+                scopes: r.default_client_scopes,
+            })
+            .collect())
+    }
+
+    /// Tenant-deprovision cascade: delete every owned SP client so no
+    /// live `client_credentials` credential survives its tenant.
+    /// Concurrent-delete 404s are tolerated; other failures propagate so
+    /// the deprovision caller retries.
+    pub async fn purge_tenant_principals(&self, tenant_id: Uuid) -> Result<usize, PluginError> {
+        let started = std::time::Instant::now();
+        let result = self.purge_tenant_principals_impl(tenant_id).await;
+        let elapsed = started.elapsed().as_secs_f64();
+        self.emit_outcome(SpOp::Purge, PluginOp::SpPurge, elapsed, &result);
+        result
+    }
+
+    async fn purge_tenant_principals_impl(&self, tenant_id: Uuid) -> Result<usize, PluginError> {
+        let mut deleted_count = 0usize;
+        for rep in self.list_owned_reps(tenant_id).await? {
+            match self.delete_client_by_uuid(&rep.client_id, rep.id).await {
+                Ok(()) => deleted_count += 1,
+                Err(PluginError::SpNotFound { .. }) => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(deleted_count)
+    }
+}
+
+#[cfg(test)]
+#[path = "service_principal_facade_tests.rs"]
+mod service_principal_facade_tests;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/service_principal_facade_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/service_principal_facade_tests.rs
@@ -1,0 +1,1482 @@
+use std::sync::{Arc, Mutex};
+
+use secrecy::ExposeSecret as _;
+use serde_json::json;
+use service_principal_sdk::{CreateServicePrincipalRequest, TenantId};
+use uuid::Uuid;
+use wiremock::matchers::{body_partial_json, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use crate::config::ServicePrincipalConfig;
+use crate::domain::credstore::CredStoreReader;
+use crate::domain::error::{AmbiguousStage, PluginError};
+use crate::domain::kc::factory::KeycloakAdminClientFactory;
+use crate::domain::kc::transport::KcTransport;
+use crate::domain::ports::metrics::{
+    FailureMetricsPort, FailureVariant, PluginOp, SpOp, SpOpMetricsPort,
+};
+use crate::domain::service_principal_facade::{
+    ServicePrincipalFacade, build_client_id, validate_name,
+};
+use crate::domain::system_actor::build_system_ctx;
+use crate::domain::test_support::{
+    StubCredStore, keycloak_cfg, noop_failure_metrics, noop_sp_metrics,
+};
+use crate::infra::kc_http::ReqwestKcTransport;
+
+// -----------------------------------------------------------------------
+// Recording metric stubs for emission tests
+// -----------------------------------------------------------------------
+
+struct RecordingSpMetrics {
+    calls: Mutex<Vec<(SpOp, f64)>>,
+}
+
+impl RecordingSpMetrics {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            calls: Mutex::new(vec![]),
+        })
+    }
+
+    fn recorded(&self) -> Vec<(SpOp, f64)> {
+        self.calls.lock().expect("lock").clone()
+    }
+}
+
+impl SpOpMetricsPort for RecordingSpMetrics {
+    fn sp_op_duration(&self, op: SpOp, secs: f64) {
+        self.calls.lock().expect("lock").push((op, secs));
+    }
+}
+
+struct RecordingFailureMetrics {
+    calls: Mutex<Vec<(PluginOp, String)>>,
+}
+
+impl RecordingFailureMetrics {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            calls: Mutex::new(vec![]),
+        })
+    }
+
+    fn recorded(&self) -> Vec<(PluginOp, String)> {
+        self.calls.lock().expect("lock").clone()
+    }
+}
+
+impl FailureMetricsPort for RecordingFailureMetrics {
+    fn failure(&self, op: PluginOp, variant: FailureVariant) {
+        self.calls
+            .lock()
+            .expect("lock")
+            .push((op, variant.as_str().to_owned()));
+    }
+}
+
+fn build_facade_with_metrics(
+    server: &MockServer,
+    cfg: ServicePrincipalConfig,
+    sp_metrics: Arc<dyn SpOpMetricsPort>,
+    failure_metrics: Arc<dyn FailureMetricsPort>,
+) -> ServicePrincipalFacade {
+    let kc_cfg = keycloak_cfg(&server.uri());
+    let cs_reader = CredStoreReader::new(Arc::new(StubCredStore), build_system_ctx(Uuid::nil()));
+    let transport: Arc<dyn KcTransport> = Arc::new(ReqwestKcTransport::new(reqwest::Client::new()));
+    let factory = Arc::new(KeycloakAdminClientFactory::new(
+        kc_cfg,
+        transport,
+        cs_reader,
+        Arc::new(crate::domain::test_support::NoopMetrics),
+    ));
+    ServicePrincipalFacade::new(cfg, factory, sp_metrics, failure_metrics)
+}
+
+// -----------------------------------------------------------------------
+// Pure-helper tests (Step 1)
+// -----------------------------------------------------------------------
+
+#[test]
+fn client_id_is_namespaced_by_tenant() {
+    let t = Uuid::nil();
+    assert_eq!(build_client_id(t, "metrics"), format!("svc-{t}-metrics"));
+}
+
+#[test]
+fn name_validation_rejects_bad_input() {
+    for bad in ["", "UPPER", "with space", "dot.ted", &"x".repeat(41)] {
+        let err = validate_name(bad).expect_err("must reject");
+        assert!(
+            matches!(err, PluginError::SpInvalidInput { field: Some(ref f), .. } if f == "name")
+        );
+    }
+    assert!(validate_name("metrics-push-1").is_ok());
+}
+
+// -----------------------------------------------------------------------
+// Wiremock integration tests (Step 5)
+// -----------------------------------------------------------------------
+
+const CLIENT_UUID: &str = "11111111-1111-1111-1111-111111111111";
+const SA_USER_UUID: &str = "22222222-2222-2222-2222-222222222222";
+const SCOPE_UUID: &str = "33333333-3333-3333-3333-333333333333";
+
+fn sp_cfg() -> ServicePrincipalConfig {
+    ServicePrincipalConfig {
+        scope_allowlist: vec!["mon:metrics:write".into()],
+        ..Default::default()
+    }
+}
+
+fn build_facade(server: &MockServer, cfg: ServicePrincipalConfig) -> ServicePrincipalFacade {
+    let kc_cfg = keycloak_cfg(&server.uri());
+    let cs_reader = CredStoreReader::new(Arc::new(StubCredStore), build_system_ctx(Uuid::nil()));
+    let transport: Arc<dyn KcTransport> = Arc::new(ReqwestKcTransport::new(reqwest::Client::new()));
+    let factory = Arc::new(KeycloakAdminClientFactory::new(
+        kc_cfg,
+        transport,
+        cs_reader,
+        Arc::new(crate::domain::test_support::NoopMetrics),
+    ));
+    ServicePrincipalFacade::new(cfg, factory, noop_sp_metrics(), noop_failure_metrics())
+}
+
+async fn mount_bootstrap_token(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/realms/master/protocol/openid-connect/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "t-master",
+            "expires_in": 600
+        })))
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn create_provisions_client_sa_attrs_scope_and_returns_secret() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+    let client_id = format!("svc-{tenant}-metrics");
+
+    // quota lookup (search=true) → empty
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("search", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&server)
+        .await;
+
+    // scopes list (pre-flight, before POST)
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/client-scopes"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(json!([{"id": SCOPE_UUID, "name": "mon:metrics:write"}])),
+        )
+        .mount(&server)
+        .await;
+
+    // create → 201; assert full confidential SA-only shape + ownership attr
+    Mock::given(method("POST"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(body_partial_json(json!({
+            "clientId": client_id,
+            "publicClient": false,
+            "serviceAccountsEnabled": true,
+            "standardFlowEnabled": false,
+            "directAccessGrantsEnabled": false,
+            "implicitFlowEnabled": false,
+            "authorizationServicesEnabled": false,
+            "clientAuthenticatorType": "client-secret",
+            "attributes": { "vhp.provisioning.tenant_id": tenant.to_string() },
+        })))
+        .respond_with(ResponseTemplate::new(201))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // exact lookup → rep
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("clientId", client_id.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([{"id": CLIENT_UUID}])))
+        .mount(&server)
+        .await;
+
+    // SA user fetch
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/admin/realms/platform/clients/{CLIENT_UUID}/service-account-user"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": SA_USER_UUID,
+            "username": format!("service-account-{client_id}"),
+        })))
+        .mount(&server)
+        .await;
+
+    // SA attrs PUT — assert tenant_id + user_type attributes
+    Mock::given(method("PUT"))
+        .and(path(format!("/admin/realms/platform/users/{SA_USER_UUID}")))
+        .and(body_partial_json(json!({
+            "attributes": {
+                "tenant_id": [tenant.to_string()],
+                "user_type": ["gts.cf.core.security.subject_service_principal.v1~"],
+            }
+        })))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // scope attach (uuid already resolved from pre-flight)
+    Mock::given(method("PUT"))
+        .and(path(format!(
+            "/admin/realms/platform/clients/{CLIENT_UUID}/default-client-scopes/{SCOPE_UUID}"
+        )))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // secret read
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/admin/realms/platform/clients/{CLIENT_UUID}/client-secret"
+        )))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"type": "secret", "value": "s3cr3t"})),
+        )
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let req = CreateServicePrincipalRequest {
+        tenant_id: TenantId(tenant),
+        name: "metrics".into(),
+        scopes: vec!["mon:metrics:write".into()],
+    };
+    let creds = facade
+        .create_inner(&ctx, &req)
+        .await
+        .expect("create must succeed");
+    assert_eq!(creds.client_id, client_id);
+    assert_eq!(creds.client_secret.expose_secret(), "s3cr3t");
+    assert!(
+        creds
+            .token_url
+            .ends_with("/realms/platform/protocol/openid-connect/token")
+    );
+    assert_eq!(creds.subject_id.to_string(), SA_USER_UUID);
+}
+
+#[tokio::test]
+async fn create_rejects_scope_outside_allowlist() {
+    let server = MockServer::start().await;
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let req = CreateServicePrincipalRequest {
+        tenant_id: TenantId(Uuid::new_v4()),
+        name: "metrics".into(),
+        scopes: vec!["admin:everything".into()],
+    };
+    let err = facade
+        .create_inner(&ctx, &req)
+        .await
+        .expect_err("must reject");
+    assert!(matches!(err, PluginError::SpInvalidInput { field: Some(ref f), .. } if f == "scopes"));
+}
+
+#[tokio::test]
+async fn create_rejects_when_quota_reached() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+    let prefix = format!("svc-{tenant}-");
+    let existing: Vec<_> = (0..10)
+        .map(|i| {
+            json!({
+                "id": Uuid::new_v4(),
+                "clientId": format!("{prefix}sp{i}"),
+                "attributes": { "vhp.provisioning.tenant_id": [tenant.to_string()] },
+            })
+        })
+        .collect();
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("search", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!(existing)))
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let req = CreateServicePrincipalRequest {
+        tenant_id: TenantId(tenant),
+        name: "metrics".into(),
+        scopes: vec![],
+    };
+    let err = facade.create_inner(&ctx, &req).await.expect_err("quota");
+    assert!(matches!(err, PluginError::SpInvalidInput { .. }));
+}
+
+/// 409 on POST /clients is a strict reject even when the existing client
+/// is owned by the same tenant: two consumers colliding on a name must
+/// not silently share credentials or graft scopes onto each other's
+/// client. Recovery from an Ambiguous half-create is revoke → create.
+#[tokio::test]
+async fn create_409_yields_invalid_input_even_for_same_tenant_owner() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+    let client_id = format!("svc-{tenant}-metrics");
+
+    // quota lookup → empty
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("search", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&server)
+        .await;
+
+    // POST → 409
+    Mock::given(method("POST"))
+        .and(path("/admin/realms/platform/clients"))
+        .respond_with(ResponseTemplate::new(409))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // No ownership reconcile: the exact-clientId lookup must never fire,
+    // even though it would report this tenant as the owner.
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("clientId", client_id.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
+            "id": CLIENT_UUID,
+            "attributes": { "vhp.provisioning.tenant_id": [tenant.to_string()] },
+        }])))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let req = CreateServicePrincipalRequest {
+        tenant_id: TenantId(tenant),
+        name: "metrics".into(),
+        scopes: vec![],
+    };
+    let err = facade
+        .create_inner(&ctx, &req)
+        .await
+        .expect_err("name collision must reject");
+    assert!(
+        matches!(
+            &err,
+            PluginError::SpInvalidInput { detail, field: Some(f) }
+                if f == "name" && detail.contains("already exists")
+        ),
+        "expected SpInvalidInput 'already exists', got {err:?}"
+    );
+}
+
+/// A 401 on the post-create uuid lookup must reach the reactive-401
+/// wrapper (token re-mint + one retry) instead of being swallowed into
+/// `AmbiguousCreated` inside the closure.
+#[tokio::test]
+async fn create_lookup_401_after_post_is_reminted_and_retried() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+    let client_id = format!("svc-{tenant}-metrics");
+
+    // quota lookup → empty
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("search", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&server)
+        .await;
+
+    // POST → 201
+    Mock::given(method("POST"))
+        .and(path("/admin/realms/platform/clients"))
+        .respond_with(ResponseTemplate::new(201))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // exact lookup: first attempt → 401 (expired token), retry → rep.
+    // Lower priority number = higher precedence in wiremock-rs.
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("clientId", client_id.clone()))
+        .respond_with(ResponseTemplate::new(401).set_body_string("token expired"))
+        .with_priority(1)
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("clientId", client_id.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([{"id": CLIENT_UUID}])))
+        .mount(&server)
+        .await;
+
+    // SA user fetch
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/admin/realms/platform/clients/{CLIENT_UUID}/service-account-user"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": SA_USER_UUID,
+            "username": format!("service-account-{client_id}"),
+        })))
+        .mount(&server)
+        .await;
+
+    // SA attrs PUT
+    Mock::given(method("PUT"))
+        .and(path(format!("/admin/realms/platform/users/{SA_USER_UUID}")))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    // secret read
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/admin/realms/platform/clients/{CLIENT_UUID}/client-secret"
+        )))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"type": "secret", "value": "s3cr3t"})),
+        )
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let req = CreateServicePrincipalRequest {
+        tenant_id: TenantId(tenant),
+        name: "metrics".into(),
+        scopes: vec![],
+    };
+    let creds = facade
+        .create_inner(&ctx, &req)
+        .await
+        .expect("401 on lookup must re-mint and retry, not fail Ambiguous");
+    assert_eq!(creds.client_secret.expose_secret(), "s3cr3t");
+}
+
+/// Mirror of `bind_admin_user_to_tenant`'s hijack guard: refuse to
+/// overwrite a foreign `tenant_id` already present on the SA user
+/// (hand-edited / inconsistent KC state).
+#[tokio::test]
+async fn create_refuses_to_overwrite_foreign_sa_user_tenant_id() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+    let other = Uuid::new_v4();
+    let client_id = format!("svc-{tenant}-metrics");
+
+    // quota lookup → empty
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("search", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&server)
+        .await;
+
+    // POST → 201
+    Mock::given(method("POST"))
+        .and(path("/admin/realms/platform/clients"))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(&server)
+        .await;
+
+    // exact lookup → rep
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("clientId", client_id.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([{"id": CLIENT_UUID}])))
+        .mount(&server)
+        .await;
+
+    // SA user carries a FOREIGN tenant_id
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/admin/realms/platform/clients/{CLIENT_UUID}/service-account-user"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": SA_USER_UUID,
+            "username": format!("service-account-{client_id}"),
+            "attributes": { "tenant_id": [other.to_string()] },
+        })))
+        .mount(&server)
+        .await;
+
+    // The guard must reject BEFORE any PUT
+    Mock::given(method("PUT"))
+        .and(path(format!("/admin/realms/platform/users/{SA_USER_UUID}")))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let req = CreateServicePrincipalRequest {
+        tenant_id: TenantId(tenant),
+        name: "metrics".into(),
+        scopes: vec![],
+    };
+    let err = facade
+        .create_inner(&ctx, &req)
+        .await
+        .expect_err("foreign SA tenant_id must refuse");
+    assert!(
+        matches!(
+            &err,
+            PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcSaAttrSet,
+                detail,
+            } if detail.contains("refusing to overwrite")
+        ),
+        "expected KcSaAttrSet guard refusal, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn create_409_foreign_owner_yields_invalid_input() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+
+    // quota lookup → empty
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("search", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&server)
+        .await;
+
+    // No scopes — skip pre-flight list fetch
+
+    // POST → 409 (strict reject — no ownership reconcile follows)
+    Mock::given(method("POST"))
+        .and(path("/admin/realms/platform/clients"))
+        .respond_with(ResponseTemplate::new(409))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let req = CreateServicePrincipalRequest {
+        tenant_id: TenantId(tenant),
+        name: "metrics".into(),
+        scopes: vec![],
+    };
+    let err = facade
+        .create_inner(&ctx, &req)
+        .await
+        .expect_err("foreign owner must reject");
+    assert!(
+        matches!(err, PluginError::SpInvalidInput { field: Some(ref f), .. } if f == "name"),
+        "unexpected err: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn create_sa_attr_put_failure_is_ambiguous_with_stage() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+    let client_id = format!("svc-{tenant}-metrics");
+
+    // quota lookup → empty
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("search", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&server)
+        .await;
+
+    // No scopes — skip pre-flight
+
+    // POST → 201
+    Mock::given(method("POST"))
+        .and(path("/admin/realms/platform/clients"))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(&server)
+        .await;
+
+    // exact lookup → rep
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("clientId", client_id.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([{"id": CLIENT_UUID}])))
+        .mount(&server)
+        .await;
+
+    // SA user fetch → ok
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/admin/realms/platform/clients/{CLIENT_UUID}/service-account-user"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": SA_USER_UUID,
+            "username": format!("service-account-{client_id}"),
+        })))
+        .mount(&server)
+        .await;
+
+    // SA attrs PUT → 500
+    Mock::given(method("PUT"))
+        .and(path(format!("/admin/realms/platform/users/{SA_USER_UUID}")))
+        .respond_with(ResponseTemplate::new(500).set_body_string("internal error"))
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let req = CreateServicePrincipalRequest {
+        tenant_id: TenantId(tenant),
+        name: "metrics".into(),
+        scopes: vec![],
+    };
+    let err = facade
+        .create_inner(&ctx, &req)
+        .await
+        .expect_err("must fail");
+    assert!(
+        matches!(
+            err,
+            PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcSaAttrSet,
+                ref detail,
+            } if detail.contains(&client_id)
+        ),
+        "expected AmbiguousCreated{{stage: KcSaAttrSet, detail contains client_id}}; got {err:?}",
+    );
+}
+
+#[tokio::test]
+async fn create_allowlisted_scope_missing_in_realm_is_config_error_preflight() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+
+    // quota lookup → empty
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("search", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&server)
+        .await;
+
+    // scopes list → does NOT contain "mon:metrics:write"
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/client-scopes"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(json!([{"id": SCOPE_UUID, "name": "other:scope"}])),
+        )
+        .mount(&server)
+        .await;
+
+    // POST must NOT be called
+    let post_mock = Mock::given(method("POST"))
+        .and(path("/admin/realms/platform/clients"))
+        .respond_with(ResponseTemplate::new(201))
+        .expect(0)
+        .mount_as_scoped(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let req = CreateServicePrincipalRequest {
+        tenant_id: TenantId(tenant),
+        name: "metrics".into(),
+        scopes: vec!["mon:metrics:write".into()],
+    };
+    let err = facade
+        .create_inner(&ctx, &req)
+        .await
+        .expect_err("must fail pre-flight");
+    assert!(
+        matches!(err, PluginError::Config { .. }),
+        "expected Config error, got {err:?}"
+    );
+    // Verify no POST happened — wiremock checks expect(0) on drop.
+    drop(post_mock);
+}
+
+// -----------------------------------------------------------------------
+// rotate / revoke / list tests (Task 5)
+// -----------------------------------------------------------------------
+
+/// Mount an exact clientId lookup that returns the given owner in attributes.
+async fn mount_owned_client_lookup(server: &MockServer, client_id: &str, owner: Uuid) {
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("clientId", client_id))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
+            "id": CLIENT_UUID,
+            "clientId": client_id,
+            "attributes": { "vhp.provisioning.tenant_id": [owner.to_string()] },
+        }])))
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn rotate_returns_new_secret_for_owned_client() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+    let client_id = format!("svc-{tenant}-metrics");
+
+    mount_owned_client_lookup(&server, &client_id, tenant).await;
+
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/admin/realms/platform/clients/{CLIENT_UUID}/client-secret"
+        )))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"type": "secret", "value": "n3w"})),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Healthy principal: SA attrs already bound → no repair PUT.
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/admin/realms/platform/clients/{CLIENT_UUID}/service-account-user"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": SA_USER_UUID,
+            "username": format!("service-account-{client_id}"),
+            "attributes": {
+                "tenant_id": [tenant.to_string()],
+                "user_type": ["gts.cf.core.security.subject_service_principal.v1~"],
+            },
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("PUT"))
+        .and(path(format!("/admin/realms/platform/users/{SA_USER_UUID}")))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let creds = facade
+        .rotate_secret_inner(&ctx, tenant, &client_id)
+        .await
+        .expect("rotate must succeed");
+    assert_eq!(creds.client_secret.expose_secret(), "n3w");
+    assert_eq!(creds.client_id, client_id);
+    assert_eq!(creds.subject_id.to_string(), SA_USER_UUID);
+    assert!(
+        creds
+            .token_url
+            .ends_with("/realms/platform/protocol/openid-connect/token")
+    );
+}
+
+/// Deletion race: client vanished between the ownership lookup and the
+/// SA-user read → terminal `NotFound`, not a retryable-looking `CleanFailure`
+/// (mirrors the 404/410 mapping of the secret POST and revoke paths).
+#[tokio::test]
+async fn rotate_sa_user_404_yields_sp_not_found() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+    let client_id = format!("svc-{tenant}-metrics");
+
+    mount_owned_client_lookup(&server, &client_id, tenant).await;
+
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/admin/realms/platform/clients/{CLIENT_UUID}/service-account-user"
+        )))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let err = facade
+        .rotate_secret_inner(&ctx, tenant, &client_id)
+        .await
+        .expect_err("deleted client must yield not-found");
+    assert!(
+        matches!(err, PluginError::SpNotFound { .. }),
+        "expected SpNotFound, got {err:?}"
+    );
+}
+
+/// Rotate on a half-created principal (create failed before the SA-attr
+/// bind) refuses to hand out credentials. Rotate cannot reconstruct the
+/// originally requested scopes, so the documented recovery is revoke → create.
+#[tokio::test]
+async fn rotate_rejects_unbound_sa_attributes() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+    let client_id = format!("svc-{tenant}-metrics");
+
+    mount_owned_client_lookup(&server, &client_id, tenant).await;
+
+    // SA user WITHOUT bound attributes — half-created principal.
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/admin/realms/platform/clients/{CLIENT_UUID}/service-account-user"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": SA_USER_UUID,
+            "username": format!("service-account-{client_id}"),
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("PUT"))
+        .and(path(format!("/admin/realms/platform/users/{SA_USER_UUID}")))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/admin/realms/platform/clients/{CLIENT_UUID}/client-secret"
+        )))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"type": "secret", "value": "n3w"})),
+        )
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let err = facade
+        .rotate_secret_inner(&ctx, tenant, &client_id)
+        .await
+        .expect_err("rotate must reject an incomplete principal");
+    assert!(
+        matches!(err, PluginError::SpInvalidInput { field: Some(ref f), .. } if f == "client_id"),
+        "expected SpInvalidInput{{field: client_id}}, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn rotate_foreign_tenant_yields_sp_not_found() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+    let other = Uuid::new_v4();
+    let client_id = format!("svc-{tenant}-metrics");
+
+    // Owned by a DIFFERENT tenant
+    mount_owned_client_lookup(&server, &client_id, other).await;
+
+    // POST must never be called
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/admin/realms/platform/clients/{CLIENT_UUID}/client-secret"
+        )))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"value": "should-not-matter"})),
+        )
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let err = facade
+        .rotate_secret_inner(&ctx, tenant, &client_id)
+        .await
+        .expect_err("foreign tenant must yield not-found");
+    assert!(
+        matches!(err, PluginError::SpNotFound { .. }),
+        "expected SpNotFound, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn rotate_non_service_principal_client_yields_sp_not_found() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+    let client_id = "realm-admin-client";
+
+    mount_owned_client_lookup(&server, client_id, tenant).await;
+
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/admin/realms/platform/clients/{CLIENT_UUID}/client-secret"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"value": "nope"})))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let err = facade
+        .rotate_secret_inner(&ctx, tenant, client_id)
+        .await
+        .expect_err("non-SP client id must yield not-found");
+    assert!(
+        matches!(err, PluginError::SpNotFound { .. }),
+        "expected SpNotFound, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn rotate_unknown_client_yields_sp_not_found() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+    let client_id = format!("svc-{tenant}-metrics");
+
+    // Exact lookup returns empty array
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("clientId", client_id.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let err = facade
+        .rotate_secret_inner(&ctx, tenant, &client_id)
+        .await
+        .expect_err("unknown client must yield not-found");
+    assert!(
+        matches!(err, PluginError::SpNotFound { .. }),
+        "expected SpNotFound, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn revoke_deletes_owned_client_and_maps_kc_404_to_not_found() {
+    // Case 1: owned client, DELETE → 204 ⇒ Ok(())
+    {
+        let server = MockServer::start().await;
+        mount_bootstrap_token(&server).await;
+        let tenant = Uuid::new_v4();
+        let client_id = format!("svc-{tenant}-metrics");
+
+        mount_owned_client_lookup(&server, &client_id, tenant).await;
+
+        Mock::given(method("DELETE"))
+            .and(path(format!(
+                "/admin/realms/platform/clients/{CLIENT_UUID}"
+            )))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server, sp_cfg());
+        let ctx = build_system_ctx(Uuid::nil());
+        facade
+            .revoke_inner(&ctx, tenant, &client_id)
+            .await
+            .expect("revoke must succeed on 204");
+    }
+
+    // Case 2: owned client, DELETE → 404 ⇒ SpNotFound with "already absent"
+    {
+        let server = MockServer::start().await;
+        mount_bootstrap_token(&server).await;
+        let tenant = Uuid::new_v4();
+        let client_id = format!("svc-{tenant}-metrics");
+
+        mount_owned_client_lookup(&server, &client_id, tenant).await;
+
+        Mock::given(method("DELETE"))
+            .and(path(format!(
+                "/admin/realms/platform/clients/{CLIENT_UUID}"
+            )))
+            .respond_with(ResponseTemplate::new(404))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server, sp_cfg());
+        let ctx = build_system_ctx(Uuid::nil());
+        let err = facade
+            .revoke_inner(&ctx, tenant, &client_id)
+            .await
+            .expect_err("404 from KC must map to SpNotFound");
+        assert!(
+            matches!(
+                &err,
+                PluginError::SpNotFound { detail } if detail.contains("already absent")
+            ),
+            "expected SpNotFound with 'already absent', got {err:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn list_returns_tenant_principals_with_scopes() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+    let prefix = format!("svc-{tenant}-");
+
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("search", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {
+                "id": CLIENT_UUID,
+                "clientId": format!("{prefix}metrics"),
+                "enabled": true,
+                "defaultClientScopes": ["mon:metrics:write"],
+                "attributes": { "vhp.provisioning.tenant_id": [tenant.to_string()] },
+            },
+            {
+                "id": "44444444-4444-4444-4444-444444444444",
+                "clientId": "unrelated-client",
+                "enabled": true,
+                "defaultClientScopes": [],
+            }
+        ])))
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let list = facade
+        .list_inner(&ctx, tenant)
+        .await
+        .expect("list must succeed");
+    assert_eq!(list.len(), 1, "substring-match noise must be filtered out");
+    assert_eq!(list[0].client_id, format!("{prefix}metrics"));
+    assert!(list[0].enabled);
+    assert_eq!(list[0].scopes, vec!["mon:metrics:write"]);
+}
+
+#[tokio::test]
+async fn list_is_empty_for_tenant_without_principals() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("search", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let list = facade
+        .list_inner(&ctx, tenant)
+        .await
+        .expect("list must succeed");
+    assert!(list.is_empty());
+}
+
+#[tokio::test]
+async fn create_quota_lookup_5xx_is_kc_rest() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+
+    // quota GET → 503
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("search", "true"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("service unavailable"))
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let req = CreateServicePrincipalRequest {
+        tenant_id: TenantId(tenant),
+        name: "metrics".into(),
+        scopes: vec![],
+    };
+    let err = facade
+        .create_inner(&ctx, &req)
+        .await
+        .expect_err("5xx must fail");
+    assert!(
+        matches!(err, PluginError::KcRest { .. }),
+        "expected KcRest error, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn revoke_foreign_tenant_yields_sp_not_found() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+    let other = Uuid::new_v4();
+    let client_id = format!("svc-{tenant}-metrics");
+
+    // Owned by a DIFFERENT tenant
+    mount_owned_client_lookup(&server, &client_id, other).await;
+
+    // DELETE must never be called
+    Mock::given(method("DELETE"))
+        .and(path(format!(
+            "/admin/realms/platform/clients/{CLIENT_UUID}"
+        )))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let err = facade
+        .revoke_inner(&ctx, tenant, &client_id)
+        .await
+        .expect_err("foreign tenant must yield not-found");
+    assert!(
+        matches!(err, PluginError::SpNotFound { .. }),
+        "expected SpNotFound, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn revoke_non_service_principal_client_yields_sp_not_found() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+    let client_id = "realm-admin-client";
+
+    mount_owned_client_lookup(&server, client_id, tenant).await;
+
+    Mock::given(method("DELETE"))
+        .and(path(format!(
+            "/admin/realms/platform/clients/{CLIENT_UUID}"
+        )))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let err = facade
+        .revoke_inner(&ctx, tenant, client_id)
+        .await
+        .expect_err("non-SP client id must yield not-found");
+    assert!(
+        matches!(err, PluginError::SpNotFound { .. }),
+        "expected SpNotFound, got {err:?}"
+    );
+}
+
+// -----------------------------------------------------------------------
+// purge (tenant-deprovision cascade) tests
+// -----------------------------------------------------------------------
+
+/// Deprovision cascade: deletes every owned `svc-<tenant>-` client,
+/// tolerates the concurrent-delete 404, skips substring/foreign noise.
+#[tokio::test]
+async fn purge_deletes_owned_clients_and_tolerates_races() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+    let other = Uuid::new_v4();
+    let prefix = format!("svc-{tenant}-");
+    let owned_a = "55555555-5555-5555-5555-555555555555";
+    let owned_b = "66666666-6666-6666-6666-666666666666";
+    let foreign = "77777777-7777-7777-7777-777777777777";
+
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("search", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {
+                "id": owned_a,
+                "clientId": format!("{prefix}metrics"),
+                "attributes": { "vhp.provisioning.tenant_id": [tenant.to_string()] },
+            },
+            {
+                "id": owned_b,
+                "clientId": format!("{prefix}push"),
+                "attributes": { "vhp.provisioning.tenant_id": [tenant.to_string()] },
+            },
+            {
+                // substring noise: prefix matches but owner is foreign
+                "id": foreign,
+                "clientId": format!("{prefix}stray"),
+                "attributes": { "vhp.provisioning.tenant_id": [other.to_string()] },
+            },
+        ])))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("DELETE"))
+        .and(path(format!("/admin/realms/platform/clients/{owned_a}")))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+    // Concurrent revoke already removed this one — tolerated.
+    Mock::given(method("DELETE"))
+        .and(path(format!("/admin/realms/platform/clients/{owned_b}")))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path(format!("/admin/realms/platform/clients/{foreign}")))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let deleted = facade
+        .purge_tenant_principals(tenant)
+        .await
+        .expect("purge must succeed");
+    assert_eq!(deleted, 1);
+}
+
+/// A KC failure mid-purge propagates so the deprovision caller retries.
+#[tokio::test]
+async fn purge_propagates_kc_failures() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("search", "true"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("kc down"))
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let err = facade
+        .purge_tenant_principals(tenant)
+        .await
+        .expect_err("kc failure must propagate");
+    assert!(
+        matches!(err, PluginError::KcRest { .. }),
+        "expected KcRest, got {err:?}"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Metric emission tests
+// -----------------------------------------------------------------------
+
+#[tokio::test]
+async fn create_happy_path_emits_sp_op_duration_no_failure() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+    let client_id = format!("svc-{tenant}-metrics");
+
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("search", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/admin/realms/platform/clients"))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("clientId", client_id.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([{"id": CLIENT_UUID}])))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/admin/realms/platform/clients/{CLIENT_UUID}/service-account-user"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": SA_USER_UUID,
+            "username": format!("service-account-{client_id}"),
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("PUT"))
+        .and(path(format!("/admin/realms/platform/users/{SA_USER_UUID}")))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/admin/realms/platform/clients/{CLIENT_UUID}/client-secret"
+        )))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"type": "secret", "value": "s3cr3t"})),
+        )
+        .mount(&server)
+        .await;
+
+    let sp_rec = RecordingSpMetrics::new();
+    let fail_rec = RecordingFailureMetrics::new();
+    let facade = build_facade_with_metrics(
+        &server,
+        ServicePrincipalConfig::default(),
+        Arc::clone(&sp_rec) as _,
+        Arc::clone(&fail_rec) as _,
+    );
+    let ctx = build_system_ctx(Uuid::nil());
+    let req = CreateServicePrincipalRequest {
+        tenant_id: TenantId(tenant),
+        name: "metrics".into(),
+        scopes: vec![],
+    };
+    facade.create_inner(&ctx, &req).await.expect("must succeed");
+
+    let sp_calls = sp_rec.recorded();
+    assert_eq!(sp_calls.len(), 1, "exactly one sp_op_duration call");
+    assert_eq!(sp_calls[0].0, SpOp::Create);
+    assert!(sp_calls[0].1 >= 0.0);
+    assert!(fail_rec.recorded().is_empty(), "no failure on success path");
+}
+
+#[tokio::test]
+async fn create_quota_reject_emits_failure_sp_create_sp_invalid_input() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+    let prefix = format!("svc-{tenant}-");
+    let existing: Vec<_> = (0..10)
+        .map(|i| {
+            json!({
+                "id": Uuid::new_v4(),
+                "clientId": format!("{prefix}sp{i}"),
+                "attributes": { "vhp.provisioning.tenant_id": [tenant.to_string()] },
+            })
+        })
+        .collect();
+
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("search", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!(existing)))
+        .mount(&server)
+        .await;
+
+    let sp_rec = RecordingSpMetrics::new();
+    let fail_rec = RecordingFailureMetrics::new();
+    let facade = build_facade_with_metrics(
+        &server,
+        ServicePrincipalConfig::default(),
+        Arc::clone(&sp_rec) as _,
+        Arc::clone(&fail_rec) as _,
+    );
+    let ctx = build_system_ctx(Uuid::nil());
+    let req = CreateServicePrincipalRequest {
+        tenant_id: TenantId(tenant),
+        name: "metrics".into(),
+        scopes: vec![],
+    };
+    facade
+        .create_inner(&ctx, &req)
+        .await
+        .expect_err("quota must reject");
+
+    // Duration is recorded on failures too (mirrors user_op_duration) so
+    // outage-time latency stays visible in the histogram.
+    let sp_calls = sp_rec.recorded();
+    assert_eq!(sp_calls.len(), 1, "duration recorded on the error path");
+    assert_eq!(sp_calls[0].0, SpOp::Create);
+    let failures = fail_rec.recorded();
+    assert_eq!(failures.len(), 1);
+    assert!(matches!(failures[0].0, PluginOp::SpCreate));
+    assert_eq!(failures[0].1, "sp_invalid_input");
+}
+
+/// Persistent 401 on SA-attrs GET (both wrapper attempts) → AmbiguousCreated{KcSaAttrSet}.
+/// The wrapper retries once on 401; the SA user endpoint returns 401 unconditionally,
+/// so the post-mutation escape is re-tagged Ambiguous at the `create_inner` call site.
+#[tokio::test]
+async fn create_sa_attrs_persistent_401_is_ambiguous() {
+    let server = MockServer::start().await;
+    mount_bootstrap_token(&server).await;
+    let tenant = Uuid::new_v4();
+    let client_id = format!("svc-{tenant}-metrics");
+
+    // quota → empty
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("search", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&server)
+        .await;
+
+    // POST → 201
+    Mock::given(method("POST"))
+        .and(path("/admin/realms/platform/clients"))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(&server)
+        .await;
+
+    // exact lookup → rep
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/clients"))
+        .and(query_param("clientId", client_id.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([{"id": CLIENT_UUID}])))
+        .mount(&server)
+        .await;
+
+    // SA user GET → always 401 (both wrapper attempts)
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/admin/realms/platform/clients/{CLIENT_UUID}/service-account-user"
+        )))
+        .respond_with(ResponseTemplate::new(401).set_body_string("Unauthorized"))
+        .mount(&server)
+        .await;
+
+    let facade = build_facade(&server, sp_cfg());
+    let ctx = build_system_ctx(Uuid::nil());
+    let req = CreateServicePrincipalRequest {
+        tenant_id: TenantId(tenant),
+        name: "metrics".into(),
+        scopes: vec![],
+    };
+    let err = facade
+        .create_inner(&ctx, &req)
+        .await
+        .expect_err("persistent 401 must yield Ambiguous");
+    assert!(
+        matches!(
+            err,
+            PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcSaAttrSet,
+                ..
+            }
+        ),
+        "expected AmbiguousCreated{{stage: KcSaAttrSet}}; got {err:?}",
+    );
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/service_principal_facade_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/service_principal_facade_tests.rs
@@ -190,7 +190,7 @@ async fn create_provisions_client_sa_attrs_scope_and_returns_secret() {
             "implicitFlowEnabled": false,
             "authorizationServicesEnabled": false,
             "clientAuthenticatorType": "client-secret",
-            "attributes": { "vhp.provisioning.tenant_id": tenant.to_string() },
+            "attributes": { "cf.provisioning.tenant_id": tenant.to_string() },
         })))
         .respond_with(ResponseTemplate::new(201))
         .expect(1)
@@ -301,7 +301,7 @@ async fn create_rejects_when_quota_reached() {
             json!({
                 "id": Uuid::new_v4(),
                 "clientId": format!("{prefix}sp{i}"),
-                "attributes": { "vhp.provisioning.tenant_id": [tenant.to_string()] },
+                "attributes": { "cf.provisioning.tenant_id": [tenant.to_string()] },
             })
         })
         .collect();
@@ -357,7 +357,7 @@ async fn create_409_yields_invalid_input_even_for_same_tenant_owner() {
         .and(query_param("clientId", client_id.clone()))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
             "id": CLIENT_UUID,
-            "attributes": { "vhp.provisioning.tenant_id": [tenant.to_string()] },
+            "attributes": { "cf.provisioning.tenant_id": [tenant.to_string()] },
         }])))
         .expect(0)
         .mount(&server)
@@ -727,7 +727,7 @@ async fn mount_owned_client_lookup(server: &MockServer, client_id: &str, owner: 
         .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
             "id": CLIENT_UUID,
             "clientId": client_id,
-            "attributes": { "vhp.provisioning.tenant_id": [owner.to_string()] },
+            "attributes": { "cf.provisioning.tenant_id": [owner.to_string()] },
         }])))
         .mount(server)
         .await;
@@ -1048,7 +1048,7 @@ async fn list_returns_tenant_principals_with_scopes() {
                 "clientId": format!("{prefix}metrics"),
                 "enabled": true,
                 "defaultClientScopes": ["mon:metrics:write"],
-                "attributes": { "vhp.provisioning.tenant_id": [tenant.to_string()] },
+                "attributes": { "cf.provisioning.tenant_id": [tenant.to_string()] },
             },
             {
                 "id": "44444444-4444-4444-4444-444444444444",
@@ -1212,18 +1212,18 @@ async fn purge_deletes_owned_clients_and_tolerates_races() {
             {
                 "id": owned_a,
                 "clientId": format!("{prefix}metrics"),
-                "attributes": { "vhp.provisioning.tenant_id": [tenant.to_string()] },
+                "attributes": { "cf.provisioning.tenant_id": [tenant.to_string()] },
             },
             {
                 "id": owned_b,
                 "clientId": format!("{prefix}push"),
-                "attributes": { "vhp.provisioning.tenant_id": [tenant.to_string()] },
+                "attributes": { "cf.provisioning.tenant_id": [tenant.to_string()] },
             },
             {
                 // substring noise: prefix matches but owner is foreign
                 "id": foreign,
                 "clientId": format!("{prefix}stray"),
-                "attributes": { "vhp.provisioning.tenant_id": [other.to_string()] },
+                "attributes": { "cf.provisioning.tenant_id": [other.to_string()] },
             },
         ])))
         .mount(&server)
@@ -1374,7 +1374,7 @@ async fn create_quota_reject_emits_failure_sp_create_sp_invalid_input() {
             json!({
                 "id": Uuid::new_v4(),
                 "clientId": format!("{prefix}sp{i}"),
-                "attributes": { "vhp.provisioning.tenant_id": [tenant.to_string()] },
+                "attributes": { "cf.provisioning.tenant_id": [tenant.to_string()] },
             })
         })
         .collect();

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/system_actor.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/system_actor.rs
@@ -30,7 +30,8 @@ use uuid::Uuid;
 /// and upgrades** — changing it breaks secret ownership in `OpenBao` for
 /// tenants whose `Created` realm secrets were written under the previous
 /// value.
-pub const VP_IDP_PLUGIN_ACTOR_UUID: Uuid = uuid::uuid!("1d70b6d4-6e2e-4f3c-9aa3-7d8c2e3f5b91");
+pub const KEYCLOAK_IDP_PLUGIN_ACTOR_UUID: Uuid =
+    uuid::uuid!("1d70b6d4-6e2e-4f3c-9aa3-7d8c2e3f5b91");
 
 /// `subject_type` recorded on every `CredStore` op the plugin performs.
 ///
@@ -38,14 +39,14 @@ pub const VP_IDP_PLUGIN_ACTOR_UUID: Uuid = uuid::uuid!("1d70b6d4-6e2e-4f3c-9aa3-
 /// `subject_service` classifier pattern) so the authz-resolver classifies the
 /// plugin as a `ServicePrincipal` and authorizes its credstore writes through
 /// **ordinary RBAC** — an Owner/credstore grant seeded for
-/// [`VP_IDP_PLUGIN_ACTOR_UUID`] — rather than a PEP bypass. The resolver
+/// [`KEYCLOAK_IDP_PLUGIN_ACTOR_UUID`] — rather than a PEP bypass. The resolver
 /// rejects an unknown `subject_type` fail-closed (Internal/500), so this MUST
 /// stay a value `classify_subject_type` accepts (i.e. contains
 /// `subject_service`); keep it in sync with
-/// `VpIdpPluginConfig.service_principal.subject_type` (config default).
+/// `KeycloakIdpPluginConfig.service_principal.subject_type` (config default).
 ///
 /// Audit attribution back to the plugin is keyed on the stable
-/// [`VP_IDP_PLUGIN_ACTOR_UUID`], NOT on this string — see [`crate::domain::audit`].
+/// [`KEYCLOAK_IDP_PLUGIN_ACTOR_UUID`], NOT on this string — see [`crate::domain::audit`].
 pub const SUBJECT_TYPE: &str = gts_id!("cf.core.security.subject_service_principal.v1~");
 
 /// First-party wildcard token scope (`"*"`). The plugin's in-process system
@@ -60,7 +61,7 @@ const FIRST_PARTY_TOKEN_SCOPE: &str = "*";
 /// Build the plugin-owned system ctx.
 ///
 /// `platform_tenant_id` comes from
-/// `VpIdpPluginConfig.security_context.platform_tenant_id` (defaults to the
+/// `KeycloakIdpPluginConfig.security_context.platform_tenant_id` (defaults to the
 /// platform root tenant `…0001`, NOT nil — credstore's own-tenant gate
 /// requires a real tenant covered by the plugin's RBAC grant; see
 /// `SecurityContextConfig`).
@@ -76,13 +77,13 @@ const FIRST_PARTY_TOKEN_SCOPE: &str = "*";
 )]
 pub fn build_system_ctx(platform_tenant_id: Uuid) -> Arc<SecurityContext> {
     tracing::debug!(
-        target: "vp_idp_plugin.system_actor",
+        target: "keycloak_idp.system_actor",
         site = "module_init",
         platform_tenant_id = %platform_tenant_id,
-        "vp-idp-plugin system actor constructed",
+        "keycloak-idp-plugin system actor constructed",
     );
     let ctx = SecurityContext::builder()
-        .subject_id(VP_IDP_PLUGIN_ACTOR_UUID)
+        .subject_id(KEYCLOAK_IDP_PLUGIN_ACTOR_UUID)
         .subject_type(SUBJECT_TYPE)
         .subject_tenant_id(platform_tenant_id)
         // First-party wildcard scope: this in-process ctx carries no bearer
@@ -91,7 +92,7 @@ pub fn build_system_ctx(platform_tenant_id: Uuid) -> Arc<SecurityContext> {
         // still the authoritative gate. See FIRST_PARTY_TOKEN_SCOPE.
         .token_scopes(vec![FIRST_PARTY_TOKEN_SCOPE.to_owned()])
         .build()
-        .expect("VP_IDP_PLUGIN_ACTOR_UUID + platform_tenant_id are always present");
+        .expect("KEYCLOAK_IDP_PLUGIN_ACTOR_UUID + platform_tenant_id are always present");
     Arc::new(ctx)
 }
 
@@ -102,7 +103,7 @@ mod tests {
     #[test]
     fn ctx_has_expected_identity() {
         let ctx = build_system_ctx(Uuid::nil());
-        assert_eq!(ctx.subject_id(), VP_IDP_PLUGIN_ACTOR_UUID);
+        assert_eq!(ctx.subject_id(), KEYCLOAK_IDP_PLUGIN_ACTOR_UUID);
         assert_eq!(ctx.subject_type(), Some(SUBJECT_TYPE));
         assert_eq!(ctx.subject_tenant_id(), Uuid::nil());
         // First-party wildcard scope clears the resolver's token-scope enforcer
@@ -114,7 +115,7 @@ mod tests {
     fn ctx_carries_custom_platform_tenant_id() {
         let tid = uuid::uuid!("11111111-2222-3333-4444-555555555555");
         let ctx = build_system_ctx(tid);
-        assert_eq!(ctx.subject_id(), VP_IDP_PLUGIN_ACTOR_UUID);
+        assert_eq!(ctx.subject_id(), KEYCLOAK_IDP_PLUGIN_ACTOR_UUID);
         assert_eq!(ctx.subject_type(), Some(SUBJECT_TYPE));
         assert_eq!(ctx.subject_tenant_id(), tid);
     }

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/system_actor.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/system_actor.rs
@@ -1,0 +1,121 @@
+//! Plugin-owned `SecurityContext` builder. Stable for the lifetime of the
+//! process.
+//!
+//! Built once at `Gear::init` and cloned (via `Arc`) into every component
+//! that performs `CredStore` reads or writes. See DESIGN §8.1 "Security
+//! context for credstore operations".
+//!
+//! Mirrors the shape of AM's `system_actor::for_module_init` (see
+//! `external/gears-rust/modules/system/account-management/account-management/src/domain/system_actor.rs`).
+//! Differences:
+//!
+//! * AM exposes named per-call-site factories (`for_bootstrap`,
+//!   `for_user_cleanup`, …) so every legitimate elevation is grep-visible.
+//!   This plugin only has **one** legitimate system-actor use case
+//!   (`CredStore` ops on tenant-scoped secrets owned by the plugin), so a
+//!   single [`build_system_ctx`] entrypoint is the whole surface.
+//! * Returns `Arc<SecurityContext>` because the resulting ctx is cloned into
+//!   the [`CredStoreReader`](super::credstore::CredStoreReader) /
+//!   [`CredStoreWriter`](super::credstore::CredStoreWriter) wrappers and lives
+//!   for the lifetime of the process.
+
+use std::sync::Arc;
+
+use toolkit_gts::gts_id;
+use toolkit_security::SecurityContext;
+use uuid::Uuid;
+
+/// Fixed UUID identifying the plugin as a system actor in audit /
+/// `CredStore` ownership. **MUST remain stable across processes, replicas,
+/// and upgrades** — changing it breaks secret ownership in `OpenBao` for
+/// tenants whose `Created` realm secrets were written under the previous
+/// value.
+pub const VP_IDP_PLUGIN_ACTOR_UUID: Uuid = uuid::uuid!("1d70b6d4-6e2e-4f3c-9aa3-7d8c2e3f5b91");
+
+/// `subject_type` recorded on every `CredStore` op the plugin performs.
+///
+/// This is the **canonical service-principal GTS subject type** (matches the
+/// `subject_service` classifier pattern) so the authz-resolver classifies the
+/// plugin as a `ServicePrincipal` and authorizes its credstore writes through
+/// **ordinary RBAC** — an Owner/credstore grant seeded for
+/// [`VP_IDP_PLUGIN_ACTOR_UUID`] — rather than a PEP bypass. The resolver
+/// rejects an unknown `subject_type` fail-closed (Internal/500), so this MUST
+/// stay a value `classify_subject_type` accepts (i.e. contains
+/// `subject_service`); keep it in sync with
+/// `VpIdpPluginConfig.service_principal.subject_type` (config default).
+///
+/// Audit attribution back to the plugin is keyed on the stable
+/// [`VP_IDP_PLUGIN_ACTOR_UUID`], NOT on this string — see [`crate::domain::audit`].
+pub const SUBJECT_TYPE: &str = gts_id!("cf.core.security.subject_service_principal.v1~");
+
+/// First-party wildcard token scope (`"*"`). The plugin's in-process system
+/// ctx carries no bearer token, so it presents this wildcard to satisfy the
+/// authz resolver's OAuth token-scope enforcer (`scope_enforcer` fail-closes on
+/// empty `token_scopes` with `scope_mismatch`, BEFORE RBAC even runs). It is
+/// the same scope the resolver synthesizes for its own trusted system actor;
+/// RBAC (the plugin's Credstore Secret Operator grant) remains the
+/// authoritative limit on what the plugin may actually do.
+const FIRST_PARTY_TOKEN_SCOPE: &str = "*";
+
+/// Build the plugin-owned system ctx.
+///
+/// `platform_tenant_id` comes from
+/// `VpIdpPluginConfig.security_context.platform_tenant_id` (defaults to the
+/// platform root tenant `…0001`, NOT nil — credstore's own-tenant gate
+/// requires a real tenant covered by the plugin's RBAC grant; see
+/// `SecurityContextConfig`).
+///
+/// # Panics
+///
+/// Never in practice: both required builder fields are set unconditionally
+/// below. The `expect` anchors the impossible-failure invariant.
+#[must_use]
+#[expect(
+    clippy::expect_used,
+    reason = "subject_id + subject_tenant_id are statically set; the expect anchors the impossible-failure invariant"
+)]
+pub fn build_system_ctx(platform_tenant_id: Uuid) -> Arc<SecurityContext> {
+    tracing::debug!(
+        target: "vp_idp_plugin.system_actor",
+        site = "module_init",
+        platform_tenant_id = %platform_tenant_id,
+        "vp-idp-plugin system actor constructed",
+    );
+    let ctx = SecurityContext::builder()
+        .subject_id(VP_IDP_PLUGIN_ACTOR_UUID)
+        .subject_type(SUBJECT_TYPE)
+        .subject_tenant_id(platform_tenant_id)
+        // First-party wildcard scope: this in-process ctx carries no bearer
+        // token, so present "*" to clear the resolver's token-scope enforcer
+        // (which fail-closes on empty token_scopes before RBAC runs). RBAC is
+        // still the authoritative gate. See FIRST_PARTY_TOKEN_SCOPE.
+        .token_scopes(vec![FIRST_PARTY_TOKEN_SCOPE.to_owned()])
+        .build()
+        .expect("VP_IDP_PLUGIN_ACTOR_UUID + platform_tenant_id are always present");
+    Arc::new(ctx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ctx_has_expected_identity() {
+        let ctx = build_system_ctx(Uuid::nil());
+        assert_eq!(ctx.subject_id(), VP_IDP_PLUGIN_ACTOR_UUID);
+        assert_eq!(ctx.subject_type(), Some(SUBJECT_TYPE));
+        assert_eq!(ctx.subject_tenant_id(), Uuid::nil());
+        // First-party wildcard scope clears the resolver's token-scope enforcer
+        // (empty token_scopes fail-close before RBAC); RBAC is still the gate.
+        assert_eq!(ctx.token_scopes(), ["*"]);
+    }
+
+    #[test]
+    fn ctx_carries_custom_platform_tenant_id() {
+        let tid = uuid::uuid!("11111111-2222-3333-4444-555555555555");
+        let ctx = build_system_ctx(tid);
+        assert_eq!(ctx.subject_id(), VP_IDP_PLUGIN_ACTOR_UUID);
+        assert_eq!(ctx.subject_type(), Some(SUBJECT_TYPE));
+        assert_eq!(ctx.subject_tenant_id(), tid);
+    }
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/tenant_facade.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/tenant_facade.rs
@@ -30,6 +30,7 @@ use uuid::Uuid;
 use crate::config::{RealmAdminConfig, TenantFacadeConfig};
 use crate::domain::audit;
 use crate::domain::credstore::CredStoreWriter;
+use crate::domain::error::redact_secrets;
 use crate::domain::error::{AmbiguousStage, KcStatusKind, PluginError};
 use crate::domain::kc::KcAdminClient;
 use crate::domain::kc::factory::{KeycloakAdminClientFactory, SecretSource};
@@ -956,7 +957,7 @@ impl TenantFacade {
             .raw_request("DELETE", url, None, path_template)
             .await
             .map_err(deprovision_translate_kc)?;
-        Ok((status, truncate_2kb(&body)))
+        Ok((status, redact_secrets(&truncate_2kb(&body))))
     }
 
     /// Decode `provisioning_metadata` and derive the EFFECTIVE realm from the
@@ -1530,7 +1531,7 @@ impl TenantFacade {
                 method: "GET",
                 path_template: "/admin/realms/{realm}".into(),
                 status: KcStatusKind::Http(status),
-                body_first_2kb: truncate_2kb(&body),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body)),
             })
         }
     }
@@ -1627,7 +1628,7 @@ impl TenantFacade {
                 stage: AmbiguousStage::KcRealmCreate,
                 detail: format!(
                     "kc:POST /admin/realms -> {status}: {}",
-                    truncate_2kb(&body_text),
+                    redact_secrets(&truncate_2kb(&body_text)),
                 ),
             });
         }
@@ -1676,7 +1677,7 @@ impl TenantFacade {
                 stage: AmbiguousStage::KcClientCreate,
                 detail: format!(
                     "kc:POST /admin/realms/{{realm}}/clients -> {status}: {}",
-                    truncate_2kb(&body_text),
+                    redact_secrets(&truncate_2kb(&body_text)),
                 ),
             });
         }
@@ -1761,7 +1762,7 @@ impl TenantFacade {
                 stage: AmbiguousStage::KcRoleMapping,
                 detail: format!(
                     "kc:POST /admin/realms/{{realm}}/users/{{user_uuid}}/role-mappings/clients/{{rm_uuid}} -> {status}: {}",
-                    truncate_2kb(&body_text),
+                    redact_secrets(&truncate_2kb(&body_text)),
                 ),
             });
         }
@@ -1794,7 +1795,7 @@ impl TenantFacade {
                 stage,
                 detail: format!(
                     "kc:GET /admin/realms/{{realm}}/clients -> {status}: {}",
-                    truncate_2kb(&body_text),
+                    redact_secrets(&truncate_2kb(&body_text)),
                 ),
             });
         }
@@ -1845,7 +1846,7 @@ impl TenantFacade {
                 stage: AmbiguousStage::KcRoleMapping,
                 detail: format!(
                     "kc:GET /admin/realms/{{realm}}/clients/{{client_uuid}}/service-account-user -> {status}: {}",
-                    truncate_2kb(&body_text),
+                    redact_secrets(&truncate_2kb(&body_text)),
                 ),
             });
         }
@@ -1887,7 +1888,7 @@ impl TenantFacade {
                 stage: AmbiguousStage::KcRoleMapping,
                 detail: format!(
                     "kc:GET /admin/realms/{{realm}}/users/{{user_uuid}}/role-mappings/clients/{{rm_uuid}}/available -> {status}: {}",
-                    truncate_2kb(&body_text),
+                    redact_secrets(&truncate_2kb(&body_text)),
                 ),
             });
         }
@@ -1931,7 +1932,7 @@ impl TenantFacade {
                 stage: AmbiguousStage::KcClientSecretRead,
                 detail: format!(
                     "kc:GET /admin/realms/{{realm}}/clients/{{client_uuid}}/client-secret -> {status}: {}",
-                    truncate_2kb(&body_text),
+                    redact_secrets(&truncate_2kb(&body_text)),
                 ),
             });
         }
@@ -1981,7 +1982,7 @@ impl TenantFacade {
                 method: "GET",
                 path_template: "/admin/realms/{realm}".into(),
                 status: KcStatusKind::Http(status),
-                body_first_2kb: truncate_2kb(&body),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body)),
             })
         }
     }
@@ -2057,7 +2058,7 @@ impl TenantFacade {
                 method: "GET",
                 path_template: "/admin/realms/{realm}/users/{user_uuid}".into(),
                 status: KcStatusKind::Http(401),
-                body_first_2kb: truncate_2kb(&get_body),
+                body_first_2kb: redact_secrets(&truncate_2kb(&get_body)),
             });
         }
         if !(200..=299).contains(&get_status) {
@@ -2071,7 +2072,7 @@ impl TenantFacade {
                 stage: AmbiguousStage::AdminUserBind,
                 detail: format!(
                     "kc:GET /admin/realms/{{realm}}/users/{{user_uuid}} -> {get_status}: {}",
-                    truncate_2kb(&get_body),
+                    redact_secrets(&truncate_2kb(&get_body)),
                 ),
             });
         }
@@ -2197,7 +2198,7 @@ impl TenantFacade {
                 method: "PUT",
                 path_template: "/admin/realms/{realm}/users/{user_uuid}".into(),
                 status: KcStatusKind::Http(401),
-                body_first_2kb: truncate_2kb(&put_body),
+                body_first_2kb: redact_secrets(&truncate_2kb(&put_body)),
             });
         }
         if !(200..=299).contains(&put_status) {
@@ -2205,7 +2206,7 @@ impl TenantFacade {
                 stage: AmbiguousStage::AdminUserBind,
                 detail: format!(
                     "kc:PUT /admin/realms/{{realm}}/users/{{user_uuid}} -> {put_status}: {}",
-                    truncate_2kb(&put_body),
+                    redact_secrets(&truncate_2kb(&put_body)),
                 ),
             });
         }
@@ -2284,7 +2285,7 @@ impl TenantFacade {
                     method: "GET",
                     path_template: "/admin/realms/{realm}/groups/{parent_uuid}/children".into(),
                     status: KcStatusKind::Http(lookup_status),
-                    body_first_2kb: truncate_2kb(&lookup_body),
+                    body_first_2kb: redact_secrets(&truncate_2kb(&lookup_body)),
                 });
             }
             let groups: Vec<GroupRep> =
@@ -2313,7 +2314,7 @@ impl TenantFacade {
                 status: KcStatusKind::Http(status),
                 body_first_2kb: format!(
                     "409 conflict but subgroup not found in parent listing: {}",
-                    truncate_2kb(&body_text),
+                    redact_secrets(&truncate_2kb(&body_text)),
                 ),
             });
         }
@@ -2322,7 +2323,7 @@ impl TenantFacade {
             method: "POST",
             path_template: "/admin/realms/{realm}/groups/{parent_uuid}/children".into(),
             status: KcStatusKind::Http(status),
-            body_first_2kb: truncate_2kb(&body_text),
+            body_first_2kb: redact_secrets(&truncate_2kb(&body_text)),
         })
     }
 
@@ -2346,7 +2347,7 @@ impl TenantFacade {
                 method: "GET",
                 path_template: "/admin/realms/{realm}/groups".into(),
                 status: KcStatusKind::Http(status),
-                body_first_2kb: truncate_2kb(&body_text),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body_text)),
             });
         }
 
@@ -2397,7 +2398,7 @@ impl TenantFacade {
                 method: "POST",
                 path_template: "/admin/realms/{realm}/groups".into(),
                 status: KcStatusKind::Http(status),
-                body_first_2kb: truncate_2kb(&body_text),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body_text)),
             });
         }
 
@@ -2414,7 +2415,7 @@ impl TenantFacade {
                 method: "GET",
                 path_template: "/admin/realms/{realm}/groups".into(),
                 status: KcStatusKind::Http(lookup_status),
-                body_first_2kb: truncate_2kb(&lookup_body),
+                body_first_2kb: redact_secrets(&truncate_2kb(&lookup_body)),
             });
         }
         let post_create: Vec<GroupRep> =
@@ -2476,7 +2477,7 @@ impl TenantFacade {
                 method: "GET",
                 path_template: "/admin/realms/{realm}/groups".into(),
                 status: KcStatusKind::Http(status),
-                body_first_2kb: truncate_2kb(&body_text),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body_text)),
             });
         }
         let groups: Vec<GroupRep> =
@@ -2537,7 +2538,7 @@ impl TenantFacade {
                 method: "GET",
                 path_template: "/admin/realms/{realm}/groups/{parent_uuid}/children".into(),
                 status: KcStatusKind::Http(status),
-                body_first_2kb: truncate_2kb(&body_text),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body_text)),
             });
         }
         let children: Vec<GroupRep> =

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/tenant_facade.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/tenant_facade.rs
@@ -397,7 +397,7 @@ impl TenantFacade {
                 // Saga was cancelled — its in-body `failure_metrics` /
                 // audit emissions never ran. Emit the failure counter
                 // here so dashboards see the timeout in
-                // `vp_idp_plugin_failure_total{op=provision_tenant,
+                // `keycloak_idp_plugin_failure_total{op=provision_tenant,
                 // failure_variant=ambiguous_created}` alongside the
                 // structured error returned to AM.
                 let err = PluginError::AmbiguousCreated {
@@ -520,7 +520,7 @@ impl TenantFacade {
     /// «orphan from prior Ambiguous» vs «normal already-cleaned cascade»
     /// — return [`PluginError::DeprovisionNotFound`] (success-equivalent
     /// at the AM boundary), and on `am.system` ctx increments the
-    /// `vp_idp_plugin_deprovision_missing_metadata_total` counter
+    /// `keycloak_idp_plugin_deprovision_missing_metadata_total` counter
     /// (DESIGN §9 trigger metric; wired to `OTel`).
     ///
     /// # Errors
@@ -1086,7 +1086,7 @@ impl TenantFacade {
         parsed: &ParsedInput,
     ) -> Result<TenantIdpMetadataV1, PluginError> {
         tracing::debug!(
-            target: "vp_idp_plugin.provision",
+            target: "keycloak_idp.provision",
             tenant_id = %req.tenant_id,
             realm = %parsed.realm_name,
             "provision_shared: step 1 — bootstrap_client + assert_realm_exists (reactive-401)"
@@ -1102,7 +1102,7 @@ impl TenantFacade {
             .await?;
 
         tracing::debug!(
-            target: "vp_idp_plugin.provision",
+            target: "keycloak_idp.provision",
             tenant_id = %req.tenant_id,
             "provision_shared: steps 2-4 — realm_client + ensure_tenant_group [+ bind_admin_user_to_tenant] (reactive-401)"
         );
@@ -1634,7 +1634,7 @@ impl TenantFacade {
         Ok(())
     }
 
-    /// Create the per-realm admin client (`vp-idp-plugin-realm-admin`) as
+    /// Create the per-realm admin client (`keycloak-idp-plugin-realm-admin`) as
     /// a confidential `client_credentials`-only client with a service
     /// account. Returns the client's Keycloak-assigned UUID, discovered via
     /// a follow-up `GET .../clients?clientId=...` (Keycloak returns no body
@@ -2297,7 +2297,7 @@ impl TenantFacade {
             let expected = tenant_id.to_string();
             if let Some(existing) = groups.into_iter().find(|g| g.name == expected) {
                 tracing::info!(
-                    target: "vp_idp_plugin.provision",
+                    target: "keycloak_idp.provision",
                     tenant_id = %tenant_id,
                     group_id = %existing.id,
                     "ensure_tenant_group: subgroup already exists (409 idempotent path)"

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/tenant_facade.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/tenant_facade.rs
@@ -66,12 +66,12 @@ const REALM_MANAGEMENT_CLIENT_ID: &str = "realm-management";
 
 /// Realm attribute key stamping the AM tenant that owns a Created-mode
 /// realm. Written into the `RealmRepresentation.attributes` map at
-/// realm-create time so that (VHP-190 / run am-functional-22):
+/// realm-create time so that (create-path idempotency):
 ///   * a retried / re-entrant realm-create recognises a realm as its own —
 ///     the unique-name 409 from a duplicate POST reconciles to idempotent
 ///     success instead of a false `AmbiguousCreated` → AM 500, and
 ///   * the orphan reaper can GC dedicated realms by owning tenant.
-pub(crate) const PROVISIONING_TENANT_ID_ATTR: &str = "vhp.provisioning.tenant_id";
+pub(crate) const PROVISIONING_TENANT_ID_ATTR: &str = "cf.provisioning.tenant_id";
 
 /// Outcome of probing whether a Created-mode realm already exists and who
 /// owns it, per the [`PROVISIONING_TENANT_ID_ATTR`] marker.
@@ -108,7 +108,7 @@ fn realm_owner_tenant_id(body: &str) -> Option<Uuid> {
 struct ParsedInput {
     realm_binding: RealmBinding,
     realm_name: String,
-    /// Optional Keycloak user UUID for admin-bind bootstrap (VHP-76 §A).
+    /// Optional Keycloak user UUID for admin-bind bootstrap.
     /// When present and `realm_binding = Shared`, `provision_shared` will
     /// PATCH that user's attributes with `tenant_id` and `user_type = "user"`.
     /// v1: bind only in Shared mode (DESIGN bump required to expand).
@@ -125,7 +125,7 @@ struct ParsedInput {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct WireMetadata {
-    /// Realm-binding mode. Optional now (VHP-1836): absent ⇒ `shared`. The
+    /// Realm-binding mode. Optional now: absent ⇒ `shared`. The
     /// effective realm is derived from `target` + mode in `parse_input`, so
     /// `mode` and `realm_name` are no longer mandatory on the wire.
     #[serde(default)]
@@ -134,7 +134,7 @@ struct WireMetadata {
     /// `shared` (inherited from the parent) and rejected for `created`.
     #[serde(default)]
     realm_name: Option<String>,
-    /// Optional Keycloak user UUID for admin-bind bootstrap (VHP-76 §A).
+    /// Optional Keycloak user UUID for admin-bind bootstrap.
     /// Missing field deserialises as `None` — backward compatible with
     /// existing call sites that omit the field.
     ///
@@ -960,7 +960,7 @@ impl TenantFacade {
     }
 
     /// Decode `provisioning_metadata` and derive the EFFECTIVE realm from the
-    /// provisioning `target` + mode (VHP-1836). Pre-KC caller-input rejections
+    /// provisioning `target` + mode. Pre-KC caller-input rejections
     /// surface as [`PluginError::ProvisionInputRejected`] (mapped to a clean
     /// 400) rather than the broad [`PluginError::Config`].
     ///
@@ -1255,7 +1255,7 @@ impl TenantFacade {
 
         // NOTE: `parsed.admin_user_id` is intentionally not acted upon in
         // Adopted mode. v1: bind only in Shared mode (DESIGN bump required
-        // to expand — see VHP-76 §A scope note).
+        // to expand — see §A scope note).
         Ok(TenantIdpMetadataV1 {
             version: "v1".into(),
             realm_name: parsed.realm_name.clone(),
@@ -1297,7 +1297,7 @@ impl TenantFacade {
         // retry narrowly scoped to the call whose token was rejected.
         //
         // Steps 1-2: idempotent realm ensure (probe → create → reconcile).
-        // DESIGN §5.2, hardened per VHP-190 (run am-functional-22): a
+        // DESIGN §5.2, hardened for create-path idempotency: a
         // `mode = created` against an existing realm that is OURS (same
         // tenant marker) is adopted idempotently; a foreign realm is a
         // CleanFailure; and a 409 / lost-response on our own create
@@ -1407,7 +1407,7 @@ impl TenantFacade {
 
         // NOTE: `parsed.admin_user_id` is intentionally not acted upon in
         // Created mode. v1: bind only in Shared mode (DESIGN bump required
-        // to expand — see VHP-76 §A scope note).
+        // to expand — see §A scope note).
         Ok(TenantIdpMetadataV1 {
             version: "v1".into(),
             realm_name: parsed.realm_name.clone(),
@@ -1418,7 +1418,7 @@ impl TenantFacade {
         })
     }
 
-    /// Idempotent realm-create step (DESIGN §5.2, hardened per VHP-190 / run
+    /// Idempotent realm-create step (DESIGN §5.2, hardened per / run
     /// am-functional-22). Folds the existence probe and the create into one
     /// reconciling step so a retried or re-entrant create is safe:
     ///
@@ -1603,7 +1603,7 @@ impl TenantFacade {
                 "displayName".into(),
                 serde_json::Value::String(req.name.clone()),
             );
-            // Ownership marker (VHP-190): stamp the AM tenant that owns this
+            // Ownership marker: stamp the AM tenant that owns this
             // realm so a retried / re-entrant create recognises it as ours
             // (`ensure_realm` reconcile) and the reaper can GC orphans by
             // owner. Plugin-set, after the allowlist gate — not operator-tunable.

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/tenant_facade.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/tenant_facade.rs
@@ -1,0 +1,2565 @@
+//! `TenantFacade` — provision/deprovision tenants against Keycloak per DESIGN §4.2.
+//!
+//! Handles all three [`RealmBinding`] modes (Shared / Adopted / Created),
+//! including the Created-mode saga that creates a per-tenant realm,
+//! realm-admin client, role mappings, and OpenBao-stored realm-admin secret.
+//!
+//! See DESIGN §4.1 (Adopted row — narrow emptiness scope), §4.2
+//! (component design), §5.2 (input contract — `mode = adopted` requires
+//! empty parent tenant group), §5.4 ("Group emptiness check" — absent
+//! parent is success-equivalent), and ADDENDUM §3.4 (the
+//! `admin_secret_ref = None` rule for default-shared-realm tenants).
+//!
+//! Suppressed module-wide: every private struct below is a wire shape — the
+//! `provisioning_metadata` blob AM forwards verbatim, and the field subsets of
+//! Keycloak's Admin REST representations this facade reads back.
+#![allow(unknown_lints, de0101_no_serde_in_contract)]
+
+use std::sync::{Arc, OnceLock};
+
+use account_management_sdk::idp::{
+    IdpDeprovisionTenantRequest, IdpProvisionTarget, IdpProvisionTenantRequest,
+};
+use credstore_sdk::{SecretRef, SecretValue, SharingMode};
+use regex::Regex;
+use serde::Deserialize;
+use toolkit_macros::domain_model;
+use toolkit_security::SecurityContext;
+use uuid::Uuid;
+
+use crate::config::{RealmAdminConfig, TenantFacadeConfig};
+use crate::domain::audit;
+use crate::domain::credstore::CredStoreWriter;
+use crate::domain::error::{AmbiguousStage, KcStatusKind, PluginError};
+use crate::domain::kc::KcAdminClient;
+use crate::domain::kc::factory::{KeycloakAdminClientFactory, SecretSource};
+use crate::domain::kc::transport::truncate_2kb;
+use crate::domain::metadata_codec::{MetadataCodec, RealmBinding, TenantIdpMetadataV1};
+use crate::domain::ports::metrics::{
+    CredstoreMetricsPort, CredstoreOp, CredstoreOutcome, FailureMetricsPort, FailureVariant,
+    MetadataCodecMetricsPort, PluginOp, TenantLifecycleMetricsPort, VersionObserved,
+};
+use crate::domain::service_principal_facade::ServicePrincipalFacade;
+
+/// Per-realm `realm-management` roles granted to the Created-mode realm-admin
+/// client's service account (DESIGN §8.1 least-privilege table for the
+/// per-realm admin). Matches the capability matrix:
+///   view-realm + view-clients      → read realm metadata
+///   query-groups + manage-realm    → manage tenant groups (group CRUD)
+///   manage-users + query-users     → manage users
+///   manage-clients                 → manage client scopes / protocol mappers
+const REALM_ADMIN_REQUIRED_ROLES: &[&str] = &[
+    "view-realm",
+    "view-clients",
+    "query-groups",
+    "manage-realm",
+    "manage-users",
+    "query-users",
+    "manage-clients",
+];
+
+/// `clientId` of the Keycloak built-in `realm-management` client. Each realm
+/// hosts one such client; its roles (`view-realm`, `manage-users`, …) are the
+/// canonical per-realm RBAC anchors granted to the plugin's realm-admin
+/// service account.
+const REALM_MANAGEMENT_CLIENT_ID: &str = "realm-management";
+
+/// Realm attribute key stamping the AM tenant that owns a Created-mode
+/// realm. Written into the `RealmRepresentation.attributes` map at
+/// realm-create time so that (VHP-190 / run am-functional-22):
+///   * a retried / re-entrant realm-create recognises a realm as its own —
+///     the unique-name 409 from a duplicate POST reconciles to idempotent
+///     success instead of a false `AmbiguousCreated` → AM 500, and
+///   * the orphan reaper can GC dedicated realms by owning tenant.
+pub(crate) const PROVISIONING_TENANT_ID_ATTR: &str = "vhp.provisioning.tenant_id";
+
+/// Outcome of probing whether a Created-mode realm already exists and who
+/// owns it, per the [`PROVISIONING_TENANT_ID_ATTR`] marker.
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RealmProbe {
+    /// `GET /admin/realms/{realm}` → 404. Realm absent; safe to create.
+    Absent,
+    /// Realm present and its ownership marker matches the requesting tenant.
+    OwnedByUs,
+    /// Realm present but the marker is missing or names a different tenant.
+    Foreign,
+}
+
+/// Parse the owning tenant id out of a `RealmRepresentation` body by reading
+/// the [`PROVISIONING_TENANT_ID_ATTR`] attribute. Tolerates both the scalar
+/// (`"id"`) and single-element-array (`["id"]`) attribute encodings Keycloak
+/// versions have used. Returns `None` when the body is unparsable or the
+/// marker is absent / malformed.
+fn realm_owner_tenant_id(body: &str) -> Option<Uuid> {
+    let value: serde_json::Value = serde_json::from_str(body).ok()?;
+    let attr = value.get("attributes")?.get(PROVISIONING_TENANT_ID_ATTR)?;
+    let raw = match attr {
+        serde_json::Value::String(s) => s.as_str(),
+        serde_json::Value::Array(items) => items.first()?.as_str()?,
+        _ => return None,
+    };
+    Uuid::parse_str(raw).ok()
+}
+
+/// Decoded `provisioning_metadata` input (DESIGN §5.2 wire shape).
+#[domain_model]
+#[derive(Debug)]
+struct ParsedInput {
+    realm_binding: RealmBinding,
+    realm_name: String,
+    /// Optional Keycloak user UUID for admin-bind bootstrap (VHP-76 §A).
+    /// When present and `realm_binding = Shared`, `provision_shared` will
+    /// PATCH that user's attributes with `tenant_id` and `user_type = "user"`.
+    /// v1: bind only in Shared mode (DESIGN bump required to expand).
+    admin_user_id: Option<Uuid>,
+}
+
+/// Wire shape of `provisioning_metadata` (DESIGN §5.2 — `mode`/`realm_name`).
+///
+/// `deny_unknown_fields` makes future schema drift (e.g. a v2 plugin emitting
+/// extra keys) loud rather than silent: a v1 plugin reading a v2 input fails
+/// the request (`ProvisionInputRejected` → 400) instead of stripping the extras
+/// and acting on a partial view.
+#[domain_model]
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireMetadata {
+    /// Realm-binding mode. Optional now (VHP-1836): absent ⇒ `shared`. The
+    /// effective realm is derived from `target` + mode in `parse_input`, so
+    /// `mode` and `realm_name` are no longer mandatory on the wire.
+    #[serde(default)]
+    mode: Option<String>,
+    /// Explicit realm name. Required only for Root and `adopted`; ignored for
+    /// `shared` (inherited from the parent) and rejected for `created`.
+    #[serde(default)]
+    realm_name: Option<String>,
+    /// Optional Keycloak user UUID for admin-bind bootstrap (VHP-76 §A).
+    /// Missing field deserialises as `None` — backward compatible with
+    /// existing call sites that omit the field.
+    ///
+    /// `""` (empty string) also deserialises as `None`. Reason: production
+    /// `config/server.yaml` always carries `admin_user_id: "${VP_..._USER_ID:-}"`
+    /// so the bind step is default-on; in dev / non-IaC environments the env
+    /// var is unset → POSIX default-empty expansion leaves an empty string,
+    /// which must decode as "no bind" rather than fail the saga.
+    #[serde(default, deserialize_with = "deserialize_optional_uuid_or_empty")]
+    admin_user_id: Option<Uuid>,
+}
+
+/// Custom deserializer treating both missing and empty-string inputs as `None`.
+/// See `WireMetadata::admin_user_id` doc comment for rationale.
+fn deserialize_optional_uuid_or_empty<'de, D>(deserializer: D) -> Result<Option<Uuid>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw: Option<String> = Option::deserialize(deserializer)?;
+    match raw {
+        None => Ok(None),
+        Some(s) if s.is_empty() => Ok(None),
+        Some(s) => Uuid::parse_str(&s)
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+    }
+}
+
+/// Subset of Keycloak's `GroupRepresentation` the facade needs (the `id`
+/// returned by `POST .../groups` / `POST .../children`, plus the `name` used
+/// to match the parent in a `search=&exact=true` listing).
+#[domain_model]
+#[derive(Deserialize)]
+struct GroupRep {
+    id: Uuid,
+    #[serde(default)]
+    name: String,
+}
+
+/// Subset of Keycloak's `ClientRepresentation` the facade needs when looking
+/// up the freshly-created realm-admin client (and the built-in
+/// `realm-management` client) by `clientId` via
+/// `GET /admin/realms/{realm}/clients?clientId=...`.
+#[domain_model]
+#[derive(Deserialize)]
+struct ClientRep {
+    id: Uuid,
+}
+
+/// Subset of Keycloak's `UserRepresentation` for the service-account-user
+/// endpoint (`GET .../clients/{uuid}/service-account-user`).
+#[domain_model]
+#[derive(Deserialize)]
+struct UserRep {
+    id: Uuid,
+}
+
+/// Subset of Keycloak's `RoleRepresentation` for role-mapping calls. Both
+/// `id` and `name` MUST be echoed back when `POST`-ing to
+/// `/role-mappings/clients/{rm_uuid}`.
+#[domain_model]
+#[derive(Deserialize, serde::Serialize, Clone)]
+struct RoleRep {
+    id: Uuid,
+    name: String,
+}
+
+/// Subset of Keycloak's `CredentialRepresentation` for the
+/// `GET .../clients/{uuid}/client-secret` endpoint.
+#[domain_model]
+#[derive(Deserialize)]
+struct CredentialRep {
+    value: String,
+}
+
+/// Compiled form of the DESIGN §5.2 realm-name regex. Initialised once via
+/// [`OnceLock`]; panics only if the literal pattern is malformed (compile-time
+/// invariant — the pattern is a constant).
+#[allow(clippy::expect_used)] // regex literal is a compile-time constant; cannot fail at runtime
+fn realm_name_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"^[A-Za-z0-9_-]{1,200}$").expect("valid regex"))
+}
+
+/// Re-tag a transport-level [`PluginError::KcRest`] surfaced by
+/// [`KcAdminClient::raw_request`] as an [`PluginError::AmbiguousCreated`] so the
+/// caller's stage attribution is preserved. Created-mode mid-saga transport
+/// failures are inherently ambiguous (the request may have landed; we just
+/// never got the response), so this collapse is correct.
+pub(crate) fn ambiguous_from_kc_error(stage: AmbiguousStage, e: PluginError) -> PluginError {
+    match e {
+        PluginError::KcRest {
+            method,
+            path_template,
+            status,
+            body_first_2kb,
+        } => PluginError::AmbiguousCreated {
+            stage,
+            detail: format!("kc:{method} {path_template} -> {status}: {body_first_2kb}"),
+        },
+        other => other,
+    }
+}
+
+// `failure_variant_label` lives in `crate::domain::error` (single source of truth).
+
+/// Re-tag any [`PluginError::KcRest`] surfaced on the deprovision saga as
+/// [`PluginError::DeprovisionRetryable`] per DESIGN §6.2 — transport /
+/// timeout / non-2xx upstream failures all defer to the next retention
+/// tick. Non-[`PluginError::KcRest`] variants (e.g.
+/// [`PluginError::CredStoreRead`],
+/// [`PluginError::BootstrapPermsMissing`]) pass through unchanged so the
+/// Phase 15 boundary can translate them.
+fn deprovision_translate_kc(e: PluginError) -> PluginError {
+    match e {
+        PluginError::KcRest {
+            method,
+            path_template,
+            status,
+            body_first_2kb,
+        } => PluginError::DeprovisionRetryable {
+            detail: format!("kc:{method} {path_template} -> {status}: {body_first_2kb}"),
+        },
+        other => other,
+    }
+}
+
+/// Classify failures from the service-principal purge step when it runs as
+/// part of tenant deprovisioning. Retryable KC statuses keep the retention row
+/// moving; permanent 4xx/config-shape failures park as Terminal so operators
+/// get one actionable row instead of an endless retention loop.
+fn deprovision_translate_sp_purge(e: PluginError) -> PluginError {
+    match e {
+        PluginError::KcRest {
+            method,
+            path_template,
+            status,
+            body_first_2kb,
+        } if status.is_retryable() => PluginError::DeprovisionRetryable {
+            detail: format!(
+                "service-principal purge: kc:{method} {path_template} -> {status}: {body_first_2kb}"
+            ),
+        },
+        PluginError::KcRest {
+            method,
+            path_template,
+            status,
+            body_first_2kb,
+        } => PluginError::DeprovisionTerminal {
+            detail: format!(
+                "service-principal purge: kc:{method} {path_template} -> {status}: {body_first_2kb}"
+            ),
+        },
+        other @ PluginError::AmbiguousCreated { .. } => PluginError::DeprovisionRetryable {
+            detail: format!("service-principal purge ambiguous: {other}"),
+        },
+        // No explicit `SpNotFound` arm: `purge_tenant_principals` swallows
+        // per-client 404s internally, so it never surfaces here. The
+        // catch-all maps any hypothetical future `SpNotFound` to
+        // `DeprovisionTerminal` — NOT `DeprovisionNotFound`, which would be
+        // read as success-equivalent and skip realm/tenant teardown.
+        other => PluginError::DeprovisionTerminal {
+            detail: format!("service-principal purge: {other}"),
+        },
+    }
+}
+
+#[domain_model]
+pub struct TenantFacade {
+    cfg: TenantFacadeConfig,
+    realm_admin_cfg: RealmAdminConfig,
+    kc_factory: Arc<KeycloakAdminClientFactory>,
+    /// Used by `deprovision_tenant_inner` to decode the persisted blob; the
+    /// encode-on-success path lives at the `idp_impl` boundary on the plugin
+    /// root struct.
+    codec: Arc<MetadataCodec>,
+    /// Used by Created mode (DESIGN §4.7 / §8.1) to persist the per-realm
+    /// admin secret under the templated `SecretRef`. Shared / Adopted never
+    /// write — those realms' admin secrets are operator-provisioned.
+    cs_writer: CredStoreWriter,
+    // Segregated metric ports (DESIGN §9). One `Arc` per subdomain so a
+    // future test fixture can mock just the surface it asserts on.
+    tenant_metrics: Arc<dyn TenantLifecycleMetricsPort>,
+    credstore_metrics: Arc<dyn CredstoreMetricsPort>,
+    metadata_metrics: Arc<dyn MetadataCodecMetricsPort>,
+    failure_metrics: Arc<dyn FailureMetricsPort>,
+    /// Optional cascade hook installed by module wiring after both facades are
+    /// constructed. Tests that focus only on tenant lifecycle leave it unset.
+    sp_purge_facade: OnceLock<Arc<ServicePrincipalFacade>>,
+}
+
+impl TenantFacade {
+    #[must_use]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "DI surface: four typed metric-port views are part of the segregated-ports refactor; a builder would just trade arg count for indirection"
+    )]
+    pub fn new(
+        cfg: TenantFacadeConfig,
+        realm_admin_cfg: RealmAdminConfig,
+        kc_factory: Arc<KeycloakAdminClientFactory>,
+        codec: Arc<MetadataCodec>,
+        cs_writer: CredStoreWriter,
+        tenant_metrics: Arc<dyn TenantLifecycleMetricsPort>,
+        credstore_metrics: Arc<dyn CredstoreMetricsPort>,
+        metadata_metrics: Arc<dyn MetadataCodecMetricsPort>,
+        failure_metrics: Arc<dyn FailureMetricsPort>,
+    ) -> Self {
+        Self {
+            cfg,
+            realm_admin_cfg,
+            kc_factory,
+            codec,
+            cs_writer,
+            tenant_metrics,
+            credstore_metrics,
+            metadata_metrics,
+            failure_metrics,
+            sp_purge_facade: OnceLock::new(),
+        }
+    }
+
+    /// Install the tenant-deprovision service-principal purge hook.
+    ///
+    /// The facade is created after `TenantFacade` in module wiring, so this is
+    /// a one-shot setter instead of a constructor argument. Repeated calls are
+    /// ignored to keep test fixtures simple and avoid panics in init code.
+    pub fn set_service_principal_purge_facade(&self, facade: Arc<ServicePrincipalFacade>) {
+        let _ = self.sp_purge_facade.set(facade);
+    }
+
+    /// Internal facade method: returns the plugin's [`TenantIdpMetadataV1`] on
+    /// success, [`PluginError`] on failure. The boundary at `idp_impl.rs`
+    /// (Phase 15) translates this into the typed SDK
+    /// `IdpProvisionFailure` variants.
+    ///
+    /// Wraps the saga body in `tokio::time::timeout` keyed on
+    /// `cfg.provision_timeout_ms` (DESIGN §4.2). A timeout returns
+    /// [`PluginError::AmbiguousCreated`] with stage
+    /// [`AmbiguousStage::Timeout`] because the saga may have partially
+    /// applied side-effects inside Keycloak or `OpenBao`.
+    ///
+    /// # Errors
+    ///
+    /// * [`PluginError::Config`] for malformed `provisioning_metadata` input.
+    /// * [`PluginError::KcRest`] for transport / non-2xx KC responses.
+    /// * [`PluginError::CredStoreRead`] if the realm-admin credential cannot
+    ///   be resolved from `OpenBao` (Adopted / Created modes).
+    /// * [`PluginError::AmbiguousCreated`] with stage [`AmbiguousStage::Timeout`]
+    ///   when the saga exceeds `provision_timeout_ms`.
+    pub async fn provision_tenant_inner(
+        &self,
+        ctx: &SecurityContext,
+        req: &IdpProvisionTenantRequest,
+    ) -> Result<TenantIdpMetadataV1, PluginError> {
+        let timeout = std::time::Duration::from_millis(self.cfg.provision_timeout_ms);
+        match tokio::time::timeout(timeout, self.provision_tenant_saga(ctx, req)).await {
+            Ok(result) => result,
+            Err(_elapsed) => {
+                // Saga was cancelled — its in-body `failure_metrics` /
+                // audit emissions never ran. Emit the failure counter
+                // here so dashboards see the timeout in
+                // `vp_idp_plugin_failure_total{op=provision_tenant,
+                // failure_variant=ambiguous_created}` alongside the
+                // structured error returned to AM.
+                let err = PluginError::AmbiguousCreated {
+                    stage: AmbiguousStage::Timeout,
+                    detail: format!(
+                        "provision_tenant timed out after {}ms (DESIGN §4.2 provision_timeout_ms)",
+                        self.cfg.provision_timeout_ms
+                    ),
+                };
+                self.failure_metrics
+                    .failure(PluginOp::ProvisionTenant, FailureVariant::from(&err));
+                Err(err)
+            }
+        }
+    }
+
+    /// Saga body for [`Self::provision_tenant_inner`]. Separated so the outer
+    /// wrapper can apply `provision_timeout_ms` (DESIGN §4.2).
+    async fn provision_tenant_saga(
+        &self,
+        ctx: &SecurityContext,
+        req: &IdpProvisionTenantRequest,
+    ) -> Result<TenantIdpMetadataV1, PluginError> {
+        let started = std::time::Instant::now();
+        // Decode the parsed metadata first so we can label the latency
+        // histogram by `realm_binding` regardless of outcome. Malformed
+        // input → bare `Config` failure with no histogram sample (the call
+        // never made it to a binding-specific path).
+        //
+        // Order rationale: parse-then-probe, NOT probe-then-parse.
+        // A malformed-input fast-fail must not pay the cost of a KC
+        // round-trip — an operator with a typo'd `provisioning_metadata`
+        // gets an immediate clear `Config` rather than racing the
+        // probe's transport timeout. Once parse succeeds we know the
+        // bind is shaped legitimately and only then is it worth
+        // confirming KC is reachable.
+        let parsed = match Self::parse_input(req) {
+            Ok(p) => p,
+            Err(e) => {
+                self.failure_metrics
+                    .failure(PluginOp::ProvisionTenant, FailureVariant::from(&e));
+                return Err(e);
+            }
+        };
+        // Pre-saga `health_probe` (DESIGN §4.4) — a flat-out KC outage
+        // surfaces as `CleanFailure` here so the binding-specific saga
+        // never starts. We re-tag the underlying `KcRest{Transport|Timeout|
+        // Http(5xx)}` (which Phase 15 would map to `Ambiguous`) as
+        // `Config` because the probe is the FIRST KC touch; nothing has
+        // been mutated yet, so "Ambiguous" would understate our
+        // knowledge and produce unnecessary AM-reaper work.
+        if let Err(e) = self.kc_factory.health_probe().await {
+            let err = PluginError::Config {
+                detail: format!("pre-saga KC health probe failed: {e}; refusing to start saga"),
+            };
+            self.failure_metrics
+                .failure(PluginOp::ProvisionTenant, FailureVariant::from(&err));
+            return Err(err);
+        }
+        let result = match parsed.realm_binding {
+            RealmBinding::Shared => self.provision_shared(ctx, req, &parsed).await,
+            RealmBinding::Adopted => self.provision_adopted(req, &parsed).await,
+            RealmBinding::Created => self.provision_created(req, &parsed).await,
+        };
+        let elapsed = started.elapsed().as_secs_f64();
+        self.tenant_metrics
+            .provision_tenant_duration(parsed.realm_binding, elapsed);
+        match &result {
+            Ok(meta) => {
+                // Cardinality watchdog lives inside the adapter — the call
+                // site just passes the realm name as `&str` and the adapter
+                // decides whether to attach the label.
+                self.tenant_metrics
+                    .realm_bound(meta.realm_binding, &meta.realm_name);
+                audit::emit_tenant_bound(
+                    ctx,
+                    req.tenant_id,
+                    &meta.realm_name,
+                    meta.realm_binding,
+                    meta.admin_secret_ref.as_deref(),
+                );
+                if meta.realm_binding == RealmBinding::Created {
+                    audit::emit_realm_created(ctx, req.tenant_id, &meta.realm_name);
+                }
+            }
+            Err(e) => {
+                // The decode-failure mirror that lived here was
+                // unreachable: provision goes through `parse_input`
+                // (which yields `PluginError::Config`, never
+                // `PluginError::MetadataDecode`), so the dedicated
+                // `metadata_decode_failure` counter only fires from
+                // the deprovision path. Removed to stop a future
+                // refactor from being misled into thinking provision
+                // emits the counter. The invariant is now load-bearing
+                // — assert it in debug builds so a refactor that
+                // legitimately surfaces a decode error here trips a
+                // loud failure instead of silently bypassing the
+                // dedicated counter.
+                debug_assert!(
+                    !matches!(e, PluginError::MetadataDecode(_)),
+                    "provision_tenant_saga is not expected to surface MetadataDecode; \
+                     if this changes, wire metadata_metrics.metadata_decode_failure here \
+                     symmetric with the deprovision path"
+                );
+                self.failure_metrics
+                    .failure(PluginOp::ProvisionTenant, FailureVariant::from(e));
+            }
+        }
+        result
+    }
+
+    /// Internal facade method for tenant deprovisioning. Decodes the
+    /// persisted [`TenantIdpMetadataV1`] from `req.tenant_context.metadata`,
+    /// deletes the per-tenant group, and for [`RealmBinding::Created`]
+    /// additionally tears down the realm + realm-admin secret when the
+    /// parent tenant group becomes empty (DESIGN §4.2, §5.5, §6.2).
+    ///
+    /// **Missing-metadata branch** (DESIGN §4.2 / §6.2 / §9): when
+    /// `req.tenant_context.metadata == None`, we cannot self-classify
+    /// «orphan from prior Ambiguous» vs «normal already-cleaned cascade»
+    /// — return [`PluginError::DeprovisionNotFound`] (success-equivalent
+    /// at the AM boundary), and on `am.system` ctx increments the
+    /// `vp_idp_plugin_deprovision_missing_metadata_total` counter
+    /// (DESIGN §9 trigger metric; wired to `OTel`).
+    ///
+    /// # Errors
+    ///
+    /// * [`PluginError::DeprovisionNotFound`] — vendor 404/410 or
+    ///   `metadata = None` (success-equivalent in AM's pipeline).
+    /// * [`PluginError::DeprovisionRetryable`] — transient 5xx / transport /
+    ///   timeout failures on any saga step.
+    /// * [`PluginError::DeprovisionTerminal`] — malformed persisted metadata
+    ///   or other operator-must-intervene state.
+    /// * [`PluginError::BootstrapPermsMissing`] — propagated unchanged so
+    ///   the Phase 15 boundary can translate it.
+    pub async fn deprovision_tenant_inner(
+        &self,
+        ctx: &SecurityContext,
+        req: &IdpDeprovisionTenantRequest,
+    ) -> Result<(), PluginError> {
+        // Wrap the saga in the same per-call timeout as provision. A hung
+        // KC call (token endpoint, group DELETE, descendant count) would
+        // otherwise hang the AM caller indefinitely; per DESIGN §4.2 the
+        // upper bound is the operator-tunable `provision_timeout_ms`
+        // (used here for symmetry — deprovision has the same saga
+        // surface area as provision).
+        let timeout = std::time::Duration::from_millis(self.cfg.provision_timeout_ms);
+        match tokio::time::timeout(timeout, self.deprovision_tenant_saga(ctx, req)).await {
+            Ok(result) => result,
+            Err(_elapsed) => {
+                // Saga cancelled — its in-body `failure_metrics`/audit
+                // emissions never ran. Emit the failure counter here so
+                // dashboards see the timeout symmetric with the
+                // provision-timeout arm above.
+                let err = PluginError::DeprovisionRetryable {
+                    detail: format!(
+                        "deprovision_tenant timed out after {}ms (DESIGN §4.2 provision_timeout_ms)",
+                        self.cfg.provision_timeout_ms
+                    ),
+                };
+                self.failure_metrics
+                    .failure(PluginOp::DeprovisionTenant, FailureVariant::from(&err));
+                Err(err)
+            }
+        }
+    }
+
+    /// Saga body for [`Self::deprovision_tenant_inner`]. Separated so the
+    /// outer wrapper can apply the per-call timeout (DESIGN §4.2).
+    async fn deprovision_tenant_saga(
+        &self,
+        ctx: &SecurityContext,
+        req: &IdpDeprovisionTenantRequest,
+    ) -> Result<(), PluginError> {
+        // Order rationale: missing-metadata + decode branches BEFORE
+        // `health_probe`. Both pre-decode paths return without touching
+        // KC at all (success-equivalent `DeprovisionNotFound` or
+        // operator-intervention `DeprovisionTerminal`), so probing KC
+        // first would (a) waste a round-trip on inputs the plugin can
+        // resolve locally and (b) mask a malformed-metadata `Terminal`
+        // behind a `Retryable` when KC also happens to be down. The
+        // probe runs once we know the saga will actually need KC.
+        // ---- Missing-metadata branch (DESIGN §4.2 / §6.2). ----
+        let Some(blob) = req.tenant_context.metadata.as_ref() else {
+            if ctx.subject_type() == Some("am.system") {
+                // Increment the DESIGN §9 trigger metric; the audit event
+                // below fires on every missing-metadata branch regardless of
+                // caller's subject_type so operators see the actor + tenant id.
+                self.tenant_metrics.deprovision_missing_metadata();
+            }
+            // Symmetric with the `Ok(None)` decode branch + the
+            // `DeprovisionNotFound` post-decode arm: every path that
+            // returns DeprovisionNotFound increments the generic failure
+            // counter so dashboards don't under-count the missing-metadata
+            // case.
+            self.failure_metrics.failure(
+                PluginOp::DeprovisionTenant,
+                FailureVariant::DEPROVISION_NOT_FOUND,
+            );
+            audit::emit_tenant_unbound(
+                ctx,
+                req.tenant_context.tenant_id,
+                "",
+                None,
+                /* already_absent = */ true,
+                /* removed_realm = */ false,
+            );
+            return Err(PluginError::DeprovisionNotFound {
+                realm_name: "unknown".into(),
+            });
+        };
+
+        // ---- Decode persisted metadata. ----
+        let metadata = match self.codec.decode(Some(blob.clone())) {
+            Ok(Some(m)) => m,
+            // Decoded `None` is unreachable when input was `Some(_)`; treat
+            // as missing metadata for safety (no `tracing::warn!` here — we
+            // already know the input WAS present, just decoded empty).
+            Ok(None) => {
+                self.failure_metrics.failure(
+                    PluginOp::DeprovisionTenant,
+                    FailureVariant::DEPROVISION_NOT_FOUND,
+                );
+                return Err(PluginError::DeprovisionNotFound {
+                    realm_name: "unknown".into(),
+                });
+            }
+            Err(e) => {
+                self.metadata_metrics
+                    .metadata_decode_failure(VersionObserved::from(&e));
+                self.failure_metrics.failure(
+                    PluginOp::DeprovisionTenant,
+                    FailureVariant::DEPROVISION_TERMINAL,
+                );
+                return Err(PluginError::DeprovisionTerminal {
+                    detail: format!("metadata decode failed: {e}"),
+                });
+            }
+        };
+
+        // Pre-saga `health_probe` (DESIGN §4.4) — runs AFTER decode so
+        // local-only resolutions (missing-metadata, decode-terminal) get
+        // their own clear failure type instead of being masked as
+        // `Retryable`. Beyond this point the saga is guaranteed to need
+        // KC, so a probe failure is unambiguously the right time to
+        // bail. The downstream `DeprovisionRetryable` carrier maps to
+        // `IdpDeprovisionFailure::Retryable` at the Phase 15 boundary.
+        if let Err(e) = self.kc_factory.health_probe().await {
+            let err = PluginError::DeprovisionRetryable {
+                detail: format!("pre-saga KC health probe failed: {e}; retry once KC is back"),
+            };
+            self.failure_metrics
+                .failure(PluginOp::DeprovisionTenant, FailureVariant::from(&err));
+            return Err(err);
+        }
+
+        if let Some(sp_facade) = self.sp_purge_facade.get() {
+            match sp_facade
+                .purge_tenant_principals(req.tenant_context.tenant_id)
+                .await
+            {
+                Ok(deleted_count) => {
+                    if deleted_count > 0 {
+                        audit::emit_service_principals_purged(
+                            ctx,
+                            req.tenant_context.tenant_id,
+                            deleted_count,
+                        );
+                    }
+                }
+                Err(e) => {
+                    let err = deprovision_translate_sp_purge(e);
+                    self.failure_metrics
+                        .failure(PluginOp::DeprovisionTenant, FailureVariant::from(&err));
+                    return Err(err);
+                }
+            }
+        }
+
+        // Delegate the post-decode saga to a helper that returns whether
+        // the realm itself was torn down (Created last-tenant), so the
+        // outer wrapper can attribute audit + metric increments
+        // consistently regardless of which step failed.
+        match self.deprovision_after_decode(&metadata).await {
+            Ok(removed_realm) => {
+                audit::emit_tenant_unbound(
+                    ctx,
+                    req.tenant_context.tenant_id,
+                    &metadata.realm_name,
+                    Some(metadata.realm_binding),
+                    /* already_absent = */ false,
+                    removed_realm,
+                );
+                // Decrement the `realms_bound` UpDownCounter on EVERY
+                // successful deprovision, symmetric with the `+1` that
+                // fires on every successful provision (see
+                // `provision_tenant_saga` Ok arm). The previous
+                // implementation only decremented on Created last-tenant
+                // teardown, which monotonically drifted the gauge upward
+                // for Shared/Adopted lifecycles. Cardinality watchdog
+                // lives inside the adapter.
+                self.tenant_metrics
+                    .realm_unbound(metadata.realm_binding, &metadata.realm_name);
+                if removed_realm {
+                    audit::emit_realm_removed(
+                        ctx,
+                        req.tenant_context.tenant_id,
+                        &metadata.realm_name,
+                    );
+                }
+                Ok(())
+            }
+            Err(e) => {
+                if matches!(e, PluginError::DeprovisionNotFound { .. }) {
+                    // 404/410 is success-equivalent at the AM boundary; emit
+                    // an `already_absent` audit event so the operator log
+                    // mirrors the Phase 15 boundary's success translation.
+                    audit::emit_tenant_unbound(
+                        ctx,
+                        req.tenant_context.tenant_id,
+                        &metadata.realm_name,
+                        Some(metadata.realm_binding),
+                        /* already_absent = */ true,
+                        /* removed_realm = */ false,
+                    );
+                }
+                self.failure_metrics
+                    .failure(PluginOp::DeprovisionTenant, FailureVariant::from(&e));
+                Err(e)
+            }
+        }
+    }
+
+    /// Post-decode portion of [`Self::deprovision_tenant_inner`]: resolves
+    /// the secret source, deletes the tenant group, and for
+    /// [`RealmBinding::Created`] additionally tears down the realm + the
+    /// `OpenBao`-backed realm-admin secret when the parent tenant group
+    /// becomes empty. Returns `Ok(removed_realm)` where `removed_realm`
+    /// is `true` iff this call `DELETE`d the realm (Created last-tenant
+    /// teardown).
+    async fn deprovision_after_decode(
+        &self,
+        metadata: &TenantIdpMetadataV1,
+    ) -> Result<bool, PluginError> {
+        // ---- Resolve realm-admin secret source. ----
+        // Shared blobs are persisted with `admin_secret_ref = None`
+        // (ADDENDUM §3.4 — Shared uses the env-backed inline secret
+        // resolved at module init via toolkit's `ExpandVars`); Adopted /
+        // Created always carry a templated OpenBao `SecretRef` on the
+        // metadata blob.
+        let secret_source = if let Some(ref_str) = metadata.admin_secret_ref.as_ref() {
+            let secret_ref =
+                SecretRef::new(ref_str).map_err(|e| PluginError::DeprovisionTerminal {
+                    detail: format!("admin_secret_ref invalid: {e}"),
+                })?;
+            SecretSource::OpenBaoRef(secret_ref)
+        } else {
+            SecretSource::Inline(
+                self.realm_admin_cfg
+                    .default_shared_realm_secret
+                    .clone_into_secret_string(),
+            )
+        };
+
+        // ---- DELETE tenant group via realm-admin (reactive-401). ----
+        //
+        // The wrapper acquires the realm-admin client, runs the DELETE,
+        // and retries on a 401 from KC's auth layer so an operator-
+        // rotated realm-admin secret converges without restart
+        // (DESIGN §8.1 rotation lifecycle). `deprovision_translate_kc`
+        // applied at the outer `.await` translates any `KcRest` that
+        // leaks from acquire-stage failures OR a second-401 escape
+        // into `DeprovisionRetryable`; closure-returned variants
+        // (`DeprovisionNotFound`, `DeprovisionRetryable`) pass through
+        // unchanged.
+        let group_url = format!(
+            "{}admin/realms/{}/groups/{}",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(&metadata.realm_name),
+            metadata.tenant_group_id,
+        );
+        self.kc_factory
+            .with_reactive_401(
+                &metadata.realm_name,
+                &metadata.admin_client_id,
+                &secret_source,
+                |realm_admin| {
+                    // Closure must be `Fn`-callable across the
+                    // wrapper's retry, so owned String captures clone
+                    // on each invocation instead of being moved once.
+                    let group_url = group_url.clone();
+                    async move {
+                        let (status, body) = Self::kc_delete_status(
+                            &realm_admin,
+                            &group_url,
+                            "/admin/realms/{realm}/groups/{tenant_group_id}",
+                        )
+                        .await?;
+                        match status {
+                            200..=299 => Ok(()),
+                            // Surface 401 as KcRest so the wrapper triggers
+                            // its single retry. `kc_delete_status` returns
+                            // 401 as `Ok((401, body))` — we re-tag here.
+                            401 => Err(PluginError::KcRest {
+                                method: "DELETE",
+                                path_template:
+                                    "/admin/realms/{realm}/groups/{tenant_group_id}".into(),
+                                status: KcStatusKind::Http(401),
+                                body_first_2kb: body,
+                            }),
+                            404 | 410 => Err(PluginError::DeprovisionNotFound {
+                                realm_name: metadata.realm_name.clone(),
+                            }),
+                            other => Err(PluginError::DeprovisionRetryable {
+                                detail: format!(
+                                    "kc:DELETE /admin/realms/{{realm}}/groups/{{tenant_group_id}} -> {other}: {body}",
+                                ),
+                            }),
+                        }
+                    }
+                },
+            )
+            .await
+            .map_err(deprovision_translate_kc)?;
+
+        // ---- Created-only: parent emptiness check + realm/secret cleanup. ----
+        if metadata.realm_binding != RealmBinding::Created {
+            return Ok(false);
+        }
+
+        let parent_name = self
+            .cfg
+            .tenant_group_root
+            .trim_start_matches('/')
+            .to_owned();
+
+        // Bootstrap-side probe (find_top_group + has_subgroup) —
+        // both reads, both idempotent, so wrapping the pair under a
+        // single reactive-401 closure is safe under exactly-once
+        // retry. `BootstrapPermsMissing` propagates so Phase 15
+        // translates verbatim (DESIGN §5.2 line 432); other KcRest
+        // hits get the `deprovision_translate_kc` mapping.
+        let has_remaining_tenants = match self
+            .kc_factory
+            .with_reactive_401_bootstrap(|bootstrap| {
+                let parent_name = parent_name.clone();
+                async move {
+                    match self
+                        .find_top_group(&bootstrap, &metadata.realm_name, &parent_name)
+                        .await?
+                    {
+                        Some(parent) => {
+                            self.has_subgroup(&bootstrap, &metadata.realm_name, parent.id)
+                                .await
+                        }
+                        None => Ok(false),
+                    }
+                }
+            })
+            .await
+        {
+            Ok(b) => b,
+            Err(PluginError::BootstrapPermsMissing { realm }) => {
+                return Err(PluginError::BootstrapPermsMissing { realm });
+            }
+            Err(other) => return Err(deprovision_translate_kc(other)),
+        };
+
+        if has_remaining_tenants {
+            // Realm still has live tenants — keep it (DESIGN §4.2 / §5.4).
+            return Ok(false);
+        }
+
+        // ---- Last tenant under a Created realm — tear down. ----
+        // Wrap the realm DELETE in reactive-401 too: bootstrap-admin
+        // secret rotation could fire 401 here. The DELETE is a
+        // one-shot non-idempotent op, but per the reactive-401
+        // contract a 401 means "auth rejected, no side effect" → one
+        // retry is safe.
+        let realm_url = format!(
+            "{}admin/realms/{}",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(&metadata.realm_name),
+        );
+        self.kc_factory
+            .with_reactive_401_bootstrap(|bootstrap| {
+                let realm_url = realm_url.clone();
+                async move {
+                    let (status, body) =
+                        Self::kc_delete_status(&bootstrap, &realm_url, "/admin/realms/{realm}")
+                            .await?;
+                    match status {
+                        200..=299 | 404 | 410 => Ok(()),
+                        401 => Err(PluginError::KcRest {
+                            method: "DELETE",
+                            path_template: "/admin/realms/{realm}".into(),
+                            status: KcStatusKind::Http(401),
+                            body_first_2kb: body,
+                        }),
+                        other => Err(PluginError::DeprovisionRetryable {
+                            detail: format!("kc:DELETE /admin/realms/{{realm}} -> {other}: {body}"),
+                        }),
+                    }
+                }
+            })
+            .await
+            .map_err(deprovision_translate_kc)?;
+
+        // Delete the OpenBao-backed realm-admin secret. Created binding
+        // always carries `admin_secret_ref` (the non-default-shared branch
+        // above already validated this — but we re-check here instead of
+        // using `expect()` so a corrupt blob downgrades to a Terminal
+        // failure rather than panicking the worker).
+        let secret_ref_str =
+            metadata
+                .admin_secret_ref
+                .as_ref()
+                .ok_or_else(|| PluginError::DeprovisionTerminal {
+                    detail: "metadata.admin_secret_ref is None on Created binding".into(),
+                })?;
+        let secret_ref =
+            SecretRef::new(secret_ref_str).map_err(|e| PluginError::DeprovisionTerminal {
+                detail: format!("admin_secret_ref invalid: {e}"),
+            })?;
+        let delete_result = self.cs_writer.delete(&secret_ref).await;
+        match &delete_result {
+            Ok(()) => {
+                self.credstore_metrics
+                    .credstore_write(CredstoreOp::Delete, CredstoreOutcome::Ok);
+            }
+            Err(_) => {
+                self.credstore_metrics
+                    .credstore_write(CredstoreOp::Delete, CredstoreOutcome::Error);
+            }
+        }
+        delete_result.map_err(|e| PluginError::DeprovisionRetryable {
+            detail: format!("openbao delete failed: {e}"),
+        })?;
+
+        Ok(true)
+    }
+
+    /// DELETE-with-status helper. Returns `(status, body_first_2kb)` on
+    /// success so the caller can both branch on the status code and embed
+    /// the body in any [`PluginError::DeprovisionRetryable`] detail
+    /// (operator runbooks key on the body text — DESIGN §6.2).
+    /// Transport / timeout failures collapse to
+    /// [`PluginError::DeprovisionRetryable`] via [`deprovision_translate_kc`].
+    /// On 2xx/4xx/5xx the body is read non-fatally (errors yield `""`).
+    async fn kc_delete_status(
+        client: &KcAdminClient,
+        url: &str,
+        path_template: &str,
+    ) -> Result<(u16, String), PluginError> {
+        let (status, body) = client
+            .raw_request("DELETE", url, None, path_template)
+            .await
+            .map_err(deprovision_translate_kc)?;
+        Ok((status, truncate_2kb(&body)))
+    }
+
+    /// Decode `provisioning_metadata` and derive the EFFECTIVE realm from the
+    /// provisioning `target` + mode (VHP-1836). Pre-KC caller-input rejections
+    /// surface as [`PluginError::ProvisionInputRejected`] (mapped to a clean
+    /// 400) rather than the broad [`PluginError::Config`].
+    ///
+    /// Effective-realm matrix:
+    /// * Root                     → explicit `realm_name`, required (unchanged).
+    /// * Child + shared/no mode   → parent realm decoded from
+    ///   `parent_context.metadata`; explicit `realm_name` ignored; missing /
+    ///   undecodable parent metadata → reject.
+    /// * Child + created          → `realm-<tenant_id>`; explicit `realm_name`
+    ///   → reject.
+    /// * Child + adopted          → explicit `realm_name`, required (unchanged).
+    fn parse_input(req: &IdpProvisionTenantRequest) -> Result<ParsedInput, PluginError> {
+        let raw = req.metadata.as_ref();
+        // Wire shape (optional now). Absent metadata ⇒ empty wire (mode None).
+        let wire: WireMetadata = match raw {
+            Some(v) => serde_json::from_value(v.clone()).map_err(|e| {
+                PluginError::ProvisionInputRejected {
+                    detail: format!("provisioning_metadata malformed: {e}"),
+                }
+            })?,
+            None => WireMetadata {
+                mode: None,
+                realm_name: None,
+                admin_user_id: None,
+            },
+        };
+        // Mode: default shared.
+        let mode = wire.mode.as_deref().unwrap_or("shared");
+        let realm_binding = match mode {
+            "shared" => RealmBinding::Shared,
+            "adopted" => RealmBinding::Adopted,
+            "created" => RealmBinding::Created,
+            other => {
+                return Err(PluginError::ProvisionInputRejected {
+                    detail: format!("provisioning_metadata.mode not allowed: {other}"),
+                });
+            }
+        };
+        // admin_user_id is only honoured in Shared mode (DESIGN-bumpable).
+        // Silently dropping it in Adopted / Created would mask an operator
+        // misconfiguration — reject so AM surfaces a clean 400 instead of
+        // provisioning a half-bound tenant.
+        if wire.admin_user_id.is_some() && realm_binding != RealmBinding::Shared {
+            return Err(PluginError::ProvisionInputRejected {
+                detail: format!(
+                    "provisioning_metadata.admin_user_id is only supported in mode=shared (got mode={mode})"
+                ),
+            });
+        }
+        // Effective realm by target + mode.
+        let realm_name = match (&req.target, realm_binding) {
+            // Root: explicit realm_name required (unchanged).
+            (IdpProvisionTarget::Root, _) => {
+                wire.realm_name
+                    .clone()
+                    .ok_or_else(|| PluginError::ProvisionInputRejected {
+                        detail: "root provisioning requires provisioning_metadata.realm_name"
+                            .into(),
+                    })?
+            }
+            // Child + shared (or mode absent): inherit parent realm; explicit ignored.
+            (IdpProvisionTarget::Child { .. }, RealmBinding::Shared) => {
+                let parent_blob = req.parent_context.as_ref().and_then(|c| c.metadata.clone());
+                let decoded = MetadataCodec.decode(parent_blob).map_err(|e| {
+                    PluginError::ProvisionInputRejected {
+                        detail: format!("cannot decode parent idp_metadata: {e}"),
+                    }
+                })?;
+                decoded.map(|m| m.realm_name).ok_or_else(|| {
+                    PluginError::ProvisionInputRejected {
+                        detail:
+                            "shared mode but parent has no idp_metadata to inherit a realm from"
+                                .into(),
+                    }
+                })?
+            }
+            // Child + created: generate; explicit realm_name is a mistake.
+            (IdpProvisionTarget::Child { .. }, RealmBinding::Created) => {
+                if wire.realm_name.is_some() {
+                    return Err(PluginError::ProvisionInputRejected {
+                        detail: "mode=created generates its own realm; do not supply realm_name"
+                            .into(),
+                    });
+                }
+                format!("realm-{}", req.tenant_id)
+            }
+            // Child + adopted: explicit realm_name required (unchanged).
+            (IdpProvisionTarget::Child { .. }, RealmBinding::Adopted) => wire
+                .realm_name
+                .clone()
+                .ok_or_else(|| PluginError::ProvisionInputRejected {
+                    detail: "mode=adopted requires provisioning_metadata.realm_name".into(),
+                })?,
+            // `IdpProvisionTarget` is `#[non_exhaustive]`; an unknown topology
+            // is a contract we don't yet support — reject as caller-input.
+            (_, _) => {
+                return Err(PluginError::ProvisionInputRejected {
+                    detail: "unsupported provisioning target topology".into(),
+                });
+            }
+        };
+        // Defence-in-depth: validate the effective realm name shape uniformly
+        // (DESIGN §5.2 — applies to inherited / generated / explicit alike).
+        if !realm_name_re().is_match(&realm_name) {
+            return Err(PluginError::ProvisionInputRejected {
+                detail: format!(
+                    "realm_name rejected: must match ^[A-Za-z0-9_-]{{1,200}}$ (got {}-char value)",
+                    realm_name.chars().count()
+                ),
+            });
+        }
+        Ok(ParsedInput {
+            realm_binding,
+            realm_name,
+            admin_user_id: wire.admin_user_id,
+        })
+    }
+
+    async fn provision_shared(
+        &self,
+        ctx: &SecurityContext,
+        req: &IdpProvisionTenantRequest,
+        parsed: &ParsedInput,
+    ) -> Result<TenantIdpMetadataV1, PluginError> {
+        tracing::debug!(
+            target: "vp_idp_plugin.provision",
+            tenant_id = %req.tenant_id,
+            realm = %parsed.realm_name,
+            "provision_shared: step 1 — bootstrap_client + assert_realm_exists (reactive-401)"
+        );
+        // Step 1: bootstrap admin verifies the realm exists. Wrapped in
+        // reactive-401 so a rotated `bootstrap_admin.client_secret`
+        // converges without operator-driven plugin restart (DESIGN §8.1).
+        self.kc_factory
+            .with_reactive_401_bootstrap(|bootstrap| async move {
+                self.assert_realm_exists(&bootstrap, &parsed.realm_name)
+                    .await
+            })
+            .await?;
+
+        tracing::debug!(
+            target: "vp_idp_plugin.provision",
+            tenant_id = %req.tenant_id,
+            "provision_shared: steps 2-4 — realm_client + ensure_tenant_group [+ bind_admin_user_to_tenant] (reactive-401)"
+        );
+        // Step 2: realm-admin always uses the env-backed inline secret in
+        // Shared mode (ADDENDUM §3.4 / §4.1 — Shared is the single
+        // env-backed path; Adopted / Created go through OpenBao).
+        let realm_admin_source = SecretSource::Inline(
+            self.realm_admin_cfg
+                .default_shared_realm_secret
+                .clone_into_secret_string(),
+        );
+        // Steps 3 (+ optional 4) — wrapped together so a 401 mid-block
+        // re-runs the idempotent `ensure_tenant_group` + (if requested)
+        // `bind_admin_user_to_tenant`. Both are safe under
+        // exactly-once retry: `ensure_tenant_group` is find-or-create,
+        // and `bind_admin_user_to_tenant` is GET-then-PUT against a
+        // user UUID whose pre-bind state already mismatched on the
+        // first attempt (otherwise we would have succeeded). The audit
+        // event fires AFTER the wrapper returns so it never doubles up
+        // on a 401-then-success path.
+        let tenant_group_id = self
+            .kc_factory
+            .with_reactive_401(
+                &parsed.realm_name,
+                &self.realm_admin_cfg.client_id_default,
+                &realm_admin_source,
+                |realm_admin| async move {
+                    let gid = self
+                        .ensure_tenant_group(&realm_admin, &parsed.realm_name, req.tenant_id)
+                        .await?;
+                    if let Some(admin_user_id) = parsed.admin_user_id {
+                        self.bind_admin_user_to_tenant(
+                            &realm_admin,
+                            &parsed.realm_name,
+                            admin_user_id,
+                            req.tenant_id,
+                        )
+                        .await?;
+                    }
+                    Ok(gid)
+                },
+            )
+            .await?;
+
+        if let Some(admin_user_id) = parsed.admin_user_id {
+            audit::emit_admin_user_bound(ctx, req.tenant_id, &parsed.realm_name, admin_user_id);
+        }
+
+        // Step 5: assemble metadata. Shared binding always persists
+        // `admin_secret_ref = None` (ADDENDUM §3.4 — the env-backed admin
+        // is plugin-config-resolved, not OpenBao-resolved).
+        Ok(TenantIdpMetadataV1 {
+            version: "v1".into(),
+            realm_name: parsed.realm_name.clone(),
+            realm_binding: RealmBinding::Shared,
+            tenant_group_id,
+            admin_secret_ref: None,
+            admin_client_id: self.realm_admin_cfg.client_id_default.clone(),
+        })
+    }
+
+    /// Adopted-mode provisioning (DESIGN §4.1 Adopted row + §5.2 validation +
+    /// §5.4 "Group emptiness check"). The caller supplies an arbitrary realm
+    /// name (NOT the default shared realm). The bootstrap admin probes that
+    /// (a) the realm exists, (b) the parent tenant group is empty — meaning
+    /// either absent, or present with zero subgroups (per §5.4: "absent
+    /// parent is success-equivalent"). Per-realm admin creds live in `OpenBao`
+    /// under the configured `secret_ref_template` ⊕ `realm_name`, so
+    /// `admin_secret_ref` is always `Some(<resolved template>)`.
+    async fn provision_adopted(
+        &self,
+        req: &IdpProvisionTenantRequest,
+        parsed: &ParsedInput,
+    ) -> Result<TenantIdpMetadataV1, PluginError> {
+        // Steps 1 + 2: bootstrap admin verifies the realm exists AND
+        // probes parent tenant group emptiness (DESIGN §5.4 / §8.1
+        // Phase 0 — bootstrap has view-realm + query-groups granted
+        // per-target-realm for adopted flows). Absent parent group is
+        // success-equivalent. Both ops share the bootstrap client, so
+        // they share the reactive-401 wrapper — a single 401 retries
+        // the assertion and the group probe together.
+        let parent_name = self
+            .cfg
+            .tenant_group_root
+            .trim_start_matches('/')
+            .to_owned();
+        self.kc_factory
+            .with_reactive_401_bootstrap(|bootstrap| {
+                let parent_name = parent_name.clone();
+                async move {
+                    self.assert_realm_exists(&bootstrap, &parsed.realm_name)
+                        .await?;
+                    if let Some(parent) = self
+                        .find_top_group(&bootstrap, &parsed.realm_name, &parent_name)
+                        .await?
+                        && self
+                            .has_subgroup(&bootstrap, &parsed.realm_name, parent.id)
+                            .await?
+                    {
+                        {
+                            // Non-empty parent → CleanFailure-equivalent.
+                            // Synthesise `Http(409)` so the Phase 15
+                            // boundary's 4xx-→-CleanFailure translation
+                            // table catches it without a new variant.
+                            return Err(PluginError::KcRest {
+                                method: "GET",
+                                path_template:
+                                    "/admin/realms/{realm}/groups/{parent_uuid}/children".into(),
+                                status: KcStatusKind::Http(409),
+                                body_first_2kb: format!(
+                                    "adopted realm '{}' is not empty: parent group '{}' has at least one subgroup",
+                                    parsed.realm_name, parent_name,
+                                ),
+                            });
+                        }
+                    }
+                    Ok(())
+                }
+            })
+            .await?;
+
+        // Step 3: realm-admin (OpenBao-backed for Adopted — operator
+        // pre-provisions the per-realm secret at `secret_ref_template` ⊕
+        // `realm_name`).
+        let secret_ref_str = self
+            .realm_admin_cfg
+            .secret_ref_template
+            .replace("{realm_name}", &parsed.realm_name);
+        let secret_ref = SecretRef::new(&secret_ref_str).map_err(|e| PluginError::Config {
+            detail: format!("templated SecretRef invalid: {e}"),
+        })?;
+        let realm_admin_source = SecretSource::OpenBaoRef(secret_ref);
+
+        // Step 4: ensure parent + child group (idempotent; `ensure_tenant_group`
+        // creates the parent if missing, then the per-tenant child).
+        // Wrapped in reactive-401 — an operator who rotated the
+        // OpenBao-backed realm-admin secret converges without restart.
+        let tenant_group_id = self
+            .kc_factory
+            .with_reactive_401(
+                &parsed.realm_name,
+                &self.realm_admin_cfg.client_id_default,
+                &realm_admin_source,
+                |realm_admin| async move {
+                    self.ensure_tenant_group(&realm_admin, &parsed.realm_name, req.tenant_id)
+                        .await
+                },
+            )
+            .await?;
+
+        // NOTE: `parsed.admin_user_id` is intentionally not acted upon in
+        // Adopted mode. v1: bind only in Shared mode (DESIGN bump required
+        // to expand — see VHP-76 §A scope note).
+        Ok(TenantIdpMetadataV1 {
+            version: "v1".into(),
+            realm_name: parsed.realm_name.clone(),
+            realm_binding: RealmBinding::Adopted,
+            tenant_group_id,
+            admin_secret_ref: Some(secret_ref_str),
+            admin_client_id: self.realm_admin_cfg.client_id_default.clone(),
+        })
+    }
+
+    /// Created-mode provisioning (DESIGN §4.2 Created row, §5.4 KC admin ops,
+    /// §8.1 Phase 2 saga). The plugin owns the realm lifecycle — it
+    /// (1) probes that the realm DOES NOT already exist (validation; if it
+    /// does, that is a [`PluginError::CreatedRealmExists`] which Phase 15
+    /// maps to `CleanFailure`), (2) creates the realm via the bootstrap
+    /// admin, (3) creates the per-realm admin client + grants its service
+    /// account the minimum per-realm `realm-management` roles, (4) reads
+    /// back the generated `client_secret`, (5) persists it to `OpenBao` under
+    /// the templated `SecretRef`, (6) finally uses the realm-admin to
+    /// ensure the per-tenant group.
+    ///
+    /// **Ambiguous failure tagging** (DESIGN §5.5 line 482): every step
+    /// after the validation probe is tagged with the corresponding
+    /// [`AmbiguousStage`] so the operator reconciliation runbook (§12 risk
+    /// #9) can prioritise cleanup. Step 5 is the saga's "point of no return"
+    /// — KC has irreversible state, `OpenBao` does not, so a failure there
+    /// surfaces specifically as
+    /// [`AmbiguousStage::OpenBaoPutAfterKcSuccess`].
+    async fn provision_created(
+        &self,
+        req: &IdpProvisionTenantRequest,
+        parsed: &ParsedInput,
+    ) -> Result<TenantIdpMetadataV1, PluginError> {
+        // Steps 3-5 are wrapped INDIVIDUALLY in `with_reactive_401_bootstrap`
+        // (NOT as a single block) because they form a non-idempotent
+        // destructive saga: create-client → grant-roles → read-secret. A
+        // 401 mid-block under a block-level wrapper would re-run earlier
+        // steps with the fresh token. Per-call wrapping keeps each step's
+        // retry narrowly scoped to the call whose token was rejected.
+        //
+        // Steps 1-2: idempotent realm ensure (probe → create → reconcile).
+        // DESIGN §5.2, hardened per VHP-190 (run am-functional-22): a
+        // `mode = created` against an existing realm that is OURS (same
+        // tenant marker) is adopted idempotently; a foreign realm is a
+        // CleanFailure; and a 409 / lost-response on our own create
+        // reconciles to success instead of a false `AmbiguousCreated`. The
+        // probe / create / re-probe calls are each `with_reactive_401_bootstrap`
+        // wrapped inside `ensure_realm`.
+        self.ensure_realm(req, parsed).await?;
+
+        // Force-refresh the bootstrap token before any per-new-realm work.
+        // Keycloak auto-grants the creator `realm-admin` on the freshly-created
+        // realm, but access tokens carry a point-in-time snapshot of role
+        // claims — the bootstrap token in flight was minted BEFORE the realm
+        // existed and does not include the new mapping. Without this
+        // invalidate, step 3's `POST /admin/realms/{realm}/clients` returns
+        // 403, which the reactive-401 wrapper does not refresh on, surfacing
+        // as `AmbiguousCreated { stage: KcClientCreate }` and bricking the
+        // saga. See `KeycloakAdminClientFactory::invalidate_bootstrap` for
+        // the full rationale.
+        self.kc_factory.invalidate_bootstrap();
+
+        // Step 3: bootstrap admin creates the realm-admin client inside the
+        // freshly-created realm.
+        let admin_client_uuid = self
+            .kc_factory
+            .with_reactive_401_bootstrap(|bootstrap| async move {
+                self.create_realm_admin_client(&bootstrap, &parsed.realm_name)
+                    .await
+            })
+            .await?;
+
+        // Step 4: grant the realm-admin client's service account the minimum
+        // per-realm `realm-management` roles (DESIGN §8.1 least-privilege
+        // table for the per-realm admin).
+        self.kc_factory
+            .with_reactive_401_bootstrap(|bootstrap| async move {
+                self.grant_realm_admin_roles(&bootstrap, &parsed.realm_name, admin_client_uuid)
+                    .await
+            })
+            .await?;
+
+        // Step 5: read back the generated `client_secret` so it can be
+        // persisted to OpenBao for subsequent realm-admin token exchanges.
+        let client_secret = self
+            .kc_factory
+            .with_reactive_401_bootstrap(|bootstrap| async move {
+                self.read_realm_admin_client_secret(
+                    &bootstrap,
+                    &parsed.realm_name,
+                    admin_client_uuid,
+                )
+                .await
+            })
+            .await?;
+
+        // Step 6: persist the secret under the templated SecretRef. Anything
+        // after this is "KC fully succeeded but OpenBao path may or may not
+        // have landed" — see AmbiguousStage::OpenBaoPutAfterKcSuccess for
+        // the reconciliation contract (§12 risk #9).
+        let secret_ref_str = self
+            .realm_admin_cfg
+            .secret_ref_template
+            .replace("{realm_name}", &parsed.realm_name);
+        let secret_ref = SecretRef::new(&secret_ref_str).map_err(|e| PluginError::Config {
+            detail: format!("templated SecretRef invalid: {e}"),
+        })?;
+        let put_result = self
+            .cs_writer
+            .put(
+                &secret_ref,
+                SecretValue::from(client_secret.as_str()),
+                SharingMode::Tenant,
+            )
+            .await;
+        match &put_result {
+            Ok(()) => {
+                self.credstore_metrics
+                    .credstore_write(CredstoreOp::Put, CredstoreOutcome::Ok);
+            }
+            Err(_) => {
+                self.credstore_metrics
+                    .credstore_write(CredstoreOp::Put, CredstoreOutcome::Error);
+            }
+        }
+        put_result.map_err(|e| PluginError::AmbiguousCreated {
+            stage: AmbiguousStage::OpenBaoPutAfterKcSuccess,
+            detail: format!("credstore: {e}"),
+        })?;
+
+        // Step 7: switch to the realm-admin (now that its secret is in
+        // OpenBao) and ensure the per-tenant group structure exists.
+        // Wrapped in reactive-401 — the OpenBao-backed secret may
+        // have been rotated by an operator since the most recent
+        // realm-admin token was cached.
+        let realm_admin_source = SecretSource::OpenBaoRef(secret_ref);
+        let tenant_group_id = self
+            .kc_factory
+            .with_reactive_401(
+                &parsed.realm_name,
+                &self.realm_admin_cfg.client_id_default,
+                &realm_admin_source,
+                |realm_admin| async move {
+                    self.ensure_tenant_group(&realm_admin, &parsed.realm_name, req.tenant_id)
+                        .await
+                },
+            )
+            .await?;
+
+        // NOTE: `parsed.admin_user_id` is intentionally not acted upon in
+        // Created mode. v1: bind only in Shared mode (DESIGN bump required
+        // to expand — see VHP-76 §A scope note).
+        Ok(TenantIdpMetadataV1 {
+            version: "v1".into(),
+            realm_name: parsed.realm_name.clone(),
+            realm_binding: RealmBinding::Created,
+            tenant_group_id,
+            admin_secret_ref: Some(secret_ref_str),
+            admin_client_id: self.realm_admin_cfg.client_id_default.clone(),
+        })
+    }
+
+    /// Idempotent realm-create step (DESIGN §5.2, hardened per VHP-190 / run
+    /// am-functional-22). Folds the existence probe and the create into one
+    /// reconciling step so a retried or re-entrant create is safe:
+    ///
+    /// * probe `OwnedByUs` → adopt (a prior attempt for THIS tenant already
+    ///   created the realm) → `Ok`;
+    /// * probe `Foreign` (or unmarked) → [`PluginError::CreatedRealmExists`]
+    ///   (clean failure — never touch a realm we don't own);
+    /// * probe `Absent` → `POST /admin/realms`. On success → `Ok`. On ANY
+    ///   failure (409 unique-name from a duplicate POST, 5xx, transport /
+    ///   timeout) re-probe: if the realm now exists and is ours the create
+    ///   landed despite the error → idempotent `Ok`; if foreign →
+    ///   `CreatedRealmExists`; if still absent / unknowable → preserve the
+    ///   original `AmbiguousCreated { stage: KcRealmCreate }` so the operator
+    ///   reconciliation runbook (§12 risk #9) still fires.
+    ///
+    /// Each KC call is wrapped in `with_reactive_401_bootstrap` so an
+    /// operator-rotated bootstrap secret is picked up on a single 401.
+    async fn ensure_realm(
+        &self,
+        req: &IdpProvisionTenantRequest,
+        parsed: &ParsedInput,
+    ) -> Result<(), PluginError> {
+        let owner = req.tenant_id;
+        let realm_name = parsed.realm_name.as_str();
+
+        // Step 1: existence + ownership probe.
+        let probe = self
+            .kc_factory
+            .with_reactive_401_bootstrap(|bootstrap| async move {
+                self.probe_realm(&bootstrap, realm_name, owner).await
+            })
+            .await?;
+        match probe {
+            RealmProbe::OwnedByUs => return Ok(()),
+            RealmProbe::Foreign => {
+                return Err(PluginError::CreatedRealmExists {
+                    realm: realm_name.to_owned(),
+                });
+            }
+            RealmProbe::Absent => {}
+        }
+
+        // Step 2: create. On success we're done.
+        let create = self
+            .kc_factory
+            .with_reactive_401_bootstrap(|bootstrap| async move {
+                self.create_realm(&bootstrap, realm_name, req).await
+            })
+            .await;
+        let Err(create_err) = create else {
+            return Ok(());
+        };
+
+        // Reconcile: a duplicate POST (409) or a lost create response may
+        // have landed the realm anyway. Re-probe to decide rather than
+        // surfacing a false Ambiguous.
+        match self
+            .kc_factory
+            .with_reactive_401_bootstrap(|bootstrap| async move {
+                self.probe_realm(&bootstrap, realm_name, owner).await
+            })
+            .await
+        {
+            Ok(RealmProbe::OwnedByUs) => Ok(()),
+            Ok(RealmProbe::Foreign) => Err(PluginError::CreatedRealmExists {
+                realm: realm_name.to_owned(),
+            }),
+            // Genuinely absent, or we couldn't confirm — keep the original
+            // ambiguous classification (its detail carries the POST
+            // status/body for the reconciliation runbook).
+            Ok(RealmProbe::Absent) | Err(_) => Err(create_err),
+        }
+    }
+
+    /// Probe whether `realm_name` exists and who owns it, per the
+    /// [`PROVISIONING_TENANT_ID_ATTR`] marker. `GET /admin/realms/{realm}`:
+    /// 404 → [`RealmProbe::Absent`]; 2xx → [`RealmProbe::OwnedByUs`] when the
+    /// marker matches `owner_tenant_id`, else [`RealmProbe::Foreign`]; 403 →
+    /// [`PluginError::BootstrapPermsMissing`]; any other non-2xx → a bare
+    /// [`PluginError::KcRest`] (transient infra failure, NO side effect yet,
+    /// so NOT tagged Ambiguous).
+    async fn probe_realm(
+        &self,
+        bootstrap: &KcAdminClient,
+        realm_name: &str,
+        owner_tenant_id: Uuid,
+    ) -> Result<RealmProbe, PluginError> {
+        let probe_url = format!(
+            "{}admin/realms/{}",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+        );
+        let (status, body) = bootstrap
+            .raw_request("GET", &probe_url, None, "/admin/realms/{realm}")
+            .await?;
+        if status == 404 {
+            Ok(RealmProbe::Absent)
+        } else if (200..=299).contains(&status) {
+            match realm_owner_tenant_id(&body) {
+                Some(owner) if owner == owner_tenant_id => Ok(RealmProbe::OwnedByUs),
+                _ => Ok(RealmProbe::Foreign),
+            }
+        } else if status == 403 {
+            Err(PluginError::BootstrapPermsMissing {
+                realm: realm_name.into(),
+            })
+        } else {
+            Err(PluginError::KcRest {
+                method: "GET",
+                path_template: "/admin/realms/{realm}".into(),
+                status: KcStatusKind::Http(status),
+                body_first_2kb: truncate_2kb(&body),
+            })
+        }
+    }
+
+    /// Bootstrap admin creates the realm via
+    /// `POST /admin/realms` with the canonical payload merged on top of
+    /// `cfg.realm_defaults` (any operator-supplied keys win unless they
+    /// collide with `realm`/`enabled`/`displayName`, which the plugin sets
+    /// last to keep semantics deterministic).
+    ///
+    /// **Allowlist**: operator-supplied `realm_defaults` may carry only a
+    /// narrow set of cosmetic / locale keys. The KC `RealmRepresentation`
+    /// schema has ~150 top-level fields and most are security-sensitive
+    /// (auth flows, federation, credential routing, security baseline
+    /// knobs). A denylist would force us to chase every new KC release
+    /// for fields we didn't know about; the operator-tunable surface at
+    /// realm-create time is genuinely small, so we fail-closed instead.
+    ///
+    /// Currently allowed:
+    /// - `displayNameHtml` — branding HTML
+    /// - `defaultLocale` / `supportedLocales` /
+    ///   `internationalizationEnabled` — i18n
+    ///
+    /// The plugin always sets `realm`, `enabled`, `displayName` itself —
+    /// these are not operator-tunable. Anything else requires a
+    /// security-reviewed PR to extend the allowlist; if you find
+    /// yourself needing more, document the use case in the PR
+    /// description and apply security review per
+    /// `guidelines/SECURITY.md`.
+    ///
+    /// Any non-2xx → ambiguous failure tagged
+    /// [`AmbiguousStage::KcRealmCreate`].
+    async fn create_realm(
+        &self,
+        bootstrap: &KcAdminClient,
+        realm_name: &str,
+        req: &IdpProvisionTenantRequest,
+    ) -> Result<(), PluginError> {
+        const ALLOWLIST: &[&str] = &[
+            "displayNameHtml",
+            "defaultLocale",
+            "supportedLocales",
+            "internationalizationEnabled",
+        ];
+
+        let url = format!("{}admin/realms", self.kc_factory.base_url_str());
+        // Start with the operator-supplied defaults (typed as
+        // `serde_json::Value`; we accept any JSON shape and the canonical
+        // keys below override on collision).
+        let mut body = self.cfg.realm_defaults.clone();
+        if !body.is_object() {
+            body = serde_json::Value::Object(serde_json::Map::new());
+        }
+        if let Some(map) = body.as_object_mut() {
+            // Allowlist enforcement: reject any operator-supplied key
+            // not on the explicit allowlist BEFORE the plugin overrides
+            // the canonical ones, so a misconfiguration surfaces as a
+            // clean Config error at provision time rather than
+            // silently widening the realm's security surface.
+            if let Some(bad_key) = map.keys().find(|k| !ALLOWLIST.contains(&k.as_str())) {
+                return Err(PluginError::Config {
+                    detail: format!(
+                        "tenant_facade.realm_defaults contains non-allowlisted key `{bad_key}` (allowed: {ALLOWLIST:?}); operator-controlled realm-creation state is rejected fail-closed — extend the allowlist via security-reviewed PR if you need a new key"
+                    ),
+                });
+            }
+            map.insert("realm".into(), serde_json::Value::String(realm_name.into()));
+            map.insert("enabled".into(), serde_json::Value::Bool(true));
+            map.insert(
+                "displayName".into(),
+                serde_json::Value::String(req.name.clone()),
+            );
+            // Ownership marker (VHP-190): stamp the AM tenant that owns this
+            // realm so a retried / re-entrant create recognises it as ours
+            // (`ensure_realm` reconcile) and the reaper can GC orphans by
+            // owner. Plugin-set, after the allowlist gate — not operator-tunable.
+            let mut attributes = serde_json::Map::new();
+            attributes.insert(
+                PROVISIONING_TENANT_ID_ATTR.into(),
+                serde_json::Value::String(req.tenant_id.to_string()),
+            );
+            map.insert("attributes".into(), serde_json::Value::Object(attributes));
+        }
+        let (status, body_text) = bootstrap
+            .raw_request("POST", &url, Some(&body), "/admin/realms")
+            .await
+            .map_err(|e| {
+                // raw_request only fails on transport — re-tag as Ambiguous so
+                // operators see WHICH stage was in flight when the call broke.
+                ambiguous_from_kc_error(AmbiguousStage::KcRealmCreate, e)
+            })?;
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcRealmCreate,
+                detail: format!(
+                    "kc:POST /admin/realms -> {status}: {}",
+                    truncate_2kb(&body_text),
+                ),
+            });
+        }
+        Ok(())
+    }
+
+    /// Create the per-realm admin client (`vp-idp-plugin-realm-admin`) as
+    /// a confidential `client_credentials`-only client with a service
+    /// account. Returns the client's Keycloak-assigned UUID, discovered via
+    /// a follow-up `GET .../clients?clientId=...` (Keycloak returns no body
+    /// on the create — only a `Location` header; the list call is more
+    /// robust across KC versions and easier to mock in tests).
+    async fn create_realm_admin_client(
+        &self,
+        bootstrap: &KcAdminClient,
+        realm_name: &str,
+    ) -> Result<Uuid, PluginError> {
+        let client_id = &self.realm_admin_cfg.client_id_default;
+        let create_url = format!(
+            "{}admin/realms/{}/clients",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+        );
+        let payload = serde_json::json!({
+            "clientId": client_id,
+            "protocol": "openid-connect",
+            "publicClient": false,
+            "serviceAccountsEnabled": true,
+            "standardFlowEnabled": false,
+            "directAccessGrantsEnabled": false,
+            "implicitFlowEnabled": false,
+            "authorizationServicesEnabled": false,
+            "clientAuthenticatorType": "client-secret",
+        });
+        let (status, body_text) = bootstrap
+            .raw_request(
+                "POST",
+                &create_url,
+                Some(&payload),
+                "/admin/realms/{realm}/clients",
+            )
+            .await
+            .map_err(|e| ambiguous_from_kc_error(AmbiguousStage::KcClientCreate, e))?;
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcClientCreate,
+                detail: format!(
+                    "kc:POST /admin/realms/{{realm}}/clients -> {status}: {}",
+                    truncate_2kb(&body_text),
+                ),
+            });
+        }
+        self.lookup_client_uuid(
+            bootstrap,
+            realm_name,
+            client_id,
+            AmbiguousStage::KcClientCreate,
+        )
+        .await
+    }
+
+    /// Find the realm-management client's UUID + the realm-admin SA user's
+    /// UUID + the role objects to map, then POST the role-mapping. Any
+    /// failure along this chain is tagged
+    /// [`AmbiguousStage::KcRoleMapping`].
+    async fn grant_realm_admin_roles(
+        &self,
+        bootstrap: &KcAdminClient,
+        realm_name: &str,
+        admin_client_uuid: Uuid,
+    ) -> Result<(), PluginError> {
+        // The two lookups are independent — fire them concurrently to save
+        // one network round-trip on the Created-mode saga.
+        let (sa_user_uuid, rm_client_uuid) = tokio::try_join!(
+            self.get_service_account_user(bootstrap, realm_name, admin_client_uuid),
+            self.lookup_client_uuid(
+                bootstrap,
+                realm_name,
+                REALM_MANAGEMENT_CLIENT_ID,
+                AmbiguousStage::KcRoleMapping,
+            ),
+        )?;
+        let available_roles = self
+            .list_available_realm_management_roles(
+                bootstrap,
+                realm_name,
+                sa_user_uuid,
+                rm_client_uuid,
+            )
+            .await?;
+        // Select the subset matching `REALM_ADMIN_REQUIRED_ROLES`. If any
+        // expected role is absent the realm-management client is malformed
+        // (KC built-in shape changed?) — tag as kc_role_mapping so the
+        // operator sees the discrepancy.
+        let mut to_map: Vec<RoleRep> = Vec::with_capacity(REALM_ADMIN_REQUIRED_ROLES.len());
+        for required in REALM_ADMIN_REQUIRED_ROLES {
+            match available_roles.iter().find(|r| r.name == *required) {
+                Some(r) => to_map.push(r.clone()),
+                None => {
+                    return Err(PluginError::AmbiguousCreated {
+                        stage: AmbiguousStage::KcRoleMapping,
+                        detail: format!(
+                            "kc:GET /admin/realms/{{realm}}/users/{{user_uuid}}/role-mappings/clients/{{rm_uuid}}/available -> 200: required realm-management role '{required}' not in available set",
+                        ),
+                    });
+                }
+            }
+        }
+        let post_url = format!(
+            "{}admin/realms/{}/users/{}/role-mappings/clients/{}",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+            sa_user_uuid,
+            rm_client_uuid,
+        );
+        let body = serde_json::to_value(&to_map).map_err(|e| PluginError::AmbiguousCreated {
+            stage: AmbiguousStage::KcRoleMapping,
+            detail: format!("serialise role-mapping body: {e}"),
+        })?;
+        let (status, body_text) = bootstrap
+            .raw_request(
+                "POST",
+                &post_url,
+                Some(&body),
+                "/admin/realms/{realm}/users/{user_uuid}/role-mappings/clients/{rm_uuid}",
+            )
+            .await
+            .map_err(|e| ambiguous_from_kc_error(AmbiguousStage::KcRoleMapping, e))?;
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcRoleMapping,
+                detail: format!(
+                    "kc:POST /admin/realms/{{realm}}/users/{{user_uuid}}/role-mappings/clients/{{rm_uuid}} -> {status}: {}",
+                    truncate_2kb(&body_text),
+                ),
+            });
+        }
+        Ok(())
+    }
+
+    /// Fetch a client's Keycloak UUID by its `clientId` via
+    /// `GET /admin/realms/{realm}/clients?clientId={clientId}`. The caller
+    /// supplies the [`AmbiguousStage`] so failures attribute to whichever
+    /// saga step triggered the lookup.
+    async fn lookup_client_uuid(
+        &self,
+        bootstrap: &KcAdminClient,
+        realm_name: &str,
+        client_id: &str,
+        stage: AmbiguousStage,
+    ) -> Result<Uuid, PluginError> {
+        let url = format!(
+            "{}admin/realms/{}/clients?clientId={}",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+            urlencoding::encode(client_id),
+        );
+        let (status, body_text) = bootstrap
+            .raw_request("GET", &url, None, "/admin/realms/{realm}/clients")
+            .await
+            .map_err(|e| ambiguous_from_kc_error(stage, e))?;
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::AmbiguousCreated {
+                stage,
+                detail: format!(
+                    "kc:GET /admin/realms/{{realm}}/clients -> {status}: {}",
+                    truncate_2kb(&body_text),
+                ),
+            });
+        }
+        let clients: Vec<ClientRep> =
+            serde_json::from_str(&body_text).map_err(|e| PluginError::AmbiguousCreated {
+                stage,
+                detail: format!("kc:GET /admin/realms/{{realm}}/clients json decode: {e}"),
+            })?;
+        clients
+            .into_iter()
+            .next()
+            .map(|c| c.id)
+            .ok_or(PluginError::AmbiguousCreated {
+                stage,
+                detail: format!(
+                    "kc:GET /admin/realms/{{realm}}/clients -> 200: clientId '{client_id}' not found after create",
+                ),
+            })
+    }
+
+    /// `GET /admin/realms/{realm}/clients/{uuid}/service-account-user` →
+    /// the service-account user's UUID. Failures are tagged
+    /// [`AmbiguousStage::KcRoleMapping`] because they block the role-mapping
+    /// step.
+    async fn get_service_account_user(
+        &self,
+        bootstrap: &KcAdminClient,
+        realm_name: &str,
+        client_uuid: Uuid,
+    ) -> Result<Uuid, PluginError> {
+        let url = format!(
+            "{}admin/realms/{}/clients/{}/service-account-user",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+            client_uuid,
+        );
+        let (status, body_text) = bootstrap
+            .raw_request(
+                "GET",
+                &url,
+                None,
+                "/admin/realms/{realm}/clients/{client_uuid}/service-account-user",
+            )
+            .await
+            .map_err(|e| ambiguous_from_kc_error(AmbiguousStage::KcRoleMapping, e))?;
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcRoleMapping,
+                detail: format!(
+                    "kc:GET /admin/realms/{{realm}}/clients/{{client_uuid}}/service-account-user -> {status}: {}",
+                    truncate_2kb(&body_text),
+                ),
+            });
+        }
+        let user: UserRep =
+            serde_json::from_str(&body_text).map_err(|e| PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcRoleMapping,
+                detail: format!("service-account-user json decode: {e}"),
+            })?;
+        Ok(user.id)
+    }
+
+    /// Fetch the list of available `realm-management` roles for a user
+    /// via `GET .../users/{u}/role-mappings/clients/{rm}/available`.
+    async fn list_available_realm_management_roles(
+        &self,
+        bootstrap: &KcAdminClient,
+        realm_name: &str,
+        sa_user_uuid: Uuid,
+        rm_client_uuid: Uuid,
+    ) -> Result<Vec<RoleRep>, PluginError> {
+        let url = format!(
+            "{}admin/realms/{}/users/{}/role-mappings/clients/{}/available",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+            sa_user_uuid,
+            rm_client_uuid,
+        );
+        let (status, body_text) = bootstrap
+            .raw_request(
+                "GET",
+                &url,
+                None,
+                "/admin/realms/{realm}/users/{user_uuid}/role-mappings/clients/{rm_uuid}/available",
+            )
+            .await
+            .map_err(|e| ambiguous_from_kc_error(AmbiguousStage::KcRoleMapping, e))?;
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcRoleMapping,
+                detail: format!(
+                    "kc:GET /admin/realms/{{realm}}/users/{{user_uuid}}/role-mappings/clients/{{rm_uuid}}/available -> {status}: {}",
+                    truncate_2kb(&body_text),
+                ),
+            });
+        }
+        serde_json::from_str::<Vec<RoleRep>>(&body_text).map_err(|e| {
+            PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcRoleMapping,
+                detail: format!("available roles json decode: {e}"),
+            }
+        })
+    }
+
+    /// `GET /admin/realms/{realm}/clients/{uuid}/client-secret` → the
+    /// generated `client_secret` plaintext. Failures are tagged
+    /// [`AmbiguousStage::KcClientSecretRead`] — these straddle the
+    /// "KC-side success vs OpenBao-side write" boundary; from the operator
+    /// runbook's point of view they look indistinguishable from a
+    /// `KcRoleMapping` partial: KC has full state but no secret in `OpenBao`.
+    async fn read_realm_admin_client_secret(
+        &self,
+        bootstrap: &KcAdminClient,
+        realm_name: &str,
+        client_uuid: Uuid,
+    ) -> Result<String, PluginError> {
+        let url = format!(
+            "{}admin/realms/{}/clients/{}/client-secret",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+            client_uuid,
+        );
+        let (status, body_text) = bootstrap
+            .raw_request(
+                "GET",
+                &url,
+                None,
+                "/admin/realms/{realm}/clients/{client_uuid}/client-secret",
+            )
+            .await
+            .map_err(|e| ambiguous_from_kc_error(AmbiguousStage::KcClientSecretRead, e))?;
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcClientSecretRead,
+                detail: format!(
+                    "kc:GET /admin/realms/{{realm}}/clients/{{client_uuid}}/client-secret -> {status}: {}",
+                    truncate_2kb(&body_text),
+                ),
+            });
+        }
+        let cred: CredentialRep =
+            serde_json::from_str(&body_text).map_err(|e| PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::KcClientSecretRead,
+                detail: format!("client-secret json decode: {e}"),
+            })?;
+        Ok(cred.value)
+    }
+
+    /// Probe `/admin/realms/{realm}` with the bootstrap admin token; non-2xx
+    /// surfaces as [`PluginError::KcRest`] (Phase 15 boundary maps this to
+    /// `CleanFailure` per DESIGN §5.2 «`mode = shared` but realm does not
+    /// exist»).
+    ///
+    /// **403 special case (DESIGN §5.2 line 432):** this helper is ALWAYS
+    /// invoked with a bootstrap-admin client (Shared and Adopted both call it
+    /// that way; the reactive-401 wrapper around its call sites doesn't
+    /// change this — 403 is a permission issue, not a rotation signal). When
+    /// the bootstrap admin is missing `view-realm` on the target realm, KC returns
+    /// 403 on the probe; we surface a dedicated
+    /// [`PluginError::BootstrapPermsMissing`] so Phase 15 can translate it to
+    /// `IdpProvisionFailure::UnsupportedOperation` (rather than the default
+    /// 4xx→`CleanFailure` mapping).
+    async fn assert_realm_exists(
+        &self,
+        bootstrap: &KcAdminClient,
+        realm_name: &str,
+    ) -> Result<(), PluginError> {
+        let probe_url = format!(
+            "{}admin/realms/{}",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+        );
+        let (status, body) = bootstrap
+            .raw_request("GET", &probe_url, None, "/admin/realms/{realm}")
+            .await?;
+        if (200..=299).contains(&status) {
+            Ok(())
+        } else if status == 403 {
+            Err(PluginError::BootstrapPermsMissing {
+                realm: realm_name.into(),
+            })
+        } else {
+            Err(PluginError::KcRest {
+                method: "GET",
+                path_template: "/admin/realms/{realm}".into(),
+                status: KcStatusKind::Http(status),
+                body_first_2kb: truncate_2kb(&body),
+            })
+        }
+    }
+
+    /// Bind a pre-provisioned Keycloak admin user to the tenant by setting
+    /// `tenant_id` and `user_type` attributes on the user.
+    ///
+    /// Implements GET-modify-PUT against Keycloak Admin REST. The mutation
+    /// surface is narrow — only the two managed attribute KEYS
+    /// (`attributes.tenant_id` and `attributes.user_type`) are touched.
+    /// Every other field of the GET'd `UserRepresentation` is round-tripped
+    /// into the PUT body verbatim.
+    ///
+    /// **Race window** (full-document last-writer-wins): KC's `/users/{id}`
+    /// PUT has no optimistic concurrency (no `ETag`, no `version` enforcement).
+    /// The PUT body is the FULL `UserRepresentation` we snapshotted at the
+    /// GET step with only those two attribute keys mutated, so ANY concurrent
+    /// edit to top-level fields (`firstName`, `email`, `enabled`, …) or to
+    /// other attribute keys between our GET and our PUT is clobbered by the
+    /// stale snapshot. v1 accepts this — the bind only runs once during
+    /// tenant bootstrap, well before any operator-level concurrent edits to
+    /// the admin user are plausible. The "narrowness" of the merge is about
+    /// what THIS call deliberately mutates, not about what survives.
+    ///
+    /// # Errors
+    ///
+    /// ALL failure branches translate to [`PluginError::AmbiguousCreated`]
+    /// tagged [`AmbiguousStage::AdminUserBind`]. The reason is the saga
+    /// ordering: this method is `provision_shared` Step 4, called AFTER
+    /// `ensure_tenant_group` (Step 3) has already created the per-tenant
+    /// Keycloak group. Any error here therefore leaves a real side-effect
+    /// (the tenant group) in KC — surfacing the failure as `CleanFailure`
+    /// at the Phase-15 boundary would lie to AM ("nothing happened, safe
+    /// to retry clean") and let the orphaned group grow unbounded on
+    /// every retry. The Ambiguous tag triggers AM's reconciliation path,
+    /// which can complete or unwind the half-built tenant. This explicitly
+    /// includes the 404-on-GET case (admin user missing) and the
+    /// hijack-guard case (`tenant_id` attribute mismatch) — both fire
+    /// AFTER Step 3's side-effect has landed.
+    async fn bind_admin_user_to_tenant(
+        &self,
+        realm_admin: &KcAdminClient,
+        realm_name: &str,
+        admin_user_id: Uuid,
+        tenant_id: Uuid,
+    ) -> Result<(), PluginError> {
+        let user_url = format!(
+            "{}admin/realms/{}/users/{}",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+            admin_user_id,
+        );
+
+        // Step 1: GET current user representation.
+        let (get_status, get_body) = realm_admin
+            .raw_request(
+                "GET",
+                &user_url,
+                None,
+                "/admin/realms/{realm}/users/{user_uuid}",
+            )
+            .await
+            .map_err(|e| ambiguous_from_kc_error(AmbiguousStage::AdminUserBind, e))?;
+        // Surface a 401 as bare `KcRest{Http(401)}` so the enclosing
+        // `with_reactive_401` wrapper sees the rotation signal and
+        // retries with a refreshed bearer. The 401 GET has no side
+        // effect (auth-rejected before any KC mutation), so collapsing
+        // it into `AmbiguousCreated` here would lock out the rotation
+        // recovery path. Non-401 non-2xx responses STILL tag as
+        // `AmbiguousCreated` per the saga-ordering invariant below.
+        if get_status == 401 {
+            return Err(PluginError::KcRest {
+                method: "GET",
+                path_template: "/admin/realms/{realm}/users/{user_uuid}".into(),
+                status: KcStatusKind::Http(401),
+                body_first_2kb: truncate_2kb(&get_body),
+            });
+        }
+        if !(200..=299).contains(&get_status) {
+            // ALL non-2xx non-401 GET responses (including 404) tag as
+            // AmbiguousCreated: `ensure_tenant_group` (Step 3) already
+            // created the per-tenant KC group, so even "user genuinely
+            // missing" leaves a real side-effect that AM must reconcile.
+            // Marking the 404 case as `CleanFailure` would let the
+            // orphaned group accumulate one per retry indefinitely.
+            return Err(PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::AdminUserBind,
+                detail: format!(
+                    "kc:GET /admin/realms/{{realm}}/users/{{user_uuid}} -> {get_status}: {}",
+                    truncate_2kb(&get_body),
+                ),
+            });
+        }
+
+        // Step 2: parse + targeted attribute merge.
+        // Modify ONLY the two managed keys; every other field of the
+        // GET'd snapshot rides along (see the race-window note in the
+        // doc-comment).
+        //
+        // Body-parse failures here are POST-side-effect: the tenant
+        // group is already created at this point, so tagging them as
+        // `Config` (which the Phase 15 boundary maps to `CleanFailure`
+        // = "nothing happened, safe to retry clean") would lie to AM.
+        // All three parse branches tag as `AmbiguousCreated{AdminUserBind}`
+        // for symmetry with the 5xx/403-on-GET path above.
+        let mut user: serde_json::Value =
+            serde_json::from_str(&get_body).map_err(|e| PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::AdminUserBind,
+                detail: format!(
+                    "kc:GET /admin/realms/{{realm}}/users/{{user_uuid}} body parse failed: {e}"
+                ),
+            })?;
+        let user_obj = user
+            .as_object_mut()
+            .ok_or_else(|| PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::AdminUserBind,
+                detail: "user representation is not a JSON object".into(),
+            })?;
+        let attrs = user_obj
+            .entry("attributes".to_string())
+            .or_insert_with(|| serde_json::json!({}));
+        let attrs_obj = attrs
+            .as_object_mut()
+            .ok_or_else(|| PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::AdminUserBind,
+                detail: "user.attributes is not a JSON object".into(),
+            })?;
+
+        // Hijack guard: refuse to overwrite an existing tenant_id whose
+        // shape isn't already a singleton matching this tenant. Two
+        // failure modes we close here:
+        //
+        //   (a) Foreign single-tenant bind — `attributes.tenant_id = ["X"]`
+        //       (or bare `"X"` from a hand-edited record) with X != the
+        //       requested tenant. An operator authorised to provision
+        //       tenants who supplied a foreign user's UUID would
+        //       silently transfer that user's attribute-based authz to
+        //       the newly-created tenant.
+        //   (b) Multi-valued overwrite — `attributes.tenant_id = ["A", "B"]`
+        //       (the user is admin of A and B). The previous version
+        //       passed the guard whenever the requested tenant_id was
+        //       ANY element of the existing array, then unconditionally
+        //       wrote `[tenant_id]`, silently dropping the user's other
+        //       bindings. v1 has a single-tenant-per-user model (see
+        //       `user_facade::provision_user`, design §nonGoals
+        //       `move_user_tenant`), so a multi-valued attribute is by
+        //       definition unexpected operator state — the plugin
+        //       refuses rather than guess which bindings are safe to
+        //       drop.
+        //
+        // Allowed shapes (idempotent re-bind during bootstrap re-run):
+        //   * no `tenant_id` attribute at all (legitimate bootstrap), OR
+        //   * `tenant_id == "T"` bare string AND T == requested, OR
+        //   * `tenant_id == ["T"]` singleton array AND T == requested.
+        //
+        // Mismatched bind tags as `AmbiguousCreated{AdminUserBind}` —
+        // NOT `Config` (CleanFailure) — because Step 3 already created
+        // the tenant group. A `Config` rejection would tell AM "nothing
+        // happened, safe to retry clean" and leak an orphaned KC group
+        // per attempt. Ambiguous routes through AM's reconciliation path.
+        if let Some(existing) = attrs_obj.get("tenant_id") {
+            let target = tenant_id.to_string();
+            let is_idempotent_rebind = match existing {
+                serde_json::Value::String(s) => s.as_str() == target.as_str(),
+                serde_json::Value::Array(values) => {
+                    values.len() == 1 && values[0].as_str() == Some(target.as_str())
+                }
+                _ => false,
+            };
+            if !is_idempotent_rebind {
+                // Distinguish hijack vs multi-valued displacement in the
+                // detail so an operator triaging the AM-reconciliation
+                // path can tell "I pasted the wrong UUID" apart from
+                // "this user is unexpectedly cross-tenant" without
+                // re-reading Keycloak. Substrings `hijack` and
+                // `multi-valued` are stable for log-grep / tests.
+                let classification = match existing {
+                    serde_json::Value::Array(values) if values.len() > 1 => "multi-valued",
+                    _ => "different tenant",
+                };
+                return Err(PluginError::AmbiguousCreated {
+                    stage: AmbiguousStage::AdminUserBind,
+                    detail: format!(
+                        "admin_user_id {admin_user_id} is already bound to a {classification} (attributes.tenant_id = {existing}); refusing to overwrite — supplying a foreign user UUID would silently hijack that user's attribute-based authz, and writing [{target}] over a multi-valued attribute would silently drop the user's other tenant bindings"
+                    ),
+                });
+            }
+        }
+
+        attrs_obj.insert(
+            "tenant_id".to_string(),
+            serde_json::json!([tenant_id.to_string()]),
+        );
+        attrs_obj.insert("user_type".to_string(), serde_json::json!(["user"]));
+
+        // Step 3: PUT updated user representation back.
+        let (put_status, put_body) = realm_admin
+            .raw_request(
+                "PUT",
+                &user_url,
+                Some(&user),
+                "/admin/realms/{realm}/users/{user_uuid}",
+            )
+            .await
+            .map_err(|e| ambiguous_from_kc_error(AmbiguousStage::AdminUserBind, e))?;
+        // Mirror the GET arm: surface 401 as `KcRest{Http(401)}` so the
+        // outer reactive-401 wrapper can re-acquire and retry the
+        // GET-modify-PUT cycle. KC's auth layer rejects the PUT before
+        // applying the mutation, so this is a no-side-effect failure
+        // that fits the wrapper's exactly-once-retry contract.
+        if put_status == 401 {
+            return Err(PluginError::KcRest {
+                method: "PUT",
+                path_template: "/admin/realms/{realm}/users/{user_uuid}".into(),
+                status: KcStatusKind::Http(401),
+                body_first_2kb: truncate_2kb(&put_body),
+            });
+        }
+        if !(200..=299).contains(&put_status) {
+            return Err(PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::AdminUserBind,
+                detail: format!(
+                    "kc:PUT /admin/realms/{{realm}}/users/{{user_uuid}} -> {put_status}: {}",
+                    truncate_2kb(&put_body),
+                ),
+            });
+        }
+        Ok(())
+    }
+
+    /// Resolve-or-create the parent tenant group and create the per-tenant
+    /// child subgroup. Returns the new child group UUID (the value persisted
+    /// as `TenantIdpMetadataV1.tenant_group_id`).
+    async fn ensure_tenant_group(
+        &self,
+        realm_admin: &KcAdminClient,
+        realm_name: &str,
+        tenant_id: Uuid,
+    ) -> Result<Uuid, PluginError> {
+        // Strip any leading `/` so a config value like `/tenants` and `tenants`
+        // both yield the same Keycloak group name.
+        let parent_name = self.cfg.tenant_group_root.trim_start_matches('/');
+        let parent_id = self
+            .find_or_create_top_group(realm_admin, realm_name, parent_name)
+            .await?;
+
+        let create_url = format!(
+            "{}admin/realms/{}/groups/{}/children",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+            parent_id
+        );
+        let body = serde_json::json!({ "name": tenant_id.to_string() });
+        let (status, body_text) = realm_admin
+            .raw_request(
+                "POST",
+                &create_url,
+                Some(&body),
+                "/admin/realms/{realm}/groups/{parent_uuid}/children",
+            )
+            .await?;
+
+        // Happy path: 2xx → parse the created GroupRepresentation and return its id.
+        if (200..=299).contains(&status) {
+            let g: GroupRep =
+                serde_json::from_str(&body_text).map_err(|e| PluginError::KcRest {
+                    method: "POST",
+                    path_template: "/admin/realms/{realm}/groups/{parent_uuid}/children".into(),
+                    status: KcStatusKind::Http(status),
+                    body_first_2kb: format!("group rep parse: {e}"),
+                })?;
+            return Ok(g.id);
+        }
+
+        // Idempotent path: a previous saga run (or any other actor) already
+        // created the subgroup → Keycloak returns 409 with "Sibling group
+        // named '<tenant_id>' already exists." Look the existing group up by
+        // listing parent's children with the same `search=&exact=true` filter
+        // used for top-level groups, and return its id. Without this branch
+        // the saga loops forever on bootstrap restart after a crash between
+        // group creation and AM-side persistence.
+        if status == 409 {
+            let lookup_url = format!(
+                "{}admin/realms/{}/groups/{}/children?search={}&exact=true",
+                self.kc_factory.base_url_str(),
+                urlencoding::encode(realm_name),
+                parent_id,
+                urlencoding::encode(&tenant_id.to_string()),
+            );
+            let (lookup_status, lookup_body) = realm_admin
+                .raw_request(
+                    "GET",
+                    &lookup_url,
+                    None,
+                    "/admin/realms/{realm}/groups/{parent_uuid}/children",
+                )
+                .await?;
+            if !(200..=299).contains(&lookup_status) {
+                return Err(PluginError::KcRest {
+                    method: "GET",
+                    path_template: "/admin/realms/{realm}/groups/{parent_uuid}/children".into(),
+                    status: KcStatusKind::Http(lookup_status),
+                    body_first_2kb: truncate_2kb(&lookup_body),
+                });
+            }
+            let groups: Vec<GroupRep> =
+                serde_json::from_str(&lookup_body).map_err(|e| PluginError::KcRest {
+                    method: "GET",
+                    path_template: "/admin/realms/{realm}/groups/{parent_uuid}/children".into(),
+                    status: KcStatusKind::Http(lookup_status),
+                    body_first_2kb: format!("groups array parse: {e}"),
+                })?;
+            let expected = tenant_id.to_string();
+            if let Some(existing) = groups.into_iter().find(|g| g.name == expected) {
+                tracing::info!(
+                    target: "vp_idp_plugin.provision",
+                    tenant_id = %tenant_id,
+                    group_id = %existing.id,
+                    "ensure_tenant_group: subgroup already exists (409 idempotent path)"
+                );
+                return Ok(existing.id);
+            }
+            // 409 returned but no matching child found — surface as KcRest
+            // with the original 409 body so operators see Keycloak's exact
+            // message in metrics / logs.
+            return Err(PluginError::KcRest {
+                method: "POST",
+                path_template: "/admin/realms/{realm}/groups/{parent_uuid}/children".into(),
+                status: KcStatusKind::Http(status),
+                body_first_2kb: format!(
+                    "409 conflict but subgroup not found in parent listing: {}",
+                    truncate_2kb(&body_text),
+                ),
+            });
+        }
+
+        Err(PluginError::KcRest {
+            method: "POST",
+            path_template: "/admin/realms/{realm}/groups/{parent_uuid}/children".into(),
+            status: KcStatusKind::Http(status),
+            body_first_2kb: truncate_2kb(&body_text),
+        })
+    }
+
+    async fn find_or_create_top_group(
+        &self,
+        realm_admin: &KcAdminClient,
+        realm_name: &str,
+        group_name: &str,
+    ) -> Result<Uuid, PluginError> {
+        let search_url = format!(
+            "{}admin/realms/{}/groups?search={}&exact=true",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+            urlencoding::encode(group_name),
+        );
+        let (status, body_text) = realm_admin
+            .raw_request("GET", &search_url, None, "/admin/realms/{realm}/groups")
+            .await?;
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::KcRest {
+                method: "GET",
+                path_template: "/admin/realms/{realm}/groups".into(),
+                status: KcStatusKind::Http(status),
+                body_first_2kb: truncate_2kb(&body_text),
+            });
+        }
+
+        let groups: Vec<GroupRep> =
+            serde_json::from_str(&body_text).map_err(|e| PluginError::KcRest {
+                method: "GET",
+                path_template: "/admin/realms/{realm}/groups".into(),
+                status: KcStatusKind::Http(status),
+                body_first_2kb: format!("groups list parse: {e}"),
+            })?;
+        if let Some(g) = groups.iter().find(|g| g.name == group_name) {
+            return Ok(g.id);
+        }
+
+        // Parent group missing — create top-level group.
+        //
+        // Keycloak returns 201 with EMPTY body on `POST /admin/realms/{realm}/groups`
+        // (the canonical group id lives in the `Location` header, not in the
+        // response body — confirmed against KC 26.x). The realm-admin
+        // `KcAdminClient::raw_request` surface does not expose response
+        // headers, so we cannot read the Location here. Re-issue the same
+        // exact-match search we ran at the top of this function to recover
+        // the id deterministically; a 2xx on POST guarantees the group now
+        // exists, so this re-search must succeed.
+        //
+        // Earlier implementations parsed `GroupRepresentation` from the POST
+        // response body. That happened to work against KC versions that
+        // returned a populated body, but produced an opaque
+        // `EOF while parsing a value at line 1 column 0` failure against
+        // KC 26.x (empty-body 201). The post-create re-search is
+        // version-agnostic — it does not depend on the response body shape.
+        let create_url = format!(
+            "{}admin/realms/{}/groups",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+        );
+        let body = serde_json::json!({ "name": group_name });
+        let (status, body_text) = realm_admin
+            .raw_request(
+                "POST",
+                &create_url,
+                Some(&body),
+                "/admin/realms/{realm}/groups",
+            )
+            .await?;
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::KcRest {
+                method: "POST",
+                path_template: "/admin/realms/{realm}/groups".into(),
+                status: KcStatusKind::Http(status),
+                body_first_2kb: truncate_2kb(&body_text),
+            });
+        }
+
+        // Post-create re-search: the just-created group MUST be findable by
+        // the same exact-match query that returned empty at the top of this
+        // function. Failure here means KC returned 2xx on POST but the group
+        // is not subsequently visible — operationally indistinguishable from
+        // a KC bug; surface as a structured error so the operator sees it.
+        let (lookup_status, lookup_body) = realm_admin
+            .raw_request("GET", &search_url, None, "/admin/realms/{realm}/groups")
+            .await?;
+        if !(200..=299).contains(&lookup_status) {
+            return Err(PluginError::KcRest {
+                method: "GET",
+                path_template: "/admin/realms/{realm}/groups".into(),
+                status: KcStatusKind::Http(lookup_status),
+                body_first_2kb: truncate_2kb(&lookup_body),
+            });
+        }
+        let post_create: Vec<GroupRep> =
+            serde_json::from_str(&lookup_body).map_err(|e| PluginError::KcRest {
+                method: "GET",
+                path_template: "/admin/realms/{realm}/groups".into(),
+                status: KcStatusKind::Http(lookup_status),
+                body_first_2kb: format!("groups list parse: {e}"),
+            })?;
+        post_create
+            .into_iter()
+            .find(|g| g.name == group_name)
+            .map(|g| g.id)
+            .ok_or_else(|| PluginError::KcRest {
+                method: "GET",
+                path_template: "/admin/realms/{realm}/groups".into(),
+                status: KcStatusKind::Http(lookup_status),
+                body_first_2kb: format!(
+                    "post-create lookup returned no entry named '{group_name}' \
+                     after KC reported {status} on create"
+                ),
+            })
+    }
+
+    /// Find-only counterpart to [`Self::find_or_create_top_group`]: probes
+    /// `GET /admin/realms/{realm}/groups?search={name}&exact=true` and
+    /// returns `Some({id, ..})` if the parent group exists, `None` if
+    /// the search returned `[]`. Used by Adopted-mode emptiness probe —
+    /// "parent absent" is treated as success-equivalent (DESIGN §5.4).
+    ///
+    /// **403 special case (DESIGN §5.2 line 432):** the Adopted emptiness
+    /// probe runs with the bootstrap admin, so a 403 here means the bootstrap
+    /// admin lacks `query-groups` on the target realm. Surface
+    /// [`PluginError::BootstrapPermsMissing`] so Phase 15 maps it to
+    /// `IdpProvisionFailure::UnsupportedOperation` rather than the default
+    /// 4xx→`CleanFailure` translation.
+    async fn find_top_group(
+        &self,
+        admin: &KcAdminClient,
+        realm_name: &str,
+        group_name: &str,
+    ) -> Result<Option<TopGroupInfo>, PluginError> {
+        let search_url = format!(
+            "{}admin/realms/{}/groups?search={}&exact=true",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+            urlencoding::encode(group_name),
+        );
+        let (status, body_text) = admin
+            .raw_request("GET", &search_url, None, "/admin/realms/{realm}/groups")
+            .await?;
+        if status == 403 {
+            return Err(PluginError::BootstrapPermsMissing {
+                realm: realm_name.into(),
+            });
+        }
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::KcRest {
+                method: "GET",
+                path_template: "/admin/realms/{realm}/groups".into(),
+                status: KcStatusKind::Http(status),
+                body_first_2kb: truncate_2kb(&body_text),
+            });
+        }
+        let groups: Vec<GroupRep> =
+            serde_json::from_str(&body_text).map_err(|e| PluginError::KcRest {
+                method: "GET",
+                path_template: "/admin/realms/{realm}/groups".into(),
+                status: KcStatusKind::Http(status),
+                body_first_2kb: format!("groups list parse: {e}"),
+            })?;
+        Ok(groups
+            .into_iter()
+            .find(|g| g.name == group_name)
+            .map(|g| TopGroupInfo { id: g.id }))
+    }
+
+    /// Probe whether a parent group has ANY subgroups via
+    /// `GET /admin/realms/{realm}/groups/{parent_id}/children?first=0&max=1`.
+    /// All callers only need a "zero vs non-zero" answer for the Adopted
+    /// emptiness check / Created last-tenant teardown, so we ask Keycloak
+    /// for at most one child and return a bool — `max=1` also keeps the
+    /// response small and stays compatible across Keycloak 24/25/26 (the
+    /// `subGroupCount` field on the parent's `GroupRepresentation` only
+    /// landed in 26).
+    ///
+    /// **403 special case (DESIGN §5.2 line 432):** only the Adopted-mode
+    /// emptiness probe calls this helper, and only with the bootstrap admin.
+    /// A 403 therefore means the bootstrap admin lacks `query-groups` on the
+    /// target realm; surface [`PluginError::BootstrapPermsMissing`] so Phase
+    /// 15 translates to `IdpProvisionFailure::UnsupportedOperation` rather
+    /// than the default 4xx→`CleanFailure` mapping.
+    async fn has_subgroup(
+        &self,
+        admin: &KcAdminClient,
+        realm_name: &str,
+        parent_id: Uuid,
+    ) -> Result<bool, PluginError> {
+        let url = format!(
+            "{}admin/realms/{}/groups/{}/children?first=0&max=1",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+            parent_id,
+        );
+        let (status, body_text) = admin
+            .raw_request(
+                "GET",
+                &url,
+                None,
+                "/admin/realms/{realm}/groups/{parent_uuid}/children",
+            )
+            .await?;
+        if status == 403 {
+            return Err(PluginError::BootstrapPermsMissing {
+                realm: realm_name.into(),
+            });
+        }
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::KcRest {
+                method: "GET",
+                path_template: "/admin/realms/{realm}/groups/{parent_uuid}/children".into(),
+                status: KcStatusKind::Http(status),
+                body_first_2kb: truncate_2kb(&body_text),
+            });
+        }
+        let children: Vec<GroupRep> =
+            serde_json::from_str(&body_text).map_err(|e| PluginError::KcRest {
+                method: "GET",
+                path_template: "/admin/realms/{realm}/groups/{parent_uuid}/children".into(),
+                status: KcStatusKind::Http(status),
+                body_first_2kb: format!("children list parse: {e}"),
+            })?;
+        Ok(!children.is_empty())
+    }
+}
+
+/// Result of [`TenantFacade::find_top_group`] — the parent group's `id`. Kept
+/// as a struct (rather than bare `Uuid`) so future Adopted-mode work can
+/// extend it (e.g. with `subGroupCount` when KC 26+ is the baseline) without
+/// rippling through call sites.
+#[domain_model]
+struct TopGroupInfo {
+    id: Uuid,
+}
+
+#[cfg(test)]
+#[path = "tenant_facade_tests.rs"]
+mod tenant_facade_tests;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/tenant_facade_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/tenant_facade_tests.rs
@@ -629,7 +629,7 @@ async fn adopted_with_empty_realm_provisions_with_secret_ref() {
             "Adopted always carries the templated SecretRef",
         );
         assert_eq!(meta.tenant_group_id, group_uuid);
-        assert_eq!(meta.admin_client_id, "vp-idp-plugin-realm-admin");
+        assert_eq!(meta.admin_client_id, "keycloak-idp-plugin-realm-admin");
     })
     .await;
 }
@@ -1179,7 +1179,7 @@ async fn mount_created_downstream(
     // Step 4: lookup created realm-admin client by clientId.
     Mock::given(method("GET"))
         .and(path(format!("/admin/realms/{realm}/clients")))
-        .and(query_param("clientId", "vp-idp-plugin-realm-admin"))
+        .and(query_param("clientId", "keycloak-idp-plugin-realm-admin"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
             {"id": admin_client_uuid.to_string()}
         ])))
@@ -1352,7 +1352,7 @@ async fn created_happy_path_writes_secret_and_returns_created_metadata() {
         assert_eq!(meta.realm_binding, RealmBinding::Created);
         assert_eq!(meta.admin_secret_ref.as_deref(), Some(secret_key.as_str()),);
         assert_eq!(meta.tenant_group_id, group_uuid);
-        assert_eq!(meta.admin_client_id, "vp-idp-plugin-realm-admin");
+        assert_eq!(meta.admin_client_id, "keycloak-idp-plugin-realm-admin");
 
         let recorded = mutator.put_calls.lock().expect("stub lock poisoned");
         assert_eq!(
@@ -1818,7 +1818,7 @@ async fn created_kc_role_mapping_5xx_returns_ambiguous_kc_role_mapping() {
             .await;
         Mock::given(method("GET"))
             .and(path(format!("/admin/realms/{realm}/clients")))
-            .and(query_param("clientId", "vp-idp-plugin-realm-admin"))
+            .and(query_param("clientId", "keycloak-idp-plugin-realm-admin"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
                 {"id": admin_client_uuid.to_string()}
             ])))
@@ -1980,7 +1980,7 @@ async fn created_client_secret_read_failure_returns_ambiguous_kc_client_secret_r
             .await;
         Mock::given(method("GET"))
             .and(path(format!("/admin/realms/{realm}/clients")))
-            .and(query_param("clientId", "vp-idp-plugin-realm-admin"))
+            .and(query_param("clientId", "keycloak-idp-plugin-realm-admin"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
                 {"id": admin_client_uuid.to_string()}
             ])))
@@ -2088,7 +2088,7 @@ fn deprovision_req(
 /// Build a [`SecurityContext`] whose `subject_type` is `"am.system"`
 /// (mirrors AM's `for_module_init` / `for_bootstrap` shape). The
 /// missing-metadata branch keys on this string per DESIGN §9 /
-/// `vp_idp_plugin_deprovision_missing_metadata_total`.
+/// `keycloak_idp_plugin_deprovision_missing_metadata_total`.
 fn build_am_system_ctx() -> Arc<SecurityContext> {
     let ctx = SecurityContext::builder()
         .subject_id(uuid::uuid!("00000000-0000-cf01-0000-616d73797374"))
@@ -2511,7 +2511,7 @@ async fn deprovision_5xx_on_group_delete_returns_retryable() {
 
 /// Missing metadata + `am.system` ctx → `DeprovisionNotFound { realm_name = "unknown" }`.
 /// Also exercises the `tracing::warn!` placeholder for the
-/// `vp_idp_plugin_deprovision_missing_metadata_total` counter that Phase
+/// `keycloak_idp_plugin_deprovision_missing_metadata_total` counter that Phase
 /// 14 will wire to `OTel` (we can't easily assert the warn emission
 /// without a tracing subscriber, but exercising the branch keeps it
 /// reachable + clippy-clean).

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/tenant_facade_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/tenant_facade_tests.rs
@@ -1,0 +1,4402 @@
+use super::*;
+use crate::domain::credstore::{CredStoreReader, CredStoreWriter};
+use crate::domain::kc::transport::KcTransport;
+use crate::domain::system_actor::build_system_ctx;
+use crate::domain::test_support::{
+    ConfigurableStubCS, StubCredStore, keycloak_cfg, make_metadata, noop_credstore_metrics,
+    noop_failure_metrics, noop_metadata_metrics, noop_tenant_metrics,
+};
+use crate::infra::kc_http::ReqwestKcTransport;
+use account_management_sdk::idp::IdpProvisionTenantRequest;
+use account_management_sdk::idp_user::IdpTenantContext;
+use async_trait::async_trait;
+use credstore_sdk::{
+    CredStoreClientV1, CredStoreError, GetSecretResponse, SecretRef, SecretValue, SharingMode,
+    WritePrecondition,
+};
+use gts::GtsTypeId;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use toolkit_security::SecurityContext;
+use wiremock::matchers::{method, path, path_regex, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Recorded `put` invocation — `(secret_ref_str, value_bytes, sharing)`.
+/// Used by Created-mode tests to assert the realm-admin secret landed
+/// under the templated key with `SharingMode::Tenant`.
+type RecordedPut = (String, Vec<u8>, SharingMode);
+
+/// Recorded `delete` invocation — `secret_ref_str`.
+/// Used by deprovision-tests to assert the realm-admin secret was
+/// purged under the templated key.
+type RecordedDelete = String;
+
+/// Configurable unified stub. Created-mode tests inject one of these to
+/// (a) record `put` calls (happy path asserts the templated key) and
+/// (b) optionally fail the next `put` (ambiguous `OpenBao` failure
+/// arm). Mirrors the `ConfigurableStubCS` pattern above. Deprovision
+/// tests additionally read [`Self::delete_calls`] to assert the
+/// Created last-tenant teardown purged the realm-admin secret.
+///
+/// `get_responses` is the read seam (mirrors `ConfigurableStubCS`):
+/// tests that need the reader to resolve a per-realm secret seed it via
+/// [`Self::with_get_entry`] (or by merging a `ConfigurableStubCS` into
+/// `build_facade_with_cs_and_mutator`).
+#[domain_model]
+#[derive(Default)]
+struct ConfigurableStubOpenBao {
+    put_calls: Mutex<Vec<RecordedPut>>,
+    delete_calls: Mutex<Vec<RecordedDelete>>,
+    /// One-shot override for the next `put` call's response. `None` →
+    /// default `Ok(())`. Consumed on read.
+    next_put_response: Mutex<Option<Result<(), CredStoreError>>>,
+    /// Keyed read responses (consumed on first match — same semantics as
+    /// [`ConfigurableStubCS`]).
+    get_responses: Mutex<std::collections::HashMap<String, GetSecretResponse>>,
+}
+
+impl ConfigurableStubOpenBao {
+    fn with_put_failure(err: CredStoreError) -> Self {
+        Self {
+            put_calls: Mutex::new(Vec::new()),
+            delete_calls: Mutex::new(Vec::new()),
+            next_put_response: Mutex::new(Some(Err(err))),
+            get_responses: Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+
+    fn seed_get(&self, key: &str, value: &str) {
+        self.get_responses
+            .lock()
+            .expect("stub lock poisoned")
+            .insert(
+                key.to_owned(),
+                GetSecretResponse {
+                    value: SecretValue::from(value),
+                    owner_tenant_id: credstore_sdk::TenantId::nil(),
+                    sharing: SharingMode::Tenant,
+                    is_inherited: false,
+                    version: 1,
+                    id: Uuid::nil(),
+                    secret_type: "gts.x.core.secret.type.v1~x.core.secret.generic.v1".to_owned(),
+                    expires_at: None,
+                },
+            );
+    }
+}
+
+#[async_trait]
+impl CredStoreClientV1 for ConfigurableStubOpenBao {
+    async fn create(
+        &self,
+        ctx: &SecurityContext,
+        key: &SecretRef,
+        value: SecretValue,
+        sharing: SharingMode,
+    ) -> Result<(), CredStoreError> {
+        self.put(ctx, key, value, sharing, WritePrecondition::Exists)
+            .await
+    }
+
+    async fn get(
+        &self,
+        _ctx: &SecurityContext,
+        key: &SecretRef,
+    ) -> Result<Option<GetSecretResponse>, CredStoreError> {
+        Ok(self
+            .get_responses
+            .lock()
+            .expect("stub lock poisoned")
+            .remove(key.as_ref()))
+    }
+
+    async fn put(
+        &self,
+        _ctx: &SecurityContext,
+        key: &SecretRef,
+        value: SecretValue,
+        sharing: SharingMode,
+        _precondition: WritePrecondition,
+    ) -> Result<(), CredStoreError> {
+        self.put_calls.lock().expect("stub lock poisoned").push((
+            key.as_ref().to_owned(),
+            value.as_bytes().to_vec(),
+            sharing,
+        ));
+        self.next_put_response
+            .lock()
+            .expect("stub lock poisoned")
+            .take()
+            .unwrap_or(Ok(()))
+    }
+
+    async fn delete(
+        &self,
+        _ctx: &SecurityContext,
+        key: &SecretRef,
+        _precondition: WritePrecondition,
+    ) -> Result<(), CredStoreError> {
+        self.delete_calls
+            .lock()
+            .expect("stub lock poisoned")
+            .push(key.as_ref().to_owned());
+        Ok(())
+    }
+}
+
+fn tenant_facade_cfg() -> TenantFacadeConfig {
+    TenantFacadeConfig {
+        realm_defaults: serde_json::Value::Null,
+        tenant_group_root: "/tenants".into(),
+        provision_timeout_ms: 30_000,
+    }
+}
+
+fn build_facade(server: &MockServer) -> TenantFacade {
+    build_facade_with_cs(server, Arc::new(StubCredStore))
+}
+
+/// Variant of [`build_facade`] that lets the caller inject a custom
+/// [`CredStoreClientV1`] — Adopted-mode tests use this to seed the
+/// per-realm `OpenBao` response.
+fn build_facade_with_cs(server: &MockServer, cs: Arc<dyn CredStoreClientV1>) -> TenantFacade {
+    build_facade_with_unified_client(server, cs)
+}
+
+/// Builder for Created-mode tests that record `put`/`delete` calls.
+/// The `mutator` is a [`ConfigurableStubOpenBao`] used as the single
+/// unified [`CredStoreClientV1`]; pre-seed any needed `get` responses via
+/// [`ConfigurableStubOpenBao::seed_get`] before calling this.
+fn build_facade_with_cs_and_mutator(
+    server: &MockServer,
+    mutator: Arc<dyn CredStoreClientV1>,
+) -> TenantFacade {
+    build_facade_with_unified_client(server, mutator)
+}
+
+fn build_facade_with_unified_client(
+    server: &MockServer,
+    client: Arc<dyn CredStoreClientV1>,
+) -> TenantFacade {
+    let kc_cfg = keycloak_cfg(&server.uri());
+    let realm_admin_cfg = kc_cfg.realm_admin.clone();
+    let tenant_cfg = tenant_facade_cfg();
+
+    let cs_reader = CredStoreReader::new(Arc::clone(&client), build_system_ctx(Uuid::nil()));
+    let cs_writer = CredStoreWriter::new(client, build_system_ctx(Uuid::nil()));
+
+    let transport: Arc<dyn KcTransport> = Arc::new(ReqwestKcTransport::new(reqwest::Client::new()));
+    let factory = Arc::new(KeycloakAdminClientFactory::new(
+        kc_cfg,
+        transport,
+        cs_reader,
+        Arc::new(crate::domain::test_support::NoopMetrics),
+    ));
+    TenantFacade::new(
+        tenant_cfg,
+        realm_admin_cfg,
+        factory,
+        Arc::new(MetadataCodec),
+        cs_writer,
+        noop_tenant_metrics(),
+        noop_credstore_metrics(),
+        noop_metadata_metrics(),
+        noop_failure_metrics(),
+    )
+}
+
+/// Build a Root-target request with the AM bootstrap saga's typical
+/// `root_tenant_metadata` forwarded as `provisioning_metadata` — mode
+/// = shared, realm = platform. This mirrors the production wiring after
+/// VHP-1505: the plugin no longer accepts `metadata = None`, so the AM
+/// deployer is required to set `bootstrap.root_tenant_metadata`.
+fn req_for_root(tenant_id: Uuid) -> IdpProvisionTenantRequest {
+    IdpProvisionTenantRequest::for_root(
+        tenant_id,
+        "platform-root",
+        GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+    )
+    .with_metadata(serde_json::json!({
+        "mode": "shared",
+        "realm_name": "platform"
+    }))
+}
+
+/// Mount `GET /realms/master` → 200 so the pre-saga
+/// [`KeycloakAdminClientFactory::health_probe`] (called at the top of
+/// every saga entry-point per DESIGN §4.4) passes. Without this mount,
+/// every facade test would hit wiremock's default 404 in the probe and
+/// surface `PluginError::Config` before the saga-specific mocks ever
+/// run. Tests that deliberately exercise the pre-saga KC-outage path
+/// SHOULD NOT call this helper.
+async fn mount_kc_health_probe_ok(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/realms/master"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+        .mount(server)
+        .await;
+}
+
+/// Mount the two token endpoints (master + the realm under test) so the
+/// factory's `bootstrap_client()` and `realm_client(...)` both succeed.
+/// Also mounts the health-probe endpoint — every saga test that issues
+/// a token POST is also going to hit the health probe first.
+async fn mount_token_endpoints(server: &MockServer, realm_under_test: &str) {
+    mount_kc_health_probe_ok(server).await;
+    Mock::given(method("POST"))
+        .and(path("/realms/master/protocol/openid-connect/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "t-master",
+            "expires_in": 600
+        })))
+        .mount(server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/realms/{realm_under_test}/protocol/openid-connect/token"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "t-realm",
+            "expires_in": 600
+        })))
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn absent_metadata_on_root_rejects_missing_realm_name() {
+    // VHP-1836: a Root provision with absent `provisioning_metadata` has no
+    // realm to bind to — explicit `realm_name` is required for Root. This is
+    // caller-input misconfiguration on the AM side, so it surfaces as
+    // `PluginError::ProvisionInputRejected` (mapped to a clean 400), which the
+    // Phase 15 boundary maps to `IdpProvisionFailure::InvalidInput`.
+    let server = MockServer::start().await;
+    // No HTTP mocks needed — the failure short-circuits before any KC call.
+    let facade = build_facade(&server);
+    let ctx = build_system_ctx(Uuid::nil());
+    let req = IdpProvisionTenantRequest::for_root(
+        Uuid::new_v4(),
+        "platform-root",
+        GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+    );
+    let err = facade
+        .provision_tenant_inner(&ctx, &req)
+        .await
+        .expect_err("absent metadata must error");
+    assert!(
+        matches!(err, PluginError::ProvisionInputRejected { ref detail } if detail.contains("root provisioning requires") && detail.contains("realm_name")),
+        "expected PluginError::ProvisionInputRejected(root provisioning requires … realm_name), got {err:?}",
+    );
+}
+
+#[tokio::test]
+async fn explicit_shared_mode_against_default_realm() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            mount_token_endpoints(&server, "platform").await;
+
+            Mock::given(method("GET"))
+                .and(path("/admin/realms/platform"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+                .mount(&server)
+                .await;
+
+            // Parent group already exists — skip the create.
+            let parent_uuid = Uuid::new_v4();
+            Mock::given(method("GET"))
+                .and(path("/admin/realms/platform/groups"))
+                .and(query_param("search", "tenants"))
+                .and(query_param("exact", "true"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                    {"id": parent_uuid.to_string(), "name": "tenants"}
+                ])))
+                .mount(&server)
+                .await;
+
+            let tenant_uuid = Uuid::new_v4();
+            let group_uuid = Uuid::new_v4();
+            Mock::given(method("POST"))
+                .and(path_regex(format!(
+                    r"^/admin/realms/platform/groups/{parent_uuid}/children$"
+                )))
+                .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                    "id": group_uuid.to_string(),
+                    "name": tenant_uuid.to_string()
+                })))
+                .mount(&server)
+                .await;
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            // VHP-1836: a shared child inherits its realm from the parent's
+            // idp_metadata (explicit `realm_name` is ignored). Supply a
+            // parent_context whose decoded realm is `platform`.
+            let req = IdpProvisionTenantRequest::new(
+                tenant_uuid,
+                Uuid::new_v4(),
+                "child-name",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            )
+            .with_metadata(serde_json::json!({ "mode": "shared" }))
+            .with_parent_context(IdpTenantContext::new(
+                Uuid::new_v4(),
+                "parent",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+                Some(make_metadata(
+                    "platform",
+                    RealmBinding::Shared,
+                    Uuid::new_v4(),
+                    None,
+                )),
+            ));
+
+            let meta = facade
+                .provision_tenant_inner(&ctx, &req)
+                .await
+                .expect("provision ok");
+
+            assert_eq!(meta.realm_name, "platform");
+            assert_eq!(meta.realm_binding, RealmBinding::Shared);
+            assert!(meta.admin_secret_ref.is_none());
+            assert_eq!(meta.tenant_group_id, group_uuid);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn explicit_shared_mode_against_non_default_realm_uses_env_backed_admin() {
+    // VHP-1505: Shared is a single env-backed path regardless of realm
+    // name. The plugin no longer distinguishes a "non-default Shared
+    // realm" sub-case; multi-region Shared is out-of-scope for v1 and
+    // future work goes through Adopted.
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            mount_token_endpoints(&server, "region-eu").await;
+
+            Mock::given(method("GET"))
+                .and(path("/admin/realms/region-eu"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+                .mount(&server)
+                .await;
+
+            let parent_uuid = Uuid::new_v4();
+            Mock::given(method("GET"))
+                .and(path("/admin/realms/region-eu/groups"))
+                .and(query_param("search", "tenants"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                    {"id": parent_uuid.to_string(), "name": "tenants"}
+                ])))
+                .mount(&server)
+                .await;
+
+            let tenant_uuid = Uuid::new_v4();
+            let group_uuid = Uuid::new_v4();
+            Mock::given(method("POST"))
+                .and(path(format!(
+                    "/admin/realms/region-eu/groups/{parent_uuid}/children"
+                )))
+                .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                    "id": group_uuid.to_string(),
+                    "name": tenant_uuid.to_string()
+                })))
+                .mount(&server)
+                .await;
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            // VHP-1836: shared child inherits the parent's realm (`region-eu`).
+            let req = IdpProvisionTenantRequest::new(
+                tenant_uuid,
+                Uuid::new_v4(),
+                "child-name",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            )
+            .with_metadata(serde_json::json!({ "mode": "shared" }))
+            .with_parent_context(IdpTenantContext::new(
+                Uuid::new_v4(),
+                "parent",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+                Some(make_metadata(
+                    "region-eu",
+                    RealmBinding::Shared,
+                    Uuid::new_v4(),
+                    None,
+                )),
+            ));
+
+            let meta = facade
+                .provision_tenant_inner(&ctx, &req)
+                .await
+                .expect("provision ok");
+
+            assert_eq!(meta.realm_name, "region-eu");
+            assert_eq!(meta.realm_binding, RealmBinding::Shared);
+            assert!(
+                meta.admin_secret_ref.is_none(),
+                "Shared binding always persists admin_secret_ref = None (ADDENDUM §3.4)",
+            );
+            assert_eq!(meta.tenant_group_id, group_uuid);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn missing_realm_surfaces_as_kc_rest_404() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            mount_token_endpoints(&server, "platform").await;
+
+            Mock::given(method("GET"))
+                .and(path("/admin/realms/platform"))
+                .respond_with(ResponseTemplate::new(404).set_body_string("Realm not found"))
+                .mount(&server)
+                .await;
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            let req = req_for_root(Uuid::new_v4());
+            let err = facade
+                .provision_tenant_inner(&ctx, &req)
+                .await
+                .expect_err("missing realm must error");
+            assert!(
+                matches!(
+                    err,
+                    PluginError::KcRest {
+                        method: "GET",
+                        status: KcStatusKind::Http(404),
+                        ref path_template,
+                        ..
+                    } if path_template == "/admin/realms/{realm}"
+                ),
+                "expected KcRest{{ GET 404 /admin/realms/{{realm}} }}, got {err:?}",
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn malformed_metadata_surfaces_as_input_rejected() {
+    let server = MockServer::start().await;
+    // No HTTP mocks needed — the failure short-circuits before any KC call.
+    let facade = build_facade(&server);
+    let ctx = build_system_ctx(Uuid::nil());
+    // `mode` typed as a number — fails `WireMetadata` deserialisation. VHP-1836
+    // surfaces wire-shape failures as `ProvisionInputRejected` ("malformed").
+    let req = IdpProvisionTenantRequest::new(
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        "child-name",
+        GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+    )
+    .with_metadata(serde_json::json!({"mode": 42}));
+
+    let err = facade
+        .provision_tenant_inner(&ctx, &req)
+        .await
+        .expect_err("malformed metadata must error");
+    assert!(
+        matches!(err, PluginError::ProvisionInputRejected { ref detail } if detail.contains("malformed")),
+        "expected PluginError::ProvisionInputRejected(malformed …), got {err:?}",
+    );
+}
+
+#[tokio::test]
+async fn invalid_mode_surfaces_as_input_rejected() {
+    let server = MockServer::start().await;
+    let facade = build_facade(&server);
+    let ctx = build_system_ctx(Uuid::nil());
+    let req = IdpProvisionTenantRequest::new(
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        "child-name",
+        GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+    )
+    .with_metadata(serde_json::json!({"mode": "wat", "realm_name": "platform"}));
+
+    let err = facade
+        .provision_tenant_inner(&ctx, &req)
+        .await
+        .expect_err("invalid mode must error");
+    assert!(
+        matches!(err, PluginError::ProvisionInputRejected { ref detail } if detail.contains("not allowed")),
+        "expected PluginError::ProvisionInputRejected(not allowed …), got {err:?}",
+    );
+}
+
+// ---------------------------------------------------------------------
+// Phase 9 — Adopted mode (DESIGN §4.1, §4.2, §5.2, §5.4)
+// ---------------------------------------------------------------------
+
+/// Happy path: target realm `partner-acme` exists, the parent `/tenants`
+/// group exists with zero subgroups, the per-realm admin secret is
+/// pre-provisioned in `OpenBao`. Expect Adopted metadata with
+/// `admin_secret_ref = Some(<templated key>)`.
+#[tokio::test]
+async fn adopted_with_empty_realm_provisions_with_secret_ref() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        mount_token_endpoints(&server, "partner-acme").await;
+
+        // Bootstrap probes that the realm exists.
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/partner-acme"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&server)
+            .await;
+
+        // Parent group search (bootstrap admin) — present.
+        let parent_uuid = Uuid::new_v4();
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/partner-acme/groups"))
+            .and(query_param("search", "tenants"))
+            .and(query_param("exact", "true"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": parent_uuid.to_string(), "name": "tenants"}
+            ])))
+            .mount(&server)
+            .await;
+
+        // Emptiness probe (bootstrap admin) — zero children.
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/admin/realms/partner-acme/groups/{parent_uuid}/children"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&server)
+            .await;
+
+        // Realm-admin then creates the per-tenant child subgroup.
+        let tenant_uuid = Uuid::new_v4();
+        let group_uuid = Uuid::new_v4();
+        Mock::given(method("POST"))
+            .and(path(format!(
+                "/admin/realms/partner-acme/groups/{parent_uuid}/children"
+            )))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "id": group_uuid.to_string(),
+                "name": tenant_uuid.to_string()
+            })))
+            .mount(&server)
+            .await;
+
+        // Per-realm OpenBao response — keyed by the templated SecretRef.
+        let cs = Arc::new(ConfigurableStubCS::with_entry(
+            "vp-idp-realm-admin-partner-acme-secret",
+            "per-realm-ra-secret",
+        ));
+        let facade = build_facade_with_cs(&server, cs);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = IdpProvisionTenantRequest::new(
+            tenant_uuid,
+            Uuid::new_v4(),
+            "child-name",
+            GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+        )
+        .with_metadata(serde_json::json!({
+            "mode": "adopted",
+            "realm_name": "partner-acme"
+        }));
+
+        let meta = facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect("adopted provision ok");
+
+        assert_eq!(meta.realm_name, "partner-acme");
+        assert_eq!(meta.realm_binding, RealmBinding::Adopted);
+        assert_eq!(
+            meta.admin_secret_ref.as_deref(),
+            Some("vp-idp-realm-admin-partner-acme-secret"),
+            "Adopted always carries the templated SecretRef",
+        );
+        assert_eq!(meta.tenant_group_id, group_uuid);
+        assert_eq!(meta.admin_client_id, "vp-idp-plugin-realm-admin");
+    })
+    .await;
+}
+
+/// Absent parent tenant group is success-equivalent (DESIGN §5.4): the
+/// realm-admin step creates both the parent and child groups.
+#[tokio::test]
+async fn adopted_with_absent_parent_group_succeeds() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        mount_token_endpoints(&server, "partner-acme").await;
+
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/partner-acme"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&server)
+            .await;
+
+        // Parent group search: returns [] on the first TWO calls (bootstrap
+        // emptiness probe at Adopted step 2 + realm-admin's initial probe
+        // in `find_or_create_top_group` step 4), then returns the created
+        // group on the third call — the post-create lookup re-search that
+        // recovers the id without parsing the empty 201 body (KC 26.x
+        // contract). See test_am_tenant_tree's barrier-flip test for the
+        // matching production codepath.
+        let parent_uuid = Uuid::new_v4();
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/partner-acme/groups"))
+            .and(query_param("search", "tenants"))
+            .and(query_param("exact", "true"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .with_priority(1)
+            .up_to_n_times(2)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/partner-acme/groups"))
+            .and(query_param("search", "tenants"))
+            .and(query_param("exact", "true"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": parent_uuid.to_string(), "name": "tenants"}
+            ])))
+            .mount(&server)
+            .await;
+
+        // Realm-admin creates parent /tenants — body intentionally empty to
+        // match KC 26.x behaviour (id is in `Location` header only).
+        Mock::given(method("POST"))
+            .and(path("/admin/realms/partner-acme/groups"))
+            .respond_with(ResponseTemplate::new(201))
+            .mount(&server)
+            .await;
+
+        // Realm-admin creates per-tenant child subgroup.
+        let tenant_uuid = Uuid::new_v4();
+        let group_uuid = Uuid::new_v4();
+        Mock::given(method("POST"))
+            .and(path(format!(
+                "/admin/realms/partner-acme/groups/{parent_uuid}/children"
+            )))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "id": group_uuid.to_string(),
+                "name": tenant_uuid.to_string()
+            })))
+            .mount(&server)
+            .await;
+
+        let cs = Arc::new(ConfigurableStubCS::with_entry(
+            "vp-idp-realm-admin-partner-acme-secret",
+            "per-realm-ra-secret",
+        ));
+        let facade = build_facade_with_cs(&server, cs);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = IdpProvisionTenantRequest::new(
+            tenant_uuid,
+            Uuid::new_v4(),
+            "child-name",
+            GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+        )
+        .with_metadata(serde_json::json!({
+            "mode": "adopted",
+            "realm_name": "partner-acme"
+        }));
+
+        let meta = facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect("adopted provision with absent parent ok");
+        assert_eq!(meta.realm_binding, RealmBinding::Adopted);
+        assert_eq!(meta.tenant_group_id, group_uuid);
+    })
+    .await;
+}
+
+/// Parent /tenants has an existing subgroup → CleanFailure-equivalent.
+/// Surfaced as `PluginError::KcRest { status: Http(409), .. }` so the
+/// Phase 15 boundary's 4xx-→-CleanFailure table picks it up without a
+/// dedicated variant (see module commit notes for the variant
+/// rationale).
+#[tokio::test]
+async fn adopted_with_non_empty_parent_group_returns_clean_failure() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        mount_token_endpoints(&server, "partner-acme").await;
+
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/partner-acme"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&server)
+            .await;
+
+        let parent_uuid = Uuid::new_v4();
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/partner-acme/groups"))
+            .and(query_param("search", "tenants"))
+            .and(query_param("exact", "true"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": parent_uuid.to_string(), "name": "tenants"}
+            ])))
+            .mount(&server)
+            .await;
+
+        // Parent has one existing subgroup → emptiness probe fails.
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/admin/realms/partner-acme/groups/{parent_uuid}/children"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": Uuid::new_v4().to_string(), "name": "existing-tenant"}
+            ])))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = IdpProvisionTenantRequest::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "child-name",
+            GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+        )
+        .with_metadata(serde_json::json!({
+            "mode": "adopted",
+            "realm_name": "partner-acme"
+        }));
+
+        let err = facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect_err("non-empty parent must error");
+        assert!(
+            matches!(
+                err,
+                PluginError::KcRest {
+                    method: "GET",
+                    status: KcStatusKind::Http(409),
+                    ref path_template,
+                    ref body_first_2kb,
+                    ..
+                } if path_template == "/admin/realms/{realm}/groups/{parent_uuid}/children"
+                    && body_first_2kb.contains("partner-acme")
+                    && body_first_2kb.contains("not empty")
+            ),
+            "expected KcRest{{ GET 409 /children, body mentions realm + not empty }}, got {err:?}",
+        );
+    })
+    .await;
+}
+
+/// Shared-mode realm probe 403 (bootstrap admin lacks `view-realm`) →
+/// `PluginError::BootstrapPermsMissing { realm }` (DESIGN §5.2 line 432).
+/// Phase 15 translates this to `IdpProvisionFailure::UnsupportedOperation`.
+#[tokio::test]
+async fn shared_with_realm_probe_403_returns_bootstrap_perms_missing() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            mount_token_endpoints(&server, "partner-acme").await;
+
+            Mock::given(method("GET"))
+                .and(path("/admin/realms/partner-acme"))
+                .respond_with(ResponseTemplate::new(403).set_body_string("Forbidden"))
+                .mount(&server)
+                .await;
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            // VHP-1836: shared child inherits the parent's realm (`partner-acme`).
+            let req = IdpProvisionTenantRequest::new(
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                "child-name",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            )
+            .with_metadata(serde_json::json!({ "mode": "shared" }))
+            .with_parent_context(IdpTenantContext::new(
+                Uuid::new_v4(),
+                "parent",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+                Some(make_metadata(
+                    "partner-acme",
+                    RealmBinding::Shared,
+                    Uuid::new_v4(),
+                    None,
+                )),
+            ));
+
+            let err = facade
+                .provision_tenant_inner(&ctx, &req)
+                .await
+                .expect_err("403 on realm probe must error");
+            assert!(
+                matches!(err, PluginError::BootstrapPermsMissing { ref realm } if realm == "partner-acme"),
+                "expected BootstrapPermsMissing{{ realm: partner-acme }}, got {err:?}",
+            );
+        },
+    )
+    .await;
+}
+
+/// Adopted-mode realm probe 403 (bootstrap admin lacks `view-realm`) →
+/// `PluginError::BootstrapPermsMissing { realm }` (DESIGN §5.2 line 432).
+#[tokio::test]
+async fn adopted_with_realm_probe_403_returns_bootstrap_perms_missing() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        mount_token_endpoints(&server, "partner-acme").await;
+
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/partner-acme"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("Forbidden"))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = IdpProvisionTenantRequest::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "child-name",
+            GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+        )
+        .with_metadata(serde_json::json!({
+            "mode": "adopted",
+            "realm_name": "partner-acme"
+        }));
+
+        let err = facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect_err("403 on realm probe must error");
+        assert!(
+            matches!(err, PluginError::BootstrapPermsMissing { ref realm } if realm == "partner-acme"),
+            "expected BootstrapPermsMissing{{ realm: partner-acme }}, got {err:?}",
+        );
+    })
+    .await;
+}
+
+/// Adopted-mode group search 403 (bootstrap admin lacks `query-groups`) →
+/// `PluginError::BootstrapPermsMissing { realm }` (DESIGN §5.2 line 432).
+#[tokio::test]
+async fn adopted_with_group_search_403_returns_bootstrap_perms_missing() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        mount_token_endpoints(&server, "partner-acme").await;
+
+        // Realm probe succeeds — gates the failure to the group-search step.
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/partner-acme"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/partner-acme/groups"))
+            .and(query_param("search", "tenants"))
+            .and(query_param("exact", "true"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("Forbidden"))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = IdpProvisionTenantRequest::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "child-name",
+            GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+        )
+        .with_metadata(serde_json::json!({
+            "mode": "adopted",
+            "realm_name": "partner-acme"
+        }));
+
+        let err = facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect_err("403 on group search must error");
+        assert!(
+            matches!(err, PluginError::BootstrapPermsMissing { ref realm } if realm == "partner-acme"),
+            "expected BootstrapPermsMissing{{ realm: partner-acme }}, got {err:?}",
+        );
+    })
+    .await;
+}
+
+/// Non-2xx coverage gap: 5xx on the Adopted group-search probe surfaces as
+/// `KcRest{ GET 503 /admin/realms/{realm}/groups }` — distinct from the
+/// 403→`BootstrapPermsMissing` and 404→`KcRest` paths.
+#[tokio::test]
+async fn adopted_with_group_search_5xx_returns_kc_rest() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        mount_token_endpoints(&server, "partner-acme").await;
+
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/partner-acme"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/partner-acme/groups"))
+            .and(query_param("search", "tenants"))
+            .and(query_param("exact", "true"))
+            .respond_with(ResponseTemplate::new(503).set_body_string("Service Unavailable"))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = IdpProvisionTenantRequest::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "child-name",
+            GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+        )
+        .with_metadata(serde_json::json!({
+            "mode": "adopted",
+            "realm_name": "partner-acme"
+        }));
+
+        let err = facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect_err("5xx on group search must error");
+        assert!(
+            matches!(
+                err,
+                PluginError::KcRest {
+                    method: "GET",
+                    status: KcStatusKind::Http(503),
+                    ref path_template,
+                    ..
+                } if path_template == "/admin/realms/{realm}/groups"
+            ),
+            "expected KcRest{{ GET 503 /admin/realms/{{realm}}/groups }}, got {err:?}",
+        );
+    })
+    .await;
+}
+
+/// Non-2xx coverage gap: 5xx on the Adopted `has_subgroup` probe surfaces
+/// as `KcRest{ GET 503 /children }` — the parent group is found, then the
+/// children-listing call fails with a transient upstream error.
+#[tokio::test]
+async fn adopted_with_has_subgroup_5xx_returns_kc_rest() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        mount_token_endpoints(&server, "partner-acme").await;
+
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/partner-acme"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&server)
+            .await;
+
+        let parent_uuid = Uuid::new_v4();
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/partner-acme/groups"))
+            .and(query_param("search", "tenants"))
+            .and(query_param("exact", "true"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": parent_uuid.to_string(), "name": "tenants"}
+            ])))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/admin/realms/partner-acme/groups/{parent_uuid}/children"
+            )))
+            .respond_with(ResponseTemplate::new(503).set_body_string("Service Unavailable"))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = IdpProvisionTenantRequest::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "child-name",
+            GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+        )
+        .with_metadata(serde_json::json!({
+            "mode": "adopted",
+            "realm_name": "partner-acme"
+        }));
+
+        let err = facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect_err("5xx on has_subgroup must error");
+        assert!(
+            matches!(
+                err,
+                PluginError::KcRest {
+                    method: "GET",
+                    status: KcStatusKind::Http(503),
+                    ref path_template,
+                    ..
+                } if path_template == "/admin/realms/{realm}/groups/{parent_uuid}/children"
+            ),
+            "expected KcRest{{ GET 503 /children }}, got {err:?}",
+        );
+    })
+    .await;
+}
+
+/// Adopted-mode realm probe 404 surfaces as `KcRest{ GET 404 }` (same
+/// shape as the Shared-mode test, but with `mode = adopted`).
+#[tokio::test]
+async fn adopted_against_missing_realm_returns_kc_rest_404() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        mount_token_endpoints(&server, "partner-acme").await;
+
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/partner-acme"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("Realm not found"))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = IdpProvisionTenantRequest::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "child-name",
+            GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+        )
+        .with_metadata(serde_json::json!({
+            "mode": "adopted",
+            "realm_name": "partner-acme"
+        }));
+
+        let err = facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect_err("missing realm must error");
+        assert!(
+            matches!(
+                err,
+                PluginError::KcRest {
+                    method: "GET",
+                    status: KcStatusKind::Http(404),
+                    ref path_template,
+                    ..
+                } if path_template == "/admin/realms/{realm}"
+            ),
+            "expected KcRest{{ GET 404 /admin/realms/{{realm}} }}, got {err:?}",
+        );
+    })
+    .await;
+}
+
+// ---------------------------------------------------------------------
+// Phase 10 — Created mode (DESIGN §4.2, §5.2, §5.4, §8.1 Phase 2)
+// ---------------------------------------------------------------------
+
+/// Mount the full happy-path KC choreography for Created mode:
+/// (1) realm probe → 404, (2) realm-create → 201, (3) client-create →
+/// 201, (4) lookup created client by clientId → returns its UUID, (5)
+/// service-account-user lookup → user UUID, (6) realm-management client
+/// lookup by clientId → its UUID, (7) available role list → all 7
+/// `REALM_ADMIN_REQUIRED_ROLES` present, (8) POST role-mappings → 204,
+/// (9) GET client-secret → plaintext. Plus the realm-admin group steps.
+///
+/// The caller passes the `tenant_uuid` (so it can derive the generated
+/// `realm-<tenant_uuid>` and seed the matching credstore key). Returns
+/// `(group_uuid, parent_uuid)`.
+async fn mount_created_happy_path(
+    server: &MockServer,
+    tenant_uuid: Uuid,
+    realm: &str,
+    client_secret_plaintext: &str,
+) -> (Uuid, Uuid) {
+    mount_token_endpoints(server, realm).await;
+
+    // Step 1: realm existence probe → 404 (realm absent).
+    Mock::given(method("GET"))
+        .and(path(format!("/admin/realms/{realm}")))
+        .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+        .mount(server)
+        .await;
+
+    // Step 2: realm-create → 201.
+    Mock::given(method("POST"))
+        .and(path("/admin/realms"))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(server)
+        .await;
+
+    mount_created_downstream(server, realm, tenant_uuid, client_secret_plaintext).await
+}
+
+/// Mount the post-realm-create KC choreography (client create, lookups,
+/// role mappings, client-secret read, and the realm-admin group steps) for
+/// Created mode. Split out of [`mount_created_happy_path`] so the
+/// idempotency / reconcile tests can drive their own realm GET/POST
+/// behaviour while reusing this long downstream tail. Does NOT mount the
+/// token endpoints, the realm existence probe, or `POST /admin/realms`.
+async fn mount_created_downstream(
+    server: &MockServer,
+    realm: &str,
+    tenant_uuid: Uuid,
+    client_secret_plaintext: &str,
+) -> (Uuid, Uuid) {
+    let admin_client_uuid = Uuid::new_v4();
+    let sa_user_uuid = Uuid::new_v4();
+    let rm_client_uuid = Uuid::new_v4();
+    let parent_uuid = Uuid::new_v4();
+    let group_uuid = Uuid::new_v4();
+
+    // Step 3: realm-admin client create → 201.
+    Mock::given(method("POST"))
+        .and(path(format!("/admin/realms/{realm}/clients")))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(server)
+        .await;
+
+    // Step 4: lookup created realm-admin client by clientId.
+    Mock::given(method("GET"))
+        .and(path(format!("/admin/realms/{realm}/clients")))
+        .and(query_param("clientId", "vp-idp-plugin-realm-admin"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            {"id": admin_client_uuid.to_string()}
+        ])))
+        .mount(server)
+        .await;
+
+    // Step 5: service-account-user lookup.
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/admin/realms/{realm}/clients/{admin_client_uuid}/service-account-user"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": sa_user_uuid.to_string()
+        })))
+        .mount(server)
+        .await;
+
+    // Step 6: realm-management client lookup.
+    Mock::given(method("GET"))
+        .and(path(format!("/admin/realms/{realm}/clients")))
+        .and(query_param("clientId", "realm-management"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            {"id": rm_client_uuid.to_string()}
+        ])))
+        .mount(server)
+        .await;
+
+    // Step 7: available realm-management roles for the SA user. Echo
+    // back all 7 required roles so the selection step succeeds.
+    let role_ids: Vec<serde_json::Value> = REALM_ADMIN_REQUIRED_ROLES
+        .iter()
+        .map(|n| {
+            serde_json::json!({
+                "id": Uuid::new_v4().to_string(),
+                "name": *n,
+            })
+        })
+        .collect();
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/admin/realms/{realm}/users/{sa_user_uuid}/role-mappings/clients/{rm_client_uuid}/available"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::Value::Array(role_ids)))
+        .mount(server).await;
+
+    // Step 8: POST role-mappings → 204.
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/admin/realms/{realm}/users/{sa_user_uuid}/role-mappings/clients/{rm_client_uuid}"
+        )))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(server)
+        .await;
+
+    // Step 9: read client_secret.
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/admin/realms/{realm}/clients/{admin_client_uuid}/client-secret"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "type": "secret",
+            "value": client_secret_plaintext,
+        })))
+        .mount(server)
+        .await;
+
+    // Realm-admin step: parent group missing on initial probe, then visible
+    // after POST creates it.
+    //
+    // Mock sequence — the saga calls `GET /groups?search=tenants&exact=true`
+    // TWICE in the create branch: once before the POST (to decide whether to
+    // create) and once AFTER the POST (to recover the new group's id, since
+    // Keycloak returns 201 + empty body + `Location` header on POST /groups).
+    // The first call must return `[]`; the second must return the populated
+    // entry. We express that with two mocks at different priorities:
+    //   * priority 1, `up_to_n_times(1)` → answers the first request only
+    //   * priority 5 (default) → answers everything after
+    // Lower priority number = higher precedence in wiremock-rs.
+    Mock::given(method("GET"))
+        .and(path(format!("/admin/realms/{realm}/groups")))
+        .and(query_param("search", "tenants"))
+        .and(query_param("exact", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .with_priority(1)
+        .up_to_n_times(1)
+        .mount(server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/admin/realms/{realm}/groups")))
+        .and(query_param("search", "tenants"))
+        .and(query_param("exact", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            {"id": parent_uuid.to_string(), "name": "tenants"}
+        ])))
+        .mount(server)
+        .await;
+    // POST returns 201 with empty body — matches KC 26.x's actual behaviour
+    // (group id only in the `Location` header). The plugin no longer parses
+    // this body; it re-issues the GET search instead.
+    Mock::given(method("POST"))
+        .and(path(format!("/admin/realms/{realm}/groups")))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(server)
+        .await;
+    // Per-tenant child subgroup.
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/admin/realms/{realm}/groups/{parent_uuid}/children"
+        )))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": group_uuid.to_string(),
+            "name": tenant_uuid.to_string()
+        })))
+        .mount(server)
+        .await;
+
+    (group_uuid, parent_uuid)
+}
+
+fn created_request(tenant_uuid: Uuid) -> IdpProvisionTenantRequest {
+    // VHP-1836: created mode GENERATES `realm-<tenant_id>` — no `realm_name`
+    // on the wire (supplying one is rejected).
+    IdpProvisionTenantRequest::new(
+        tenant_uuid,
+        Uuid::new_v4(),
+        "child-name",
+        GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+    )
+    .with_metadata(serde_json::json!({ "mode": "created" }))
+}
+
+/// Happy path: full Created saga succeeds end-to-end. Asserts
+/// (1) the returned metadata carries `realm_binding = Created` and
+/// the templated `admin_secret_ref`, (2) the `tenant_group_id` comes
+/// from the realm-admin child-group create, (3) the `OpenBao` stub
+/// recorded exactly ONE `put` keyed by the templated `SecretRef` with
+/// `SharingMode::Tenant` and the verbatim client-secret bytes.
+#[tokio::test]
+async fn created_happy_path_writes_secret_and_returns_created_metadata() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        // VHP-1836: created mode generates `realm-<tenant_id>`.
+        let tenant_uuid = Uuid::new_v4();
+        let realm = format!("realm-{tenant_uuid}");
+        let secret_key = format!("vp-idp-realm-admin-{realm}-secret");
+        let (group_uuid, _parent_uuid) =
+            mount_created_happy_path(&server, tenant_uuid, &realm, "the-generated-client-secret")
+                .await;
+
+        // Per-realm OpenBao read for the realm-admin client AFTER the
+        // plugin's `put` lands (the factory caches the resulting token
+        // so this only needs the read seam wired). Seed the read
+        // response directly into the unified stub.
+        let mutator = Arc::new(ConfigurableStubOpenBao::default());
+        mutator.seed_get(&secret_key, "the-generated-client-secret");
+        let facade = build_facade_with_unified_client(
+            &server,
+            Arc::clone(&mutator) as Arc<dyn CredStoreClientV1>,
+        );
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = created_request(tenant_uuid);
+
+        let meta = facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect("created provision ok");
+
+        assert_eq!(meta.version, "v1");
+        assert_eq!(meta.realm_name, realm);
+        assert_eq!(meta.realm_binding, RealmBinding::Created);
+        assert_eq!(meta.admin_secret_ref.as_deref(), Some(secret_key.as_str()),);
+        assert_eq!(meta.tenant_group_id, group_uuid);
+        assert_eq!(meta.admin_client_id, "vp-idp-plugin-realm-admin");
+
+        let recorded = mutator.put_calls.lock().expect("stub lock poisoned");
+        assert_eq!(
+            recorded.len(),
+            1,
+            "Created mode MUST persist exactly one OpenBao put"
+        );
+        assert_eq!(recorded[0].0, secret_key);
+        assert_eq!(recorded[0].1, b"the-generated-client-secret");
+        assert_eq!(
+            recorded[0].2,
+            SharingMode::Tenant,
+            "Created-mode put must use SharingMode::Tenant per ADDENDUM / §8.1",
+        );
+    })
+    .await;
+}
+
+/// Regression: Created-mode saga MUST force-refresh the bootstrap token
+/// between `create_realm` (step 2) and `create_realm_admin_client` (step 3).
+///
+/// Why this matters — Keycloak's role-claim issuance is point-in-time. When
+/// the bootstrap client creates a new realm via `POST /admin/realms`, KC
+/// auto-grants the creator `realm-admin` on the new realm, but the access
+/// token already in flight (minted BEFORE the realm existed) does not carry
+/// the new mapping. The next bootstrap call against
+/// `POST /admin/realms/{new_realm}/clients` then returns `403 Forbidden`.
+/// The reactive-401 wrapper only refreshes on 401, so without the explicit
+/// `invalidate_bootstrap()` between steps 2 and 3 the saga surfaces
+/// `AmbiguousCreated { stage: KcClientCreate }` → AM 500.
+///
+/// We pin the observable consequence of the fix: the bootstrap `master`
+/// token endpoint is hit AT LEAST TWICE per Created-mode tenant create —
+/// once for the cold-cache warm-up that covers steps 1-2, and once more
+/// after the mid-saga invalidate so step 3 carries a fresh bearer with the
+/// new `realm-admin` claim. Drop the invalidate and the count collapses to
+/// 1 — the assertion below catches that regression directly.
+#[tokio::test]
+async fn created_saga_remints_bootstrap_token_after_realm_create() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        let tenant_uuid = Uuid::new_v4();
+        let realm = format!("realm-{tenant_uuid}");
+        let (_group_uuid, _parent_uuid) =
+            mount_created_happy_path(&server, tenant_uuid, &realm, "the-generated-client-secret")
+                .await;
+        let cs = Arc::new(ConfigurableStubCS::with_entry(
+            &format!("vp-idp-realm-admin-{realm}-secret"),
+            "the-generated-client-secret",
+        ));
+        let facade = build_facade_with_cs(&server, cs);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = created_request(tenant_uuid);
+
+        facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect("created provision ok");
+
+        // Count POST hits on the bootstrap (master) token endpoint. The
+        // cold-cache warm-up at the start of the saga is one hit; the
+        // post-`create_realm` invalidate forces a second one so step 3's
+        // `POST /admin/realms/{realm}/clients` is sent with a token that
+        // carries the just-granted `realm-admin` claim.
+        let bootstrap_token_mints = server
+            .received_requests()
+            .await
+            .expect("mock server records requests")
+            .iter()
+            .filter(|r| {
+                r.method == wiremock::http::Method::POST
+                    && r.url.path() == "/realms/master/protocol/openid-connect/token"
+            })
+            .count();
+        assert!(
+            bootstrap_token_mints >= 2,
+            "Created-mode saga MUST re-mint the bootstrap token after `create_realm` \
+             so the step-3 bearer carries the new `realm-admin` claim; observed \
+             {bootstrap_token_mints} mint(s) — fix likely reverted"
+        );
+    })
+    .await;
+}
+
+/// `mode = created` against a realm that already exists → bootstrap
+/// probe returns 200 → [`PluginError::CreatedRealmExists`]. NO realm
+/// is created and NO `OpenBao` put happens. Phase 15 maps this to
+/// `CleanFailure` per DESIGN §5.2.
+#[tokio::test]
+async fn created_against_existing_realm_returns_clean_failure_equivalent() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        let tenant_uuid = Uuid::new_v4();
+        let realm = format!("realm-{tenant_uuid}");
+        mount_token_endpoints(&server, &realm).await;
+        Mock::given(method("GET"))
+            .and(path(format!("/admin/realms/{realm}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&server)
+            .await;
+
+        let mutator = Arc::new(ConfigurableStubOpenBao::default());
+        let facade = build_facade_with_cs_and_mutator(
+            &server,
+            Arc::clone(&mutator) as Arc<dyn CredStoreClientV1>,
+        );
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = created_request(tenant_uuid);
+
+        let err = facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect_err("existing realm must error");
+        assert!(
+            matches!(
+                err,
+                PluginError::CreatedRealmExists { realm: ref got }
+                    if got == &realm
+            ),
+            "expected CreatedRealmExists{{ realm: {realm} }}, got {err:?}",
+        );
+        assert!(
+            mutator.put_calls.lock().unwrap().is_empty(),
+            "no OpenBao writes on validation rejection",
+        );
+    })
+    .await;
+}
+
+/// Bootstrap probe 404; realm-create POST returns 500 →
+/// `AmbiguousCreated { stage: KcRealmCreate, .. }`. From the operator's
+/// point of view the realm may or may not exist; reconciliation is the runbook.
+#[tokio::test]
+async fn created_kc_realm_create_5xx_returns_ambiguous_kc_realm_create() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        let tenant_uuid = Uuid::new_v4();
+        let realm = format!("realm-{tenant_uuid}");
+        mount_token_endpoints(&server, &realm).await;
+        Mock::given(method("GET"))
+            .and(path(format!("/admin/realms/{realm}")))
+            .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/admin/realms"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+            .mount(&server)
+            .await;
+
+        let mutator = Arc::new(ConfigurableStubOpenBao::default());
+        let facade =
+            build_facade_with_cs_and_mutator(&server, Arc::clone(&mutator) as Arc<dyn CredStoreClientV1>);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = created_request(tenant_uuid);
+
+        let err = facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect_err("5xx on realm-create must error");
+        assert!(
+            matches!(
+                err,
+                PluginError::AmbiguousCreated {
+                    stage: AmbiguousStage::KcRealmCreate,
+                    ref detail,
+                } if detail.contains("500") && detail.contains("boom")
+            ),
+            "expected AmbiguousCreated{{ stage: KcRealmCreate, detail mentions 500/boom }}, got {err:?}",
+        );
+        assert!(
+            mutator.put_calls.lock().unwrap().is_empty(),
+            "no OpenBao writes when KC realm-create fails",
+        );
+    })
+    .await;
+}
+
+// ---------------------------------------------------------------------
+// Created-mode realm-create idempotency (VHP-190 / run am-functional-22):
+// the realm-create step must reconcile a 409 / lost-our-own-create against
+// an ownership marker instead of blanket-tagging `AmbiguousCreated`.
+// ---------------------------------------------------------------------
+
+/// A `GET /admin/realms/{realm}` body carrying the plugin's ownership
+/// attribute for `tenant_id` — reconcile recognises this realm as "ours".
+fn realm_body_with_owner(realm: &str, tenant_id: Uuid) -> serde_json::Value {
+    serde_json::json!({
+        "realm": realm,
+        "attributes": { "vhp.provisioning.tenant_id": tenant_id.to_string() },
+    })
+}
+
+/// Regression (run am-functional-22): under KC load the realm-create POST
+/// is retried after a timeout; the first POST already created the realm, so
+/// the retry hits KC's unique-name constraint → 409. The plugin MUST
+/// recognise the realm as its own (ownership marker on the re-GET) and treat
+/// the create as idempotent success — NOT surface `AmbiguousCreated` → 500.
+#[tokio::test]
+async fn created_realm_create_409_with_our_marker_reconciles_to_success() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        let tenant_uuid = Uuid::new_v4();
+        let realm = format!("realm-{tenant_uuid}");
+        let realm = realm.as_str();
+        mount_token_endpoints(&server, realm).await;
+
+        // Initial existence probe → 404 (realm absent at decision time).
+        Mock::given(method("GET"))
+            .and(path(format!("/admin/realms/{realm}")))
+            .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+            .with_priority(1)
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        // Re-GET after the 409 → realm present, carrying OUR ownership marker.
+        Mock::given(method("GET"))
+            .and(path(format!("/admin/realms/{realm}")))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(realm_body_with_owner(realm, tenant_uuid)),
+            )
+            .mount(&server)
+            .await;
+        // realm-create POST → 409 (the duplicate from the retried POST).
+        Mock::given(method("POST"))
+            .and(path("/admin/realms"))
+            .respond_with(ResponseTemplate::new(409).set_body_string("Conflict detected"))
+            .mount(&server)
+            .await;
+
+        let _ = mount_created_downstream(&server, realm, tenant_uuid, "sekret").await;
+
+        let cs = Arc::new(ConfigurableStubCS::with_entry(
+            &format!("vp-idp-realm-admin-{realm}-secret"),
+            "sekret",
+        ));
+        let facade = build_facade_with_cs(&server, cs);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = created_request(tenant_uuid);
+
+        let meta = facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect("409 on our own realm-create retry must reconcile to success");
+        assert_eq!(meta.realm_binding, RealmBinding::Created);
+        assert_eq!(meta.realm_name, realm);
+    })
+    .await;
+}
+
+/// Re-provisioning a tenant whose dedicated realm already exists AND carries
+/// our ownership marker is idempotent: the plugin adopts the existing realm
+/// (no second `POST /admin/realms`) and completes the saga.
+#[tokio::test]
+async fn created_existing_realm_with_our_marker_is_adopted() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        let tenant_uuid = Uuid::new_v4();
+        let realm = format!("realm-{tenant_uuid}");
+        let realm = realm.as_str();
+        mount_token_endpoints(&server, realm).await;
+        // Existence probe → 200 with our marker (a prior attempt made it).
+        Mock::given(method("GET"))
+            .and(path(format!("/admin/realms/{realm}")))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(realm_body_with_owner(realm, tenant_uuid)),
+            )
+            .mount(&server)
+            .await;
+        let _ = mount_created_downstream(&server, realm, tenant_uuid, "sekret").await;
+
+        let cs = Arc::new(ConfigurableStubCS::with_entry(
+            &format!("vp-idp-realm-admin-{realm}-secret"),
+            "sekret",
+        ));
+        let facade = build_facade_with_cs(&server, cs);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = created_request(tenant_uuid);
+
+        let meta = facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect("existing realm with our marker must be adopted");
+        assert_eq!(meta.realm_binding, RealmBinding::Created);
+
+        let realm_creates = server
+            .received_requests()
+            .await
+            .expect("recorded")
+            .iter()
+            .filter(|r| r.method == wiremock::http::Method::POST && r.url.path() == "/admin/realms")
+            .count();
+        assert_eq!(realm_creates, 0, "adopt path must NOT create a realm");
+    })
+    .await;
+}
+
+/// Existence probe returns a realm owned by a DIFFERENT tenant (foreign
+/// marker) → clean `CreatedRealmExists`, never adoption, never a POST.
+#[tokio::test]
+async fn created_existing_realm_with_foreign_marker_returns_clean_failure() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        let tenant_uuid = Uuid::new_v4();
+        let realm = format!("realm-{tenant_uuid}");
+        let realm = realm.as_str();
+        mount_token_endpoints(&server, realm).await;
+        Mock::given(method("GET"))
+            .and(path(format!("/admin/realms/{realm}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(realm_body_with_owner(realm, Uuid::new_v4())),
+            )
+            .mount(&server)
+            .await;
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = created_request(tenant_uuid);
+        let err = facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect_err("foreign realm must be a clean failure");
+        assert!(
+            matches!(err, PluginError::CreatedRealmExists { realm: ref got } if got == realm),
+            "expected CreatedRealmExists, got {err:?}",
+        );
+    })
+    .await;
+}
+
+/// A 409 on realm-create where the existing realm is FOREIGN (someone else
+/// won a create race) → clean `CreatedRealmExists`, not success and not
+/// ambiguous.
+#[tokio::test]
+async fn created_realm_create_409_with_foreign_marker_returns_clean_failure() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        let tenant_uuid = Uuid::new_v4();
+        let realm = format!("realm-{tenant_uuid}");
+        let realm = realm.as_str();
+        mount_token_endpoints(&server, realm).await;
+        Mock::given(method("GET"))
+            .and(path(format!("/admin/realms/{realm}")))
+            .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+            .with_priority(1)
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/admin/realms/{realm}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(realm_body_with_owner(realm, Uuid::new_v4())),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/admin/realms"))
+            .respond_with(ResponseTemplate::new(409).set_body_string("conflict"))
+            .mount(&server)
+            .await;
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = created_request(tenant_uuid);
+        let err = facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect_err("409 with foreign owner must be clean failure");
+        assert!(
+            matches!(err, PluginError::CreatedRealmExists { .. }),
+            "expected CreatedRealmExists, got {err:?}",
+        );
+    })
+    .await;
+}
+
+/// Bootstrap probe 404, realm-create 201; client-create POST returns 500
+/// → `AmbiguousCreated { stage: KcClientCreate, .. }`. KC may have
+/// created the realm-admin client; reconciliation is the runbook.
+#[tokio::test]
+async fn created_kc_client_create_5xx_returns_ambiguous_kc_client_create() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        let tenant_uuid = Uuid::new_v4();
+        let realm = format!("realm-{tenant_uuid}");
+        mount_token_endpoints(&server, &realm).await;
+        Mock::given(method("GET"))
+            .and(path(format!("/admin/realms/{realm}")))
+            .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/admin/realms"))
+            .respond_with(ResponseTemplate::new(201))
+            .mount(&server)
+            .await;
+        // Client-create fails with 500 — the test's whole point.
+        Mock::given(method("POST"))
+            .and(path(format!("/admin/realms/{realm}/clients")))
+            .respond_with(ResponseTemplate::new(500).set_body_string("client boom"))
+            .mount(&server)
+            .await;
+
+        let mutator = Arc::new(ConfigurableStubOpenBao::default());
+        let facade =
+            build_facade_with_cs_and_mutator(&server, Arc::clone(&mutator) as Arc<dyn CredStoreClientV1>);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = created_request(tenant_uuid);
+
+        let err = facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect_err("5xx on client-create must error");
+        assert!(
+            matches!(
+                err,
+                PluginError::AmbiguousCreated {
+                    stage: AmbiguousStage::KcClientCreate,
+                    ref detail,
+                } if detail.contains("500") && detail.contains("client boom")
+            ),
+            "expected AmbiguousCreated{{ stage: KcClientCreate, detail mentions 500/client boom }}, got {err:?}",
+        );
+        assert!(
+            mutator.put_calls.lock().unwrap().is_empty(),
+            "no OpenBao writes when KC client-create fails",
+        );
+    })
+    .await;
+}
+
+/// KC realm-create + client-create succeed; the POST role-mappings call
+/// returns 500 → `AmbiguousCreated { stage: KcRoleMapping, .. }`. KC has
+/// the realm-admin client and SA user but the role binding may be
+/// partial — reconciliation re-applies the mapping.
+#[tokio::test]
+async fn created_kc_role_mapping_5xx_returns_ambiguous_kc_role_mapping() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        // Manually mount the choreography up to (but excluding) the
+        // POST role-mappings so we can override that step with 500.
+        let tenant_uuid = Uuid::new_v4();
+        let realm = format!("realm-{tenant_uuid}");
+        mount_token_endpoints(&server, &realm).await;
+        let admin_client_uuid = Uuid::new_v4();
+        let sa_user_uuid = Uuid::new_v4();
+        let rm_client_uuid = Uuid::new_v4();
+
+        Mock::given(method("GET"))
+            .and(path(format!("/admin/realms/{realm}")))
+            .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/admin/realms"))
+            .respond_with(ResponseTemplate::new(201))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(format!("/admin/realms/{realm}/clients")))
+            .respond_with(ResponseTemplate::new(201))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/admin/realms/{realm}/clients")))
+            .and(query_param("clientId", "vp-idp-plugin-realm-admin"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": admin_client_uuid.to_string()}
+            ])))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/admin/realms/{realm}/clients/{admin_client_uuid}/service-account-user"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": sa_user_uuid.to_string()
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/admin/realms/{realm}/clients")))
+            .and(query_param("clientId", "realm-management"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": rm_client_uuid.to_string()}
+            ])))
+            .mount(&server)
+            .await;
+        let role_ids: Vec<serde_json::Value> = REALM_ADMIN_REQUIRED_ROLES
+            .iter()
+            .map(|n| {
+                serde_json::json!({
+                    "id": Uuid::new_v4().to_string(),
+                    "name": *n,
+                })
+            })
+            .collect();
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/admin/realms/{realm}/users/{sa_user_uuid}/role-mappings/clients/{rm_client_uuid}/available"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::Value::Array(role_ids)))
+            .mount(&server)
+            .await;
+        // POST role-mappings fails with 500 — the test's whole point.
+        Mock::given(method("POST"))
+            .and(path(format!(
+                "/admin/realms/{realm}/users/{sa_user_uuid}/role-mappings/clients/{rm_client_uuid}"
+            )))
+            .respond_with(ResponseTemplate::new(500).set_body_string("rm boom"))
+            .mount(&server)
+            .await;
+
+        let mutator = Arc::new(ConfigurableStubOpenBao::default());
+        let facade =
+            build_facade_with_cs_and_mutator(&server, Arc::clone(&mutator) as Arc<dyn CredStoreClientV1>);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = created_request(tenant_uuid);
+
+        let err = facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect_err("5xx on POST role-mappings must error");
+        assert!(
+            matches!(
+                err,
+                PluginError::AmbiguousCreated {
+                    stage: AmbiguousStage::KcRoleMapping,
+                    ref detail,
+                } if detail.contains("500") && detail.contains("rm boom")
+            ),
+            "expected AmbiguousCreated{{ stage: KcRoleMapping, detail mentions 500/rm boom }}, got {err:?}",
+        );
+        assert!(
+            mutator.put_calls.lock().unwrap().is_empty(),
+            "no OpenBao writes when KC role-mapping fails",
+        );
+    })
+    .await;
+}
+
+/// All KC steps succeed; `OpenBao` `put` fails →
+/// `AmbiguousCreated { stage: OpenBaoPutAfterKcSuccess, .. }`. This is
+/// the saga's "point of no return" — KC has irreversible state and
+/// reconciliation must `DELETE` the realm + defensive `OpenBao` delete
+/// (§12 risk #9).
+#[tokio::test]
+async fn created_openbao_put_failure_returns_ambiguous_openbao_after_kc_success() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        let tenant_uuid = Uuid::new_v4();
+        let realm = format!("realm-{tenant_uuid}");
+        let _ = mount_created_happy_path(&server, tenant_uuid, &realm, "secret-value").await;
+
+        let mutator = Arc::new(ConfigurableStubOpenBao::with_put_failure(
+            CredStoreError::service_unavailable("openbao down"),
+        ));
+        // put fails before the realm-admin token exchange (step 7), so no
+        // get-response seed is needed.
+        let facade = build_facade_with_cs_and_mutator(
+            &server,
+            Arc::clone(&mutator) as Arc<dyn CredStoreClientV1>,
+        );
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = created_request(tenant_uuid);
+
+        let err = facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect_err("openbao put failure must error");
+        assert!(
+            matches!(
+                err,
+                PluginError::AmbiguousCreated {
+                    stage: AmbiguousStage::OpenBaoPutAfterKcSuccess,
+                    ref detail,
+                } if detail.contains("credstore") && detail.contains("openbao down")
+            ),
+            "expected AmbiguousCreated{{ stage: OpenBaoPutAfterKcSuccess }}, got {err:?}",
+        );
+        // The plugin DID attempt the put (recorded by the stub) even
+        // though the response was an Err — that's the whole point of
+        // "Ambiguous": the call may have landed.
+        assert_eq!(
+            mutator.put_calls.lock().unwrap().len(),
+            1,
+            "the put was attempted exactly once before the failure",
+        );
+    })
+    .await;
+}
+
+/// KC realm-create, client-create, role-mapping all succeed; the
+/// `client-secret` GET returns 500 →
+/// `AmbiguousCreated { stage: KcClientSecretRead, .. }`. KC has full
+/// state at this point but the plugin cannot complete the `OpenBao`
+/// write without the plaintext.
+#[tokio::test]
+async fn created_client_secret_read_failure_returns_ambiguous_kc_client_secret_read() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        // Manually mount the choreography up to (but excluding) the
+        // client-secret read so we can override that step with 500.
+        let tenant_uuid = Uuid::new_v4();
+        let realm = format!("realm-{tenant_uuid}");
+        mount_token_endpoints(&server, &realm).await;
+        let admin_client_uuid = Uuid::new_v4();
+        let sa_user_uuid = Uuid::new_v4();
+        let rm_client_uuid = Uuid::new_v4();
+
+        Mock::given(method("GET"))
+            .and(path(format!("/admin/realms/{realm}")))
+            .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/admin/realms"))
+            .respond_with(ResponseTemplate::new(201))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(format!("/admin/realms/{realm}/clients")))
+            .respond_with(ResponseTemplate::new(201))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/admin/realms/{realm}/clients")))
+            .and(query_param("clientId", "vp-idp-plugin-realm-admin"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": admin_client_uuid.to_string()}
+            ])))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/admin/realms/{realm}/clients/{admin_client_uuid}/service-account-user"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": sa_user_uuid.to_string()
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/admin/realms/{realm}/clients")))
+            .and(query_param("clientId", "realm-management"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": rm_client_uuid.to_string()}
+            ])))
+            .mount(&server)
+            .await;
+        let role_ids: Vec<serde_json::Value> = REALM_ADMIN_REQUIRED_ROLES
+            .iter()
+            .map(|n| {
+                serde_json::json!({
+                    "id": Uuid::new_v4().to_string(),
+                    "name": *n,
+                })
+            })
+            .collect();
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/admin/realms/{realm}/users/{sa_user_uuid}/role-mappings/clients/{rm_client_uuid}/available"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::Value::Array(role_ids)))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(format!(
+                "/admin/realms/{realm}/users/{sa_user_uuid}/role-mappings/clients/{rm_client_uuid}"
+            )))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+        // Client-secret read fails with 500 — the test's whole point.
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/admin/realms/{realm}/clients/{admin_client_uuid}/client-secret"
+            )))
+            .respond_with(ResponseTemplate::new(500).set_body_string("kc broke"))
+            .mount(&server)
+            .await;
+
+        let mutator = Arc::new(ConfigurableStubOpenBao::default());
+        let facade =
+            build_facade_with_cs_and_mutator(&server, Arc::clone(&mutator) as Arc<dyn CredStoreClientV1>);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = created_request(tenant_uuid);
+
+        let err = facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect_err("client-secret read failure must error");
+        assert!(
+            matches!(
+                err,
+                PluginError::AmbiguousCreated {
+                    stage: AmbiguousStage::KcClientSecretRead,
+                    ref detail,
+                } if detail.contains("500") && detail.contains("kc broke")
+            ),
+            "expected AmbiguousCreated{{ stage: KcClientSecretRead }}, got {err:?}",
+        );
+        assert!(
+            mutator.put_calls.lock().unwrap().is_empty(),
+            "the saga never reached the OpenBao put",
+        );
+    })
+    .await;
+}
+
+// ---------------------------------------------------------------------
+// Phase 11 — Deprovision (DESIGN §4.2, §5.5, §6.2, §9, ADDENDUM §3.4)
+// ---------------------------------------------------------------------
+
+use account_management_sdk::idp::IdpDeprovisionTenantRequest;
+use wiremock::matchers::method as wm_method;
+
+/// Build an [`IdpDeprovisionTenantRequest`] with the given `tenant_id`
+/// and persisted metadata blob. `tenant_name` and `tenant_type` are
+/// stubbed — the facade doesn't read them.
+fn deprovision_req(
+    tenant_id: Uuid,
+    metadata: Option<serde_json::Value>,
+) -> IdpDeprovisionTenantRequest {
+    IdpDeprovisionTenantRequest::new(IdpTenantContext::new(
+        tenant_id,
+        "stub-tenant",
+        GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+        metadata,
+    ))
+}
+
+/// Build a [`SecurityContext`] whose `subject_type` is `"am.system"`
+/// (mirrors AM's `for_module_init` / `for_bootstrap` shape). The
+/// missing-metadata branch keys on this string per DESIGN §9 /
+/// `vp_idp_plugin_deprovision_missing_metadata_total`.
+fn build_am_system_ctx() -> Arc<SecurityContext> {
+    let ctx = SecurityContext::builder()
+        .subject_id(uuid::uuid!("00000000-0000-cf01-0000-616d73797374"))
+        .subject_type("am.system")
+        .subject_tenant_id(Uuid::nil())
+        .build()
+        .expect("am.system ctx builds");
+    Arc::new(ctx)
+}
+
+/// Build a non-system [`SecurityContext`] (REST-forwarded user, etc.).
+/// `subject_type = "rest"` — used to verify the missing-metadata branch
+/// does NOT emit the system-actor warn for non-system callers.
+fn build_non_system_ctx() -> Arc<SecurityContext> {
+    let ctx = SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_type("rest")
+        .subject_tenant_id(Uuid::nil())
+        .build()
+        .expect("rest ctx builds");
+    Arc::new(ctx)
+}
+
+/// Default-shared platform realm; happy path. The realm-admin secret
+/// resolves via env (ADDENDUM §3.4 — `admin_secret_ref = None`), the
+/// realm-admin DELETEs the tenant group with 204, and the facade
+/// short-circuits without touching the bootstrap or `OpenBao` seams.
+#[tokio::test]
+async fn deprovision_shared_happy_path_returns_ok() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            mount_token_endpoints(&server, "platform").await;
+
+            let tenant_uuid = Uuid::new_v4();
+            let group_uuid = Uuid::new_v4();
+            Mock::given(wm_method("DELETE"))
+                .and(path(format!("/admin/realms/platform/groups/{group_uuid}")))
+                .respond_with(ResponseTemplate::new(204))
+                .mount(&server)
+                .await;
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            let req = deprovision_req(
+                tenant_uuid,
+                Some(make_metadata(
+                    "platform",
+                    RealmBinding::Shared,
+                    group_uuid,
+                    None,
+                )),
+            );
+            facade
+                .deprovision_tenant_inner(&ctx, &req)
+                .await
+                .expect("deprovision ok");
+        },
+    )
+    .await;
+}
+
+/// Adopted realm `partner-acme`; happy path. The realm-admin secret
+/// is in `OpenBao` under the templated key. After the realm-admin
+/// DELETEs the tenant group, the facade returns OK without touching
+/// the realm-delete endpoint (NOT mocked → would 404 if hit).
+#[tokio::test]
+async fn deprovision_adopted_happy_path_returns_ok() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        mount_token_endpoints(&server, "partner-acme").await;
+
+        let tenant_uuid = Uuid::new_v4();
+        let group_uuid = Uuid::new_v4();
+        Mock::given(wm_method("DELETE"))
+            .and(path(format!(
+                "/admin/realms/partner-acme/groups/{group_uuid}"
+            )))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let cs = Arc::new(ConfigurableStubCS::with_entry(
+            "vp-idp-realm-admin-partner-acme-secret",
+            "per-realm-ra-secret",
+        ));
+        let facade = build_facade_with_cs(&server, cs);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = deprovision_req(
+            tenant_uuid,
+            Some(make_metadata(
+                "partner-acme",
+                RealmBinding::Adopted,
+                group_uuid,
+                Some("vp-idp-realm-admin-partner-acme-secret"),
+            )),
+        );
+        facade
+            .deprovision_tenant_inner(&ctx, &req)
+            .await
+            .expect("deprovision ok");
+    })
+    .await;
+}
+
+/// Created realm `partner-created`; last-tenant teardown. After the
+/// realm-admin DELETEs the tenant group with 204, the bootstrap admin
+/// counts subgroups under `/tenants` → 0 → realm DELETE + `OpenBao`
+/// secret DELETE.
+#[tokio::test]
+async fn deprovision_created_last_tenant_tears_down_realm_and_secret() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        mount_token_endpoints(&server, "partner-created").await;
+
+        let tenant_uuid = Uuid::new_v4();
+        let group_uuid = Uuid::new_v4();
+        let parent_uuid = Uuid::new_v4();
+
+        // realm-admin DELETE group → 204.
+        Mock::given(wm_method("DELETE"))
+            .and(path(format!(
+                "/admin/realms/partner-created/groups/{group_uuid}"
+            )))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        // bootstrap admin: find parent /tenants → present.
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/partner-created/groups"))
+            .and(query_param("search", "tenants"))
+            .and(query_param("exact", "true"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": parent_uuid.to_string(), "name": "tenants"}
+            ])))
+            .mount(&server)
+            .await;
+
+        // bootstrap admin: count subgroups → 0.
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/admin/realms/partner-created/groups/{parent_uuid}/children"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&server)
+            .await;
+
+        // bootstrap admin: DELETE realm → 204.
+        Mock::given(wm_method("DELETE"))
+            .and(path("/admin/realms/partner-created"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let mutator = Arc::new(ConfigurableStubOpenBao::default());
+        mutator.seed_get(
+            "vp-idp-realm-admin-partner-created-secret",
+            "per-realm-ra-secret",
+        );
+        let facade = build_facade_with_unified_client(
+            &server,
+            Arc::clone(&mutator) as Arc<dyn CredStoreClientV1>,
+        );
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = deprovision_req(
+            tenant_uuid,
+            Some(make_metadata(
+                "partner-created",
+                RealmBinding::Created,
+                group_uuid,
+                Some("vp-idp-realm-admin-partner-created-secret"),
+            )),
+        );
+        facade
+            .deprovision_tenant_inner(&ctx, &req)
+            .await
+            .expect("deprovision ok");
+
+        let deletes = mutator.delete_calls.lock().expect("stub lock poisoned");
+        assert_eq!(
+            deletes.len(),
+            1,
+            "Created last-tenant teardown MUST issue exactly one OpenBao delete",
+        );
+        assert_eq!(
+            deletes[0], "vp-idp-realm-admin-partner-created-secret",
+            "OpenBao delete MUST key on the templated realm-admin SecretRef",
+        );
+    })
+    .await;
+}
+
+/// Created realm with one remaining tenant under `/tenants`. The
+/// realm DELETE and `OpenBao` secret DELETE MUST NOT happen — the
+/// realm stays live for the other tenant (DESIGN §4.2 / §5.4).
+#[tokio::test]
+async fn deprovision_created_with_remaining_tenants_keeps_realm() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
+        mount_token_endpoints(&server, "partner-busy").await;
+
+        let tenant_uuid = Uuid::new_v4();
+        let group_uuid = Uuid::new_v4();
+        let parent_uuid = Uuid::new_v4();
+        let surviving_uuid = Uuid::new_v4();
+
+        Mock::given(wm_method("DELETE"))
+            .and(path(format!(
+                "/admin/realms/partner-busy/groups/{group_uuid}"
+            )))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/partner-busy/groups"))
+            .and(query_param("search", "tenants"))
+            .and(query_param("exact", "true"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": parent_uuid.to_string(), "name": "tenants"}
+            ])))
+            .mount(&server)
+            .await;
+
+        // One surviving sibling under /tenants — keep the realm.
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/admin/realms/partner-busy/groups/{parent_uuid}/children"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": surviving_uuid.to_string(), "name": "other-tenant"}
+            ])))
+            .mount(&server)
+            .await;
+
+        // Realm DELETE intentionally NOT mocked — would 404 if hit.
+
+        let mutator = Arc::new(ConfigurableStubOpenBao::default());
+        mutator.seed_get(
+            "vp-idp-realm-admin-partner-busy-secret",
+            "per-realm-ra-secret",
+        );
+        let facade = build_facade_with_unified_client(
+            &server,
+            Arc::clone(&mutator) as Arc<dyn CredStoreClientV1>,
+        );
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = deprovision_req(
+            tenant_uuid,
+            Some(make_metadata(
+                "partner-busy",
+                RealmBinding::Created,
+                group_uuid,
+                Some("vp-idp-realm-admin-partner-busy-secret"),
+            )),
+        );
+        facade
+            .deprovision_tenant_inner(&ctx, &req)
+            .await
+            .expect("deprovision ok");
+
+        assert!(
+            mutator
+                .delete_calls
+                .lock()
+                .expect("stub lock poisoned")
+                .is_empty(),
+            "OpenBao secret MUST stay when the realm is still occupied",
+        );
+    })
+    .await;
+}
+
+/// Vendor 404 on the tenant group DELETE → `DeprovisionNotFound`
+/// keyed on the metadata realm name (success-equivalent in AM's
+/// hard-delete pipeline; Phase 15 maps to `IdpDeprovisionFailure::NotFound`).
+#[tokio::test]
+async fn deprovision_with_vendor_404_on_group_delete_returns_not_found() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            mount_token_endpoints(&server, "platform").await;
+
+            let group_uuid = Uuid::new_v4();
+            Mock::given(wm_method("DELETE"))
+                .and(path(format!(
+                    "/admin/realms/platform/groups/{group_uuid}"
+                )))
+                .respond_with(ResponseTemplate::new(404).set_body_string("gone"))
+                .mount(&server)
+                .await;
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            let req = deprovision_req(
+                Uuid::new_v4(),
+                Some(make_metadata(
+                    "platform",
+                    RealmBinding::Shared,
+                    group_uuid,
+                    None,
+                )),
+            );
+            let err = facade
+                .deprovision_tenant_inner(&ctx, &req)
+                .await
+                .expect_err("404 on group delete must error");
+            assert!(
+                matches!(err, PluginError::DeprovisionNotFound { ref realm_name } if realm_name == "platform"),
+                "expected DeprovisionNotFound{{ realm_name: platform }}, got {err:?}",
+            );
+        },
+    )
+    .await;
+}
+
+/// Vendor 410 on the tenant group DELETE → same `DeprovisionNotFound`
+/// shape as the 404 case (DESIGN §6.2 — both are "already absent").
+#[tokio::test]
+async fn deprovision_with_vendor_410_on_group_delete_returns_not_found() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            mount_token_endpoints(&server, "platform").await;
+
+            let group_uuid = Uuid::new_v4();
+            Mock::given(wm_method("DELETE"))
+                .and(path(format!(
+                    "/admin/realms/platform/groups/{group_uuid}"
+                )))
+                .respond_with(ResponseTemplate::new(410).set_body_string("gone-gone"))
+                .mount(&server)
+                .await;
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            let req = deprovision_req(
+                Uuid::new_v4(),
+                Some(make_metadata(
+                    "platform",
+                    RealmBinding::Shared,
+                    group_uuid,
+                    None,
+                )),
+            );
+            let err = facade
+                .deprovision_tenant_inner(&ctx, &req)
+                .await
+                .expect_err("410 on group delete must error");
+            assert!(
+                matches!(err, PluginError::DeprovisionNotFound { ref realm_name } if realm_name == "platform"),
+                "expected DeprovisionNotFound{{ realm_name: platform }}, got {err:?}",
+            );
+        },
+    )
+    .await;
+}
+
+/// Vendor 503 on the tenant group DELETE → `DeprovisionRetryable`
+/// with the status code AND body text embedded in `detail` (so the
+/// operator runbook can grep for "503"/body specifics; DESIGN §6.2).
+#[tokio::test]
+async fn deprovision_5xx_on_group_delete_returns_retryable() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            mount_token_endpoints(&server, "platform").await;
+
+            let group_uuid = Uuid::new_v4();
+            Mock::given(wm_method("DELETE"))
+                .and(path(format!("/admin/realms/platform/groups/{group_uuid}")))
+                .respond_with(ResponseTemplate::new(503).set_body_string("kc-out"))
+                .mount(&server)
+                .await;
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            let req = deprovision_req(
+                Uuid::new_v4(),
+                Some(make_metadata(
+                    "platform",
+                    RealmBinding::Shared,
+                    group_uuid,
+                    None,
+                )),
+            );
+            let err = facade
+                .deprovision_tenant_inner(&ctx, &req)
+                .await
+                .expect_err("503 on group delete must error");
+            assert!(
+                matches!(
+                    err,
+                    PluginError::DeprovisionRetryable { ref detail }
+                        if detail.contains("503") && detail.contains("kc-out")
+                ),
+                "expected DeprovisionRetryable detail to mention 503 + body, got {err:?}",
+            );
+        },
+    )
+    .await;
+}
+
+/// Missing metadata + `am.system` ctx → `DeprovisionNotFound { realm_name = "unknown" }`.
+/// Also exercises the `tracing::warn!` placeholder for the
+/// `vp_idp_plugin_deprovision_missing_metadata_total` counter that Phase
+/// 14 will wire to `OTel` (we can't easily assert the warn emission
+/// without a tracing subscriber, but exercising the branch keeps it
+/// reachable + clippy-clean).
+#[tokio::test]
+async fn deprovision_missing_metadata_am_system_returns_not_found() {
+    let server = MockServer::start().await;
+    // No HTTP / OpenBao mocks needed — the failure short-circuits
+    // before any KC call (DESIGN §4.2 / §6.2 missing-metadata branch).
+    let facade = build_facade(&server);
+    let ctx = build_am_system_ctx();
+    let req = deprovision_req(Uuid::new_v4(), None);
+    let err = facade
+        .deprovision_tenant_inner(&ctx, &req)
+        .await
+        .expect_err("missing metadata must error");
+    assert!(
+        matches!(err, PluginError::DeprovisionNotFound { ref realm_name } if realm_name == "unknown"),
+        "expected DeprovisionNotFound{{ realm_name: unknown }}, got {err:?}",
+    );
+}
+
+/// Missing metadata + non-system ctx → `DeprovisionNotFound { realm_name = "unknown" }`
+/// (same outer shape; the only difference vs the `am.system` case is
+/// no warn is emitted — see DESIGN §9 on why only system-actor
+/// callers contribute to the trigger metric).
+#[tokio::test]
+async fn deprovision_missing_metadata_non_system_returns_not_found() {
+    let server = MockServer::start().await;
+    let facade = build_facade(&server);
+    let ctx = build_non_system_ctx();
+    let req = deprovision_req(Uuid::new_v4(), None);
+    let err = facade
+        .deprovision_tenant_inner(&ctx, &req)
+        .await
+        .expect_err("missing metadata must error");
+    assert!(
+        matches!(err, PluginError::DeprovisionNotFound { ref realm_name } if realm_name == "unknown"),
+        "expected DeprovisionNotFound{{ realm_name: unknown }}, got {err:?}",
+    );
+}
+
+/// Malformed metadata blob (decodes as raw JSON but does not match
+/// the `TenantIdpMetadataV1` shape — missing `version`) →
+/// `DeprovisionTerminal { detail }`. Operator-must-intervene.
+#[tokio::test]
+async fn deprovision_with_malformed_metadata_returns_terminal() {
+    let server = MockServer::start().await;
+    let facade = build_facade(&server);
+    let ctx = build_system_ctx(Uuid::nil());
+    let req = deprovision_req(
+        Uuid::new_v4(),
+        Some(serde_json::json!({"this_is_not_a_valid_blob": true})),
+    );
+    let err = facade
+        .deprovision_tenant_inner(&ctx, &req)
+        .await
+        .expect_err("malformed metadata must error");
+    assert!(
+        matches!(err, PluginError::DeprovisionTerminal { ref detail } if detail.contains("metadata decode failed")),
+        "expected DeprovisionTerminal{{ detail mentions decode }}, got {err:?}",
+    );
+}
+
+// ── DESIGN §5.2: `realm_name` regex validation tests ────────────────────
+
+/// Helper: a Root request carrying explicit `{mode: shared, realm_name}` — the
+/// realm-regex validator runs on the explicit Root realm (VHP-1836).
+fn root_req_with_realm(realm: &str) -> IdpProvisionTenantRequest {
+    IdpProvisionTenantRequest::for_root(
+        Uuid::new_v4(),
+        "platform-root",
+        GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+    )
+    .with_metadata(serde_json::json!({ "mode": "shared", "realm_name": realm }))
+}
+
+/// A `realm_name` containing a dot (`bad.name`) MUST be rejected with
+/// `PluginError::ProvisionInputRejected` and the canonical detail string that
+/// starts with `realm_name rejected`.
+#[test]
+fn parse_input_rejects_realm_name_with_dot() {
+    let req = root_req_with_realm("bad.name");
+    let err = TenantFacade::parse_input(&req).expect_err("must reject");
+    let detail = match err {
+        PluginError::ProvisionInputRejected { detail } => detail,
+        #[allow(clippy::panic)] // test-only assertion; unreachable on correct implementation
+        other => panic!("expected PluginError::ProvisionInputRejected, got {other:?}"),
+    };
+    assert!(
+        detail.contains("realm_name rejected"),
+        "detail must explain rejection, got: {detail}"
+    );
+}
+
+/// A valid `realm_name` with letters, hyphens, and underscores MUST be
+/// accepted and round-trip through `ParsedInput` unchanged.
+#[test]
+fn parse_input_accepts_realm_name_partner_acme_v2() {
+    let req = root_req_with_realm("partner-acme_v2");
+    let parsed = TenantFacade::parse_input(&req).expect("must accept");
+    assert_eq!(parsed.realm_name, "partner-acme_v2");
+    assert_eq!(parsed.realm_binding, RealmBinding::Shared);
+}
+
+/// A `realm_name` of 201 characters MUST be rejected (max is 200).
+#[test]
+fn parse_input_rejects_realm_name_over_200_chars() {
+    let long = "a".repeat(201);
+    let req = root_req_with_realm(&long);
+    let err = TenantFacade::parse_input(&req).expect_err("must reject over-length");
+    assert!(matches!(err, PluginError::ProvisionInputRejected { .. }));
+}
+
+/// An empty `realm_name` MUST be rejected (min length is 1). Root with an empty
+/// explicit `realm_name` deserialises as `Some("")` and fails the regex.
+#[test]
+fn parse_input_rejects_empty_realm_name() {
+    let req = root_req_with_realm("");
+    let err = TenantFacade::parse_input(&req).expect_err("must reject empty");
+    assert!(matches!(err, PluginError::ProvisionInputRejected { .. }));
+}
+
+/// DESIGN §4.2 — when the saga body takes longer than `provision_timeout_ms`,
+/// `provision_tenant_inner` must return `AmbiguousCreated { stage: Timeout }`.
+///
+/// We set `provision_timeout_ms = 50ms` and wire the token endpoint to
+/// delay 200ms, which is longer than the budget. The delay is injected at
+/// the very first Keycloak call (bootstrap token exchange) so the saga
+/// naturally stalls past the timeout without requiring KC admin mocks.
+#[tokio::test]
+async fn provision_tenant_returns_ambiguous_timeout_when_saga_exceeds_provision_timeout_ms() {
+    use std::time::Duration;
+
+    let server = wiremock::MockServer::start().await;
+    mount_kc_health_probe_ok(&server).await;
+
+    // Mount the master-realm token endpoint with a 200ms delay — longer than
+    // our 50ms budget so the timeout fires before any saga step completes.
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path(
+            "/realms/master/protocol/openid-connect/token",
+        ))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200)
+                .set_delay(Duration::from_millis(200))
+                .set_body_json(serde_json::json!({
+                    "access_token": "tok",
+                    "expires_in": 600
+                })),
+        )
+        .mount(&server)
+        .await;
+
+    // Build a facade with a 50ms timeout.
+    let kc_cfg = keycloak_cfg(&server.uri());
+    let realm_admin_cfg = kc_cfg.realm_admin.clone();
+    let tenant_cfg = TenantFacadeConfig {
+        realm_defaults: serde_json::Value::Null,
+        tenant_group_root: "/tenants".into(),
+        provision_timeout_ms: 50,
+    };
+
+    let client: Arc<dyn CredStoreClientV1> = Arc::new(StubCredStore);
+    let cs_reader = crate::domain::credstore::CredStoreReader::new(
+        Arc::clone(&client),
+        crate::domain::system_actor::build_system_ctx(uuid::Uuid::nil()),
+    );
+    let cs_writer = crate::domain::credstore::CredStoreWriter::new(
+        client,
+        crate::domain::system_actor::build_system_ctx(uuid::Uuid::nil()),
+    );
+    let transport: Arc<dyn crate::domain::kc::transport::KcTransport> =
+        Arc::new(ReqwestKcTransport::new(reqwest::Client::new()));
+    let factory = Arc::new(crate::domain::kc::factory::KeycloakAdminClientFactory::new(
+        kc_cfg,
+        transport,
+        cs_reader,
+        Arc::new(crate::domain::test_support::NoopMetrics),
+    ));
+    let facade = TenantFacade::new(
+        tenant_cfg,
+        realm_admin_cfg,
+        factory,
+        Arc::new(crate::domain::metadata_codec::MetadataCodec),
+        cs_writer,
+        noop_tenant_metrics(),
+        noop_credstore_metrics(),
+        noop_metadata_metrics(),
+        noop_failure_metrics(),
+    );
+
+    let ctx = crate::domain::system_actor::build_system_ctx(uuid::Uuid::nil());
+    let req = req_for_root(uuid::Uuid::nil());
+    let result = facade.provision_tenant_inner(&ctx, &req).await;
+
+    assert!(
+        matches!(
+            result,
+            Err(PluginError::AmbiguousCreated {
+                stage: AmbiguousStage::Timeout,
+                ..
+            })
+        ),
+        "expected AmbiguousCreated(Timeout), got: {result:?}"
+    );
+}
+
+// ── VHP-76 §A — admin_user_id bind tests ────────────────────────────────────
+
+/// Mount the Shared-mode happy-path KC calls (realm probe + token endpoints +
+/// parent group search + child group create) for `platform`. Returns
+/// `(tenant_uuid, group_uuid, parent_uuid)`.
+async fn mount_shared_happy_path(server: &MockServer) -> (Uuid, Uuid, Uuid) {
+    mount_token_endpoints(server, "platform").await;
+
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .mount(server)
+        .await;
+
+    let parent_uuid = Uuid::new_v4();
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/platform/groups"))
+        .and(query_param("search", "tenants"))
+        .and(query_param("exact", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            {"id": parent_uuid.to_string(), "name": "tenants"}
+        ])))
+        .mount(server)
+        .await;
+
+    let tenant_uuid = Uuid::new_v4();
+    let group_uuid = Uuid::new_v4();
+    Mock::given(method("POST"))
+        .and(path_regex(format!(
+            r"^/admin/realms/platform/groups/{parent_uuid}/children$"
+        )))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": group_uuid.to_string(),
+            "name": tenant_uuid.to_string()
+        })))
+        .mount(server)
+        .await;
+
+    (tenant_uuid, group_uuid, parent_uuid)
+}
+
+/// Happy path: `admin_user_id` present → GET then PUT on the user endpoint.
+/// Assert the PUT body contains `attributes.tenant_id` and
+/// `attributes.user_type`, and that the returned metadata is unchanged.
+#[tokio::test]
+async fn provision_tenant_shared_binds_admin_user_when_metadata_has_user_id() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            let (tenant_uuid, group_uuid, _parent_uuid) = mount_shared_happy_path(&server).await;
+
+            let admin_user_id = Uuid::new_v4();
+            let existing_user_json = serde_json::json!({
+                "id": admin_user_id.to_string(),
+                "username": "admin",
+                "attributes": {}
+            });
+
+            // GET user → 200 with existing representation.
+            Mock::given(method("GET"))
+                .and(path(format!(
+                    "/admin/realms/platform/users/{admin_user_id}"
+                )))
+                .respond_with(ResponseTemplate::new(200).set_body_json(existing_user_json.clone()))
+                .mount(&server)
+                .await;
+
+            // PUT user → 204 (Keycloak returns 204 No Content on success).
+            Mock::given(method("PUT"))
+                .and(path(format!(
+                    "/admin/realms/platform/users/{admin_user_id}"
+                )))
+                .respond_with(ResponseTemplate::new(204))
+                .mount(&server)
+                .await;
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            let req = IdpProvisionTenantRequest::new(
+                tenant_uuid,
+                Uuid::new_v4(),
+                "admin-name",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            )
+            .with_metadata(serde_json::json!({
+                "mode": "shared",
+                "admin_user_id": admin_user_id.to_string()
+            }))
+            .with_parent_context(IdpTenantContext::new(
+                Uuid::new_v4(),
+                "parent",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+                Some(make_metadata(
+                    "platform",
+                    RealmBinding::Shared,
+                    Uuid::new_v4(),
+                    None,
+                )),
+            ));
+
+            let meta = facade
+                .provision_tenant_inner(&ctx, &req)
+                .await
+                .expect("provision with admin_user_id ok");
+
+            // Returned metadata is unchanged — same as non-bind Shared.
+            assert_eq!(meta.realm_name, "platform");
+            assert_eq!(meta.realm_binding, RealmBinding::Shared);
+            assert!(meta.admin_secret_ref.is_none());
+            assert_eq!(meta.tenant_group_id, group_uuid);
+
+            // Verify the PUT was received by inspecting wiremock's received requests.
+            let received = server.received_requests().await.unwrap();
+            let put_req = received.iter().find(|r| {
+                r.method.as_str() == "PUT"
+                    && r.url.path().ends_with(&format!("/users/{admin_user_id}"))
+            });
+            assert!(put_req.is_some(), "PUT /users/{admin_user_id} must be sent");
+
+            let put_body: serde_json::Value =
+                serde_json::from_slice(&put_req.unwrap().body).expect("PUT body is JSON");
+            let attrs = put_body
+                .get("attributes")
+                .expect("PUT body must have attributes");
+            assert_eq!(
+                attrs.get("tenant_id"),
+                Some(&serde_json::json!([tenant_uuid.to_string()])),
+                "attributes.tenant_id must be set to [request.tenant_id]"
+            );
+            assert_eq!(
+                attrs.get("user_type"),
+                Some(&serde_json::json!(["user"])),
+                "attributes.user_type must be [\"user\"]"
+            );
+        },
+    )
+    .await;
+}
+
+/// No `admin_user_id` in metadata → NO GET/PUT on /users/ is issued.
+/// Existing happy-path behavior is preserved.
+#[tokio::test]
+async fn provision_tenant_shared_no_bind_when_metadata_omits_user_id() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            let (tenant_uuid, group_uuid, _parent_uuid) = mount_shared_happy_path(&server).await;
+
+            // NOTE: No /users/ mock mounted — if the impl hits it, wiremock
+            // returns 404 and the test would fail.
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            let req = IdpProvisionTenantRequest::new(
+                tenant_uuid,
+                Uuid::new_v4(),
+                "admin-name",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            )
+            .with_metadata(serde_json::json!({
+                "mode": "shared"
+                // admin_user_id intentionally omitted
+            }))
+            .with_parent_context(IdpTenantContext::new(
+                Uuid::new_v4(),
+                "parent",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+                Some(make_metadata(
+                    "platform",
+                    RealmBinding::Shared,
+                    Uuid::new_v4(),
+                    None,
+                )),
+            ));
+
+            let meta = facade
+                .provision_tenant_inner(&ctx, &req)
+                .await
+                .expect("provision without admin_user_id ok");
+
+            assert_eq!(meta.realm_binding, RealmBinding::Shared);
+            assert_eq!(meta.tenant_group_id, group_uuid);
+
+            // Assert no GET/PUT /users/ was issued.
+            let received = server.received_requests().await.unwrap();
+            let user_reqs: Vec<_> = received
+                .iter()
+                .filter(|r| r.url.path().contains("/users/"))
+                .collect();
+            assert!(
+                user_reqs.is_empty(),
+                "no /users/ requests expected when admin_user_id is absent, got: {user_reqs:?}"
+            );
+        },
+    )
+    .await;
+}
+
+/// GET /users/{id} returns 404 → `PluginError::AmbiguousCreated` tagged
+/// `AdminUserBind`. The 404 happens AFTER `ensure_tenant_group` has
+/// already created the per-tenant KC group, so the saga left a real
+/// side-effect — surfacing this as `CleanFailure` would tell AM
+/// "nothing happened, safe to retry clean" and leak an orphaned group
+/// on every retry. Ambiguous triggers AM's reconciliation path.
+#[tokio::test]
+async fn provision_tenant_shared_bind_user_not_found_returns_ambiguous_admin_user_bind() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            let (tenant_uuid, _group_uuid, _parent_uuid) =
+                mount_shared_happy_path(&server).await;
+
+            let admin_user_id = Uuid::new_v4();
+
+            Mock::given(method("GET"))
+                .and(path(format!(
+                    "/admin/realms/platform/users/{admin_user_id}"
+                )))
+                .respond_with(
+                    ResponseTemplate::new(404).set_body_string("User not found"),
+                )
+                .mount(&server)
+                .await;
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            let req = IdpProvisionTenantRequest::new(
+                tenant_uuid,
+                Uuid::new_v4(),
+                "admin-name",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            )
+            .with_metadata(serde_json::json!({
+                "mode": "shared",
+                "admin_user_id": admin_user_id.to_string()
+            }))
+            .with_parent_context(IdpTenantContext::new(
+                Uuid::new_v4(),
+                "parent",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+                Some(make_metadata("platform", RealmBinding::Shared, Uuid::new_v4(), None)),
+            ));
+
+            let err = facade
+                .provision_tenant_inner(&ctx, &req)
+                .await
+                .expect_err("404 on user GET must error");
+            assert!(
+                matches!(
+                    err,
+                    PluginError::AmbiguousCreated {
+                        stage: AmbiguousStage::AdminUserBind,
+                        ref detail,
+                    } if detail.contains("404") && detail.contains("/users/")
+                ),
+                "expected AmbiguousCreated{{AdminUserBind}} (saga had already created the tenant group at step 3), got {err:?}"
+            );
+        },
+    )
+    .await;
+}
+
+/// GET → 200 valid user; PUT → 500 → `PluginError::AmbiguousCreated`
+/// tagged `AdminUserBind` (the tenant group was already created at this
+/// point, so the bind failure is a partial side-effect, not a clean
+/// rejection).
+#[tokio::test]
+async fn provision_tenant_shared_bind_put_failure_returns_ambiguous_admin_user_bind() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            let (tenant_uuid, _group_uuid, _parent_uuid) =
+                mount_shared_happy_path(&server).await;
+
+            let admin_user_id = Uuid::new_v4();
+
+            Mock::given(method("GET"))
+                .and(path(format!(
+                    "/admin/realms/platform/users/{admin_user_id}"
+                )))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": admin_user_id.to_string(),
+                    "username": "admin"
+                })))
+                .mount(&server)
+                .await;
+
+            Mock::given(method("PUT"))
+                .and(path(format!(
+                    "/admin/realms/platform/users/{admin_user_id}"
+                )))
+                .respond_with(
+                    ResponseTemplate::new(500).set_body_string("kc boom"),
+                )
+                .mount(&server)
+                .await;
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            let req = IdpProvisionTenantRequest::new(
+                tenant_uuid,
+                Uuid::new_v4(),
+                "admin-name",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            )
+            .with_metadata(serde_json::json!({
+                "mode": "shared",
+                "admin_user_id": admin_user_id.to_string()
+            }))
+            .with_parent_context(IdpTenantContext::new(
+                Uuid::new_v4(),
+                "parent",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+                Some(make_metadata("platform", RealmBinding::Shared, Uuid::new_v4(), None)),
+            ));
+
+            let err = facade
+                .provision_tenant_inner(&ctx, &req)
+                .await
+                .expect_err("500 on user PUT must error");
+            assert!(
+                matches!(
+                    err,
+                    PluginError::AmbiguousCreated {
+                        stage: AmbiguousStage::AdminUserBind,
+                        ref detail,
+                    } if detail.contains("PUT") && detail.contains("500") && detail.contains("kc boom")
+                ),
+                "expected AmbiguousCreated {{ AdminUserBind, PUT 500 body kc boom }}, got {err:?}"
+            );
+        },
+    )
+    .await;
+}
+
+/// GET returns user with existing `attributes.foo = ["bar"]`.
+/// After bind, PUT body must still contain `foo` alongside new `tenant_id`
+/// and `user_type`.
+#[tokio::test]
+async fn provision_tenant_shared_bind_preserves_existing_user_attributes() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            let (tenant_uuid, _group_uuid, _parent_uuid) = mount_shared_happy_path(&server).await;
+
+            let admin_user_id = Uuid::new_v4();
+
+            // User has an existing attribute `foo = ["bar"]`.
+            Mock::given(method("GET"))
+                .and(path(format!(
+                    "/admin/realms/platform/users/{admin_user_id}"
+                )))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": admin_user_id.to_string(),
+                    "username": "admin",
+                    "attributes": {
+                        "foo": ["bar"]
+                    }
+                })))
+                .mount(&server)
+                .await;
+
+            Mock::given(method("PUT"))
+                .and(path(format!(
+                    "/admin/realms/platform/users/{admin_user_id}"
+                )))
+                .respond_with(ResponseTemplate::new(204))
+                .mount(&server)
+                .await;
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            let req = IdpProvisionTenantRequest::new(
+                tenant_uuid,
+                Uuid::new_v4(),
+                "admin-name",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            )
+            .with_metadata(serde_json::json!({
+                "mode": "shared",
+                "admin_user_id": admin_user_id.to_string()
+            }))
+            .with_parent_context(IdpTenantContext::new(
+                Uuid::new_v4(),
+                "parent",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+                Some(make_metadata(
+                    "platform",
+                    RealmBinding::Shared,
+                    Uuid::new_v4(),
+                    None,
+                )),
+            ));
+
+            facade
+                .provision_tenant_inner(&ctx, &req)
+                .await
+                .expect("provision with existing attributes ok");
+
+            let received = server.received_requests().await.unwrap();
+            let put_req = received
+                .iter()
+                .find(|r| {
+                    r.method.as_str() == "PUT"
+                        && r.url.path().ends_with(&format!("/users/{admin_user_id}"))
+                })
+                .expect("PUT /users/{id} must be sent");
+            let put_body: serde_json::Value =
+                serde_json::from_slice(&put_req.body).expect("PUT body is JSON");
+            let attrs = put_body
+                .get("attributes")
+                .expect("PUT body must have attributes");
+
+            // Existing `foo` attribute must be preserved.
+            assert_eq!(
+                attrs.get("foo"),
+                Some(&serde_json::json!(["bar"])),
+                "existing attribute foo must be preserved"
+            );
+            // New attributes must be set.
+            assert_eq!(
+                attrs.get("tenant_id"),
+                Some(&serde_json::json!([tenant_uuid.to_string()])),
+            );
+            assert_eq!(attrs.get("user_type"), Some(&serde_json::json!(["user"])),);
+        },
+    )
+    .await;
+}
+
+/// Pure parser test: `admin_user_id` present as valid UUID string →
+/// deserialises cleanly. Built as a Root request so the explicit `realm_name`
+/// is honoured (shared mode permits `admin_user_id`).
+#[test]
+fn parse_input_accepts_metadata_with_admin_user_id() {
+    let user_id = Uuid::new_v4();
+    let req = IdpProvisionTenantRequest::for_root(
+        Uuid::new_v4(),
+        "platform-root",
+        GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+    )
+    .with_metadata(serde_json::json!({
+        "mode": "shared",
+        "realm_name": "platform",
+        "admin_user_id": user_id.to_string()
+    }));
+    let parsed = TenantFacade::parse_input(&req).expect("must accept valid UUID");
+    assert_eq!(parsed.realm_name, "platform");
+    assert_eq!(parsed.realm_binding, RealmBinding::Shared);
+    assert_eq!(parsed.admin_user_id, Some(user_id));
+}
+
+/// Pure parser test: `admin_user_id = "not-a-uuid"` → malformed wire shape →
+/// `PluginError::ProvisionInputRejected` (detail mentions `malformed`).
+#[test]
+fn parse_input_rejects_malformed_admin_user_id() {
+    let req = IdpProvisionTenantRequest::for_root(
+        Uuid::new_v4(),
+        "platform-root",
+        GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+    )
+    .with_metadata(serde_json::json!({
+        "mode": "shared",
+        "realm_name": "platform",
+        "admin_user_id": "not-a-uuid"
+    }));
+    let err = TenantFacade::parse_input(&req).expect_err("must reject bad UUID");
+    assert!(
+        matches!(err, PluginError::ProvisionInputRejected { ref detail } if detail.contains("malformed")),
+        "expected PluginError::ProvisionInputRejected(malformed …), got {err:?}"
+    );
+}
+
+/// Pure parser test: `admin_user_id = ""` (empty string) → decodes to `None`.
+///
+/// Reason: production server.yaml carries `admin_user_id: "${VP_..._USER_ID:-}"`
+/// with POSIX default-empty; in dev / pre-IaC environments the env var is unset
+/// and the expansion yields `""`. The decoder must treat that as "no bind"
+/// rather than fail the saga.
+#[test]
+fn parse_input_accepts_empty_admin_user_id_as_none() {
+    let req = IdpProvisionTenantRequest::for_root(
+        Uuid::new_v4(),
+        "platform-root",
+        GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+    )
+    .with_metadata(serde_json::json!({
+        "mode": "shared",
+        "realm_name": "platform",
+        "admin_user_id": ""
+    }));
+    let parsed = TenantFacade::parse_input(&req).expect("empty admin_user_id must decode as None");
+    assert_eq!(parsed.admin_user_id, None);
+}
+
+/// Pure parser test: `admin_user_id` is only honoured in `mode=shared`.
+/// Adopted-mode requests carrying the field MUST be rejected at parse
+/// time so a silent drop doesn't mask operator misconfiguration.
+#[test]
+fn parse_input_rejects_admin_user_id_in_adopted_mode() {
+    let req = IdpProvisionTenantRequest::new(
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        "child-name",
+        GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+    )
+    .with_metadata(serde_json::json!({
+        "mode": "adopted",
+        "realm_name": "partner-acme",
+        "admin_user_id": "550e8400-e29b-41d4-a716-446655440000"
+    }));
+    let err = TenantFacade::parse_input(&req)
+        .expect_err("admin_user_id in adopted mode must be rejected");
+    assert!(
+        matches!(
+            err,
+            PluginError::ProvisionInputRejected { ref detail }
+                if detail.contains("admin_user_id is only supported in mode=shared")
+                    && detail.contains("adopted")
+        ),
+        "expected ProvisionInputRejected(admin_user_id only in shared, got mode=adopted), got {err:?}",
+    );
+}
+
+/// Same as the adopted-mode case for `mode=created`.
+#[test]
+fn parse_input_rejects_admin_user_id_in_created_mode() {
+    let req = IdpProvisionTenantRequest::new(
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        "child-name",
+        GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+    )
+    .with_metadata(serde_json::json!({
+        "mode": "created",
+        "realm_name": "partner-acme",
+        "admin_user_id": "550e8400-e29b-41d4-a716-446655440000"
+    }));
+    let err = TenantFacade::parse_input(&req)
+        .expect_err("admin_user_id in created mode must be rejected");
+    assert!(
+        matches!(
+            err,
+            PluginError::ProvisionInputRejected { ref detail }
+                if detail.contains("admin_user_id is only supported in mode=shared")
+                    && detail.contains("created")
+        ),
+        "expected ProvisionInputRejected(admin_user_id only in shared, got mode=created), got {err:?}",
+    );
+}
+
+/// DESIGN §4.2 — symmetric with the provision-timeout test above:
+/// `deprovision_tenant_inner` wraps its saga in `tokio::time::timeout`
+/// keyed on `provision_timeout_ms` and returns `DeprovisionRetryable`
+/// on elapse. The bootstrap-admin token endpoint is wired with a
+/// 200ms delay; 50ms budget guarantees the saga is cancelled at the
+/// first KC hop.
+#[tokio::test]
+async fn deprovision_tenant_returns_retryable_when_saga_exceeds_provision_timeout_ms() {
+    use std::time::Duration;
+
+    let server = wiremock::MockServer::start().await;
+    mount_kc_health_probe_ok(&server).await;
+
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path(
+            "/realms/master/protocol/openid-connect/token",
+        ))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200)
+                .set_delay(Duration::from_millis(200))
+                .set_body_json(serde_json::json!({
+                    "access_token": "tok",
+                    "expires_in": 600
+                })),
+        )
+        .mount(&server)
+        .await;
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path(
+            "/realms/platform/protocol/openid-connect/token",
+        ))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200)
+                .set_delay(Duration::from_millis(200))
+                .set_body_json(serde_json::json!({
+                    "access_token": "tok",
+                    "expires_in": 600
+                })),
+        )
+        .mount(&server)
+        .await;
+
+    let kc_cfg = keycloak_cfg(&server.uri());
+    let realm_admin_cfg = kc_cfg.realm_admin.clone();
+    let tenant_cfg = TenantFacadeConfig {
+        realm_defaults: serde_json::Value::Null,
+        tenant_group_root: "/tenants".into(),
+        provision_timeout_ms: 50,
+    };
+
+    let client: Arc<dyn CredStoreClientV1> = Arc::new(StubCredStore);
+    let cs_reader = crate::domain::credstore::CredStoreReader::new(
+        Arc::clone(&client),
+        crate::domain::system_actor::build_system_ctx(uuid::Uuid::nil()),
+    );
+    let cs_writer = crate::domain::credstore::CredStoreWriter::new(
+        client,
+        crate::domain::system_actor::build_system_ctx(uuid::Uuid::nil()),
+    );
+    let transport: Arc<dyn crate::domain::kc::transport::KcTransport> =
+        Arc::new(ReqwestKcTransport::new(reqwest::Client::new()));
+    let factory = Arc::new(crate::domain::kc::factory::KeycloakAdminClientFactory::new(
+        kc_cfg,
+        transport,
+        cs_reader,
+        Arc::new(crate::domain::test_support::NoopMetrics),
+    ));
+    let facade = TenantFacade::new(
+        tenant_cfg,
+        realm_admin_cfg,
+        factory,
+        Arc::new(crate::domain::metadata_codec::MetadataCodec),
+        cs_writer,
+        noop_tenant_metrics(),
+        noop_credstore_metrics(),
+        noop_metadata_metrics(),
+        noop_failure_metrics(),
+    );
+
+    let ctx = crate::domain::system_actor::build_system_ctx(uuid::Uuid::nil());
+    let tenant_id = uuid::Uuid::new_v4();
+    let metadata = make_metadata(
+        "platform",
+        crate::domain::metadata_codec::RealmBinding::Shared,
+        uuid::Uuid::new_v4(),
+        None,
+    );
+    let req = deprovision_req(tenant_id, Some(metadata));
+    let result = facade.deprovision_tenant_inner(&ctx, &req).await;
+
+    assert!(
+        matches!(
+            result,
+            Err(PluginError::DeprovisionRetryable { ref detail })
+                if detail.contains("timed out")
+                    && detail.contains("provision_timeout_ms")
+        ),
+        "expected DeprovisionRetryable{{timed out}}, got {result:?}",
+    );
+}
+
+/// Created-mode provision with operator-supplied `realm_defaults`
+/// containing a non-allowlisted key must fail with `PluginError::Config`
+/// BEFORE the `POST /admin/realms` is issued. The allowlist check sits
+/// at the top of `create_realm`; we wire only the preconditions
+/// (token endpoint + realm-absent probe) and expect the saga to
+/// short-circuit on the allowlist guard.
+#[tokio::test]
+async fn create_realm_rejects_non_allowlisted_realm_defaults_key() {
+    let server = wiremock::MockServer::start().await;
+    mount_kc_health_probe_ok(&server).await;
+
+    // Bootstrap-admin token endpoint.
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path(
+            "/realms/master/protocol/openid-connect/token",
+        ))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "tok",
+                "expires_in": 600
+            })),
+        )
+        .mount(&server)
+        .await;
+    // `assert_realm_absent` probe — 404 means the realm does not yet
+    // exist, which is the precondition Created mode requires.
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/admin/realms/new-tenant-realm"))
+        .respond_with(wiremock::ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    // Build a facade whose tenant config carries an explicitly
+    // non-allowlisted realm-default key (`smtpServer` — credential-
+    // exfil-risk).
+    let kc_cfg = keycloak_cfg(&server.uri());
+    let realm_admin_cfg = kc_cfg.realm_admin.clone();
+    let tenant_cfg = TenantFacadeConfig {
+        realm_defaults: serde_json::json!({
+            "smtpServer": {"host": "evil.example", "from": "no-reply@evil"}
+        }),
+        tenant_group_root: "/tenants".into(),
+        provision_timeout_ms: 30_000,
+    };
+
+    let client: Arc<dyn CredStoreClientV1> = Arc::new(StubCredStore);
+    let cs_reader = crate::domain::credstore::CredStoreReader::new(
+        Arc::clone(&client),
+        crate::domain::system_actor::build_system_ctx(uuid::Uuid::nil()),
+    );
+    let cs_writer = crate::domain::credstore::CredStoreWriter::new(
+        client,
+        crate::domain::system_actor::build_system_ctx(uuid::Uuid::nil()),
+    );
+    let transport: Arc<dyn crate::domain::kc::transport::KcTransport> =
+        Arc::new(ReqwestKcTransport::new(reqwest::Client::new()));
+    let factory = Arc::new(crate::domain::kc::factory::KeycloakAdminClientFactory::new(
+        kc_cfg,
+        transport,
+        cs_reader,
+        Arc::new(crate::domain::test_support::NoopMetrics),
+    ));
+    let facade = TenantFacade::new(
+        tenant_cfg,
+        realm_admin_cfg,
+        factory,
+        Arc::new(crate::domain::metadata_codec::MetadataCodec),
+        cs_writer,
+        noop_tenant_metrics(),
+        noop_credstore_metrics(),
+        noop_metadata_metrics(),
+        noop_failure_metrics(),
+    );
+
+    let ctx = crate::domain::system_actor::build_system_ctx(uuid::Uuid::nil());
+    let req = IdpProvisionTenantRequest::for_root(
+        uuid::Uuid::new_v4(),
+        "tenant-with-bad-defaults",
+        GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+    )
+    .with_metadata(serde_json::json!({
+        "mode": "created",
+        "realm_name": "new-tenant-realm"
+    }));
+
+    let result = facade.provision_tenant_inner(&ctx, &req).await;
+    assert!(
+        matches!(
+            &result,
+            Err(PluginError::Config { detail })
+                if detail.contains("non-allowlisted key `smtpServer`")
+        ),
+        "expected Config(non-allowlisted key smtpServer), got {result:?}",
+    );
+}
+
+/// Hijack guard: a `provision_tenant` POST that supplies an
+/// `admin_user_id` pointing at a KC user already bound to a DIFFERENT
+/// tenant must be rejected with `PluginError::AmbiguousCreated` tagged
+/// `AdminUserBind`. Without the guard, an operator authorised to
+/// provision tenants could silently transfer that user's
+/// attribute-based authz to the new tenant.
+///
+/// Why `AmbiguousCreated` and not `Config`: the hijack check happens
+/// AFTER `ensure_tenant_group` (`provision_shared` Step 3) has already
+/// created the per-tenant KC group. A `Config` rejection would tell
+/// AM "nothing happened, safe to retry clean" and leak an orphaned
+/// group on every retry. The Ambiguous tag routes through AM's
+/// reconciliation path.
+#[tokio::test]
+async fn provision_tenant_shared_bind_rejects_admin_user_already_bound_to_other_tenant() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            let (tenant_uuid, _group_uuid, _parent_uuid) =
+                mount_shared_happy_path(&server).await;
+
+            let admin_user_id = Uuid::new_v4();
+            let foreign_tenant_id = Uuid::new_v4();
+
+            // GET returns user already bound to a DIFFERENT tenant.
+            Mock::given(method("GET"))
+                .and(path(format!(
+                    "/admin/realms/platform/users/{admin_user_id}"
+                )))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": admin_user_id.to_string(),
+                    "username": "admin",
+                    "attributes": {
+                        "tenant_id": [foreign_tenant_id.to_string()],
+                        "user_type": ["user"]
+                    }
+                })))
+                .mount(&server)
+                .await;
+
+            // PUT must NOT be sent. To distinguish "no PUT" from "PUT
+            // returned 404 → AmbiguousCreated with body about 404", we
+            // assert on the `detail` carrying the hijack-guard message
+            // (which only the in-process guard can produce); a PUT-to-
+            // wiremock-default-404 would surface a `detail` mentioning
+            // `kc:PUT` and `404`.
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            let req = IdpProvisionTenantRequest::new(
+                tenant_uuid,
+                Uuid::new_v4(),
+                "admin-name",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            )
+            .with_metadata(serde_json::json!({
+                "mode": "shared",
+                "admin_user_id": admin_user_id.to_string()
+            }))
+            .with_parent_context(IdpTenantContext::new(
+                Uuid::new_v4(),
+                "parent",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+                Some(make_metadata("platform", RealmBinding::Shared, Uuid::new_v4(), None)),
+            ));
+
+            let err = facade
+                .provision_tenant_inner(&ctx, &req)
+                .await
+                .expect_err("foreign tenant_id must be rejected");
+            assert!(
+                matches!(
+                    err,
+                    PluginError::AmbiguousCreated {
+                        stage: AmbiguousStage::AdminUserBind,
+                        ref detail,
+                    } if detail.contains("already bound to a different tenant")
+                        && detail.contains("hijack")
+                ),
+                "expected AmbiguousCreated{{AdminUserBind}} (hijack guard fires AFTER tenant group is created at step 3), got {err:?}",
+            );
+        },
+    )
+    .await;
+}
+
+/// Hijack guard counterpoint: idempotent re-bind (same admin user,
+/// same tenant — bootstrap re-run scenario) MUST succeed without
+/// `PluginError::Config`. Otherwise a re-bootstrap after a partial
+/// AM-saga failure would falsely refuse to converge.
+#[tokio::test]
+async fn provision_tenant_shared_bind_accepts_admin_user_already_bound_to_same_tenant() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            let (tenant_uuid, _group_uuid, _parent_uuid) = mount_shared_happy_path(&server).await;
+
+            let admin_user_id = Uuid::new_v4();
+
+            // GET returns user already bound to THIS same tenant.
+            Mock::given(method("GET"))
+                .and(path(format!(
+                    "/admin/realms/platform/users/{admin_user_id}"
+                )))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": admin_user_id.to_string(),
+                    "username": "admin",
+                    "attributes": {
+                        "tenant_id": [tenant_uuid.to_string()],
+                        "user_type": ["user"]
+                    }
+                })))
+                .mount(&server)
+                .await;
+            Mock::given(method("PUT"))
+                .and(path(format!(
+                    "/admin/realms/platform/users/{admin_user_id}"
+                )))
+                .respond_with(ResponseTemplate::new(204))
+                .mount(&server)
+                .await;
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            let req = IdpProvisionTenantRequest::new(
+                tenant_uuid,
+                Uuid::new_v4(),
+                "admin-name",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            )
+            .with_metadata(serde_json::json!({
+                "mode": "shared",
+                "admin_user_id": admin_user_id.to_string()
+            }))
+            .with_parent_context(IdpTenantContext::new(
+                Uuid::new_v4(),
+                "parent",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+                Some(make_metadata(
+                    "platform",
+                    RealmBinding::Shared,
+                    Uuid::new_v4(),
+                    None,
+                )),
+            ));
+
+            facade
+                .provision_tenant_inner(&ctx, &req)
+                .await
+                .expect("re-bind with same tenant_id must be idempotent OK");
+        },
+    )
+    .await;
+}
+
+/// Regression: previously, a multi-valued `attributes.tenant_id`
+/// (e.g. `["A", "B"]`) where the requested tenant matched ANY element
+/// passed the hijack guard, after which the PUT step unconditionally
+/// wrote `[tenant_id]` — silently dropping the user's other tenant
+/// binding(s). The plugin's v1 model is single-tenant-per-user
+/// (`user_facade::provision_user` writes a singleton; design §nonGoals
+/// defers `move_user_tenant`), so multi-valued attribute state is by
+/// definition unexpected operator state. The guard now refuses to
+/// guess which bindings are safe to drop and bails as
+/// `AmbiguousCreated{AdminUserBind}` (Step 3 already created the
+/// tenant group → reconciliation, not retry-clean). Substring
+/// `multi-valued` is stable for log-grep and for distinguishing this
+/// bail-class from the foreign-single-tenant hijack case.
+#[tokio::test]
+async fn provision_tenant_shared_bind_rejects_multi_valued_tenant_id_containing_target() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            let (tenant_uuid, _group_uuid, _parent_uuid) = mount_shared_happy_path(&server).await;
+
+            let admin_user_id = Uuid::new_v4();
+            let other_tenant_id = Uuid::new_v4();
+
+            // GET returns user bound to a multi-valued tenant_id whose
+            // first element is the REQUESTED tenant. The previous
+            // guard's `.any()` check would pass and then drop
+            // `other_tenant_id` on the PUT. The new guard refuses.
+            Mock::given(method("GET"))
+                .and(path(format!(
+                    "/admin/realms/platform/users/{admin_user_id}"
+                )))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": admin_user_id.to_string(),
+                    "username": "admin",
+                    "attributes": {
+                        "tenant_id": [tenant_uuid.to_string(), other_tenant_id.to_string()],
+                        "user_type": ["user"]
+                    }
+                })))
+                .mount(&server)
+                .await;
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            let req = IdpProvisionTenantRequest::new(
+                tenant_uuid,
+                Uuid::new_v4(),
+                "admin-name",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            )
+            .with_metadata(serde_json::json!({
+                "mode": "shared",
+                "admin_user_id": admin_user_id.to_string()
+            }))
+            .with_parent_context(IdpTenantContext::new(
+                Uuid::new_v4(),
+                "parent",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+                Some(make_metadata("platform", RealmBinding::Shared, Uuid::new_v4(), None)),
+            ));
+
+            let err = facade
+                .provision_tenant_inner(&ctx, &req)
+                .await
+                .expect_err("multi-valued tenant_id must be rejected even when target is present");
+            assert!(
+                matches!(
+                    err,
+                    PluginError::AmbiguousCreated {
+                        stage: AmbiguousStage::AdminUserBind,
+                        ref detail,
+                    } if detail.contains("multi-valued")
+                        && detail.contains("silently drop")
+                ),
+                "expected AmbiguousCreated{{AdminUserBind}} with multi-valued classification, got {err:?}",
+            );
+
+            // The PUT must NOT have happened — otherwise other_tenant_id
+            // would be silently dropped on Keycloak's side.
+            let received = server.received_requests().await.unwrap();
+            let put_to_user = received.iter().find(|r| {
+                r.method.as_str() == "PUT"
+                    && r.url.path().ends_with(&format!("/users/{admin_user_id}"))
+            });
+            assert!(
+                put_to_user.is_none(),
+                "PUT /users/{admin_user_id} must NOT be issued — the displacement is the bug we're fixing"
+            );
+        },
+    )
+    .await;
+}
+
+/// Multi-valued `attributes.tenant_id` with NO match for the requested
+/// tenant also bails — but classified as `multi-valued` (not `different
+/// tenant`) so the operator's mental model of "user is unexpectedly
+/// cross-tenant" matches the log message. Previously this case was
+/// caught by the same `.any()`-returns-false branch as the
+/// foreign-single-tenant case and reported as "different tenant", which
+/// understated the underlying anomaly.
+#[tokio::test]
+async fn provision_tenant_shared_bind_rejects_multi_valued_tenant_id_all_foreign() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            let (tenant_uuid, _group_uuid, _parent_uuid) = mount_shared_happy_path(&server).await;
+
+            let admin_user_id = Uuid::new_v4();
+            let foreign_a = Uuid::new_v4();
+            let foreign_b = Uuid::new_v4();
+
+            Mock::given(method("GET"))
+                .and(path(format!(
+                    "/admin/realms/platform/users/{admin_user_id}"
+                )))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": admin_user_id.to_string(),
+                    "username": "admin",
+                    "attributes": {
+                        "tenant_id": [foreign_a.to_string(), foreign_b.to_string()],
+                        "user_type": ["user"]
+                    }
+                })))
+                .mount(&server)
+                .await;
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            let req = IdpProvisionTenantRequest::new(
+                tenant_uuid,
+                Uuid::new_v4(),
+                "admin-name",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            )
+            .with_metadata(serde_json::json!({
+                "mode": "shared",
+                "admin_user_id": admin_user_id.to_string()
+            }))
+            .with_parent_context(IdpTenantContext::new(
+                Uuid::new_v4(),
+                "parent",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+                Some(make_metadata("platform", RealmBinding::Shared, Uuid::new_v4(), None)),
+            ));
+
+            let err = facade
+                .provision_tenant_inner(&ctx, &req)
+                .await
+                .expect_err("multi-valued tenant_id (all foreign) must be rejected");
+            assert!(
+                matches!(
+                    err,
+                    PluginError::AmbiguousCreated {
+                        stage: AmbiguousStage::AdminUserBind,
+                        ref detail,
+                    } if detail.contains("multi-valued") && detail.contains("hijack")
+                ),
+                "expected AmbiguousCreated{{AdminUserBind}} with multi-valued classification, got {err:?}",
+            );
+        },
+    )
+    .await;
+}
+
+/// Empty array `attributes.tenant_id = []` is unexpected state — KC
+/// normally drops attribute keys when their value list empties. The
+/// guard treats it as a non-singleton (len != 1) → bail. Pinned so
+/// future refactors don't quietly accept it.
+#[tokio::test]
+async fn provision_tenant_shared_bind_rejects_empty_array_tenant_id() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            let (tenant_uuid, _group_uuid, _parent_uuid) = mount_shared_happy_path(&server).await;
+            let admin_user_id = Uuid::new_v4();
+
+            Mock::given(method("GET"))
+                .and(path(format!(
+                    "/admin/realms/platform/users/{admin_user_id}"
+                )))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": admin_user_id.to_string(),
+                    "username": "admin",
+                    "attributes": {
+                        "tenant_id": [],
+                        "user_type": ["user"]
+                    }
+                })))
+                .mount(&server)
+                .await;
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            let req = IdpProvisionTenantRequest::new(
+                tenant_uuid,
+                Uuid::new_v4(),
+                "admin-name",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            )
+            .with_metadata(serde_json::json!({
+                "mode": "shared",
+                "admin_user_id": admin_user_id.to_string()
+            }))
+            .with_parent_context(IdpTenantContext::new(
+                Uuid::new_v4(),
+                "parent",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+                Some(make_metadata(
+                    "platform",
+                    RealmBinding::Shared,
+                    Uuid::new_v4(),
+                    None,
+                )),
+            ));
+
+            let err = facade
+                .provision_tenant_inner(&ctx, &req)
+                .await
+                .expect_err("empty-array tenant_id must be rejected");
+            assert!(
+                matches!(
+                    err,
+                    PluginError::AmbiguousCreated {
+                        stage: AmbiguousStage::AdminUserBind,
+                        ..
+                    }
+                ),
+                "expected AmbiguousCreated{{AdminUserBind}}, got {err:?}",
+            );
+        },
+    )
+    .await;
+}
+
+/// Legacy / hand-edited shape: bare string `attributes.tenant_id = "T"`
+/// (not the canonical array). The plugin never writes this shape
+/// (`user_facade::provision_user` and this function both write a
+/// singleton array), but an operator may have set it manually. When
+/// T matches the requested tenant, the guard accepts it as an
+/// idempotent re-bind for backward-compat with hand-edited records.
+/// Pinned because the new guard's stricter array-len check could
+/// otherwise regress this case.
+#[tokio::test]
+async fn provision_tenant_shared_bind_accepts_bare_string_tenant_id_matching_target() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            let (tenant_uuid, _group_uuid, _parent_uuid) = mount_shared_happy_path(&server).await;
+            let admin_user_id = Uuid::new_v4();
+
+            Mock::given(method("GET"))
+                .and(path(format!(
+                    "/admin/realms/platform/users/{admin_user_id}"
+                )))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": admin_user_id.to_string(),
+                    "username": "admin",
+                    "attributes": {
+                        "tenant_id": tenant_uuid.to_string(),
+                        "user_type": ["user"]
+                    }
+                })))
+                .mount(&server)
+                .await;
+            Mock::given(method("PUT"))
+                .and(path(format!(
+                    "/admin/realms/platform/users/{admin_user_id}"
+                )))
+                .respond_with(ResponseTemplate::new(204))
+                .mount(&server)
+                .await;
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            let req = IdpProvisionTenantRequest::new(
+                tenant_uuid,
+                Uuid::new_v4(),
+                "admin-name",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            )
+            .with_metadata(serde_json::json!({
+                "mode": "shared",
+                "admin_user_id": admin_user_id.to_string()
+            }))
+            .with_parent_context(IdpTenantContext::new(
+                Uuid::new_v4(),
+                "parent",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+                Some(make_metadata(
+                    "platform",
+                    RealmBinding::Shared,
+                    Uuid::new_v4(),
+                    None,
+                )),
+            ));
+
+            facade
+                .provision_tenant_inner(&ctx, &req)
+                .await
+                .expect("bare-string tenant_id matching target must be idempotent OK");
+        },
+    )
+    .await;
+}
+
+/// Singleton array with a non-string element (e.g. `[42]`) — bizarre
+/// operator state, but pin the rejection so a refactor that loosens
+/// the `values[0].as_str() == Some(target)` check doesn't silently
+/// start accepting it.
+#[tokio::test]
+async fn provision_tenant_shared_bind_rejects_singleton_array_with_non_string_element() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            let (tenant_uuid, _group_uuid, _parent_uuid) = mount_shared_happy_path(&server).await;
+            let admin_user_id = Uuid::new_v4();
+
+            Mock::given(method("GET"))
+                .and(path(format!(
+                    "/admin/realms/platform/users/{admin_user_id}"
+                )))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": admin_user_id.to_string(),
+                    "username": "admin",
+                    "attributes": {
+                        "tenant_id": [42],
+                        "user_type": ["user"]
+                    }
+                })))
+                .mount(&server)
+                .await;
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            let req = IdpProvisionTenantRequest::new(
+                tenant_uuid,
+                Uuid::new_v4(),
+                "admin-name",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            )
+            .with_metadata(serde_json::json!({
+                "mode": "shared",
+                "admin_user_id": admin_user_id.to_string()
+            }))
+            .with_parent_context(IdpTenantContext::new(
+                Uuid::new_v4(),
+                "parent",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+                Some(make_metadata(
+                    "platform",
+                    RealmBinding::Shared,
+                    Uuid::new_v4(),
+                    None,
+                )),
+            ));
+
+            let err = facade
+                .provision_tenant_inner(&ctx, &req)
+                .await
+                .expect_err("non-string array element must be rejected");
+            assert!(
+                matches!(
+                    err,
+                    PluginError::AmbiguousCreated {
+                        stage: AmbiguousStage::AdminUserBind,
+                        ..
+                    }
+                ),
+                "expected AmbiguousCreated{{AdminUserBind}}, got {err:?}",
+            );
+        },
+    )
+    .await;
+}
+
+// =====================================================================
+// Pre-saga health_probe wiring (DESIGN §4.4)
+//
+// The probe runs at the top of every `provision_tenant_inner` and at
+// the post-decode step of every `deprovision_tenant_inner` so a
+// flat-out KC outage short-circuits BEFORE any saga step touches KC.
+// Provision maps to `CleanFailure` (no side effect yet — AM can retry
+// clean). Deprovision maps to `Retryable` (KC down is transient by
+// definition).
+// =====================================================================
+
+#[tokio::test]
+async fn provision_tenant_bails_with_clean_failure_when_kc_unreachable_at_pre_saga_probe() {
+    let server = MockServer::start().await;
+    // No /realms/master mock — wiremock's default 404 simulates a KC
+    // that's listening but not serving the master realm. With the
+    // pre-saga health_probe wired, this should bail BEFORE saga work.
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async move {
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = req_for_root(Uuid::new_v4());
+
+        let err = facade
+            .provision_tenant_inner(&ctx, &req)
+            .await
+            .expect_err("pre-saga KC outage must bail before saga work");
+        assert!(
+            matches!(
+                err,
+                PluginError::Config { ref detail }
+                    if detail.contains("pre-saga KC health probe failed")
+            ),
+            "expected Config(pre-saga KC health probe failed …), got {err:?}",
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn deprovision_tenant_bails_with_retryable_when_kc_unreachable_at_pre_saga_probe() {
+    let server = MockServer::start().await;
+    // No /realms/master mock.
+    temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async move {
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let tenant_id = Uuid::new_v4();
+        // Well-formed metadata so the deprovision saga gets past
+        // the missing-metadata + decode branches and reaches the
+        // post-decode health-probe gate (the only point at which
+        // the probe is expected to fire on the deprovision path).
+        let metadata = make_metadata("platform", RealmBinding::Shared, Uuid::new_v4(), None);
+        let req = deprovision_req(tenant_id, Some(metadata));
+
+        let err = facade
+            .deprovision_tenant_inner(&ctx, &req)
+            .await
+            .expect_err("pre-saga KC outage must bail before saga work");
+        assert!(
+            matches!(
+                err,
+                PluginError::DeprovisionRetryable { ref detail }
+                    if detail.contains("pre-saga KC health probe failed")
+            ),
+            "expected DeprovisionRetryable(pre-saga KC health probe failed …), got {err:?}",
+        );
+    })
+    .await;
+}
+
+// =====================================================================
+// Reactive-401 wiring (DESIGN §8.1 rotation lifecycle)
+//
+// When KC rejects the cached realm-admin bearer with 401 (operator
+// rotated the secret + OpenBao was updated; only the in-process
+// token cache is stale), the per-realm Admin REST call inside the
+// saga must re-acquire and retry exactly once. The end-to-end
+// provision_tenant call has to succeed; the operator never sees the
+// 401 surface as an AM-reaper bounce.
+// =====================================================================
+
+#[tokio::test]
+async fn provision_tenant_recovers_from_realm_admin_rotation_via_reactive_401() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars(
+        [
+            ("TEST_BOOTSTRAP_SECRET", Some("topsecret")),
+            ("TEST_REALM_ADMIN_SECRET", Some("ra")),
+        ],
+        async move {
+            // Health probe + bootstrap-side work — all happy-path.
+            mount_kc_health_probe_ok(&server).await;
+            Mock::given(method("POST"))
+                .and(path("/realms/master/protocol/openid-connect/token"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "access_token": "t-master",
+                    "expires_in": 600
+                })))
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/admin/realms/platform"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+                .mount(&server)
+                .await;
+
+            // Realm-admin token endpoint — count how often we mint a
+            // fresh bearer so the test can assert the wrapper actually
+            // invalidated and re-acquired (rotation recovery proof).
+            let realm_token_calls = Arc::new(AtomicUsize::new(0));
+            let realm_token_clone = Arc::clone(&realm_token_calls);
+            Mock::given(method("POST"))
+                .and(path("/realms/platform/protocol/openid-connect/token"))
+                .respond_with(move |_req: &wiremock::Request| {
+                    realm_token_clone.fetch_add(1, Ordering::SeqCst);
+                    ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                        "access_token": "t-realm",
+                        "expires_in": 600
+                    }))
+                })
+                .mount(&server)
+                .await;
+
+            // Parent tenant group lookup (`find_top_group`, inside
+            // `ensure_tenant_group` → `find_or_create_top_group`): 401
+            // on the first attempt (simulating a stale bearer post-
+            // rotation), 200 on the second.
+            let parent_uuid = Uuid::new_v4();
+            let lookup_calls = Arc::new(AtomicUsize::new(0));
+            let lookup_clone = Arc::clone(&lookup_calls);
+            Mock::given(method("GET"))
+                .and(path("/admin/realms/platform/groups"))
+                .and(query_param("search", "tenants"))
+                .and(query_param("exact", "true"))
+                .respond_with(move |_req: &wiremock::Request| {
+                    let n = lookup_clone.fetch_add(1, Ordering::SeqCst);
+                    if n == 0 {
+                        ResponseTemplate::new(401).set_body_string("invalid_token")
+                    } else {
+                        ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                            { "id": parent_uuid.to_string(), "name": "tenants" }
+                        ]))
+                    }
+                })
+                .mount(&server)
+                .await;
+
+            // Child group create — happy path. This step only runs on
+            // the SECOND attempt (after the wrapper retried the whole
+            // closure with the fresh bearer).
+            let tenant_uuid = Uuid::new_v4();
+            let group_uuid = Uuid::new_v4();
+            Mock::given(method("POST"))
+                .and(path_regex(format!(
+                    r"^/admin/realms/platform/groups/{parent_uuid}/children$"
+                )))
+                .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                    "id": group_uuid.to_string(),
+                    "name": tenant_uuid.to_string()
+                })))
+                .mount(&server)
+                .await;
+
+            let facade = build_facade(&server);
+            let ctx = build_system_ctx(Uuid::nil());
+            let req = IdpProvisionTenantRequest::for_root(
+                tenant_uuid,
+                "platform-root",
+                GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            )
+            .with_metadata(serde_json::json!({
+                "mode": "shared",
+                "realm_name": "platform"
+            }));
+
+            facade
+                .provision_tenant_inner(&ctx, &req)
+                .await
+                .expect("reactive-401 retry must recover provision_tenant");
+
+            // Two realm-admin token POSTs: initial cache-miss fetch +
+            // post-401 re-acquire. If the wrapper hadn't invalidated,
+            // this would be 1.
+            assert_eq!(
+                realm_token_calls.load(Ordering::SeqCst),
+                2,
+                "realm-admin token endpoint must be hit twice (initial + invalidate-refetch)",
+            );
+            // Two group-lookup GETs: the 401 attempt + the retry.
+            assert_eq!(
+                lookup_calls.load(Ordering::SeqCst),
+                2,
+                "find_top_group must be retried exactly once after the 401",
+            );
+        },
+    )
+    .await;
+}
+
+// ── VHP-1836: effective-realm resolution in `parse_input` ───────────────────
+//
+// `parse_input` now takes the whole `IdpProvisionTenantRequest` and derives the
+// effective realm from `target` + mode:
+//   * Root                       → explicit `realm_name` (required, unchanged)
+//   * Child + shared / no mode   → inherit parent realm from `parent_context`;
+//                                  explicit `realm_name` ignored; no parent
+//                                  metadata → `ProvisionInputRejected`
+//   * Child + created            → generate `realm-<tenant_id>`; explicit
+//                                  `realm_name` → `ProvisionInputRejected`
+//   * Child + adopted            → explicit `realm_name` (required, unchanged)
+mod effective_realm {
+    use super::*;
+
+    fn tt() -> GtsTypeId {
+        GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~")
+    }
+
+    fn child(tenant_id: Uuid) -> IdpProvisionTenantRequest {
+        IdpProvisionTenantRequest::new(tenant_id, Uuid::new_v4(), "child-name", tt())
+    }
+
+    fn parent_ctx_with_realm(realm: &str) -> IdpTenantContext {
+        IdpTenantContext::new(
+            Uuid::new_v4(),
+            "parent",
+            tt(),
+            Some(make_metadata(
+                realm,
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+        )
+    }
+
+    /// Shared child inherits the parent's realm from `parent_context`.
+    #[test]
+    fn shared_child_inherits_parent_realm() {
+        let req = child(Uuid::new_v4())
+            .with_metadata(serde_json::json!({ "mode": "shared" }))
+            .with_parent_context(parent_ctx_with_realm("platform"));
+        let parsed = TenantFacade::parse_input(&req).expect("shared child must inherit");
+        assert_eq!(parsed.realm_binding, RealmBinding::Shared);
+        assert_eq!(parsed.realm_name, "platform");
+    }
+
+    /// Mode absent defaults to shared and still inherits from the parent.
+    #[test]
+    fn mode_absent_defaults_to_shared_and_inherits() {
+        let req = child(Uuid::new_v4()).with_parent_context(parent_ctx_with_realm("region-eu"));
+        // No provisioning_metadata at all → mode defaults to shared.
+        let parsed = TenantFacade::parse_input(&req).expect("absent mode must default to shared");
+        assert_eq!(parsed.realm_binding, RealmBinding::Shared);
+        assert_eq!(parsed.realm_name, "region-eu");
+    }
+
+    /// Shared child IGNORES an explicit `realm_name` and inherits anyway.
+    #[test]
+    fn shared_child_ignores_explicit_realm_name() {
+        let req = child(Uuid::new_v4())
+            .with_metadata(serde_json::json!({ "mode": "shared", "realm_name": "ignored" }))
+            .with_parent_context(parent_ctx_with_realm("platform"));
+        let parsed = TenantFacade::parse_input(&req).expect("shared child must inherit");
+        assert_eq!(parsed.realm_name, "platform");
+    }
+
+    /// Created child generates `realm-<tenant_id>` and binds Created.
+    #[test]
+    fn created_child_generates_realm_name() {
+        let id = Uuid::from_u128(1);
+        let req = child(id).with_metadata(serde_json::json!({ "mode": "created" }));
+        let parsed = TenantFacade::parse_input(&req).expect("created child must generate a realm");
+        assert_eq!(parsed.realm_binding, RealmBinding::Created);
+        assert_eq!(parsed.realm_name, format!("realm-{id}"));
+    }
+
+    /// Created child with an explicit `realm_name` is rejected (generated only).
+    #[test]
+    fn created_with_explicit_realm_rejected() {
+        let req = child(Uuid::new_v4())
+            .with_metadata(serde_json::json!({ "mode": "created", "realm_name": "foo" }));
+        assert!(matches!(
+            TenantFacade::parse_input(&req),
+            Err(PluginError::ProvisionInputRejected { .. })
+        ));
+    }
+
+    /// Shared child with no `parent_context` cannot inherit a realm → rejected.
+    #[test]
+    fn shared_child_no_parent_metadata_rejected() {
+        let req = child(Uuid::new_v4()).with_metadata(serde_json::json!({ "mode": "shared" }));
+        assert!(matches!(
+            TenantFacade::parse_input(&req),
+            Err(PluginError::ProvisionInputRejected { .. })
+        ));
+    }
+
+    /// Shared child whose parent carries an undecodable metadata blob → rejected.
+    #[test]
+    fn shared_child_undecodable_parent_metadata_rejected() {
+        let req = child(Uuid::new_v4())
+            .with_metadata(serde_json::json!({ "mode": "shared" }))
+            .with_parent_context(IdpTenantContext::new(
+                Uuid::new_v4(),
+                "parent",
+                tt(),
+                // No `version` key → MetadataCodec::decode errors.
+                Some(serde_json::json!({ "realm_name": "platform" })),
+            ));
+        assert!(matches!(
+            TenantFacade::parse_input(&req),
+            Err(PluginError::ProvisionInputRejected { .. })
+        ));
+    }
+
+    /// Root still requires an explicit `realm_name` (unchanged behaviour).
+    #[test]
+    fn root_requires_explicit_realm() {
+        let req = IdpProvisionTenantRequest::for_root(Uuid::new_v4(), "platform-root", tt())
+            .with_metadata(serde_json::json!({ "mode": "shared", "realm_name": "platform" }));
+        let parsed = TenantFacade::parse_input(&req).expect("root must accept explicit realm");
+        assert_eq!(parsed.realm_name, "platform");
+        assert_eq!(parsed.realm_binding, RealmBinding::Shared);
+    }
+
+    /// Root with no `realm_name` in its metadata is rejected.
+    #[test]
+    fn root_without_realm_name_rejected() {
+        let req = IdpProvisionTenantRequest::for_root(Uuid::new_v4(), "platform-root", tt())
+            .with_metadata(serde_json::json!({ "mode": "shared" }));
+        assert!(matches!(
+            TenantFacade::parse_input(&req),
+            Err(PluginError::ProvisionInputRejected { .. })
+        ));
+    }
+
+    /// Adopted child still requires an explicit `realm_name` (unchanged).
+    #[test]
+    fn adopted_child_requires_explicit_realm() {
+        let req = child(Uuid::new_v4())
+            .with_metadata(serde_json::json!({ "mode": "adopted", "realm_name": "partner-acme" }));
+        let parsed = TenantFacade::parse_input(&req).expect("adopted child must accept realm");
+        assert_eq!(parsed.realm_binding, RealmBinding::Adopted);
+        assert_eq!(parsed.realm_name, "partner-acme");
+    }
+
+    /// Adopted child with no `realm_name` is rejected.
+    #[test]
+    fn adopted_child_without_realm_rejected() {
+        let req = child(Uuid::new_v4()).with_metadata(serde_json::json!({ "mode": "adopted" }));
+        assert!(matches!(
+            TenantFacade::parse_input(&req),
+            Err(PluginError::ProvisionInputRejected { .. })
+        ));
+    }
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/tenant_facade_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/tenant_facade_tests.rs
@@ -208,7 +208,7 @@ fn build_facade_with_unified_client(
 /// Build a Root-target request with the AM bootstrap saga's typical
 /// `root_tenant_metadata` forwarded as `provisioning_metadata` — mode
 /// = shared, realm = platform. This mirrors the production wiring after
-/// VHP-1505: the plugin no longer accepts `metadata = None`, so the AM
+/// the plugin no longer accepts `metadata = None`, so the AM
 /// deployer is required to set `bootstrap.root_tenant_metadata`.
 fn req_for_root(tenant_id: Uuid) -> IdpProvisionTenantRequest {
     IdpProvisionTenantRequest::for_root(
@@ -265,7 +265,7 @@ async fn mount_token_endpoints(server: &MockServer, realm_under_test: &str) {
 
 #[tokio::test]
 async fn absent_metadata_on_root_rejects_missing_realm_name() {
-    // VHP-1836: a Root provision with absent `provisioning_metadata` has no
+    // a Root provision with absent `provisioning_metadata` has no
     // realm to bind to — explicit `realm_name` is required for Root. This is
     // caller-input misconfiguration on the AM side, so it surfaces as
     // `PluginError::ProvisionInputRejected` (mapped to a clean 400), which the
@@ -333,7 +333,7 @@ async fn explicit_shared_mode_against_default_realm() {
 
             let facade = build_facade(&server);
             let ctx = build_system_ctx(Uuid::nil());
-            // VHP-1836: a shared child inherits its realm from the parent's
+            // a shared child inherits its realm from the parent's
             // idp_metadata (explicit `realm_name` is ignored). Supply a
             // parent_context whose decoded realm is `platform`.
             let req = IdpProvisionTenantRequest::new(
@@ -371,7 +371,7 @@ async fn explicit_shared_mode_against_default_realm() {
 
 #[tokio::test]
 async fn explicit_shared_mode_against_non_default_realm_uses_env_backed_admin() {
-    // VHP-1505: Shared is a single env-backed path regardless of realm
+    // Shared is a single env-backed path regardless of realm
     // name. The plugin no longer distinguishes a "non-default Shared
     // realm" sub-case; multi-region Shared is out-of-scope for v1 and
     // future work goes through Adopted.
@@ -415,7 +415,7 @@ async fn explicit_shared_mode_against_non_default_realm_uses_env_backed_admin() 
 
             let facade = build_facade(&server);
             let ctx = build_system_ctx(Uuid::nil());
-            // VHP-1836: shared child inherits the parent's realm (`region-eu`).
+            // shared child inherits the parent's realm (`region-eu`).
             let req = IdpProvisionTenantRequest::new(
                 tenant_uuid,
                 Uuid::new_v4(),
@@ -499,7 +499,7 @@ async fn malformed_metadata_surfaces_as_input_rejected() {
     // No HTTP mocks needed — the failure short-circuits before any KC call.
     let facade = build_facade(&server);
     let ctx = build_system_ctx(Uuid::nil());
-    // `mode` typed as a number — fails `WireMetadata` deserialisation. VHP-1836
+    // `mode` typed as a number — fails `WireMetadata` deserialisation.
     // surfaces wire-shape failures as `ProvisionInputRejected` ("malformed").
     let req = IdpProvisionTenantRequest::new(
         Uuid::new_v4(),
@@ -600,7 +600,7 @@ async fn adopted_with_empty_realm_provisions_with_secret_ref() {
 
         // Per-realm OpenBao response — keyed by the templated SecretRef.
         let cs = Arc::new(ConfigurableStubCS::with_entry(
-            "vp-idp-realm-admin-partner-acme-secret",
+            "keycloak-idp-realm-admin-partner-acme-secret",
             "per-realm-ra-secret",
         ));
         let facade = build_facade_with_cs(&server, cs);
@@ -625,7 +625,7 @@ async fn adopted_with_empty_realm_provisions_with_secret_ref() {
         assert_eq!(meta.realm_binding, RealmBinding::Adopted);
         assert_eq!(
             meta.admin_secret_ref.as_deref(),
-            Some("vp-idp-realm-admin-partner-acme-secret"),
+            Some("keycloak-idp-realm-admin-partner-acme-secret"),
             "Adopted always carries the templated SecretRef",
         );
         assert_eq!(meta.tenant_group_id, group_uuid);
@@ -698,7 +698,7 @@ async fn adopted_with_absent_parent_group_succeeds() {
             .await;
 
         let cs = Arc::new(ConfigurableStubCS::with_entry(
-            "vp-idp-realm-admin-partner-acme-secret",
+            "keycloak-idp-realm-admin-partner-acme-secret",
             "per-realm-ra-secret",
         ));
         let facade = build_facade_with_cs(&server, cs);
@@ -821,7 +821,7 @@ async fn shared_with_realm_probe_403_returns_bootstrap_perms_missing() {
 
             let facade = build_facade(&server);
             let ctx = build_system_ctx(Uuid::nil());
-            // VHP-1836: shared child inherits the parent's realm (`partner-acme`).
+            // shared child inherits the parent's realm (`partner-acme`).
             let req = IdpProvisionTenantRequest::new(
                 Uuid::new_v4(),
                 Uuid::new_v4(),
@@ -1300,7 +1300,7 @@ async fn mount_created_downstream(
 }
 
 fn created_request(tenant_uuid: Uuid) -> IdpProvisionTenantRequest {
-    // VHP-1836: created mode GENERATES `realm-<tenant_id>` — no `realm_name`
+    // created mode GENERATES `realm-<tenant_id>` — no `realm_name`
     // on the wire (supplying one is rejected).
     IdpProvisionTenantRequest::new(
         tenant_uuid,
@@ -1321,10 +1321,10 @@ fn created_request(tenant_uuid: Uuid) -> IdpProvisionTenantRequest {
 async fn created_happy_path_writes_secret_and_returns_created_metadata() {
     let server = MockServer::start().await;
     temp_env::async_with_vars([("TEST_BOOTSTRAP_SECRET", Some("topsecret"))], async {
-        // VHP-1836: created mode generates `realm-<tenant_id>`.
+        // created mode generates `realm-<tenant_id>`.
         let tenant_uuid = Uuid::new_v4();
         let realm = format!("realm-{tenant_uuid}");
-        let secret_key = format!("vp-idp-realm-admin-{realm}-secret");
+        let secret_key = format!("keycloak-idp-realm-admin-{realm}-secret");
         let (group_uuid, _parent_uuid) =
             mount_created_happy_path(&server, tenant_uuid, &realm, "the-generated-client-secret")
                 .await;
@@ -1400,7 +1400,7 @@ async fn created_saga_remints_bootstrap_token_after_realm_create() {
             mount_created_happy_path(&server, tenant_uuid, &realm, "the-generated-client-secret")
                 .await;
         let cs = Arc::new(ConfigurableStubCS::with_entry(
-            &format!("vp-idp-realm-admin-{realm}-secret"),
+            &format!("keycloak-idp-realm-admin-{realm}-secret"),
             "the-generated-client-secret",
         ));
         let facade = build_facade_with_cs(&server, cs);
@@ -1532,7 +1532,7 @@ async fn created_kc_realm_create_5xx_returns_ambiguous_kc_realm_create() {
 }
 
 // ---------------------------------------------------------------------
-// Created-mode realm-create idempotency (VHP-190 / run am-functional-22):
+// Created-mode realm-create idempotency (create-path idempotency):
 // the realm-create step must reconcile a 409 / lost-our-own-create against
 // an ownership marker instead of blanket-tagging `AmbiguousCreated`.
 // ---------------------------------------------------------------------
@@ -1542,11 +1542,11 @@ async fn created_kc_realm_create_5xx_returns_ambiguous_kc_realm_create() {
 fn realm_body_with_owner(realm: &str, tenant_id: Uuid) -> serde_json::Value {
     serde_json::json!({
         "realm": realm,
-        "attributes": { "vhp.provisioning.tenant_id": tenant_id.to_string() },
+        "attributes": { "cf.provisioning.tenant_id": tenant_id.to_string() },
     })
 }
 
-/// Regression (run am-functional-22): under KC load the realm-create POST
+/// Regression (the duplicate-create incident): under KC load the realm-create POST
 /// is retried after a timeout; the first POST already created the realm, so
 /// the retry hits KC's unique-name constraint → 409. The plugin MUST
 /// recognise the realm as its own (ownership marker on the re-GET) and treat
@@ -1586,7 +1586,7 @@ async fn created_realm_create_409_with_our_marker_reconciles_to_success() {
         let _ = mount_created_downstream(&server, realm, tenant_uuid, "sekret").await;
 
         let cs = Arc::new(ConfigurableStubCS::with_entry(
-            &format!("vp-idp-realm-admin-{realm}-secret"),
+            &format!("keycloak-idp-realm-admin-{realm}-secret"),
             "sekret",
         ));
         let facade = build_facade_with_cs(&server, cs);
@@ -1625,7 +1625,7 @@ async fn created_existing_realm_with_our_marker_is_adopted() {
         let _ = mount_created_downstream(&server, realm, tenant_uuid, "sekret").await;
 
         let cs = Arc::new(ConfigurableStubCS::with_entry(
-            &format!("vp-idp-realm-admin-{realm}-secret"),
+            &format!("keycloak-idp-realm-admin-{realm}-secret"),
             "sekret",
         ));
         let facade = build_facade_with_cs(&server, cs);
@@ -2176,7 +2176,7 @@ async fn deprovision_adopted_happy_path_returns_ok() {
             .await;
 
         let cs = Arc::new(ConfigurableStubCS::with_entry(
-            "vp-idp-realm-admin-partner-acme-secret",
+            "keycloak-idp-realm-admin-partner-acme-secret",
             "per-realm-ra-secret",
         ));
         let facade = build_facade_with_cs(&server, cs);
@@ -2187,7 +2187,7 @@ async fn deprovision_adopted_happy_path_returns_ok() {
                 "partner-acme",
                 RealmBinding::Adopted,
                 group_uuid,
-                Some("vp-idp-realm-admin-partner-acme-secret"),
+                Some("keycloak-idp-realm-admin-partner-acme-secret"),
             )),
         );
         facade
@@ -2250,7 +2250,7 @@ async fn deprovision_created_last_tenant_tears_down_realm_and_secret() {
 
         let mutator = Arc::new(ConfigurableStubOpenBao::default());
         mutator.seed_get(
-            "vp-idp-realm-admin-partner-created-secret",
+            "keycloak-idp-realm-admin-partner-created-secret",
             "per-realm-ra-secret",
         );
         let facade = build_facade_with_unified_client(
@@ -2264,7 +2264,7 @@ async fn deprovision_created_last_tenant_tears_down_realm_and_secret() {
                 "partner-created",
                 RealmBinding::Created,
                 group_uuid,
-                Some("vp-idp-realm-admin-partner-created-secret"),
+                Some("keycloak-idp-realm-admin-partner-created-secret"),
             )),
         );
         facade
@@ -2279,7 +2279,7 @@ async fn deprovision_created_last_tenant_tears_down_realm_and_secret() {
             "Created last-tenant teardown MUST issue exactly one OpenBao delete",
         );
         assert_eq!(
-            deletes[0], "vp-idp-realm-admin-partner-created-secret",
+            deletes[0], "keycloak-idp-realm-admin-partner-created-secret",
             "OpenBao delete MUST key on the templated realm-admin SecretRef",
         );
     })
@@ -2333,7 +2333,7 @@ async fn deprovision_created_with_remaining_tenants_keeps_realm() {
 
         let mutator = Arc::new(ConfigurableStubOpenBao::default());
         mutator.seed_get(
-            "vp-idp-realm-admin-partner-busy-secret",
+            "keycloak-idp-realm-admin-partner-busy-secret",
             "per-realm-ra-secret",
         );
         let facade = build_facade_with_unified_client(
@@ -2347,7 +2347,7 @@ async fn deprovision_created_with_remaining_tenants_keeps_realm() {
                 "partner-busy",
                 RealmBinding::Created,
                 group_uuid,
-                Some("vp-idp-realm-admin-partner-busy-secret"),
+                Some("keycloak-idp-realm-admin-partner-busy-secret"),
             )),
         );
         facade
@@ -2578,7 +2578,7 @@ async fn deprovision_with_malformed_metadata_returns_terminal() {
 // ── DESIGN §5.2: `realm_name` regex validation tests ────────────────────
 
 /// Helper: a Root request carrying explicit `{mode: shared, realm_name}` — the
-/// realm-regex validator runs on the explicit Root realm (VHP-1836).
+/// realm-regex validator runs on the explicit Root realm.
 fn root_req_with_realm(realm: &str) -> IdpProvisionTenantRequest {
     IdpProvisionTenantRequest::for_root(
         Uuid::new_v4(),
@@ -2719,7 +2719,7 @@ async fn provision_tenant_returns_ambiguous_timeout_when_saga_exceeds_provision_
     );
 }
 
-// ── VHP-76 §A — admin_user_id bind tests ────────────────────────────────────
+// ── admin_user_id bind tests ────────────────────────────────────
 
 /// Mount the Shared-mode happy-path KC calls (realm probe + token endpoints +
 /// parent group search + child group create) for `platform`. Returns
@@ -4243,7 +4243,7 @@ async fn provision_tenant_recovers_from_realm_admin_rotation_via_reactive_401() 
     .await;
 }
 
-// ── VHP-1836: effective-realm resolution in `parse_input` ───────────────────
+// ── effective-realm resolution in `parse_input` ───────────────────
 //
 // `parse_input` now takes the whole `IdpProvisionTenantRequest` and derives the
 // effective realm from `target` + mode:

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/test_support.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/test_support.rs
@@ -223,11 +223,11 @@ pub(crate) fn keycloak_cfg(base: &str) -> KeycloakConfig {
         base_url: url::Url::parse(base).expect("valid base url"),
         bootstrap_admin: BootstrapAdminConfig {
             realm: "master".into(),
-            client_id: "vp-idp-plugin-bootstrap".into(),
+            client_id: "keycloak-idp-plugin-bootstrap".into(),
             client_secret: SecretFromEnv::from_literal_unchecked("topsecret"),
         },
         realm_admin: RealmAdminConfig {
-            client_id_default: "vp-idp-plugin-realm-admin".into(),
+            client_id_default: "keycloak-idp-plugin-realm-admin".into(),
             default_shared_realm_secret: SecretFromEnv::from_literal_unchecked("ra"),
             secret_ref_template: "vp-idp-realm-admin-{realm_name}-secret".into(),
         },
@@ -271,7 +271,7 @@ pub(crate) fn noop_sp_metrics() -> Arc<dyn SpOpMetricsPort> {
 
 /// Build a `TenantIdpMetadataV1` JSON blob for use in test request fixtures.
 ///
-/// The `admin_client_id` is always `"vp-idp-plugin-realm-admin"` (the
+/// The `admin_client_id` is always `"keycloak-idp-plugin-realm-admin"` (the
 /// test-default from `keycloak_cfg`).
 pub(crate) fn make_metadata(
     realm: &str,
@@ -289,7 +289,7 @@ pub(crate) fn make_metadata(
         "realm_name": realm,
         "realm_binding": binding_str,
         "tenant_group_id": tenant_group_id.to_string(),
-        "admin_client_id": "vp-idp-plugin-realm-admin",
+        "admin_client_id": "keycloak-idp-plugin-realm-admin",
     });
     if let Some(secret) = admin_secret_ref {
         obj.as_object_mut().expect("json::Value is object").insert(

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/test_support.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/test_support.rs
@@ -229,7 +229,7 @@ pub(crate) fn keycloak_cfg(base: &str) -> KeycloakConfig {
         realm_admin: RealmAdminConfig {
             client_id_default: "keycloak-idp-plugin-realm-admin".into(),
             default_shared_realm_secret: SecretFromEnv::from_literal_unchecked("ra"),
-            secret_ref_template: "vp-idp-realm-admin-{realm_name}-secret".into(),
+            secret_ref_template: "keycloak-idp-realm-admin-{realm_name}-secret".into(),
         },
         tls_ca_bundle_ref: None,
         admin_token_lifetime_safety_ms: 30_000,

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/test_support.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/test_support.rs
@@ -1,0 +1,301 @@
+//! Shared test fixtures for the domain layer's `*_tests.rs` siblings.
+//!
+//! Only compiled under `#[cfg(test)]`. Provides:
+//!
+//! - [`StubCredStore`] — no-op `CredStoreClientV1` (every `get` returns `None`).
+//! - [`ConfigurableStubCS`] — keyed-map `CredStoreClientV1` for tests that
+//!   need predetermined `get` responses.
+//! - [`keycloak_cfg`]`(base_url)` — minimal valid `KeycloakConfig` builder.
+//! - [`noop_metrics_*`]`()` typed-port accessors — one `Arc<dyn ...Port>`
+//!   per facade-required port, all backed by `NoopMetrics`.
+//! - [`make_metadata`]`(...)` — `serde_json::Value` blob simulating persisted `TenantIdpMetadataV1`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use credstore_sdk::{
+    CredStoreClientV1, CredStoreError, GetSecretResponse, SecretRef, SecretValue, SharingMode,
+    TenantId, WritePrecondition,
+};
+use toolkit_macros::domain_model;
+use toolkit_security::SecurityContext;
+use uuid::Uuid;
+
+use crate::config::RealmAdminConfig;
+use crate::config::{
+    BootstrapAdminConfig, HttpRetryPolicy, KeycloakConfig, KeycloakMetricsConfig, SecretFromEnv,
+};
+use crate::domain::metadata_codec::RealmBinding;
+use crate::domain::ports::metrics::{
+    CredstoreMetricsPort, CredstoreOp, CredstoreOutcome, EndpointClass, FailureMetricsPort,
+    FailureVariant, KcAdminMetricsPort, MetadataCodecMetricsPort, OrphanCompensationOutcome,
+    PluginOp, SpOp, SpOpMetricsPort, TenantLifecycleMetricsPort, TokenRefreshOutcome, TokenTier,
+    UserOp, UserOpMetricsPort, VersionObserved,
+};
+
+/// No-op implementation of every metrics port. Lives here (under
+/// `cfg(test)`-gated `test_support`) because that's the only call site
+/// today; if a future caller wants a genuine production "metrics-off"
+/// adapter, move the struct + impls back into `domain::ports::metrics`
+/// and drop the `cfg(test)` gate.
+#[domain_model]
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct NoopMetrics;
+
+impl TenantLifecycleMetricsPort for NoopMetrics {
+    fn provision_tenant_duration(&self, _realm_binding: RealmBinding, _secs: f64) {}
+    fn realm_bound(&self, _realm_binding: RealmBinding, _realm_name: &str) {}
+    fn realm_unbound(&self, _realm_binding: RealmBinding, _realm_name: &str) {}
+    fn deprovision_missing_metadata(&self) {}
+}
+
+impl UserOpMetricsPort for NoopMetrics {
+    fn user_op_duration(&self, _op: UserOp, _secs: f64) {}
+    fn orphan_user_compensation(&self, _outcome: OrphanCompensationOutcome) {}
+}
+
+impl KcAdminMetricsPort for NoopMetrics {
+    fn kc_admin_request_duration(&self, _endpoint_class: EndpointClass, _secs: f64) {}
+    fn kc_admin_token_refresh(
+        &self,
+        _outcome: TokenRefreshOutcome,
+        _tier: TokenTier,
+        _realm: &str,
+    ) {
+    }
+    fn credential_refresh(&self, _outcome: TokenRefreshOutcome, _tier: TokenTier, _realm: &str) {}
+}
+
+impl CredstoreMetricsPort for NoopMetrics {
+    fn credstore_write(&self, _op: CredstoreOp, _outcome: CredstoreOutcome) {}
+}
+
+impl MetadataCodecMetricsPort for NoopMetrics {
+    fn metadata_decode_failure(&self, _version_observed: VersionObserved) {}
+}
+
+impl FailureMetricsPort for NoopMetrics {
+    fn failure(&self, _op: PluginOp, _variant: FailureVariant) {}
+}
+
+impl SpOpMetricsPort for NoopMetrics {
+    fn sp_op_duration(&self, _op: SpOp, _secs: f64) {}
+}
+
+/// No-op `CredStoreClientV1` — every `get` returns `Ok(None)`.
+///
+/// Suitable for Shared-mode tests that never resolve a `SecretSource::OpenBaoRef`
+/// (the bootstrap path uses the inline secret carried on the parsed config).
+#[domain_model]
+pub(crate) struct StubCredStore;
+
+#[async_trait]
+impl CredStoreClientV1 for StubCredStore {
+    async fn create(
+        &self,
+        ctx: &SecurityContext,
+        key: &SecretRef,
+        value: SecretValue,
+        sharing: SharingMode,
+    ) -> Result<(), CredStoreError> {
+        self.put(ctx, key, value, sharing, WritePrecondition::Exists)
+            .await
+    }
+
+    async fn get(
+        &self,
+        _ctx: &SecurityContext,
+        _key: &SecretRef,
+    ) -> Result<Option<GetSecretResponse>, CredStoreError> {
+        Ok(None)
+    }
+
+    async fn put(
+        &self,
+        _ctx: &SecurityContext,
+        _key: &SecretRef,
+        _value: SecretValue,
+        _sharing: SharingMode,
+        _precondition: WritePrecondition,
+    ) -> Result<(), CredStoreError> {
+        Ok(())
+    }
+
+    async fn delete(
+        &self,
+        _ctx: &SecurityContext,
+        _key: &SecretRef,
+        _precondition: WritePrecondition,
+    ) -> Result<(), CredStoreError> {
+        Ok(())
+    }
+}
+
+/// Configurable stub keyed by `SecretRef`.
+///
+/// Adopted-mode tests seed a response for the per-realm `OpenBao` key so
+/// `realm_client(...)` can resolve the secret. `GetSecretResponse` is not
+/// `Clone` (contains `SecretValue`), so each entry is `take()`n on first
+/// match — fine because the factory caches the resulting token.
+#[domain_model]
+#[derive(Default)]
+pub(crate) struct ConfigurableStubCS {
+    pub(crate) responses: Mutex<HashMap<String, GetSecretResponse>>,
+}
+
+impl ConfigurableStubCS {
+    pub(crate) fn with_entry(key: &str, value: &str) -> Self {
+        let mut map = HashMap::new();
+        map.insert(
+            key.to_owned(),
+            GetSecretResponse {
+                value: SecretValue::from(value),
+                owner_tenant_id: TenantId::nil(),
+                sharing: SharingMode::Tenant,
+                is_inherited: false,
+                version: 1,
+                id: Uuid::nil(),
+                secret_type: "gts.x.core.secret.type.v1~x.core.secret.generic.v1".to_owned(),
+                expires_at: None,
+            },
+        );
+        Self {
+            responses: Mutex::new(map),
+        }
+    }
+}
+
+#[async_trait]
+impl CredStoreClientV1 for ConfigurableStubCS {
+    async fn create(
+        &self,
+        ctx: &SecurityContext,
+        key: &SecretRef,
+        value: SecretValue,
+        sharing: SharingMode,
+    ) -> Result<(), CredStoreError> {
+        self.put(ctx, key, value, sharing, WritePrecondition::Exists)
+            .await
+    }
+
+    async fn get(
+        &self,
+        _ctx: &SecurityContext,
+        key: &SecretRef,
+    ) -> Result<Option<GetSecretResponse>, CredStoreError> {
+        Ok(self
+            .responses
+            .lock()
+            .expect("stub lock poisoned")
+            .remove(key.as_ref()))
+    }
+
+    async fn put(
+        &self,
+        _ctx: &SecurityContext,
+        _key: &SecretRef,
+        _value: SecretValue,
+        _sharing: SharingMode,
+        _precondition: WritePrecondition,
+    ) -> Result<(), CredStoreError> {
+        Ok(())
+    }
+
+    async fn delete(
+        &self,
+        _ctx: &SecurityContext,
+        _key: &SecretRef,
+        _precondition: WritePrecondition,
+    ) -> Result<(), CredStoreError> {
+        Ok(())
+    }
+}
+
+/// Build a `KeycloakConfig` pointing at `base` with canonical test defaults.
+///
+/// Used by `tenant_facade_tests` and `user_facade_tests`; the factory tests
+/// use `cfg_with_base_url` which is an alias for this function under a
+/// different name.
+pub(crate) fn keycloak_cfg(base: &str) -> KeycloakConfig {
+    KeycloakConfig {
+        base_url: url::Url::parse(base).expect("valid base url"),
+        bootstrap_admin: BootstrapAdminConfig {
+            realm: "master".into(),
+            client_id: "vp-idp-plugin-bootstrap".into(),
+            client_secret: SecretFromEnv::from_literal_unchecked("topsecret"),
+        },
+        realm_admin: RealmAdminConfig {
+            client_id_default: "vp-idp-plugin-realm-admin".into(),
+            default_shared_realm_secret: SecretFromEnv::from_literal_unchecked("ra"),
+            secret_ref_template: "vp-idp-realm-admin-{realm_name}-secret".into(),
+        },
+        tls_ca_bundle_ref: None,
+        admin_token_lifetime_safety_ms: 30_000,
+        http_request_timeout_ms: 5_000,
+        credential_refresh_interval: None,
+        http_retry_policy: HttpRetryPolicy::default(),
+        metrics: KeycloakMetricsConfig::default(),
+        bootstrap_pre_warm: crate::config::BootstrapPreWarmConfig::default(),
+    }
+}
+
+/// Typed-port `Arc<dyn ...>` views backed by [`NoopMetrics`] — the
+/// safe default for facade tests that don't assert on metric emission.
+/// Five accessors so a test can wire exactly the ports its facade
+/// constructor expects without taking a dependency on the others.
+pub(crate) fn noop_tenant_metrics() -> Arc<dyn TenantLifecycleMetricsPort> {
+    Arc::new(NoopMetrics)
+}
+
+pub(crate) fn noop_user_metrics() -> Arc<dyn UserOpMetricsPort> {
+    Arc::new(NoopMetrics)
+}
+
+pub(crate) fn noop_credstore_metrics() -> Arc<dyn CredstoreMetricsPort> {
+    Arc::new(NoopMetrics)
+}
+
+pub(crate) fn noop_metadata_metrics() -> Arc<dyn MetadataCodecMetricsPort> {
+    Arc::new(NoopMetrics)
+}
+
+pub(crate) fn noop_failure_metrics() -> Arc<dyn FailureMetricsPort> {
+    Arc::new(NoopMetrics)
+}
+
+pub(crate) fn noop_sp_metrics() -> Arc<dyn SpOpMetricsPort> {
+    Arc::new(NoopMetrics)
+}
+
+/// Build a `TenantIdpMetadataV1` JSON blob for use in test request fixtures.
+///
+/// The `admin_client_id` is always `"vp-idp-plugin-realm-admin"` (the
+/// test-default from `keycloak_cfg`).
+pub(crate) fn make_metadata(
+    realm: &str,
+    binding: RealmBinding,
+    tenant_group_id: Uuid,
+    admin_secret_ref: Option<&str>,
+) -> serde_json::Value {
+    let binding_str = match binding {
+        RealmBinding::Shared => "shared",
+        RealmBinding::Adopted => "adopted",
+        RealmBinding::Created => "created",
+    };
+    let mut obj = serde_json::json!({
+        "version": "v1",
+        "realm_name": realm,
+        "realm_binding": binding_str,
+        "tenant_group_id": tenant_group_id.to_string(),
+        "admin_client_id": "vp-idp-plugin-realm-admin",
+    });
+    if let Some(secret) = admin_secret_ref {
+        obj.as_object_mut().expect("json::Value is object").insert(
+            "admin_secret_ref".into(),
+            serde_json::Value::String(secret.into()),
+        );
+    }
+    obj
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/user_facade.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/user_facade.rs
@@ -1,0 +1,1981 @@
+//! `UserFacade` — provision/deprovision/list users against Keycloak per DESIGN §4.3.
+//!
+//! Implements `provision_user_inner`, `deprovision_user_inner`, and
+//! `list_users_inner` across all three [`RealmBinding`] modes (Shared /
+//! Adopted / Created). Metadata decode, secret-source selection (ADDENDUM §3.4),
+//! and user-operation audit events are handled within this facade; the SDK
+//! boundary in `idp_impl.rs` translates [`PluginError`] into the typed
+//! `IdpUserOperationFailure` variants (`Rejected` / `Unavailable` /
+//! `UnsupportedOperation`).
+//!
+//! [`TenantFacade`]: crate::domain::tenant_facade::TenantFacade
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use account_management_sdk::idp_user::{
+    IdpDeprovisionUserRequest, IdpListUsersRequest, IdpProvisionUserRequest, IdpUser,
+    IdpUserFilterField,
+};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use credstore_sdk::SecretRef;
+use serde::Deserialize;
+use toolkit_odata::filter::{FilterNode, FilterOp, ODataValue};
+use toolkit_odata::{CursorV1, Page, PageInfo, SortDir};
+use toolkit_security::SecurityContext;
+use uuid::Uuid;
+
+use crate::config::{RealmAdminConfig, UserFacadeConfig};
+use crate::domain::audit;
+use crate::domain::error::{KcStatusKind, PluginError, redact_secrets};
+use crate::domain::kc::KcAdminClient;
+use crate::domain::kc::factory::{KeycloakAdminClientFactory, SecretSource};
+use crate::domain::kc::transport::truncate_2kb;
+use crate::domain::metadata_codec::{MetadataCodec, RealmBinding, TenantIdpMetadataV1};
+use crate::domain::ports::metrics::{
+    FailureMetricsPort, FailureVariant, MetadataCodecMetricsPort, OrphanCompensationOutcome,
+    PluginOp, UserOp, UserOpMetricsPort, VersionObserved,
+};
+use toolkit_macros::domain_model;
+
+// `failure_variant_label` lives in `crate::domain::error` (single source of truth).
+
+/// Re-tag any [`PluginError::KcRest`] surfaced inside the user-op saga as a
+/// [`PluginError::UserOpUnavailable`] per DESIGN §5.5 — transport / timeout /
+/// 5xx upstream failures all map to the "provider is unreachable" lane Phase
+/// 15 boundary translates to [`IdpUserOperationFailure::Unavailable`].
+/// Non-[`PluginError::KcRest`] variants (e.g.
+/// [`PluginError::CredStoreRead`], [`PluginError::BootstrapPermsMissing`])
+/// pass through unchanged so the Phase 15 boundary can translate them.
+///
+/// [`IdpUserOperationFailure::Unavailable`]: account_management_sdk::idp_user::IdpUserOperationFailure::Unavailable
+fn user_translate_kc(e: PluginError) -> PluginError {
+    match e {
+        // Preserve `KcRest{Http(401)}` verbatim so any enclosing
+        // `with_reactive_401` wrapper can detect the rotation signal and
+        // retry with a refreshed bearer. Without this carve-out the
+        // wrapper would never see a 401 (everything would already be
+        // collapsed into `UserOpUnavailable`). A 401 that escapes the
+        // wrapper (i.e. the second-strike scenario) falls through the
+        // Phase-15 boundary to `IdpUserOperationFailure::Unavailable`
+        // via the catch-all in `translate_user_op_failure` (idp_impl.rs).
+        e @ PluginError::KcRest {
+            status: KcStatusKind::Http(401),
+            ..
+        } => e,
+        PluginError::KcRest {
+            method,
+            path_template,
+            status,
+            body_first_2kb,
+        } => PluginError::UserOpUnavailable {
+            detail: format!("kc:{method} {path_template} -> {status}: {body_first_2kb}"),
+        },
+        other => other,
+    }
+}
+
+/// Attribute a KC 409 user-create body to the colliding unique field
+/// (VHP-2158). The HTTP 409 status itself is the machine signal that a
+/// uniqueness invariant fired — on this endpoint it has no other cause
+/// — so the caller classifies EVERY 409 as a duplicate and this
+/// function only refines which field, never whether.
+///
+/// KC's admin REST emits machine constants in `errorMessage` (from KC
+/// code, not the locale-dependent login theme):
+/// `"User exists with same username"`, `"User exists with same
+/// email"`, and the combined `"User exists with same username or
+/// email"` from the `ModelDuplicateException` path — on KC 26 the
+/// combined constant is the ONLY 409 `createUser` produces directly.
+/// Matched case-insensitively on the discriminating nouns; a message
+/// naming both fields, an unparseable body, or unrecognised wording
+/// all yield the honest [`UsernameOrEmail`] attribution — wording
+/// drift can degrade the field token, never the 409 status.
+///
+/// [`UsernameOrEmail`]: account_management_sdk::IdpUserDuplicateField::UsernameOrEmail
+fn classify_kc_conflict(body_text: &str) -> account_management_sdk::IdpUserDuplicateField {
+    use account_management_sdk::IdpUserDuplicateField as F;
+    let msg = serde_json::from_str::<serde_json::Value>(body_text)
+        .ok()
+        .and_then(|v| v.get("errorMessage")?.as_str().map(str::to_ascii_lowercase));
+    let Some(msg) = msg else {
+        return F::UsernameOrEmail;
+    };
+    match (msg.contains("username"), msg.contains("email")) {
+        (true, false) => F::Username,
+        (false, true) => F::Email,
+        _ => F::UsernameOrEmail,
+    }
+}
+
+/// Detect a KC 400 password-policy reject on user-create (VHP-2158).
+/// KC signals policy failures in two shapes depending on version/path:
+/// `{"errorMessage": "Password policy not met"}` (admin user-create with
+/// an embedded credential) and `{"error": "invalidPasswordMinLengthMessage",
+/// "error_description": ...}` (credential endpoints). Both carry an
+/// `invalidPassword*` key or the literal "password policy" phrase; other
+/// 400s (malformed payload, unknown fields) return `false` and keep the
+/// current handling.
+fn is_kc_password_policy_reject(body_text: &str) -> bool {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(body_text) else {
+        return false;
+    };
+    let field_str = |k: &str| {
+        v.get(k)
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+    };
+    let error_message = field_str("errorMessage");
+    let error = field_str("error");
+    error_message.contains("password policy")
+        || error_message.starts_with("invalidpassword")
+        || error.starts_with("invalidpassword")
+}
+
+/// Subset of Keycloak's `UserRepresentation` the facade needs:
+///
+/// * UUID discovery after `provision_user` — only `id` is required.
+/// * `list_users` group-members listing — `id` + profile fields the
+///   facade projects into [`IdpUser`].
+///
+/// `firstName` / `lastName` are concatenated into [`IdpUser::display_name`]
+/// per DESIGN §4.3 (KC `firstName + lastName` is the canonical KC profile
+/// shape; OIDC `name` claim is not surfaced by the admin REST endpoint).
+///
+/// `createdTimestamp` is used by the `list_users` cursor sort key
+/// `(createdTimestamp ASC, id ASC)` per DESIGN §4.3.
+// Field subset of Keycloak's `UserRepresentation`; the derive is the decoder.
+#[allow(unknown_lints, de0101_no_serde_in_contract)]
+#[domain_model]
+#[derive(Deserialize)]
+struct UserRep {
+    id: Uuid,
+    // `default` resolves to 0 (epoch). Real KC always emits `createdTimestamp`;
+    // the default exists only for minimal test fixtures. Such users sort
+    // before all real users — acceptable for v1 but document if writing new fixtures.
+    #[serde(default, rename = "createdTimestamp")]
+    created_timestamp: i64,
+    #[serde(default)]
+    username: Option<String>,
+    #[serde(default)]
+    email: Option<String>,
+    #[serde(default, rename = "firstName")]
+    first_name: Option<String>,
+    #[serde(default, rename = "lastName")]
+    last_name: Option<String>,
+}
+
+/// Decoded view of the `IdpUserPagination.cursor` opaque string, as
+/// constructed by [`UserFacade::encode_cursor`] and consumed by
+/// [`UserFacade::decode_cursor`].
+///
+/// Wire format is [`toolkit_odata::CursorV1`] base64url-JSON — the same
+/// cursor envelope AM's tenant `list_children` flow uses, so `OData`
+/// extractor parsing + handler order-recovery (`ODataOrderBy::
+/// from_signed_tokens(&c.s)`) work uniformly across the
+/// plugin-emitted and AM-native cursor paths (see
+/// `account-management/src/api/rest/handlers/users.rs::
+/// lower_odata_to_list_users_query`).
+///
+/// Field mapping into [`CursorV1`]:
+///
+///   * `k = [last_created_at_ms.to_string(), last_user_id.to_string()]`
+///     — composite tiebreaker per DESIGN §4.3 sort
+///     `(createdTimestamp ASC, id ASC)`.
+///   * `o = SortDir::Asc`, `s = [CURSOR_ORDER_TOKENS]` — pin the
+///     hard-coded plugin sort order in the cursor so AM's handler
+///     can recover `req.order` on continuation requests via
+///     `ODataOrderBy::from_signed_tokens`.
+///   * `f = Some(filter_hash)` — short FNV-1a fingerprint of
+///     `(tenant_id, realm_name, id_filter, string_filters)`. The
+///     `realm_name` fold replaces the pre-CursorV1 explicit
+///     `decoded.realm_name != metadata.realm_name` reject — same
+///     effective check, now bundled in the hash so a re-binding
+///     across pages surfaces as `invalid cursor` through the same
+///     path as a filter / tenant change.
+///   * `d = "fwd"` — the plugin does not implement backward
+///     pagination (it would require fetching from an offset > 0,
+///     which v1 forbids).
+#[domain_model]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ListUsersCursor {
+    filter_hash: String,
+    last_created_at: i64,
+    last_user_id: Uuid,
+}
+
+/// Pre-CursorV1 cursor shape kept ALIVE on the decode side for the
+/// rolling-deploy grace window. Mirrors the JSON shape the previous
+/// encoder produced: opaque base64url-no-pad of a serde-tagged struct
+/// with `realm_name` carried alongside `filter_hash`. Used ONLY by
+/// [`UserFacade::decode_cursor_with_legacy_fallback`]; the encoder
+/// always emits the current [`CursorV1`] shape.
+///
+/// Why keep this around: the rolling rollout window means clients
+/// that fetched page 1 BEFORE the deploy and page 2 AFTER the deploy
+/// would otherwise see `invalid cursor` mid-walk on a server-issued
+/// token. The grace decode accepts both shapes; once all in-flight
+/// pagination drains (matter of minutes), the legacy struct can be
+/// retired.
+// The derive IS the grace-window decoder described above.
+#[allow(unknown_lints, de0101_no_serde_in_contract)]
+#[domain_model]
+#[derive(Debug, Deserialize)]
+struct LegacyListUsersCursor {
+    realm_name: String,
+    filter_hash: String,
+    #[serde(default)]
+    last_created_at: Option<i64>,
+    #[serde(default)]
+    last_user_id: Option<Uuid>,
+}
+
+/// Pre-CursorV1 `filter_hash` computation. Kept ALIVE for the same
+/// rolling-deploy grace window as [`LegacyListUsersCursor`]: a legacy
+/// cursor is accepted only if its `filter_hash` re-derives from this
+/// function given the current request's `(tenant_id, id_filter)` —
+/// i.e. the legacy filter context matches today's request.
+///
+/// Scope of revalidation: tenant + UUID-typed `id` filter only.
+/// Legacy cursors were minted before the string-filter predicate
+/// ([`StringMatcher`]) was folded into the hash; the encoded hash
+/// never folded `realm_name` or
+/// `username/email/first_name/last_name/display_name` into its
+/// state, so this routine intentionally does not either. Feeding
+/// today's [`StringMatcher`] in would change every legacy hash
+/// byte-for-byte and reject every legacy cursor minted by the prior
+/// release — defeating the rolling-deploy grace window.
+///
+/// Safety vs. drift: realm rebinding is caught upstream by the
+/// explicit `legacy.realm_name != expected_realm` check in
+/// [`UserFacade::decode_cursor_with_legacy_fallback`]. A request
+/// that adds string filters mid-walk reuses a legacy cursor for at
+/// most one more page — the response always emits a fresh `CursorV1`
+/// `next_cursor` with the full modern hash, after which the modern
+/// equality check guards every subsequent page.
+/// FNV-1a 64-bit offset basis / prime — deterministic, non-cryptographic
+/// fingerprint (DE0708: no non-FIPS hashers). Public Fowler–Noll–Vo spec with
+/// fixed constants → identical output across Rust versions and platforms.
+const FNV1A_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV1A_PRIME: u64 = 0x0000_0100_0000_01B3;
+
+/// Mix `bytes` into an in-progress FNV-1a 64-bit state.
+fn fnv1a_update(state: &mut u64, bytes: impl AsRef<[u8]>) {
+    for &b in bytes.as_ref() {
+        *state ^= u64::from(b);
+        *state = state.wrapping_mul(FNV1A_PRIME);
+    }
+}
+
+fn legacy_filter_hash(tenant_id: Uuid, user_id_filter: Option<Uuid>) -> String {
+    let mut h = FNV1A_BASIS;
+    fnv1a_update(&mut h, tenant_id.as_bytes());
+    match user_id_filter {
+        Some(u) => {
+            fnv1a_update(&mut h, [1u8]);
+            fnv1a_update(&mut h, u.as_bytes());
+        }
+        None => {
+            fnv1a_update(&mut h, [0u8]);
+        }
+    }
+    format!("{h:016x}")
+}
+
+/// Plugin's sort order, hard-coded to `(createdTimestamp ASC, id
+/// ASC)` per DESIGN §4.3. The literal token strings here are opaque
+/// to KC — they live only in the cursor envelope so [`CursorV1`]'s
+/// `o`/`s` fields round-trip correctly through the AM handler's
+/// order-recovery step. If the plugin ever forwards `req.order` to
+/// the KC sort (the open TODO inside `list_users_impl`), the literals
+/// here become inputs to a runtime computation instead of a fixed
+/// constant.
+const CURSOR_ORDER_TOKENS: &str = "+created_at,+id";
+const CURSOR_ORDER_DIR: SortDir = SortDir::Asc;
+const CURSOR_DIRECTION: &str = "fwd";
+
+/// Hard cap on the total tenant-group members drained in one
+/// `list_users` call. Bounds memory on a pathological membership;
+/// reaching it is logged loudly in `list_users_impl` rather than
+/// silently truncating. The realm-wide `/users?q=tenant_id:UUID`
+/// path is the scale answer past this cap.
+const MEMBERS_DRAIN_HARD_CAP: usize = 10_000;
+
+/// String-field match operator lowered from the `OData` `$filter`.
+#[domain_model]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+enum StringMatchOp {
+    /// `eq` — exact, case-sensitive (mirrors KC `exact=true`).
+    Eq,
+    /// `contains` — substring, case-insensitive (user search).
+    Contains,
+}
+
+/// Client-side predicate lowered from the typed `OData` `$filter`,
+/// evaluated over each KC-fetched member. Mirrors the operator subset
+/// the `/users` list contract supports: `and` / `or` of `eq` /
+/// `contains` clauses on the string fields (`username` / `email` /
+/// `first_name` / `last_name` / `display_name`).
+///
+/// `id eq <uuid>` is captured separately by
+/// [`UserFacade::extract_id_filter`]; inside a top-level `and` it
+/// lowers to [`StringMatcher::Always`] here, and inside an `or` it is
+/// rejected (the id half cannot be hoisted out of a disjunction).
+///
+/// [`StringMatcher::Always`] is the "no string constraint" identity
+/// (the no-`$filter` case) and matches every member.
+#[domain_model]
+#[derive(Default, PartialEq, Eq, Debug, Clone)]
+enum StringMatcher {
+    #[default]
+    Always,
+    Field {
+        field: IdpUserFilterField,
+        op: StringMatchOp,
+        needle: String,
+    },
+    All(Vec<StringMatcher>),
+    Any(Vec<StringMatcher>),
+}
+
+impl StringMatcher {
+    /// `true` when `rep` satisfies the predicate. `Always` matches
+    /// unconditionally; `All` is conjunction, `Any` disjunction. A
+    /// `Field` clause reads the named field off the rep and applies
+    /// `op` (case-insensitive substring for `Contains`, exact for
+    /// `Eq`); a field absent on the rep never matches.
+    fn matches(&self, rep: &UserRep) -> bool {
+        match self {
+            StringMatcher::Always => true,
+            StringMatcher::All(children) => children.iter().all(|c| c.matches(rep)),
+            StringMatcher::Any(children) => children.iter().any(|c| c.matches(rep)),
+            StringMatcher::Field { field, op, needle } => {
+                let actual: Option<String> = match field {
+                    IdpUserFilterField::Username => rep.username.clone(),
+                    IdpUserFilterField::Email => rep.email.clone(),
+                    IdpUserFilterField::FirstName => rep.first_name.clone(),
+                    IdpUserFilterField::LastName => rep.last_name.clone(),
+                    IdpUserFilterField::DisplayName => UserFacade::user_rep_display_name(rep),
+                    // `id` never reaches a Field clause (handled in the
+                    // builder); treat defensively as non-matching.
+                    IdpUserFilterField::Id => None,
+                };
+                match (actual, op) {
+                    (Some(a), StringMatchOp::Eq) => a == *needle,
+                    (Some(a), StringMatchOp::Contains) => {
+                        a.to_lowercase().contains(needle.to_lowercase().as_str())
+                    }
+                    (None, _) => false,
+                }
+            }
+        }
+    }
+
+    /// Feed the predicate into the cursor `filter_hash` in a canonical,
+    /// collision-resistant shape (variant tag + length-prefixed parts)
+    /// so a continuation cursor is only valid for an identical filter.
+    fn feed_hash(&self, state: &mut u64) {
+        match self {
+            StringMatcher::Always => fnv1a_update(state, [0u8]),
+            StringMatcher::Field { field, op, needle } => {
+                let field_tag: u8 = match field {
+                    IdpUserFilterField::Id => 0,
+                    IdpUserFilterField::Username => 1,
+                    IdpUserFilterField::Email => 2,
+                    IdpUserFilterField::FirstName => 3,
+                    IdpUserFilterField::LastName => 4,
+                    IdpUserFilterField::DisplayName => 5,
+                };
+                let op_tag: u8 = match op {
+                    StringMatchOp::Eq => 0,
+                    StringMatchOp::Contains => 1,
+                };
+                fnv1a_update(state, [1u8]);
+                fnv1a_update(state, [field_tag]);
+                fnv1a_update(state, [op_tag]);
+                fnv1a_update(state, needle.len().to_be_bytes());
+                fnv1a_update(state, needle.as_bytes());
+            }
+            StringMatcher::All(children) => {
+                fnv1a_update(state, [2u8]);
+                fnv1a_update(state, children.len().to_be_bytes());
+                for c in children {
+                    c.feed_hash(state);
+                }
+            }
+            StringMatcher::Any(children) => {
+                fnv1a_update(state, [3u8]);
+                fnv1a_update(state, children.len().to_be_bytes());
+                for c in children {
+                    c.feed_hash(state);
+                }
+            }
+        }
+    }
+}
+
+#[domain_model]
+pub struct UserFacade {
+    cfg: UserFacadeConfig,
+    realm_admin_cfg: RealmAdminConfig,
+    kc_factory: Arc<KeycloakAdminClientFactory>,
+    codec: Arc<MetadataCodec>,
+    // Segregated metric ports (DESIGN §9). One `Arc` per subdomain.
+    user_metrics: Arc<dyn UserOpMetricsPort>,
+    metadata_metrics: Arc<dyn MetadataCodecMetricsPort>,
+    failure_metrics: Arc<dyn FailureMetricsPort>,
+}
+
+impl UserFacade {
+    #[must_use]
+    pub fn new(
+        cfg: UserFacadeConfig,
+        realm_admin_cfg: RealmAdminConfig,
+        kc_factory: Arc<KeycloakAdminClientFactory>,
+        codec: Arc<MetadataCodec>,
+        user_metrics: Arc<dyn UserOpMetricsPort>,
+        metadata_metrics: Arc<dyn MetadataCodecMetricsPort>,
+        failure_metrics: Arc<dyn FailureMetricsPort>,
+    ) -> Self {
+        Self {
+            cfg,
+            realm_admin_cfg,
+            kc_factory,
+            codec,
+            user_metrics,
+            metadata_metrics,
+            failure_metrics,
+        }
+    }
+
+    /// Provision a user in the tenant's bound realm (DESIGN §4.3 / §5.4).
+    ///
+    /// 1. Decode tenant metadata.
+    /// 2. Resolve realm-admin secret source (env for default-shared,
+    ///    `OpenBao` [`SecretRef`] otherwise — ADDENDUM §3.4).
+    /// 3. `POST /admin/realms/{realm}/users` with `requiredActions` from
+    ///    config.
+    /// 4. Discover the user's UUID via
+    ///    `GET .../users?username=...&exact=true` (defensive — sibling Phase
+    ///    10 client-create uses the same pattern instead of parsing
+    ///    `Location`).
+    /// 5. Add the user to the tenant group via
+    ///    `PUT .../users/{uuid}/groups/{tenant_group_id}`.
+    ///
+    /// # Errors
+    ///
+    /// * [`PluginError::UserOpRejected`] — malformed metadata, KC 409 on
+    ///   user-create (duplicate), or KC 404 on group-add (tenant group
+    ///   disappeared).
+    /// * [`PluginError::UserOpUnavailable`] — KC 5xx / transport / timeout
+    ///   on any step (re-tagged from [`PluginError::KcRest`] by
+    ///   [`user_translate_kc`]).
+    /// * [`PluginError::CredStoreRead`] — realm-admin credential resolution
+    ///   failure from `OpenBao` (Adopted / Created modes; Phase 15 maps this
+    ///   via the same boundary table as the tenant-side facade).
+    pub async fn provision_user_inner(
+        &self,
+        ctx: &SecurityContext,
+        req: &IdpProvisionUserRequest,
+    ) -> Result<IdpUser, PluginError> {
+        let started = Instant::now();
+        let result = self.provision_user_impl(req).await;
+        let elapsed = started.elapsed().as_secs_f64();
+        self.user_metrics
+            .user_op_duration(UserOp::ProvisionUser, elapsed);
+        match &result {
+            Ok((user, realm_name, realm_binding)) => {
+                audit::emit_user_provisioned(
+                    ctx,
+                    req.tenant_context.tenant_id,
+                    realm_name,
+                    *realm_binding,
+                    user.id,
+                    &user.username,
+                );
+            }
+            Err(e) => {
+                self.record_user_op_failure(PluginOp::ProvisionUser, e);
+            }
+        }
+        result.map(|(user, _, _)| user)
+    }
+
+    /// Inner implementation returning the [`IdpUser`] plus the bound
+    /// realm name / binding so the outer wrapper can emit a fully-labelled
+    /// `user.provisioned` audit event without re-decoding the metadata.
+    async fn provision_user_impl(
+        &self,
+        req: &IdpProvisionUserRequest,
+    ) -> Result<(IdpUser, String, RealmBinding), PluginError> {
+        // ---- Step 1: decode metadata. ----
+        let metadata = self.decode_tenant_metadata(req.tenant_context.metadata.as_ref())?;
+
+        // ---- Step 2: resolve realm-admin secret source. ----
+        let secret_source = self.build_secret_source(&metadata)?;
+
+        // ---- Step 4: create user in target realm. ----
+        //
+        // Each KC step is wrapped INDIVIDUALLY in `with_reactive_401`
+        // (not as a single block) because `create_user` is the only
+        // non-idempotent step in the chain: a block-level retry would
+        // re-issue the POST on the 2nd pass and trip KC's 409
+        // duplicate-username branch, surfacing as a phantom
+        // `UserOpRejected` to AM. Per-call wrapping keeps each retry
+        // narrowly scoped to the call whose token was rejected.
+        self.kc_factory
+            .with_reactive_401(
+                &metadata.realm_name,
+                &metadata.admin_client_id,
+                &secret_source,
+                |realm_admin| {
+                    // Clone-in-closure: the `Fn` bound requires the
+                    // closure to be callable multiple times (the
+                    // wrapper may invoke it twice on a 401 retry), so
+                    // owned-`String` captures must clone here rather
+                    // than be moved by the inner `async move`.
+                    let realm_name = metadata.realm_name.clone();
+                    async move { self.create_user(&realm_admin, &realm_name, req).await }
+                },
+            )
+            .await
+            .map_err(user_translate_kc)?;
+
+        // ---- Step 5: discover the new user's UUID. ----
+        let user_uuid = self
+            .kc_factory
+            .with_reactive_401(
+                &metadata.realm_name,
+                &metadata.admin_client_id,
+                &secret_source,
+                |realm_admin| {
+                    let realm_name = metadata.realm_name.clone();
+                    let username = req.payload.username.clone();
+                    async move {
+                        self.lookup_user_uuid(&realm_admin, &realm_name, &username)
+                            .await
+                    }
+                },
+            )
+            .await
+            .map_err(user_translate_kc)?;
+
+        // ---- Step 6: add user to tenant group. ----
+        // If the group-add fails after the user was just created, the
+        // user is orphaned in KC with no tenant binding. Best-effort
+        // delete the user before propagating the error so AM doesn't
+        // leave a permanent dangling identity behind. Delete failure
+        // is logged but doesn't override the original group-add error
+        // — operators see the primary failure first.
+        let add_result = self
+            .kc_factory
+            .with_reactive_401(
+                &metadata.realm_name,
+                &metadata.admin_client_id,
+                &secret_source,
+                |realm_admin| {
+                    let realm_name = metadata.realm_name.clone();
+                    let tenant_group_id = metadata.tenant_group_id;
+                    async move {
+                        self.add_user_to_group(
+                            &realm_admin,
+                            &realm_name,
+                            user_uuid,
+                            tenant_group_id,
+                        )
+                        .await
+                    }
+                },
+            )
+            .await
+            .map_err(user_translate_kc);
+        if let Err(group_err) = add_result {
+            // Compensation: delete the orphan user. Same reactive-401
+            // wrap so a rotated secret doesn't break the compensation
+            // path (which would leave a permanent dangling identity).
+            let compensation = self
+                .kc_factory
+                .with_reactive_401(
+                    &metadata.realm_name,
+                    &metadata.admin_client_id,
+                    &secret_source,
+                    |realm_admin| {
+                        let realm_name = metadata.realm_name.clone();
+                        async move { self.delete_user(&realm_admin, &realm_name, user_uuid).await }
+                    },
+                )
+                .await
+                .map_err(user_translate_kc);
+            if let Err(compensation_err) = compensation {
+                tracing::warn!(
+                    target: "vp_idp_plugin.user_facade",
+                    user_uuid = %user_uuid,
+                    realm = %metadata.realm_name,
+                    primary_error = %group_err,
+                    compensation_error = %compensation_err,
+                    "orphan-user compensation FAILED: KC user remains without tenant binding",
+                );
+                // Emit the actionable counter so dashboards alert on
+                // dangling KC users — `tracing::warn!` alone isn't a
+                // metric and operators have no way to graph it.
+                self.user_metrics
+                    .orphan_user_compensation(OrphanCompensationOutcome::Failed);
+            } else {
+                tracing::info!(
+                    target: "vp_idp_plugin.user_facade",
+                    user_uuid = %user_uuid,
+                    realm = %metadata.realm_name,
+                    primary_error = %group_err,
+                    "orphan-user compensation OK: deleted KC user after add_user_to_group failure",
+                );
+                self.user_metrics
+                    .orphan_user_compensation(OrphanCompensationOutcome::Ok);
+            }
+            return Err(group_err);
+        }
+
+        // ---- Step 7: build the projection. ----
+        let mut user = IdpUser::new(user_uuid, &req.payload.username);
+        if let Some(email) = req.payload.email.as_ref() {
+            user = user.with_email(email);
+        }
+        if let Some(display_name) = req.payload.display_name.as_ref() {
+            user = user.with_display_name(display_name);
+        }
+        Ok((user, metadata.realm_name, metadata.realm_binding))
+    }
+
+    /// Shared failure-recording helper for user-op sites. Increments both
+    /// the generic `vp_idp_plugin_failure_total` counter and (when the
+    /// underlying error is a metadata-decode failure) the dedicated
+    /// `vp_idp_plugin_metadata_decode_failure_total` trigger metric.
+    fn record_user_op_failure(&self, op: PluginOp, e: &PluginError) {
+        if let PluginError::MetadataDecode(de) = e {
+            self.metadata_metrics
+                .metadata_decode_failure(VersionObserved::from(de));
+        }
+        self.failure_metrics.failure(op, FailureVariant::from(e));
+    }
+
+    /// Decode the persisted [`TenantIdpMetadataV1`] from an optional metadata
+    /// blob. A missing or malformed blob is a user-op rejection (the tenant
+    /// must exist and be bound before users can be provisioned into it).
+    ///
+    /// All three user-op entry points (`provision_user_impl`,
+    /// `deprovision_user_impl`, `list_users_impl`) share this single decode
+    /// step so error messages and error variant stay consistent.
+    ///
+    /// **Variant preservation**: a malformed blob surfaces as
+    /// [`PluginError::MetadataDecode`] (not `UserOpRejected`), so
+    /// [`record_user_op_failure`]'s dedicated
+    /// `metadata_decode_failure` counter fires with the right
+    /// `version_observed` label on the user-side path symmetric with
+    /// the tenant-side. The SDK boundary in `idp_impl.rs` translates
+    /// `MetadataDecode` to `IdpUserOperationFailure::Rejected`, so
+    /// AM sees the same `Rejected` shape as before — but operators
+    /// now keep the per-decode-variant telemetry.
+    ///
+    /// [`record_user_op_failure`]: Self::record_user_op_failure
+    fn decode_tenant_metadata(
+        &self,
+        blob: Option<&serde_json::Value>,
+    ) -> Result<TenantIdpMetadataV1, PluginError> {
+        match self.codec.decode(blob.cloned()) {
+            Ok(Some(m)) => Ok(m),
+            Ok(None) => Err(PluginError::UserOpRejected {
+                detail: "metadata decode failed: tenant has no persisted IdP metadata".into(),
+            }),
+            // Keep the typed `DecodeError` so the dedicated decode-
+            // failure counter can be incremented at the failure-
+            // recording seam. The Phase 15 SDK boundary translates
+            // `MetadataDecode` → `IdpUserOperationFailure::Rejected`
+            // so AM sees no behaviour change.
+            Err(e) => Err(PluginError::MetadataDecode(e)),
+        }
+    }
+
+    /// ADDENDUM §3.4 selection: Shared blobs are persisted with
+    /// `admin_secret_ref = None` and resolve via the env-backed inline
+    /// secret (the `${VAR}` placeholder is expanded at module init via
+    /// toolkit's `ExpandVars`); Adopted / Created always carry a templated
+    /// `OpenBao` [`SecretRef`] on the metadata blob.
+    fn build_secret_source(
+        &self,
+        metadata: &TenantIdpMetadataV1,
+    ) -> Result<SecretSource, PluginError> {
+        if let Some(ref_str) = metadata.admin_secret_ref.as_ref() {
+            let secret_ref = SecretRef::new(ref_str).map_err(|e| PluginError::UserOpRejected {
+                detail: format!("admin_secret_ref invalid: {e}"),
+            })?;
+            Ok(SecretSource::OpenBaoRef(secret_ref))
+        } else {
+            Ok(SecretSource::Inline(
+                self.realm_admin_cfg
+                    .default_shared_realm_secret
+                    .clone_into_secret_string(),
+            ))
+        }
+    }
+
+    /// `POST /admin/realms/{realm}/users` with the canonical create-user
+    /// payload (DESIGN §5.4). Returns success on any 2xx. Every 409 is
+    /// [`PluginError::UserOpDuplicate`] — the status itself is the
+    /// uniqueness signal; KC's `errorMessage` only refines the colliding
+    /// field (VHP-2158). A 400/422 carrying a KC password-policy reject
+    /// becomes [`PluginError::UserOpPasswordPolicy`], any other 400/422
+    /// is a terminal [`PluginError::UserOpRejected`]; 5xx / transport /
+    /// timeout re-tag as [`PluginError::UserOpUnavailable`] via
+    /// [`user_translate_kc`].
+    async fn create_user(
+        &self,
+        realm_admin: &KcAdminClient,
+        realm_name: &str,
+        req: &IdpProvisionUserRequest,
+    ) -> Result<(), PluginError> {
+        let url = format!(
+            "{}admin/realms/{}/users",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+        );
+        let mut body = serde_json::Map::new();
+        body.insert(
+            "username".into(),
+            serde_json::Value::String(req.payload.username.clone()),
+        );
+        body.insert("enabled".into(), serde_json::Value::Bool(true));
+        // Tenant-scoped users always get `user_type=user`. The realm protocol
+        // mapper consumes this attribute into the `user_type` JWT claim that
+        // the AuthN plugin propagates into the SecurityContext. Platform /
+        // system identities have separate provisioning paths and set their
+        // own `user_type` outside this facade.
+        body.insert(
+            "attributes".into(),
+            serde_json::json!({
+                "tenant_id": [req.tenant_context.tenant_id.to_string()],
+                "user_type": ["user"],
+            }),
+        );
+        // Required actions: start from the plugin-level default and append
+        // UPDATE_PASSWORD when the caller supplied a temporary password. This
+        // preserves operator-configured baseline (e.g. VERIFY_EMAIL in prod)
+        // while still honouring the per-request temporary-credential signal.
+        let mut required_actions: Vec<String> = self.cfg.default_user_required_actions.clone();
+        if let Some(pw) = req.payload.password.as_ref()
+            && pw.temporary
+            && !required_actions.iter().any(|a| a == "UPDATE_PASSWORD")
+        {
+            required_actions.push("UPDATE_PASSWORD".to_string());
+        }
+        // `emailVerified` is derived from `required_actions` so the two stay
+        // coupled: KC silently skips the `VERIFY_EMAIL` action when the user
+        // is already marked verified. When the operator opts users into
+        // VERIFY_EMAIL we send `emailVerified=false` so the verify-email
+        // flow actually gates token issuance; otherwise AM is treated as
+        // authoritative for the address and the user is immediately usable
+        // for the password grant. Single source of truth prevents the
+        // classic misconfiguration where `[VERIFY_EMAIL]` is set but the
+        // pre-verified flag silently nullifies it.
+        let email_verified = !required_actions.iter().any(|a| a == "VERIFY_EMAIL");
+        body.insert(
+            "emailVerified".into(),
+            serde_json::Value::Bool(email_verified),
+        );
+        body.insert(
+            "requiredActions".into(),
+            serde_json::json!(required_actions),
+        );
+        if let Some(email) = req.payload.email.as_ref() {
+            body.insert("email".into(), serde_json::Value::String(email.clone()));
+        }
+        if let Some(first_name) = req.payload.first_name.as_ref() {
+            body.insert(
+                "firstName".into(),
+                serde_json::Value::String(first_name.clone()),
+            );
+        }
+        if let Some(last_name) = req.payload.last_name.as_ref() {
+            body.insert(
+                "lastName".into(),
+                serde_json::Value::String(last_name.clone()),
+            );
+        }
+        if let Some(pw) = req.payload.password.as_ref() {
+            // Embed the initial credential in the same POST so the user is
+            // immediately usable for password grant. Keycloak accepts a
+            // credentials array on user-create; `temporary: false` makes the
+            // password permanent, `true` flips the required-actions branch
+            // above. The plaintext value lives only on this request's stack
+            // and the outbound HTTPS body — AM never persists it.
+            body.insert(
+                "credentials".into(),
+                serde_json::json!([
+                    {
+                        "type": "password",
+                        "value": pw.value,
+                        "temporary": pw.temporary,
+                    }
+                ]),
+            );
+        }
+        let body = serde_json::Value::Object(body);
+        let (status, body_text) = realm_admin
+            .raw_request("POST", &url, Some(&body), "/admin/realms/{realm}/users")
+            .await
+            .map_err(user_translate_kc)?;
+        if (200..=299).contains(&status) {
+            return Ok(());
+        }
+        if status == 401 {
+            // Surface to the enclosing reactive-401 wrapper for rotation
+            // recovery. Auth-layer rejection → no user created → safe
+            // for the wrapper's exactly-once retry contract.
+            return Err(PluginError::KcRest {
+                method: "POST",
+                path_template: "/admin/realms/{realm}/users".into(),
+                status: KcStatusKind::Http(401),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body_text)),
+            });
+        }
+        let redacted = redact_secrets(&truncate_2kb(&body_text));
+        if status == 409 {
+            // VHP-2158: on this endpoint a 409 has no cause other than a
+            // uniqueness collision, so the STATUS is the classification —
+            // every 409 rides the typed duplicate lane and stays HTTP 409
+            // at the AM boundary regardless of KC wording drift; the body
+            // only refines which field collided (unattributable bodies →
+            // `UsernameOrEmail`).
+            return Err(PluginError::UserOpDuplicate {
+                field: classify_kc_conflict(&body_text),
+                detail: format!(
+                    "user already exists: kc:POST /admin/realms/{{realm}}/users -> 409: {redacted}"
+                ),
+            });
+        }
+        // VHP-2158: KC's payload-rejection statuses. A recognised
+        // password-policy reject surfaces the structured `password` /
+        // `PASSWORD_POLICY` violation; every other 400/422 (invalid email
+        // format, user-profile attribute validation, malformed payload) is
+        // a terminal rejection — previously these fell through to the
+        // catch-all below and mis-surfaced as a retryable 503.
+        if status == 400 || status == 422 {
+            if is_kc_password_policy_reject(&body_text) {
+                return Err(PluginError::UserOpPasswordPolicy {
+                    detail: format!(
+                        "password policy rejected: kc:POST /admin/realms/{{realm}}/users -> \
+                         {status}: {redacted}"
+                    ),
+                });
+            }
+            return Err(PluginError::UserOpRejected {
+                detail: format!("kc:POST /admin/realms/{{realm}}/users -> {status}: {redacted}"),
+            });
+        }
+        // Everything else (5xx, transport oddities, 403/404 realm-level
+        // problems) keeps the unavailable lane: not a payload rejection,
+        // and a retry after operator intervention can succeed.
+        Err(PluginError::UserOpUnavailable {
+            detail: format!("kc:POST /admin/realms/{{realm}}/users -> {status}: {redacted}"),
+        })
+    }
+
+    /// `GET /admin/realms/{realm}/users?username={u}&exact=true` — defensive
+    /// UUID discovery to avoid the `Location`-header parse Keycloak returns
+    /// on `POST /users` (Phase 10's `lookup_client_uuid` uses the same
+    /// pattern). Empty result → [`PluginError::UserOpUnavailable`] (the
+    /// user was created moments ago; this is a KC-side consistency
+    /// anomaly, not a payload rejection).
+    async fn lookup_user_uuid(
+        &self,
+        realm_admin: &KcAdminClient,
+        realm_name: &str,
+        username: &str,
+    ) -> Result<Uuid, PluginError> {
+        let url = format!(
+            "{}admin/realms/{}/users?username={}&exact=true",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+            urlencoding::encode(username),
+        );
+        let (status, body_text) = realm_admin
+            .raw_request("GET", &url, None, "/admin/realms/{realm}/users")
+            .await
+            .map_err(user_translate_kc)?;
+        if status == 401 {
+            // Surface 401 verbatim so the enclosing reactive-401 wrapper
+            // re-acquires + retries against a fresh bearer.
+            return Err(PluginError::KcRest {
+                method: "GET",
+                path_template: "/admin/realms/{realm}/users".into(),
+                status: KcStatusKind::Http(401),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body_text)),
+            });
+        }
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::UserOpUnavailable {
+                detail: format!(
+                    "kc:GET /admin/realms/{{realm}}/users -> {status}: {}",
+                    redact_secrets(&truncate_2kb(&body_text)),
+                ),
+            });
+        }
+        let users: Vec<UserRep> =
+            serde_json::from_str(&body_text).map_err(|e| PluginError::UserOpUnavailable {
+                detail: format!("kc:GET /admin/realms/{{realm}}/users json decode: {e}"),
+            })?;
+        users
+            .into_iter()
+            .next()
+            .map(|u| u.id)
+            .ok_or_else(|| PluginError::UserOpUnavailable {
+                detail: format!(
+                    "kc:GET /admin/realms/{{realm}}/users -> 200: username '{username}' not found after create",
+                ),
+            })
+    }
+
+    /// `PUT /admin/realms/{realm}/users/{user_uuid}/groups/{tenant_group_id}`
+    /// — idempotent membership add. 2xx → success. 404 → tenant group
+    /// disappeared (operator/concurrent delete) — surface as
+    /// [`PluginError::UserOpRejected`] so AM treats the call as a payload
+    /// rejection rather than a transient outage. 5xx / transport →
+    /// [`PluginError::UserOpUnavailable`] via [`user_translate_kc`].
+    async fn add_user_to_group(
+        &self,
+        realm_admin: &KcAdminClient,
+        realm_name: &str,
+        user_uuid: Uuid,
+        tenant_group_id: Uuid,
+    ) -> Result<(), PluginError> {
+        let url = format!(
+            "{}admin/realms/{}/users/{}/groups/{}",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+            user_uuid,
+            tenant_group_id,
+        );
+        let (status, body_text) = realm_admin
+            .raw_request(
+                "PUT",
+                &url,
+                None,
+                "/admin/realms/{realm}/users/{user_uuid}/groups/{tenant_group_id}",
+            )
+            .await
+            .map_err(user_translate_kc)?;
+        if (200..=299).contains(&status) {
+            return Ok(());
+        }
+        if status == 401 {
+            return Err(PluginError::KcRest {
+                method: "PUT",
+                path_template: "/admin/realms/{realm}/users/{user_uuid}/groups/{tenant_group_id}"
+                    .into(),
+                status: KcStatusKind::Http(401),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body_text)),
+            });
+        }
+        if status == 404 {
+            return Err(PluginError::UserOpRejected {
+                detail: format!(
+                    "tenant group disappeared: kc:PUT /admin/realms/{{realm}}/users/{{user_uuid}}/groups/{{tenant_group_id}} -> 404: {}",
+                    redact_secrets(&truncate_2kb(&body_text)),
+                ),
+            });
+        }
+        Err(PluginError::UserOpUnavailable {
+            detail: format!(
+                "kc:PUT /admin/realms/{{realm}}/users/{{user_uuid}}/groups/{{tenant_group_id}} -> {status}: {}",
+                redact_secrets(&truncate_2kb(&body_text)),
+            ),
+        })
+    }
+
+    /// Deprovision a user from the tenant's bound realm (DESIGN §4.3 /
+    /// §5.4 / §5.5).
+    ///
+    /// 1. Decode tenant metadata.
+    /// 2. Resolve realm-admin secret source (env vs `OpenBaoRef`).
+    /// 3. *(Optional)* `POST /admin/realms/{realm}/users/{id}/logout` to
+    ///    revoke active sessions when
+    ///    [`UserFacadeConfig::session_revoke_on_deprovision`] is `true`.
+    ///    Logout is best-effort: 2xx and 404 both proceed; transport /
+    ///    5xx are logged + ignored — the delete is the primary effect
+    ///    per the DESIGN trait-doc contract.
+    /// 4. `DELETE /admin/realms/{realm}/users/{user_id}`:
+    ///    - 2xx → `Ok(())`.
+    ///    - 404 / 410 → `Ok(())` (idempotency contract — DESIGN §5.4).
+    ///    - 5xx / transport / timeout → [`PluginError::UserOpUnavailable`].
+    ///
+    /// # Errors
+    ///
+    /// * [`PluginError::UserOpRejected`] — malformed metadata.
+    /// * [`PluginError::UserOpUnavailable`] — KC 5xx / transport /
+    ///   timeout on the delete step (re-tagged from
+    ///   [`PluginError::KcRest`] by [`user_translate_kc`]).
+    pub async fn deprovision_user_inner(
+        &self,
+        ctx: &SecurityContext,
+        req: &IdpDeprovisionUserRequest,
+    ) -> Result<(), PluginError> {
+        let started = Instant::now();
+        let result = self.deprovision_user_impl(req).await;
+        let elapsed = started.elapsed().as_secs_f64();
+        self.user_metrics
+            .user_op_duration(UserOp::DeprovisionUser, elapsed);
+        match &result {
+            Ok((realm_name, realm_binding)) => {
+                audit::emit_user_deprovisioned(
+                    ctx,
+                    req.tenant_context.tenant_id,
+                    realm_name,
+                    *realm_binding,
+                    req.user_id,
+                    // The DELETE step folds 404/410 into success per the
+                    // idempotency contract — we don't currently distinguish
+                    // the two at this layer, so `already_absent = false`
+                    // for every Ok path. (DESIGN §6.2 marks this as a
+                    // future-precision target.)
+                    /* already_absent = */
+                    false,
+                );
+            }
+            Err(e) => {
+                self.record_user_op_failure(PluginOp::DeprovisionUser, e);
+            }
+        }
+        result.map(|_| ())
+    }
+
+    /// Inner implementation returning the bound realm name / binding so
+    /// the outer wrapper can emit a fully-labelled `user.deprovisioned`
+    /// audit event without re-decoding the metadata.
+    async fn deprovision_user_impl(
+        &self,
+        req: &IdpDeprovisionUserRequest,
+    ) -> Result<(String, RealmBinding), PluginError> {
+        // ---- Step 1: decode metadata. ----
+        let metadata = self.decode_tenant_metadata(req.tenant_context.metadata.as_ref())?;
+
+        // ---- Step 2: resolve realm-admin secret source. ----
+        let secret_source = self.build_secret_source(&metadata)?;
+
+        // ---- Step 2.5: binding check before any destructive call. ----
+        //
+        // Refuse to drive the delete unless the user's stored
+        // `tenant_id` attribute (set by `create_user` per `ADR-0006`) matches
+        // the request's `tenant_context.tenant_id`. Without this check the
+        // handler is willing to delete any KC user by `user_id` from any
+        // tenant path — the AuthZ-emitted SQL constraint
+        // (`OWNER_TENANT_ID IN [caller_tid]`) clamps AM-DB writes, but
+        // users live in KC, so the SQL clamp never sees this path. The
+        // binding check is therefore the only defence against
+        // cross-tenant user deletion.
+        //
+        // A mismatch (or a missing attribute) is collapsed onto the
+        // idempotent-absent success contract documented in
+        // `cpt-cf-account-management-fr-idp-user-deprovision`: the call
+        // returns the same shape a "user already gone" path would, so the
+        // caller cannot distinguish "wrong tenant" from "already
+        // deprovisioned". A tracing WARN under
+        // `vp_idp_plugin.user_binding` records the rejection for
+        // operator visibility without leaking the discriminator over the
+        // wire.
+        let expected_tid = req.tenant_context.tenant_id;
+        let actual_tid = self
+            .kc_factory
+            .with_reactive_401(
+                &metadata.realm_name,
+                &metadata.admin_client_id,
+                &secret_source,
+                |realm_admin| {
+                    let realm_name = metadata.realm_name.clone();
+                    async move {
+                        self.read_user_owner_tenant(&realm_admin, &realm_name, req.user_id)
+                            .await
+                    }
+                },
+            )
+            .await
+            .map_err(user_translate_kc)?;
+        if actual_tid != Some(expected_tid) {
+            tracing::warn!(
+                target: "vp_idp_plugin.user_binding",
+                user_id = %req.user_id,
+                expected_tenant_id = %expected_tid,
+                actual_tenant_id = ?actual_tid,
+                realm_name = %metadata.realm_name,
+                "user deprovision skipped: stored tenant_id attribute does not match request — cross-tenant DELETE prevented"
+            );
+            // Idempotent-absent return: skip revoke_sessions + delete_user
+            // entirely. AM observes `Ok(())` and surfaces HTTP 204 No
+            // Content to the caller, identical to the genuine
+            // already-absent path.
+            return Ok((metadata.realm_name, metadata.realm_binding));
+        }
+
+        // ---- Steps 3-5: realm-admin work wrapped in reactive-401.
+        // Both `revoke_sessions` (idempotent best-effort) and
+        // `delete_user` (idempotent: KC vendor 404/410 → ok) tolerate
+        // exactly-once retry, so a single closure wrap is safe even
+        // if the 401 fires on `delete_user` after `revoke_sessions`
+        // already succeeded.
+        //
+        // `realm_name` is cloned INSIDE the outer closure (not in the
+        // inner `async move`) so the `Fn` bound on `with_reactive_401`
+        // is satisfied — the wrapper may invoke the closure twice on a
+        // 401 retry, and each invocation needs its own owned copy.
+        self.kc_factory
+            .with_reactive_401(
+                &metadata.realm_name,
+                &metadata.admin_client_id,
+                &secret_source,
+                |realm_admin| {
+                    let realm_name = metadata.realm_name.clone();
+                    async move {
+                        if self.cfg.session_revoke_on_deprovision {
+                            self.revoke_sessions(&realm_admin, &realm_name, req.user_id)
+                                .await;
+                        }
+                        self.delete_user(&realm_admin, &realm_name, req.user_id)
+                            .await
+                    }
+                },
+            )
+            .await
+            .map_err(user_translate_kc)?;
+        Ok((metadata.realm_name, metadata.realm_binding))
+    }
+
+    /// List users from the tenant's bound realm (DESIGN §4.3 / §5.4).
+    ///
+    /// 1. Decode tenant metadata.
+    /// 2. Resolve realm-admin secret source.
+    /// 3. Decode the opaque cursor (if any) and validate that its
+    ///    `realm_name` + `filter_hash` still match this request —
+    ///    mismatch → [`PluginError::UserOpRejected`] ("invalid cursor").
+    /// 4. Resolve effective page limit:
+    ///    `limit = min(req.pagination.top(), max)`. (`top()` is already
+    ///    `>= 1` and `<= MAX_TOP` per SDK constructor invariants; the
+    ///    facade's own `list_users_page_limit_max` is the stricter
+    ///    cap.)
+    /// 5. `GET /admin/realms/{realm}/groups/{tenant_group_id}/members?first=0&max={limit+1}`.
+    /// 6. Sort response `(createdTimestamp ASC, id ASC)` client-side.
+    /// 7. Skip entries already returned on prior pages (cursor tiebreaker).
+    /// 8. Apply optional `user_id_filter` post-skip.
+    /// 9. Emit first `limit` items; encode `(last_created_at, last_user_id)`
+    ///    of the last-emitted user as `next_cursor` when `limit+1` results
+    ///    were present after the skip step.
+    ///
+    /// # Errors
+    ///
+    /// * [`PluginError::UserOpRejected`] — malformed metadata or
+    ///   mismatched cursor.
+    /// * [`PluginError::UserOpUnavailable`] — KC 4xx (non-404 group
+    ///   gone) / 5xx / transport / timeout on the members fetch.
+    pub async fn list_users_inner(
+        &self,
+        _ctx: &SecurityContext, // list_users emits no audit event (read-only) — DESIGN §6.2
+        req: &IdpListUsersRequest,
+    ) -> Result<Page<IdpUser>, PluginError> {
+        let started = Instant::now();
+        let result = self.list_users_impl(req).await;
+        let elapsed = started.elapsed().as_secs_f64();
+        self.user_metrics
+            .user_op_duration(UserOp::ListUsers, elapsed);
+        if let Err(e) = &result {
+            self.record_user_op_failure(PluginOp::ListUsers, e);
+        }
+        result
+    }
+
+    // TODO(VHP-76 follow-up): the `order` clause is still dropped in
+    // favour of the hard-coded `(createdTimestamp ASC, id ASC)` cursor
+    // sort, and the v1 client-side filter strategy fetches a single
+    // page from KC's `/groups/{tenant_group_id}/members` endpoint
+    // (which has no search params) and post-filters. That is correct
+    // for small/medium tenants but doesn't scale to "find one user in
+    // a tenant with 100k members". Larger follow-up: (a) switch to
+    // KC's realm-wide `/users?username=…&q=tenant_id:<uuid>&exact=true`
+    // when string filters are present so KC narrows server-side; (b)
+    // forward `req.order` to the chosen sort key (timestamp /
+    // username / email); (c) widen the test matrix across
+    // field×op×order×pagination shapes. The wire-contract bug
+    // (string-field filters returning the full user set) is closed by
+    // [`Self::build_string_matcher`] + the post-id-filter retain
+    // below — `InList`/`not`/`ne`/`startswith`/`endswith`/non-string
+    // shapes (and `id eq` inside `or`) surface `UnsupportedOperation`
+    // (HTTP 501) instead of silently dropping the filter clause.
+    async fn list_users_impl(
+        &self,
+        req: &IdpListUsersRequest,
+    ) -> Result<Page<IdpUser>, PluginError> {
+        // ---- Step 1: decode metadata. ----
+        let metadata = self.decode_tenant_metadata(req.tenant_context.metadata.as_ref())?;
+
+        // ---- Step 2: resolve realm-admin secret source. ----
+        let secret_source = self.build_secret_source(&metadata)?;
+
+        // ---- Step 3: decode + validate the inbound cursor (if any). ----
+        let tenant_id = req.tenant_context.tenant_id;
+        let id_filter = Self::extract_id_filter(req.filter.as_ref());
+        // Lower the string half of the filter into a predicate (`eq` /
+        // `contains` / `and` / `or`). Unsupported operators (`ne`, `in`,
+        // `not`, `startswith`, …, or `id eq` inside `or`) surface as
+        // `UnsupportedOperation` → 501 BEFORE any KC call, distinct from
+        // a 200-with-unfiltered-set false-success.
+        let string_matcher = Self::build_string_matcher(req.filter.as_ref())?;
+        let filter_hash =
+            Self::filter_hash(tenant_id, &metadata.realm_name, id_filter, &string_matcher);
+        // Decode the optional inbound cursor + verify its filter_hash
+        // matches the current request's filter shape. The hash folds in
+        // `realm_name`, so a realm-rebinding mid-pagination surfaces
+        // here as `invalid cursor` (replaces the pre-CursorV1 explicit
+        // `decoded.realm_name != metadata.realm_name` reject).
+        let (last_created_at_param, last_user_id_param) = match req.pagination.cursor() {
+            Some(c) => {
+                // `decode_cursor_with_legacy_fallback` validates the
+                // cursor against the current request's filter context
+                // internally — both for the modern CursorV1 shape AND
+                // the legacy pre-CursorV1 shape accepted during the
+                // rolling-deploy grace window. Caller no longer
+                // compares hashes here.
+                let (created_at, user_id) = Self::decode_cursor_with_legacy_fallback(
+                    c,
+                    &metadata.realm_name,
+                    tenant_id,
+                    id_filter,
+                    &filter_hash,
+                )?;
+                (Some(created_at), Some(user_id))
+            }
+            None => (None, None),
+        };
+
+        // ---- Step 4: resolve effective page limit. ----
+        // `top()` is already bounded by `IdpUserPagination::MAX_TOP` (200)
+        // per the SDK constructor; the facade's `list_users_page_limit_max`
+        // can further tighten the cap (operator policy).
+        let limit = req.pagination.top().min(self.cfg.list_users_page_limit_max);
+
+        // ---- Step 5: drain the FULL group membership, then sort / skip /
+        //              filter client-side (reactive-401 wrapped). ----
+        //
+        // `/admin/realms/{realm}/groups/{tenant_group_id}/members` has no
+        // server-side sort or `q=`-filter knobs, so the facade pages the
+        // ENTIRE membership into memory and applies the DESIGN §4.3 sort
+        // key `(createdTimestamp ASC, id ASC)` + cursor-skip + filters
+        // itself. The loop drains every KC page (`first += page_size`)
+        // until a short page signals the end.
+        //
+        // The pre-fix code fetched a single `first = 0` window of
+        // `list_users_page_limit_max + 1` rows, which silently hid every
+        // member KC ordered past that window (KC orders group members by
+        // username). Any tenant with more than one page of members lost
+        // users from BOTH the listing and `$filter` — create-then-list
+        // returned 201 yet the user never appeared (VHP-1973).
+        //
+        // `MEMBERS_DRAIN_HARD_CAP` bounds the total pulled so a
+        // pathological membership cannot pin unbounded memory; reaching it
+        // is logged loudly, never silently truncated. The realm-wide
+        // `/users?q=tenant_id:UUID` path is the scale answer past that cap.
+        //
+        // `fetch_group_members` is a pure read, so the exactly-once 401
+        // retry `with_reactive_401` performs re-runs the whole drain
+        // safely (realm-admin secret rotation recovery without surfacing a
+        // transient 401 to AM).
+        let page_size = self.cfg.list_users_page_limit_max.max(1);
+        let mut members = self
+            .kc_factory
+            .with_reactive_401(
+                &metadata.realm_name,
+                &metadata.admin_client_id,
+                &secret_source,
+                |realm_admin| {
+                    let realm_name = metadata.realm_name.clone();
+                    let tenant_group_id = metadata.tenant_group_id;
+                    async move {
+                        let mut all: Vec<UserRep> = Vec::new();
+                        let mut offset: u32 = 0;
+                        loop {
+                            let batch = self
+                                .fetch_group_members(
+                                    &realm_admin,
+                                    &realm_name,
+                                    tenant_group_id,
+                                    offset,
+                                    page_size,
+                                )
+                                .await?;
+                            let got = batch.len();
+                            all.extend(batch);
+                            // Short page ⇒ the group is fully drained.
+                            if got < page_size as usize {
+                                break;
+                            }
+                            // Loud safety valve — see cap rationale above.
+                            if all.len() >= MEMBERS_DRAIN_HARD_CAP {
+                                tracing::warn!(
+                                    target: "vp_idp_plugin.user_facade",
+                                    tenant_id = %tenant_id,
+                                    realm = %realm_name,
+                                    drained = all.len(),
+                                    cap = MEMBERS_DRAIN_HARD_CAP,
+                                    "list_users: tenant group membership exceeds drain \
+                                     hard-cap; returning a truncated member set"
+                                );
+                                break;
+                            }
+                            offset = offset.saturating_add(page_size);
+                        }
+                        Ok(all)
+                    }
+                },
+            )
+            .await
+            .map_err(user_translate_kc)?;
+
+        // Defensive sort: KC does not guarantee stable order across pages.
+        members.sort_by(|a, b| {
+            a.created_timestamp
+                .cmp(&b.created_timestamp)
+                .then_with(|| a.id.cmp(&b.id))
+        });
+        // Offset paging over that unstable order can re-observe a row that
+        // shifted across a page boundary during the drain. Equal-id rows
+        // are adjacent after the sort above (same user ⇒ same timestamp),
+        // so drop adjacent duplicates by id to keep a user from being
+        // double-counted in the page or the cursor math.
+        members.dedup_by(|a, b| a.id == b.id);
+
+        // Skip entries already returned on prior pages (cursor tiebreaker).
+        if let (Some(t_cur), Some(id_cur)) = (last_created_at_param, last_user_id_param) {
+            members.retain(|u| (u.created_timestamp, u.id) > (t_cur, id_cur));
+        }
+
+        // Apply optional id-eq filter post-skip.
+        members.retain(|u| id_filter.is_none_or(|wanted| u.id == wanted));
+        // Apply the string-field predicate (`eq` / `contains` / `and` /
+        // `or`) lowered from `$filter`. `StringMatcher::Always` (the
+        // no-`$filter` case) matches every row, so this is a no-op then.
+        members.retain(|u| string_matcher.matches(u));
+
+        // `has_more` is computed AFTER cursor-skip + filter-retain so
+        // it reflects how many rows the CALLER still has past this
+        // page. Pre-fix this was computed pre-filter against
+        // `limit + 1`, which masked the offset-zero fetch limitation
+        // by stamping `has_more = true` even when client-side skip
+        // left no real follow-on row. Now `has_more` is the
+        // authoritative "should I emit a cursor" signal.
+        let has_more = members.len() > limit as usize;
+        members.truncate(limit as usize);
+
+        // Encode (last_created_at, last_user_id) of the last emitted
+        // user as the next page's cursor. CursorV1 envelope; the
+        // realm_name pinning lives inside `filter_hash` now.
+        let next_cursor = if has_more {
+            members.last().map(|last| {
+                Self::encode_cursor(&ListUsersCursor {
+                    filter_hash: filter_hash.clone(),
+                    last_created_at: last.created_timestamp,
+                    last_user_id: last.id,
+                })
+            })
+        } else {
+            None
+        };
+
+        let items: Vec<IdpUser> = members
+            .into_iter()
+            .map(Self::user_rep_to_idp_user)
+            .collect();
+
+        Ok(Page::new(
+            items,
+            PageInfo {
+                next_cursor,
+                prev_cursor: None,
+                limit: u64::from(limit),
+            },
+        ))
+    }
+
+    /// Best-effort `POST /admin/realms/{realm}/users/{id}/logout` —
+    /// logout-all to invalidate active sessions before the delete. Per
+    /// DESIGN §4.3, sessions cleanup is non-fatal: 2xx and 404 both
+    /// continue silently; transport / 5xx are logged + ignored so the
+    /// delete (the primary effect) still gets a chance to run.
+    async fn revoke_sessions(&self, realm_admin: &KcAdminClient, realm_name: &str, user_id: Uuid) {
+        let url = format!(
+            "{}admin/realms/{}/users/{}/logout",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+            user_id,
+        );
+        match realm_admin
+            .raw_request(
+                "POST",
+                &url,
+                None,
+                "/admin/realms/{realm}/users/{user_id}/logout",
+            )
+            .await
+        {
+            Ok((status, _)) => {
+                if !(200..=299).contains(&status) && status != 404 {
+                    tracing::warn!(
+                        target: "vp.idp.plugin",
+                        %status,
+                        %user_id,
+                        realm = %realm_name,
+                        "session-revoke best-effort: KC logout returned non-2xx/404; continuing to DELETE",
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "vp.idp.plugin",
+                    error = %e,
+                    %user_id,
+                    realm = %realm_name,
+                    "session-revoke best-effort: KC logout transport error; continuing to DELETE",
+                );
+            }
+        }
+    }
+
+    /// `DELETE /admin/realms/{realm}/users/{user_id}` — the primary
+    /// effect of `deprovision_user`. 404 / 410 are folded into success
+    /// per the idempotency contract (DESIGN §5.4). 5xx / transport →
+    /// [`PluginError::UserOpUnavailable`].
+    async fn delete_user(
+        &self,
+        realm_admin: &KcAdminClient,
+        realm_name: &str,
+        user_id: Uuid,
+    ) -> Result<(), PluginError> {
+        let url = format!(
+            "{}admin/realms/{}/users/{}",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+            user_id,
+        );
+        let (status, body_text) = realm_admin
+            .raw_request(
+                "DELETE",
+                &url,
+                None,
+                "/admin/realms/{realm}/users/{user_id}",
+            )
+            .await
+            .map_err(user_translate_kc)?;
+        if (200..=299).contains(&status) || status == 404 || status == 410 {
+            return Ok(());
+        }
+        if status == 401 {
+            return Err(PluginError::KcRest {
+                method: "DELETE",
+                path_template: "/admin/realms/{realm}/users/{user_id}".into(),
+                status: KcStatusKind::Http(401),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body_text)),
+            });
+        }
+        Err(PluginError::UserOpUnavailable {
+            detail: format!(
+                "kc:DELETE /admin/realms/{{realm}}/users/{{user_id}} -> {status}: {}",
+                redact_secrets(&truncate_2kb(&body_text)),
+            ),
+        })
+    }
+
+    /// Read a KC user's stored `tenant_id` attribute — the binding check
+    /// primitive for [`Self::deprovision_user_impl`] (`ADR-0006`: `IdP` stores
+    /// the user-tenant binding as a tenant identity attribute on the user
+    /// record). Returns:
+    ///
+    /// * `Ok(None)` — KC returned 404 (user absent from this realm), OR the
+    ///   user exists but has no `tenant_id` attribute / the value is not a
+    ///   parseable `Uuid`. Both collapse to the same "no usable binding"
+    ///   outcome — the caller treats this as `mismatch` for safety so that
+    ///   data anomalies cannot become silent cross-tenant writes.
+    /// * `Ok(Some(uuid))` — user exists with a parseable `tenant_id`.
+    /// * `Err(PluginError::KcRest)` with `Http(401)` — surfaced verbatim so
+    ///   the enclosing `with_reactive_401` wrapper re-mints the bearer
+    ///   and retries the closure once.
+    /// * `Err(PluginError::UserOpUnavailable)` — any other non-2xx / non-404
+    ///   response or JSON decode failure (transient infra signal — AM may
+    ///   retry).
+    async fn read_user_owner_tenant(
+        &self,
+        realm_admin: &KcAdminClient,
+        realm_name: &str,
+        user_id: Uuid,
+    ) -> Result<Option<Uuid>, PluginError> {
+        let url = format!(
+            "{}admin/realms/{}/users/{}",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+            user_id,
+        );
+        let (status, body_text) = realm_admin
+            .raw_request("GET", &url, None, "/admin/realms/{realm}/users/{user_id}")
+            .await
+            .map_err(user_translate_kc)?;
+        if status == 404 || status == 410 {
+            return Ok(None);
+        }
+        if status == 401 {
+            return Err(PluginError::KcRest {
+                method: "GET",
+                path_template: "/admin/realms/{realm}/users/{user_id}".into(),
+                status: KcStatusKind::Http(401),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body_text)),
+            });
+        }
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::UserOpUnavailable {
+                detail: format!(
+                    "kc:GET /admin/realms/{{realm}}/users/{{user_id}} -> {status}: {}",
+                    redact_secrets(&truncate_2kb(&body_text)),
+                ),
+            });
+        }
+        // Parse the user record loosely — we only need `attributes.tenant_id[0]`,
+        // not the full `UserRep`. Tolerating `Value` keeps the helper resilient
+        // to future KC representation additions.
+        let user: serde_json::Value =
+            serde_json::from_str(&body_text).map_err(|e| PluginError::UserOpUnavailable {
+                detail: format!(
+                    "kc:GET /admin/realms/{{realm}}/users/{{user_id}} json decode: {e}"
+                ),
+            })?;
+        let tid_str = user
+            .get("attributes")
+            .and_then(|a| a.get("tenant_id"))
+            .and_then(|t| t.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|v| v.as_str());
+        match tid_str {
+            Some(s) => Ok(Uuid::parse_str(s).ok()),
+            // Attribute absent or malformed — treat as "no binding" so the
+            // caller's mismatch check fires. We do NOT return Err here:
+            // a data anomaly on the user row should not block the
+            // idempotent-absent contract for the deprovision endpoint.
+            None => Ok(None),
+        }
+    }
+
+    /// `GET /admin/realms/{realm}/groups/{tenant_group_id}/members?first={offset}&max={limit}`
+    /// — the listing primitive for `list_users`. 2xx → parsed
+    /// `Vec<UserRep>`. Any non-2xx → [`PluginError::UserOpUnavailable`]:
+    /// a 404 here means the tenant group disappeared (operator /
+    /// concurrent delete), which the user-list surface treats as a
+    /// provider outage (AM has no way to repair the group from this
+    /// path) — same lane as 5xx so AM gets a consistent retry signal.
+    async fn fetch_group_members(
+        &self,
+        realm_admin: &KcAdminClient,
+        realm_name: &str,
+        tenant_group_id: Uuid,
+        offset: u32,
+        limit: u32,
+    ) -> Result<Vec<UserRep>, PluginError> {
+        let url = format!(
+            "{}admin/realms/{}/groups/{}/members?first={}&max={}",
+            self.kc_factory.base_url_str(),
+            urlencoding::encode(realm_name),
+            tenant_group_id,
+            offset,
+            limit,
+        );
+        let (status, body_text) = realm_admin
+            .raw_request(
+                "GET",
+                &url,
+                None,
+                "/admin/realms/{realm}/groups/{tenant_group_id}/members",
+            )
+            .await
+            .map_err(user_translate_kc)?;
+        if status == 401 {
+            return Err(PluginError::KcRest {
+                method: "GET",
+                path_template: "/admin/realms/{realm}/groups/{tenant_group_id}/members".into(),
+                status: KcStatusKind::Http(401),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body_text)),
+            });
+        }
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::UserOpUnavailable {
+                detail: format!(
+                    "kc:GET /admin/realms/{{realm}}/groups/{{tenant_group_id}}/members -> {status}: {}",
+                    redact_secrets(&truncate_2kb(&body_text)),
+                ),
+            });
+        }
+        serde_json::from_str::<Vec<UserRep>>(&body_text)
+            .map_err(|e| PluginError::UserOpUnavailable {
+                detail: format!(
+                    "kc:GET /admin/realms/{{realm}}/groups/{{tenant_group_id}}/members json decode: {e}",
+                ),
+            })
+    }
+
+    /// Project a Keycloak [`UserRep`] into the SDK-facing [`IdpUser`].
+    /// `firstName + lastName` populates `display_name` when at least one
+    /// is present (KC convention; OIDC `name` claim is not surfaced by
+    /// the admin-REST shape).
+    fn user_rep_to_idp_user(rep: UserRep) -> IdpUser {
+        let username = rep.username.unwrap_or_default();
+        let mut user = IdpUser::new(rep.id, username);
+        if let Some(email) = rep.email {
+            user = user.with_email(email);
+        }
+        let display_name = match (rep.first_name, rep.last_name) {
+            (Some(f), Some(l)) if !f.is_empty() && !l.is_empty() => Some(format!("{f} {l}")),
+            (Some(f), _) if !f.is_empty() => Some(f),
+            (_, Some(l)) if !l.is_empty() => Some(l),
+            _ => None,
+        };
+        if let Some(dn) = display_name {
+            user = user.with_display_name(dn);
+        }
+        user
+    }
+
+    /// Extract the canonical `id eq <uuid>` shape from a SDK filter.
+    /// Mirrors `IdpListUsersRequest::with_id`. Returns `None` when the
+    /// id-eq clause is not present at the top level or under a
+    /// supported `and` composition; the rest of the filter (string
+    /// fields) is handled by [`Self::build_string_matcher`].
+    fn extract_id_filter(filter: Option<&FilterNode<IdpUserFilterField>>) -> Option<Uuid> {
+        let node = filter?;
+        // Drill through one level of `and` so a caller may combine
+        // `id eq <uuid> and username eq '<name>'` — the id-eq half is
+        // captured here; the string half is captured by
+        // `build_string_matcher` which walks the same tree.
+        match node {
+            FilterNode::Binary {
+                field: IdpUserFilterField::Id,
+                op: FilterOp::Eq,
+                value: ODataValue::Uuid(uuid),
+            } => Some(*uuid),
+            FilterNode::Composite {
+                op: FilterOp::And,
+                children,
+            } => children
+                .iter()
+                .find_map(|child| Self::extract_id_filter(Some(child))),
+            _ => None,
+        }
+    }
+
+    /// Lower the typed `OData` `$filter` into a [`StringMatcher`]
+    /// predicate evaluated client-side over the KC-fetched member set.
+    ///
+    /// Supported shapes (the `/users` list contract):
+    ///   * `<string_field> eq '<literal>'` — exact, case-sensitive
+    ///   * `<string_field> contains '<literal>'` — substring, case-insensitive
+    ///   * `<a> and <b> …`, `<a> or <b> …` — nested freely
+    ///   * `id eq <uuid>` — captured by [`Self::extract_id_filter`];
+    ///     inside a top-level `and` it lowers to
+    ///     [`StringMatcher::Always`] here.
+    ///
+    /// String fields: `username` / `email` / `first_name` /
+    /// `last_name` / `display_name`.
+    ///
+    /// Unsupported shapes surface as [`PluginError::UserOpUnsupported`]
+    /// (HTTP 501): operators other than `eq` / `contains` / `and` /
+    /// `or` (`ne`, `in`, `not`, `startswith`, `endswith`, comparisons),
+    /// a non-string literal on a field, or an `id` clause nested inside
+    /// an `or` (the id half cannot be hoisted out of a disjunction).
+    /// `None` (no `$filter`) lowers to [`StringMatcher::Always`].
+    fn build_string_matcher(
+        filter: Option<&FilterNode<IdpUserFilterField>>,
+    ) -> Result<StringMatcher, PluginError> {
+        match filter {
+            None => Ok(StringMatcher::Always),
+            Some(node) => Self::build_string_matcher_node(node, false),
+        }
+    }
+
+    fn build_string_matcher_node(
+        node: &FilterNode<IdpUserFilterField>,
+        in_or: bool,
+    ) -> Result<StringMatcher, PluginError> {
+        match node {
+            // `id eq <uuid>` is captured by `extract_id_filter`. Inside
+            // an `and` it is the identity here; inside an `or` it cannot
+            // be hoisted out, so reject rather than silently widen.
+            FilterNode::Binary {
+                field: IdpUserFilterField::Id,
+                op: FilterOp::Eq,
+                ..
+            } => {
+                if in_or {
+                    Err(PluginError::UserOpUnsupported {
+                        detail: "`id eq` inside `or` is not supported on /users filter".into(),
+                    })
+                } else {
+                    Ok(StringMatcher::Always)
+                }
+            }
+            FilterNode::Binary {
+                field,
+                op: op @ (FilterOp::Eq | FilterOp::Contains),
+                value,
+            } => {
+                let needle = match value {
+                    ODataValue::String(s) => s.clone(),
+                    other => {
+                        return Err(PluginError::UserOpUnsupported {
+                            detail: format!(
+                                "filter field `{field:?}`: expected string literal, got {other}"
+                            ),
+                        });
+                    }
+                };
+                let match_op = match op {
+                    FilterOp::Contains => StringMatchOp::Contains,
+                    _ => StringMatchOp::Eq,
+                };
+                Ok(StringMatcher::Field {
+                    field: *field,
+                    op: match_op,
+                    needle,
+                })
+            }
+            FilterNode::Binary { op, .. } => Err(PluginError::UserOpUnsupported {
+                detail: format!(
+                    "operator `{op}` not supported on /users filter; \
+                     supported: `eq`, `contains`, `and`, `or`"
+                ),
+            }),
+            FilterNode::Composite {
+                op: FilterOp::And,
+                children,
+            } => {
+                let parts = children
+                    .iter()
+                    .map(|c| Self::build_string_matcher_node(c, in_or))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(StringMatcher::All(parts))
+            }
+            FilterNode::Composite {
+                op: FilterOp::Or,
+                children,
+            } => {
+                let parts = children
+                    .iter()
+                    .map(|c| Self::build_string_matcher_node(c, true))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(StringMatcher::Any(parts))
+            }
+            FilterNode::Composite { op, .. } => Err(PluginError::UserOpUnsupported {
+                detail: format!(
+                    "composite operator `{op}` not supported on /users filter; \
+                     supported: `and`, `or`"
+                ),
+            }),
+            FilterNode::InList { .. } => Err(PluginError::UserOpUnsupported {
+                detail: "operator `in` not supported on /users filter".into(),
+            }),
+            FilterNode::Not(_) => Err(PluginError::UserOpUnsupported {
+                detail: "operator `not` not supported on /users filter".into(),
+            }),
+        }
+    }
+
+    /// Mirror of [`Self::user_rep_to_idp_user`]'s `display_name`
+    /// derivation, used for client-side filter matching without
+    /// fully projecting the rep first.
+    fn user_rep_display_name(rep: &UserRep) -> Option<String> {
+        match (&rep.first_name, &rep.last_name) {
+            (Some(f), Some(l)) if !f.is_empty() && !l.is_empty() => Some(format!("{f} {l}")),
+            (Some(f), _) if !f.is_empty() => Some(f.clone()),
+            (_, Some(l)) if !l.is_empty() => Some(l.clone()),
+            _ => None,
+        }
+    }
+
+    /// Short hash of `(tenant_id, realm_name, id_filter,
+    /// string_filters)` stuffed into [`CursorV1::f`] so cursor
+    /// continuation requests carry their original filter context.
+    /// FNV-1a 64-bit rendered as 16 hex chars — adequate for the small
+    /// filter space the API exposes and well below
+    /// [`IdpUserPagination::MAX_CURSOR_LEN`].
+    ///
+    /// `realm_name` is folded into the hash so a tenant whose
+    /// realm binding changes between pages surfaces as `invalid
+    /// cursor` through the same path as a filter / tenant change —
+    /// this replaces the pre-CursorV1 explicit `decoded.realm_name
+    /// != metadata.realm_name` reject (same effective check, now
+    /// bundled in the hash).
+    ///
+    /// Including the string filter set is load-bearing: a client
+    /// that pages through `username eq 'alice'` results and then
+    /// changes the filter MUST be rejected rather than silently
+    /// jumping between result sets. The [`StringMatcher::feed_hash`]
+    /// helper encodes the predicate tree canonically (variant tag +
+    /// length-prefixed parts) so a cursor is only valid for an
+    /// identical filter.
+    fn filter_hash(
+        tenant_id: Uuid,
+        realm_name: &str,
+        user_id_filter: Option<Uuid>,
+        matcher: &StringMatcher,
+    ) -> String {
+        let mut h = FNV1A_BASIS;
+        fnv1a_update(&mut h, tenant_id.as_bytes());
+        // Length-prefix the realm name so `realm_name="ab" + ...` and
+        // `realm_name="a" + "b" + ...` can't collide via concatenation.
+        fnv1a_update(&mut h, realm_name.len().to_be_bytes());
+        fnv1a_update(&mut h, realm_name.as_bytes());
+        // Distinguish "no filter" from "filter = Uuid::nil()" by salting
+        // the hash with a 1-byte presence tag.
+        match user_id_filter {
+            Some(u) => {
+                fnv1a_update(&mut h, [1u8]);
+                fnv1a_update(&mut h, u.as_bytes());
+            }
+            None => {
+                fnv1a_update(&mut h, [0u8]);
+            }
+        }
+        matcher.feed_hash(&mut h);
+        // 16 hex chars (64-bit) is plenty for a cursor fingerprint.
+        format!("{h:016x}")
+    }
+
+    /// Encode the opaque pagination cursor as
+    /// [`CursorV1`]-base64url-JSON. Wire-compatible with AM's
+    /// tenant `list_children` cursor (and any other toolkit-odata
+    /// consumer) so the `OData` query extractor on the *next* request
+    /// parses our cursor through the exact same `CursorV1::decode`
+    /// path, with no plugin-specific extractor hook.
+    ///
+    /// The `k`/`o`/`s` triple pins the plugin's hard-coded sort
+    /// order; AM's handler recovers `req.order` from `cursor.s` via
+    /// `ODataOrderBy::from_signed_tokens`, so a continuation request
+    /// without `$orderby` still reaches the plugin with the right
+    /// effective order.
+    //
+    // `CursorV1::encode` returns `serde_json::Result<String>`;
+    // serialisation can only fail on a non-serialisable inner type,
+    // and CursorV1's wire shape is all primitives. The `expect`
+    // anchors the invariant in the same style as the previous
+    // hand-rolled implementation.
+    #[expect(
+        clippy::expect_used,
+        reason = "CursorV1 has no serialiser-defeating shape; the expect anchors that invariant"
+    )]
+    fn encode_cursor(cursor: &ListUsersCursor) -> String {
+        CursorV1 {
+            k: vec![
+                cursor.last_created_at.to_string(),
+                cursor.last_user_id.to_string(),
+            ],
+            o: CURSOR_ORDER_DIR,
+            s: CURSOR_ORDER_TOKENS.to_owned(),
+            f: Some(cursor.filter_hash.clone()),
+            d: CURSOR_DIRECTION.to_owned(),
+        }
+        .encode()
+        .expect("CursorV1 with primitive fields is always serialisable")
+    }
+
+    /// Decode the opaque pagination cursor. Failure modes that all
+    /// surface as [`PluginError::UserOpRejected`] ("invalid cursor"):
+    ///
+    ///   * Malformed base64 / unsupported `v` / shape mismatch from
+    ///     [`CursorV1::decode`].
+    ///   * `o` or `s` deviates from the plugin's hard-coded
+    ///     `(createdTimestamp ASC, id ASC)` sort. A request that
+    ///     somehow surfaces a different order-pin almost certainly
+    ///     came from a different list endpoint's cursor — reject so
+    ///     the caller cannot accidentally walk our pages with
+    ///     someone else's tiebreakers.
+    ///   * `k` doesn't carry exactly the two tiebreaker strings the
+    ///     `(created_at, id)` shape expects, or those strings don't
+    ///     parse back to `i64` / `Uuid`.
+    ///   * `f` (`filter_hash`) is absent — the cursor was emitted
+    ///     under "no filter context", which the plugin always sets,
+    ///     so this is structurally invalid.
+    fn decode_cursor(raw: &str) -> Result<ListUsersCursor, PluginError> {
+        let invalid = || PluginError::UserOpRejected {
+            detail: "invalid cursor".into(),
+        };
+        let cursor = CursorV1::decode(raw).map_err(|_| invalid())?;
+        if cursor.o != CURSOR_ORDER_DIR || cursor.s != CURSOR_ORDER_TOKENS {
+            return Err(invalid());
+        }
+        if cursor.k.len() != 2 {
+            return Err(invalid());
+        }
+        let last_created_at: i64 = cursor.k[0].parse().map_err(|_| invalid())?;
+        let last_user_id: Uuid = cursor.k[1].parse().map_err(|_| invalid())?;
+        let filter_hash = cursor.f.ok_or_else(invalid)?;
+        Ok(ListUsersCursor {
+            filter_hash,
+            last_created_at,
+            last_user_id,
+        })
+    }
+
+    /// Production decode used by [`UserFacade::list_users_impl`]. Tries
+    /// the modern [`Self::decode_cursor`] shape first and validates its
+    /// `filter_hash` against the current request's modern hash. On
+    /// failure, falls back to the pre-CursorV1
+    /// [`LegacyListUsersCursor`] shape for the rolling-deploy grace
+    /// window: a pre-deploy client whose page 1 lands on the new
+    /// build still gets page 2 served correctly (realm + legacy
+    /// `filter_hash` are revalidated against the current request).
+    ///
+    /// Returns the `(last_created_at, last_user_id)` tiebreaker pair
+    /// once validation passes. Any failure path (parse, shape, realm
+    /// mismatch, filter mismatch) collapses to
+    /// `PluginError::UserOpRejected { detail: "invalid cursor" }` so
+    /// the caller cannot distinguish between modern-invalid and
+    /// legacy-invalid (both are equally "client must re-paginate").
+    fn decode_cursor_with_legacy_fallback(
+        raw: &str,
+        expected_realm: &str,
+        expected_tenant_id: Uuid,
+        expected_id_filter: Option<Uuid>,
+        expected_modern_filter_hash: &str,
+    ) -> Result<(i64, Uuid), PluginError> {
+        let invalid = || PluginError::UserOpRejected {
+            detail: "invalid cursor".into(),
+        };
+
+        // --- Modern shape: validated by `decode_cursor`, then compare
+        //     filter_hash against the current request's context.
+        if let Ok(modern) = Self::decode_cursor(raw) {
+            if modern.filter_hash != expected_modern_filter_hash {
+                return Err(invalid());
+            }
+            return Ok((modern.last_created_at, modern.last_user_id));
+        }
+
+        // --- Legacy shape: pre-CursorV1 base64url(serde_json).
+        //     Revalidate realm + legacy filter context so a query
+        //     change mid-walk still rejects, matching the modern
+        //     path's safety guarantee.
+        let bytes = URL_SAFE_NO_PAD.decode(raw).map_err(|_| invalid())?;
+        let legacy: LegacyListUsersCursor =
+            serde_json::from_slice(&bytes).map_err(|_| invalid())?;
+        if legacy.realm_name != expected_realm {
+            return Err(invalid());
+        }
+        if legacy.filter_hash != legacy_filter_hash(expected_tenant_id, expected_id_filter) {
+            return Err(invalid());
+        }
+        let last_created_at = legacy.last_created_at.ok_or_else(invalid)?;
+        let last_user_id = legacy.last_user_id.ok_or_else(invalid)?;
+        Ok((last_created_at, last_user_id))
+    }
+}
+
+#[cfg(test)]
+#[path = "user_facade_tests.rs"]
+mod user_facade_tests;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/user_facade.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/user_facade.rs
@@ -609,7 +609,7 @@ impl UserFacade {
                 .map_err(user_translate_kc);
             if let Err(compensation_err) = compensation {
                 tracing::warn!(
-                    target: "vp_idp_plugin.user_facade",
+                    target: "keycloak_idp.user_facade",
                     user_uuid = %user_uuid,
                     realm = %metadata.realm_name,
                     primary_error = %group_err,
@@ -623,7 +623,7 @@ impl UserFacade {
                     .orphan_user_compensation(OrphanCompensationOutcome::Failed);
             } else {
                 tracing::info!(
-                    target: "vp_idp_plugin.user_facade",
+                    target: "keycloak_idp.user_facade",
                     user_uuid = %user_uuid,
                     realm = %metadata.realm_name,
                     primary_error = %group_err,
@@ -647,9 +647,9 @@ impl UserFacade {
     }
 
     /// Shared failure-recording helper for user-op sites. Increments both
-    /// the generic `vp_idp_plugin_failure_total` counter and (when the
+    /// the generic `keycloak_idp_plugin_failure_total` counter and (when the
     /// underlying error is a metadata-decode failure) the dedicated
-    /// `vp_idp_plugin_metadata_decode_failure_total` trigger metric.
+    /// `keycloak_idp_plugin_metadata_decode_failure_total` trigger metric.
     fn record_user_op_failure(&self, op: PluginOp, e: &PluginError) {
         if let PluginError::MetadataDecode(de) = e {
             self.metadata_metrics
@@ -1078,7 +1078,7 @@ impl UserFacade {
         // returns the same shape a "user already gone" path would, so the
         // caller cannot distinguish "wrong tenant" from "already
         // deprovisioned". A tracing WARN under
-        // `vp_idp_plugin.user_binding` records the rejection for
+        // `keycloak_idp_plugin.user_binding` records the rejection for
         // operator visibility without leaking the discriminator over the
         // wire.
         let expected_tid = req.tenant_context.tenant_id;
@@ -1100,7 +1100,7 @@ impl UserFacade {
             .map_err(user_translate_kc)?;
         if actual_tid != Some(expected_tid) {
             tracing::warn!(
-                target: "vp_idp_plugin.user_binding",
+                target: "keycloak_idp.user_binding",
                 user_id = %req.user_id,
                 expected_tenant_id = %expected_tid,
                 actual_tenant_id = ?actual_tid,
@@ -1316,7 +1316,7 @@ impl UserFacade {
                             // Loud safety valve — see cap rationale above.
                             if all.len() >= MEMBERS_DRAIN_HARD_CAP {
                                 tracing::warn!(
-                                    target: "vp_idp_plugin.user_facade",
+                                    target: "keycloak_idp.user_facade",
                                     tenant_id = %tenant_id,
                                     realm = %realm_name,
                                     drained = all.len(),
@@ -1424,7 +1424,7 @@ impl UserFacade {
             Ok((status, _)) => {
                 if !(200..=299).contains(&status) && status != 404 {
                     tracing::warn!(
-                        target: "vp.idp.plugin",
+                        target: "keycloak_idp",
                         %status,
                         %user_id,
                         realm = %realm_name,
@@ -1434,7 +1434,7 @@ impl UserFacade {
             }
             Err(e) => {
                 tracing::warn!(
-                    target: "vp.idp.plugin",
+                    target: "keycloak_idp",
                     error = %e,
                     %user_id,
                     realm = %realm_name,

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/user_facade.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/user_facade.rs
@@ -76,7 +76,7 @@ fn user_translate_kc(e: PluginError) -> PluginError {
 }
 
 /// Attribute a KC 409 user-create body to the colliding unique field
-/// (VHP-2158). The HTTP 409 status itself is the machine signal that a
+///. The HTTP 409 status itself is the machine signal that a
 /// uniqueness invariant fired — on this endpoint it has no other cause
 /// — so the caller classifies EVERY 409 as a duplicate and this
 /// function only refines which field, never whether.
@@ -108,7 +108,7 @@ fn classify_kc_conflict(body_text: &str) -> account_management_sdk::IdpUserDupli
     }
 }
 
-/// Detect a KC 400 password-policy reject on user-create (VHP-2158).
+/// Detect a KC 400 password-policy reject on user-create.
 /// KC signals policy failures in two shapes depending on version/path:
 /// `{"errorMessage": "Password policy not met"}` (admin user-create with
 /// an embedded credential) and `{"error": "invalidPasswordMinLengthMessage",
@@ -722,7 +722,7 @@ impl UserFacade {
     /// payload (DESIGN §5.4). Returns success on any 2xx. Every 409 is
     /// [`PluginError::UserOpDuplicate`] — the status itself is the
     /// uniqueness signal; KC's `errorMessage` only refines the colliding
-    /// field (VHP-2158). A 400/422 carrying a KC password-policy reject
+    /// field. A 400/422 carrying a KC password-policy reject
     /// becomes [`PluginError::UserOpPasswordPolicy`], any other 400/422
     /// is a terminal [`PluginError::UserOpRejected`]; 5xx / transport /
     /// timeout re-tag as [`PluginError::UserOpUnavailable`] via
@@ -839,7 +839,7 @@ impl UserFacade {
         }
         let redacted = redact_secrets(&truncate_2kb(&body_text));
         if status == 409 {
-            // VHP-2158: on this endpoint a 409 has no cause other than a
+            // on this endpoint a 409 has no cause other than a
             // uniqueness collision, so the STATUS is the classification —
             // every 409 rides the typed duplicate lane and stays HTTP 409
             // at the AM boundary regardless of KC wording drift; the body
@@ -852,7 +852,7 @@ impl UserFacade {
                 ),
             });
         }
-        // VHP-2158: KC's payload-rejection statuses. A recognised
+        // KC's payload-rejection statuses. A recognised
         // password-policy reject surfaces the structured `password` /
         // `PASSWORD_POLICY` violation; every other 400/422 (invalid email
         // format, user-profile attribute validation, malformed payload) is
@@ -1189,7 +1189,7 @@ impl UserFacade {
         result
     }
 
-    // TODO(VHP-76 follow-up): the `order` clause is still dropped in
+    // TODO(follow-up): the `order` clause is still dropped in
     // favour of the hard-coded `(createdTimestamp ASC, id ASC)` cursor
     // sort, and the v1 client-side filter strategy fetches a single
     // page from KC's `/groups/{tenant_group_id}/members` endpoint
@@ -1273,7 +1273,7 @@ impl UserFacade {
         // member KC ordered past that window (KC orders group members by
         // username). Any tenant with more than one page of members lost
         // users from BOTH the listing and `$filter` — create-then-list
-        // returned 201 yet the user never appeared (VHP-1973).
+        // returned 201 yet the user never appeared.
         //
         // `MEMBERS_DRAIN_HARD_CAP` bounds the total pulled so a
         // pathological membership cannot pin unbounded memory; reaching it

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/user_facade_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/user_facade_tests.rs
@@ -1,0 +1,2355 @@
+use super::*;
+use crate::config::UserFacadeConfig;
+use crate::domain::credstore::CredStoreReader;
+use crate::domain::kc::transport::KcTransport;
+use crate::domain::system_actor::build_system_ctx;
+use crate::domain::test_support::{
+    ConfigurableStubCS, StubCredStore, keycloak_cfg, make_metadata, noop_failure_metrics,
+    noop_metadata_metrics, noop_user_metrics,
+};
+use crate::infra::kc_http::ReqwestKcTransport;
+use account_management_sdk::idp_user::{
+    IdpDeprovisionUserRequest, IdpListUsersRequest, IdpNewUser, IdpProvisionUserRequest,
+    IdpTenantContext, IdpUserFilterField, IdpUserPagination,
+};
+use credstore_sdk::CredStoreClientV1;
+use gts::GtsTypeId;
+use toolkit_odata::filter::{FilterNode, FilterOp, ODataValue};
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn user_facade_cfg() -> UserFacadeConfig {
+    UserFacadeConfig {
+        default_user_required_actions: vec!["VERIFY_EMAIL".into()],
+        list_users_page_limit_default: 50,
+        list_users_page_limit_max: 200,
+        session_revoke_on_deprovision: true,
+    }
+}
+
+fn build_facade_with_cs(server: &MockServer, cs: Arc<dyn CredStoreClientV1>) -> UserFacade {
+    build_facade_with_cs_and_cfg(server, cs, user_facade_cfg())
+}
+
+fn build_facade_with_cs_and_cfg(
+    server: &MockServer,
+    cs: Arc<dyn CredStoreClientV1>,
+    user_cfg: UserFacadeConfig,
+) -> UserFacade {
+    let kc_cfg = keycloak_cfg(&server.uri());
+    let realm_admin_cfg = kc_cfg.realm_admin.clone();
+
+    let cs_reader = CredStoreReader::new(cs, build_system_ctx(Uuid::nil()));
+    let transport: Arc<dyn KcTransport> = Arc::new(ReqwestKcTransport::new(reqwest::Client::new()));
+    let factory = Arc::new(KeycloakAdminClientFactory::new(
+        kc_cfg,
+        transport,
+        cs_reader,
+        Arc::new(crate::domain::test_support::NoopMetrics),
+    ));
+    UserFacade::new(
+        user_cfg,
+        realm_admin_cfg,
+        factory,
+        Arc::new(MetadataCodec),
+        noop_user_metrics(),
+        noop_metadata_metrics(),
+        noop_failure_metrics(),
+    )
+}
+
+fn build_facade(server: &MockServer) -> UserFacade {
+    build_facade_with_cs(server, Arc::new(StubCredStore))
+}
+
+fn build_facade_with_required_actions(
+    server: &MockServer,
+    required_actions: Vec<String>,
+) -> UserFacade {
+    let cfg = UserFacadeConfig {
+        default_user_required_actions: required_actions,
+        ..user_facade_cfg()
+    };
+    build_facade_with_cs_and_cfg(server, Arc::new(StubCredStore), cfg)
+}
+
+fn provision_user_req(
+    tenant_id: Uuid,
+    metadata: Option<serde_json::Value>,
+    username: &str,
+    email: Option<&str>,
+) -> IdpProvisionUserRequest {
+    let mut payload = IdpNewUser::new(username);
+    if let Some(e) = email {
+        payload = payload.with_email(e);
+    }
+    IdpProvisionUserRequest::new(
+        IdpTenantContext::new(
+            tenant_id,
+            "stub-tenant",
+            GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            metadata,
+        ),
+        payload,
+    )
+}
+
+/// Mount the realm-admin token endpoint so the factory's
+/// `realm_client(...)` call succeeds. Shared/default-realm tests only
+/// need this realm's endpoint; Adopted tests can call it again with
+/// a different `realm_under_test`.
+async fn mount_token_endpoint(server: &MockServer, realm_under_test: &str) {
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/realms/{realm_under_test}/protocol/openid-connect/token"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "t-realm",
+            "expires_in": 600
+        })))
+        .mount(server)
+        .await;
+}
+
+// -----------------------------------------------------------------
+// Phase 12 — provision_user
+// -----------------------------------------------------------------
+
+#[tokio::test]
+async fn provision_user_happy_path_default_shared_realm_returns_idp_user() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        let tenant_uuid = Uuid::new_v4();
+        let group_uuid = Uuid::new_v4();
+        let user_uuid = Uuid::new_v4();
+
+        // Step 4: POST /users → 201 (no body required — we re-discover
+        // the UUID via the username probe).
+        Mock::given(method("POST"))
+            .and(path("/admin/realms/platform/users"))
+            .respond_with(ResponseTemplate::new(201))
+            .mount(&server)
+            .await;
+
+        // Step 5: GET /users?username=...&exact=true → [{ id }].
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/platform/users"))
+            .and(query_param("username", "alice"))
+            .and(query_param("exact", "true"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": user_uuid.to_string()}
+            ])))
+            .mount(&server)
+            .await;
+
+        // Step 6: PUT /users/{user}/groups/{tenant_group} → 204.
+        Mock::given(method("PUT"))
+            .and(path(format!(
+                "/admin/realms/platform/users/{user_uuid}/groups/{group_uuid}"
+            )))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = provision_user_req(
+            tenant_uuid,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                group_uuid,
+                None,
+            )),
+            "alice",
+            Some("alice@example.com"),
+        );
+
+        let user = facade
+            .provision_user_inner(&ctx, &req)
+            .await
+            .expect("provision_user ok");
+        assert_eq!(user.id, user_uuid);
+        assert_eq!(user.username, "alice");
+        assert_eq!(user.email.as_deref(), Some("alice@example.com"));
+    })
+    .await;
+}
+
+/// Regression for the `VERIFY_EMAIL`/`emailVerified` coupling bug.
+///
+/// When the operator opts users into `VERIFY_EMAIL` via
+/// `default_user_required_actions`, the POST /users body MUST send
+/// `emailVerified=false` — otherwise KC silently skips the action and the
+/// operator-configured gate becomes a no-op. The two fields share a single
+/// source of truth in [`UserFacade::create_user`].
+#[tokio::test]
+async fn provision_user_with_verify_email_sends_email_verified_false() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        let tenant_uuid = Uuid::new_v4();
+        let group_uuid = Uuid::new_v4();
+        let user_uuid = Uuid::new_v4();
+
+        Mock::given(method("POST"))
+            .and(path("/admin/realms/platform/users"))
+            .respond_with(ResponseTemplate::new(201))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/platform/users"))
+            .and(query_param("username", "alice"))
+            .and(query_param("exact", "true"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": user_uuid.to_string()}
+            ])))
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path(format!(
+                "/admin/realms/platform/users/{user_uuid}/groups/{group_uuid}"
+            )))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade_with_required_actions(&server, vec!["VERIFY_EMAIL".into()]);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = provision_user_req(
+            tenant_uuid,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                group_uuid,
+                None,
+            )),
+            "alice",
+            Some("alice@example.com"),
+        );
+
+        facade
+            .provision_user_inner(&ctx, &req)
+            .await
+            .expect("provision_user ok");
+
+        let received = server.received_requests().await.unwrap();
+        let post = received
+            .iter()
+            .find(|r| r.method.as_str() == "POST" && r.url.path() == "/admin/realms/platform/users")
+            .expect("POST /users must be sent");
+        let body: serde_json::Value =
+            serde_json::from_slice(&post.body).expect("POST body is JSON");
+        assert_eq!(
+            body.get("emailVerified"),
+            Some(&serde_json::Value::Bool(false)),
+            "VERIFY_EMAIL in required_actions ⇒ emailVerified MUST be false",
+        );
+        assert_eq!(
+            body.get("requiredActions"),
+            Some(&serde_json::json!(["VERIFY_EMAIL"])),
+            "required_actions must be forwarded verbatim",
+        );
+    })
+    .await;
+}
+
+/// Counterpart to [`provision_user_with_verify_email_sends_email_verified_false`].
+///
+/// When the operator clears `default_user_required_actions` (dev/E2E
+/// posture), AM is treated as authoritative for the email and the POST
+/// /users body MUST send `emailVerified=true` so the password grant on
+/// freshly-provisioned users works without a manual KC admin step.
+#[tokio::test]
+async fn provision_user_without_required_actions_sends_email_verified_true() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        let tenant_uuid = Uuid::new_v4();
+        let group_uuid = Uuid::new_v4();
+        let user_uuid = Uuid::new_v4();
+
+        Mock::given(method("POST"))
+            .and(path("/admin/realms/platform/users"))
+            .respond_with(ResponseTemplate::new(201))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/platform/users"))
+            .and(query_param("username", "alice"))
+            .and(query_param("exact", "true"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": user_uuid.to_string()}
+            ])))
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path(format!(
+                "/admin/realms/platform/users/{user_uuid}/groups/{group_uuid}"
+            )))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade_with_required_actions(&server, vec![]);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = provision_user_req(
+            tenant_uuid,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                group_uuid,
+                None,
+            )),
+            "alice",
+            Some("alice@example.com"),
+        );
+
+        facade
+            .provision_user_inner(&ctx, &req)
+            .await
+            .expect("provision_user ok");
+
+        let received = server.received_requests().await.unwrap();
+        let post = received
+            .iter()
+            .find(|r| r.method.as_str() == "POST" && r.url.path() == "/admin/realms/platform/users")
+            .expect("POST /users must be sent");
+        let body: serde_json::Value =
+            serde_json::from_slice(&post.body).expect("POST body is JSON");
+        assert_eq!(
+            body.get("emailVerified"),
+            Some(&serde_json::Value::Bool(true)),
+            "empty required_actions ⇒ AM authoritative ⇒ emailVerified MUST be true",
+        );
+        assert_eq!(
+            body.get("requiredActions"),
+            Some(&serde_json::json!([])),
+            "required_actions must be forwarded verbatim (empty array)",
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn provision_user_in_adopted_realm_uses_openbao_ref() {
+    let server = MockServer::start().await;
+    mount_token_endpoint(&server, "partner-acme").await;
+
+    let tenant_uuid = Uuid::new_v4();
+    let group_uuid = Uuid::new_v4();
+    let user_uuid = Uuid::new_v4();
+
+    Mock::given(method("POST"))
+        .and(path("/admin/realms/partner-acme/users"))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/admin/realms/partner-acme/users"))
+        .and(query_param("username", "bob"))
+        .and(query_param("exact", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            {"id": user_uuid.to_string()}
+        ])))
+        .mount(&server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path(format!(
+            "/admin/realms/partner-acme/users/{user_uuid}/groups/{group_uuid}"
+        )))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    // OpenBao stub returns the per-realm admin secret keyed by the
+    // templated SecretRef.
+    let cs = Arc::new(ConfigurableStubCS::with_entry(
+        "vp-idp-realm-admin-partner-acme-secret",
+        "per-realm-ra-secret",
+    ));
+    let facade = build_facade_with_cs(&server, cs);
+    let ctx = build_system_ctx(Uuid::nil());
+    let req = provision_user_req(
+        tenant_uuid,
+        Some(make_metadata(
+            "partner-acme",
+            RealmBinding::Adopted,
+            group_uuid,
+            Some("vp-idp-realm-admin-partner-acme-secret"),
+        )),
+        "bob",
+        None,
+    );
+
+    let user = facade
+        .provision_user_inner(&ctx, &req)
+        .await
+        .expect("provision_user ok");
+    assert_eq!(user.id, user_uuid);
+    assert_eq!(user.username, "bob");
+    assert!(user.email.is_none());
+}
+
+#[tokio::test]
+async fn provision_user_with_duplicate_username_returns_rejected() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        // POST /users → 409 Conflict (duplicate).
+        Mock::given(method("POST"))
+            .and(path("/admin/realms/platform/users"))
+            .respond_with(
+                ResponseTemplate::new(409).set_body_string("User exists with same username"),
+            )
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = provision_user_req(
+            Uuid::new_v4(),
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+            "alice",
+            None,
+        );
+
+        let err = facade
+            .provision_user_inner(&ctx, &req)
+            .await
+            .expect_err("duplicate must error");
+        // VHP-2158: every 409 rides the typed duplicate lane. This mock
+        // returns a plain-text (non-JSON) body, so the attribution is the
+        // honest unattributed token, not a misread field.
+        assert!(
+            matches!(
+                err,
+                PluginError::UserOpDuplicate {
+                    field: account_management_sdk::IdpUserDuplicateField::UsernameOrEmail,
+                    ref detail,
+                } if detail.contains("409")
+            ),
+            "expected UserOpDuplicate(UsernameOrEmail) with 409 detail, got {err:?}",
+        );
+    })
+    .await;
+}
+
+/// Regression for B-H1. When KC echoes the request
+/// payload back in a 4xx error body, secret-shaped strings
+/// (`password=`, `client_secret=`, etc.) MUST be redacted before
+/// landing in `UserOpRejected.detail` — `detail` rides downstream to
+/// AM logs and may end up in user-facing error envelopes. The capture
+/// path is `redact_secrets(&truncate_2kb(&body_text))`; missing
+/// redaction was the round-4 finding.
+#[tokio::test]
+async fn provision_user_4xx_body_redacts_leaked_password() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        Mock::given(method("POST"))
+            .and(path("/admin/realms/platform/users"))
+            .respond_with(ResponseTemplate::new(409).set_body_string(
+                r#"{"error":"Conflict","echo":{"password":"hunter2-leak-me-not"}}"#,
+            ))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = provision_user_req(
+            Uuid::new_v4(),
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+            "alice",
+            None,
+        );
+
+        let err = facade
+            .provision_user_inner(&ctx, &req)
+            .await
+            .expect_err("409 must error");
+        // VHP-2158 moved 409s to the typed duplicate lane; the B-H1
+        // redaction guarantee must hold on its `detail` all the same.
+        assert!(
+            matches!(
+                &err,
+                PluginError::UserOpDuplicate { detail, .. }
+                    if !detail.contains("hunter2-leak-me-not")
+                        && detail.contains("<redacted>")
+            ),
+            "expected UserOpDuplicate with `hunter2-leak-me-not` masked as `<redacted>` (B-H1 regression), got {err:?}",
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn provision_user_with_5xx_returns_unavailable() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        // POST /users → 503 Service Unavailable.
+        Mock::given(method("POST"))
+            .and(path("/admin/realms/platform/users"))
+            .respond_with(ResponseTemplate::new(503).set_body_string("Service Unavailable"))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = provision_user_req(
+            Uuid::new_v4(),
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+            "alice",
+            None,
+        );
+
+        let err = facade
+            .provision_user_inner(&ctx, &req)
+            .await
+            .expect_err("5xx must error");
+        assert!(
+            matches!(err, PluginError::UserOpUnavailable { ref detail } if detail.contains("503")),
+            "expected UserOpUnavailable{{ detail contains 503 }}, got {err:?}",
+        );
+    })
+    .await;
+}
+
+/// `add_user_to_group` returns 404 (tenant group disappeared mid-saga)
+/// AFTER `create_user` succeeded → the freshly-created KC user is an
+/// orphan. The facade MUST issue a best-effort `delete_user` compensation
+/// and propagate the original group-add error.
+///
+/// Wiremock `.expect(1)` on the DELETE pins the contract: compensation
+/// fires exactly once. Without the compensation logic, the test catches
+/// a regression that re-introduces dangling KC users.
+#[tokio::test]
+async fn provision_user_orphan_compensation_calls_delete_on_group_add_failure() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        let tenant_uuid = Uuid::new_v4();
+        let group_uuid = Uuid::new_v4();
+        let user_uuid = Uuid::new_v4();
+
+        Mock::given(method("POST"))
+            .and(path("/admin/realms/platform/users"))
+            .respond_with(ResponseTemplate::new(201))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/platform/users"))
+            .and(query_param("username", "alice"))
+            .and(query_param("exact", "true"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": user_uuid.to_string()}
+            ])))
+            .mount(&server)
+            .await;
+        // PUT (group bind) → 404: tenant group disappeared.
+        Mock::given(method("PUT"))
+            .and(path(format!(
+                "/admin/realms/platform/users/{user_uuid}/groups/{group_uuid}"
+            )))
+            .respond_with(ResponseTemplate::new(404).set_body_string("group missing"))
+            .mount(&server)
+            .await;
+        // DELETE (compensation) → 204. `.expect(1)` is the contract:
+        // compensation MUST fire exactly once on this code path.
+        Mock::given(method("DELETE"))
+            .and(path(format!("/admin/realms/platform/users/{user_uuid}")))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = provision_user_req(
+            tenant_uuid,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                group_uuid,
+                None,
+            )),
+            "alice",
+            None,
+        );
+
+        let err = facade
+            .provision_user_inner(&ctx, &req)
+            .await
+            .expect_err("group-add 404 must error after compensation");
+        // Primary error propagated — not masked by the compensation call.
+        assert!(
+            matches!(err, PluginError::UserOpRejected { ref detail } if detail.contains("404")),
+            "expected UserOpRejected{{ detail contains 404 }}, got {err:?}",
+        );
+        // wiremock's `.expect(1)` is verified on drop — the test passes
+        // only if the DELETE fired exactly once.
+    })
+    .await;
+}
+
+/// Compensation `delete_user` itself fails → primary group-add error
+/// still propagates without being masked. The "orphan-user
+/// compensation FAILED" warn log path runs but doesn't change the
+/// caller-visible failure (operators see the primary cause first).
+#[tokio::test]
+async fn provision_user_orphan_compensation_failure_does_not_mask_primary_error() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        let tenant_uuid = Uuid::new_v4();
+        let group_uuid = Uuid::new_v4();
+        let user_uuid = Uuid::new_v4();
+
+        Mock::given(method("POST"))
+            .and(path("/admin/realms/platform/users"))
+            .respond_with(ResponseTemplate::new(201))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/platform/users"))
+            .and(query_param("username", "alice"))
+            .and(query_param("exact", "true"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": user_uuid.to_string()}
+            ])))
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path(format!(
+                "/admin/realms/platform/users/{user_uuid}/groups/{group_uuid}"
+            )))
+            .respond_with(ResponseTemplate::new(404).set_body_string("group missing"))
+            .mount(&server)
+            .await;
+        // DELETE compensation FAILS with 500 — drives the warn-level
+        // "compensation FAILED" log path. The primary error must still
+        // propagate verbatim. Don't `.expect(N)` — `delete_user` runs
+        // through `execute_with_retry` and 5xx triggers the standard
+        // retry policy, so the exact call count is policy-dependent;
+        // what matters here is the propagated error.
+        Mock::given(method("DELETE"))
+            .and(path(format!("/admin/realms/platform/users/{user_uuid}")))
+            .respond_with(ResponseTemplate::new(500).set_body_string("kc boom"))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = provision_user_req(
+            tenant_uuid,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                group_uuid,
+                None,
+            )),
+            "alice",
+            None,
+        );
+
+        let err = facade
+            .provision_user_inner(&ctx, &req)
+            .await
+            .expect_err("primary group-add error must propagate even when compensation fails");
+        // The primary `UserOpRejected{tenant group disappeared}` from
+        // `add_user_to_group`'s 404 path is what surfaces — the 500 on
+        // DELETE is logged but not raised, so the caller sees the
+        // original cause.
+        assert!(
+            matches!(err, PluginError::UserOpRejected { ref detail } if detail.contains("404")),
+            "compensation failure masked the primary error: {err:?}",
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn provision_user_with_malformed_metadata_returns_rejected() {
+    let server = MockServer::start().await;
+    // No HTTP mocks needed — failure short-circuits before any KC call.
+    let facade = build_facade(&server);
+    let ctx = build_system_ctx(Uuid::nil());
+    let req = provision_user_req(
+        Uuid::new_v4(),
+        // Garbage metadata — missing required keys.
+        Some(serde_json::json!({"version": "v1", "realm_name": "platform"})),
+        "alice",
+        None,
+    );
+
+    let err = facade
+        .provision_user_inner(&ctx, &req)
+        .await
+        .expect_err("malformed metadata must error");
+    // The inner method propagates `MetadataDecode` verbatim so the
+    // metrics adapter can observe the `version_observed` label;
+    // `translate_user_op_failure` (idp_impl.rs) is what converts it to
+    // `UserOpRejected{ detail: "metadata decode failed: …" }` at the
+    // outer IDP boundary. Asserting on the variant keeps this test
+    // focused on the facade layer's actual contract.
+    assert!(
+        matches!(err, PluginError::MetadataDecode(_)),
+        "expected PluginError::MetadataDecode(_), got {err:?}",
+    );
+}
+
+// -----------------------------------------------------------------
+// Phase 13 — deprovision_user / list_users
+// -----------------------------------------------------------------
+
+/// Build a facade with a tweaked [`UserFacadeConfig`] — Phase 13
+/// tests flip `session_revoke_on_deprovision` per scenario.
+fn build_facade_with_user_cfg(server: &MockServer, user_cfg: UserFacadeConfig) -> UserFacade {
+    let kc_cfg = keycloak_cfg(&server.uri());
+    let realm_admin_cfg = kc_cfg.realm_admin.clone();
+
+    let cs_reader = CredStoreReader::new(Arc::new(StubCredStore), build_system_ctx(Uuid::nil()));
+    let transport: Arc<dyn KcTransport> = Arc::new(ReqwestKcTransport::new(reqwest::Client::new()));
+    let factory = Arc::new(KeycloakAdminClientFactory::new(
+        kc_cfg,
+        transport,
+        cs_reader,
+        Arc::new(crate::domain::test_support::NoopMetrics),
+    ));
+    UserFacade::new(
+        user_cfg,
+        realm_admin_cfg,
+        factory,
+        Arc::new(MetadataCodec),
+        noop_user_metrics(),
+        noop_metadata_metrics(),
+        noop_failure_metrics(),
+    )
+}
+
+/// Mount the KC `GET /admin/realms/{realm}/users/{user_uuid}` mock that
+/// the binding-check step (`read_user_owner_tenant`) consumes before any
+/// destructive call. Returns a minimal user representation with
+/// `attributes.tenant_id = [tenant_id]` so the check accepts the binding.
+///
+/// Tests that need to exercise the binding-MISMATCH branch should NOT call
+/// this helper — they should mount their own response (e.g. 404, or a body
+/// with a different `tenant_id`) so `read_user_owner_tenant` returns
+/// `Ok(None)` / `Ok(Some(other_uuid))` and the saga skips the delete.
+async fn mount_user_binding_returns(
+    server: &MockServer,
+    realm: &str,
+    user_uuid: Uuid,
+    tenant_id: Uuid,
+) {
+    Mock::given(method("GET"))
+        .and(path(format!("/admin/realms/{realm}/users/{user_uuid}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": user_uuid.to_string(),
+            "attributes": {
+                "tenant_id": [tenant_id.to_string()],
+                "user_type": ["user"],
+            },
+        })))
+        .mount(server)
+        .await;
+}
+
+fn deprovision_user_req(
+    tenant_id: Uuid,
+    metadata: Option<serde_json::Value>,
+    user_id: Uuid,
+) -> IdpDeprovisionUserRequest {
+    IdpDeprovisionUserRequest::new(
+        IdpTenantContext::new(
+            tenant_id,
+            "stub-tenant",
+            GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            metadata,
+        ),
+        user_id,
+    )
+}
+
+fn list_users_req(
+    tenant_id: Uuid,
+    metadata: Option<serde_json::Value>,
+    pagination: IdpUserPagination,
+    user_id_filter: Option<Uuid>,
+) -> IdpListUsersRequest {
+    let mut req = IdpListUsersRequest::new(
+        IdpTenantContext::new(
+            tenant_id,
+            "stub-tenant",
+            GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            metadata,
+        ),
+        pagination,
+    );
+    if let Some(filter) = user_id_filter {
+        req = req.with_filter(FilterNode::binary(
+            IdpUserFilterField::Id,
+            FilterOp::Eq,
+            ODataValue::Uuid(filter),
+        ));
+    }
+    req
+}
+
+#[tokio::test]
+async fn deprovision_user_happy_path_returns_ok() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        let tenant_id = Uuid::new_v4();
+        let user_uuid = Uuid::new_v4();
+        // Binding check: GET /users/{user_uuid} returns the user with the
+        // matching tenant_id attribute, so deprovision proceeds.
+        mount_user_binding_returns(&server, "platform", user_uuid, tenant_id).await;
+        // Session revoke disabled → no /logout mock needed.
+        Mock::given(method("DELETE"))
+            .and(path(format!("/admin/realms/platform/users/{user_uuid}")))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let user_cfg = UserFacadeConfig {
+            session_revoke_on_deprovision: false,
+            ..user_facade_cfg()
+        };
+        let facade = build_facade_with_user_cfg(&server, user_cfg);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = deprovision_user_req(
+            tenant_id,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+            user_uuid,
+        );
+
+        facade
+            .deprovision_user_inner(&ctx, &req)
+            .await
+            .expect("deprovision_user ok");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn deprovision_user_with_session_revoke_calls_logout_then_delete() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        let tenant_id = Uuid::new_v4();
+        let user_uuid = Uuid::new_v4();
+        // Binding check passes (matching tenant_id) → revoke + delete proceed.
+        mount_user_binding_returns(&server, "platform", user_uuid, tenant_id).await;
+        // session_revoke enabled by default in `user_facade_cfg`.
+        Mock::given(method("POST"))
+            .and(path(format!(
+                "/admin/realms/platform/users/{user_uuid}/logout"
+            )))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path(format!("/admin/realms/platform/users/{user_uuid}")))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = deprovision_user_req(
+            tenant_id,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+            user_uuid,
+        );
+
+        facade
+            .deprovision_user_inner(&ctx, &req)
+            .await
+            .expect("deprovision_user ok");
+        // `.expect(1)` on each mock asserts call ordering implicitly:
+        // both endpoints saw exactly one request.
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn deprovision_user_vendor_404_returns_ok() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        let tenant_id = Uuid::new_v4();
+        let user_uuid = Uuid::new_v4();
+        // Binding check passes — even if a concurrent deleter races us, the
+        // user still has its tenant_id attribute at this exact moment.
+        // The KC-side delete then 404s because the concurrent deleter
+        // already cleared the row — that is the idempotent-absent path
+        // this test pins.
+        mount_user_binding_returns(&server, "platform", user_uuid, tenant_id).await;
+        // Logout returns 404 too (user already gone) — best-effort,
+        // continues to DELETE.
+        Mock::given(method("POST"))
+            .and(path(format!(
+                "/admin/realms/platform/users/{user_uuid}/logout"
+            )))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path(format!("/admin/realms/platform/users/{user_uuid}")))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = deprovision_user_req(
+            tenant_id,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+            user_uuid,
+        );
+
+        facade
+            .deprovision_user_inner(&ctx, &req)
+            .await
+            .expect("404 must be idempotent ok");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn deprovision_user_5xx_returns_unavailable() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        let tenant_id = Uuid::new_v4();
+        let user_uuid = Uuid::new_v4();
+        // Binding check passes so the failure surface is unambiguously
+        // the DELETE step (not the new pre-check).
+        mount_user_binding_returns(&server, "platform", user_uuid, tenant_id).await;
+        // Disable session-revoke so the failure surface is unambiguously
+        // the DELETE step.
+        Mock::given(method("DELETE"))
+            .and(path(format!("/admin/realms/platform/users/{user_uuid}")))
+            .respond_with(ResponseTemplate::new(503).set_body_string("Service Unavailable"))
+            .mount(&server)
+            .await;
+
+        let user_cfg = UserFacadeConfig {
+            session_revoke_on_deprovision: false,
+            ..user_facade_cfg()
+        };
+        let facade = build_facade_with_user_cfg(&server, user_cfg);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = deprovision_user_req(
+            tenant_id,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+            user_uuid,
+        );
+
+        let err = facade
+            .deprovision_user_inner(&ctx, &req)
+            .await
+            .expect_err("5xx must error");
+        assert!(
+            matches!(err, PluginError::UserOpUnavailable { ref detail } if detail.contains("503")),
+            "expected UserOpUnavailable{{ detail contains 503 }}, got {err:?}",
+        );
+    })
+    .await;
+}
+
+/// Regression: cross-tenant deprovision is silently skipped (no destructive
+/// KC call) when the stored `tenant_id` attribute on the user does not match
+/// the request's `tenant_context.tenant_id`.
+///
+/// This pins the security fix that closed
+/// `tests/e2e/.../test_delete_user_in_wrong_tenant_rejected_for_scoped_user`
+/// (e2e xfail strict). Before the fix, AM's User-resource PEP grants
+/// `User.delete` on `OWNER_TENANT_ID` derived from the URL path; the IMPL
+/// then forwarded `user_id` to KC without verifying the binding, so any
+/// caller authorised for `User.delete` on their own tenant could delete a
+/// user owned by ANY other tenant by routing through their own `tenant_id`
+/// path. Users are KC-stored (`ADR-0005`) so the SQL constraint the `AuthZ`
+/// resolver emits never applies — the binding check must be explicit.
+///
+/// What this test asserts:
+///   * The KC `GET /users/{user_uuid}` mock returns a user with a `tenant_id`
+///     attribute set to a UUID that DIFFERS from the request's `tenant_id`.
+///   * `deprovision_user_inner` returns `Ok(())` — same shape as the genuine
+///     idempotent-absent path, so AM surfaces HTTP 204 to the caller
+///     (enumeration-resistant; caller cannot distinguish "wrong tenant"
+///     from "already deleted").
+///   * NO `DELETE /users/{user_uuid}` request is issued — the destructive
+///     call is skipped entirely. `.expect(0)` on the DELETE mock fails the
+///     test the moment the binding check is bypassed.
+///   * NO `POST /users/{user_uuid}/logout` request either — same reason.
+#[tokio::test]
+async fn deprovision_user_skips_delete_when_binding_mismatches() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        let user_uuid = Uuid::new_v4();
+        let request_tenant_id = Uuid::new_v4();
+        // Crucial: the user's stored tenant_id is DIFFERENT — this is the
+        // cross-tenant scenario where alice (in request_tenant_id) is
+        // trying to delete bob (owned by user_actual_tenant_id).
+        let user_actual_tenant_id = Uuid::new_v4();
+        assert_ne!(
+            request_tenant_id, user_actual_tenant_id,
+            "test setup invariant: tenants must differ"
+        );
+        mount_user_binding_returns(&server, "platform", user_uuid, user_actual_tenant_id).await;
+        // Both destructive calls MUST NOT be issued — `.expect(0)` blows up
+        // the test instantly if the binding-check skip ever regresses.
+        Mock::given(method("POST"))
+            .and(path(format!(
+                "/admin/realms/platform/users/{user_uuid}/logout"
+            )))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(0)
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path(format!("/admin/realms/platform/users/{user_uuid}")))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = deprovision_user_req(
+            request_tenant_id,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+            user_uuid,
+        );
+
+        // Enumeration-resistant: Ok(()) shape — caller cannot distinguish
+        // this from a real already-absent deprovision.
+        facade
+            .deprovision_user_inner(&ctx, &req)
+            .await
+            .expect("binding mismatch must return Ok (idempotent-absent shape)");
+    })
+    .await;
+}
+
+/// Regression companion: user absent from KC entirely (GET → 404) also
+/// short-circuits to the idempotent-absent path, with no DELETE issued.
+#[tokio::test]
+async fn deprovision_user_skips_delete_when_user_absent_in_kc() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        let user_uuid = Uuid::new_v4();
+        let tenant_id = Uuid::new_v4();
+        // GET /users/{uuid} → 404 (user not in KC). Binding check collapses
+        // to Ok(None) which short-circuits the delete.
+        Mock::given(method("GET"))
+            .and(path(format!("/admin/realms/platform/users/{user_uuid}")))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path(format!("/admin/realms/platform/users/{user_uuid}")))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = deprovision_user_req(
+            tenant_id,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+            user_uuid,
+        );
+
+        facade
+            .deprovision_user_inner(&ctx, &req)
+            .await
+            .expect("user-absent must return Ok (idempotent-absent)");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn list_users_happy_path_returns_page() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        let group_uuid = Uuid::new_v4();
+        let u1 = Uuid::new_v4();
+        let u2 = Uuid::new_v4();
+        let u3 = Uuid::new_v4();
+        // `top = 2`, 3-member fixture (fits one page) → has_more=true after
+        // the drain → next_cursor must be set.
+        // Items are sorted by (createdTimestamp ASC, id ASC) client-side.
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/admin/realms/platform/groups/{group_uuid}/members"
+            )))
+            .and(query_param("first", "0"))
+            // Plugin drains the full membership a page at a time, fetching
+            // `list_users_page_limit_max` rows per KC call (test cfg sets it
+            // to 200). Small fixtures fit in the first page, so a single
+            // `first=0` call still serves the request.
+            .and(query_param("max", "200"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": u1.to_string(), "username": "alice", "email": "alice@example.com", "createdTimestamp": 1_716_400_000_000_i64},
+                {"id": u2.to_string(), "username": "bob", "firstName": "Bob", "lastName": "Builder", "createdTimestamp": 1_716_400_001_000_i64},
+                {"id": u3.to_string(), "username": "carol", "createdTimestamp": 1_716_400_002_000_i64},
+            ])))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = list_users_req(
+            Uuid::new_v4(),
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                group_uuid,
+                None,
+            )),
+            IdpUserPagination::new(2, None).expect("valid pagination"),
+            None,
+        );
+
+        let page = facade
+            .list_users_inner(&ctx, &req)
+            .await
+            .expect("list_users ok");
+        assert_eq!(page.items.len(), 2);
+        assert_eq!(page.items[0].id, u1);
+        assert_eq!(page.items[0].username, "alice");
+        assert_eq!(page.items[0].email.as_deref(), Some("alice@example.com"));
+        assert_eq!(page.items[1].id, u2);
+        assert_eq!(page.items[1].display_name.as_deref(), Some("Bob Builder"));
+        assert_eq!(page.page_info.limit, 2);
+        assert!(
+            page.page_info.next_cursor.is_some(),
+            "has_more=true must produce a next_cursor",
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn list_users_with_cursor_continues_from_tiebreaker() {
+    // DESIGN §4.3: both page requests hit KC with first=0; cursor carries
+    // (last_created_at, last_user_id) and client-side filtering skips the
+    // already-returned users.
+    //
+    // Both fetches are identical (first=0&max=3), so we mount a single
+    // permissive mock that returns all 3 users on every call, and rely on
+    // client-side skip to produce the correct second page.
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        let tenant_uuid = Uuid::new_v4();
+        let group_uuid = Uuid::new_v4();
+        // Use fixed UUIDs so we can assert on the second page items.
+        let u1 = Uuid::parse_str("aaaaaaaa-0000-0000-0000-000000000001").unwrap();
+        let u2 = Uuid::parse_str("aaaaaaaa-0000-0000-0000-000000000002").unwrap();
+        let u3 = Uuid::parse_str("aaaaaaaa-0000-0000-0000-000000000003").unwrap();
+
+        // Single mock for both pages: KC always returns all 3 users.
+        // sorted order: u1(ts=1000) < u2(ts=2000) < u3(ts=3000).
+        // Page 1: limit=2, no cursor → emit u1,u2; cursor encodes u2.
+        // Page 2: limit=2, cursor=(ts=2000,u2) → skip u1,u2 → emit u3 only.
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/admin/realms/platform/groups/{group_uuid}/members"
+            )))
+            .and(query_param("first", "0"))
+            // Plugin drains the full membership a page at a time, fetching
+            // `list_users_page_limit_max` rows per KC call (test cfg sets it
+            // to 200). Small fixtures fit in the first page, so a single
+            // `first=0` call still serves the request.
+            .and(query_param("max", "200"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": u1.to_string(), "username": "a", "createdTimestamp": 1000_i64},
+                {"id": u2.to_string(), "username": "b", "createdTimestamp": 2000_i64},
+                {"id": u3.to_string(), "username": "c", "createdTimestamp": 3000_i64},
+            ])))
+            .expect(2) // page 1 + page 2 each call the same endpoint
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let metadata = Some(make_metadata(
+            "platform",
+            RealmBinding::Shared,
+            group_uuid,
+            None,
+        ));
+
+        // Page 1.
+        let req1 = list_users_req(
+            tenant_uuid,
+            metadata.clone(),
+            IdpUserPagination::new(2, None).expect("valid pagination"),
+            None,
+        );
+        let page1 = facade
+            .list_users_inner(&ctx, &req1)
+            .await
+            .expect("page 1 ok");
+        assert_eq!(page1.items.len(), 2);
+        assert_eq!(page1.items[0].id, u1);
+        assert_eq!(page1.items[1].id, u2);
+        let cursor = page1
+            .page_info
+            .next_cursor
+            .clone()
+            .expect("page 1 produced cursor");
+
+        // Verify cursor encodes u2's tiebreaker.
+        let decoded = UserFacade::decode_cursor(&cursor).expect("cursor decodes");
+        assert_eq!(decoded.last_created_at, 2000_i64);
+        assert_eq!(decoded.last_user_id, u2);
+
+        // Page 2 — re-issue with cursor; client-side skip removes u1,u2.
+        let req2 = list_users_req(
+            tenant_uuid,
+            metadata,
+            IdpUserPagination::new(2, Some(cursor)).expect("valid pagination"),
+            None,
+        );
+        let page2 = facade
+            .list_users_inner(&ctx, &req2)
+            .await
+            .expect("page 2 ok");
+        assert_eq!(page2.items.len(), 1);
+        assert_eq!(page2.items[0].id, u3);
+        assert!(
+            page2.page_info.next_cursor.is_none(),
+            "last page must not produce a next_cursor",
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn list_users_cursor_filter_mismatch_returns_rejected() {
+    let server = MockServer::start().await;
+    // No KC mocks needed — failure short-circuits before fetching members.
+
+    // Encode a cursor whose `filter_hash` was computed against
+    // `user_id_filter = Some(filter_a)`; the request will then ask
+    // with `user_id_filter = Some(filter_b)`.
+    let tenant_uuid = Uuid::new_v4();
+    let filter_a = Uuid::new_v4();
+    let filter_b = Uuid::new_v4();
+    let group_uuid = Uuid::new_v4();
+    let stale_cursor = UserFacade::encode_cursor(&ListUsersCursor {
+        filter_hash: UserFacade::filter_hash(
+            tenant_uuid,
+            "platform",
+            Some(filter_a),
+            &StringMatcher::Always,
+        ),
+        last_created_at: 1_716_400_001_000_i64,
+        last_user_id: filter_a,
+    });
+
+    let facade = build_facade(&server);
+    let ctx = build_system_ctx(Uuid::nil());
+    let req = list_users_req(
+        tenant_uuid,
+        Some(make_metadata(
+            "platform",
+            RealmBinding::Shared,
+            group_uuid,
+            None,
+        )),
+        IdpUserPagination::new(2, Some(stale_cursor)).expect("valid pagination"),
+        Some(filter_b),
+    );
+
+    let err = facade
+        .list_users_inner(&ctx, &req)
+        .await
+        .expect_err("filter mismatch must error");
+    assert!(
+        matches!(err, PluginError::UserOpRejected { ref detail } if detail == "invalid cursor"),
+        "expected UserOpRejected{{ detail == 'invalid cursor' }}, got {err:?}",
+    );
+}
+
+#[tokio::test]
+async fn list_users_5xx_returns_unavailable() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        let group_uuid = Uuid::new_v4();
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/admin/realms/platform/groups/{group_uuid}/members"
+            )))
+            .respond_with(ResponseTemplate::new(503).set_body_string("Service Unavailable"))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = list_users_req(
+            Uuid::new_v4(),
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                group_uuid,
+                None,
+            )),
+            IdpUserPagination::default(),
+            None,
+        );
+
+        let err = facade
+            .list_users_inner(&ctx, &req)
+            .await
+            .expect_err("5xx must error");
+        assert!(
+            matches!(err, PluginError::UserOpUnavailable { ref detail } if detail.contains("503")),
+            "expected UserOpUnavailable{{ detail contains 503 }}, got {err:?}",
+        );
+    })
+    .await;
+}
+
+// -----------------------------------------------------------------
+// Tasks 8+9 — cursor codec round-trips and list_users tiebreaker
+// -----------------------------------------------------------------
+
+// `cursor_round_trip_first_page_has_null_tiebreaker` (pre-CursorV1)
+// was retired with the CursorV1 migration: the new envelope always
+// carries a concrete `(last_created_at, last_user_id)` pair (the
+// plugin only emits a cursor when `has_more=true`, which means at
+// least one row was emitted and its tiebreaker is known). The
+// "first page" case is now "no cursor at all" — covered implicitly
+// by every test that calls `list_users_inner` without a cursor.
+
+#[test]
+fn cursor_round_trip_with_tiebreaker() {
+    use uuid::uuid;
+    let c = ListUsersCursor {
+        filter_hash: "abc123".into(),
+        last_created_at: 1_716_400_000_000_i64,
+        last_user_id: uuid!("9c4a6b2e-0000-0000-0000-000000000001"),
+    };
+    let encoded = UserFacade::encode_cursor(&c);
+    let decoded = UserFacade::decode_cursor(&encoded).expect("decodes");
+    assert_eq!(decoded.last_created_at, 1_716_400_000_000_i64);
+    assert_eq!(
+        decoded.last_user_id,
+        uuid!("9c4a6b2e-0000-0000-0000-000000000001"),
+    );
+    assert_eq!(decoded.filter_hash, "abc123");
+}
+
+/// `CursorV1` envelope is wire-compatible with `toolkit_odata::CursorV1`:
+/// the AM handler `lower_odata_to_list_users_query` MUST be able to
+/// parse our cursor through the same `CursorV1::decode` path it uses
+/// for tenant `list_children`. Verify the plugin's emitted cursor
+/// decodes cleanly as `CursorV1` and carries the documented
+/// `(o, s, d)` triple plus our `(k[0], k[1])` tiebreaker.
+#[test]
+fn cursor_wire_shape_is_cursor_v1_compatible() {
+    use toolkit_odata::{CursorV1, SortDir};
+    use uuid::uuid;
+    let c = ListUsersCursor {
+        filter_hash: "abc123".into(),
+        last_created_at: 1_716_400_000_000_i64,
+        last_user_id: uuid!("9c4a6b2e-0000-0000-0000-000000000001"),
+    };
+    let encoded = UserFacade::encode_cursor(&c);
+    let parsed = CursorV1::decode(&encoded).expect("encoded cursor MUST be a valid CursorV1");
+    assert_eq!(parsed.o, SortDir::Asc);
+    assert_eq!(parsed.s, "+created_at,+id");
+    assert_eq!(parsed.d, "fwd");
+    assert_eq!(parsed.f.as_deref(), Some("abc123"));
+    assert_eq!(parsed.k.len(), 2);
+    assert_eq!(parsed.k[0], "1716400000000");
+    assert_eq!(parsed.k[1], "9c4a6b2e-0000-0000-0000-000000000001");
+}
+
+/// Cursors emitted under one `(o, s)` order-pin MUST be rejected
+/// when sent back with a different order shape. Forging a `CursorV1`
+/// with the wrong `s` (e.g. another endpoint's cursor accidentally
+/// reused) surfaces as `UserOpRejected("invalid cursor")`.
+#[test]
+fn cursor_decode_rejects_mismatched_order_pin() {
+    use toolkit_odata::{CursorV1, SortDir};
+    let forged = CursorV1 {
+        k: vec!["1716400000000".into(), Uuid::nil().to_string()],
+        o: SortDir::Desc,      // mismatched
+        s: "+username".into(), // mismatched
+        f: Some("abc123".into()),
+        d: "fwd".into(),
+    }
+    .encode()
+    .expect("forged cursor encodes");
+    let err = UserFacade::decode_cursor(&forged).expect_err("mismatched order rejected");
+    assert!(matches!(err, PluginError::UserOpRejected { .. }));
+}
+
+/// `CursorV1` with absent `f` (no filter context) is structurally
+/// invalid for our envelope — the plugin always sets a filter hash
+/// (even for "no filter" requests, it hashes the `tenant_id` +
+/// `realm_name` + empty filter set). Reject so a hand-rolled or
+/// foreign cursor doesn't silently bypass filter-pinning.
+#[test]
+fn cursor_decode_rejects_missing_filter_hash() {
+    use toolkit_odata::{CursorV1, SortDir};
+    let forged = CursorV1 {
+        k: vec!["1716400000000".into(), Uuid::nil().to_string()],
+        o: SortDir::Asc,
+        s: "+created_at,+id".into(),
+        f: None, // missing
+        d: "fwd".into(),
+    }
+    .encode()
+    .expect("forged cursor encodes");
+    let err = UserFacade::decode_cursor(&forged).expect_err("missing f rejected");
+    assert!(matches!(err, PluginError::UserOpRejected { .. }));
+}
+
+#[tokio::test]
+async fn list_users_emits_cursor_when_more_results_exist() {
+    use uuid::uuid;
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        let group_uuid = Uuid::new_v4();
+        // limit=2, 3-member fixture (fits one page) → has_more=true.
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/admin/realms/platform/groups/{group_uuid}/members"
+            )))
+            .and(query_param("first", "0"))
+            // Plugin drains the full membership a page at a time, fetching
+            // `list_users_page_limit_max` rows per KC call (test cfg sets it
+            // to 200). Small fixtures fit in the first page, so a single
+            // `first=0` call still serves the request.
+            .and(query_param("max", "200"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": "9c4a6b2e-0000-0000-0000-000000000001", "username": "u1", "createdTimestamp": 1_716_400_000_000_i64},
+                {"id": "9c4a6b2e-0000-0000-0000-000000000002", "username": "u2", "createdTimestamp": 1_716_400_001_000_i64},
+                {"id": "9c4a6b2e-0000-0000-0000-000000000003", "username": "u3", "createdTimestamp": 1_716_400_002_000_i64},
+            ])))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = list_users_req(
+            Uuid::new_v4(),
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                group_uuid,
+                None,
+            )),
+            IdpUserPagination::new(2, None).expect("valid pagination"),
+            None,
+        );
+
+        let page = facade.list_users_inner(&ctx, &req).await.expect("ok");
+        assert_eq!(page.items.len(), 2, "must emit exactly limit=2 items");
+        assert!(
+            page.page_info.next_cursor.is_some(),
+            "next_cursor must be set when more results exist",
+        );
+        let next =
+            UserFacade::decode_cursor(page.page_info.next_cursor.as_ref().unwrap())
+                .expect("decodes");
+        assert_eq!(next.last_created_at, 1_716_400_001_000_i64);
+        assert_eq!(
+            next.last_user_id,
+            uuid!("9c4a6b2e-0000-0000-0000-000000000002"),
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn list_users_no_cursor_on_last_page() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        let group_uuid = Uuid::new_v4();
+        // limit=10, 2-member fixture (one short page) → has_more=false.
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/admin/realms/platform/groups/{group_uuid}/members"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": "9c4a6b2e-0000-0000-0000-000000000001", "username": "u1", "createdTimestamp": 1_716_400_000_000_i64},
+                {"id": "9c4a6b2e-0000-0000-0000-000000000002", "username": "u2", "createdTimestamp": 1_716_400_001_000_i64},
+            ])))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = list_users_req(
+            Uuid::new_v4(),
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                group_uuid,
+                None,
+            )),
+            IdpUserPagination::new(10, None).expect("valid pagination"),
+            None,
+        );
+
+        let page = facade.list_users_inner(&ctx, &req).await.expect("ok");
+        assert_eq!(page.items.len(), 2);
+        assert!(
+            page.page_info.next_cursor.is_none(),
+            "next_cursor must be None on last page",
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn list_users_drains_members_past_first_page() {
+    // VHP-1973 regression: a member KC orders past the first members page
+    // must still be reachable via pagination. With
+    // `list_users_page_limit_max = 2` the facade pages the group in windows
+    // of 2; the third member lives in the SECOND KC window (first=2). The
+    // pre-fix single-window fetch (first=0 only) dropped it from every page
+    // — create-then-list returned 201 yet the user never appeared.
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        let tenant_uuid = Uuid::new_v4();
+        let group_uuid = Uuid::new_v4();
+        let u1 = Uuid::parse_str("bbbbbbbb-0000-0000-0000-000000000001").unwrap();
+        let u2 = Uuid::parse_str("bbbbbbbb-0000-0000-0000-000000000002").unwrap();
+        let u3 = Uuid::parse_str("bbbbbbbb-0000-0000-0000-000000000003").unwrap();
+
+        // First window (first=0, full page of 2) → drain continues.
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/admin/realms/platform/groups/{group_uuid}/members"
+            )))
+            .and(query_param("first", "0"))
+            .and(query_param("max", "2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": u1.to_string(), "username": "u1", "createdTimestamp": 1000_i64},
+                {"id": u2.to_string(), "username": "u2", "createdTimestamp": 2000_i64},
+            ])))
+            .mount(&server)
+            .await;
+        // Second window (first=2, short page of 1) → drain stops here.
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/admin/realms/platform/groups/{group_uuid}/members"
+            )))
+            .and(query_param("first", "2"))
+            .and(query_param("max", "2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": u3.to_string(), "username": "u3", "createdTimestamp": 3000_i64},
+            ])))
+            .mount(&server)
+            .await;
+
+        let user_cfg = UserFacadeConfig {
+            list_users_page_limit_max: 2,
+            ..user_facade_cfg()
+        };
+        let facade = build_facade_with_user_cfg(&server, user_cfg);
+        let ctx = build_system_ctx(Uuid::nil());
+        let metadata = Some(make_metadata(
+            "platform",
+            RealmBinding::Shared,
+            group_uuid,
+            None,
+        ));
+
+        // Page 1: limit clamped to 2 → [u1, u2], cursor at u2, has_more.
+        let req1 = list_users_req(
+            tenant_uuid,
+            metadata.clone(),
+            IdpUserPagination::new(10, None).expect("valid pagination"),
+            None,
+        );
+        let page1 = facade
+            .list_users_inner(&ctx, &req1)
+            .await
+            .expect("page 1 ok");
+        assert_eq!(
+            page1.items.iter().map(|u| u.id).collect::<Vec<_>>(),
+            vec![u1, u2],
+        );
+        let cursor = page1
+            .page_info
+            .next_cursor
+            .clone()
+            .expect("page 1 produced a cursor");
+
+        // Page 2: the second-window member MUST appear (the bug: it never did).
+        let req2 = list_users_req(
+            tenant_uuid,
+            metadata,
+            IdpUserPagination::new(10, Some(cursor)).expect("valid pagination"),
+            None,
+        );
+        let page2 = facade
+            .list_users_inner(&ctx, &req2)
+            .await
+            .expect("page 2 ok");
+        assert_eq!(
+            page2.items.iter().map(|u| u.id).collect::<Vec<_>>(),
+            vec![u3],
+            "member in the second KC window must be reachable via pagination",
+        );
+        assert!(
+            page2.page_info.next_cursor.is_none(),
+            "u3 is the last row — no further cursor",
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn list_users_filter_finds_member_past_first_page() {
+    // VHP-1973 regression: `$filter=username eq '<name>'` must find a user
+    // even when KC orders it past the first members page. The filter is
+    // applied client-side over the DRAINED set, so the drain must pull the
+    // second window first; the pre-fix single-window fetch returned an
+    // empty result for a user that plainly exists in the group.
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+
+        let group_uuid = Uuid::new_v4();
+        let target = Uuid::parse_str("cccccccc-0000-0000-0000-000000000003").unwrap();
+
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/admin/realms/platform/groups/{group_uuid}/members"
+            )))
+            .and(query_param("first", "0"))
+            .and(query_param("max", "2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": "cccccccc-0000-0000-0000-000000000001", "username": "alice", "createdTimestamp": 1000_i64},
+                {"id": "cccccccc-0000-0000-0000-000000000002", "username": "bob", "createdTimestamp": 2000_i64},
+            ])))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/admin/realms/platform/groups/{group_uuid}/members"
+            )))
+            .and(query_param("first", "2"))
+            .and(query_param("max", "2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"id": target.to_string(), "username": "rty.fgh", "createdTimestamp": 3000_i64},
+            ])))
+            .mount(&server)
+            .await;
+
+        let user_cfg = UserFacadeConfig {
+            list_users_page_limit_max: 2,
+            ..user_facade_cfg()
+        };
+        let facade = build_facade_with_user_cfg(&server, user_cfg);
+        let ctx = build_system_ctx(Uuid::nil());
+        let req = list_users_req(
+            Uuid::new_v4(),
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                group_uuid,
+                None,
+            )),
+            IdpUserPagination::new(10, None).expect("valid pagination"),
+            None,
+        )
+        .with_filter(FilterNode::binary(
+            IdpUserFilterField::Username,
+            FilterOp::Eq,
+            ODataValue::String("rty.fgh".into()),
+        ));
+
+        let page = facade
+            .list_users_inner(&ctx, &req)
+            .await
+            .expect("list ok");
+        assert_eq!(
+            page.items.iter().map(|u| u.id).collect::<Vec<_>>(),
+            vec![target],
+            "username filter must find a member living past the first KC window",
+        );
+    })
+    .await;
+}
+
+// =============================================================================
+// build_string_matcher — $filter lowering tests
+//
+// Pins the FilterNode → StringMatcher lowering: the supported operator
+// subset (`eq` / `contains` / `and` / `or` on string fields; `id eq`
+// folded to `Always`) plus the UnsupportedOperation (501) surface for
+// shapes the /users contract does not support. Helper-level tests (no
+// wiremock) — symmetric with the `extract_id_filter` tests.
+// =============================================================================
+
+fn lit_string(v: &str) -> ODataValue {
+    ODataValue::String(v.into())
+}
+
+#[test]
+fn build_string_matcher_none_is_always() {
+    let got = UserFacade::build_string_matcher(None).expect("no filter is valid");
+    assert_eq!(got, StringMatcher::Always);
+}
+
+#[test]
+fn build_string_matcher_id_only_is_always() {
+    // `id eq <uuid>` is captured by `extract_id_filter`; at the top
+    // level it lowers to `Always` so the string predicate is a no-op.
+    let node = FilterNode::binary(
+        IdpUserFilterField::Id,
+        FilterOp::Eq,
+        ODataValue::Uuid(Uuid::new_v4()),
+    );
+    let got = UserFacade::build_string_matcher(Some(&node))
+        .expect("id-eq alone is supported via extract_id_filter");
+    assert_eq!(got, StringMatcher::Always);
+}
+
+#[test]
+fn build_string_matcher_single_eq_on_username() {
+    let node = FilterNode::binary(
+        IdpUserFilterField::Username,
+        FilterOp::Eq,
+        lit_string("alice"),
+    );
+    let got = UserFacade::build_string_matcher(Some(&node)).expect("supported");
+    assert_eq!(
+        got,
+        StringMatcher::Field {
+            field: IdpUserFilterField::Username,
+            op: StringMatchOp::Eq,
+            needle: "alice".into(),
+        }
+    );
+}
+
+#[test]
+fn build_string_matcher_contains_on_username() {
+    // `contains` is the user-search operator (VHP-1957) — previously 501.
+    let node = FilterNode::binary(
+        IdpUserFilterField::Username,
+        FilterOp::Contains,
+        lit_string("ali"),
+    );
+    let got = UserFacade::build_string_matcher(Some(&node)).expect("contains is supported");
+    assert_eq!(
+        got,
+        StringMatcher::Field {
+            field: IdpUserFilterField::Username,
+            op: StringMatchOp::Contains,
+            needle: "ali".into(),
+        }
+    );
+}
+
+#[test]
+#[allow(clippy::panic)] // test-only assertion: panic on unsupported field reveals codegen drift
+fn build_string_matcher_each_supported_string_field() {
+    for field in [
+        IdpUserFilterField::Username,
+        IdpUserFilterField::Email,
+        IdpUserFilterField::FirstName,
+        IdpUserFilterField::LastName,
+        IdpUserFilterField::DisplayName,
+    ] {
+        let node = FilterNode::binary(field, FilterOp::Eq, lit_string("v"));
+        let got = UserFacade::build_string_matcher(Some(&node))
+            .unwrap_or_else(|e| panic!("field {field:?} should be supported, got {e:?}"));
+        assert_eq!(
+            got,
+            StringMatcher::Field {
+                field,
+                op: StringMatchOp::Eq,
+                needle: "v".into(),
+            },
+            "field {field:?} lowered to the wrong clause"
+        );
+    }
+}
+
+#[test]
+fn build_string_matcher_and_is_conjunction() {
+    let node = FilterNode::and(vec![
+        FilterNode::binary(
+            IdpUserFilterField::Username,
+            FilterOp::Eq,
+            lit_string("alice"),
+        ),
+        FilterNode::binary(IdpUserFilterField::Email, FilterOp::Eq, lit_string("a@b")),
+    ]);
+    let got = UserFacade::build_string_matcher(Some(&node)).expect("supported");
+    assert_eq!(
+        got,
+        StringMatcher::All(vec![
+            StringMatcher::Field {
+                field: IdpUserFilterField::Username,
+                op: StringMatchOp::Eq,
+                needle: "alice".into(),
+            },
+            StringMatcher::Field {
+                field: IdpUserFilterField::Email,
+                op: StringMatchOp::Eq,
+                needle: "a@b".into(),
+            },
+        ])
+    );
+}
+
+#[test]
+fn build_string_matcher_or_of_contains_is_disjunction() {
+    // The exact shape the Users-list search screen sends (VHP-1957):
+    // `contains(username,'a') or contains(email,'a') or contains(display_name,'a')`.
+    let node = FilterNode::or(vec![
+        FilterNode::binary(
+            IdpUserFilterField::Username,
+            FilterOp::Contains,
+            lit_string("a"),
+        ),
+        FilterNode::binary(
+            IdpUserFilterField::Email,
+            FilterOp::Contains,
+            lit_string("a"),
+        ),
+        FilterNode::binary(
+            IdpUserFilterField::DisplayName,
+            FilterOp::Contains,
+            lit_string("a"),
+        ),
+    ]);
+    let got = UserFacade::build_string_matcher(Some(&node)).expect("or of contains is supported");
+    assert_eq!(
+        got,
+        StringMatcher::Any(vec![
+            StringMatcher::Field {
+                field: IdpUserFilterField::Username,
+                op: StringMatchOp::Contains,
+                needle: "a".into(),
+            },
+            StringMatcher::Field {
+                field: IdpUserFilterField::Email,
+                op: StringMatchOp::Contains,
+                needle: "a".into(),
+            },
+            StringMatcher::Field {
+                field: IdpUserFilterField::DisplayName,
+                op: StringMatchOp::Contains,
+                needle: "a".into(),
+            },
+        ])
+    );
+}
+
+#[test]
+fn build_string_matcher_id_combined_with_username_under_and() {
+    // `id eq <uuid> and username eq 'alice'` → All[Always, Field(username)].
+    let node = FilterNode::and(vec![
+        FilterNode::binary(
+            IdpUserFilterField::Id,
+            FilterOp::Eq,
+            ODataValue::Uuid(Uuid::new_v4()),
+        ),
+        FilterNode::binary(
+            IdpUserFilterField::Username,
+            FilterOp::Eq,
+            lit_string("alice"),
+        ),
+    ]);
+    let got = UserFacade::build_string_matcher(Some(&node)).expect("supported combo");
+    assert_eq!(
+        got,
+        StringMatcher::All(vec![
+            StringMatcher::Always,
+            StringMatcher::Field {
+                field: IdpUserFilterField::Username,
+                op: StringMatchOp::Eq,
+                needle: "alice".into(),
+            },
+        ])
+    );
+}
+
+#[test]
+fn build_string_matcher_rejects_id_eq_inside_or() {
+    // `id` cannot be hoisted out of a disjunction → explicit 501.
+    let node = FilterNode::or(vec![
+        FilterNode::binary(
+            IdpUserFilterField::Id,
+            FilterOp::Eq,
+            ODataValue::Uuid(Uuid::new_v4()),
+        ),
+        FilterNode::binary(
+            IdpUserFilterField::Username,
+            FilterOp::Eq,
+            lit_string("alice"),
+        ),
+    ]);
+    let err = UserFacade::build_string_matcher(Some(&node)).expect_err("id-in-or unsupported");
+    assert!(matches!(err, PluginError::UserOpUnsupported { .. }));
+}
+
+#[test]
+fn build_string_matcher_rejects_ne() {
+    let node = FilterNode::binary(
+        IdpUserFilterField::Username,
+        FilterOp::Ne,
+        lit_string("alice"),
+    );
+    let err = UserFacade::build_string_matcher(Some(&node)).expect_err("ne is unsupported");
+    assert!(matches!(err, PluginError::UserOpUnsupported { .. }));
+    assert!(
+        err.to_string().contains("ne"),
+        "detail should name op: {err}"
+    );
+}
+
+#[test]
+#[allow(clippy::panic)] // test-only assertion: panic on unexpected Ok signals contract drift
+fn build_string_matcher_rejects_startswith_and_endswith() {
+    // `contains` is now supported; the other substring ops are not.
+    for op in [FilterOp::StartsWith, FilterOp::EndsWith] {
+        let node = FilterNode::binary(IdpUserFilterField::Username, op, lit_string("a"));
+        let Err(err) = UserFacade::build_string_matcher(Some(&node)) else {
+            panic!("op {op:?} must be UnsupportedOperation")
+        };
+        assert!(matches!(err, PluginError::UserOpUnsupported { .. }));
+    }
+}
+
+#[test]
+fn build_string_matcher_rejects_in_list() {
+    let node = FilterNode::InList {
+        field: IdpUserFilterField::Username,
+        values: vec![lit_string("alice"), lit_string("bob")],
+    };
+    let err = UserFacade::build_string_matcher(Some(&node)).expect_err("in unsupported");
+    assert!(matches!(err, PluginError::UserOpUnsupported { .. }));
+}
+
+#[test]
+fn build_string_matcher_rejects_not() {
+    let inner = FilterNode::binary(
+        IdpUserFilterField::Username,
+        FilterOp::Eq,
+        lit_string("alice"),
+    );
+    let node = FilterNode::not(inner);
+    let err = UserFacade::build_string_matcher(Some(&node)).expect_err("not unsupported");
+    assert!(matches!(err, PluginError::UserOpUnsupported { .. }));
+}
+
+#[test]
+fn build_string_matcher_rejects_non_string_literal_on_string_field() {
+    // Username is a string field; a Uuid literal is a type mismatch the
+    // AM-side validator usually catches first, but the plugin's
+    // belt-and-braces check rejects it explicitly too.
+    let node = FilterNode::binary(
+        IdpUserFilterField::Username,
+        FilterOp::Eq,
+        ODataValue::Uuid(Uuid::new_v4()),
+    );
+    let err = UserFacade::build_string_matcher(Some(&node)).expect_err("type mismatch");
+    assert!(matches!(err, PluginError::UserOpUnsupported { .. }));
+}
+
+// =============================================================================
+// StringMatcher::matches — predicate evaluation tests
+// =============================================================================
+
+fn make_rep(
+    id: Uuid,
+    username: &str,
+    email: Option<&str>,
+    first: Option<&str>,
+    last: Option<&str>,
+) -> UserRep {
+    UserRep {
+        id,
+        created_timestamp: 0,
+        username: Some(username.into()),
+        email: email.map(str::to_owned),
+        first_name: first.map(str::to_owned),
+        last_name: last.map(str::to_owned),
+    }
+}
+
+fn eq(field: IdpUserFilterField, needle: &str) -> StringMatcher {
+    StringMatcher::Field {
+        field,
+        op: StringMatchOp::Eq,
+        needle: needle.into(),
+    }
+}
+
+fn contains(field: IdpUserFilterField, needle: &str) -> StringMatcher {
+    StringMatcher::Field {
+        field,
+        op: StringMatchOp::Contains,
+        needle: needle.into(),
+    }
+}
+
+#[test]
+fn matches_always_matches_every_rep() {
+    let rep = make_rep(Uuid::new_v4(), "alice", Some("a@b"), Some("A"), Some("B"));
+    assert!(StringMatcher::Always.matches(&rep));
+}
+
+#[test]
+fn matches_eq_is_case_sensitive_exact() {
+    let rep = make_rep(Uuid::new_v4(), "alice", None, None, None);
+    assert!(eq(IdpUserFilterField::Username, "alice").matches(&rep));
+    assert!(
+        !eq(IdpUserFilterField::Username, "Alice").matches(&rep),
+        "eq is case-sensitive"
+    );
+    assert!(!eq(IdpUserFilterField::Username, "bob").matches(&rep));
+}
+
+#[test]
+fn matches_contains_is_case_insensitive_substring() {
+    let rep = make_rep(
+        Uuid::new_v4(),
+        "alice",
+        Some("Alice@Example.COM"),
+        None,
+        None,
+    );
+    assert!(
+        contains(IdpUserFilterField::Username, "LIC").matches(&rep),
+        "case-insensitive substring on username"
+    );
+    assert!(
+        contains(IdpUserFilterField::Email, "example").matches(&rep),
+        "case-insensitive substring on email"
+    );
+    assert!(!contains(IdpUserFilterField::Username, "xyz").matches(&rep));
+}
+
+#[test]
+fn matches_display_name_derived_from_first_and_last() {
+    // `display_name` is not on UserRep — derived as `"first last"`
+    // when both are present (mirrors `user_rep_to_idp_user`).
+    let rep = make_rep(Uuid::new_v4(), "u", None, Some("Alice"), Some("Liddell"));
+    assert!(eq(IdpUserFilterField::DisplayName, "Alice Liddell").matches(&rep));
+    assert!(contains(IdpUserFilterField::DisplayName, "lid").matches(&rep));
+}
+
+#[test]
+fn matches_absent_field_never_satisfies_a_clause() {
+    let rep = make_rep(Uuid::new_v4(), "u", None, None, None);
+    assert!(!eq(IdpUserFilterField::Email, "a@b").matches(&rep));
+    assert!(!contains(IdpUserFilterField::Email, "a").matches(&rep));
+}
+
+#[test]
+fn matches_all_is_conjunction() {
+    let rep = make_rep(Uuid::new_v4(), "alice", Some("a@b"), None, None);
+    let all_ok = StringMatcher::All(vec![
+        eq(IdpUserFilterField::Username, "alice"),
+        eq(IdpUserFilterField::Email, "a@b"),
+    ]);
+    assert!(all_ok.matches(&rep));
+    let one_bad = StringMatcher::All(vec![
+        eq(IdpUserFilterField::Username, "alice"),
+        eq(IdpUserFilterField::Email, "other"),
+    ]);
+    assert!(!one_bad.matches(&rep));
+}
+
+#[test]
+fn matches_any_is_disjunction_frontend_search_shape() {
+    // `contains(username,'a') or contains(email,'a') or contains(display_name,'a')`.
+    let search = StringMatcher::Any(vec![
+        contains(IdpUserFilterField::Username, "a"),
+        contains(IdpUserFilterField::Email, "a"),
+        contains(IdpUserFilterField::DisplayName, "a"),
+    ]);
+    // Matches via email even though username/display-name lack 'a'.
+    let rep = make_rep(Uuid::new_v4(), "zzz", Some("qa@x"), None, None);
+    assert!(search.matches(&rep));
+    // No 'a' anywhere → no match.
+    let rep2 = make_rep(Uuid::new_v4(), "zzz", Some("q@x"), Some("Bob"), Some("Lee"));
+    assert!(!search.matches(&rep2));
+}
+
+// =============================================================================
+// filter_hash — cursor pinning extension tests
+// =============================================================================
+
+#[test]
+fn filter_hash_changes_when_string_filter_added() {
+    let tenant = Uuid::new_v4();
+    let h0 = UserFacade::filter_hash(tenant, "platform", None, &StringMatcher::Always);
+    let h1 = UserFacade::filter_hash(
+        tenant,
+        "platform",
+        None,
+        &eq(IdpUserFilterField::Username, "alice"),
+    );
+    assert_ne!(
+        h0, h1,
+        "adding a string filter MUST change the hash so the previous \
+         cursor is rejected as `invalid cursor`",
+    );
+}
+
+#[test]
+fn filter_hash_changes_when_string_filter_value_changes() {
+    let tenant = Uuid::new_v4();
+    let h1 = UserFacade::filter_hash(
+        tenant,
+        "platform",
+        None,
+        &eq(IdpUserFilterField::Username, "alice"),
+    );
+    let h2 = UserFacade::filter_hash(
+        tenant,
+        "platform",
+        None,
+        &eq(IdpUserFilterField::Username, "bob"),
+    );
+    assert_ne!(h1, h2, "changing the filter value MUST change the hash");
+}
+
+#[test]
+fn filter_hash_changes_when_operator_changes() {
+    // A cursor minted under `username eq 'a'` must be rejected under
+    // `username contains 'a'` — the op is part of the filter identity.
+    let tenant = Uuid::new_v4();
+    let h_eq = UserFacade::filter_hash(
+        tenant,
+        "platform",
+        None,
+        &eq(IdpUserFilterField::Username, "a"),
+    );
+    let h_contains = UserFacade::filter_hash(
+        tenant,
+        "platform",
+        None,
+        &contains(IdpUserFilterField::Username, "a"),
+    );
+    assert_ne!(h_eq, h_contains, "eq vs contains MUST change the hash");
+}
+
+#[test]
+fn filter_hash_changes_between_and_and_or() {
+    let tenant = Uuid::new_v4();
+    let clauses = || {
+        vec![
+            contains(IdpUserFilterField::Username, "a"),
+            contains(IdpUserFilterField::Email, "a"),
+        ]
+    };
+    let h_and = UserFacade::filter_hash(tenant, "platform", None, &StringMatcher::All(clauses()));
+    let h_or = UserFacade::filter_hash(tenant, "platform", None, &StringMatcher::Any(clauses()));
+    assert_ne!(h_and, h_or, "and vs or over the same clauses MUST differ");
+}
+
+#[test]
+fn filter_hash_distinguishes_some_empty_string_from_none() {
+    let tenant = Uuid::new_v4();
+    let h_none = UserFacade::filter_hash(tenant, "platform", None, &StringMatcher::Always);
+    let h_empty = UserFacade::filter_hash(
+        tenant,
+        "platform",
+        None,
+        &eq(IdpUserFilterField::Username, ""),
+    );
+    assert_ne!(
+        h_none, h_empty,
+        "`username eq ''` and no filter MUST hash differently",
+    );
+}
+
+/// `realm_name` is folded into the hash so a tenant whose realm
+/// rebinds mid-pagination produces a different cursor signature —
+/// `invalid cursor` reject on the continuation request, same path
+/// as a filter/tenant change. Pre-CursorV1 this was an explicit
+/// `decoded.realm_name != metadata.realm_name` check on the plugin
+/// side; the hash fold replaces it.
+#[test]
+fn filter_hash_changes_when_realm_name_changes() {
+    let tenant = Uuid::new_v4();
+    let h_a = UserFacade::filter_hash(tenant, "platform", None, &StringMatcher::Always);
+    let h_b = UserFacade::filter_hash(tenant, "partner-acme", None, &StringMatcher::Always);
+    assert_ne!(
+        h_a, h_b,
+        "realm rebind MUST change the hash (replaces the pre-CursorV1 \
+         explicit realm-name equality check)",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// VHP-2158: KC response classification for user-create rejections.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn kc_conflict_classifies_duplicate_username() {
+    let body = r#"{"errorMessage":"User exists with same username"}"#;
+    assert_eq!(
+        classify_kc_conflict(body),
+        account_management_sdk::IdpUserDuplicateField::Username
+    );
+}
+
+#[test]
+fn kc_conflict_classifies_duplicate_email() {
+    let body = r#"{"errorMessage":"User exists with same email"}"#;
+    assert_eq!(
+        classify_kc_conflict(body),
+        account_management_sdk::IdpUserDuplicateField::Email
+    );
+}
+
+// KC's ModelDuplicateException path emits the combined constant — on
+// KC 26 it is the ONLY 409 `createUser` produces directly. A message
+// naming both nouns must NOT be misattributed to username (the
+// contains("username") check running first).
+#[test]
+fn kc_conflict_combined_message_is_username_or_email() {
+    let body = r#"{"errorMessage":"User exists with same username or email"}"#;
+    assert_eq!(
+        classify_kc_conflict(body),
+        account_management_sdk::IdpUserDuplicateField::UsernameOrEmail
+    );
+}
+
+// The 409 status alone is the uniqueness signal: unknown wording,
+// non-JSON proxy bodies, and JSON without `errorMessage` all stay in
+// the duplicate lane with the honest unattributed field — wording
+// drift can degrade the field token, never the 409 status.
+#[test]
+fn kc_conflict_unrecognised_body_is_unattributed_duplicate() {
+    use account_management_sdk::IdpUserDuplicateField as F;
+    assert_eq!(
+        classify_kc_conflict(r#"{"errorMessage":"Some vendor surprise"}"#),
+        F::UsernameOrEmail
+    );
+    assert_eq!(
+        classify_kc_conflict("<html>proxy error</html>"),
+        F::UsernameOrEmail
+    );
+    assert_eq!(
+        classify_kc_conflict(r#"{"error":"conflict"}"#),
+        F::UsernameOrEmail
+    );
+}
+
+#[test]
+fn kc_password_policy_reject_both_shapes_detected() {
+    // Admin user-create with embedded credential (KC errorMessage shape).
+    assert!(is_kc_password_policy_reject(
+        r#"{"errorMessage":"Password policy not met"}"#
+    ));
+    // Credential-endpoint shape (`error` = invalidPassword* constant).
+    assert!(is_kc_password_policy_reject(
+        r#"{"error":"invalidPasswordMinLengthMessage","error_description":"Invalid password: minimum length 12"}"#
+    ));
+    // errorMessage carrying the invalidPassword* constant directly.
+    assert!(is_kc_password_policy_reject(
+        r#"{"errorMessage":"invalidPasswordMinDigitsMessage"}"#
+    ));
+}
+
+#[test]
+fn kc_password_policy_ignores_other_400s() {
+    assert!(!is_kc_password_policy_reject(
+        r#"{"errorMessage":"unrecognized field"}"#
+    ));
+    assert!(!is_kc_password_policy_reject("not json"));
+    assert!(!is_kc_password_policy_reject(
+        r#"{"error":"unknown_error"}"#
+    ));
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/user_facade_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/user_facade_tests.rs
@@ -369,7 +369,7 @@ async fn provision_user_in_adopted_realm_uses_openbao_ref() {
     // OpenBao stub returns the per-realm admin secret keyed by the
     // templated SecretRef.
     let cs = Arc::new(ConfigurableStubCS::with_entry(
-        "vp-idp-realm-admin-partner-acme-secret",
+        "keycloak-idp-realm-admin-partner-acme-secret",
         "per-realm-ra-secret",
     ));
     let facade = build_facade_with_cs(&server, cs);
@@ -380,7 +380,7 @@ async fn provision_user_in_adopted_realm_uses_openbao_ref() {
             "partner-acme",
             RealmBinding::Adopted,
             group_uuid,
-            Some("vp-idp-realm-admin-partner-acme-secret"),
+            Some("keycloak-idp-realm-admin-partner-acme-secret"),
         )),
         "bob",
         None,
@@ -428,7 +428,7 @@ async fn provision_user_with_duplicate_username_returns_rejected() {
             .provision_user_inner(&ctx, &req)
             .await
             .expect_err("duplicate must error");
-        // VHP-2158: every 409 rides the typed duplicate lane. This mock
+        // every 409 rides the typed duplicate lane. This mock
         // returns a plain-text (non-JSON) body, so the attribution is the
         // honest unattributed token, not a misread field.
         assert!(
@@ -484,7 +484,7 @@ async fn provision_user_4xx_body_redacts_leaked_password() {
             .provision_user_inner(&ctx, &req)
             .await
             .expect_err("409 must error");
-        // VHP-2158 moved 409s to the typed duplicate lane; the B-H1
+        // 409s ride the typed duplicate lane; the B-H1
         // redaction guarantee must hold on its `detail` all the same.
         assert!(
             matches!(
@@ -1589,7 +1589,7 @@ async fn list_users_no_cursor_on_last_page() {
 
 #[tokio::test]
 async fn list_users_drains_members_past_first_page() {
-    // VHP-1973 regression: a member KC orders past the first members page
+    // Regression: a member KC orders past the first members page
     // must still be reachable via pagination. With
     // `list_users_page_limit_max = 2` the facade pages the group in windows
     // of 2; the third member lives in the SECOND KC window (first=2). The
@@ -1691,7 +1691,7 @@ async fn list_users_drains_members_past_first_page() {
 
 #[tokio::test]
 async fn list_users_filter_finds_member_past_first_page() {
-    // VHP-1973 regression: `$filter=username eq '<name>'` must find a user
+    // Regression: `$filter=username eq '<name>'` must find a user
     // even when KC orders it past the first members page. The filter is
     // applied client-side over the DRAINED set, so the drain must pull the
     // second window first; the pre-fix single-window fetch returned an
@@ -1817,7 +1817,7 @@ fn build_string_matcher_single_eq_on_username() {
 
 #[test]
 fn build_string_matcher_contains_on_username() {
-    // `contains` is the user-search operator (VHP-1957) — previously 501.
+    // `contains` is the user-search operator — previously 501.
     let node = FilterNode::binary(
         IdpUserFilterField::Username,
         FilterOp::Contains,
@@ -1889,7 +1889,7 @@ fn build_string_matcher_and_is_conjunction() {
 
 #[test]
 fn build_string_matcher_or_of_contains_is_disjunction() {
-    // The exact shape the Users-list search screen sends (VHP-1957):
+    // The exact shape the Users-list search screen sends:
     // `contains(username,'a') or contains(email,'a') or contains(display_name,'a')`.
     let node = FilterNode::or(vec![
         FilterNode::binary(
@@ -2272,7 +2272,7 @@ fn filter_hash_changes_when_realm_name_changes() {
 }
 
 // ---------------------------------------------------------------------------
-// VHP-2158: KC response classification for user-create rejections.
+// KC response classification for user-create rejections.
 // ---------------------------------------------------------------------------
 
 #[test]

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/idp_impl.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/idp_impl.rs
@@ -167,7 +167,7 @@ fn translate_provision_failure(e: PluginError) -> IdpProvisionFailure {
         },
 
         // ---- InvalidInput — caller-supplied `provisioning_metadata`
-        //      rejected by `parse_input` BEFORE any KC call (VHP-1836:
+        //      rejected by `parse_input` BEFORE any KC call (
         //      created+explicit-realm, shared with no parent metadata to
         //      inherit, bad mode/realm shape). Distinct from `Config`
         //      (which is also emitted post-KC), so this dedicated pre-KC
@@ -277,9 +277,9 @@ fn translate_deprovision_failure(e: PluginError) -> IdpDeprovisionFailure {
 ///
 /// * `UserOpRejected` → [`IdpUserOperationFailure::Rejected`] (validation).
 /// * `UserOpDuplicate` → [`IdpUserOperationFailure::DuplicateUser`]
-///   (VHP-2158: AM surfaces 409 `already_exists` attributed to the field).
+///   (AM surfaces 409 `already_exists` attributed to the field).
 /// * `UserOpPasswordPolicy` → [`IdpUserOperationFailure::PasswordPolicy`]
-///   (VHP-2158: AM surfaces the `password`/`PASSWORD_POLICY` violation).
+///   (AM surfaces the `password`/`PASSWORD_POLICY` violation).
 /// * `UserOpUnavailable` / any leaked `KcRest` →
 ///   [`IdpUserOperationFailure::Unavailable`] (provider unreachable — AM
 ///   surfaces `idp_unavailable`).
@@ -290,7 +290,7 @@ fn translate_deprovision_failure(e: PluginError) -> IdpDeprovisionFailure {
 fn translate_user_op_failure(e: PluginError) -> IdpUserOperationFailure {
     match e {
         PluginError::UserOpRejected { detail } => IdpUserOperationFailure::Rejected { detail },
-        // VHP-2158: classified rejections ride their typed SDK variants so
+        // classified rejections ride their typed SDK variants so
         // AM can surface 409 already_exists / the structured password
         // field-violation instead of the redacted generic reject.
         PluginError::UserOpDuplicate { field, detail } => {

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/idp_impl.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/idp_impl.rs
@@ -148,7 +148,7 @@ fn translate_provision_failure(e: PluginError) -> IdpProvisionFailure {
     // anchor (digest + len); this is a *complementary* breadcrumb upstream of it.
     if let PluginError::AmbiguousCreated { stage, .. } = &e {
         tracing::warn!(
-            target: "vp_idp_plugin.provision",
+            target: "keycloak_idp.provision",
             failure_variant = "ambiguous_created",
             stage = %stage,
             "Created-mode saga failed with Ambiguous outcome — operator must reconcile via reaper"

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/idp_impl.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/idp_impl.rs
@@ -1,0 +1,341 @@
+//! Plugin root struct + [`IdpPluginClient`] boundary.
+//!
+//! This module owns the translation between the plugin-internal
+//! [`PluginError`] taxonomy (rich; one variant per failure shape) and the
+//! typed SDK failure variants per DESIGN §5.5. Every facade call returns a
+//! `Result<_, PluginError>`; every boundary method below funnels the failure
+//! through a `translate_*_failure` helper before handing it back to AM.
+//!
+//! See:
+//! * DESIGN §4.0 (Plugin Root + Gear Lifecycle).
+//! * DESIGN §5.1 (Method mapping).
+//! * DESIGN §5.5 (error mapping table).
+//! * ADDENDUM §4.4 (Plugin root struct fields).
+
+use std::sync::Arc;
+
+use account_management_sdk::idp::{
+    IdpDeprovisionFailure, IdpDeprovisionTenantRequest, IdpPluginClient, IdpProvisionFailure,
+    IdpProvisionResult, IdpProvisionTenantRequest,
+};
+use account_management_sdk::idp_user::{
+    IdpDeprovisionUserRequest, IdpListUsersRequest, IdpProvisionUserRequest, IdpUser,
+    IdpUserOperationFailure,
+};
+use async_trait::async_trait;
+use toolkit_odata::Page;
+use toolkit_security::SecurityContext;
+
+use crate::domain::error::{KcStatusKind, PluginError};
+use crate::domain::metadata_codec::MetadataCodec;
+use crate::domain::service_principal_facade::ServicePrincipalFacade;
+use crate::domain::tenant_facade::TenantFacade;
+use crate::domain::user_facade::UserFacade;
+
+/// Plugin root struct. Holds [`Arc`]-shared facades + codec.
+///
+/// Per ADDENDUM §4.4, the root carries the two facades and the metadata
+/// codec — every other resource (Keycloak factory, `CredStore` reader /
+/// writer, metrics) is closed over by the facades themselves. The
+/// `Arc<dyn IdpPluginClient>` registered in `ClientHub` is the single
+/// entry-point AM consumes; the facades remain plugin-private.
+pub struct KeycloakIdpPlugin {
+    pub tenant_facade: Arc<TenantFacade>,
+    pub user_facade: Arc<UserFacade>,
+    pub codec: Arc<MetadataCodec>,
+    pub sp_facade: Arc<ServicePrincipalFacade>,
+}
+
+#[async_trait]
+impl IdpPluginClient for KeycloakIdpPlugin {
+    async fn provision_tenant(
+        &self,
+        ctx: &SecurityContext,
+        req: &IdpProvisionTenantRequest,
+    ) -> Result<IdpProvisionResult, IdpProvisionFailure> {
+        match self.tenant_facade.provision_tenant_inner(ctx, req).await {
+            Ok(meta) => Ok(IdpProvisionResult::new(Some(self.codec.encode(&meta)))),
+            Err(e) => Err(translate_provision_failure(e)),
+        }
+    }
+
+    async fn deprovision_tenant(
+        &self,
+        ctx: &SecurityContext,
+        req: &IdpDeprovisionTenantRequest,
+    ) -> Result<(), IdpDeprovisionFailure> {
+        self.tenant_facade
+            .deprovision_tenant_inner(ctx, req)
+            .await
+            .map_err(translate_deprovision_failure)
+    }
+
+    async fn provision_user(
+        &self,
+        ctx: &SecurityContext,
+        req: &IdpProvisionUserRequest,
+    ) -> Result<IdpUser, IdpUserOperationFailure> {
+        self.user_facade
+            .provision_user_inner(ctx, req)
+            .await
+            .map_err(translate_user_op_failure)
+    }
+
+    async fn deprovision_user(
+        &self,
+        ctx: &SecurityContext,
+        req: &IdpDeprovisionUserRequest,
+    ) -> Result<(), IdpUserOperationFailure> {
+        self.user_facade
+            .deprovision_user_inner(ctx, req)
+            .await
+            .map_err(translate_user_op_failure)
+    }
+
+    async fn list_users(
+        &self,
+        ctx: &SecurityContext,
+        req: &IdpListUsersRequest,
+    ) -> Result<Page<IdpUser>, IdpUserOperationFailure> {
+        self.user_facade
+            .list_users_inner(ctx, req)
+            .await
+            .map_err(translate_user_op_failure)
+    }
+}
+
+/// Translate a [`PluginError`] surfaced by
+/// `TenantFacade::provision_tenant_inner` into the typed SDK failure variant
+/// per DESIGN §5.5.
+///
+/// * `MetadataDecode` → [`IdpProvisionFailure::InvalidInput`] — the
+///   caller's `provisioning_metadata` failed to deserialize before any
+///   KC call. AM surfaces this as `CanonicalError::InvalidArgument`
+///   (HTTP 400) so the caller sees "fix your request" rather than the
+///   503 retry shape that `CleanFailure` would produce. SAFE to
+///   classify as caller-input because this variant is only emitted on
+///   the deprovision path's `parse_input` and never after KC state
+///   has been touched.
+/// * `Config` → [`IdpProvisionFailure::CleanFailure`] — this variant is
+///   too broad to classify as caller-input. It IS emitted by
+///   `parse_input` for shape-bad metadata (which IS caller-input), BUT
+///   also by post-KC-creation paths (the `SecretRef::new(...)` parses
+///   in `TenantFacade::provision_created` / `provision_shared` run
+///   AFTER realm + admin-client + role-grants exist in KC, and a
+///   `Config` produced there means real vendor state has been
+///   created). Classifying THOSE as `InvalidInput` would tell AM to
+///   compensate the provisioning row and return 400 to the caller —
+///   the reaper would never run, KC state would leak. Keep the
+///   `CleanFailure` mapping (the original behaviour) and lose the
+///   400-on-bad-metadata signal on the few caller-input subpaths;
+///   that's better than the worse failure mode.
+/// * 4xx KC responses + `CreatedRealmExists` →
+///   [`IdpProvisionFailure::CleanFailure`] (AM proves no `IdP`-side state
+///   retained; the `IdP` did reject but vendor state is clean → 503).
+/// * `BootstrapPermsMissing` → [`IdpProvisionFailure::UnsupportedOperation`]
+///   (operator must intervene on the `IaC` checklist).
+/// * 5xx KC + transport / timeout + `AmbiguousCreated` + `CredStoreWrite`
+///   (post-KC) → [`IdpProvisionFailure::Ambiguous`] (provisioning reaper
+///   compensates asynchronously).
+fn translate_provision_failure(e: PluginError) -> IdpProvisionFailure {
+    // Plugin-side observability: emit a stage-labelled WARN at the translation
+    // boundary BEFORE the AM canonical-error layer redacts vendor detail to a
+    // FNV-1a digest. The stage label is plugin-internal (an `AmbiguousStage`
+    // variant string, not vendor text), so this leaks no upstream payload —
+    // it just gives operators a direct "which saga step failed" signal in the
+    // long-retention plugin log without having to bump RUST_LOG to debug.
+    // Keeps the AM-side `am.idp` redacted line as the canonical correlation
+    // anchor (digest + len); this is a *complementary* breadcrumb upstream of it.
+    if let PluginError::AmbiguousCreated { stage, .. } = &e {
+        tracing::warn!(
+            target: "vp_idp_plugin.provision",
+            failure_variant = "ambiguous_created",
+            stage = %stage,
+            "Created-mode saga failed with Ambiguous outcome — operator must reconcile via reaper"
+        );
+    }
+    match e {
+        // ---- InvalidInput — caller-supplied `provisioning_metadata`
+        //      failed deserialization BEFORE any KC call. Only emitted
+        //      on the deprovision path's `parse_input`; never on the
+        //      provision saga (which surfaces `Config`, asserted by a
+        //      debug_assert in `TenantFacade::provision_tenant_saga`).
+        //      Safe to surface as 400 invalid_argument.
+        PluginError::MetadataDecode(_) => IdpProvisionFailure::InvalidInput {
+            detail: e.to_string(),
+            field: Some("provisioning_metadata".into()),
+        },
+
+        // ---- InvalidInput — caller-supplied `provisioning_metadata`
+        //      rejected by `parse_input` BEFORE any KC call (VHP-1836:
+        //      created+explicit-realm, shared with no parent metadata to
+        //      inherit, bad mode/realm shape). Distinct from `Config`
+        //      (which is also emitted post-KC), so this dedicated pre-KC
+        //      variant is safe to surface as a clean 400.
+        PluginError::ProvisionInputRejected { ref detail } => IdpProvisionFailure::InvalidInput {
+            detail: detail.clone(),
+            field: Some("provisioning_metadata".into()),
+        },
+
+        // ---- CleanFailure — IdP rejected (or pre-saga config check
+        //      tripped) but no IdP-side side effect retained. NOTE:
+        //      `Config` is intentionally NOT classified as
+        //      `InvalidInput` even though some of its emit sites
+        //      (notably `parse_input` shape checks) ARE caller-input
+        //      problems. The `Config` variant is also emitted by post-
+        //      KC-creation paths (`SecretRef::new(...)` parses in
+        //      `provision_created`/`provision_shared` after realm +
+        //      admin-client exist in KC); classifying those as
+        //      `InvalidInput` would tell AM to compensate the row and
+        //      return 400 to the caller, leaving real KC state behind
+        //      with no reaper to clean it up. The conservative
+        //      `CleanFailure` mapping loses the precise 400 signal on
+        //      the parse_input subpath but preserves the
+        //      KC-state-doesn't-leak invariant on the post-saga subpaths.
+        PluginError::Config { ref detail } => IdpProvisionFailure::CleanFailure {
+            detail: detail.clone(),
+        },
+        PluginError::CreatedRealmExists { ref realm } => IdpProvisionFailure::CleanFailure {
+            detail: format!("mode = created but realm '{realm}' already exists"),
+        },
+        // 4xx upstream → CleanFailure (request validated server-side without
+        // retained state). 5xx falls through to the Ambiguous arm below.
+        PluginError::KcRest {
+            status: KcStatusKind::Http(s),
+            ..
+        } if (400..=499).contains(&s) => IdpProvisionFailure::CleanFailure {
+            detail: e.to_string(),
+        },
+
+        // ---- UnsupportedOperation. ----
+        PluginError::BootstrapPermsMissing { .. } => IdpProvisionFailure::UnsupportedOperation {
+            detail: e.to_string(),
+        },
+
+        // ---- Ambiguous — 5xx, transport, timeout, or anything mid-saga. ----
+        // The first three arms collapse into one body because they share the
+        // same `detail` source (`e.to_string()`) and the same SDK variant —
+        // clippy's `match_same_arms` lint would otherwise flag the duplication.
+        PluginError::KcRest {
+            status: KcStatusKind::Http(s),
+            ..
+        } if (500..=599).contains(&s) => IdpProvisionFailure::Ambiguous {
+            detail: e.to_string(),
+        },
+        PluginError::KcRest {
+            status: KcStatusKind::Transport | KcStatusKind::Timeout,
+            ..
+        }
+        | PluginError::AmbiguousCreated { .. } => IdpProvisionFailure::Ambiguous {
+            detail: e.to_string(),
+        },
+
+        // ---- CleanFailure fall-through for remaining internal-only errors
+        //      that shouldn't normally surface on the provision path. ----
+        PluginError::CredStoreRead { detail } => IdpProvisionFailure::CleanFailure { detail },
+
+        // ---- Should never appear on the provision path; map conservatively. ----
+        other => IdpProvisionFailure::CleanFailure {
+            detail: other.to_string(),
+        },
+    }
+}
+
+/// Translate a [`PluginError`] surfaced by
+/// `TenantFacade::deprovision_tenant_inner` into the typed SDK failure
+/// variant per DESIGN §5.5 / §6.2.
+///
+/// * `DeprovisionNotFound` → [`IdpDeprovisionFailure::NotFound`] (AM treats
+///   as success-equivalent).
+/// * `DeprovisionRetryable` → [`IdpDeprovisionFailure::Retryable`]
+///   (deferred to next retention tick).
+/// * `DeprovisionTerminal` / `BootstrapPermsMissing` / `MetadataDecode` →
+///   [`IdpDeprovisionFailure::Terminal`] (operator must intervene).
+/// * Any other variant that leaks through is also mapped to `Terminal` so
+///   the operational signal stays observable.
+fn translate_deprovision_failure(e: PluginError) -> IdpDeprovisionFailure {
+    match e {
+        PluginError::DeprovisionNotFound { .. } => IdpDeprovisionFailure::NotFound {
+            detail: e.to_string(),
+        },
+        PluginError::DeprovisionRetryable { .. } => IdpDeprovisionFailure::Retryable {
+            detail: e.to_string(),
+        },
+        // `DeprovisionTerminal` + `BootstrapPermsMissing` + `MetadataDecode`
+        // + every other unexpected leak all map to `Terminal` per the
+        // operator-must-intervene contract; combined with the catch-all
+        // below into one body so clippy's `match_same_arms` lint stays
+        // satisfied without obscuring the intent.
+        other => IdpDeprovisionFailure::Terminal {
+            detail: other.to_string(),
+        },
+    }
+}
+
+/// Translate a [`PluginError`] surfaced by the user-side facade methods
+/// into the typed SDK failure variant per DESIGN §5.5.
+///
+/// * `UserOpRejected` → [`IdpUserOperationFailure::Rejected`] (validation).
+/// * `UserOpDuplicate` → [`IdpUserOperationFailure::DuplicateUser`]
+///   (VHP-2158: AM surfaces 409 `already_exists` attributed to the field).
+/// * `UserOpPasswordPolicy` → [`IdpUserOperationFailure::PasswordPolicy`]
+///   (VHP-2158: AM surfaces the `password`/`PASSWORD_POLICY` violation).
+/// * `UserOpUnavailable` / any leaked `KcRest` →
+///   [`IdpUserOperationFailure::Unavailable`] (provider unreachable — AM
+///   surfaces `idp_unavailable`).
+/// * `UserOpUnsupported` → [`IdpUserOperationFailure::UnsupportedOperation`].
+/// * Anything else leaking through (e.g. `CredStoreRead`) is treated as
+///   `Unavailable` so the existing `idp_unavailable` lane carries the
+///   operational signal rather than misreporting as `Rejected`.
+fn translate_user_op_failure(e: PluginError) -> IdpUserOperationFailure {
+    match e {
+        PluginError::UserOpRejected { detail } => IdpUserOperationFailure::Rejected { detail },
+        // VHP-2158: classified rejections ride their typed SDK variants so
+        // AM can surface 409 already_exists / the structured password
+        // field-violation instead of the redacted generic reject.
+        PluginError::UserOpDuplicate { field, detail } => {
+            IdpUserOperationFailure::DuplicateUser { field, detail }
+        }
+        PluginError::UserOpPasswordPolicy { detail } => {
+            IdpUserOperationFailure::PasswordPolicy { detail }
+        }
+        PluginError::UserOpUnavailable { detail } => {
+            IdpUserOperationFailure::Unavailable { detail }
+        }
+        PluginError::UserOpUnsupported { detail } => {
+            IdpUserOperationFailure::UnsupportedOperation { detail }
+        }
+        PluginError::KcRest { .. } => IdpUserOperationFailure::Unavailable {
+            detail: e.to_string(),
+        },
+        // Malformed / missing-version metadata is a clean rejection —
+        // AM should NOT retry. Mirrors the tenant-side `CleanFailure`
+        // mapping. Surface a fresh detail with the underlying decode
+        // error message so the operator log line is self-contained.
+        PluginError::MetadataDecode(ref de) => IdpUserOperationFailure::Rejected {
+            detail: format!("metadata decode failed: {de}"),
+        },
+        // Operator-must-intervene: collapsing this onto `Unavailable`
+        // would have AM retry forever; route to `UnsupportedOperation`
+        // symmetric with the tenant-side `translate_deprovision_failure`.
+        PluginError::BootstrapPermsMissing { ref realm } => {
+            IdpUserOperationFailure::UnsupportedOperation {
+                detail: format!(
+                    "bootstrap admin lacks view-realm/query-groups in {realm} — see Phase 0 IaC checklist"
+                ),
+            }
+        }
+        // `Config` is the misconfigured-input variant; treat as a clean
+        // rejection so callers fix their request rather than retry.
+        PluginError::Config { ref detail } => IdpUserOperationFailure::Rejected {
+            detail: format!("config: {detail}"),
+        },
+        other => IdpUserOperationFailure::Unavailable {
+            detail: other.to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+#[path = "idp_impl_tests.rs"]
+mod idp_impl_tests;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/idp_impl_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/idp_impl_tests.rs
@@ -129,7 +129,7 @@ fn translate_provision_metadata_decode_is_invalid_input() {
     assert_eq!(field.as_deref(), Some("provisioning_metadata"));
 }
 
-/// VHP-1836: `ProvisionInputRejected` is the dedicated pre-KC caller-input
+/// `ProvisionInputRejected` is the dedicated pre-KC caller-input
 /// rejection (created+explicit-realm, shared-with-no-parent-metadata, bad
 /// mode/realm shape). Unlike `Config`, it is emitted only by `parse_input`
 /// before any KC call, so it maps cleanly to
@@ -152,7 +152,7 @@ fn provision_input_rejected_maps_to_invalid_input() {
 }
 
 /// `PluginError::Config` maps to `CleanFailure` (503), NOT `InvalidInput`
-/// (400). Since VHP-1836 the pre-KC caller-input rejections moved to
+/// (400). Pre-KC caller-input rejections moved to
 /// `ProvisionInputRejected` (→ 400); what still emits `Config` is the
 /// post-KC-creation paths (`SecretRef::new(...)` in
 /// `TenantFacade::provision_created` / `provision_shared`, AFTER realm +
@@ -263,7 +263,7 @@ fn translate_user_op_rejected_is_rejected() {
     assert_eq!(f.detail(), "user already exists");
 }
 
-// VHP-2158: classified rejections must ride their typed SDK variants —
+// classified rejections must ride their typed SDK variants —
 // a fallback to `Rejected`/`Unavailable` here would silently revert the
 // duplicate/password classification to the redacted generic envelope.
 #[test]
@@ -510,7 +510,7 @@ mod deprovision_cascade {
             .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
                 "id": sp_uuid,
                 "clientId": format!("svc-{tenant}-metrics"),
-                "attributes": { "vhp.provisioning.tenant_id": [tenant.to_string()] },
+                "attributes": { "cf.provisioning.tenant_id": [tenant.to_string()] },
             }])))
             .mount(&server)
             .await;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/idp_impl_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/idp_impl_tests.rs
@@ -1,0 +1,606 @@
+use super::*;
+use crate::domain::error::{AmbiguousStage, KcStatusKind, PluginError};
+use crate::domain::metadata_codec::DecodeError;
+
+// ----- provision_failure translations -----
+
+#[test]
+fn translate_provision_kc_404_is_clean_failure() {
+    let e = PluginError::KcRest {
+        method: "GET",
+        path_template: "/admin/realms/{realm}".into(),
+        status: KcStatusKind::Http(404),
+        body_first_2kb: "missing".into(),
+    };
+    assert!(matches!(
+        translate_provision_failure(e),
+        IdpProvisionFailure::CleanFailure { .. }
+    ));
+}
+
+#[test]
+fn translate_provision_kc_500_is_ambiguous() {
+    let e = PluginError::KcRest {
+        method: "POST",
+        path_template: "/admin/realms".into(),
+        status: KcStatusKind::Http(500),
+        body_first_2kb: "boom".into(),
+    };
+    assert!(matches!(
+        translate_provision_failure(e),
+        IdpProvisionFailure::Ambiguous { .. }
+    ));
+}
+
+#[test]
+fn translate_provision_kc_transport_is_ambiguous() {
+    let e = PluginError::KcRest {
+        method: "POST",
+        path_template: "/admin/realms".into(),
+        status: KcStatusKind::Transport,
+        body_first_2kb: "connection refused".into(),
+    };
+    assert!(matches!(
+        translate_provision_failure(e),
+        IdpProvisionFailure::Ambiguous { .. }
+    ));
+}
+
+#[test]
+fn translate_provision_kc_timeout_is_ambiguous() {
+    let e = PluginError::KcRest {
+        method: "GET",
+        path_template: "/admin/realms/{realm}".into(),
+        status: KcStatusKind::Timeout,
+        body_first_2kb: "deadline exceeded".into(),
+    };
+    assert!(matches!(
+        translate_provision_failure(e),
+        IdpProvisionFailure::Ambiguous { .. }
+    ));
+}
+
+#[test]
+fn translate_provision_bootstrap_perms_missing_is_unsupported() {
+    let e = PluginError::BootstrapPermsMissing {
+        realm: "partner-acme".into(),
+    };
+    let f = translate_provision_failure(e);
+    assert!(matches!(
+        f,
+        IdpProvisionFailure::UnsupportedOperation { .. }
+    ));
+    assert!(
+        f.detail()
+            .contains("bootstrap admin lacks view-realm/query-groups"),
+        "expected runbook-friendly detail, got: {}",
+        f.detail()
+    );
+}
+
+#[test]
+fn translate_provision_ambiguous_created_is_ambiguous_with_prefix() {
+    let e = PluginError::AmbiguousCreated {
+        stage: AmbiguousStage::KcRealmCreate,
+        detail: "kc:POST /admin/realms -> 500: boom".into(),
+    };
+    let f = translate_provision_failure(e);
+    assert!(matches!(f, IdpProvisionFailure::Ambiguous { .. }));
+    assert!(
+        f.detail().starts_with("ambig:kc_realm_create:"),
+        "expected ambig:kc_realm_create: prefix, got: {}",
+        f.detail()
+    );
+}
+
+#[test]
+fn translate_provision_created_realm_exists_is_clean_failure() {
+    let e = PluginError::CreatedRealmExists {
+        realm: "partner-acme".into(),
+    };
+    let f = translate_provision_failure(e);
+    assert!(matches!(f, IdpProvisionFailure::CleanFailure { .. }));
+    assert!(f.detail().contains("partner-acme"));
+    assert!(f.detail().contains("already exists"));
+}
+
+/// Malformed wire shape of `provisioning_metadata` (serde decode
+/// failure, missing required fields, unknown variants) is a permanent
+/// client error — the plugin proved no KC call was made because the
+/// input failed shape-validation up front. Translate to
+/// [`IdpProvisionFailure::InvalidInput`] so AM surfaces
+/// `CanonicalError::InvalidArgument` (HTTP 400) rather than the
+/// `CleanFailure` 503 "retry later" shape, which would mislead callers
+/// into retrying a permanent error.
+#[test]
+fn translate_provision_metadata_decode_is_invalid_input() {
+    let e = PluginError::MetadataDecode(DecodeError::MissingVersion);
+    let f = translate_provision_failure(e);
+    assert!(
+        matches!(f, IdpProvisionFailure::InvalidInput { .. }),
+        "expected InvalidInput, got {f:?}"
+    );
+    // The `field` must point at the offending input key so the AM
+    // canonical envelope can populate `field_violations` with a
+    // useful pointer.
+    let IdpProvisionFailure::InvalidInput { field, .. } = f else {
+        unreachable!()
+    };
+    assert_eq!(field.as_deref(), Some("provisioning_metadata"));
+}
+
+/// VHP-1836: `ProvisionInputRejected` is the dedicated pre-KC caller-input
+/// rejection (created+explicit-realm, shared-with-no-parent-metadata, bad
+/// mode/realm shape). Unlike `Config`, it is emitted only by `parse_input`
+/// before any KC call, so it maps cleanly to
+/// [`IdpProvisionFailure::InvalidInput`] (HTTP 400) with the
+/// `provisioning_metadata` field pointer.
+#[test]
+fn provision_input_rejected_maps_to_invalid_input() {
+    let e = PluginError::ProvisionInputRejected {
+        detail: "created + explicit realm_name".into(),
+    };
+    let f = translate_provision_failure(e);
+    assert!(
+        matches!(f, IdpProvisionFailure::InvalidInput { .. }),
+        "expected InvalidInput, got {f:?}"
+    );
+    let IdpProvisionFailure::InvalidInput { field, .. } = f else {
+        unreachable!()
+    };
+    assert_eq!(field.as_deref(), Some("provisioning_metadata"));
+}
+
+/// `PluginError::Config` maps to `CleanFailure` (503), NOT `InvalidInput`
+/// (400). Since VHP-1836 the pre-KC caller-input rejections moved to
+/// `ProvisionInputRejected` (→ 400); what still emits `Config` is the
+/// post-KC-creation paths (`SecretRef::new(...)` in
+/// `TenantFacade::provision_created` / `provision_shared`, AFTER realm +
+/// admin-client exist in KC). Tagging THOSE as `InvalidInput` would tell AM
+/// to compensate the row and return 400 to the caller, leaking real KC state
+/// with no reaper run — so `Config` stays in the conservative `CleanFailure`
+/// bucket. This pins that boundary mapping.
+#[test]
+fn translate_provision_config_is_clean_failure() {
+    let e = PluginError::Config {
+        detail: "secret_ref invalid for realm-admin client secret".into(),
+    };
+    let f = translate_provision_failure(e);
+    assert!(
+        matches!(f, IdpProvisionFailure::CleanFailure { .. }),
+        "expected CleanFailure (Config is too broad to be InvalidInput; see translate_provision_failure docs), got {f:?}"
+    );
+    assert_eq!(
+        f.detail(),
+        "secret_ref invalid for realm-admin client secret"
+    );
+}
+
+/// The pre-saga KC health-probe failure also surfaces via `PluginError::Config`
+/// (`provision_tenant_saga` re-tags the probe's transport error as `Config`
+/// because nothing has been mutated yet). Same translation rule as above —
+/// `Config` collapses to `CleanFailure` (503 retry-later), which is exactly
+/// right for a transient KC-unreachable probe.
+#[test]
+fn translate_provision_config_from_health_probe_is_clean_failure() {
+    let e = PluginError::Config {
+        detail: "pre-saga KC health probe failed: connection refused".into(),
+    };
+    let f = translate_provision_failure(e);
+    assert!(
+        matches!(f, IdpProvisionFailure::CleanFailure { .. }),
+        "expected CleanFailure, got {f:?}"
+    );
+    assert!(f.detail().contains("health probe failed"));
+}
+
+// ----- deprovision_failure translations -----
+
+#[test]
+fn translate_deprovision_not_found_is_not_found() {
+    let e = PluginError::DeprovisionNotFound {
+        realm_name: "partner-acme".into(),
+    };
+    assert!(matches!(
+        translate_deprovision_failure(e),
+        IdpDeprovisionFailure::NotFound { .. }
+    ));
+}
+
+#[test]
+fn translate_deprovision_retryable_is_retryable() {
+    let e = PluginError::DeprovisionRetryable {
+        detail: "kc:DELETE /admin/realms/{realm}/groups/{tenant_group_id} -> 503: boom".into(),
+    };
+    assert!(matches!(
+        translate_deprovision_failure(e),
+        IdpDeprovisionFailure::Retryable { .. }
+    ));
+}
+
+#[test]
+fn translate_deprovision_terminal_is_terminal() {
+    let e = PluginError::DeprovisionTerminal {
+        detail: "metadata corrupt".into(),
+    };
+    assert!(matches!(
+        translate_deprovision_failure(e),
+        IdpDeprovisionFailure::Terminal { .. }
+    ));
+}
+
+#[test]
+fn translate_deprovision_bootstrap_perms_missing_is_terminal() {
+    let e = PluginError::BootstrapPermsMissing {
+        realm: "partner-acme".into(),
+    };
+    assert!(matches!(
+        translate_deprovision_failure(e),
+        IdpDeprovisionFailure::Terminal { .. }
+    ));
+}
+
+#[test]
+fn translate_deprovision_metadata_decode_is_terminal() {
+    let e = PluginError::MetadataDecode(DecodeError::UnsupportedVersion {
+        observed: "v2".into(),
+    });
+    assert!(matches!(
+        translate_deprovision_failure(e),
+        IdpDeprovisionFailure::Terminal { .. }
+    ));
+}
+
+// ----- user-op failure translations -----
+
+#[test]
+fn translate_user_op_rejected_is_rejected() {
+    let e = PluginError::UserOpRejected {
+        detail: "user already exists".into(),
+    };
+    let f = translate_user_op_failure(e);
+    assert!(matches!(f, IdpUserOperationFailure::Rejected { .. }));
+    assert_eq!(f.detail(), "user already exists");
+}
+
+// VHP-2158: classified rejections must ride their typed SDK variants —
+// a fallback to `Rejected`/`Unavailable` here would silently revert the
+// duplicate/password classification to the redacted generic envelope.
+#[test]
+fn translate_user_op_duplicate_is_duplicate_user() {
+    let e = PluginError::UserOpDuplicate {
+        field: account_management_sdk::IdpUserDuplicateField::Username,
+        detail: "kc 409".into(),
+    };
+    let f = translate_user_op_failure(e);
+    assert!(matches!(
+        f,
+        IdpUserOperationFailure::DuplicateUser {
+            field: account_management_sdk::IdpUserDuplicateField::Username,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn translate_user_op_password_policy_is_password_policy() {
+    let e = PluginError::UserOpPasswordPolicy {
+        detail: "kc 400 policy".into(),
+    };
+    let f = translate_user_op_failure(e);
+    assert!(matches!(f, IdpUserOperationFailure::PasswordPolicy { .. }));
+}
+
+#[test]
+fn translate_user_op_unavailable_is_unavailable() {
+    let e = PluginError::UserOpUnavailable {
+        detail: "kc:POST /admin/realms/{realm}/users -> 503: boom".into(),
+    };
+    let f = translate_user_op_failure(e);
+    assert!(matches!(f, IdpUserOperationFailure::Unavailable { .. }));
+    assert!(f.detail().contains("503"));
+}
+
+#[test]
+fn translate_user_op_unsupported_is_unsupported() {
+    let e = PluginError::UserOpUnsupported {
+        detail: "provider is read-only".into(),
+    };
+    let f = translate_user_op_failure(e);
+    assert!(matches!(
+        f,
+        IdpUserOperationFailure::UnsupportedOperation { .. }
+    ));
+    assert_eq!(f.detail(), "provider is read-only");
+}
+
+#[test]
+fn translate_user_op_leaked_kc_rest_is_unavailable() {
+    // Defensive: if a `KcRest` ever leaks past the user-side translator
+    // in the facade, the boundary still maps it to Unavailable so AM
+    // surfaces the right public envelope.
+    let e = PluginError::KcRest {
+        method: "GET",
+        path_template: "/admin/realms/{realm}/users".into(),
+        status: KcStatusKind::Http(500),
+        body_first_2kb: "boom".into(),
+    };
+    assert!(matches!(
+        translate_user_op_failure(e),
+        IdpUserOperationFailure::Unavailable { .. }
+    ));
+}
+
+// ----- deprovision_tenant service-principal cascade -----
+
+mod deprovision_cascade {
+    use std::sync::Arc;
+
+    use account_management_sdk::idp::IdpDeprovisionTenantRequest;
+    use account_management_sdk::idp_user::IdpTenantContext;
+    use gts::GtsTypeId;
+    use serde_json::json;
+    use uuid::Uuid;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+    use crate::config::{ServicePrincipalConfig, TenantFacadeConfig, UserFacadeConfig};
+    use crate::domain::credstore::{CredStoreReader, CredStoreWriter};
+    use crate::domain::kc::factory::KeycloakAdminClientFactory;
+    use crate::domain::kc::transport::KcTransport;
+    use crate::domain::metadata_codec::RealmBinding;
+    use crate::domain::service_principal_facade::ServicePrincipalFacade;
+    use crate::domain::system_actor::build_system_ctx;
+    use crate::domain::tenant_facade::TenantFacade;
+    use crate::domain::test_support::{
+        StubCredStore, keycloak_cfg, make_metadata, noop_credstore_metrics, noop_failure_metrics,
+        noop_metadata_metrics, noop_sp_metrics, noop_tenant_metrics, noop_user_metrics,
+    };
+    use crate::domain::user_facade::UserFacade;
+    use crate::infra::kc_http::ReqwestKcTransport;
+
+    fn build_plugin(server: &MockServer) -> KeycloakIdpPlugin {
+        let kc_cfg = keycloak_cfg(&server.uri());
+        let realm_admin_cfg = kc_cfg.realm_admin.clone();
+        let cs: Arc<dyn credstore_sdk::CredStoreClientV1> = Arc::new(StubCredStore);
+        let cs_reader = CredStoreReader::new(Arc::clone(&cs), build_system_ctx(Uuid::nil()));
+        let cs_writer = CredStoreWriter::new(cs, build_system_ctx(Uuid::nil()));
+        let transport: Arc<dyn KcTransport> =
+            Arc::new(ReqwestKcTransport::new(reqwest::Client::new()));
+        let factory = Arc::new(KeycloakAdminClientFactory::new(
+            kc_cfg,
+            transport,
+            cs_reader,
+            Arc::new(crate::domain::test_support::NoopMetrics),
+        ));
+        let codec = Arc::new(MetadataCodec);
+        let tenant_facade = Arc::new(TenantFacade::new(
+            TenantFacadeConfig {
+                realm_defaults: serde_json::Value::Null,
+                tenant_group_root: "/tenants".into(),
+                provision_timeout_ms: 30_000,
+            },
+            realm_admin_cfg.clone(),
+            Arc::clone(&factory),
+            Arc::clone(&codec),
+            cs_writer,
+            noop_tenant_metrics(),
+            noop_credstore_metrics(),
+            noop_metadata_metrics(),
+            noop_failure_metrics(),
+        ));
+        let user_facade = Arc::new(UserFacade::new(
+            UserFacadeConfig {
+                default_user_required_actions: vec![],
+                list_users_page_limit_default: 50,
+                list_users_page_limit_max: 200,
+                session_revoke_on_deprovision: true,
+            },
+            realm_admin_cfg,
+            Arc::clone(&factory),
+            Arc::clone(&codec),
+            noop_user_metrics(),
+            noop_metadata_metrics(),
+            noop_failure_metrics(),
+        ));
+        let sp_facade = Arc::new(ServicePrincipalFacade::new(
+            ServicePrincipalConfig::default(),
+            factory,
+            noop_sp_metrics(),
+            noop_failure_metrics(),
+        ));
+        tenant_facade.set_service_principal_purge_facade(Arc::clone(&sp_facade));
+        KeycloakIdpPlugin {
+            tenant_facade,
+            user_facade,
+            codec,
+            sp_facade,
+        }
+    }
+
+    async fn mount_tokens_and_probe(server: &MockServer) {
+        Mock::given(method("GET"))
+            .and(path("/realms/master"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+            .mount(server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/realms/master/protocol/openid-connect/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "access_token": "t-master",
+                "expires_in": 600
+            })))
+            .mount(server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/realms/platform/protocol/openid-connect/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "access_token": "t-realm",
+                "expires_in": 600
+            })))
+            .mount(server)
+            .await;
+    }
+
+    fn deprovision_req(tenant_id: Uuid, group_uuid: Uuid) -> IdpDeprovisionTenantRequest {
+        IdpDeprovisionTenantRequest::new(IdpTenantContext::new(
+            tenant_id,
+            "stub-tenant",
+            GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                group_uuid,
+                None,
+            )),
+        ))
+    }
+
+    fn deprovision_req_without_metadata(tenant_id: Uuid) -> IdpDeprovisionTenantRequest {
+        IdpDeprovisionTenantRequest::new(IdpTenantContext::new(
+            tenant_id,
+            "stub-tenant",
+            GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            None,
+        ))
+    }
+
+    /// Missing metadata is a local deprovision fast-path. The SP purge hook
+    /// must not force a live KC/SP realm before the saga classifies it as
+    /// success-equivalent `NotFound`.
+    #[tokio::test]
+    async fn deprovision_tenant_missing_metadata_does_not_purge_service_principals() {
+        let server = MockServer::start().await;
+        let tenant = Uuid::new_v4();
+
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/platform/clients"))
+            .and(query_param("search", "true"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let plugin = build_plugin(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let err = plugin
+            .deprovision_tenant(&ctx, &deprovision_req_without_metadata(tenant))
+            .await
+            .expect_err("missing metadata maps to NotFound");
+        assert!(
+            matches!(err, IdpDeprovisionFailure::NotFound { .. }),
+            "expected NotFound, got {err:?}"
+        );
+    }
+
+    /// Tenant teardown deletes the tenant's service principals before the
+    /// group — no orphaned `client_credentials` clients survive.
+    #[tokio::test]
+    async fn deprovision_tenant_purges_service_principals() {
+        let server = MockServer::start().await;
+        mount_tokens_and_probe(&server).await;
+        let tenant = Uuid::new_v4();
+        let group_uuid = Uuid::new_v4();
+        let sp_uuid = "55555555-5555-5555-5555-555555555555";
+
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/platform/clients"))
+            .and(query_param("search", "true"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
+                "id": sp_uuid,
+                "clientId": format!("svc-{tenant}-metrics"),
+                "attributes": { "vhp.provisioning.tenant_id": [tenant.to_string()] },
+            }])))
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path(format!("/admin/realms/platform/clients/{sp_uuid}")))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path(format!("/admin/realms/platform/groups/{group_uuid}")))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let plugin = build_plugin(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        plugin
+            .deprovision_tenant(&ctx, &deprovision_req(tenant, group_uuid))
+            .await
+            .expect("deprovision with SP cascade must succeed");
+    }
+
+    /// A failed purge blocks teardown and surfaces Retryable so AM's
+    /// retention loop retries the whole deprovision.
+    #[tokio::test]
+    async fn deprovision_tenant_purge_failure_is_retryable_and_blocks_teardown() {
+        let server = MockServer::start().await;
+        mount_tokens_and_probe(&server).await;
+        let tenant = Uuid::new_v4();
+        let group_uuid = Uuid::new_v4();
+
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/platform/clients"))
+            .and(query_param("search", "true"))
+            .respond_with(ResponseTemplate::new(503).set_body_string("kc down"))
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path(format!("/admin/realms/platform/groups/{group_uuid}")))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let plugin = build_plugin(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let err = plugin
+            .deprovision_tenant(&ctx, &deprovision_req(tenant, group_uuid))
+            .await
+            .expect_err("purge failure must fail deprovision");
+        assert!(
+            matches!(err, IdpDeprovisionFailure::Retryable { .. }),
+            "expected Retryable, got {err:?}"
+        );
+    }
+
+    /// Permanent SP-realm failures park the AM retention row instead of
+    /// retrying forever. A 403 means the bootstrap admin lacks SP-realm
+    /// permissions, so operator intervention is required.
+    #[tokio::test]
+    async fn deprovision_tenant_purge_403_is_terminal_and_blocks_teardown() {
+        let server = MockServer::start().await;
+        mount_tokens_and_probe(&server).await;
+        let tenant = Uuid::new_v4();
+        let group_uuid = Uuid::new_v4();
+
+        Mock::given(method("GET"))
+            .and(path("/admin/realms/platform/clients"))
+            .and(query_param("search", "true"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path(format!("/admin/realms/platform/groups/{group_uuid}")))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let plugin = build_plugin(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let err = plugin
+            .deprovision_tenant(&ctx, &deprovision_req(tenant, group_uuid))
+            .await
+            .expect_err("permanent purge failure must fail deprovision");
+        assert!(
+            matches!(err, IdpDeprovisionFailure::Terminal { .. }),
+            "expected Terminal, got {err:?}"
+        );
+    }
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/infra.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/infra.rs
@@ -1,0 +1,5 @@
+//! Infrastructure adapters — Keycloak Admin REST (Phase 6+) +
+//! OpenTelemetry-backed metrics adapter implementing the domain ports.
+
+pub mod kc_http;
+pub mod metrics;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/infra/kc_http.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/infra/kc_http.rs
@@ -86,7 +86,7 @@ pub(crate) fn method_static(m: &Method) -> &'static str {
 /// Whether a verb is safe to replay after a connect/timeout error — i.e.
 /// re-sending it cannot duplicate a side effect. GET/PUT/DELETE are
 /// idempotent; POST is not (re-POSTing a create can duplicate it, as the
-/// duplicate `POST /admin/realms` in run am-functional-22 showed). The
+/// duplicate `POST /admin/realms` in the duplicate-create incident showed). The
 /// token-endpoint `form_post` is also a POST but opts back into retry
 /// explicitly because re-fetching a token is harmless.
 fn idempotent_method(m: &Method) -> bool {
@@ -249,7 +249,7 @@ impl ReqwestKcTransport {
     /// `build()` itself fails.
     ///
     /// `retry_transport_errors` gates retrying connect/timeout failures
-    /// (VHP-190): a transport error does NOT prove the server skipped the
+    ///: a transport error does NOT prove the server skipped the
     /// request, so replaying a NON-idempotent verb can duplicate a side
     /// effect (the double `POST /admin/realms` → duplicate realm → false
     /// ambiguous 500). Callers pass `false` for non-idempotent POSTs and
@@ -403,7 +403,7 @@ impl KcTransport for ReqwestKcTransport {
         };
         // Non-idempotent verbs (POST) must NOT be replayed on a connect/
         // timeout error — the request may already have taken effect server
-        // side (VHP-190). Idempotent verbs are safe to retry.
+        // side. Idempotent verbs are safe to retry.
         let retry_transport = idempotent_method(&m);
         self.execute_with_retry(build, &m, path_template, retry_transport)
             .await
@@ -444,7 +444,7 @@ impl KcTransport for ReqwestKcTransport {
         };
         // A token fetch is a POST, but re-fetching a token has no durable
         // side effect, so it opts back into transport retry — important
-        // under load where the token endpoint is the bottleneck (VHP-190).
+        // under load where the token endpoint is the bottleneck.
         self.execute_with_retry(build, &Method::POST, path_template, true)
             .await
     }

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/infra/kc_http.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/infra/kc_http.rs
@@ -1,0 +1,483 @@
+//! Reqwest-backed implementation of [`KcTransport`].
+//!
+//! All reqwest imports are confined to this file. Domain code interacts only
+//! with the [`crate::domain::kc::transport::KcTransport`] trait.
+
+use opentelemetry::propagation::{Injector, TextMapPropagator};
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use reqwest::{Client, Method, RequestBuilder};
+use serde_json::Value;
+use std::sync::OnceLock;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+use crate::domain::error::{KcStatusKind, PluginError, redact_secrets};
+use crate::domain::kc::transport::{KcTransport, truncate_2kb};
+
+/// Truncate + redact the `Display` form of an error before stuffing it into
+/// `PluginError::KcRest::body_first_2kb`.
+///
+/// DESIGN §4.4 mandates that every `KcRest` construction site on the transport
+/// seam goes through `truncate_2kb` + `redact_secrets`. Without this helper the
+/// transport-error / build-error paths embedded raw `reqwest::Error` strings,
+/// which can carry URLs (operationally sensitive) or, on the token-endpoint
+/// `form_post` path, fragments of the form-encoded `client_secret`.
+fn redact_error_body(s: &str) -> String {
+    redact_secrets(&truncate_2kb(s))
+}
+
+/// Adapts a `reqwest::HeaderMap` to the `OTel` `Injector` interface so that the
+/// W3C `TraceContextPropagator` can write `traceparent` / `tracestate` headers
+/// directly into an outgoing request.
+struct HeaderInjector<'a>(&'a mut reqwest::header::HeaderMap);
+
+impl Injector for HeaderInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        if let (Ok(name), Ok(val)) = (
+            reqwest::header::HeaderName::from_bytes(key.as_bytes()),
+            reqwest::header::HeaderValue::from_str(&value),
+        ) {
+            self.0.insert(name, val);
+        }
+    }
+}
+
+/// Returns the process-wide W3C `TraceContextPropagator` instance (lazy-init).
+///
+/// Initialisation is deliberately local — the global `OTel` propagator is an
+/// application-level concern (`vpserver` main) and is intentionally *not* set
+/// here. Using a private `OnceLock` keeps this crate self-contained and
+/// testable without touching global state.
+fn propagator() -> &'static TraceContextPropagator {
+    static P: OnceLock<TraceContextPropagator> = OnceLock::new();
+    P.get_or_init(TraceContextPropagator::new)
+}
+
+/// Inject W3C `traceparent` (and `tracestate` when present) from the current
+/// tracing span into the request's header map. Per DESIGN §8.2 this binds
+/// every Keycloak Admin REST hop to the platform trace tree.
+fn inject_trace_headers(headers: &mut reqwest::header::HeaderMap) {
+    let context = tracing::Span::current().context();
+    propagator().inject_context(&context, &mut HeaderInjector(headers));
+}
+
+/// Map `reqwest::Method` to the static string the `PluginError::KcRest.method`
+/// field expects. We keep `&'static str` (not `String`) on the error because
+/// HTTP verbs are a fixed set and this stays grep-friendly.
+///
+/// Narrowed to the canonical verb set the plugin actually issues against
+/// Keycloak Admin REST: GET / POST / PUT / DELETE. PATCH / HEAD / OPTIONS
+/// used to be paranoia branches with no callers — dropped to keep the
+/// verb whitelist single-sourced with `raw_request`'s match.
+///
+/// `http::Method` is non-Copy (it stores an inline tag for standard
+/// methods and a `Box<[u8]>` for extension methods), so we take it by
+/// shared reference rather than by value.
+#[must_use]
+pub(crate) fn method_static(m: &Method) -> &'static str {
+    match *m {
+        Method::GET => "GET",
+        Method::POST => "POST",
+        Method::PUT => "PUT",
+        Method::DELETE => "DELETE",
+        _ => "OTHER",
+    }
+}
+
+/// Whether a verb is safe to replay after a connect/timeout error — i.e.
+/// re-sending it cannot duplicate a side effect. GET/PUT/DELETE are
+/// idempotent; POST is not (re-POSTing a create can duplicate it, as the
+/// duplicate `POST /admin/realms` in run am-functional-22 showed). The
+/// token-endpoint `form_post` is also a POST but opts back into retry
+/// explicitly because re-fetching a token is harmless.
+fn idempotent_method(m: &Method) -> bool {
+    matches!(*m, Method::GET | Method::PUT | Method::DELETE)
+}
+
+/// Construct a `PluginError::KcRest` from a transport error (no HTTP exchange).
+#[must_use]
+pub(crate) fn transport_error(
+    method: &Method,
+    path_template: &str,
+    e: &reqwest::Error,
+) -> PluginError {
+    let status = if e.is_timeout() {
+        KcStatusKind::Timeout
+    } else {
+        KcStatusKind::Transport
+    };
+    PluginError::KcRest {
+        method: method_static(method),
+        path_template: path_template.into(),
+        status,
+        body_first_2kb: redact_error_body(&e.to_string()),
+    }
+}
+
+/// Construct a `PluginError::KcRest` from a non-success HTTP response.
+#[must_use]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "used only from kc_http_tests.rs; the companion-file test cannot import it otherwise"
+    )
+)]
+pub(crate) fn http_status_error(
+    method: &Method,
+    path_template: &str,
+    status: u16,
+    body: &str,
+) -> PluginError {
+    PluginError::KcRest {
+        method: method_static(method),
+        path_template: path_template.into(),
+        status: KcStatusKind::Http(status),
+        body_first_2kb: redact_error_body(body),
+    }
+}
+
+/// Reqwest-backed implementation of [`KcTransport`].
+///
+/// Constructed once per process (typically in `module.rs`) from a
+/// pre-configured `reqwest::Client`. The TLS bundle, timeout, and other
+/// transport-level settings are baked into the client at construction time.
+///
+/// Fields are `pub(crate)` so the cfg(test) companion `kc_http_tests`
+/// can attach test-only constructors without splitting tests across two
+/// files (DE1101).
+pub struct ReqwestKcTransport {
+    pub(crate) http: Client,
+    pub(crate) retry_policy: crate::config::HttpRetryPolicy,
+}
+
+impl ReqwestKcTransport {
+    /// Build a `ReqwestKcTransport` from the plugin's Keycloak config.
+    ///
+    /// When `cfg.tls_ca_bundle_ref` is `Some(ref_id)` the referenced PEM
+    /// bundle is fetched from `CredStore` and installed as an additional trust
+    /// anchor (DESIGN §4.4 `tls_ca_bundle_ref`). When `None`, the system trust
+    /// store is used.
+    ///
+    /// # Errors
+    /// * [`crate::domain::error::PluginError::CredStoreRead`] when
+    ///   `tls_ca_bundle_ref` is set but `CredStore` returns an error or `None`.
+    /// * [`crate::domain::error::PluginError::Config`] when the PEM cannot be
+    ///   parsed or the `reqwest::Client` builder fails.
+    pub async fn from_config(
+        cfg: &crate::config::KeycloakConfig,
+        cs_reader: &crate::domain::credstore::CredStoreReader,
+    ) -> Result<Self, crate::domain::error::PluginError> {
+        use secrecy::ExposeSecret as _;
+        use std::time::Duration;
+
+        let mut builder =
+            Client::builder().timeout(Duration::from_millis(cfg.http_request_timeout_ms));
+        if let Some(ref_id) = cfg.tls_ca_bundle_ref.as_deref() {
+            let secret_ref = credstore_sdk::SecretRef::new(ref_id).map_err(|e| {
+                crate::domain::error::PluginError::CredStoreRead {
+                    detail: format!("invalid tls_ca_bundle_ref '{ref_id}': {e}"),
+                }
+            })?;
+            let pem = cs_reader.get(&secret_ref).await.map_err(|e| {
+                crate::domain::error::PluginError::CredStoreRead {
+                    detail: format!("read tls_ca_bundle_ref '{ref_id}': {e}"),
+                }
+            })?;
+            let pem = pem.ok_or_else(|| crate::domain::error::PluginError::CredStoreRead {
+                detail: format!("tls_ca_bundle_ref '{ref_id}' not found"),
+            })?;
+            let cert =
+                reqwest::Certificate::from_pem(pem.expose_secret().as_bytes()).map_err(|e| {
+                    crate::domain::error::PluginError::Config {
+                        detail: format!("tls_ca_bundle_ref '{ref_id}' is not a valid PEM: {e}"),
+                    }
+                })?;
+            builder = builder.add_root_certificate(cert);
+        }
+        let http = builder
+            .build()
+            .map_err(|e| crate::domain::error::PluginError::Config {
+                detail: format!("reqwest client build failed: {e}"),
+            })?;
+        Ok(Self {
+            http,
+            retry_policy: cfg.http_retry_policy.clone(),
+        })
+    }
+
+    /// Compute backoff delay for the given attempt index (0-based: attempt 0 = first retry).
+    /// Returns duration in milliseconds.
+    fn backoff_ms(&self, attempt: u32) -> u64 {
+        use crate::config::JitterKind;
+        let policy = &self.retry_policy;
+        // Exponential: initial * 2^attempt, capped at max_backoff_ms.
+        let shift = attempt.min(10);
+        let multiplier = 1u64.checked_shl(shift).unwrap_or(1);
+        let base = policy.initial_backoff_ms.saturating_mul(multiplier);
+        let capped = base.min(policy.max_backoff_ms);
+        match policy.jitter {
+            JitterKind::Full => {
+                use rand::RngExt as _;
+                rand::rng().random_range(0..=capped)
+            }
+            JitterKind::None => capped,
+        }
+    }
+
+    /// Parse the `Retry-After` header value into a backoff in milliseconds,
+    /// CAPPED by `retry_policy.max_backoff_ms` so a misbehaving server
+    /// can't pin a request thread for an unbounded delay.
+    ///
+    /// Only the delta-seconds form of [`RFC 9110 §10.2.3`] is honoured
+    /// (`Retry-After: 30`). The HTTP-date form (`Retry-After: Fri, 31
+    /// Dec 1999 23:59:59 GMT`) is rare in practice for KC's 429/503
+    /// surface and is intentionally ignored — fall back to the
+    /// computed exponential backoff in that case.
+    ///
+    /// [`RFC 9110 §10.2.3`]: https://www.rfc-editor.org/rfc/rfc9110#name-retry-after
+    fn parse_retry_after_ms(&self, headers: &reqwest::header::HeaderMap) -> Option<u64> {
+        let value = headers.get(reqwest::header::RETRY_AFTER)?;
+        let secs: u64 = value.to_str().ok()?.trim().parse().ok()?;
+        let ms = secs.saturating_mul(1000);
+        Some(ms.min(self.retry_policy.max_backoff_ms))
+    }
+
+    /// Execute a request-builder factory with retry logic.
+    ///
+    /// `build` is called once per attempt to produce a fresh `reqwest::Request`
+    /// (requests are consumed on `execute`). Returns `Err` immediately if
+    /// `build()` itself fails.
+    ///
+    /// `retry_transport_errors` gates retrying connect/timeout failures
+    /// (VHP-190): a transport error does NOT prove the server skipped the
+    /// request, so replaying a NON-idempotent verb can duplicate a side
+    /// effect (the double `POST /admin/realms` → duplicate realm → false
+    /// ambiguous 500). Callers pass `false` for non-idempotent POSTs and
+    /// `true` for idempotent verbs (GET/PUT/DELETE) and the safe-to-replay
+    /// token `form_post`. Retryable HTTP statuses (5xx/429) are unaffected.
+    async fn execute_with_retry<F>(
+        &self,
+        build: F,
+        method: &Method,
+        path_template: &str,
+        retry_transport_errors: bool,
+    ) -> Result<(u16, String), crate::domain::error::PluginError>
+    where
+        F: Fn() -> Result<reqwest::Request, crate::domain::error::PluginError>,
+    {
+        let policy = &self.retry_policy;
+        let mut attempt: u32 = 0;
+        loop {
+            let req = build()?;
+            let result = self.http.execute(req).await;
+            // Classify transport errors before inspecting the result.
+            // `is_connect()` / `is_timeout()` are the genuine transient
+            // signals. `is_request()` covers errors that originate in
+            // request CONSTRUCTION (invalid URI escape, header build,
+            // body-encoding failures) — none transient; retrying just
+            // burns the entire `max_retries * max_backoff_ms` budget on
+            // the same construction failure. Drop it from the predicate.
+            let retryable_transport = retry_transport_errors
+                && matches!(&result, Err(e) if e.is_connect() || e.is_timeout());
+            match result {
+                Ok(resp) => {
+                    let status = resp.status().as_u16();
+                    if crate::domain::error::is_retryable_status(status)
+                        && attempt < policy.max_retries
+                    {
+                        // Honour `Retry-After` (RFC 9110 §10.2.3) before
+                        // falling back to the exponential schedule.
+                        // Reading the header BEFORE consuming the body
+                        // is fine — `reqwest::Response::headers` is
+                        // available pre-body. Header is capped at
+                        // `max_backoff_ms` inside `parse_retry_after_ms`
+                        // so a hostile server can't pin the worker.
+                        let retry_after = self.parse_retry_after_ms(resp.headers());
+                        // Consume the body so the connection can be reused.
+                        let _ = resp.bytes().await;
+                        let delay = retry_after.unwrap_or_else(|| self.backoff_ms(attempt));
+                        tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                        attempt += 1;
+                        // continue to next attempt
+                    } else {
+                        // Preserve the observed HTTP status when the body
+                        // read fails — `with_reactive_401` / per-realm
+                        // error classifiers branch on `KcStatusKind::Http(_)`,
+                        // and demoting a real reply to `Transport` on a
+                        // body-read blip would misroute 401 / 5xx retry
+                        // semantics. Synthesise a body-first-2kb that
+                        // tells the operator what happened.
+                        match resp.bytes().await {
+                            Ok(body_bytes) => {
+                                let body = String::from_utf8_lossy(&body_bytes).into_owned();
+                                return Ok((status, body));
+                            }
+                            Err(e) => {
+                                return Err(crate::domain::error::PluginError::KcRest {
+                                    method: method_static(method),
+                                    path_template: path_template.to_owned(),
+                                    status: crate::domain::error::KcStatusKind::Http(status),
+                                    body_first_2kb: redact_error_body(&format!(
+                                        "<body-read-failed: {e}>"
+                                    )),
+                                });
+                            }
+                        }
+                    }
+                }
+                Err(ref e) if retryable_transport && attempt < policy.max_retries => {
+                    let delay = self.backoff_ms(attempt);
+                    tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                    attempt += 1;
+                }
+                Err(e) => {
+                    return Err(transport_error(method, path_template, &e));
+                }
+            }
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl KcTransport for ReqwestKcTransport {
+    async fn raw_request(
+        &self,
+        method: &str,
+        url: &str,
+        bearer_token: &str,
+        body: Option<&Value>,
+        path_template: &str,
+    ) -> Result<(u16, String), PluginError> {
+        // Restrict to the verb set the plugin actually issues against
+        // Keycloak Admin REST: GET / POST / PUT / DELETE. The previous
+        // `parse().unwrap_or(Method::GET)` was doubly wrong:
+        // `http::Method::from_str` accepts arbitrary extension methods
+        // (e.g. `"DLETE"` parses fine and would have been sent over the
+        // wire), and the GET fallback only kicked in for truly-invalid
+        // bytes (empty / whitespace / non-ASCII). PATCH/HEAD/OPTIONS were
+        // also in this whitelist as paranoia placeholders with no
+        // callers — pruning them keeps the verb set single-sourced with
+        // `method_static`. Reject anything outside the canonical set so
+        // a typo in a path-template constant surfaces as
+        // `PluginError::Config` instead of either a silent GET or a
+        // server 405.
+        let m = match method {
+            "GET" => Method::GET,
+            "POST" => Method::POST,
+            "PUT" => Method::PUT,
+            "DELETE" => Method::DELETE,
+            _ => {
+                return Err(PluginError::Config {
+                    detail: format!("invalid HTTP method in raw_request: {method}"),
+                });
+            }
+        };
+        // Clone the inputs we need inside the closure. The `Fn` bound on
+        // `execute_with_retry`'s `build` requires the closure to produce
+        // a fresh `Request` on every invocation (retry path constructs
+        // the request again). `http::Method` is non-Copy, so the closure
+        // captures an owned `m_clone` and clones it per invocation.
+        let url = url.to_owned();
+        let bearer_token = bearer_token.to_owned();
+        let body = body.cloned();
+        let http = self.http.clone();
+        let m_clone = m.clone();
+        let pt = path_template.to_owned();
+        let build = move || {
+            let mut req: RequestBuilder = http
+                .request(m_clone.clone(), &url)
+                .bearer_auth(&bearer_token);
+            if let Some(ref b) = body {
+                req = req.json(b);
+            }
+            let mut built = req
+                .build()
+                .map_err(|e| crate::domain::error::PluginError::KcRest {
+                    method: method_static(&m_clone),
+                    path_template: pt.clone(),
+                    status: crate::domain::error::KcStatusKind::Transport,
+                    body_first_2kb: redact_error_body(&e.to_string()),
+                })?;
+            inject_trace_headers(built.headers_mut());
+            Ok(built)
+        };
+        // Non-idempotent verbs (POST) must NOT be replayed on a connect/
+        // timeout error — the request may already have taken effect server
+        // side (VHP-190). Idempotent verbs are safe to retry.
+        let retry_transport = idempotent_method(&m);
+        self.execute_with_retry(build, &m, path_template, retry_transport)
+            .await
+    }
+
+    async fn form_post(
+        &self,
+        url: &str,
+        fields: &[(&str, &str)],
+        path_template: &str,
+    ) -> Result<(u16, String), PluginError> {
+        let url = url.to_owned();
+        let fields_owned: Vec<(String, String)> = fields
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .collect();
+        let http = self.http.clone();
+        let pt = path_template.to_owned();
+        let build = move || {
+            let refs: Vec<(&str, &str)> = fields_owned
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str()))
+                .collect();
+            let mut built = http.post(&url).form(&refs).build().map_err(|e| {
+                crate::domain::error::PluginError::KcRest {
+                    method: "POST",
+                    path_template: pt.clone(),
+                    status: crate::domain::error::KcStatusKind::Transport,
+                    body_first_2kb: redact_error_body(&e.to_string()),
+                }
+            })?;
+            // DESIGN §8.2: every KC Admin REST hop carries W3C
+            // traceparent from the current span. Token-endpoint POSTs
+            // are admin hops too — without this, cold-cache token
+            // failures lose the platform trace link.
+            inject_trace_headers(built.headers_mut());
+            Ok(built)
+        };
+        // A token fetch is a POST, but re-fetching a token has no durable
+        // side effect, so it opts back into transport retry — important
+        // under load where the token endpoint is the bottleneck (VHP-190).
+        self.execute_with_retry(build, &Method::POST, path_template, true)
+            .await
+    }
+
+    async fn get_unauthenticated(
+        &self,
+        url: &str,
+        path_template: &str,
+    ) -> Result<(u16, String), PluginError> {
+        let url = url.to_owned();
+        let http = self.http.clone();
+        let pt = path_template.to_owned();
+        let build = move || {
+            let mut built =
+                http.get(&url)
+                    .build()
+                    .map_err(|e| crate::domain::error::PluginError::KcRest {
+                        method: "GET",
+                        path_template: pt.clone(),
+                        status: crate::domain::error::KcStatusKind::Transport,
+                        body_first_2kb: redact_error_body(&e.to_string()),
+                    })?;
+            // DESIGN §8.2: health-probe GETs reach KC and MUST carry
+            // traceparent so a flat outage surfaces with the platform
+            // trace link intact for post-mortem.
+            inject_trace_headers(built.headers_mut());
+            Ok(built)
+        };
+        self.execute_with_retry(build, &Method::GET, path_template, true)
+            .await
+    }
+}
+
+#[cfg(test)]
+#[path = "kc_http_tests.rs"]
+mod kc_http_tests;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/infra/kc_http_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/infra/kc_http_tests.rs
@@ -383,7 +383,7 @@ async fn raw_request_no_retry_on_404() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Method-aware transport retry (VHP-190 / run am-functional-22)
+// Method-aware transport retry (create-path idempotency)
 //
 // A connect/timeout error does NOT prove the server didn't process the
 // request. Retrying a NON-idempotent POST on such an error can therefore

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/infra/kc_http_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/infra/kc_http_tests.rs
@@ -58,7 +58,7 @@ async fn raw_request_injects_traceparent_header() {
     //    emit OTel context. `set_default` returns a guard that restores the
     //    previous default when dropped — safe to use in parallel tests.
     let provider = SdkTracerProvider::builder().build();
-    let tracer = provider.tracer("vp-idp-plugin-test");
+    let tracer = provider.tracer("keycloak-idp-plugin-test");
     let subscriber = tracing_subscriber::registry().with(OpenTelemetryLayer::new(tracer));
     let _guard = subscriber.set_default();
 

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/infra/kc_http_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/infra/kc_http_tests.rs
@@ -1,0 +1,608 @@
+use super::*;
+use crate::config::{BackoffKind, HttpRetryPolicy, JitterKind};
+use crate::domain::kc::transport::{KcTransport, truncate_2kb};
+
+// Test-only constructors. Production code reaches the transport through
+// `ReqwestKcTransport::from_config`, which plumbs the retry policy from
+// `KeycloakConfig`; these short-form builders only matter when wiremock
+// + a `reqwest::Client::new()` are enough and the test wants to dictate
+// (or default) the retry policy explicitly. Lives in the companion test
+// file rather than next to `from_config` so DE1101 stays happy (no
+// `#[cfg(test)] fn` items in a file with a companion `_tests.rs`).
+impl ReqwestKcTransport {
+    #[must_use]
+    pub(crate) fn new(http: reqwest::Client) -> Self {
+        Self {
+            http,
+            retry_policy: HttpRetryPolicy::default(),
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn with_retry_policy(http: reqwest::Client, retry_policy: HttpRetryPolicy) -> Self {
+        Self { http, retry_policy }
+    }
+}
+
+/// Verify that every outbound Keycloak Admin REST call carries a W3C
+/// `traceparent` header extracted from the current tracing span.
+///
+/// Matches DESIGN §8.2: "Every Keycloak Admin REST call carries a W3C
+/// `traceparent` (and `tracestate` when present) header extracted from the
+/// current tracing span via `tracing-opentelemetry`, so the Keycloak hop
+/// joins the platform trace tree."
+#[tokio::test]
+async fn raw_request_injects_traceparent_header() {
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_sdk::trace::SdkTracerProvider;
+    use tracing_opentelemetry::OpenTelemetryLayer;
+    use tracing_subscriber::layer::SubscriberExt as _;
+    use tracing_subscriber::util::SubscriberInitExt as _;
+
+    // 1. Stand up a wiremock server that captures the incoming headers.
+    //    We store `Option<bool>` to record whether `traceparent` was present;
+    //    this avoids a direct dependency on the `http` crate in test code.
+    let captured = std::sync::Arc::new(std::sync::Mutex::new(None::<bool>));
+    let server = wiremock::MockServer::start().await;
+    let cap = captured.clone();
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(move |req: &wiremock::Request| {
+            let has_tp = req.headers.contains_key("traceparent");
+            *cap.lock().unwrap() = Some(has_tp);
+            wiremock::ResponseTemplate::new(200).set_body_string("{}")
+        })
+        .mount(&server)
+        .await;
+
+    // 2. Install a tracing subscriber with an OTel layer so that spans
+    //    emit OTel context. `set_default` returns a guard that restores the
+    //    previous default when dropped — safe to use in parallel tests.
+    let provider = SdkTracerProvider::builder().build();
+    let tracer = provider.tracer("vp-idp-plugin-test");
+    let subscriber = tracing_subscriber::registry().with(OpenTelemetryLayer::new(tracer));
+    let _guard = subscriber.set_default();
+
+    // 3. Enter a span and make the outbound request — inject_trace_headers
+    //    should populate traceparent from this span's OTel context.
+    let span = tracing::info_span!("test-traceparent-span");
+    let _enter = span.enter();
+
+    let transport = ReqwestKcTransport::new(reqwest::Client::new());
+    let url = format!("{}/admin/realms/test", server.uri());
+    let _ = transport
+        .raw_request("GET", &url, "dummy-token", None, "/admin/realms/{realm}")
+        .await;
+
+    // 4. Assert the header was injected.
+    let guard = captured.lock().unwrap();
+    let has_traceparent = guard.expect("wiremock must have captured a request");
+    assert!(
+        has_traceparent,
+        "traceparent header must be injected on outbound KC requests"
+    );
+}
+
+#[test]
+fn truncate_short_passthrough() {
+    let s = "hello world";
+    assert_eq!(truncate_2kb(s), "hello world");
+}
+
+#[test]
+fn truncate_long_appends_ellipsis() {
+    let s: String = "a".repeat(3000);
+    let out = truncate_2kb(&s);
+    assert!(out.ends_with('…'));
+    // 2048 'a' chars + ellipsis = 2049 chars
+    assert_eq!(out.chars().count(), 2049);
+}
+
+#[test]
+fn truncate_escapes_non_printable_ascii() {
+    // \x01 is non-printable
+    let s = "ok\x01here";
+    let out = truncate_2kb(s);
+    assert_eq!(out, "ok\\x01here");
+}
+
+#[test]
+fn method_static_covers_canonical_verbs() {
+    assert_eq!(method_static(&Method::GET), "GET");
+    assert_eq!(method_static(&Method::POST), "POST");
+    assert_eq!(method_static(&Method::PUT), "PUT");
+    assert_eq!(method_static(&Method::DELETE), "DELETE");
+}
+
+#[test]
+fn http_status_error_constructs_with_truncated_body() {
+    let err = http_status_error(&Method::GET, "/admin/realms/{realm}", 404, "not found");
+    assert_eq!(
+        format!("{err}"),
+        "kc:GET /admin/realms/{realm} -> 404: not found"
+    );
+}
+
+#[test]
+#[allow(clippy::panic)] // test helper: intentional panic on unexpected variant
+fn http_status_error_redacts_client_secret_in_body_capture() {
+    let body = r#"{"error":"bad","client_secret":"leak-value"}"#;
+    let err = http_status_error(&Method::GET, "/admin/realms/{realm}", 400, body);
+    match err {
+        PluginError::KcRest { body_first_2kb, .. } => {
+            assert!(
+                !body_first_2kb.contains("leak-value"),
+                "secret must be redacted: {body_first_2kb}"
+            );
+            assert!(
+                body_first_2kb.contains("<redacted>"),
+                "redaction marker absent: {body_first_2kb}"
+            );
+        }
+        other => panic!("expected KcRest, got {other:?}"),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Retry-policy tests (DESIGN §4.4 / §10)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build a `ReqwestKcTransport` with zero-delay retry policy (deterministic,
+/// fast tests) and `max_retries = n`.
+fn transport_with_retries(max_retries: u32) -> ReqwestKcTransport {
+    let policy = HttpRetryPolicy {
+        max_retries,
+        backoff: BackoffKind::Exponential,
+        jitter: JitterKind::None,
+        initial_backoff_ms: 0,
+        max_backoff_ms: 0,
+    };
+    ReqwestKcTransport::with_retry_policy(reqwest::Client::new(), policy)
+}
+
+#[tokio::test]
+async fn raw_request_retries_on_502_then_succeeds() {
+    // Wire: 502 twice, then 200.
+    let server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(wiremock::ResponseTemplate::new(502).set_body_string("bad gateway"))
+        .up_to_n_times(2)
+        .mount(&server)
+        .await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&server)
+        .await;
+
+    let transport = transport_with_retries(3);
+    let url = format!("{}/admin/realms/test", server.uri());
+    let (status, body) = transport
+        .raw_request("GET", &url, "tok", None, "/admin/realms/{realm}")
+        .await
+        .expect("must succeed after retries");
+
+    assert_eq!(status, 200);
+    assert_eq!(body, "ok");
+    // 3 total requests: 2 failures + 1 success.
+    let reqs = server
+        .received_requests()
+        .await
+        .expect("must have requests");
+    assert_eq!(reqs.len(), 3);
+}
+
+#[tokio::test]
+async fn raw_request_exhausts_retries_on_persistent_503() {
+    // Wire: always 503.
+    let server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(wiremock::ResponseTemplate::new(503).set_body_string("unavailable"))
+        .mount(&server)
+        .await;
+
+    let transport = transport_with_retries(2);
+    let url = format!("{}/admin/realms/test", server.uri());
+    let (status, _body) = transport
+        .raw_request("GET", &url, "tok", None, "/admin/realms/{realm}")
+        .await
+        .expect("should return last status, not error");
+
+    // Returns 503 to the caller after exhausting retries.
+    assert_eq!(status, 503);
+    // max_retries=2 → 3 total requests (1 original + 2 retries).
+    let reqs = server
+        .received_requests()
+        .await
+        .expect("must have requests");
+    assert_eq!(reqs.len(), 3);
+}
+
+#[tokio::test]
+async fn raw_request_retries_on_429_then_succeeds() {
+    let server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(wiremock::ResponseTemplate::new(429).set_body_string("rate limited"))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&server)
+        .await;
+
+    let transport = transport_with_retries(3);
+    let url = format!("{}/admin/realms/test", server.uri());
+    let (status, body) = transport
+        .raw_request("GET", &url, "tok", None, "/admin/realms/{realm}")
+        .await
+        .expect("must succeed after retry");
+
+    assert_eq!(status, 200);
+    assert_eq!(body, "ok");
+    let reqs = server
+        .received_requests()
+        .await
+        .expect("must have requests");
+    assert_eq!(reqs.len(), 2);
+}
+
+/// RFC 9110 §10.2.3 — when the server returns `Retry-After: <seconds>` on
+/// a 429 or 503, the transport MUST honour the header instead of falling
+/// straight through to the computed exponential backoff. Verified by
+/// configuring zero-delay backoff and asserting elapsed time ≥ header.
+#[tokio::test]
+async fn raw_request_honours_retry_after_header_on_429() {
+    let server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(429)
+                .insert_header("Retry-After", "1")
+                .set_body_string("rate limited"),
+        )
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&server)
+        .await;
+
+    // initial=0 / max=10000: without honouring Retry-After the retry
+    // would fire essentially instantly. Honouring the header forces a
+    // ~1s wait before the second attempt lands.
+    let policy = HttpRetryPolicy {
+        max_retries: 3,
+        backoff: BackoffKind::Exponential,
+        jitter: JitterKind::None,
+        initial_backoff_ms: 0,
+        max_backoff_ms: 10_000,
+    };
+    let transport = ReqwestKcTransport::with_retry_policy(reqwest::Client::new(), policy);
+    let url = format!("{}/admin/realms/test", server.uri());
+    let started = std::time::Instant::now();
+    let (status, _) = transport
+        .raw_request("GET", &url, "tok", None, "/admin/realms/{realm}")
+        .await
+        .expect("must succeed after Retry-After-driven retry");
+    let elapsed = started.elapsed();
+    assert_eq!(status, 200);
+    assert!(
+        elapsed >= std::time::Duration::from_millis(900),
+        "Retry-After: 1 must drive at least ~1s of delay; elapsed = {elapsed:?}",
+    );
+}
+
+/// A hostile or misconfigured server returning `Retry-After: 3600` (1
+/// hour) MUST NOT pin a worker thread for that long. The transport
+/// caps the parsed value at `retry_policy.max_backoff_ms` before
+/// sleeping.
+#[tokio::test]
+async fn raw_request_caps_retry_after_at_max_backoff_ms() {
+    let server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(429)
+                .insert_header("Retry-After", "3600")
+                .set_body_string("rate limited"),
+        )
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&server)
+        .await;
+
+    let policy = HttpRetryPolicy {
+        max_retries: 1,
+        backoff: BackoffKind::Exponential,
+        jitter: JitterKind::None,
+        initial_backoff_ms: 0,
+        // 100ms cap — the 3600s header value must collapse to this.
+        max_backoff_ms: 100,
+    };
+    let transport = ReqwestKcTransport::with_retry_policy(reqwest::Client::new(), policy);
+    let url = format!("{}/admin/realms/test", server.uri());
+    let started = std::time::Instant::now();
+    let (status, _) = transport
+        .raw_request("GET", &url, "tok", None, "/admin/realms/{realm}")
+        .await
+        .expect("must complete fast despite hostile Retry-After");
+    let elapsed = started.elapsed();
+    assert_eq!(status, 200);
+    assert!(
+        elapsed < std::time::Duration::from_secs(2),
+        "Retry-After must be capped by max_backoff_ms; elapsed = {elapsed:?}",
+    );
+}
+
+#[tokio::test]
+async fn raw_request_no_retry_on_400() {
+    let server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(wiremock::ResponseTemplate::new(400).set_body_string("bad request"))
+        .mount(&server)
+        .await;
+
+    let transport = transport_with_retries(3);
+    let url = format!("{}/admin/realms/test", server.uri());
+    let (status, _body) = transport
+        .raw_request("GET", &url, "tok", None, "/admin/realms/{realm}")
+        .await
+        .expect("must return status without retry");
+
+    assert_eq!(status, 400);
+    // Exactly 1 request — no retry on 4xx (except 429).
+    let reqs = server
+        .received_requests()
+        .await
+        .expect("must have requests");
+    assert_eq!(reqs.len(), 1);
+}
+
+#[tokio::test]
+async fn raw_request_no_retry_on_404() {
+    let server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(wiremock::ResponseTemplate::new(404).set_body_string("not found"))
+        .mount(&server)
+        .await;
+
+    let transport = transport_with_retries(3);
+    let url = format!("{}/admin/realms/test", server.uri());
+    let (status, _body) = transport
+        .raw_request("GET", &url, "tok", None, "/admin/realms/{realm}")
+        .await
+        .expect("must return status without retry");
+
+    assert_eq!(status, 404);
+    let reqs = server
+        .received_requests()
+        .await
+        .expect("must have requests");
+    assert_eq!(reqs.len(), 1);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Method-aware transport retry (VHP-190 / run am-functional-22)
+//
+// A connect/timeout error does NOT prove the server didn't process the
+// request. Retrying a NON-idempotent POST on such an error can therefore
+// duplicate a side effect — exactly the double `POST /admin/realms` that
+// created a duplicate realm and produced the false-ambiguous 500. So the
+// transport retries connect/timeout ONLY for idempotent verbs (GET/PUT/
+// DELETE) and for the token-endpoint `form_post` (re-fetching a token is
+// safe). A non-idempotent `raw_request` POST must be surfaced, not replayed.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Zero-backoff retry policy + a client with a short request timeout, so a
+/// `set_delay` longer than the timeout deterministically produces a
+/// `reqwest` timeout (transport) error fast.
+fn transport_short_timeout(max_retries: u32) -> ReqwestKcTransport {
+    let policy = HttpRetryPolicy {
+        max_retries,
+        backoff: BackoffKind::Exponential,
+        jitter: JitterKind::None,
+        initial_backoff_ms: 0,
+        max_backoff_ms: 0,
+    };
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_millis(150))
+        .build()
+        .expect("client builds");
+    ReqwestKcTransport::with_retry_policy(client, policy)
+}
+
+/// A non-idempotent `POST` that TIMES OUT must be surfaced after exactly ONE
+/// attempt — never replayed (the first POST may have already taken effect).
+#[tokio::test]
+async fn raw_request_does_not_retry_post_on_timeout() {
+    let server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(201).set_delay(std::time::Duration::from_millis(800)),
+        )
+        .mount(&server)
+        .await;
+
+    let transport = transport_short_timeout(3);
+    let url = format!("{}/admin/realms", server.uri());
+    let err = transport
+        .raw_request("POST", &url, "tok", None, "/admin/realms")
+        .await
+        .expect_err("timed-out POST must surface, not silently succeed");
+    assert!(
+        matches!(
+            err,
+            PluginError::KcRest {
+                status: crate::domain::error::KcStatusKind::Timeout,
+                ..
+            }
+        ),
+        "expected a Timeout KcRest, got {err:?}",
+    );
+
+    let reqs = server
+        .received_requests()
+        .await
+        .expect("must have requests");
+    assert_eq!(
+        reqs.len(),
+        1,
+        "non-idempotent POST must NOT be retried on timeout; observed {} attempts",
+        reqs.len(),
+    );
+}
+
+/// An idempotent `GET` that times out IS retried on transport failure
+/// (re-reading is harmless) — guards that the method-aware gate doesn't
+/// over-restrict.
+#[tokio::test]
+async fn raw_request_retries_get_on_timeout() {
+    let server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_delay(std::time::Duration::from_millis(800)),
+        )
+        .mount(&server)
+        .await;
+
+    let transport = transport_short_timeout(2);
+    let url = format!("{}/admin/realms/test", server.uri());
+    let _ = transport
+        .raw_request("GET", &url, "tok", None, "/admin/realms/{realm}")
+        .await;
+
+    let reqs = server
+        .received_requests()
+        .await
+        .expect("must have requests");
+    assert!(
+        reqs.len() >= 2,
+        "idempotent GET must retry on timeout; observed {} attempt(s)",
+        reqs.len(),
+    );
+}
+
+/// The token-endpoint `form_post` is a POST, but re-fetching a token is
+/// safe and important under load — it MUST still retry on timeout (this is
+/// the path that would otherwise be starved if we naively gated all POSTs).
+#[tokio::test]
+async fn form_post_retries_on_timeout() {
+    let server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_delay(std::time::Duration::from_millis(800)),
+        )
+        .mount(&server)
+        .await;
+
+    let transport = transport_short_timeout(2);
+    let url = format!(
+        "{}/realms/master/protocol/openid-connect/token",
+        server.uri()
+    );
+    let _ = transport
+        .form_post(
+            &url,
+            &[("grant_type", "client_credentials")],
+            "/realms/{realm}/protocol/openid-connect/token",
+        )
+        .await;
+
+    let reqs = server
+        .received_requests()
+        .await
+        .expect("must have requests");
+    assert!(
+        reqs.len() >= 2,
+        "token form_post must retry on timeout; observed {} attempt(s)",
+        reqs.len(),
+    );
+}
+
+#[tokio::test]
+#[allow(clippy::panic)] // test helper: intentional panic on unexpected variant
+async fn raw_request_rejects_unknown_http_method() {
+    // A typo in a path-template constant — e.g. "DLETE" — used to silently
+    // coerce to GET, turning a delete into a read. The transport must now
+    // reject the verb up front.
+    let transport = transport_with_retries(0);
+    let err = transport
+        .raw_request(
+            "DLETE",
+            "https://kc.invalid/admin/realms/test",
+            "tok",
+            None,
+            "/admin/realms/{realm}",
+        )
+        .await
+        .expect_err("invalid method must fail before any HTTP exchange");
+    match err {
+        PluginError::Config { detail } => {
+            assert!(
+                detail.contains("DLETE"),
+                "detail should name the offending verb: {detail}"
+            );
+        }
+        other => panic!("expected PluginError::Config, got {other:?}"),
+    }
+}
+
+#[test]
+fn backoff_ms_none_jitter_is_deterministic_exponential() {
+    let policy = HttpRetryPolicy {
+        max_retries: 5,
+        backoff: BackoffKind::Exponential,
+        jitter: JitterKind::None,
+        initial_backoff_ms: 100,
+        max_backoff_ms: 10_000,
+    };
+    let transport = ReqwestKcTransport::with_retry_policy(reqwest::Client::new(), policy);
+
+    // attempt 0 → 100ms, attempt 1 → 200ms, attempt 2 → 400ms, attempt 3 → 800ms
+    assert_eq!(transport.backoff_ms(0), 100);
+    assert_eq!(transport.backoff_ms(1), 200);
+    assert_eq!(transport.backoff_ms(2), 400);
+    assert_eq!(transport.backoff_ms(3), 800);
+}
+
+#[test]
+fn backoff_ms_none_jitter_is_capped_at_max() {
+    let policy = HttpRetryPolicy {
+        max_retries: 5,
+        backoff: BackoffKind::Exponential,
+        jitter: JitterKind::None,
+        initial_backoff_ms: 100,
+        max_backoff_ms: 300,
+    };
+    let transport = ReqwestKcTransport::with_retry_policy(reqwest::Client::new(), policy);
+
+    // 100, 200, then capped at 300 for any higher attempt
+    assert_eq!(transport.backoff_ms(0), 100);
+    assert_eq!(transport.backoff_ms(1), 200);
+    assert_eq!(transport.backoff_ms(2), 300);
+    assert_eq!(transport.backoff_ms(10), 300);
+}
+
+#[test]
+fn backoff_ms_full_jitter_within_bounds() {
+    let policy = HttpRetryPolicy {
+        max_retries: 5,
+        backoff: BackoffKind::Exponential,
+        jitter: JitterKind::Full,
+        initial_backoff_ms: 100,
+        max_backoff_ms: 5_000,
+    };
+    let transport = ReqwestKcTransport::with_retry_policy(reqwest::Client::new(), policy);
+
+    // Full jitter → result must be in [0, cap]. Cap at attempt 0 is 100ms.
+    for _ in 0..20 {
+        let delay = transport.backoff_ms(0);
+        assert!(delay <= 100, "full jitter delay {delay} exceeds cap 100");
+    }
+    // At attempt 3 cap is 800ms.
+    for _ in 0..20 {
+        let delay = transport.backoff_ms(3);
+        assert!(delay <= 800, "full jitter delay {delay} exceeds cap 800");
+    }
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/infra/metrics.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/infra/metrics.rs
@@ -1,9 +1,9 @@
-//! OpenTelemetry-backed adapter for the `vp-idp-plugin` metric ports.
+//! OpenTelemetry-backed adapter for the `keycloak-idp-plugin` metric ports.
 //!
-//! [`VpIdpPluginMetricsAdapter`] owns all OpenTelemetry instruments
+//! [`KeycloakIdpPluginMetricsAdapter`] owns all OpenTelemetry instruments
 //! declared by the catalog in [`crate::domain::metrics`] and implements
 //! every port trait from [`crate::domain::ports::metrics`]. A single
-//! `Arc<VpIdpPluginMetricsAdapter>` is constructed at module init
+//! `Arc<KeycloakIdpPluginMetricsAdapter>` is constructed at module init
 //! ([`crate::module`]) and coerced into per-trait `Arc<dyn ...>` views
 //! by DI.
 //!
@@ -11,7 +11,7 @@
 //!
 //! Instrument names are **literal Prometheus** names with the wire-side
 //! suffix baked into the name: counters end with `_total`
-//! (`vp_idp_plugin_failure_total`), histograms end with their unit
+//! (`keycloak_idp_plugin_failure_total`), histograms end with their unit
 //! (`_seconds`, or `_ms` only where genuinely milliseconds), and
 //! gauges / up-down-counters carry no suffix. The adapter does **not**
 //! call `with_unit(...)` — the unit lives in the name. This matches the
@@ -37,12 +37,12 @@ use opentelemetry::metrics::{Counter, Histogram, Meter, UpDownCounter};
 
 use crate::domain::metadata_codec::RealmBinding;
 use crate::domain::metrics::{
-    DEFAULT_PREFIX, VP_IDP_PLUGIN_CREDENTIAL_REFRESH, VP_IDP_PLUGIN_CREDSTORE_WRITE,
-    VP_IDP_PLUGIN_DEPROVISION_MISSING_METADATA, VP_IDP_PLUGIN_FAILURE,
-    VP_IDP_PLUGIN_KC_ADMIN_REQUEST_DURATION, VP_IDP_PLUGIN_KC_ADMIN_TOKEN_REFRESH,
-    VP_IDP_PLUGIN_METADATA_DECODE_FAILURE, VP_IDP_PLUGIN_ORPHAN_USER_COMPENSATION,
-    VP_IDP_PLUGIN_PROVISION_TENANT_DURATION, VP_IDP_PLUGIN_REALMS_BOUND,
-    VP_IDP_PLUGIN_SP_OP_DURATION, VP_IDP_PLUGIN_USER_OP_DURATION,
+    DEFAULT_PREFIX, KEYCLOAK_IDP_PLUGIN_CREDENTIAL_REFRESH, KEYCLOAK_IDP_PLUGIN_CREDSTORE_WRITE,
+    KEYCLOAK_IDP_PLUGIN_DEPROVISION_MISSING_METADATA, KEYCLOAK_IDP_PLUGIN_FAILURE,
+    KEYCLOAK_IDP_PLUGIN_KC_ADMIN_REQUEST_DURATION, KEYCLOAK_IDP_PLUGIN_KC_ADMIN_TOKEN_REFRESH,
+    KEYCLOAK_IDP_PLUGIN_METADATA_DECODE_FAILURE, KEYCLOAK_IDP_PLUGIN_ORPHAN_USER_COMPENSATION,
+    KEYCLOAK_IDP_PLUGIN_PROVISION_TENANT_DURATION, KEYCLOAK_IDP_PLUGIN_REALMS_BOUND,
+    KEYCLOAK_IDP_PLUGIN_SP_OP_DURATION, KEYCLOAK_IDP_PLUGIN_USER_OP_DURATION,
 };
 use crate::domain::ports::metrics::{
     CredstoreMetricsPort, CredstoreOp, CredstoreOutcome, EndpointClass, FailureMetricsPort,
@@ -53,7 +53,7 @@ use crate::domain::ports::metrics::{
 
 /// OpenTelemetry adapter that owns one instrument per plugin metric
 /// family and implements every port trait.
-pub struct VpIdpPluginMetricsAdapter {
+pub struct KeycloakIdpPluginMetricsAdapter {
     // Histograms (4)
     provision_tenant_duration: Histogram<f64>,
     user_op_duration: Histogram<f64>,
@@ -77,13 +77,13 @@ pub struct VpIdpPluginMetricsAdapter {
     realm_label_cap: u32,
 }
 
-/// Substitute the leading `vp_idp_plugin` namespace token of a literal
+/// Substitute the leading `keycloak_idp_plugin` namespace token of a literal
 /// metric family name with the adapter's `prefix`, preserving the rest
 /// of the (already suffixed) name verbatim. With the default prefix
-/// (`"vp_idp_plugin"`) this is a no-op and the name is emitted exactly
+/// (`"keycloak_idp_plugin"`) this is a no-op and the name is emitted exactly
 /// as declared in the catalog.
 ///
-/// `"vp_idp_plugin_failure_total"` + `"my_plugin"` →
+/// `"keycloak_idp_plugin_failure_total"` + `"my_plugin"` →
 /// `"my_plugin_failure_total"`. A family that does not start with the
 /// default token (should not happen for catalog constants) is prefixed
 /// as `"{prefix}_{family}"` so the host prefix still shows up.
@@ -95,10 +95,10 @@ fn rename(family: &str, prefix: &str) -> String {
     }
 }
 
-impl VpIdpPluginMetricsAdapter {
+impl KeycloakIdpPluginMetricsAdapter {
     /// Build every instrument. `prefix` defaults to
-    /// [`crate::domain::metrics::DEFAULT_PREFIX`] (`"vp_idp_plugin"`)
-    /// and substitutes the leading `vp_idp_plugin` namespace token of
+    /// [`crate::domain::metrics::DEFAULT_PREFIX`] (`"keycloak_idp_plugin"`)
+    /// and substitutes the leading `keycloak_idp_plugin` namespace token of
     /// every literal metric family name (a no-op with the default
     /// prefix; the unit/`_total` suffix already baked into the name is
     /// preserved). `realm_label_cap` controls the cardinality watchdog
@@ -107,55 +107,64 @@ impl VpIdpPluginMetricsAdapter {
     pub fn new(meter: &Meter, prefix: &str, realm_label_cap: u32) -> Self {
         Self {
             provision_tenant_duration: meter
-                .f64_histogram(rename(VP_IDP_PLUGIN_PROVISION_TENANT_DURATION, prefix))
+                .f64_histogram(rename(
+                    KEYCLOAK_IDP_PLUGIN_PROVISION_TENANT_DURATION,
+                    prefix,
+                ))
                 .with_description("provision_tenant end-to-end latency in seconds by realm_binding")
                 .build(),
             user_op_duration: meter
-                .f64_histogram(rename(VP_IDP_PLUGIN_USER_OP_DURATION, prefix))
+                .f64_histogram(rename(KEYCLOAK_IDP_PLUGIN_USER_OP_DURATION, prefix))
                 .with_description("User-op latency in seconds by op")
                 .build(),
             kc_admin_request_duration: meter
-                .f64_histogram(rename(VP_IDP_PLUGIN_KC_ADMIN_REQUEST_DURATION, prefix))
+                .f64_histogram(rename(
+                    KEYCLOAK_IDP_PLUGIN_KC_ADMIN_REQUEST_DURATION,
+                    prefix,
+                ))
                 .with_description("Single KC Admin REST call latency in seconds by endpoint_class")
                 .build(),
             sp_op_duration: meter
-                .f64_histogram(rename(VP_IDP_PLUGIN_SP_OP_DURATION, prefix))
+                .f64_histogram(rename(KEYCLOAK_IDP_PLUGIN_SP_OP_DURATION, prefix))
                 .with_description("Service-principal op latency in seconds by op")
                 .build(),
             failure: meter
-                .u64_counter(rename(VP_IDP_PLUGIN_FAILURE, prefix))
+                .u64_counter(rename(KEYCLOAK_IDP_PLUGIN_FAILURE, prefix))
                 .with_description("Plugin failures by op x failure_variant")
                 .build(),
             kc_admin_token_refresh: meter
-                .u64_counter(rename(VP_IDP_PLUGIN_KC_ADMIN_TOKEN_REFRESH, prefix))
+                .u64_counter(rename(KEYCLOAK_IDP_PLUGIN_KC_ADMIN_TOKEN_REFRESH, prefix))
                 .with_description("Admin token refresh count by outcome x tier x realm")
                 .build(),
             credential_refresh: meter
-                .u64_counter(rename(VP_IDP_PLUGIN_CREDENTIAL_REFRESH, prefix))
+                .u64_counter(rename(KEYCLOAK_IDP_PLUGIN_CREDENTIAL_REFRESH, prefix))
                 .with_description(
                     "Admin client_secret re-resolution count by outcome x tier x realm",
                 )
                 .build(),
             credstore_write: meter
-                .u64_counter(rename(VP_IDP_PLUGIN_CREDSTORE_WRITE, prefix))
+                .u64_counter(rename(KEYCLOAK_IDP_PLUGIN_CREDSTORE_WRITE, prefix))
                 .with_description("OpenBao writes/deletes for per-realm admin secrets")
                 .build(),
             metadata_decode_failure: meter
-                .u64_counter(rename(VP_IDP_PLUGIN_METADATA_DECODE_FAILURE, prefix))
+                .u64_counter(rename(KEYCLOAK_IDP_PLUGIN_METADATA_DECODE_FAILURE, prefix))
                 .with_description("Malformed / unsupported-version metadata blob counter")
                 .build(),
             deprovision_missing_metadata: meter
-                .u64_counter(rename(VP_IDP_PLUGIN_DEPROVISION_MISSING_METADATA, prefix))
+                .u64_counter(rename(
+                    KEYCLOAK_IDP_PLUGIN_DEPROVISION_MISSING_METADATA,
+                    prefix,
+                ))
                 .with_description("deprovision_tenant with metadata=None and am.system ctx")
                 .build(),
             orphan_user_compensation: meter
-                .u64_counter(rename(VP_IDP_PLUGIN_ORPHAN_USER_COMPENSATION, prefix))
+                .u64_counter(rename(KEYCLOAK_IDP_PLUGIN_ORPHAN_USER_COMPENSATION, prefix))
                 .with_description(
                     "Orphan-user compensation outcome (after add_user_to_group failure) by outcome",
                 )
                 .build(),
             realms_bound: meter
-                .i64_up_down_counter(rename(VP_IDP_PLUGIN_REALMS_BOUND, prefix))
+                .i64_up_down_counter(rename(KEYCLOAK_IDP_PLUGIN_REALMS_BOUND, prefix))
                 .with_description("Active realm bindings by realm_binding x realm_name")
                 .build(),
             seen_realms: DashSet::new(),
@@ -220,10 +229,10 @@ impl VpIdpPluginMetricsAdapter {
         // We bound the warn to "this is the realm that wanted in but
         // couldn't" so operators see the proximate cause.
         tracing::warn!(
-            target: "vp_idp_plugin.metrics",
+            target: "keycloak_idp.metrics",
             cap = self.realm_label_cap,
             tripping_realm = realm,
-            "vp_idp_plugin realm_label_cap reached; `realm_name` label dropped for new realms across realms_bound + kc_admin_token_refresh + credential_refresh (shared budget)"
+            "keycloak_idp_plugin realm_label_cap reached; `realm_name` label dropped for new realms across realms_bound + kc_admin_token_refresh + credential_refresh (shared budget)"
         );
         false
     }
@@ -260,13 +269,13 @@ impl VpIdpPluginMetricsAdapter {
 }
 
 /// Convenience constructor used at module init: builds an
-/// `Arc<VpIdpPluginMetricsAdapter>` against the process-global
+/// `Arc<KeycloakIdpPluginMetricsAdapter>` against the process-global
 /// OpenTelemetry meter provider, scoped to the plugin instrumentation
 /// library, with the default prefix.
 #[must_use]
-pub fn build_default_adapter(realm_label_cap: u32) -> Arc<VpIdpPluginMetricsAdapter> {
-    let meter = opentelemetry::global::meter("vp-idp-plugin");
-    Arc::new(VpIdpPluginMetricsAdapter::new(
+pub fn build_default_adapter(realm_label_cap: u32) -> Arc<KeycloakIdpPluginMetricsAdapter> {
+    let meter = opentelemetry::global::meter("keycloak-idp-plugin");
+    Arc::new(KeycloakIdpPluginMetricsAdapter::new(
         &meter,
         DEFAULT_PREFIX,
         realm_label_cap,
@@ -277,7 +286,7 @@ pub fn build_default_adapter(realm_label_cap: u32) -> Arc<VpIdpPluginMetricsAdap
 //  Port-trait implementations
 // ════════════════════════════════════════════════════════════════════
 
-impl TenantLifecycleMetricsPort for VpIdpPluginMetricsAdapter {
+impl TenantLifecycleMetricsPort for KeycloakIdpPluginMetricsAdapter {
     fn provision_tenant_duration(&self, realm_binding: RealmBinding, secs: f64) {
         self.provision_tenant_duration.record(
             secs,
@@ -317,7 +326,7 @@ impl TenantLifecycleMetricsPort for VpIdpPluginMetricsAdapter {
     }
 }
 
-impl UserOpMetricsPort for VpIdpPluginMetricsAdapter {
+impl UserOpMetricsPort for KeycloakIdpPluginMetricsAdapter {
     fn user_op_duration(&self, op: UserOp, secs: f64) {
         self.user_op_duration
             .record(secs, &[KeyValue::new("op", op.as_str())]);
@@ -329,7 +338,7 @@ impl UserOpMetricsPort for VpIdpPluginMetricsAdapter {
     }
 }
 
-impl KcAdminMetricsPort for VpIdpPluginMetricsAdapter {
+impl KcAdminMetricsPort for KeycloakIdpPluginMetricsAdapter {
     fn kc_admin_request_duration(&self, endpoint_class: EndpointClass, secs: f64) {
         self.kc_admin_request_duration.record(
             secs,
@@ -360,7 +369,7 @@ impl KcAdminMetricsPort for VpIdpPluginMetricsAdapter {
     }
 }
 
-impl CredstoreMetricsPort for VpIdpPluginMetricsAdapter {
+impl CredstoreMetricsPort for KeycloakIdpPluginMetricsAdapter {
     fn credstore_write(&self, op: CredstoreOp, outcome: CredstoreOutcome) {
         self.credstore_write.add(
             1,
@@ -372,7 +381,7 @@ impl CredstoreMetricsPort for VpIdpPluginMetricsAdapter {
     }
 }
 
-impl MetadataCodecMetricsPort for VpIdpPluginMetricsAdapter {
+impl MetadataCodecMetricsPort for KeycloakIdpPluginMetricsAdapter {
     fn metadata_decode_failure(&self, version_observed: VersionObserved) {
         // VersionObserved holds Cow; the OTel KeyValue API needs an
         // owned String for non-static labels, so we allocate here. The
@@ -388,7 +397,7 @@ impl MetadataCodecMetricsPort for VpIdpPluginMetricsAdapter {
     }
 }
 
-impl FailureMetricsPort for VpIdpPluginMetricsAdapter {
+impl FailureMetricsPort for KeycloakIdpPluginMetricsAdapter {
     fn failure(&self, op: PluginOp, variant: FailureVariant) {
         self.failure.add(
             1,
@@ -400,7 +409,7 @@ impl FailureMetricsPort for VpIdpPluginMetricsAdapter {
     }
 }
 
-impl SpOpMetricsPort for VpIdpPluginMetricsAdapter {
+impl SpOpMetricsPort for KeycloakIdpPluginMetricsAdapter {
     fn sp_op_duration(&self, op: SpOp, secs: f64) {
         self.sp_op_duration
             .record(secs, &[KeyValue::new("op", op.as_str())]);

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/infra/metrics.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/infra/metrics.rs
@@ -1,0 +1,412 @@
+//! OpenTelemetry-backed adapter for the `vp-idp-plugin` metric ports.
+//!
+//! [`VpIdpPluginMetricsAdapter`] owns all OpenTelemetry instruments
+//! declared by the catalog in [`crate::domain::metrics`] and implements
+//! every port trait from [`crate::domain::ports::metrics`]. A single
+//! `Arc<VpIdpPluginMetricsAdapter>` is constructed at module init
+//! ([`crate::module`]) and coerced into per-trait `Arc<dyn ...>` views
+//! by DI.
+//!
+//! ## Naming convention (mirrors RMS / policy-engine)
+//!
+//! Instrument names are **literal Prometheus** names with the wire-side
+//! suffix baked into the name: counters end with `_total`
+//! (`vp_idp_plugin_failure_total`), histograms end with their unit
+//! (`_seconds`, or `_ms` only where genuinely milliseconds), and
+//! gauges / up-down-counters carry no suffix. The adapter does **not**
+//! call `with_unit(...)` — the unit lives in the name. This matches the
+//! platform collector's `add_metric_suffixes: false` posture, which
+//! preserves these names verbatim and does NOT auto-append suffixes
+//! (same as RMS / policy-engine).
+//!
+//! ## Cardinality watchdog
+//!
+//! Per DESIGN §4.4 / §9, `realm_name` is a partner-controlled label.
+//! The adapter tracks distinct realm names in an internal `DashSet`;
+//! once the cap (`realm_label_cap`, sourced from config) is exceeded,
+//! the `realm_name` label is dropped from all subsequent emissions and
+//! a `tracing::field` is recorded on the current span instead. The
+//! policy is enforced inside the adapter — call sites pass `&str` and
+//! never decide whether to emit the label.
+
+use std::sync::Arc;
+
+use dashmap::DashSet;
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::{Counter, Histogram, Meter, UpDownCounter};
+
+use crate::domain::metadata_codec::RealmBinding;
+use crate::domain::metrics::{
+    DEFAULT_PREFIX, VP_IDP_PLUGIN_CREDENTIAL_REFRESH, VP_IDP_PLUGIN_CREDSTORE_WRITE,
+    VP_IDP_PLUGIN_DEPROVISION_MISSING_METADATA, VP_IDP_PLUGIN_FAILURE,
+    VP_IDP_PLUGIN_KC_ADMIN_REQUEST_DURATION, VP_IDP_PLUGIN_KC_ADMIN_TOKEN_REFRESH,
+    VP_IDP_PLUGIN_METADATA_DECODE_FAILURE, VP_IDP_PLUGIN_ORPHAN_USER_COMPENSATION,
+    VP_IDP_PLUGIN_PROVISION_TENANT_DURATION, VP_IDP_PLUGIN_REALMS_BOUND,
+    VP_IDP_PLUGIN_SP_OP_DURATION, VP_IDP_PLUGIN_USER_OP_DURATION,
+};
+use crate::domain::ports::metrics::{
+    CredstoreMetricsPort, CredstoreOp, CredstoreOutcome, EndpointClass, FailureMetricsPort,
+    FailureVariant, KcAdminMetricsPort, MetadataCodecMetricsPort, OrphanCompensationOutcome,
+    PluginOp, SpOp, SpOpMetricsPort, TenantLifecycleMetricsPort, TokenRefreshOutcome, TokenTier,
+    UserOp, UserOpMetricsPort, VersionObserved,
+};
+
+/// OpenTelemetry adapter that owns one instrument per plugin metric
+/// family and implements every port trait.
+pub struct VpIdpPluginMetricsAdapter {
+    // Histograms (4)
+    provision_tenant_duration: Histogram<f64>,
+    user_op_duration: Histogram<f64>,
+    kc_admin_request_duration: Histogram<f64>,
+    sp_op_duration: Histogram<f64>,
+
+    // Counters (7)
+    failure: Counter<u64>,
+    kc_admin_token_refresh: Counter<u64>,
+    credential_refresh: Counter<u64>,
+    credstore_write: Counter<u64>,
+    metadata_decode_failure: Counter<u64>,
+    deprovision_missing_metadata: Counter<u64>,
+    orphan_user_compensation: Counter<u64>,
+
+    // UpDownCounter (1)
+    realms_bound: UpDownCounter<i64>,
+
+    // Cardinality watchdog (DESIGN §4.4, §9). `0` disables.
+    seen_realms: DashSet<String>,
+    realm_label_cap: u32,
+}
+
+/// Substitute the leading `vp_idp_plugin` namespace token of a literal
+/// metric family name with the adapter's `prefix`, preserving the rest
+/// of the (already suffixed) name verbatim. With the default prefix
+/// (`"vp_idp_plugin"`) this is a no-op and the name is emitted exactly
+/// as declared in the catalog.
+///
+/// `"vp_idp_plugin_failure_total"` + `"my_plugin"` →
+/// `"my_plugin_failure_total"`. A family that does not start with the
+/// default token (should not happen for catalog constants) is prefixed
+/// as `"{prefix}_{family}"` so the host prefix still shows up.
+#[inline]
+fn rename(family: &str, prefix: &str) -> String {
+    match family.strip_prefix(DEFAULT_PREFIX) {
+        Some(tail) => format!("{prefix}{tail}"),
+        None => format!("{prefix}_{family}"),
+    }
+}
+
+impl VpIdpPluginMetricsAdapter {
+    /// Build every instrument. `prefix` defaults to
+    /// [`crate::domain::metrics::DEFAULT_PREFIX`] (`"vp_idp_plugin"`)
+    /// and substitutes the leading `vp_idp_plugin` namespace token of
+    /// every literal metric family name (a no-op with the default
+    /// prefix; the unit/`_total` suffix already baked into the name is
+    /// preserved). `realm_label_cap` controls the cardinality watchdog
+    /// (pass `0` to disable).
+    #[must_use]
+    pub fn new(meter: &Meter, prefix: &str, realm_label_cap: u32) -> Self {
+        Self {
+            provision_tenant_duration: meter
+                .f64_histogram(rename(VP_IDP_PLUGIN_PROVISION_TENANT_DURATION, prefix))
+                .with_description("provision_tenant end-to-end latency in seconds by realm_binding")
+                .build(),
+            user_op_duration: meter
+                .f64_histogram(rename(VP_IDP_PLUGIN_USER_OP_DURATION, prefix))
+                .with_description("User-op latency in seconds by op")
+                .build(),
+            kc_admin_request_duration: meter
+                .f64_histogram(rename(VP_IDP_PLUGIN_KC_ADMIN_REQUEST_DURATION, prefix))
+                .with_description("Single KC Admin REST call latency in seconds by endpoint_class")
+                .build(),
+            sp_op_duration: meter
+                .f64_histogram(rename(VP_IDP_PLUGIN_SP_OP_DURATION, prefix))
+                .with_description("Service-principal op latency in seconds by op")
+                .build(),
+            failure: meter
+                .u64_counter(rename(VP_IDP_PLUGIN_FAILURE, prefix))
+                .with_description("Plugin failures by op x failure_variant")
+                .build(),
+            kc_admin_token_refresh: meter
+                .u64_counter(rename(VP_IDP_PLUGIN_KC_ADMIN_TOKEN_REFRESH, prefix))
+                .with_description("Admin token refresh count by outcome x tier x realm")
+                .build(),
+            credential_refresh: meter
+                .u64_counter(rename(VP_IDP_PLUGIN_CREDENTIAL_REFRESH, prefix))
+                .with_description(
+                    "Admin client_secret re-resolution count by outcome x tier x realm",
+                )
+                .build(),
+            credstore_write: meter
+                .u64_counter(rename(VP_IDP_PLUGIN_CREDSTORE_WRITE, prefix))
+                .with_description("OpenBao writes/deletes for per-realm admin secrets")
+                .build(),
+            metadata_decode_failure: meter
+                .u64_counter(rename(VP_IDP_PLUGIN_METADATA_DECODE_FAILURE, prefix))
+                .with_description("Malformed / unsupported-version metadata blob counter")
+                .build(),
+            deprovision_missing_metadata: meter
+                .u64_counter(rename(VP_IDP_PLUGIN_DEPROVISION_MISSING_METADATA, prefix))
+                .with_description("deprovision_tenant with metadata=None and am.system ctx")
+                .build(),
+            orphan_user_compensation: meter
+                .u64_counter(rename(VP_IDP_PLUGIN_ORPHAN_USER_COMPENSATION, prefix))
+                .with_description(
+                    "Orphan-user compensation outcome (after add_user_to_group failure) by outcome",
+                )
+                .build(),
+            realms_bound: meter
+                .i64_up_down_counter(rename(VP_IDP_PLUGIN_REALMS_BOUND, prefix))
+                .with_description("Active realm bindings by realm_binding x realm_name")
+                .build(),
+            seen_realms: DashSet::new(),
+            realm_label_cap,
+        }
+    }
+
+    /// Decide whether the `realm_name` label should be emitted for
+    /// `realm` and record the decision (so the unbind side can match).
+    ///
+    /// Contract:
+    /// * `realm_label_cap == 0` → always emit (cap disabled).
+    /// * `seen_realms` holds **exactly** the realms whose label has
+    ///   already been emitted at least once. On a new realm:
+    ///   * if `len() < cap`, insert it and emit (`true`);
+    ///   * otherwise drop the label (`false`) and **do NOT insert** —
+    ///     a realm whose `+1` was emitted unlabelled MUST get an
+    ///     unlabelled `-1` too, and that requires `contains(realm)`
+    ///     to be `false` on the unbind lookup.
+    ///
+    /// Previously `seen_realms` was populated **before** the cap
+    /// check, which let realms bound past-cap drift into the set; the
+    /// unbind helper (`realm_key_value_no_observe`) then keyed off
+    /// `contains()` and KEPT the label on `-1`, breaking the
+    /// `+1`/`-1` pairing on the `realms_bound` `UpDownCounter`.
+    ///
+    /// **Shared budget**: every emit site that takes a realm name
+    /// (`realm_bound`, `kc_admin_token_refresh`, `credential_refresh`)
+    /// shares the SAME `realm_label_cap`. A high-churn token-refresh
+    /// path against many partner realms can independently exhaust the
+    /// cap and silently drop `realm_name` from `realms_bound` for
+    /// legitimate low-churn tenants. The single-budget design mirrors
+    /// AM's posture; a one-shot `tracing::warn!` fires the first time
+    /// the cap is crossed so operators see WHICH realm tipped it over.
+    pub(crate) fn observe_realm_and_should_emit(&self, realm: &str) -> bool {
+        if self.realm_label_cap == 0 {
+            return true;
+        }
+        // Already-labelled realm — always emit the label, no budget
+        // change.
+        if self.seen_realms.contains(realm) {
+            return true;
+        }
+        // New realm. Check the budget BEFORE inserting; only insert if
+        // we're going to emit the label, so the set's membership stays
+        // 1:1 with "label was emitted".
+        let cap = self.realm_label_cap as usize;
+        if self.seen_realms.len() < cap {
+            // Race-tolerant insert: `DashSet::insert` is atomic. If
+            // two threads race the same new realm, one wins the insert
+            // (returns `true`), the other sees the entry on its own
+            // `insert` (returns `false`); both return `true` here
+            // because both are guaranteed to find the realm in the
+            // set on any subsequent lookup. The set may briefly grow
+            // by 1 past the cap in a tight race, which is acceptable
+            // — operator dashboards aren't sensitive to ±1 cardinality.
+            self.seen_realms.insert(realm.to_string());
+            return true;
+        }
+        // Cap reached and this realm is genuinely new — one-shot
+        // operator signal the first time the cap is first crossed.
+        // We bound the warn to "this is the realm that wanted in but
+        // couldn't" so operators see the proximate cause.
+        tracing::warn!(
+            target: "vp_idp_plugin.metrics",
+            cap = self.realm_label_cap,
+            tripping_realm = realm,
+            "vp_idp_plugin realm_label_cap reached; `realm_name` label dropped for new realms across realms_bound + kc_admin_token_refresh + credential_refresh (shared budget)"
+        );
+        false
+    }
+
+    /// Look up the watchdog decision **without** observing — used on
+    /// the `realm_unbound` path. The bind side recorded membership
+    /// only when the label was actually emitted; this helper therefore
+    /// mirrors the bind decision exactly (`contains` ↔ "label was
+    /// emitted at bind"), keeping the `+1`/`-1` pairing on
+    /// `realms_bound` symmetric per `(realm_binding, realm_name)`.
+    fn realm_key_value_no_observe(&self, label_key: &'static str, realm: &str) -> Option<KeyValue> {
+        if self.realm_label_cap == 0 || self.seen_realms.contains(realm) {
+            Some(KeyValue::new(label_key, realm.to_owned()))
+        } else {
+            tracing::Span::current().record("realm.name", tracing::field::display(realm));
+            None
+        }
+    }
+
+    /// Helper shared between `realm_bound` and the reserved
+    /// `kc_admin_token_refresh` / `credential_refresh` paths: observes
+    /// the realm (counts against the shared budget) and, when the
+    /// label is dropped, records the realm name on the current
+    /// tracing span so operators can still see which realm a sample
+    /// originated from at trace level.
+    fn realm_key_value(&self, label_key: &'static str, realm: &str) -> Option<KeyValue> {
+        if self.observe_realm_and_should_emit(realm) {
+            Some(KeyValue::new(label_key, realm.to_owned()))
+        } else {
+            tracing::Span::current().record("realm.name", tracing::field::display(realm));
+            None
+        }
+    }
+}
+
+/// Convenience constructor used at module init: builds an
+/// `Arc<VpIdpPluginMetricsAdapter>` against the process-global
+/// OpenTelemetry meter provider, scoped to the plugin instrumentation
+/// library, with the default prefix.
+#[must_use]
+pub fn build_default_adapter(realm_label_cap: u32) -> Arc<VpIdpPluginMetricsAdapter> {
+    let meter = opentelemetry::global::meter("vp-idp-plugin");
+    Arc::new(VpIdpPluginMetricsAdapter::new(
+        &meter,
+        DEFAULT_PREFIX,
+        realm_label_cap,
+    ))
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Port-trait implementations
+// ════════════════════════════════════════════════════════════════════
+
+impl TenantLifecycleMetricsPort for VpIdpPluginMetricsAdapter {
+    fn provision_tenant_duration(&self, realm_binding: RealmBinding, secs: f64) {
+        self.provision_tenant_duration.record(
+            secs,
+            &[KeyValue::new(
+                "realm_binding",
+                realm_binding.as_metric_label(),
+            )],
+        );
+    }
+
+    fn realm_bound(&self, realm_binding: RealmBinding, realm_name: &str) {
+        let mut labels = vec![KeyValue::new(
+            "realm_binding",
+            realm_binding.as_metric_label(),
+        )];
+        if let Some(kv) = self.realm_key_value("realm_name", realm_name) {
+            labels.push(kv);
+        }
+        self.realms_bound.add(1, &labels);
+    }
+
+    fn realm_unbound(&self, realm_binding: RealmBinding, realm_name: &str) {
+        let mut labels = vec![KeyValue::new(
+            "realm_binding",
+            realm_binding.as_metric_label(),
+        )];
+        // No-observe path: don't consume budget on the unbind side. See
+        // `realm_key_value_no_observe` docstring for the rationale.
+        if let Some(kv) = self.realm_key_value_no_observe("realm_name", realm_name) {
+            labels.push(kv);
+        }
+        self.realms_bound.add(-1, &labels);
+    }
+
+    fn deprovision_missing_metadata(&self) {
+        self.deprovision_missing_metadata.add(1, &[]);
+    }
+}
+
+impl UserOpMetricsPort for VpIdpPluginMetricsAdapter {
+    fn user_op_duration(&self, op: UserOp, secs: f64) {
+        self.user_op_duration
+            .record(secs, &[KeyValue::new("op", op.as_str())]);
+    }
+
+    fn orphan_user_compensation(&self, outcome: OrphanCompensationOutcome) {
+        self.orphan_user_compensation
+            .add(1, &[KeyValue::new("outcome", outcome.as_str())]);
+    }
+}
+
+impl KcAdminMetricsPort for VpIdpPluginMetricsAdapter {
+    fn kc_admin_request_duration(&self, endpoint_class: EndpointClass, secs: f64) {
+        self.kc_admin_request_duration.record(
+            secs,
+            &[KeyValue::new("endpoint_class", endpoint_class.as_str())],
+        );
+    }
+
+    fn kc_admin_token_refresh(&self, outcome: TokenRefreshOutcome, tier: TokenTier, realm: &str) {
+        let mut labels = vec![
+            KeyValue::new("outcome", outcome.as_str()),
+            KeyValue::new("tier", tier.as_str()),
+        ];
+        if let Some(kv) = self.realm_key_value("realm", realm) {
+            labels.push(kv);
+        }
+        self.kc_admin_token_refresh.add(1, &labels);
+    }
+
+    fn credential_refresh(&self, outcome: TokenRefreshOutcome, tier: TokenTier, realm: &str) {
+        let mut labels = vec![
+            KeyValue::new("outcome", outcome.as_str()),
+            KeyValue::new("tier", tier.as_str()),
+        ];
+        if let Some(kv) = self.realm_key_value("realm", realm) {
+            labels.push(kv);
+        }
+        self.credential_refresh.add(1, &labels);
+    }
+}
+
+impl CredstoreMetricsPort for VpIdpPluginMetricsAdapter {
+    fn credstore_write(&self, op: CredstoreOp, outcome: CredstoreOutcome) {
+        self.credstore_write.add(
+            1,
+            &[
+                KeyValue::new("op", op.as_str()),
+                KeyValue::new("outcome", outcome.as_str()),
+            ],
+        );
+    }
+}
+
+impl MetadataCodecMetricsPort for VpIdpPluginMetricsAdapter {
+    fn metadata_decode_failure(&self, version_observed: VersionObserved) {
+        // VersionObserved holds Cow; the OTel KeyValue API needs an
+        // owned String for non-static labels, so we allocate here. The
+        // metric is low-frequency (only fires on decode failures) so
+        // the allocation cost is irrelevant.
+        self.metadata_decode_failure.add(
+            1,
+            &[KeyValue::new(
+                "version_observed",
+                version_observed.as_str().to_owned(),
+            )],
+        );
+    }
+}
+
+impl FailureMetricsPort for VpIdpPluginMetricsAdapter {
+    fn failure(&self, op: PluginOp, variant: FailureVariant) {
+        self.failure.add(
+            1,
+            &[
+                KeyValue::new("op", op.as_str()),
+                KeyValue::new("failure_variant", variant.as_str()),
+            ],
+        );
+    }
+}
+
+impl SpOpMetricsPort for VpIdpPluginMetricsAdapter {
+    fn sp_op_duration(&self, op: SpOp, secs: f64) {
+        self.sp_op_duration
+            .record(secs, &[KeyValue::new("op", op.as_str())]);
+    }
+}
+
+#[cfg(test)]
+#[path = "metrics_tests.rs"]
+mod tests;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/infra/metrics_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/infra/metrics_tests.rs
@@ -1,0 +1,182 @@
+use std::sync::Arc;
+
+use super::*;
+use crate::domain::error::PluginError;
+use crate::domain::metadata_codec::{DecodeError, RealmBinding};
+use crate::domain::ports::metrics::{
+    CredstoreMetricsPort, CredstoreOp, CredstoreOutcome, EndpointClass, FailureMetricsPort,
+    FailureVariant, KcAdminMetricsPort, MetadataCodecMetricsPort, PluginOp, SpOp, SpOpMetricsPort,
+    TenantLifecycleMetricsPort, TokenRefreshOutcome, TokenTier, UserOp, UserOpMetricsPort,
+    VersionObserved,
+};
+
+// ---- adapter construction smoke ----
+
+#[test]
+fn adapter_builds_against_global_meter() {
+    // Must not panic; instruments construct against NoopMeterProvider
+    // when the global meter provider has not been overridden.
+    let _adapter = build_default_adapter(/*realm_label_cap=*/ 0);
+}
+
+#[test]
+fn rename_helper_substitutes_namespace_token() {
+    // Leading `vp_idp_plugin` token is swapped for the prefix; the
+    // already-suffixed remainder (`_failure_total`) is preserved.
+    assert_eq!(
+        rename("vp_idp_plugin_failure_total", "my_plugin"),
+        "my_plugin_failure_total"
+    );
+    assert_eq!(
+        rename("vp_idp_plugin_provision_tenant_duration_seconds", "x"),
+        "x_provision_tenant_duration_seconds"
+    );
+    // With the default prefix the substitution is a no-op.
+    assert_eq!(
+        rename("vp_idp_plugin_realms_bound", DEFAULT_PREFIX),
+        "vp_idp_plugin_realms_bound"
+    );
+    // A family that does not start with the default token falls into the
+    // "{prefix}_{family}" arm.
+    assert_eq!(rename("nodot", "x"), "x_nodot");
+}
+
+// ---- cardinality watchdog ----
+
+#[test]
+fn realm_label_drops_once_cap_is_exceeded() {
+    let adapter = build_default_adapter(/*cap=*/ 3);
+    adapter.realm_bound(RealmBinding::Created, "realm-a");
+    adapter.realm_bound(RealmBinding::Created, "realm-b");
+    adapter.realm_bound(RealmBinding::Created, "realm-c");
+    assert!(
+        adapter.observe_realm_and_should_emit("realm-c"),
+        "3rd distinct realm == cap, must still emit",
+    );
+    adapter.realm_bound(RealmBinding::Created, "realm-d");
+    assert!(
+        !adapter.observe_realm_and_should_emit("realm-d"),
+        "cap exceeded at the 4th distinct realm, label must drop",
+    );
+}
+
+#[test]
+fn realm_label_cap_zero_never_drops() {
+    let adapter = build_default_adapter(/*cap=*/ 0);
+    for i in 0..1000 {
+        adapter.realm_bound(RealmBinding::Created, &format!("realm-{i}"));
+    }
+    assert!(
+        adapter.observe_realm_and_should_emit("realm-999"),
+        "cap=0 disables the watchdog; must always emit",
+    );
+}
+
+#[test]
+fn realm_bound_unbound_label_symmetry_holds_past_cap() {
+    // Regression guard for the round-2 watchdog refactor: a realm
+    // bound *past* the cap (label dropped on `+1`) must also have its
+    // `-1` emitted WITHOUT the label, so the `(realm_binding,
+    // realm_name=Y)` series and the unlabelled `(realm_binding)`
+    // series stay symmetric on the `realms_bound` UpDownCounter.
+    //
+    // The earlier implementation inserted into `seen_realms` BEFORE
+    // the cap check, so the unbind `contains()` lookup kept the
+    // label on `-1` even though `+1` went out unlabelled.
+    let adapter = build_default_adapter(/*cap=*/ 2);
+
+    // Fill the budget with two realms — both labelled.
+    assert!(adapter.observe_realm_and_should_emit("realm-a"));
+    assert!(adapter.observe_realm_and_should_emit("realm-b"));
+
+    // A third realm is bound past-cap — the bind side returns false
+    // (label dropped) and MUST NOT enter `seen_realms`. The unbind
+    // side then mirrors that decision via `contains()`.
+    assert!(
+        !adapter.observe_realm_and_should_emit("realm-c"),
+        "past-cap bind must NOT emit the realm_name label",
+    );
+    let unbind_kv = adapter.realm_key_value_no_observe("realm_name", "realm-c");
+    assert!(
+        unbind_kv.is_none(),
+        "past-cap unbind must NOT emit the realm_name label (symmetric with bind); got {unbind_kv:?}"
+    );
+
+    // Sanity: a labelled realm bound within the cap still emits its
+    // label on the unbind side.
+    let labelled_kv = adapter.realm_key_value_no_observe("realm_name", "realm-a");
+    assert!(
+        labelled_kv.is_some(),
+        "within-cap unbind must keep the realm_name label",
+    );
+}
+
+#[test]
+fn realm_label_repeated_observation_does_not_inflate_cardinality() {
+    let adapter = build_default_adapter(/*cap=*/ 2);
+    adapter.realm_bound(RealmBinding::Created, "realm-a");
+    adapter.realm_bound(RealmBinding::Created, "realm-a"); // duplicate
+    adapter.realm_bound(RealmBinding::Created, "realm-b");
+    assert!(
+        adapter.observe_realm_and_should_emit("realm-b"),
+        "duplicates must not count against the cap",
+    );
+    adapter.realm_bound(RealmBinding::Created, "realm-c");
+    assert!(
+        !adapter.observe_realm_and_should_emit("realm-c"),
+        "cap hits at the 3rd distinct realm",
+    );
+}
+
+// ---- adapter implements every port ----
+
+#[test]
+fn adapter_implements_every_port() {
+    let adapter = build_default_adapter(0);
+    let _t: Arc<dyn TenantLifecycleMetricsPort> = Arc::clone(&adapter) as _;
+    let _u: Arc<dyn UserOpMetricsPort> = Arc::clone(&adapter) as _;
+    let _k: Arc<dyn KcAdminMetricsPort> = Arc::clone(&adapter) as _;
+    let _c: Arc<dyn CredstoreMetricsPort> = Arc::clone(&adapter) as _;
+    let _m: Arc<dyn MetadataCodecMetricsPort> = Arc::clone(&adapter) as _;
+    let _f: Arc<dyn FailureMetricsPort> = Arc::clone(&adapter) as _;
+    let _s: Arc<dyn SpOpMetricsPort> = Arc::clone(&adapter) as _;
+}
+
+// ---- end-to-end no-panic smoke covering every port method ----
+
+#[test]
+fn every_port_method_runs_against_noop_meter_without_panic() {
+    let adapter = build_default_adapter(/*cap=*/ 100);
+
+    adapter.provision_tenant_duration(RealmBinding::Shared, 0.42);
+    adapter.realm_bound(RealmBinding::Created, "alpha");
+    adapter.realm_unbound(RealmBinding::Created, "alpha");
+    adapter.deprovision_missing_metadata();
+
+    adapter.user_op_duration(UserOp::ProvisionUser, 0.1);
+    adapter.user_op_duration(UserOp::DeprovisionUser, 0.2);
+    adapter.user_op_duration(UserOp::ListUsers, 0.05);
+
+    adapter.kc_admin_request_duration(EndpointClass::UNKNOWN, 0.01);
+    adapter.kc_admin_token_refresh(TokenRefreshOutcome::Success, TokenTier::StaticEnv, "shared");
+    adapter.credential_refresh(TokenRefreshOutcome::Error, TokenTier::OpenBao, "tenant-r");
+
+    adapter.credstore_write(CredstoreOp::Put, CredstoreOutcome::Ok);
+    adapter.credstore_write(CredstoreOp::Delete, CredstoreOutcome::Error);
+
+    adapter.metadata_decode_failure(VersionObserved::MISSING);
+    adapter.metadata_decode_failure(VersionObserved::from(&DecodeError::UnsupportedVersion {
+        observed: "v9".into(),
+    }));
+
+    adapter.failure(PluginOp::ProvisionTenant, FailureVariant::CONFIG);
+    adapter.failure(
+        PluginOp::DeprovisionUser,
+        FailureVariant::from(&PluginError::DeprovisionRetryable { detail: "x".into() }),
+    );
+
+    adapter.sp_op_duration(SpOp::Create, 0.1);
+    adapter.sp_op_duration(SpOp::RotateSecret, 0.2);
+    adapter.sp_op_duration(SpOp::Revoke, 0.05);
+    adapter.sp_op_duration(SpOp::List, 0.03);
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/infra/metrics_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/infra/metrics_tests.rs
@@ -21,20 +21,20 @@ fn adapter_builds_against_global_meter() {
 
 #[test]
 fn rename_helper_substitutes_namespace_token() {
-    // Leading `vp_idp_plugin` token is swapped for the prefix; the
+    // Leading `keycloak_idp_plugin` token is swapped for the prefix; the
     // already-suffixed remainder (`_failure_total`) is preserved.
     assert_eq!(
-        rename("vp_idp_plugin_failure_total", "my_plugin"),
+        rename("keycloak_idp_plugin_failure_total", "my_plugin"),
         "my_plugin_failure_total"
     );
     assert_eq!(
-        rename("vp_idp_plugin_provision_tenant_duration_seconds", "x"),
+        rename("keycloak_idp_plugin_provision_tenant_duration_seconds", "x"),
         "x_provision_tenant_duration_seconds"
     );
     // With the default prefix the substitution is a no-op.
     assert_eq!(
-        rename("vp_idp_plugin_realms_bound", DEFAULT_PREFIX),
-        "vp_idp_plugin_realms_bound"
+        rename("keycloak_idp_plugin_realms_bound", DEFAULT_PREFIX),
+        "keycloak_idp_plugin_realms_bound"
     );
     // A family that does not start with the default token falls into the
     // "{prefix}_{family}" arm.

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/lib.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/lib.rs
@@ -1,0 +1,31 @@
+//! VHP `IdP` Plugin (Keycloak) — implements `account_management_sdk::IdpPluginClient`.
+//!
+//! Spec: [`docs/DESIGN.md`](../docs/DESIGN.md) / [`docs/PRD.md`](../docs/PRD.md)
+//! adjacent to this crate.
+
+// Ported verbatim from vhp-core (`crates/gears/plugins/vp-idp-plugin`), which
+// builds under a laxer clippy profile. These style lints are allowed crate-wide
+// to keep the port diffable against the vhp-core original; the same pattern is
+// used by other ported crates (see `chat-engine`, `mini-chat`).
+#![allow(
+    clippy::non_ascii_literal,
+    clippy::str_to_string,
+    clippy::redundant_pub_crate,
+    clippy::cognitive_complexity,
+    clippy::let_underscore_must_use
+)]
+
+// `config` stays `pub` so the upstream AM-SDK conformance harness (once
+// it lands — see `tests/contract_am_sdk.rs`) can build a test plugin via
+// the typed config. Everything else is implementation detail reached
+// through the two re-exports below and `Arc<dyn IdpPluginClient>` in
+// ClientHub.
+pub mod config;
+pub(crate) mod domain;
+pub(crate) mod idp_impl;
+pub(crate) mod infra;
+pub(crate) mod module;
+pub(crate) mod sp_impl;
+
+pub use idp_impl::KeycloakIdpPlugin;
+pub use module::VpIdpPluginGear;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/lib.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/lib.rs
@@ -4,10 +4,9 @@
 //! Spec: [`docs/DESIGN.md`](../docs/DESIGN.md) / [`docs/PRD.md`](../docs/PRD.md)
 //! adjacent to this crate.
 
-// Ported from vhp-core (`crates/gears/plugins/vp-idp-plugin`), which builds
-// under a laxer clippy profile. These style lints are allowed crate-wide to
-// keep the port diffable against the vhp-core original; the same pattern is
-// used by other ported crates (see `chat-engine`, `mini-chat`).
+// These style lints are allowed crate-wide so the crate keeps building
+// unchanged against its upstream profile; the same pattern is used by
+// other ported crates (see `chat-engine`, `mini-chat`).
 #![allow(
     clippy::non_ascii_literal,
     clippy::str_to_string,

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/lib.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/lib.rs
@@ -1,11 +1,12 @@
-//! VHP `IdP` Plugin (Keycloak) — implements `account_management_sdk::IdpPluginClient`.
+//! Keycloak `IdP` plugin — implements `account_management_sdk::IdpPluginClient`
+//! and `service_principal_sdk::ServicePrincipalClientV1`.
 //!
 //! Spec: [`docs/DESIGN.md`](../docs/DESIGN.md) / [`docs/PRD.md`](../docs/PRD.md)
 //! adjacent to this crate.
 
-// Ported verbatim from vhp-core (`crates/gears/plugins/vp-idp-plugin`), which
-// builds under a laxer clippy profile. These style lints are allowed crate-wide
-// to keep the port diffable against the vhp-core original; the same pattern is
+// Ported from vhp-core (`crates/gears/plugins/vp-idp-plugin`), which builds
+// under a laxer clippy profile. These style lints are allowed crate-wide to
+// keep the port diffable against the vhp-core original; the same pattern is
 // used by other ported crates (see `chat-engine`, `mini-chat`).
 #![allow(
     clippy::non_ascii_literal,
@@ -28,4 +29,4 @@ pub(crate) mod module;
 pub(crate) mod sp_impl;
 
 pub use idp_impl::KeycloakIdpPlugin;
-pub use module::VpIdpPluginGear;
+pub use module::KeycloakIdpPluginGear;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/module.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/module.rs
@@ -1,0 +1,371 @@
+//! `toolkit` module wiring for the VHP `IdP` Plugin.
+
+use std::sync::Arc;
+
+use account_management_sdk::IdpPluginSpecV1;
+use account_management_sdk::idp::IdpPluginClient;
+use async_trait::async_trait;
+use credstore_sdk::SecretRef;
+use service_principal_sdk::ServicePrincipalClientV1;
+use toolkit::client_hub::ClientScope;
+use toolkit::gts::PluginV1;
+use toolkit::{Gear, context::GearCtx};
+use types_registry_sdk::{RegisterResult, TypesRegistryClient};
+
+use crate::config::{VpIdpPluginConfig, VpIdpPluginEnabledProbe};
+use crate::domain::credstore::{CredStoreReader, CredStoreWriter};
+use crate::domain::kc::factory::KeycloakAdminClientFactory;
+use crate::domain::metadata_codec::MetadataCodec;
+use crate::domain::ports::metrics::{
+    CredstoreMetricsPort, FailureMetricsPort, KcAdminMetricsPort, MetadataCodecMetricsPort,
+    SpOpMetricsPort, TenantLifecycleMetricsPort, UserOpMetricsPort,
+};
+use crate::domain::service_principal_facade::ServicePrincipalFacade;
+use crate::domain::system_actor::build_system_ctx;
+use crate::domain::tenant_facade::TenantFacade;
+use crate::domain::user_facade::UserFacade;
+use crate::idp_impl::KeycloakIdpPlugin;
+use crate::infra::kc_http::ReqwestKcTransport;
+use crate::infra::metrics::build_default_adapter;
+
+// `account-management-sdk` is a Rust SDK dep (Cargo.toml); the plugin
+// publishes a `PluginV1<IdpPluginSpecV1>` instance to types-registry
+// at init and registers `Arc<dyn IdpPluginClient>` in ClientHub under
+// `register_scoped(scope = gts_id)`. AM's `Gear::init` resolves it
+// via `choose_plugin_instance` + `get_scoped` against the configured
+// `idp.vendor` (default `"cf"`, deploys override to `"virtuozzo"` to
+// pick this plugin).
+//
+// NO toolkit runtime `deps` entry for `account-management` because
+// the host process may legitimately not load that module (e.g. this
+// dev/PoC build) and the plugin must still install. `types-registry`
+// IS declared as a dep because the catalogue publish is a hard
+// prerequisite of the AM-side scoped resolution.
+#[toolkit::gear(name = "vp-idp-plugin", deps = [types_registry, credstore])]
+#[derive(Default)]
+pub struct VpIdpPluginGear;
+
+#[async_trait]
+impl Gear for VpIdpPluginGear {
+    async fn init(&self, ctx: &GearCtx) -> anyhow::Result<()> {
+        // Phase 1: read the `enabled` flag without requiring Keycloak fields.
+        // Uses `config_or_default` so a missing module section → enabled = true
+        // (production default). This mirrors the temporal-workflow-executor-plugin
+        // pattern and allows test/CI configs to opt out with `enabled: false`.
+        let probe: VpIdpPluginEnabledProbe = ctx
+            .config_or_default()
+            .map_err(|e| anyhow::anyhow!("vp-idp-plugin: failed to read enabled flag: {e}"))?;
+        if !probe.enabled {
+            tracing::info!(
+                module = "vp-idp-plugin",
+                "disabled via config; skipping initialization"
+            );
+            return Ok(());
+        }
+
+        // Phase 2: `config_expanded` runs toolkit's `${VAR}` substitution over
+        // fields marked `#[expand_vars]` — the static admin secrets resolve here
+        // (ADDENDUM §3.1 / §3.2), symmetric with the AM DB DSN's `${PGPASSWORD}`.
+        let cfg: VpIdpPluginConfig = ctx
+            .config_expanded()
+            .map_err(|e| anyhow::anyhow!("vp-idp-plugin: failed to load config: {e}"))?;
+
+        // DESIGN §4.0: validate the SecretRef template at init by interpolating
+        // against a 64-char synthetic realm name and feeding the result through
+        // SecretRef::new (which enforces [A-Za-z0-9_-]+, ≤255 chars).
+        let synthetic_realm = "a".repeat(64);
+        let probe = cfg
+            .keycloak
+            .realm_admin
+            .secret_ref_template
+            .replace("{realm_name}", &synthetic_realm);
+        SecretRef::new(&probe).map_err(|e| {
+            anyhow::anyhow!(
+                "vp-idp-plugin: secret_ref_template '{}' produces invalid SecretRef \
+                 for synthetic realm of length 64: {e}",
+                cfg.keycloak.realm_admin.secret_ref_template,
+            )
+        })?;
+
+        cfg.service_principal
+            .validate()
+            .map_err(|e| anyhow::anyhow!("vp-idp-plugin: {e}"))?;
+
+        // ---- Plugin-owned system ctx (DESIGN §8.1). ----
+        let system_ctx = build_system_ctx(cfg.security_context.platform_tenant_id);
+
+        // ---- CredStore unified client (credstore-sdk). ----
+        let cs_client: Arc<dyn credstore_sdk::CredStoreClientV1> = ctx
+            .client_hub()
+            .get::<dyn credstore_sdk::CredStoreClientV1>()
+            .map_err(|e| anyhow::anyhow!("vp-idp-plugin: get CredStoreClientV1: {e}"))?;
+        let cs_reader = CredStoreReader::new(Arc::clone(&cs_client), Arc::clone(&system_ctx));
+        let cs_writer = CredStoreWriter::new(cs_client, Arc::clone(&system_ctx));
+
+        // ---- Metrics adapter + metadata codec. ----
+        // One OTel-backed adapter owns every plugin instrument and
+        // implements every port trait; per-facade DI takes typed
+        // `Arc<dyn ...Port>` views below.
+        let metrics_adapter =
+            build_default_adapter(cfg.keycloak.metrics.drop_realm_label_at_cardinality);
+        let tenant_metrics: Arc<dyn TenantLifecycleMetricsPort> = Arc::clone(&metrics_adapter) as _;
+        let user_metrics: Arc<dyn UserOpMetricsPort> = Arc::clone(&metrics_adapter) as _;
+        let credstore_metrics: Arc<dyn CredstoreMetricsPort> = Arc::clone(&metrics_adapter) as _;
+        let metadata_metrics: Arc<dyn MetadataCodecMetricsPort> = Arc::clone(&metrics_adapter) as _;
+        let failure_metrics: Arc<dyn FailureMetricsPort> = Arc::clone(&metrics_adapter) as _;
+        let kc_metrics: Arc<dyn KcAdminMetricsPort> = Arc::clone(&metrics_adapter) as _;
+        let sp_metrics: Arc<dyn SpOpMetricsPort> = Arc::clone(&metrics_adapter) as _;
+        let codec = Arc::new(MetadataCodec);
+
+        // ---- KC transport (reqwest-backed) + factory. ----
+        // Transport construction is async because the optional TLS CA bundle
+        // resolution funnels through `CredStoreReader::get`.
+        let transport = Arc::new(
+            ReqwestKcTransport::from_config(&cfg.keycloak, &cs_reader)
+                .await
+                .map_err(|e| anyhow::anyhow!("vp-idp-plugin: KC transport init failed: {e}"))?,
+        );
+        let kc_factory = Arc::new(KeycloakAdminClientFactory::new(
+            cfg.keycloak.clone(),
+            transport,
+            cs_reader.clone(),
+            kc_metrics,
+        ));
+
+        // Pre-warm bootstrap admin token per DESIGN §4.0 init lifecycle.
+        // ADDENDUM §4.4: init fails fast if the token endpoint is unreachable.
+        // Note: a missing/empty `${VAR}` referenced from `client_secret` /
+        // `default_shared_realm_secret` is caught earlier by
+        // `ctx.config_expanded()` above.
+        //
+        // Bounded retry inside this init absorbs transient k8s-deploy-ordering
+        // races (KC pod not yet `Ready`, DNS still propagating) without
+        // bouncing the whole orchestrator-level `idp_wait_timeout: 15m` loop
+        // and re-running every module's init. Budget is operator-tunable via
+        // `keycloak.bootstrap_pre_warm.{max_attempts, backoff}` — defaults
+        // (5 attempts × 3s backoff) give `~12s of pure backoff + up to ~25s of
+        // attempt time = ~37s worst case` before init bails. Beyond that the
+        // orchestrator's outer retry takes over.
+        let pre_warm_cfg = &cfg.keycloak.bootstrap_pre_warm;
+        pre_warm_bootstrap_admin_with_retry(
+            &kc_factory,
+            pre_warm_cfg.max_attempts,
+            pre_warm_cfg.backoff,
+        )
+        .await?;
+
+        // ---- Facades. ----
+        let tenant_facade = Arc::new(TenantFacade::new(
+            cfg.tenant_facade.clone(),
+            cfg.keycloak.realm_admin.clone(),
+            Arc::clone(&kc_factory),
+            Arc::clone(&codec),
+            cs_writer,
+            Arc::clone(&tenant_metrics),
+            Arc::clone(&credstore_metrics),
+            Arc::clone(&metadata_metrics),
+            Arc::clone(&failure_metrics),
+        ));
+        let user_facade = Arc::new(UserFacade::new(
+            cfg.user_facade.clone(),
+            cfg.keycloak.realm_admin.clone(),
+            Arc::clone(&kc_factory),
+            Arc::clone(&codec),
+            Arc::clone(&user_metrics),
+            Arc::clone(&metadata_metrics),
+            Arc::clone(&failure_metrics),
+        ));
+        let sp_facade = Arc::new(ServicePrincipalFacade::new(
+            cfg.service_principal.clone(),
+            Arc::clone(&kc_factory),
+            sp_metrics,
+            Arc::clone(&failure_metrics),
+        ));
+        tenant_facade.set_service_principal_purge_facade(Arc::clone(&sp_facade));
+
+        // ---- Plugin root + types-registry catalogue publish +
+        //      scoped ClientHub registration. ----
+        //
+        // Build the `PluginV1<IdpPluginSpecV1>` instance carrying
+        // (vendor, priority) so AM's `choose_plugin_instance` filter
+        // can match against `account-management.idp.vendor`. The
+        // instance segment `vz.virtuozzo.vp_idp.plugin.v1` is the
+        // vendor-namespaced suffix that distinguishes this plugin
+        // from the in-process `static-idp-plugin` (which publishes
+        // as `cf.builtin.static_idp.plugin.v1`).
+        let (instance_id, instance_json) = PluginV1::<IdpPluginSpecV1>::build_registration(
+            "vz.virtuozzo.vp_idp.plugin.v1",
+            cfg.vendor.clone(),
+            cfg.priority,
+        )
+        .map_err(|e| anyhow::anyhow!("vp-idp-plugin: build_registration: {e}"))?;
+
+        // Publish to types-registry. Idempotent restart: treat
+        // `AlreadyExists` as success ONLY when the stored spec
+        // matches our current serialised instance — otherwise fail
+        // immediately so a stale catalogue entry surfaces as an
+        // operator-actionable error rather than a silent drift.
+        // Mirrors the pattern in `static-idp-plugin` and the AM-
+        // owned TR plugin in `account-management::module`.
+        let registry = ctx
+            .client_hub()
+            .get::<dyn TypesRegistryClient>()
+            .map_err(|e| anyhow::anyhow!("vp-idp-plugin: get TypesRegistryClient: {e}"))?;
+        let results = registry
+            .register(vec![instance_json.clone()])
+            .await
+            .map_err(|e| anyhow::anyhow!("vp-idp-plugin: types-registry register: {e}"))?;
+        for result in &results {
+            if let RegisterResult::Err { error, .. } = result {
+                if matches!(
+                    error,
+                    toolkit::api::canonical_prelude::CanonicalError::AlreadyExists { .. }
+                ) {
+                    let existing =
+                        registry
+                            .get_instance(instance_id.as_ref())
+                            .await
+                            .map_err(|e| {
+                                anyhow::anyhow!("vp-idp-plugin: verify existing instance: {e}")
+                            })?;
+                    if existing.object != instance_json {
+                        return Err(anyhow::anyhow!(
+                            "vp-idp-plugin: instance `{instance_id}` already registered \
+                             with a different spec — refusing to silently drift",
+                        ));
+                    }
+                } else {
+                    return Err(anyhow::anyhow!(
+                        "vp-idp-plugin: types-registry registration failed: {error}"
+                    ));
+                }
+            }
+        }
+
+        let plugin = Arc::new(KeycloakIdpPlugin {
+            tenant_facade,
+            user_facade,
+            codec: Arc::clone(&codec),
+            sp_facade,
+        });
+
+        // Unscoped: service-principal consumers need no vendor selection.
+        let sp_dyn: Arc<dyn ServicePrincipalClientV1> = Arc::clone(&plugin) as _;
+        ctx.client_hub()
+            .register::<dyn ServicePrincipalClientV1>(sp_dyn);
+
+        let plugin_dyn: Arc<dyn IdpPluginClient> = plugin;
+        // Scoped registration keyed on the catalogue instance id
+        // (`ClientScope::gts_id`). AM resolves via
+        // `ClientHub::get_scoped::<dyn IdpPluginClient>` after
+        // selecting this instance through `choose_plugin_instance`
+        // — see `account_management::module::resolve_idp_plugin`.
+        ctx.client_hub()
+            .register_scoped::<dyn IdpPluginClient>(ClientScope::gts_id(&instance_id), plugin_dyn);
+
+        tracing::info!(
+            module = "vp-idp-plugin",
+            keycloak_base_url = %cfg.keycloak.base_url,
+            vendor = %cfg.vendor,
+            priority = cfg.priority,
+            instance_id = %instance_id,
+            "published PluginV1<IdpPluginSpecV1>, registered scoped IdpPluginClient and unscoped ServicePrincipalClientV1"
+        );
+
+        Ok(())
+    }
+}
+
+/// Decide whether a pre-warm failure deserves another attempt.
+///
+/// The retry loop exists to absorb deploy-ordering transients (KC pod not
+/// yet `Ready`, `OpenBao` still warming up). Errors that are guaranteed to
+/// reproduce — bad `client_secret`, missing realm, broken base URL —
+/// MUST fast-bail so init surfaces the real cause within milliseconds
+/// instead of burning the full retry budget on a futile poll.
+fn is_pre_warm_retryable(err: &crate::domain::error::PluginError) -> bool {
+    use crate::domain::error::PluginError;
+    match err {
+        // KC token endpoint: 5xx + 429 transient, transport/timeout transient,
+        // 4xx-non-429 permanent (invalid_client, unauthorized_client, etc.).
+        PluginError::KcRest { status, .. } => status.is_retryable(),
+        // OpenBao readiness lag is a real deploy-ordering transient — vp-idp
+        // pods sometimes win the readiness race against credstore. Retry.
+        PluginError::CredStoreRead { .. } => true,
+        // Anything else reaching this path (`Config` from a malformed base URL,
+        // etc.) is operator misconfiguration and will not heal on its own.
+        _ => false,
+    }
+}
+
+/// Pre-warm the bootstrap-admin token cache with bounded retry. Each
+/// failure logs WARN with attempt count + the underlying error; the
+/// final error (if budget exhausts) is annotated with the attempt
+/// total so it's distinguishable from a single-shot failure in logs /
+/// support tickets. Permanent failures (4xx-non-429, malformed base URL)
+/// bail on the first attempt — see [`is_pre_warm_retryable`]. Budget is
+/// caller-supplied (operator-tunable via
+/// [`crate::config::BootstrapPreWarmConfig`]); tests pass scaled-down
+/// values so they don't hold the runtime for the full production budget.
+async fn pre_warm_bootstrap_admin_with_retry(
+    kc_factory: &KeycloakAdminClientFactory,
+    max_attempts: u32,
+    backoff: std::time::Duration,
+) -> anyhow::Result<()> {
+    let mut last_err: Option<(u32, crate::domain::error::PluginError)> = None;
+    for attempt in 1..=max_attempts {
+        match kc_factory.bootstrap_client().await {
+            Ok(_) => {
+                if attempt > 1 {
+                    tracing::info!(
+                        target: "vp_idp_plugin.init",
+                        attempt,
+                        "bootstrap admin pre-warm succeeded after retry"
+                    );
+                }
+                return Ok(());
+            }
+            Err(e) => {
+                let retryable = is_pre_warm_retryable(&e);
+                tracing::warn!(
+                    target: "vp_idp_plugin.init",
+                    attempt,
+                    max_attempts,
+                    error = %e,
+                    retryable,
+                    "bootstrap admin pre-warm failed"
+                );
+                last_err = Some((attempt, e));
+                // Fast-bail on permanent failures: another sleep+attempt
+                // against the same broken credential / missing realm cannot
+                // recover. Surface the real error to the operator now.
+                if !retryable {
+                    break;
+                }
+                if attempt < max_attempts {
+                    tokio::time::sleep(backoff).await;
+                }
+            }
+        }
+    }
+    let (attempts_used, final_err) = last_err.unwrap_or_else(|| {
+        // Unreachable: the loop above only exits via `return Ok(())` on
+        // success or by recording an error into `last_err`. The
+        // `unwrap_or_else` here exists purely to satisfy clippy's
+        // `expect_used` lint without changing program behaviour.
+        (
+            0,
+            crate::domain::error::PluginError::Config {
+                detail: "internal: pre_warm retry loop exhausted with no recorded error"
+                    .to_string(),
+            },
+        )
+    });
+    Err(anyhow::anyhow!(
+        "vp-idp-plugin: bootstrap admin pre-warm bailed after {attempts_used}/{max_attempts} attempt(s) ({backoff:?} backoff between attempts); last error: {final_err}"
+    ))
+}
+
+#[cfg(test)]
+#[path = "module_tests.rs"]
+mod module_tests;

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/module.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/module.rs
@@ -1,4 +1,4 @@
-//! `toolkit` module wiring for the VHP `IdP` Plugin.
+//! `toolkit` module wiring for the Keycloak `IdP` plugin.
 
 use std::sync::Arc;
 

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/module.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/module.rs
@@ -12,7 +12,7 @@ use toolkit::gts::PluginV1;
 use toolkit::{Gear, context::GearCtx};
 use types_registry_sdk::{RegisterResult, TypesRegistryClient};
 
-use crate::config::{VpIdpPluginConfig, VpIdpPluginEnabledProbe};
+use crate::config::{KeycloakIdpPluginConfig, KeycloakIdpPluginEnabledProbe};
 use crate::domain::credstore::{CredStoreReader, CredStoreWriter};
 use crate::domain::kc::factory::KeycloakAdminClientFactory;
 use crate::domain::metadata_codec::MetadataCodec;
@@ -33,7 +33,7 @@ use crate::infra::metrics::build_default_adapter;
 // at init and registers `Arc<dyn IdpPluginClient>` in ClientHub under
 // `register_scoped(scope = gts_id)`. AM's `Gear::init` resolves it
 // via `choose_plugin_instance` + `get_scoped` against the configured
-// `idp.vendor` (default `"cf"`, deploys override to `"virtuozzo"` to
+// `idp.vendor` (default `"cf"`, deploys override to `"keycloak"` to
 // pick this plugin).
 //
 // NO toolkit runtime `deps` entry for `account-management` because
@@ -41,23 +41,23 @@ use crate::infra::metrics::build_default_adapter;
 // dev/PoC build) and the plugin must still install. `types-registry`
 // IS declared as a dep because the catalogue publish is a hard
 // prerequisite of the AM-side scoped resolution.
-#[toolkit::gear(name = "vp-idp-plugin", deps = [types_registry, credstore])]
+#[toolkit::gear(name = "keycloak-idp-plugin", deps = [types_registry, credstore])]
 #[derive(Default)]
-pub struct VpIdpPluginGear;
+pub struct KeycloakIdpPluginGear;
 
 #[async_trait]
-impl Gear for VpIdpPluginGear {
+impl Gear for KeycloakIdpPluginGear {
     async fn init(&self, ctx: &GearCtx) -> anyhow::Result<()> {
         // Phase 1: read the `enabled` flag without requiring Keycloak fields.
         // Uses `config_or_default` so a missing module section → enabled = true
         // (production default). This mirrors the temporal-workflow-executor-plugin
         // pattern and allows test/CI configs to opt out with `enabled: false`.
-        let probe: VpIdpPluginEnabledProbe = ctx
-            .config_or_default()
-            .map_err(|e| anyhow::anyhow!("vp-idp-plugin: failed to read enabled flag: {e}"))?;
+        let probe: KeycloakIdpPluginEnabledProbe = ctx.config_or_default().map_err(|e| {
+            anyhow::anyhow!("keycloak-idp-plugin: failed to read enabled flag: {e}")
+        })?;
         if !probe.enabled {
             tracing::info!(
-                module = "vp-idp-plugin",
+                module = "keycloak-idp-plugin",
                 "disabled via config; skipping initialization"
             );
             return Ok(());
@@ -66,9 +66,9 @@ impl Gear for VpIdpPluginGear {
         // Phase 2: `config_expanded` runs toolkit's `${VAR}` substitution over
         // fields marked `#[expand_vars]` — the static admin secrets resolve here
         // (ADDENDUM §3.1 / §3.2), symmetric with the AM DB DSN's `${PGPASSWORD}`.
-        let cfg: VpIdpPluginConfig = ctx
+        let cfg: KeycloakIdpPluginConfig = ctx
             .config_expanded()
-            .map_err(|e| anyhow::anyhow!("vp-idp-plugin: failed to load config: {e}"))?;
+            .map_err(|e| anyhow::anyhow!("keycloak-idp-plugin: failed to load config: {e}"))?;
 
         // DESIGN §4.0: validate the SecretRef template at init by interpolating
         // against a 64-char synthetic realm name and feeding the result through
@@ -81,7 +81,7 @@ impl Gear for VpIdpPluginGear {
             .replace("{realm_name}", &synthetic_realm);
         SecretRef::new(&probe).map_err(|e| {
             anyhow::anyhow!(
-                "vp-idp-plugin: secret_ref_template '{}' produces invalid SecretRef \
+                "keycloak-idp-plugin: secret_ref_template '{}' produces invalid SecretRef \
                  for synthetic realm of length 64: {e}",
                 cfg.keycloak.realm_admin.secret_ref_template,
             )
@@ -89,7 +89,7 @@ impl Gear for VpIdpPluginGear {
 
         cfg.service_principal
             .validate()
-            .map_err(|e| anyhow::anyhow!("vp-idp-plugin: {e}"))?;
+            .map_err(|e| anyhow::anyhow!("keycloak-idp-plugin: {e}"))?;
 
         // ---- Plugin-owned system ctx (DESIGN §8.1). ----
         let system_ctx = build_system_ctx(cfg.security_context.platform_tenant_id);
@@ -98,7 +98,7 @@ impl Gear for VpIdpPluginGear {
         let cs_client: Arc<dyn credstore_sdk::CredStoreClientV1> = ctx
             .client_hub()
             .get::<dyn credstore_sdk::CredStoreClientV1>()
-            .map_err(|e| anyhow::anyhow!("vp-idp-plugin: get CredStoreClientV1: {e}"))?;
+            .map_err(|e| anyhow::anyhow!("keycloak-idp-plugin: get CredStoreClientV1: {e}"))?;
         let cs_reader = CredStoreReader::new(Arc::clone(&cs_client), Arc::clone(&system_ctx));
         let cs_writer = CredStoreWriter::new(cs_client, Arc::clone(&system_ctx));
 
@@ -123,7 +123,9 @@ impl Gear for VpIdpPluginGear {
         let transport = Arc::new(
             ReqwestKcTransport::from_config(&cfg.keycloak, &cs_reader)
                 .await
-                .map_err(|e| anyhow::anyhow!("vp-idp-plugin: KC transport init failed: {e}"))?,
+                .map_err(|e| {
+                    anyhow::anyhow!("keycloak-idp-plugin: KC transport init failed: {e}")
+                })?,
         );
         let kc_factory = Arc::new(KeycloakAdminClientFactory::new(
             cfg.keycloak.clone(),
@@ -189,16 +191,16 @@ impl Gear for VpIdpPluginGear {
         // Build the `PluginV1<IdpPluginSpecV1>` instance carrying
         // (vendor, priority) so AM's `choose_plugin_instance` filter
         // can match against `account-management.idp.vendor`. The
-        // instance segment `vz.virtuozzo.vp_idp.plugin.v1` is the
+        // instance segment `cf.builtin.keycloak_idp.plugin.v1` is the
         // vendor-namespaced suffix that distinguishes this plugin
         // from the in-process `static-idp-plugin` (which publishes
         // as `cf.builtin.static_idp.plugin.v1`).
         let (instance_id, instance_json) = PluginV1::<IdpPluginSpecV1>::build_registration(
-            "vz.virtuozzo.vp_idp.plugin.v1",
+            "cf.builtin.keycloak_idp.plugin.v1",
             cfg.vendor.clone(),
             cfg.priority,
         )
-        .map_err(|e| anyhow::anyhow!("vp-idp-plugin: build_registration: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("keycloak-idp-plugin: build_registration: {e}"))?;
 
         // Publish to types-registry. Idempotent restart: treat
         // `AlreadyExists` as success ONLY when the stored spec
@@ -210,11 +212,11 @@ impl Gear for VpIdpPluginGear {
         let registry = ctx
             .client_hub()
             .get::<dyn TypesRegistryClient>()
-            .map_err(|e| anyhow::anyhow!("vp-idp-plugin: get TypesRegistryClient: {e}"))?;
+            .map_err(|e| anyhow::anyhow!("keycloak-idp-plugin: get TypesRegistryClient: {e}"))?;
         let results = registry
             .register(vec![instance_json.clone()])
             .await
-            .map_err(|e| anyhow::anyhow!("vp-idp-plugin: types-registry register: {e}"))?;
+            .map_err(|e| anyhow::anyhow!("keycloak-idp-plugin: types-registry register: {e}"))?;
         for result in &results {
             if let RegisterResult::Err { error, .. } = result {
                 if matches!(
@@ -226,17 +228,19 @@ impl Gear for VpIdpPluginGear {
                             .get_instance(instance_id.as_ref())
                             .await
                             .map_err(|e| {
-                                anyhow::anyhow!("vp-idp-plugin: verify existing instance: {e}")
+                                anyhow::anyhow!(
+                                    "keycloak-idp-plugin: verify existing instance: {e}"
+                                )
                             })?;
                     if existing.object != instance_json {
                         return Err(anyhow::anyhow!(
-                            "vp-idp-plugin: instance `{instance_id}` already registered \
+                            "keycloak-idp-plugin: instance `{instance_id}` already registered \
                              with a different spec — refusing to silently drift",
                         ));
                     }
                 } else {
                     return Err(anyhow::anyhow!(
-                        "vp-idp-plugin: types-registry registration failed: {error}"
+                        "keycloak-idp-plugin: types-registry registration failed: {error}"
                     ));
                 }
             }
@@ -264,7 +268,7 @@ impl Gear for VpIdpPluginGear {
             .register_scoped::<dyn IdpPluginClient>(ClientScope::gts_id(&instance_id), plugin_dyn);
 
         tracing::info!(
-            module = "vp-idp-plugin",
+            module = "keycloak-idp-plugin",
             keycloak_base_url = %cfg.keycloak.base_url,
             vendor = %cfg.vendor,
             priority = cfg.priority,
@@ -289,7 +293,7 @@ fn is_pre_warm_retryable(err: &crate::domain::error::PluginError) -> bool {
         // KC token endpoint: 5xx + 429 transient, transport/timeout transient,
         // 4xx-non-429 permanent (invalid_client, unauthorized_client, etc.).
         PluginError::KcRest { status, .. } => status.is_retryable(),
-        // OpenBao readiness lag is a real deploy-ordering transient — vp-idp
+        // OpenBao readiness lag is a real deploy-ordering transient — plugin
         // pods sometimes win the readiness race against credstore. Retry.
         PluginError::CredStoreRead { .. } => true,
         // Anything else reaching this path (`Config` from a malformed base URL,
@@ -318,7 +322,7 @@ async fn pre_warm_bootstrap_admin_with_retry(
             Ok(_) => {
                 if attempt > 1 {
                     tracing::info!(
-                        target: "vp_idp_plugin.init",
+                        target: "keycloak_idp.init",
                         attempt,
                         "bootstrap admin pre-warm succeeded after retry"
                     );
@@ -328,7 +332,7 @@ async fn pre_warm_bootstrap_admin_with_retry(
             Err(e) => {
                 let retryable = is_pre_warm_retryable(&e);
                 tracing::warn!(
-                    target: "vp_idp_plugin.init",
+                    target: "keycloak_idp.init",
                     attempt,
                     max_attempts,
                     error = %e,
@@ -362,7 +366,7 @@ async fn pre_warm_bootstrap_admin_with_retry(
         )
     });
     Err(anyhow::anyhow!(
-        "vp-idp-plugin: bootstrap admin pre-warm bailed after {attempts_used}/{max_attempts} attempt(s) ({backoff:?} backoff between attempts); last error: {final_err}"
+        "keycloak-idp-plugin: bootstrap admin pre-warm bailed after {attempts_used}/{max_attempts} attempt(s) ({backoff:?} backoff between attempts); last error: {final_err}"
     ))
 }
 

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/module_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/module_tests.rs
@@ -49,7 +49,7 @@ fn cfg_no_transport_retries(base: &str) -> KeycloakConfig {
         realm_admin: RealmAdminConfig {
             client_id_default: "keycloak-idp-plugin-realm-admin".into(),
             default_shared_realm_secret: SecretFromEnv::from_literal_unchecked("ra"),
-            secret_ref_template: "vp-idp-realm-admin-{realm_name}-secret".into(),
+            secret_ref_template: "keycloak-idp-realm-admin-{realm_name}-secret".into(),
         },
         tls_ca_bundle_ref: None,
         admin_token_lifetime_safety_ms: 30_000,

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/module_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/module_tests.rs
@@ -43,11 +43,11 @@ fn cfg_no_transport_retries(base: &str) -> KeycloakConfig {
         base_url: url::Url::parse(base).expect("valid base url"),
         bootstrap_admin: BootstrapAdminConfig {
             realm: "master".into(),
-            client_id: "vp-idp-plugin-bootstrap".into(),
+            client_id: "keycloak-idp-plugin-bootstrap".into(),
             client_secret: SecretFromEnv::from_literal_unchecked("topsecret"),
         },
         realm_admin: RealmAdminConfig {
-            client_id_default: "vp-idp-plugin-realm-admin".into(),
+            client_id_default: "keycloak-idp-plugin-realm-admin".into(),
             default_shared_realm_secret: SecretFromEnv::from_literal_unchecked("ra"),
             secret_ref_template: "vp-idp-realm-admin-{realm_name}-secret".into(),
         },
@@ -108,7 +108,7 @@ fn is_pre_warm_retryable_classifies_kc_statuses() {
     assert!(is_pre_warm_retryable(&mk(KcStatusKind::Transport)));
     assert!(is_pre_warm_retryable(&mk(KcStatusKind::Timeout)));
     // CredStoreRead transient — OpenBao readiness lag is a real
-    // deploy-ordering race vp-idp pods hit in practice.
+    // deploy-ordering race the plugin's pods hit in practice.
     assert!(is_pre_warm_retryable(&PluginError::CredStoreRead {
         detail: "openbao 503".into(),
     }));

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/module_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/module_tests.rs
@@ -1,0 +1,247 @@
+//! Regression coverage for [`pre_warm_bootstrap_admin_with_retry`].
+//!
+//! These tests pin the three behaviours the operator runbook depends on:
+//!
+//! 1. **Fast-bail on permanent KC failures** (4xx-non-429) — bad
+//!    `client_secret` / missing realm MUST NOT eat the full retry budget.
+//! 2. **Recovery on transient failures** — a single 5xx followed by 200
+//!    succeeds within the budget, and the success-path tags `attempt > 1`
+//!    so the "succeeded after retry" log carries the right count.
+//! 3. **Exhausted budget annotation** — when all attempts fail, the
+//!    anyhow error message carries the attempt total so post-mortems can
+//!    distinguish "single-shot failure" from "burned the whole budget".
+//!
+//! The transport's own `[http_retry_policy].max_retries` is set to `0` so
+//! transient-status retries surface to `pre_warm` instead of being absorbed
+//! one layer down. Backoff is dialled to 1ms so the test suite stays fast.
+
+use super::{is_pre_warm_retryable, pre_warm_bootstrap_admin_with_retry};
+use crate::config::{
+    BootstrapAdminConfig, BootstrapPreWarmConfig, HttpRetryPolicy, KeycloakConfig,
+    KeycloakMetricsConfig, RealmAdminConfig, SecretFromEnv,
+};
+use crate::domain::credstore::CredStoreReader;
+use crate::domain::error::{KcStatusKind, PluginError};
+use crate::domain::kc::factory::KeycloakAdminClientFactory;
+use crate::domain::system_actor::build_system_ctx;
+use crate::domain::test_support::NoopMetrics;
+use crate::domain::test_support::StubCredStore;
+use crate::infra::kc_http::ReqwestKcTransport;
+use credstore_sdk::CredStoreClientV1;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use uuid::Uuid;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// `KeycloakConfig` with transport-level retries disabled so test
+/// behaviour is driven by `pre_warm`'s own loop, not by the inner
+/// reqwest retry budget.
+fn cfg_no_transport_retries(base: &str) -> KeycloakConfig {
+    KeycloakConfig {
+        base_url: url::Url::parse(base).expect("valid base url"),
+        bootstrap_admin: BootstrapAdminConfig {
+            realm: "master".into(),
+            client_id: "vp-idp-plugin-bootstrap".into(),
+            client_secret: SecretFromEnv::from_literal_unchecked("topsecret"),
+        },
+        realm_admin: RealmAdminConfig {
+            client_id_default: "vp-idp-plugin-realm-admin".into(),
+            default_shared_realm_secret: SecretFromEnv::from_literal_unchecked("ra"),
+            secret_ref_template: "vp-idp-realm-admin-{realm_name}-secret".into(),
+        },
+        tls_ca_bundle_ref: None,
+        admin_token_lifetime_safety_ms: 30_000,
+        http_request_timeout_ms: 5_000,
+        credential_refresh_interval: None,
+        http_retry_policy: HttpRetryPolicy {
+            max_retries: 0,
+            ..HttpRetryPolicy::default()
+        },
+        metrics: KeycloakMetricsConfig::default(),
+        bootstrap_pre_warm: BootstrapPreWarmConfig::default(),
+    }
+}
+
+fn factory_for(server: &MockServer) -> KeycloakAdminClientFactory {
+    let cfg = cfg_no_transport_retries(&server.uri());
+    let stub: Arc<dyn CredStoreClientV1> = Arc::new(StubCredStore);
+    let reader = CredStoreReader::new(stub, build_system_ctx(Uuid::nil()));
+    // `ReqwestKcTransport::new` defaults to `HttpRetryPolicy::default()`
+    // (max_retries=3). The pre_warm tests need transport-level retries
+    // disabled so the count we observe at wiremock is driven purely by
+    // `pre_warm`'s own loop — use `with_retry_policy` to plumb through
+    // the test cfg's zero-retry policy.
+    let transport = Arc::new(ReqwestKcTransport::with_retry_policy(
+        reqwest::Client::new(),
+        cfg.http_retry_policy.clone(),
+    ));
+    KeycloakAdminClientFactory::new(cfg, transport, reader, Arc::new(NoopMetrics))
+}
+
+const TOKEN_PATH: &str = "/realms/master/protocol/openid-connect/token";
+
+// -----------------------------------------------------------------
+// Unit coverage for the classifier itself — guards against silent
+// behaviour drift if a future hand adds a new `PluginError` variant.
+// -----------------------------------------------------------------
+
+#[test]
+fn is_pre_warm_retryable_classifies_kc_statuses() {
+    let mk = |status| PluginError::KcRest {
+        method: "POST",
+        path_template: "/realms/{realm}/protocol/openid-connect/token".into(),
+        status,
+        body_first_2kb: String::new(),
+    };
+    // 4xx-non-429 → permanent.
+    assert!(!is_pre_warm_retryable(&mk(KcStatusKind::Http(400))));
+    assert!(!is_pre_warm_retryable(&mk(KcStatusKind::Http(401))));
+    assert!(!is_pre_warm_retryable(&mk(KcStatusKind::Http(403))));
+    assert!(!is_pre_warm_retryable(&mk(KcStatusKind::Http(404))));
+    // 429 + 5xx → transient.
+    assert!(is_pre_warm_retryable(&mk(KcStatusKind::Http(429))));
+    assert!(is_pre_warm_retryable(&mk(KcStatusKind::Http(500))));
+    assert!(is_pre_warm_retryable(&mk(KcStatusKind::Http(503))));
+    // Transport / timeout always transient.
+    assert!(is_pre_warm_retryable(&mk(KcStatusKind::Transport)));
+    assert!(is_pre_warm_retryable(&mk(KcStatusKind::Timeout)));
+    // CredStoreRead transient — OpenBao readiness lag is a real
+    // deploy-ordering race vp-idp pods hit in practice.
+    assert!(is_pre_warm_retryable(&PluginError::CredStoreRead {
+        detail: "openbao 503".into(),
+    }));
+    // Config errors are operator misconfig — never retryable.
+    assert!(!is_pre_warm_retryable(&PluginError::Config {
+        detail: "bad base url".into(),
+    }));
+}
+
+// -----------------------------------------------------------------
+// (a) 4xx-non-429 fast-bails on the first attempt.
+// -----------------------------------------------------------------
+
+#[tokio::test]
+async fn pre_warm_fast_bails_on_4xx_non_429() {
+    let server = MockServer::start().await;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_clone = Arc::clone(&calls);
+    Mock::given(method("POST"))
+        .and(path(TOKEN_PATH))
+        .respond_with(move |_req: &wiremock::Request| {
+            calls_clone.fetch_add(1, Ordering::SeqCst);
+            // 401 invalid_client — the canonical broken-bootstrap-secret
+            // shape. Retrying this is guaranteed to reproduce.
+            ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "error": "invalid_client",
+                "error_description": "Invalid client or Invalid client credentials"
+            }))
+        })
+        .mount(&server)
+        .await;
+
+    let factory = factory_for(&server);
+    let err = pre_warm_bootstrap_admin_with_retry(&factory, 5, Duration::from_millis(1))
+        .await
+        .expect_err("401 must surface as error");
+
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "permanent 4xx MUST fast-bail on the first attempt — no retry budget burn",
+    );
+    // Error message carries the attempt count (1, not the configured 5)
+    // so post-mortems distinguish fast-bail from exhausted-budget.
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("1/5"),
+        "error message must record the actual attempt count, got: {msg}",
+    );
+    assert!(
+        msg.contains("401"),
+        "error message must surface the underlying status, got: {msg}",
+    );
+}
+
+// -----------------------------------------------------------------
+// (b) Transient-then-success returns Ok after exactly 2 attempts.
+//     The `attempt > 1` branch in the loop emits the
+//     "succeeded after retry" INFO log; here we assert the observable
+//     side of that branch (call count + Ok result).
+// -----------------------------------------------------------------
+
+#[tokio::test]
+async fn pre_warm_recovers_from_transient_then_success() {
+    let server = MockServer::start().await;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_clone = Arc::clone(&calls);
+    Mock::given(method("POST"))
+        .and(path(TOKEN_PATH))
+        .respond_with(move |_req: &wiremock::Request| {
+            let n = calls_clone.fetch_add(1, Ordering::SeqCst);
+            if n == 0 {
+                // First attempt: KC still warming up.
+                ResponseTemplate::new(503).set_body_string("Service Unavailable")
+            } else {
+                // Second attempt: ready.
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "access_token": "tok",
+                    "expires_in": 600
+                }))
+            }
+        })
+        .mount(&server)
+        .await;
+
+    let factory = factory_for(&server);
+    pre_warm_bootstrap_admin_with_retry(&factory, 5, Duration::from_millis(1))
+        .await
+        .expect("transient-then-success must return Ok");
+
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        2,
+        "exactly one retry must be issued (1 × 503 + 1 × 200)",
+    );
+}
+
+// -----------------------------------------------------------------
+// (c) Exhausted budget on persistent transient — final error message
+//     carries the attempt total.
+// -----------------------------------------------------------------
+
+#[tokio::test]
+async fn pre_warm_exhausts_budget_on_persistent_transient() {
+    let server = MockServer::start().await;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_clone = Arc::clone(&calls);
+    Mock::given(method("POST"))
+        .and(path(TOKEN_PATH))
+        .respond_with(move |_req: &wiremock::Request| {
+            calls_clone.fetch_add(1, Ordering::SeqCst);
+            ResponseTemplate::new(503).set_body_string("Service Unavailable")
+        })
+        .mount(&server)
+        .await;
+
+    let factory = factory_for(&server);
+    let err = pre_warm_bootstrap_admin_with_retry(&factory, 5, Duration::from_millis(1))
+        .await
+        .expect_err("budget exhausted must surface as error");
+
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        5,
+        "all 5 attempts must be issued before bailing",
+    );
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("5/5"),
+        "error message must record exhausted-budget attempt total, got: {msg}",
+    );
+    assert!(
+        msg.contains("503"),
+        "error message must surface the underlying status, got: {msg}",
+    );
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/sp_impl.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/sp_impl.rs
@@ -1,0 +1,119 @@
+//! `ServicePrincipalClientV1` implementation — thin delegation to
+//! [`ServicePrincipalFacade`] + `PluginError` → SDK failure translation.
+
+use async_trait::async_trait;
+use service_principal_sdk::{
+    CreateServicePrincipalRequest, ServicePrincipalClientV1, ServicePrincipalCredentials,
+    ServicePrincipalFailure, ServicePrincipalSummary, TenantId,
+};
+use toolkit_security::SecurityContext;
+
+use crate::domain::error::PluginError;
+use crate::idp_impl::KeycloakIdpPlugin;
+
+fn translate_sp_failure(e: PluginError) -> ServicePrincipalFailure {
+    match e {
+        PluginError::SpInvalidInput { detail, field } => {
+            ServicePrincipalFailure::InvalidInput { detail, field }
+        }
+        PluginError::SpNotFound { detail } => ServicePrincipalFailure::NotFound { detail },
+        PluginError::AmbiguousCreated { stage, detail } => ServicePrincipalFailure::Ambiguous {
+            detail: format!("{stage}: {detail}"),
+        },
+        // Everything else is a pre-mutation failure (reads, pre-flight
+        // validation, config): no vendor state was retained. Post-mutation
+        // escapes are re-tagged Ambiguous in the facade before reaching here.
+        other => ServicePrincipalFailure::CleanFailure {
+            detail: other.to_string(),
+        },
+    }
+}
+
+#[async_trait]
+impl ServicePrincipalClientV1 for KeycloakIdpPlugin {
+    async fn create(
+        &self,
+        ctx: &SecurityContext,
+        req: &CreateServicePrincipalRequest,
+    ) -> Result<ServicePrincipalCredentials, ServicePrincipalFailure> {
+        self.sp_facade
+            .create_inner(ctx, req)
+            .await
+            .map_err(translate_sp_failure)
+    }
+
+    async fn rotate_secret(
+        &self,
+        ctx: &SecurityContext,
+        tenant_id: TenantId,
+        client_id: &str,
+    ) -> Result<ServicePrincipalCredentials, ServicePrincipalFailure> {
+        self.sp_facade
+            .rotate_secret_inner(ctx, tenant_id.0, client_id)
+            .await
+            .map_err(translate_sp_failure)
+    }
+
+    async fn revoke(
+        &self,
+        ctx: &SecurityContext,
+        tenant_id: TenantId,
+        client_id: &str,
+    ) -> Result<(), ServicePrincipalFailure> {
+        self.sp_facade
+            .revoke_inner(ctx, tenant_id.0, client_id)
+            .await
+            .map_err(translate_sp_failure)
+    }
+
+    async fn list(
+        &self,
+        ctx: &SecurityContext,
+        tenant_id: TenantId,
+    ) -> Result<Vec<ServicePrincipalSummary>, ServicePrincipalFailure> {
+        self.sp_facade
+            .list_inner(ctx, tenant_id.0)
+            .await
+            .map_err(translate_sp_failure)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn translate_maps_plugin_errors_to_sp_failures() {
+        use crate::domain::error::{AmbiguousStage, KcStatusKind, PluginError};
+        let cases = [
+            (
+                PluginError::SpInvalidInput {
+                    detail: "d".into(),
+                    field: None,
+                },
+                "invalid_input",
+            ),
+            (PluginError::SpNotFound { detail: "d".into() }, "not_found"),
+            (
+                PluginError::AmbiguousCreated {
+                    stage: AmbiguousStage::KcClientDelete,
+                    detail: "d".into(),
+                },
+                "ambiguous",
+            ),
+            (PluginError::Config { detail: "d".into() }, "clean_failure"),
+            (
+                PluginError::KcRest {
+                    method: "GET",
+                    path_template: "/admin/realms/{realm}/clients".into(),
+                    status: KcStatusKind::Http(401),
+                    body_first_2kb: String::new(),
+                },
+                "clean_failure",
+            ),
+        ];
+        for (e, label) in cases {
+            assert_eq!(translate_sp_failure(e).as_metric_label(), label);
+        }
+    }
+}

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/tests/contract_am_sdk.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/tests/contract_am_sdk.rs
@@ -6,7 +6,7 @@
 //! conformance harness for the `IdpPluginClient` trait — `src/idp.rs`
 //! defines the trait + DTOs, and the SDK's only `*_tests.rs` modules
 //! cover DTO (de)serialisation, not plugin behaviour. When the harness
-//! lands upstream (tracked separately — see the VHP-1505 follow-up
+//! lands upstream (tracked separately — see the follow-up
 //! ticket), replace this placeholder with a wired test, roughly:
 //!
 //! ```ignore

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/tests/contract_am_sdk.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/tests/contract_am_sdk.rs
@@ -32,6 +32,6 @@
 #[test]
 fn placeholder_until_am_sdk_conformance_harness_lands() {
     // No-op test to ensure the file compiles and is discovered by
-    // `cargo test -p vp-idp-plugin`. Replace with the wired
+    // `cargo test -p cf-gears-keycloak-idp-plugin`. Replace with the wired
     // conformance call when the upstream harness is published.
 }

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/tests/contract_am_sdk.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/tests/contract_am_sdk.rs
@@ -1,0 +1,37 @@
+//! Contract tests via the AM SDK plugin-conformance harness
+//! (DESIGN §11 Level 3).
+//!
+//! As of commit `1fdc57b` (Phase 16b), the upstream
+//! `account-management-sdk` crate does not expose a
+//! conformance harness for the `IdpPluginClient` trait — `src/idp.rs`
+//! defines the trait + DTOs, and the SDK's only `*_tests.rs` modules
+//! cover DTO (de)serialisation, not plugin behaviour. When the harness
+//! lands upstream (tracked separately — see the VHP-1505 follow-up
+//! ticket), replace this placeholder with a wired test, roughly:
+//!
+//! ```ignore
+//! #[tokio::test]
+//! async fn am_sdk_idp_plugin_conformance() {
+//!     let plugin = build_test_plugin().await;
+//!     account_management_sdk::idp::conformance::run(&plugin)
+//!         .await
+//!         .expect("conformance");
+//! }
+//! ```
+//!
+//! `build_test_plugin()` will most likely reuse the testcontainer
+//! Keycloak scaffolding from `tests/integration_keycloak.rs` (Phase
+//! 16b). If the harness ships as a non-Docker pure-trait fixture, the
+//! call site stays gate-free; otherwise gate behind `#[ignore]` and
+//! run on the Docker-enabled CI lane.
+//!
+//! Until then, the unit tests under `src/` and the integration tests
+//! under `tests/integration_keycloak.rs` cover the trait surface
+//! directly (DESIGN §11 Levels 1 & 2).
+
+#[test]
+fn placeholder_until_am_sdk_conformance_harness_lands() {
+    // No-op test to ensure the file compiles and is discovered by
+    // `cargo test -p vp-idp-plugin`. Replace with the wired
+    // conformance call when the upstream harness is published.
+}

--- a/gears/system/service-principal/docs/DESIGN.md
+++ b/gears/system/service-principal/docs/DESIGN.md
@@ -1,0 +1,842 @@
+Created: 2026-08-07 by Constructor Studio
+
+# Technical Design — Service Principal
+
+<!-- toc -->
+
+- [1. Architecture Overview](#1-architecture-overview)
+  - [1.1 Architectural Vision](#11-architectural-vision)
+  - [1.2 Architecture Drivers](#12-architecture-drivers)
+  - [1.3 Architecture Layers](#13-architecture-layers)
+- [2. Principles & Constraints](#2-principles--constraints)
+  - [2.1 Design Principles](#21-design-principles)
+  - [2.2 Constraints](#22-constraints)
+- [3. Technical Architecture](#3-technical-architecture)
+  - [3.1 Domain Model](#31-domain-model)
+  - [3.2 Component Model](#32-component-model)
+  - [3.3 API Contracts](#33-api-contracts)
+  - [3.4 Internal Dependencies](#34-internal-dependencies)
+  - [3.5 External Dependencies](#35-external-dependencies)
+  - [3.6 Interactions & Sequences](#36-interactions--sequences)
+  - [3.7 Database Schemas & Tables](#37-database-schemas--tables)
+  - [3.8 Deployment Topology](#38-deployment-topology)
+- [4. Additional Context](#4-additional-context)
+  - [4.1 Failure Taxonomy and Wire Safety](#41-failure-taxonomy-and-wire-safety)
+  - [4.2 Operation-Key Reconciliation](#42-operation-key-reconciliation)
+  - [4.3 Configuration](#43-configuration)
+  - [4.4 Security and Data Protection](#44-security-and-data-protection)
+  - [4.5 Auditability and Observability](#45-auditability-and-observability)
+  - [4.6 Fault Tolerance](#46-fault-tolerance)
+  - [4.7 Testability and Verification](#47-testability-and-verification)
+  - [4.8 Compliance and Privacy Posture](#48-compliance-and-privacy-posture)
+  - [4.9 Migration Impact](#49-migration-impact)
+  - [4.10 Assumptions and Baseline Deviations](#410-assumptions-and-baseline-deviations)
+  - [4.11 Explicit Non-Applicability](#411-explicit-non-applicability)
+- [5. Traceability](#5-traceability)
+  - [Requirement Allocation Summary](#requirement-allocation-summary)
+
+<!-- /toc -->
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-design-provider-neutral-lifecycle`
+
+## 1. Architecture Overview
+
+### 1.1 Architectural Vision
+
+Service Principal is a stateless system gear for managing tenant-owned machine identities. It exposes stable REST and Rust contracts for create, list, rotate, and revoke. It authenticates and authorizes every request for an explicit tenant, applies provider-neutral policy, delegates to one configured identity-provider adapter, and maps the result to safe public responses.
+
+The identity provider remains authoritative for principals, credentials, verifier material, and token issuance. The adapter owns any durable state needed to reconcile create or rotation after an uncertain provider result. Service Principal owns no principal database, operation repository, cleanup record, lease, retry scheduler, or background worker.
+
+Create and rotate require a caller-generated operation key. Service Principal validates and forwards the opaque key and canonical request identity. A repeated identical request with the same key is the only public reconciliation path. There is no recovery-status API, server-generated operation identifier, or public reconciliation handle. Plaintext credentials are returned only by a confirmed create or rotation response and are never persisted or replayed.
+
+Tenant cleanup is part of the identity-provider tenant-deprovision contract, not the Service Principal API. The tenant lifecycle owner retains durable deprovision state and retries the whole operation after transient failure. The provider adapter deletes only principals authoritatively owned by the target tenant and returns success only after confirming that none remain.
+
+This multi-owner design is shown explicitly in the component and sequence diagrams. The diagrams are warranted because request authorization, provider reconciliation, and tenant cleanup have different state and retry owners.
+
+### 1.2 Architecture Drivers
+
+#### Functional Drivers
+
+| Requirement | Design Response |
+|-------------|-----------------|
+| `cpt-cf-service-principal-fr-create` | The application service authorizes the explicit tenant and delegates a keyed create to the provider adapter. |
+| `cpt-cf-service-principal-fr-client-credentials-only` | The provider contract accepts only confidential `client_credentials` identity requests. |
+| `cpt-cf-service-principal-fr-identity-context` | Provider conformance verifies tenant, subject, and service identity in issued tokens. |
+| `cpt-cf-service-principal-fr-name-policy` | Typed configuration supplies bounded name rules checked before provider invocation. |
+| `cpt-cf-service-principal-fr-scope-allowlist` | The application service rejects scopes outside the deployment allowlist. |
+| `cpt-cf-service-principal-fr-tenant-quota` | Provider-owned inventory supplies the observed count for best-effort quota checks. |
+| `cpt-cf-service-principal-fr-create-collision` | A collision is invalid input; create never adopts or modifies the occupied principal. |
+| `cpt-cf-service-principal-fr-list` | Listing delegates after tenant authorization and returns provider-authoritative summaries. |
+| `cpt-cf-service-principal-fr-secret-free-listing` | Summary models have no secret field and are distinct from credential models. |
+| `cpt-cf-service-principal-fr-ownership-addressing` | Item operations use `(tenant_id, client_id)` and do not distinguish foreign from absent principals publicly. |
+| `cpt-cf-service-principal-fr-rotate-secret` | Keyed rotation returns one transient credential result after confirmed invalidation. |
+| `cpt-cf-service-principal-fr-rotate-complete-state` | The adapter verifies tenant ownership and managed state before rotation. |
+| `cpt-cf-service-principal-fr-revoke` | Revocation uses a tenant-qualified provider address and confirms deletion or absence. |
+| `cpt-cf-service-principal-fr-revoke-idempotent` | Provider not-found is success-equivalent for revoke. |
+| `cpt-cf-service-principal-fr-authenticated-management` | REST routes are authenticated and Rust operations require `SecurityContext`. |
+| `cpt-cf-service-principal-fr-independent-permissions` | GTS permissions define create, read, rotate-secret, and revoke independently. |
+| `cpt-cf-service-principal-fr-tenant-authorization` | `PolicyEnforcer` evaluates the target tenant and the service verifies covering constraints. |
+| `cpt-cf-service-principal-fr-authz-fail-closed` | Missing identity, denial, evaluation failure, or mismatched constraints prevents provider access. |
+| `cpt-cf-service-principal-fr-provider-delegation` | A major-versioned provider SDK isolates provider-specific behavior. |
+| `cpt-cf-service-principal-fr-provider-required` | Missing provider registration maps to provider unavailable; success is never simulated. |
+| `cpt-cf-service-principal-fr-failure-categories` | Adapter outcomes map to the closed public taxonomy and canonical errors. |
+| `cpt-cf-service-principal-fr-ambiguous-create-recovery` | Same-key create retries reconcile in the adapter before any further mutation. |
+| `cpt-cf-service-principal-fr-ambiguous-rotate-recovery` | Same-key rotation retries reconcile; lost credentials are replaced by a new confirmed rotation. |
+| `cpt-cf-service-principal-fr-ambiguous-revoke-recovery` | Revoke remains safely repeatable until deletion or absence is confirmed. |
+| `cpt-cf-service-principal-fr-tenant-cleanup` | The identity-provider tenant-deprovision path performs cleanup while the lifecycle owner retains retry state. |
+
+#### NFR Allocation
+
+| NFR ID | Allocated To | Design Response | Verification Approach |
+|--------|--------------|-----------------|----------------------|
+| `cpt-cf-service-principal-nfr-secret-confidentiality` | Credential models, REST adapter, logging policy | Credential responses are non-cacheable and secret values are absent from all other contracts. | Secret-negative unit, route, conformance, and E2E tests |
+| `cpt-cf-service-principal-nfr-data-classification` | SDK models, adapter contract, audit boundary | Contract fields are classified; human profile fields are excluded. | Contract inspection and security review |
+| `cpt-cf-service-principal-nfr-no-secret-persistence` | Stateless service and adapter conformance | Service Principal persists nothing; adapters never retain credential responses for replay. | State-boundary inspection and secret-negative tests |
+| `cpt-cf-service-principal-nfr-tenant-isolation` | Authorization gate and provider adapter | PDP constraints cover the target tenant and provider addressing is tenant-qualified. | Cross-tenant security suite |
+| `cpt-cf-service-principal-nfr-credential-invalidation` | Provider adapter | Rotation and revoke success require superseded credentials to stop working. | Provider conformance and E2E tests |
+| `cpt-cf-service-principal-nfr-provider-conformance` | Provider SDK and conformance harness | Every adapter runs common lifecycle, ownership, reconciliation, and credential checks. | Mandatory adapter suite |
+| `cpt-cf-service-principal-nfr-contract-compatibility` | REST V1 and Rust V1 contracts | Breaking route, model, identifier, or category changes require a new major version. | API and SDK compatibility checks |
+| `cpt-cf-service-principal-nfr-auditability` | Service, adapter, and tenant lifecycle owner | Each layer records the facts it owns under shared correlation and tenant identity. | Layered audit-completeness tests |
+| `cpt-cf-service-principal-nfr-observability` | Service, adapter, and tenant lifecycle owner | API, reconciliation, and cleanup signals remain separated and correlatable. | Telemetry integration tests |
+| `cpt-cf-service-principal-nfr-stateless-recovery` | Provider adapter contract | Adapter reconciliation survives restart; Service Principal owns no durable state. | Restart and same-key retry tests |
+| `cpt-cf-service-principal-nfr-cleanup-reliability` | Tenant lifecycle owner and identity-provider integration | Lifecycle state survives restart and teardown remains blocked until zero principals are confirmed. | Deprovision retry and terminal-failure tests |
+| `cpt-cf-service-principal-nfr-performance-baseline` | Benchmark harness | Release evidence supplies measured objectives instead of invented values. | Versioned benchmark report |
+| `cpt-cf-service-principal-nfr-operational-documentation` | OpenAPI and operator guidance | Guidance covers secret handoff, same-key retry, rotation recovery, cleanup ownership, and alerts. | Release-readiness inspection |
+
+### 1.3 Architecture Layers
+
+```mermaid
+graph TB
+    Caller[Administrator or Consuming Gear]
+    REST[REST and OpenAPI Adapter]
+    Local[Public Rust Local Client]
+    Service[Stateless Application Service]
+    AuthZ[Authorization Gate]
+    Provider[Provider Adapter Contract]
+    AdapterState[Adapter-Private Reconciliation State]
+    OAGW[Outbound API Gateway]
+    IdP[Identity Provider]
+    Lifecycle[Tenant Lifecycle Owner]
+    Audit[Layered Audit and Observability]
+
+    Caller --> REST
+    Caller --> Local
+    REST --> Service
+    Local --> Service
+    Service --> AuthZ
+    Service --> Provider
+    Provider --> AdapterState
+    Provider --> OAGW
+    OAGW --> IdP
+    Lifecycle -->|tenant deprovision| Provider
+    Service --> Audit
+    Provider --> Audit
+    Lifecycle --> Audit
+```
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-tech-layered-control-plane`
+
+| Layer | Responsibility | Technology |
+|-------|----------------|------------|
+| Presentation | Authenticated routing, DTO conversion, `Idempotency-Key`, non-cacheable credential responses, canonical errors | Axum, `OperationBuilder`, OpenAPI |
+| Application | Validation, explicit-tenant authorization, provider delegation, public outcome mapping | Rust domain service, `PolicyEnforcer`, ClientHub |
+| Domain | Stable lifecycle models, operation-key binding, failure semantics | Rust SDK and domain models |
+| Provider integration | Provider protocol, authoritative state access, restart-safe reconciliation, tenant purge implementation | Provider adapter, adapter-private state, OAGW |
+| Tenant lifecycle | Durable deprovision operation, cleanup retry scheduling, terminal disposition | Tenant lifecycle contract and owner |
+
+## 2. Principles & Constraints
+
+### 2.1 Design Principles
+
+#### Provider Authority
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-principle-provider-authority`
+
+The identity provider is the sole authority for principal existence, credentials, verifier material, and token behavior. Service Principal does not copy provider inventory or retain reconciliation state.
+
+#### One-Time Secret Boundary
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-principle-one-time-secret`
+
+Plaintext credentials cross the public boundary only after confirmed create or rotation. Lost credentials are replaced through a new rotation and are never retrieved or replayed.
+
+#### Authorize the Explicit Tenant
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-principle-explicit-tenant-authorization`
+
+Every public request and same-key retry re-authenticates and authorizes its explicit target tenant before provider access. Prior authorization stored by another component never substitutes for the current decision.
+
+#### Stateless Recovery Boundary
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-principle-safe-recovery`
+
+Service Principal forwards operation identity but owns no recovery execution. The adapter reconciles create and rotation before mutation. Revoke converges through repeated tenant-qualified deletion. Tenant cleanup converges through lifecycle-owned deprovision retries.
+
+#### Stable Contracts, Replaceable Providers
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-principle-versioned-contracts`
+
+Public and provider contracts are major-versioned and provider-neutral. Unknown result categories are always non-success and behave as ambiguous when mutation cannot be ruled out.
+
+### 2.2 Constraints
+
+#### One Provider per Deployment
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-constraint-single-provider`
+
+The initial design resolves one provider adapter for the deployment. Selection does not vary by tenant or request. Missing registration is an explicit provider-unavailable failure.
+
+#### No Distributed Transaction
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-constraint-no-distributed-transaction`
+
+Service Principal and the external identity provider do not share a transaction. Mutation uncertainty is represented by the adapter outcome and reconciled under the same operation key.
+
+#### Provider Capability Floor
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-constraint-provider-capabilities`
+
+A conforming adapter supports confidential client credentials, tenant-qualified ownership, immediate invalidation, collision detection, restart-safe keyed reconciliation, safe failure classification, and authoritative tenant-principal cleanup through the tenant-deprovision integration.
+
+#### Bounded Administrative Workload
+
+- [ ] `p2` - **ID**: `cpt-cf-service-principal-constraint-bounded-workload`
+
+Lifecycle calls are low-frequency administrative operations. Initial listing is unpaginated and bounded by the configured tenant quota. Pagination and strong quota serialization require measured evidence and a compatible contract extension.
+
+## 3. Technical Architecture
+
+### 3.1 Domain Model
+
+**Technology**: GTS identifiers and transport-neutral Rust models
+
+**Location**: `gears/system/service-principal/service-principal-sdk/src/`
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-entity-lifecycle-model`
+
+| Entity | Description | Security Classification |
+|--------|-------------|-------------------------|
+| Create Request | Explicit tenant, bounded name, allowed scopes, and `OperationKey` | Security-sensitive control-plane metadata |
+| Rotate Request | Tenant-qualified principal and `OperationKey` | Security-sensitive control-plane metadata |
+| Service Principal Credentials | Client ID, one-time secret, token endpoint, stable subject ID | Secret is restricted; other fields are security-sensitive |
+| Service Principal Summary | Client ID, enabled state, scopes, stable subject when supported | Security-sensitive; never contains a secret |
+| Canonical Request Identity | Versioned identity of tenant, operation, and normalized non-secret input | Security-sensitive reconciliation metadata |
+| Provider Outcome | Stable category, mutation certainty, safe remediation, and optional confirmed principal identity | Security-sensitive operational metadata |
+| Provider Proof Classification | Adapter-private `exact_binding`, `authoritative_absence`, or `inconclusive` result | Security-sensitive adapter metadata; not public wire data |
+| Audit Fact | Actor, tenant, action, time, correlation, and outcome | Security-sensitive audit metadata |
+
+Relationships are bounded as follows:
+
+- An operation key is bound to one tenant, operation kind, and canonical request identity.
+- Credential models are returned only by confirmed create and rotation.
+- Provider proof classification maps to a public category and remediation without exposing provider evidence.
+- Service Principal retains none of these entities after request completion.
+
+### 3.2 Component Model
+
+```mermaid
+graph LR
+    API[REST Adapter]
+    SDK[Public Local Client]
+    SVC[Stateless Application Service]
+    PEP[Authorization Gate]
+    SPI[Service Principal Provider Client V1]
+    TLS[Tenant Lifecycle Owner]
+    TDP[Tenant Deprovision Provider Contract]
+    CAT[GTS Catalog]
+    OBS[Layered Audit and Observability]
+
+    API --> SVC
+    SDK --> SVC
+    SVC --> PEP
+    SVC --> SPI
+    TLS --> TDP
+    CAT -. registers .-> PEP
+    SVC --> OBS
+    SPI --> OBS
+    TDP --> OBS
+    TLS --> OBS
+```
+
+#### REST and OpenAPI Adapter
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-component-rest-adapter`
+
+**Purpose**: Expose the stable HTTP contract while keeping HTTP types outside domain and SDK layers.
+
+**Responsibilities**:
+
+- Register the four routes with `OperationBuilder`.
+- Require authentication and standard errors.
+- Require `Idempotency-Key` for create and rotate.
+- Convert DTOs and apply `Location` and `Cache-Control: no-store` where required.
+- Render canonical RFC-9457 Problems without provider diagnostics.
+
+**Boundaries**: It does not authorize, call the provider directly, persist state, expose status endpoints, or log credential-bearing bodies.
+
+#### Public Rust Local Client
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-component-public-client`
+
+**Purpose**: Give trusted gears the same four operations without REST coupling.
+
+**Responsibilities**: Propagate `SecurityContext`, explicit tenant identity, and `OperationKey` for create and rotate; delegate to the application service; map domain failures to the closed public taxonomy.
+
+**Boundaries**: It exposes no provider client, cleanup method, recovery lookup, retry scheduler, or provider proof model.
+
+#### Application Service
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-component-application-service`
+
+**Purpose**: Enforce public lifecycle policy before provider access.
+
+**Responsibilities**:
+
+- Validate names, scopes, quota policy, operation keys, and tenant-qualified addresses.
+- Authenticate and authorize the explicit tenant for every call, including same-key retries.
+- Derive the versioned canonical non-secret request identity.
+- Delegate lifecycle operations and map provider outcomes.
+- Return one-time credentials only on confirmed synchronous success.
+- Emit request-level audit and telemetry facts.
+
+**Boundaries**: It has no database, durable operation model, cleanup method, worker, provider protocol, or plaintext-secret store.
+
+#### Authorization Gate
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-component-authorization-gate`
+
+**Purpose**: Enforce tenant object-level authorization for high-impact machine identities.
+
+**Responsibilities**: Use `PolicyEnforcer` with `owner_tenant_id`, require constraints, and verify that `AccessScope` covers the explicit tenant for `create`, `read`, `rotate_secret`, or `revoke`.
+
+**Boundaries**: It does not authorize tenant deprovisioning, infer tenant ownership from client identifiers, author policy, or expose PDP diagnostics.
+
+#### Provider Boundary
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-component-provider-boundary`
+
+**Purpose**: Isolate provider protocol, authoritative state, and reconciliation behavior.
+
+**Responsibilities**:
+
+- Implement create, list, rotate, and revoke for tenant-qualified requests.
+- Bind create and rotate operation keys to canonical request identity.
+- Reconcile an identical same-key retry before any further mutation.
+- Preserve unresolved reconciliation across adapter restart.
+- Return stable provider outcomes and safe non-secret remediation data.
+- Keep proof evidence, provider identifiers, and private state behind the adapter boundary.
+
+**Boundaries**: It does not make Service Principal authorization decisions, return raw provider diagnostics, expose credential verifier material, or persist plaintext credential responses for replay.
+
+#### Tenant Lifecycle Cleanup Integration
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-component-tenant-lifecycle-cleanup`
+
+**Purpose**: Remove tenant-owned principals as part of authoritative tenant deprovisioning.
+
+**Responsibilities**:
+
+- The tenant lifecycle owner authenticates and authorizes deprovisioning and retains durable retry state.
+- The identity-provider integration enumerates and deletes only exact tenant-owned principals.
+- Already-absent principals are success-equivalent.
+- Retryable and terminal failures block subsequent tenant teardown.
+- Success requires a final authoritative zero-principal confirmation.
+
+**Boundaries**: Service Principal is not invoked and owns no cleanup API, permission, record, schedule, or status.
+
+#### GTS Resource and Permission Catalog
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-component-gts-catalog`
+
+The catalog defines the final managed-resource type `gts.cf.core.service_principal.service_principal.v1~` and final subject classification `gts.cf.core.security.subject_service.v1~`. Both are generated from Rust, registered through Types Registry inventory, and treated as closed V1 classifications.
+
+Permissions are well-known instances of `gts.cf.toolkit.authz.permission.v1~`:
+
+| Permission Instance ID | Action |
+|------------------------|--------|
+| `gts.cf.toolkit.authz.permission.v1~cf.service_principal._.service_principal_create.v1` | `create` |
+| `gts.cf.toolkit.authz.permission.v1~cf.service_principal._.service_principal_read.v1` | `read` |
+| `gts.cf.toolkit.authz.permission.v1~cf.service_principal._.service_principal_rotate_secret.v1` | `rotate_secret` |
+| `gts.cf.toolkit.authz.permission.v1~cf.service_principal._.service_principal_revoke.v1` | `revoke` |
+
+The catalog defines identifiers, not grants or role assignments. Tenant deprovision authorization belongs to the tenant lifecycle contract and is not a Service Principal permission.
+
+#### Audit and Observability
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-component-audit-observability`
+
+**Purpose**: Provide incident-ready attribution and operational signals without secret leakage.
+
+**Responsibilities**: Service Principal emits authorization and public operation outcomes. The adapter emits provider mutation and reconciliation outcomes. The tenant lifecycle owner emits cleanup retries and final tenant disposition. All layers propagate correlation and explicit tenant identity.
+
+**Boundaries**: No layer records plaintext credentials, bearer tokens, raw provider responses, raw operation keys, or tenant/client identifiers as metric labels. Operation-key correlation uses a non-reversible fingerprint.
+
+### 3.3 API Contracts
+
+#### Service Principal REST V1
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-interface-rest-v1`
+
+- **Contracts**: `cpt-cf-service-principal-interface-rest`, `cpt-cf-service-principal-contract-authorization`
+- **Technology**: REST, JSON, OpenAPI, RFC-9457 Problem Details
+- **Location**: Generated from `OperationBuilder` registrations
+
+| Method | Path | Request Requirement | Success |
+|--------|------|---------------------|---------|
+| `POST` | `/service-principal/v1/tenants/{tenant_id}/service-principals` | `Idempotency-Key` | `201 Created`, `Location`, `Cache-Control: no-store` |
+| `GET` | `/service-principal/v1/tenants/{tenant_id}/service-principals` | None beyond authenticated tenant request | `200 OK` |
+| `POST` | `/service-principal/v1/tenants/{tenant_id}/service-principals/{client_id}/rotate-secret` | `Idempotency-Key` | `200 OK`, `Cache-Control: no-store` |
+| `DELETE` | `/service-principal/v1/tenants/{tenant_id}/service-principals/{client_id}` | None beyond authenticated tenant request | `204 No Content` |
+
+No operation-status, recovery-retry, or tenant-cleanup endpoint is registered. No server operation identifier or reconciliation handle is returned. Platform trace context remains available through canonical errors and response tracing.
+
+A create or rotate retry must repeat the identical request with the same key. Key reuse with another tenant, operation kind, or canonical request identity is invalid input. When reconciliation confirms that the original mutation succeeded but its credential response was lost, the response is a `credentials_unavailable` failed precondition. It contains only safe confirmed identity and remediation and never claims a credential-bearing success.
+
+All routes use `.authenticated()`, explicit license posture, typed schemas, and registered standard errors. Gateway-owned CORS, timeout, compression, tracing, and body-limit middleware are not duplicated.
+
+#### Service Principal Rust SDK V1
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-interface-rust-v1`
+
+- **Contracts**: `cpt-cf-service-principal-interface-rust-sdk`
+- **Technology**: Async transport-neutral Rust trait registered in ClientHub
+- **Location**: `service-principal-sdk`
+
+The public client provides create, list, rotate-secret, and revoke. Every operation accepts `SecurityContext` and an explicit tenant. Create and rotate carry a validated `OperationKey` newtype. The SDK exposes no cleanup, recovery lookup, operation status, or explicit retry method; retry uses the original create or rotate method.
+
+Credential models use redacting secret wrappers and do not support general serialization. Public failures carry one of the six stable categories plus stable safe reason and remediation fields. `credentials_unavailable` is a reason under invalid input/failed precondition, not a seventh category. Unknown wire categories remain non-success and behave as ambiguous when mutation certainty is unavailable.
+
+#### Provider Adapter V1
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-interface-provider-v1`
+
+- **Contracts**: `cpt-cf-service-principal-contract-provider-adapter`
+- **Technology**: Async transport-neutral Rust provider trait registered in ClientHub
+- **Location**: `service-principal-sdk`
+
+The provider client defines create, list, rotate, and revoke. Create and rotate receive the opaque operation key and versioned canonical request identity. Provider outcomes use invalid input, not found, clean failure, or ambiguous outcome; authorization failure and provider unavailability are added by the public service boundary.
+
+The adapter classifies reconciliation evidence internally as `exact_binding`, `authoritative_absence`, or `inconclusive`. Public contracts receive only stable category, reason, safe remediation, and confirmed non-secret identity when applicable. Provider proof material and provider-specific diagnostics never cross the boundary.
+
+#### Tenant Deprovision Contract
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-interface-tenant-deprovision`
+
+- **Contracts**: `cpt-cf-service-principal-contract-tenant-cleanup`
+- **Technology**: Tenant lifecycle to identity-provider integration contract
+
+The lifecycle owner supplies a validated security context and explicit tenant to the identity-provider tenant-deprovision contract. The integration returns success, success-equivalent absence, retryable failure, or terminal failure. Retry state and scheduling remain in the lifecycle owner. This contract is separate from Provider Adapter V1 and is not exposed through Service Principal REST or Rust APIs.
+
+#### Managed Resource and Permissions
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-interface-managed-resource-v1`
+
+| Action | Purpose |
+|--------|---------|
+| `create` | Mint a tenant-owned machine identity |
+| `read` | List tenant-owned principals |
+| `rotate_secret` | Replace an existing principal secret |
+| `revoke` | Remove a principal or confirm absence |
+
+Boundary identifiers use typed GTS IDs. Types Registry resolves and validates them before authorization or processing; SQL string matching and handler branching on raw GTS strings are prohibited.
+
+### 3.4 Internal Dependencies
+
+| Dependency | Interface Used | Purpose |
+|------------|----------------|---------|
+| AuthZ Resolver | `PolicyEnforcer` and resolver SDK | Evaluate independent actions and compile tenant constraints |
+| Types Registry | GTS inventory registration | Register resource, subject, and permission instances |
+| Tenant contracts | Canonical `TenantId` and hierarchy semantics | Preserve tenant identity across boundaries |
+| ToolKit runtime | Gear, REST, ClientHub, lifecycle registration | Register routes and public/provider clients |
+| Canonical errors | Canonical categories and Problem rendering | Produce safe public errors |
+| API Gateway | Authenticated route policy and OpenAPI registry | Authenticate and publish REST contracts |
+| Outbound API Gateway | OAGW upstream and route contracts | Apply egress policy and credential isolation to provider HTTP calls |
+| Platform observability | Tracing, metrics, and audit delivery | Collect layered correlation and outcomes |
+
+Service Principal has no ToolKit database, migration, Secure ORM, task lease, or stateful-worker dependency. SDK contracts never depend on implementation types. Provider adapters are resolved through ClientHub and are not direct dependencies of consuming gears.
+
+### 3.5 External Dependencies
+
+#### Identity Provider
+
+- **Contract**: `cpt-cf-service-principal-contract-provider-adapter`
+
+Only the adapter translates provider-neutral operations to provider administration calls. All provider HTTP or HTTPS traffic, including token-conformance requests, traverses OAGW with declared upstreams, routes, TLS policy, bounded timeouts, and credential references. A non-HTTP transport requires a separately approved boundary with equivalent controls.
+
+The adapter classifies uncertainty honestly. Timeout after request transmission is ambiguous unless non-mutation is established. The provider owns principal backup, residency, and credential-verifier storage. Adapter qualification is required before a supported release enables it.
+
+#### Tenant Lifecycle Owner
+
+- **Contract**: `cpt-cf-service-principal-contract-tenant-cleanup`
+
+The lifecycle owner owns durable deprovision state, retry scheduling, terminal parking, and final tenant disposition. Its identity-provider integration owns authoritative principal purge behavior. Service Principal has no dependency edge in this path.
+
+### 3.6 Interactions & Sequences
+
+#### Create Workload Identity
+
+**ID**: `cpt-cf-service-principal-seq-create`
+
+```mermaid
+sequenceDiagram
+    participant C as Caller
+    participant S as Stateless Service
+    participant Z as Authorization Resolver
+    participant P as Provider Adapter
+
+    C->>S: Create tenant, request, Idempotency-Key
+    S->>Z: Authorize create for tenant
+    Z-->>S: Decision and covering constraints
+    S->>P: Create with key and canonical request identity
+    alt Confirmed new success
+        P-->>S: One-time credentials and subject
+        S-->>C: 201, Location, no-store
+    else Confirmed prior success, response lost
+        P-->>S: Safe confirmed identity, no credential
+        S-->>C: credentials_unavailable failed precondition
+    else Authoritative absence
+        P-->>S: Safe fresh-attempt guidance
+        S-->>C: Non-success; new key permitted
+    else Inconclusive
+        P-->>S: Ambiguous outcome
+        S-->>C: Ambiguous; identical same-key retry only
+    end
+```
+
+The service holds only request-local state. Every retry re-authenticates and re-authorizes before adapter reconciliation. No credential or operation record is written by the gear.
+
+#### Inventory Tenant Principals
+
+**ID**: `cpt-cf-service-principal-seq-list`
+
+```mermaid
+sequenceDiagram
+    participant C as Caller
+    participant S as Stateless Service
+    participant Z as Authorization Resolver
+    participant P as Provider Adapter
+
+    C->>S: List explicit tenant
+    S->>Z: Authorize read
+    Z-->>S: Covering constraints
+    S->>P: List tenant-owned principals
+    P-->>S: Secret-free summaries
+    S-->>C: Secret-free list
+```
+
+#### Rotate Credential
+
+**ID**: `cpt-cf-service-principal-seq-rotate`
+
+```mermaid
+sequenceDiagram
+    participant C as Caller
+    participant S as Stateless Service
+    participant Z as Authorization Resolver
+    participant P as Provider Adapter
+
+    C->>S: Rotate tenant principal, Idempotency-Key
+    S->>Z: Authorize rotate_secret
+    Z-->>S: Covering constraints
+    S->>P: Rotate with key and canonical request identity
+    alt Confirmed new success
+        P-->>S: Replacement secret and invalidation confirmation
+        S-->>C: Replacement once, no-store
+    else Confirmed prior success, response lost
+        P-->>S: Safe confirmed identity, no credential
+        S-->>C: credentials_unavailable; rotate with new key
+    else Inconclusive
+        P-->>S: Credential state uncertain
+        S-->>C: Ambiguous; identical same-key retry only
+    end
+```
+
+A caller adopts only credentials received by a confirmed rotation response. The service never delivers a secret asynchronously.
+
+#### Revoke Workload Identity
+
+**ID**: `cpt-cf-service-principal-seq-revoke`
+
+```mermaid
+sequenceDiagram
+    participant C as Caller
+    participant S as Stateless Service
+    participant Z as Authorization Resolver
+    participant P as Provider Adapter
+
+    C->>S: Revoke tenant-qualified principal
+    S->>Z: Authorize revoke
+    Z-->>S: Covering constraints
+    S->>P: Delete tenant-owned principal
+    alt Deleted or absent
+        P-->>S: Confirmed success or not found
+        S-->>C: 204 No Content
+    else Ambiguous
+        P-->>S: Mutation uncertain
+        S-->>C: Ambiguous; repeat normal revoke
+    end
+```
+
+Revoke requires no operation key. The caller repeats the tenant-qualified operation until deletion or absence is confirmed.
+
+#### Tenant Deprovision Cleanup
+
+**ID**: `cpt-cf-service-principal-seq-tenant-cleanup`
+
+```mermaid
+sequenceDiagram
+    participant T as Tenant Lifecycle Owner
+    participant P as Identity-Provider Integration
+    participant I as Identity Provider
+
+    T->>T: Authenticate and authorize tenant deprovision
+    T->>P: Deprovision explicit tenant
+    P->>I: Enumerate exact tenant-owned principals
+    P->>I: Delete each owned principal
+    P->>I: Confirm zero owned principals
+    alt Zero confirmed
+        P-->>T: Success
+        T->>T: Continue tenant teardown
+    else Transient failure
+        P-->>T: Retryable
+        T->>T: Retain durable state and retry whole operation
+    else Permanent failure
+        P-->>T: Terminal
+        T->>T: Block teardown and expose intervention state
+    end
+```
+
+Service Principal is absent from this sequence. Cleanup and its retries share the durable tenant-deprovision lifecycle.
+
+### 3.7 Database Schemas & Tables
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-db-state-ownership`
+
+| State | Durable Owner | Service Principal Access |
+|-------|---------------|--------------------------|
+| Principal, credential, verifier, token behavior | Identity provider | Through provider adapter only |
+| Create/rotation reconciliation binding and outcome | Provider adapter or its provider-native facility | Forward key and canonical request identity; receive safe outcome |
+| Tenant-deprovision retry and terminal disposition | Tenant lifecycle owner | None |
+| Audit and telemetry retention | Platform observability and owning emitting layer | Emit through platform interfaces |
+| Plaintext credential response | No platform persistence owner | Request-local delivery only |
+
+Service Principal declares no schema or table and runs no migration. It does not lease work, retain resolved operations, restore state after restart, or define adapter-private retention. An adapter may use provider-native or private durable storage, but that storage is outside the gear boundary and must satisfy conformance without containing replayable plaintext credential responses.
+
+### 3.8 Deployment Topology
+
+- [ ] `p2` - **ID**: `cpt-cf-service-principal-topology-deployment-neutral`
+
+```mermaid
+graph LR
+    GW[API Gateway]
+    SP1[Service Principal Instance]
+    SP2[Service Principal Instance]
+    AZ[AuthZ Resolver]
+    HUB[ClientHub]
+    ADAPTER[Provider Adapter]
+    ASTATE[(Adapter-Private State)]
+    OAGW[Outbound API Gateway]
+    IDP[Identity Provider]
+    OBS[Observability and Audit]
+    TL[Tenant Lifecycle Owner]
+
+    GW --> SP1
+    GW --> SP2
+    SP1 --> AZ
+    SP2 --> AZ
+    SP1 --> HUB
+    SP2 --> HUB
+    HUB --> ADAPTER
+    ADAPTER --> ASTATE
+    ADAPTER --> OAGW
+    OAGW --> IDP
+    TL --> ADAPTER
+    SP1 --> OBS
+    SP2 --> OBS
+    ADAPTER --> OBS
+    TL --> OBS
+```
+
+Instances are horizontally scalable and interchangeable. They require authorization, GTS, ClientHub, canonical error, gateway, and observability wiring. They do not require a database, migration, work lease, or worker readiness probe. Provider availability is reported separately so an outage produces an explicit failure rather than simulated success. Adapter-private reconciliation infrastructure is deployed and operated with the adapter, outside the Service Principal lifecycle.
+
+## 4. Additional Context
+
+### 4.1 Failure Taxonomy and Wire Safety
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-design-failure-taxonomy`
+
+| Public Category | Source | Mutation Semantics | Retry Guidance | Canonical Mapping |
+|-----------------|--------|--------------------|----------------|-------------------|
+| Invalid input | Validation, provider, key mismatch, or `credentials_unavailable` | Current request retains no new state | Change invalid input; use a new rotation key after lost credential response | `InvalidArgument`, HTTP 400; failed precondition reason for `credentials_unavailable` |
+| Not found | Provider ownership lookup | No addressed tenant-owned principal | Revoke treats as success-equivalent | `NotFound`, HTTP 404; revoke returns 204 |
+| Clean failure | Provider | Provider confirms no new state | Follow safe remediation; a fresh mutation uses a new key | `ServiceUnavailable`, HTTP 503 |
+| Ambiguous outcome | Provider after possible mutation | State may have changed | Repeat only the identical request with the same key for create/rotate; repeat revoke normally | `Aborted`, HTTP 409 |
+| Authorization failure | Authentication or policy boundary | Provider not invoked | Retry only after identity or authorization changes | Canonical 401, 403, or fail-closed internal error |
+| Provider unavailable | Missing adapter or known pre-mutation outage | No provider mutation | Retry according to safe availability guidance | `ServiceUnavailable`, HTTP 503 |
+
+`credentials_unavailable` is a stable reason under invalid input/failed precondition, not a seventh category. It may contain confirmed non-secret principal identity and rotation guidance. It never contains a credential, raw operation key, adapter proof, or provider diagnostic.
+
+Unknown categories remain non-success. If mutation certainty is unavailable, compatibility handling is ambiguous. Provider detail is sanitized before logging and never placed on the public wire.
+
+Tenant cleanup uses the tenant-lifecycle contract's success, success-equivalent absence, retryable, and terminal outcomes. Those outcomes do not extend the Service Principal taxonomy.
+
+### 4.2 Operation-Key Reconciliation
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-design-reconciliation`
+
+Create and rotation use these contract rules:
+
+1. The caller supplies `Idempotency-Key` or the Rust `OperationKey` equivalent.
+2. Service Principal validates the key, authenticates and authorizes the current caller, derives a canonical non-secret request identity, and forwards both values.
+3. The adapter binds the key to tenant, operation kind, and request identity and retains only a non-reversible key fingerprint plus private binding and outcome metadata.
+4. An identical same-key retry reconciles before any mutation. A changed tenant, operation, or request identity is invalid input.
+5. `exact_binding` maps to safe confirmed identity. If the one-time response was lost, the public result is `credentials_unavailable` and the caller performs a new rotation with a new key.
+6. `authoritative_absence` permits a fresh operation with a new key.
+7. `inconclusive` remains ambiguous and blocks conflicting mutation.
+
+The adapter's execution mechanism is private. Reconciliation may occur during the repeated request or through adapter-owned background execution. In both cases unresolved behavior survives adapter restart and Service Principal schedules nothing.
+
+No public status lookup exists. No server-generated operation ID or provider proof handle is returned. Platform correlation identifiers continue to correlate request, adapter, and audit records; operation-key telemetry uses only a non-reversible fingerprint.
+
+### 4.3 Configuration
+
+- [ ] `p2` - **ID**: `cpt-cf-service-principal-design-configuration`
+
+Typed Service Principal configuration contains:
+
+- principal name length and accepted character policy;
+- allowed client scopes;
+- best-effort maximum principals per tenant;
+- provider request timeout;
+- benchmark-approved deployment envelope once established.
+
+Configuration is explicit under `gears.service-principal.config`. Secrets, provider administrator credentials, worker settings, lease periods, retry schedules, database settings, and reconciliation retention are absent. Provider-adapter and tenant-lifecycle configuration remain owned by those components.
+
+### 4.4 Security and Data Protection
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-design-security-boundaries`
+
+Security boundaries are:
+
+1. API Gateway authenticates REST callers and injects `SecurityContext`.
+2. Service Principal authorizes the explicit tenant for every public call and retry.
+3. The provider adapter accepts only the provider-neutral contract and enforces tenant-qualified ownership against authoritative provider state.
+4. The tenant lifecycle owner authorizes deprovisioning; the provider integration deletes only exact tenant-owned principals.
+5. The identity provider owns credentials, verifier material, and token issuance.
+6. Adapter-private reconciliation contains no plaintext credential response and exposes no provider proof publicly.
+
+Credential values use redacting wrappers until final response conversion. Create and rotation bodies are excluded from logging and tracing. Panic, debug, and error formatting cannot expose secret fields. Credential responses use `Cache-Control: no-store`, and upstream proxies must not cache them. Transport security follows platform TLS and FIPS posture without gear-specific cryptography.
+
+### 4.5 Auditability and Observability
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-design-operational-signals`
+
+Audit ownership is layered:
+
+| Layer | Audit and Signal Ownership |
+|-------|----------------------------|
+| Service Principal | Current caller, target tenant, public action, authorization result, correlation ID, provider invocation status, and public outcome |
+| Provider adapter | Provider mutation, reconciliation classification, provider availability, and adapter-private retry state |
+| Tenant lifecycle owner | Cleanup attempt, retryable or terminal disposition, initiating/system actor, and final tenant disposition |
+
+Every layer propagates platform correlation and explicit tenant identity. Raw operation keys are excluded; a non-reversible fingerprint may correlate adapter records. Audit content excludes plaintext credentials, bearer tokens, full credential-bearing request bodies, and raw provider responses.
+
+Service Principal metrics include operation latency and count by action and stable public outcome plus provider availability. Adapter metrics include ambiguity, reconciliation age, and adapter execution health. Tenant lifecycle metrics include cleanup retries, terminal failures, and blocked deprovisioning. Service Principal exposes no recovery backlog, cleanup backlog, lease, or worker-health metric. Tenant and principal identifiers are never metric labels.
+
+### 4.6 Fault Tolerance
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-design-fault-tolerance`
+
+Service Principal fails closed before provider invocation when authentication, authorization, configuration, or required client resolution fails. A provider result that cannot exclude mutation is ambiguous. Restart loses only transient request context; a caller may reach any instance and repeat the identical keyed request.
+
+The adapter guarantees restart-safe reconciliation and prevents duplicate logical create or rotation mutation under concurrent or repeated same-key requests. Revoke converges through repeated deletion and success-equivalent absence.
+
+Tenant cleanup failure blocks tenant teardown. A retryable result keeps the lifecycle-owned operation eligible for retry after restart. A terminal result parks the lifecycle operation for intervention. No component reports deprovision success before authoritative zero-principal confirmation.
+
+### 4.7 Testability and Verification
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-design-test-strategy`
+
+Verification follows the repository test split:
+
+- Unit tests cover policy validation, canonical request identity, operation-key validation, secret redaction, DTO conversion, failure mapping, and permission identifiers.
+- Service tests verify authorize-before-provider ordering, re-authorization on retry, tenant-scope mismatch denial, provider absence, idempotent revoke, and absence of persistence or worker dependencies.
+- Router tests verify four operations, `Idempotency-Key` on create/rotate, OpenAPI metadata, `Location`, `no-store`, `credentials_unavailable`, RFC-9457 shape, and absence of recovery/status/cleanup routes.
+- Shared adapter conformance verifies same-key concurrency, post-restart resumption, tenant/request binding, four provider outcomes, all three proof classifications, no duplicate logical mutation, no secret replay, ownership, invalidation, and OAGW-mediated HTTP transport.
+- Tenant-lifecycle integration tests verify exact-owner purge, foreign-principal exclusion, success-equivalent absence, retryable failure, terminal failure, restart-safe lifecycle retry, and zero-principal confirmation before teardown.
+- Security tests attempt cross-tenant addressing, operation-key substitution, foreign-principal probing, scope escalation, cache disclosure, and log/telemetry disclosure.
+- E2E tests cover real REST/Rust wiring, real authorization, adapter restart seams, lost credential responses, provider integration, secret-negative surfaces, and tenant deprovisioning.
+- Benchmarks establish the PRD-required scale, latency, throughput, unavailable-provider behavior, and availability objectives before GA.
+
+### 4.8 Compliance and Privacy Posture
+
+- [ ] `p2` - **ID**: `cpt-cf-service-principal-design-compliance-posture`
+
+The gear models machine identities and intentionally collects no human profile attributes. Subject, tenant, client, scope, operation-key fingerprint, and audit identifiers remain security-sensitive and may be personal data where they identify natural persons.
+
+The provider owns principal-record residency and backup. Adapter operators own private reconciliation retention and residency. The tenant lifecycle owner owns deprovision-operation retention. Platform observability owns telemetry and audit retention. Service Principal owns no durable data set. No gear-specific regulatory claim is made; deployment-specific privacy and industry controls remain applicable.
+
+### 4.9 Migration Impact
+
+- [ ] `p2` - **ID**: `cpt-cf-service-principal-design-migration-impact`
+
+No Service Principal data migration is required because the recovery schema, worker, cleanup API, and operation-status API described by the earlier design were not implemented. The revision removes planned components rather than migrating stored records.
+
+The four lifecycle paths and operations remain. Create and rotation gain required operation-key inputs before the V1 contract is declared production-stable. Introducing that requirement after V1 stabilization would require a compatible transition or a new major version. Existing one-time credential handoff remains unchanged.
+
+Each provider adapter owns migration of any private reconciliation state and must pass the revised conformance suite before qualification. Tenant lifecycle integration owns any migration of its deprovision state. No plaintext credential data is migrated.
+
+### 4.10 Assumptions and Baseline Deviations
+
+- [ ] `p2` - **ID**: `cpt-cf-service-principal-design-assumptions-deviations`
+
+Assumptions:
+
+- One conforming provider adapter is configured per deployment.
+- The adapter can bind keyed create and rotation to authoritative provider evidence and preserve unresolved reconciliation across restart.
+- The identity provider can immediately invalidate superseded credentials and confirm tenant-owned principal absence.
+- The tenant lifecycle owner supplies durable deprovision retry state.
+- Production objectives are supplied by the benchmark release gate.
+
+Local architecture allocations:
+
+- Service Principal is a stateless authorization and provider-delegation boundary.
+- The adapter owns create and rotation reconciliation semantics and private state.
+- The tenant lifecycle owner and identity-provider integration own tenant cleanup durability and execution.
+- Service Principal emits public lifecycle audit facts in addition to platform request and authorization records.
+
+There are no approved deviations from SDK-first contracts, authenticated `OperationBuilder` routes, canonical RFC-9457 errors, OAGW-mediated HTTP egress, or fail-closed authorization.
+
+### 4.11 Explicit Non-Applicability
+
+- Frontend state, responsive design, accessibility, internationalization, and offline UI support are not applicable because the capability has no user interface.
+- Browser sessions, gear-owned MFA, and gear-owned SSO are not applicable because platform authentication owns management-call identity.
+- CDN and edge caching are not applicable; credential responses are explicitly non-cacheable.
+- Service Principal event sourcing, public lifecycle streaming, event replay, and broker dead-letter queues are not applicable.
+- Service Principal databases, schemas, migrations, Secure ORM repositories, task leases, retry workers, and recovery queues are not applicable.
+- Gear-owned Terraform, container manifests, service-mesh policy, canary logic, and blue/green orchestration are not applicable because the gear is deployment-neutral.
+- Provider-principal sharding, replication, backup, and point-in-time recovery are not applicable because the identity provider owns authoritative principal data.
+- A currency-denominated gear cost budget is not applicable; quotas and benchmark-approved deployment envelopes provide capacity inputs.
+- Industry-specific certification and consent-management workflows are not applicable because the capability introduces no human profile collection.
+
+## 5. Traceability
+
+- **PRD**: [PRD.md](./PRD.md)
+- **UPSTREAM_REQS**: No upstream requirements artifact exists for this gear.
+- **ADRs**: None. This DESIGN states architecture without embedding decision debates.
+- **Features**: No feature artifact exists for this gear.
+- **Implementation allocation**: Feature decomposition and code traceability are downstream work.
+
+### Requirement Allocation Summary
+
+| Design Area | PRD Coverage |
+|-------------|--------------|
+| Stateless architecture and provider boundary | `cpt-cf-service-principal-fr-provider-delegation`, `cpt-cf-service-principal-fr-provider-required`, `cpt-cf-service-principal-interface-rust-sdk`, `cpt-cf-service-principal-contract-provider-adapter`, `cpt-cf-service-principal-nfr-stateless-recovery` |
+| REST and public SDK contracts | `cpt-cf-service-principal-fr-create`, `cpt-cf-service-principal-fr-list`, `cpt-cf-service-principal-fr-rotate-secret`, `cpt-cf-service-principal-fr-revoke`, `cpt-cf-service-principal-interface-rest`, `cpt-cf-service-principal-interface-rust-sdk` |
+| Authorization and GTS catalog | `cpt-cf-service-principal-fr-authenticated-management`, `cpt-cf-service-principal-fr-independent-permissions`, `cpt-cf-service-principal-fr-tenant-authorization`, `cpt-cf-service-principal-fr-authz-fail-closed`, `cpt-cf-service-principal-interface-managed-resource`, `cpt-cf-service-principal-contract-authorization` |
+| Secret safety and invalidation | `cpt-cf-service-principal-fr-client-credentials-only`, `cpt-cf-service-principal-fr-identity-context`, `cpt-cf-service-principal-fr-secret-free-listing`, `cpt-cf-service-principal-nfr-secret-confidentiality`, `cpt-cf-service-principal-nfr-no-secret-persistence`, `cpt-cf-service-principal-nfr-credential-invalidation` |
+| Input, quota, collision, and ownership | `cpt-cf-service-principal-fr-name-policy`, `cpt-cf-service-principal-fr-scope-allowlist`, `cpt-cf-service-principal-fr-tenant-quota`, `cpt-cf-service-principal-fr-create-collision`, `cpt-cf-service-principal-fr-ownership-addressing`, `cpt-cf-service-principal-fr-rotate-complete-state` |
+| Failure and operation-key reconciliation | `cpt-cf-service-principal-fr-failure-categories`, `cpt-cf-service-principal-fr-ambiguous-create-recovery`, `cpt-cf-service-principal-fr-ambiguous-rotate-recovery`, `cpt-cf-service-principal-fr-ambiguous-revoke-recovery` |
+| Tenant lifecycle cleanup | `cpt-cf-service-principal-fr-revoke-idempotent`, `cpt-cf-service-principal-fr-tenant-cleanup`, `cpt-cf-service-principal-contract-tenant-cleanup`, `cpt-cf-service-principal-nfr-cleanup-reliability` |
+| Security, audit, and operations | `cpt-cf-service-principal-nfr-data-classification`, `cpt-cf-service-principal-nfr-tenant-isolation`, `cpt-cf-service-principal-nfr-auditability`, `cpt-cf-service-principal-nfr-observability` |
+| Conformance and release qualification | `cpt-cf-service-principal-nfr-provider-conformance`, `cpt-cf-service-principal-nfr-contract-compatibility`, `cpt-cf-service-principal-nfr-performance-baseline`, `cpt-cf-service-principal-nfr-operational-documentation` |

--- a/gears/system/service-principal/docs/DESIGN.md
+++ b/gears/system/service-principal/docs/DESIGN.md
@@ -22,7 +22,7 @@ Created: 2026-08-07 by Constructor Studio
   - [3.8 Deployment Topology](#38-deployment-topology)
 - [4. Additional Context](#4-additional-context)
   - [4.1 Failure Taxonomy and Wire Safety](#41-failure-taxonomy-and-wire-safety)
-  - [4.2 Operation-Key Reconciliation](#42-operation-key-reconciliation)
+  - [4.2 Ambiguous Outcome Handling](#42-ambiguous-outcome-handling)
   - [4.3 Configuration](#43-configuration)
   - [4.4 Security and Data Protection](#44-security-and-data-protection)
   - [4.5 Auditability and Observability](#45-auditability-and-observability)
@@ -34,24 +34,44 @@ Created: 2026-08-07 by Constructor Studio
   - [4.11 Explicit Non-Applicability](#411-explicit-non-applicability)
 - [5. Traceability](#5-traceability)
   - [Requirement Allocation Summary](#requirement-allocation-summary)
+- [Appendix A: Decision Rationale](#appendix-a-decision-rationale)
+  - [No by-id read on the item path](#no-by-id-read-on-the-item-path)
+  - [409 for ambiguous outcomes](#409-for-ambiguous-outcomes)
+  - [Supersession of pre-port drafts](#supersession-of-pre-port-drafts)
 
 <!-- /toc -->
 
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-design-provider-neutral-lifecycle`
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-design-provider-neutral-facade`
 
 ## 1. Architecture Overview
 
 ### 1.1 Architectural Vision
 
-Service Principal is a stateless system gear for managing tenant-owned machine identities. It exposes stable REST and Rust contracts for create, list, rotate, and revoke. It authenticates and authorizes every request for an explicit tenant, applies provider-neutral policy, delegates to one configured identity-provider adapter, and maps the result to safe public responses.
+Service Principal is a stateless system gear that exposes create, list, rotate-secret, and revoke
+operations for tenant-owned machine identities (confidential OAuth 2.0 `client_credentials`
+clients). It is a thin authenticated REST facade: it holds no database and starts no background
+work. Its only logic is authorization and error mapping.
 
-The identity provider remains authoritative for principals, credentials, verifier material, and token issuance. The adapter owns any durable state needed to reconcile create or rotation after an uncertain provider result. Service Principal owns no principal database, operation repository, cleanup record, lease, retry scheduler, or background worker.
+Per request the gear acts as the local Policy Enforcement Point (PEP). It asks the platform's
+Policy Decision Point (PDP), the `authz-resolver` gear, for a decision and a tenant-scoped
+constraint through `authz_resolver_sdk::pep::PolicyEnforcer`, verifies that the returned scope
+actually covers the explicit target tenant, and only then resolves the registered
+`ServicePrincipalClientV1` provider adapter lazily from the `toolkit::ClientHub` and delegates.
+The provider adapter is not shipped in this repository; it is a pluggable implementation a
+deployment registers.
 
-Create and rotate require a caller-generated operation key. Service Principal validates and forwards the opaque key and canonical request identity. A repeated identical request with the same key is the only public reconciliation path. There is no recovery-status API, server-generated operation identifier, or public reconciliation handle. Plaintext credentials are returned only by a confirmed create or rotation response and are never persisted or replayed.
+The identity provider behind the adapter is authoritative for principal existence, credentials,
+and token issuance. The adapter enforces name syntax, the scope allowlist, and a best-effort
+per-tenant quota; Service Principal performs no independent validation of those fields before
+delegating. The adapter's four-category failure taxonomy
+(`InvalidInput`/`NotFound`/`CleanFailure`/`Ambiguous`) is mapped, together with the gear's own
+`AccessDenied` and `ProviderUnavailable` outcomes, onto canonical RFC-9457 problem responses at
+the REST boundary. An ambiguous provider outcome is surfaced as its own distinct failure; the gear
+performs no idempotency-key or operation-key based reconciliation of it.
 
-Tenant cleanup is part of the identity-provider tenant-deprovision contract, not the Service Principal API. The tenant lifecycle owner retains durable deprovision state and retries the whole operation after transient failure. The provider adapter deletes only principals authoritatively owned by the target tenant and returns success only after confirming that none remain.
-
-This multi-owner design is shown explicitly in the component and sequence diagrams. The diagrams are warranted because request authorization, provider reconciliation, and tenant cleanup have different state and retry owners.
+The component and sequence diagrams in this document are warranted because create, list, rotate,
+and revoke each cross three independent trust boundaries — the caller, the PDP, and the pluggable
+provider — and the diagrams make that boundary crossing explicit.
 
 ### 1.2 Architecture Drivers
 
@@ -59,90 +79,74 @@ This multi-owner design is shown explicitly in the component and sequence diagra
 
 | Requirement | Design Response |
 |-------------|-----------------|
-| `cpt-cf-service-principal-fr-create` | The application service authorizes the explicit tenant and delegates a keyed create to the provider adapter. |
-| `cpt-cf-service-principal-fr-client-credentials-only` | The provider contract accepts only confidential `client_credentials` identity requests. |
-| `cpt-cf-service-principal-fr-identity-context` | Provider conformance verifies tenant, subject, and service identity in issued tokens. |
-| `cpt-cf-service-principal-fr-name-policy` | Typed configuration supplies bounded name rules checked before provider invocation. |
-| `cpt-cf-service-principal-fr-scope-allowlist` | The application service rejects scopes outside the deployment allowlist. |
-| `cpt-cf-service-principal-fr-tenant-quota` | Provider-owned inventory supplies the observed count for best-effort quota checks. |
-| `cpt-cf-service-principal-fr-create-collision` | A collision is invalid input; create never adopts or modifies the occupied principal. |
-| `cpt-cf-service-principal-fr-list` | Listing delegates after tenant authorization and returns provider-authoritative summaries. |
-| `cpt-cf-service-principal-fr-secret-free-listing` | Summary models have no secret field and are distinct from credential models. |
-| `cpt-cf-service-principal-fr-ownership-addressing` | Item operations use `(tenant_id, client_id)` and do not distinguish foreign from absent principals publicly. |
-| `cpt-cf-service-principal-fr-rotate-secret` | Keyed rotation returns one transient credential result after confirmed invalidation. |
-| `cpt-cf-service-principal-fr-rotate-complete-state` | The adapter verifies tenant ownership and managed state before rotation. |
-| `cpt-cf-service-principal-fr-revoke` | Revocation uses a tenant-qualified provider address and confirms deletion or absence. |
-| `cpt-cf-service-principal-fr-revoke-idempotent` | Provider not-found is success-equivalent for revoke. |
-| `cpt-cf-service-principal-fr-authenticated-management` | REST routes are authenticated and Rust operations require `SecurityContext`. |
-| `cpt-cf-service-principal-fr-independent-permissions` | GTS permissions define create, read, rotate-secret, and revoke independently. |
-| `cpt-cf-service-principal-fr-tenant-authorization` | `PolicyEnforcer` evaluates the target tenant and the service verifies covering constraints. |
-| `cpt-cf-service-principal-fr-authz-fail-closed` | Missing identity, denial, evaluation failure, or mismatched constraints prevents provider access. |
-| `cpt-cf-service-principal-fr-provider-delegation` | A major-versioned provider SDK isolates provider-specific behavior. |
-| `cpt-cf-service-principal-fr-provider-required` | Missing provider registration maps to provider unavailable; success is never simulated. |
-| `cpt-cf-service-principal-fr-failure-categories` | Adapter outcomes map to the closed public taxonomy and canonical errors. |
-| `cpt-cf-service-principal-fr-ambiguous-create-recovery` | Same-key create retries reconcile in the adapter before any further mutation. |
-| `cpt-cf-service-principal-fr-ambiguous-rotate-recovery` | Same-key rotation retries reconcile; lost credentials are replaced by a new confirmed rotation. |
-| `cpt-cf-service-principal-fr-ambiguous-revoke-recovery` | Revoke remains safely repeatable until deletion or absence is confirmed. |
-| `cpt-cf-service-principal-fr-tenant-cleanup` | The identity-provider tenant-deprovision path performs cleanup while the lifecycle owner retains retry state. |
+| `cpt-cf-service-principal-fr-create` | `Service::create` authorizes the `create` action for the explicit tenant, then delegates to `ServicePrincipalClientV1::create`; the REST handler returns `201 Created` with `Location` and `Cache-Control: no-store`. |
+| `cpt-cf-service-principal-fr-client-credentials-only` | The SDK request/response models (`CreateServicePrincipalRequest`, `ServicePrincipalCredentials`) carry no field for an interactive or session-based flow. |
+| `cpt-cf-service-principal-fr-identity-context` | `CreateServicePrincipalRequest.tenant_id` is forwarded to the adapter; `ServicePrincipalCredentials.subject_id` returns the adapter-assigned subject. |
+| `cpt-cf-service-principal-fr-name-policy` | The gear forwards `name` unmodified; the registered adapter enforces bounded syntax and reports a violation as `ServicePrincipalFailure::InvalidInput`. |
+| `cpt-cf-service-principal-fr-scope-allowlist` | The gear forwards `scopes` unmodified; the registered adapter enforces its deployment-controlled allowlist and reports a violation as `InvalidInput`. |
+| `cpt-cf-service-principal-fr-tenant-quota` | The registered adapter may apply a best-effort maximum-per-tenant check; `Service` performs no counting of its own. |
+| `cpt-cf-service-principal-fr-create-collision` | A taken client identifier is reported by the adapter as `InvalidInput`; `Service` never resumes or modifies an existing principal. |
+| `cpt-cf-service-principal-fr-list` | `Service::list` authorizes `read` and returns `ServicePrincipalSummary` values in the adapter's own order; the REST handler wraps them in `ListServicePrincipalsResponseDto`. |
+| `cpt-cf-service-principal-fr-secret-free-listing` | `ServicePrincipalSummary` and `ServicePrincipalSummaryDto` declare no secret field. |
+| `cpt-cf-service-principal-fr-ownership-addressing` | `rotate_secret` and `revoke` take `(tenant_id, client_id)`; the adapter returns `NotFound` for an id that does not resolve within that tenant, without revealing whether it exists under another tenant. |
+| `cpt-cf-service-principal-fr-rotate-secret` | `Service::rotate_secret` authorizes `rotate_secret` and returns one new `ServicePrincipalCredentials`; the REST handler returns `200 OK` with `Cache-Control: no-store`. |
+| `cpt-cf-service-principal-fr-rotate-complete-state` | An unresolved `client_id` at rotation time is mapped from the adapter's `NotFound` to a `404` canonical problem, never a success. |
+| `cpt-cf-service-principal-fr-revoke` | `Service::revoke` authorizes `revoke`, delegates to `ServicePrincipalClientV1::revoke`, and the REST handler returns `204 No Content` carrying no body. |
+| `cpt-cf-service-principal-fr-revoke-idempotent` | `Service::revoke` maps both `Ok(())` and `ServicePrincipalFailure::NotFound` to success before any error conversion. |
+| `cpt-cf-service-principal-fr-authenticated-management` | All four `OperationBuilder` routes call `.authenticated()`; every handler takes a `SecurityContext` extension. |
+| `cpt-cf-service-principal-fr-independent-permissions` | `gts::permissions` declares four `AuthzPermissionV1` instances (`create`, `read`, `rotate_secret`, `revoke`) against the service-principal resource type. |
+| `cpt-cf-service-principal-fr-tenant-authorization` | `Service::authorize` builds an `AccessRequest` with `OWNER_TENANT_ID` and `require_constraints(true)`, then `authz::ensure_scope_permits` checks the returned `AccessScope` against the explicit tenant. |
+| `cpt-cf-service-principal-fr-authz-fail-closed` | `authz::map_enforcer_err` maps `Denied` and `CompileFailed` to `AccessDenied`, and `EvaluationFailed` to `Upstream`; no branch defaults to allow. |
+| `cpt-cf-service-principal-fr-provider-delegation` | Every lifecycle call goes through the versioned `ServicePrincipalClientV1` trait, resolved by `hub.get::<dyn ServicePrincipalClientV1>()`. |
+| `cpt-cf-service-principal-fr-provider-required` | `Service::sp_client` maps a `ClientHub` resolution failure to `DomainError::ProviderUnavailable` (`503`), logging the underlying `ClientHubError` rather than simulating success. |
+| `cpt-cf-service-principal-fr-failure-categories` | `From<ServicePrincipalFailure> for DomainError` and `From<DomainError> for CanonicalError` together render a distinct, machine-readable problem for each of the six outcomes. |
+| `cpt-cf-service-principal-fr-ambiguous-outcome-signaling` | `DomainError::Ambiguous` maps to `409 Aborted` with reason `AMBIGUOUS_OUTCOME`, distinct from the `503` used for `Upstream`/`ProviderUnavailable`. |
 
 #### NFR Allocation
 
-| NFR ID | Allocated To | Design Response | Verification Approach |
-|--------|--------------|-----------------|----------------------|
-| `cpt-cf-service-principal-nfr-secret-confidentiality` | Credential models, REST adapter, logging policy | Credential responses are non-cacheable and secret values are absent from all other contracts. | Secret-negative unit, route, conformance, and E2E tests |
-| `cpt-cf-service-principal-nfr-data-classification` | SDK models, adapter contract, audit boundary | Contract fields are classified; human profile fields are excluded. | Contract inspection and security review |
-| `cpt-cf-service-principal-nfr-no-secret-persistence` | Stateless service and adapter conformance | Service Principal persists nothing; adapters never retain credential responses for replay. | State-boundary inspection and secret-negative tests |
-| `cpt-cf-service-principal-nfr-tenant-isolation` | Authorization gate and provider adapter | PDP constraints cover the target tenant and provider addressing is tenant-qualified. | Cross-tenant security suite |
-| `cpt-cf-service-principal-nfr-credential-invalidation` | Provider adapter | Rotation and revoke success require superseded credentials to stop working. | Provider conformance and E2E tests |
-| `cpt-cf-service-principal-nfr-provider-conformance` | Provider SDK and conformance harness | Every adapter runs common lifecycle, ownership, reconciliation, and credential checks. | Mandatory adapter suite |
-| `cpt-cf-service-principal-nfr-contract-compatibility` | REST V1 and Rust V1 contracts | Breaking route, model, identifier, or category changes require a new major version. | API and SDK compatibility checks |
-| `cpt-cf-service-principal-nfr-auditability` | Service, adapter, and tenant lifecycle owner | Each layer records the facts it owns under shared correlation and tenant identity. | Layered audit-completeness tests |
-| `cpt-cf-service-principal-nfr-observability` | Service, adapter, and tenant lifecycle owner | API, reconciliation, and cleanup signals remain separated and correlatable. | Telemetry integration tests |
-| `cpt-cf-service-principal-nfr-stateless-recovery` | Provider adapter contract | Adapter reconciliation survives restart; Service Principal owns no durable state. | Restart and same-key retry tests |
-| `cpt-cf-service-principal-nfr-cleanup-reliability` | Tenant lifecycle owner and identity-provider integration | Lifecycle state survives restart and teardown remains blocked until zero principals are confirmed. | Deprovision retry and terminal-failure tests |
-| `cpt-cf-service-principal-nfr-performance-baseline` | Benchmark harness | Release evidence supplies measured objectives instead of invented values. | Versioned benchmark report |
-| `cpt-cf-service-principal-nfr-operational-documentation` | OpenAPI and operator guidance | Guidance covers secret handoff, same-key retry, rotation recovery, cleanup ownership, and alerts. | Release-readiness inspection |
+| NFR ID | NFR Summary | Allocated To | Design Response | Verification Approach |
+|--------|-------------|--------------|-----------------|----------------------|
+| `cpt-cf-service-principal-nfr-secret-confidentiality` | No secret in listings, `Debug`, or cacheable responses | `ServicePrincipalCredentials`, `ServicePrincipalCredentialsDto`, REST handlers | `client_secret` is a `secrecy::SecretString`; the DTO hand-writes a redacting `Debug`; `create`/`rotate_secret` handlers set `Cache-Control: no-store`. | `dto_tests::credentials_debug_redacts_secret`; `models.rs::credentials_debug_hides_secret`; router `no-store` assertions |
+| `cpt-cf-service-principal-nfr-data-classification` | Restricted-vs-sensitive field classification | SDK models, DTOs | The secret is a redacting, non-`Serialize` wrapper; client id, subject id, tenant id, and scopes are plain fields carrying no human profile data. | Contract inspection; redaction tests |
+| `cpt-cf-service-principal-nfr-no-secret-persistence` | No gear-owned persistence of secrets or state | `domain::service::Service` | `Service` holds only a `PolicyEnforcer` and an `Arc<ClientHub>`; the crate declares no database or storage dependency. | Cargo.toml dependency inspection; `#[domain_model]` compile-time check |
+| `cpt-cf-service-principal-nfr-tenant-isolation` | No cross-tenant management success | `domain::authz` | `ensure_scope_permits` denies unless the PDP scope is unconstrained or explicitly covers the target tenant UUID. | `domain/authz.rs` unit tests; `service_tests::create_for_a_different_tenant_than_the_pdp_scope_is_access_denied` |
+| `cpt-cf-service-principal-nfr-stateless-recovery` | No authoritative state carried across requests | `ServicePrincipalGear`, `Service` | The gear declares no database, migration, or worker dependency in `Cargo.toml`; every field the `Service` holds is re-usable, not per-request state. | Dependency-graph inspection |
+| `cpt-cf-service-principal-nfr-contract-compatibility` | Explicit major-version markers | REST paths, `ServicePrincipalClientV1` | REST paths embed `v1`; the SDK crate name and trait carry `V1`; a breaking change requires a new major surface. | Route and SDK naming inspection |
+
+#### Key ADRs
+
+No ADR artifact exists for this gear. The body sections state the resulting architecture directly;
+the rationale behind three of those facts is recorded non-normatively in
+[Appendix A](#appendix-a-decision-rationale).
 
 ### 1.3 Architecture Layers
 
 ```mermaid
 graph TB
-    Caller[Administrator or Consuming Gear]
+    Caller[Tenant Automation Administrator or Consuming Gear]
     REST[REST and OpenAPI Adapter]
-    Local[Public Rust Local Client]
     Service[Stateless Application Service]
     AuthZ[Authorization Gate]
-    Provider[Provider Adapter Contract]
-    AdapterState[Adapter-Private Reconciliation State]
-    OAGW[Outbound API Gateway]
+    Hub[ClientHub]
+    SPI[Provider Adapter - ServicePrincipalClientV1]
     IdP[Identity Provider]
-    Lifecycle[Tenant Lifecycle Owner]
-    Audit[Layered Audit and Observability]
 
     Caller --> REST
-    Caller --> Local
     REST --> Service
-    Local --> Service
     Service --> AuthZ
-    Service --> Provider
-    Provider --> AdapterState
-    Provider --> OAGW
-    OAGW --> IdP
-    Lifecycle -->|tenant deprovision| Provider
-    Service --> Audit
-    Provider --> Audit
-    Lifecycle --> Audit
+    Service --> Hub
+    Hub --> SPI
+    SPI --> IdP
 ```
 
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-tech-layered-control-plane`
+- [ ] `p3` - **ID**: `cpt-cf-service-principal-tech-layered-facade`
 
 | Layer | Responsibility | Technology |
-|-------|----------------|------------|
-| Presentation | Authenticated routing, DTO conversion, `Idempotency-Key`, non-cacheable credential responses, canonical errors | Axum, `OperationBuilder`, OpenAPI |
-| Application | Validation, explicit-tenant authorization, provider delegation, public outcome mapping | Rust domain service, `PolicyEnforcer`, ClientHub |
-| Domain | Stable lifecycle models, operation-key binding, failure semantics | Rust SDK and domain models |
-| Provider integration | Provider protocol, authoritative state access, restart-safe reconciliation, tenant purge implementation | Provider adapter, adapter-private state, OAGW |
-| Tenant lifecycle | Durable deprovision operation, cleanup retry scheduling, terminal disposition | Tenant lifecycle contract and owner |
+|-------|-----------------|------------|
+| Presentation | Authenticated routing, DTO conversion, `Location`/`Cache-Control: no-store` headers, RFC-9457 rendering | `axum`, `toolkit::api::OperationBuilder`, OpenAPI |
+| Application | Explicit-tenant authorization, provider delegation, outcome mapping | `domain::service::Service`, `authz_resolver_sdk::pep::PolicyEnforcer` |
+| Domain | Domain error model, PEP resource type, permission catalog | `domain::error::DomainError`, `domain::authz`, `gts::permissions` |
+| Infrastructure | Transport-neutral SDK models and the pluggable provider contract, resolved through `ClientHub` | `service-principal-sdk`, `toolkit::ClientHub` |
 
 ## 2. Principles & Constraints
 
@@ -152,31 +156,42 @@ graph TB
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-principle-provider-authority`
 
-The identity provider is the sole authority for principal existence, credentials, verifier material, and token behavior. Service Principal does not copy provider inventory or retain reconciliation state.
+The registered identity-provider adapter is the sole authority for principal existence,
+credentials, and token issuance. Service Principal copies no provider inventory and retains no
+provider state between requests.
 
-#### One-Time Secret Boundary
+#### One-Time Secret Disclosure
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-principle-one-time-secret`
 
-Plaintext credentials cross the public boundary only after confirmed create or rotation. Lost credentials are replaced through a new rotation and are never retrieved or replayed.
+A plaintext client secret crosses the public boundary only in the response body of a successful
+`create` or `rotate_secret` call. It is never returned by `list`, and a lost secret is recovered
+only through a new rotation.
 
 #### Authorize the Explicit Tenant
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-principle-explicit-tenant-authorization`
 
-Every public request and same-key retry re-authenticates and authorizes its explicit target tenant before provider access. Prior authorization stored by another component never substitutes for the current decision.
+Every request re-authenticates and re-authorizes its explicit target tenant against the PDP
+before any provider delegation. A PDP decision that is `true` for a different tenant or a wider
+subtree never substitutes for a check against the requested tenant.
 
-#### Stateless Recovery Boundary
+#### Delegated Validation, Delegated Reconciliation
 
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-principle-safe-recovery`
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-principle-delegated-validation`
 
-Service Principal forwards operation identity but owns no recovery execution. The adapter reconciles create and rotation before mutation. Revoke converges through repeated tenant-qualified deletion. Tenant cleanup converges through lifecycle-owned deprovision retries.
+Name syntax, scope allowlisting, and per-tenant quota are enforced entirely by the registered
+provider adapter. Service Principal performs no independent validation of those fields and
+performs no automatic recovery when the adapter reports an ambiguous outcome; recovery is left to
+the caller.
 
 #### Stable Contracts, Replaceable Providers
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-principle-versioned-contracts`
 
-Public and provider contracts are major-versioned and provider-neutral. Unknown result categories are always non-success and behave as ambiguous when mutation cannot be ruled out.
+The REST surface and the `ServicePrincipalClientV1` trait are each versioned, so a conforming
+provider adapter can be substituted without changing callers, and a breaking change to either
+surface requires a new major version.
 
 ### 2.2 Constraints
 
@@ -184,192 +199,172 @@ Public and provider contracts are major-versioned and provider-neutral. Unknown 
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-constraint-single-provider`
 
-The initial design resolves one provider adapter for the deployment. Selection does not vary by tenant or request. Missing registration is an explicit provider-unavailable failure.
+Exactly one `ServicePrincipalClientV1` implementation is resolved from the `ClientHub` per
+deployment. Selection does not vary by tenant or by request. No adapter implementation ships in
+this repository.
 
 #### No Distributed Transaction
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-constraint-no-distributed-transaction`
 
-Service Principal and the external identity provider do not share a transaction. Mutation uncertainty is represented by the adapter outcome and reconciled under the same operation key.
+Service Principal and the registered provider do not share a transaction. Transport uncertainty is
+reported by the adapter as `ServicePrincipalFailure::Ambiguous` and surfaced to the caller as a
+distinct `409` outcome; the gear applies no retry or reconciliation logic of its own.
 
-#### Provider Capability Floor
+#### No Adapter Conformance Harness
 
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-constraint-provider-capabilities`
+- [ ] `p2` - **ID**: `cpt-cf-service-principal-constraint-no-conformance-harness`
 
-A conforming adapter supports confidential client credentials, tenant-qualified ownership, immediate invalidation, collision detection, restart-safe keyed reconciliation, safe failure classification, and authoritative tenant-principal cleanup through the tenant-deprovision integration.
+This repository defines only the `ServicePrincipalClientV1` trait contract. No shared
+cross-adapter conformance test suite exists to validate a second adapter's ownership,
+invalidation, or failure-category behavior.
 
 #### Bounded Administrative Workload
 
 - [ ] `p2` - **ID**: `cpt-cf-service-principal-constraint-bounded-workload`
 
-Lifecycle calls are low-frequency administrative operations. Initial listing is unpaginated and bounded by the configured tenant quota. Pagination and strong quota serialization require measured evidence and a compatible contract extension.
+Lifecycle calls are low-frequency administrative operations, not request-path operations. Listing
+is unpaginated; the collection size is bounded by whatever quota the registered adapter enforces.
 
 ## 3. Technical Architecture
 
 ### 3.1 Domain Model
 
-**Technology**: GTS identifiers and transport-neutral Rust models
+**Technology**: Transport-neutral Rust structs and a `thiserror` domain error enum
 
-**Location**: `gears/system/service-principal/service-principal-sdk/src/`
+**Location**: `gears/system/service-principal/service-principal-sdk/src/models.rs`,
+`gears/system/service-principal/service-principal-sdk/src/error.rs`,
+`gears/system/service-principal/service-principal/src/domain/error.rs`
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-entity-lifecycle-model`
 
 | Entity | Description | Security Classification |
-|--------|-------------|-------------------------|
-| Create Request | Explicit tenant, bounded name, allowed scopes, and `OperationKey` | Security-sensitive control-plane metadata |
-| Rotate Request | Tenant-qualified principal and `OperationKey` | Security-sensitive control-plane metadata |
-| Service Principal Credentials | Client ID, one-time secret, token endpoint, stable subject ID | Secret is restricted; other fields are security-sensitive |
-| Service Principal Summary | Client ID, enabled state, scopes, stable subject when supported | Security-sensitive; never contains a secret |
-| Canonical Request Identity | Versioned identity of tenant, operation, and normalized non-secret input | Security-sensitive reconciliation metadata |
-| Provider Outcome | Stable category, mutation certainty, safe remediation, and optional confirmed principal identity | Security-sensitive operational metadata |
-| Provider Proof Classification | Adapter-private `exact_binding`, `authoritative_absence`, or `inconclusive` result | Security-sensitive adapter metadata; not public wire data |
-| Audit Fact | Actor, tenant, action, time, correlation, and outcome | Security-sensitive audit metadata |
+|--------|-------------|--------------------------|
+| `CreateServicePrincipalRequest` | Explicit `tenant_id`, caller-chosen `name`, and `scopes` for a create call | Security-sensitive control-plane metadata |
+| `ServicePrincipalCredentials` | `client_id`, `client_secret` (`SecretString`), `token_url`, `subject_id` | `client_secret` is restricted; other fields are security-sensitive |
+| `ServicePrincipalSummary` | `client_id`, `enabled`, `scopes`; no secret field | Security-sensitive; never contains a secret |
+| `ServicePrincipalFailure` | Closed four-variant adapter failure taxonomy: `InvalidInput`, `NotFound`, `CleanFailure`, `Ambiguous` | Security-sensitive operational metadata |
+| `DomainError` | Gear-level error enum: `InvalidInput`, `NotFound`, `AccessDenied`, `ProviderUnavailable`, `Upstream`, `Ambiguous` | Security-sensitive operational metadata |
 
 Relationships are bounded as follows:
 
-- An operation key is bound to one tenant, operation kind, and canonical request identity.
-- Credential models are returned only by confirmed create and rotation.
-- Provider proof classification maps to a public category and remediation without exposing provider evidence.
-- Service Principal retains none of these entities after request completion.
+- `ServicePrincipalCredentials` is produced only by `create` and `rotate_secret`.
+- `DomainError` is derived from `ServicePrincipalFailure` (via `From<ServicePrincipalFailure>`) for
+  every operation except `revoke`, which treats `NotFound` as success before that conversion runs.
+- `DomainError::AccessDenied` and `DomainError::ProviderUnavailable` originate in the gear, not in
+  the adapter.
+- Service Principal retains none of these values after a request completes.
 
 ### 3.2 Component Model
 
 ```mermaid
 graph LR
     API[REST Adapter]
-    SDK[Public Local Client]
-    SVC[Stateless Application Service]
+    SVC[Application Service]
     PEP[Authorization Gate]
-    SPI[Service Principal Provider Client V1]
-    TLS[Tenant Lifecycle Owner]
-    TDP[Tenant Deprovision Provider Contract]
-    CAT[GTS Catalog]
-    OBS[Layered Audit and Observability]
+    HUB[ClientHub]
+    SPI[Provider Adapter - ServicePrincipalClientV1]
+    CAT[GTS Permission Catalog]
 
     API --> SVC
-    SDK --> SVC
     SVC --> PEP
-    SVC --> SPI
-    TLS --> TDP
+    SVC --> HUB
+    HUB --> SPI
     CAT -. registers .-> PEP
-    SVC --> OBS
-    SPI --> OBS
-    TDP --> OBS
-    TLS --> OBS
 ```
 
 #### REST and OpenAPI Adapter
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-component-rest-adapter`
 
-**Purpose**: Expose the stable HTTP contract while keeping HTTP types outside domain and SDK layers.
+**Purpose**: Expose the stable HTTP contract while keeping HTTP types out of the domain and SDK
+layers.
 
 **Responsibilities**:
 
-- Register the four routes with `OperationBuilder`.
-- Require authentication and standard errors.
-- Require `Idempotency-Key` for create and rotate.
-- Convert DTOs and apply `Location` and `Cache-Control: no-store` where required.
-- Render canonical RFC-9457 Problems without provider diagnostics.
+- Register the four routes in `api::rest::routes::register_routes` through `OperationBuilder`.
+- Require `.authenticated()` and register standard errors and OpenAPI schemas for every route.
+- Convert DTOs (`api::rest::dto`) at the boundary and add `Location` (create) and
+  `Cache-Control: no-store` (create, rotate_secret).
+- Render `DomainError` as a canonical RFC-9457 problem via `api::rest::error`.
 
-**Boundaries**: It does not authorize, call the provider directly, persist state, expose status endpoints, or log credential-bearing bodies.
-
-#### Public Rust Local Client
-
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-component-public-client`
-
-**Purpose**: Give trusted gears the same four operations without REST coupling.
-
-**Responsibilities**: Propagate `SecurityContext`, explicit tenant identity, and `OperationKey` for create and rotate; delegate to the application service; map domain failures to the closed public taxonomy.
-
-**Boundaries**: It exposes no provider client, cleanup method, recovery lookup, retry scheduler, or provider proof model.
+**Boundaries**: It does not authorize, call the provider adapter directly, persist state, or
+expose a single-item `GET` (the item path registers only `rotate-secret` and `DELETE`).
 
 #### Application Service
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-component-application-service`
 
-**Purpose**: Enforce public lifecycle policy before provider access.
+**Purpose**: Enforce authorization before provider delegation and map provider outcomes.
 
 **Responsibilities**:
 
-- Validate names, scopes, quota policy, operation keys, and tenant-qualified addresses.
-- Authenticate and authorize the explicit tenant for every call, including same-key retries.
-- Derive the versioned canonical non-secret request identity.
-- Delegate lifecycle operations and map provider outcomes.
-- Return one-time credentials only on confirmed synchronous success.
-- Emit request-level audit and telemetry facts.
+- Authorize the explicit tenant for `create`, `read`, `rotate_secret`, or `revoke` via
+  `domain::service::Service::authorize` before any provider call.
+- Resolve `ServicePrincipalClientV1` lazily from the `ClientHub` per call.
+- Delegate the four lifecycle operations and map `ServicePrincipalFailure` to `DomainError`.
+- Treat a `revoke` against an absent principal as success.
 
-**Boundaries**: It has no database, durable operation model, cleanup method, worker, provider protocol, or plaintext-secret store.
+**Boundaries**: It performs no name, scope, or quota validation of its own; it holds no database,
+worker, or provider protocol logic.
 
 #### Authorization Gate
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-component-authorization-gate`
 
-**Purpose**: Enforce tenant object-level authorization for high-impact machine identities.
+**Purpose**: Enforce object-level (tenant) authorization for a high-impact machine-identity
+resource type.
 
-**Responsibilities**: Use `PolicyEnforcer` with `owner_tenant_id`, require constraints, and verify that `AccessScope` covers the explicit tenant for `create`, `read`, `rotate_secret`, or `revoke`.
+**Responsibilities**: Build an `AccessRequest` with `pep_properties::OWNER_TENANT_ID` and
+`require_constraints(true)`, call `PolicyEnforcer::access_scope_with` against the
+`SERVICE_PRINCIPAL` `ResourceType`, and verify with `ensure_scope_permits` that the returned
+`AccessScope` covers the explicit tenant UUID (or is unconstrained).
 
-**Boundaries**: It does not authorize tenant deprovisioning, infer tenant ownership from client identifiers, author policy, or expose PDP diagnostics.
+**Boundaries**: It does not author policy, does not infer tenant ownership from a `client_id`
+without an authoritative adapter lookup, and exposes no PDP diagnostics on the wire.
 
-#### Provider Boundary
+#### Provider Adapter Boundary
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-component-provider-boundary`
 
-**Purpose**: Isolate provider protocol, authoritative state, and reconciliation behavior.
+**Purpose**: Isolate provider-specific protocol and authoritative state behind a single trait.
 
-**Responsibilities**:
+**Responsibilities** (of a conforming, deployment-registered adapter):
 
-- Implement create, list, rotate, and revoke for tenant-qualified requests.
-- Bind create and rotate operation keys to canonical request identity.
-- Reconcile an identical same-key retry before any further mutation.
-- Preserve unresolved reconciliation across adapter restart.
-- Return stable provider outcomes and safe non-secret remediation data.
-- Keep proof evidence, provider identifiers, and private state behind the adapter boundary.
+- Implement `create`, `list`, `rotate_secret`, and `revoke` for a `(tenant_id, client_id)`-scoped
+  resource.
+- Enforce name syntax, the scope allowlist, and a best-effort per-tenant quota before mutation.
+- Return `NotFound` for an address that does not resolve within the given tenant.
+- Return the secret only from `create`/`rotate_secret`.
+- Report transport uncertainty as `Ambiguous`, never as success.
+- Delete a tenant's principals as part of that tenant's deprovisioning (a documented obligation of
+  the SPI contract, not an operation Service Principal exposes or verifies).
 
-**Boundaries**: It does not make Service Principal authorization decisions, return raw provider diagnostics, expose credential verifier material, or persist plaintext credential responses for replay.
-
-#### Tenant Lifecycle Cleanup Integration
-
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-component-tenant-lifecycle-cleanup`
-
-**Purpose**: Remove tenant-owned principals as part of authoritative tenant deprovisioning.
-
-**Responsibilities**:
-
-- The tenant lifecycle owner authenticates and authorizes deprovisioning and retains durable retry state.
-- The identity-provider integration enumerates and deletes only exact tenant-owned principals.
-- Already-absent principals are success-equivalent.
-- Retryable and terminal failures block subsequent tenant teardown.
-- Success requires a final authoritative zero-principal confirmation.
-
-**Boundaries**: Service Principal is not invoked and owns no cleanup API, permission, record, schedule, or status.
+**Boundaries**: No adapter implementation ships in this repository; `Service` makes no
+authorization decision on the adapter's behalf and exposes no provider diagnostics on the wire.
 
 #### GTS Resource and Permission Catalog
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-component-gts-catalog`
 
-The catalog defines the final managed-resource type `gts.cf.core.service_principal.service_principal.v1~` and final subject classification `gts.cf.core.security.subject_service.v1~`. Both are generated from Rust, registered through Types Registry inventory, and treated as closed V1 classifications.
+The catalog defines the managed-resource type
+`gts.cf.core.service_principal.service_principal.v1~` (`SERVICE_PRINCIPAL_RESOURCE_TYPE`,
+declared once in the SDK and mirrored by the gear's `ResourceType` and `#[resource_error(...)]`
+marker), registered with `types-registry` through the link-time GTS inventory. This type is
+distinct from the account-management `user` type and from the deployment-configured
+service-subject classification a token carries when it authenticates.
 
 Permissions are well-known instances of `gts.cf.toolkit.authz.permission.v1~`:
 
 | Permission Instance ID | Action |
-|------------------------|--------|
-| `gts.cf.toolkit.authz.permission.v1~cf.service_principal._.service_principal_create.v1` | `create` |
-| `gts.cf.toolkit.authz.permission.v1~cf.service_principal._.service_principal_read.v1` | `read` |
-| `gts.cf.toolkit.authz.permission.v1~cf.service_principal._.service_principal_rotate_secret.v1` | `rotate_secret` |
-| `gts.cf.toolkit.authz.permission.v1~cf.service_principal._.service_principal_revoke.v1` | `revoke` |
+|-------------------------|--------|
+| `gts.cf.toolkit.authz.permission.v1~cf.core.service_principal.create.v1` | `create` |
+| `gts.cf.toolkit.authz.permission.v1~cf.core.service_principal.read.v1` | `read` |
+| `gts.cf.toolkit.authz.permission.v1~cf.core.service_principal.rotate_secret.v1` | `rotate_secret` |
+| `gts.cf.toolkit.authz.permission.v1~cf.core.service_principal.revoke.v1` | `revoke` |
 
-The catalog defines identifiers, not grants or role assignments. Tenant deprovision authorization belongs to the tenant lifecycle contract and is not a Service Principal permission.
-
-#### Audit and Observability
-
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-component-audit-observability`
-
-**Purpose**: Provide incident-ready attribution and operational signals without secret leakage.
-
-**Responsibilities**: Service Principal emits authorization and public operation outcomes. The adapter emits provider mutation and reconciliation outcomes. The tenant lifecycle owner emits cleanup retries and final tenant disposition. All layers propagate correlation and explicit tenant identity.
-
-**Boundaries**: No layer records plaintext credentials, bearer tokens, raw provider responses, raw operation keys, or tenant/client identifiers as metric labels. Operation-key correlation uses a non-reversible fingerprint.
+The catalog defines identifiers, not grants or role assignments; role authoring and evaluation
+belong to the Authorization Resolver.
 
 ### 3.3 API Contracts
 
@@ -379,97 +374,120 @@ The catalog defines identifiers, not grants or role assignments. Tenant deprovis
 
 - **Contracts**: `cpt-cf-service-principal-interface-rest`, `cpt-cf-service-principal-contract-authorization`
 - **Technology**: REST, JSON, OpenAPI, RFC-9457 Problem Details
-- **Location**: Generated from `OperationBuilder` registrations
+- **Location**: `gears/system/service-principal/service-principal/src/api/rest/routes.rs`
 
 | Method | Path | Request Requirement | Success |
-|--------|------|---------------------|---------|
-| `POST` | `/service-principal/v1/tenants/{tenant_id}/service-principals` | `Idempotency-Key` | `201 Created`, `Location`, `Cache-Control: no-store` |
-| `GET` | `/service-principal/v1/tenants/{tenant_id}/service-principals` | None beyond authenticated tenant request | `200 OK` |
-| `POST` | `/service-principal/v1/tenants/{tenant_id}/service-principals/{client_id}/rotate-secret` | `Idempotency-Key` | `200 OK`, `Cache-Control: no-store` |
-| `DELETE` | `/service-principal/v1/tenants/{tenant_id}/service-principals/{client_id}` | None beyond authenticated tenant request | `204 No Content` |
+|--------|------|----------------------|---------|
+| `POST` | `/service-principal/v1/tenants/{tenant_id}/service-principals` | Authenticated; JSON body `{name, scopes}` | `201 Created`, `Location`, `Cache-Control: no-store` |
+| `GET` | `/service-principal/v1/tenants/{tenant_id}/service-principals` | Authenticated | `200 OK` |
+| `POST` | `/service-principal/v1/tenants/{tenant_id}/service-principals/{client_id}/rotate-secret` | Authenticated | `200 OK`, `Cache-Control: no-store` |
+| `DELETE` | `/service-principal/v1/tenants/{tenant_id}/service-principals/{client_id}` | Authenticated | `204 No Content` |
 
-No operation-status, recovery-retry, or tenant-cleanup endpoint is registered. No server operation identifier or reconciliation handle is returned. Platform trace context remains available through canonical errors and response tracing.
+The item path registers `rotate-secret` and `DELETE` only; there is deliberately no by-id read, and
+the SPI exposes none either. `Location` on `create` identifies the created resource without
+promising that it answers `GET` (rationale: [Appendix A](#appendix-a-decision-rationale)).
 
-A create or rotate retry must repeat the identical request with the same key. Key reuse with another tenant, operation kind, or canonical request identity is invalid input. When reconciliation confirms that the original mutation succeeded but its credential response was lost, the response is a `credentials_unavailable` failed precondition. It contains only safe confirmed identity and remediation and never claims a credential-bearing success.
+Errors render as canonical RFC-9457 problems: `400` (`InvalidInput`, with a field violation when
+the adapter attributes one), `403` (`AccessDenied`), `404` (`NotFound`, rotate-secret only), `409`
+(`Ambiguous`, reason `AMBIGUOUS_OUTCOME`), and `503` (`ProviderUnavailable` or `Upstream`). No
+recovery-status, reconciliation, or cleanup endpoint is registered.
 
-All routes use `.authenticated()`, explicit license posture, typed schemas, and registered standard errors. Gateway-owned CORS, timeout, compression, tracing, and body-limit middleware are not duplicated.
-
-#### Service Principal Rust SDK V1
+#### Service Principal Rust SDK and Provider SPI V1
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-interface-rust-v1`
 
-- **Contracts**: `cpt-cf-service-principal-interface-rust-sdk`
-- **Technology**: Async transport-neutral Rust trait registered in ClientHub
-- **Location**: `service-principal-sdk`
+- **Contracts**: `cpt-cf-service-principal-interface-rust-sdk`, `cpt-cf-service-principal-contract-provider-adapter`
+- **Technology**: Rust SDK crate (`service-principal-sdk`) containing transport-neutral models and
+  the `ServicePrincipalClientV1` provider trait resolved via `ClientHub`
+- **Location**: `gears/system/service-principal/service-principal-sdk/src/`
 
-The public client provides create, list, rotate-secret, and revoke. Every operation accepts `SecurityContext` and an explicit tenant. Create and rotate carry a validated `OperationKey` newtype. The SDK exposes no cleanup, recovery lookup, operation status, or explicit retry method; retry uses the original create or rotate method.
+The SDK exports `create`/`list`/`rotate_secret`/`revoke` request and response models, `TenantId`
+(re-exported from `tenant-resolver-sdk`), the closed `ServicePrincipalFailure` taxonomy, and the
+`ServicePrincipalClientV1` trait. It defines no separate public in-process management client for
+trusted callers; every caller resolves the same trait. `SecurityContext` is carried on every SPI
+method for audit; the SPI itself is not an authorization boundary, so every caller must satisfy
+its documented authorization precondition before invocation.
 
-Credential models use redacting secret wrappers and do not support general serialization. Public failures carry one of the six stable categories plus stable safe reason and remediation fields. `credentials_unavailable` is a reason under invalid input/failed precondition, not a seventh category. Unknown wire categories remain non-success and behave as ambiguous when mutation certainty is unavailable.
+Credential models wrap the secret in `secrecy::SecretString`, which redacts `Debug` and declares
+no `Serialize` implementation.
 
-#### Provider Adapter V1
+#### Provider Adapter Contract V1
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-interface-provider-v1`
 
 - **Contracts**: `cpt-cf-service-principal-contract-provider-adapter`
-- **Technology**: Async transport-neutral Rust provider trait registered in ClientHub
-- **Location**: `service-principal-sdk`
+- **Technology**: Async transport-neutral Rust trait (`ServicePrincipalClientV1`), registered in
+  the `ClientHub`
+- **Location**: `gears/system/service-principal/service-principal-sdk/src/api.rs`
 
-The provider client defines create, list, rotate, and revoke. Create and rotate receive the opaque operation key and versioned canonical request identity. Provider outcomes use invalid input, not found, clean failure, or ambiguous outcome; authorization failure and provider unavailability are added by the public service boundary.
-
-The adapter classifies reconciliation evidence internally as `exact_binding`, `authoritative_absence`, or `inconclusive`. Public contracts receive only stable category, reason, safe remediation, and confirmed non-secret identity when applicable. Provider proof material and provider-specific diagnostics never cross the boundary.
-
-#### Tenant Deprovision Contract
-
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-interface-tenant-deprovision`
-
-- **Contracts**: `cpt-cf-service-principal-contract-tenant-cleanup`
-- **Technology**: Tenant lifecycle to identity-provider integration contract
-
-The lifecycle owner supplies a validated security context and explicit tenant to the identity-provider tenant-deprovision contract. The integration returns success, success-equivalent absence, retryable failure, or terminal failure. Retry state and scheduling remain in the lifecycle owner. This contract is separate from Provider Adapter V1 and is not exposed through Service Principal REST or Rust APIs.
+The trait defines `create`, `rotate_secret`, `revoke`, and `list`. An implementation must address
+`(tenant_id, client_id)` as the scoped resource, return `NotFound` for an address outside the
+tenant, return the secret only from `create`/`rotate_secret`, and classify transport uncertainty as
+`Ambiguous` rather than success. Provider-specific diagnostics never cross into
+`ServicePrincipalFailure`.
 
 #### Managed Resource and Permissions
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-interface-managed-resource-v1`
 
+- **Contracts**: `cpt-cf-service-principal-interface-managed-resource`
+- **Technology**: GTS type schema and permission instances aggregated by `types-registry`
+- **Location**: `gears/system/service-principal/service-principal-sdk/src/gts.rs`,
+  `gears/system/service-principal/service-principal/src/gts/permissions.rs`
+
 | Action | Purpose |
 |--------|---------|
 | `create` | Mint a tenant-owned machine identity |
 | `read` | List tenant-owned principals |
-| `rotate_secret` | Replace an existing principal secret |
+| `rotate_secret` | Replace an existing principal's secret |
 | `revoke` | Remove a principal or confirm absence |
 
-Boundary identifiers use typed GTS IDs. Types Registry resolves and validates them before authorization or processing; SQL string matching and handler branching on raw GTS strings are prohibited.
+Boundary identifiers use typed GTS IDs generated with `gts_id!`; SQL string matching and handler
+branching on raw GTS strings are prohibited.
 
 ### 3.4 Internal Dependencies
 
-| Dependency | Interface Used | Purpose |
-|------------|----------------|---------|
-| AuthZ Resolver | `PolicyEnforcer` and resolver SDK | Evaluate independent actions and compile tenant constraints |
-| Types Registry | GTS inventory registration | Register resource, subject, and permission instances |
-| Tenant contracts | Canonical `TenantId` and hierarchy semantics | Preserve tenant identity across boundaries |
-| ToolKit runtime | Gear, REST, ClientHub, lifecycle registration | Register routes and public/provider clients |
-| Canonical errors | Canonical categories and Problem rendering | Produce safe public errors |
-| API Gateway | Authenticated route policy and OpenAPI registry | Authenticate and publish REST contracts |
-| Outbound API Gateway | OAGW upstream and route contracts | Apply egress policy and credential isolation to provider HTTP calls |
-| Platform observability | Tracing, metrics, and audit delivery | Collect layered correlation and outcomes |
+| Dependency Gear | Interface Used | Purpose |
+|-----------------|-----------------|---------|
+| `authz-resolver` | `authz_resolver_sdk::pep::PolicyEnforcer` | Evaluate `create`/`read`/`rotate_secret`/`revoke` and compile tenant-scoped constraints |
+| `types-registry` | Link-time GTS inventory aggregation | Register the managed-resource type and the four permission instances at startup |
+| `tenant-resolver-sdk` | `TenantId` | Supply the canonical tenant identifier type shared by the REST and provider contracts |
+| ToolKit runtime (`toolkit`) | `Gear`, `RestApiCapability`, `ClientHub`, `OperationBuilder` | Host the gear, mount REST routes, and resolve the provider adapter |
+| `toolkit-canonical-errors` | `CanonicalError`, `resource_error` | Map `DomainError` to RFC-9457 problem responses |
 
-Service Principal has no ToolKit database, migration, Secure ORM, task lease, or stateful-worker dependency. SDK contracts never depend on implementation types. Provider adapters are resolved through ClientHub and are not direct dependencies of consuming gears.
+**Dependency Rules** (per project conventions):
+
+- No circular dependencies.
+- Inter-gear communication uses only the `authz-resolver-sdk` and `service-principal-sdk` crates,
+  never internal types of another gear.
+- The provider adapter is resolved through `ClientHub`, not through a direct gear dependency, so it
+  stays substitutable.
+- `SecurityContext` is propagated from the REST handler through `Service` into every SPI call.
+
+Service Principal declares no database, migration, Secure ORM, task-lease, or stateful-worker
+dependency in its `Cargo.toml`.
 
 ### 3.5 External Dependencies
 
-#### Identity Provider
+#### Identity Provider (via the registered adapter)
 
 - **Contract**: `cpt-cf-service-principal-contract-provider-adapter`
 
-Only the adapter translates provider-neutral operations to provider administration calls. All provider HTTP or HTTPS traffic, including token-conformance requests, traverses OAGW with declared upstreams, routes, TLS policy, bounded timeouts, and credential references. A non-HTTP transport requires a separately approved boundary with equivalent controls.
+| Dependency Gear | Interface Used | Purpose |
+|-----------------|-----------------|---------|
+| Registered `ServicePrincipalClientV1` implementation | `ServicePrincipalClientV1` trait | Own authoritative principal, credential, and token-issuance state; enforce name/scope/quota policy |
 
-The adapter classifies uncertainty honestly. Timeout after request transmission is ambiguous unless non-mutation is established. The provider owns principal backup, residency, and credential-verifier storage. Adapter qualification is required before a supported release enables it.
+Only the adapter communicates with the identity provider. This repository defines no adapter
+implementation and therefore makes no claim about the adapter's transport, egress gateway, or TLS
+posture; those are the registered adapter's responsibility and are outside this gear's dependency
+graph.
 
-#### Tenant Lifecycle Owner
+**Dependency Rules** (per project conventions):
 
-- **Contract**: `cpt-cf-service-principal-contract-tenant-cleanup`
-
-The lifecycle owner owns durable deprovision state, retry scheduling, terminal parking, and final tenant disposition. Its identity-provider integration owns authoritative principal purge behavior. Service Principal has no dependency edge in this path.
+- No circular dependencies.
+- Only the provider adapter talks to the external identity provider; `Service` never does so
+  directly.
+- `SecurityContext` is passed to every SPI call for audit.
 
 ### 3.6 Interactions & Sequences
 
@@ -477,154 +495,149 @@ The lifecycle owner owns durable deprovision state, retry scheduling, terminal p
 
 **ID**: `cpt-cf-service-principal-seq-create`
 
+**Use cases**: `cpt-cf-service-principal-usecase-create`
+
+**Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`,
+`cpt-cf-service-principal-actor-authz-resolver`, `cpt-cf-service-principal-actor-provider-adapter`
+
 ```mermaid
 sequenceDiagram
     participant C as Caller
-    participant S as Stateless Service
-    participant Z as Authorization Resolver
+    participant S as Application Service
+    participant Z as Authorization Resolver (PDP)
     participant P as Provider Adapter
 
-    C->>S: Create tenant, request, Idempotency-Key
+    C->>S: POST create (tenant, name, scopes)
     S->>Z: Authorize create for tenant
-    Z-->>S: Decision and covering constraints
-    S->>P: Create with key and canonical request identity
-    alt Confirmed new success
-        P-->>S: One-time credentials and subject
-        S-->>C: 201, Location, no-store
-    else Confirmed prior success, response lost
-        P-->>S: Safe confirmed identity, no credential
-        S-->>C: credentials_unavailable failed precondition
-    else Authoritative absence
-        P-->>S: Safe fresh-attempt guidance
-        S-->>C: Non-success; new key permitted
-    else Inconclusive
-        P-->>S: Ambiguous outcome
-        S-->>C: Ambiguous; identical same-key retry only
+    Z-->>S: Decision and covering scope
+    alt Scope does not cover tenant
+        S-->>C: 403 access denied
+    else Scope covers tenant
+        S->>P: create(tenant, name, scopes)
+        alt Success
+            P-->>S: Credentials and subject id
+            S-->>C: 201, Location, no-store, credentials
+        else InvalidInput
+            P-->>S: Rejection detail
+            S-->>C: 400 invalid input
+        else Ambiguous
+            P-->>S: Uncertain outcome
+            S-->>C: 409 aborted (caller resolves manually)
+        else CleanFailure / provider absent
+            P-->>S: Clean failure or ClientHub miss
+            S-->>C: 503 service unavailable
+        end
     end
 ```
 
-The service holds only request-local state. Every retry re-authenticates and re-authorizes before adapter reconciliation. No credential or operation record is written by the gear.
+`Service` holds only request-local state. No credential or operation record is written by the
+gear; recovery from an ambiguous outcome (for example, `list` then revoke-and-retry) is the
+caller's responsibility.
 
 #### Inventory Tenant Principals
 
 **ID**: `cpt-cf-service-principal-seq-list`
 
+**Use cases**: `cpt-cf-service-principal-usecase-list`
+
+**Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`,
+`cpt-cf-service-principal-actor-authz-resolver`
+
 ```mermaid
 sequenceDiagram
     participant C as Caller
-    participant S as Stateless Service
-    participant Z as Authorization Resolver
+    participant S as Application Service
+    participant Z as Authorization Resolver (PDP)
     participant P as Provider Adapter
 
-    C->>S: List explicit tenant
-    S->>Z: Authorize read
-    Z-->>S: Covering constraints
-    S->>P: List tenant-owned principals
+    C->>S: GET list (tenant)
+    S->>Z: Authorize read for tenant
+    Z-->>S: Decision and covering scope
+    S->>P: list(tenant)
     P-->>S: Secret-free summaries
-    S-->>C: Secret-free list
+    S-->>C: 200, secret-free list
 ```
 
 #### Rotate Credential
 
 **ID**: `cpt-cf-service-principal-seq-rotate`
 
+**Use cases**: `cpt-cf-service-principal-usecase-rotate`
+
+**Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`,
+`cpt-cf-service-principal-actor-provider-adapter`
+
 ```mermaid
 sequenceDiagram
     participant C as Caller
-    participant S as Stateless Service
-    participant Z as Authorization Resolver
+    participant S as Application Service
+    participant Z as Authorization Resolver (PDP)
     participant P as Provider Adapter
 
-    C->>S: Rotate tenant principal, Idempotency-Key
-    S->>Z: Authorize rotate_secret
-    Z-->>S: Covering constraints
-    S->>P: Rotate with key and canonical request identity
-    alt Confirmed new success
-        P-->>S: Replacement secret and invalidation confirmation
-        S-->>C: Replacement once, no-store
-    else Confirmed prior success, response lost
-        P-->>S: Safe confirmed identity, no credential
-        S-->>C: credentials_unavailable; rotate with new key
-    else Inconclusive
+    C->>S: POST rotate-secret (tenant, client_id)
+    S->>Z: Authorize rotate_secret for tenant
+    Z-->>S: Decision and covering scope
+    S->>P: rotate_secret(tenant, client_id)
+    alt Success
+        P-->>S: New credentials
+        S-->>C: 200, no-store, new secret
+    else NotFound
+        P-->>S: Address does not resolve in tenant
+        S-->>C: 404 not found
+    else Ambiguous
         P-->>S: Credential state uncertain
-        S-->>C: Ambiguous; identical same-key retry only
+        S-->>C: 409 aborted
     end
 ```
 
-A caller adopts only credentials received by a confirmed rotation response. The service never delivers a secret asynchronously.
+The caller adopts only credentials received in a successful rotation response; the gear never
+delivers a secret asynchronously or through a separate lookup.
 
 #### Revoke Workload Identity
 
 **ID**: `cpt-cf-service-principal-seq-revoke`
 
+**Use cases**: `cpt-cf-service-principal-usecase-revoke`
+
+**Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`
+
 ```mermaid
 sequenceDiagram
     participant C as Caller
-    participant S as Stateless Service
-    participant Z as Authorization Resolver
+    participant S as Application Service
+    participant Z as Authorization Resolver (PDP)
     participant P as Provider Adapter
 
-    C->>S: Revoke tenant-qualified principal
-    S->>Z: Authorize revoke
-    Z-->>S: Covering constraints
-    S->>P: Delete tenant-owned principal
-    alt Deleted or absent
-        P-->>S: Confirmed success or not found
-        S-->>C: 204 No Content
-    else Ambiguous
-        P-->>S: Mutation uncertain
-        S-->>C: Ambiguous; repeat normal revoke
-    end
+    C->>S: DELETE revoke (tenant, client_id)
+    S->>Z: Authorize revoke for tenant
+    Z-->>S: Decision and covering scope
+    S->>P: revoke(tenant, client_id)
+    P-->>S: Ok(()) or NotFound
+    Note over S: Both map to success
+    S-->>C: 204 No Content
 ```
 
-Revoke requires no operation key. The caller repeats the tenant-qualified operation until deletion or absence is confirmed.
-
-#### Tenant Deprovision Cleanup
-
-**ID**: `cpt-cf-service-principal-seq-tenant-cleanup`
-
-```mermaid
-sequenceDiagram
-    participant T as Tenant Lifecycle Owner
-    participant P as Identity-Provider Integration
-    participant I as Identity Provider
-
-    T->>T: Authenticate and authorize tenant deprovision
-    T->>P: Deprovision explicit tenant
-    P->>I: Enumerate exact tenant-owned principals
-    P->>I: Delete each owned principal
-    P->>I: Confirm zero owned principals
-    alt Zero confirmed
-        P-->>T: Success
-        T->>T: Continue tenant teardown
-    else Transient failure
-        P-->>T: Retryable
-        T->>T: Retain durable state and retry whole operation
-    else Permanent failure
-        P-->>T: Terminal
-        T->>T: Block teardown and expose intervention state
-    end
-```
-
-Service Principal is absent from this sequence. Cleanup and its retries share the durable tenant-deprovision lifecycle.
+`Service::revoke` treats `Ok(())` and `ServicePrincipalFailure::NotFound` identically as success,
+so revoking an already-absent principal is indistinguishable from revoking a present one.
 
 ### 3.7 Database Schemas & Tables
 
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-db-state-ownership`
+- [ ] `p3` - **ID**: `cpt-cf-service-principal-db-state-ownership`
+
+Not applicable: Service Principal declares no schema, table, or migration. It does not lease work,
+persist an operation record, or restore state after restart.
 
 | State | Durable Owner | Service Principal Access |
-|-------|---------------|--------------------------|
-| Principal, credential, verifier, token behavior | Identity provider | Through provider adapter only |
-| Create/rotation reconciliation binding and outcome | Provider adapter or its provider-native facility | Forward key and canonical request identity; receive safe outcome |
-| Tenant-deprovision retry and terminal disposition | Tenant lifecycle owner | None |
-| Audit and telemetry retention | Platform observability and owning emitting layer | Emit through platform interfaces |
+|-------|-----------------|-----------------------------|
+| Principal, credential, and token-issuance state | Registered identity-provider adapter | Through `ServicePrincipalClientV1` only |
 | Plaintext credential response | No platform persistence owner | Request-local delivery only |
 
-Service Principal declares no schema or table and runs no migration. It does not lease work, retain resolved operations, restore state after restart, or define adapter-private retention. An adapter may use provider-native or private durable storage, but that storage is outside the gear boundary and must satisfy conformance without containing replayable plaintext credential responses.
+An adapter may use its own durable storage to satisfy the SPI contract, but that storage is
+outside this gear's boundary and outside this document's scope.
 
 ### 3.8 Deployment Topology
 
-- [ ] `p2` - **ID**: `cpt-cf-service-principal-topology-deployment-neutral`
+- [ ] `p3` - **ID**: `cpt-cf-service-principal-topology-deployment-neutral`
 
 ```mermaid
 graph LR
@@ -633,12 +646,8 @@ graph LR
     SP2[Service Principal Instance]
     AZ[AuthZ Resolver]
     HUB[ClientHub]
-    ADAPTER[Provider Adapter]
-    ASTATE[(Adapter-Private State)]
-    OAGW[Outbound API Gateway]
+    ADAPTER[Registered Provider Adapter]
     IDP[Identity Provider]
-    OBS[Observability and Audit]
-    TL[Tenant Lifecycle Owner]
 
     GW --> SP1
     GW --> SP2
@@ -647,17 +656,12 @@ graph LR
     SP1 --> HUB
     SP2 --> HUB
     HUB --> ADAPTER
-    ADAPTER --> ASTATE
-    ADAPTER --> OAGW
-    OAGW --> IDP
-    TL --> ADAPTER
-    SP1 --> OBS
-    SP2 --> OBS
-    ADAPTER --> OBS
-    TL --> OBS
+    ADAPTER --> IDP
 ```
 
-Instances are horizontally scalable and interchangeable. They require authorization, GTS, ClientHub, canonical error, gateway, and observability wiring. They do not require a database, migration, work lease, or worker readiness probe. Provider availability is reported separately so an outage produces an explicit failure rather than simulated success. Adapter-private reconciliation infrastructure is deployed and operated with the adapter, outside the Service Principal lifecycle.
+Instances are horizontally scalable and interchangeable. They require authorization, GTS, and
+`ClientHub` wiring, but no database, migration, or work-lease infrastructure. Provider absence
+produces an explicit `503`; it is never reported as a simulated success.
 
 ## 4. Additional Context
 
@@ -665,52 +669,41 @@ Instances are horizontally scalable and interchangeable. They require authorizat
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-design-failure-taxonomy`
 
-| Public Category | Source | Mutation Semantics | Retry Guidance | Canonical Mapping |
-|-----------------|--------|--------------------|----------------|-------------------|
-| Invalid input | Validation, provider, key mismatch, or `credentials_unavailable` | Current request retains no new state | Change invalid input; use a new rotation key after lost credential response | `InvalidArgument`, HTTP 400; failed precondition reason for `credentials_unavailable` |
-| Not found | Provider ownership lookup | No addressed tenant-owned principal | Revoke treats as success-equivalent | `NotFound`, HTTP 404; revoke returns 204 |
-| Clean failure | Provider | Provider confirms no new state | Follow safe remediation; a fresh mutation uses a new key | `ServiceUnavailable`, HTTP 503 |
-| Ambiguous outcome | Provider after possible mutation | State may have changed | Repeat only the identical request with the same key for create/rotate; repeat revoke normally | `Aborted`, HTTP 409 |
-| Authorization failure | Authentication or policy boundary | Provider not invoked | Retry only after identity or authorization changes | Canonical 401, 403, or fail-closed internal error |
-| Provider unavailable | Missing adapter or known pre-mutation outage | No provider mutation | Retry according to safe availability guidance | `ServiceUnavailable`, HTTP 503 |
+| `DomainError` Variant | Source | HTTP Status | Canonical Reason |
+|-------------------------|--------|--------------|---------------------|
+| `InvalidInput { detail, field }` | `ServicePrincipalFailure::InvalidInput` | `400` | `INVALID_INPUT`, with a field violation |
+| `NotFound` | `ServicePrincipalFailure::NotFound` (surfaces only outside `revoke`) | `404` | Not-found resource error |
+| `AccessDenied` | `authz::map_enforcer_err` (`Denied`, `CompileFailed`) or a scope that does not cover the tenant | `403` | `ACCESS_DENIED` |
+| `ProviderUnavailable` | No `ServicePrincipalClientV1` registered in `ClientHub` | `503` | Service-unavailable |
+| `Upstream { detail }` | `ServicePrincipalFailure::CleanFailure` or `authz::map_enforcer_err`'s `EvaluationFailed` | `503` | Service-unavailable |
+| `Ambiguous { detail }` | `ServicePrincipalFailure::Ambiguous` | `409` | `AMBIGUOUS_OUTCOME` |
 
-`credentials_unavailable` is a stable reason under invalid input/failed precondition, not a seventh category. It may contain confirmed non-secret principal identity and rotation guidance. It never contains a credential, raw operation key, adapter proof, or provider diagnostic.
+The taxonomy on both sides of the boundary (`ServicePrincipalFailure` and `DomainError`) is closed:
+neither type is `#[non_exhaustive]`, so every match is compile-checked to cover every variant.
+`Ambiguous` carries `409`, a status distinct from the `503` used for `Upstream` and
+`ProviderUnavailable` (rationale: [Appendix A](#appendix-a-decision-rationale)).
+Provider-specific diagnostic detail stays in the `detail` string surfaced by canonical error
+rendering; no adapter-internal state crosses the wire.
 
-Unknown categories remain non-success. If mutation certainty is unavailable, compatibility handling is ambiguous. Provider detail is sanitized before logging and never placed on the public wire.
+### 4.2 Ambiguous Outcome Handling
 
-Tenant cleanup uses the tenant-lifecycle contract's success, success-equivalent absence, retryable, and terminal outcomes. Those outcomes do not extend the Service Principal taxonomy.
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-design-ambiguous-handling`
 
-### 4.2 Operation-Key Reconciliation
-
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-design-reconciliation`
-
-Create and rotation use these contract rules:
-
-1. The caller supplies `Idempotency-Key` or the Rust `OperationKey` equivalent.
-2. Service Principal validates the key, authenticates and authorizes the current caller, derives a canonical non-secret request identity, and forwards both values.
-3. The adapter binds the key to tenant, operation kind, and request identity and retains only a non-reversible key fingerprint plus private binding and outcome metadata.
-4. An identical same-key retry reconciles before any mutation. A changed tenant, operation, or request identity is invalid input.
-5. `exact_binding` maps to safe confirmed identity. If the one-time response was lost, the public result is `credentials_unavailable` and the caller performs a new rotation with a new key.
-6. `authoritative_absence` permits a fresh operation with a new key.
-7. `inconclusive` remains ambiguous and blocks conflicting mutation.
-
-The adapter's execution mechanism is private. Reconciliation may occur during the repeated request or through adapter-owned background execution. In both cases unresolved behavior survives adapter restart and Service Principal schedules nothing.
-
-No public status lookup exists. No server-generated operation ID or provider proof handle is returned. Platform correlation identifiers continue to correlate request, adapter, and audit records; operation-key telemetry uses only a non-reversible fingerprint.
+The gear defines no idempotency-key or operation-key mechanism. When the registered adapter
+reports `Ambiguous`, `Service` forwards it unchanged as `DomainError::Ambiguous`, and the REST
+layer renders `409` with reason `AMBIGUOUS_OUTCOME`. The caller is expected to inspect state
+through `list` and resolve manually — for example, `revoke` followed by a fresh `create` — since
+neither `Service` nor any adapter contract defined here performs automatic reconciliation.
+Introducing a caller-supplied key to make an ambiguous create or rotate safely retryable is target
+work tracked as an open question in the PRD, not part of the current contract.
 
 ### 4.3 Configuration
 
-- [ ] `p2` - **ID**: `cpt-cf-service-principal-design-configuration`
+- [ ] `p3` - **ID**: `cpt-cf-service-principal-design-configuration`
 
-Typed Service Principal configuration contains:
-
-- principal name length and accepted character policy;
-- allowed client scopes;
-- best-effort maximum principals per tenant;
-- provider request timeout;
-- benchmark-approved deployment envelope once established.
-
-Configuration is explicit under `gears.service-principal.config`. Secrets, provider administrator credentials, worker settings, lease periods, retry schedules, database settings, and reconciliation retention are absent. Provider-adapter and tenant-lifecycle configuration remain owned by those components.
+Not applicable: the gear declares no gear-specific configuration section or typed configuration
+struct. Name-syntax rules, the scope allowlist, and the per-tenant quota are configuration owned by
+the registered provider adapter, not by this gear.
 
 ### 4.4 Security and Data Protection
 
@@ -718,125 +711,190 @@ Configuration is explicit under `gears.service-principal.config`. Secrets, provi
 
 Security boundaries are:
 
-1. API Gateway authenticates REST callers and injects `SecurityContext`.
-2. Service Principal authorizes the explicit tenant for every public call and retry.
-3. The provider adapter accepts only the provider-neutral contract and enforces tenant-qualified ownership against authoritative provider state.
-4. The tenant lifecycle owner authorizes deprovisioning; the provider integration deletes only exact tenant-owned principals.
-5. The identity provider owns credentials, verifier material, and token issuance.
-6. Adapter-private reconciliation contains no plaintext credential response and exposes no provider proof publicly.
+1. The platform authenticates REST callers and attaches a validated `SecurityContext` before a
+   handler runs (`.authenticated()` on every route).
+2. `Service::authorize` requests a PDP decision and verifies, via `ensure_scope_permits`, that the
+   returned scope covers the explicit target tenant before any provider call.
+3. The registered provider adapter accepts only the provider-neutral SPI and is responsible for
+   tenant-qualified ownership checks against its own authoritative state.
+4. `secrecy::SecretString` wraps every client secret; `ServicePrincipalCredentialsDto` hand-writes
+   a redacting `Debug` so no formatting path exposes the secret.
+5. `create` and `rotate_secret` responses carry `Cache-Control: no-store`.
 
-Credential values use redacting wrappers until final response conversion. Create and rotation bodies are excluded from logging and tracing. Panic, debug, and error formatting cannot expose secret fields. Credential responses use `Cache-Control: no-store`, and upstream proxies must not cache them. Transport security follows platform TLS and FIPS posture without gear-specific cryptography.
+Transport security and any credential handling for the provider's own external calls are the
+registered adapter's responsibility; this repository makes no claim about them because no adapter
+ships here.
 
 ### 4.5 Auditability and Observability
 
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-design-operational-signals`
+- [ ] `p2` - **ID**: `cpt-cf-service-principal-design-operational-signals`
 
-Audit ownership is layered:
-
-| Layer | Audit and Signal Ownership |
-|-------|----------------------------|
-| Service Principal | Current caller, target tenant, public action, authorization result, correlation ID, provider invocation status, and public outcome |
-| Provider adapter | Provider mutation, reconciliation classification, provider availability, and adapter-private retry state |
-| Tenant lifecycle owner | Cleanup attempt, retryable or terminal disposition, initiating/system actor, and final tenant disposition |
-
-Every layer propagates platform correlation and explicit tenant identity. Raw operation keys are excluded; a non-reversible fingerprint may correlate adapter records. Audit content excludes plaintext credentials, bearer tokens, full credential-bearing request bodies, and raw provider responses.
-
-Service Principal metrics include operation latency and count by action and stable public outcome plus provider availability. Adapter metrics include ambiguity, reconciliation age, and adapter execution health. Tenant lifecycle metrics include cleanup retries, terminal failures, and blocked deprovisioning. Service Principal exposes no recovery backlog, cleanup backlog, lease, or worker-health metric. Tenant and principal identifiers are never metric labels.
+The gear emits one `tracing::info!` at successful `init` and one `tracing::warn!` when
+`Service::sp_client` fails to resolve the provider, logging the underlying `ClientHubError` for
+diagnosis. Beyond platform-wide request tracing and canonical-error correlation, the gear defines
+no dedicated audit trail, metric, or alert of its own; this matches the PRD's explicit NFR
+exclusion for bespoke auditability and observability.
 
 ### 4.6 Fault Tolerance
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-design-fault-tolerance`
 
-Service Principal fails closed before provider invocation when authentication, authorization, configuration, or required client resolution fails. A provider result that cannot exclude mutation is ambiguous. Restart loses only transient request context; a caller may reach any instance and repeat the identical keyed request.
-
-The adapter guarantees restart-safe reconciliation and prevents duplicate logical create or rotation mutation under concurrent or repeated same-key requests. Revoke converges through repeated deletion and success-equivalent absence.
-
-Tenant cleanup failure blocks tenant teardown. A retryable result keeps the lifecycle-owned operation eligible for retry after restart. A terminal result parks the lifecycle operation for intervention. No component reports deprovision success before authoritative zero-principal confirmation.
+Service Principal fails closed before any provider call when authentication is missing, the PDP
+denies the request, constraint compilation fails, or PDP evaluation itself fails. Provider absence
+is reported as `503`, never as simulated success. Because `Service` carries no per-request state
+across calls, a gear restart loses nothing a caller needs to retry; the caller may reach any
+instance and repeat an identical request. The gear applies no automatic recovery for an
+`Ambiguous` outcome — see §4.2.
 
 ### 4.7 Testability and Verification
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-design-test-strategy`
 
-Verification follows the repository test split:
+The current test suite, aligned with the repository's unit/service/router split:
 
-- Unit tests cover policy validation, canonical request identity, operation-key validation, secret redaction, DTO conversion, failure mapping, and permission identifiers.
-- Service tests verify authorize-before-provider ordering, re-authorization on retry, tenant-scope mismatch denial, provider absence, idempotent revoke, and absence of persistence or worker dependencies.
-- Router tests verify four operations, `Idempotency-Key` on create/rotate, OpenAPI metadata, `Location`, `no-store`, `credentials_unavailable`, RFC-9457 shape, and absence of recovery/status/cleanup routes.
-- Shared adapter conformance verifies same-key concurrency, post-restart resumption, tenant/request binding, four provider outcomes, all three proof classifications, no duplicate logical mutation, no secret replay, ownership, invalidation, and OAGW-mediated HTTP transport.
-- Tenant-lifecycle integration tests verify exact-owner purge, foreign-principal exclusion, success-equivalent absence, retryable failure, terminal failure, restart-safe lifecycle retry, and zero-principal confirmation before teardown.
-- Security tests attempt cross-tenant addressing, operation-key substitution, foreign-principal probing, scope escalation, cache disclosure, and log/telemetry disclosure.
-- E2E tests cover real REST/Rust wiring, real authorization, adapter restart seams, lost credential responses, provider integration, secret-negative surfaces, and tenant deprovisioning.
-- Benchmarks establish the PRD-required scale, latency, throughput, unavailable-provider behavior, and availability objectives before GA.
+- SDK unit tests (`service-principal-sdk/src/models.rs`, `error.rs`, `gts.rs`) cover secret
+  redaction in `Debug`, stable failure-category metric labels and `Display` shape, and the
+  managed-resource GTS id.
+- Domain unit tests (`domain/authz.rs`) cover `ensure_scope_permits` for unconstrained, matching,
+  mismatched, and deny-all scopes, and `map_enforcer_err` fail-closed mapping.
+- Service tests (`domain/service_tests.rs`) cover authorize-before-provider ordering, tenant-scope
+  mismatch denial, provider absence, and idempotent revoke on `NotFound`.
+- Permission catalog tests (`gts/permissions_tests.rs`) verify all four permissions register in the
+  link-time inventory, carry the SDK resource type, and match their action to their instance-id
+  verb.
+- DTO tests (`api/rest/dto_tests.rs`) verify secret redaction in `Debug`, unknown-field rejection,
+  and the default-empty `scopes` field.
+- Router tests (`api/rest/routes_tests.rs`) verify all four operations register in the OpenAPI
+  registry and exercise their success and error responses end-to-end through the router.
+- Error-mapping tests (`api/rest/error.rs`) verify every `DomainError` variant maps to its expected
+  HTTP status and that the resource-error literal matches the SDK's `SERVICE_PRINCIPAL_RESOURCE_TYPE`
+  constant.
+
+No cross-adapter provider-conformance suite and no performance benchmark exist in this repository;
+both are tracked as open PRD questions rather than as claims of this design.
 
 ### 4.8 Compliance and Privacy Posture
 
-- [ ] `p2` - **ID**: `cpt-cf-service-principal-design-compliance-posture`
+- [ ] `p3` - **ID**: `cpt-cf-service-principal-design-compliance-posture`
 
-The gear models machine identities and intentionally collects no human profile attributes. Subject, tenant, client, scope, operation-key fingerprint, and audit identifiers remain security-sensitive and may be personal data where they identify natural persons.
-
-The provider owns principal-record residency and backup. Adapter operators own private reconciliation retention and residency. The tenant lifecycle owner owns deprovision-operation retention. Platform observability owns telemetry and audit retention. Service Principal owns no durable data set. No gear-specific regulatory claim is made; deployment-specific privacy and industry controls remain applicable.
+The gear models machine identities and collects no human profile attributes. Client id, subject
+id, tenant id, and scope values remain security-sensitive control-plane metadata; the registered
+provider owns any residency or backup posture for the principal records it stores. No
+gear-specific regulatory claim is made.
 
 ### 4.9 Migration Impact
 
-- [ ] `p2` - **ID**: `cpt-cf-service-principal-design-migration-impact`
+- [ ] `p3` - **ID**: `cpt-cf-service-principal-design-migration-impact`
 
-No Service Principal data migration is required because the recovery schema, worker, cleanup API, and operation-status API described by the earlier design were not implemented. The revision removes planned components rather than migrating stored records.
-
-The four lifecycle paths and operations remain. Create and rotation gain required operation-key inputs before the V1 contract is declared production-stable. Introducing that requirement after V1 stabilization would require a compatible transition or a new major version. Existing one-time credential handoff remains unchanged.
-
-Each provider adapter owns migration of any private reconciliation state and must pass the revised conformance suite before qualification. Tenant lifecycle integration owns any migration of its deprovision state. No plaintext credential data is migrated.
+The `service-principal` and `service-principal-sdk` crates are new to this repository. No stored
+data migration applies because the gear owns no database. This gear defines no recovery schema,
+background worker, cleanup API, or operation-status API (supersession of earlier drafts:
+[Appendix A](#appendix-a-decision-rationale)). A future operation-key or idempotency-key retry
+mechanism (PRD open question) would need a compatible transition or a new major contract version,
+since it is not part of the current REST or SDK contract.
 
 ### 4.10 Assumptions and Baseline Deviations
 
-- [ ] `p2` - **ID**: `cpt-cf-service-principal-design-assumptions-deviations`
+- [ ] `p3` - **ID**: `cpt-cf-service-principal-design-assumptions-deviations`
 
 Assumptions:
 
-- One conforming provider adapter is configured per deployment.
-- The adapter can bind keyed create and rotation to authoritative provider evidence and preserve unresolved reconciliation across restart.
-- The identity provider can immediately invalidate superseded credentials and confirm tenant-owned principal absence.
-- The tenant lifecycle owner supplies durable deprovision retry state.
-- Production objectives are supplied by the benchmark release gate.
+- Exactly one conforming `ServicePrincipalClientV1` implementation is registered per deployment;
+  none ships with this repository.
+- The registered adapter enforces name syntax, scope allowlisting, and quota; this gear performs no
+  independent validation.
+- The platform attaches a validated `SecurityContext` before a route handler runs.
+- Lifecycle operations remain low-frequency administrative calls, not request-path traffic.
 
-Local architecture allocations:
+Baseline implementation status (not approved production deviations, but the current, verified
+state of this codebase):
 
-- Service Principal is a stateless authorization and provider-delegation boundary.
-- The adapter owns create and rotation reconciliation semantics and private state.
-- The tenant lifecycle owner and identity-provider integration own tenant cleanup durability and execution.
-- Service Principal emits public lifecycle audit facts in addition to platform request and authorization records.
-
-There are no approved deviations from SDK-first contracts, authenticated `OperationBuilder` routes, canonical RFC-9457 errors, OAGW-mediated HTTP egress, or fail-closed authorization.
+- There is no single-item `GET`; the collection listing and the `Location` header from `create` are
+  the only ways to learn a principal's non-secret state (PRD open question 4).
+- There is no idempotency-key or operation-key retry mechanism for an ambiguous create or rotate
+  outcome; the caller must resolve it manually (PRD open question 2).
+- No cross-adapter conformance harness exists to validate a second adapter (PRD open question 3).
+- Nothing in this repository demonstrates that a registered adapter actually deletes a tenant's
+  principals on tenant deprovisioning; the obligation is stated in the SPI contract only (PRD open
+  question 1).
+- No performance or scale benchmark exists in this repository (PRD NFR exclusion).
 
 ### 4.11 Explicit Non-Applicability
 
-- Frontend state, responsive design, accessibility, internationalization, and offline UI support are not applicable because the capability has no user interface.
-- Browser sessions, gear-owned MFA, and gear-owned SSO are not applicable because platform authentication owns management-call identity.
+- Frontend state, responsive design, accessibility, and internationalization are not applicable;
+  the capability has no user interface.
+- Browser sessions, gear-owned MFA, and gear-owned SSO are not applicable; platform authentication
+  owns management-call identity.
 - CDN and edge caching are not applicable; credential responses are explicitly non-cacheable.
-- Service Principal event sourcing, public lifecycle streaming, event replay, and broker dead-letter queues are not applicable.
-- Service Principal databases, schemas, migrations, Secure ORM repositories, task leases, retry workers, and recovery queues are not applicable.
-- Gear-owned Terraform, container manifests, service-mesh policy, canary logic, and blue/green orchestration are not applicable because the gear is deployment-neutral.
-- Provider-principal sharding, replication, backup, and point-in-time recovery are not applicable because the identity provider owns authoritative principal data.
-- A currency-denominated gear cost budget is not applicable; quotas and benchmark-approved deployment envelopes provide capacity inputs.
-- Industry-specific certification and consent-management workflows are not applicable because the capability introduces no human profile collection.
+- Event sourcing, lifecycle event streaming, and broker dead-letter queues are not applicable; this
+  gear defines none.
+- Databases, schemas, migrations, Secure ORM repositories, task leases, and retry workers are not
+  applicable; this gear declares none.
+- Gear-owned Terraform, container manifests, service-mesh policy, canary logic, and blue/green
+  orchestration are not applicable; the gear is deployment-neutral.
+- Tenant-deprovision cleanup orchestration is not applicable to this gear; it is a documented
+  obligation of the registered provider adapter, discharged outside this gear's API and outside its
+  dependency graph.
+- Gear-specific configuration (§4.3) is not applicable; there is no typed configuration section for
+  this gear beyond adapter-owned policy.
+- A currency-denominated cost budget is not applicable; the gear runs no capacity dimension of its
+  own beyond a single authorization check and one delegated provider call per request.
+- **Regulatory, data-residency, vendor/licensing, and resource constraints** are not applicable as
+  gear-specific constraints: the gear stores no data of its own and is provider-agnostic by
+  construction (§2.1 Provider Authority); legacy-system integration does not apply to a newly
+  ported gear; and budget, team, and time constraints are inherited from the platform-wide release
+  process rather than declared here.
 
 ## 5. Traceability
 
 - **PRD**: [PRD.md](./PRD.md)
 - **UPSTREAM_REQS**: No upstream requirements artifact exists for this gear.
-- **ADRs**: None. This DESIGN states architecture without embedding decision debates.
+- **ADRs**: None. The body sections state architecture without embedding decision debates; see
+  [Appendix A](#appendix-a-decision-rationale) for non-normative rationale.
 - **Features**: No feature artifact exists for this gear.
 - **Implementation allocation**: Feature decomposition and code traceability are downstream work.
 
 ### Requirement Allocation Summary
 
 | Design Area | PRD Coverage |
-|-------------|--------------|
+|-------------|---------------|
 | Stateless architecture and provider boundary | `cpt-cf-service-principal-fr-provider-delegation`, `cpt-cf-service-principal-fr-provider-required`, `cpt-cf-service-principal-interface-rust-sdk`, `cpt-cf-service-principal-contract-provider-adapter`, `cpt-cf-service-principal-nfr-stateless-recovery` |
-| REST and public SDK contracts | `cpt-cf-service-principal-fr-create`, `cpt-cf-service-principal-fr-list`, `cpt-cf-service-principal-fr-rotate-secret`, `cpt-cf-service-principal-fr-revoke`, `cpt-cf-service-principal-interface-rest`, `cpt-cf-service-principal-interface-rust-sdk` |
+| REST and Rust provider contracts | `cpt-cf-service-principal-fr-create`, `cpt-cf-service-principal-fr-list`, `cpt-cf-service-principal-fr-rotate-secret`, `cpt-cf-service-principal-fr-revoke`, `cpt-cf-service-principal-interface-rest`, `cpt-cf-service-principal-interface-rust-sdk` |
 | Authorization and GTS catalog | `cpt-cf-service-principal-fr-authenticated-management`, `cpt-cf-service-principal-fr-independent-permissions`, `cpt-cf-service-principal-fr-tenant-authorization`, `cpt-cf-service-principal-fr-authz-fail-closed`, `cpt-cf-service-principal-interface-managed-resource`, `cpt-cf-service-principal-contract-authorization` |
-| Secret safety and invalidation | `cpt-cf-service-principal-fr-client-credentials-only`, `cpt-cf-service-principal-fr-identity-context`, `cpt-cf-service-principal-fr-secret-free-listing`, `cpt-cf-service-principal-nfr-secret-confidentiality`, `cpt-cf-service-principal-nfr-no-secret-persistence`, `cpt-cf-service-principal-nfr-credential-invalidation` |
+| Secret safety and classification | `cpt-cf-service-principal-fr-client-credentials-only`, `cpt-cf-service-principal-fr-identity-context`, `cpt-cf-service-principal-fr-secret-free-listing`, `cpt-cf-service-principal-nfr-secret-confidentiality`, `cpt-cf-service-principal-nfr-no-secret-persistence`, `cpt-cf-service-principal-nfr-data-classification` |
 | Input, quota, collision, and ownership | `cpt-cf-service-principal-fr-name-policy`, `cpt-cf-service-principal-fr-scope-allowlist`, `cpt-cf-service-principal-fr-tenant-quota`, `cpt-cf-service-principal-fr-create-collision`, `cpt-cf-service-principal-fr-ownership-addressing`, `cpt-cf-service-principal-fr-rotate-complete-state` |
-| Failure and operation-key reconciliation | `cpt-cf-service-principal-fr-failure-categories`, `cpt-cf-service-principal-fr-ambiguous-create-recovery`, `cpt-cf-service-principal-fr-ambiguous-rotate-recovery`, `cpt-cf-service-principal-fr-ambiguous-revoke-recovery` |
-| Tenant lifecycle cleanup | `cpt-cf-service-principal-fr-revoke-idempotent`, `cpt-cf-service-principal-fr-tenant-cleanup`, `cpt-cf-service-principal-contract-tenant-cleanup`, `cpt-cf-service-principal-nfr-cleanup-reliability` |
-| Security, audit, and operations | `cpt-cf-service-principal-nfr-data-classification`, `cpt-cf-service-principal-nfr-tenant-isolation`, `cpt-cf-service-principal-nfr-auditability`, `cpt-cf-service-principal-nfr-observability` |
-| Conformance and release qualification | `cpt-cf-service-principal-nfr-provider-conformance`, `cpt-cf-service-principal-nfr-contract-compatibility`, `cpt-cf-service-principal-nfr-performance-baseline`, `cpt-cf-service-principal-nfr-operational-documentation` |
+| Failure handling and ambiguous outcomes | `cpt-cf-service-principal-fr-failure-categories`, `cpt-cf-service-principal-fr-ambiguous-outcome-signaling`, `cpt-cf-service-principal-fr-revoke-idempotent` |
+| Tenant isolation | `cpt-cf-service-principal-nfr-tenant-isolation` |
+| Compatibility | `cpt-cf-service-principal-nfr-contract-compatibility` |
+
+## Appendix A: Decision Rationale
+
+Non-normative. No ADR artifact exists for this gear, so the rationale behind three architectural
+facts stated above is recorded here rather than in the body sections, which state architecture
+only. Nothing in this appendix adds, removes, or qualifies a requirement.
+
+### No by-id read on the item path
+
+Adding a single-item `GET` would require a by-id read on the `ServicePrincipalClientV1` trait, an
+SDK trait change every registered adapter would have to implement, while the collection `GET`
+already enumerates a tenant's full principal set. The `Location` header on `create` therefore
+follows RFC 9110 §10.2.2, which requires only that the header identify the created resource, not
+that the identified URI answer `GET`. Whether to add a by-id read is tracked as PRD open question
+4 (see §4.10).
+
+### 409 for ambiguous outcomes
+
+`Ambiguous` is mapped to `409` rather than to the `503` used for `Upstream` and
+`ProviderUnavailable` because `503` invites a naive same-request retry, and a retried create after
+an ambiguous create can hit `InvalidInput` ("name taken") when the first attempt in fact succeeded.
+`409` signals instead that recovery is caller-driven — `revoke` followed by a fresh `create` — not a
+blind retry. Automating that recovery behind a caller-supplied idempotency key is tracked as PRD
+open question 2 (see §4.2 and §4.10).
+
+### Supersession of pre-port drafts
+
+Design drafts predating the port of this gear into this repository assumed a recovery schema, a
+background worker, a cleanup API, and an operation-status API. None of those exist in the
+implementation this document describes, and §3.7, §4.2, and §4.11 state their absence
+normatively. This entry records only that the earlier drafts are superseded, so that the body
+sections need carry no historical framing.

--- a/gears/system/service-principal/docs/PRD.md
+++ b/gears/system/service-principal/docs/PRD.md
@@ -22,7 +22,7 @@ Created: 2026-08-06 by Constructor Studio
   - [5.2 Principal Discovery](#52-principal-discovery)
   - [5.3 Credential Rotation and Revocation](#53-credential-rotation-and-revocation)
   - [5.4 Authentication and Authorization](#54-authentication-and-authorization)
-  - [5.5 Provider Contract and Recovery](#55-provider-contract-and-recovery)
+  - [5.5 Provider Contract and Failure Handling](#55-provider-contract-and-failure-handling)
 - [6. Non-Functional Requirements](#6-non-functional-requirements)
   - [6.1 Gear-Specific NFRs](#61-gear-specific-nfrs)
   - [6.2 NFR Exclusions](#62-nfr-exclusions)
@@ -32,9 +32,8 @@ Created: 2026-08-06 by Constructor Studio
 - [8. Use Cases](#8-use-cases)
   - [8.1 Create Workload Identity](#81-create-workload-identity)
   - [8.2 Inventory Tenant Principals](#82-inventory-tenant-principals)
-  - [8.3 Rotate Compromised or Expiring Credential](#83-rotate-compromised-or-expiring-credential)
+  - [8.3 Rotate a Credential](#83-rotate-a-credential)
   - [8.4 Revoke Workload Identity](#84-revoke-workload-identity)
-  - [8.5 Deprovision Tenant Principals](#85-deprovision-tenant-principals)
 - [9. Acceptance Criteria](#9-acceptance-criteria)
 - [10. Dependencies](#10-dependencies)
 - [11. Assumptions](#11-assumptions)
@@ -48,50 +47,71 @@ Created: 2026-08-06 by Constructor Studio
 
 ### 1.1 Purpose
 
-Service Principal provides tenant-scoped machine identities for workloads that need to authenticate without using human credentials. It gives authorized administrators one provider-neutral contract to create, inspect, rotate, and revoke confidential OAuth 2.0 `client_credentials` identities.
+Service Principal is a thin, authenticated REST facade that gives authorized administrators tenant-scoped
+machine identities for workloads that must authenticate without human credentials. It exposes create, list,
+rotate-secret, and revoke operations for confidential OAuth 2.0 `client_credentials` identities, and delegates
+every lifecycle operation to a pluggable identity-provider adapter through a versioned Rust trait
+(`ServicePrincipalClientV1`) resolved at request time from the platform `ClientHub`.
 
-The capability separates machine-identity management from human-user management. It also separates the stable Gears contract from identity-provider-specific behavior. Each principal belongs to one tenant, receives independently grantable management permissions, and exposes its secret only after creation or rotation.
+The gear holds no database, no background workers, and no local business logic beyond authorization and error
+mapping. It separates the stable, provider-neutral contract that callers depend on from the identity-provider
+specific behavior that an adapter implementation owns.
 
 ### 1.2 Background / Problem Statement
 
-Platform workloads need identities for service-to-service access, automation, and unattended jobs. Reusing human accounts weakens accountability, complicates credential rotation, and ties workload availability to a person's lifecycle. Direct identity-provider administration also gives every consumer a different integration surface and error model.
+Platform workloads need identities for service-to-service access, automation, and unattended jobs. Reusing
+human accounts weakens accountability, complicates credential rotation, and ties workload availability to a
+person's lifecycle. Direct identity-provider administration also gives every consumer a different integration
+surface and error model.
 
-A shared Gears capability is needed to manage machine identities consistently across tenants and provider implementations. It must protect high-value client secrets, prevent cross-tenant access, distinguish safe failures from uncertain provider outcomes, and remove credentials when their owning tenant is deprovisioned.
+A shared Gears capability is needed to manage machine identities consistently across tenants without binding
+consumers to one identity provider. It must keep client secrets out of inventory responses, logs, and caches;
+prevent cross-tenant management; and give callers a stable, versioned contract regardless of which provider
+adapter a deployment registers.
+
+Service Principal answers this by staying a stateless authorization-and-delegation boundary. The gear itself is
+the local Policy Enforcement Point (PEP) for machine-identity management: it asks the platform's external Policy
+Decision Point (PDP) whether the caller may perform the action, enforces the returned tenant-scoped decision
+against the explicit target tenant, resolves whichever adapter a deployment has registered in the `ClientHub`,
+and maps that adapter's outcome to a canonical RFC-9457 response. No adapter implementation ships in this
+repository; the SDK crate defines only the contract an adapter must satisfy.
 
 ### 1.3 Goals (Business Outcomes)
 
-- Give authorized tenant administrators a complete machine-identity lifecycle without direct provider administration.
-- Prevent workloads from relying on shared or human credentials.
-- Provide one provider-neutral REST and Rust contract for machine-identity management.
-- Enforce tenant isolation and least-privilege permissions for every management operation.
-- Make credential rotation, revocation, uncertain outcomes, and tenant cleanup observable and testable.
+- Give authorized tenant administrators a REST-only machine-identity lifecycle (create, list, rotate, revoke)
+  without direct identity-provider administration.
+- Keep the REST contract provider-neutral so a deployment can substitute its identity-provider adapter without
+  changing callers.
+- Prevent workloads from relying on shared or human credentials by minting dedicated confidential
+  `client_credentials` clients per workload.
+- Enforce tenant isolation and independently grantable permissions for every management action.
+- Keep client secrets out of every non-credential response, log, and cache.
 
 **Success criteria:**
 
 | Measure | Baseline | Initial target | Timeframe |
 |---|---:|---:|---|
-| Required lifecycle workflows passing provider conformance tests | No accepted Gears implementation | 100% | Before initial GA |
-| Unauthorized cross-tenant management operations succeeding in security tests | No accepted Gears implementation | 0 | Before initial GA |
-| Successful rotations that invalidate the superseded secret | No accepted Gears implementation | 100% | Before initial GA |
-| Successful revocations that prevent subsequent token acquisition | No accepted Gears implementation | 100% | Before initial GA |
-| Secret disclosures through list, log, diagnostic, telemetry, or cacheable-response checks | No accepted Gears implementation | 0 | Before initial GA |
-| Conforming identity-provider adapters | 0 accepted | At least 1 | Before initial GA |
-| Tenant deprovisioning scenarios leaving live owned principals | No accepted Gears implementation | 0 | Before initial GA |
+| Cross-tenant management operations that succeed despite a PDP scope not covering the target tenant | Not measured | 0 | Ongoing, verified by the authorization test suite |
+| Client secrets present in list/summary responses or in `Debug`-formatted credential values | Not measured | 0 | Ongoing, verified by DTO and domain tests |
+| Successful create/rotate responses that are not marked non-cacheable | Not measured | 0 | Ongoing, verified by the router test suite |
+| Revoke calls against an absent principal that return a failure instead of a success-equivalent result | Not measured | 0 | Ongoing, verified by the domain and router test suites |
+| REST operations reachable without a validated security context | Not measured | 0 | Ongoing, verified by route registration (`.authenticated()`) |
 
 ### 1.4 Glossary
 
 | Term | Definition |
 |---|---|
 | Service Principal | A tenant-owned, non-human identity used by a workload. |
+| Policy Decision Point (PDP) | The platform authorization service (`authz-resolver`) that evaluates an access request and returns a decision together with a tenant-scoped constraint. |
+| Policy Enforcement Point (PEP) | The component that requests a decision from the PDP and enforces it before acting. This gear is the PEP for every service-principal management operation. |
 | Machine Workload | A service, job, agent, or automation process that authenticates without a human user. |
 | Client Credentials | OAuth 2.0 grant in which a confidential client authenticates with its client identifier and secret. |
-| Provider Adapter | A conforming implementation that maps provider-neutral lifecycle operations to an identity provider and owns any durable reconciliation state required by those operations. |
+| Provider SPI (`ServicePrincipalClientV1`) | The versioned Rust trait an identity-provider adapter implements and registers in the `ClientHub`; the gear resolves it lazily per request. |
 | Owning Tenant | The tenant that controls a service principal and defines its authorization boundary. |
-| Subject ID | Stable identifier represented by the authenticated principal's subject claim. |
-| Clean Failure | A known failure in which the provider retained no new state from the operation. |
-| Ambiguous Outcome | A failure where provider state may have changed, so success cannot be claimed and reconciliation is required. |
-| One-Time Disclosure | Plaintext secret exposure through the Service Principal public contract only after successful creation or rotation. |
-| Reconciliation | A follow-up action that establishes a known principal or credential state after an ambiguous outcome. |
+| Subject ID | The stable identifier carried by the principal's subject claim, used for RBAC bindings. |
+| Clean Failure | An SPI failure category in which the provider retained no new state from the operation. |
+| Ambiguous Outcome | An SPI failure category in which the provider may have retained state, so the operation cannot be reported as success. |
+| One-Time Disclosure | Plaintext secret exposure through the create/rotate-secret responses only. |
 
 ## 2. Actors
 
@@ -102,9 +122,10 @@ A shared Gears capability is needed to manage machine identities consistently ac
 **ID**: `cpt-cf-service-principal-actor-tenant-automation-admin`
 
 - **Role**: An authorized operator who manages machine identities within an allowed tenant scope.
-- **Needs**: Create workload identities, inspect their non-secret state, rotate credentials, revoke access, and recover safely from uncertain outcomes.
+- **Needs**: Create workload identities, inspect their non-secret state, rotate credentials, and revoke access.
 
-A platform administrator can perform the same workflow across broader tenant scopes when platform policy grants that access. This is not a separate product workflow.
+A platform administrator can perform the same workflow across broader tenant scopes when platform policy grants
+that access (an unconstrained or wider PDP scope). This is not a separate product workflow.
 
 ### 2.2 System Actors
 
@@ -113,104 +134,123 @@ A platform administrator can perform the same workflow across broader tenant sco
 **ID**: `cpt-cf-service-principal-actor-machine-workload`
 
 - **Role**: Uses issued credentials to request access tokens through the OAuth 2.0 `client_credentials` grant.
-- **Needs**: A stable tenant-scoped identity, valid credentials, and immediate invalidation of superseded or revoked credentials.
+- **Needs**: A stable tenant-scoped identity and valid credentials, with superseded or revoked credentials
+  becoming unusable.
 
 #### Authorization Resolver
 
 **ID**: `cpt-cf-service-principal-actor-authz-resolver`
 
-- **Role**: Decides whether a caller may perform a specific Service Principal action for the target tenant.
+- **Role**: The platform Policy Decision Point (PDP) (`authz-resolver`). The gear, acting as the Policy
+  Enforcement Point, asks it whether the caller may perform a given action, and it returns a tenant-scoped
+  constraint the gear checks against the explicit target tenant before delegating.
 
 #### Identity Provider Adapter
 
 **ID**: `cpt-cf-service-principal-actor-provider-adapter`
 
-- **Role**: Implements the provider-neutral lifecycle contract, owns restart-safe create and rotation reconciliation, and reports clean or ambiguous outcomes accurately.
+- **Role**: Implements `ServicePrincipalClientV1` and registers itself in the `ClientHub`. Owns authoritative
+  principal state, enforces provider-side input policy (name syntax, scope allowlist, per-tenant quota), and
+  classifies its own outcomes into the four SPI failure categories. No adapter implementation ships in this
+  repository.
 
 #### Consuming Gear
 
 **ID**: `cpt-cf-service-principal-actor-consuming-gear`
 
-- **Role**: Uses the public Rust interface to manage service principals as part of a wider platform workflow.
-
-#### Tenant Lifecycle Owner
-
-**ID**: `cpt-cf-service-principal-actor-tenant-lifecycle-owner`
-
-- **Role**: Owns durable tenant-deprovision state, invokes the identity-provider tenant-deprovision contract, and requires all machine identities owned by that tenant to be removed.
+- **Role**: Calls the authenticated REST interface to manage service principals as part of a wider platform
+  workflow. Behaves like any other authenticated REST caller; the gear defines no separate in-process client for
+  trusted callers.
 
 #### Types and Permission Registry
 
 **ID**: `cpt-cf-service-principal-actor-types-registry`
 
-- **Role**: Registers the managed-resource type, service-subject classification, and independently grantable actions.
+- **Role**: Aggregates, at startup, the managed-resource type and the four permission instances this gear
+  declares through the link-time GTS inventory (`types-registry` gear dependency).
 
 ## 3. Operational Concept & Environment
 
-Service Principal follows the project-wide Gears and ToolKit baselines in [ToolKit Architecture & Developer Guide](../../../../docs/toolkit_unified_system/README.md). This PRD records only capability-specific constraints.
+Service Principal follows the project-wide Gears and ToolKit baselines in
+[ToolKit Architecture & Developer Guide](../../../../docs/toolkit_unified_system/README.md). This PRD records
+only capability-specific constraints.
 
-The capability is an administrative control-plane surface. It does not participate in request-path token validation. Its provider-neutral contract is separate from the provider adapter that owns identity-provider state.
+The gear is an administrative control-plane surface with two hard `#[toolkit::gear]` dependencies
+(`types_registry`, `authz_resolver`) and one `rest` capability. It holds no database and starts no background
+task; per request it acts as the Policy Enforcement Point — obtaining a decision from the external Policy
+Decision Point and enforcing it against the explicit tenant — then resolves the registered
+`ServicePrincipalClientV1` implementation from the `ClientHub`, delegates, and maps the result to a canonical
+response.
 
 ```mermaid
 graph LR
-    Admin["Tenant Automation Administrator"] -->|manage tenant-owned identities| SP["Service Principal Capability"]
-    Gear["Consuming Gear"] -->|provider-neutral lifecycle contract| SP
-    SP -->|authorize action for tenant| AuthZ["Authorization Resolver"]
-    SP -->|delegate lifecycle operation| Provider["Identity Provider Adapter"]
-    Provider -->|manage confidential identity| IdP["Identity Provider"]
+    Admin["Tenant Automation Administrator"] -->|create, list, rotate, revoke| SP["Service Principal REST Facade"]
+    Gear["Consuming Gear"] -->|authenticated REST calls| SP
+    SP -->|request decision for explicit tenant| AuthZ["Authorization Resolver (PDP)"]
+    SP -->|resolve from ClientHub, delegate| Provider["Identity Provider Adapter (ServicePrincipalClientV1)"]
+    Provider -->|manage confidential client| IdP["Identity Provider"]
     Workload["Machine Workload"] -->|client_credentials| IdP
-    TenantOwner["Tenant Lifecycle Owner"] -->|authorized tenant deprovision| Provider
 ```
 
-The diagram is warranted because the capability coordinates several independent actors and trust boundaries.
+The diagram is warranted because the facade, as the Policy Enforcement Point, coordinates three independent trust
+boundaries: the caller, the Policy Decision Point, and the pluggable provider.
 
 ### 3.1 Gear-Specific Environment Constraints
 
-- A deployment must provide one conforming identity-provider adapter before lifecycle operations can succeed.
-- The identity provider must support confidential `client_credentials` identities and immediate credential invalidation.
-- Callers must have approved credential storage because the capability does not retain plaintext secrets for later retrieval.
+- A deployment must register one `ServicePrincipalClientV1` implementation in the `ClientHub` before any
+  lifecycle operation can succeed; absence is reported as the capability being unavailable rather than as a
+  simulated success.
+- Name syntax, scope allowlisting, and per-tenant quota are enforced by the registered provider adapter, not by
+  this gear; the gear performs no independent validation of those fields before delegating.
 - Lifecycle operations are low-frequency administrative operations, not high-volume request-path operations.
 
 ## 4. Scope
 
 ### 4.1 In Scope
 
-- Tenant-scoped service-principal creation.
-- Secret-free listing by owning tenant.
-- Secret rotation and superseded-secret invalidation.
-- Idempotent revocation and credential invalidation.
-- Independent authorization for create, read, rotate-secret, and revoke actions.
-- Provider-neutral REST and Rust interfaces.
-- Provider conformance and failure classification.
-- Configurable name, scope, and per-tenant quota policy.
-- Tenant-deprovision cleanup through the identity-provider tenant-lifecycle contract.
-- Lifecycle latency and categorized failure telemetry.
-- Stable managed-resource, subject, and permission identifiers.
+- Tenant-scoped creation of a confidential `client_credentials` service principal via REST, returning a client
+  identifier, one-time plaintext secret, token endpoint, and subject identifier.
+- Secret-free listing of a tenant's service principals in upstream order (no pagination).
+- Secret rotation returning a new one-time secret through a non-cacheable response.
+- Idempotent revocation: an already-absent principal is treated as a successful revoke.
+- Independent authorization of the `create`, `read`, `rotate_secret`, and `revoke` actions against the explicit
+  target tenant.
+- A versioned REST management interface and a versioned Rust provider SPI; the gear defines no separate public
+  in-process Rust management client.
+- Mapping of the SPI's four failure categories (invalid input, not found, clean failure, ambiguous), plus the
+  gear's own access-denied and provider-unavailable outcomes, to RFC-9457 canonical error responses.
+- Registration of a managed-resource GTS type and four independently grantable permission instances.
 
 ### 4.2 Out of Scope
 
 - Human-user identity, password, session, MFA, or interactive-login management.
-- Authorization policy authoring, role assignment, or policy evaluation implementation.
+- Authorization policy authoring, role assignment, or policy-evaluation implementation (owned by the
+  Authorization Resolver).
 - Long-term credential storage, secret distribution, or workload injection.
-- Retrieval of an existing plaintext client secret.
+- Retrieval of an existing plaintext client secret; the secret is returned only by create and rotate-secret.
 - Access-token validation, token exchange, refresh tokens, or authorization-code flows.
 - Workload-side token acquisition or token caching.
 - Get-by-ID, principal updates, enable/disable, search, filtering, sorting, or pagination.
 - Bulk lifecycle operations.
-- Multi-provider selection per tenant or request.
+- Multi-provider selection per tenant or request; exactly one adapter is resolved per deployment.
 - Provider migration or credential portability.
 - A dedicated CLI or graphical management interface.
-- A Service Principal-owned principal database, provider-state replica, recovery repository, retry worker, or cleanup coordinator.
-- Distributed transactions across the capability, provider, credential store, and workload.
-- Automatic repair of every ambiguous provider outcome.
-- Offline lifecycle mutations while the provider is unavailable.
-- Strongly serialized quota enforcement across concurrent requests.
-- Lifecycle event streaming in the initial version.
+- A Service Principal-owned principal database, provider-state replica, or retry/reconciliation worker.
+- Idempotency-key or operation-key based retry of ambiguous create/rotate outcomes; the gear surfaces an
+  ambiguous outcome as its own distinct failure and leaves recovery to the caller.
+- Name-syntax, scope-allowlist, and quota validation performed by this gear; these are delegated entirely to the
+  registered provider adapter.
+- Tenant-deprovision cleanup orchestration. Deleting a tenant's principals when that tenant is deprovisioned is
+  a documented obligation of the provider SPI contract, discharged by the registered adapter; this gear performs
+  no tenant-lifecycle orchestration of its own.
+- A common cross-adapter provider-conformance test harness; only the trait contract is defined here.
+- Lifecycle event streaming.
 - Provider-specific realm, mapper, account, or administration behavior.
 
 ## 5. Functional Requirements
 
-> **Testing strategy**: Functional requirements are verified through automated unit, contract, integration, security, and end-to-end tests unless a requirement states otherwise.
+> **Testing strategy**: Functional requirements are verified through automated unit, service, and router tests
+> in the `service-principal` and `service-principal-sdk` crates unless a requirement states otherwise.
 
 ### 5.1 Principal Creation
 
@@ -218,63 +258,80 @@ The diagram is warranted because the capability coordinates several independent 
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-create`
 
-The system **MUST** allow an authorized administrator to create a confidential service principal owned by an explicit target tenant. A successful operation **MUST** return a client identifier, plaintext client secret, token endpoint, and stable subject identifier.
+The system **MUST** allow an authorized administrator to create a confidential `client_credentials` service
+principal owned by an explicit target tenant. A successful creation **MUST** report the new principal's address
+and disclose, exactly once, everything the workload needs to authenticate: the client identifier, the plaintext
+client secret, the token endpoint, and the subject identifier. That credential-bearing response **MUST NOT** be
+cached or stored by intermediaries.
 
-- **Rationale**: Workloads need dedicated non-human credentials and stable identity for policy bindings.
+- **Rationale**: Workloads need dedicated non-human credentials and a stable identity for policy bindings.
 - **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-machine-workload`
+- **Acceptance Evidence**: `service-principal/src/api/rest/routes_tests.rs::create_returns_201_with_location_and_no_store_and_secret_body`
 
 #### Client Credentials Only
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-client-credentials-only`
 
-The system **MUST** create service principals that authenticate as confidential OAuth 2.0 `client_credentials` identities and **MUST NOT** enable interactive human authentication flows through this capability.
+The system **MUST** create service principals that authenticate only as confidential OAuth 2.0
+`client_credentials` identities. The create request and response models carry no field for an interactive or
+human authentication flow.
 
 - **Rationale**: Machine identities must remain separate from human login and session semantics.
 - **Actors**: `cpt-cf-service-principal-actor-machine-workload`
 
-#### Tenant and Subject Classification
+#### Tenant and Subject Identity Binding
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-identity-context`
 
-The system **MUST** ensure that an access token obtained through `client_credentials` using credentials returned by successful creation contains the target tenant, a subject exactly equal to the creation response's `Subject`, and `client_credentials` identity context. Every supported provider adapter **MUST** prove this credential-to-token binding through conformance tests.
+The system **MUST** pass the explicit target tenant to the provider adapter on create, and the create response
+**MUST** return the subject identifier the adapter assigned. Every registered provider adapter is responsible for
+issuing tokens that carry that tenant and subject as a non-human identity.
 
 - **Rationale**: Downstream authorization needs an unambiguous tenant and non-human subject classification.
 - **Actors**: `cpt-cf-service-principal-actor-machine-workload`, `cpt-cf-service-principal-actor-provider-adapter`
 
-#### Name Policy
+#### Provider-Enforced Name Policy
 
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-name-policy`
+- [ ] `p2` - **ID**: `cpt-cf-service-principal-fr-name-policy`
 
-The system **MUST** validate caller-selected principal names against a bounded deployment policy before requesting provider mutation.
+The registered provider adapter **MUST** reject a caller-selected principal name that violates its bounded
+syntax before any provider mutation. The gear forwards the caller-supplied name unmodified and surfaces the
+adapter's rejection as invalid input.
 
 - **Rationale**: Safe, bounded names prevent invalid provider resources and inconsistent public identifiers.
-- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`
+- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-provider-adapter`
 
-#### Scope Allowlist
+#### Provider-Enforced Scope Allowlist
 
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-scope-allowlist`
+- [ ] `p2` - **ID**: `cpt-cf-service-principal-fr-scope-allowlist`
 
-The system **MUST** reject any requested client scope that is not present in the deployment-controlled allowlist.
+The registered provider adapter **MUST** reject any requested client scope that is not present in its
+deployment-controlled allowlist. The gear forwards the caller-supplied scopes unmodified and surfaces the
+adapter's rejection as invalid input.
 
 - **Rationale**: Callers must not escalate workload privileges by requesting arbitrary provider scopes.
 - **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-provider-adapter`
 
-#### Configurable Tenant Quota
+#### Provider-Enforced Tenant Quota
 
-- [ ] `p2` - **ID**: `cpt-cf-service-principal-fr-tenant-quota`
+- [ ] `p3` - **ID**: `cpt-cf-service-principal-fr-tenant-quota`
 
-The system **MUST** support a configurable maximum number of service principals per tenant and reject creation when the observed count reaches that maximum. The quota is best-effort under concurrent creation and **MUST NOT** be presented as a security boundary.
+The registered provider adapter **MAY** enforce a best-effort maximum number of service principals per tenant
+and reject creation once that maximum is reached. The gear neither counts nor enforces a quota itself.
 
-- **Rationale**: A bounded initial collection limits accidental growth while preserving honest concurrency semantics.
+- **Rationale**: A bounded collection limits accidental growth while preserving honest concurrency semantics;
+  the gear stays a stateless facade with no principal inventory of its own.
 - **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-provider-adapter`
 
 #### Creation Collision Safety
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-create-collision`
 
-The system **MUST** reject a creation request when its provider-side identifier is already occupied and **MUST NOT** resume, reveal, or modify the existing principal as part of that request.
+The system **MUST** reject a creation request as invalid input when the provider reports its target identifier
+is already occupied, and **MUST NOT** resume, reveal, or modify the existing principal as part of that request.
 
-- **Rationale**: Reusing an existing identity could disclose credentials or attach privileges to the wrong workload.
+- **Rationale**: Reusing an existing identity could disclose credentials or attach privileges to the wrong
+  workload.
 - **Actors**: `cpt-cf-service-principal-actor-provider-adapter`
 
 ### 5.2 Principal Discovery
@@ -283,16 +340,19 @@ The system **MUST** reject a creation request when its provider-side identifier 
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-list`
 
-The system **MUST** list service principals owned by an authorized target tenant and return each principal's non-secret management state.
+The system **MUST** list the service principals owned by an authorized target tenant, returning each principal's
+client id, enabled state, and attached scopes in upstream order.
 
 - **Rationale**: Administrators need inventory for audit, rotation, and revocation workflows.
 - **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`
+- **Acceptance Evidence**: `service-principal/src/api/rest/routes_tests.rs::list_returns_200_with_summaries`
 
 #### Secret-Free Discovery
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-secret-free-listing`
 
-The system **MUST NOT** expose client secrets through list or future read operations.
+The system **MUST NOT** include a client secret field in the listing model or in any future read model derived
+from it.
 
 - **Rationale**: Inventory access must not grant credential access.
 - **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`
@@ -301,7 +361,9 @@ The system **MUST NOT** expose client secrets through list or future read operat
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-ownership-addressing`
 
-The system **MUST** treat a principal as addressable only when it belongs to the explicit target tenant. A missing or foreign principal **MUST NOT** disclose foreign ownership details.
+The system **MUST** treat a `client_id` as addressable, for rotate-secret and revoke, only when it resolves
+within the explicit target tenant. An address that does not resolve within that tenant **MUST** return not-found
+without disclosing whether the id exists under a different tenant.
 
 - **Rationale**: Tenant-qualified addressing prevents cross-tenant object access and information leakage.
 - **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-provider-adapter`
@@ -312,37 +374,48 @@ The system **MUST** treat a principal as addressable only when it belongs to the
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-rotate-secret`
 
-The system **MUST** allow an authorized administrator to rotate a tenant-owned principal's secret. A successful rotation **MUST** return the new secret and invalidate the superseded secret.
+The system **MUST** allow an authorized administrator to rotate a tenant-owned principal's secret without
+changing its identity. A successful rotation **MUST** disclose the new secret exactly once, in a response that
+**MUST NOT** be cached or stored by intermediaries.
 
-- **Rationale**: Workloads need regular and incident-driven credential replacement without replacing their identity.
+- **Rationale**: Workloads need regular and incident-driven credential replacement without replacing their
+  identity.
 - **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-machine-workload`
+- **Acceptance Evidence**: `service-principal/src/api/rest/routes_tests.rs::rotate_secret_returns_200_with_no_store_and_new_secret`
 
-#### Reject Incomplete Principal Rotation
+#### Reject Rotation for an Unresolved Principal
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-rotate-complete-state`
 
-The system **MUST** reject rotation when the provider cannot confirm the principal's ownership and required managed identity state.
+The system **MUST** return not-found, rather than succeeding, when the addressed `client_id` does not resolve
+within the target tenant at rotation time.
 
-- **Rationale**: Rotation must not issue a credential for a foreign, incomplete, or corrupted identity.
+- **Rationale**: Rotation must not issue a credential for a foreign or nonexistent identity.
 - **Actors**: `cpt-cf-service-principal-actor-provider-adapter`
+- **Acceptance Evidence**: `service-principal/src/api/rest/routes_tests.rs::rotate_secret_not_found_renders_canonical_problem`
 
 #### Revoke Principal
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-revoke`
 
-The system **MUST** allow an authorized administrator to revoke a tenant-owned service principal. Successful revocation **MUST** prevent subsequent token acquisition by that principal.
+The system **MUST** allow an authorized administrator to revoke a tenant-owned service principal, and **MUST**
+report the outcome as a success that carries no principal state and no credential material.
 
 - **Rationale**: Administrators need an immediate way to terminate workload access.
 - **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-machine-workload`
+- **Acceptance Evidence**: `service-principal/src/api/rest/routes_tests.rs::revoke_returns_204`
 
 #### Idempotent Revocation
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-revoke-idempotent`
 
-The system **MUST** treat revocation of an already-absent principal as success-equivalent.
+The system **MUST** treat revocation of an already-absent principal (a provider not-found outcome) as
+indistinguishable from revocation of a present one, not as a failure.
 
-- **Rationale**: Cleanup and reconciliation must converge without requiring callers to distinguish concurrent deletion from prior success.
-- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-tenant-lifecycle-owner`
+- **Rationale**: Cleanup and reconciliation must converge without requiring callers to distinguish concurrent
+  deletion from prior success.
+- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`
+- **Acceptance Evidence**: `service-principal/src/domain/service_tests.rs::revoke_is_idempotent_on_not_found`
 
 ### 5.4 Authentication and Authorization
 
@@ -350,7 +423,8 @@ The system **MUST** treat revocation of an already-absent principal as success-e
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-authenticated-management`
 
-The system **MUST** require a validated platform security context for every public management operation.
+The system **MUST** require a validated platform security context for every management route (`create`, `list`,
+`rotate_secret`, `revoke`).
 
 - **Rationale**: Anonymous callers must never manage machine credentials.
 - **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-authz-resolver`
@@ -359,36 +433,45 @@ The system **MUST** require a validated platform security context for every publ
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-independent-permissions`
 
-The system **MUST** authorize create, read, rotate-secret, and revoke as independently grantable actions.
+The system **MUST** authorize `create`, `read`, `rotate_secret`, and `revoke` as four independently grantable
+GTS permission instances against the service-principal managed-resource type.
 
 - **Rationale**: Credential minting and revocation require narrower delegation than general inventory access.
 - **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-authz-resolver`
+- **Acceptance Evidence**: `service-principal/src/gts/permissions_tests.rs`
 
 #### Explicit Tenant Authorization
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-tenant-authorization`
 
-The system **MUST** authorize each operation against the explicit owning tenant and verify that returned tenant constraints cover that target. Authorization for one tenant or subtree **MUST NOT** authorize an unrelated tenant.
+The system **MUST** authorize each operation against the explicit owning tenant and verify that the PDP's
+returned scope actually covers that tenant (or is unconstrained) before delegating. A decision that is `true`
+for a different tenant or subtree **MUST NOT** authorize the explicit target tenant.
 
 - **Rationale**: A broad or mismatched policy decision must not create a broken object-level authorization path.
 - **Actors**: `cpt-cf-service-principal-actor-authz-resolver`
+- **Acceptance Evidence**: `service-principal/src/domain/service_tests.rs::create_for_a_different_tenant_than_the_pdp_scope_is_access_denied`
 
 #### Fail-Closed Authorization
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-authz-fail-closed`
 
-The system **MUST** deny the operation when caller identity, policy evaluation, or required tenant constraints cannot be established.
+The system **MUST** deny the operation when the PDP denies the request, when constraint compilation fails, or
+when policy evaluation itself fails.
 
 - **Rationale**: Security dependency failures must not widen access.
 - **Actors**: `cpt-cf-service-principal-actor-authz-resolver`
+- **Acceptance Evidence**: `service-principal/src/domain/authz.rs` (`map_enforcer_err` tests)
 
-### 5.5 Provider Contract and Recovery
+### 5.5 Provider Contract and Failure Handling
 
 #### Provider-Neutral Delegation
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-provider-delegation`
 
-The system **MUST** delegate principal lifecycle operations through a versioned provider-neutral contract so conforming adapters can be substituted without changing callers.
+The system **MUST** delegate every lifecycle operation through the versioned `ServicePrincipalClientV1` trait,
+resolved lazily per request from the `ClientHub`, so a conforming adapter can be substituted without changing
+callers or the REST contract.
 
 - **Rationale**: The Gears capability must not bind consumers to one identity provider.
 - **Actors**: `cpt-cf-service-principal-actor-provider-adapter`, `cpt-cf-service-principal-actor-consuming-gear`
@@ -397,59 +480,45 @@ The system **MUST** delegate principal lifecycle operations through a versioned 
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-provider-required`
 
-The system **MUST** fail explicitly and without simulated success when no conforming provider adapter is available.
+The system **MUST** report the capability as unavailable, without attempting a simulated success, when no
+provider adapter is registered in the `ClientHub`.
 
 - **Rationale**: Provider absence means authoritative identity state cannot be created or changed safely.
 - **Actors**: `cpt-cf-service-principal-actor-provider-adapter`
+- **Acceptance Evidence**: `service-principal/src/domain/service_tests.rs::provider_absent_is_provider_unavailable`
 
 #### Stable Failure Categories
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-failure-categories`
 
-The system **MUST** define one six-category failure taxonomy for end-to-end classification of provider outcomes, REST responses, and Rust SDK errors: invalid input, not found, clean failure, ambiguous outcome, authorization failure, and provider unavailability. The provider contract's four outcomes **MUST** map directly to the first four categories. Authorization failure **MUST** identify failure to establish caller identity, policy approval, or matching tenant constraints before provider invocation. Provider unavailability **MUST** identify provider absence or an availability failure known to prevent mutation; if a provider request may have mutated state, the outcome **MUST** instead be ambiguous and **MUST NOT** be reported as success. REST and Rust consumers **MUST** receive the same category and retry or reconciliation semantics. Adding, renaming, or splitting a Rust SDK or provider category **MUST** require a new major contract version with migration guidance; older consumers encountering an unknown category **MUST** treat it as failure and as ambiguous whenever mutation cannot be ruled out.
+The system **MUST** map the SPI's four closed failure categories (invalid input, not found, clean failure,
+ambiguous) plus its own access-denied and provider-unavailable outcomes onto canonical RFC-9457 problem
+responses, such that a caller can distinguish invalid input, not found, access denied, an unavailable or cleanly
+failed provider, and an ambiguous outcome from one another without parsing free text.
 
-- **Rationale**: Callers need deterministic retry and reconciliation behavior.
+- **Rationale**: Callers need a deterministic, machine-readable response for every outcome the provider can
+  report.
 - **Actors**: `cpt-cf-service-principal-actor-provider-adapter`, `cpt-cf-service-principal-actor-consuming-gear`
+- **Acceptance Evidence**: `service-principal/src/api/rest/error.rs::variants_map_to_expected_statuses`
 
-#### Ambiguous Creation Recovery
+#### Ambiguous Outcome Signaling
 
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-ambiguous-create-recovery`
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-ambiguous-outcome-signaling`
 
-Every create attempt **MUST** carry a caller-generated operation key bound to the explicit tenant and canonical request identity. After an ambiguous result, the caller **MUST** reconcile by repeating the identical request with the same key. The adapter **MUST** reconcile before further mutation and classify provider evidence as `exact_binding`, `authoritative_absence`, or `inconclusive`. `exact_binding` **MUST** return a non-secret `credentials_unavailable` failed-precondition result with the confirmed principal identity and rotation guidance. `authoritative_absence` **MAY** permit a fresh create with a new key. `inconclusive` **MUST** remain ambiguous and block conflicting mutation. Reusing a key for another tenant, operation, or request identity **MUST** be invalid input.
+The system **MUST** report a provider outcome the adapter classifies as ambiguous (state may have been retained)
+as its own distinct outcome — never as success and never as the same outcome used for a safely retryable
+provider failure — so a caller does not blindly retry a request that may have already mutated provider state.
 
-- **Rationale**: Ambiguous creation must not justify destructive action against a tenant principal whose relationship to the uncertain request is unproven.
+- **Rationale**: A half-applied create or rotation must not be indistinguishable from a transient, safely
+  retryable failure.
 - **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-provider-adapter`
-
-#### Ambiguous Rotation Recovery
-
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-ambiguous-rotate-recovery`
-
-Every rotation **MUST** carry a caller-generated operation key. After an ambiguous result, the caller **MUST** repeat only the identical request with the same key. The adapter **MUST** reconcile before further mutation. A confirmed prior rotation whose secret response was lost **MUST** return `credentials_unavailable`; the caller **MUST** use a new operation key for a subsequently confirmed rotation before adopting replacement credentials. Plaintext credentials **MUST NOT** be persisted or replayed.
-
-- **Rationale**: An uncertain rotation cannot establish which credential is safe to use.
-- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-machine-workload`
-
-#### Ambiguous Revocation Recovery
-
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-ambiguous-revoke-recovery`
-
-When revocation has an ambiguous outcome, the system **MUST** allow repeated revocation until the principal is confirmed revoked or already absent.
-
-- **Rationale**: Repeated deletion is the safe convergence path after transport uncertainty.
-- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-provider-adapter`
-
-#### Tenant Deprovision Cleanup
-
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-tenant-cleanup`
-
-The tenant lifecycle owner **MUST** authenticate and authorize tenant deprovisioning for an explicit target tenant, durably retain retryable lifecycle state, and invoke the identity-provider tenant-deprovision contract. The provider adapter **MUST** delete only principals authoritatively owned by that tenant and **MUST** confirm that no live owned principal remains before returning success. Already-absent principals are success-equivalent. A transient cleanup failure **MUST** block teardown and remain retryable through the tenant-lifecycle operation; a permanent failure **MUST** block teardown and remain operator-visible. Service Principal **MUST NOT** own cleanup state, scheduling, or a cleanup API.
-
-- **Rationale**: A machine credential must not outlive its authorization boundary, and cleanup must preserve the same tenant isolation and accountability as other lifecycle operations.
-- **Actors**: `cpt-cf-service-principal-actor-tenant-lifecycle-owner`, `cpt-cf-service-principal-actor-provider-adapter`
 
 ## 6. Non-Functional Requirements
 
-Architecture and engineering conventions are inherited from the [ToolKit Architecture & Developer Guide](../../../../docs/toolkit_unified_system/README.md) and [project guidelines](../../../../guidelines/README.md). The requirements below define Service Principal-specific obligations. Where a quantitative target still requires production evidence, this section defines an explicit release gate rather than assuming an undocumented baseline.
+Architecture and engineering conventions are inherited from the
+[ToolKit Architecture & Developer Guide](../../../../docs/toolkit_unified_system/README.md) and
+[project guidelines](../../../../guidelines/README.md). The requirements below define Service Principal-specific
+obligations grounded in the current implementation.
 
 ### 6.1 Gear-Specific NFRs
 
@@ -457,143 +526,120 @@ Architecture and engineering conventions are inherited from the [ToolKit Archite
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-secret-confidentiality`
 
-The system **MUST** prevent plaintext client secrets from appearing in list responses, logs, debug output, diagnostics, telemetry, and cacheable responses. Credential-bearing responses **MUST** be non-cacheable.
+The system **MUST** prevent plaintext client secrets from appearing in list responses or in the `Debug`
+representation of any credential-bearing type, and every credential-bearing response **MUST NOT** be cached or
+stored by intermediaries.
 
-- **Threshold**: Zero secret disclosures across automated negative checks for these surfaces.
+- **Threshold**: Zero secret disclosures across the DTO redaction tests and zero credential responses that are
+  not marked non-cacheable across the router test suite.
 - **Rationale**: A leaked client secret grants workload identity until rotation or revocation.
-- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [REST V1 contract](./DESIGN.md#service-principal-rest-v1), and [Security and Data Protection](./DESIGN.md#44-security-and-data-protection).
+- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation) and
+  [Security and Data Protection](./DESIGN.md#44-security-and-data-protection).
 
-#### Data Classification and Privacy
+#### Data Classification
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-data-classification`
 
-The system **MUST** treat plaintext client secrets and provider verifier material as restricted authentication credentials. It **MUST** treat client identifiers, subject identifiers, tenant ownership, scopes, operation keys and fingerprints, and lifecycle outcomes as security-sensitive control-plane metadata. The capability **MUST NOT** intentionally collect human profile attributes or unrelated personal data.
+The system **MUST** treat plaintext client secrets as restricted authentication credentials, wrapped in a
+redacting, non-serializable secret type. It **MUST** treat client identifiers, subject identifiers, tenant
+ownership, and scopes as security-sensitive control-plane metadata, distinct from and never mixed with human
+profile attributes.
 
-- **Threshold**: Every field in the public and provider contracts has an approved security classification before release, and conformance checks find zero human profile attributes or unrelated personal data.
-- **Rationale**: Explicit classification keeps credential controls, telemetry, retention, and privacy treatment aligned with actual data sensitivity.
-- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [Security and Data Protection](./DESIGN.md#44-security-and-data-protection), and [Compliance and Privacy Posture](./DESIGN.md#48-compliance-and-privacy-posture).
+- **Threshold**: Zero plaintext secret disclosures in debug-formatted output or serialized representations of
+  the credential model, verified by the redaction tests.
+- **Rationale**: Explicit classification keeps credential handling aligned with actual data sensitivity.
+- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation) and
+  [Security and Data Protection](./DESIGN.md#44-security-and-data-protection).
 
-#### No Plaintext Secret Persistence
+#### No Local Secret Persistence
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-no-secret-persistence`
 
-The Service Principal capability **MUST NOT** persist plaintext client secrets or operation-reconciliation state. A provider adapter **MUST NOT** persist or replay plaintext credential responses as part of reconciliation. The identity provider may retain verifier material according to its security contract.
+The Service Principal gear **MUST NOT** persist plaintext client secrets or any lifecycle state. The gear's
+domain `Service` holds only the PDP `PolicyEnforcer` and a `ClientHub` handle; it declares no database and no
+storage dependency.
 
-- **Threshold**: Zero Service Principal-owned plaintext secret records and zero adapter reconciliation records containing a plaintext or replayable credential response.
-- **Rationale**: The capability is a lifecycle facade, not a credential store.
-- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [Database Schemas and Tables](./DESIGN.md#37-database-schemas--tables), and [Security and Data Protection](./DESIGN.md#44-security-and-data-protection).
+- **Threshold**: Zero Service Principal-owned tables, files, or caches containing a plaintext or replayable
+  credential.
+- **Rationale**: The gear is a lifecycle facade, not a credential store.
+- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation) and
+  [Database Schemas and Tables](./DESIGN.md#37-database-schemas--tables).
 
 #### Tenant Isolation
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-tenant-isolation`
 
-The system **MUST** prevent management operations from crossing unauthorized tenant boundaries.
+The system **MUST** prevent management operations from crossing unauthorized tenant boundaries, even when the
+PDP grants an unconstrained or differently-scoped decision.
 
-- **Threshold**: Zero unauthorized successes in the cross-tenant security suite.
+- **Threshold**: Zero unauthorized successes in the cross-tenant authorization tests.
 - **Rationale**: Machine credentials are high-impact tenant resources.
-- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [Authorization Gate](./DESIGN.md#authorization-gate), and [Provider Boundary](./DESIGN.md#provider-boundary).
-
-#### Credential Invalidation
-
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-credential-invalidation`
-
-Successful rotation and revocation **MUST** make superseded credentials unusable without an additional grace period.
-
-- **Threshold**: 100% of successful rotation and revocation conformance scenarios reject superseded credentials.
-- **Rationale**: Security response depends on immediate credential termination.
-- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [Provider Boundary](./DESIGN.md#provider-boundary), and [Interactions and Sequences](./DESIGN.md#36-interactions--sequences).
-
-#### Provider Conformance
-
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-provider-conformance`
-
-Every supported identity-provider integration **MUST** pass the common conformance suite. Its Service Principal adapter coverage **MUST** include lifecycle, ownership, operation-key reconciliation, failure classification, and credential security. Its tenant-deprovision coverage **MUST** include exact-owner cleanup, retryable and terminal failures, and authoritative zero-principal confirmation.
-
-- **Threshold**: 100% of mandatory Service Principal adapter and tenant-deprovision scenarios pass for each supported identity-provider integration.
-- **Rationale**: Provider substitution is safe only when contract behavior is equivalent.
-- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [Provider Adapter V1](./DESIGN.md#provider-adapter-v1), and [Testability and Verification](./DESIGN.md#47-testability-and-verification).
-
-#### Contract Compatibility
-
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-contract-compatibility`
-
-REST and Rust contract changes within a major version **MUST** remain backward-compatible and additive. Breaking changes **MUST** use a new major contract version with migration guidance.
-
-- **Threshold**: Zero unversioned breaking changes in compatibility checks.
-- **Rationale**: Callers must remain independent of provider and implementation release cadence.
-- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [API Contracts](./DESIGN.md#33-api-contracts), and [Failure Taxonomy and Wire Safety](./DESIGN.md#41-failure-taxonomy-and-wire-safety).
-
-#### Security Auditability
-
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-auditability`
-
-Every management decision and lifecycle operation **MUST** produce an auditable record attributable to the validated initiating caller or approved system actor, target tenant, action, timestamp, correlation identifier, and terminal outcome without recording a plaintext client secret.
-
-- **Threshold**: 100% of lifecycle and authorization conformance scenarios produce complete attributable records, with zero plaintext client secrets in audit data.
-- **Rationale**: Credential administration must support incident investigation and accountability regardless of whether the platform or the gear emits the final audit record.
-- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [Audit and Observability component](./DESIGN.md#audit-and-observability), and [Auditability and Observability](./DESIGN.md#45-auditability-and-observability).
-
-#### Operational Observability
-
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-observability`
-
-The system **MUST** record latency and a stable outcome category for every Service Principal lifecycle operation. Operators **MUST** be able to distinguish invalid input, not found, clean failure, ambiguous outcome, authorization failure, and provider unavailability. Service Principal ambiguous outcomes and provider unavailability **MUST** produce adapter-correlated signals suitable for platform alerting. The tenant lifecycle owner **MUST** provide cleanup retry and terminal-failure signals.
-
-- **Threshold**: 100% of Service Principal lifecycle calls emit one latency observation and one public outcome category; 100% of tenant-cleanup attempts emit a lifecycle-native outcome; conformance tests demonstrate an alertable signal for each specified operational condition.
-- **Rationale**: Operators need to detect provider degradation and unresolved credential state.
-- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [Audit and Observability component](./DESIGN.md#audit-and-observability), and [Auditability and Observability](./DESIGN.md#45-auditability-and-observability).
+- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation) and
+  [Authorization Gate](./DESIGN.md#authorization-gate).
 
 #### Stateless Recovery
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-stateless-recovery`
 
-Service Principal restart **MUST** lose no authoritative principal or recovery state because the gear owns neither. Create and rotation operation keys **MUST** be forwarded to an adapter that provides restart-safe, tenant-bound reconciliation. The adapter may reconcile during a repeated request or through adapter-private execution, but Service Principal **MUST NOT** schedule or persist that work.
+The gear **MUST** hold no authoritative principal or session state across requests, so a gear restart requires no
+state restoration and loses no in-flight authorization decision.
 
-- **Threshold**: Restart tests prove that Service Principal requires no database restoration and that every supported adapter deterministically resumes an unresolved same-key create or rotation without duplicate logical mutation.
-- **Rationale**: The gear remains a stateless authorization and provider-delegation boundary while the integration closest to provider behavior owns reconciliation correctness.
-- **Architecture Allocation**: [Provider Boundary](./DESIGN.md#provider-boundary), [Database Schemas and Tables](./DESIGN.md#37-database-schemas--tables), and [Operation-Key Reconciliation](./DESIGN.md#42-operation-key-reconciliation).
+- **Threshold**: The gear crate declares no database, migration, or stateful-worker dependency.
+- **Rationale**: The gear is purely an authorization and provider-delegation boundary; authoritative state, if
+  any, belongs to the registered provider adapter.
+- **Architecture Allocation**: [Provider Adapter Boundary](./DESIGN.md#provider-adapter-boundary).
 
-#### Cleanup Reliability
+#### Contract Versioning
 
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-cleanup-reliability`
+- [ ] `p2` - **ID**: `cpt-cf-service-principal-nfr-contract-compatibility`
 
-Tenant-deprovision cleanup failures **MUST** remain durably visible and retryable in the tenant lifecycle owner's deprovision operation until the provider adapter confirms no live owned principal remains. Service Principal **MUST NOT** retain cleanup records or run cleanup retries.
+The REST surface and the provider contract **MUST** each carry an explicit major-version marker, so a breaking
+change requires a new major version rather than an in-place change to the existing surface.
 
-- **Threshold**: Zero cleanup failures are silently discarded; every retryable tenant-deprovision operation survives lifecycle-owner restart; permanent failures remain operator-visible; successful deprovisioning leaves zero live owned principals.
-- **Rationale**: Credential survival after tenant removal is a security incident, while retry durability belongs with the lifecycle operation that gates tenant removal.
-- **Architecture Allocation**: [Tenant Lifecycle Cleanup Integration](./DESIGN.md#tenant-lifecycle-cleanup-integration), [Auditability and Observability](./DESIGN.md#45-auditability-and-observability), and [Fault Tolerance](./DESIGN.md#46-fault-tolerance).
-
-#### Performance and Availability Qualification
-
-- [ ] `p2` - **ID**: `cpt-cf-service-principal-nfr-performance-baseline`
-
-Initial GA approval **MUST** be blocked until representative provider benchmarks establish and approve the supported tenant and principal envelope, p95 lifecycle latency, sustained administrative request rate, provider-unavailable behavior, and availability objective. Published service objectives **MUST** then be used as release-conformance thresholds.
-
-- **Threshold**: Before GA, a versioned benchmark report records approved values for all five dimensions; each subsequent supported release satisfies the published objectives or documents an approved revision.
-- **Rationale**: Provider latency dominates operations, so targets must be measurable without inventing unsupported values.
-- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [Configuration](./DESIGN.md#43-configuration), [Fault Tolerance](./DESIGN.md#46-fault-tolerance), and [Testability and Verification](./DESIGN.md#47-testability-and-verification).
-
-#### Operational Readiness Documentation
-
-- [ ] `p2` - **ID**: `cpt-cf-service-principal-nfr-operational-documentation`
-
-Each supported release **MUST** publish API and operator guidance covering one-time secret handling, approved credential-store handoff, stable outcome categories, ambiguous-outcome reconciliation, tenant-cleanup retry, alert interpretation, and troubleshooting without plaintext secrets.
-
-- **Threshold**: Release readiness evidence verifies that all seven topics are present and that documentation examples contain zero plaintext production credentials.
-- **Rationale**: Operators and API consumers need safe recovery instructions for credential-bearing and uncertain provider operations.
-- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [API Contracts](./DESIGN.md#33-api-contracts), [Auditability and Observability](./DESIGN.md#45-auditability-and-observability), and [Testability and Verification](./DESIGN.md#47-testability-and-verification).
+- **Threshold**: Every published management operation and the provider contract expose a major-version marker;
+  zero breaking changes are applied in place within a published major version.
+- **Rationale**: Callers and adapters must remain independent of unrelated release cadence.
+- **Architecture Allocation**: [API Contracts](./DESIGN.md#33-api-contracts).
 
 ### 6.2 NFR Exclusions
 
-- **Authoritative principal-data RPO and backup**: Not applicable because the provider owns principal records and Service Principal owns no principal database, reconciliation repository, or plaintext secret store.
-- **Offline mutation availability**: Not applicable because authoritative lifecycle changes require a reachable provider.
-- **Physical safety**: Not applicable because this is an information-system control plane with no direct physical actuation.
-- **End-user accessibility and internationalization**: Not applicable to the initial server/API-only capability; future user interfaces must define their own requirements.
-- **Gear-specific disaster recovery**: No Service Principal data restoration is required. Authoritative principal recovery and adapter-private reconciliation durability remain provider-integration obligations; tenant-cleanup retry durability remains a tenant-lifecycle obligation.
-- **Personal-data privacy**: No gear-specific privacy regime applies because the capability intentionally processes machine identities rather than human profiles. This exclusion ceases to apply in deployments where tenant or account identifiers can identify natural persons.
-- **Industry-specific regulation**: No regulation is introduced by this provider-neutral capability. Deployment-specific regulatory controls remain mandatory where the platform, provider, tenant, or workload is subject to them.
-- **Data retention and residency**: The identity provider owns principal-record retention and residency, adapters own any private reconciliation-record policy, tenant lifecycle owns deprovision-operation retention, and platform observability owns telemetry retention and residency. Service Principal owns none of these durable records.
-- **Dedicated deployment and release process**: Not applicable; the capability uses the project-wide release process, with the additional benchmark and documentation gates defined above.
+- **Immediate credential invalidation on rotate/revoke**: Not verified by this codebase. Invalidating the
+  superseded credential is the registered provider adapter's responsibility; no adapter ships in this
+  repository to test against.
+- **Cross-adapter provider conformance suite**: Not applicable today. Only the `ServicePrincipalClientV1` trait
+  contract is defined here; a shared conformance harness across multiple adapters does not exist in this
+  repository.
+- **Bespoke auditability and observability**: Not applicable beyond the project baseline. The gear emits one
+  init-time log line and one `warn!` on provider absence; it defines no dedicated audit trail, metrics, or
+  alerting beyond platform-wide request tracing and canonical-error correlation.
+- **Tenant-deprovision cleanup and retry durability**: Not applicable to this gear. Removing a deprovisioned
+  tenant's principals is a documented obligation of the provider SPI contract, owned by the adapter behind
+  `ServicePrincipalClientV1`; the gear itself performs no tenant-lifecycle orchestration and keeps no durable
+  work queue to retry.
+- **Performance and scale benchmarking**: Not measured. No dedicated latency, throughput, or capacity code path
+  exists beyond delegating to the registered provider; project-wide platform baselines apply.
+- **Scalability targets**: Not applicable because the gear holds no state, runs no background work, and adds no
+  capacity dimension of its own — every lifecycle call is a single authorization check plus one delegated
+  provider call, so achievable throughput and tenant/principal volume are properties of the registered provider
+  adapter and the platform request path, not of this gear. No gear-specific scale target is stated, and none can
+  be verified from this codebase.
+- **API rate limiting**: Not applicable at the gear level; lifecycle operations are low-frequency administrative
+  calls (§3.1), and any rate limiting is enforced by the platform API gateway baseline.
+- **Authoritative principal-data RPO and backup**: Not applicable because the provider owns principal records and
+  Service Principal owns no principal database.
+- **Offline mutation availability**: Not applicable because authoritative lifecycle changes require a reachable
+  provider.
+- **Physical safety**: Not applicable because this is an information-system control plane with no physical
+  actuation.
+- **End-user accessibility and internationalization**: Not applicable to this server/API-only capability.
+- **Personal-data privacy**: No gear-specific privacy regime applies because the capability processes machine
+  identities rather than human profiles.
+- **Data retention and residency**: The identity provider owns principal-record retention and residency;
+  Service Principal owns no durable record of its own.
+- **Dedicated deployment and release process**: Not applicable; the capability uses the project-wide release
+  process.
+- **Documentation and support requirements**: Follow the project-wide platform documentation and support
+  baseline; no gear-specific deviation.
 
 ## 7. Public Library Interfaces
 
@@ -605,16 +651,25 @@ Each supported release **MUST** publish API and operator guidance covering one-t
 
 - **Type**: Versioned authenticated REST API.
 - **Stability**: Stable within a major version.
-- **Description**: Provides create, list, rotate-secret, and revoke operations for an explicit owning tenant. Create and rotate require the standard `Idempotency-Key` request header. Credential-bearing operations disclose plaintext secrets once and mark responses as non-cacheable; no recovery-status surface exists.
+- **Description**: Exposes exactly four operations — create, list, rotate-secret, and revoke — addressed by
+  owning tenant and, for rotate-secret and revoke, by client identifier. There is deliberately no single-item
+  read: the collection listing and the address returned by create are the only ways to learn a principal's
+  non-secret state. Credential-bearing responses are non-cacheable and disclose the plaintext secret exactly
+  once.
 - **Breaking Change Policy**: A breaking change requires a new major API version and migration guidance.
 
-#### Service Principal Rust Interface
+#### Service Principal Rust Provider Interface
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-interface-rust-sdk`
 
-- **Type**: Transport-neutral Rust SDK and service-provider contract.
+- **Type**: Transport-neutral Rust SDK models and a versioned provider SPI (`ServicePrincipalClientV1`), resolved
+  via `ClientHub`.
 - **Stability**: Stable within a major version.
-- **Description**: Provides the same four lifecycle operations, validated `OperationKey` values for create and rotate, one-time credentials, secret-free summaries, tenant identity, and a major-versioned failure taxonomy with non-success handling for unknown categories.
+- **Description**: Provides the four lifecycle methods (`create`, `list`, `rotate_secret`, `revoke`), a one-time
+  credentials model, a secret-free summary model, an explicit `TenantId`, and a closed four-variant failure
+  taxonomy (`InvalidInput`, `NotFound`, `CleanFailure`, `Ambiguous`). It is not a public authorization boundary:
+  every caller is a trusted platform module that must satisfy the SPI's documented authorization precondition
+  before invocation; `SecurityContext` is carried for audit, not enforcement.
 - **Breaking Change Policy**: A breaking change requires a new major SDK contract version and migration guidance.
 
 #### Service Principal Managed Resource
@@ -623,7 +678,10 @@ Each supported release **MUST** publish API and operator guidance covering one-t
 
 - **Type**: GTS managed-resource and permission catalog.
 - **Stability**: Stable within a major version.
-- **Description**: Defines Service Principal as a resource distinct from human users and exposes create, read, rotate-secret, and revoke permissions.
+- **Description**: Registers `gts.cf.core.service_principal.service_principal.v1~` as a resource distinct from
+  the account-management user type and from the service-principal subject-classification type, and exposes four
+  permission instances (`create`, `read`, `rotate_secret`, `revoke`) under
+  `gts.cf.toolkit.authz.permission.v1~cf.core.service_principal.<action>.v1`.
 - **Breaking Change Policy**: Resource and action identifiers cannot change within a major version.
 
 ### 7.2 External Integration Contracts
@@ -632,25 +690,22 @@ Each supported release **MUST** publish API and operator guidance covering one-t
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-contract-provider-adapter`
 
-- **Direction**: Required from provider implementations.
-- **Protocol/Format**: Versioned provider-neutral Rust contract.
-- **Compatibility**: Adapters must preserve lifecycle, ownership, operation-key reconciliation, one-time disclosure, invalidation, and failure semantics for the contract version they implement.
+- **Direction**: Required from provider implementations, registered in the `ClientHub`.
+- **Protocol/Format**: The `ServicePrincipalClientV1` Rust trait.
+- **Compatibility**: An adapter must implement all four methods, address `(tenant_id, client_id)` as the scoped
+  resource, return `NotFound` for an address that does not resolve within the tenant, return the secret only
+  from `create`/`rotate_secret`, delete a tenant's principals when that tenant is deprovisioned, and report
+  transport uncertainty as `Ambiguous` rather than as success.
 
 #### Authorization Contract
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-contract-authorization`
 
 - **Direction**: Required from the platform Authorization Resolver.
-- **Protocol/Format**: Authenticated action request with explicit tenant resource attributes and tenant constraints.
-- **Compatibility**: Decisions must support the stable managed-resource and action identifiers for the active major version.
-
-#### Tenant Lifecycle Cleanup Contract
-
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-contract-tenant-cleanup`
-
-- **Direction**: Required from the identity-provider integration by the tenant lifecycle owner; Service Principal does not provide or proxy this contract.
-- **Protocol/Format**: Versioned authenticated tenant-deprovision request with a validated platform security context, explicit target tenant, and lifecycle-native success-equivalent, retryable, or terminal outcome.
-- **Compatibility**: The tenant lifecycle owner **MUST** retain retryable state and block teardown after retryable or terminal failure. The adapter **MUST** enforce exact tenant ownership, treat already-absent principals as success-equivalent, and return success only after confirming removal or absence of every live principal owned by the target tenant.
+- **Protocol/Format**: An `AccessRequest` carrying the `OWNER_TENANT_ID` resource property and
+  `require_constraints(true)`, evaluated through `PolicyEnforcer::access_scope_with`.
+- **Compatibility**: The returned `AccessScope` must be checked against the explicit target tenant (or be
+  unconstrained) before any provider call proceeds.
 
 ## 8. Use Cases
 
@@ -661,23 +716,26 @@ Each supported release **MUST** publish API and operator guidance covering one-t
 **Actor**: `cpt-cf-service-principal-actor-tenant-automation-admin`
 
 **Preconditions**:
-- The caller is authenticated and authorized for the target tenant and create action.
-- A conforming provider adapter is available.
-- The request carries a new caller-generated operation key.
-- The requested name, scopes, and tenant quota satisfy deployment policy.
+- The caller is authenticated and the PDP's returned scope covers the target tenant for the `create` action.
+- A `ServicePrincipalClientV1` implementation is registered in the `ClientHub`.
+- The requested name and scopes satisfy the registered provider's policy.
 
 **Main Flow**:
-1. The administrator requests a tenant-owned service principal.
-2. The system creates the provider identity.
-3. The system returns its client identifier, one-time secret, token endpoint, and subject identifier.
-4. The administrator stores the secret in approved credential storage.
+1. The administrator submits a name and optional scopes for a tenant-owned service principal.
+2. The system authorizes the request, then delegates creation to the registered provider.
+3. The system reports the new principal's address and discloses, in a response that must not be cached or stored
+   by intermediaries, the client identifier, one-time secret, token endpoint, and subject identifier.
+4. The administrator stores the secret immediately, since it is never returned again except by rotation.
 
 **Postconditions**:
 - The principal can authenticate as a service subject owned by the target tenant.
 
 **Alternative Flows**:
-- **Invalid policy input**: The request is rejected without new provider state.
-- **Ambiguous provider outcome**: The caller repeats only the identical request with the same operation key. The adapter reconciles before mutation. Confirmed prior creation returns `credentials_unavailable` with non-secret identity and rotation guidance; authoritative absence permits a fresh create with a new key; inconclusive evidence remains ambiguous and blocks conflicting mutation.
+- **Invalid input** (bad name, disallowed scope, quota exceeded, or a taken identifier): the request is rejected
+  as invalid input and no provider state is created.
+- **Ambiguous provider outcome**: the system reports the outcome as ambiguous; the caller must investigate
+  through `list` and resolve manually (for example, revoke and retry) since the gear performs no automatic
+  reconciliation.
 
 ### 8.2 Inventory Tenant Principals
 
@@ -686,38 +744,40 @@ Each supported release **MUST** publish API and operator guidance covering one-t
 **Actor**: `cpt-cf-service-principal-actor-tenant-automation-admin`
 
 **Preconditions**:
-- The caller is authenticated and authorized for the target tenant and read action.
+- The caller is authenticated and the PDP's returned scope covers the target tenant for the `read` action.
 
 **Main Flow**:
 1. The administrator requests the tenant's service-principal inventory.
-2. The system returns only principals owned by that tenant.
+2. The system returns every principal the registered provider reports for that tenant.
 3. The response contains no client secrets.
 
 **Postconditions**:
 - The administrator has current non-secret state for audit and lifecycle management.
 
-### 8.3 Rotate Compromised or Expiring Credential
+### 8.3 Rotate a Credential
 
 - [ ] `p1` - **ID**: `cpt-cf-service-principal-usecase-rotate`
 
 **Actor**: `cpt-cf-service-principal-actor-tenant-automation-admin`
 
 **Preconditions**:
-- The caller is authorized for the target tenant and rotate-secret action.
-- The provider confirms the principal's ownership and managed identity state.
-- The request carries a new caller-generated operation key.
+- The caller is authorized for the target tenant and the `rotate_secret` action.
+- The `client_id` resolves within the target tenant.
 
 **Main Flow**:
-1. The administrator requests secret rotation.
-2. The system invalidates the superseded secret.
-3. The system returns the new secret through a non-cacheable response.
-4. The administrator updates approved credential storage.
+1. The administrator requests secret rotation for a `client_id`.
+2. The system delegates to the registered provider and discloses the new secret in a response that must not be
+   cached or stored by intermediaries.
+3. The administrator updates the workload's stored credential.
 
 **Postconditions**:
-- The new secret authenticates and the superseded secret does not.
+- The workload can authenticate with the new secret.
 
 **Alternative Flows**:
-- **Ambiguous rotation**: The caller repeats only the identical request with the same operation key. A confirmed prior rotation whose response was lost returns `credentials_unavailable`; the caller performs a new rotation with a new key and adopts only its confirmed response.
+- **Unresolved principal**: the system reports not found when the `client_id` does not resolve within the target
+  tenant.
+- **Ambiguous provider outcome**: the system reports the outcome as ambiguous instead of as a silent success or a
+  safely retryable provider failure.
 
 ### 8.4 Revoke Workload Identity
 
@@ -726,139 +786,116 @@ Each supported release **MUST** publish API and operator guidance covering one-t
 **Actor**: `cpt-cf-service-principal-actor-tenant-automation-admin`
 
 **Preconditions**:
-- The caller is authorized for the target tenant and revoke action.
+- The caller is authorized for the target tenant and the `revoke` action.
 
 **Main Flow**:
-1. The administrator requests revocation.
-2. The system removes or confirms absence of the tenant-owned principal.
-3. Subsequent token acquisition fails.
+1. The administrator requests revocation of a `client_id`.
+2. The system delegates to the registered provider.
+3. The system concludes successfully, carrying no principal state and no credential material, whether the
+   principal was removed or was already absent.
 
 **Postconditions**:
 - The addressed principal no longer grants workload access.
 
 **Alternative Flows**:
-- **Already absent**: The operation is success-equivalent.
-- **Ambiguous revocation**: The administrator repeats revocation until success or confirmed absence.
-
-### 8.5 Deprovision Tenant Principals
-
-- [ ] `p1` - **ID**: `cpt-cf-service-principal-usecase-tenant-cleanup`
-
-**Actor**: `cpt-cf-service-principal-actor-tenant-lifecycle-owner`
-
-**Preconditions**:
-- The tenant lifecycle owner has authenticated and authorized tenant deprovisioning for the explicit target tenant.
-- The tenant lifecycle operation has durable retry state.
-- A conforming identity-provider integration is available.
-
-**Main Flow**:
-1. The tenant lifecycle owner invokes the identity-provider tenant-deprovision contract.
-2. The provider adapter selects only principals authoritatively owned by the explicit tenant.
-3. The adapter removes each owned principal, treating already-absent principals as success-equivalent.
-4. The adapter confirms that no live owned principal remains.
-5. The tenant lifecycle owner records final disposition and completes tenant deprovisioning.
-
-**Postconditions**:
-- Successful tenant deprovisioning leaves no live principal owned by that tenant.
-- Service Principal has stored no cleanup state and has not participated in the call.
-
-**Alternative Flows**:
-- **Transient provider failure**: The adapter returns retryable, teardown remains blocked, and the tenant lifecycle owner retries the whole deprovision operation from durable state.
-- **Permanent or configuration failure**: The adapter returns terminal, teardown remains blocked, and the tenant lifecycle owner keeps the operation visible for intervention.
+- **Already absent**: revoking an unknown principal still concludes successfully rather than reporting not found.
 
 ## 9. Acceptance Criteria
 
-- [ ] An authorized administrator can complete create, list, rotate, and revoke through the public contract without provider-specific administration.
-- [ ] Every supported provider adapter passes conformance tests proving that an access token obtained through `client_credentials` using credentials returned by successful creation contains the target tenant, a subject exactly equal to the creation response's `Subject`, and `client_credentials` identity context.
-- [ ] Unauthorized and cross-tenant management operations have zero successful outcomes in the security suite.
-- [ ] Credential-bearing responses are non-cacheable, and secret-negative checks find zero disclosures on prohibited surfaces.
-- [ ] Every successful rotation test rejects the superseded secret and accepts the confirmed replacement.
-- [ ] Every successful revocation test prevents later token acquisition.
-- [ ] Every supported provider adapter passes all mandatory conformance scenarios.
-- [ ] Conformance tests exercise all six Service Principal failure categories and verify consistent classification across applicable provider, REST, and Rust surfaces, including major-version compatibility and non-success handling for unknown or mutation-uncertain outcomes.
-- [ ] Concurrent and post-restart same-key create and rotation retries produce at most one logical mutation, reject cross-tenant or changed-request key reuse, and never persist or replay a plaintext credential.
-- [ ] `exact_binding`, `authoritative_absence`, and `inconclusive` adapter scenarios produce the required safe retry behavior without exposing provider proof material publicly.
-- [ ] Tenant cleanup deletes only principals authoritatively owned by the target tenant and never deletes foreign principals.
-- [ ] Transient tenant-cleanup failures block teardown and survive tenant-lifecycle restart; terminal failures remain operator-visible; successful tenant deprovisioning leaves zero live service principals owned by that tenant.
-- [ ] A security review classifies every public and provider-contract field and confirms that no human profile attributes or unrelated personal data are collected.
-- [ ] Every lifecycle and authorization scenario produces a complete attributable audit record with no plaintext client secret.
-- [ ] Initial GA evidence includes approved benchmark values for the supported scale envelope, p95 lifecycle latency, sustained request rate, provider-unavailable behavior, and availability objective.
-- [ ] API and operator documentation covers every required readiness topic without exposing plaintext production credentials.
-- [ ] REST, Rust SDK, GTS registration, authorization, provider conformance, security, and end-to-end evidence exist within the Gears artifact and implementation chain before completion is claimed.
+- [ ] An authorized administrator can complete create, list, rotate-secret, and revoke through the REST contract
+      without direct identity-provider administration.
+- [ ] Unauthorized and cross-tenant management requests have zero successful outcomes in the authorization test
+      suite.
+- [ ] Every create and rotate-secret success response is marked as not to be cached or stored by intermediaries,
+      and no listing or `Debug` output ever contains a plaintext client secret.
+- [ ] A revoke request against an already-absent principal concludes successfully, indistinguishably from a
+      revoke against a present one.
+- [ ] The SPI's four failure categories plus the gear's access-denied and provider-unavailable outcomes render as
+      distinguishable, machine-readable problem responses per the platform's error baseline (RFC-9457).
+- [ ] Exactly four management operations (create, list, rotate-secret, revoke) are exposed, and no
+      single-principal read operation exists.
+- [ ] All four service-principal permission instances (`create`, `read`, `rotate_secret`, `revoke`) are present
+      in the GTS link-time inventory and reference the service-principal managed-resource type.
+- [ ] A request against a `ClientHub` with no registered provider reports the capability as unavailable rather
+      than a simulated success.
 
 ## 10. Dependencies
 
 | Dependency | Description | Criticality |
 |---|---|---|
-| Gears ToolKit runtime | Hosts the gear and its authenticated public capability. | p1 |
-| Platform client registry | Resolves the configured provider-neutral adapter for trusted callers. | p1 |
-| Authorization Resolver | Supplies action decisions and tenant-scoped constraints. | p1 |
-| Tenant model and resolver contracts | Supply canonical tenant identity and hierarchy semantics. | p1 |
-| Types and Permission Registry | Registers resource, subject, and permission identifiers. | p1 |
-| Canonical error framework | Supplies standardized public error categories. | p1 |
-| API Gateway and OpenAPI registry | Routes and documents the versioned REST interface. | p1 |
-| Identity Provider Adapter | Owns authoritative principal state and implements lifecycle operations. | p1 |
-| Approved Credential Store | Retains one-time disclosed credentials for consuming workloads. | p1 |
-| Platform observability | Collects lifecycle latency, outcomes, logs, and alerts. | p2 |
+| Gears ToolKit runtime (`toolkit`) | Hosts the gear, mounts the REST routes, and provides the `ClientHub` used to resolve the provider adapter. | p1 |
+| Authorization Resolver (`authz-resolver`, `authz-resolver-sdk`) | Supplies action decisions and tenant-scoped constraints through `PolicyEnforcer`. | p1 |
+| Types and Permission Registry (`types-registry`) | Aggregates the GTS managed-resource type and permission catalog at startup. | p1 |
+| Tenant identity contract (`tenant-resolver-sdk::TenantId`) | Supplies the canonical tenant identifier type used across the REST and provider contracts. | p1 |
+| Canonical error framework (`toolkit-canonical-errors`) | Maps domain errors to RFC-9457 Problem responses. | p1 |
+| API Gateway / OpenAPI registry (`toolkit::api`) | Authenticates and publishes the versioned REST routes. | p1 |
+| Identity Provider Adapter (`ServicePrincipalClientV1` implementation) | Owns authoritative principal state and implements the four lifecycle operations; resolved through `ClientHub`, not shipped in this repository. | p1 |
+| Platform observability (`tracing`) | Collects the gear's init-time and provider-absence log events. | p3 |
 
 ## 11. Assumptions
 
-- The platform provides stable tenant identifiers and tenant hierarchy semantics.
-- The platform authenticates public API callers before Service Principal authorization.
-- Consuming workloads can protect credentials and perform OAuth 2.0 `client_credentials` requests.
-- One conforming provider adapter is configured for the initial deployment.
-- Identity-provider state is authoritative; Service Principal owns no principal database, recovery repository, cleanup state, or retry scheduler.
-- Administrators choose names and scopes according to deployment policy.
-- Lifecycle operations are low-frequency administrative operations.
-- The initial capability is server/API-facing and has no dedicated user interface.
+- The platform authenticates callers and attaches a validated `SecurityContext` before this gear's route
+  handlers run.
+- The platform supplies a stable `Uuid` tenant identifier used consistently across the authorization and
+  provider contracts.
+- Exactly one conforming `ServicePrincipalClientV1` implementation is registered in the `ClientHub` per
+  deployment; none ships with this repository.
+- The registered provider adapter enforces name syntax, scope allowlisting, and quota policy; this gear performs
+  no independent validation of those fields.
+- Consumers persist a returned client secret immediately, since only create and rotate-secret ever return it.
+- Lifecycle operations are low-frequency administrative calls, not request-path operations.
 
 ## 12. Risks
 
 | Risk | Impact | Mitigation |
 |---|---|---|
-| Only one provider initially proves the contract | Hidden provider assumptions may limit future portability. | Keep contracts provider-neutral and require the same conformance suite for every adapter. |
-| Caller loses the one-time secret | The workload cannot authenticate. | Require immediate approved storage and recover through rotation. |
-| Secret leaks through diagnostics or caching | An attacker can impersonate a workload. | Enforce redaction, non-cacheability, and secret-negative tests. |
-| Cross-tenant object access | A caller can manage another tenant's credentials. | Authorize the explicit tenant and verify returned tenant constraints. |
-| Over-privileged administrators | Credential minting is delegated too broadly. | Keep lifecycle actions independently grantable. |
-| Scope escalation | A workload receives unintended privileges. | Restrict requested scopes to a deployment-controlled allowlist. |
-| Ambiguous provider mutation | Caller and provider disagree about principal or credential state. | Use stable ambiguity reporting and operation-specific reconciliation. |
-| Concurrent creation exceeds quota | Tenant count briefly exceeds the configured cap. | Document best-effort semantics, monitor counts, and reassess strong enforcement from measured need. |
-| Tenant cleanup fails | Credentials survive their tenant boundary. | Keep the tenant-lifecycle operation durable and visible, retry the whole deprovision workflow after transient failure, and block successful deprovisioning until the adapter confirms zero owned principals. |
-| Unpaginated listing grows too large | Administrative latency and payload size increase. | Start with bounded tenant quotas and define a measured trigger for pagination. |
-| Resource or permission identifiers drift | Authorization grants no longer match enforcement. | Pin identifiers and validate registry-to-enforcement consistency. |
+| No provider adapter ships with this repository | Lifecycle operations report the capability as unavailable until a deployment registers one | Treat provider absence as an explicit `ProviderUnavailable` failure rather than a simulated success; document the `ClientHub` registration requirement. |
+| Ambiguous provider outcomes require manual recovery | Operators may be uncertain whether a principal exists after an ambiguous outcome | Report `Ambiguous` as its own distinct outcome, separate from a safely retryable provider failure, so callers know to inspect state via `list` rather than retry blindly. |
+| Secret leaks through logs, `Debug`, or caching | An attacker can impersonate a workload | Enforce redacting `Debug` on credential types and ensure every credential-bearing response must not be cached or stored by intermediaries; verified by DTO and router tests. |
+| Cross-tenant object access | A caller can manage another tenant's credentials | Authorize the explicit tenant and verify the returned PDP scope actually covers it before any provider call. |
+| Name, scope, and quota policy are fully delegated to the provider | Enforcement can vary by adapter implementation | Document the delegation explicitly in the SPI contract so future adapters implement it consistently. |
+| Deletion of principals on tenant deprovision is an SPI obligation the adapter alone discharges | An adapter that does not honor the obligation leaves credentials alive after their owning tenant is removed, and the gear cannot detect it | State the obligation normatively in the provider SPI contract; treat verification of adapter conformance as open work before a deployment relies on this gear for tenant offboarding. |
+| No cross-adapter conformance suite exists | A future second adapter could diverge in ownership, invalidation, or failure-category behavior | Tracked as future qualification work before a second adapter is accepted. |
 
 ## 13. Open Questions
 
-1. **What production scale and lifecycle latency targets should the gear support?**
-   - **Owner**: Platform Performance and Operations.
-   - **Resolution target**: Before initial GA benchmark approval.
+1. **How will a registered adapter's conformance to the SPI obligation to delete a tenant's principals on
+   deprovision be verified?** The obligation is stated in the provider SPI contract and the gear performs no
+   tenant-lifecycle orchestration, so nothing in this repository demonstrates that an adapter actually honors it.
+   - **Owner**: Gears Architecture.
+   - **Resolution target**: Before this gear is relied upon for tenant offboarding.
 
-2. **When is a second provider adapter required to substantiate portability?**
+2. **Should create and rotate-secret gain an idempotency or operation-key mechanism to let a caller safely retry
+   after an ambiguous outcome?**
+   - **Owner**: Gears Architecture.
+   - **Resolution target**: Before a stronger consistency guarantee is offered to callers.
+
+3. **What common provider-conformance suite will validate a second adapter's ownership, invalidation, and
+   failure-category behavior?**
+   - **Owner**: Provider Integration Owners.
+   - **Resolution target**: Before a second adapter is accepted.
+
+4. **Should the REST surface add a single-principal read now that create returns an address for an otherwise
+   unreadable resource?**
    - **Owner**: Product and Gears Architecture.
-   - **Resolution target**: Before claiming multi-provider production support.
+   - **Resolution target**: Before the next breaking API version.
 
-3. **What measured tenant volume triggers pagination or strongly enforced quota semantics?**
+5. **What measured tenant volume should trigger enforced (rather than provider-delegated, best-effort) quota
+   semantics?**
    - **Owner**: Product and Capacity Engineering.
-   - **Resolution target**: Before raising the initial supported tenant limit.
-
-4. **Should adapter incompatibility fail registration or the first lifecycle operation?**
-   - **Owner**: Gears Architecture and Provider Integration Owners.
-   - **Resolution target**: Before provider-adapter contract freeze.
-
-5. **What retention policy applies to adapter-private reconciliation records?**
-   - **Owner**: Security, Operations, and Provider Integration Owners.
-   - **Resolution target**: Before initial adapter production qualification.
-
-Resolved during design: audit and operational signals use layered ownership. Service Principal records authorization and public lifecycle outcomes, provider adapters record provider mutation and reconciliation outcomes, and the tenant lifecycle owner records cleanup retries and final tenant disposition. The allocation is defined in [DESIGN §4.5](./DESIGN.md#45-auditability-and-observability).
+   - **Resolution target**: Before raising the supported tenant limit.
 
 ## 14. Traceability
 
 - **System slug**: `service-principal`
 - **ID prefix**: `cpt-cf-service-principal-*`
 - **UPSTREAM_REQS**: No upstream requirements artifact exists for this gear.
-- **DESIGN**: [DESIGN.md](./DESIGN.md) allocates every FR and NFR and defines the implementation boundaries.
-- **ADRs**: None. This artifact records requirements; DESIGN records the resulting architecture without embedding decision debates. Explicit-tenant authorization follows the shared platform PDP/PEP baseline.
+- **DESIGN**: [DESIGN.md](./DESIGN.md) allocates the FRs and NFRs above and defines the implementation
+  boundaries; DESIGN.md may describe additional target-state architecture beyond what this PRD requires of the
+  current implementation.
+- **ADRs**: None. This artifact records requirements; DESIGN records the resulting architecture without
+  embedding decision debates.
 - **DECOMPOSITION**: Not yet authored.
 - **FEATURES**: Not yet authored.
-- **CODE**: No Gears implementation is registered for this artifact yet. Implementation traceability begins when FEATURE and CODE artifacts are added.
+- **CODE**: `gears/system/service-principal/service-principal` (gear crate) and
+  `gears/system/service-principal/service-principal-sdk` (SDK/SPI crate).

--- a/gears/system/service-principal/docs/PRD.md
+++ b/gears/system/service-principal/docs/PRD.md
@@ -1,0 +1,864 @@
+Created: 2026-08-06 by Constructor Studio
+
+# PRD — Service Principal
+
+<!-- toc -->
+
+- [1. Overview](#1-overview)
+  - [1.1 Purpose](#11-purpose)
+  - [1.2 Background / Problem Statement](#12-background--problem-statement)
+  - [1.3 Goals (Business Outcomes)](#13-goals-business-outcomes)
+  - [1.4 Glossary](#14-glossary)
+- [2. Actors](#2-actors)
+  - [2.1 Human Actors](#21-human-actors)
+  - [2.2 System Actors](#22-system-actors)
+- [3. Operational Concept & Environment](#3-operational-concept--environment)
+  - [3.1 Gear-Specific Environment Constraints](#31-gear-specific-environment-constraints)
+- [4. Scope](#4-scope)
+  - [4.1 In Scope](#41-in-scope)
+  - [4.2 Out of Scope](#42-out-of-scope)
+- [5. Functional Requirements](#5-functional-requirements)
+  - [5.1 Principal Creation](#51-principal-creation)
+  - [5.2 Principal Discovery](#52-principal-discovery)
+  - [5.3 Credential Rotation and Revocation](#53-credential-rotation-and-revocation)
+  - [5.4 Authentication and Authorization](#54-authentication-and-authorization)
+  - [5.5 Provider Contract and Recovery](#55-provider-contract-and-recovery)
+- [6. Non-Functional Requirements](#6-non-functional-requirements)
+  - [6.1 Gear-Specific NFRs](#61-gear-specific-nfrs)
+  - [6.2 NFR Exclusions](#62-nfr-exclusions)
+- [7. Public Library Interfaces](#7-public-library-interfaces)
+  - [7.1 Public API Surface](#71-public-api-surface)
+  - [7.2 External Integration Contracts](#72-external-integration-contracts)
+- [8. Use Cases](#8-use-cases)
+  - [8.1 Create Workload Identity](#81-create-workload-identity)
+  - [8.2 Inventory Tenant Principals](#82-inventory-tenant-principals)
+  - [8.3 Rotate Compromised or Expiring Credential](#83-rotate-compromised-or-expiring-credential)
+  - [8.4 Revoke Workload Identity](#84-revoke-workload-identity)
+  - [8.5 Deprovision Tenant Principals](#85-deprovision-tenant-principals)
+- [9. Acceptance Criteria](#9-acceptance-criteria)
+- [10. Dependencies](#10-dependencies)
+- [11. Assumptions](#11-assumptions)
+- [12. Risks](#12-risks)
+- [13. Open Questions](#13-open-questions)
+- [14. Traceability](#14-traceability)
+
+<!-- /toc -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+Service Principal provides tenant-scoped machine identities for workloads that need to authenticate without using human credentials. It gives authorized administrators one provider-neutral contract to create, inspect, rotate, and revoke confidential OAuth 2.0 `client_credentials` identities.
+
+The capability separates machine-identity management from human-user management. It also separates the stable Gears contract from identity-provider-specific behavior. Each principal belongs to one tenant, receives independently grantable management permissions, and exposes its secret only after creation or rotation.
+
+### 1.2 Background / Problem Statement
+
+Platform workloads need identities for service-to-service access, automation, and unattended jobs. Reusing human accounts weakens accountability, complicates credential rotation, and ties workload availability to a person's lifecycle. Direct identity-provider administration also gives every consumer a different integration surface and error model.
+
+A shared Gears capability is needed to manage machine identities consistently across tenants and provider implementations. It must protect high-value client secrets, prevent cross-tenant access, distinguish safe failures from uncertain provider outcomes, and remove credentials when their owning tenant is deprovisioned.
+
+### 1.3 Goals (Business Outcomes)
+
+- Give authorized tenant administrators a complete machine-identity lifecycle without direct provider administration.
+- Prevent workloads from relying on shared or human credentials.
+- Provide one provider-neutral REST and Rust contract for machine-identity management.
+- Enforce tenant isolation and least-privilege permissions for every management operation.
+- Make credential rotation, revocation, uncertain outcomes, and tenant cleanup observable and testable.
+
+**Success criteria:**
+
+| Measure | Baseline | Initial target | Timeframe |
+|---|---:|---:|---|
+| Required lifecycle workflows passing provider conformance tests | No accepted Gears implementation | 100% | Before initial GA |
+| Unauthorized cross-tenant management operations succeeding in security tests | No accepted Gears implementation | 0 | Before initial GA |
+| Successful rotations that invalidate the superseded secret | No accepted Gears implementation | 100% | Before initial GA |
+| Successful revocations that prevent subsequent token acquisition | No accepted Gears implementation | 100% | Before initial GA |
+| Secret disclosures through list, log, diagnostic, telemetry, or cacheable-response checks | No accepted Gears implementation | 0 | Before initial GA |
+| Conforming identity-provider adapters | 0 accepted | At least 1 | Before initial GA |
+| Tenant deprovisioning scenarios leaving live owned principals | No accepted Gears implementation | 0 | Before initial GA |
+
+### 1.4 Glossary
+
+| Term | Definition |
+|---|---|
+| Service Principal | A tenant-owned, non-human identity used by a workload. |
+| Machine Workload | A service, job, agent, or automation process that authenticates without a human user. |
+| Client Credentials | OAuth 2.0 grant in which a confidential client authenticates with its client identifier and secret. |
+| Provider Adapter | A conforming implementation that maps provider-neutral lifecycle operations to an identity provider and owns any durable reconciliation state required by those operations. |
+| Owning Tenant | The tenant that controls a service principal and defines its authorization boundary. |
+| Subject ID | Stable identifier represented by the authenticated principal's subject claim. |
+| Clean Failure | A known failure in which the provider retained no new state from the operation. |
+| Ambiguous Outcome | A failure where provider state may have changed, so success cannot be claimed and reconciliation is required. |
+| One-Time Disclosure | Plaintext secret exposure through the Service Principal public contract only after successful creation or rotation. |
+| Reconciliation | A follow-up action that establishes a known principal or credential state after an ambiguous outcome. |
+
+## 2. Actors
+
+### 2.1 Human Actors
+
+#### Tenant Automation Administrator
+
+**ID**: `cpt-cf-service-principal-actor-tenant-automation-admin`
+
+- **Role**: An authorized operator who manages machine identities within an allowed tenant scope.
+- **Needs**: Create workload identities, inspect their non-secret state, rotate credentials, revoke access, and recover safely from uncertain outcomes.
+
+A platform administrator can perform the same workflow across broader tenant scopes when platform policy grants that access. This is not a separate product workflow.
+
+### 2.2 System Actors
+
+#### Machine Workload
+
+**ID**: `cpt-cf-service-principal-actor-machine-workload`
+
+- **Role**: Uses issued credentials to request access tokens through the OAuth 2.0 `client_credentials` grant.
+- **Needs**: A stable tenant-scoped identity, valid credentials, and immediate invalidation of superseded or revoked credentials.
+
+#### Authorization Resolver
+
+**ID**: `cpt-cf-service-principal-actor-authz-resolver`
+
+- **Role**: Decides whether a caller may perform a specific Service Principal action for the target tenant.
+
+#### Identity Provider Adapter
+
+**ID**: `cpt-cf-service-principal-actor-provider-adapter`
+
+- **Role**: Implements the provider-neutral lifecycle contract, owns restart-safe create and rotation reconciliation, and reports clean or ambiguous outcomes accurately.
+
+#### Consuming Gear
+
+**ID**: `cpt-cf-service-principal-actor-consuming-gear`
+
+- **Role**: Uses the public Rust interface to manage service principals as part of a wider platform workflow.
+
+#### Tenant Lifecycle Owner
+
+**ID**: `cpt-cf-service-principal-actor-tenant-lifecycle-owner`
+
+- **Role**: Owns durable tenant-deprovision state, invokes the identity-provider tenant-deprovision contract, and requires all machine identities owned by that tenant to be removed.
+
+#### Types and Permission Registry
+
+**ID**: `cpt-cf-service-principal-actor-types-registry`
+
+- **Role**: Registers the managed-resource type, service-subject classification, and independently grantable actions.
+
+## 3. Operational Concept & Environment
+
+Service Principal follows the project-wide Gears and ToolKit baselines in [ToolKit Architecture & Developer Guide](../../../../docs/toolkit_unified_system/README.md). This PRD records only capability-specific constraints.
+
+The capability is an administrative control-plane surface. It does not participate in request-path token validation. Its provider-neutral contract is separate from the provider adapter that owns identity-provider state.
+
+```mermaid
+graph LR
+    Admin["Tenant Automation Administrator"] -->|manage tenant-owned identities| SP["Service Principal Capability"]
+    Gear["Consuming Gear"] -->|provider-neutral lifecycle contract| SP
+    SP -->|authorize action for tenant| AuthZ["Authorization Resolver"]
+    SP -->|delegate lifecycle operation| Provider["Identity Provider Adapter"]
+    Provider -->|manage confidential identity| IdP["Identity Provider"]
+    Workload["Machine Workload"] -->|client_credentials| IdP
+    TenantOwner["Tenant Lifecycle Owner"] -->|authorized tenant deprovision| Provider
+```
+
+The diagram is warranted because the capability coordinates several independent actors and trust boundaries.
+
+### 3.1 Gear-Specific Environment Constraints
+
+- A deployment must provide one conforming identity-provider adapter before lifecycle operations can succeed.
+- The identity provider must support confidential `client_credentials` identities and immediate credential invalidation.
+- Callers must have approved credential storage because the capability does not retain plaintext secrets for later retrieval.
+- Lifecycle operations are low-frequency administrative operations, not high-volume request-path operations.
+
+## 4. Scope
+
+### 4.1 In Scope
+
+- Tenant-scoped service-principal creation.
+- Secret-free listing by owning tenant.
+- Secret rotation and superseded-secret invalidation.
+- Idempotent revocation and credential invalidation.
+- Independent authorization for create, read, rotate-secret, and revoke actions.
+- Provider-neutral REST and Rust interfaces.
+- Provider conformance and failure classification.
+- Configurable name, scope, and per-tenant quota policy.
+- Tenant-deprovision cleanup through the identity-provider tenant-lifecycle contract.
+- Lifecycle latency and categorized failure telemetry.
+- Stable managed-resource, subject, and permission identifiers.
+
+### 4.2 Out of Scope
+
+- Human-user identity, password, session, MFA, or interactive-login management.
+- Authorization policy authoring, role assignment, or policy evaluation implementation.
+- Long-term credential storage, secret distribution, or workload injection.
+- Retrieval of an existing plaintext client secret.
+- Access-token validation, token exchange, refresh tokens, or authorization-code flows.
+- Workload-side token acquisition or token caching.
+- Get-by-ID, principal updates, enable/disable, search, filtering, sorting, or pagination.
+- Bulk lifecycle operations.
+- Multi-provider selection per tenant or request.
+- Provider migration or credential portability.
+- A dedicated CLI or graphical management interface.
+- A Service Principal-owned principal database, provider-state replica, recovery repository, retry worker, or cleanup coordinator.
+- Distributed transactions across the capability, provider, credential store, and workload.
+- Automatic repair of every ambiguous provider outcome.
+- Offline lifecycle mutations while the provider is unavailable.
+- Strongly serialized quota enforcement across concurrent requests.
+- Lifecycle event streaming in the initial version.
+- Provider-specific realm, mapper, account, or administration behavior.
+
+## 5. Functional Requirements
+
+> **Testing strategy**: Functional requirements are verified through automated unit, contract, integration, security, and end-to-end tests unless a requirement states otherwise.
+
+### 5.1 Principal Creation
+
+#### Create Tenant-Owned Service Principal
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-create`
+
+The system **MUST** allow an authorized administrator to create a confidential service principal owned by an explicit target tenant. A successful operation **MUST** return a client identifier, plaintext client secret, token endpoint, and stable subject identifier.
+
+- **Rationale**: Workloads need dedicated non-human credentials and stable identity for policy bindings.
+- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-machine-workload`
+
+#### Client Credentials Only
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-client-credentials-only`
+
+The system **MUST** create service principals that authenticate as confidential OAuth 2.0 `client_credentials` identities and **MUST NOT** enable interactive human authentication flows through this capability.
+
+- **Rationale**: Machine identities must remain separate from human login and session semantics.
+- **Actors**: `cpt-cf-service-principal-actor-machine-workload`
+
+#### Tenant and Subject Classification
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-identity-context`
+
+The system **MUST** ensure that an access token obtained through `client_credentials` using credentials returned by successful creation contains the target tenant, a subject exactly equal to the creation response's `Subject`, and `client_credentials` identity context. Every supported provider adapter **MUST** prove this credential-to-token binding through conformance tests.
+
+- **Rationale**: Downstream authorization needs an unambiguous tenant and non-human subject classification.
+- **Actors**: `cpt-cf-service-principal-actor-machine-workload`, `cpt-cf-service-principal-actor-provider-adapter`
+
+#### Name Policy
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-name-policy`
+
+The system **MUST** validate caller-selected principal names against a bounded deployment policy before requesting provider mutation.
+
+- **Rationale**: Safe, bounded names prevent invalid provider resources and inconsistent public identifiers.
+- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`
+
+#### Scope Allowlist
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-scope-allowlist`
+
+The system **MUST** reject any requested client scope that is not present in the deployment-controlled allowlist.
+
+- **Rationale**: Callers must not escalate workload privileges by requesting arbitrary provider scopes.
+- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-provider-adapter`
+
+#### Configurable Tenant Quota
+
+- [ ] `p2` - **ID**: `cpt-cf-service-principal-fr-tenant-quota`
+
+The system **MUST** support a configurable maximum number of service principals per tenant and reject creation when the observed count reaches that maximum. The quota is best-effort under concurrent creation and **MUST NOT** be presented as a security boundary.
+
+- **Rationale**: A bounded initial collection limits accidental growth while preserving honest concurrency semantics.
+- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-provider-adapter`
+
+#### Creation Collision Safety
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-create-collision`
+
+The system **MUST** reject a creation request when its provider-side identifier is already occupied and **MUST NOT** resume, reveal, or modify the existing principal as part of that request.
+
+- **Rationale**: Reusing an existing identity could disclose credentials or attach privileges to the wrong workload.
+- **Actors**: `cpt-cf-service-principal-actor-provider-adapter`
+
+### 5.2 Principal Discovery
+
+#### List Tenant Service Principals
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-list`
+
+The system **MUST** list service principals owned by an authorized target tenant and return each principal's non-secret management state.
+
+- **Rationale**: Administrators need inventory for audit, rotation, and revocation workflows.
+- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`
+
+#### Secret-Free Discovery
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-secret-free-listing`
+
+The system **MUST NOT** expose client secrets through list or future read operations.
+
+- **Rationale**: Inventory access must not grant credential access.
+- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`
+
+#### Ownership-Checked Addressing
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-ownership-addressing`
+
+The system **MUST** treat a principal as addressable only when it belongs to the explicit target tenant. A missing or foreign principal **MUST NOT** disclose foreign ownership details.
+
+- **Rationale**: Tenant-qualified addressing prevents cross-tenant object access and information leakage.
+- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-provider-adapter`
+
+### 5.3 Credential Rotation and Revocation
+
+#### Rotate Secret
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-rotate-secret`
+
+The system **MUST** allow an authorized administrator to rotate a tenant-owned principal's secret. A successful rotation **MUST** return the new secret and invalidate the superseded secret.
+
+- **Rationale**: Workloads need regular and incident-driven credential replacement without replacing their identity.
+- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-machine-workload`
+
+#### Reject Incomplete Principal Rotation
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-rotate-complete-state`
+
+The system **MUST** reject rotation when the provider cannot confirm the principal's ownership and required managed identity state.
+
+- **Rationale**: Rotation must not issue a credential for a foreign, incomplete, or corrupted identity.
+- **Actors**: `cpt-cf-service-principal-actor-provider-adapter`
+
+#### Revoke Principal
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-revoke`
+
+The system **MUST** allow an authorized administrator to revoke a tenant-owned service principal. Successful revocation **MUST** prevent subsequent token acquisition by that principal.
+
+- **Rationale**: Administrators need an immediate way to terminate workload access.
+- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-machine-workload`
+
+#### Idempotent Revocation
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-revoke-idempotent`
+
+The system **MUST** treat revocation of an already-absent principal as success-equivalent.
+
+- **Rationale**: Cleanup and reconciliation must converge without requiring callers to distinguish concurrent deletion from prior success.
+- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-tenant-lifecycle-owner`
+
+### 5.4 Authentication and Authorization
+
+#### Authenticated Management
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-authenticated-management`
+
+The system **MUST** require a validated platform security context for every public management operation.
+
+- **Rationale**: Anonymous callers must never manage machine credentials.
+- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-authz-resolver`
+
+#### Independent Management Permissions
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-independent-permissions`
+
+The system **MUST** authorize create, read, rotate-secret, and revoke as independently grantable actions.
+
+- **Rationale**: Credential minting and revocation require narrower delegation than general inventory access.
+- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-authz-resolver`
+
+#### Explicit Tenant Authorization
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-tenant-authorization`
+
+The system **MUST** authorize each operation against the explicit owning tenant and verify that returned tenant constraints cover that target. Authorization for one tenant or subtree **MUST NOT** authorize an unrelated tenant.
+
+- **Rationale**: A broad or mismatched policy decision must not create a broken object-level authorization path.
+- **Actors**: `cpt-cf-service-principal-actor-authz-resolver`
+
+#### Fail-Closed Authorization
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-authz-fail-closed`
+
+The system **MUST** deny the operation when caller identity, policy evaluation, or required tenant constraints cannot be established.
+
+- **Rationale**: Security dependency failures must not widen access.
+- **Actors**: `cpt-cf-service-principal-actor-authz-resolver`
+
+### 5.5 Provider Contract and Recovery
+
+#### Provider-Neutral Delegation
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-provider-delegation`
+
+The system **MUST** delegate principal lifecycle operations through a versioned provider-neutral contract so conforming adapters can be substituted without changing callers.
+
+- **Rationale**: The Gears capability must not bind consumers to one identity provider.
+- **Actors**: `cpt-cf-service-principal-actor-provider-adapter`, `cpt-cf-service-principal-actor-consuming-gear`
+
+#### Provider Absence
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-provider-required`
+
+The system **MUST** fail explicitly and without simulated success when no conforming provider adapter is available.
+
+- **Rationale**: Provider absence means authoritative identity state cannot be created or changed safely.
+- **Actors**: `cpt-cf-service-principal-actor-provider-adapter`
+
+#### Stable Failure Categories
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-failure-categories`
+
+The system **MUST** define one six-category failure taxonomy for end-to-end classification of provider outcomes, REST responses, and Rust SDK errors: invalid input, not found, clean failure, ambiguous outcome, authorization failure, and provider unavailability. The provider contract's four outcomes **MUST** map directly to the first four categories. Authorization failure **MUST** identify failure to establish caller identity, policy approval, or matching tenant constraints before provider invocation. Provider unavailability **MUST** identify provider absence or an availability failure known to prevent mutation; if a provider request may have mutated state, the outcome **MUST** instead be ambiguous and **MUST NOT** be reported as success. REST and Rust consumers **MUST** receive the same category and retry or reconciliation semantics. Adding, renaming, or splitting a Rust SDK or provider category **MUST** require a new major contract version with migration guidance; older consumers encountering an unknown category **MUST** treat it as failure and as ambiguous whenever mutation cannot be ruled out.
+
+- **Rationale**: Callers need deterministic retry and reconciliation behavior.
+- **Actors**: `cpt-cf-service-principal-actor-provider-adapter`, `cpt-cf-service-principal-actor-consuming-gear`
+
+#### Ambiguous Creation Recovery
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-ambiguous-create-recovery`
+
+Every create attempt **MUST** carry a caller-generated operation key bound to the explicit tenant and canonical request identity. After an ambiguous result, the caller **MUST** reconcile by repeating the identical request with the same key. The adapter **MUST** reconcile before further mutation and classify provider evidence as `exact_binding`, `authoritative_absence`, or `inconclusive`. `exact_binding` **MUST** return a non-secret `credentials_unavailable` failed-precondition result with the confirmed principal identity and rotation guidance. `authoritative_absence` **MAY** permit a fresh create with a new key. `inconclusive` **MUST** remain ambiguous and block conflicting mutation. Reusing a key for another tenant, operation, or request identity **MUST** be invalid input.
+
+- **Rationale**: Ambiguous creation must not justify destructive action against a tenant principal whose relationship to the uncertain request is unproven.
+- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-provider-adapter`
+
+#### Ambiguous Rotation Recovery
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-ambiguous-rotate-recovery`
+
+Every rotation **MUST** carry a caller-generated operation key. After an ambiguous result, the caller **MUST** repeat only the identical request with the same key. The adapter **MUST** reconcile before further mutation. A confirmed prior rotation whose secret response was lost **MUST** return `credentials_unavailable`; the caller **MUST** use a new operation key for a subsequently confirmed rotation before adopting replacement credentials. Plaintext credentials **MUST NOT** be persisted or replayed.
+
+- **Rationale**: An uncertain rotation cannot establish which credential is safe to use.
+- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-machine-workload`
+
+#### Ambiguous Revocation Recovery
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-ambiguous-revoke-recovery`
+
+When revocation has an ambiguous outcome, the system **MUST** allow repeated revocation until the principal is confirmed revoked or already absent.
+
+- **Rationale**: Repeated deletion is the safe convergence path after transport uncertainty.
+- **Actors**: `cpt-cf-service-principal-actor-tenant-automation-admin`, `cpt-cf-service-principal-actor-provider-adapter`
+
+#### Tenant Deprovision Cleanup
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-fr-tenant-cleanup`
+
+The tenant lifecycle owner **MUST** authenticate and authorize tenant deprovisioning for an explicit target tenant, durably retain retryable lifecycle state, and invoke the identity-provider tenant-deprovision contract. The provider adapter **MUST** delete only principals authoritatively owned by that tenant and **MUST** confirm that no live owned principal remains before returning success. Already-absent principals are success-equivalent. A transient cleanup failure **MUST** block teardown and remain retryable through the tenant-lifecycle operation; a permanent failure **MUST** block teardown and remain operator-visible. Service Principal **MUST NOT** own cleanup state, scheduling, or a cleanup API.
+
+- **Rationale**: A machine credential must not outlive its authorization boundary, and cleanup must preserve the same tenant isolation and accountability as other lifecycle operations.
+- **Actors**: `cpt-cf-service-principal-actor-tenant-lifecycle-owner`, `cpt-cf-service-principal-actor-provider-adapter`
+
+## 6. Non-Functional Requirements
+
+Architecture and engineering conventions are inherited from the [ToolKit Architecture & Developer Guide](../../../../docs/toolkit_unified_system/README.md) and [project guidelines](../../../../guidelines/README.md). The requirements below define Service Principal-specific obligations. Where a quantitative target still requires production evidence, this section defines an explicit release gate rather than assuming an undocumented baseline.
+
+### 6.1 Gear-Specific NFRs
+
+#### Secret Confidentiality
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-secret-confidentiality`
+
+The system **MUST** prevent plaintext client secrets from appearing in list responses, logs, debug output, diagnostics, telemetry, and cacheable responses. Credential-bearing responses **MUST** be non-cacheable.
+
+- **Threshold**: Zero secret disclosures across automated negative checks for these surfaces.
+- **Rationale**: A leaked client secret grants workload identity until rotation or revocation.
+- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [REST V1 contract](./DESIGN.md#service-principal-rest-v1), and [Security and Data Protection](./DESIGN.md#44-security-and-data-protection).
+
+#### Data Classification and Privacy
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-data-classification`
+
+The system **MUST** treat plaintext client secrets and provider verifier material as restricted authentication credentials. It **MUST** treat client identifiers, subject identifiers, tenant ownership, scopes, operation keys and fingerprints, and lifecycle outcomes as security-sensitive control-plane metadata. The capability **MUST NOT** intentionally collect human profile attributes or unrelated personal data.
+
+- **Threshold**: Every field in the public and provider contracts has an approved security classification before release, and conformance checks find zero human profile attributes or unrelated personal data.
+- **Rationale**: Explicit classification keeps credential controls, telemetry, retention, and privacy treatment aligned with actual data sensitivity.
+- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [Security and Data Protection](./DESIGN.md#44-security-and-data-protection), and [Compliance and Privacy Posture](./DESIGN.md#48-compliance-and-privacy-posture).
+
+#### No Plaintext Secret Persistence
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-no-secret-persistence`
+
+The Service Principal capability **MUST NOT** persist plaintext client secrets or operation-reconciliation state. A provider adapter **MUST NOT** persist or replay plaintext credential responses as part of reconciliation. The identity provider may retain verifier material according to its security contract.
+
+- **Threshold**: Zero Service Principal-owned plaintext secret records and zero adapter reconciliation records containing a plaintext or replayable credential response.
+- **Rationale**: The capability is a lifecycle facade, not a credential store.
+- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [Database Schemas and Tables](./DESIGN.md#37-database-schemas--tables), and [Security and Data Protection](./DESIGN.md#44-security-and-data-protection).
+
+#### Tenant Isolation
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-tenant-isolation`
+
+The system **MUST** prevent management operations from crossing unauthorized tenant boundaries.
+
+- **Threshold**: Zero unauthorized successes in the cross-tenant security suite.
+- **Rationale**: Machine credentials are high-impact tenant resources.
+- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [Authorization Gate](./DESIGN.md#authorization-gate), and [Provider Boundary](./DESIGN.md#provider-boundary).
+
+#### Credential Invalidation
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-credential-invalidation`
+
+Successful rotation and revocation **MUST** make superseded credentials unusable without an additional grace period.
+
+- **Threshold**: 100% of successful rotation and revocation conformance scenarios reject superseded credentials.
+- **Rationale**: Security response depends on immediate credential termination.
+- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [Provider Boundary](./DESIGN.md#provider-boundary), and [Interactions and Sequences](./DESIGN.md#36-interactions--sequences).
+
+#### Provider Conformance
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-provider-conformance`
+
+Every supported identity-provider integration **MUST** pass the common conformance suite. Its Service Principal adapter coverage **MUST** include lifecycle, ownership, operation-key reconciliation, failure classification, and credential security. Its tenant-deprovision coverage **MUST** include exact-owner cleanup, retryable and terminal failures, and authoritative zero-principal confirmation.
+
+- **Threshold**: 100% of mandatory Service Principal adapter and tenant-deprovision scenarios pass for each supported identity-provider integration.
+- **Rationale**: Provider substitution is safe only when contract behavior is equivalent.
+- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [Provider Adapter V1](./DESIGN.md#provider-adapter-v1), and [Testability and Verification](./DESIGN.md#47-testability-and-verification).
+
+#### Contract Compatibility
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-contract-compatibility`
+
+REST and Rust contract changes within a major version **MUST** remain backward-compatible and additive. Breaking changes **MUST** use a new major contract version with migration guidance.
+
+- **Threshold**: Zero unversioned breaking changes in compatibility checks.
+- **Rationale**: Callers must remain independent of provider and implementation release cadence.
+- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [API Contracts](./DESIGN.md#33-api-contracts), and [Failure Taxonomy and Wire Safety](./DESIGN.md#41-failure-taxonomy-and-wire-safety).
+
+#### Security Auditability
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-auditability`
+
+Every management decision and lifecycle operation **MUST** produce an auditable record attributable to the validated initiating caller or approved system actor, target tenant, action, timestamp, correlation identifier, and terminal outcome without recording a plaintext client secret.
+
+- **Threshold**: 100% of lifecycle and authorization conformance scenarios produce complete attributable records, with zero plaintext client secrets in audit data.
+- **Rationale**: Credential administration must support incident investigation and accountability regardless of whether the platform or the gear emits the final audit record.
+- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [Audit and Observability component](./DESIGN.md#audit-and-observability), and [Auditability and Observability](./DESIGN.md#45-auditability-and-observability).
+
+#### Operational Observability
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-observability`
+
+The system **MUST** record latency and a stable outcome category for every Service Principal lifecycle operation. Operators **MUST** be able to distinguish invalid input, not found, clean failure, ambiguous outcome, authorization failure, and provider unavailability. Service Principal ambiguous outcomes and provider unavailability **MUST** produce adapter-correlated signals suitable for platform alerting. The tenant lifecycle owner **MUST** provide cleanup retry and terminal-failure signals.
+
+- **Threshold**: 100% of Service Principal lifecycle calls emit one latency observation and one public outcome category; 100% of tenant-cleanup attempts emit a lifecycle-native outcome; conformance tests demonstrate an alertable signal for each specified operational condition.
+- **Rationale**: Operators need to detect provider degradation and unresolved credential state.
+- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [Audit and Observability component](./DESIGN.md#audit-and-observability), and [Auditability and Observability](./DESIGN.md#45-auditability-and-observability).
+
+#### Stateless Recovery
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-stateless-recovery`
+
+Service Principal restart **MUST** lose no authoritative principal or recovery state because the gear owns neither. Create and rotation operation keys **MUST** be forwarded to an adapter that provides restart-safe, tenant-bound reconciliation. The adapter may reconcile during a repeated request or through adapter-private execution, but Service Principal **MUST NOT** schedule or persist that work.
+
+- **Threshold**: Restart tests prove that Service Principal requires no database restoration and that every supported adapter deterministically resumes an unresolved same-key create or rotation without duplicate logical mutation.
+- **Rationale**: The gear remains a stateless authorization and provider-delegation boundary while the integration closest to provider behavior owns reconciliation correctness.
+- **Architecture Allocation**: [Provider Boundary](./DESIGN.md#provider-boundary), [Database Schemas and Tables](./DESIGN.md#37-database-schemas--tables), and [Operation-Key Reconciliation](./DESIGN.md#42-operation-key-reconciliation).
+
+#### Cleanup Reliability
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-nfr-cleanup-reliability`
+
+Tenant-deprovision cleanup failures **MUST** remain durably visible and retryable in the tenant lifecycle owner's deprovision operation until the provider adapter confirms no live owned principal remains. Service Principal **MUST NOT** retain cleanup records or run cleanup retries.
+
+- **Threshold**: Zero cleanup failures are silently discarded; every retryable tenant-deprovision operation survives lifecycle-owner restart; permanent failures remain operator-visible; successful deprovisioning leaves zero live owned principals.
+- **Rationale**: Credential survival after tenant removal is a security incident, while retry durability belongs with the lifecycle operation that gates tenant removal.
+- **Architecture Allocation**: [Tenant Lifecycle Cleanup Integration](./DESIGN.md#tenant-lifecycle-cleanup-integration), [Auditability and Observability](./DESIGN.md#45-auditability-and-observability), and [Fault Tolerance](./DESIGN.md#46-fault-tolerance).
+
+#### Performance and Availability Qualification
+
+- [ ] `p2` - **ID**: `cpt-cf-service-principal-nfr-performance-baseline`
+
+Initial GA approval **MUST** be blocked until representative provider benchmarks establish and approve the supported tenant and principal envelope, p95 lifecycle latency, sustained administrative request rate, provider-unavailable behavior, and availability objective. Published service objectives **MUST** then be used as release-conformance thresholds.
+
+- **Threshold**: Before GA, a versioned benchmark report records approved values for all five dimensions; each subsequent supported release satisfies the published objectives or documents an approved revision.
+- **Rationale**: Provider latency dominates operations, so targets must be measurable without inventing unsupported values.
+- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [Configuration](./DESIGN.md#43-configuration), [Fault Tolerance](./DESIGN.md#46-fault-tolerance), and [Testability and Verification](./DESIGN.md#47-testability-and-verification).
+
+#### Operational Readiness Documentation
+
+- [ ] `p2` - **ID**: `cpt-cf-service-principal-nfr-operational-documentation`
+
+Each supported release **MUST** publish API and operator guidance covering one-time secret handling, approved credential-store handoff, stable outcome categories, ambiguous-outcome reconciliation, tenant-cleanup retry, alert interpretation, and troubleshooting without plaintext secrets.
+
+- **Threshold**: Release readiness evidence verifies that all seven topics are present and that documentation examples contain zero plaintext production credentials.
+- **Rationale**: Operators and API consumers need safe recovery instructions for credential-bearing and uncertain provider operations.
+- **Architecture Allocation**: [DESIGN NFR Allocation](./DESIGN.md#nfr-allocation), [API Contracts](./DESIGN.md#33-api-contracts), [Auditability and Observability](./DESIGN.md#45-auditability-and-observability), and [Testability and Verification](./DESIGN.md#47-testability-and-verification).
+
+### 6.2 NFR Exclusions
+
+- **Authoritative principal-data RPO and backup**: Not applicable because the provider owns principal records and Service Principal owns no principal database, reconciliation repository, or plaintext secret store.
+- **Offline mutation availability**: Not applicable because authoritative lifecycle changes require a reachable provider.
+- **Physical safety**: Not applicable because this is an information-system control plane with no direct physical actuation.
+- **End-user accessibility and internationalization**: Not applicable to the initial server/API-only capability; future user interfaces must define their own requirements.
+- **Gear-specific disaster recovery**: No Service Principal data restoration is required. Authoritative principal recovery and adapter-private reconciliation durability remain provider-integration obligations; tenant-cleanup retry durability remains a tenant-lifecycle obligation.
+- **Personal-data privacy**: No gear-specific privacy regime applies because the capability intentionally processes machine identities rather than human profiles. This exclusion ceases to apply in deployments where tenant or account identifiers can identify natural persons.
+- **Industry-specific regulation**: No regulation is introduced by this provider-neutral capability. Deployment-specific regulatory controls remain mandatory where the platform, provider, tenant, or workload is subject to them.
+- **Data retention and residency**: The identity provider owns principal-record retention and residency, adapters own any private reconciliation-record policy, tenant lifecycle owns deprovision-operation retention, and platform observability owns telemetry retention and residency. Service Principal owns none of these durable records.
+- **Dedicated deployment and release process**: Not applicable; the capability uses the project-wide release process, with the additional benchmark and documentation gates defined above.
+
+## 7. Public Library Interfaces
+
+### 7.1 Public API Surface
+
+#### Service Principal REST Interface
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-interface-rest`
+
+- **Type**: Versioned authenticated REST API.
+- **Stability**: Stable within a major version.
+- **Description**: Provides create, list, rotate-secret, and revoke operations for an explicit owning tenant. Create and rotate require the standard `Idempotency-Key` request header. Credential-bearing operations disclose plaintext secrets once and mark responses as non-cacheable; no recovery-status surface exists.
+- **Breaking Change Policy**: A breaking change requires a new major API version and migration guidance.
+
+#### Service Principal Rust Interface
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-interface-rust-sdk`
+
+- **Type**: Transport-neutral Rust SDK and service-provider contract.
+- **Stability**: Stable within a major version.
+- **Description**: Provides the same four lifecycle operations, validated `OperationKey` values for create and rotate, one-time credentials, secret-free summaries, tenant identity, and a major-versioned failure taxonomy with non-success handling for unknown categories.
+- **Breaking Change Policy**: A breaking change requires a new major SDK contract version and migration guidance.
+
+#### Service Principal Managed Resource
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-interface-managed-resource`
+
+- **Type**: GTS managed-resource and permission catalog.
+- **Stability**: Stable within a major version.
+- **Description**: Defines Service Principal as a resource distinct from human users and exposes create, read, rotate-secret, and revoke permissions.
+- **Breaking Change Policy**: Resource and action identifiers cannot change within a major version.
+
+### 7.2 External Integration Contracts
+
+#### Identity Provider Adapter Contract
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-contract-provider-adapter`
+
+- **Direction**: Required from provider implementations.
+- **Protocol/Format**: Versioned provider-neutral Rust contract.
+- **Compatibility**: Adapters must preserve lifecycle, ownership, operation-key reconciliation, one-time disclosure, invalidation, and failure semantics for the contract version they implement.
+
+#### Authorization Contract
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-contract-authorization`
+
+- **Direction**: Required from the platform Authorization Resolver.
+- **Protocol/Format**: Authenticated action request with explicit tenant resource attributes and tenant constraints.
+- **Compatibility**: Decisions must support the stable managed-resource and action identifiers for the active major version.
+
+#### Tenant Lifecycle Cleanup Contract
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-contract-tenant-cleanup`
+
+- **Direction**: Required from the identity-provider integration by the tenant lifecycle owner; Service Principal does not provide or proxy this contract.
+- **Protocol/Format**: Versioned authenticated tenant-deprovision request with a validated platform security context, explicit target tenant, and lifecycle-native success-equivalent, retryable, or terminal outcome.
+- **Compatibility**: The tenant lifecycle owner **MUST** retain retryable state and block teardown after retryable or terminal failure. The adapter **MUST** enforce exact tenant ownership, treat already-absent principals as success-equivalent, and return success only after confirming removal or absence of every live principal owned by the target tenant.
+
+## 8. Use Cases
+
+### 8.1 Create Workload Identity
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-usecase-create`
+
+**Actor**: `cpt-cf-service-principal-actor-tenant-automation-admin`
+
+**Preconditions**:
+- The caller is authenticated and authorized for the target tenant and create action.
+- A conforming provider adapter is available.
+- The request carries a new caller-generated operation key.
+- The requested name, scopes, and tenant quota satisfy deployment policy.
+
+**Main Flow**:
+1. The administrator requests a tenant-owned service principal.
+2. The system creates the provider identity.
+3. The system returns its client identifier, one-time secret, token endpoint, and subject identifier.
+4. The administrator stores the secret in approved credential storage.
+
+**Postconditions**:
+- The principal can authenticate as a service subject owned by the target tenant.
+
+**Alternative Flows**:
+- **Invalid policy input**: The request is rejected without new provider state.
+- **Ambiguous provider outcome**: The caller repeats only the identical request with the same operation key. The adapter reconciles before mutation. Confirmed prior creation returns `credentials_unavailable` with non-secret identity and rotation guidance; authoritative absence permits a fresh create with a new key; inconclusive evidence remains ambiguous and blocks conflicting mutation.
+
+### 8.2 Inventory Tenant Principals
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-usecase-list`
+
+**Actor**: `cpt-cf-service-principal-actor-tenant-automation-admin`
+
+**Preconditions**:
+- The caller is authenticated and authorized for the target tenant and read action.
+
+**Main Flow**:
+1. The administrator requests the tenant's service-principal inventory.
+2. The system returns only principals owned by that tenant.
+3. The response contains no client secrets.
+
+**Postconditions**:
+- The administrator has current non-secret state for audit and lifecycle management.
+
+### 8.3 Rotate Compromised or Expiring Credential
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-usecase-rotate`
+
+**Actor**: `cpt-cf-service-principal-actor-tenant-automation-admin`
+
+**Preconditions**:
+- The caller is authorized for the target tenant and rotate-secret action.
+- The provider confirms the principal's ownership and managed identity state.
+- The request carries a new caller-generated operation key.
+
+**Main Flow**:
+1. The administrator requests secret rotation.
+2. The system invalidates the superseded secret.
+3. The system returns the new secret through a non-cacheable response.
+4. The administrator updates approved credential storage.
+
+**Postconditions**:
+- The new secret authenticates and the superseded secret does not.
+
+**Alternative Flows**:
+- **Ambiguous rotation**: The caller repeats only the identical request with the same operation key. A confirmed prior rotation whose response was lost returns `credentials_unavailable`; the caller performs a new rotation with a new key and adopts only its confirmed response.
+
+### 8.4 Revoke Workload Identity
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-usecase-revoke`
+
+**Actor**: `cpt-cf-service-principal-actor-tenant-automation-admin`
+
+**Preconditions**:
+- The caller is authorized for the target tenant and revoke action.
+
+**Main Flow**:
+1. The administrator requests revocation.
+2. The system removes or confirms absence of the tenant-owned principal.
+3. Subsequent token acquisition fails.
+
+**Postconditions**:
+- The addressed principal no longer grants workload access.
+
+**Alternative Flows**:
+- **Already absent**: The operation is success-equivalent.
+- **Ambiguous revocation**: The administrator repeats revocation until success or confirmed absence.
+
+### 8.5 Deprovision Tenant Principals
+
+- [ ] `p1` - **ID**: `cpt-cf-service-principal-usecase-tenant-cleanup`
+
+**Actor**: `cpt-cf-service-principal-actor-tenant-lifecycle-owner`
+
+**Preconditions**:
+- The tenant lifecycle owner has authenticated and authorized tenant deprovisioning for the explicit target tenant.
+- The tenant lifecycle operation has durable retry state.
+- A conforming identity-provider integration is available.
+
+**Main Flow**:
+1. The tenant lifecycle owner invokes the identity-provider tenant-deprovision contract.
+2. The provider adapter selects only principals authoritatively owned by the explicit tenant.
+3. The adapter removes each owned principal, treating already-absent principals as success-equivalent.
+4. The adapter confirms that no live owned principal remains.
+5. The tenant lifecycle owner records final disposition and completes tenant deprovisioning.
+
+**Postconditions**:
+- Successful tenant deprovisioning leaves no live principal owned by that tenant.
+- Service Principal has stored no cleanup state and has not participated in the call.
+
+**Alternative Flows**:
+- **Transient provider failure**: The adapter returns retryable, teardown remains blocked, and the tenant lifecycle owner retries the whole deprovision operation from durable state.
+- **Permanent or configuration failure**: The adapter returns terminal, teardown remains blocked, and the tenant lifecycle owner keeps the operation visible for intervention.
+
+## 9. Acceptance Criteria
+
+- [ ] An authorized administrator can complete create, list, rotate, and revoke through the public contract without provider-specific administration.
+- [ ] Every supported provider adapter passes conformance tests proving that an access token obtained through `client_credentials` using credentials returned by successful creation contains the target tenant, a subject exactly equal to the creation response's `Subject`, and `client_credentials` identity context.
+- [ ] Unauthorized and cross-tenant management operations have zero successful outcomes in the security suite.
+- [ ] Credential-bearing responses are non-cacheable, and secret-negative checks find zero disclosures on prohibited surfaces.
+- [ ] Every successful rotation test rejects the superseded secret and accepts the confirmed replacement.
+- [ ] Every successful revocation test prevents later token acquisition.
+- [ ] Every supported provider adapter passes all mandatory conformance scenarios.
+- [ ] Conformance tests exercise all six Service Principal failure categories and verify consistent classification across applicable provider, REST, and Rust surfaces, including major-version compatibility and non-success handling for unknown or mutation-uncertain outcomes.
+- [ ] Concurrent and post-restart same-key create and rotation retries produce at most one logical mutation, reject cross-tenant or changed-request key reuse, and never persist or replay a plaintext credential.
+- [ ] `exact_binding`, `authoritative_absence`, and `inconclusive` adapter scenarios produce the required safe retry behavior without exposing provider proof material publicly.
+- [ ] Tenant cleanup deletes only principals authoritatively owned by the target tenant and never deletes foreign principals.
+- [ ] Transient tenant-cleanup failures block teardown and survive tenant-lifecycle restart; terminal failures remain operator-visible; successful tenant deprovisioning leaves zero live service principals owned by that tenant.
+- [ ] A security review classifies every public and provider-contract field and confirms that no human profile attributes or unrelated personal data are collected.
+- [ ] Every lifecycle and authorization scenario produces a complete attributable audit record with no plaintext client secret.
+- [ ] Initial GA evidence includes approved benchmark values for the supported scale envelope, p95 lifecycle latency, sustained request rate, provider-unavailable behavior, and availability objective.
+- [ ] API and operator documentation covers every required readiness topic without exposing plaintext production credentials.
+- [ ] REST, Rust SDK, GTS registration, authorization, provider conformance, security, and end-to-end evidence exist within the Gears artifact and implementation chain before completion is claimed.
+
+## 10. Dependencies
+
+| Dependency | Description | Criticality |
+|---|---|---|
+| Gears ToolKit runtime | Hosts the gear and its authenticated public capability. | p1 |
+| Platform client registry | Resolves the configured provider-neutral adapter for trusted callers. | p1 |
+| Authorization Resolver | Supplies action decisions and tenant-scoped constraints. | p1 |
+| Tenant model and resolver contracts | Supply canonical tenant identity and hierarchy semantics. | p1 |
+| Types and Permission Registry | Registers resource, subject, and permission identifiers. | p1 |
+| Canonical error framework | Supplies standardized public error categories. | p1 |
+| API Gateway and OpenAPI registry | Routes and documents the versioned REST interface. | p1 |
+| Identity Provider Adapter | Owns authoritative principal state and implements lifecycle operations. | p1 |
+| Approved Credential Store | Retains one-time disclosed credentials for consuming workloads. | p1 |
+| Platform observability | Collects lifecycle latency, outcomes, logs, and alerts. | p2 |
+
+## 11. Assumptions
+
+- The platform provides stable tenant identifiers and tenant hierarchy semantics.
+- The platform authenticates public API callers before Service Principal authorization.
+- Consuming workloads can protect credentials and perform OAuth 2.0 `client_credentials` requests.
+- One conforming provider adapter is configured for the initial deployment.
+- Identity-provider state is authoritative; Service Principal owns no principal database, recovery repository, cleanup state, or retry scheduler.
+- Administrators choose names and scopes according to deployment policy.
+- Lifecycle operations are low-frequency administrative operations.
+- The initial capability is server/API-facing and has no dedicated user interface.
+
+## 12. Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Only one provider initially proves the contract | Hidden provider assumptions may limit future portability. | Keep contracts provider-neutral and require the same conformance suite for every adapter. |
+| Caller loses the one-time secret | The workload cannot authenticate. | Require immediate approved storage and recover through rotation. |
+| Secret leaks through diagnostics or caching | An attacker can impersonate a workload. | Enforce redaction, non-cacheability, and secret-negative tests. |
+| Cross-tenant object access | A caller can manage another tenant's credentials. | Authorize the explicit tenant and verify returned tenant constraints. |
+| Over-privileged administrators | Credential minting is delegated too broadly. | Keep lifecycle actions independently grantable. |
+| Scope escalation | A workload receives unintended privileges. | Restrict requested scopes to a deployment-controlled allowlist. |
+| Ambiguous provider mutation | Caller and provider disagree about principal or credential state. | Use stable ambiguity reporting and operation-specific reconciliation. |
+| Concurrent creation exceeds quota | Tenant count briefly exceeds the configured cap. | Document best-effort semantics, monitor counts, and reassess strong enforcement from measured need. |
+| Tenant cleanup fails | Credentials survive their tenant boundary. | Keep the tenant-lifecycle operation durable and visible, retry the whole deprovision workflow after transient failure, and block successful deprovisioning until the adapter confirms zero owned principals. |
+| Unpaginated listing grows too large | Administrative latency and payload size increase. | Start with bounded tenant quotas and define a measured trigger for pagination. |
+| Resource or permission identifiers drift | Authorization grants no longer match enforcement. | Pin identifiers and validate registry-to-enforcement consistency. |
+
+## 13. Open Questions
+
+1. **What production scale and lifecycle latency targets should the gear support?**
+   - **Owner**: Platform Performance and Operations.
+   - **Resolution target**: Before initial GA benchmark approval.
+
+2. **When is a second provider adapter required to substantiate portability?**
+   - **Owner**: Product and Gears Architecture.
+   - **Resolution target**: Before claiming multi-provider production support.
+
+3. **What measured tenant volume triggers pagination or strongly enforced quota semantics?**
+   - **Owner**: Product and Capacity Engineering.
+   - **Resolution target**: Before raising the initial supported tenant limit.
+
+4. **Should adapter incompatibility fail registration or the first lifecycle operation?**
+   - **Owner**: Gears Architecture and Provider Integration Owners.
+   - **Resolution target**: Before provider-adapter contract freeze.
+
+5. **What retention policy applies to adapter-private reconciliation records?**
+   - **Owner**: Security, Operations, and Provider Integration Owners.
+   - **Resolution target**: Before initial adapter production qualification.
+
+Resolved during design: audit and operational signals use layered ownership. Service Principal records authorization and public lifecycle outcomes, provider adapters record provider mutation and reconciliation outcomes, and the tenant lifecycle owner records cleanup retries and final tenant disposition. The allocation is defined in [DESIGN §4.5](./DESIGN.md#45-auditability-and-observability).
+
+## 14. Traceability
+
+- **System slug**: `service-principal`
+- **ID prefix**: `cpt-cf-service-principal-*`
+- **UPSTREAM_REQS**: No upstream requirements artifact exists for this gear.
+- **DESIGN**: [DESIGN.md](./DESIGN.md) allocates every FR and NFR and defines the implementation boundaries.
+- **ADRs**: None. This artifact records requirements; DESIGN records the resulting architecture without embedding decision debates. Explicit-tenant authorization follows the shared platform PDP/PEP baseline.
+- **DECOMPOSITION**: Not yet authored.
+- **FEATURES**: Not yet authored.
+- **CODE**: No Gears implementation is registered for this artifact yet. Implementation traceability begins when FEATURE and CODE artifacts are added.

--- a/gears/system/service-principal/service-principal-sdk/Cargo.toml
+++ b/gears/system/service-principal/service-principal-sdk/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "service-principal-sdk"
+edition.workspace = true
+license.workspace = true
+description = "Service Principal SDK: contract types and client API for the service-principal gear"
+
+[lints]
+workspace = true
+
+[dependencies]
+async-trait = { workspace = true }
+secrecy = { workspace = true }
+tenant-resolver-sdk = { workspace = true }
+toolkit-security = { workspace = true }
+uuid = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+schemars = { workspace = true }
+gts = { workspace = true }
+gts-macros = { workspace = true }
+toolkit-gts = { workspace = true }
+toolkit = { workspace = true }
+
+[package.metadata.cargo-shear]
+# `toolkit_gts::gts_type_schema` expands into code referencing `gts_macros`;
+# `cargo expand` hides it from cargo-shear, so declare it ignored.
+ignored = ["gts-macros"]

--- a/gears/system/service-principal/service-principal-sdk/src/api.rs
+++ b/gears/system/service-principal/service-principal-sdk/src/api.rs
@@ -1,0 +1,66 @@
+//! The service-principal SPI trait, resolved via `ClientHub`.
+
+use async_trait::async_trait;
+use toolkit_security::SecurityContext;
+
+use crate::error::ServicePrincipalFailure;
+use crate::models::{
+    CreateServicePrincipalRequest, ServicePrincipalCredentials, ServicePrincipalSummary, TenantId,
+};
+
+/// Lifecycle of tenant-scoped machine identities (confidential OAuth
+/// `client_credentials` clients).
+///
+/// Contract:
+/// - Callers are trusted platform modules; caller authorization
+///   (including parent→child tenant subtree semantics) happens in the
+///   consumer's RBAC/PDP BEFORE calling. `ctx` is for audit.
+/// - `(tenant_id, client_id)` is the scoped resource address; an
+///   address that does not resolve within the tenant yields `NotFound`.
+/// - The secret is returned only by `create`/`rotate_secret`. Persist
+///   it immediately (credstore); a lost secret is recovered by rotate.
+/// - Calls run outside any DB transaction. The adapter owns transport
+///   resilience and reports transport uncertainty as `Ambiguous`,
+///   never as success.
+/// - Deployments without an adapter simply have no `ClientHub`
+///   registration — `get::<dyn ServicePrincipalClientV1>()` fails.
+#[async_trait]
+pub trait ServicePrincipalClientV1: Send + Sync + 'static {
+    /// Create a confidential `client_credentials`-only client owned by
+    /// `req.tenant_id`. Tokens carry `tenant_id` and a service-subject
+    /// `user_type`.
+    ///
+    /// A taken name yields `InvalidInput` — including a half-created
+    /// principal left behind by an earlier `Ambiguous` failure; recover
+    /// via `revoke` + `create`. Principals are deleted when their owning
+    /// tenant is deprovisioned.
+    async fn create(
+        &self,
+        ctx: &SecurityContext,
+        req: &CreateServicePrincipalRequest,
+    ) -> Result<ServicePrincipalCredentials, ServicePrincipalFailure>;
+
+    /// Regenerate the secret; the old one stops working.
+    async fn rotate_secret(
+        &self,
+        ctx: &SecurityContext,
+        tenant_id: TenantId,
+        client_id: &str,
+    ) -> Result<ServicePrincipalCredentials, ServicePrincipalFailure>;
+
+    /// Delete the client. Repeat revokes yield `NotFound`, which callers treat as success-equivalent.
+    async fn revoke(
+        &self,
+        ctx: &SecurityContext,
+        tenant_id: TenantId,
+        client_id: &str,
+    ) -> Result<(), ServicePrincipalFailure>;
+
+    /// List the tenant's service principals (no secrets). Backs audit
+    /// and future management surfaces.
+    async fn list(
+        &self,
+        ctx: &SecurityContext,
+        tenant_id: TenantId,
+    ) -> Result<Vec<ServicePrincipalSummary>, ServicePrincipalFailure>;
+}

--- a/gears/system/service-principal/service-principal-sdk/src/error.rs
+++ b/gears/system/service-principal/service-principal-sdk/src/error.rs
@@ -1,0 +1,102 @@
+//! Failure categories for service-principal operations: clean vendor
+//! failures (no state retained) vs ambiguous transport outcomes (state
+//! may have been retained).
+
+use std::fmt;
+
+/// The taxonomy is intentionally closed (no `#[non_exhaustive]`): consumers must handle every category explicitly.
+#[derive(Debug)]
+pub enum ServicePrincipalFailure {
+    /// Rejected with no vendor state retained by this call (bad name,
+    /// scope not in allowlist, quota exceeded, client id taken).
+    /// Permanent — do not retry the same input.
+    InvalidInput {
+        detail: String,
+        field: Option<String>,
+    },
+    /// Target client absent on the vendor side (404/410) or not owned
+    /// by the addressed tenant. Success-equivalent for revoke.
+    NotFound { detail: String },
+    /// Vendor call failed cleanly — no state retained. Retry is harmless, though not necessarily productive.
+    CleanFailure { detail: String },
+    /// Transport uncertainty — vendor may have retained state. Never
+    /// reported as success.
+    Ambiguous { detail: String },
+}
+
+impl ServicePrincipalFailure {
+    #[must_use]
+    pub const fn as_metric_label(&self) -> &'static str {
+        match self {
+            Self::InvalidInput { .. } => "invalid_input",
+            Self::NotFound { .. } => "not_found",
+            Self::CleanFailure { .. } => "clean_failure",
+            Self::Ambiguous { .. } => "ambiguous",
+        }
+    }
+
+    #[must_use]
+    pub fn detail(&self) -> &str {
+        match self {
+            Self::InvalidInput { detail, .. }
+            | Self::NotFound { detail }
+            | Self::CleanFailure { detail }
+            | Self::Ambiguous { detail } => detail,
+        }
+    }
+}
+
+impl fmt::Display for ServicePrincipalFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.as_metric_label(), self.detail())
+    }
+}
+
+impl std::error::Error for ServicePrincipalFailure {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metric_labels_are_stable() {
+        let cases = [
+            (
+                ServicePrincipalFailure::InvalidInput {
+                    detail: String::new(),
+                    field: None,
+                },
+                "invalid_input",
+            ),
+            (
+                ServicePrincipalFailure::NotFound {
+                    detail: String::new(),
+                },
+                "not_found",
+            ),
+            (
+                ServicePrincipalFailure::CleanFailure {
+                    detail: String::new(),
+                },
+                "clean_failure",
+            ),
+            (
+                ServicePrincipalFailure::Ambiguous {
+                    detail: String::new(),
+                },
+                "ambiguous",
+            ),
+        ];
+        for (f, label) in cases {
+            assert_eq!(f.as_metric_label(), label);
+        }
+    }
+
+    #[test]
+    fn display_shape_is_stable() {
+        assert_eq!(
+            ServicePrincipalFailure::NotFound { detail: "x".into() }.to_string(),
+            "not_found: x"
+        );
+    }
+}

--- a/gears/system/service-principal/service-principal-sdk/src/gts.rs
+++ b/gears/system/service-principal/service-principal-sdk/src/gts.rs
@@ -1,0 +1,72 @@
+//! GTS (Global Type System) declarations for the service-principal SDK.
+//!
+//! Declares the **managed-resource** type for a service principal — the type
+//! RBAC/PEP authorizes create/list/rotate/revoke operations against. This is a
+//! new resource type owned by the service-principal gear (NOT the account-
+//! management `user` type): a service principal is a machine identity backed by
+//! an `IdP` client + service-account user, with its own lifecycle (incl. secret
+//! rotation) and no account-management user record. Folding it into `cf.core.am.*`
+//! would let "manage users" silently grant machine-credential minting.
+//!
+//! Distinct from the service-principal *subject* type
+//! (`cf.core.security.subject_service_principal.v1~`): that is what the principal
+//! IS when it authenticates; this is what RBAC protects when it is managed. The id
+//! deliberately contains `service_principal` but NOT the substring `subject_service`
+//! so it cannot collide with substring-based principal-type classification.
+//!
+//! Registering the `#[gts_type_schema]` struct with the types-registry (link-time
+//! inventory) is what makes the type authorizable: RBAC validates a role's
+//! `target_type` against the registry and the PDP compiles a tenant-scoped grant
+//! into an `InTenantSubtree` constraint on `owner_tenant_id`. Without it every
+//! operation is denied (403) because no role can name the type.
+
+use toolkit_gts::{gts_id, gts_type_schema};
+
+/// GTS resource-type id for the service principal as a **managed resource** — the
+/// single source of truth for this string. Mirrored by the impl gear's
+/// `domain::authz::SERVICE_PRINCIPAL` PEP `ResourceType`, the permission catalog,
+/// and the `#[resource_error(...)]` marker (pinned by a unit test there).
+pub const SERVICE_PRINCIPAL_RESOURCE_TYPE: &str =
+    gts_id!("cf.core.service_principal.service_principal.v1~");
+
+/// GTS type-schema for the service-principal managed resource.
+///
+/// Registered with an empty property set: authorization only needs the type *id*
+/// known to the registry (RBAC `target_type` validation) and the PDP — the
+/// tenant-scope binding comes from the impl gear's `ResourceType`
+/// (`OWNER_TENANT_ID`), not the schema body. Mirrors `credstore_sdk::SecretV1`.
+#[derive(Default)]
+#[gts_type_schema(
+    dir_path = "schemas",
+    type_id = gts_id!("cf.core.service_principal.service_principal.v1~"),
+    description = "Service principal — tenant-scoped machine identity, RBAC/PEP protected",
+    properties = "",
+    base = true
+)]
+pub struct ServicePrincipalV1;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use toolkit_gts::GTS_ID_PREFIX;
+
+    #[test]
+    fn resource_type_id_is_stable() {
+        // Pin the human-authored suffix. The leading `gts.` prefix is
+        // build-time configurable (GTS_ID_PREFIX) and is exactly what `gts_id!`
+        // prepends, so reconstruct the expected id from the prefix constant
+        // rather than hard-coding it — hard-coding the prefix would defeat the
+        // configuration and is rejected by the DE0904 lint.
+        assert_eq!(
+            SERVICE_PRINCIPAL_RESOURCE_TYPE,
+            format!("{GTS_ID_PREFIX}cf.core.service_principal.service_principal.v1~")
+        );
+    }
+
+    #[test]
+    fn resource_type_id_is_not_a_subject_type() {
+        // Guard against colliding with substring-based principal classification,
+        // which matches on `subject_service` / `subject_user`.
+        assert!(!SERVICE_PRINCIPAL_RESOURCE_TYPE.contains("subject_service"));
+    }
+}

--- a/gears/system/service-principal/service-principal-sdk/src/lib.rs
+++ b/gears/system/service-principal/service-principal-sdk/src/lib.rs
@@ -1,0 +1,14 @@
+//! service-principal SDK — SPI for tenant-scoped machine identities
+//! (confidential OAuth `client_credentials` clients).
+
+pub mod api;
+pub mod error;
+pub mod gts;
+pub mod models;
+
+pub use api::ServicePrincipalClientV1;
+pub use error::ServicePrincipalFailure;
+pub use gts::SERVICE_PRINCIPAL_RESOURCE_TYPE;
+pub use models::{
+    CreateServicePrincipalRequest, ServicePrincipalCredentials, ServicePrincipalSummary, TenantId,
+};

--- a/gears/system/service-principal/service-principal-sdk/src/models.rs
+++ b/gears/system/service-principal/service-principal-sdk/src/models.rs
@@ -1,0 +1,62 @@
+//! Request/response models for the service-principal SPI.
+
+use secrecy::SecretString;
+use uuid::Uuid;
+
+pub use tenant_resolver_sdk::TenantId;
+
+/// Request to create a confidential `client_credentials` service client.
+#[derive(Debug, Clone)]
+pub struct CreateServicePrincipalRequest {
+    /// Tenant that owns the principal; lands in the token's `tenant_id`.
+    pub tenant_id: TenantId,
+    /// Short caller-chosen suffix (lowercase alnum + '-', max 40 chars); the
+    /// adapter builds the final client id as `svc-<tenant_id>-<name>`.
+    pub name: String,
+    /// Client scopes to attach; validated against the adapter allowlist.
+    pub scopes: Vec<String>,
+}
+
+/// Live credentials. The secret is returned ONLY by create/rotate —
+/// persist it immediately; recovery from loss is `rotate_secret`.
+///
+/// `client_secret` is a [`secrecy::SecretString`] (workspace MUST-wrap rule
+/// for secret-shaped strings): redacted `Debug`, zeroize-on-drop, no Serde.
+#[derive(Debug)]
+pub struct ServicePrincipalCredentials {
+    pub client_id: String,
+    pub client_secret: SecretString,
+    /// OAuth token endpoint for the `client_credentials` grant.
+    pub token_url: String,
+    /// The principal's subject id (`sub` claim of issued tokens — the
+    /// IdP/service-account user UUID). Use it for RBAC bindings.
+    pub subject_id: Uuid,
+}
+
+/// Listing entry — no secrets.
+#[derive(Debug, Clone)]
+pub struct ServicePrincipalSummary {
+    pub client_id: String,
+    pub enabled: bool,
+    /// Attached client scopes as reported by the `IdP` — includes realm-default scopes, not only consumer-requested ones.
+    pub scopes: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use secrecy::ExposeSecret as _;
+
+    use super::*;
+
+    #[test]
+    fn credentials_debug_hides_secret() {
+        let creds = ServicePrincipalCredentials {
+            client_id: "svc-abc".into(),
+            client_secret: SecretString::from("super-secret".to_owned()),
+            token_url: "https://example.com/token".into(),
+            subject_id: Uuid::nil(),
+        };
+        assert!(!format!("{creds:?}").contains("super-secret"));
+        assert_eq!(creds.client_secret.expose_secret(), "super-secret");
+    }
+}

--- a/gears/system/service-principal/service-principal/Cargo.toml
+++ b/gears/system/service-principal/service-principal/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "service-principal"
+edition.workspace = true
+license.workspace = true
+description = "Service Principal gear: machine identity lifecycle and credential management"
+
+[lints]
+workspace = true
+
+[dependencies]
+service-principal-sdk = { workspace = true }
+authz-resolver-sdk = { workspace = true }
+# Full gear crates for the `deps = [authz_resolver, types_registry]` gear-macro arg:
+# the macro re-exports `::<crate>` to force-link each dependency gear's inventory
+# registration, so the crates (not just the SDKs) must be direct deps.
+authz-resolver = { workspace = true }
+types-registry = { workspace = true }
+toolkit = { workspace = true }
+toolkit-macros = { workspace = true }
+toolkit-security = { workspace = true }
+toolkit-gts = { workspace = true }
+toolkit-canonical-errors = { workspace = true }
+gts = { workspace = true }
+async-trait = { workspace = true }
+axum = { workspace = true }
+serde = { workspace = true }
+# Required as a normal dependency (NOT dev-only): the `gts_instance!` macro in
+# `gts::permissions` expands to code that references `serde_json` at the crate
+# root, so the production build needs it even though no non-test source names it
+# literally. cargo-shear still sees the literal uses in the test modules, so it
+# is not reported as unused.
+serde_json = { workspace = true }
+utoipa = { workspace = true }
+uuid = { workspace = true }
+secrecy = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+anyhow = { workspace = true }
+
+[package.metadata.cargo-shear]
+# `gts` is used only via `gts_instance!`/`gts_id!` macro expansion in
+# `gts::permissions`, which cargo-shear cannot see.
+ignored = ["gts"]
+
+[dev-dependencies]
+tower = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/gears/system/service-principal/service-principal/src/api.rs
+++ b/gears/system/service-principal/service-principal/src/api.rs
@@ -1,0 +1,3 @@
+//! REST API surface.
+
+pub mod rest;

--- a/gears/system/service-principal/service-principal/src/api/rest.rs
+++ b/gears/system/service-principal/service-principal/src/api/rest.rs
@@ -1,0 +1,8 @@
+//! REST API surface for the service-principal gear.
+
+pub mod dto;
+pub mod error;
+pub mod handlers;
+pub mod routes;
+
+pub use routes::register_routes;

--- a/gears/system/service-principal/service-principal/src/api/rest/dto.rs
+++ b/gears/system/service-principal/service-principal/src/api/rest/dto.rs
@@ -1,0 +1,94 @@
+//! REST DTOs for the service-principal gear.
+
+use secrecy::ExposeSecret as _;
+use service_principal_sdk::{ServicePrincipalCredentials, ServicePrincipalSummary};
+use uuid::Uuid;
+
+/// Request body for `POST …/service-principals`. `tenant_id` comes from the path.
+///
+/// `name`/`scopes` are not secret, so `Debug` is plain-derived (unlike the
+/// credential DTOs below, which hand-write a redacting `Debug`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[toolkit_macros::api_dto(request)]
+#[serde(deny_unknown_fields)]
+pub struct CreateServicePrincipalRequestDto {
+    /// Short caller-chosen suffix (lowercase alnum + '-', max 40 chars). The
+    /// adapter builds the final client id as `svc-<tenant_id>-<name>`.
+    pub name: String,
+    /// Client scopes to attach; validated against the adapter allowlist.
+    #[serde(default)]
+    pub scopes: Vec<String>,
+}
+
+/// Live credentials returned by create + rotate. The secret is returned ONLY here —
+/// hand-written `Debug` redacts it, and the handler sets `Cache-Control: no-store`.
+#[derive(Clone, PartialEq, Eq)]
+#[toolkit_macros::api_dto(response)]
+pub struct ServicePrincipalCredentialsDto {
+    /// The service principal's client id (`svc-<tenant_id>-<name>`).
+    pub client_id: String,
+    /// The `client_credentials` secret. Returned exactly once by create/rotate —
+    /// persist it immediately; recovery from loss is `rotate_secret`.
+    pub client_secret: String,
+    /// OAuth token endpoint for the `client_credentials` grant.
+    pub token_url: String,
+    /// The principal's subject id (`sub` of issued tokens) — use it for RBAC bindings.
+    pub subject_id: Uuid,
+}
+
+impl std::fmt::Debug for ServicePrincipalCredentialsDto {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ServicePrincipalCredentialsDto")
+            .field("client_id", &self.client_id)
+            .field("client_secret", &"[REDACTED]")
+            .field("token_url", &self.token_url)
+            .field("subject_id", &self.subject_id)
+            .finish()
+    }
+}
+
+impl From<ServicePrincipalCredentials> for ServicePrincipalCredentialsDto {
+    fn from(c: ServicePrincipalCredentials) -> Self {
+        Self {
+            client_id: c.client_id,
+            client_secret: c.client_secret.expose_secret().to_owned(),
+            token_url: c.token_url,
+            subject_id: c.subject_id,
+        }
+    }
+}
+
+/// A listing entry (no secrets).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[toolkit_macros::api_dto(response)]
+pub struct ServicePrincipalSummaryDto {
+    /// The service principal's client id (`svc-<tenant_id>-<name>`).
+    pub client_id: String,
+    /// Whether the client can currently authenticate.
+    pub enabled: bool,
+    /// Attached client scopes as reported by the `IdP` — includes realm-default
+    /// scopes, not only consumer-requested ones.
+    pub scopes: Vec<String>,
+}
+
+impl From<ServicePrincipalSummary> for ServicePrincipalSummaryDto {
+    fn from(s: ServicePrincipalSummary) -> Self {
+        Self {
+            client_id: s.client_id,
+            enabled: s.enabled,
+            scopes: s.scopes,
+        }
+    }
+}
+
+/// Response body for `GET …/service-principals`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[toolkit_macros::api_dto(response)]
+pub struct ListServicePrincipalsResponseDto {
+    /// The tenant's service principals, in upstream `IdP` order (no pagination).
+    pub service_principals: Vec<ServicePrincipalSummaryDto>,
+}
+
+#[cfg(test)]
+#[path = "dto_tests.rs"]
+mod tests;

--- a/gears/system/service-principal/service-principal/src/api/rest/dto_tests.rs
+++ b/gears/system/service-principal/service-principal/src/api/rest/dto_tests.rs
@@ -1,0 +1,41 @@
+//! DTO tests: secret redaction + request deserialization.
+
+use secrecy::SecretString;
+use service_principal_sdk::ServicePrincipalCredentials;
+use uuid::Uuid;
+
+use super::*;
+
+#[test]
+fn credentials_debug_redacts_secret() {
+    let dto = ServicePrincipalCredentialsDto::from(ServicePrincipalCredentials {
+        client_id: "svc-abc".to_owned(),
+        client_secret: SecretString::from("super-secret".to_owned()),
+        token_url: "https://idp/token".to_owned(),
+        subject_id: Uuid::nil(),
+    });
+    let rendered = format!("{dto:?}");
+    assert!(
+        !rendered.contains("super-secret"),
+        "secret must not appear in Debug"
+    );
+    // The value still round-trips into JSON (that is the whole point of the DTO).
+    assert_eq!(dto.client_secret, "super-secret");
+}
+
+#[test]
+fn create_request_rejects_unknown_fields() {
+    let ok: Result<CreateServicePrincipalRequestDto, _> =
+        serde_json::from_str(r#"{"name":"ci","scopes":["openid"]}"#);
+    assert!(ok.is_ok());
+    let bad: Result<CreateServicePrincipalRequestDto, _> =
+        serde_json::from_str(r#"{"name":"ci","unexpected":true}"#);
+    assert!(bad.is_err(), "deny_unknown_fields must reject extra keys");
+}
+
+#[test]
+fn create_request_scopes_default_to_empty() {
+    let dto: CreateServicePrincipalRequestDto =
+        serde_json::from_str(r#"{"name":"ci"}"#).expect("scopes optional");
+    assert!(dto.scopes.is_empty());
+}

--- a/gears/system/service-principal/service-principal/src/api/rest/error.rs
+++ b/gears/system/service-principal/service-principal/src/api/rest/error.rs
@@ -1,0 +1,98 @@
+//! `DomainError` → [`CanonicalError`] boundary mapping for the REST layer.
+
+use toolkit_canonical_errors::{CanonicalError, resource_error};
+
+use crate::domain::error::DomainError;
+
+/// Binds canonical errors to the service-principal resource type. The literal MUST
+/// equal the SDK's single source of truth — a divergence trips the unit test below.
+#[resource_error(gts_id!("cf.core.service_principal.service_principal.v1~"))]
+pub(crate) struct ServicePrincipalResource;
+
+impl From<DomainError> for CanonicalError {
+    fn from(err: DomainError) -> Self {
+        match err {
+            // Maps to 400, not 422. rest-api-design §7 would prefer 422 for a
+            // valid-body-but-failed-validation error, but the platform canonical
+            // taxonomy (toolkit-canonical-errors) maps InvalidArgument → 400 and
+            // has no 422 variant; routing every gear through the one canonical
+            // Problem pipeline is worth more than the 400/422 nuance here. (An
+            // unknown-field body surfaces as 422 from axum's JSON extractor, which
+            // sits upstream of this mapping and is outside our control.)
+            DomainError::InvalidInput { detail, field } => {
+                ServicePrincipalResource::invalid_argument()
+                    .with_field_violation(
+                        field.unwrap_or_else(|| "request".to_owned()),
+                        detail,
+                        "INVALID_INPUT",
+                    )
+                    .create()
+            }
+            DomainError::NotFound => {
+                ServicePrincipalResource::not_found("service principal not found")
+                    .with_resource("service_principal")
+                    .create()
+            }
+            DomainError::AccessDenied => ServicePrincipalResource::permission_denied()
+                .with_reason("ACCESS_DENIED")
+                .create(),
+            DomainError::ProviderUnavailable => CanonicalError::service_unavailable()
+                .with_detail("service-principal provider unavailable")
+                .create(),
+            DomainError::Upstream { detail } => CanonicalError::service_unavailable()
+                .with_detail(detail)
+                .create(),
+            // 409, not 503: an Ambiguous create may have half-applied upstream, so
+            // "retry the same request" — what 503 signals — would hit InvalidInput
+            // ("name taken"). 409 tells the caller to resolve the conflict via the
+            // SPI's revoke + create recovery rather than blindly retry. Aborted
+            // preserves the detail and carries a machine-readable reason.
+            DomainError::Ambiguous { detail } => ServicePrincipalResource::aborted(format!(
+                "upstream outcome uncertain, state may have been retained: {detail}"
+            ))
+            .with_reason("AMBIGUOUS_OUTCOME")
+            .create(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn status_of(err: DomainError) -> u16 {
+        CanonicalError::from(err).status_code()
+    }
+
+    #[test]
+    fn variants_map_to_expected_statuses() {
+        assert_eq!(
+            status_of(DomainError::InvalidInput {
+                detail: "b".into(),
+                field: Some("name".into())
+            }),
+            400
+        );
+        assert_eq!(status_of(DomainError::NotFound), 404);
+        assert_eq!(status_of(DomainError::AccessDenied), 403);
+        assert_eq!(status_of(DomainError::ProviderUnavailable), 503);
+        assert_eq!(status_of(DomainError::Upstream { detail: "x".into() }), 503);
+        // Ambiguous → 409 (Aborted), not 503: a half-applied create must not
+        // advertise "retry the same request".
+        assert_eq!(
+            status_of(DomainError::Ambiguous { detail: "x".into() }),
+            409
+        );
+    }
+
+    #[test]
+    fn resource_error_string_matches_sdk_constant() {
+        // The `#[resource_error(...)]` literal must equal the SDK constant; NotFound
+        // flows through the marker, so the built error carries the resource type.
+        let err = CanonicalError::from(DomainError::NotFound);
+        assert_eq!(
+            err.resource_type(),
+            Some(service_principal_sdk::SERVICE_PRINCIPAL_RESOURCE_TYPE)
+        );
+    }
+}

--- a/gears/system/service-principal/service-principal/src/api/rest/handlers.rs
+++ b/gears/system/service-principal/service-principal/src/api/rest/handlers.rs
@@ -1,0 +1,112 @@
+//! REST handlers for the service-principal gear. Thin: parse the path/body, call
+//! the service, map the domain result to a canonical response. Errors propagate
+//! via `?` through `From<DomainError> for CanonicalError`.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Extension, Path};
+use axum::http::{StatusCode, header};
+use axum::response::IntoResponse;
+use service_principal_sdk::TenantId;
+use toolkit::api::canonical_prelude::*;
+use toolkit_security::SecurityContext;
+use uuid::Uuid;
+
+use super::dto::{
+    CreateServicePrincipalRequestDto, ListServicePrincipalsResponseDto,
+    ServicePrincipalCredentialsDto,
+};
+use crate::domain::service::Service;
+
+/// Build a JSON response carrying a `ServicePrincipalCredentialsDto` with
+/// `Cache-Control: no-store`. Centralizes the "credential responses must never
+/// be cached by any intermediary" rule for `rotate_secret` (`create` builds its
+/// response inline since it additionally needs a `Location` header).
+fn no_store_json(status: StatusCode, dto: ServicePrincipalCredentialsDto) -> impl IntoResponse {
+    (status, [(header::CACHE_CONTROL, "no-store")], Json(dto))
+}
+
+/// `POST …/tenants/{tenant_id}/service-principals`
+///
+/// # Errors
+/// Canonical `Problem` on invalid input (400), access denied (403), an ambiguous
+/// upstream outcome that may have half-created the principal (409 — recover via
+/// revoke + create), or upstream unavailable (503).
+pub async fn create(
+    Extension(svc): Extension<Arc<Service>>,
+    Extension(ctx): Extension<SecurityContext>,
+    Path(tenant_id): Path<Uuid>,
+    uri: axum::http::Uri,
+    Json(body): Json<CreateServicePrincipalRequestDto>,
+) -> ApiResult<impl IntoResponse> {
+    let creds = svc
+        .create(&ctx, TenantId(tenant_id), body.name, body.scopes)
+        .await?;
+    // The created resource's canonical address is this same collection path with
+    // the new `client_id` appended, e.g.
+    // `/service-principal/v1/tenants/{tenant_id}/service-principals/{client_id}`
+    // (mirrors `credstore`'s `create_secret`). A 201 without `Location` is
+    // non-compliant REST house style, so this is built alongside (not instead
+    // of) the `no-store` requirement below — the secret body must still never
+    // be cached.
+    let location = format!("{}/{}", uri.path().trim_end_matches('/'), creds.client_id);
+    let dto = ServicePrincipalCredentialsDto::from(creds);
+    Ok((
+        StatusCode::CREATED,
+        [
+            (header::LOCATION, location),
+            (header::CACHE_CONTROL, "no-store".to_owned()),
+        ],
+        Json(dto),
+    )
+        .into_response())
+}
+
+/// `GET …/tenants/{tenant_id}/service-principals`
+///
+/// # Errors
+/// Canonical `Problem` on access denied (403) or upstream unavailable (503).
+pub async fn list(
+    Extension(svc): Extension<Arc<Service>>,
+    Extension(ctx): Extension<SecurityContext>,
+    Path(tenant_id): Path<Uuid>,
+) -> ApiResult<impl IntoResponse> {
+    let items = svc.list(&ctx, TenantId(tenant_id)).await?;
+    let dto = ListServicePrincipalsResponseDto {
+        service_principals: items.into_iter().map(Into::into).collect(),
+    };
+    Ok((StatusCode::OK, Json(dto)).into_response())
+}
+
+/// `POST …/tenants/{tenant_id}/service-principals/{client_id}/rotate-secret`
+///
+/// # Errors
+/// Canonical `Problem` on not found (404), access denied (403), an ambiguous
+/// upstream outcome (409), or upstream unavailable (503).
+pub async fn rotate_secret(
+    Extension(svc): Extension<Arc<Service>>,
+    Extension(ctx): Extension<SecurityContext>,
+    Path((tenant_id, client_id)): Path<(Uuid, String)>,
+) -> ApiResult<impl IntoResponse> {
+    let creds = svc
+        .rotate_secret(&ctx, TenantId(tenant_id), &client_id)
+        .await?;
+    let dto = ServicePrincipalCredentialsDto::from(creds);
+    Ok(no_store_json(StatusCode::OK, dto).into_response())
+}
+
+/// `DELETE …/tenants/{tenant_id}/service-principals/{client_id}`
+///
+/// Idempotent: a missing principal returns `204`.
+///
+/// # Errors
+/// Canonical `Problem` on access denied (403) or upstream unavailable (503).
+pub async fn revoke(
+    Extension(svc): Extension<Arc<Service>>,
+    Extension(ctx): Extension<SecurityContext>,
+    Path((tenant_id, client_id)): Path<(Uuid, String)>,
+) -> ApiResult<impl IntoResponse> {
+    svc.revoke(&ctx, TenantId(tenant_id), &client_id).await?;
+    Ok(StatusCode::NO_CONTENT.into_response())
+}

--- a/gears/system/service-principal/service-principal/src/api/rest/routes.rs
+++ b/gears/system/service-principal/service-principal/src/api/rest/routes.rs
@@ -1,0 +1,130 @@
+//! REST route registration for the service-principal gear.
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::http::StatusCode;
+use toolkit::api::{OpenApiRegistry, OperationBuilder};
+
+use super::dto::{
+    CreateServicePrincipalRequestDto, ListServicePrincipalsResponseDto,
+    ServicePrincipalCredentialsDto,
+};
+use super::handlers;
+use crate::domain::service::Service;
+
+const TAG: &str = "Service Principals";
+const TENANT_PARAM: &str = "Owning tenant id (UUID). The caller must be authorized \
+    for this tenant (its own or a descendant via a subtree grant).";
+const CLIENT_ID_PARAM: &str = "Service-principal client id (`svc-<tenant_id>-<name>`).";
+
+/// Register all REST routes for the service-principal gear.
+///
+/// NOTE: no `#[must_use]` here — `axum::Router` (the return type) is already
+/// `#[must_use]`, so an explicit attribute on this fn would double up and trip
+/// `clippy::double_must_use`.
+pub fn register_routes(router: Router, openapi: &dyn OpenApiRegistry, svc: Arc<Service>) -> Router {
+    let router =
+        OperationBuilder::post("/service-principal/v1/tenants/{tenant_id}/service-principals")
+            .operation_id("service_principal.create")
+            .summary("Create a service principal")
+            .description(
+                "Create a confidential client_credentials machine identity owned by the tenant. \
+             Returns the client secret exactly once.",
+            )
+            .tag(TAG)
+            .authenticated()
+            .no_license_required()
+            .path_param("tenant_id", TENANT_PARAM)
+            .json_request::<CreateServicePrincipalRequestDto>(
+                openapi,
+                "Service-principal name and scopes",
+            )
+            .handler(handlers::create)
+            .json_response_with_schema::<ServicePrincipalCredentialsDto>(
+                openapi,
+                StatusCode::CREATED,
+                "Created - credentials (secret returned once; Cache-Control: no-store)",
+            )
+            .standard_errors(openapi)
+            .register(router, openapi);
+
+    let router =
+        OperationBuilder::get("/service-principal/v1/tenants/{tenant_id}/service-principals")
+            .operation_id("service_principal.list")
+            .summary("List the tenant's service principals")
+            .description(
+                "List the tenant's service principals (no secrets). The upstream IdP is \
+             unpaginated, so the full collection is returned.",
+            )
+            .tag(TAG)
+            .authenticated()
+            .no_license_required()
+            .path_param("tenant_id", TENANT_PARAM)
+            .handler(handlers::list)
+            .json_response_with_schema::<ListServicePrincipalsResponseDto>(
+                openapi,
+                StatusCode::OK,
+                "The tenant's service principals",
+            )
+            .standard_errors(openapi)
+            .register(router, openapi);
+
+    let router = OperationBuilder::post(
+        "/service-principal/v1/tenants/{tenant_id}/service-principals/{client_id}/rotate-secret",
+    )
+    .operation_id("service_principal.rotate_secret")
+    .summary("Rotate a service principal's secret")
+    .description(
+        "Regenerate the secret; the old one stops working. Returns the new secret exactly once.",
+    )
+    .tag(TAG)
+    .authenticated()
+    .no_license_required()
+    .path_param("tenant_id", TENANT_PARAM)
+    .path_param("client_id", CLIENT_ID_PARAM)
+    .handler(handlers::rotate_secret)
+    .json_response_with_schema::<ServicePrincipalCredentialsDto>(
+        openapi,
+        StatusCode::OK,
+        "Rotated - new credentials (secret returned once; Cache-Control: no-store)",
+    )
+    .standard_errors(openapi)
+    .register(router, openapi);
+
+    // NOTE: the item path deliberately registers no `GET`, so the URL that
+    // `create` returns in its `Location` header answers `DELETE` but 405s a
+    // `GET`. This is a known, bounded seam rather than an oversight:
+    //
+    //  * the SPI (`ServicePrincipalClientV1`) exposes no by-id `get` — adding one
+    //    means changing the SDK trait and every adapter, beyond this facade's scope;
+    //  * RFC 9110 §10.2.2 has `Location` *identify* the created resource; it does
+    //    not promise the URL is `GET`-able, and rotate/revoke both address the item
+    //    without reading it;
+    //  * nothing is write-only: the collection `GET` above enumerates the tenant's
+    //    principals in full (the upstream quota bounds a tenant to ~10).
+    //
+    // Adding by-id read (either an SPI `get`, or serving it from `list` + filter
+    // in the facade) is tracked as follow-up work.
+    let router = OperationBuilder::delete(
+        "/service-principal/v1/tenants/{tenant_id}/service-principals/{client_id}",
+    )
+    .operation_id("service_principal.revoke")
+    .summary("Revoke a service principal")
+    .description("Delete the service principal. Idempotent: a missing principal returns 204.")
+    .tag(TAG)
+    .authenticated()
+    .no_license_required()
+    .path_param("tenant_id", TENANT_PARAM)
+    .path_param("client_id", CLIENT_ID_PARAM)
+    .handler(handlers::revoke)
+    .no_content_response(StatusCode::NO_CONTENT, "Revoked (or already absent)")
+    .standard_errors(openapi)
+    .register(router, openapi);
+
+    router.layer(axum::Extension(svc))
+}
+
+#[cfg(test)]
+#[path = "routes_tests.rs"]
+mod tests;

--- a/gears/system/service-principal/service-principal/src/api/rest/routes_tests.rs
+++ b/gears/system/service-principal/service-principal/src/api/rest/routes_tests.rs
@@ -1,0 +1,378 @@
+//! Route-registration + behavioral tests for the service-principal REST surface.
+//!
+//! Builds the router via [`register_routes`] against a *real* `OpenApiRegistryImpl`
+//! (mirrors `credstore`/`token-issuer` `routes_tests.rs` — there is no separate
+//! "Noop" registry test double in this toolkit version) and drives it end-to-end
+//! with `tower::ServiceExt::oneshot`, injecting `SecurityContext` as a request
+//! extension the way the real auth middleware would.
+
+use std::sync::Arc;
+
+use authz_resolver_sdk::AuthZResolverClient;
+use authz_resolver_sdk::constraints::{Constraint, InPredicate, Predicate};
+use authz_resolver_sdk::error::AuthZResolverError;
+use authz_resolver_sdk::models::{
+    EvaluationRequest, EvaluationResponse, EvaluationResponseContext,
+};
+use authz_resolver_sdk::pep::PolicyEnforcer;
+use axum::Router;
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use secrecy::SecretString;
+use service_principal_sdk::{
+    CreateServicePrincipalRequest, ServicePrincipalClientV1, ServicePrincipalCredentials,
+    ServicePrincipalFailure, ServicePrincipalSummary, TenantId,
+};
+use toolkit::ClientHub;
+use toolkit::api::OpenApiRegistryImpl;
+use toolkit_security::{SecurityContext, pep_properties};
+use tower::ServiceExt as _;
+use uuid::Uuid;
+
+use super::*;
+use crate::domain::service::Service;
+
+const TENANT: &str = "11111111-1111-1111-1111-111111111111";
+const SUBJECT: &str = "22222222-2222-2222-2222-222222222222";
+
+fn uuid(s: &str) -> Uuid {
+    Uuid::parse_str(s).expect("valid test uuid")
+}
+
+fn test_ctx() -> SecurityContext {
+    SecurityContext::builder()
+        .subject_id(uuid(SUBJECT))
+        .subject_tenant_id(uuid(TENANT))
+        .build()
+        .expect("valid ctx")
+}
+
+/// PDP that permits, scoping the returned constraint to whatever owner tenant the
+/// request carries — i.e. it always authorizes the resource actually being acted
+/// on (mirrors `domain::service_tests::AllowTenantPdp`).
+struct AllowTenantPdp;
+#[async_trait::async_trait]
+impl AuthZResolverClient for AllowTenantPdp {
+    async fn evaluate(
+        &self,
+        req: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let tid = req
+            .resource
+            .properties
+            .get(pep_properties::OWNER_TENANT_ID)
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok())
+            .unwrap_or_default();
+        Ok(EvaluationResponse {
+            decision: true,
+            context: EvaluationResponseContext {
+                constraints: vec![Constraint {
+                    predicates: vec![Predicate::In(InPredicate::new(
+                        pep_properties::OWNER_TENANT_ID,
+                        [tid],
+                    ))],
+                }],
+                ..Default::default()
+            },
+        })
+    }
+}
+
+/// PDP that always denies.
+struct DenyPdp;
+#[async_trait::async_trait]
+impl AuthZResolverClient for DenyPdp {
+    async fn evaluate(
+        &self,
+        _req: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        Ok(EvaluationResponse {
+            decision: false,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+/// Configurable SPI mock — fixed success responses by default, with an
+/// overridable `rotate_result` so a single test can drive a domain failure
+/// through the real HTTP stack (mirrors `domain::service_tests::MockSp`).
+#[derive(Default)]
+struct MockSp {
+    rotate_result: Option<ServicePrincipalFailure>,
+}
+
+#[async_trait::async_trait]
+impl ServicePrincipalClientV1 for MockSp {
+    async fn create(
+        &self,
+        _ctx: &SecurityContext,
+        req: &CreateServicePrincipalRequest,
+    ) -> Result<ServicePrincipalCredentials, ServicePrincipalFailure> {
+        Ok(ServicePrincipalCredentials {
+            client_id: format!("svc-{}-{}", req.tenant_id.0, req.name),
+            client_secret: SecretString::from("s3cr3t".to_owned()),
+            token_url: "https://idp/token".to_owned(),
+            subject_id: Uuid::new_v4(),
+        })
+    }
+    async fn rotate_secret(
+        &self,
+        _ctx: &SecurityContext,
+        _tenant_id: TenantId,
+        client_id: &str,
+    ) -> Result<ServicePrincipalCredentials, ServicePrincipalFailure> {
+        match &self.rotate_result {
+            Some(e) => Err(clone_failure(e)),
+            None => Ok(ServicePrincipalCredentials {
+                client_id: client_id.to_owned(),
+                client_secret: SecretString::from("rotated".to_owned()),
+                token_url: "https://idp/token".to_owned(),
+                subject_id: Uuid::new_v4(),
+            }),
+        }
+    }
+    async fn revoke(
+        &self,
+        _ctx: &SecurityContext,
+        _tenant_id: TenantId,
+        _client_id: &str,
+    ) -> Result<(), ServicePrincipalFailure> {
+        Ok(())
+    }
+    async fn list(
+        &self,
+        _ctx: &SecurityContext,
+        _tenant_id: TenantId,
+    ) -> Result<Vec<ServicePrincipalSummary>, ServicePrincipalFailure> {
+        Ok(vec![ServicePrincipalSummary {
+            client_id: "svc-x".to_owned(),
+            enabled: true,
+            scopes: vec!["openid".to_owned()],
+        }])
+    }
+}
+
+/// Hand-rolled clone: `ServicePrincipalFailure` intentionally derives only
+/// `Debug` (it is not meant to be persisted/cloned in production code), so the
+/// mock reconstructs an equivalent value from a shared reference (mirrors
+/// `domain::service_tests::clone_failure`).
+fn clone_failure(f: &ServicePrincipalFailure) -> ServicePrincipalFailure {
+    match f {
+        ServicePrincipalFailure::InvalidInput { detail, field } => {
+            ServicePrincipalFailure::InvalidInput {
+                detail: detail.clone(),
+                field: field.clone(),
+            }
+        }
+        ServicePrincipalFailure::NotFound { detail } => ServicePrincipalFailure::NotFound {
+            detail: detail.clone(),
+        },
+        ServicePrincipalFailure::CleanFailure { detail } => ServicePrincipalFailure::CleanFailure {
+            detail: detail.clone(),
+        },
+        ServicePrincipalFailure::Ambiguous { detail } => ServicePrincipalFailure::Ambiguous {
+            detail: detail.clone(),
+        },
+    }
+}
+
+/// Build a router wired to a `Service` backed by the given PDP and SPI mock.
+fn router_with_pdp_and_sp(
+    pdp: Arc<dyn AuthZResolverClient>,
+    sp: MockSp,
+) -> (Router, Arc<OpenApiRegistryImpl>) {
+    let hub = Arc::new(ClientHub::default());
+    hub.register::<dyn ServicePrincipalClientV1>(Arc::new(sp));
+    let svc = Arc::new(Service::new(PolicyEnforcer::new(pdp), hub));
+    let openapi = Arc::new(OpenApiRegistryImpl::new());
+    let router = register_routes(Router::new(), openapi.as_ref(), svc);
+    (router, openapi)
+}
+
+/// Build a router wired to a `Service` backed by the given PDP, with a
+/// default (all-success) `MockSp` registered in the `ClientHub`.
+fn router_with_pdp(pdp: Arc<dyn AuthZResolverClient>) -> (Router, Arc<OpenApiRegistryImpl>) {
+    router_with_pdp_and_sp(pdp, MockSp::default())
+}
+
+fn authorized_router() -> Router {
+    router_with_pdp(Arc::new(AllowTenantPdp)).0
+}
+
+/// Inject the `SecurityContext` extension the way the real auth middleware would.
+fn request_with_ctx(method: &str, uri: &str, body: Option<serde_json::Value>) -> Request<Body> {
+    let mut builder = Request::builder().method(method).uri(uri);
+    if body.is_some() {
+        builder = builder.header("content-type", "application/json");
+    }
+    let body = match body {
+        Some(json) => Body::from(serde_json::to_vec(&json).expect("serializable body")),
+        None => Body::empty(),
+    };
+    let mut req = builder.body(body).expect("valid request");
+    req.extensions_mut().insert(test_ctx());
+    req
+}
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = to_bytes(resp.into_body(), 1024 * 64).await.expect("body");
+    serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+}
+
+#[test]
+fn all_four_routes_register_in_the_openapi_registry() {
+    let (_router, openapi) = router_with_pdp(Arc::new(AllowTenantPdp));
+    let keys: std::collections::BTreeSet<String> = openapi
+        .operation_specs
+        .iter()
+        .map(|e| e.key().clone())
+        .collect();
+    let expected: std::collections::BTreeSet<String> = [
+        "POST:/service-principal/v1/tenants/{tenant_id}/service-principals",
+        "GET:/service-principal/v1/tenants/{tenant_id}/service-principals",
+        "POST:/service-principal/v1/tenants/{tenant_id}/service-principals/{client_id}/rotate-secret",
+        "DELETE:/service-principal/v1/tenants/{tenant_id}/service-principals/{client_id}",
+    ]
+    .into_iter()
+    .map(str::to_owned)
+    .collect();
+    assert_eq!(
+        keys, expected,
+        "exactly the four documented operations must be registered"
+    );
+}
+
+#[tokio::test]
+async fn create_returns_201_with_location_and_no_store_and_secret_body() {
+    let router = authorized_router();
+    let uri = format!("/service-principal/v1/tenants/{TENANT}/service-principals");
+    let req = request_with_ctx("POST", &uri, Some(serde_json::json!({ "name": "ci" })));
+    let resp = router.oneshot(req).await.expect("router");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    // Pull the headers we need into owned values before `body_json` consumes
+    // `resp` (it takes the response, not a reference, to drain the body).
+    let cache_control = resp
+        .headers()
+        .get(axum::http::header::CACHE_CONTROL)
+        .expect("Cache-Control header present")
+        .to_str()
+        .expect("ascii")
+        .to_owned();
+    assert!(
+        cache_control.contains("no-store"),
+        "secret responses must not be cached"
+    );
+    // A 201 MUST carry `Location` pointing at the new resource — asserted
+    // below once we know the `client_id` from the body.
+    let location = resp
+        .headers()
+        .get(axum::http::header::LOCATION)
+        .expect("Location header present")
+        .to_str()
+        .expect("ascii")
+        .to_owned();
+
+    let body = body_json(resp).await;
+    assert_eq!(body["client_secret"], "s3cr3t");
+    let client_id = body["client_id"].as_str().expect("client_id").to_owned();
+    assert!(client_id.starts_with("svc-"));
+
+    assert!(
+        location.ends_with(&format!("/service-principals/{client_id}")),
+        "Location {location:?} must end with /service-principals/{client_id}"
+    );
+}
+
+#[tokio::test]
+async fn list_returns_200_with_summaries() {
+    let router = authorized_router();
+    let uri = format!("/service-principal/v1/tenants/{TENANT}/service-principals");
+    let req = request_with_ctx("GET", &uri, None);
+    let resp = router.oneshot(req).await.expect("router");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["service_principals"][0]["client_id"], "svc-x");
+    assert_eq!(body["service_principals"][0]["enabled"], true);
+    assert_eq!(body["service_principals"][0]["scopes"][0], "openid");
+}
+
+#[tokio::test]
+async fn rotate_secret_returns_200_with_no_store_and_new_secret() {
+    let router = authorized_router();
+    let uri =
+        format!("/service-principal/v1/tenants/{TENANT}/service-principals/svc-x/rotate-secret");
+    let req = request_with_ctx("POST", &uri, None);
+    let resp = router.oneshot(req).await.expect("router");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let cache_control = resp
+        .headers()
+        .get(axum::http::header::CACHE_CONTROL)
+        .expect("Cache-Control header present")
+        .to_str()
+        .expect("ascii");
+    assert!(cache_control.contains("no-store"));
+    let body = body_json(resp).await;
+    assert_eq!(body["client_secret"], "rotated");
+}
+
+#[tokio::test]
+async fn revoke_returns_204() {
+    let router = authorized_router();
+    let uri = format!("/service-principal/v1/tenants/{TENANT}/service-principals/svc-x");
+    let req = request_with_ctx("DELETE", &uri, None);
+    let resp = router.oneshot(req).await.expect("router");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn denied_request_returns_403() {
+    let router = router_with_pdp(Arc::new(DenyPdp)).0;
+    let uri = format!("/service-principal/v1/tenants/{TENANT}/service-principals");
+    let req = request_with_ctx("GET", &uri, None);
+    let resp = router.oneshot(req).await.expect("router");
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+/// A domain failure (SPI `NotFound`) must render as an RFC 9457
+/// `application/problem+json` envelope through the *real* HTTP stack — not just
+/// the right status code. This exercises the full chain: handler `?` →
+/// `From<DomainError> for CanonicalError` → `Problem::from_error` →
+/// `IntoResponse`.
+#[tokio::test]
+async fn rotate_secret_not_found_renders_canonical_problem() {
+    let sp = MockSp {
+        rotate_result: Some(ServicePrincipalFailure::NotFound {
+            detail: "no such client".to_owned(),
+        }),
+    };
+    let router = router_with_pdp_and_sp(Arc::new(AllowTenantPdp), sp).0;
+    let uri = format!(
+        "/service-principal/v1/tenants/{TENANT}/service-principals/svc-ghost/rotate-secret"
+    );
+    let req = request_with_ctx("POST", &uri, None);
+    let resp = router.oneshot(req).await.expect("router");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    let content_type = resp
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .expect("Content-Type header present")
+        .to_str()
+        .expect("ascii");
+    assert!(
+        content_type.contains("problem+json"),
+        "canonical errors must render as RFC 9457 problem+json, got {content_type:?}"
+    );
+
+    let body = body_json(resp).await;
+    assert_eq!(body["status"], 404);
+    assert!(
+        body["type"].as_str().is_some_and(|t| !t.is_empty()),
+        "problem envelope must carry a non-empty `type` URI, got {body:?}"
+    );
+    assert!(
+        body["title"].as_str().is_some_and(|t| !t.is_empty()),
+        "problem envelope must carry a `title`, got {body:?}"
+    );
+}

--- a/gears/system/service-principal/service-principal/src/domain.rs
+++ b/gears/system/service-principal/service-principal/src/domain.rs
@@ -1,0 +1,5 @@
+//! Domain layer: authorization gate, error model, and the facade service.
+
+pub(crate) mod authz;
+pub mod error;
+pub mod service;

--- a/gears/system/service-principal/service-principal/src/domain/authz.rs
+++ b/gears/system/service-principal/service-principal/src/domain/authz.rs
@@ -1,0 +1,129 @@
+//! PDP authorization gate for service-principal management.
+//!
+//! Tenant-scoped: the PEP resource carries only `OWNER_TENANT_ID`. The
+//! `(tenant_id, client_id)` coupling is enforced downstream by the SPI adapter
+//! (a `client_id` not owned by `tenant_id` is `NotFound`), so no per-instance
+//! UUID authz is needed here.
+
+use authz_resolver_sdk::pep::{EnforcerError, ResourceType};
+use toolkit_security::{AccessScope, pep_properties};
+use uuid::Uuid;
+
+use crate::domain::error::DomainError;
+
+/// PDP resource type for the service principal. The id comes from the SDK's single
+/// source of truth ([`service_principal_sdk::SERVICE_PRINCIPAL_RESOURCE_TYPE`]).
+pub const SERVICE_PRINCIPAL: ResourceType = ResourceType::from_static(
+    service_principal_sdk::SERVICE_PRINCIPAL_RESOURCE_TYPE,
+    &[pep_properties::OWNER_TENANT_ID],
+);
+
+/// Per-verb RBAC actions (matching account-management's identity-management style,
+/// not the coarse read/write/delete triad). `rotate_secret` is a distinct action
+/// so credential minting can be granted independently.
+pub mod actions {
+    pub const CREATE: &str = "create";
+    pub const READ: &str = "read";
+    pub const ROTATE_SECRET: &str = "rotate_secret";
+    pub const REVOKE: &str = "revoke";
+}
+
+/// Map a PEP enforcement failure to a domain error (fail-closed).
+/// `Denied` / `CompileFailed` → `AccessDenied` (403); `EvaluationFailed` → `Upstream` (503).
+#[must_use]
+// By-value (not `&EnforcerError`) so this can be passed directly as a bare
+// function pointer to `Result::map_err` at the call site (e.g.
+// `.map_err(authz::map_enforcer_err)`), which requires `FnOnce(EnforcerError) -> _`.
+#[allow(clippy::needless_pass_by_value)]
+pub fn map_enforcer_err(err: EnforcerError) -> DomainError {
+    match err {
+        EnforcerError::Denied { .. } | EnforcerError::CompileFailed(_) => DomainError::AccessDenied,
+        EnforcerError::EvaluationFailed(_) => DomainError::Upstream {
+            detail: "authorization evaluation failed".to_owned(),
+        },
+    }
+}
+
+/// Object-level (BOLA) check: the PDP-returned `scope` must actually cover the
+/// explicit target `tenant`. A `decision=true` for *some* subtree must never
+/// authorize a *different* target tenant — hence this check rather than trusting
+/// the bare decision. `allow_all` (a legitimate unconstrained PDP outcome, e.g. a
+/// platform superuser) permits any tenant.
+///
+/// # Errors
+/// Returns [`DomainError::AccessDenied`] when the scope does not cover `tenant`.
+pub fn ensure_scope_permits(scope: &AccessScope, tenant: Uuid) -> Result<(), DomainError> {
+    if scope.is_unconstrained() || scope.contains_uuid(pep_properties::OWNER_TENANT_ID, tenant) {
+        Ok(())
+    } else {
+        Err(DomainError::AccessDenied)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use authz_resolver_sdk::pep::EnforcerError;
+    use toolkit_security::AccessScope;
+    use uuid::Uuid;
+
+    use super::*;
+
+    #[test]
+    fn allow_all_scope_permits_any_tenant() {
+        assert!(ensure_scope_permits(&AccessScope::allow_all(), Uuid::new_v4()).is_ok());
+    }
+
+    #[test]
+    fn scope_permits_only_the_covered_tenant() {
+        let target = Uuid::new_v4();
+        let scope = AccessScope::for_tenant(target);
+        assert!(ensure_scope_permits(&scope, target).is_ok());
+        // A grant covering a *different* tenant must not authorize this target.
+        assert!(matches!(
+            ensure_scope_permits(&scope, Uuid::new_v4()),
+            Err(DomainError::AccessDenied)
+        ));
+    }
+
+    #[test]
+    fn deny_all_scope_permits_nothing() {
+        assert!(matches!(
+            ensure_scope_permits(&AccessScope::deny_all(), Uuid::new_v4()),
+            Err(DomainError::AccessDenied)
+        ));
+    }
+
+    #[test]
+    fn enforcer_errors_fail_closed() {
+        assert!(matches!(
+            map_enforcer_err(EnforcerError::Denied { deny_reason: None }),
+            DomainError::AccessDenied
+        ));
+    }
+
+    #[test]
+    fn compile_failed_fails_closed_as_access_denied() {
+        // `ConstraintsRequiredButAbsent` is the simplest real value the SDK
+        // exposes for this variant: the PDP was asked for row-level
+        // constraints (require_constraints(true)) and returned none, which
+        // the compiler treats as a fail-closed deny.
+        assert!(matches!(
+            map_enforcer_err(EnforcerError::CompileFailed(
+                authz_resolver_sdk::pep::ConstraintCompileError::ConstraintsRequiredButAbsent
+            )),
+            DomainError::AccessDenied
+        ));
+    }
+
+    #[test]
+    fn evaluation_failed_maps_to_upstream() {
+        // `NoPluginAvailable` is the simplest real value the SDK exposes for
+        // this variant (no AuthZ plugin registered to serve the request).
+        assert!(matches!(
+            map_enforcer_err(EnforcerError::EvaluationFailed(
+                authz_resolver_sdk::AuthZResolverError::NoPluginAvailable
+            )),
+            DomainError::Upstream { .. }
+        ));
+    }
+}

--- a/gears/system/service-principal/service-principal/src/domain/error.rs
+++ b/gears/system/service-principal/service-principal/src/domain/error.rs
@@ -1,0 +1,100 @@
+//! Domain error model for the service-principal REST facade.
+//!
+//! Fail-closed. Each variant carries the typed data its `#[error(...)]` message
+//! needs; the human-readable message is never assembled at the call site. Mapped
+//! to a canonical `Problem` at the REST boundary in `api::rest::error`.
+
+use service_principal_sdk::ServicePrincipalFailure;
+use thiserror::Error;
+use toolkit_macros::domain_model;
+
+/// Errors raised by the service-principal domain layer.
+#[domain_model]
+#[derive(Debug, Error)]
+pub enum DomainError {
+    /// The SPI rejected the input with no state retained (bad name, scope not in
+    /// allowlist, quota exceeded, client id taken) → `400`.
+    #[error("invalid input: {detail}")]
+    InvalidInput {
+        /// Human-readable detail of the invalid-input rejection.
+        detail: String,
+        /// The offending field, when the SPI attributes one.
+        field: Option<String>,
+    },
+
+    /// The addressed principal does not exist within the tenant → `404`.
+    /// (revoke treats this as success-equivalent before conversion — see `service`.)
+    #[error("service principal not found")]
+    NotFound,
+
+    /// The PDP denied the request (or its constraints failed to compile) → `403`.
+    #[error("access denied")]
+    AccessDenied,
+
+    /// No SPI provider is registered in the `ClientHub` → `503`.
+    #[error("service-principal provider unavailable")]
+    ProviderUnavailable,
+
+    /// A clean upstream failure or a PDP evaluation failure — no state retained,
+    /// retry is harmless → `503`.
+    #[error("upstream unavailable: {detail}")]
+    Upstream {
+        /// Human-readable detail of the upstream failure.
+        detail: String,
+    },
+
+    /// Transport uncertainty — the vendor may have retained state → `409`.
+    /// A naive retry would hit `InvalidInput` ("name taken"); recovery for a
+    /// create is revoke + create, which `409` signals over `503`'s retry-same.
+    #[error("upstream outcome ambiguous: {detail}")]
+    Ambiguous {
+        /// Human-readable detail of the ambiguous outcome.
+        detail: String,
+    },
+}
+
+/// General SPI-failure → domain mapping. NOTE: `revoke` handles `NotFound` as
+/// success *before* calling this (idempotent delete), so this blanket mapping is
+/// only reached for the non-idempotent operations.
+impl From<ServicePrincipalFailure> for DomainError {
+    fn from(err: ServicePrincipalFailure) -> Self {
+        match err {
+            ServicePrincipalFailure::InvalidInput { detail, field } => {
+                Self::InvalidInput { detail, field }
+            }
+            ServicePrincipalFailure::NotFound { .. } => Self::NotFound,
+            ServicePrincipalFailure::CleanFailure { detail } => Self::Upstream { detail },
+            ServicePrincipalFailure::Ambiguous { detail } => Self::Ambiguous { detail },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use service_principal_sdk::ServicePrincipalFailure as F;
+
+    use super::*;
+
+    #[test]
+    fn maps_sdk_failures_to_domain() {
+        assert!(matches!(
+            DomainError::from(F::InvalidInput {
+                detail: "bad".into(),
+                field: Some("name".into())
+            }),
+            DomainError::InvalidInput { field: Some(_), .. }
+        ));
+        assert!(matches!(
+            DomainError::from(F::NotFound { detail: "x".into() }),
+            DomainError::NotFound
+        ));
+        assert!(matches!(
+            DomainError::from(F::CleanFailure { detail: "x".into() }),
+            DomainError::Upstream { .. }
+        ));
+        assert!(matches!(
+            DomainError::from(F::Ambiguous { detail: "x".into() }),
+            DomainError::Ambiguous { .. }
+        ));
+    }
+}

--- a/gears/system/service-principal/service-principal/src/domain/service.rs
+++ b/gears/system/service-principal/service-principal/src/domain/service.rs
@@ -1,0 +1,151 @@
+//! The service-principal facade service.
+//!
+//! Per request: authorize the explicit target tenant against the PDP, resolve the
+//! SPI client lazily from the `ClientHub` (pluggable adapter), delegate, and map
+//! failures. Stateless — a gear restart loses nothing.
+
+use std::sync::Arc;
+
+use authz_resolver_sdk::pep::{AccessRequest, PolicyEnforcer};
+use service_principal_sdk::{
+    CreateServicePrincipalRequest, ServicePrincipalClientV1, ServicePrincipalCredentials,
+    ServicePrincipalFailure, ServicePrincipalSummary, TenantId,
+};
+use toolkit::ClientHub;
+use toolkit_macros::domain_model;
+use toolkit_security::{SecurityContext, pep_properties};
+use tracing::warn;
+
+use crate::domain::authz::{self, actions};
+use crate::domain::error::DomainError;
+
+/// The facade service. Holds the PDP enforcer and the `ClientHub` (for lazy SPI
+/// resolution). No SPI client is held directly, keeping the adapter pluggable.
+///
+/// This is the gear's application/facade service and belongs in the domain layer
+/// (mirroring e.g. usage-collector's identically-shaped `Service`). `#[domain_model]`
+/// (DE0309) marks it as a domain type and enforces at compile time that no concrete
+/// infrastructure type (HTTP/DB clients, etc.) leaks into its fields; the PEP
+/// `PolicyEnforcer` and the `ClientHub` are SDK abstractions, not such infra, so the
+/// marker applies cleanly.
+#[domain_model]
+pub struct Service {
+    enforcer: PolicyEnforcer,
+    hub: Arc<ClientHub>,
+}
+
+impl Service {
+    #[must_use]
+    pub fn new(enforcer: PolicyEnforcer, hub: Arc<ClientHub>) -> Self {
+        Self { enforcer, hub }
+    }
+
+    /// Create a `client_credentials` service principal owned by `tenant`.
+    ///
+    /// # Errors
+    /// [`DomainError`] on authorization failure, absent provider, or SPI failure.
+    pub async fn create(
+        &self,
+        ctx: &SecurityContext,
+        tenant: TenantId,
+        name: String,
+        scopes: Vec<String>,
+    ) -> Result<ServicePrincipalCredentials, DomainError> {
+        self.authorize(ctx, tenant, actions::CREATE).await?;
+        let sp = self.sp_client()?;
+        let req = CreateServicePrincipalRequest {
+            tenant_id: tenant,
+            name,
+            scopes,
+        };
+        sp.create(ctx, &req).await.map_err(DomainError::from)
+    }
+
+    /// List the tenant's service principals (no secrets).
+    ///
+    /// # Errors
+    /// [`DomainError`] on authorization failure, absent provider, or SPI failure.
+    pub async fn list(
+        &self,
+        ctx: &SecurityContext,
+        tenant: TenantId,
+    ) -> Result<Vec<ServicePrincipalSummary>, DomainError> {
+        self.authorize(ctx, tenant, actions::READ).await?;
+        let sp = self.sp_client()?;
+        sp.list(ctx, tenant).await.map_err(DomainError::from)
+    }
+
+    /// Rotate the principal's secret; the old one stops working.
+    ///
+    /// # Errors
+    /// [`DomainError`] on authorization failure, absent provider, or SPI failure.
+    pub async fn rotate_secret(
+        &self,
+        ctx: &SecurityContext,
+        tenant: TenantId,
+        client_id: &str,
+    ) -> Result<ServicePrincipalCredentials, DomainError> {
+        self.authorize(ctx, tenant, actions::ROTATE_SECRET).await?;
+        let sp = self.sp_client()?;
+        sp.rotate_secret(ctx, tenant, client_id)
+            .await
+            .map_err(DomainError::from)
+    }
+
+    /// Revoke (delete) the principal. Idempotent: a missing principal is success.
+    ///
+    /// # Errors
+    /// [`DomainError`] on authorization failure, absent provider, or SPI failure
+    /// other than `NotFound`.
+    pub async fn revoke(
+        &self,
+        ctx: &SecurityContext,
+        tenant: TenantId,
+        client_id: &str,
+    ) -> Result<(), DomainError> {
+        self.authorize(ctx, tenant, actions::REVOKE).await?;
+        let sp = self.sp_client()?;
+        match sp.revoke(ctx, tenant, client_id).await {
+            Ok(()) | Err(ServicePrincipalFailure::NotFound { .. }) => Ok(()),
+            Err(other) => Err(DomainError::from(other)),
+        }
+    }
+
+    /// Authorize `action` on the explicit target `tenant`, fail-closed.
+    async fn authorize(
+        &self,
+        ctx: &SecurityContext,
+        tenant: TenantId,
+        action: &str,
+    ) -> Result<(), DomainError> {
+        let request = AccessRequest::new()
+            .resource_property(pep_properties::OWNER_TENANT_ID, tenant.0)
+            .require_constraints(true);
+        let scope = self
+            .enforcer
+            .access_scope_with(ctx, &authz::SERVICE_PRINCIPAL, action, None, &request)
+            .await
+            .map_err(authz::map_enforcer_err)?;
+        authz::ensure_scope_permits(&scope, tenant.0)
+    }
+
+    /// Resolve the SPI client lazily; absent registration → `ProviderUnavailable`.
+    ///
+    /// `DomainError::ProviderUnavailable` carries no field (it maps to a generic
+    /// `503` at the REST boundary), so the underlying `ClientHubError` — which
+    /// distinguishes "adapter simply not installed" (`NotFound`) from a genuine
+    /// misregistration (`TypeMismatch`) — is logged here rather than silently
+    /// discarded.
+    fn sp_client(&self) -> Result<Arc<dyn ServicePrincipalClientV1>, DomainError> {
+        self.hub
+            .get::<dyn ServicePrincipalClientV1>()
+            .map_err(|err| {
+                warn!(error = %err, "service-principal SPI client unavailable");
+                DomainError::ProviderUnavailable
+            })
+    }
+}
+
+#[cfg(test)]
+#[path = "service_tests.rs"]
+mod tests;

--- a/gears/system/service-principal/service-principal/src/domain/service_tests.rs
+++ b/gears/system/service-principal/service-principal/src/domain/service_tests.rs
@@ -1,0 +1,315 @@
+//! Service-level tests: authorization outcomes + SPI delegation + revoke idempotency.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use authz_resolver_sdk::AuthZResolverClient;
+use authz_resolver_sdk::constraints::{Constraint, InPredicate, Predicate};
+use authz_resolver_sdk::error::AuthZResolverError;
+use authz_resolver_sdk::models::{
+    EvaluationRequest, EvaluationResponse, EvaluationResponseContext,
+};
+use secrecy::SecretString;
+use service_principal_sdk::{
+    CreateServicePrincipalRequest, ServicePrincipalClientV1, ServicePrincipalCredentials,
+    ServicePrincipalFailure, ServicePrincipalSummary, TenantId,
+};
+use toolkit::ClientHub;
+use toolkit_security::{SecurityContext, pep_properties};
+use uuid::Uuid;
+
+use super::*;
+use crate::domain::error::DomainError;
+
+const TENANT: &str = "11111111-1111-1111-1111-111111111111";
+const SUBJECT: &str = "22222222-2222-2222-2222-222222222222";
+
+fn uuid(s: &str) -> Uuid {
+    Uuid::parse_str(s).expect("valid test uuid")
+}
+
+fn ctx() -> SecurityContext {
+    SecurityContext::builder()
+        .subject_id(uuid(SUBJECT))
+        .subject_tenant_id(uuid(TENANT))
+        .build()
+        .expect("valid ctx")
+}
+
+/// PDP that permits, scoping the returned constraint to the requested owner tenant.
+struct AllowTenantPdp;
+#[async_trait]
+impl AuthZResolverClient for AllowTenantPdp {
+    async fn evaluate(
+        &self,
+        req: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let tid = req
+            .resource
+            .properties
+            .get(pep_properties::OWNER_TENANT_ID)
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok())
+            .unwrap_or_default();
+        Ok(EvaluationResponse {
+            decision: true,
+            context: EvaluationResponseContext {
+                constraints: vec![Constraint {
+                    predicates: vec![Predicate::In(InPredicate::new(
+                        pep_properties::OWNER_TENANT_ID,
+                        [tid],
+                    ))],
+                }],
+                ..Default::default()
+            },
+        })
+    }
+}
+
+/// PDP that permits, but the returned constraint is scoped to a FIXED tenant
+/// regardless of which tenant the request actually names — models a PDP that
+/// grants "allow, but only for tenant A" while the caller is acting on a
+/// different tenant B. The object-level (BOLA) check in
+/// `authz::ensure_scope_permits` must reject the mismatch: a bare
+/// `decision: true` is never sufficient on its own, the returned scope must
+/// actually cover the tenant being acted on.
+struct AllowOnlyTenantPdp {
+    allowed_tenant: Uuid,
+}
+#[async_trait]
+impl AuthZResolverClient for AllowOnlyTenantPdp {
+    async fn evaluate(
+        &self,
+        _req: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        Ok(EvaluationResponse {
+            decision: true,
+            context: EvaluationResponseContext {
+                constraints: vec![Constraint {
+                    predicates: vec![Predicate::In(InPredicate::new(
+                        pep_properties::OWNER_TENANT_ID,
+                        [self.allowed_tenant],
+                    ))],
+                }],
+                ..Default::default()
+            },
+        })
+    }
+}
+
+/// PDP that always denies.
+struct DenyPdp;
+#[async_trait]
+impl AuthZResolverClient for DenyPdp {
+    async fn evaluate(
+        &self,
+        _req: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        Ok(EvaluationResponse {
+            decision: false,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+/// Configurable SPI mock. `None` means "succeed"; the `Ok(())` state is never
+/// needed since a configured mock only ever needs to express a failure.
+#[derive(Default)]
+struct MockSp {
+    create_result: Option<ServicePrincipalFailure>,
+    revoke_result: Option<ServicePrincipalFailure>,
+}
+
+#[async_trait]
+impl ServicePrincipalClientV1 for MockSp {
+    async fn create(
+        &self,
+        _ctx: &SecurityContext,
+        req: &CreateServicePrincipalRequest,
+    ) -> Result<ServicePrincipalCredentials, ServicePrincipalFailure> {
+        match &self.create_result {
+            Some(e) => Err(clone_failure(e)),
+            None => Ok(ServicePrincipalCredentials {
+                client_id: format!("svc-{}-{}", req.tenant_id.0, req.name),
+                client_secret: SecretString::from("s3cr3t".to_owned()),
+                token_url: "https://idp/token".to_owned(),
+                subject_id: Uuid::new_v4(),
+            }),
+        }
+    }
+    async fn rotate_secret(
+        &self,
+        _ctx: &SecurityContext,
+        _tenant_id: TenantId,
+        client_id: &str,
+    ) -> Result<ServicePrincipalCredentials, ServicePrincipalFailure> {
+        Ok(ServicePrincipalCredentials {
+            client_id: client_id.to_owned(),
+            client_secret: SecretString::from("rotated".to_owned()),
+            token_url: "https://idp/token".to_owned(),
+            subject_id: Uuid::new_v4(),
+        })
+    }
+    async fn revoke(
+        &self,
+        _ctx: &SecurityContext,
+        _tenant_id: TenantId,
+        _client_id: &str,
+    ) -> Result<(), ServicePrincipalFailure> {
+        match &self.revoke_result {
+            Some(e) => Err(clone_failure(e)),
+            None => Ok(()),
+        }
+    }
+    async fn list(
+        &self,
+        _ctx: &SecurityContext,
+        _tenant_id: TenantId,
+    ) -> Result<Vec<ServicePrincipalSummary>, ServicePrincipalFailure> {
+        Ok(vec![ServicePrincipalSummary {
+            client_id: "svc-x".to_owned(),
+            enabled: true,
+            scopes: vec!["openid".to_owned()],
+        }])
+    }
+}
+
+/// Hand-rolled clone: `ServicePrincipalFailure` intentionally derives only
+/// `Debug` (it is not meant to be persisted/cloned in production code), so
+/// the mock reconstructs an equivalent value from a shared reference.
+fn clone_failure(f: &ServicePrincipalFailure) -> ServicePrincipalFailure {
+    match f {
+        ServicePrincipalFailure::InvalidInput { detail, field } => {
+            ServicePrincipalFailure::InvalidInput {
+                detail: detail.clone(),
+                field: field.clone(),
+            }
+        }
+        ServicePrincipalFailure::NotFound { detail } => ServicePrincipalFailure::NotFound {
+            detail: detail.clone(),
+        },
+        ServicePrincipalFailure::CleanFailure { detail } => ServicePrincipalFailure::CleanFailure {
+            detail: detail.clone(),
+        },
+        ServicePrincipalFailure::Ambiguous { detail } => ServicePrincipalFailure::Ambiguous {
+            detail: detail.clone(),
+        },
+    }
+}
+
+fn service(pdp: Arc<dyn AuthZResolverClient>, sp: MockSp) -> Service {
+    let hub = Arc::new(ClientHub::default());
+    hub.register::<dyn ServicePrincipalClientV1>(Arc::new(sp));
+    Service::new(PolicyEnforcer::new(pdp), hub)
+}
+
+#[tokio::test]
+async fn create_authorized_returns_credentials() {
+    let svc = service(Arc::new(AllowTenantPdp), MockSp::default());
+    let creds = svc
+        .create(&ctx(), TenantId(uuid(TENANT)), "ci".to_owned(), vec![])
+        .await
+        .expect("authorized create");
+    assert!(creds.client_id.starts_with("svc-"));
+}
+
+/// Cross-tenant BOLA: a PDP `decision: true` scoped (via constraint) to tenant A
+/// must NOT authorize a request explicitly targeting a different tenant B. This
+/// exercises the full `Service::authorize` chain (not just the pure
+/// `ensure_scope_permits` unit) — `access_scope_with` → `ensure_scope_permits` —
+/// through a real `Service::create` call, proving the object-level check is
+/// actually wired into the request path and not merely unit-testable in
+/// isolation.
+#[tokio::test]
+async fn create_for_a_different_tenant_than_the_pdp_scope_is_access_denied() {
+    let tenant_a = uuid(TENANT);
+    let tenant_b = Uuid::new_v4();
+    let svc = service(
+        Arc::new(AllowOnlyTenantPdp {
+            allowed_tenant: tenant_a,
+        }),
+        MockSp::default(),
+    );
+    let err = svc
+        .create(&ctx(), TenantId(tenant_b), "ci".to_owned(), vec![])
+        .await
+        .expect_err("PDP scope covers tenant A only; tenant B must be denied");
+    assert!(matches!(err, DomainError::AccessDenied));
+}
+
+#[tokio::test]
+async fn denied_request_is_access_denied() {
+    let svc = service(Arc::new(DenyPdp), MockSp::default());
+    let err = svc
+        .create(&ctx(), TenantId(uuid(TENANT)), "ci".to_owned(), vec![])
+        .await
+        .expect_err("denied");
+    assert!(matches!(err, DomainError::AccessDenied));
+}
+
+#[tokio::test]
+async fn revoke_is_idempotent_on_not_found() {
+    let sp = MockSp {
+        revoke_result: Some(ServicePrincipalFailure::NotFound {
+            detail: "gone".into(),
+        }),
+        ..MockSp::default()
+    };
+    let svc = service(Arc::new(AllowTenantPdp), sp);
+    svc.revoke(&ctx(), TenantId(uuid(TENANT)), "svc-x")
+        .await
+        .expect("revoke treats NotFound as success");
+}
+
+#[tokio::test]
+async fn provider_absent_is_provider_unavailable() {
+    // A hub with no SPI registration.
+    let hub = Arc::new(ClientHub::default());
+    let svc = Service::new(PolicyEnforcer::new(Arc::new(AllowTenantPdp)), hub);
+    let err = svc
+        .list(&ctx(), TenantId(uuid(TENANT)))
+        .await
+        .expect_err("no provider");
+    assert!(matches!(err, DomainError::ProviderUnavailable));
+}
+
+#[tokio::test]
+async fn create_spi_failure_maps_to_domain_invalid_input() {
+    // Confirms the `.map_err(DomainError::from)` delegate-failure path on the
+    // non-idempotent `create` op actually reaches the service boundary (until
+    // now only `revoke`'s `NotFound` special-case was exercised here).
+    let sp = MockSp {
+        create_result: Some(ServicePrincipalFailure::InvalidInput {
+            detail: "bad name".into(),
+            field: Some("name".into()),
+        }),
+        ..MockSp::default()
+    };
+    let svc = service(Arc::new(AllowTenantPdp), sp);
+    let err = svc
+        .create(&ctx(), TenantId(uuid(TENANT)), "ci".to_owned(), vec![])
+        .await
+        .expect_err("SPI rejected the input");
+    assert!(matches!(err, DomainError::InvalidInput { .. }));
+}
+
+#[tokio::test]
+async fn rotate_secret_authorized_returns_credentials() {
+    let svc = service(Arc::new(AllowTenantPdp), MockSp::default());
+    let creds = svc
+        .rotate_secret(&ctx(), TenantId(uuid(TENANT)), "svc-x")
+        .await
+        .expect("authorized rotate_secret");
+    assert_eq!(creds.client_id, "svc-x");
+}
+
+#[tokio::test]
+async fn list_authorized_returns_sp_summaries() {
+    let svc = service(Arc::new(AllowTenantPdp), MockSp::default());
+    let summaries = svc
+        .list(&ctx(), TenantId(uuid(TENANT)))
+        .await
+        .expect("authorized list");
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].client_id, "svc-x");
+}

--- a/gears/system/service-principal/service-principal/src/gts.rs
+++ b/gears/system/service-principal/service-principal/src/gts.rs
@@ -1,0 +1,3 @@
+//! GTS declarations compiled for link-time inventory registration.
+
+mod permissions;

--- a/gears/system/service-principal/service-principal/src/gts/permissions.rs
+++ b/gears/system/service-principal/service-principal/src/gts/permissions.rs
@@ -1,0 +1,56 @@
+//! Service-principal authorization permissions catalog.
+//!
+//! Declares each grantable permission as an [`AuthzPermissionV1`] GTS instance via
+//! [`gts_instance!`]. `types-registry::init()` aggregates them from the link-time
+//! inventory at startup — no registration code in `crate::module`. `resource_type`
+//! is the SDK's single source of truth; `action` mirrors `domain::authz::actions`,
+//! so the catalog and the enforcement path share one source of truth.
+//!
+//! Instance-id layout: `gts.cf.toolkit.authz.permission.v1~cf.core.service_principal.<action>.v1`.
+
+// The expected-id string literals below trip DE0901 (`gts_string_pattern`);
+// they are legitimate catalog literals. Suppress file-wide (mirrors rms).
+#![allow(unknown_lints)]
+#![allow(de0901_gts_string_pattern)]
+
+use service_principal_sdk::SERVICE_PRINCIPAL_RESOURCE_TYPE;
+use toolkit_gts::{AuthzPermissionV1, gts_instance};
+
+use crate::domain::authz::actions;
+
+gts_instance! {
+    AuthzPermissionV1 {
+        id: gts_id!("cf.toolkit.authz.permission.v1~cf.core.service_principal.create.v1"),
+        resource_type: SERVICE_PRINCIPAL_RESOURCE_TYPE.to_owned(),
+        action: actions::CREATE.to_owned(),
+        display_name: "Create service principal".to_owned(),
+    }
+}
+gts_instance! {
+    AuthzPermissionV1 {
+        id: gts_id!("cf.toolkit.authz.permission.v1~cf.core.service_principal.read.v1"),
+        resource_type: SERVICE_PRINCIPAL_RESOURCE_TYPE.to_owned(),
+        action: actions::READ.to_owned(),
+        display_name: "Read service principals".to_owned(),
+    }
+}
+gts_instance! {
+    AuthzPermissionV1 {
+        id: gts_id!("cf.toolkit.authz.permission.v1~cf.core.service_principal.rotate_secret.v1"),
+        resource_type: SERVICE_PRINCIPAL_RESOURCE_TYPE.to_owned(),
+        action: actions::ROTATE_SECRET.to_owned(),
+        display_name: "Rotate service-principal secret".to_owned(),
+    }
+}
+gts_instance! {
+    AuthzPermissionV1 {
+        id: gts_id!("cf.toolkit.authz.permission.v1~cf.core.service_principal.revoke.v1"),
+        resource_type: SERVICE_PRINCIPAL_RESOURCE_TYPE.to_owned(),
+        action: actions::REVOKE.to_owned(),
+        display_name: "Revoke service principal".to_owned(),
+    }
+}
+
+#[cfg(test)]
+#[path = "permissions_tests.rs"]
+mod tests;

--- a/gears/system/service-principal/service-principal/src/gts/permissions_tests.rs
+++ b/gears/system/service-principal/service-principal/src/gts/permissions_tests.rs
@@ -1,0 +1,129 @@
+//! Tests for the service-principal permission catalog ([`super`]).
+//!
+//! Verifies the `gts_instance!`-declared permissions land in the link-time
+//! inventory and that the set exactly matches the expected ids.
+
+// Deliberate panic on a malformed instance id in a test-only helper — a
+// pinning assertion, not production code (matches the convention used by
+// other `*_tests.rs` files, e.g. rbac's `canonical_mapping_tests.rs`).
+#![allow(clippy::panic)]
+
+use toolkit_gts::{InventoryInstance, gts_id};
+
+const PERMISSION_TYPE_ID: &str = gts_id!("cf.toolkit.authz.permission.v1~");
+/// This gear's instance-id namespace segment, appended after `PERMISSION_TYPE_ID`.
+const SP_INSTANCE_NS: &str = "cf.core.service_principal.";
+
+const EXPECTED_PERMISSION_IDS: &[&str] = &[
+    gts_id!("cf.toolkit.authz.permission.v1~cf.core.service_principal.create.v1"),
+    gts_id!("cf.toolkit.authz.permission.v1~cf.core.service_principal.read.v1"),
+    gts_id!("cf.toolkit.authz.permission.v1~cf.core.service_principal.rotate_secret.v1"),
+    gts_id!("cf.toolkit.authz.permission.v1~cf.core.service_principal.revoke.v1"),
+];
+
+fn sp_permission_instances() -> Vec<&'static InventoryInstance> {
+    toolkit_gts::inventory::iter::<InventoryInstance>
+        .into_iter()
+        .filter(|e| {
+            e.instance_id
+                .strip_prefix(PERMISSION_TYPE_ID)
+                .is_some_and(|seg| seg.starts_with(SP_INSTANCE_NS))
+        })
+        .collect()
+}
+
+#[test]
+fn all_permissions_are_registered_in_inventory() {
+    let entries = sp_permission_instances();
+    assert_eq!(
+        entries.len(),
+        EXPECTED_PERMISSION_IDS.len(),
+        "expected {} permission instances; found {}: {:?}",
+        EXPECTED_PERMISSION_IDS.len(),
+        entries.len(),
+        entries.iter().map(|e| e.instance_id).collect::<Vec<_>>()
+    );
+    for entry in &entries {
+        assert_eq!(entry.type_id, PERMISSION_TYPE_ID);
+    }
+}
+
+#[test]
+fn permission_inventory_covers_every_expected_id() {
+    let actual: std::collections::BTreeSet<&str> = sp_permission_instances()
+        .iter()
+        .map(|e| e.instance_id)
+        .collect();
+    for expected in EXPECTED_PERMISSION_IDS {
+        assert!(
+            actual.contains(expected),
+            "missing expected permission id: {expected}"
+        );
+    }
+    assert_eq!(actual.len(), EXPECTED_PERMISSION_IDS.len());
+}
+
+#[test]
+fn every_permission_carries_the_sdk_resource_type() {
+    for entry in sp_permission_instances() {
+        assert_eq!(
+            (entry.payload_fn)()["resource_type"].as_str(),
+            Some(service_principal_sdk::SERVICE_PRINCIPAL_RESOURCE_TYPE),
+        );
+    }
+}
+
+/// Guards the trap that makes a catalogued permission un-grantable: the PDP
+/// canonicalizes the *request-side* action (`get`/`list` → `read`) before querying
+/// RBAC, but RBAC matches grant operations by exact string equality with no
+/// grant-side canonicalization. A catalog entry naming an alias therefore tells a
+/// role-builder to author `operation: "list"`, which validates, persists, and
+/// silently authorizes nothing. Only the canonical verb may be published.
+#[test]
+fn no_permission_publishes_a_canonicalization_alias() {
+    /// Request-side aliases the PDP rewrites before consulting RBAC. Kept in
+    /// lock-step with the resolver plugin's `canonicalize_operation`.
+    const READ_ALIASES: &[&str] = &["get", "list"];
+    for entry in sp_permission_instances() {
+        let payload = (entry.payload_fn)();
+        let action = payload["action"].as_str().unwrap_or_default();
+        assert!(
+            !READ_ALIASES.contains(&action),
+            "permission `{}` publishes `{action}`, which the PDP rewrites to \
+             `read` before querying RBAC — a grant naming it can never match. \
+             Publish the canonical verb instead.",
+            entry.instance_id
+        );
+    }
+}
+
+/// Anti-drift: catches a copy-paste slip where an entry's `action` field
+/// doesn't match the verb encoded in its own instance id (e.g. the
+/// `rotate_secret` entry accidentally carrying `action: actions::REVOKE`).
+/// Derives the expected action from the id suffix
+/// (`…service_principal.<action>.v1`) and compares it against the
+/// catalogued `AuthzPermissionV1::action` payload field.
+#[test]
+fn every_permission_action_matches_its_instance_id_verb() {
+    for entry in sp_permission_instances() {
+        let expected_action = entry
+            .instance_id
+            .strip_prefix(PERMISSION_TYPE_ID)
+            .and_then(|seg| seg.strip_prefix(SP_INSTANCE_NS))
+            .and_then(|rest| rest.strip_suffix(".v1"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "instance id `{}` does not match the expected \
+                     `{PERMISSION_TYPE_ID}{SP_INSTANCE_NS}<action>.v1` shape",
+                    entry.instance_id
+                )
+            });
+        assert_eq!(
+            (entry.payload_fn)()["action"].as_str(),
+            Some(expected_action),
+            "permission `{}` carries an action that does not match the verb \
+             encoded in its own instance id",
+            entry.instance_id
+        );
+    }
+}

--- a/gears/system/service-principal/service-principal/src/lib.rs
+++ b/gears/system/service-principal/service-principal/src/lib.rs
@@ -1,0 +1,15 @@
+//! service-principal — a thin REST facade over the `ServicePrincipalClientV1` SPI
+//! for managing tenant-scoped machine identities (confidential OAuth
+//! `client_credentials` clients).
+//!
+//! REST → PDP authorization (own RBAC resource type) → the SPI resolved lazily
+//! from `ClientHub` → canonical error mapping. No storage, no business logic.
+
+pub mod api;
+pub mod domain;
+pub mod module;
+
+// Compiled for its link-time `AuthzPermissionV1` inventory registration.
+pub(crate) mod gts;
+
+pub use module::ServicePrincipalGear;

--- a/gears/system/service-principal/service-principal/src/module.rs
+++ b/gears/system/service-principal/service-principal/src/module.rs
@@ -1,0 +1,73 @@
+//! `toolkit` gear wiring for the service-principal REST facade: resolve the PDP
+//! at init, hold the `ClientHub` for lazy SPI resolution, and mount the REST
+//! surface. No DB, no background lifecycle — a thin authorizing facade.
+
+use std::sync::{Arc, OnceLock};
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use authz_resolver_sdk::{AuthZResolverClient, pep::PolicyEnforcer};
+use toolkit::api::OpenApiRegistry;
+use toolkit::{Gear, GearCtx, RestApiCapability};
+use tracing::info;
+
+use crate::domain::service::Service;
+
+#[toolkit::gear(
+    name = "service-principal",
+    capabilities = [rest],
+    deps = [types_registry, authz_resolver],
+)]
+pub struct ServicePrincipalGear {
+    service: OnceLock<Arc<Service>>,
+}
+
+impl Default for ServicePrincipalGear {
+    fn default() -> Self {
+        Self {
+            service: OnceLock::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl Gear for ServicePrincipalGear {
+    #[tracing::instrument(skip_all, fields(module = "service-principal"))]
+    async fn init(&self, ctx: &GearCtx) -> anyhow::Result<()> {
+        // PEP boundary: resolve the PDP (authz-resolver) hard dependency. No
+        // `TenantHierarchy` capability is advertised, so the PDP pre-expands a
+        // subtree grant into a flat allowed-tenant list — this DB-less gear needs
+        // no local tenant-closure to authorize a descendant tenant.
+        let authz = ctx
+            .client_hub()
+            .get::<dyn AuthZResolverClient>()
+            .map_err(|e| anyhow!("service-principal requires an authz-resolver client: {e}"))?;
+        let enforcer = PolicyEnforcer::new(authz);
+
+        // The SPI provider (an IdP adapter) is intentionally NOT a gear dep — it is
+        // resolved lazily per request from the ClientHub so adapters stay pluggable.
+        let svc = Arc::new(Service::new(enforcer, ctx.client_hub()));
+        self.service
+            .set(svc)
+            .map_err(|_| anyhow!("{} module already initialized", Self::MODULE_NAME))?;
+
+        info!("service-principal module initialized");
+        Ok(())
+    }
+}
+
+impl RestApiCapability for ServicePrincipalGear {
+    fn register_rest(
+        &self,
+        _ctx: &GearCtx,
+        router: axum::Router,
+        openapi: &dyn OpenApiRegistry,
+    ) -> anyhow::Result<axum::Router> {
+        let svc = self
+            .service
+            .get()
+            .cloned()
+            .ok_or_else(|| anyhow!("service-principal Service not initialized"))?;
+        Ok(crate::api::rest::register_routes(router, openapi, svc))
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> **Scope: documentation only.** This PR carries the Keycloak IdP plugin's PRD and DESIGN. The implementation crate (53 files) is delivered in a separate change, so these two artifacts can be reviewed on their own.
>
> Stacked on [#4434](https://github.com/constructorfabric/gears-rust/pull/4434) (`docs/service-principal-prd`), which owns the service-principal module that the plugin's machine-identity requirements reference. **Do not merge before #4434.**

## Description

Closes: https://github.com/constructorfabric/gears-rust/issues/4429

Adds the PRD and technical design for the Keycloak IdP plugin under `gears/system/account-management/plugins/keycloak-idp-plugin/docs/`, plus the cf-studio autodetect scope that registers them for validation.

Both documents were written against the working implementation rather than ahead of it, and every factual claim in them was verified against that code — identifiers, configuration defaults, metric names and label sets, audit event kinds, tracing targets, the ambiguity stage tokens, the error taxonomy and its SDK mappings, saga ordering, and the init lifecycle. Where a document and the code disagreed, the document was corrected; in one case (provider error-body redaction in the tenant saga) the code was corrected instead, because the documented control was the right one.

What they describe: the plugin implements `IdpPluginClient` for tenant and user lifecycle and `ServicePrincipalClientV1` for machine identities, talks to Keycloak Admin REST directly over HTTPS with a two-tier `client_credentials` administrator model, supports the shared, adopted and created realm bindings, and fails module init if its bootstrap-token pre-warm budget is exhausted. `update_user` is not implemented and returns `UnsupportedOperation` (documented as p2).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] New tests added
- [x] Not applicable — documentation and artifact-discovery configuration only

`cfs validate` reports 0 errors, both tables of contents are correct, and every relative link in the two documents resolves.

## Documentation

- [x] Added the Keycloak IdP plugin PRD and DESIGN, aligned with the implementation
- [x] Registered the plugin's PRD/DESIGN/ADR/DECOMPOSITION/FEATURE artifact paths

## Checklist

- [x] Self-review completed
- [x] Reviewed with `/cf-gears-pr-review`; findings addressed
- [x] Unrelated `.cf-studio/whatsnew.toml` changes excluded

## Related Issues

Implementation follows in a separate change.

