### PR TITLE
fix(toolkit): emit array responses inline instead of a `Vec` component

### DIFF
--- a/docs/api/api.json
+++ b/docs/api/api.json
@@ -1252,6 +1252,62 @@
         ],
         "type": "object"
       },
+      "GearDto": {
+        "description": "Response DTO for a single registered gear",
+        "properties": {
+          "capabilities": {
+            "description": "Declared capabilities (e.g., \"rest\", \"grpc\", \"system\", \"db\")",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "dependencies": {
+            "description": "Gear dependencies (other gear names)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "deployment_mode": {
+            "$ref": "#/components/schemas/DeploymentModeDto",
+            "description": "Whether the gear is compiled-in or out-of-process"
+          },
+          "instances": {
+            "description": "Running instances of this gear",
+            "items": {
+              "$ref": "#/components/schemas/GearInstanceDto"
+            },
+            "type": "array"
+          },
+          "name": {
+            "description": "Gear name",
+            "type": "string"
+          },
+          "plugins": {
+            "description": "Plugins provided by this gear (reserved for follow-up implementation)",
+            "items": {
+              "$ref": "#/components/schemas/PluginDto"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Gear version (if reported by a running instance)",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "capabilities",
+          "dependencies",
+          "deployment_mode",
+          "instances"
+        ],
+        "type": "object"
+      },
       "GearInstanceDto": {
         "description": "Response DTO for a running gear instance",
         "properties": {
@@ -2884,6 +2940,24 @@
           "items": {
             "items": {
               "$ref": "#/components/schemas/UserDto"
+            },
+            "type": "array"
+          },
+          "page_info": {
+            "$ref": "#/components/schemas/PageInfo"
+          }
+        },
+        "required": [
+          "items",
+          "page_info"
+        ],
+        "type": "object"
+      },
+      "Page_UsersInfoUserDto": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/UsersInfoUserDto"
             },
             "type": "array"
           },
@@ -5500,77 +5574,41 @@
         },
         "type": "object"
       },
-      "Vec": {
-        "items": {
-          "properties": {
-            "cors": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "$ref": "#/components/schemas/CorsConfig"
-                }
-              ]
-            },
-            "enabled": {
-              "type": "boolean"
-            },
-            "id": {
-              "type": "string"
-            },
-            "match": {
-              "$ref": "#/components/schemas/MatchRules"
-            },
-            "plugins": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "$ref": "#/components/schemas/PluginsConfig"
-                }
-              ]
-            },
-            "priority": {
-              "format": "int32",
-              "type": "integer"
-            },
-            "rate_limit": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "$ref": "#/components/schemas/RateLimitConfig"
-                }
-              ]
-            },
-            "tags": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "tenant_id": {
-              "format": "uuid",
-              "type": "string"
-            },
-            "upstream_id": {
-              "type": "string"
-            }
+      "UsersInfoUserDto": {
+        "description": "REST DTO for user representation with serde/utoipa\n\nAliased in the `OpenAPI` components as `UsersInfoUserDto`: the\naccount-management gear ships an unrelated `UserDto` and both are mounted in\nthe same server, so the bare ident would collide in `components.schemas`.",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "type": "string"
           },
-          "required": [
-            "id",
-            "tenant_id",
-            "upstream_id",
-            "match",
-            "priority",
-            "enabled"
-          ],
-          "type": "object"
+          "display_name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "tenant_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": "string"
+          }
         },
-        "type": "array"
+        "required": [
+          "id",
+          "tenant_id",
+          "email",
+          "display_name",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
       },
       "VersionDto": {
         "description": "One content version (`GET /files/{id}/versions`).\n\nWire shape documented in `docs/api.md` (`hash_mode`/`part_count`/`manifest`\nfields, ADR-0006).\n\n@cpt-dod:cpt-cf-file-storage-dod-content-hash-modes-docs:p2",
@@ -12604,7 +12642,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Vec"
+                  "items": {
+                    "$ref": "#/components/schemas/GearDto"
+                  },
+                  "type": "array"
                 }
               }
             },
@@ -14775,7 +14816,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Vec"
+                  "items": {
+                    "$ref": "#/components/schemas/NodeDto"
+                  },
+                  "type": "array"
                 }
               }
             },
@@ -15022,7 +15066,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Vec"
+                  "items": {
+                    "$ref": "#/components/schemas/RouteResponse"
+                  },
+                  "type": "array"
                 }
               }
             },
@@ -15576,7 +15623,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Vec"
+                  "items": {
+                    "$ref": "#/components/schemas/UpstreamResponse"
+                  },
+                  "type": "array"
                 }
               }
             },
@@ -18537,7 +18587,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Page_UserDto"
+                  "$ref": "#/components/schemas/Page_UsersInfoUserDto"
                 }
               }
             },
@@ -18629,7 +18679,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserDto"
+                  "$ref": "#/components/schemas/UsersInfoUserDto"
                 }
               }
             },
@@ -18829,7 +18879,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserDto"
+                  "$ref": "#/components/schemas/UsersInfoUserDto"
                 }
               }
             },
@@ -18916,7 +18966,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserDto"
+                  "$ref": "#/components/schemas/UsersInfoUserDto"
                 }
               }
             },

