### PR TITLE
fix(account-management): register user_update in the permission catalog

### DIFF
--- a/gears/system/account-management/account-management/src/domain/conversion/service.rs
+++ b/gears/system/account-management/account-management/src/domain/conversion/service.rs
@@ -351,6 +351,11 @@ pub(crate) mod pep {
         pub const APPROVE: &str = "approve";
         pub const LIST_OWN: &str = "list_own";
         pub const LIST_INBOUND: &str = "list_inbound";
+
+        /// Every action in this vocabulary — see the note on the user
+        /// service's `actions::ALL`. Add new actions here as well as above.
+        #[cfg(test)]
+        pub const ALL: &[&str] = &[REQUEST, CANCEL, REJECT, APPROVE, LIST_OWN, LIST_INBOUND];
     }
 }
 

--- a/gears/system/account-management/account-management/src/domain/metadata/service.rs
+++ b/gears/system/account-management/account-management/src/domain/metadata/service.rs
@@ -144,6 +144,11 @@ pub(crate) mod pep {
         /// not AM.
         pub const WRITE: &str = "write";
         pub const DELETE: &str = "delete";
+
+        /// Every action in this vocabulary — see the note on the user
+        /// service's `actions::ALL`. Add new actions here as well as above.
+        #[cfg(test)]
+        pub const ALL: &[&str] = &[READ, LIST, WRITE, DELETE];
     }
 }
 

--- a/gears/system/account-management/account-management/src/domain/tenant/service/mod.rs
+++ b/gears/system/account-management/account-management/src/domain/tenant/service/mod.rs
@@ -67,6 +67,11 @@ pub(crate) mod pep {
         pub const UPDATE: &str = "update";
         pub const DELETE: &str = "delete";
         pub const LIST_CHILDREN: &str = "list_children";
+
+        /// Every action in this vocabulary — see the note on the user
+        /// service's `actions::ALL`. Add new actions here as well as above.
+        #[cfg(test)]
+        pub const ALL: &[&str] = &[CREATE, READ, UPDATE, DELETE, LIST_CHILDREN];
     }
 }
 

--- a/gears/system/account-management/account-management/src/domain/user/service.rs
+++ b/gears/system/account-management/account-management/src/domain/user/service.rs
@@ -133,6 +133,16 @@ pub(crate) mod pep {
         pub const LIST: &str = "list";
         pub const DELETE: &str = "delete";
         pub const UPDATE: &str = "update";
+
+        /// Every action in this vocabulary, in declaration order. The
+        /// permission-catalog test asserts one `AuthzPermissionV1` per
+        /// `(resource_type, action)` pair drawn from these slices, so an
+        /// action that is enforced at a PEP gate but never declared as a
+        /// grantable permission fails the test instead of silently
+        /// becoming ungrantable. Add new actions here as well as above.
+        /// Test-only: nothing in the production path enumerates actions.
+        #[cfg(test)]
+        pub const ALL: &[&str] = &[CREATE, LIST, DELETE, UPDATE];
     }
 }
 

--- a/gears/system/account-management/account-management/src/gts/permissions.rs
+++ b/gears/system/account-management/account-management/src/gts/permissions.rs
@@ -180,10 +180,23 @@ gts_instance! {
         display_name: "Delete user".to_owned(),
     }
 }
