### PR TITLE
Fix(event-broker): Gate test-util-only helpers behind cfg(feature = "test-util")

### DIFF
--- a/gears/system/event-broker/event-broker-sdk/src/consumer/builder_tests.rs
+++ b/gears/system/event-broker/event-broker-sdk/src/consumer/builder_tests.rs
@@ -1,5 +1,3 @@
-#[cfg(all(feature = "db", feature = "test-util"))]
-use crate::consumer::ConsumerCommitMode;
 use crate::consumer::{
     BatchHandlerOutcome, ConsumerBuffering, ConsumerBuilder, ConsumerGroupRef, ConsumerHandle,
     ConsumerHandler, ConsumerListenerSettings, ConsumerProfile, EventBatch, EventTypeRef, Fallback,
@@ -580,6 +578,7 @@ mod tx_typestate {
     #[tokio::test]
     async fn transactional_consumer_does_not_auto_commit_when_handler_omits_commit_in_tx() {
         use crate::EventBrokerApi;
+        use crate::consumer::ConsumerCommitMode;
         use crate::mock::stubs::test_ctx_for_tenant;
         use crate::mock::{MockBroker, MockBrokerHandle};
         use crate::models::Event;

--- a/gears/system/event-broker/event-broker-sdk/src/consumer/dispatcher_test_util.rs
+++ b/gears/system/event-broker/event-broker-sdk/src/consumer/dispatcher_test_util.rs
@@ -1,0 +1,287 @@
+//! Test helpers used exclusively by `#[cfg(feature = "test-util")]` dispatcher integration tests.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use super::{
+    BatchHandlerOutcome, CommitOffset, ConsumerHandler, ConsumerRuntimeEvent,
+    ConsumerRuntimeListener, EventBatch, OffsetManagerError, OffsetStore, ResolvedPosition,
+};
+use crate::error::ConsumerError;
+use crate::ids::{ConsumerGroupId, TopicId};
+
+pub(super) type SharedAttempts = Arc<Mutex<Vec<u16>>>;
+pub(super) type SharedTimeline = Arc<Mutex<Vec<&'static str>>>;
+pub(super) type CommitRecord = (ConsumerGroupId, TopicId, u32, i64);
+pub(super) type SharedCommits = Arc<Mutex<Vec<CommitRecord>>>;
+pub(super) type SharedScopes = Arc<Mutex<Vec<(String, u32, usize)>>>;
+pub(super) type SharedViolations = Arc<Mutex<Vec<String>>>;
+pub(super) type SharedRuntimeEvents = Arc<Mutex<Vec<ConsumerRuntimeEvent>>>;
+
+pub(super) fn partition_key_for_partition(target: u32, partitions: u32) -> String {
+    assert_eq!(partitions, 2, "only the two-partition fixture is supported");
+    match target {
+        0 => "partition-key-0-1",
+        1 => "partition-key-1-0",
+        _ => panic!("two-partition fixture cannot target partition {target}"),
+    }
+    .to_owned()
+}
+
+type SharedPartitionCalls = Arc<Mutex<Vec<(String, u32, i64)>>>;
+
+pub(super) struct SleepingBatchHandler {
+    pub(super) calls: SharedPartitionCalls,
+    pub(super) delay: Duration,
+}
+
+#[async_trait::async_trait]
+impl ConsumerHandler for SleepingBatchHandler {
+    async fn handle_batch(
+        &self,
+        batch: &EventBatch<'_>,
+        _attempts: u16,
+    ) -> Result<BatchHandlerOutcome, ConsumerError> {
+        tokio::time::sleep(self.delay).await;
+        let chunk = batch.next_chunk(batch.len());
+        self.calls.lock().unwrap().extend(
+            chunk
+                .iter()
+                .map(|event| (event.topic.clone(), event.partition, event.offset)),
+        );
+        Ok(chunk
+            .last()
+            .map(|event| BatchHandlerOutcome::AdvanceThrough {
+                offset: event.offset,
+            })
+            .unwrap_or(BatchHandlerOutcome::Success))
+    }
+}
+
+pub(super) struct FailingThenCommitBatchHandler {
+    pub(super) failures_remaining: Arc<Mutex<usize>>,
+    pub(super) calls: SharedAttempts,
+}
+
+#[async_trait::async_trait]
+impl ConsumerHandler for FailingThenCommitBatchHandler {
+    async fn handle_batch(
+        &self,
+        _batch: &EventBatch<'_>,
+        attempts: u16,
+    ) -> Result<BatchHandlerOutcome, ConsumerError> {
+        {
+            let mut guard = self.failures_remaining.lock().unwrap();
+            if *guard > 0 {
+                *guard -= 1;
+                return Err(ConsumerError::Internal(
+                    "intentional representative handler failure".to_owned(),
+                ));
+            }
+        }
+
+        self.calls.lock().unwrap().push(attempts);
+        Ok(BatchHandlerOutcome::Success)
+    }
+}
+
+pub(super) struct SequencedOffsetManager {
+    pub(super) timeline: SharedTimeline,
+}
+
+#[async_trait::async_trait]
+impl OffsetStore for SequencedOffsetManager {
+    async fn load_position(
+        &self,
+        _group: &ConsumerGroupId,
+        _topic: &TopicId,
+        _partition: u32,
+    ) -> Result<ResolvedPosition, OffsetManagerError> {
+        self.timeline.lock().unwrap().push("load");
+        Ok(ResolvedPosition::Earliest)
+    }
+}
+
+#[async_trait::async_trait]
+impl CommitOffset for SequencedOffsetManager {
+    async fn commit(
+        &self,
+        _group: &ConsumerGroupId,
+        _topic: &TopicId,
+        _partition: u32,
+        _offset: i64,
+    ) -> Result<(), OffsetManagerError> {
+        Ok(())
+    }
+}
+
+#[derive(Clone, Default)]
+pub(super) struct RecordingCommitOffsetManager {
+    pub(super) commits: SharedCommits,
+}
+
+#[async_trait::async_trait]
+impl OffsetStore for RecordingCommitOffsetManager {
+    async fn load_position(
+        &self,
+        _group: &ConsumerGroupId,
+        _topic: &TopicId,
+        _partition: u32,
+    ) -> Result<ResolvedPosition, OffsetManagerError> {
+        Ok(ResolvedPosition::Earliest)
+    }
+}
+
+#[async_trait::async_trait]
+impl CommitOffset for RecordingCommitOffsetManager {
+    async fn commit(
+        &self,
+        group: &ConsumerGroupId,
+        topic: &TopicId,
+        partition: u32,
+        offset: i64,
+    ) -> Result<(), OffsetManagerError> {
+        self.commits
+            .lock()
+            .unwrap()
+            .push((*group, *topic, partition, offset));
+        Ok(())
+    }
+}
+
+pub(super) struct SequencedBatchHandler {
+    pub(super) timeline: SharedTimeline,
+}
+
+#[async_trait::async_trait]
+impl ConsumerHandler for SequencedBatchHandler {
+    async fn handle_batch(
+        &self,
+        _batch: &EventBatch<'_>,
+        _attempts: u16,
+    ) -> Result<BatchHandlerOutcome, ConsumerError> {
+        self.timeline.lock().unwrap().push("handle");
+        Ok(BatchHandlerOutcome::Success)
+    }
+}
+
+#[derive(Default)]
+pub(super) struct BatchScopeRecorder {
+    pub(super) scopes: SharedScopes,
+    pub(super) violations: SharedViolations,
+}
+
+#[async_trait::async_trait]
+impl ConsumerHandler for BatchScopeRecorder {
+    async fn handle_batch(
+        &self,
+        batch: &EventBatch<'_>,
+        _attempts: u16,
+    ) -> Result<BatchHandlerOutcome, ConsumerError> {
+        let chunk = batch.next_chunk(batch.len());
+        if let Some(first) = chunk.first() {
+            if chunk
+                .iter()
+                .any(|event| event.topic != first.topic || event.partition != first.partition)
+            {
+                self.violations
+                    .lock()
+                    .unwrap()
+                    .push("batch mixed topic IDs or partitions".to_owned());
+            }
+            self.scopes
+                .lock()
+                .unwrap()
+                .push((first.topic.clone(), first.partition, chunk.len()));
+        }
+        Ok(chunk
+            .last()
+            .map(|event| BatchHandlerOutcome::AdvanceThrough {
+                offset: event.offset,
+            })
+            .unwrap_or(BatchHandlerOutcome::Success))
+    }
+}
+
+#[derive(Clone, Default)]
+pub(super) struct RecordingRuntimeListener {
+    pub(super) events: SharedRuntimeEvents,
+}
+
+#[async_trait::async_trait]
+impl ConsumerRuntimeListener for RecordingRuntimeListener {
+    async fn on_consumer_event(&self, event: &ConsumerRuntimeEvent) -> Result<(), ConsumerError> {
+        self.events.lock().unwrap().push(event.clone());
+        Ok(())
+    }
+}
+
+pub(super) struct FailingRuntimeListener;
+
+#[async_trait::async_trait]
+impl ConsumerRuntimeListener for FailingRuntimeListener {
+    async fn on_consumer_event(&self, _event: &ConsumerRuntimeEvent) -> Result<(), ConsumerError> {
+        Err(ConsumerError::Internal(
+            "intentional listener failure".to_owned(),
+        ))
+    }
+}
+
+pub(super) struct SlowRuntimeListener {
+    pub(super) delay: Duration,
+}
+
+#[async_trait::async_trait]
+impl ConsumerRuntimeListener for SlowRuntimeListener {
+    async fn on_consumer_event(&self, _event: &ConsumerRuntimeEvent) -> Result<(), ConsumerError> {
+        tokio::time::sleep(self.delay).await;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) enum RuntimeEventKind {
+    SubscriptionJoining,
+    SubscriptionStarted,
+    SubscriptionRejoining,
+    SubscriptionTerminated,
+    SubscriptionConnectionDropped,
+    AssignmentChanged,
+    ProgressAdvanced,
+    PartitionBufferStateChanged,
+    HandlerBatchStarted,
+    HandlerBatchCompleted,
+    HandlerFailed,
+    OffsetLoaded,
+    OffsetCommitted,
+    RetryScheduled,
+}
+
+pub(super) fn runtime_event_kind(event: &ConsumerRuntimeEvent) -> RuntimeEventKind {
+    match event {
+        ConsumerRuntimeEvent::SubscriptionJoining { .. } => RuntimeEventKind::SubscriptionJoining,
+        ConsumerRuntimeEvent::SubscriptionStarted { .. } => RuntimeEventKind::SubscriptionStarted,
+        ConsumerRuntimeEvent::SubscriptionRejoining { .. } => {
+            RuntimeEventKind::SubscriptionRejoining
+        }
+        ConsumerRuntimeEvent::SubscriptionTerminated { .. } => {
+            RuntimeEventKind::SubscriptionTerminated
+        }
+        ConsumerRuntimeEvent::SubscriptionConnectionDropped { .. } => {
+            RuntimeEventKind::SubscriptionConnectionDropped
+        }
+        ConsumerRuntimeEvent::AssignmentChanged { .. } => RuntimeEventKind::AssignmentChanged,
+        ConsumerRuntimeEvent::ProgressAdvanced { .. } => RuntimeEventKind::ProgressAdvanced,
+        ConsumerRuntimeEvent::PartitionBufferStateChanged { .. } => {
+            RuntimeEventKind::PartitionBufferStateChanged
+        }
+        ConsumerRuntimeEvent::HandlerBatchStarted { .. } => RuntimeEventKind::HandlerBatchStarted,
+        ConsumerRuntimeEvent::HandlerBatchCompleted { .. } => {
+            RuntimeEventKind::HandlerBatchCompleted
+        }
+        ConsumerRuntimeEvent::HandlerFailed { .. } => RuntimeEventKind::HandlerFailed,
+        ConsumerRuntimeEvent::OffsetLoaded { .. } => RuntimeEventKind::OffsetLoaded,
+        ConsumerRuntimeEvent::OffsetCommitted { .. } => RuntimeEventKind::OffsetCommitted,
+        ConsumerRuntimeEvent::RetryScheduled { .. } => RuntimeEventKind::RetryScheduled,
+    }
+}

--- a/gears/system/event-broker/event-broker-sdk/src/consumer/dispatcher_tests.rs
+++ b/gears/system/event-broker/event-broker-sdk/src/consumer/dispatcher_tests.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "test-util")]
-use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -18,36 +16,25 @@ use super::{
     BatchHandlerOutcome, ConsumerHandler, EventBatch, EventTypeRef, HandlerOutcome, RawEvent,
     SingleEventHandlerAdapter, TopicRef,
 };
-#[cfg(feature = "test-util")]
-use super::{
-    CommitOffset, ConnectionDropReason, ConsumerBuffering, ConsumerBuilder, ConsumerCommitMode,
-    ConsumerGroupRef, ConsumerListenerSettings, ConsumerRuntimeEvent, ConsumerRuntimeListener,
-    ConsumerSlowDetection, Fallback, InMemoryOffsetManager, OffsetManagerError, OffsetStore,
-    PartitionBufferState, ResolvedPosition, SlowConsumerTrigger,
-};
 use crate::error::ConsumerError;
-#[cfg(feature = "test-util")]
-use crate::ids::ConsumerGroupId;
 use crate::ids::TopicId;
+#[cfg(feature = "test-util")]
+use {
+    super::dispatcher_test_util::*,
+    super::{
+        CommitOffset, ConnectionDropReason, ConsumerBuffering, ConsumerBuilder, ConsumerCommitMode,
+        ConsumerGroupRef, ConsumerListenerSettings, ConsumerRuntimeEvent, ConsumerSlowDetection,
+        Fallback, InMemoryOffsetManager, OffsetManagerError, OffsetStore, PartitionBufferState,
+        ResolvedPosition, SlowConsumerTrigger,
+    },
+    crate::ids::ConsumerGroupId,
+    std::collections::BTreeSet,
+};
 
 type SharedOffsets = Arc<Mutex<Vec<i64>>>;
 type SharedNamedOffsets = Arc<Mutex<Vec<(&'static str, i64)>>>;
 type PartitionCall = (String, u32, i64);
 type SharedPartitionCalls = Arc<Mutex<Vec<PartitionCall>>>;
-#[cfg(feature = "test-util")]
-type SharedAttempts = Arc<Mutex<Vec<u16>>>;
-#[cfg(feature = "test-util")]
-type SharedTimeline = Arc<Mutex<Vec<&'static str>>>;
-#[cfg(feature = "test-util")]
-type CommitRecord = (ConsumerGroupId, TopicId, u32, i64);
-#[cfg(feature = "test-util")]
-type SharedCommits = Arc<Mutex<Vec<CommitRecord>>>;
-#[cfg(feature = "test-util")]
-type SharedScopes = Arc<Mutex<Vec<(String, u32, usize)>>>;
-#[cfg(feature = "test-util")]
-type SharedViolations = Arc<Mutex<Vec<String>>>;
-#[cfg(feature = "test-util")]
-type SharedRuntimeEvents = Arc<Mutex<Vec<ConsumerRuntimeEvent>>>;
 type TestPartitionBuffers =
     Arc<RwLock<HashMap<TopicPartitionKey, super::dispatcher::PartitionEventBuffer>>>;
 
@@ -72,17 +59,6 @@ fn raw_event_on(topic: &str, type_id: &str, partition: u32, offset: i64) -> RawE
         trace_parent: None,
         data: serde_json::json!({ "offset": offset }),
     }
-}
-
-#[cfg(feature = "test-util")]
-fn partition_key_for_partition(target: u32, partitions: u32) -> String {
-    assert_eq!(partitions, 2, "only the two-partition fixture is supported");
-    match target {
-        0 => "partition-key-0-1",
-        1 => "partition-key-1-0",
-        _ => panic!("two-partition fixture cannot target partition {target}"),
-    }
-    .to_owned()
 }
 
 struct RecordingSingleHandler {
@@ -139,284 +115,6 @@ impl ConsumerHandler for AckAllBatchHandler {
                 .iter()
                 .map(|event| (event.topic.clone(), event.partition, event.offset)),
         );
-        Ok(chunk
-            .last()
-            .map(|event| BatchHandlerOutcome::AdvanceThrough {
-                offset: event.offset,
-            })
-            .unwrap_or(BatchHandlerOutcome::Success))
-    }
-}
-
-#[cfg(feature = "test-util")]
-struct SleepingBatchHandler {
-    calls: SharedPartitionCalls,
-    delay: Duration,
-}
-
-#[cfg(feature = "test-util")]
-#[async_trait::async_trait]
-impl ConsumerHandler for SleepingBatchHandler {
-    async fn handle_batch(
-        &self,
-        batch: &EventBatch<'_>,
-        _attempts: u16,
-    ) -> Result<BatchHandlerOutcome, ConsumerError> {
-        tokio::time::sleep(self.delay).await;
-        let chunk = batch.next_chunk(batch.len());
-        self.calls.lock().unwrap().extend(
-            chunk
-                .iter()
-                .map(|event| (event.topic.clone(), event.partition, event.offset)),
-        );
-        Ok(chunk
-            .last()
-            .map(|event| BatchHandlerOutcome::AdvanceThrough {
-                offset: event.offset,
-            })
-            .unwrap_or(BatchHandlerOutcome::Success))
-    }
-}
-
-#[cfg(feature = "test-util")]
-struct FailingThenCommitBatchHandler {
-    failures_remaining: Arc<Mutex<usize>>,
-    calls: SharedAttempts,
-}
-
-#[cfg(feature = "test-util")]
-#[async_trait::async_trait]
-impl ConsumerHandler for FailingThenCommitBatchHandler {
-    async fn handle_batch(
-        &self,
-        _batch: &EventBatch<'_>,
-        attempts: u16,
-    ) -> Result<BatchHandlerOutcome, ConsumerError> {
-        {
-            let mut guard = self.failures_remaining.lock().unwrap();
-            if *guard > 0 {
-                *guard -= 1;
-                return Err(ConsumerError::Internal(
-                    "intentional representative handler failure".to_owned(),
-                ));
-            }
-        }
-
-        self.calls.lock().unwrap().push(attempts);
-        Ok(BatchHandlerOutcome::Success)
-    }
-}
-
-#[cfg(feature = "test-util")]
-struct SequencedOffsetManager {
-    timeline: SharedTimeline,
-}
-
-#[cfg(feature = "test-util")]
-#[async_trait::async_trait]
-impl OffsetStore for SequencedOffsetManager {
-    async fn load_position(
-        &self,
-        _group: &ConsumerGroupId,
-        _topic: &TopicId,
-        _partition: u32,
-    ) -> Result<ResolvedPosition, OffsetManagerError> {
-        self.timeline.lock().unwrap().push("load");
-        Ok(ResolvedPosition::Earliest)
-    }
-}
-
-#[cfg(feature = "test-util")]
-#[async_trait::async_trait]
-impl CommitOffset for SequencedOffsetManager {
-    async fn commit(
-        &self,
-        _group: &ConsumerGroupId,
-        _topic: &TopicId,
-        _partition: u32,
-        _offset: i64,
-    ) -> Result<(), OffsetManagerError> {
-        Ok(())
-    }
-}
-
-#[cfg(feature = "test-util")]
-#[derive(Clone, Default)]
-struct RecordingCommitOffsetManager {
-    commits: SharedCommits,
-}
-
-#[cfg(feature = "test-util")]
-#[async_trait::async_trait]
-impl OffsetStore for RecordingCommitOffsetManager {
-    async fn load_position(
-        &self,
-        _group: &ConsumerGroupId,
-        _topic: &TopicId,
-        _partition: u32,
-    ) -> Result<ResolvedPosition, OffsetManagerError> {
-        Ok(ResolvedPosition::Earliest)
-    }
-}
-
-#[cfg(feature = "test-util")]
-#[async_trait::async_trait]
-impl CommitOffset for RecordingCommitOffsetManager {
-    async fn commit(
-        &self,
-        group: &ConsumerGroupId,
-        topic: &TopicId,
-        partition: u32,
-        offset: i64,
-    ) -> Result<(), OffsetManagerError> {
-        self.commits
-            .lock()
-            .unwrap()
-            .push((*group, *topic, partition, offset));
-        Ok(())
-    }
-}
-
-#[cfg(feature = "test-util")]
-struct SequencedBatchHandler {
-    timeline: SharedTimeline,
-}
-
-#[cfg(feature = "test-util")]
-#[async_trait::async_trait]
-impl ConsumerHandler for SequencedBatchHandler {
-    async fn handle_batch(
-        &self,
-        _batch: &EventBatch<'_>,
-        _attempts: u16,
-    ) -> Result<BatchHandlerOutcome, ConsumerError> {
-        self.timeline.lock().unwrap().push("handle");
-        Ok(BatchHandlerOutcome::Success)
-    }
-}
-
-#[cfg(feature = "test-util")]
-#[derive(Default)]
-struct BatchScopeRecorder {
-    scopes: SharedScopes,
-    violations: SharedViolations,
-}
-
-#[cfg(feature = "test-util")]
-#[derive(Clone, Default)]
-struct RecordingRuntimeListener {
-    events: SharedRuntimeEvents,
-}
-
-#[cfg(feature = "test-util")]
-#[async_trait::async_trait]
-impl ConsumerRuntimeListener for RecordingRuntimeListener {
-    async fn on_consumer_event(&self, event: &ConsumerRuntimeEvent) -> Result<(), ConsumerError> {
-        self.events.lock().unwrap().push(event.clone());
-        Ok(())
-    }
-}
-
-#[cfg(feature = "test-util")]
-struct FailingRuntimeListener;
-
-#[cfg(feature = "test-util")]
-#[async_trait::async_trait]
-impl ConsumerRuntimeListener for FailingRuntimeListener {
-    async fn on_consumer_event(&self, _event: &ConsumerRuntimeEvent) -> Result<(), ConsumerError> {
-        Err(ConsumerError::Internal(
-            "intentional listener failure".to_owned(),
-        ))
-    }
-}
-
-#[cfg(feature = "test-util")]
-struct SlowRuntimeListener {
-    delay: Duration,
-}
-
-#[cfg(feature = "test-util")]
-#[async_trait::async_trait]
-impl ConsumerRuntimeListener for SlowRuntimeListener {
-    async fn on_consumer_event(&self, _event: &ConsumerRuntimeEvent) -> Result<(), ConsumerError> {
-        tokio::time::sleep(self.delay).await;
-        Ok(())
-    }
-}
-
-#[cfg(feature = "test-util")]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-enum RuntimeEventKind {
-    SubscriptionJoining,
-    SubscriptionStarted,
-    SubscriptionRejoining,
-    SubscriptionTerminated,
-    SubscriptionConnectionDropped,
-    AssignmentChanged,
-    ProgressAdvanced,
-    PartitionBufferStateChanged,
-    HandlerBatchStarted,
-    HandlerBatchCompleted,
-    HandlerFailed,
-    OffsetLoaded,
-    OffsetCommitted,
-    RetryScheduled,
-}
-
-#[cfg(feature = "test-util")]
-fn runtime_event_kind(event: &ConsumerRuntimeEvent) -> RuntimeEventKind {
-    match event {
-        ConsumerRuntimeEvent::SubscriptionJoining { .. } => RuntimeEventKind::SubscriptionJoining,
-        ConsumerRuntimeEvent::SubscriptionStarted { .. } => RuntimeEventKind::SubscriptionStarted,
-        ConsumerRuntimeEvent::SubscriptionRejoining { .. } => {
-            RuntimeEventKind::SubscriptionRejoining
-        }
-        ConsumerRuntimeEvent::SubscriptionTerminated { .. } => {
-            RuntimeEventKind::SubscriptionTerminated
-        }
-        ConsumerRuntimeEvent::SubscriptionConnectionDropped { .. } => {
-            RuntimeEventKind::SubscriptionConnectionDropped
-        }
-        ConsumerRuntimeEvent::AssignmentChanged { .. } => RuntimeEventKind::AssignmentChanged,
-        ConsumerRuntimeEvent::ProgressAdvanced { .. } => RuntimeEventKind::ProgressAdvanced,
-        ConsumerRuntimeEvent::PartitionBufferStateChanged { .. } => {
-            RuntimeEventKind::PartitionBufferStateChanged
-        }
-        ConsumerRuntimeEvent::HandlerBatchStarted { .. } => RuntimeEventKind::HandlerBatchStarted,
-        ConsumerRuntimeEvent::HandlerBatchCompleted { .. } => {
-            RuntimeEventKind::HandlerBatchCompleted
-        }
-        ConsumerRuntimeEvent::HandlerFailed { .. } => RuntimeEventKind::HandlerFailed,
-        ConsumerRuntimeEvent::OffsetLoaded { .. } => RuntimeEventKind::OffsetLoaded,
-        ConsumerRuntimeEvent::OffsetCommitted { .. } => RuntimeEventKind::OffsetCommitted,
-        ConsumerRuntimeEvent::RetryScheduled { .. } => RuntimeEventKind::RetryScheduled,
-    }
-}
-
-#[cfg(feature = "test-util")]
-#[async_trait::async_trait]
-impl ConsumerHandler for BatchScopeRecorder {
-    async fn handle_batch(
-        &self,
-        batch: &EventBatch<'_>,
-        _attempts: u16,
-    ) -> Result<BatchHandlerOutcome, ConsumerError> {
-        let chunk = batch.next_chunk(batch.len());
-        if let Some(first) = chunk.first() {
-            if chunk
-                .iter()
-                .any(|event| event.topic != first.topic || event.partition != first.partition)
-            {
-                self.violations
-                    .lock()
-                    .unwrap()
-                    .push("batch mixed topic IDs or partitions".to_owned());
-            }
-            self.scopes
-                .lock()
-                .unwrap()
-                .push((first.topic.clone(), first.partition, chunk.len()));
-        }
         Ok(chunk
             .last()
             .map(|event| BatchHandlerOutcome::AdvanceThrough {

--- a/gears/system/event-broker/event-broker-sdk/src/consumer/mod.rs
+++ b/gears/system/event-broker/event-broker-sdk/src/consumer/mod.rs
@@ -13,6 +13,9 @@ mod builder_tests;
 #[cfg(test)]
 mod commit_tests;
 #[cfg(test)]
+#[cfg(feature = "test-util")]
+mod dispatcher_test_util;
+#[cfg(test)]
 mod dispatcher_tests;
 #[cfg(test)]
 #[cfg(feature = "db")]


### PR DESCRIPTION
Fixes clippy `dead_code` errors when building with `--no-default-features --all-targets`.
Test helpers used exclusively by `#[cfg(feature = "test-util")]` tests are now gated behind the same feature flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test organization by conditionally compiling test-only utilities when the `test-util` feature is enabled.
  * Centralized shared test helpers for event dispatching, offset handling, runtime events, and handler behavior.
  * Cleaned up unused test imports and declarations without changing public functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->