### PR TITLE
fix(event-broker): drop comment-only files that fail cargo-shear

### DIFF
--- a/gears/system/event-broker/event-broker/src/api/rest/dto.rs
+++ b/gears/system/event-broker/event-broker/src/api/rest/dto.rs
@@ -1,2 +1,0 @@
-//! REST DTOs (serde + utoipa). Shapes finalized in #4346 against
-//! `docs/openapi.yaml` - intentionally empty until then.

--- a/gears/system/event-broker/event-broker/src/api/rest/error.rs
+++ b/gears/system/event-broker/event-broker/src/api/rest/error.rs
@@ -1,3 +1,0 @@
-//! Error response mapping: `DomainError` → RFC 9457 `Problem`
-//! (`DESIGN.md` §3.3 Error Response Format). Finalized in #4346 -
-//! intentionally empty until then.

--- a/gears/system/event-broker/event-broker/src/api/rest/extractors.rs
+++ b/gears/system/event-broker/event-broker/src/api/rest/extractors.rs
@@ -1,2 +1,0 @@
-//! Custom Axum extractors. Finalized in #4346 - intentionally empty until
-//! then.

--- a/gears/system/event-broker/event-broker/src/api/rest/mod.rs
+++ b/gears/system/event-broker/event-broker/src/api/rest/mod.rs
@@ -1,9 +1,13 @@
 //! REST transport layer (`DESIGN.md` §1.3 Architecture Layers, §3.3 API
 //! Contracts). Handler bodies and DTO wire shapes land with #4346; this
 //! crate only holds the shells `module.rs` will eventually gate per mode.
+//!
+//! #4346 adds three more modules here, left undeclared until they hold code
+//! because `cargo shear --deny-warnings` rejects comment-only files:
+//!
+//! - `dto` - serde + utoipa shapes, finalized against `docs/openapi.yaml`
+//! - `error` - `DomainError` → RFC 9457 `Problem` (§3.3 Error Response Format)
+//! - `extractors` - custom Axum extractors
 
-pub mod dto;
-pub mod error;
-pub mod extractors;
 pub mod handlers;
 pub mod routes;

--- a/gears/system/event-broker/event-broker/src/lib.rs
+++ b/gears/system/event-broker/event-broker/src/lib.rs
@@ -3,14 +3,15 @@
 //!
 //! See `docs/DESIGN.md` (module tree, §3.8 Deployment Topology, §4.1
 //! Deployment Modes) and `docs/ADR/0007-service-decomposition.md`.
+//!
+//! A `test_support` module for shared test fixtures (`DESIGN.md:614`) joins
+//! this tree once #4346/#4347 need shared test doubles.
 
 pub mod api;
 pub mod config;
 pub mod domain;
 pub mod infra;
 pub mod module;
-#[cfg(test)]
-pub mod test_support;
 
 pub use config::{DeploymentMode, EventBrokerConfig};
 pub use module::EventBrokerModule;

--- a/gears/system/event-broker/event-broker/src/test_support/mod.rs
+++ b/gears/system/event-broker/event-broker/src/test_support/mod.rs
@@ -1,2 +1,0 @@
-//! Shared test fixtures (`DESIGN.md:614`). Empty until #4346/#4347 need
-//! shared test doubles.


### PR DESCRIPTION
The REST `dto`/`error`/`extractors` shells and `test_support/mod.rs` landed in #4410 holding only doc comments. `cargo shear --expand --deny-warnings` (Makefile `shear` target) counts a file that expands to no items as empty and exits 2, so the Unused Deps job has failed on every PR based on main since that merge.

Delete the four files and their `pub mod` declarations. Their notes about what #4346/#4347 will put there move into the parent module docs, along with why the modules stay undeclared until they hold code.

No behaviour change: nothing referenced these modules, and `test_support` was `#[cfg(test)]`-gated with no test doubles in it yet.