--- a/examples/toolkit/users-info/users-info/src/api/rest/dto.rs
+++ b/examples/toolkit/users-info/users-info/src/api/rest/dto.rs
@@ -5,8 +5,13 @@ use users_info_sdk::{Address, City, NewAddress, NewCity, NewUser, User, UserFull
 use uuid::Uuid;
 
 /// REST DTO for user representation with serde/utoipa
+///
+/// Aliased in the `OpenAPI` components as `UsersInfoUserDto`: the
+/// account-management gear ships an unrelated `UserDto` and both are mounted in
+/// the same server, so the bare ident would collide in `components.schemas`.
 #[derive(Debug, Clone)]
 #[toolkit_macros::api_dto(request, response)]
+#[schema(as = UsersInfoUserDto)]
 pub struct UserDto {
     pub id: Uuid,
     pub tenant_id: Uuid,

--- a/gears/chat-engine/chat-engine/src/api/rest/routes/mod.rs
+++ b/gears/chat-engine/chat-engine/src/api/rest/routes/mod.rs
@@ -120,7 +120,7 @@ pub fn register_routes(
         .authenticated()
         .require_license_features([&ChatEngineLicense])
         .handler(handlers::session_types::list_session_types)
-        .json_response_with_schema::<Vec<SessionTypeDto>>(
+        .json_array_response_with_schema::<SessionTypeDto>(
             openapi,
             StatusCode::OK,
             "Session type list",

--- a/gears/system/api-gateway/tests/integration_router.rs
+++ b/gears/system/api-gateway/tests/integration_router.rs
@@ -86,7 +86,7 @@ impl RestApiCapability for TestUsersGear {
             .query_param("limit", false, "Maximum number of users to return")
             .query_param("offset", false, "Number of users to skip")
             .public()
-            .json_response_with_schema::<Vec<User>>(
+            .json_array_response_with_schema::<User>(
                 openapi,
                 http::StatusCode::OK,
                 "Users retrieved successfully",

--- a/gears/system/gear-orchestrator/src/api/rest/routes.rs
+++ b/gears/system/gear-orchestrator/src/api/rest/routes.rs
@@ -26,7 +26,7 @@ pub fn register_routes(
         .authenticated()
         .no_license_required()
         .handler(handlers::list_gears)
-        .json_response_with_schema::<Vec<GearDto>>(
+        .json_array_response_with_schema::<GearDto>(
             openapi,
             http::StatusCode::OK,
             "List of registered gears",

--- a/gears/system/nodes-registry/nodes-registry/src/api/rest/routes.rs
+++ b/gears/system/nodes-registry/nodes-registry/src/api/rest/routes.rs
@@ -25,7 +25,7 @@ pub fn register_routes(
         .query_param("details", false, "Include detailed system information and capabilities")
         .query_param("force_refresh", false, "Force refresh syscap, ignoring cache (only applies when details=true)")
         .handler(handlers::list_nodes)
-        .json_response_with_schema::<Vec<NodeDto>>(openapi, http::StatusCode::OK, "List of nodes")
+        .json_array_response_with_schema::<NodeDto>(openapi, http::StatusCode::OK, "List of nodes")
         .error_500(openapi)
         .register(router, openapi);
 

--- a/gears/system/oagw/oagw/src/api/rest/routes/route.rs
+++ b/gears/system/oagw/oagw/src/api/rest/routes/route.rs
@@ -108,7 +108,7 @@ pub(super) fn register(
         .authenticated()
         .require_license_features::<License>([])
         .handler(handlers::route::list_routes)
-        .json_response_with_schema::<Vec<dto::RouteResponse>>(
+        .json_array_response_with_schema::<dto::RouteResponse>(
             openapi,
             http::StatusCode::OK,
             "List of routes",

--- a/gears/system/oagw/oagw/src/api/rest/routes/upstream.rs
+++ b/gears/system/oagw/oagw/src/api/rest/routes/upstream.rs
@@ -49,7 +49,7 @@ pub(super) fn register(
         .authenticated()
         .require_license_features::<License>([])
         .handler(handlers::upstream::list_upstreams)
-        .json_response_with_schema::<Vec<dto::UpstreamResponse>>(
+        .json_array_response_with_schema::<dto::UpstreamResponse>(
             openapi,
             http::StatusCode::OK,
             "List of upstreams",

--- a/gears/system/usage-collector/usage-collector/src/api/rest/routes/usage_records_tests.rs
+++ b/gears/system/usage-collector/usage-collector/src/api/rest/routes/usage_records_tests.rs
@@ -53,7 +53,7 @@ fn assert_standard_errors_registered(spec: &OperationSpec) {
         let found = spec.responses.iter().any(|r| {
             r.status == *status
                 && r.content_type == "application/problem+json"
-                && r.schema_name.is_some()
+                && r.schema_name().is_some()
         });
         assert!(
             found,
@@ -116,7 +116,7 @@ async fn create_usage_records_route_is_registered_with_documented_contract() {
             .unwrap_or_else(|| panic!("create-records route MUST declare a {status} response"));
         assert_eq!(response.content_type, "application/json");
         assert_eq!(
-            response.schema_name.as_deref(),
+            response.schema_name(),
             Some(expected_response.as_str()),
             "create-records {status} MUST point at `CreateUsageRecordsResponse`",
         );
@@ -157,7 +157,7 @@ async fn get_usage_record_route_is_registered_with_documented_contract() {
         .expect("get route MUST declare a 200 OK response");
     assert_eq!(ok_resp.content_type, "application/json");
     assert_eq!(
-        ok_resp.schema_name.as_deref(),
+        ok_resp.schema_name(),
         Some(expected_response.as_str()),
         "get 200 MUST point at `UsageRecordDto`",
     );
@@ -199,7 +199,7 @@ async fn deactivate_usage_record_route_is_registered_with_documented_contract() 
         .find(|r| r.status == StatusCode::NO_CONTENT.as_u16())
         .expect("deactivate route MUST declare a 204 No Content response");
     assert!(
-        no_content.schema_name.is_none(),
+        no_content.schema_name().is_none(),
         "deactivate 204 MUST NOT carry a body schema",
     );
 

--- a/gears/system/usage-collector/usage-collector/src/api/rest/routes/usage_types_tests.rs
+++ b/gears/system/usage-collector/usage-collector/src/api/rest/routes/usage_types_tests.rs
@@ -58,7 +58,7 @@ fn assert_standard_errors_registered(spec: &OperationSpec) {
         let found = spec.responses.iter().any(|r| {
             r.status == *status
                 && r.content_type == "application/problem+json"
-                && r.schema_name.is_some()
+                && r.schema_name().is_some()
         });
         assert!(
             found,
@@ -122,7 +122,7 @@ async fn create_usage_type_route_is_registered_with_documented_contract() {
         .expect("create-usage-type route MUST declare a 201 Created response");
     assert_eq!(created.content_type, "application/json");
     assert_eq!(
-        created.schema_name.as_deref(),
+        created.schema_name(),
         Some(expected_response.as_str()),
         "create-usage-type 201 MUST point at `UsageTypeDto`",
     );
@@ -188,7 +188,7 @@ async fn list_usage_types_route_is_registered_with_documented_contract() {
         .expect("list route MUST declare a 200 OK response");
     assert_eq!(ok.content_type, "application/json");
     assert!(
-        ok.schema_name.is_some(),
+        ok.schema_name().is_some(),
         "list 200 MUST be bound to a registered schema",
     );
 
@@ -233,7 +233,7 @@ async fn get_usage_type_route_is_registered_with_documented_contract() {
         .expect("get route MUST declare a 200 OK response");
     assert_eq!(ok.content_type, "application/json");
     assert_eq!(
-        ok.schema_name.as_deref(),
+        ok.schema_name(),
         Some(expected_response.as_str()),
         "get 200 MUST point at `UsageTypeDto`",
     );
@@ -277,7 +277,7 @@ async fn delete_usage_type_route_is_registered_with_documented_contract() {
         .find(|r| r.status == StatusCode::NO_CONTENT.as_u16())
         .expect("delete route MUST declare a 204 No Content response");
     assert!(
-        no_content.schema_name.is_none(),
+        no_content.schema_name().is_none(),
         "delete 204 MUST NOT carry a body schema",
     );
 

--- a/libs/toolkit/src/api/openapi_registry.rs
+++ b/libs/toolkit/src/api/openapi_registry.rs
@@ -19,7 +19,7 @@ use utoipa::openapi::{
     },
     request_body::RequestBodyBuilder,
     response::{ResponseBuilder, ResponsesBuilder},
-    schema::{ComponentsBuilder, ObjectBuilder, Schema, SchemaFormat, SchemaType},
+    schema::{ArrayBuilder, ComponentsBuilder, ObjectBuilder, Schema, SchemaFormat, SchemaType},
     security::{HttpAuthScheme, HttpBuilder, SecurityScheme},
     server::Server,
 };
@@ -65,6 +65,14 @@ pub trait OpenApiRegistry: Send + Sync {
 }
 
 /// Helper function to call `ensure_schema` with proper type information
+///
+/// # Panics
+/// Panics if `T` is a `Vec<_>`. utoipa names every `Vec<_>` `Vec`, so
+/// registering one as a component would collide with every other list
+/// response; use
+/// [`OperationBuilder::json_array_response_with_schema`](crate::api::operation_builder::OperationBuilder::json_array_response_with_schema)
+/// instead. Also panics if `T`'s name is already registered with a different
+/// definition (see `ensure_schema_raw`).
 pub fn ensure_schema<T: utoipa::ToSchema + utoipa::PartialSchema + 'static>(
     registry: &dyn OpenApiRegistry,
 ) -> String {
@@ -72,6 +80,19 @@ pub fn ensure_schema<T: utoipa::ToSchema + utoipa::PartialSchema + 'static>(
 
     // 1) Canonical component name for T as seen by utoipa
     let root_name = T::name().to_string();
+
+    // utoipa's default `ToSchema::name()` drops generic arguments, so every
+    // `Vec<_>` collapses to the single name `Vec` and distinct list responses
+    // clobber each other (or, since M-14, panic on collision). `Vec` is a std
+    // type, so `#[schema(as = "...")]` cannot rescue it — the caller has to use
+    // the array-aware builder instead. Guard only this one name: a legitimate
+    // user DTO could plausibly be called `Option`, `Page`, or `Map`.
+    assert!(
+        root_name != "Vec",
+        "ensure_schema::<Vec<_>>() would register the component name `Vec`, which every other \
+         Vec<T> also resolves to. Use `OperationBuilder::json_array_response_with_schema::<Item>()` \
+         to emit an inline array with only the item type named."
+    );
 
     // 2) Always insert T's own schema first (actual object, not a ref)
     //    This avoids self-referential components.
@@ -221,26 +242,14 @@ impl OpenApiRegistryImpl {
                     || r.content_type == problem::APPLICATION_PROBLEM_JSON
                     || r.content_type == "text/event-stream";
                 let resp = if is_json_like {
-                    if let Some(name) = &r.schema_name {
-                        // Manually build content to preserve the correct content type
-                        let content = ContentBuilder::new()
-                            .schema(Some(RefOr::Ref(Ref::new(format!(
-                                "#/components/schemas/{name}"
-                            )))))
-                            .build();
-                        ResponseBuilder::new()
-                            .description(&r.description)
-                            .content(r.content_type, content)
-                            .build()
-                    } else {
-                        let content = ContentBuilder::new()
-                            .schema(Some(Schema::Object(ObjectBuilder::new().build())))
-                            .build();
-                        ResponseBuilder::new()
-                            .description(&r.description)
-                            .content(r.content_type, content)
-                            .build()
-                    }
+                    // Manually build content to preserve the correct content type
+                    let content = ContentBuilder::new()
+                        .schema(Some(build_response_schema(r.schema.as_ref())))
+                        .build();
+                    ResponseBuilder::new()
+                        .description(&r.description)
+                        .content(r.content_type, content)
+                        .build()
                 } else {
                     let schema = Schema::Object(
                         ObjectBuilder::new()
@@ -356,14 +365,28 @@ impl OpenApiRegistry for OpenApiRegistryImpl {
         let mut reg = (**current).clone();
 
         for (name, schema) in schemas {
-            // Conflict policy: identical → no-op; different → warn & override
+            // Conflict policy: identical → no-op; different → HARD ERROR. Two
+            // distinct types resolving to the same schema name (utoipa uses the
+            // bare type ident by default) would otherwise silently clobber each
+            // other in `components.schemas`, producing a spec where one type
+            // masquerades under another's name — a hard-to-diagnose wire
+            // mismatch. Fail fast at registration instead.
             if let Some(existing) = reg.get(&name) {
                 let a = serde_json::to_value(existing).ok();
                 let b = serde_json::to_value(&schema).ok();
                 if a == b {
                     continue; // Skip identical schemas
                 }
-                tracing::warn!(%name, "Schema content conflict; overriding with latest");
+                panic!(
+                    "OpenAPI schema name collision: `{name}` is registered with two different \
+                     definitions. Two distinct types share the same schema name — rename one, or \
+                     give it a distinct `#[schema(as = \"...\")]` alias. For a `Vec<T>` response \
+                     use `OperationBuilder::json_array_response_with_schema::<T>()`, which emits \
+                     an inline array instead of registering a component named `Vec`. \
+                     existing={}, new={}",
+                    a.map(|v| truncate_json(&v)).unwrap_or_default(),
+                    b.map(|v| truncate_json(&v)).unwrap_or_default(),
+                );
             }
             reg.insert(name, schema);
         }
@@ -374,6 +397,20 @@ impl OpenApiRegistry for OpenApiRegistryImpl {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+/// Render a JSON value to a compact, length-bounded string for diagnostics.
+/// Bounded by character count (char-boundary safe) rather than bytes.
+fn truncate_json(v: &serde_json::Value) -> String {
+    const MAX: usize = 200;
+    let s = v.to_string();
+    if s.chars().count() > MAX {
+        let mut out: String = s.chars().take(MAX).collect();
+        out.push('\u{2026}');
+        out
+    } else {
+        s
     }
 }
 
@@ -421,6 +458,30 @@ fn build_request_body_content(
                 .schema(Some(Schema::Object(ObjectBuilder::new().build())))
                 .build()
         }
+    }
+}
+
+/// Build the response body schema for a [`operation_builder::ResponseSchema`].
+///
+/// `None` — a JSON response with no declared schema — yields a free-form
+/// object, preserving the previous behaviour.
+fn build_response_schema(schema: Option<&operation_builder::ResponseSchema>) -> RefOr<Schema> {
+    match schema {
+        Some(operation_builder::ResponseSchema::Ref { schema_name }) => {
+            RefOr::Ref(Ref::from_schema_name(schema_name.clone()))
+        }
+        // Top-level arrays are emitted INLINE, with only the item type
+        // registered as a named component. Naming the array itself would use
+        // utoipa's `Vec` (generics are stripped from `ToSchema::name()`), so
+        // every list endpoint in the process would fight over one component.
+        Some(operation_builder::ResponseSchema::Array { items_schema_name }) => {
+            RefOr::T(Schema::Array(
+                ArrayBuilder::new()
+                    .items(RefOr::Ref(Ref::from_schema_name(items_schema_name.clone())))
+                    .build(),
+            ))
+        }
+        None => RefOr::T(Schema::Object(ObjectBuilder::new().build())),
     }
 }
 
@@ -494,9 +555,55 @@ fn collect_refs_from_json(value: &serde_json::Value, refs: &mut HashSet<String>)
 mod tests {
     use super::*;
     use crate::api::operation_builder::{
-        OperationSpec, ParamLocation, ParamSpec, ResponseSpec, VendorExtensions,
+        OperationSpec, ParamLocation, ParamSpec, ResponseSchema, ResponseSpec, VendorExtensions,
     };
     use http::Method;
+
+    /// Minimal `OperationSpec` carrying a single 200 response with `schema`.
+    fn spec_with_response(
+        path: &str,
+        handler: &str,
+        schema: Option<ResponseSchema>,
+    ) -> OperationSpec {
+        OperationSpec {
+            method: Method::GET,
+            path: path.to_owned(),
+            operation_id: Some(handler.to_owned()),
+            summary: None,
+            description: None,
+            tags: vec![],
+            params: vec![],
+            request_body: None,
+            responses: vec![ResponseSpec {
+                status: 200,
+                content_type: "application/json",
+                description: "OK".to_owned(),
+                schema,
+            }],
+            handler_id: handler.to_owned(),
+            authenticated: false,
+            is_public: false,
+            rate_limit: None,
+            allowed_request_content_types: None,
+            vendor_extensions: VendorExtensions::default(),
+            license_requirement: None,
+        }
+    }
+
+    /// The 200 response schema for `path`, as JSON.
+    fn response_schema_json(doc: &serde_json::Value, path: &str) -> serde_json::Value {
+        doc["paths"][path]["get"]["responses"]["200"]["content"]["application/json"]["schema"]
+            .clone()
+    }
+
+    fn test_info() -> OpenApiInfo {
+        OpenApiInfo {
+            title: "T".to_owned(),
+            version: "1".to_owned(),
+            description: None,
+            servers: Vec::new(),
+        }
+    }
 
     #[test]
     fn test_registry_creation() {
@@ -521,7 +628,7 @@ mod tests {
                 status: 200,
                 content_type: "application/json",
                 description: "Success".to_owned(),
-                schema_name: None,
+                schema: None,
             }],
             handler_id: "get_test".to_owned(),
             authenticated: false,
@@ -585,7 +692,7 @@ mod tests {
                 status: 200,
                 content_type: "application/json",
                 description: "User found".to_owned(),
-                schema_name: None,
+                schema: None,
             }],
             handler_id: "get_users_id".to_owned(),
             authenticated: false,
@@ -645,7 +752,7 @@ mod tests {
                 status: 200,
                 content_type: "application/json",
                 description: "Upload successful".to_owned(),
-                schema_name: None,
+                schema: None,
             }],
             handler_id: "post_upload".to_owned(),
             authenticated: false,
@@ -724,7 +831,7 @@ mod tests {
                 status: 200,
                 content_type: "application/json",
                 description: "OK".to_owned(),
-                schema_name: None,
+                schema: None,
             }],
             handler_id: "get_test".to_owned(),
             authenticated: false,
@@ -846,5 +953,163 @@ mod tests {
         let openapi: OpenApi = serde_json::from_value(openapi_json).unwrap();
         let dangling = collect_all_dangling_refs_in_openapi(&openapi);
         assert_eq!(dangling, vec!["MissingDto".to_owned()]);
+    }
+
+    // --- array responses -------------------------------------------------
+    //
+    // A top-level array must be emitted inline, referencing the item type,
+    // and must NOT create a component of its own. utoipa names every `Vec<T>`
+    // `Vec`, so a named array component makes all list endpoints collide.
+
+    #[test]
+    fn array_response_emits_inline_array_referencing_item() {
+        let registry = OpenApiRegistryImpl::new();
+        registry.register_operation(&spec_with_response(
+            "/gears",
+            "list_gears",
+            Some(ResponseSchema::Array {
+                items_schema_name: "GearDto".to_owned(),
+            }),
+        ));
+
+        let doc = serde_json::to_value(registry.build_openapi(&test_info()).unwrap()).unwrap();
+        let schema = response_schema_json(&doc, "/gears");
+
+        assert_eq!(schema["type"], "array");
+        assert_eq!(schema["items"]["$ref"], "#/components/schemas/GearDto");
+        // The array itself is not a component.
+        assert!(schema.get("$ref").is_none());
+        assert!(doc["components"]["schemas"].get("Vec").is_none());
+    }
+
+    #[test]
+    fn ref_response_still_emits_plain_ref() {
+        let registry = OpenApiRegistryImpl::new();
+        registry.register_operation(&spec_with_response(
+            "/gear",
+            "get_gear",
+            Some(ResponseSchema::Ref {
+                schema_name: "GearDto".to_owned(),
+            }),
+        ));
+
+        let doc = serde_json::to_value(registry.build_openapi(&test_info()).unwrap()).unwrap();
+        let schema = response_schema_json(&doc, "/gear");
+
+        assert_eq!(schema["$ref"], "#/components/schemas/GearDto");
+        assert!(schema.get("type").is_none());
+    }
+
+    #[test]
+    fn schemaless_json_response_still_emits_free_form_object() {
+        let registry = OpenApiRegistryImpl::new();
+        registry.register_operation(&spec_with_response("/any", "any_op", None));
+
+        let doc = serde_json::to_value(registry.build_openapi(&test_info()).unwrap()).unwrap();
+        let schema = response_schema_json(&doc, "/any");
+
+        assert!(schema.get("$ref").is_none());
+        assert_ne!(schema["type"], "array");
+    }
+
+    /// The regression this whole change exists for: two list endpoints
+    /// returning different item types used to both register a component named
+    /// `Vec`, silently clobbering each other (and, after M-14, panicking).
+    #[test]
+    fn two_distinct_array_responses_do_not_collide() {
+        #[derive(utoipa::ToSchema)]
+        #[allow(dead_code)]
+        struct AlphaDto {
+            alpha: String,
+        }
+        #[derive(utoipa::ToSchema)]
+        #[allow(dead_code)]
+        struct BetaDto {
+            beta: i32,
+        }
+
+        let registry = OpenApiRegistryImpl::new();
+        // Registering the ITEM types is what the array builder method does.
+        let a = ensure_schema::<AlphaDto>(&registry);
+        let b = ensure_schema::<BetaDto>(&registry);
+        assert_eq!((a.as_str(), b.as_str()), ("AlphaDto", "BetaDto"));
+
+        registry.register_operation(&spec_with_response(
+            "/alphas",
+            "list_alphas",
+            Some(ResponseSchema::Array {
+                items_schema_name: a,
+            }),
+        ));
+        registry.register_operation(&spec_with_response(
+            "/betas",
+            "list_betas",
+            Some(ResponseSchema::Array {
+                items_schema_name: b,
+            }),
+        ));
+
+        let openapi = registry.build_openapi(&test_info()).unwrap();
+        assert!(
+            collect_all_dangling_refs_in_openapi(&openapi).is_empty(),
+            "array item refs must point at registered components"
+        );
+
+        let doc = serde_json::to_value(&openapi).unwrap();
+        let schemas = &doc["components"]["schemas"];
+        assert!(schemas.get("AlphaDto").is_some());
+        assert!(schemas.get("BetaDto").is_some());
+        assert!(schemas.get("Vec").is_none());
+        assert_eq!(
+            response_schema_json(&doc, "/alphas")["items"]["$ref"],
+            "#/components/schemas/AlphaDto"
+        );
+        assert_eq!(
+            response_schema_json(&doc, "/betas")["items"]["$ref"],
+            "#/components/schemas/BetaDto"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "would register the component name `Vec`")]
+    fn ensure_schema_rejects_vec_directly() {
+        #[derive(utoipa::ToSchema)]
+        #[allow(dead_code)]
+        struct ItemDto {
+            x: u8,
+        }
+        let registry = OpenApiRegistryImpl::new();
+        let _ = ensure_schema::<Vec<ItemDto>>(&registry);
+    }
+
+    #[test]
+    #[should_panic(expected = "OpenAPI schema name collision")]
+    fn ensure_schema_raw_panics_on_conflicting_definition() {
+        let registry = OpenApiRegistryImpl::new();
+        registry.ensure_schema_raw(
+            "Dup",
+            vec![("Dup".to_owned(), RefOr::Ref(Ref::from_schema_name("First")))],
+        );
+        registry.ensure_schema_raw(
+            "Dup",
+            vec![(
+                "Dup".to_owned(),
+                RefOr::Ref(Ref::from_schema_name("Second")),
+            )],
+        );
+    }
+
+    #[test]
+    fn ensure_schema_raw_allows_identical_reregistration() {
+        let registry = OpenApiRegistryImpl::new();
+        let entry = || {
+            vec![(
+                "Same".to_owned(),
+                RefOr::Ref(Ref::from_schema_name("Target")),
+            )]
+        };
+        registry.ensure_schema_raw("Same", entry());
+        registry.ensure_schema_raw("Same", entry());
+        assert_eq!(registry.components_registry.load().len(), 1);
     }
 }

--- a/libs/toolkit/src/api/operation_builder.rs
+++ b/libs/toolkit/src/api/operation_builder.rs
@@ -182,14 +182,53 @@ pub struct RequestBodySpec {
     pub required: bool,
 }
 
+/// Response body schema variants.
+///
+/// Mirrors [`RequestBodySchema`]. `Array` exists because utoipa's default
+/// `ToSchema::name()` strips generic arguments, so `Vec<A>` and `Vec<B>` both
+/// resolve to the component name `Vec` and clobber each other in
+/// `components.schemas`. A top-level array is therefore emitted **inline** —
+/// `{type: array, items: {$ref: T}}` — registering only the item type as a
+/// named component. That is both the `OpenAPI` norm and what utoipa's own
+/// `#[utoipa::path]` produces for a `Vec<T>` body.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ResponseSchema {
+    /// Reference to a component schema in `#/components/schemas/{schema_name}`
+    Ref { schema_name: String },
+    /// Inline array whose items `$ref` the named item component.
+    Array { items_schema_name: String },
+}
+
+impl ResponseSchema {
+    /// The component name this response ultimately references: the type itself
+    /// for [`Self::Ref`], the item type for [`Self::Array`].
+    #[must_use]
+    pub fn schema_name(&self) -> &str {
+        match self {
+            Self::Ref { schema_name } => schema_name,
+            Self::Array { items_schema_name } => items_schema_name,
+        }
+    }
+}
+
 /// Response specification for API operations
 #[derive(Clone, Debug)]
 pub struct ResponseSpec {
     pub status: u16,
     pub content_type: &'static str,
     pub description: String,
-    /// Name of a registered component schema (if any).
-    pub schema_name: Option<String>,
+    /// Schema of the response body (if any).
+    pub schema: Option<ResponseSchema>,
+}
+
+impl ResponseSpec {
+    /// Name of the component schema this response references, if any.
+    ///
+    /// For an array response this is the **item** component, not the array.
+    #[must_use]
+    pub fn schema_name(&self) -> Option<&str> {
+        self.schema.as_ref().map(ResponseSchema::schema_name)
+    }
 }
 
 /// License requirement specification for an operation
@@ -1067,7 +1106,7 @@ where
             status: status.as_u16(),
             content_type: "application/json",
             description: description.into(),
-            schema_name: None,
+            schema: None,
         });
         OperationBuilder {
             spec: self.spec,
@@ -1096,7 +1135,7 @@ where
             status: status.as_u16(),
             content_type: "",
             description: description.into(),
-            schema_name: None,
+            schema: None,
         });
         OperationBuilder {
             spec: self.spec,
@@ -1124,7 +1163,45 @@ where
             status: status.as_u16(),
             content_type: "application/json",
             description: description.into(),
-            schema_name: Some(name),
+            schema: Some(ResponseSchema::Ref { schema_name: name }),
+        });
+        OperationBuilder {
+            spec: self.spec,
+            method_router: self.method_router,
+            _has_handler: self._has_handler,
+            _has_response: PhantomData::<Present>,
+            _state: self._state,
+            _auth_state: self._auth_state,
+            _license_state: self._license_state,
+        }
+    }
+
+    /// Add a JSON response whose body is a **top-level array** of `T`
+    /// (transitions from Missing to Present).
+    ///
+    /// `T` is the *item* type — pass `GearDto`, not `Vec<GearDto>`. Registers
+    /// `T` as a named component and emits an inline
+    /// `{type: array, items: {$ref: T}}` schema for the response body.
+    ///
+    /// Never pass `Vec<T>` to [`Self::json_response_with_schema`]: utoipa's
+    /// default `ToSchema::name()` strips generic arguments, so every `Vec<_>`
+    /// registers under the single component name `Vec` and two such responses
+    /// collide fatally in `OpenApiRegistryImpl::ensure_schema_raw`.
+    pub fn json_array_response_with_schema<T>(
+        mut self,
+        registry: &dyn OpenApiRegistry,
+        status: http::StatusCode,
+        description: impl Into<String>,
+    ) -> OperationBuilder<H, Present, S, A, L>
+    where
+        T: utoipa::ToSchema + utoipa::PartialSchema + api_dto::ResponseApiDto + 'static,
+    {
+        let items_schema_name = ensure_schema::<T>(registry);
+        self.spec.responses.push(ResponseSpec {
+            status: status.as_u16(),
+            content_type: "application/json",
+            description: description.into(),
+            schema: Some(ResponseSchema::Array { items_schema_name }),
         });
         OperationBuilder {
             spec: self.spec,
@@ -1159,7 +1236,7 @@ where
             status: status.as_u16(),
             content_type,
             description: description.into(),
-            schema_name: None,
+            schema: None,
         });
         OperationBuilder {
             spec: self.spec,
@@ -1182,7 +1259,7 @@ where
             status: status.as_u16(),
             content_type: "text/html",
             description: description.into(),
-            schema_name: None,
+            schema: None,
         });
         OperationBuilder {
             spec: self.spec,
@@ -1208,7 +1285,9 @@ where
             status: status.as_u16(),
             content_type: problem::APPLICATION_PROBLEM_JSON,
             description: description.into(),
-            schema_name: Some(problem_name),
+            schema: Some(ResponseSchema::Ref {
+                schema_name: problem_name,
+            }),
         });
         OperationBuilder {
             spec: self.spec,
@@ -1235,7 +1314,7 @@ where
             status: http::StatusCode::OK.as_u16(),
             content_type: "text/event-stream",
             description: description.into(),
-            schema_name: Some(name),
+            schema: Some(ResponseSchema::Ref { schema_name: name }),
         });
         OperationBuilder {
             spec: self.spec,
@@ -1268,7 +1347,7 @@ where
             status: status.as_u16(),
             content_type: "application/json",
             description: description.into(),
-            schema_name: None,
+            schema: None,
         });
         self
     }
@@ -1283,7 +1362,7 @@ where
             status: status.as_u16(),
             content_type: "",
             description: description.into(),
-            schema_name: None,
+            schema: None,
         });
         self
     }
@@ -1303,7 +1382,31 @@ where
             status: status.as_u16(),
             content_type: "application/json",
             description: description.into(),
-            schema_name: Some(name),
+            schema: Some(ResponseSchema::Ref { schema_name: name }),
+        });
+        self
+    }
+
+    /// Add a JSON response whose body is a **top-level array** of `T` (additional).
+    ///
+    /// `T` is the *item* type — pass `GearDto`, not `Vec<GearDto>`. See
+    /// [`OperationBuilder::json_array_response_with_schema`] on the
+    /// `Missing`-response builder for why arrays are emitted inline.
+    pub fn json_array_response_with_schema<T>(
+        mut self,
+        registry: &dyn OpenApiRegistry,
+        status: http::StatusCode,
+        description: impl Into<String>,
+    ) -> Self
+    where
+        T: utoipa::ToSchema + utoipa::PartialSchema + api_dto::ResponseApiDto + 'static,
+    {
+        let items_schema_name = ensure_schema::<T>(registry);
+        self.spec.responses.push(ResponseSpec {
+            status: status.as_u16(),
+            content_type: "application/json",
+            description: description.into(),
+            schema: Some(ResponseSchema::Array { items_schema_name }),
         });
         self
     }
@@ -1330,7 +1433,7 @@ where
             status: status.as_u16(),
             content_type,
             description: description.into(),
-            schema_name: None,
+            schema: None,
         });
         self
     }
@@ -1345,7 +1448,7 @@ where
             status: status.as_u16(),
             content_type: "text/html",
             description: description.into(),
-            schema_name: None,
+            schema: None,
         });
         self
     }
@@ -1363,7 +1466,9 @@ where
             status: status.as_u16(),
             content_type: problem::APPLICATION_PROBLEM_JSON,
             description: description.into(),
-            schema_name: Some(problem_name),
+            schema: Some(ResponseSchema::Ref {
+                schema_name: problem_name,
+            }),
         });
         self
     }
@@ -1382,7 +1487,7 @@ where
             status: http::StatusCode::OK.as_u16(),
             content_type: "text/event-stream",
             description: description.into(),
-            schema_name: Some(name),
+            schema: Some(ResponseSchema::Ref { schema_name: name }),
         });
         self
     }