+gts_instance! {
+    AuthzPermissionV1 {
+        id: gts_id!("cf.toolkit.authz.permission.v1~cf.core.am.user_update.v1"),
+        resource_type: USER_RESOURCE_TYPE.to_owned(),
+        action: user_actions::UPDATE.to_owned(),
+        display_name: "Update user".to_owned(),
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use toolkit_gts::{InventoryInstance, gts_id};
+
+    use super::{
+        CONVERSION_REQUEST_RESOURCE_TYPE, TENANT_METADATA_RESOURCE_TYPE, TENANT_RESOURCE_TYPE,
+        USER_RESOURCE_TYPE, conversion_actions, metadata_actions, tenant_actions, user_actions,
+    };
 
     const PERMISSION_TYPE_ID: &str = gts_id!("cf.toolkit.authz.permission.v1~");
     /// AM's instance-id namespace segment, appended after
@@ -212,6 +225,7 @@ mod tests {
         gts_id!("cf.toolkit.authz.permission.v1~cf.core.am.user_create.v1"),
         gts_id!("cf.toolkit.authz.permission.v1~cf.core.am.user_list.v1"),
         gts_id!("cf.toolkit.authz.permission.v1~cf.core.am.user_delete.v1"),
+        gts_id!("cf.toolkit.authz.permission.v1~cf.core.am.user_update.v1"),
     ];
 
     fn am_permission_instances() -> Vec<&'static InventoryInstance> {
@@ -243,6 +257,73 @@ mod tests {
                 entry.instance_id
             );
         }
+    }
+
+    /// Every `(resource_type, action)` pair an AM PEP gate can enforce,
+    /// assembled from the per-service action vocabularies rather than
+    /// restated by hand — the vocabularies are the same constants the
+    /// `PolicyEnforcer` call sites pass.
+    fn enforced_permission_pairs() -> std::collections::BTreeSet<(&'static str, &'static str)> {
+        let vocabularies: [(&'static str, &'static [&'static str]); 4] = [
+            (TENANT_RESOURCE_TYPE, tenant_actions::ALL),
+            (TENANT_METADATA_RESOURCE_TYPE, metadata_actions::ALL),
+            (CONVERSION_REQUEST_RESOURCE_TYPE, conversion_actions::ALL),
+            (USER_RESOURCE_TYPE, user_actions::ALL),
+        ];
+        vocabularies
+            .into_iter()
+            .flat_map(|(resource_type, actions)| {
+                actions.iter().map(move |action| (resource_type, *action))
+            })
+            .collect()
+    }
+
+    /// Reads the `(resource_type, action)` pair back out of each registered
+    /// instance's serialized payload.
+    fn declared_permission_pairs() -> std::collections::BTreeSet<(String, String)> {
+        am_permission_instances()
+            .iter()
+            .map(|entry| {
+                let payload = (entry.payload_fn)();
+                let field = |name: &str| {
+                    payload
+                        .get(name)
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or_else(|| {
+                            panic!("instance {} lacks a string `{name}`", entry.instance_id)
+                        })
+                        .to_owned()
+                };
+                (field("resource_type"), field("action"))
+            })
+            .collect()
+    }
+
+    /// Catalog-vs-enforcement drift guard.
+    ///
+    /// [`EXPECTED_PERMISSION_IDS`] pins instance *ids*, which only catches a
+    /// renamed or dropped instance; it cannot notice a service that starts
+    /// enforcing a brand-new action nobody declared as grantable. Comparing
+    /// the semantic `(resource_type, action)` pairs closes that gap in both
+    /// directions: an enforced-but-undeclared action leaves the permission
+    /// ungrantable to least-privilege roles, and a declared-but-unenforced
+    /// one advertises a grant that gates nothing.
+    #[test]
+    fn am_permission_catalog_matches_enforced_action_vocabulary() {
+        let declared = declared_permission_pairs();
+        let enforced: std::collections::BTreeSet<(String, String)> = enforced_permission_pairs()
+            .into_iter()
+            .map(|(resource_type, action)| (resource_type.to_owned(), action.to_owned()))
+            .collect();
+
+        let undeclared: Vec<_> = enforced.difference(&declared).collect();
+        let unenforced: Vec<_> = declared.difference(&enforced).collect();
+        assert!(
+            undeclared.is_empty() && unenforced.is_empty(),
+            "AM permission catalog drifted from the enforced action vocabulary; \
+             enforced but not declared as an AuthzPermissionV1: {undeclared:?}; \
+             declared but not in any pep::actions::ALL: {unenforced:?}"
+        );
     }
 
     #[test]

--- a/gears/system/account-management/docs/account-management-v1.yaml
+++ b/gears/system/account-management/docs/account-management-v1.yaml
@@ -274,16 +274,20 @@ paths:
       summary: List users provisioned in a tenant
       description: |
         Lists users provisioned in the tenant via the configured IdP plugin.
-        Supplying `user_id` turns the response into an authoritative existence
+        There is no per-user GET. A point lookup is
+        `?$filter=id eq <uuid>&limit=1`, which is an authoritative existence
         check — the page contains at most one element and an empty page is the
         canonical "user absent" signal (no 404). AM persists no local user
         state; every read is a pass-through to the IdP.
 
-        When `user_id` is supplied the server pins `top=1` and ignores any
-        client-provided `limit` / `cursor` — the filtered shape is an
-        existence check, not a paginated query.
+        With `id eq` the caller MUST supply `limit=1` and MUST NOT supply a
+        `cursor`; either violation is rejected with 400 rather than silently
+        corrected. `limit` is the page-size parameter — `$top` is not honoured
+        as a substitute. Filterable / sortable columns: `id`, `username`,
+        `email`, `display_name`, `first_name`, `last_name`.
       parameters:
-        - $ref: '#/components/parameters/UserIdFilter'
+        - $ref: '#/components/parameters/ODataFilter'
+        - $ref: '#/components/parameters/ODataOrderBy'
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Cursor'
       responses:
@@ -755,14 +759,6 @@ components:
       schema:
         type: string
         description: Full chained GTS schema identifier.
-    UserIdFilter:
-      name: user_id
-      in: query
-      required: false
-      schema:
-        type: string
-        format: uuid
-        description: Optional UUID user identifier filter for point lookup behavior.
     Limit:
       name: limit
       in: query


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added authorization support for updating users.
  - Tenant-user listing now supports standard `$filter` and `$orderby` query parameters.
  - Documented supported filtering and sorting fields.

- **Bug Fixes**
  - Point lookups now require `id eq <uuid>`, `limit=1`, and no cursor.
  - Removed the obsolete dedicated `user_id` query parameter and unsupported `$top` alternative.

- **Tests**
  - Added validation to ensure declared permissions and service actions remain synchronized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->