### PR TITLE
feat(toolkit)!: bind $top/$skiptoken, reject other $ options

### DIFF
--- a/docs/toolkit_unified_system/07_odata_pagination_select_filter.md
+++ b/docs/toolkit_unified_system/07_odata_pagination_select_filter.md
@@ -349,6 +349,101 @@ pub fn page_to_projected_json<T: serde::Serialize>(
 
 ## Cursor-based pagination
 
+### Page size (`$top` / `limit`)
+
+The page size binds off the query string in exactly one place —
+`toolkit::api::odata::ODataParams` — and lands in `ODataQuery.limit`. Two
+spellings reach that slot:
+
+| Spelling | Notes |
+|----------|-------|
+| `$top` | Canonical OData (OASIS OData 4.01 Part 2: URL Conventions, §5.1.6). Serde alias. |
+| `limit` | The unprefixed spelling most gears publish in their OpenAPI documents. |
+
+```bash
+# Equivalent
+/users-info/v1/users?$top=20
+/users-info/v1/users?limit=20
+
+# Ambiguous — 400 InvalidArgument (duplicate field)
+/users-info/v1/users?$top=20&limit=50
+```
+
+Both spellings are one parameter, so a gear needs no per-endpoint handling to
+honor either. Two consequences worth knowing:
+
+- OpenAPI cannot express one parameter under two names. Publish the spelling
+  your gear treats as canonical and mention the other in its `description`.
+- `$top=0` is rejected (`InvalidLimit` → `400`, `field_violations[0].field` is
+  `$top`). Enforcing an upper bound is the handler's job — the extractor caps
+  filter/orderby/select size, not page size.
+- **`$skip` is not supported.** Offset paging is not the platform's model, and
+  a request that pairs `$top` with `$skip` is refused rather than served with a
+  page size it asked for at an offset it did not get. Continue a page with
+  `$skiptoken` (alias `cursor`); see [Unsupported system query
+  options](#unsupported-system-query-options).
+
+### Continuation token (`$skiptoken` / `cursor`)
+
+The same one-slot-two-spellings rule applies to the continuation token: both
+`$skiptoken` and `cursor` land in `ODataQuery.cursor`. `$skiptoken` is OData's
+opaque continuation token for server-driven paging, which is exactly what
+`PageInfo.next_cursor` is — pass the previous page's `next_cursor` back under
+either spelling.
+
+```bash
+# Equivalent
+/users-info/v1/users?$top=20&$skiptoken=eyJ2IjoxLC…
+/users-info/v1/users?limit=20&cursor=eyJ2IjoxLC…
+```
+
+### Unsupported system query options
+
+Every `$`-prefixed query key the extractor does not bind is **rejected**, not
+ignored:
+
+```bash
+# 400 InvalidArgument, field_violations[0] = { field: "$skip",
+#   reason: "UNSUPPORTED_QUERY_PARAM" }
+/users-info/v1/users?$top=20&$skip=20
+```
+
+The accepted set is `toolkit::api::odata::ACCEPTED_SYSTEM_QUERY_OPTIONS` —
+`$filter`, `$orderby`, `$select`, `$top`, `$skiptoken`. Anything else in the
+`$` namespace answers `400` with one `UNSUPPORTED_QUERY_PARAM` violation per
+offending key, so one round trip names every problem:
+
+| Option | Why it is refused |
+|--------|-------------------|
+| `$skip` | Offset paging is not the model. Use `$skiptoken` / `cursor`. |
+| `$count` | A page carries no total; `PageInfo` is `{next_cursor, prev_cursor, limit}`. Serving a total would mean a `COUNT(*)` per page, which keyset pagination exists to avoid. |
+| `$expand`, `$search`, `$compute`, `$index`, `$schemaversion` | Not implemented. |
+| `$format` | Responses are JSON; negotiate the media type with `Accept`. |
+| `$filtre`, `$topp`, … | Not OData options at all, so the violation reads `unknown query option` rather than `unsupported`. A dropped `$filtre` returns the whole unfiltered collection with a `200`. |
+
+This is required behavior, not a house rule — OASIS OData 4.01 Part 1:
+Protocol, §6.1 "Query Option Extensibility":
+
+> OData services SHOULD NOT require any query options to be specified in a
+> request. Services SHOULD fail any request that contains query options that
+> they do not understand and MUST fail any request that contains unsupported
+> OData query options defined in the version of this specification supported by
+> the service.
+
+Two boundaries follow from the same section:
+
+- **Unprefixed keys are out of scope.** §6.1 reserves the `$` prefix for
+  OData, so a non-`$` key belongs to the handler's own params struct — the
+  extractor never rejects one. A gear that wants `?status=approved` refused
+  instead of ignored needs its own guard; account-management has one
+  (`reject_non_odata_params`).
+- **Spelling is case-sensitive, deliberately.** OData 4.01 Part 2 §5.1 asks a
+  4.01 service to accept system query option names case-insensitively and with
+  or without the `$` prefix. This platform accepts neither `$Top` nor the
+  unprefixed canonical `top`; it answers `400` naming the spelling that binds
+  rather than dropping the request. Closing that gap is a separate conformance
+  change.
+
 ### Page structure
 
 ```rust
@@ -475,15 +570,21 @@ OData errors are defined in `toolkit_odata::Error` (aliased as `ODataError` in `
 
 | Variant | Description | HTTP status |
 |---------|-------------|-------------|
-| `InvalidFilter(String)` | Malformed `$filter` expression | 422 |
-| `InvalidOrderByField(String)` | Unsupported `$orderby` field | 422 |
-| `InvalidCursor` / `CursorInvalid*` | Malformed or expired cursor | 422 |
-| `OrderMismatch` | Cursor/query order conflict | 422 |
-| `FilterMismatch` | Cursor/query filter conflict | 422 |
-| `InvalidLimit` | Invalid limit parameter | 422 |
+| `InvalidFilter(String)` | Malformed `$filter` expression | 400 |
+| `InvalidOrderByField(String)` | Unsupported `$orderby` field | 400 |
+| `InvalidCursor` / `CursorInvalid*` | Malformed or expired cursor | 400 |
+| `OrderMismatch` | Cursor/query order conflict | 400 |
+| `FilterMismatch` | Cursor/query filter conflict | 400 |
+| `InvalidLimit` | Invalid page size parameter (`$top`, alias `limit`) | 400 |
 | `Db(String)` | Database error (logged, generic message returned) | 500 |
 
+Every variant above except `Db` maps through `OdataError::invalid_argument()`, and
+`CanonicalError::InvalidArgument` renders as `400`. The canonical error taxonomy has no `422`
+status, so no `OData` error can produce one.
+
 `$select` validation errors (too long, too many fields, duplicates) are caught during parsing in the `OData` extractor and returned as `400 Bad Request` with RFC 9457 Problem Details before reaching the handler.
+
+Unsupported system query options are not `toolkit_odata::Error` variants — the extractor builds the canonical `InvalidArgument` itself, before any value parsing, with one `UNSUPPORTED_QUERY_PARAM` field violation per offending key. See [Unsupported system query options](#unsupported-system-query-options).
 
 ### Error conversion
 

--- a/gears/system/account-management/account-management/src/api/rest/handlers/common.rs
+++ b/gears/system/account-management/account-management/src/api/rest/handlers/common.rs
@@ -20,8 +20,8 @@ pub(super) fn clamp_listing_top(mut query: ODataQuery, max_top: u32) -> ODataQue
 /// Reject any query parameter that does not start with `$`.
 ///
 /// AM list endpoints use `OData` as the single filter / ordering /
-/// pagination surface (`$filter`, `$orderby`, `$top`, `$skip`,
-/// `$select`, `$count`). Without this guard, Axum silently drops
+/// pagination surface (`$filter`, `$orderby`, `$select`, `$top`,
+/// `$skiptoken`). Without this guard, Axum silently drops
 /// query keys that no extractor claimed — a caller writing in a
 /// generic-REST convention like `?status=approved` would receive
 /// HTTP 200 with the **unfiltered** result set and assume the filter
@@ -35,9 +35,10 @@ pub(super) fn clamp_listing_top(mut query: ODataQuery, max_top: u32) -> ODataQue
 /// envelope.
 ///
 /// `$`-prefixed keys are intentionally out of scope: the `OData`
-/// extractor parses them and rejects unknown ones (`$filtre` etc.)
-/// through its own `Validation` path. This check is the seam for
-/// non-`OData` accidents only.
+/// extractor binds the options in
+/// `toolkit::api::odata::ACCEPTED_SYSTEM_QUERY_OPTIONS` and rejects
+/// every other `$` key (`$skip`, `$count`, `$filtre`) with its own
+/// `400`. This check is the seam for non-`OData` accidents only.
 pub(super) fn reject_non_odata_params(query: &HashMap<String, String>) -> Result<(), DomainError> {
     if let Some(unknown) = query.keys().find(|k| !k.starts_with('$')) {
         return Err(DomainError::Validation {

--- a/gears/system/account-management/account-management/src/api/rest/handlers/common_tests.rs
+++ b/gears/system/account-management/account-management/src/api/rest/handlers/common_tests.rs
@@ -61,13 +61,17 @@ fn reject_non_odata_params_passes_odata_only_keys() {
     // The full set of `OData` keys AM listing endpoints accept must
     // pass the gate; a regression that accidentally narrowed the
     // allow-shape would trip here.
+    //
+    // This gate polices the non-`$` namespace only, so it is not the
+    // place that refuses unsupported system query options: `$skip` and
+    // `$count` pass here and are rejected downstream by the extractor
+    // (`toolkit::api::odata::ACCEPTED_SYSTEM_QUERY_OPTIONS`).
     let mut q = HashMap::new();
     q.insert("$filter".to_owned(), "status eq 'approved'".to_owned());
     q.insert("$orderby".to_owned(), "created_at desc".to_owned());
     q.insert("$top".to_owned(), "10".to_owned());
-    q.insert("$skip".to_owned(), "20".to_owned());
+    q.insert("$skiptoken".to_owned(), "opaque-cursor".to_owned());
     q.insert("$select".to_owned(), "id,status".to_owned());
-    q.insert("$count".to_owned(), "true".to_owned());
     reject_non_odata_params(&q).expect("OData-only query must pass");
 }
 

--- a/libs/toolkit-odata/src/lib.rs
+++ b/libs/toolkit-odata/src/lib.rs
@@ -276,7 +276,8 @@ impl std::fmt::Display for ODataOrderBy {
 /// - `InvalidFilter` / `InvalidOrderByField` / cursor errors / cursor-vs-query
 ///   mismatches / `InvalidLimit` / `OrderWithCursor` → canonical
 ///   `InvalidArgument` (HTTP 400), with the offending parameter surfaced as
-///   a `field_violation` (`$filter`, `$orderby`, `$top`, or `cursor`).
+///   a `field_violation` (`$filter`, `$orderby`, `$top` — the page-size slot,
+///   which `toolkit::api::odata` also accepts as `limit` — or `cursor`).
 /// - `Db` / `ParsingUnavailable` → canonical `Internal` (HTTP 500).
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum Error {

--- a/libs/toolkit-odata/src/limits.rs
+++ b/libs/toolkit-odata/src/limits.rs
@@ -1,7 +1,16 @@
-//! Input validation and safety limits for `OData` parsing
+//! Opt-in input validation and safety limits for `OData` parsing
 //!
-//! This gear enforces sane caps to prevent abuse and resource exhaustion:
-//! - Maximum `$top` value
+//! [`ODataLimits`] is a caller-driven validator, **not** an ambient policy: a
+//! caller constructs it and invokes the `validate_*` helpers itself. Nothing
+//! in the `toolkit::api::odata` extractor constructs or applies it, so the
+//! defaults below are a suggested starting point, not caps the platform
+//! enforces on your behalf. The caps that do apply to every request are the
+//! extractor's own budgets (`MAX_FILTER_LEN`, `MAX_ORDERBY_LEN`,
+//! `MAX_SELECT_LEN`, … in `toolkit::api::odata`); page size is capped
+//! per-endpoint by the owning handler.
+//!
+//! Covers:
+//! - Maximum page size (`$top`, also spelled `limit` on the wire)
 //! - Maximum number of `$orderby` fields
 //! - Maximum filter expression length
 //! - Cursor integrity checks (HMAC signing)
@@ -12,7 +21,9 @@ use crate::Error;
 #[derive(Debug, Clone)]
 #[must_use]
 pub struct ODataLimits {
-    /// Maximum value for $top (default: 1000)
+    /// Maximum value for the page size `$top` / `limit` (default: 1000).
+    /// Applied only through [`ODataLimits::validate_top`] — see the module
+    /// docs.
     pub max_top: usize,
     /// Maximum number of fields in $orderby (default: 5)
     pub max_orderby_fields: usize,
@@ -42,7 +53,7 @@ impl ODataLimits {
         Self::default()
     }
 
-    /// Set maximum $top value
+    /// Set maximum page size (`$top` / `limit`)
     pub fn with_max_top(mut self, max_top: usize) -> Self {
         self.max_top = max_top;
         self
@@ -67,10 +78,10 @@ impl ODataLimits {
         self
     }
 
-    /// Validate a $top value against limits.
+    /// Validate a page size (`$top` / `limit`) against [`Self::max_top`].
     ///
     /// # Errors
-    /// Returns `Error::InvalidLimit` if the top value exceeds the maximum allowed.
+    /// Returns `Error::InvalidLimit` if the page size exceeds the maximum allowed.
     pub fn validate_top(&self, top: usize) -> Result<(), Error> {
         if top > self.max_top {
             return Err(Error::InvalidLimit);

--- a/libs/toolkit-odata/src/problem_mapping.rs
+++ b/libs/toolkit-odata/src/problem_mapping.rs
@@ -102,8 +102,16 @@ impl From<Error> for CanonicalError {
                 )
                 .create(),
 
+            // Keyed to the canonical `OData` spelling. `toolkit::api::odata`
+            // binds page size from either `$top` or `limit` (one slot, two
+            // accepted names), so the violation names `$top` and the
+            // description names both.
             InvalidLimit => OdataError::invalid_argument()
-                .with_field_violation("$top", "Invalid limit parameter", "INVALID_LIMIT")
+                .with_field_violation(
+                    "$top",
+                    "Invalid page size parameter ($top, alias limit)",
+                    "INVALID_LIMIT",
+                )
                 .create(),
 
             // Surface both halves of the conflict so a client filtering by

--- a/libs/toolkit/src/api/odata.rs
+++ b/libs/toolkit/src/api/odata.rs
@@ -9,6 +9,11 @@ use toolkit_odata::{CursorV1, Error as ODataError, ODataOrderBy, OrderKey, SortD
 pub use toolkit_odata::ODataQuery;
 // CursorV1 is available through the private import above for internal use
 
+/// Wire binding for the `OData` query-parameter family.
+///
+/// This struct is the single place where `OData` query parameters are bound
+/// off the URL: `toolkit-odata` operates on already-parsed values and does no
+/// HTTP query parsing of its own.
 #[derive(Deserialize, Default)]
 pub struct ODataParams {
     #[serde(rename = "$filter")]
@@ -17,9 +22,65 @@ pub struct ODataParams {
     pub orderby: Option<String>,
     #[serde(rename = "$select")]
     pub select: Option<String>,
+    /// Page size. Accepted as `limit` or as the canonical `OData` spelling
+    /// `$top` (OASIS `OData` 4.01 Part 2: URL Conventions, §5.1.6 "System
+    /// Query Options $top and $skip") — both spellings fold onto this one
+    /// slot, so a gear needs no per-endpoint handling to honor either.
+    ///
+    /// Sending both in one request is ambiguous and is rejected with
+    /// `400 InvalidArgument` (serde reports the second spelling as a
+    /// duplicate field).
+    #[serde(alias = "$top")]
     pub limit: Option<u64>,
+    /// Opaque keyset token from the previous page's `next_cursor`. Accepted
+    /// as `cursor` or as `$skiptoken`, `OData`'s opaque continuation token
+    /// for server-driven paging; both spellings fold onto this one slot.
+    ///
+    /// This is the platform's only pagination continuation. `$skip` — offset
+    /// paging — is not supported and is rejected; see
+    /// [`ACCEPTED_SYSTEM_QUERY_OPTIONS`].
+    #[serde(alias = "$skiptoken")]
     pub cursor: Option<String>,
 }
+
+/// `OData` system query options this extractor binds, in the exact spelling
+/// that binds.
+///
+/// Any other `$`-prefixed query key is rejected rather than ignored. OASIS
+/// `OData` 4.01 Part 1: Protocol, §6.1 "Query Option Extensibility": a
+/// service "MUST fail any request that contains unsupported `OData` query
+/// options defined in the version of this specification supported by the
+/// service", and SHOULD fail any option it does not understand. §6.1 also
+/// reserves the `$` prefix for `OData`, so unprefixed keys stay out of
+/// scope — those belong to the handler's own params struct, and policing
+/// them is each gear's business.
+pub const ACCEPTED_SYSTEM_QUERY_OPTIONS: [&str; 5] =
+    ["$filter", "$orderby", "$select", "$top", "$skiptoken"];
+
+/// Every system query option `OData` 4.01 defines, whether or not this
+/// platform binds it (OASIS `OData` 4.01 Part 2: URL Conventions, §§5.1.2 —
+/// 5.1.12).
+///
+/// Splits the two ways a `$` key can be refused: one of these is
+/// *unsupported* and may become supported later, while a `$` key outside
+/// this set is *unknown* — which is what a typo like `$filtre` should hear.
+const ODATA_SYSTEM_QUERY_OPTIONS: [&str; 12] = [
+    "$filter",
+    "$expand",
+    "$select",
+    "$orderby",
+    "$top",
+    "$skip",
+    "$count",
+    "$search",
+    "$format",
+    "$compute",
+    "$index",
+    "$schemaversion",
+];
+
+/// Reason code carried by every unsupported-option violation.
+const UNSUPPORTED_QUERY_PARAM: &str = "UNSUPPORTED_QUERY_PARAM";
 
 pub const MAX_FILTER_LEN: usize = 8 * 1024;
 pub const MAX_NODES: usize = 2000;
@@ -164,8 +225,104 @@ fn query_params_invalid_arg(detail: impl Into<String>) -> CanonicalError {
         .create()
 }
 
+/// Replacement hint appended to the violation description, so a caller who
+/// sent a plausible option learns what to send instead of only that the
+/// option is refused.
+fn unsupported_option_hint(option: &str) -> &'static str {
+    match option {
+        "$skip" => {
+            "this platform pages by cursor, not by offset: send the previous \
+             page's `next_cursor` as `$skiptoken` (alias `cursor`)"
+        }
+        "$count" => {
+            "a page carries no total: `PageInfo` is \
+             `{next_cursor, prev_cursor, limit}`"
+        }
+        "$format" => {
+            "responses are JSON: negotiate the media type with the `Accept` \
+             header"
+        }
+        _ => "not implemented by this platform",
+    }
+}
+
+/// Describe one rejected `$`-prefixed query key.
+fn unsupported_option_detail(option: &str) -> String {
+    let canonical = option.to_ascii_lowercase();
+    if ACCEPTED_SYSTEM_QUERY_OPTIONS.contains(&canonical.as_str()) {
+        // The option is supported, the spelling is not: binding is
+        // case-sensitive, so honoring `$Top` would take a second code path.
+        // Say which spelling binds instead of dropping the request.
+        return format!("`{option}` binds only as `{canonical}`");
+    }
+    if ODATA_SYSTEM_QUERY_OPTIONS.contains(&canonical.as_str()) {
+        return format!(
+            "unsupported OData system query option `{option}`; {}",
+            unsupported_option_hint(&canonical)
+        );
+    }
+    format!(
+        "unknown query option `{option}`; the `$` prefix is reserved for \
+         OData system query options"
+    )
+}
+
+/// Reject every `$`-prefixed query key this extractor does not bind.
+///
+/// Required by OASIS `OData` 4.01 Part 1: Protocol, §6.1 "Query Option
+/// Extensibility" — see [`ACCEPTED_SYSTEM_QUERY_OPTIONS`]. Without this,
+/// axum drops unclaimed query keys and the caller gets `200` with a result
+/// set that ignored what they asked for: `?$skip=20` re-reads page one,
+/// `?$filtre=…` returns the whole unfiltered collection.
+///
+/// Every offending option is reported in one response so a caller fixes
+/// them in one round trip.
+///
+/// # Errors
+/// Returns a canonical `InvalidArgument` (`400`) carrying one
+/// `UNSUPPORTED_QUERY_PARAM` field violation per offending key, in wire
+/// order.
+#[allow(clippy::result_large_err)]
+fn reject_unsupported_system_query_options(
+    pairs: &[(String, String)],
+) -> Result<(), CanonicalError> {
+    // Deduplicated in wire order: a repeated option is one mistake to fix,
+    // and the offender list is bounded by the query string, so a linear
+    // `contains` is cheaper than a set.
+    let mut offending: Vec<&str> = Vec::new();
+    for key in pairs.iter().map(|(key, _)| key.as_str()) {
+        if key.starts_with('$')
+            && !ACCEPTED_SYSTEM_QUERY_OPTIONS.contains(&key)
+            && !offending.contains(&key)
+        {
+            offending.push(key);
+        }
+    }
+
+    let mut offenders = offending.into_iter();
+    let Some(first) = offenders.next() else {
+        return Ok(());
+    };
+
+    let mut violations = OdataError::invalid_argument().with_field_violation(
+        first,
+        unsupported_option_detail(first),
+        UNSUPPORTED_QUERY_PARAM,
+    );
+    for option in offenders {
+        violations = violations.with_field_violation(
+            option,
+            unsupported_option_detail(option),
+            UNSUPPORTED_QUERY_PARAM,
+        );
+    }
+
+    Err(violations.create())
+}
+
 /// Extract and validate full `OData` query from request parts.
-/// - Parses $filter, $orderby, limit, cursor
+/// - Rejects any `$`-prefixed key outside [`ACCEPTED_SYSTEM_QUERY_OPTIONS`]
+/// - Parses $filter, $orderby, $top / limit, $skiptoken / cursor
 /// - Enforces budgets and validates formats
 /// - Returns unified `ODataQuery`
 ///
@@ -181,6 +338,15 @@ pub async fn extract_odata_query<S>(
 where
     S: Send + Sync,
 {
+    // Runs before any value parsing: a request naming an option this
+    // extractor does not bind is malformed whatever the other values say.
+    // Deserializing the raw pairs first keeps percent-decoding identical to
+    // what `Query::<ODataParams>` binds below.
+    let Query(pairs) = Query::<Vec<(String, String)>>::from_request_parts(parts, state)
+        .await
+        .map_err(|e| query_params_invalid_arg(format!("Invalid query parameters: {e}")))?;
+    reject_unsupported_system_query_options(&pairs)?;
+
     let Query(params) = Query::<ODataParams>::from_request_parts(parts, state)
         .await
         .map_err(|e| query_params_invalid_arg(format!("Invalid query parameters: {e}")))?;

--- a/libs/toolkit/src/api/odata_tests.rs
+++ b/libs/toolkit/src/api/odata_tests.rs
@@ -241,6 +241,295 @@ mod tests {
         assert_eq!(odata.limit, Some(10));
     }
 
+    // ─── `$top` ⇄ `limit` alias ──────────────────────────────────────
+    //
+    // `$top` is the canonical OData page-size spelling (OASIS OData 4.01
+    // Part 2: URL Conventions, §5.1.6). It is a serde alias of `limit`,
+    // so both spellings fold onto the same `ODataQuery.limit` slot.
+
+    #[tokio::test]
+    async fn test_extract_odata_query_top_binds_limit() {
+        let uri = "/?%24top=25";
+
+        let request = Request::builder().uri(uri).body(()).unwrap();
+
+        let (mut parts, _body) = request.into_parts();
+
+        let query = extract_odata_query(&mut parts, &()).await.unwrap();
+
+        assert_eq!(
+            query.limit,
+            Some(25),
+            "`$top` must bind the same slot as `limit`"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_extract_odata_query_top_zero_error() {
+        // Same floor as `limit=0`: zero is not a usable page size.
+        let uri = "/?%24top=0";
+
+        let request = Request::builder().uri(uri).body(()).unwrap();
+
+        let (mut parts, _body) = request.into_parts();
+
+        let canonical = extract_odata_query(&mut parts, &())
+            .await
+            .expect_err("`$top=0` must be rejected");
+        assert_eq!(canonical.status_code(), 400);
+
+        // The violation names `$top` — a caller who sent `$top` must not be
+        // told about a parameter they did not use.
+        let problem = toolkit_canonical_errors::Problem::from(canonical);
+        let violations = problem
+            .context
+            .get("field_violations")
+            .and_then(|v| v.as_array())
+            .expect("invalid_argument must carry field_violations[]");
+        assert_eq!(
+            violations[0].get("field").and_then(|f| f.as_str()),
+            Some("$top"),
+            "violation was {:?}",
+            violations[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_extract_odata_query_top_and_limit_conflict() {
+        // Two spellings of one slot in one request is ambiguous: reject it
+        // rather than silently picking a winner.
+        let uri = "/?%24top=25&limit=10";
+
+        let request = Request::builder().uri(uri).body(()).unwrap();
+
+        let (mut parts, _body) = request.into_parts();
+
+        let canonical = extract_odata_query(&mut parts, &())
+            .await
+            .expect_err("`$top` together with `limit` must be rejected");
+        assert_eq!(canonical.status_code(), 400);
+
+        // Surfaces through the axum-level deserialization path, so the
+        // violation is keyed to `query` (gear OpenAPI documents cite this
+        // reason for the two-spellings-in-one-request case).
+        let problem = toolkit_canonical_errors::Problem::from(canonical);
+        let violations = problem
+            .context
+            .get("field_violations")
+            .and_then(|v| v.as_array())
+            .expect("invalid_argument must carry field_violations[]");
+        assert_eq!(
+            violations[0].get("reason").and_then(|r| r.as_str()),
+            Some("INVALID_QUERY_PARAMS"),
+            "violation was {:?}",
+            violations[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_odata_extractor_top_alias() {
+        let uri = "/?%24filter=email%20eq%20%27test%40example.com%27&%24top=10";
+
+        let request = Request::builder().uri(uri).body(()).unwrap();
+
+        let (mut parts, _body) = request.into_parts();
+
+        let odata = OData::from_request_parts(&mut parts, &()).await.unwrap();
+
+        assert!(odata.filter.is_some());
+        assert_eq!(odata.limit, Some(10));
+    }
+
+    // ─── unsupported system query options ────────────────────────────
+    //
+    // OASIS OData 4.01 Part 1: Protocol, §6.1 "Query Option
+    // Extensibility": a service "MUST fail any request that contains
+    // unsupported OData query options defined in the version of this
+    // specification supported by the service", and SHOULD fail options it
+    // does not understand. Accepting-and-dropping `$skip` left a caller
+    // re-reading page one while believing the offset advanced.
+
+    /// Lift `field_violations[]` off a canonical error as
+    /// `(field, reason, description)` triples in wire order.
+    fn violations_of(canonical: CanonicalError) -> Vec<(String, String, String)> {
+        let problem = toolkit_canonical_errors::Problem::from(canonical);
+        problem
+            .context
+            .get("field_violations")
+            .and_then(|v| v.as_array())
+            .expect("invalid_argument must carry field_violations[]")
+            .iter()
+            .map(|v| {
+                let get = |key: &str| {
+                    v.get(key)
+                        .and_then(|s| s.as_str())
+                        .unwrap_or_default()
+                        .to_owned()
+                };
+                (get("field"), get("reason"), get("description"))
+            })
+            .collect()
+    }
+
+    /// Run the extractor over a bare query string.
+    async fn extract(query: &str) -> Result<ODataQuery, CanonicalError> {
+        let request = Request::builder()
+            .uri(format!("/?{query}"))
+            .body(())
+            .unwrap();
+        let (mut parts, _body) = request.into_parts();
+        extract_odata_query(&mut parts, &()).await
+    }
+
+    #[tokio::test]
+    async fn test_extract_odata_query_skip_rejected() {
+        // Offset paging is not the model: the platform pages by cursor, and
+        // honoring `$top` while dropping `$skip` would serve a page of the
+        // requested size at a fixed offset forever.
+        let canonical = extract("%24skip=20")
+            .await
+            .expect_err("`$skip` must be rejected, not dropped");
+        assert_eq!(canonical.status_code(), 400);
+
+        let violations = violations_of(canonical);
+        assert_eq!(violations.len(), 1, "violations were {violations:?}");
+        let (field, reason, description) = &violations[0];
+        assert_eq!(field, "$skip");
+        assert_eq!(reason, "UNSUPPORTED_QUERY_PARAM");
+        assert!(
+            description.contains("$skiptoken"),
+            "detail must name the cursor replacement: {description}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_extract_odata_query_count_rejected() {
+        // `PageInfo` carries no total, so `$count` has no truthful answer.
+        let canonical = extract("%24count=true")
+            .await
+            .expect_err("`$count` must be rejected, not dropped");
+        assert_eq!(canonical.status_code(), 400);
+
+        let violations = violations_of(canonical);
+        assert_eq!(violations.len(), 1, "violations were {violations:?}");
+        let (field, reason, description) = &violations[0];
+        assert_eq!(field, "$count");
+        assert_eq!(reason, "UNSUPPORTED_QUERY_PARAM");
+        assert!(
+            description.contains("total"),
+            "detail must say totals are not part of the page contract: {description}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_extract_odata_query_misspelled_option_rejected() {
+        // The §6.1 SHOULD case: an option the service does not understand.
+        // A dropped `$filtre` returns the whole unfiltered collection with
+        // a 200.
+        let canonical = extract("%24filtre=email%20eq%20%27a%40b.c%27")
+            .await
+            .expect_err("`$filtre` must be rejected, not dropped");
+        assert_eq!(canonical.status_code(), 400);
+
+        let violations = violations_of(canonical);
+        assert_eq!(violations.len(), 1, "violations were {violations:?}");
+        let (field, _, description) = &violations[0];
+        assert_eq!(field, "$filtre");
+        // `$filtre` is not an OData-defined option, so it must not be
+        // described as one: it is unknown, not unimplemented.
+        assert!(
+            description.contains("unknown"),
+            "a typo must read as unknown, not as unsupported: {description}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_extract_odata_query_reports_every_unsupported_option() {
+        // One round trip should name every offending option, in wire order,
+        // rather than making the caller fix them one request at a time.
+        let canonical = extract("%24skip=20&%24count=true&%24expand=tenant")
+            .await
+            .expect_err("unsupported options must be rejected");
+
+        let fields: Vec<String> = violations_of(canonical)
+            .into_iter()
+            .map(|(field, _, _)| field)
+            .collect();
+        assert_eq!(fields, ["$skip", "$count", "$expand"]);
+    }
+
+    #[tokio::test]
+    async fn test_extract_odata_query_repeated_unsupported_option_reported_once() {
+        // One violation per offending key, not per occurrence: a repeated
+        // option is one mistake to fix.
+        let canonical = extract("%24skip=20&%24skip=40")
+            .await
+            .expect_err("`$skip` must be rejected");
+
+        let fields: Vec<String> = violations_of(canonical)
+            .into_iter()
+            .map(|(field, _, _)| field)
+            .collect();
+        assert_eq!(fields, ["$skip"]);
+    }
+
+    #[tokio::test]
+    async fn test_extract_odata_query_miscased_option_rejected() {
+        // `ODataParams` binds `$top` case-sensitively, so `$Top` would
+        // otherwise be dropped. Reject it and name the spelling that binds.
+        // (OData 4.01 Part 2 §5.1 asks a 4.01 service to accept
+        // case-insensitive option names; this platform does not, and says
+        // so instead of ignoring the request.)
+        let canonical = extract("%24Top=10")
+            .await
+            .expect_err("`$Top` must be rejected, not dropped");
+        assert_eq!(canonical.status_code(), 400);
+
+        let violations = violations_of(canonical);
+        assert_eq!(violations.len(), 1, "violations were {violations:?}");
+        let (field, _, description) = &violations[0];
+        assert_eq!(field, "$Top");
+        assert!(
+            description.contains("$top"),
+            "detail must name the spelling that binds: {description}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_extract_odata_query_skiptoken_binds_cursor() {
+        // `$skiptoken` is the canonical OData spelling of what this
+        // platform calls `cursor` — alias, same slot, same as `$top`.
+        let token = CursorV1 {
+            k: vec!["2026-08-10T00:00:00Z".to_owned()],
+            o: SortDir::Asc,
+            s: "created_at".to_owned(),
+            f: None,
+            d: "fwd".to_owned(),
+        }
+        .encode()
+        .expect("cursor must encode");
+
+        let query = extract(&format!("%24skiptoken={token}"))
+            .await
+            .expect("`$skiptoken` must be accepted");
+        assert!(
+            query.cursor.is_some(),
+            "`$skiptoken` must bind the same slot as `cursor`"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_extract_odata_query_non_odata_params_pass_through() {
+        // Part 1 §6.1 reserves the `$` prefix for OData system query
+        // options, so unprefixed keys belong to the handler's own params
+        // struct — chat-engine's `q` / `context`, file-storage's `offset`.
+        // The extractor must not police that namespace.
+        let query = extract("q=needle&context=2&limit=5")
+            .await
+            .expect("non-OData params belong to the handler, not this extractor");
+        assert_eq!(query.limit, Some(5));
+    }
+
     #[test]
     fn test_odata_deref() {
         use toolkit_odata::ast::*;


### PR DESCRIPTION
`$top` is canonical OData (OASIS OData 4.01 Part 2: URL Conventions, §5.1.6 "System Query Options
$top and $skip"), and this repo already documented it, tested it, and named it in error payloads.
Nothing bound it. The wire binding for the whole OData family lives in exactly one place,
`toolkit::api::odata::ODataParams`, which declared an unprefixed `limit` with no `$top` field and no
alias — and `toolkit-odata` does no HTTP query parsing at all. So `?$top=<n>` was accepted and
discarded on every endpoint using the `OData` extractor, and `limit` was the only page-size
parameter that actually worked.

This binds `$top` as `#[serde(alias = "$top")]` on `ODataParams.limit`: one slot, two accepted
spellings. `limit` keeps working for every current caller, the platform matches canonical OData, and
the `$top` field violation already emitted by `toolkit-odata::problem_mapping` becomes truthful
without a rename.

**Binding `$top` alone would have made the `$` namespace worse, not better** — raised in review, and
the second half of this PR. `ODataParams` claims every `$`-prefixed query key by convention but
bound four of them, and axum drops query keys no extractor claimed. A client paginating the
canonical way sends `$top` with `$skip`: before, both were dropped and the wrong page size was an
immediate tell; with `$top` bound and `$skip` still dropped, the page size is honored, the offset
silently is not, and the client re-reads page one while believing it advanced.

OData does not leave this to taste. Part 1: Protocol, §6.1 "Query Option Extensibility":

> OData services SHOULD NOT require any query options to be specified in a request. Services SHOULD
> fail any request that contains query options that they do not understand and MUST fail any request
> that contains unsupported OData query options defined in the version of this specification
> supported by the service.

`$skip` and `$count` are OData-defined and unsupported here, so refusing them is a **MUST**; a typo
like `$filtre` is the SHOULD case. The same section reserves the `$` and `@` prefixes for OData,
which is why this guard polices `$` keys only: an unprefixed key belongs to the handler's own params
struct (chat-engine's `q`, file-storage's `offset`), and refusing those stays each gear's business
(account-management has `reject_non_odata_params`).

**Changes**

- `libs/toolkit/src/api/odata.rs`
  - `#[serde(alias = "$top")]` on `ODataParams.limit`, plus rustdoc on the struct stating that this
    is the single wire-binding point for OData query parameters.
  - `#[serde(alias = "$skiptoken")]` on `ODataParams.cursor` — the same one-slot-two-spellings shape
    as `$top`. `$skiptoken` is OData's opaque continuation token for server-driven paging, which is
    what `PageInfo.next_cursor` already is, and resource-group's own docs advertise the spelling.
  - `ACCEPTED_SYSTEM_QUERY_OPTIONS` (`$filter`, `$orderby`, `$select`, `$top`, `$skiptoken`) and a
    guard that answers `400` for every other `$`-prefixed key, before any value parsing. One
    `UNSUPPORTED_QUERY_PARAM` field violation per offending key, deduplicated, in wire order, so one
    round trip names every mistake.
  - The violation description separates the three cases a caller can hit: `$skip` / `$count` /
    `$format` are OData-defined but unsupported and each says what to send instead; `$Top` is a
    supported option in a spelling that does not bind, and names the one that does; `$filtre` is not
    an OData option at all and reads as `unknown query option`, not `unsupported`.
- `libs/toolkit-odata/src/problem_mapping.rs` — the `InvalidLimit` violation keeps `$top` as the
  field name and now describes both spellings: `"Invalid page size parameter ($top, alias limit)"`.
- `libs/toolkit-odata/src/limits.rs` — docs only. `ODataLimits::max_top` was documented as an
  enforced "maximum $top value (default 1000)"; nothing in the repo constructs `ODataLimits`, so
  nothing enforced it. The module docs now say it is an opt-in validator and point at what actually
  caps each request. Deleting the type was the alternative and was rejected: it is a `pub`
  re-export, so removal breaks downstream compilation for no gain.
- `docs/toolkit_unified_system/07_odata_pagination_select_filter.md` — the page-size section (both
  spellings, the ambiguity rule, `$top=0`, and the note that upper-bound capping is the handler's
  job), a continuation-token section, and an **Unsupported system query options** section: the
  accepted set, the refusal table, the §6.1 quote behind it, and the two boundaries it implies —
  unprefixed keys are out of scope, and case-sensitivity is a stated deviation from Part 2 §5.1
  (which wants option names accepted case-insensitively and with or without `$`) rather than an
  oversight. Also corrects that file's error table, which listed HTTP `422` for every `OData` error
  variant: all of them except `Db` map through `OdataError::invalid_argument()`, which renders as
  `400`, and the canonical error taxonomy has no `422` status at all — so no `OData` error could ever
  have produced one. That is a pre-existing documentation error independent of `$top`; five of the
  six corrected rows concern `$filter`, `$orderby`, and cursors. Fixed here (raised in review)
  because the same table names `InvalidLimit`.
- `gears/system/account-management/.../handlers/common.rs` — `reject_non_odata_params` claimed
  `$`-prefixed keys were "out of scope: the `OData` extractor parses them and rejects unknown ones
  (`$filtre` etc.)". That was false when written — it is exactly the hole this PR closes — and the
  gear built its non-`$` guard on top of the assumption. The comment now points at
  `ACCEPTED_SYSTEM_QUERY_OPTIONS`, and its test no longer pins `$skip` / `$count` as keys AM accepts.

**Why `$skip` is refused rather than implemented.** Offset paging is not this platform's model:
`ODataQuery` carries no offset field and `paginate_odata` is keyset-only, so honoring `$skip` would
mean adding a pagination mode, not binding a parameter. `$count` has no truthful answer either —
`PageInfo` is `{next_cursor, prev_cursor, limit}`, and serving a total would mean the `COUNT(*)` per
page that keyset pagination exists to avoid.

**Out of scope.** Toolkit crates plus the one account-management comment this PR falsifies. The
gear-side items from #4413 — the vacuous `$top` clamp test in account-management, and the
chat-engine `SearchQuery` doc comment that credits `toolkit-odata` for its own serde renames — are
left to a separate change. Accepting `$Top` case-insensitively and the unprefixed canonical spellings
(`top`, `filter`) that Part 2 §5.1 asks for is a separate conformance change; this PR answers `400`
naming the spelling that binds instead of dropping the request.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Breaking change details

Two wire-behavior changes, both on every endpoint using the `OData` extractor (ledger, chat-engine,
mini-chat, account-management, resource-group, usage-collector).

**1. `?$top=<n>` now sets the page size** instead of being silently ignored.

- A caller that sent `$top` and received the endpoint default now receives the page size it asked
  for.
- Gears that reject an out-of-range page size rather than clamping now answer `400` where they
  answered `200`. Concretely: usage-collector rejects `$top > 1000`
  (`gears/system/usage-collector/.../usage_records.rs`) — that branch was unreachable from the wire
  before and is reachable now.
- Sending `$top` and `limit` in one request is ambiguous and answers `400 INVALID_QUERY_PARAMS`
  (serde reports the second spelling as a duplicate field).

**2. Unsupported `$`-prefixed keys now answer `400`** where they previously answered `200` with the
key discarded. Anything outside `$filter`, `$orderby`, `$select`, `$top`, `$skiptoken`: `$skip`,
`$count`, `$expand`, `$search`, `$format`, `$compute`, `$index`, `$schemaversion`, miscased
spellings such as `$Top`, and typos such as `$filtre`. The response is
`400 UNSUPPORTED_QUERY_PARAM`, one violation per offending key, each naming the key and what to
send instead.

Migration:

- Callers using `limit` and `cursor` — none.
- Callers that sent `$top` expecting it to be ignored must stop sending it, or send a value within
  the endpoint's cap. Do not send both spellings in one request.
- Callers that sent `$skip` must drop it and page with the previous response's
  `page_info.next_cursor`, sent as `$skiptoken` or `cursor`.
- Callers that sent any other `$` option must drop it.

Not affected: unprefixed query parameters of any name, and chat-engine's `/search`, which binds its
own `$top` / `$skip` in `SearchQuery` outside this extractor and is unchanged. That leaves `$skip`
working on `/search` and refused elsewhere — a platform inconsistency this PR documents but does not
resolve.

### Version bump justification

Required by CONTRIBUTING §Enforcement. No `Cargo.toml` versions are touched in this PR —
release-plz derives them from the conventional commit (`feat(toolkit)!:` + `BREAKING CHANGE:`
footer).

| Crate | Current | Expected | Why |
|---|---|---|---|
| `cf-gears-toolkit` | 0.6.18 | 0.7.0 | Breaking wire-behavior change (two of them), pre-1.0 → bump `0.(x+1).0` per the CONTRIBUTING table. No Rust-API break: the `ODataParams` field set is unchanged (serde aliases only) and `ACCEPTED_SYSTEM_QUERY_OPTIONS` is additive, so `semver_check` has nothing to flag and downstream compilation is unaffected. |
| `cf-gears-toolkit-odata` | 0.8.4 | 0.8.5 (PATCH) | Error-description string and rustdoc only. No public API or type change; `ODataLimits` intentionally kept. |
| `cf-gears-account-management` | 0.5.0 | 0.5.1 (PATCH) | One rustdoc comment corrected and one unit test's key set updated. No API, behavior, or wire change of its own. Flagged because release-plz keys off the commit, whose `!` marker describes the toolkit wire contract — if it proposes a breaking bump for AM, that is the marker leaking, not a real break. |

## Testing
- [x] Unit tests pass
  - `cargo test -p cf-gears-toolkit --lib odata` → 37 passed, 0 failed
  - `cargo test -p cf-gears-toolkit --lib` → 261 passed, 0 failed
  - `cargo test -p cf-gears-toolkit-odata --lib` → 111 passed, 0 failed
  - Blast radius, gears using the extractor: `cf-gears-account-management` → 800 passed,
    `cf-gears-usage-collector` → 368 passed
- [ ] Integration tests pass — not run locally (AM's `tests/api_*.rs` need Postgres). All six
      extractor gears were grepped for requests carrying a now-rejected option; there are none, so
      no integration expectation flips. Left to CI.
- [ ] Manual testing completed — behavior is covered by extractor-level tests that build real
      `axum` requests, so no manual pass was made.
- [x] New tests added for new functionality

Twelve tests in `libs/toolkit/src/api/odata_tests.rs`, each watched fail before the code existed:

| Test | Asserts |
|---|---|
| `test_extract_odata_query_top_binds_limit` | `?$top=10` reaches `ODataQuery.limit` |
| `test_extract_odata_query_top_zero_error` | `?$top=0` → `400`, `field_violations[0].field == "$top"`, code `INVALID_LIMIT` |
| `test_extract_odata_query_top_and_limit_conflict` | `?$top=20&limit=50` → `400 INVALID_QUERY_PARAMS` |
| `test_odata_extractor_top_alias` | End-to-end through the `OData` extractor with `$filter` + `$top` |
| `test_extract_odata_query_skiptoken_binds_cursor` | `?$skiptoken=<encoded CursorV1>` reaches `ODataQuery.cursor` |
| `test_extract_odata_query_skip_rejected` | `?$skip=20` → `400`, field `$skip`, reason `UNSUPPORTED_QUERY_PARAM`, detail names `$skiptoken` |
| `test_extract_odata_query_count_rejected` | `?$count=true` → `400`, field `$count`, detail says a page carries no total |
| `test_extract_odata_query_misspelled_option_rejected` | `?$filtre=…` → `400`, described as `unknown`, not `unsupported` |
| `test_extract_odata_query_miscased_option_rejected` | `?$Top=10` → `400`, detail names the spelling that binds |
| `test_extract_odata_query_reports_every_unsupported_option` | `?$skip&$count&$expand` → three violations, in wire order |
| `test_extract_odata_query_repeated_unsupported_option_reported_once` | `?$skip=20&$skip=40` → one violation, not two |
| `test_extract_odata_query_non_odata_params_pass_through` | `?q=needle&context=2&limit=5` → `200`; the guard must not police the non-`$` namespace |

The last one is the regression guard that matters most: it pins that handlers sharing the query
string with the extractor (chat-engine's `q` / `context`, file-storage's `offset`) keep working.

## Documentation
- [x] Code is documented with rustdoc comments — `ODataParams` (wire-binding role),
      `ODataParams.limit` and `.cursor` (both spellings each, ambiguity rule),
      `ACCEPTED_SYSTEM_QUERY_OPTIONS` and `ODATA_SYSTEM_QUERY_OPTIONS` (why a `$` key is refused as
      unsupported vs unknown), the guard itself (§6.1, and what a silent drop looks like to a
      caller), `ODataLimits` / `max_top` / `validate_top` (opt-in, not automatic), and the
      `InvalidLimit` arm in `problem_mapping.rs`
- [ ] README updated (if applicable) — not applicable
- [x] API documentation updated (if applicable) —
      `docs/toolkit_unified_system/07_odata_pagination_select_filter.md`: page size, continuation
      token, unsupported system query options, plus the error-table status correction (`422` → `400`)
      described under **Changes**. The correction changes no behavior and no crate version — the file
      lives in `docs/`, outside both crates.
      Note for gear owners: OpenAPI cannot express one parameter under two names — publish the
      spelling your gear treats as canonical and mention the other in its `description`. A gear that
      wants unprefixed accidents like `?status=approved` refused rather than ignored needs its own
      guard; the extractor only polices the `$` namespace.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No linting errors (`cargo clippy -p cf-gears-toolkit -p cf-gears-toolkit-odata -p cf-gears-account-management --all-targets` → clean)
- [x] Code is properly formatted (`cargo fmt -p cf-gears-toolkit -p cf-gears-toolkit-odata -p cf-gears-account-management -- --check` → clean)
- [x] Tests pass (see **Testing**)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - OData pagination now accepts `$top` alongside `limit`.
  - Continuation requests can use `$skiptoken` alongside `cursor`.
  - Duplicate aliases are rejected, and invalid page sizes return clear validation errors.
  - Unknown, unsupported, repeated, or incorrectly cased OData system options are rejected with HTTP 400 responses.

- **Documentation**
  - Expanded guidance on pagination aliases, supported query options, validation behavior, and error responses.
  - Clarified that non-OData query parameters continue to pass through.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