@@ -1448,7 +1553,9 @@ where
                 status: status.as_u16(),
                 content_type: problem::APPLICATION_PROBLEM_JSON,
                 description: description.to_owned(),
-                schema_name: Some(problem_name.clone()),
+                schema: Some(ResponseSchema::Ref {
+                    schema_name: problem_name.clone(),
+                }),
             });
         }
 
@@ -1498,7 +1605,9 @@ where
             status: http::StatusCode::BAD_REQUEST.as_u16(),
             content_type: problem::APPLICATION_PROBLEM_JSON,
             description: "Validation Error".to_owned(),
-            schema_name: Some(problem_name),
+            schema: Some(ResponseSchema::Ref {
+                schema_name: problem_name,
+            }),
         });
 
         self
@@ -1896,7 +2005,7 @@ mod tests {
                 resp.content_type,
                 toolkit_canonical_errors::problem::APPLICATION_PROBLEM_JSON
             );
-            assert!(resp.schema_name.is_some());
+            assert!(resp.schema_name().is_some());
         }
     }
 
@@ -2014,7 +2123,7 @@ mod tests {
             validation_response.content_type,
             toolkit_canonical_errors::problem::APPLICATION_PROBLEM_JSON
         );
-        assert!(validation_response.schema_name.is_some());
+        assert!(validation_response.schema_name().is_some());
     }
 
     #[test]


### PR DESCRIPTION
- utoipa's default `ToSchema::name()` strips generic arguments, so every `Vec<T>` resolves to the single component name `Vec`. Four list endpoints across gear-orchestrator, nodes-registry and oagw register a `Vec<T>` response into the same registry, so they all wrote to `components.schemas.Vec` and the last one won. The committed spec shows the damage: `Vec` holds oagw's RouteResponse array shape, all four endpoints `$ref` it, and `GearDto` is absent entirely — `Vec<T>::schemas()` forwards to `T::schemas()`, which pushes T's fields but never T itself.

- Top-level arrays are now emitted inline — `{type: array, items: {$ref: T}}` — with only the item type registered as a named component. That is the OpenAPI norm (cf. the OAI Petstore example), what utoipa's own `#[utoipa::path]` produces for a `Vec<T>` body, and what lets client generators emit `Vec<Pet>` rather than a wrapper type named after the container.

  - `ResponseSpec.schema_name: Option<String>` becomes `schema: Option<ResponseSchema>`, mirroring the `RequestBodySchema` enum already used on the request side. `ResponseSpec::schema_name()` keeps the read sites a one-word change. Adding any field would have broken the same 22 construction sites, all in-repo, so the enum costs nothing extra and rules out the illegal `(None, is_array: true)` state.
  - New `OperationBuilder::json_array_response_with_schema::<Item>()` on both response states.
  - `ensure_schema::<Vec<_>>()` now asserts: `Vec` is a std type, so `#[schema(as = ...)]` cannot disambiguate it and callers must use the array method. Guarded on that one name only — a real DTO could be called `Option` or `Map`.

- Also turns a schema-name collision into a hard error at registration instead of a warn-and-override, and fixes the one other collision that surfaced: users-info and account-management both ship a `UserDto`. The example's is aliased to `UsersInfoUserDto`, leaving the production component name (6 refs in the spec) untouched.

Spec regenerated: `Vec` removed, `GearDto` and `UsersInfoUserDto` added, no dangling refs. Seven endpoints' 200 responses change because the type they document was wrong, not because the wire format moved — the servers have always returned these shapes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation with explicit schemas for gears, nodes, routes, upstreams, and user information.
  - List endpoints now clearly describe their typed array responses.
  - User information endpoints now document dedicated user and pagination response formats.

- **Bug Fixes**
  - Improved API response definitions for more accurate schema validation and clearer integration expectations.
  - Preserved existing response behavior while resolving ambiguous generic collection descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->