### PR TITLE
feat(cluster): add the redis cluster plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,6 +393,9 @@ jobs:
       - name: Test coord with Postgres (integration)
         run: make test-coord-pg
 
+      - name: Test redis-cluster-plugin (redis integration)
+        run: make test-cluster-redis
+
       - name: Test toolkit-db (sqlite integration)
         run: make test-sqlite
 
@@ -701,6 +704,21 @@ jobs:
           tool: cargo-llvm-cov, nextest
 
       # Generate lcov.info for upload. Customize flags/features as needed.
+      #
+      # Two instrumented passes are accumulated (`--no-report`) into one target
+      # dir and merged into a single lcov.info at the end (`report`):
+      #
+      #   1. `nextest --workspace` — the whole workspace at default features.
+      #   2. The redis-cluster-plugin integration suites. These live behind
+      #      `required-features = ["integration"]` and drive a real Redis via
+      #      testcontainers, so pass 1 never builds or runs them and the plugin's
+      #      actual logic (connection / lock / pub-sub / lifecycle) showed as
+      #      uncovered — the reason this crate's patch coverage understates it.
+      #      Running them here, instead of mocking the Redis connection (brittle,
+      #      tautological), credits that code with the coverage its integration
+      #      tests already exercise. Redis containers are lightweight and
+      #      unprivileged, so this mirrors `make test-cluster-redis` verbatim
+      #      (plain `nextest`, no per-binary loop) — keep the two in sync.
       - name: Coverage (lcov)
         env:
           RUSTFLAGS: "-C debuginfo=0 --cfg coverage_nightly"
@@ -708,7 +726,13 @@ jobs:
           CARGO_LLVM_COV_BUILD_DIR: llvm-cov-build
         run: |
           cargo llvm-cov clean --workspace
-          cargo llvm-cov nextest --workspace --lcov --output-path lcov.info
+          # Pass 1: whole workspace, default features. Accumulate, don't report.
+          cargo llvm-cov nextest --workspace --no-report
+          # Pass 2: redis-cluster-plugin integration suites (real Redis via
+          # testcontainers). Same instrumentation, still no report.
+          cargo llvm-cov nextest --no-report -p cf-redis-cluster-plugin --features integration --retries 1
+          # Merge both passes into the single report that gets uploaded.
+          cargo llvm-cov report --lcov --output-path lcov.info
 
       # Upload LCOV report as a GitHub Actions artifact so it is always
       # available, even when Codecov is unavailable or rejects the upload.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,6 +1298,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "bytestring"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,6 +2131,7 @@ dependencies = [
  "cf-gears-toolkit-transport-grpc",
  "cf-gears-toolkit-utils",
  "cf-postgres-cluster-plugin",
+ "cf-redis-cluster-plugin",
  "clap",
  "futures-util",
  "opentelemetry",
@@ -4074,6 +4085,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cf-redis-cluster-plugin"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "cf-gears-cluster",
+ "cf-gears-cluster-conformance",
+ "cf-gears-cluster-sdk",
+ "cf-gears-standalone-cluster-plugin",
+ "cf-gears-toolkit",
+ "cf-gears-toolkit-macros",
+ "dashmap",
+ "fred",
+ "futures-util",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "cf-rustracing"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4436,6 +4475,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "cookie-factory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396de984970346b0d9e93d1415082923c679e5ae5c3ee3dcbd104f5610af126b"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4503,6 +4548,12 @@ dependencies = [
  "digest 0.10.7",
  "spin 0.10.0",
 ]
+
+[[package]]
+name = "crc16"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
 name = "crc32c"
@@ -5334,6 +5385,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fluent-uri"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5411,6 +5471,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
 dependencies = [
  "futures-core",
+]
+
+[[package]]
+name = "fred"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a7b2fd0f08b23315c13b6156f971aeedb6f75fb16a29ac1872d2eabccc1490e"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "bytes-utils",
+ "float-cmp",
+ "fred-macros",
+ "futures",
+ "log",
+ "parking_lot",
+ "rand 0.8.5",
+ "redis-protocol",
+ "rustls",
+ "rustls-native-certs 0.8.3",
+ "semver",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "urlencoding",
+]
+
+[[package]]
+name = "fred-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1458c6e22d36d61507034d5afecc64f105c1d39712b7ac6ec3b352c423f715cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6152,7 +6254,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -8421,7 +8523,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "sfv",
- "socket2",
+ "socket2 0.6.3",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tokio",
@@ -9073,7 +9175,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -9112,7 +9214,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -9341,6 +9443,20 @@ dependencies = [
  "time",
  "x509-parser 0.18.1",
  "yasna",
+]
+
+[[package]]
+name = "redis-protocol"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdba59219406899220fc4cdfd17a95191ba9c9afb719b5fa5a083d63109a9f1"
+dependencies = [
+ "bytes",
+ "bytes-utils",
+ "cookie-factory",
+ "crc16",
+ "log",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -10763,6 +10879,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -11530,7 +11656,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -11727,7 +11853,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2",
+ "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -11898,6 +12024,16 @@ checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
 dependencies = [
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ members = [
     "gears/system/cluster/cluster-conformance",
     "gears/system/cluster/plugins/standalone-cluster-plugin",
     "gears/system/cluster/plugins/postgres-cluster-plugin",
+    "gears/system/cluster/plugins/redis-cluster-plugin",
     "gears/system/grpc-hub",
     "gears/system/nodes-registry/nodes-registry",
     "gears/system/nodes-registry/nodes-registry-sdk",
@@ -582,6 +583,61 @@ sea-orm-migration = { version = "2.0", default-features = false, features = [
 # (not runtime-tokio-rustls) to avoid pulling in ring.
 sqlx = { version = "0.9", default-features = false, features = ["runtime-tokio", "tls-rustls-aws-lc-rs"] }
 
+# Redis/Valkey client, used only by the Redis cluster plugin
+# (gears/system/cluster/plugins/redis-cluster-plugin, see its docs/DESIGN.md §3.1).
+#
+# TLS note, and it is the same trap as the sea-orm one above: `enable-rustls`
+# activates tokio-rustls/aws_lc_rs, matching the workspace provider. fred also
+# offers `enable-rustls-ring`, which activates tokio-rustls/ring -- do NOT use it,
+# for exactly the reason recorded in the sea-orm comment above: two active rustls
+# providers make rustls 0.23 panic at runtime process-wide, not just in this plugin.
+#
+# The interface features are named individually rather than via fred's `i-std`
+# umbrella, which would additionally pull in i-lists/i-sets/i-streams/i-sorted-sets.
+# Leaving i-lists out is deliberate and load-bearing: it makes BLPOP and the rest of
+# the blocking-command family unreachable at compile time, which is what the plugin's
+# docs/TESTING.md §6 "no blocking commands" rule wants (a blocking command on a
+# shared Redis parks a connection the plugin's shutdown budget has to wait out).
+#
+# `sha-1` is deliberately absent. It gates fred's `Script::from_lua`, which hashes
+# the script client-side; the plugin instead uses the SHA that `SCRIPT LOAD` returns
+# (DESIGN.md §3.2 step 3), keeping a SHA-1 implementation out of a FIPS-gated
+# workspace's graph for what is only script-cache addressing.
+#
+# What each enabled feature buys, in the order they appear below:
+#   i-keys            GET/SET/DEL/EXISTS/PEXPIRE/PERSIST/PTTL
+#   i-hashes          HGET/HSET/HMGET/HINCRBY (the cache entry encoding)
+#   i-pubsub          PUBLISH/SUBSCRIBE/PSUBSCRIBE/PUBSUB NUMPAT
+#   i-server          INFO, WAIT
+#   i-scripts         SCRIPT LOAD / EVALSHA
+#   i-config          CONFIG GET / CONFIG SET (the startup preflight)
+#   i-cluster         Redis Cluster routing + CLUSTER COUNTKEYSINSLOT
+#   subscriber-client fred::clients::SubscriberClient (watch + lock waiters)
+#   sentinel-client   Sentinel topology discovery
+#   enable-rustls     rediss:// -- see the TLS note above
+#   partial-tracing   fred's own spans, behind the workspace tracing stack
+#
+# The mapping lives here rather than as trailing comments on the array entries,
+# and that is a tooling constraint rather than a style preference:
+# `tools/scripts/check_packaging_metadata.py` collapses multi-line inline tables
+# onto one line so Python's strict `tomllib` accepts them, and it does not strip
+# comments while doing so — a `#` inside these braces therefore swallows the
+# closing `] }` and makes the whole manifest unparseable to `make
+# check-packaging-metadata`. Keep comments about this dependency above it.
+fred = { version = "10.1", default-features = false, features = [
+    "i-keys",
+    "i-hashes",
+    "i-pubsub",
+    "i-server",
+    "i-scripts",
+    "i-config",
+    "i-cluster",
+    "subscriber-client",
+    "sentinel-client",
+    "enable-rustls",
+    "partial-tracing",
+] }
+
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 
 # File rotation for logging
@@ -694,7 +750,7 @@ trybuild = "1"
 serial_test = { version = "3", features = ["file_locks"] }
 criterion = { version = "0.8", default-features = false }
 testcontainers = { version = "0.27", default-features = false, features = ["aws-lc-rs"] }
-testcontainers-modules = { version = "0.15", default-features = false, features = ["aws-lc-rs", "postgres", "mysql"] }
+testcontainers-modules = { version = "0.15", default-features = false, features = ["aws-lc-rs", "postgres", "mysql", "redis"] }
 httpmock = "0.8"
 flate2 = "1"
 

--- a/Makefile
+++ b/Makefile
@@ -666,7 +666,7 @@ OPENAPI_BUILD_FEATURE_ARGS := $(if $(GEAR),$(GEAR_OPENAPI_FEATURE_ARGS),$(OPENAP
 
 # -------- Tests --------
 
-.PHONY: test test-no-macros test-macros test-sqlite test-pg test-pgq test-mysql test-db test-users-info-pg test-usage-collector-pg test-types-registry-db test-cluster-pg test-rg-pg test-pricing-pg test-coord-pg test-fixtures-narrow test-fips
+.PHONY: test test-no-macros test-macros test-sqlite test-pg test-pgq test-mysql test-db test-users-info-pg test-usage-collector-pg test-types-registry-db test-cluster-pg test-cluster-redis test-rg-pg test-pricing-pg test-coord-pg test-fixtures-narrow test-fips
 
 # Run all tests, or a single gear when GEAR=<gear> is set.
 # When GEAR= is set, cargo gears ls packages finds matching crates + their
@@ -820,6 +820,28 @@ test-coord-pg: install-tools
 ## consumer is the example server's release build, which never runs a test.
 test-fixtures-narrow: install-tools
 	cargo nextest run -p cf-gears-bss-fixtures --no-default-features --test production_surface
+
+## Run the Redis cluster plugin's conformance (Layer 2) and Layer 3 integration
+## suites (Docker required; each spins up its own redis container via
+## testcontainers — see
+## gears/system/cluster/plugins/redis-cluster-plugin/docs/TESTING.md §7).
+##
+## Several container shapes run per PR, all single-node: a stock server (declares
+## EventuallyConsistent), an `--appendonly yes --appendfsync always` node (declares
+## Linearizable, which the leader-election conformance suite requires), and the
+## variants the declaration-and-environment scenarios need — no keyspace
+## notifications, an unsafe `maxmemory-policy`, a tiny `maxmemory` that forces real
+## eviction, `appendfsync everysec`, a `CONFIG`-denied ACL user, and one Redis 6.
+## The Sentinel and 3-node Cluster fixtures run here too — `RD-SPEC-002` on
+## Sentinel, `RD-SPEC-008/009/010` and `RD-LOCK-014` on the Cluster. A quorum or a
+## slot assignment costs tens of seconds, but nextest overlaps that startup with
+## the rest of the suite, so it is not wall clock the run as a whole pays.
+##
+## `--retries 1` for the same reason as test-cluster-pg: container setup is
+## load-sensitive on a busy host, and a genuine logic regression fails both
+## attempts, so this absorbs Docker churn without masking one.
+test-cluster-redis: install-tools
+	cargo nextest run -p cf-redis-cluster-plugin --features integration --retries 1
 
 ## Run FIPS-mode integration tests (requires Go for aws-lc-fips-sys).
 ## Covers:

--- a/gears/system/cluster/cluster/Cargo.toml
+++ b/gears/system/cluster/cluster/Cargo.toml
@@ -108,6 +108,16 @@ uuid = { workspace = true, features = ["v4"] }
 rand = { workspace = true }
 cf-gears-standalone-cluster-plugin = { path = "../plugins/standalone-cluster-plugin", version = "0.2.3" }
 cf-postgres-cluster-plugin = { path = "../plugins/postgres-cluster-plugin", version = "0.4.1" }
+# Non-optional, following the two plugin entries above: `ClusterGear::provider_registry`
+# registers `RedisCacheProvider` and `RedisLockProvider` unconditionally, so
+# `provider: redis` resolves in any build of this gear rather than behind a cargo
+# feature an operator would have to know to enable. The accepted cost is that
+# every cluster-gear build — and therefore `cf-gears-example-server` — links
+# `fred` and its rustls stack whether or not a profile binds Redis. `sqlx` above
+# already
+# establishes that trade; if link time or binary size ever becomes a measured
+# problem, *both* plugins want the same feature gate rather than one of them.
+cf-redis-cluster-plugin = { path = "../plugins/redis-cluster-plugin", version = "0.1.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 # `fence_retention: 1h` in operator YAML (DESIGN.md). Taken

--- a/gears/system/cluster/cluster/src/config.rs
+++ b/gears/system/cluster/cluster/src/config.rs
@@ -17,6 +17,31 @@
 
 use serde::Deserialize;
 
+/// The reserved [`BackendBinding::provider`] name meaning "the SDK default backend
+/// over this profile's cache" — the omit-default behaviour, but as an *explicit*
+/// binding that can carry options.
+///
+/// Omitting a primitive entirely and binding it to `default` resolve to the same
+/// backend; the difference is that a binding has somewhere to put options.
+///
+/// The only such option today is `allow_weak_consistency`, which a profile over an
+/// eventually-consistent cache needs in order to start at all: both CAS-based SDK
+/// defaults reject such a cache, so without the opt-in a profile binding
+/// `cache: { provider: redis }` and omitting `leader_election` or `lock` fails
+/// startup (ADR-009). The option is accepted on `leader_election` and `lock`, whose
+/// defaults have that consistency guard. It defaults to `false`, so the loud startup
+/// failure stays the default behaviour, and it does **not** launder capability
+/// validation — a consumer
+/// requiring [`CacheCapability::Linearizable`](cluster_sdk::CacheCapability::Linearizable)
+/// against the same profile still fails startup regardless.
+///
+/// It is a reserved name, not a registry entry: `ClusterWiring::from_config`
+/// intercepts it *before* any [`ProviderRegistry`](crate::ProviderRegistry)
+/// lookup, so a plugin that registered a provider literally called `default` would
+/// never be reached. It is rejected outright on the `cache` binding — the cache is
+/// the anchor the defaults wrap, so there is no default cache to resolve to.
+pub const DEFAULT_PROVIDER: &str = "default";
+
 /// The whole cluster section of operator YAML: a set of named profiles.
 ///
 /// ```yaml
@@ -113,6 +138,12 @@ pub struct BackendBinding {
     /// The backend provider name, e.g. `standalone`, `postgres`, `redis`,
     /// `k8s-lease`. Matched against the registered providers at wiring time; an
     /// unknown provider fails startup with `ClusterError::InvalidConfig`.
+    ///
+    /// [`DEFAULT_PROVIDER`] (`default`) is reserved: on `leader_election` or `lock`
+    /// it selects the SDK default backend over this
+    /// profile's cache — the same backend omitting the primitive would produce,
+    /// but as a binding that can carry `allow_weak_consistency`. It is rejected
+    /// on `cache`.
     pub provider: String,
     /// A provisional, OPEN reference to the credential the backend uses to reach
     /// its infrastructure (DESIGN §3 open question — credential wiring is deferred

--- a/gears/system/cluster/cluster/src/config_tests.rs
+++ b/gears/system/cluster/cluster/src/config_tests.rs
@@ -9,12 +9,14 @@ use std::time::Duration;
 use async_trait::async_trait;
 use cluster_sdk::lock::{DistributedLockBackend, LockFeatures, LockGuard};
 use cluster_sdk::{
-    CacheCapability, ClusterCacheV1, ClusterError, ClusterLockProvider, ClusterProfile,
-    DistributedLockV1, LeaderElectionV1, ProfileHealth, StopHook, WireCacheConsistency,
+    CacheCapability, ClusterCacheBackend, ClusterCacheProvider, ClusterCacheV1, ClusterError,
+    ClusterLockProvider, ClusterProfile, DistributedLockV1, LeaderElectionV1, ProfileHealth,
+    StopHook, WireCacheConsistency,
 };
 use standalone_cluster_plugin::StandaloneCacheProvider;
 use toolkit::client_hub::ClientHub;
 
+use crate::defaults::test_cache::MemoryCache;
 use crate::domain::wiring::ClusterHandle;
 use crate::{
     BoundProfile, ClusterConfig, ClusterWiring, InstanceId, ProfileRegistry, ProviderRegistry,
@@ -546,4 +548,380 @@ profiles:
     );
 
     handle.stop().await;
+}
+
+// ---------------------------------------------------------------------------
+// The reserved `provider: default` binding and the weak-consistency opt-in
+// (`config::DEFAULT_PROVIDER` / `config::DefaultBindingOptions`).
+//
+// These exist for the Redis backend, which is the first cache in the workspace
+// to declare `EventuallyConsistent` — see
+// `plugins/redis-cluster-plugin/docs/DESIGN.md` §13 D1. Both CAS-based
+// SDK defaults reject such a cache, so without an opt-in the `Redis-only`
+// deployment shape in `gears/system/cluster/docs/DESIGN.md` §4.2 cannot start at
+// all. `MemoryCache::eventually_consistent` stands in for the Redis cache, so
+// none of this needs a container.
+// ---------------------------------------------------------------------------
+
+/// A cache provider whose backend declares `EventuallyConsistent`, standing in for
+/// the Redis cache in every replicated or non-fsync-durable configuration.
+struct WeakCacheProvider;
+
+#[async_trait]
+impl ClusterCacheProvider for WeakCacheProvider {
+    fn provider(&self) -> &'static str {
+        "weak-cache"
+    }
+
+    async fn build_cache(
+        &self,
+        _options: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<(Arc<dyn ClusterCacheBackend>, StopHook), ClusterError> {
+        Ok((
+            MemoryCache::eventually_consistent(),
+            Box::new(|| Box::pin(async {})),
+        ))
+    }
+}
+
+fn weak_cache_registry() -> ProviderRegistry {
+    ProviderRegistry::new().with_cache_provider(Arc::new(WeakCacheProvider))
+}
+
+/// A cache provider whose stop hook records that it ran, so a test can assert a
+/// failed wiring shut down the backends it had already started.
+struct StoppableCacheProvider(Arc<AtomicUsize>);
+
+#[async_trait]
+impl ClusterCacheProvider for StoppableCacheProvider {
+    fn provider(&self) -> &'static str {
+        "stoppable-weak-cache"
+    }
+
+    async fn build_cache(
+        &self,
+        _options: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<(Arc<dyn ClusterCacheBackend>, StopHook), ClusterError> {
+        let stops = Arc::clone(&self.0);
+        Ok((
+            MemoryCache::eventually_consistent(),
+            Box::new(move || {
+                Box::pin(async move {
+                    stops.fetch_add(1, Ordering::SeqCst);
+                })
+            }),
+        ))
+    }
+}
+
+#[tokio::test]
+async fn a_wiring_that_fails_stops_the_backends_it_already_started() {
+    // The regression test for the unwind DESIGN.md §3.13 describes.
+    // `from_config` builds each profile's cache — opening real pools,
+    // tasks, and connections — before it can discover that an *omitted* primitive
+    // cannot be auto-filled over that cache. On that failure it used to drop the
+    // builder, discarding the stop hooks without running them, so every backend it
+    // had started stayed running for the life of the process.
+    //
+    // It went unnoticed because the leak is quiet for the backends that existed at
+    // the time: an idle Postgres pool. The Redis plugin has an ADR-006 `Drop`
+    // guard, so the same leak *panics in a debug build* — which is how it was
+    // found, by a scenario (`RD-SPEC-004`) whose entire subject is a profile that
+    // must fail startup.
+    //
+    // A weak cache with `leader_election` omitted is the smallest way to reach it:
+    // the omit-default is a CAS backend whose consistency guard rejects the cache,
+    // and that rejection happens after `build_cache` has returned.
+    let stops = Arc::new(AtomicUsize::new(0));
+    let providers = ProviderRegistry::new()
+        .with_cache_provider(Arc::new(StoppableCacheProvider(Arc::clone(&stops))));
+    let yaml = "
+profiles:
+  event-broker:
+    cache: { provider: stoppable-weak-cache }
+";
+    let config: ClusterConfig = serde_saphyr::from_str(yaml).expect("the profile config parses");
+    let outcome = ClusterWiring::from_config(Arc::new(ClientHub::new()), &config, &providers).await;
+
+    assert!(
+        outcome.is_err(),
+        "a weak cache with leader_election omitted must fail startup - that is the default-off \
+         behaviour the opt-in exists to override"
+    );
+    assert_eq!(
+        stops.load(Ordering::SeqCst),
+        1,
+        "and the cache backend it had already started must be stopped before the error is \
+         reported, not leaked for the life of the process"
+    );
+}
+
+#[test]
+fn parses_a_default_provider_binding() {
+    let yaml = "
+profiles:
+  event-broker:
+    cache: { provider: weak-cache }
+    leader_election:
+      provider: default
+      allow_weak_consistency: true
+";
+    let cfg: ClusterConfig = serde_saphyr::from_str(yaml).expect("config parses");
+    let binding = cfg.profiles["event-broker"]
+        .leader_election
+        .as_ref()
+        .expect("the binding is present");
+    assert_eq!(binding.provider, "default");
+    assert_eq!(
+        binding
+            .options
+            .get("allow_weak_consistency")
+            .and_then(serde_json::Value::as_bool),
+        Some(true),
+        "the flag rides the flattened options map like any provider option"
+    );
+}
+
+#[tokio::test]
+async fn weak_cache_profile_fails_without_the_opt_in() {
+    // The default-off behaviour ADR-009 wants, and the behaviour an operator hits
+    // today when they bind Redis and omit the other primitives. Pinned so the
+    // opt-in cannot quietly become the default.
+    let yaml = "
+profiles:
+  event-broker:
+    cache: { provider: weak-cache }
+";
+    let cfg: ClusterConfig = serde_saphyr::from_str(yaml).expect("config parses");
+    let hub = Arc::new(ClientHub::new());
+
+    let result = ClusterWiring::from_config(Arc::clone(&hub), &cfg, &weak_cache_registry()).await;
+    let Err(ClusterError::InvalidConfig { reason }) = result else {
+        panic!("an eventually-consistent cache must not silently get the CAS defaults");
+    };
+    assert!(
+        reason.contains("linearizable") && reason.contains("new_allow_weak_consistency"),
+        "the error must say what is required and name the opt-in, got: {reason}"
+    );
+}
+
+#[tokio::test]
+async fn opting_in_on_leader_election_alone_still_fails_on_the_lock() {
+    // The regression this pair of flags exists for. `CasBasedDistributedLockBackend::new`
+    // shares `reject_weak_consistency` with the leader default, and the leader is
+    // resolved first — so waiving only the leader guard moves the startup failure
+    // a few lines down rather than resolving it. A single-flag implementation
+    // passes every leader-election test and fails here.
+    let yaml = "
+profiles:
+  event-broker:
+    cache: { provider: weak-cache }
+    leader_election:
+      provider: default
+      allow_weak_consistency: true
+";
+    let cfg: ClusterConfig = serde_saphyr::from_str(yaml).expect("config parses");
+    let hub = Arc::new(ClientHub::new());
+
+    let result = ClusterWiring::from_config(Arc::clone(&hub), &cfg, &weak_cache_registry()).await;
+    let Err(ClusterError::InvalidConfig { reason }) = result else {
+        panic!("the lock default's own consistency guard must still bite");
+    };
+    assert!(
+        reason.contains("CasBasedDistributedLockBackend"),
+        "the surviving failure must be the *lock* guard, not the leader one, got: {reason}"
+    );
+}
+
+#[tokio::test]
+async fn opting_in_on_both_cas_defaults_starts_a_weak_cache_profile() {
+    // The `Redis-only` shape, expressible at last: all three primitives resolve
+    // over an eventually-consistent cache once the operator has acknowledged the
+    // split-brain risk on each guarded primitive.
+    let yaml = "
+profiles:
+  event-broker:
+    cache: { provider: weak-cache }
+    leader_election:
+      provider: default
+      allow_weak_consistency: true
+    lock:
+      provider: default
+      allow_weak_consistency: true
+";
+    let cfg: ClusterConfig = serde_saphyr::from_str(yaml).expect("config parses");
+    let hub = Arc::new(ClientHub::new());
+
+    let (mut handle, bound) =
+        ClusterWiring::from_config(Arc::clone(&hub), &cfg, &weak_cache_registry())
+            .await
+            .expect("both opt-ins present, so the profile must start");
+    let _profiles = publish(&mut handle, bound);
+
+    for resolved in [
+        ClusterCacheV1::resolver(&hub)
+            .profile(EventBroker)
+            .resolve()
+            .await
+            .is_ok(),
+        LeaderElectionV1::resolver(&hub)
+            .profile(EventBroker)
+            .resolve()
+            .await
+            .is_ok(),
+        DistributedLockV1::resolver(&hub)
+            .profile(EventBroker)
+            .resolve()
+            .await
+            .is_ok(),
+    ] {
+        assert!(resolved, "every primitive must resolve under the opt-in");
+    }
+
+    // The flag waives a *constructor guard*; it does not launder capability
+    // validation. A consumer that declares it needs linearizable CAS still fails
+    // startup, because the cache's declaration has not changed and nothing about
+    // this flag makes it change.
+    assert!(
+        matches!(
+            ClusterCacheV1::resolver(&hub)
+                .profile(EventBroker)
+                .require(CacheCapability::Linearizable)
+                .resolve()
+                .await,
+            Err(ClusterError::CapabilityNotMet { .. })
+        ),
+        "the opt-in must not make a weak cache satisfy CacheCapability::Linearizable"
+    );
+
+    handle.stop().await;
+}
+
+#[tokio::test]
+async fn the_default_provider_is_never_looked_up_in_the_registry() {
+    // `default` is a reserved name the wiring resolves itself, not a registry
+    // entry. If the interception were ordered after the lookup, a plugin that
+    // registered a provider called `default` would silently take over the
+    // omit-default path for every profile that named it.
+    // Both guarded primitives opt in: the impostor squats on `lock`, but a profile
+    // over a weak cache still has to waive the leader guard to start at all.
+    let yaml = "
+profiles:
+  event-broker:
+    cache: { provider: weak-cache }
+    leader_election:
+      provider: default
+      allow_weak_consistency: true
+    lock:
+      provider: default
+      allow_weak_consistency: true
+";
+    let cfg: ClusterConfig = serde_saphyr::from_str(yaml).expect("config parses");
+    let hub = Arc::new(ClientHub::new());
+    let impostor_calls = Arc::new(AtomicUsize::new(0));
+    let registry =
+        weak_cache_registry().with_lock_provider(Arc::new(ImpostorDefaultLockProvider {
+            calls: Arc::clone(&impostor_calls),
+        }));
+
+    let (mut handle, bound) = ClusterWiring::from_config(Arc::clone(&hub), &cfg, &registry)
+        .await
+        .expect("the reserved name resolves without the registry");
+    let _profiles = publish(&mut handle, bound);
+
+    assert_eq!(
+        impostor_calls.load(Ordering::SeqCst),
+        0,
+        "a provider registered under the reserved name must never be built"
+    );
+
+    // And the backend actually bound is the SDK default over the cache, not the
+    // impostor: the CAS default grants an uncontended lock, the impostor refuses
+    // every acquisition.
+    let lock = DistributedLockV1::resolver(&hub)
+        .profile(EventBroker)
+        .resolve()
+        .await
+        .expect("the lock resolves");
+    assert!(
+        lock.try_lock("shard-assignment", Duration::from_secs(5))
+            .await
+            .is_ok(),
+        "the SDK default must serve the call, not a registry entry named `default`"
+    );
+
+    handle.stop().await;
+}
+
+/// A lock provider squatting on the reserved [`crate::config::DEFAULT_PROVIDER`]
+/// name. Registering it is legal — nothing stops a plugin choosing that string —
+/// so the wiring's interception order is what has to keep it unreachable.
+struct ImpostorDefaultLockProvider {
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl ClusterLockProvider for ImpostorDefaultLockProvider {
+    fn provider(&self) -> &'static str {
+        "default"
+    }
+
+    async fn build_lock(
+        &self,
+        _options: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<(Arc<dyn DistributedLockBackend>, StopHook), ClusterError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let backend = Arc::new(FakeNativeLock {
+            calls: Arc::clone(&self.calls),
+        });
+        Ok((backend, Box::new(|| Box::pin(async {}))))
+    }
+}
+
+#[tokio::test]
+async fn cache_bound_to_the_default_provider_is_rejected() {
+    // `default` means "the SDK default backend *over* a profile's cache", so it
+    // cannot name the cache itself — there would be nothing left to wrap.
+    let yaml = "
+profiles:
+  event-broker:
+    cache: { provider: default }
+";
+    let cfg: ClusterConfig = serde_saphyr::from_str(yaml).expect("config parses");
+    let hub = Arc::new(ClientHub::new());
+
+    let result = ClusterWiring::from_config(Arc::clone(&hub), &cfg, &weak_cache_registry()).await;
+    let Err(ClusterError::InvalidConfig { reason }) = result else {
+        panic!("`cache: {{ provider: default }}` must be rejected");
+    };
+    assert!(
+        reason.contains("cache") && !reason.contains("unknown cache provider"),
+        "the error must explain the reserved name rather than report it as unknown, got: {reason}"
+    );
+}
+
+#[tokio::test]
+async fn a_misspelled_option_on_a_default_binding_is_rejected() {
+    // These options reach no provider, so this is the only layer that can catch
+    // the typo. Silently ignoring it would leave the profile failing startup with
+    // the consistency-guard error, which says nothing about the misspelling.
+    let yaml = "
+profiles:
+  event-broker:
+    cache: { provider: weak-cache }
+    leader_election:
+      provider: default
+      allow_weak_consistancy: true
+";
+    let cfg: ClusterConfig = serde_saphyr::from_str(yaml).expect("config parses");
+    let hub = Arc::new(ClientHub::new());
+
+    let result = ClusterWiring::from_config(Arc::clone(&hub), &cfg, &weak_cache_registry()).await;
+    let Err(ClusterError::InvalidConfig { reason }) = result else {
+        panic!("an unknown option on a `default` binding must be rejected");
+    };
+    assert!(
+        reason.contains("allow_weak_consistancy") && reason.contains("allow_weak_consistency"),
+        "the error must show both the typo and the accepted spelling, got: {reason}"
+    );
 }

--- a/gears/system/cluster/cluster/src/defaults/test_cache.rs
+++ b/gears/system/cluster/cluster/src/defaults/test_cache.rs
@@ -111,34 +111,65 @@ enum WatchBehavior {
     Rotating,
 }
 
+/// How a fixture's [`watch_prefix`](ClusterCacheBackend::watch_prefix) behaves.
+///
+/// One enum rather than two booleans, because the three states are alternatives
+/// rather than independent switches — and because the declaration
+/// (`features().prefix_watch`) and the delivery behaviour have to agree, which two
+/// bools leave free to disagree.
+#[derive(Clone, Copy)]
+enum PrefixWatchBehavior {
+    /// A live prefix watch registered against the store, delivering on every
+    /// matching write. `features().prefix_watch` is `true`.
+    Native,
+    /// `features().prefix_watch` is `false` and `watch_prefix` answers
+    /// [`ClusterError::Unsupported`] — the no-native-prefix-watch degradation path.
+    Unsupported,
+}
+
 /// A functional in-memory cache backend for default-backend unit tests.
 pub struct MemoryCache {
     inner: Mutex<Inner>,
     consistency: CacheConsistency,
-    prefix_watch: bool,
+    prefix_watch: PrefixWatchBehavior,
     watch_behavior: WatchBehavior,
-    /// When `prefix_watch` is `false`, suspend once (`yield_now`) before
-    /// returning `Unsupported` from `watch_prefix`. Lets a test deterministically
-    /// interleave two concurrent `register`s at the maintainer-startup await.
+    /// When prefix watch is [`PrefixWatchBehavior::Unsupported`], suspend once
+    /// (`yield_now`) before returning `Unsupported` from `watch_prefix`. Lets a
+    /// test deterministically interleave two concurrent `register`s at the
+    /// maintainer-startup await.
     slow_unsupported_watch: bool,
 }
 
 impl MemoryCache {
     /// A linearizable cache with native prefix-watch support — the common case.
-    pub(super) fn linearizable() -> Arc<Self> {
-        Self::spawn(CacheConsistency::Linearizable, true)
+    /// `pub(crate)` for the same reason as
+    /// [`eventually_consistent`](Self::eventually_consistent): the wiring tests
+    /// build a *native* backend over a linearizable cache to stand beside a weak
+    /// one, proving a native binding needs no opt-in.
+    pub(crate) fn linearizable() -> Arc<Self> {
+        Self::spawn(CacheConsistency::Linearizable, PrefixWatchBehavior::Native)
     }
 
     /// An eventually-consistent cache, for exercising the constructor guard.
-    pub(super) fn eventually_consistent() -> Arc<Self> {
-        Self::spawn(CacheConsistency::EventuallyConsistent, true)
+    /// `pub(crate)` rather than `pub(super)` because the wiring's own tests need it
+    /// too: it is the stand-in for the Redis cache in the weak-consistency opt-in
+    /// tests (`config_tests.rs`, `wiring_tests.rs`), Redis being the first backend
+    /// in the workspace to declare `EventuallyConsistent`.
+    pub(crate) fn eventually_consistent() -> Arc<Self> {
+        Self::spawn(
+            CacheConsistency::EventuallyConsistent,
+            PrefixWatchBehavior::Native,
+        )
     }
 
     /// A linearizable cache that declares no native prefix watch, so
     /// `watch_prefix` returns [`ClusterError::Unsupported`] — for the
     /// prefix-watch degradation path.
     pub fn linearizable_without_prefix_watch() -> Arc<Self> {
-        Self::spawn(CacheConsistency::Linearizable, false)
+        Self::spawn(
+            CacheConsistency::Linearizable,
+            PrefixWatchBehavior::Unsupported,
+        )
     }
 
     /// A linearizable cache whose exact `watch` ends immediately on every
@@ -147,7 +178,7 @@ impl MemoryCache {
     pub(super) fn linearizable_with_dead_watch() -> Arc<Self> {
         Self::spawn_with(
             CacheConsistency::Linearizable,
-            true,
+            PrefixWatchBehavior::Native,
             WatchBehavior::DeadImmediate,
         )
     }
@@ -158,18 +189,18 @@ impl MemoryCache {
     pub(super) fn linearizable_with_rotating_watch() -> Arc<Self> {
         Self::spawn_with(
             CacheConsistency::Linearizable,
-            true,
+            PrefixWatchBehavior::Native,
             WatchBehavior::Rotating,
         )
     }
 
-    fn spawn(consistency: CacheConsistency, prefix_watch: bool) -> Arc<Self> {
+    fn spawn(consistency: CacheConsistency, prefix_watch: PrefixWatchBehavior) -> Arc<Self> {
         Self::spawn_with(consistency, prefix_watch, WatchBehavior::Normal)
     }
 
     fn spawn_with(
         consistency: CacheConsistency,
-        prefix_watch: bool,
+        prefix_watch: PrefixWatchBehavior,
         watch_behavior: WatchBehavior,
     ) -> Arc<Self> {
         Self::spawn_full(consistency, prefix_watch, watch_behavior, false)
@@ -177,7 +208,7 @@ impl MemoryCache {
 
     fn spawn_full(
         consistency: CacheConsistency,
-        prefix_watch: bool,
+        prefix_watch: PrefixWatchBehavior,
         watch_behavior: WatchBehavior,
         slow_unsupported_watch: bool,
     ) -> Arc<Self> {
@@ -335,7 +366,10 @@ impl ClusterCacheBackend for MemoryCache {
     }
 
     fn features(&self) -> CacheFeatures {
-        CacheFeatures::new(self.prefix_watch)
+        CacheFeatures::new(!matches!(
+            self.prefix_watch,
+            PrefixWatchBehavior::Unsupported
+        ))
     }
 
     async fn get(&self, key: &str) -> Result<Option<CacheEntry>, ClusterError> {
@@ -534,17 +568,21 @@ impl ClusterCacheBackend for MemoryCache {
     }
 
     async fn watch_prefix(&self, prefix: &str) -> Result<CacheWatch, ClusterError> {
-        if !self.prefix_watch {
-            if self.slow_unsupported_watch {
-                // Suspend so a concurrent caller can observe the in-progress
-                // maintainer mark before this attempt fails and rolls it back.
-                tokio::task::yield_now().await;
+        match self.prefix_watch {
+            PrefixWatchBehavior::Native => {
+                Ok(self.register_watch(WatchKind::Prefix(prefix.to_owned())))
             }
-            return Err(ClusterError::Unsupported {
-                feature: "prefix_watch",
-            });
+            PrefixWatchBehavior::Unsupported => {
+                if self.slow_unsupported_watch {
+                    // Suspend so a concurrent caller can observe the in-progress
+                    // maintainer mark before this attempt fails and rolls it back.
+                    tokio::task::yield_now().await;
+                }
+                Err(ClusterError::Unsupported {
+                    feature: "prefix_watch",
+                })
+            }
         }
-        Ok(self.register_watch(WatchKind::Prefix(prefix.to_owned())))
     }
 
     async fn scan_prefix(&self, prefix: &str) -> Result<Vec<String>, ClusterError> {

--- a/gears/system/cluster/cluster/src/domain/wiring.rs
+++ b/gears/system/cluster/cluster/src/domain/wiring.rs
@@ -18,7 +18,7 @@ use crate::defaults::{
 };
 use toolkit::client_hub::ClientHub;
 
-use crate::config::{BackendBinding, ClusterConfig, ProfileConfig};
+use crate::config::{BackendBinding, ClusterConfig, DEFAULT_PROVIDER, ProfileConfig};
 use crate::domain::local_client::LocalClusterClient;
 use crate::domain::provider::ProviderRegistry;
 use crate::domain::registry::{BoundProfile, InstanceId, ProfileInstanceRefs, ProfileRegistry};
@@ -53,6 +53,15 @@ pub struct ProfileBackends {
     /// programmatic builder path, where the resolved backends' own
     /// `provider_name()` is the only identity there is.
     providers: Option<ProviderIdentities>,
+    /// Whether an auto-filled [`CasBasedLeaderElectionBackend`] may be built over
+    /// an eventually-consistent cache, via
+    /// [`ProfileBackends::allow_weak_leader_election`]. Ignored when
+    /// `leader_election` is explicitly bound to a native backend.
+    allow_weak_leader_election: bool,
+    /// Whether an auto-filled [`CasBasedDistributedLockBackend`] may be built over
+    /// an eventually-consistent cache, via [`ProfileBackends::allow_weak_lock`].
+    /// Ignored when `lock` is explicitly bound to a native backend.
+    allow_weak_lock: bool,
 }
 
 /// The provider name behind each primitive of one profile, as the operator wrote
@@ -101,7 +110,52 @@ impl ProfileBackends {
             leader_election: None,
             lock: None,
             providers: None,
+            allow_weak_leader_election: false,
+            allow_weak_lock: false,
         }
+    }
+
+    /// Permits the auto-filled leader-election default to be built over an
+    /// eventually-consistent cache, routing it through
+    /// [`CasBasedLeaderElectionBackend::new_allow_weak_consistency`] instead of the
+    /// default-safe `new`.
+    ///
+    /// Takes no argument on purpose: calling it *is* the acknowledgement, mirroring
+    /// the SDK constructor it selects, so there is no `false` to pass and no way to
+    /// reach the weak path without naming it. Without this, a profile whose cache
+    /// declares `EventuallyConsistent` fails
+    /// [`build_and_start`](ClusterWiringBuilder::build_and_start) with
+    /// `InvalidConfig` — which is the correct default (ADR-009), not a bug to work
+    /// around.
+    ///
+    /// The config-driven equivalent is
+    /// `leader_election: { provider: default, allow_weak_consistency: true }`.
+    /// No-op when `leader_election` is bound to a native backend, which brings its
+    /// own guarantees.
+    #[must_use]
+    pub fn allow_weak_leader_election(mut self) -> Self {
+        self.allow_weak_leader_election = true;
+        self
+    }
+
+    /// Permits the auto-filled lock default to be built over an
+    /// eventually-consistent cache, routing it through
+    /// [`CasBasedDistributedLockBackend::new_allow_weak_consistency`].
+    ///
+    /// The lock counterpart of
+    /// [`allow_weak_leader_election`](Self::allow_weak_leader_election), and needed
+    /// just as often: both CAS-based defaults share the same constructor guard, so a
+    /// weak-cache profile that only permits the weak leader election still fails on
+    /// the lock. The config-driven equivalent is
+    /// `lock: { provider: default, allow_weak_consistency: true }`.
+    ///
+    /// A profile that can bind a *native* lock should prefer that — the Redis
+    /// plugin's `SET NX PX` lease is a purpose-built primitive, whereas this flag
+    /// only silences a guard over CAS on a cache that cannot support it.
+    #[must_use]
+    pub fn allow_weak_lock(mut self) -> Self {
+        self.allow_weak_lock = true;
+        self
     }
 
     /// Binds a native leader-election backend, overriding the SDK default.
@@ -167,12 +221,69 @@ impl ClusterWiring {
         config: &ClusterConfig,
         providers: &ProviderRegistry,
     ) -> Result<WiredCluster, ClusterError> {
-        // Read before any backend is built: a zero window is an operator error
-        // that must fail before a pool is opened, not after (§5.8.1).
-        let mut builder = Self::builder(hub).with_fence_retention(config.fence_retention()?)?;
+        // Wiring is all-or-nothing, and on the failure path that means *shutting
+        // down what already started* rather than merely not returning a handle.
+        // Every `?` in `wire_profiles`/`build_and_start_bound_returning_hooks` can
+        // fire after one or more profiles have had real backends built — a
+        // `build_cache_for_profile` opens a connection pool, background tasks, and
+        // (for Redis) a second subscriber connection — and those live behind stop
+        // hooks accumulated on `builder`. Dropping the builder discards the hooks
+        // without running them, so a misconfigured profile leaked every backend it
+        // managed to build before failing.
+        //
+        // Invisible for a long time, because the Postgres plugin's leak is a quiet
+        // idle pool. The Redis plugin has an ADR-006 `Drop` guard, so the same
+        // leak **panics in a debug build** — which is how this was found, by
+        // `RD-SPEC-004`, whose whole subject is a profile that must fail startup
+        // (redis-cluster-plugin/docs/TESTING.md §4.6).
+        //
+        // `fence_retention` is read before any backend is built: a zero window is
+        // an operator error that must fail before a pool is opened, and with no
+        // hooks yet accumulated a plain `?` here has nothing to unwind (§5.8.1).
+        let builder = Self::builder(hub).with_fence_retention(config.fence_retention()?)?;
+        let builder = match Self::wire_profiles(builder, config, providers).await {
+            Ok(builder) => builder,
+            Err((err, hooks)) => {
+                run_stop_hooks_on_failed_wiring(hooks).await;
+                return Err(err);
+            }
+        };
+        match builder.build_and_start_bound_returning_hooks() {
+            Ok(wired) => Ok(wired),
+            Err((err, hooks)) => {
+                run_stop_hooks_on_failed_wiring(hooks).await;
+                Err(err)
+            }
+        }
+    }
+
+    /// Wires every profile in `config` onto `builder`.
+    ///
+    /// Hands the accumulated [`StopHook`]s back alongside the error rather than
+    /// letting them drop, so [`from_config`](Self::from_config) can shut down the
+    /// backends earlier profiles already started. That is the only reason this is a
+    /// separate function: the loop body is otherwise unchanged, and `?` inside it
+    /// would discard exactly what the caller needs.
+    async fn wire_profiles(
+        mut builder: ClusterWiringBuilder,
+        config: &ClusterConfig,
+        providers: &ProviderRegistry,
+    ) -> Result<ClusterWiringBuilder, (ClusterError, Vec<StopHook>)> {
+        macro_rules! unwind_on_err {
+            ($result:expr, $builder:expr) => {
+                match $result {
+                    Ok(value) => value,
+                    Err(err) => return Err((err, $builder.take_stop_hooks())),
+                }
+            };
+        }
+
         for (name, profile) in &config.profiles {
             tracing::debug!(profile = %name, "wiring cluster profile from config");
-            let (cache, cache_stop) = build_cache_for_profile(name, profile, providers).await?;
+            let (cache, cache_stop) = unwind_on_err!(
+                build_cache_for_profile(name, profile, providers).await,
+                builder
+            );
             // Pushed immediately, so it matches the cache's actual start-order
             // position (first). `build_and_start` runs `stop_hooks` in reverse push
             // order, so pushing here — before the leader/lock hooks below — means
@@ -183,7 +294,9 @@ impl ClusterWiring {
             let mut backends = ProfileBackends::new(Arc::clone(&cache));
             // Recorded before the bindings are resolved, because it is the
             // *config* that says which provider serves each primitive, and an
-            // omitted primitive inherits the cache's provider (§5.5).
+            // omitted primitive — or a `default` sentinel binding, which the SDK
+            // default still layers over this cache — inherits the cache's provider
+            // (§5.5). `binding_provider` folds the sentinel into that omitted case.
             backends.providers = Some(ProviderIdentities {
                 cache: profile.cache.provider.clone(),
                 leader_election: binding_provider(
@@ -193,47 +306,180 @@ impl ClusterWiring {
                 lock: binding_provider(profile.lock.as_ref(), &profile.cache.provider),
             });
 
-            if let Some(binding) = &profile.leader_election {
-                let provider = providers
-                    .leader_election_provider(&binding.provider)
-                    .ok_or_else(|| ClusterError::InvalidConfig {
-                        reason: format!(
-                            "profile `{name}`: unknown leader_election provider `{}`",
-                            binding.provider
-                        ),
-                    })?;
-                let (backend, stop) = provider.build_leader_election(&binding.options).await?;
-                backends = backends.with_leader_election(backend);
+            // The two optional primitives, each either natively bound through its
+            // own provider registry or riding the omit-default auto-wrap, and each
+            // honouring the reserved [`DEFAULT_PROVIDER`] sentinel. One helper
+            // apiece rather than two near-identical blocks inline: they differ only
+            // in which registry they consult and which `with_*` setter they call.
+            //
+            // Each appends its plugin stop hook to `hooks` rather than pushing
+            // straight onto the builder, so a failure in a later binding can unwind
+            // the earlier ones too — `bind_lock` failing after `bind_leader_election`
+            // started a native leader backend has to stop it. The local hooks are
+            // handed to the builder before any error is returned, which is what
+            // `take_stop_hooks` then collects.
+            let mut hooks: Vec<StopHook> = Vec::new();
+            let bound = async {
+                let backends =
+                    bind_leader_election(name, profile, providers, backends, &mut hooks).await?;
+                bind_lock(name, profile, providers, backends, &mut hooks).await
+            }
+            .await;
+            for stop in hooks {
                 builder = builder.on_stop(move || async move { stop().await });
             }
-
-            if let Some(binding) = &profile.lock {
-                let provider = providers.lock_provider(&binding.provider).ok_or_else(|| {
-                    ClusterError::InvalidConfig {
-                        reason: format!(
-                            "profile `{name}`: unknown lock provider `{}`",
-                            binding.provider
-                        ),
-                    }
-                })?;
-                let (backend, stop) = provider.build_lock(&binding.options).await?;
-                backends = backends.with_lock(backend);
-                builder = builder.on_stop(move || async move { stop().await });
-            }
+            backends = unwind_on_err!(bound, builder);
 
             builder = builder.profile_named(name.clone(), backends);
         }
-        builder.build_and_start_bound()
+        Ok(builder)
     }
 }
 
-/// The provider serving a primitive: its own binding's when it has one, else the
-/// `cache_provider` the omit-default SDK backend is layered over (§5.5).
+/// Runs the stop hooks of a wiring that failed partway, newest first.
+///
+/// Reverse push order, the same order [`ClusterHandle::stop`] uses, so a
+/// primitive layered on a cache is stopped before the cache it rides. Failures
+/// are not propagated: the caller already has an error to report, and it is the
+/// *configuration* error an operator needs to see rather than whatever a
+/// best-effort teardown then said.
+async fn run_stop_hooks_on_failed_wiring(hooks: Vec<StopHook>) {
+    if hooks.is_empty() {
+        return;
+    }
+    tracing::debug!(
+        hooks = hooks.len(),
+        "cluster wiring failed after starting backends; stopping them before reporting"
+    );
+    for hook in hooks.into_iter().rev() {
+        hook().await;
+    }
+}
+
+/// Binds a profile's `leader_election`, honouring the reserved
+/// [`DEFAULT_PROVIDER`] sentinel.
+///
+/// The sentinel is checked *before* the registry lookup, so the reserved name can
+/// never be shadowed by a plugin that registers a provider called `default`. It
+/// contributes no backend and no stop hook — [`resolve_profile_backends`] still
+/// supplies the SDK default and owns its shutdown-revoke seam; all the binding does
+/// is carry the operator's `allow_weak_consistency` acknowledgement to it.
+async fn bind_leader_election(
+    name: &str,
+    profile: &ProfileConfig,
+    providers: &ProviderRegistry,
+    mut backends: ProfileBackends,
+    hooks: &mut Vec<StopHook>,
+) -> Result<ProfileBackends, ClusterError> {
+    let Some(binding) = &profile.leader_election else {
+        return Ok(backends);
+    };
+    if binding.provider == DEFAULT_PROVIDER {
+        if guarded_default_options(name, "leader_election", binding)?.allow_weak_consistency {
+            backends = backends.allow_weak_leader_election();
+        }
+        return Ok(backends);
+    }
+    let provider = providers
+        .leader_election_provider(&binding.provider)
+        .ok_or_else(|| ClusterError::InvalidConfig {
+            reason: format!(
+                "profile `{name}`: unknown leader_election provider `{}`",
+                binding.provider
+            ),
+        })?;
+    let (backend, stop) = provider.build_leader_election(&binding.options).await?;
+    hooks.push(stop);
+    Ok(backends.with_leader_election(backend))
+}
+
+/// Binds a profile's `lock`, honouring the reserved [`DEFAULT_PROVIDER`] sentinel.
+/// See [`bind_leader_election`] for how the sentinel is handled.
+async fn bind_lock(
+    name: &str,
+    profile: &ProfileConfig,
+    providers: &ProviderRegistry,
+    mut backends: ProfileBackends,
+    hooks: &mut Vec<StopHook>,
+) -> Result<ProfileBackends, ClusterError> {
+    let Some(binding) = &profile.lock else {
+        return Ok(backends);
+    };
+    if binding.provider == DEFAULT_PROVIDER {
+        if guarded_default_options(name, "lock", binding)?.allow_weak_consistency {
+            backends = backends.allow_weak_lock();
+        }
+        return Ok(backends);
+    }
+    let provider =
+        providers
+            .lock_provider(&binding.provider)
+            .ok_or_else(|| ClusterError::InvalidConfig {
+                reason: format!(
+                    "profile `{name}`: unknown lock provider `{}`",
+                    binding.provider
+                ),
+            })?;
+    let (backend, stop) = provider.build_lock(&binding.options).await?;
+    hooks.push(stop);
+    Ok(backends.with_lock(backend))
+}
+
+/// The options a `provider: `[`DEFAULT_PROVIDER`] binding may carry, for a primitive
+/// whose SDK default backend has a consistency guard (`leader_election` and `lock`).
+///
+/// Lives here rather than in [`crate::config`] because it is a wiring-internal
+/// parsing detail: unlike every other binding option, these keys never reach a
+/// provider, so nothing outside this module ever sees the parsed form. The
+/// operator-facing half — what the flag means and where it is accepted — is
+/// documented on [`DEFAULT_PROVIDER`].
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DefaultBindingOptions {
+    /// Route this primitive's SDK default through `new_allow_weak_consistency`
+    /// instead of the default-safe `new`, accepting that an eventually-consistent
+    /// cache may produce split-brain (dual leaders / dual lock holders) under
+    /// partition (ADR-009). Default `false`.
+    #[serde(default)]
+    allow_weak_consistency: bool,
+}
+
+/// Parses a `provider: `[`DEFAULT_PROVIDER`] binding's options for one of the two
+/// primitives whose SDK default carries a consistency guard.
+///
+/// `deny_unknown_fields` on [`DefaultBindingOptions`] does the work: these options
+/// reach no provider, so this is the only layer that can catch an operator's typo,
+/// and a silently-ignored `allow_weak_consistancy` would leave the profile failing
+/// startup with an error that says nothing about the misspelling.
+fn guarded_default_options(
+    profile: &str,
+    primitive: &str,
+    binding: &BackendBinding,
+) -> Result<DefaultBindingOptions, ClusterError> {
+    serde_json::from_value(serde_json::Value::Object(binding.options.clone())).map_err(|err| {
+        ClusterError::InvalidConfig {
+            reason: format!(
+                "profile `{profile}`: invalid options on `{primitive}: {{ provider: \
+                 {DEFAULT_PROVIDER} }}`: {err}. The only option this binding accepts is \
+                 `allow_weak_consistency: <bool>`"
+            ),
+        }
+    })
+}
+
+/// The provider serving a primitive: its own binding's when it names a real one,
+/// else the `cache_provider` the omit-default SDK backend is layered over (§5.5).
+///
+/// A `provider: `[`DEFAULT_PROVIDER`] binding reports the cache provider too, not
+/// the literal `default`: the sentinel selects the same SDK default an omitted
+/// primitive gets, layered over this profile's cache, so the identity a consumer
+/// sees in `CapabilityNotMet { provider }` is that cache's — the backend that
+/// actually stores the coordination records.
 fn binding_provider(binding: Option<&BackendBinding>, cache_provider: &str) -> String {
-    binding.map_or_else(
-        || cache_provider.to_owned(),
-        |binding| binding.provider.clone(),
-    )
+    match binding {
+        Some(binding) if binding.provider != DEFAULT_PROVIDER => binding.provider.clone(),
+        _ => cache_provider.to_owned(),
+    }
 }
 
 async fn build_cache_for_profile(
@@ -241,6 +487,21 @@ async fn build_cache_for_profile(
     profile: &ProfileConfig,
     providers: &ProviderRegistry,
 ) -> Result<(Arc<dyn ClusterCacheBackend>, StopHook), ClusterError> {
+    // The cache is the anchor every SDK default wraps, so there is no "default
+    // cache" for the reserved name to resolve to. Caught here rather than left to
+    // the registry lookup, which would answer the misleading "unknown cache
+    // provider `default`" — misleading because `default` *is* a name the wiring
+    // knows, just not one this binding can use.
+    if profile.cache.provider == DEFAULT_PROVIDER {
+        return Err(ClusterError::InvalidConfig {
+            reason: format!(
+                "profile `{name}`: `cache: {{ provider: {DEFAULT_PROVIDER} }}` is not valid — \
+                 `{DEFAULT_PROVIDER}` selects the SDK default backend *over* a profile's cache, \
+                 so the cache itself must name a real provider (e.g. `standalone`, `postgres`, \
+                 `redis`)"
+            ),
+        });
+    }
     let provider = providers
         .cache_provider(&profile.cache.provider)
         .ok_or_else(|| ClusterError::InvalidConfig {
@@ -348,28 +609,71 @@ impl ClusterWiringBuilder {
         Ok(handle)
     }
 
+    /// Removes and returns every stop hook registered so far.
+    ///
+    /// Exists for one caller: [`ClusterWiring::from_config`]'s failure path, which
+    /// has to shut down the backends already-wired profiles started rather than
+    /// drop their hooks unrun (see the note there). Deliberately **not** public —
+    /// a builder that has had its hooks taken will not stop what it started, which
+    /// is only safe when the caller is about to run them itself.
+    fn take_stop_hooks(&mut self) -> Vec<StopHook> {
+        std::mem::take(&mut self.stop_hooks)
+    }
+
     /// [`build_and_start`](Self::build_and_start), also returning the
     /// bound-profile set (DESIGN §5.2).
     ///
     /// The config-driven [`ClusterWiring::from_config`] surfaces this set to its
     /// caller; the programmatic builder path does not need it yet, so
     /// `build_and_start` keeps its shape and drops it.
+    ///
+    /// A direct builder caller registered its stop hooks itself and still owns
+    /// whatever they close over, so a resolution failure drops them — the
+    /// pre-existing contract. Only [`ClusterWiring::from_config`], which built
+    /// those backends on the caller's behalf, uses the hook-returning form so it
+    /// can shut them down.
     fn build_and_start_bound(self) -> Result<WiredCluster, ClusterError> {
+        self.build_and_start_bound_returning_hooks()
+            .map_err(|(err, hooks)| {
+                drop(hooks);
+                err
+            })
+    }
+
+    /// [`build_and_start_bound`](Self::build_and_start_bound), handing the
+    /// accumulated stop hooks back on failure instead of dropping them.
+    ///
+    /// The distinction matters only for [`ClusterWiring::from_config`], which
+    /// starts every backend itself: a resolution failure there leaves real pools,
+    /// tasks, and connections running behind these hooks, and the Redis plugin's
+    /// ADR-006 `Drop` guard turns leaking them into a debug-build panic
+    /// (redis-cluster-plugin/docs/DESIGN.md §11).
+    fn build_and_start_bound_returning_hooks(
+        mut self,
+    ) -> Result<WiredCluster, (ClusterError, Vec<StopHook>)> {
+        macro_rules! unwind_on_err {
+            ($result:expr, $self:expr) => {
+                match $result {
+                    Ok(value) => value,
+                    Err(err) => return Err((err, $self.take_stop_hooks())),
+                }
+            };
+        }
+
         // Phase 1 — resolve all backends (fallible) before touching the hub.
         // Default leader-election and lock backends the wiring itself creates
         // expose a shutdown-revoke seam; collect them so
         // `ClusterHandle::stop` can revoke in-flight coordination before shutdown
         // completes (DESIGN §3.13). Native (explicitly-bound) backends are not
         // revoked here — they manage shutdown through their own plugin stop hook.
-        let mut bound = Vec::with_capacity(self.profiles.len());
+        let profiles = std::mem::take(&mut self.profiles);
+        let mut bound = Vec::with_capacity(profiles.len());
         let mut revokers: Vec<Arc<dyn ShutdownRevoke>> = Vec::new();
-        for (name, backends) in self.profiles {
-            bound.push(resolve_profile_backends(
-                name,
-                backends,
-                self.fence_retention,
-                &mut revokers,
-            )?);
+        for (name, backends) in profiles {
+            bound.push(unwind_on_err!(
+                resolve_profile_backends(name, backends, self.fence_retention, &mut revokers),
+                self
+            ));
         }
 
         // Phase 2 — register every primitive under the profile scope. A failure
@@ -378,15 +682,19 @@ impl ClusterWiringBuilder {
         // so far before propagating the error — the hub stays all-or-nothing.
         let mut registered: Vec<String> = Vec::with_capacity(bound.len());
         for profile in &bound {
-            register_profile_or_rollback(&self.hub, profile, &registered)?;
+            unwind_on_err!(
+                register_profile_or_rollback(&self.hub, profile, &registered),
+                self
+            );
             registered.push(profile.name.clone());
         }
 
+        let stop_hooks = self.take_stop_hooks();
         Ok((
             ClusterHandle {
                 hub: self.hub,
                 registered,
-                stop_hooks: self.stop_hooks,
+                stop_hooks,
                 revokers,
                 profiles: None,
                 stopped: false,
@@ -437,20 +745,33 @@ fn resolve_profile_backends(
         if let Some(backend) = backends.leader_election {
             backend
         } else {
-            let default = Arc::new(
+            // Both arms build the same backend over the reserved lease cache; they
+            // differ only in whether the consistency guard is enforced or explicitly
+            // waived (`ProfileBackends::allow_weak_leader_election`, reached from YAML
+            // as `leader_election: { provider: default, allow_weak_consistency: true }`).
+            // The weak constructor is infallible and logs its own split-brain
+            // warning, so the `?` lives on the guarded arm alone.
+            let backend = if backends.allow_weak_leader_election {
+                CasBasedLeaderElectionBackend::new_allow_weak_consistency(Arc::clone(&lease_cache))
+            } else {
                 CasBasedLeaderElectionBackend::new(Arc::clone(&lease_cache))?
-                    .with_fence_retention(fence_retention),
-            );
+            };
+            let default = Arc::new(backend.with_fence_retention(fence_retention));
             revokers.push(Arc::clone(&default) as Arc<dyn ShutdownRevoke + Send + Sync>);
             default as Arc<dyn LeaderElectionBackend>
         };
     let lock: Arc<dyn DistributedLockBackend> = if let Some(backend) = backends.lock {
         backend
     } else {
-        let default = Arc::new(
+        // The lock default shares the leader default's constructor guard, so a
+        // weak-cache profile has to waive both or neither — waiving only the leader
+        // one moves the startup failure four lines down rather than resolving it.
+        let backend = if backends.allow_weak_lock {
+            CasBasedDistributedLockBackend::new_allow_weak_consistency(Arc::clone(&lease_cache))
+        } else {
             CasBasedDistributedLockBackend::new(Arc::clone(&lease_cache))?
-                .with_fence_retention(fence_retention),
-        );
+        };
+        let default = Arc::new(backend.with_fence_retention(fence_retention));
         revokers.push(Arc::clone(&default) as Arc<dyn ShutdownRevoke>);
         default as Arc<dyn DistributedLockBackend>
     };
@@ -618,11 +939,11 @@ impl ClusterHandle {
     ///    started is stopped first). The standalone plugin's stop hook closes
     ///    active **cache** watches via the plugin's `StandaloneCache::shutdown`,
     ///    so a cache-watch consumer observes `Closed(Shutdown)` one phase after the
-    ///    leader/lock/SD revocation — still within `stop()` (the chosen simplest
+    ///    leader/lock revocation — still within `stop()` (the chosen simplest
     ///    path; the slight ordering is intentional).
     ///
     /// No best-effort remote cleanup is attempted; TTL bounds any remaining
-    /// cluster resources — held leader claims, locks, and service registrations
+    /// cluster resources — held leader claims and locks
     /// all lapse via their backend TTL (`cpt-cf-clst-fr-shutdown-ttl-cleanup`).
     pub async fn stop(mut self) {
         tracing::info!(

--- a/gears/system/cluster/cluster/src/domain/wiring_tests.rs
+++ b/gears/system/cluster/cluster/src/domain/wiring_tests.rs
@@ -12,6 +12,7 @@ use cluster_sdk::{
 };
 use standalone_cluster_plugin::StandaloneClusterPlugin;
 
+use crate::defaults::test_cache::MemoryCache;
 use crate::defaults::{CasBasedDistributedLockBackend, CasBasedLeaderElectionBackend};
 use toolkit::client_hub::ClientHub;
 use tracing_test::traced_test;
@@ -441,6 +442,97 @@ async fn two_profiles_on_one_cache_report_one_cache_instance() {
     handle.stop().await;
 }
 
+// ---------------------------------------------------------------------------
+// The programmatic weak-consistency opt-in
+// (`ProfileBackends::allow_weak_leader_election` / `allow_weak_lock`).
+//
+// The config-driven half of this — the reserved `provider: default` binding that
+// reaches these builders from operator YAML — is tested in `config_tests.rs`
+// alongside the rest of the `from_config` path. These cover the builder API a
+// host using `ClusterWiring::builder()` calls directly, which is a separate
+// public entry point rather than a wrapper over the YAML one.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_weak_cache_profile_fails_without_the_builder_opt_ins() {
+    let hub = Arc::new(ClientHub::new());
+
+    let result = ClusterWiring::builder(hub)
+        .profile(
+            EventBroker,
+            ProfileBackends::new(MemoryCache::eventually_consistent()),
+        )
+        .build_and_start();
+
+    assert!(
+        matches!(result, Err(ClusterError::InvalidConfig { .. })),
+        "the CAS defaults' consistency guard must reject a weak cache by default"
+    );
+}
+
+#[tokio::test]
+async fn the_leader_opt_in_alone_still_fails_on_the_lock() {
+    // Both CAS defaults share one guard, and the leader is resolved first, so a
+    // single-flag implementation looks correct until the lock is reached. The
+    // config-level counterpart is
+    // `opting_in_on_leader_election_alone_still_fails_on_the_lock`.
+    let hub = Arc::new(ClientHub::new());
+
+    let result = ClusterWiring::builder(hub)
+        .profile(
+            EventBroker,
+            ProfileBackends::new(MemoryCache::eventually_consistent()).allow_weak_leader_election(),
+        )
+        .build_and_start();
+
+    let Err(ClusterError::InvalidConfig { reason }) = result else {
+        panic!("the lock default's guard must still bite");
+    };
+    assert!(
+        reason.contains("CasBasedDistributedLockBackend"),
+        "the surviving failure must be the lock guard, got: {reason}"
+    );
+}
+
+#[tokio::test]
+async fn both_builder_opt_ins_start_a_weak_cache_profile() {
+    let hub = Arc::new(ClientHub::new());
+
+    let handle = ClusterWiring::builder(Arc::clone(&hub))
+        .profile(
+            EventBroker,
+            ProfileBackends::new(MemoryCache::eventually_consistent())
+                .allow_weak_leader_election()
+                .allow_weak_lock(),
+        )
+        .build_and_start()
+        .expect("both opt-ins present, so the profile must start");
+
+    // The auto-filled defaults track the cache's declaration rather than claiming
+    // a guarantee the opt-in cannot confer: waiving the *constructor guard* does
+    // not make the backend linearizable.
+    let leader = LeaderElectionV1::resolver(&hub)
+        .profile(EventBroker)
+        .resolve()
+        .await
+        .expect("the weak leader default resolves");
+    assert!(
+        !leader.features().linearizable,
+        "the leader default must keep reporting linearizable: false over a weak cache"
+    );
+    let lock = DistributedLockV1::resolver(&hub)
+        .profile(EventBroker)
+        .resolve()
+        .await
+        .expect("the weak lock default resolves");
+    assert!(
+        !lock.features().linearizable,
+        "the lock default must keep reporting linearizable: false over a weak cache"
+    );
+
+    handle.stop().await;
+}
+
 /// The hub stays all-or-nothing: a later profile failing registration rolls back
 /// every profile registered before it (DESIGN §3.7). Returning the bound-profile
 /// set does not change that — the set is built first, but nothing is published
@@ -483,4 +575,58 @@ async fn a_failed_registration_rolls_back_the_profiles_before_it() {
     );
 
     plugin.stop().await;
+}
+
+#[tokio::test]
+async fn a_natively_bound_lock_needs_no_opt_in_over_a_weak_cache() {
+    // The shape the Redis plugin actually ships: a weak cache with a *native*
+    // lock bound over it. The lock guard never runs, because no CAS default is
+    // auto-filled for that primitive — so only leader election needs the flag.
+    // This is why the plugin's own operator YAML binds `lock: { provider: redis }`
+    // rather than reaching for a second opt-in.
+    let hub = Arc::new(ClientHub::new());
+    let calls = Arc::new(AtomicUsize::new(0));
+
+    let handle = ClusterWiring::builder(Arc::clone(&hub))
+        .profile(
+            EventBroker,
+            ProfileBackends::new(MemoryCache::eventually_consistent())
+                .allow_weak_leader_election()
+                .with_lock(Arc::new(MarkerLockBackend {
+                    // Stands in for a purpose-built lock (the Redis plugin's
+                    // `SET NX PX` lease). Its own inner backend rides a
+                    // linearizable cache, which is exactly the point: a native
+                    // binding brings its own guarantees rather than inheriting the
+                    // profile cache's.
+                    inner: Arc::new(
+                        CasBasedDistributedLockBackend::new(MemoryCache::linearizable())
+                            .expect("lock backend over linearizable cache"),
+                    ),
+                    calls: Arc::clone(&calls),
+                })),
+        )
+        .build_and_start()
+        .expect("a native lock over a weak cache needs no lock opt-in");
+
+    let lock = DistributedLockV1::resolver(&hub)
+        .profile(EventBroker)
+        .resolve()
+        .await
+        .expect("the native lock resolves");
+    let acquired = lock
+        .try_lock("shard-assignment", Duration::from_secs(5))
+        .await;
+    assert!(
+        acquired.is_ok(),
+        "the native lock's own backend rides a linearizable cache, so this uncontended \
+         acquisition must succeed: {acquired:?}"
+    );
+    drop(acquired);
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "the natively-bound lock must serve the call, not a CAS default"
+    );
+
+    handle.stop().await;
 }

--- a/gears/system/cluster/cluster/src/gear.rs
+++ b/gears/system/cluster/cluster/src/gear.rs
@@ -98,11 +98,32 @@ impl Default for ClusterGear {
 impl ClusterGear {
     /// Assembles the provider registry from the backend plugins linked into this
     /// build; future plugins add a `with_*_provider` line here.
+    ///
+    /// The two Redis lines are what make `provider: redis` resolvable at all.
+    /// They are separate registrations rather than one, because the SDK keeps the
+    /// cache and lock provider traits independent: a profile may bind
+    /// `lock: { provider: redis }` over a cache on another backend entirely
+    /// (redis-cluster-plugin/docs/DESIGN.md §3.5), and the standalone
+    /// `RedisLockPlugin` behind `RedisLockProvider` opens its own pool for
+    /// exactly that shape.
+    ///
+    /// Note what is deliberately *not* here: no Redis leader-election provider.
+    /// It is the SDK default over the Redis cache
+    /// (§7), and since that cache normally declares `EventuallyConsistent`, a
+    /// profile binding `cache: { provider: redis }` and omitting
+    /// `leader_election` **fails startup** until the operator either routes
+    /// leader election elsewhere or opts in via `provider: default` plus
+    /// `allow_weak_consistency` (Phase 1's [`DEFAULT_PROVIDER`] sentinel). That
+    /// is the honest declaration doing its job, not a missing registration.
+    ///
+    /// [`DEFAULT_PROVIDER`]: crate::DEFAULT_PROVIDER
     fn provider_registry() -> ProviderRegistry {
         ProviderRegistry::new()
             .with_cache_provider(Arc::new(standalone_cluster_plugin::StandaloneCacheProvider))
             .with_cache_provider(Arc::new(postgres_cluster_plugin::PostgresCacheProvider))
             .with_lock_provider(Arc::new(postgres_cluster_plugin::PostgresLockProvider))
+            .with_cache_provider(Arc::new(redis_cluster_plugin::RedisCacheProvider))
+            .with_lock_provider(Arc::new(redis_cluster_plugin::RedisLockProvider))
     }
 
     /// The profile index, or an error naming the lifecycle violation.

--- a/gears/system/cluster/cluster/src/lib.rs
+++ b/gears/system/cluster/cluster/src/lib.rs
@@ -66,7 +66,7 @@ mod config;
 mod domain;
 mod gear;
 
-pub use config::{BackendBinding, ClusterConfig, ProfileConfig, SecretRef};
+pub use config::{BackendBinding, ClusterConfig, DEFAULT_PROVIDER, ProfileConfig, SecretRef};
 pub use domain::health::{ClusterReadiness, READINESS_PROBE_BUDGET};
 pub use domain::local_client::LocalClusterClient;
 pub use domain::provider::ProviderRegistry;

--- a/gears/system/cluster/docs/DESIGN.md
+++ b/gears/system/cluster/docs/DESIGN.md
@@ -799,6 +799,8 @@ The cluster gear ships three default backend implementations built on `Arc<dyn C
 - `CasBasedLeaderElectionBackend` — `put_if_absent(election_key, node_id, ttl)` for candidacy, `watch(election_key)` for status changes, background renewal task at `ttl / (max_missed_renewals + 1)`, TTL expiry → `Status(Lost)` followed by auto-reenroll. `features()` returns `LeaderElectionFeatures { linearizable: cache.consistency() == Linearizable }` — derives from the underlying cache's consistency.
 - `CasBasedDistributedLockBackend` — `put_if_absent(lock_key, holder_id, ttl)` for `try_lock`, `watch(lock_key)` to notify blocked waiters on release, background TTL reaper. Release via delete-if-still-holder using CAS (a foreign holder cannot release another's lock). No fencing tokens (the no-remote-in-critical-section rule eliminates the stale-writer scenario). `features()` returns `LockFeatures { linearizable: cache.consistency() == Linearizable }`.
 
+  **`discover` reconciles from backend truth on every call, whatever the cache's watch capability.** The membership view the watch maintains is not a sound source for `discover`, and the reason is the difference between a stream and a point query: being one event behind is what a stream *is*, while `discover` is a point query callers expect to reflect writes that have already returned. The view can be stale two ways, and only one of them is obvious. Without a native prefix watch it is as fresh as the last `PollingPrefixWatch` tick, so up to a poll interval behind — that case was always reconciled. **With a native prefix watch on a *remote* backend it is as fresh as the last delivered event, and delivery is a network round trip**: a `set_state` that has already returned has published its event and not yet had it applied. `discover` used to skip the sweep in that second case, on the reasoning that an event-maintained view is already current, which held only while every prefix-watch-capable cache was in-process and an event was a task yield away. The Redis plugin is the first remote backend in the platform to declare `prefix_watch: true`, and it fails `SC-DISC-002` under the old condition — the disabled instance is still reported enabled. Nothing in the SDK can ask a cache whether its watch is local, and a correctness property should not rest on the answer anyway. Note the asymmetry that hid this: `register` pre-inserts into the local view, so read-your-writes held for registration and failed only for `set_state`/`set_metadata`/`deregister`, which run inside the heartbeat task and hold no reference to that view. The cost is one cursor-based `scan_prefix` plus a `get` per instance per `discover`, over a single service's prefix; the sweep already snapshots the view's revision and discards its rebuilt map if a concurrent mutation raced it, so this path needs no new concurrency reasoning. (Found while building the Redis plugin, which is what made the second staleness case reachable.)
+
 **Constructor pair per default backend**:
 - `new(cache: Arc<dyn ClusterCacheBackend>) -> Result<Self, ClusterError>` — returns `Err(ClusterError::InvalidConfig)` if `cache.consistency() == EventuallyConsistent`. Default-safe.
 - `new_allow_weak_consistency(cache: Arc<dyn ClusterCacheBackend>) -> Self` — always succeeds. Caller acknowledges the safety implications. Construction emits a warning log at instantiation. Required by spec for use cases where the underlying cache is intentionally `EventuallyConsistent` (Redis Sentinel, NATS R=1, Postgres `synchronous_commit=off`) and the consumer accepts the split-brain risk.
@@ -900,6 +902,28 @@ Enumeration is provided by `ClusterCacheBackend::scan_prefix(prefix) -> Vec<Stri
 
   Consumer gears now resolve via *V1::resolver(...).profile(P).resolve()
 ```
+
+**A startup that fails partway stops the backends it already started.** The diagram
+above is the success path; the failure path matters as much, because by the time any
+one primitive fails to resolve, the plugins for the earlier ones are *running* — a
+connection pool, background tasks, and for a Redis binding a second subscriber
+connection. `ClusterWiring::from_config` therefore owns the unwind: profile wiring
+hands the accumulated stop hooks back alongside the error rather than dropping them
+with the builder, and they are run newest-first — the same order `ClusterHandle::stop()`
+uses, so a primitive is stopped before the cache it rides.
+
+Reaching that path needs only a weak cache with `leader_election` omitted: the
+cache's `build_cache` has returned by the time the CAS default's consistency guard
+rejects it (§3.11). The leak was latent for as long as the failure path existed,
+because it is quiet for the backends that predate the Redis plugin — an idle
+Postgres pool costs nothing visible. The Redis plugin's ADR-006 `Drop` guard turns
+the same leak into a **debug-build panic**, which is how a scenario whose entire
+subject is a profile that *must fail startup* found it.
+
+The public builder's `build_and_start` keeps its existing contract and does **not**
+unwind: a direct builder caller registered those hooks itself and still owns
+whatever they close over. Only the config-driven path, which owns the hooks it
+accumulated, can safely run them.
 
 #### Shutdown Sequence
 

--- a/gears/system/cluster/plugins/redis-cluster-plugin/Cargo.toml
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/Cargo.toml
@@ -1,0 +1,191 @@
+[package]
+name = "cf-redis-cluster-plugin"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Redis backend plugin for the cluster gear: a native ClusterCacheBackend over a fred connection pool plus a native DistributedLockBackend over a SET NX PX lease with Lua-fenced renew and release, for high-throughput cache and lock deployments"
+readme = "README.md"
+keywords = ["constructorfabric", "cf-gears"]
+categories = ["development-tools"]
+metadata.docs.rs.all-features = true
+
+[lib]
+name = "redis_cluster_plugin"
+
+# `testcontainers`/`testcontainers-modules` are declared as *optional* entries
+# under `[dependencies]` (not `[dev-dependencies]`) on purpose: Cargo does not
+# allow optional dev-dependencies, and the `integration` feature must name them
+# via `dep:` (see the `[features]` doc below). cargo-shear's "misplaced optional
+# dependency" heuristic flags that placement; ignore it here since the placement
+# is required, not accidental.
+[package.metadata.cargo-shear]
+ignored = ["testcontainers", "testcontainers-modules"]
+
+[lints]
+workspace = true
+
+[features]
+# Gates the Layer 2 conformance and Layer 3 testcontainers suites
+# (docs/TESTING.md §4, §7) so a default `cargo test` never requires a Docker
+# daemon. `testcontainers`/`testcontainers-modules` are declared as optional
+# entries under `[dependencies]` below (not `[dev-dependencies]`, which Cargo
+# does not allow to be optional) purely so this feature array can name them
+# directly; every reference to them lives in `tests/`, so enabling this feature
+# has no effect on the plugin's own compiled artifact. Run with
+# `cargo test -p cf-redis-cluster-plugin --features integration`, or
+# `make test-cluster-redis`.
+integration = ["dep:testcontainers", "dep:testcontainers-modules"]
+
+# Every entry below carries the reason it is here, since several are less
+# obvious than the crate name suggests — `uuid` and `rand` are load-bearing for
+# correctness rather than convenience, and `opentelemetry` is a direct dependency
+# only because the ADR-004 port cannot express a gauge.
+[dependencies]
+# `ClusterError` / `ProviderErrorKind` (the `redis_error.rs` mapping table),
+# `CacheConsistency` (the `preflight.rs` declaration), and the ADR-004
+# observability contract: the `ClusterMetrics` port, the
+# `InstrumentedCache` decorator the cache is handed out through, and
+# `emit_provider_error`. `otel` pulls in the SDK's OpenTelemetry-backed
+# `OtelClusterMetrics` sink, which is the one concrete `ClusterMetrics` every
+# plugin shares so instrument names and the label allowlist are defined once.
+cluster-sdk = { workspace = true, features = ["otel"] }
+# The four plugin-local metrics of DESIGN.md §9, emitted through a meter this
+# plugin owns rather than through the `ClusterMetrics` port — which has no gauge
+# method, and `cluster_redis_connection_state` is a gauge. Same underlying API the SDK's own
+# adapter uses; postgres-cluster-plugin carries this dependency for the same
+# reason.
+opentelemetry = { workspace = true }
+# The Redis client. Feature selection — including why `enable-rustls` and not
+# `enable-rustls-ring`, why the interfaces are named individually instead of
+# via `i-std`, and why `sha-1` is absent — is documented at the workspace
+# `[workspace.dependencies]` entry and in DESIGN.md §3.1.
+fred = { workspace = true }
+serde = { workspace = true }
+# Deserializes `RedisClusterConfig` / `RedisLockConfig` out of the flattened
+# operator-config options the wiring crate passes through as a serde map
+# (DESIGN.md §8) — the shape `provider.rs` reads, and the shape the Layer 1
+# config tests construct.
+serde_json = { workspace = true }
+# `${VAR}` / `${VAR:-default}` expansion for `url` (DESIGN.md §8), the same
+# mechanism `libs/toolkit-db` uses for DB DSNs. `toolkit` rather than
+# `toolkit-utils` directly, because the `ExpandVars` derive expands to
+# `::toolkit::var_expand::ExpandVars`.
+toolkit = { workspace = true }
+toolkit-macros = { workspace = true }
+# The DEBUG on a `NOSCRIPT` recovery (`scripts.rs`, DESIGN.md §6) and the
+# preflight's WARNs, one per conservative fallback (DESIGN.md §3.4). Those WARNs
+# are emitted by the preflight *runner*, which holds the client; the decision
+# table it feeds is pure and logs nothing, which is what keeps every row of
+# DESIGN.md §3.6 unit-testable with no server.
+tracing = { workspace = true }
+# `ClusterCacheBackend` and `ClusterCacheProvider` are both `#[async_trait]`, so
+# their impls must be too.
+async-trait = { workspace = true }
+# `tokio::time::timeout` around the bounded pool close (`shutdown.rs`), and the
+# runtime the plugin's futures are polled on.
+tokio = { workspace = true }
+# The `CancellationToken` both handles share with their background tasks
+# (DESIGN.md §11 step 1), which the ADR-006 `Drop` guard also cancels — one
+# token per handle, shared by every task that handle owns.
+tokio-util = { workspace = true }
+# `TryStreamExt::try_collect` over the `SCAN` page stream `fred` returns
+# (`cache/scan.rs`).
+futures-util = { workspace = true }
+# The per-key and per-prefix watcher maps (`cache/watch.rs`). Concurrent because
+# the subscriber's fan-out reads and prunes them on its own task while `watch()`
+# inserts from the caller's, and the fan-out must never block.
+dashmap = { workspace = true }
+# The per-acquisition holder token (DESIGN.md §2.4, §5.1) — a fresh v4 UUID that
+# `renew` and `release` fence on. `v4` is declared here rather than inherited:
+# the workspace entry carries `serde` and `v5` only.
+uuid = { workspace = true, features = ["v4"] }
+# Full jitter on the blocking-acquire retry delay (DESIGN.md §5.3). Without it
+# every instance contending for one name retries on the same deterministic
+# schedule, turning a hot lock into synchronized fleet-wide `SET NX` bursts.
+rand = { workspace = true }
+# Layer 3 testcontainers fixtures (`tests/common/mod.rs`, TESTING.md §4.1) —
+# optional, only pulled in by `--features integration`. See the `[features]`
+# doc above for why these live here rather than `[dev-dependencies]`.
+testcontainers = { workspace = true, optional = true }
+testcontainers-modules = { workspace = true, optional = true }
+
+[dev-dependencies]
+# `#[tokio::test]`, for the async unit tests that drive `ScriptExecutor` doubles
+# and the provider's pre-connection config failures.
+tokio = { workspace = true, features = ["macros"] }
+# The four plugin-local metrics of DESIGN.md §9 are OpenTelemetry instruments
+# rather than `ClusterMetrics` calls, so a recording sink cannot observe them.
+# `testing` gates `InMemoryMetricExporter`, which lets a Layer 1 test read a
+# counter back by its contracted name with no server and no collector — the same
+# readback `postgres-cluster-plugin` uses for its own plugin-local gauge.
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
+
+# `tests/common/mod.rs` installs `tracing` subscribers so the Layer 3 scenarios
+# can assert on the DESIGN.md §9 log events. Process-global (`set_global_default`)
+# for the events emitted from spawned tasks — the eviction WARN and the watch
+# reset come off the subscriber fan-out, which `tracing-test`'s thread-local
+# capture never sees — and thread-local (`set_default`) for the scenarios that
+# assert an event's *absence* and so need a buffer no other test can pollute.
+# Same pair, and the same reason, as postgres-cluster-plugin's.
+tracing-subscriber = { workspace = true }
+# Layer 2 conformance suite (TESTING.md §3): the same parametrized suites every
+# other backend runs, wired against this plugin's real Redis-backed
+# cache/lock/leader in `tests/conformance.rs`.
+#
+# Path-only — no version, and not `workspace = true` — because it is an internal
+# dev-dep inside the cluster dependency cycle and so must not pin its own release
+# ahead of this crate's publish (release-plz.toml; the same shape
+# postgres-cluster-plugin uses).
+cf-gears-cluster-conformance = { path = "../../cluster-conformance" }
+# `cluster::defaults::CasBasedLeaderElectionBackend` for the leader conformance
+# suite — the SDK default over this plugin's cache (DESIGN.md §7), so the test
+# exercises that real combination rather than a stand-in — plus
+# `ClusterWiring::from_config` for `RD-LOCK-008` and `RD-SPEC-004`/`004b`, which
+# are about operator YAML resolving through the registry and cannot be written
+# against anything else.
+#
+# This is a **dev-only dependency cycle**: `cf-gears-cluster` now depends on this
+# crate normally (its `provider_registry` registers both Redis providers), and this
+# crate depends on it for tests. Cargo permits that, because a dev-dependency does
+# not participate in the normal build graph — the cycle exists only when building
+# this crate's test targets. postgres-cluster-plugin relies on exactly the same
+# arrangement.
+cluster = { package = "cf-gears-cluster", path = "../../cluster" }
+# `RD-LOCK-008` (TESTING.md §4.3): the "cache on a different provider" half of the
+# end-to-end YAML routing test binds `cache: { provider: standalone }` alongside
+# `lock: { provider: redis }`, which is the point of the scenario — the lock
+# provider must resolve independently of which backend serves the cache.
+cf-gears-standalone-cluster-plugin = { path = "../standalone-cluster-plugin" }
+
+# Layer 2 (conformance) and Layer 3 (testcontainers) test binaries all require a
+# real Docker daemon, so each is gated behind `required-features =
+# ["integration"]` (TESTING.md §7). `cargo test -p cf-redis-cluster-plugin` with
+# no flag then skips *building* these binaries entirely, rather than building them
+# and skipping the test functions inside — which is what keeps a default test run
+# free of both Docker and the testcontainers dependency tree.
+[[test]]
+name = "conformance"
+required-features = ["integration"]
+
+[[test]]
+name = "cache_integration"
+required-features = ["integration"]
+
+[[test]]
+name = "lock_integration"
+required-features = ["integration"]
+
+[[test]]
+name = "watch_integration"
+required-features = ["integration"]
+
+[[test]]
+name = "lifecycle_integration"
+required-features = ["integration"]
+
+[[test]]
+name = "redis_specific"
+required-features = ["integration"]

--- a/gears/system/cluster/plugins/redis-cluster-plugin/README.md
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/README.md
@@ -1,0 +1,22 @@
+# cf-redis-cluster-plugin
+
+The Redis backend plugin for the `cluster` gear: a native `ClusterCacheBackend` over
+a `fred` connection pool plus a native `DistributedLockBackend` over a `SET NX PX`
+lease with Lua-fenced renew and release. Recommended for high-throughput cache and
+lock deployments, paired with a linearizable backend (K8s Lease) for leader election.
+
+**Status: feature-complete.** Both primitives and both providers are implemented and
+registered, so `provider: redis` under either `cache` or `lock` resolves in any build
+of the cluster gear. Unit, conformance and integration tests all run under
+`make test-cluster-redis`; [`docs/TESTING.md`](./docs/TESTING.md) §7 is the register of
+what that covers. Both the Sentinel and the 3-node Cluster fixture are
+built and run on every PR; there is no fault-injection layer, and
+[`docs/TESTING.md`](./docs/TESTING.md) §8 registers what that leaves unverified.
+
+This backend declares `EventuallyConsistent` in every replicated or non-fsync-durable
+configuration, per ADR-009. A profile binding `cache: { provider: redis }` and
+omitting `leader_election` or `lock` fails startup by design; see
+[`docs/DESIGN.md`](./docs/DESIGN.md) §7 for the three supported ways out.
+
+See [`docs/DESIGN.md`](./docs/DESIGN.md) for the full design and
+[`docs/TESTING.md`](./docs/TESTING.md) for the test plan.

--- a/gears/system/cluster/plugins/redis-cluster-plugin/docs/DESIGN.md
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/docs/DESIGN.md
@@ -1,0 +1,2188 @@
+# Technical Design — Redis Cluster Plugin
+
+> **Status: implemented.** This document describes the crate as it is built,
+> registered, and tested. It is the implementation design for
+> `cf-redis-cluster-plugin`, paired with [TESTING.md](./TESTING.md), and it
+> originated as the design deliverable of
+> [#4373](https://github.com/constructorfabric/gears-rust/issues/4373).
+>
+> The six questions this design opened are **decided** — §13 records each decision
+> and what it commits v1 to. One of them (D1) is a change to `cf-gears-cluster`
+> rather than to this crate, delivered alongside the plugin.
+>
+> What is *not* here: the fault-injection layer.
+> [TESTING.md](./TESTING.md) §8 is the register of what that leaves unverified.
+> Both multi-node fixtures are built and run on every PR, so the two statements in
+> this document that once rested on unit tests are now tested against the topology
+> they describe — §3.6's replicated-topology row by `RD-SPEC-002` on Sentinel, and
+> §13 D2's cluster-mode declaration by `RD-SPEC-010` on a 3-node Cluster.
+
+<!-- toc -->
+
+- [1. Overview](#1-overview)
+  - [1.1 Role in the Cluster Architecture](#11-role-in-the-cluster-architecture)
+  - [1.2 Primitive Coverage](#12-primitive-coverage)
+  - [1.3 What This Plugin Deliberately Is Not](#13-what-this-plugin-deliberately-is-not)
+- [2. Domain Model](#2-domain-model)
+  - [2.1 Key Layout](#21-key-layout)
+  - [2.2 The Cache Entry Is a Hash, and Why Not a Framed String](#22-the-cache-entry-is-a-hash-and-why-not-a-framed-string)
+  - [2.3 Version Semantics](#23-version-semantics)
+  - [2.4 The Lock Entry](#24-the-lock-entry)
+  - [2.5 Event Channel and Payload Format](#25-event-channel-and-payload-format)
+- [3. Component Model](#3-component-model)
+  - [3.1 Crate Structure](#31-crate-structure)
+  - [3.2 Builder / Handle Lifecycle](#32-builder--handle-lifecycle)
+  - [3.3 Connection Model](#33-connection-model)
+  - [3.4 Startup Preflight](#34-startup-preflight)
+  - [3.5 Standalone Lock Provider](#35-standalone-lock-provider)
+  - [3.6 Topology and the Consistency Declaration](#36-topology-and-the-consistency-declaration)
+  - [3.7 Eviction Is a Correctness Concern, Not a Capacity One](#37-eviction-is-a-correctness-concern-not-a-capacity-one)
+- [4. Cache Implementation](#4-cache-implementation)
+  - [4.1 Command Contract per Operation](#41-command-contract-per-operation)
+  - [4.2 TTL](#42-ttl)
+  - [4.3 Watch](#43-watch)
+  - [4.4 scan_prefix](#44-scan_prefix)
+  - [4.5 Consistency Declaration](#45-consistency-declaration)
+- [5. Distributed Lock Implementation](#5-distributed-lock-implementation)
+  - [5.1 The Lock Entry and the Holder Token](#51-the-lock-entry-and-the-holder-token)
+  - [5.2 Renew and Release Are Token-Fenced](#52-renew-and-release-are-token-fenced)
+  - [5.3 Blocking lock()](#53-blocking-lock)
+  - [5.4 No RedLock, No Fencing Tokens](#54-no-redlock-no-fencing-tokens)
+  - [5.5 Inspecting Locks (operators)](#55-inspecting-locks-operators)
+- [6. Lua Script Catalog](#6-lua-script-catalog)
+- [7. Leader Election](#7-leader-election)
+- [8. Configuration](#8-configuration)
+- [9. Observability](#9-observability)
+- [10. ProviderErrorKind Mapping](#10-providererrorkind-mapping)
+- [11. Shutdown Sequence](#11-shutdown-sequence)
+- [12. Risks / Trade-offs](#12-risks--trade-offs)
+- [13. Decisions (formerly Open Questions)](#13-decisions-formerly-open-questions)
+
+<!-- /toc -->
+
+## 1. Overview
+
+`cf-redis-cluster-plugin` is the Redis backend plugin for the cluster gear. It
+provides a native `ClusterCacheBackend` over a `fred` connection pool and a native
+`DistributedLockBackend` over a `SET NX PX` lease key with Lua-fenced renew and
+release. Leader election is derived from the SDK default backend over the Redis
+cache — no additional keys or connections are required for that primitive.
+
+The plugin is the recommended cache and lock backend for the **K8s +
+high-throughput cache** deployment shape (`docs/DESIGN.md` §4.2), where Redis serves
+cache and lock and K8s Lease serves leader election. ADR-001
+puts Redis 10–100× above every other backend on cache and lock throughput
+(100k–200k ops/sec single node, ~0.15 ms p50), which is what makes the OAGW
+requirement of 10 000+ counter updates per second (`cpt-cf-clst-actor-oagw`)
+reachable at all.
+
+It is also the backend ADR-009 rates **unsafe for CAS-based leader election in
+every replicated configuration**. That tension is the single most important thing
+this design has to handle honestly rather than paper over, and §3.6 / §4.5 / §7 are
+where it is handled.
+
+### 1.1 Role in the Cluster Architecture
+
+The plugin satisfies `cpt-cf-clst-component-plugins` for the Redis backend. It:
+
+- Implements `ClusterCacheProvider` (the provider trait from `cluster-sdk`) so the
+  wiring crate can instantiate the cache from operator YAML
+  (`cache: { provider: redis }`).
+- Implements `ClusterLockProvider` so the wiring crate can *independently*
+  instantiate the native lock (`lock: { provider: redis }`), whether or not `cache`
+  in the same profile is bound to redis — see §3.5. This is what makes the native
+  `SET NX PX` lock reachable from YAML at all; the wiring's per-primitive routing
+  (`cpt-cf-clst-fr-routing-per-primitive`, already implemented in
+  `cluster/src/domain/wiring.rs`) dispatches `lock` against its own registry and needs
+  something registered there.
+- Exposes a builder/handle pair
+  (`RedisClusterPlugin::builder(...).build_and_start() -> RedisClusterHandle`)
+  following the outbox-style lifecycle pattern (`docs/DESIGN.md` §3.7, ADR-006). It
+  is NOT a `RunnableCapability`; the cluster gear (`cf-gears-cluster`) owns its
+  lifecycle.
+- Returns a `StopHook` from `build_cache` (and, independently, from `build_lock`)
+  that closes the relevant connection pool, the subscriber client, and all
+  background tasks it owns.
+
+Registration is two lines in the wiring's provider registry (`cluster/src/gear.rs`):
+
+```rust
+ProviderRegistry::new()
+    // … existing providers …
+    .with_cache_provider(Arc::new(redis_cluster_plugin::RedisCacheProvider))
+    .with_lock_provider(Arc::new(redis_cluster_plugin::RedisLockProvider))
+```
+
+### 1.2 Primitive Coverage
+
+| Primitive | Implementation | Consistency | `*Features` |
+|---|---|---|---|
+| `ClusterCacheBackend` | Native — hash-per-entry, Lua CAS, native `PX` TTL | `EventuallyConsistent` by default; `Linearizable` only under a verified single-node durable topology (§3.6) | `prefix_watch: true` in `watch_mode: publish` on a non-clustered deployment; `false` otherwise (§4.3) |
+| `DistributedLockBackend` | Native — `SET NX PX` lease key, Lua token-fenced renew/release. Independently routable via `lock: { provider: redis }` (§3.5), with its own pool and config | `linearizable` mirrors the cache's declared consistency — `false` by default | — |
+| `LeaderElectionBackend` | SDK default `CasBasedLeaderElectionBackend` over the Redis cache — **but the strict constructor rejects an `EventuallyConsistent` cache, so a Redis-only profile that omits `leader_election` fails startup unless the operator opts in explicitly** (§7). The same is true of an omitted `lock`, which auto-wraps the same cache in `CasBasedDistributedLockBackend` and shares the guard | Inherits cache | — |
+
+`prefix_watch: true` (where it holds) means a consumer may declare
+`CacheCapability::PrefixWatch` against this backend and gets real reactive prefix
+watches. That it is *conditional* on topology and watch mode is the part that must
+not be glossed — see §4.3.
+
+### 1.3 What This Plugin Deliberately Is Not
+
+- **Not RedLock.** Multi-master lock acquisition across independent Redis nodes is
+  not implemented and will not be. ADR-009 and Kleppmann's analysis are the
+  reasons; §5.4 states the position.
+- **Not a fencing-token issuer.** ADR-002's "no remote I/O inside the critical
+  section" rule removes the failure mode fencing tokens exist for, and explicitly
+  spares every plugin the Lua `INCR` counter it would otherwise need.
+- **Not a replica-read cache.** All traffic — reads included — is routed to
+  primaries. A replica read would let a `get` observe a value older than a
+  `compare_and_swap` this same process just committed, which is a stronger
+  violation than the topology-level weakness §3.6 already declares. `fred`'s
+  replica-routing feature is deliberately left off.
+- **Not a durability layer.** Redis persistence configuration belongs to the
+  operator. The plugin *reads* it (§3.4) to decide what it may honestly declare,
+  and never changes it.
+
+## 2. Domain Model
+
+Redis has no schema, so the "domain model" here is a key layout and a set of value
+encodings. There is no migration step and nothing to create at startup — the
+first write creates its own key.
+
+### 2.1 Key Layout
+
+Every key this plugin touches is built from an operator-configurable
+`key_prefix` (default `cluster`) plus a one-character primitive segment:
+
+| Purpose | Key | Type |
+|---|---|---|
+| Cache entry | `<prefix>:c:<key>` | hash (`v`, `ver`) |
+| Lock lease | `<prefix>:l:<name>` | string (the holder token) |
+| Cache event channel | `<prefix>:e:c:<key>` | pub/sub channel (no key exists) |
+| Lock-release channel | `<prefix>:e:l:<name>` | pub/sub channel (no key exists) |
+
+`<key>` and `<name>` arrive already scope-prefixed by the SDK's
+`ScopedCacheBackend` / `ScopedDistributedLockBackend`
+(`cpt-cf-clst-fr-namespacing-scoped`); the plugin adds its own prefix on top and
+never inspects the consumer's portion.
+
+**No hash tags.** Keys are deliberately *not* wrapped in `{…}` to co-locate them
+in one Redis Cluster slot. Cluster's whole benefit here is that a million cache
+keys spread across shards, and every script this plugin runs touches exactly one
+key (§6), so there is no `CROSSSLOT` failure to design around. The cost is that
+`SCAN` and expiry notifications become per-shard concerns (§4.3, §4.4) — the right
+trade, since forcing one slot would cap the deployment at one shard's throughput
+and defeat the reason Redis was chosen.
+
+**Key length** is not constrained by the plugin. Redis keys may be up to 512 MB and
+are not index entries, so there is no size ceiling a legitimate key — including one
+carrying several composed scope prefixes — could realistically exceed.
+`InvalidName` is therefore never returned for length; the SDK's own name validation
+is the only gate.
+
+### 2.2 The Cache Entry Is a Hash, and Why Not a Framed String
+
+Each cache entry is one Redis hash with exactly two fields:
+
+```
+HGETALL cluster:c:shard/t-42
+1) "v"     2) "\x00\x01…"        # opaque consumer bytes
+3) "ver"   4) "7"                # decimal integer, as a Redis string
+```
+
+The obvious alternative — a plain string holding a fixed-width version prefix
+followed by the value (`<20 ASCII digits><value>`), which keeps `get` a single
+`GET` and needs no hash overhead — was rejected on one specific ground: **Lua
+cannot compare or increment a u64 version safely.** Redis's embedded Lua is 5.1,
+whose numbers are IEEE doubles, so `tonumber` on a version past 2^53 silently
+loses precision and `ver + 1` starts producing duplicate versions. With a hash:
+
+- **Comparison is a string compare.** `redis.call('HGET', key, 'ver')` returns a
+  string, `ARGV[1]` is a string, and `==` between them is exact for every u64. No
+  number ever enters Lua.
+- **Increment is server-side 64-bit.** `HINCRBY` is integer arithmetic in C, exact
+  to i64 (§2.3 records the resulting ceiling).
+
+The costs are real and accepted: `get` is `HMGET key v ver` rather than `GET key`
+(one round trip either way, marginally larger reply), `put_if_absent` needs Lua
+rather than a bare `SET NX` (§4.1), and a two-field hash carries a little more
+memory than a string — mitigated by Redis's listpack encoding for small hashes,
+which keeps a 2-field hash within tens of bytes of the equivalent string. ADR-001's
+~180 MB-per-million-entries envelope still holds.
+
+Every mutation writes both fields inside one Lua script, so no reader ever observes
+a value with a stale version or vice versa.
+
+### 2.3 Version Semantics
+
+Version starts at 1 on first insert and increments by 1 on every successful write,
+matching the SDK contract (`docs/DESIGN.md` §3.1 `CacheEntry`): version 0 is the
+reserved "absent" sentinel, `put_if_absent` returns version 1, each subsequent write
+increments by 1. The counter is per key — there is no global sequence.
+
+Two ceilings and one caveat:
+
+- **`HINCRBY` is i64**, so the version wraps out of range at 2^63−1 rather than
+  2^64−1. At the OAGW's 10 000 writes/sec against a single key that is ~29 million
+  years; recorded for completeness, not mitigated. Exceeding it surfaces as a Redis
+  `increment or decrement would overflow` error → `Provider { Other }`.
+- **Version resets to 1 on delete-and-recreate**, as the SDK documents for every
+  backend (`[cluster-cache-version-reset-caveat]`). This is
+  why `compare_and_delete` is **value**-guarded, not version-guarded: a successor
+  that re-claimed a key after a TTL lapse wrote a different value, so the guarded
+  delete is a safe no-op against it and cannot wipe the successor's claim.
+- **Expiry and eviction both destroy the counter**, and eviction can do so without
+  any TTL having lapsed. §3.7 is why that is a configuration error rather than a
+  fact of life.
+
+### 2.4 The Lock Entry
+
+A lock is one string key whose *value is the holder token* — a per-acquisition
+random UUID:
+
+```
+GET cluster:l:tenant-42/rate-limit
+"9f1c…"          # holder token; PTTL is the remaining lease
+```
+
+The key's presence is the lock; its TTL is the lease deadline, enforced by Redis
+itself with no reaper anywhere in this plugin (§4.2, §5.1). The token is what makes
+`renew` and `release` safe against a successor (§5.2). Nothing sits beside it
+tracking holder liveness, because none is needed: a lease that is not renewed simply
+ceases to exist, with nothing having to notice or sweep it.
+
+### 2.5 Event Channel and Payload Format
+
+The plugin publishes its own watch events rather than relying solely on Redis
+keyspace notifications (§4.3 argues why). Channel and payload:
+
+```
+channel: <prefix>:e:c:<key>
+payload: C | D          # C = Changed, D = Deleted
+```
+
+One character, because the channel already carries the key and the SDK's cache
+events are key-only by contract (`docs/DESIGN.md` §2.1 Lightweight Notifications).
+`Expired` has no `E` payload: nothing runs plugin code when a TTL lapses, so that
+one event necessarily comes from Redis's own `expired` keyspace notification
+(§4.3). The lock-release channel is the same shape with a fixed `R` payload on
+`<prefix>:e:l:<name>`.
+
+An unrecognized payload on a *published* channel is treated as `Reset` and broadcast to
+every watcher on that key, per ADR-003's mapping for an unintelligible backend signal.
+It costs a spurious re-read and cannot be mistaken for a real event, and it emits
+`cluster.watch.reset` (§9) because that is what it is.
+
+**The same rule is wrong for the keyspace family, which is why that one drops
+instead.** A server whose `notify-keyspace-events` is configured more widely than
+§4.3 asks for emits a notification per Redis *command* — `hset`, `hincrby`,
+`expire` — and mapping those to `Reset` would cost a re-read on every mutation the
+in-script publish has already reported correctly. So the parser has a fourth
+outcome for them: dropped, silently, on the grounds that nothing was lost. Only
+`expired` and `evicted` carry information no plugin code could have published.
+
+The lock-release channel is the same shape with a fixed `R` payload on
+`<prefix>:e:l:<name>`, but a waiter wakes on **any** payload there rather than only
+on `R`. The wake is a hint and the acquisition loop re-attempts its `SET NX` as the
+source of truth (§5.3), so a spurious wake costs one round trip while a wake
+withheld on an unrecognized payload would cost a real waiter its whole delay.
+
+## 3. Component Model
+
+### 3.1 Crate Structure
+
+```
+cf-redis-cluster-plugin/
+  src/
+    lib.rs          — public API re-exports
+    config.rs       — RedisClusterConfig, RedisLockConfig (serde, §8)
+    provider.rs     — ClusterCacheProvider impl ("redis") + ClusterLockProvider impl ("redis")
+    plugin.rs       — RedisClusterPlugin, builder, handle (combined cache+lock)
+    preflight.rs    — startup INFO / CONFIG GET checks and the consistency decision (§3.4, §3.6)
+    scripts.rs      — the Lua catalog (§6): source, SHA cache, EVALSHA with EVAL recovery
+    redis_error.rs  — fred Error → ClusterError / ProviderErrorKind (§10)
+    observability.rs— RedisSignals: the ADR-004 sink plus the plugin-local meter (§9)
+    connect.rs      — the pool + subscriber open and the reconnect policy, shared by both handles
+    subscriber.rs   — the subscriber's fan-out, reconnect-observer, and watchdog tasks,
+                      carrying all three message families (§3.3), shared by both handles
+    wait.rs         — WaitPolicy + wait_for_replicas, shared by the cache and the lock
+    shutdown.rs     — POOL_CLOSE_TIMEOUT, GUARD_DRAIN_TIMEOUT, close_pool,
+                      drain_tracked_tasks, cancel_and_diagnose_drop, shared by both handles
+    cache/
+      mod.rs        — RedisCache (ClusterCacheBackend impl)
+      watch.rs      — per-key/per-prefix watcher registry, fan-out, and channel naming
+      scan.rs       — SCAN-based scan_prefix, per-shard in cluster mode (§4.4)
+    lock/
+      mod.rs        — RedisLock (DistributedLockBackend impl); RedisLockPlugin, builder,
+                       handle (standalone lock-only construction, §3.5)
+      waiters.rs    — in-process release-waiter registry fed by the subscriber (§5.3)
+  docs/
+    DESIGN.md       — this document
+    TESTING.md
+```
+
+**The five top-level files below `redis_error.rs` are shared machinery, and each is
+there because there are two handles rather than one.** `RedisClusterHandle` and
+`RedisLockHandle` (§3.5) open the same pair of connections, apply the same shutdown
+rules, and offer the same `WAIT`, and every one of those is a *policy* the two must
+not differ on — the client-side command timeout that makes `stop()` finite (§11,
+§12), the bounded pool close, the ADR-006 `Drop` guard's cancel-before-diagnose
+ordering, what a short `WAIT` count means. The obvious alternative — the `Drop`
+guard in `plugin.rs` and the bounded pool close in `lock/mod.rs`, one copy per
+handle — is exactly what `postgres-cluster-plugin` does, and its two copies drifted
+in both directions: `postgres-cluster-plugin/src/shutdown.rs` exists to record that
+they did. This plugin has the identical two-handle shape, so it holds one
+implementation of each rule and neither handle can drift from a rule it does not
+own. `subscriber.rs` is shared for the same reason: the connection it drives is a
+*plugin*-level one carrying three families (§3.3), one of which is the lock's, and
+it draws names from `cache/watch.rs` and `lock/` alike, so it belongs to neither.
+The standalone lock handle starts the same fan-out with no cache route at all,
+which a module owned by `cache/` could not serve.
+
+No `migrations/` directory and no schema step: Redis creates each key on first write,
+so there is nothing to provision at startup. That is also why the combined and
+standalone shapes (§3.5) differ so little.
+
+**Why `fred`, and why a Redis client at all.** The workspace has no Redis client
+today (verified: no `redis`, `fred`, `deadpool-redis`, or `bb8-redis` anywhere in
+`Cargo.toml` or `Cargo.lock`), so this plugin introduces one. `docs/DESIGN.md` §3.5
+already names `fred` for this plugin, and §4.1's `ProviderErrorKind` mapping table
+is written in `fred`'s `ErrorKind` vocabulary (`IO`, `Timeout`, `Auth`,
+`Backpressure`) — adopting `redis-rs` instead would mean rewriting that committed
+column. On top of matching the parent design, `fred` supplies four things this
+plugin would otherwise hand-roll: a reconnect/backoff policy with subscription
+replay (§4.3 depends on it), first-class Sentinel and Cluster routing, a
+`SubscriberClient` that survives failover, and `EVALSHA` with `NOSCRIPT`
+recovery (§6). Two of those four carry a caveat: `fred` supplies **no reconnect
+policy by default** (§10), so the replay half of the third holds only because
+`connect.rs` sets one; and the fourth is reached through the SHA `SCRIPT LOAD`
+returns rather than through `Script`, for the reason the feature list gives below.
+
+`fred = "10"` (10.1.0 at time of writing), pinned with an explicit interface list:
+
+```toml
+fred = { version = "10", default-features = false, features = [
+    "i-keys",            # GET/SET/DEL/EXISTS/PEXPIRE/PERSIST/PTTL
+    "i-hashes",          # HGET/HSET/HMGET/HINCRBY
+    "i-pubsub",          # PUBLISH/SUBSCRIBE/PSUBSCRIBE/PUBSUB NUMPAT
+    "i-server",          # INFO, WAIT
+    "i-scripts",         # SCRIPT LOAD / EVALSHA / EVAL
+    "i-config",          # CONFIG GET / CONFIG SET  (the §3.4 preflight)
+    "i-cluster",         # CLUSTER routing + CLUSTER COUNTKEYSINSLOT
+    "subscriber-client", # fred::clients::SubscriberClient (§3.3, §4.3)
+    "sentinel-client",   # Sentinel topology
+    "enable-rustls",     # rediss:// — activates tokio-rustls/aws_lc_rs
+    "partial-tracing",
+] }
+```
+
+No `metrics`/`dynamic-pool`: this plugin emits the ADR-004 catalog itself (§9).
+Four properties of that list are load-bearing rather than incidental:
+
+- **`i-config` and `subscriber-client` are not optional extras.** `i-config` gates
+  `ConfigInterface`, which is every `CONFIG GET` and `CONFIG SET` in §3.4;
+  `subscriber-client` gates `SubscriberClient`, which §3.3 and §4.3 are built on.
+  Without either, this design does not compile. `enable-rustls` is likewise not
+  optional, since §8's production YAML uses `rediss://`.
+- **`enable-rustls`, never `enable-rustls-ring`.** The workspace standardizes on
+  the `aws-lc-rs` rustls provider, and the root `Cargo.toml` records the reason in
+  the imperative: with both providers active, rustls 0.23 can no longer auto-detect
+  and panics at runtime. `fred`'s `enable-rustls` activates
+  `tokio-rustls/aws_lc_rs`; `enable-rustls-ring` activates `tokio-rustls/ring` and
+  would break the whole binary, not just this plugin.
+- **No `i-std`.** It expands to `i-hashes i-keys i-lists i-sets i-streams i-pubsub
+  i-sorted-sets i-server`, pulling in four interfaces this plugin never uses.
+  Naming interfaces exactly leaves `i-lists` out, which makes `BLPOP` and the rest
+  of the blocking family *unreachable at compile time* — so TESTING §6's "no
+  blocking commands" rule stops being a grep and becomes a type error. That is why
+  §5.3 can dismiss a companion-list wait in one sentence, and why the mechanical
+  check in TESTING §6 scans for `KEYS`/`FLUSHALL`/`FLUSHDB` and deliberately does
+  not scan for `B*`.
+- **No `sha-1`.** `Script::from_lua` is gated behind it because it hashes the
+  script client-side. The plugin uses the SHA `SCRIPT LOAD` returns instead — which
+  is what §3.2 step 3 describes anyway — keeping a SHA-1 implementation out of a
+  FIPS-gated workspace's dependency graph for what is only script-cache addressing;
+  `dylint.toml`'s DE0708 non-FIPS hasher allow-list is the independent
+  corroboration. The consequence to know about is that `script_load_cluster`,
+  `fred`'s only broadcasting API, is gated behind the same feature and therefore
+  unreachable, which is what §6's recovery design is built around.
+
+`fred` is used directly and needs no lint exemption: no workspace rule routes Redis
+access through a shared abstraction, and adding one is not proposed here — this is
+the workspace's only Redis consumer, so an abstraction would have one implementation
+and one caller (§13 D6).
+
+### 3.2 Builder / Handle Lifecycle
+
+```rust
+pub struct RedisClusterPlugin;
+
+impl RedisClusterPlugin {
+    pub fn builder(config: RedisClusterConfig) -> RedisClusterBuilder;
+}
+
+impl RedisClusterBuilder {
+    pub async fn build_and_start(self) -> Result<RedisClusterHandle, ClusterError>;
+}
+
+pub struct RedisClusterHandle {
+    cache: Arc<RedisCache>,
+    lock:  Arc<RedisLock>,
+    /* command pool, subscriber client, background tasks, script SHAs */
+    /// Set by `stop` so the `Drop` guard can tell a graceful shutdown from a
+    /// forgotten one (ADR-006 §Confirmation).
+    stopped: bool,
+}
+
+impl RedisClusterHandle {
+    pub fn cache(&self) -> Arc<dyn ClusterCacheBackend>;
+    pub fn lock(&self)  -> Arc<dyn DistributedLockBackend>;
+    pub async fn stop(mut self);
+}
+```
+
+`Drop` carries the ADR-006 diagnostic guard in full — `stopped` short-circuit,
+`std::thread::panicking()` check so a
+handle dropped mid-unwind degrades to a WARN instead of a double-panic abort,
+debug-build `panic!` / release-build `tracing::warn!` otherwise, and cancellation of
+the shared token *before* the diagnostic so a dropped `stop()` future still unwinds
+the background tasks. It follows the guard the wiring's own `ClusterHandle` uses
+(`cluster/src/domain/wiring.rs`) rather than inventing a variation, so a reader who knows one
+knows both.
+
+`build_and_start`:
+
+0. Validates the config values that can only fail at startup — a zero `pool_size`,
+   `command_timeout_ms`, or `wait_timeout_ms` (§8) — before
+   anything is opened, since each of those silently *removes* a bound rather than
+   tightening it.
+1. Builds the `fred` client pool against the configured server(s) and `.await`s the
+   initial connect, so a bad DSN or an unreachable server fails here rather than at
+   first use. Both clients are built with an **explicit bounded reconnect policy**,
+   because `fred` supplies none (§10), and the initial connect is separately bounded
+   by a 10 s `CONNECT_TIMEOUT` — the policy applies to the first connect too, so
+   without that bound a URL pointing at a closed port would retry for the policy's
+   whole schedule before this returned (`RD-LIFE-005`).
+2. Runs the startup preflight (§3.4) — server topology, persistence settings,
+   `maxmemory-policy`, keyspace-notification flags — and computes the consistency
+   declaration (§3.6) once, storing it for `consistency()` / `features()` to return.
+3. `SCRIPT LOAD`s the Lua catalog once and keeps the SHAs the *server* computed (§6).
+   Deliberately **not** broadcast to every primary in cluster mode: `fred`'s only
+   broadcasting API is gated behind the `sha-1` feature §3.1 excludes, and the
+   `NOSCRIPT` recovery §6 describes warms each node lazily and self-heals across a
+   reshard, which a startup broadcast could not.
+4. Opens the `SubscriberClient`, issues its initial `PSUBSCRIBE`s, and **confirms
+   them with an awaited `PING` on the same connection** before returning. Both
+   halves are load-bearing. The ordering is: a release published in the startup
+   window would otherwise have no subscriber, and the resulting bug is invisible
+   except as a blocked `lock()` that waits out its heartbeat instead of waking
+   promptly (`RD-LOCK-003`, TESTING.md §4.3, is the regression test). The `PING` is:
+   awaiting `fred`'s `subscribe`/`psubscribe` is **not** a barrier that the server
+   has processed the subscription — those futures resolve when the command reaches
+   the connection, and `fred`'s reader classifies the server's confirmation frame as
+   a subscription response and drops it before it can complete anything. §4.3
+   explains the mechanism and what it costs.
+5. Spawns the tasks that ride the subscriber: the fan-out, the reconnect observer
+   (cache only — a lock has nothing to reset, §3.5), the connection watchdog that
+   fires when the reconnect policy is exhausted (§10), and `fred`'s own
+   subscription-replay task. A fifth task samples `cluster_redis_connection_state`
+   (§9).
+6. Returns the handle. By the time it resolves, the pool is connected, the scripts
+   are loaded, and the subscriber is live — no readiness gate for callers to reason
+   about. A failure at any step tears down whatever the earlier steps started: past
+   the connect, every error path closes the pool on the way out, and a subscriber
+   that fails to subscribe is quit rather than left half-open.
+
+`stop`: §11.
+
+### 3.3 Connection Model
+
+| Connection | Purpose | Owned by |
+|---|---|---|
+| Command pool (`fred::clients::Pool`, default 4 connections) | Every cache read/write, every lock command, every `EVALSHA`, every `SCAN` | The plugin (combined or standalone) |
+| Subscriber client (1, outside the pool) | All `SUBSCRIBE`/`PSUBSCRIBE` traffic: plugin-published cache events, lock-release events, and Redis `expired`/`evicted` keyspace notifications | The plugin |
+
+Two shapes, and deliberately no more. There is no liveness-tracking connection (a
+lease that stops being renewed expires by itself) and no TTL-sweep task (Redis expires
+keys natively), so the plugin owns no connection whose purpose is to prove something
+about itself. A held lock consumes **no connection at all** — not a pooled one, and
+nothing per-lock.
+
+The subscriber must be its own client because a Redis connection in subscribe mode
+accepts only subscribe-family commands; `fred`'s `SubscriberClient` additionally
+tracks its subscription set and replays it after reconnect, which is what §4.3's
+`Reset` handling is built on.
+
+**The subscriber is opened whatever `watch_mode` says, including `disabled`.** That
+is worth stating because the opposite is the intuitive reading: `watch_mode` is a
+*cache* setting, and closing the connection on its account would silently take the
+lock's release wake with it — the third family in the table above — and push every
+blocked acquisition onto the jittered heartbeat. What `disabled` saves is the
+watcher registry, the cache's subscriptions, and the in-script `PUBLISH` on the
+write path (§4.3); what it does not save is the connection.
+
+Steady-state connection count is therefore `pool_size + 1` for the combined plugin
+and `pool_size + 1` for the standalone lock plugin, independent of how many locks
+are held or keys are watched. Redis connections cost ~20 KB each (ADR-001), so there is
+no pressure to keep the pool small; the default of 4 is about pipelining headroom,
+not resource thrift.
+
+### 3.4 Startup Preflight
+
+`build_and_start` (and `build_lock`) issue a fixed set of read-only commands once,
+before returning, and decide three things from the answers. Each check degrades
+explicitly when the command is refused — managed Redis (ElastiCache,
+MemoryDB, Azure Cache) commonly restricts `CONFIG`, and a plugin that treated an
+ACL denial as a hard failure would be unusable there.
+
+| Command | Decides | If refused / unreadable |
+|---|---|---|
+| `INFO server` | Redis version; whether `spublish`-family sharded pub/sub is available | Fail `InvalidConfig` — an unreadable `INFO` means an unusably locked-down server |
+| `INFO replication` | Topology: standalone / replicated primary / cluster | WARN + treat as replicated (the conservative direction, §3.6) |
+| `CONFIG GET appendonly`, `appendfsync` | Whether single-node writes are durable at ack time | Treat as non-durable (conservative) |
+| `CONFIG GET maxmemory-policy` | Whether cluster keys can be evicted (§3.7) | WARN `cluster.provider.maxmemory_policy_unknown`; proceed |
+| `CONFIG GET notify-keyspace-events` | Whether `expired` notifications will arrive (§4.3) | WARN; `Expired` events are then best-effort |
+
+Three inputs on this behaviour, in strict precedence order — each layer is more
+specific about intent than the one below it:
+
+- **`topology` / `durability` config (§8)** — operator-supplied hints, and the
+  strongest input. This is the escape hatch for a locked-down managed instance whose
+  operator *knows* the answer the plugin cannot read. The two hints are treated
+  asymmetrically: a `topology` hint replaces detection outright, while a
+  `durability: fsync_always` hint is **cross-checked** against `CONFIG GET` wherever
+  that is readable, because `fsync_always` is the one claim that unlocks
+  `Linearizable` on its own and is therefore the one worth verifying (§3.6).
+- **The connection URL's own scheme** — `redis-cluster://` means cluster and
+  `redis-sentinel://` means Sentinel, and both outrank detection because they are
+  facts about the *client* rather than claims about a server: a clustered client is
+  talking to a cluster whatever one node's `INFO replication` reports about its own
+  replicas. A plain `redis://`/`rediss://` URL says nothing and falls through — in
+  particular it is **not** read as `standalone`, since it means "one address", not
+  "no replicas", and the single-node row of §3.6 is the one place a wrong answer
+  weakens a guarantee.
+- **Detection**, per the table above.
+
+Plus one lever that writes rather than reads:
+
+- **`manage_keyspace_notifications: bool` (default `false`)** — when `true`, and the
+  detected `notify-keyspace-events` flags lack what §4.3 needs, the plugin issues one
+  `CONFIG SET notify-keyspace-events` **additively** merging in the missing flags,
+  then re-reads to confirm the write took. Additive because the setting is
+  server-wide: replacing it with just this plugin's flags would switch off
+  notifications an unrelated tenant of the same Redis is subscribed to. Re-read
+  rather than trusted because a `CONFIG SET` can succeed against a proxy that
+  accepts and drops it, and the plugin would then spend the deployment's life
+  believing in events that never arrive. Default off because mutating a shared
+  server's global config on a gear's behalf is exactly the kind of surprise an
+  operator should opt into. The flag check itself honours Redis's `A` alias — a
+  server configured `KA` already emits `expired` and `evicted` and needs nothing
+  added, though `K` is still required alongside it, since `A` does not imply the
+  keyspace routing that puts those events on a `__keyspace@…__` channel.
+
+Nothing in the preflight ever *upgrades* a guarantee beyond what it verified, and
+nothing it discovers changes behaviour silently: every conservative fallback logs
+the reason (§9).
+
+### 3.5 Standalone Lock Provider
+
+`RedisLockProvider` implements `ClusterLockProvider` (`provider() -> "redis"`) and
+builds a standalone `RedisLockPlugin` with its own pool, its own subscriber, and its
+own config type (`RedisLockConfig`, §8) — never reusing a pool from a co-located
+`cache: { provider: redis }` binding, per the SDK provider contract's "non-cache
+providers do not receive the cache backend". Sharing would couple two providers the
+SDK deliberately made independent, and would need a lifecycle-ownership story for the
+shared pool — which provider's `stop()` closes it? The cost of not sharing is a
+second small pool when both primitives point at the same server: at ~20 KB per
+connection, cheaper than the coupling it avoids.
+
+What differs between the two shapes:
+
+| | Combined (`RedisClusterPlugin`) | Standalone (`RedisLockPlugin`) |
+|---|---|---|
+| Lua scripts loaded | Cache + lock catalog (§6) | Lock catalog only |
+| Subscriber subscriptions | Cache event channels + lock-release channels + the `expired`/`evicted` keyspace pattern | Lock-release channels + the same keyspace pattern |
+| `notify-keyspace-events` flags | `Kxe` — `x` for the cache's `Expired` (§4.3), `e` for the eviction signal (§3.7) | `Ke` — the eviction signal only, **never** `x` |
+| Without those flags | The cache's `Expired` degrades to best-effort, and no eviction is reported | **Nothing degrades.** The lock keeps working unchanged; only the eviction report is lost |
+| Preflight checks | All of §3.4 | All of §3.4, asking for the narrower flag set and never writing it |
+| Background tasks | Subscriber fan-out, reconnect observer, connection watchdog, connection-state sampler | Subscriber fan-out, connection watchdog, connection-state sampler — **no reconnect observer** |
+
+The middle rows are worth calling out: a Redis **lock-only** deployment works
+against a managed instance with keyspace notifications entirely unavailable, with
+no degradation at all. Nothing it needs to operate depends on them — a lease lapse
+is discovered by the next acquire attempt, which is the source of truth throughout
+— so the flags it asks for buy *observability* rather than function. That is why it
+asks for `Ke` and not `Kxe`: `x` would be a server-wide flag charged to every other
+tenant of the instance for an event this deployment never reads. It is also why it
+never sets them itself. `manage_keyspace_notifications` stays a combined-plugin
+opt-in, because a server-wide `CONFIG SET` is too blunt an instrument to reach for
+on behalf of a report, as against a cache that genuinely degrades without it.
+
+So is the last. **The standalone plugin runs no reconnect observer**, because that
+task exists to broadcast a cache `Reset` after a subscription gap and a lock has no
+equivalent to reset: a release missed during a gap costs its waiter one jittered
+delay, after which the `SET NX` — the source of truth throughout — answers
+correctly. Telling anyone about the gap would give them nothing to do with it. The
+consequence to know about is in §9: `cluster_redis_subscriber_resubscribes_total`
+lives on that observer, so the standalone plugin does not emit it. The *watchdog*
+is spawned either way, because an exhausted reconnect policy has something to say
+about the lock too — a permanently gone subscriber means every blocked acquisition
+falls back to the heartbeat, which costs latency rather than correctness, and that
+is worth a line even though there is nothing to close.
+
+The fan-out itself is the same task in both shapes rather than two near-copies: it
+takes a routing table whose cache half is optional, and the standalone plugin runs
+it with that half empty. That is what keeps the lock's wake path identical between
+the two (`RD-LOCK-009`) instead of a second `select!` free to drift from the first.
+
+Operator YAML — Redis lock alongside a non-Redis cache:
+
+```yaml
+cluster:
+  profiles:
+    default:
+      cache:
+        provider: standalone
+      lock:
+        provider: redis
+        url: "redis://:${REDIS_PASSWORD}@redis:6379/0"
+        pool_size: 4
+```
+
+`RedisLockPlugin`'s handle carries the same `stopped` field and the same ADR-006
+`Drop` guard as the combined handle — it owns its own pool and subscriber, so it
+needs the same protection independently.
+
+### 3.6 Topology and the Consistency Declaration
+
+ADR-009's per-backend table is unambiguous, and this plugin's declaration is
+derived from it mechanically rather than chosen:
+
+| Detected / declared topology and durability | `consistency()` | Rationale (ADR-009) |
+|---|---|---|
+| Single node, `appendonly yes` + `appendfsync always`, no replicas | `Linearizable` | The one Redis configuration ADR-009 marks safe: nothing is acked before it is fsynced, and there is no replica to fail over to |
+| Single node, `appendfsync everysec` (default) or `appendonly no` | `EventuallyConsistent` | Crash between ack and fsync loses up to 1 s of accepted writes → two leaders |
+| Sentinel / any replicated primary | `EventuallyConsistent` | Async replication: every failover may promote a replica that never saw an accepted write |
+| Redis Cluster | `EventuallyConsistent` | Same async replication, plus slot-migration edge cases |
+| Unknown (preflight refused, no operator hint) | `EventuallyConsistent` | Conservative default |
+
+Three properties of this mechanism matter more than the table:
+
+- **`Linearizable` is opt-in and verified, not asserted.** An operator claiming
+  `durability: fsync_always` still has it checked against `CONFIG GET appendonly`
+  *and* `appendfsync` when those are readable — both, because `appendfsync always`
+  means nothing with `appendonly no`, and a check reading only the policy would
+  declare `Linearizable` for a server keeping no durable log at all. A claim
+  contradicted by the server fails startup with `InvalidConfig` naming both values.
+  A claim the plugin *cannot* check is trusted instead, and logs
+  `cluster.provider.consistency_asserted` (WARN, once) saying so — an operator lie
+  is then visible in the logs of the deployment that told it.
+
+  That warning fires whenever **either** leg of a `Linearizable` declaration rests
+  on something unchecked, not only the durability one: a `topology: standalone` hint
+  means no `INFO replication` was read, so the "no replicas" half is also the
+  operator's word. Only the single-node row can reach `Linearizable`, so only it
+  needs the provenance distinction at all — every other row decides
+  `EventuallyConsistent` whether the plugin read it off the server or took the
+  operator's word for it, and there is no such thing as an unverified *downgrade*.
+  Only the upgrade direction can fail, too: a hint *weaker* than the server's actual
+  setting can only under-declare, which is safe and is a legitimate choice for an
+  operator who does not want a durable-today server silently becoming the basis of a
+  `Linearizable` declaration tomorrow.
+
+  The contradiction check runs on **every** row rather than only the one that could
+  reach `Linearizable`. A `durability: fsync_always` the server denies is untrue on
+  a Sentinel deployment too, and checking it only where it would have mattered lets
+  the same config sit unreported until the day it is moved to a single node.
+- **`WAIT` does not upgrade anything.** The plugin supports an optional
+  `wait_replicas` / `wait_timeout_ms` pair that appends `WAIT n timeout` after a
+  write whose outcome a failover must not silently undo, which genuinely narrows the
+  Sentinel failover window and is worth having. Per ADR-009 §"No linearizable-ish
+  middle ground" it does **not** move the declaration: `WAIT 1` reduces but does not
+  eliminate the window, and the `CacheConsistency` enum is deliberately two-valued.
+  A `WAIT` that times out is surfaced as `Provider { ResourceExhausted }` on that
+  write rather than being swallowed — the command does not *error* on timeout, it
+  returns however many replicas acknowledged, so a caller that ignored the count
+  would have opted into a guarantee and then silently not received it.
+
+  **The policy is a `WaitPolicy` built once, before anything is opened**, rather
+  than an `Option<WaitPolicy>` read at each write. `WAIT`'s timeout argument is
+  signed, so a `wait_timeout_ms` past `i64::MAX` has no honest rendering — and the
+  only place with somewhere to report that is startup. `WaitPolicy::from_config`
+  is therefore fallible and its enabled variant's fields are unreachable outside
+  `wait.rs`, so the clamp that would otherwise turn an unreadable config into a
+  ~292-million-year deadline cannot be written. It is called beside
+  `config.validate()` and for the same reason: an unrepresentable value fails
+  before there is a pool or a subscriber to tear down.
+
+  **Which writes carry it is narrower than "each lock and CAS write" reads.** On
+  the cache it is the three *conditional* writes — `put_if_absent`,
+  `compare_and_swap`, `compare_and_delete` — and not an unconditional `put` or
+  `delete`, which carry no decision made on a value a failover could invalidate. On
+  the lock it is **acquisition only**, not `renew` and not `release`: losing an
+  acquisition to a promotion is the failure `WAIT` exists for, since the new primary
+  has no lease key and a second instance takes the name while this one believes it
+  holds it, whereas losing a renewal fails the other way (the lease reverts to its
+  earlier, shorter deadline) and losing a release only leaves a name unacquirable
+  until its TTL. Neither of those can produce two holders, so neither is worth a
+  round trip on every call. A short count on acquisition gives the lease back before
+  reporting, rather than wedging a name nobody took for a whole TTL.
+- **The declaration is computed once at startup, never re-evaluated.** A topology
+  that changes under a running plugin (a replica attached to what was a single node)
+  will not downgrade a live `Linearizable` declaration. This is a real gap, recorded
+  in §12 rather than solved: re-declaring mid-flight would mean a backend whose
+  capability answers change after consumers have already resolved against them,
+  which the resolution model (`cpt-cf-clst-fr-validation-startup-fail`) has no way to
+  express.
+
+### 3.7 Eviction Is a Correctness Concern, Not a Capacity One
+
+Under `maxmemory` pressure with any `allkeys-*` or `volatile-*` policy, Redis
+deletes keys nobody asked it to delete. For an application cache that is the
+feature. For this plugin it is silent corruption of every primitive at once: an
+evicted lock key hands the lock to a second holder while the first still believes it
+holds it; an evicted leader-election key elects a second leader. No TTL has lapsed
+and no consumer is told.
+
+The plugin therefore:
+
+- Reads `maxmemory-policy` at startup and, if it is anything other than
+  `noeviction`, logs `cluster.provider.maxmemory_policy_unsafe` (WARN, once, naming
+  the policy and this section) — warn rather than fail, because the policy is a
+  server-wide setting the cluster keys may be sharing with unrelated tenants, and
+  refusing to start would make this plugin unusable on any shared Redis.
+- Subscribes to the `evicted` keyspace notification (when notifications are
+  available at all) and, on each one for **any key** under its own prefix — cache
+  entry or lock lease — logs `cluster.provider.eviction_observed` (WARN,
+  rate-limited) and increments
+  `cluster_redis_evictions_observed_total{provider, primitive}` (§9). This turns a
+  silent failure into an alertable one — the single highest-value operational
+  signal this plugin emits.
+- Maps the event to `CacheEvent::Deleted` for watchers, not `Expired`: no TTL
+  elapsed, and a consumer distinguishing the two would be misled.
+
+Two things about that counter and its scope:
+
+- **The counter is plugin-local, and it has to be.** The catalog counter
+  `cluster_provider_errors_total` cannot carry an eviction in two independent ways:
+  it takes `{provider, kind}` and no `op` at all, and its label set is a hard
+  ADR-004 contract rather than a convention; and an eviction is not a
+  `ClusterError`, so it cannot travel through `emit_provider_error`, which returns
+  early on anything that is not `ClusterError::Provider`. Folding it on as
+  `kind = "other"` would make an eviction indistinguishable from every other
+  unclassified backend failure *and* would put something that is not an operation
+  failure into a provider-error rate. A counter that says what it counts is the
+  honest form. The WARN keeps its contracted name.
+- **Observation spans both primitives, and the label is what makes it usable.**
+  The keyspace pattern is `__keyspace@<db>__:<prefix>:*` rather than one scoped to
+  the cache's `:c:` segment, because the paragraph above opens with the lock case
+  and rates it worst. One pattern and a classifier, rather than one pattern per
+  primitive: the notification stream is a single connection's, sorting a key is a
+  prefix compare, and the classifier asks `ChannelNames` and then `LockNames` — the
+  same types that *build* those names — so no third place spells `:c:` or `:l:`.
+  A key under this prefix that neither claims is declined and logged at DEBUG,
+  which today means the event channels the pattern also matches and at which no key
+  exists.
+
+  `primitive` is `cache` or `lock` and it labels the counter, appears on the WARN,
+  and selects the rate limiter. The last of those is not bookkeeping: the two
+  windows are independent, because a shared one would let an eviction storm in the
+  cache — thousands of entries, each costing a re-read — spend the budget that the
+  one line reporting a **double-held lock** needs, and it is exactly under that
+  much memory pressure that the lock line gets emitted.
+
+  The **standalone lock plugin** (§3.5) subscribes the same pattern for the same
+  reason, with its cache half empty so that a `<prefix>:c:` key belongs to a
+  different deployment sharing the prefix and is never claimed. It is the shape
+  likeliest to be pointed at a shared Redis, having no cache working set to argue
+  for its own instance.
+
+**The operator guidance is unambiguous and belongs in the deployment docs: run
+cluster keys on a Redis instance (or `noeviction` policy) where they cannot be
+evicted.** A dedicated instance, or a separate logical database, is the
+recommendation; a shared cache instance under `allkeys-lru` is a documented
+misconfiguration this plugin can report but not prevent.
+
+## 4. Cache Implementation
+
+### 4.1 Command Contract per Operation
+
+`K` is `<prefix>:c:<key>`; `CH` is `<prefix>:e:c:<key>`. `PX` is the millisecond
+TTL from `PutRequest.ttl` (`Ttl::Of(d)` → `d.as_millis()`, `Ttl::Indefinite` →
+`PERSIST`). Scripts are named per §6 and invoked by `EVALSHA` with one key.
+
+| Operation | Redis |
+|---|---|
+| `get(key) -> Option<CacheEntry>` | `HMGET K v ver` — both `nil` → `None`; both present → `CacheEntry { value, version }`; **exactly one present → `Provider { Other }`**, not `None` (see below). No Lua |
+| `put(req) -> ()` | `cache_put` script: `HSET K v <value>`, `HINCRBY K ver 1` (creating at 1 when absent), TTL applied or cleared, `PUBLISH CH C` |
+| `put_if_absent(req) -> Option<CacheEntry>` | `cache_put_if_absent` script: if `EXISTS K` → return `nil`; else `HSET K v <value> ver 1`, apply TTL, `PUBLISH CH C`, return version 1 |
+| `compare_and_swap(key, expected, new, ttl) -> CacheEntry` | `cache_cas` script: string-compare `HGET K ver` against `expected`; equal → `HSET`/`HINCRBY`/TTL/`PUBLISH`, return new version; unequal or absent → return the current `{ver, v}` so the caller's `CasConflict.current` is populated in the same round trip |
+| `compare_and_delete(key, expected_value) -> bool` | `cache_compare_and_delete` script: byte-compare `HGET K v`; equal → `DEL K`, `PUBLISH CH D`, return 1; else return 0 (never an error) |
+| `delete(key) -> bool` | `cache_delete` script: `DEL K`; if it removed something, `PUBLISH CH D` and return 1; else return 0 with no event. A script rather than a bare `DEL` only so the publish is atomic with the delete, and so a delete of an absent key emits nothing |
+| `contains(key) -> bool` | `EXISTS K`. No Lua |
+| `scan_prefix(prefix) -> Vec<String>` | `SCAN` loop, §4.4. No Lua |
+| `watch(key)` / `watch_prefix(prefix)` | Subscriber registration, §4.3. No server round trip beyond the initial subscribe |
+
+Two invariants across the table: **every mutation publishes its own event inside the
+same script**, so a consumer cannot observe a write without its notification
+arriving (modulo pub/sub's fire-and-forget delivery, §4.3, and modulo
+`watch_mode: disabled`, under which the channel argument is empty and every script
+skips its `PUBLISH`); and **every script touches exactly one key**, passed via
+`KEYS[1]`, so Redis Cluster routes it correctly and no `CROSSSLOT` error is
+reachable (§6).
+
+`get`, `contains`, and `scan_prefix` are the only operations that avoid Lua. That is
+not an oversight to fix later: each mutation needs an atomic read-modify-write over
+two hash fields plus a conditional TTL plus a publish, which no single Redis command
+expresses.
+
+**A half-populated hash is an error, not an absence.** Every mutation writes `v` and
+`ver` inside one script, so exactly one field present means a key at this name that
+something other than this plugin owns. Reporting it as `None` would be worse than
+failing: the caller's next `put_if_absent` would find the key "absent", and the
+write would merge into a stranger's hash rather than being refused. The three
+conditional writes additionally issue the operator's `WAIT`, if one is configured
+(§3.6).
+
+### 4.2 TTL
+
+TTL is native. `Ttl::Of(d)` becomes `PEXPIRE K <ms>` inside the write script;
+`Ttl::Indefinite` becomes `PERSIST K`. **There is no TTL reaper in this plugin**: TTL
+enforcement is entirely Redis's own, which is why ADR-001 rates native per-entry TTL a
+first-class advantage of this backend.
+
+Consequences worth stating:
+
+- A write always sets the entry's TTL explicitly from the request; it never
+  preserves a previous one implicitly. `Ttl::Indefinite` on an entry that had a TTL
+  clears it, which is what the SDK's two-valued `Ttl` says should happen.
+- A sub-millisecond `Ttl::Of` rounds **up** to 1 ms rather than down to 0.
+  `PEXPIRE k 0` deletes the key outright, so rounding down would turn "expires
+  almost immediately" into "was never stored", and the caller's next read would see
+  an absence it could not distinguish from a failed write. The lock's `PX` argument
+  is floored the same way and for a sharper reason: `PX 0` is an error reply, so an
+  acquisition would fail rather than expire.
+- `Expired` watch events depend on Redis's own notification, which fires when the key
+  is actively expired or lazily deleted on access — up to the active-expire cycle
+  (~100 ms typical) after the deadline. That is "shortly after", not "at the
+  deadline": a consumer needing the exact moment must read the TTL rather than wait
+  for the event.
+- Redis replicas do not expire keys themselves. Since all traffic goes to primaries
+  (§1.3), no read can observe a logically-expired entry.
+
+### 4.3 Watch
+
+The subscriber client holds three kinds of subscription and one fan-out task routes
+everything to a per-key / per-prefix watcher registry. **Three families, but two
+streams** — which is a `fred` behaviour rather than a design choice, and the single
+most misleading thing about the obvious reading of this diagram:
+
+```
+plugin PUBLISH (in-script)  ──►  <prefix>:e:c:<key>       ──►  message_rx()        ──┐
+Redis `expired` keyspace    ──►  __keyspace@<db>__:<K>    ──►  keyspace_event_rx() ──┼─► fan-out ─► watchers
+Redis `evicted` keyspace    ──►  __keyspace@<db>__:<K>    ──►  keyspace_event_rx() ──┘
+```
+
+`fred`'s router recognizes the `__keyspace@`/`__keyevent@` channel prefixes and
+diverts those messages to a separate broadcast stream, pre-parsed into a
+`{ db, key, operation }` triple, so they **never appear on the pub/sub stream at
+all**. A fan-out reading only the pub/sub stream — which is what "one fan-out task
+routes everything" reads as — subscribes to the keyspace pattern successfully,
+watches the server deliver on it, and still emits not one `Expired`. The split is
+invisible below Layer 3: every unit test passes throughout, because nothing about it
+is a decision this plugin makes. So the fan-out `select!`s over both receivers. The
+keyspace half needs no channel parsing in exchange, `fred` having already done it —
+but it does need its `db` checked against the cache's own, or a notification from
+another logical database on the same server is reported as a deletion of a key this
+cache never had.
+
+**Why plugin-published events rather than keyspace notifications alone.** Raw
+keyspace notifications would need no `PUBLISH` at all, which is tempting on a
+10 000-writes/sec path. They were rejected as the primary mechanism for a reason
+that is not about cost:
+
+- **They fire per Redis command, not per logical write.** A single `put` executes
+  `HSET` + `HINCRBY` + `PEXPIRE`, so a hash-based entry (§2.2) would emit three
+  notifications — three `Changed` events for one write, against
+  `cpt-cf-clst-nfr-watch-delivery`'s "zero duplicate events per subscriber per key
+  in normal operation". Coalescing them downstream means guessing which commands
+  belonged to which write.
+- **They cannot express the plugin's event taxonomy.** `hset`, `hincrby`, `expire`,
+  `del`, `unlink`, `expired`, `evicted` must be mapped to three SDK events, and the
+  mapping is lossy in the direction that matters (an `expire` command is not a
+  change to the value).
+- **They require global server configuration** (`notify-keyspace-events`) that
+  managed Redis often will not grant, and getting the flag string wrong degrades
+  silently.
+
+Publishing inside the script solves all three: exactly one event per logical
+mutation, the correct event type by construction, atomic with the write, and no
+server configuration needed. The costs, accepted and documented: one extra command
+per write (no extra round trip — it is inside the same script), and Redis Cluster's
+`PUBLISH` broadcast to all nodes, whose ~12 500 publishes/sec ceiling (ADR-001) is
+well below the plugin's write ceiling and therefore becomes the binding constraint
+on a clustered, heavily-watched deployment (§12).
+
+**`Expired` is the one event that cannot be self-published**, since no plugin code
+runs when a TTL lapses. It comes from Redis's `expired` keyspace notification, which
+requires `notify-keyspace-events` to include `K` to route events to a
+`__keyspace@…__` channel at all, `x` for `expired`, and `e` for `evicted` (§3.7).
+**The minimal correct flag set is therefore `Kxe`**, and that is what the plugin
+checks for at startup (§3.4). Minimal matters here rather than being tidiness: every
+flag is **server-wide**, and `manage_keyspace_notifications: true` writes the
+setting globally, so anything beyond `Kxe` is traffic unrelated tenants of the same
+Redis pay for and this plugin never reads. The tempting additions are the worst
+offenders — `g` adds a notification for every generic command and `$` for every
+string command. A server configured more widely still works: the extra
+notifications arrive, are recognized as outside this plugin's vocabulary, and are
+dropped (§2.5).
+
+When the flags are absent and cannot be set, the plugin logs
+`cluster.provider.expiry_events_unavailable` (WARN, once) and delivers no `Expired`
+events at all. This degrades promptness, not correctness: an expired entry still
+reads as absent, and both SDK default backends that ride this cache have
+timer-driven fallbacks (`CasBasedLeaderElectionBackend` renews on a timer and only
+uses the watch for promptness; `CasBasedDistributedLockBackend` has a timeout
+fallback), so neither depends on the event arriving.
+
+**Watch modes.** One config lever (`watch_mode`, §8) with exactly two settings —
+§13 D4 decided against a third:
+
+| Mode | Behaviour | `features().prefix_watch` |
+|---|---|---|
+| `publish` (default) | As above: in-script publish + `expired`/`evicted` keyspace events | `true` on standalone/Sentinel; `false` in Cluster (see below) |
+| `disabled` | No publish, no watcher registry, no cache subscriptions. `watch`/`watch_prefix` return `Unsupported`; a consumer relying on prefix watch falls back to `PollingPrefixWatch` over `scan_prefix`, the documented behaviour on any prefix-watch-incapable cache | `false` |
+
+`disabled` exists because the issue explicitly permits it ("if prefix-watch proves
+inefficient, use the SDK's polling fallback") and because it is the honest answer for
+a managed Redis where neither `CONFIG` nor the publish overhead is acceptable.
+
+**"No publish" is enforced through one accessor, and it has to be.** The write path
+is where the saving is: gating only the watcher registry and the subscriptions would
+leave every mutation still running its `PUBLISH`, to a channel that by construction
+has no subscriber — watches off, and none of the cost saved that the mode exists to
+save, which is precisely backwards for the deployment the previous paragraph names.
+So the cache's channel accessor answers the **empty string** under `disabled`, and
+every mutation script guards its `PUBLISH` on a non-empty channel argument. Putting
+it in the one accessor all five mutation paths already call is what keeps them from
+disagreeing about the mode — none of them needs to know it exists — and a Layer 1
+test asserts that every script in the catalog carries as many empty-channel guards
+as it has `PUBLISH` calls, so a sixth mutation script cannot be added unguarded.
+
+What `disabled` does **not** turn off is the subscriber connection itself (§3.3):
+the lock's release wake rides it, and a cache setting must not silently push every
+blocked acquisition onto the heartbeat.
+
+A third mode — raw keyspace notifications with best-effort duplicate coalescing, for
+a deployment wanting watches without paying `PUBLISH` — was considered and rejected
+(§13 D4): the two modes above cover both ends, and coalescing per-command
+notifications back into logical writes carries a test matrix disproportionate to a
+benefit nothing has asked for. `WatchMode` is therefore a two-variant enum, not a
+three-variant one with a `todo!()`.
+
+**Prefix watch.** `watch_prefix(p)` is `PSUBSCRIBE <prefix>:e:c:<p>*` — a genuine
+native prefix watch, satisfying `CacheCapability::PrefixWatch` rather than polyfilling
+it. Two caveats bound it:
+
+- **Redis Cluster.** Plain `PUBLISH` is broadcast cluster-wide, so plugin-published
+  events *do* reach a subscriber on any node — but `expired`/`evicted` keyspace
+  notifications are emitted only by the node owning the key, so expiry events in
+  cluster mode need a subscription on every primary plus re-subscription on slot
+  migration. Until that is implemented and verified against a real 3-node cluster
+  (`RD-SPEC-010`, TESTING.md §4.6), **`features().prefix_watch` returns `false` in
+  cluster mode** and `watch_prefix` returns `Unsupported`. Declaring `true` on the
+  strength of an untested code path is precisely the dishonest declaration ADR-009
+  §"Honest backend declaration" forbids. §13 D2 records the decision to ship `false`
+  and designates `RD-SPEC-010` as the gate on lifting it.
+- **Pattern-subscription cost.** `PSUBSCRIBE` matching is per-published-message
+  against every registered pattern, so a deployment with thousands of distinct
+  prefix watches pays on every write. The plugin registers **one** Redis pattern per
+  distinct prefix and fans out in-process to every watcher on it, so N consumers
+  watching the same prefix cost one pattern, not N.
+
+The consumer's prefix is **glob-escaped** before it becomes a pattern, for the same
+reason `scan_prefix` escapes it (§4.4) and with a worse consequence if it is not:
+the key space is opaque to this plugin (§2.1), so a prefix containing `[` or `*`
+would subscribe to something other than what was asked for, and the watcher would
+then receive events for keys it does not watch *and* miss the ones it does.
+
+Three registry properties beyond the fan-out itself:
+
+- **Subscriptions are reference-counted, not merely deduplicated.** `SUBSCRIBE` on a
+  key's first watcher and `UNSUBSCRIBE` when its last one is pruned. The second half
+  matters as much as the first: a key watched once and then abandoned would
+  otherwise keep costing a message per write for the life of the process. Both
+  decisions run under one mutex, and that is load-bearing rather than defensive —
+  the prune is noticed on the *delivery* path while registration happens on the
+  *caller's*, so unserialized an `UNSUBSCRIBE` decided just before a new `watch()`
+  can land just after its `SUBSCRIBE`, leaving a registered watcher with no
+  server-side subscription and no event ever again. Delivery itself never takes the
+  mutex.
+- **Each message serves one watcher family.** A key with both an exact watcher and a
+  covering prefix watcher is subscribed twice server-side, so one `PUBLISH` arrives
+  twice. Redis distinguishes the two (`message` versus `pmessage`) and so does the
+  fan-out: an exact-subscription message reaches only exact watchers and a pattern
+  message only prefix watchers. Routing both to both — the obvious implementation —
+  would deliver two `Changed`s for one `put` to any doubly-covered watcher, which is
+  the duplicate `cpt-cf-clst-nfr-watch-delivery` forbids and `RD-WATCH-001` pins.
+  The keyspace family has no such twin, being one blanket pattern, so it is served
+  to both.
+- **The keyspace pattern is always on and covers every key this cache owns**, not
+  just the watched ones, because §3.7's eviction signal has to observe evictions of
+  keys nobody is watching.
+
+**Lifecycle signals.** All three are produced, and Redis is the first backend to
+produce all three natively:
+
+- **`Lagged { count }`** — the per-watcher channel is bounded (64 slots). A
+  `try_send` that reports full drops the event and coalesces the drop count, and the
+  count then **rides the next successful send to that watcher**. Not "when the
+  buffer drains": nothing polls a drained buffer, so there is no moment at which
+  something could notice. The limitation that follows is real and is recorded rather
+  than papered over — *a watcher that lags and then sees no further traffic on its
+  key never learns it lagged*. It is why `RD-WATCH-008` drives enough writes to make
+  the coalesced event actually fire. This is ADR-003's "Redis pub/sub backpressure →
+  `Lagged`" row, and this plugin is the first thing in the platform that produces
+  the variant at all.
+- **`Reset`** — emitted from three places, all meaning "re-read": the subscriber
+  reconnected; the fan-out's own broadcast stream lagged, so messages were lost
+  before the task could read them and there is no way to know which; or an
+  unrecognized payload arrived on a published channel (§2.5), which resets that
+  key's watchers rather than the registry. Redis pub/sub is fire-and-forget with no
+  resumption point, so every gap is a total gap. Each `Reset` logs
+  `cluster.watch.reset` and increments
+  `cluster_watch_resets_total{provider="redis",primitive="cache"}`.
+
+  On the reconnect path the `Reset` goes out **as soon as the reconnect is
+  observed**, which may be marginally before `fred` finishes replaying the
+  subscription set. That ordering is deliberate: the events in the gap are lost
+  either way, the re-read travels the command pool rather than this client, and
+  telling the consumer late would leave a window in which it believes stale data is
+  current. And **every** reconnect notification is acted on, including the first —
+  see §10 for why skipping one was wrong.
+- **`Closed(ClusterError::Shutdown)`** — on `stop()`, before it returns (§11).
+  `Closed(Provider { ConnectionLost })` when the reconnect policy gives up (§10);
+  `ConnectionLost` specifically, because only a retryable error lets the SDK's
+  `RestartingWatch` combinator run against what is in fact a recoverable outage.
+
+Two registry properties are load-bearing rather than incidental. The fan-out task
+**never awaits a slow watcher** — one stalled subscriber must not stall delivery for
+everyone, so a full buffer produces `Lagged` rather than backpressure. And a `closed`
+latch plus a mutex serializing terminal broadcasts guarantee that no `Reset` is ever
+delivered after a terminal `Closed` (which the SDK's `CacheWatch` contract forbids)
+and that a `watch()` arriving after shutdown receives its terminal event immediately
+rather than registering into a registry nothing will dispatch to again.
+
+### 4.4 scan_prefix
+
+`scan_prefix(p)` is a cursor loop — `SCAN <cursor> MATCH <prefix>:c:<p>* COUNT 500`
+until the cursor returns to 0 — with the plugin's own prefix stripped from each
+returned key. `KEYS` is never used: it is O(N) *blocking* the whole server, which on
+a shared production Redis is an outage.
+
+Three properties to be explicit about:
+
+- **Cluster mode scans every primary** and concatenates, since `SCAN` is per-node.
+  Slot migration during a scan can therefore duplicate or miss a key; the returned
+  order is unspecified anyway, and the
+  polling polyfill that consumes this diffs sets rather than trusting order.
+- **`SCAN` guarantees are weak by design**: keys present for the whole scan are
+  returned at least once; keys added or removed mid-scan may or may not appear. That
+  is exactly the contract `PollingPrefixWatch` needs and no stronger.
+- **Cost scales with the whole keyspace**, not the matched subset, because `MATCH`
+  filters after the fact — which is why `watch_mode: publish`, making native prefix
+  watch available and the polling polyfill unnecessary, is the default.
+
+**The consumer's prefix is glob-escaped before it becomes a `MATCH` pattern.** The
+key space is opaque to this plugin (§2.1), so nothing upstream rules out a `[` or a
+`*` in it: unescaped, `scan_prefix("report[2024]")` is a character class matching
+keys the caller never asked about, and `scan_prefix("*")` returns the entire cache.
+Redis's glob syntax treats `\` as the escape character and gives `*`, `?`, `[`, and
+`]` their special meanings, so the backslash is escaped first — otherwise a key that
+legitimately contains one consumes the character after it. The same escaping is
+applied to a prefix watch's pattern (§4.3) and to the lock's release pattern, for
+the same reason each time.
+
+### 4.5 Consistency Declaration
+
+`consistency()` returns whatever §3.6 computed at startup — `EventuallyConsistent`
+in every replicated or non-fsync-durable configuration, `Linearizable` only for a
+verified single-node `appendfsync always` deployment. It never changes over the
+handle's life.
+
+What is *not* weak, and should not be conflated with the topology-level declaration:
+every individual operation in §4.1 is atomic. Redis executes a Lua script to
+completion without interleaving, so a `compare_and_swap` cannot lose to a concurrent
+CAS on the same key, and `put_if_absent` cannot admit two winners — on a single
+primary. The weakness ADR-009 names is entirely about *losing an acknowledged write*
+(to an fsync gap or a failover), not about racing two concurrent ones. Consumers
+that need the former are the ones that must not bind Redis; consumers that only need
+the latter (rate-limit counters, per-tenant budgets — the OAGW's actual use case)
+are well served here.
+
+## 5. Distributed Lock Implementation
+
+**A held lock costs one task.** The SDK hands the consumer a `LockGuard` built by
+`LockGuard::channel`, and the backend owns the paired `LockCommandReceiver`: `renew`
+and `release` do not arrive as method calls on the backend at all, they arrive as
+`LockRequest`s on that channel, long after the acquisition that produced the guard
+returned. So something has to be selecting on it for as long as the lock is held —
+one task per held guard.
+
+That is compatible with §3.3's "a held lock consumes no *connection*", which remains
+true: a guard task borrows a pooled connection only for the round trip a `renew` or
+a `release` actually needs. But it is exactly the detached-task class §3.1's
+`shutdown.rs` exists to warn about, so the tasks are spawned onto a tracker rather
+than with a bare spawn, and `stop()` drains them under a bound **before** closing
+the pool they share — a task caught mid-`renew` still needs a connection to finish
+on (§11). Each task also selects on the shutdown token, which is what keeps that
+drain bounded by the in-flight command rather than by the consumer's critical
+section.
+
+### 5.1 The Lock Entry and the Holder Token
+
+Acquisition is one command:
+
+```
+SET <prefix>:l:<name> <holder_token> NX PX <ttl_ms>
+```
+
+`OK` → acquired, `nil` → held by someone else (`ClusterError::LockContended`). The
+holder token is a fresh `uuid::Uuid` per acquisition. That is the entire mutual
+exclusion mechanism: `NX` is atomic on a single primary, and `PX` makes the entry
+its own reaper.
+
+**Nothing else participates in exclusion.** There is no liveness proxy, no
+reclamation sweep, and no in-process registry of what this instance holds — none is
+needed, because the design never has to distinguish "the holder crashed" from "the
+lease lapsed". A crashed holder stops renewing and the key evaporates on its own
+deadline, and the next acquirer's `SET NX` is the only thing that has to notice.
+There is no orphaned-state class either: a `try_lock` cancelled after its `SET`
+committed leaves a key that expires at its TTL exactly like any other, with nothing
+local claiming to own it.
+
+The cost of that simplicity is that reclamation is **TTL-bounded, never faster**:
+nothing detects a dead holder sooner than its lease expires, because nothing is
+watching the holder. Consumers tune that with the `ttl` they pass per acquisition,
+which is where the SDK already puts the control — a shorter TTL buys faster recovery
+at the price of more renewal traffic.
+
+`features().linearizable` mirrors the cache's declared consistency: `true` only
+under the verified single-node durable topology, `false` otherwise. A consumer
+requiring `LockCapability::Linearizable` against a Sentinel or Cluster deployment
+therefore fails startup with `CapabilityNotMet` — loudly, per
+`cpt-cf-clst-fr-validation-startup-fail`, rather than getting a lock that a failover
+can hand to two holders.
+
+### 5.2 Renew and Release Are Token-Fenced
+
+Both are Lua, both fence on the token, and both are one round trip:
+
+- **`renew(ttl)`** — `lock_renew`: if `GET K == token` then `PEXPIRE K <ms>`, return
+  1; else return 0 → `ClusterError::LockExpired`. Zero rows means either the lease
+  lapsed or a successor took it; the consumer's response is the same in both cases
+  (abort the critical section), which is why the SDK models it as one error.
+- **`release()`** — `lock_release`: if `GET K == token` then `DEL K` +
+  `PUBLISH <prefix>:e:l:<name> R`, return 1; else return 0. Returning 0 is not an
+  error: it is the SDK's release-if-still-holder contract
+  (`cpt-cf-clst-algo-distributed-lock-release-if-holder`) — a foreign holder's entry
+  is left alone rather than deleted.
+
+The token check is what makes the canonical `SET NX PX` pattern safe; a bare `DEL`
+on release is the classic bug where a holder whose lease lapsed deletes its
+successor's lock. Doing the compare in Lua rather than as `GET`-then-`DEL` is what
+makes it atomic.
+
+`PEXPIRE` on renew is absolute-from-now, computed by Redis's own clock, so a lease
+deadline never depends on the client's wall clock and a skewed instance cannot hold a
+lock longer than it was granted.
+
+### 5.3 Blocking lock()
+
+```
+loop {
+    register interest in `name` with the in-process waiter registry
+    SET K token NX PX ttl  → OK? return LockGuard
+    if past deadline → LockTimeout
+    wait on (that registration resolving)
+         OR jitter(min(PTTL K, heartbeat 250ms, remaining budget))
+         OR shutdown
+}
+```
+
+**The registration comes before the attempt, not after it.** A release landing in
+the window between a failed `SET NX` and a registration made afterwards would be
+missed entirely, and the waiter would then sit out a full delay for a lock that is
+already free — which is precisely the "the notification was missed, not slow"
+outcome `RD-LOCK-003` exists to catch. Registering first costs nothing: a waiter
+that acquires on the attempt drops its registration unused, and the registry
+deregisters on drop.
+
+Three things wake a waiter, in order of preference: an explicit release (the holder
+published to `<prefix>:e:l:<name>`, and the subscriber's fan-out task notifies the
+in-process waiter registry), the lock's own remaining `PTTL` (read on the previous
+attempt — a lease due in 40 ms should not be waited out for a 250 ms heartbeat), and
+a 250 ms heartbeat as the safety net against a missed publish. A lost wake costs
+latency up to the heartbeat, never correctness: the loop always re-attempts the
+`SET NX` itself as the source of truth.
+
+The delay is capped by a **third** bound beside those two — whatever is left of the
+caller's own `timeout`. Without it a waiter with 5 ms of budget left sleeps 250 ms
+and reports `LockTimeout` 245 ms late, which is visible to any caller that measures
+its own budget.
+
+`PTTL`'s two negative sentinels are read as opposites, and getting them the same way
+round would be a real bug: **`-2`** (the key does not exist) means the name is free
+*now*, so the waiter should retry immediately rather than sleep, while **`-1`** (the
+key exists with no expiry) is not a lease this plugin wrote — every acquisition
+carries `PX` — so there is no deadline to schedule against and the heartbeat is the
+honest answer. An unreadable `PTTL` is not worth failing over: the heartbeat covers
+it and the next attempt reports the outage properly if it is still there.
+
+Retry delays carry **full jitter** — uniform over `[0, cap]`, drawing from zero
+rather than perturbing a fixed delay — which is why `rand` is a direct dependency.
+Without it, every instance contending for the same name retries on the same
+deterministic schedule, and a hot lock turns the fleet's retries into synchronized
+`SET NX` bursts, a thundering herd against the one key already under contention.
+Drawing from zero means an occasional near-immediate retry, so the mean is half the
+cap and a waiter blocked on a healthy lock costs about eight `SET NX`s a second
+rather than four. A floor would be cheap and is deliberately absent: it would
+reintroduce exactly the correlation the jitter exists to break.
+
+The wake path itself is one blanket `PSUBSCRIBE <prefix>:e:l:*` rather than a
+`SUBSCRIBE` per contended name. A waiter's interest lasts one loop iteration, so
+per-name subscriptions would put a round trip either side of every retry and
+re-introduce the ordering race the cache's registry needs a mutex to exclude (§4.3).
+Releases are bounded by critical sections rather than by write rate, so what a
+blanket pattern costs an uninterested instance is a hash-map miss.
+
+`lock()` distinguishes three failure outcomes, because a caller's correct response
+differs for each:
+
+- `ClusterError::Shutdown` — checked before any lock work, so an acquisition
+  arriving after `stop()` answers immediately instead of retrying a torn-down
+  backend. `try_lock` takes the same check so the two agree.
+- `Provider { ConnectionLost }` / `{ Timeout }` — the budget ran out while Redis was
+  unreachable. Retried inside the caller's budget (`fred`'s reconnect is what
+  carries a `lock()` through a Sentinel failover), then reported as itself rather
+  than as a contention timeout.
+- `LockTimeout` — the budget ran out while Redis was answering and saying the lock
+  was held. Genuine contention, and only this case reports it.
+
+No server-side blocking primitive is used. Redis has no "wait for this key" command
+short of `BLPOP` on a companion list, which would need its own cleanup story and
+would leak a list per lock name; the retry-plus-publish loop is both simpler and
+cheap, since a blocked waiter holds no connection between attempts.
+
+### 5.4 No RedLock, No Fencing Tokens
+
+**RedLock is not implemented.** ADR-009 rates Redis Cluster as having "no known safe
+config for this use case" and directs Redis-heavy stacks to route correctness-
+critical coordination elsewhere; ADR-001 records RedLock's known correctness issues
+directly ("use single-node + Sentinel instead"). Implementing a quorum protocol
+across N independent Redis masters would add substantial machinery to obtain a
+guarantee this platform's own ADRs decline to rely on, and would invite exactly the
+misreading — "the Redis lock is safe now" — that §3.6's honest declaration exists to
+prevent. A single primary is the arbiter; its declared consistency is the truth
+about what that buys.
+
+**No fencing tokens** (ADR-002). The `LockGuard` API has no `fencing_token()`, and
+this plugin adds no Lua `INCR` counter to produce one — ADR-002 lists that omission
+as a named benefit of the no-remote-I/O-in-the-critical-section rule.
+
+**Nothing mechanically enforces that rule.** There is no
+`no-remote-in-lock-critical-section` dylint lint in this workspace:
+`tools/dylint_lints/` contains only `de12_documentation`, and there is no
+`lint_utils` crate for such a rule to be built on. (The postgres plugin's
+TESTING.md claims one exists, and its `Cargo.toml` comment references a
+`lint_utils::is_in_postgres_cluster_plugin_path` that does not exist either — both
+are worth disregarding rather than following.) ADR-002's rule therefore stands as a
+design constraint **reviewers** enforce, and the benefit above is a benefit of the
+constraint rather than of any tooling. Worth stating plainly, because a rule
+believed to be lint-enforced gets less review attention than one known not to be.
+
+### 5.5 Inspecting Locks (operators)
+
+```
+# What is held right now, and for how long
+SCAN 0 MATCH 'cluster:l:*' COUNT 500
+GET  cluster:l:tenant-42/rate-limit    # → the holder token
+PTTL cluster:l:tenant-42/rate-limit    # → ms remaining on the lease
+```
+
+The token identifies an *acquisition*, not a human-meaningful instance: a random UUID
+does not resolve to a pod, host, or process on its own. It is greppable, though — the
+token is a log field on `cluster.lock.acquired` (§9), so a token read out of Redis
+leads back to the acquiring instance's logs. Storing a `holder_instance` value
+alongside it would duplicate identity already present in log context, and is
+deliberately not done.
+
+`SCAN`, never `KEYS` (§4.4) — including in operator runbooks, since a `KEYS
+cluster:l:*` on a production instance blocks the server for the duration.
+
+## 6. Lua Script Catalog
+
+Seven scripts — five for the cache, two for the lock — loaded once at startup by
+`SCRIPT LOAD` and invoked by `EVALSHA`.
+
+**The startup load is one `SCRIPT LOAD` per script, not a per-primary broadcast, and
+a `NOSCRIPT` recovers with `EVAL` rather than with a second load.** Those two are
+one decision. A per-primary broadcast is unreachable here: `fred`'s only
+broadcasting API, `script_load_cluster`, is gated behind the `sha-1` feature §3.1
+excludes — it hashes the script client-side in order to have a SHA to return — and
+`WithOptions` does not implement the Lua interface, so
+`with_cluster_node(...).script_load(...)` is unavailable too, while `split_cluster()`
+returns *unconnected* clients, which would mean a connection per primary opened and
+closed just to warm a cache.
+
+The recovery path answers the same need better than a broadcast would. On a
+`NOSCRIPT` — the server restarted, its cache was flushed, or in cluster mode this is
+simply the first call to reach a given shard — the call is retried as
+`EVAL <source>` with the same key:
+
+- **it is routed by the key**, so it necessarily reaches the node that reported the
+  miss, where a keyless `SCRIPT LOAD` goes to whichever node the client picks and
+  could easily warm a different one;
+- **it is one round trip instead of two**, and it both executes the call and
+  populates that node's script cache, so subsequent `EVALSHA`s on the shard hit;
+- **it self-heals**, which a startup broadcast cannot: a primary added by a reshard,
+  or restarted mid-life, has an empty script cache no startup-time load ever
+  reached.
+
+Each recovery is counted as `cluster_redis_script_reloads_total` and logged at
+DEBUG. The recovery path is entered **at most once per call** and never re-entered —
+that is the property that bounds it, and it is what the tests assert. A server
+restarting under load answers `NOSCRIPT` to everything, and a policy that recovered
+on each failure without a limit would turn one restart into a retry storm against a
+server already struggling. Anything that goes wrong inside the recovery, including a
+second `NOSCRIPT` that `EVAL` cannot actually produce, falls through the §10 mapping
+to `Provider { Other }`.
+
+Startup still issues `SCRIPT LOAD` for a reason the recovery does not cover: it is
+where the SHA comes from, and it is the check that the server accepts each script at
+all, rather than discovering a syntax error on the first write.
+
+**Every script takes exactly one key via `KEYS[1]`.** That is what makes them
+Cluster-correct: Redis routes an `EVALSHA` by its declared keys, so a single-key
+script always lands on the owning node and `CROSSSLOT` is unreachable. The published
+channel name is passed as an `ARGV` rather than as a second key, so the publish does
+not make the script multi-key (`PUBLISH` is not slot-routed).
+
+The invariant is asserted **structurally** rather than trusted: a unit test reads
+the distinct `KEYS[n]` indices back out of each script's own Lua source and requires
+the answer to be exactly `{1}`, so a future two-key script fails the build's tests
+instead of production's `CROSSSLOT`. Reading it out of the source rather than
+storing a hand-maintained key count is the point — a count gets copied along with
+the script it has stopped describing, and a scan cannot. The rule is encoded a
+second time in the executor's signature, which takes one key and cannot express two.
+
+`ARGV[n]` conventions: `-1` in a TTL position means "no TTL" (`PERSIST`); an
+**empty string** in a channel position means "do not publish", which is how
+`watch_mode: disabled` reaches the write path (§4.3); versions are always compared
+as strings and only ever incremented by `HINCRBY` (§2.2).
+
+```lua
+-- cache_put: KEYS[1]=entry  ARGV[1]=value  ARGV[2]=px_or_-1  ARGV[3]=channel_suffix
+-- Returns: the new version, as an integer
+local ver = redis.call('HINCRBY', KEYS[1], 'ver', 1)
+redis.call('HSET', KEYS[1], 'v', ARGV[1])
+if ARGV[2] == '-1' then redis.call('PERSIST', KEYS[1])
+else redis.call('PEXPIRE', KEYS[1], ARGV[2]) end
+if ARGV[3] ~= '' then redis.call('PUBLISH', ARGV[3], 'C') end
+return ver
+```
+
+```lua
+-- cache_put_if_absent: KEYS[1]=entry  ARGV[1]=value  ARGV[2]=px_or_-1  ARGV[3]=channel
+-- Returns: 1 when created (version 1), or false when the key already existed
+if redis.call('EXISTS', KEYS[1]) == 1 then return false end
+redis.call('HSET', KEYS[1], 'v', ARGV[1], 'ver', 1)
+if ARGV[2] ~= '-1' then redis.call('PEXPIRE', KEYS[1], ARGV[2]) end
+if ARGV[3] ~= '' then redis.call('PUBLISH', ARGV[3], 'C') end
+return 1
+```
+
+```lua
+-- cache_cas: KEYS[1]=entry  ARGV[1]=expected_version  ARGV[2]=new_value
+--            ARGV[3]=px_or_-1  ARGV[4]=channel
+-- Returns: {1, new_version} on success
+--          {0, current_version, current_value} on version mismatch
+--          {0} when the key is absent (caller reports CasConflict{current: None})
+local cur = redis.call('HGET', KEYS[1], 'ver')
+if not cur then return {0} end
+if cur ~= ARGV[1] then
+    return {0, cur, redis.call('HGET', KEYS[1], 'v')}
+end
+local ver = redis.call('HINCRBY', KEYS[1], 'ver', 1)
+redis.call('HSET', KEYS[1], 'v', ARGV[2])
+if ARGV[3] == '-1' then redis.call('PERSIST', KEYS[1])
+else redis.call('PEXPIRE', KEYS[1], ARGV[3]) end
+if ARGV[4] ~= '' then redis.call('PUBLISH', ARGV[4], 'C') end
+return {1, ver}
+```
+
+```lua
+-- cache_compare_and_delete: KEYS[1]=entry  ARGV[1]=expected_value  ARGV[2]=channel
+-- Returns: 1 when deleted, 0 on value mismatch or absent key (never an error)
+if redis.call('HGET', KEYS[1], 'v') ~= ARGV[1] then return 0 end
+redis.call('DEL', KEYS[1])
+if ARGV[2] ~= '' then redis.call('PUBLISH', ARGV[2], 'D') end
+return 1
+```
+
+```lua
+-- cache_delete: KEYS[1]=entry  ARGV[1]=channel
+-- Returns: 1 when the key existed, else 0
+if redis.call('DEL', KEYS[1]) == 0 then return 0 end
+if ARGV[1] ~= '' then redis.call('PUBLISH', ARGV[1], 'D') end
+return 1
+```
+
+```lua
+-- lock_renew: KEYS[1]=lock  ARGV[1]=holder_token  ARGV[2]=px
+-- Returns: 1 when renewed, 0 when the token does not match or the key is gone
+if redis.call('GET', KEYS[1]) ~= ARGV[1] then return 0 end
+return redis.call('PEXPIRE', KEYS[1], ARGV[2])
+```
+
+```lua
+-- lock_release: KEYS[1]=lock  ARGV[1]=holder_token  ARGV[2]=channel
+-- Returns: 1 when released, 0 when we are no longer the holder
+if redis.call('GET', KEYS[1]) ~= ARGV[1] then return 0 end
+redis.call('DEL', KEYS[1])
+redis.call('PUBLISH', ARGV[2], 'R')
+return 1
+```
+
+Acquisition needs no script — `SET K token NX PX ttl` is already atomic (§5.1) — and
+`get`/`contains`/`scan_prefix` need none either (§4.1). Seven across the two
+primitives, then: five cache and two lock, and the standalone lock plugin (§3.5)
+loads only the last two.
+
+`lock_release` publishes unguarded where the five cache scripts guard on a non-empty
+channel, and that asymmetry is correct rather than an oversight: the empty-channel
+sentinel exists for `watch_mode: disabled`, which is a *cache* setting, and a
+release wake has no equivalent switch to be turned off by (§3.3).
+
+Two Redis-version notes: `PUBLISH` from a script is permitted on modern Redis and
+flags the script as "may replicate", which is why scripts run only against primaries
+(§1.3); and `redis.call` errors abort the script and surface to the caller, so no
+script needs its own error handling.
+
+## 7. Leader Election
+
+Leader election uses the SDK default over the Redis cache, and §1.2's table records a
+blocker that this section states plainly because it affects whether the "Redis-only"
+deployment shape in `docs/DESIGN.md` §4.2 is expressible at all today.
+
+**Leader election and the omit-default lock** — both are CAS defaults over this
+cache, and both hit the same guard. `ClusterWiring::from_config` builds an omitted
+`leader_election` with the **strict** `CasBasedLeaderElectionBackend::new(cache)?`,
+which rejects an `EventuallyConsistent` cache — and it builds an omitted `lock` with
+`CasBasedDistributedLockBackend::new(cache)?`, which shares that rejection. So a
+profile binding `cache: { provider: redis }` and omitting either primitive **fails
+startup** in every Redis configuration except the verified single-node durable one.
+Naming both matters: an operator who fixed only the leader-election half would clear
+one failure and land on the next.
+
+That is arguably correct behaviour — ADR-009's whole point is that Redis leader
+election is unsafe and should fail loudly rather than silently — but it means a
+Redis-only deployment has exactly three options, and an operator hitting the error
+deserves to find them documented here:
+
+1. **Route leader election to a backend ADR-009's safety table rates linearizable**
+   (K8s Lease being the one paired with Redis in `docs/DESIGN.md` §4.2's recommended
+   production shape) in the same profile, and bind `lock: { provider: redis }`
+   explicitly so the native lease-based lock serves it rather than the CAS default.
+   This is ADR-009's own recommendation for Redis-heavy stacks, and the intended
+   answer. Note that the native lock needs **no** opt-in over a weak cache: it is
+   not a CAS default and no consistency guard stands in front of it — it declares
+   `linearizable: false` and a consumer requiring otherwise fails capability
+   validation, which is the check that belongs there.
+2. **Verify a single-node durable topology** (`appendonly yes`,
+   `appendfsync always`, no replicas) so the cache declares `Linearizable` and the
+   strict constructors pass. Legitimate for dev and single-instance deployments;
+   not a production HA answer.
+3. **Opt in explicitly, per profile and per binding**, through the reserved provider
+   name `default` (§13 D1):
+
+   ```yaml
+   leader_election:
+     provider: default            # the SDK default over this profile's cache
+     allow_weak_consistency: true # explicit acknowledgement; default false
+   ```
+
+   which routes to the SDK's `new_allow_weak_consistency`, and which the `lock`
+   binding accepts identically. This is the honest way to express "I am running
+   Redis-only in dev and I accept split-brain on failover", and it stays an explicit
+   operator opt-in: **nothing in this plugin makes it implicit.** There is no
+   plugin-side "pretend linearizable" path and no plugin-side default-backend
+   construction bypassing the wiring, even though both crates were changed together.
+
+   The sentinel is `provider: default` rather than a bare
+   `leader_election: { allow_weak_consistency: true }`, because that shorter form
+   cannot deserialize at all — `BackendBinding.provider` is a required field — and
+   writing `provider: redis` instead fails differently, since this plugin registers
+   no leader-election provider and the wiring answers "unknown leader_election
+   provider". §13 D1 records the three homes the flag was weighed against and why
+   this one won.
+
+`LeaderElectionFeatures::linearizable` follows the cache's declaration either way:
+waiving a constructor guard confers no guarantee, and a consumer declaring
+`CacheCapability::Linearizable` against the same profile still fails startup with
+`CapabilityNotMet` whatever the flag says.
+
+## 8. Configuration
+
+```rust
+// `Debug` is hand-written, not derived — see below.
+#[derive(Clone, Deserialize, toolkit_macros::ExpandVars)]
+#[serde(deny_unknown_fields)]
+pub struct RedisClusterConfig {
+    /// Connection URL(s). One entry for standalone; several for Sentinel or
+    /// Cluster (`redis://`, `rediss://`, `redis-sentinel://`, `redis-cluster://`).
+    /// Supports `${VAR}` / `${VAR:-default}` expansion via
+    /// `toolkit_utils::var_expand`, resolved through `ctx.config_expanded()` —
+    /// the same mechanism `libs/toolkit-db` uses for DB DSNs. A credstore-backed
+    /// (`secret_ref`) path is deferred (§13 D5).
+    #[expand_vars]
+    pub url: String,
+
+    /// Command-pool size. Default: 4.
+    #[serde(default = "default_pool_size")]
+    pub pool_size: u32,
+
+    /// Per-command timeout. Default: 5s. Enforced client-side by `fred`, so no
+    /// command can block indefinitely once issued — the bound `stop()` and
+    /// `RD-LIFE-009` rely on (§11, §12).
+    #[serde(default = "default_command_timeout")]
+    pub command_timeout_ms: u64,
+
+    /// Prefix for every key and channel this plugin owns. Default: "cluster".
+    #[serde(default = "default_key_prefix")]
+    pub key_prefix: String,
+
+    /// Logical database index. Ignored in Cluster mode (db 0 only). Default: 0.
+    #[serde(default)]
+    pub database: u8,
+
+    /// Operator hint for topology. Omitted → detected via `INFO replication`
+    /// (§3.4). Drives the consistency declaration (§3.6).
+    #[serde(default)]
+    pub topology: Option<Topology>,
+
+    /// Operator hint for write durability. Omitted → detected via
+    /// `CONFIG GET appendonly|appendfsync`. A hint contradicted by a readable
+    /// server config fails startup with `InvalidConfig` (§3.6).
+    #[serde(default)]
+    pub durability: Option<Durability>,
+
+    /// Append `WAIT <n> <wait_timeout_ms>` to lock and CAS writes. Narrows the
+    /// Sentinel failover window; per ADR-009 it does NOT upgrade the declared
+    /// consistency (§3.6). Default: none.
+    #[serde(default)]
+    pub wait_replicas: Option<u32>,
+
+    /// Timeout for the `WAIT` above, in milliseconds. Default: **1000**. `WAIT`
+    /// rides the tail of a write that already carries a 5 s command timeout, and a
+    /// replica that has not acknowledged within a second is not about to, so
+    /// spending the whole command budget there would turn a narrowed failover
+    /// window into a latency regression. A short count is surfaced rather than
+    /// swallowed (§3.6), so the shorter bound loses no information. A value past
+    /// `i64::MAX` — which `WAIT`'s signed timeout cannot express — fails startup
+    /// with `InvalidConfig` rather than being clamped.
+    #[serde(default = "default_wait_timeout")]
+    pub wait_timeout_ms: u64,
+
+    /// How cache watches are sourced (§4.3). Default: `publish`.
+    #[serde(default)]
+    pub watch_mode: WatchMode,
+
+    /// When true, and the server's `notify-keyspace-events` lacks the flags
+    /// `Expired` events need, issue one `CONFIG SET` to add them (§3.4).
+    /// Default: false — mutating a shared server's global config is opt-in.
+    #[serde(default)]
+    pub manage_keyspace_notifications: bool,
+}
+
+#[derive(Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Topology { Standalone, Sentinel, Cluster }
+
+#[derive(Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Durability { FsyncAlways, FsyncEverysec, None }
+
+#[derive(Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum WatchMode { #[default] Publish, Disabled }
+```
+
+`RedisLockConfig` (standalone lock provider, §3.5) carries the same fields **minus**
+`watch_mode` and `manage_keyspace_notifications`, which have
+no meaning without the cache half — and `deny_unknown_fields` turns each of them
+into a startup error there rather than an ignored key, since a lock-only binding
+that sets `watch_mode` has misunderstood something and should hear so.
+
+**The shared subset is duplicated field-for-field, not factored into an inner
+struct.** Factoring it out is the obvious way to keep the two types from drifting
+and it is not available: sharing an inner struct needs `#[serde(flatten)]`, and
+serde refuses to derive `flatten` together with the `deny_unknown_fields` this
+section and TESTING.md §2 both require. Flattening is
+implemented by buffering every unmatched key and replaying it into the inner type,
+so the outer type can no longer tell an inner field from an operator's typo — serde
+rejects the combination at compile time rather than silently picking one.
+`deny_unknown_fields` is the more valuable half by some distance: it is what turns
+`pool_sise: 8` into a startup error instead of a silently-ignored key, and it is
+also what makes a misplaced `allow_weak_consistency` on a *native* binding (§7) fail
+loudly rather than being swallowed into an options map.
+
+Two things hold the duplicated copies together instead. Every default lives in one
+`default_*` function shared by both types, so a default cannot drift even in
+principle; and a unit test reads each type's accepted field set back out of serde's
+own `unknown field …, expected one of …` error and asserts the lock type is exactly
+the cluster type minus the two cache-only fields. Deriving the guard from serde
+rather than from a hand-written list is deliberate: a hand-written list would have
+to be maintained by the same person who forgot to update the second type.
+
+**`Debug` is hand-written on both types and masks `url`.** After `${VAR}` expansion
+that field embeds a password, and a `{:?}` in a log line or a panic message would
+leak it. This is not hypothetical for a config type: a `#[derive(Debug)]` config is
+exactly the sort of thing that ends up in a startup error's context. Everything else
+prints normally, following the postgres plugin's `REDACTED_DSN`.
+
+**`validate()` runs before anything is opened**, rejecting a zero `pool_size`,
+`command_timeout_ms`, or `wait_timeout_ms`. Each of those
+zeros *removes* a bound rather than tightening it, which is why none can be left for
+the backend to discover: `fred` reads a zero command timeout as "no timeout at all",
+which silently deletes the property §11 and §12 rest on; and `wait_timeout_ms: 0`
+makes `WAIT` block with no deadline. `pool_size: 0` is refused
+here rather than by `fred` so the operator reads the name of the field they have to
+change.
+
+Operator YAML — the recommended production shape from `docs/DESIGN.md` §4.2, with
+Redis serving cache and lock and K8s Lease serving the other two (the K8s plugin
+being a separate follow-up):
+
+```yaml
+cluster:
+  profiles:
+    event-broker:
+      cache:
+        provider: redis
+        url: "rediss://:${REDIS_PASSWORD}@redis-primary:6379/0"
+        pool_size: 8
+        topology: sentinel
+      lock:
+        provider: redis
+        url: "rediss://:${REDIS_PASSWORD}@redis-primary:6379/0"
+        wait_replicas: 1
+      leader_election:
+        provider: k8s-lease      # follow-up plugin; see §7
+```
+
+## 9. Observability
+
+The plugin satisfies the versioned observability contract (ADR-004,
+`docs/OBSERVABILITY.md`) verbatim and emits no catalog signal under a different name.
+All signals carry `provider = "redis"`.
+
+**Cache** — `RedisCache` is wrapped in the SDK's
+`cluster_sdk::observability::InstrumentedCache` decorator, the supported path for the
+cache signal set, so the full set comes for free: spans
+`cluster.cache.{get,put,delete,contains,put_if_absent,compare_and_swap,watch,watch_prefix}`,
+counter `cluster_cache_ops_total{provider,op,result}`, histogram
+`cluster_cache_op_duration_seconds{provider,op}`.
+
+**Lock** — `RedisLock` is a native implementation, so it emits lock signals directly
+at each site (mirroring `CasBasedDistributedLockBackend::record_lock`): spans
+`cluster.lock.{try_lock,lock,renew,release}`, counter
+`cluster_lock_ops_total{provider,op,result}`, histogram
+`cluster_lock_op_duration_seconds{provider,op}` via the injected
+`cluster_sdk::observability::ClusterMetrics` sink.
+
+**Shared** — every backend failure routes through
+`cluster_sdk::observability::emit_provider_error`, incrementing
+`cluster_provider_errors_total{provider,kind}` and logging `cluster.provider.error`
+(ERROR) with `op`, `kind`, `message`, and the `key`/`lock` resource as a *field*.
+Watch resets call `ClusterMetrics::watch_reset("cache")`, backing
+`cluster_watch_resets_total{provider,primitive}`.
+
+**Plugin-local metrics** (outside the ADR-004 catalog; adding signals is
+non-breaking per ADR-004):
+
+| Metric | Type | Why |
+|---|---|---|
+| `cluster_redis_watch_events_dropped_total{provider}` | counter | Events dropped to a full watcher buffer, i.e. the `Lagged` count. The signal that a consumer is too slow, which no catalog metric carries. Incremented once per dropped event — including a dropped `Lagged` that itself found no room — so it agrees with the `dropped` count the consumer eventually receives |
+| `cluster_redis_subscriber_resubscribes_total{provider}` | counter | Subscriber reconnect-and-replay cycles. Pairs with `cluster_watch_resets_total` to separate "the subscriber flapped once" from "every watcher reset". **Combined plugin only** — it lives on the reconnect observer, which the standalone lock plugin does not spawn (§3.5); spawning a task purely to count was not worth it, so the gap is named rather than filled |
+| `cluster_redis_script_reloads_total{provider}` | counter | `NOSCRIPT` recoveries (§6). A steady stream means something is flushing the script cache under the plugin; a burst at startup in cluster mode is just each shard being reached for the first time |
+| `cluster_redis_evictions_observed_total{provider, primitive}` | counter | Evictions of this plugin's own keys (§3.7). `primitive` is `cache` or `lock`, and it is what makes the counter actionable rather than merely present: an evicted entry costs a re-read, an evicted lease means two holders believe they hold one lock, and an alert that cannot separate them has to treat every eviction as one or the other. **Never throttled**, unlike the WARN beside it: an alert has to see every eviction, while an operator reading the log needs one line naming a key plus how many others it stands for |
+| `cluster_redis_connection_state{provider}` | gauge, 0/1 | Whether every connection in the command pool believes it is connected. The cheapest "is Redis reachable" panel |
+
+**The gauge is sampled by a cancellable task, not reported by an OpenTelemetry
+*observable* gauge.** The observable form is the obvious fit and the wrong one: its
+callback is registered on the meter provider for the life of the process and is not
+unregistered when the instrument handle drops, so it would outlive `stop()` holding
+a pool clone, and a second plugin instance would register a second callback
+reporting the same `{provider}` series — a conflict rather than a sum. A task is
+cancellable, which is exactly the property that mismatch needs. It samples every
+10 s, which is under any ordinary scrape interval, and records 0 on the way out so
+the last sample a scrape can see says the pool is gone rather than leaving the
+series stuck at its final live reading.
+
+**Why these four are not `ClusterMetrics` calls.** The ADR-004 port has no gauge
+method at all, so `cluster_redis_connection_state` could not go through it under any
+naming; and the other three name Redis-specific subjects no catalog instrument
+covers. So this plugin owns an OpenTelemetry meter directly, under its own
+instrumentation scope, exactly as `postgres-cluster-plugin` does for its own
+plugin-local gauge. `RedisSignals` holds both sinks and is threaded into the cache,
+the lock, the watcher registry, and the subscriber fan-out as one value, so no
+emitting site has to know which half a given signal belongs to — and one per plugin
+rather than one per component, because the `provider` label is fixed at construction
+and two sinks would mean two `cluster_cache_ops_total` instruments disagreeing about
+one deployment.
+
+`cluster_redis_evictions_observed_total` is where §3.7's eviction signal lands. The
+catalog counter cannot carry it — `cluster_provider_errors_total` has no `op` label
+and an eviction is not a `ClusterError` — and §3.7 records why folding it on as
+`kind = "other"` would be worse than either alternative.
+
+Keys, lock names, and holder tokens are **never** metric label values
+(`METRIC_LABEL_ALLOWLIST`); they appear only as span attributes and log fields. That
+rule is structural rather than observed here: the `ClusterMetrics` port takes no
+such parameter, and the plugin-local instruments above attach only `provider`.
+
+**Plugin-local log events**, all following `cluster.{primitive}.{event}`:
+
+| Event | Level | Meaning |
+|---|---|---|
+| `cluster.provider.maxmemory_policy_unsafe` | WARN, once at startup | `maxmemory-policy` is not `noeviction`, so cluster keys can be evicted — locks handed to two holders, leader keys vanishing (§3.7). Alert on this |
+| `cluster.provider.eviction_observed` | WARN, rate-limited **per primitive** | An `evicted` notification arrived for a key under this plugin's prefix, carrying `primitive` and the key. The above risk *materializing*. The highest-value signal this plugin emits. The two primitives have independent windows, so a cache eviction storm cannot suppress the one line reporting a lost lease (§3.7) |
+| `cluster.provider.weak_consistency` | WARN, once at startup | The declared consistency is `EventuallyConsistent`, naming the detected topology and ADR-009's table. Not an error — the expected state for Sentinel and Cluster — but it must appear in the log of every deployment it applies to |
+| `cluster.provider.consistency_asserted` | WARN, once at startup | An operator `durability`/`topology` hint was trusted because the server refused the verifying `CONFIG GET` (§3.6). If the hint is wrong, this line is the only trace |
+| `cluster.provider.expiry_events_unavailable` | WARN, once at startup | `notify-keyspace-events` lacks the expiry flags and could not be set, so `Expired` watch events will not be delivered (§4.3). Promptness only |
+| `cluster.provider.keyspace_notifications_set` | INFO, once | `manage_keyspace_notifications: true` took effect and the server's global flags were changed. A config mutation should never be silent |
+| `cluster.provider.sharded_pubsub_available` | DEBUG, once at startup | The server supports `SPUBLISH`/`SSUBSCRIBE`, which v1 detects and records but does not use (§13 D3). DEBUG, not INFO: it is an input to a future decision, not an operator action |
+| `cluster.provider.topology_unknown` | WARN, once at startup | `INFO replication` was refused, so the topology could not be detected and the conservative `EventuallyConsistent` is declared (§3.4). Distinct from the row above it because an operator debugging a surprise weak declaration needs to know whether the plugin *saw* a replica or saw nothing |
+| `cluster.provider.durability_unknown` | WARN, once at startup | `appendfsync` reported a value this plugin does not recognize, so durability is treated as unverifiable (§3.4) |
+| `cluster.provider.maxmemory_policy_unknown` | WARN, once at startup | `CONFIG GET maxmemory-policy` was refused, so the plugin cannot tell whether its keys can be evicted at all — the `unsafe` row above it is the answer being *known* to be bad, this one is it being unknowable (§3.7) |
+| `cluster.provider.pool_close_timeout` | WARN, at shutdown | The command pool did not finish draining inside `POOL_CLOSE_TIMEOUT`; the client is shut down either way, but at least one connection may outlive `stop()` (§11) |
+| `cluster.provider.task_drain_timeout` | WARN, at shutdown | Tracked background tasks — the per-guard lock tasks of §5 — did not finish inside their bound. Same shape as the row above and the same reason it is a WARN rather than an error: `stop()` proceeds regardless, and the line is the only trace that it proceeded over something |
+| `cluster.provider.subscriber_lost` | WARN, once | The subscriber's reconnect policy is exhausted, so the connection is not coming back (§10). Every cache watch is closed terminally with a *retryable* error, and blocked `lock()` callers fall back to the jittered heartbeat, which costs latency rather than correctness (§5.3). The most severe runtime condition this plugin reports, and the reason it carries a name at all: a collector filtering structurally on `name` has to be able to match the one line announcing that outcome |
+| `cluster.lock.acquired` | DEBUG | Lock name and holder token — the line that makes a token read out of Redis traceable to an instance (§5.5). A *log field* and never a metric label: a holder token is unbounded and would explode the cardinality of anything it touched |
+| `cluster.watch.reset` | WARN | Catalog event, emitted from all three of §4.3's `Reset` sources: a subscriber reconnect, the fan-out's own stream lagging, and an unintelligible payload on a published channel |
+
+**Every event carries its name twice**: `name:` set for a collector to match on
+structurally, and the same name opening the human message. The default `tracing`
+`fmt` layer prints the message and not the event name, so the structural form alone
+would leave an operator tailing logs with prose and no way to tell which catalogued
+event they are reading. The cost is one duplicated string constant per site.
+
+The plugin emits no `cluster.leader.transition` of its own: leader election is the
+SDK default over this cache and emits that itself.
+
+**Startup failures are deliberately not routed through `emit_provider_error`.** A
+`build_and_start` that fails returns its error to the wiring, which fails the gear's
+boot with the text — it is not silent — and a counter incremented by a process that
+then exits is not something a scrape will ever see. What *is* routed, because
+nothing else would count it, are the two backend failures no catalogued operation
+wraps: the lock's giveback of a lease it took but never handed out, and the
+registry's `UNSUBSCRIBE` for a subscription whose last watcher went away. Both were
+previously swallowed at DEBUG, which would have left a Redis failing every release
+with no signal but a debug line.
+
+## 10. ProviderErrorKind Mapping
+
+Matches the platform mapping table (`docs/DESIGN.md` §4.1, Redis/`fred` column) and
+extends it with the Redis-specific server replies that column does not enumerate.
+
+| `fred` error / server reply | `ClusterError` / `ProviderErrorKind` |
+|---|---|
+| `ErrorKind::IO` | `ConnectionLost` |
+| `ErrorKind::Timeout` | `Timeout` |
+| `ErrorKind::Auth`, `NOAUTH`, `WRONGPASS` | `AuthFailure` |
+| `ErrorKind::Backpressure` | `ResourceExhausted` |
+| `ErrorKind::Config`, `ErrorKind::Url`, malformed URL | `InvalidConfig` — an unparseable URL is an operator config error, not a runtime backend fault, so it is *not* wrapped as `Provider` — an operator reading the error should be looking at their YAML, not at their server (`RD-LIFE-004`) |
+| `OOM command not allowed when used memory > 'maxmemory'` | `ResourceExhausted` — retryable with backoff, and a pointer to §3.7 |
+| `READONLY You can't write against a read only replica` | `ConnectionLost` — the routing landed on a demoted primary mid-failover. Retryable; `fred` re-resolves the topology |
+| `LOADING Redis is loading the dataset in memory` | `ResourceExhausted` — retryable; a restarting server |
+| `MASTERDOWN`, `CLUSTERDOWN` | `ResourceExhausted` — retryable |
+| `NOSCRIPT` | Not surfaced: recovered once with a key-routed `EVAL` (§6), and `Other` if anything goes wrong inside that recovery |
+| `CROSSSLOT` | `Other` — unreachable by construction (§6, every script is single-key); if it ever appears it is a plugin bug, not an operator one |
+| `NOPERM` / ACL denial on a preflight command | Handled per §3.4's degradation table, not as an operation error |
+| Any other `fred::Error` | `Other` |
+
+Two notes on how those rows are actually recognized, neither of which is guessable
+from the table. **A Redis error reply is not a distinct `ErrorKind`**: `fred`'s reply
+parser switches on the first token and recognizes only `ERR`, `WRONGTYPE`, `NOAUTH`,
+`WRONGPASS`, `MOVED`, `ASK`, and `CLUSTERDOWN`, so `OOM`, `READONLY`, `LOADING`,
+`MASTERDOWN`, `NOSCRIPT`, and `CROSSSLOT` all arrive as `ErrorKind::Unknown` with the
+reply text in the details. The server-reply rows above are therefore matched by
+reading that leading code back out, and that check has to run *before* the
+`ErrorKind` match or every one of them collapses into `Other`. And **`MOVED`/`ASK`
+are left to `Other` on purpose**: `fred` follows redirections and re-resolves the
+slot map itself, so one surfacing to a caller means the redirection could not be
+followed, which no retry at this layer improves.
+
+**The reconnect policy is this plugin's, not `fred`'s.** `fred` supplies none at all — `Builder::from_config` leaves it
+unset — and everything above and in §4.3 about recovery presumes one: the
+subscription replay, the `Reset` a watcher receives afterwards, and the terminal
+close "once the reconnect policy is exhausted". Without one, a single dropped TCP
+connection ends the client permanently, so every subsequent command fails forever
+and every watcher is closed on the first blip. So both clients are built with an
+explicit **bounded exponential** policy: 100 ms doubling to a 30 s ceiling, 20
+attempts, roughly six minutes of outage ridden out — enough for a rolling restart or
+a Sentinel failover.
+
+**Bounded rather than unlimited is the load-bearing half.** The watchdog task that
+closes every watch has exactly one signal, the connect handle resolving, and that
+happens only when the policy gives up; unlimited retries would make it dead code,
+and a watcher waiting on a server that is never coming back would wait forever,
+told nothing. The policy also governs the *initial* connect, which is why §3.2 step 1
+wraps that separately in a 10 s bound.
+
+Subscriber connection loss therefore surfaces to watchers as `Reset` while `fred` is
+still retrying, and as `Closed(Provider { ConnectionLost })` once the policy is
+exhausted. **Every reconnect notification produces the `Reset`, including the
+first, and the observer deliberately skips none.** The tempting reasoning for a skip
+is that `fred` fires a notification on the initial connect, which it does — but the
+observer's receiver is created *after* `build_and_start` has awaited that connect,
+and a broadcast receiver only ever sees sends that follow its own subscription, so
+that notification is already gone and a skip consumes the first **genuine**
+reconnect instead. The failure that produces is quiet and severe: the first
+subscription gap of a process's life delivers no `Reset` at all, and every watcher
+keeps believing a stale view is current until a second reconnect happens along.
+Acting on every notification is safe even if that ordering ever changes, since an
+initial-connect notification would cost one registry-wide `Reset` at startup, and
+`build_and_start` has not returned at that point, so no consumer has had the chance
+to register a watch for it to reach.
+
+## 11. Shutdown Sequence
+
+`RedisClusterHandle::stop()` follows `docs/DESIGN.md` §3.13:
+
+1. Cancel the `CancellationToken` shared by every task this handle owns. That ends
+   the subscriber fan-out, the reconnect observer, the watchdog, and the
+   connection-state sampler; it ends every per-guard lock task (§5); and it unparks
+   every blocked `lock()` waiter, which returns `ClusterError::Shutdown` rather than
+   `LockTimeout` (§5.3).
+2. Send `CacheWatchEvent::Closed(ClusterError::Shutdown)` to every active watcher,
+   dispatched directly against the registry before any task is awaited, so every
+   watcher observes it before `stop()` returns (`cpt-cf-clst-fr-shutdown-revoke`).
+   Going through the registry rather than through the fan-out is what makes that
+   independent of whether the fan-out has noticed the cancel yet.
+3. Drain the tracked guard tasks under `GUARD_DRAIN_TIMEOUT` (5 s), **before** the
+   pool closes — a task caught mid-`renew` still needs a connection to finish on.
+   The bound is generous rather than tight: each task selects on the token, so the
+   only thing that can delay one is an in-flight command, which
+   `command_timeout_ms` already bounds client-side.
+4. Await the remaining task handles, then quit the subscriber client, then the
+   command pool under a bounded `POOL_CLOSE_TIMEOUT` (10 s). `fred`'s `quit` drains
+   in-flight commands, which is the behaviour worth having — severing the socket
+   mid-command would turn an orderly shutdown into a spurious `ConnectionLost` — but
+   that drain is only as fast as the server, so a supervisor's shutdown budget must
+   not be spent on an unresponsive one. Both timeouts log rather than fail (§9);
+   giving up on the wait still leaves the client shut down, and what is lost is only
+   the guarantee that the server saw the `QUIT`, which an unresponsive peer was
+   never going to give.
+5. Set `self.stopped = true` last, so the ADR-006 `Drop` guard does not fire.
+
+**The `Drop` guard cancels before it diagnoses**, and that ordering is deliberate
+rather than incidental. Reaching `Drop` with `stopped == false` covers two cases: a
+handle genuinely forgotten, which is the programming error the diagnostic exists to
+shout about, and a `stop()` future *dropped part-way*, which is exactly what
+`tokio::time::timeout(d, handle.stop())` does when its budget elapses — the
+supervisor-level pattern this section recommends. In both, cancelling is what lets
+the background tasks observe shutdown and exit instead of running on against a
+handle nobody owns while each still holds a pool clone. In the second the caller has
+not misused anything at all, so a diagnostic that ran *instead of* cancelling would
+punish them for following the advice. The cancel must also precede the debug-build
+`panic!`, or it would be unreachable in exactly the configuration tests run in.
+
+**No remote cleanup**, per `cpt-cf-clst-fr-shutdown-ttl-cleanup`: held locks, leader
+claims, and service registrations are not deleted on the way out — they lapse via
+their TTL. This is cheap to honour here: a Redis lease expires by itself, so there is
+no drain step on the way out, no statement that can half-succeed, and no
+partial-cleanup failure mode to log or alert on. The cost is the TTL-bounded gap the
+requirement already accepts: a
+name held by a cleanly-stopped instance stays held until its lease expires. A
+consumer wanting the gap closed calls `release()` before shutdown, which is what the
+explicit-release contract asks of it anyway.
+
+## 12. Risks / Trade-offs
+
+**[Risk: eviction silently breaks every primitive]** Covered in §3.7. The plugin
+warns at startup on a non-`noeviction` policy and warns again on each observed
+eviction, but cannot prevent it: `maxmemory-policy` is server-wide and may be owned
+by an unrelated tenant. **This is the top operational risk of running this plugin**
+and the reason the deployment recommendation is a dedicated instance. Alert on
+`cluster.provider.eviction_observed`.
+
+**[Risk: Redis is not linearizable in any HA configuration]** §3.6 declares this
+rather than mitigating it, per ADR-009. The consequence is not theoretical: an
+operator who binds Redis cache and omits `leader_election` gets a startup failure
+today (§7), and one who binds the native lock on Sentinel gets a lock that a
+failover can grant twice. The mitigations are architectural, not code:
+per-primitive routing, honest declaration, and startup capability validation.
+
+**[Risk: `PUBLISH` cost in Redis Cluster caps the watch path well below the write
+path]** Pre-7.0 Cluster broadcasts every `PUBLISH` to all nodes; ADR-001 puts the
+ceiling around 12 500 publishes/sec on a 10-node cluster, an order of magnitude
+below this plugin's write ceiling. A clustered deployment doing 10 000+ writes/sec
+with watches enabled will hit the pub/sub ceiling first. Mitigations, in order:
+`watch_mode: disabled` (polling polyfill, no publish at all); Redis 7 sharded
+pub/sub (`SPUBLISH`/`SSUBSCRIBE`), which confines a publish to the key's own shard
+and is the real fix — **decided as detect-and-record only in v1** (§13 D3), designed
+together with D2's per-shard subscription work when a deployment actually hits the
+ceiling; or keeping the high-write primitive on a non-clustered instance.
+
+**[Risk: pub/sub delivery is fire-and-forget]** There is no resumption point, no
+sequence number, and no replay. Every subscriber gap is total, which is why every
+reconnect emits `Reset` and every consumer must re-read (§4.3). This is a permanent
+property of Redis pub/sub, not a gap to close, and it is why ADR-003's uniform
+lag/reset/close contract exists. Consumers needing delivery guarantees want the
+event broker, not cluster watches.
+
+**[Risk: the consistency declaration is computed once and never re-evaluated]**
+§3.6. A single node that gains a replica under a running plugin keeps a
+`Linearizable` declaration that is no longer true. Deliberately not solved:
+re-declaring mid-flight would change capability answers after consumers have already
+resolved against them, which the resolution model cannot express. The practical
+mitigation is that topology changes are deployment events, and a deployment event
+restarts the gear.
+
+**[Trade-off: lock reclamation is strictly TTL-bounded]** §5.1. A crashed holder's
+lock waits out its full TTL; nothing in the design detects the crash sooner, because
+nothing watches the holder. Accepted: sub-TTL detection would mean a per-instance
+heartbeat key, a TTL on that heartbeat, and a sweep to act on it — machinery native
+expiry exists to avoid — for a promptness gain consumers can already buy by passing a
+shorter `ttl`.
+
+**[Trade-off: `Expired` events depend on server configuration]** §4.3. Without the
+`notify-keyspace-events` expiry flags there are no `Expired` events at all. Costs
+promptness only (both SDK defaults over this cache have timer-driven fallbacks;
+an expired entry still reads as absent), and the state is logged loudly at startup.
+
+**[Trade-off: hash-per-entry costs a little memory and a Lua call on
+`put_if_absent`]** §2.2. The framed-string alternative would make `get` a bare `GET`
+and `put_if_absent` a bare `SET NX`, but puts a u64 version through Lua 5.1's
+doubles. Precision over micro-optimization; revisit only if profiling on the OAGW
+path shows the hash is the bottleneck, which the ADR-001 envelope says it will not
+be.
+
+**[Design choice: no in-process read cache]** `get` is always a round trip. A local
+cache would be per instance rather than shared, so at N instances it multiplies
+staleness risk instead of amortizing it — each instance racing event-driven
+invalidation against its own concurrent reads, so two instances could transiently
+observe different values for one key. It would also silently reach the leader-election
+default riding on this cache (§7). At ~0.15 ms per read
+(ADR-001) there is little to buy anyway. A consumer wanting a local hot cache should
+build one where it can reason about its own invalidation, not inherit one here.
+
+**[Trade-off: no RedLock]** §5.4. Operators wanting multi-master lock quorum do not
+get it from this plugin, by ADR decision rather than omission.
+
+**[Property: every command is bounded client-side]** A server that freezes *after*
+accepting a command is the case a server-side timeout cannot cover — the peer that
+would enforce it is the one that stopped answering — and where the caller is a
+background task, an unbounded command blocks `stop()` on that task's join. `fred`
+enforces `command_timeout` (§8, default 5 s) on every command, so no operation in this
+plugin is unbounded and `RD-LIFE-009`'s shutdown budget is a general claim rather than
+an accident of timing. Stated as a property rather than left implicit, because it is
+what lets §11 promise a bounded `stop()` at all.
+
+## 13. Decisions (formerly Open Questions)
+
+All six questions this design opened are decided. Each states the decision, what it
+commits v1 to, and what would reopen it. **D1 is in scope for this change** — it
+lands in `cf-gears-cluster` alongside the plugin rather than as separate work. The
+rest are settled scope boundaries, deliberately narrow rather than deferred
+indefinitely.
+
+### D1 — Wiring-level opt-in for the weak-consistency CAS defaults
+
+**Decided: reserve the provider name `default` to mean "the SDK default backend over
+this profile's cache, with options", and carry `allow_weak_consistency: bool` on
+that binding — for `leader_election` and for `lock` alike — routing to the SDK's
+existing `new_allow_weak_consistency`. A `cf-gears-cluster` change rather than a
+plugin one, delivered as part of this change.**
+
+Without it, the strict `CasBasedLeaderElectionBackend::new(cache)?` means a profile
+binding `cache: { provider: redis }` and omitting `leader_election` fails startup in
+every Redis configuration except the verified single-node durable one (§7) — so the
+`Redis-only` shape in `docs/DESIGN.md` §4.2 would be unreachable, and the
+`K8s + Redis` shape depends on a K8s plugin that has not shipped.
+
+Two properties of that shape are easy to get wrong, and both are load-bearing.
+
+*It covers the lock as well as leader election.* The omit-default `lock` is built
+with `CasBasedDistributedLockBackend::new(cache)?`, which shares the leader
+default's consistency guard, so a leader-only flag clears one startup failure and
+lands on the next — `RD-SPEC-004b` would elect a leader over the weak cache and then
+die on the lock. The flag therefore covers both primitives.
+
+*The flag needs a binding to live on, and `provider` is required.* The compact form —
+
+```yaml
+leader_election:
+  allow_weak_consistency: true     # cannot deserialize
+```
+
+— cannot parse at all: `BackendBinding.provider` is a required field. Writing
+`provider: redis` instead fails differently, since this plugin registers no
+leader-election provider and the wiring answers "unknown leader_election provider".
+Three homes were weighed:
+
+| Option | Why not chosen |
+|---|---|
+| Make `provider` optional, absent ⇒ SDK default | Matches the YAML above exactly, but `BackendBinding` captures unknown keys into its options map, so a misspelled `providr: redis` would silently become an SDK default instead of a startup error. A config typo must not change which backend runs |
+| A profile-level `allow_weak_consistency: bool` | Fixes leader and lock in one field with no new vocabulary, but is per-*profile*, and the constraint below requires per-binding |
+| **Reserved `provider: default`** | **Chosen.** Per-binding as required, uniform across `leader_election`/`lock`, self-documenting in YAML, and typo-safe because `provider` stays required |
+
+```yaml
+leader_election:
+  provider: default                # the SDK default over this profile's cache
+  allow_weak_consistency: true     # explicit acknowledgement; default false
+```
+
+Two rules on the sentinel itself. It is **rejected on `cache`**, which is the
+omit-default anchor and has no default to resolve to, with a naming error rather
+than a confusing "unknown cache provider `default`". And it is **intercepted before
+the registry lookup**, so a plugin that registered a provider literally named
+`default` cannot shadow it.
+
+One pleasant side effect worth keeping: `allow_weak_consistency` misplaced onto a
+*native* binding — `lock: { provider: redis, allow_weak_consistency: true }` — lands
+in this plugin's options map and trips its `deny_unknown_fields` (§8), so a
+misplacement fails loudly instead of being quietly ignored.
+
+Three constraints on that change, all following from ADR-009:
+
+- **Default `false`.** Absent the flag, the current loud startup failure is the
+  correct behaviour and must not change.
+- **The flag is per profile and per binding**, never global — a deployment may
+  legitimately accept weak leader election for one profile and require linearizable
+  for another.
+- **It routes to the SDK's existing constructor**, which already emits its own
+  warning at construction. No new warning, no new consistency semantics, and no
+  change to capability validation: a consumer that declares
+  `CacheCapability::Linearizable` still fails startup regardless of this flag.
+
+**The plugin still must not work around it** — no plugin-side "pretend linearizable"
+path and no plugin-side default-backend construction bypassing the wiring, even
+though both crates are being changed together. The flag is the operator's
+acknowledgement; nothing in the plugin may make it implicit.
+
+**Delivery.** Two crates, one change, in this order so neither half is ever on a
+broken base:
+
+1. `cf-gears-cluster`: the reserved `default` provider name, the options struct
+   carrying `allow_weak_consistency`, its dispatch to `new_allow_weak_consistency`
+   on both primitives, and its own tests over a stub weak cache — default-off still
+   fails, flag-on constructs, **the leader flag alone still fails on the lock**, the
+   reserved name is never looked up in the registry, and capability validation is
+   unaffected. Those tests need no Redis and belong to the cluster crate's own
+   suite, split across its config-parsing and builder-API test modules because the
+   crate already partitions them that way.
+2. The Redis plugin, whose `RD-SPEC-004` / `RD-SPEC-004b` (TESTING.md §4.6) then
+   cover the same two paths end to end through real operator YAML against a real
+   Redis container. `RD-SPEC-004b`'s profile binds `lock: { provider: redis }`
+   explicitly alongside the opted-in `leader_election`, which is what keeps the
+   lock's own guard out of the way of a scenario about leader election.
+
+The duplication between (1) and (2) is deliberate and not redundant: (1) proves the
+wiring dispatches correctly against any weak cache, (2) proves an operator's YAML
+actually reaches it with the Redis backend bound.
+
+### D2 — Native prefix watch in Redis Cluster
+
+**Decided: v1 declares `features().prefix_watch == false` in cluster mode;
+`watch_prefix` returns `Unsupported` there.** Per-shard `expired` subscriptions and
+slot-migration re-subscribe are a follow-up, not v1 scope. Declaring `true` on an
+unwritten, unverified code path is exactly the dishonest declaration ADR-009
+§"Honest backend declaration" forbids, and a consumer relying on prefix watch
+degrades cleanly to `PollingPrefixWatch` in the meantime (§4.3).
+
+`RD-SPEC-010` (TESTING.md §4.6) is the gate: it asserts the `false` declaration, and
+the follow-up that implements per-shard subscriptions **replaces** that test with
+its positive counterpart rather than adding one beside it. Standalone and Sentinel
+deployments are unaffected — they get native prefix watch in v1.
+
+**The gate is built**, on the 3-node Cluster fixture of TESTING.md §4.1, so the
+declaration this decision turns on is held mechanically rather than by review: a
+change that made `prefix_watch` ignore cluster mode fails `RD-SPEC-010` rather than
+reaching a clustered deployment that would otherwise start
+trusting a prefix watch that silently drops every `expired` outside its own shard.
+The unit test on the decision function over a constructed clustered cache remains
+beside it — it pins the logic, and `RD-SPEC-010` pins the environment.
+
+Note that only *prefix* watch is refused in cluster mode. Exact `watch(key)` keeps
+working there, because plain `PUBLISH` is broadcast cluster-wide so `Changed` and
+`Deleted` reach a subscriber on any node — it is `expired`/`evicted` that are
+emitted only by the owning node, which makes `Expired` best-effort in cluster mode
+exactly as it is on a server with notifications unavailable (§4.3). Refusing exact
+watch as well would remove a working capability in order to describe one that is
+partial.
+
+### D3 — Redis 7 sharded pub/sub (`SPUBLISH` / `SSUBSCRIBE`)
+
+**Decided: v1 detects availability and logs it; it does not use it and does not
+carry it.** The preflight already reads the server version from `INFO server`
+(§3.4), so v1 emits one DEBUG line at startup when the server is new enough — an
+observation, not a behaviour change. Publishing stays on plain `PUBLISH`.
+
+The finding is deliberately **not** carried on the preflight's outcome. Nothing
+reads it: no code path branches on sharded pub/sub, so a field holding it would be
+state the plugin maintains and never consults, and the change that first *uses* it
+should decide where it lives alongside the per-shard subscription work D2 defers
+rather than inherit a slot chosen a change earlier. A log line is the whole of what
+"record it" needs to mean, and `RD-SPEC-014` asserts it in both directions —
+present on a Redis 7 container, absent on a Redis 6 one, with `INFO commandstats`
+confirming no `SPUBLISH`/`SSUBSCRIBE` is issued either way.
+
+Switching to sharded publish is the real fix for the Cluster publish ceiling (§12)
+but changes the channel-to-shard mapping, which means a subscriber must derive a
+shard from a key prefix to know where to `SSUBSCRIBE` — that interacts directly with
+D2's per-shard work and wants one design pass covering both, not two independent
+ones. Reopened by: a clustered deployment measurably hitting the ~12 500
+publishes/sec ceiling, at which point the two follow-ups are designed together.
+
+### D4 — `watch_mode: keyspace`
+
+**Decided: not implemented. `WatchMode` is `Publish | Disabled` and nothing else.**
+The two shipped modes cover both ends — `publish` for correct, low-latency watches;
+`disabled` for a deployment that wants no `PUBLISH` overhead and accepts polling. The
+middle mode's only advantage is watches without publish cost, paid for with
+duplicate-event coalescing whose test matrix (every command that touches a hash,
+against every event type) is disproportionate to a benefit no deployment has asked
+for. Reopened by: a real deployment that needs watches, cannot afford `PUBLISH`, and
+cannot use polling — all three at once.
+
+### D5 — Credential resolution for `url`
+
+**Decided: `${VAR}` / `${VAR:-default}` env-var expansion via
+`#[derive(toolkit_macros::ExpandVars)]` + `#[expand_vars]`, resolved through
+`ctx.config_expanded()` — the mechanism `libs/toolkit-db` already uses for DB
+credentials and DSNs. No plugin-local `secret_ref` field.**
+
+When the OOP/credstore wiring contract is committed, the credential path reuses the
+wiring's existing `BackendBinding.secret_ref` (`cluster/src/config.rs:83`) rather than
+adding a plugin-level field of the same name at a different layer — two `secret_ref`s
+at two layers is exactly the ambiguity that makes credential handling hard to audit.
+Tracked by the platform OOP deployment design, not by this plugin.
+
+### D6 — A shared Redis-access abstraction for the workspace
+
+**Decided: no. This plugin uses `fred` directly and no `libs/`-level Redis
+abstraction is created.** This is the workspace's first and only Redis consumer, so
+an abstraction would have exactly one implementation and one caller — premature by
+construction, and it would have to be redesigned the moment a second consumer's
+needs differed. No dylint rule is added either, since there is nothing yet to
+constrain (§3.1).
+
+Reopened by: a second gear needing Redis directly. At that point the two consumers'
+actual overlap is visible, and the crate-local no-`KEYS` check (TESTING.md §6) is
+the first thing worth promoting to a workspace dylint rule — it exists as a source
+scan today and inherits nothing to a second consumer, which is precisely the
+limitation that makes it the natural first candidate rather than an argument for
+writing the rule now.

--- a/gears/system/cluster/plugins/redis-cluster-plugin/docs/TESTING.md
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/docs/TESTING.md
@@ -1,0 +1,652 @@
+# Testing Strategy — Redis Cluster Plugin
+
+> **Status: implemented, with §8 as the register of what is not.** The suite is
+> **280 tests** — 211 unit, three conformance suites, and the 63 Layer 3 scenarios
+> of §4.2–§4.6 — running green in about ten seconds of test time via
+> `make test-cluster-redis`, which is wired into `ci.yml`'s `integration` job. This
+> is the test plan for `cf-redis-cluster-plugin`, paired with
+> [DESIGN.md](./DESIGN.md), and it originated as the design deliverable of
+> [#4373](https://github.com/constructorfabric/gears-rust/issues/4373).
+>
+> **Three of the four layers are delivered.** Layer 3 now includes the Sentinel and
+> 3-node Cluster topologies of §4.1, so `RD-SPEC-002`, `008`, `009`, `010` and
+> `RD-LOCK-014` run on every PR. What remains undelivered is §5's **fault-injection
+> layer** — the platform has no harness for it — and §8 is where that is recorded
+> rather than implied. Read §5 and the rows marked **Not built** as specifications,
+> not as coverage.
+
+> **Companion documents:**
+> - [DESIGN.md](./DESIGN.md) — implementation design for this plugin
+> - [TESTING-STRATEGY.md](../../../docs/TESTING-STRATEGY.md) — platform-wide cluster testing strategy (layers, tooling, CI cadence)
+> - [Scenario Catalog](../../../docs/scenarios/README.md) — `SC-*` IDs referenced below
+
+<!-- toc -->
+
+- [1. Overview](#1-overview)
+- [2. Layer 1 — Unit Tests (in-crate)](#2-layer-1--unit-tests-in-crate)
+- [3. Layer 2 — Conformance Suite](#3-layer-2--conformance-suite)
+- [4. Layer 3 — Integration Tests (testcontainers)](#4-layer-3--integration-tests-testcontainers)
+  - [4.1 Container Setup](#41-container-setup)
+  - [4.2 Cache Integration Scenarios](#42-cache-integration-scenarios)
+  - [4.3 Lock Integration Scenarios](#43-lock-integration-scenarios)
+  - [4.4 Watch Integration Scenarios](#44-watch-integration-scenarios)
+  - [4.5 Lifecycle Integration Scenarios](#45-lifecycle-integration-scenarios)
+  - [4.6 Redis-specific Scenarios](#46-redis-specific-scenarios)
+- [5. Layer 4 — Fault Injection (Toxiproxy) and Failover](#5-layer-4--fault-injection-toxiproxy-and-failover)
+- [6. Static Analysis](#6-static-analysis)
+- [7. CI Cadence](#7-ci-cadence)
+- [8. Coverage Gaps and Follow-ups](#8-coverage-gaps-and-follow-ups)
+  - [8.1 Deferred scope — specified but not covered](#81-deferred-scope--specified-but-not-covered)
+  - [8.2 Known limits of what *is* covered](#82-known-limits-of-what-is-covered)
+  - [8.3 Non-gaps, recorded so they are not re-investigated](#83-non-gaps-recorded-so-they-are-not-re-investigated)
+
+<!-- /toc -->
+
+## 1. Overview
+
+The Redis plugin follows the four-layer pyramid from the platform-wide
+[TESTING-STRATEGY.md](../../../docs/TESTING-STRATEGY.md):
+
+```
+L4  Fault injection (Toxiproxy) + Sentinel failover               — NOT BUILT (§5, §8)
+L3  Integration tests (testcontainers Redis)                       — per-PR in this crate
+      …  Sentinel / Cluster fixtures                               — per-PR in this crate
+L2  Conformance suite (cluster-conformance crate)                  — driven by L3 container
+L1  Unit tests (co-located, no external dependencies)              — every PR, sub-second
+```
+
+The conformance suite (L2) is the keystone: the shared, backend-agnostic scenario
+bodies every cluster backend runs, executed here against a real Redis container.
+Passing it is the primary signal that this plugin implements the
+`ClusterCacheBackend` and `DistributedLockBackend` contracts.
+
+Three concerns shape this plan beyond the shared pyramid, and account for most of what
+is specific to it:
+
+- **The consistency declaration is computed, so it must be tested as a function of
+  the environment** (DESIGN §3.6). Most of §4.6 exists for this: the same plugin
+  code must declare `EventuallyConsistent` against a replicated container and
+  `Linearizable` against a verified single-node durable one, and must *fail startup*
+  when an operator hint contradicts a readable server config. A plugin that
+  declared the wrong thing here would defeat every capability check downstream and
+  no conformance scenario would notice.
+- **`Lagged` is producible here.** Redis pub/sub backpressure is ADR-003's canonical
+  `Lagged` source, so `RD-WATCH-008` exercises a watch variant the contract has always
+  specified but which needs a backend that can actually drop events under
+  backpressure to test.
+- **Eviction is a correctness scenario, not a capacity one** (DESIGN §3.7).
+  `RD-SPEC-006`/`007` drive a real `maxmemory` eviction and assert both the warning
+  path and the watch mapping, because this is the plugin's top operational risk.
+
+## 2. Layer 1 — Unit Tests (in-crate)
+
+Co-located with source (`src/**/*_tests.rs`). No Redis, no Docker; run with
+`cargo test -p cf-redis-cluster-plugin --lib`.
+
+| Module | What is tested |
+|---|---|
+| `config.rs` | serde round-trip for every field and every default (`pool_size` 4, `command_timeout_ms` 5000, `key_prefix` "cluster", `wait_timeout_ms` 1000, `watch_mode` `publish`, `manage_keyspace_notifications` false); `topology`/`durability`/`watch_mode` enum variants round-trip and an unknown variant is rejected; `deny_unknown_fields` turns an operator typo into `InvalidConfig`; `validate()` rejects each of the three zeros that would remove a bound rather than tighten it (DESIGN §8); `Debug` masks `url` on both types; `RedisLockConfig`'s accepted field set is exactly `RedisClusterConfig`'s minus the two cache-only fields, read back out of serde's own error rather than from a hand-written list (the drift guard the duplication needs, DESIGN §8) |
+| `config.rs` — `${VAR}` expansion | **Half-coverable, permanently.** The `${VAR:-default}` branch is tested and the plain `${VAR}` branch cannot be: edition 2024 makes `std::env::set_var` `unsafe` and this crate is `#![forbid(unsafe_code)]`, so no unit test can set a variable for it to resolve — nothing in the cluster tree uses `set_var`, for the same reason. The `:-default` test drives the identical `expand_vars()` call down the other branch, and `provider.rs`'s unresolvable-variable test covers the failure path, so what is untested is the successful *lookup* alone. Recorded as a constraint rather than left as an apparent gap (§8.2) |
+| `preflight.rs` | The consistency decision table (DESIGN §3.6) as a pure function of (topology, durability, readability): all five rows; unknown → `EventuallyConsistent`; a `durability: fsync_always` hint contradicted by a readable `appendfsync everysec` → `InvalidConfig` naming both values; the same hint with `CONFIG GET` unreadable → trusted, and flagged as asserted-not-verified. Parsing of `INFO replication` (`role:master` with and without `connected_slaves`, `role:slave`) and of `CONFIG GET` replies including the empty-value case |
+| `scripts.rs` | Every script's SHA is loaded once and cached; a `NOSCRIPT` classification enters the `EVAL` recovery **at most once per call** and never re-enters it, which is the property that actually bounds it (DESIGN §6 — the earlier phrasing, "exactly one reload-and-retry", described a two-round-trip mechanism the recovery replaced); every script in the catalog declares exactly `{1}` as its `KEYS[n]` set, read back out of the Lua source rather than from a stored count, with a deliberately two-key script proving the guard is capable of failing; and every cache script carries as many empty-channel `PUBLISH` guards as it has `PUBLISH` calls, so a sixth mutation script cannot be added unguarded (DESIGN §4.3). All of it drives a `ScriptExecutor` test double, which is what makes the retry bound observable at all — it is only visible by counting calls |
+| `connect.rs` | The URL-scheme topology mapping (DESIGN §3.4): a `redis-cluster://` URL reports `Cluster`, and a plain `redis://` reports **nothing** rather than `Standalone` — the trap being that reading one address as "no replicas" would let a Sentinel-managed primary reach the one row of DESIGN §3.6 that declares `Linearizable` |
+| `wait.rs`, `shutdown.rs` | The `WAIT` short-count arm as an error rather than a silent success; what the operator's two config fields become — an absent `wait_replicas` is `Disabled`, a present one carries both values, and a `wait_timeout_ms` past `i64::MAX` is rejected as `InvalidConfig` at startup rather than clamped into a ~292-million-year deadline at the first write (DESIGN §3.6); and the `Drop`-ordering rule — that the shutdown token is cancelled *before* the diagnosis is returned, which is why the diagnosis is returned rather than emitted in place (DESIGN §11) |
+| `observability.rs` | The eviction WARN's rate-limiting policy as a pure function of an elapsed-millisecond reading — first eviction always emits, a second inside the window is suppressed and counted, the suppressed count rides the next line that gets through — that an evicted entry and an evicted lease are both counted under their own `primitive` label, and the contract-name/`_total` rule the Prometheus exporter forces. The signal-per-outcome assertions live beside the primitives that emit them, over a recording `ClusterMetrics` double and an in-memory OTel reader |
+| `cache/mod.rs` | Key construction: `<prefix>:c:<key>` and the channel `<prefix>:e:c:<key>` for the same input; `Ttl::Of`→ ms, `Ttl::Indefinite` → the `-1` sentinel the scripts expect, a sub-millisecond `Ttl` rounding *up* to 1 rather than down to the `0` that deletes, and a `Duration::MAX` saturating rather than wrapping into a short TTL — deliberate, and pinned as such, exactly as `px_millis`'s sibling test does for the lock; `CacheEntry` decoding from an `HMGET` reply shape, including both-`nil` → `None` and a version string at `i64::MAX` decoding losslessly (the precision claim DESIGN §2.2 rests on) |
+| `cache/watch.rs` | The registry: per-key fan-out; one Redis pattern per distinct prefix with N in-process watchers on it; a dropped watcher pruned; `Reset` broadcast and counted, leaving every registration in place and every stream open, with a later `dispatch` asserted to still reach the reset watcher — the positive form, because a `Reset` that ended the stream would make `recv()` hang rather than fail; the terminal `Closed` still delivered to a full 64-slot buffer; no `Reset` ever delivered after a terminal `Closed`; a `watch()` arriving after `close_all` gets its terminal event immediately; a full buffer drops events, coalesces the count, and emits exactly one `Lagged { count }` when it drains. Payload mapping: `C`→`Changed`, `D`→`Deleted`, keyspace `expired`→`Expired`, keyspace `evicted`→`Deleted` (not `Expired` — DESIGN §3.7), unrecognized→`Reset` |
+| `subscriber.rs` | The keyspace naming and its classifier (DESIGN §3.7): the pattern spans `<prefix>:*` rather than the cache's `<prefix>:c:` share of it — the regression that left an evicted **lock lease** unobservable — stays scoped to this plugin's prefix and database, and glob-escapes an operator prefix containing `[`. Classification sorts an entry to `Cache` and a lease to `Lock` by delegating to the two namers that *build* those names, declines a key under this prefix that neither owns (the event channels the pattern also matches), declines another deployment's prefix entirely, and — with the cache half absent, as in the standalone lock plugin — claims leases while disclaiming cache entries. The reconnect observer's arms, over `observe_reconnect`: a missed notification resets every watcher, moves `cluster_watch_resets_total`, **and** emits the catalogued `cluster.watch.reset` carrying the missed count — asserted together, since the defect was a counter moving with nothing in the log to explain it — while a closed stream ends the observer and resets nothing |
+| `lock/mod.rs` | Key/channel construction; the holder token is a fresh v4 UUID per acquisition and two acquisitions differ; the `SET NX PX` argument assembly; the three-outcome classification of a failed `lock()` (`Shutdown` / `Provider` / `LockTimeout`, DESIGN §5.3) as a pure function of (elapsed, last error); and DESIGN §5.3's third bound over `park`, driven against a pool that is built but never `init()`ed — the `PTTL` future is then pending forever, which is a stalled server without a server, and `tokio::time::pause()` supplies the clock so the assertion is on virtual time |
+| `lock/waiters.rs` | Register/notify/deregister-on-drop; a notification for a name with no waiter is a no-op; a waiter dropped mid-wait leaves nothing behind; the wake delay is `min(PTTL, heartbeat)` and is jittered (asserted as a range plus non-identity across draws, not as an exact value) |
+| `redis_error.rs` | The full §10 mapping table, row by row, including the ones the parent `docs/DESIGN.md` §4.1 column does not list: `OOM`→`ResourceExhausted`, `READONLY`→`ConnectionLost`, `LOADING`/`MASTERDOWN`/`CLUSTERDOWN`→`ResourceExhausted`, `NOAUTH`/`WRONGPASS`→`AuthFailure`, malformed URL→`InvalidConfig` (**not** a `Provider` error — a config fault must not read as a backend fault) |
+| `provider.rs` | `ClusterCacheProvider::provider()` and `ClusterLockProvider::provider()` both return `"redis"`; `build_cache`/`build_lock` each return `InvalidConfig` for a malformed URL and for an unknown option key; `build_lock` neither receives nor consults a cache backend (the SDK's "non-cache providers do not receive the cache backend" contract) |
+
+No Redis command is executed at layer 1. All command and script behaviour is
+covered at layer 3.
+
+Test modules that would exceed 100 lines live out-of-line in a `*_tests.rs` file
+reached by `#[path = "..."]`, because `dylint.toml`'s DE1101 caps an inline test
+block at that and the cluster tree is not in its excluded paths — the same
+arrangement the Postgres plugin uses. §6's mechanical source check is the one L1
+module that is crate-level rather than co-located, since the rule it enforces is
+about the whole of `src/`.
+
+## 3. Layer 2 — Conformance Suite
+
+`cf-gears-cluster-conformance` is a `[dev-dependencies]` entry;
+`tests/conformance.rs` wires the layer-3 container fixture into every entry point.
+Each suite goes through one `run_*_conformance(factory, time)` call whose async
+factory returns a `cluster_conformance::ScenarioBackend` that **owns the plugin
+handle** and stops it via teardown before the next scenario is built — mandatory,
+not cosmetic: `RedisClusterHandle`/`RedisLockHandle` panic on drop if never
+`stop()`ed (DESIGN §3.2's ADR-006 guard).
+
+```rust
+// tests/conformance.rs
+
+#[tokio::test]
+async fn cache_conformance() {
+    run_cache_conformance(
+        || async {
+            let handle = RedisClusterPlugin::builder(test_config())
+                .build_and_start()
+                .await
+                .expect("plugin starts against test container");
+            let cache = handle.cache();
+            ScenarioBackend::with_teardown(cache, async move { handle.stop().await })
+        },
+        // A real backend gets real (bounded) time, never a paused clock: `fred`'s
+        // own command timeouts and reconnect timers run on the same runtime and a
+        // paused/auto-advancing clock fires them spuriously.
+        TimeControl::Real,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn lock_conformance() {
+    run_lock_conformance(
+        || async {
+            // The standalone lock-only path (DESIGN §3.5) — the same one
+            // ClusterLockProvider::build_lock uses in production. The runner
+            // hands the factory no cache (`F: Fn() -> Fut`), which matches this
+            // plugin's shape exactly: the native lock builds its own pool and
+            // never rides a cache, so there is no shared-pool shortcut to take.
+            let handle = RedisLockPlugin::builder(test_lock_config())
+                .build_and_start()
+                .await
+                .expect("standalone lock plugin starts");
+            let lock = handle.lock();
+            ScenarioBackend::with_teardown(lock, async move { handle.stop().await })
+        },
+        TimeControl::Real,
+    )
+    .await;
+}
+```
+
+`leader_conformance` is wired the same way, over
+`CasBasedLeaderElectionBackend` on this
+plugin's cache (DESIGN §7) — and the leader suite carries a wrinkle no other backend
+has:
+
+**The leader suite runs against a single-node durable container, not the default
+one.** `CasBasedLeaderElectionBackend::new` is the strict constructor and rejects an
+`EventuallyConsistent` cache, so on the default container it would fail to construct
+at all. `tests/common` therefore provides a second fixture
+(`start_redis_durable()` — `appendonly yes`, `appendfsync always`, no replicas) whose
+cache declares `Linearizable`, and the leader suite uses it. The *negative* half —
+that the strict constructor really does refuse the ordinary container's cache — is
+`RD-SPEC-004`, and it is the more important of the two assertions.
+
+This stays the arrangement despite DESIGN §13 D1's wiring flag landing in the same
+change: the flag makes weak-cache leader election *expressible by an operator who
+opts in*, not correct, so the conformance suite — which asserts correctness
+properties like single-leader-among-contenders — keeps running on the fixture whose
+declaration supports them. Pointing the suite at a weak cache via the flag would
+produce a suite that asserts guarantees the backend does not claim, which is a test
+that fails for the right reason at the wrong layer. The flag's own path is
+`RD-SPEC-004b` instead.
+
+Each scenario runs on a shared container under **both** isolations rather than
+either: its own logical Redis database *and* its own `key_prefix`. Database
+isolation alone runs out at 15, and prefix isolation alone leaves a scenario able to
+see another's keyspace via `scan_prefix` if a prefix bug exists — which is exactly
+the class of bug `RD-CACHE-006` looks for. Doing both is strictly stronger than
+either, costs nothing, and removes the branch: the suites with more than 15
+scenarios need no special case, and no suite needs a container per scenario. The
+database cycles `1..=15` rather than from 0, so nothing lands where a
+stray client would connect by default and every scenario's `expired` notifications
+arrive on a non-zero `__keyspace@<n>__` — the off-by-one-database bug `RD-SPEC-012`
+exists to catch would otherwise be invisible here.
+
+A fresh plugin instance is built per scenario rather than shared across them, and
+that is required rather than tidy: the scenarios reuse key and lock names, and this
+plugin's `stop()` deliberately *leaves* held leases to expire rather than handing
+them back (`cpt-cf-clst-fr-shutdown-ttl-cleanup`, `RD-LOCK-013`), so a lease held
+past one scenario's teardown would still be held when the next asked for the name.
+
+**One conformance scenario does not run here at all.** `TimeControl::Real` is
+mandatory against a real backend — `fred` runs its own command timeouts and
+reconnect backoff on the same runtime, and `tokio`'s paused clock auto-advances to
+the next pending timer whenever nothing is polling, which while a socket read is
+parked is constantly, so every command would report `Provider { Timeout }` against a
+healthy server. The cost is that the shared runners skip `SC-LEAD-006`,
+which forces a *missed* renewal that a healthy real backend
+never exhibits by waiting. It maps to fault injection, which §8 defers; §8.2
+records it, because a green suite says nothing about a scenario it skipped.
+
+**Capability-gated assertions.** The suite reads `features()` and `consistency()`
+before running scenarios. For this plugin they vary by fixture, which is itself
+worth asserting:
+
+- Default (replicated/non-durable) container: `CacheConsistency::EventuallyConsistent`
+  → linearizability-dependent scenarios are skipped, and the
+  `CacheCapability::Linearizable` mismatch scenario runs (expects `CapabilityNotMet`).
+- Durable single-node container: `Linearizable` → single-leader and
+  lock-contention correctness scenarios run.
+- `watch_mode: publish`, non-clustered: `CacheFeatures::prefix_watch == true` →
+  the native-prefix-watch scenarios run and the `PrefixWatch` mismatch scenario does
+  **not**. This is the first backend for which that is true, so it is also the first
+  real exercise of the capability check's *positive* branch.
+- `watch_mode: disabled` or cluster mode: `prefix_watch == false` → `watch_prefix`
+  returns `Unsupported`.
+- `LockFeatures::linearizable` tracks the cache declaration per fixture.
+
+**Routing conformance is out of scope.** `run_routing_conformance` does not exist in
+`cluster-conformance` and per-primitive routing
+(`cpt-cf-clst-fr-routing-per-primitive`) is wiring-crate logic — `ClusterWiring::from_config`
+dispatching through `ProviderRegistry` — not backend logic any plugin implements or
+could conformance-test in isolation. It belongs to the `cluster` gear's own suite, plus
+this plugin's one routing-adjacent integration test (`RD-LOCK-008`).
+
+**`SC-SCOP-001..006` need no per-backend conformance function.** The scoping wrappers
+(`ScopedCacheBackend` and siblings) are pure decorators: each holds an
+`Arc<dyn ClusterCacheBackend>` and only ever calls the generic trait interface, so the
+wrapped backend could be Redis or a test stub and the prefix apply/strip/compose logic
+behaves identically. They have their own SDK-level unit tests against recording stubs,
+and running the same string manipulation again through a Redis container would reach no
+Redis-specific code path. There is not even a key-length interaction to cover: Redis
+keys have no size ceiling composed scope prefixes could push a key past (DESIGN §2.1).
+
+## 4. Layer 3 — Integration Tests (testcontainers)
+
+### 4.1 Container Setup
+
+`testcontainers-modules` carries a `redis` feature, enabled on its workspace entry.
+The fixtures are **one parameterized `RedisRecipe`** — a set of `redis-server`
+command-line flags plus an image tag — behind seventeen named wrappers covering
+**ten container shapes**, eight of them single-node and two multi-node.
+
+There are ten rather than one or two for two separate reasons. Eight of them are
+single-node because this plugin's declared capabilities and several of its
+warnings are functions of *server configuration* rather than of plugin logic, so a
+scenario about one of them needs a server configured for it. The other two are
+multi-node because topology is itself one of those inputs: the consistency
+declaration reads `INFO replication`, and cluster mode changes how keys route and
+what the cache can honestly claim about prefix watching. Several wrappers share a
+shape and differ only in the config type they hand back — a `RedisLockConfig`
+rather than a `RedisClusterConfig`, say — which is why there are more wrappers than
+shapes:
+
+| Shape | Needed by |
+|---|---|
+| stock (no AOF) — declares `EventuallyConsistent` | most of §4.2–§4.5, `RD-SPEC-001` |
+| durable single node (`--appendonly yes --appendfsync always`) — declares `Linearizable` | the leader conformance suite (§3), `RD-SPEC-003` |
+| no `notify-keyspace-events` | `RD-SPEC-005`, `RD-SPEC-005b`, `RD-LOCK-009` |
+| `--maxmemory-policy allkeys-lru` with **no** ceiling | `RD-SPEC-006` |
+| tiny `--maxmemory` plus `allkeys-lru`, so writes really evict | `RD-SPEC-007`, `RD-SPEC-007b` |
+| the same, returning a `RedisLockConfig` **and its URL** | `RD-LOCK-015` — the standalone plugin owns no cache to write filler through, so the pressure comes from a raw client |
+| `appendfsync everysec` | `RD-SPEC-011`'s contradiction half |
+| the same, plus a `CONFIG`-denied ACL user | `RD-SPEC-011`'s asserted-not-verified half |
+| Redis 6 | `RD-SPEC-014`'s negative half |
+| **Sentinel**: primary + replica + Sentinel, one container, ports mapped 1:1 | `RD-SPEC-002`, `RD-LOCK-014` |
+| **Cluster**: 3 primaries, one container, ports mapped 1:1 | `RD-SPEC-008`, `RD-SPEC-009`, `RD-SPEC-010` |
+
+Two of those shapes are worth singling out. The unsafe-policy and evicting shapes
+are deliberately **separate**: `RD-SPEC-006` is about the startup WARN firing on a
+policy that *could* evict, and keeping the ceiling off means it asserts that without
+also being at the mercy of a real eviction landing mid-test. And the ACL user is
+declared as a **server flag** (`--user limited on '>pw' '~*' '&*' +@all -config`)
+rather than with `ACL SETUSER`, which is not merely tidier: `ACL` sits on a `fred`
+interface the feature list leaves out, so no build of this crate can issue one. The
+`&*` in that flag is load-bearing — without it the user cannot subscribe, and the
+plugin opens its subscriber before it reaches the durability check.
+
+One retrying start-and-map-port sequence serves all the single-node shapes, which is
+the reason for a recipe rather than a function each: a duplicated retry loop is the
+kind of thing that gets fixed in one copy.
+
+#### The two multi-node topologies, and why each is one container
+
+`start_redis_sentinel` (primary + replica + Sentinel) and `start_redis_cluster`
+(3 primaries) each run **every node as a process inside a single container**, with
+host ports mapped **1:1**. That is not a shortcut; it is the only arrangement that
+works from this side of the Docker network boundary.
+
+Both topologies *advertise an address to the client*. Sentinel answers
+`get-master-addr-by-name` with the primary's address; a cluster node answers a
+wrong-slot command with `MOVED <slot> <addr>`, which the client is required to
+follow. Under testcontainers' usual random port mapping the address a node knows
+about is its container port, and the address the host can reach is the mapped port —
+so every advertised address points somewhere the test process cannot go. Mapping
+1:1 collapses the difference: `127.0.0.1:7000` means the same endpoint inside the
+container and outside it, so one advertised address is correct for both the nodes'
+gossip and the test's client. Separate containers on a Docker network cannot achieve
+that, because an address that reaches a peer across the network is not one the host
+can dial.
+
+The ports are therefore chosen by the fixture rather than by Docker, from a probed
+run of free ports in a fixed window (the ephemeral range is unusable: a cluster
+node's bus port sits `10000` above its data port and would overflow `u16`).
+
+**What the arrangement costs is failover.** The processes share a failure domain, so
+killing the container takes the quorum with the primary. This fixture can watch a
+replica *leave* — which is what `RD-LOCK-014` needs — and cannot observe a failover,
+which is why `RD-FAULT-005..007` stay deferred to a harness with separately killable
+nodes (§8.1).
+
+Every fixture that wants keyspace notifications sets **`notify-keyspace-events Kxe`**
+by container flag rather than by `CONFIG SET`, so the *default* test posture matches
+a well-configured production server — a plugin that only works after mutating a
+server-wide setting is not what §4 means to exercise. `Kxe` is the minimal correct
+set: `K` plus `x` yields `expired` and `K` plus `e` yields `evicted`, the two events
+no plugin code can publish for itself, while anything wider adds notifications
+server-wide that unrelated tenants pay for and this plugin never reads
+(DESIGN §4.3).
+
+The fixtures deliberately spell that constant out rather than importing the plugin's
+own `REQUIRED_KEYSPACE_FLAGS`: a fixture configured from the same constant the
+plugin checks against would agree with the plugin by construction, and `RD-SPEC-005`'s
+whole subject is what happens when the two disagree. The no-notifications shape is
+how that degradation path is covered, and `RD-SPEC-005b` takes its **own** container
+rather than sharing one — it is the single scenario that issues
+`CONFIG SET notify-keyspace-events`, and that setting is server-wide and outlives the
+test, so a shared container would make the pair order-dependent.
+
+### 4.2 Cache Integration Scenarios
+
+These mirror the conformance scenarios (§3) with Redis-specific assertions on the
+actual keyspace.
+
+| ID | Scenario | What it verifies |
+|---|---|---|
+| `RD-CACHE-001` | `put` + `get` round-trip | Value and version stored and retrieved; the underlying key is a **hash** with exactly the fields `v` and `ver` (the DESIGN §2.2 encoding, asserted at the server so a future re-encoding is a test failure rather than a silent wire change) |
+| `RD-CACHE-002` | Version increment monotonicity | Each `put` increments `ver` by exactly 1; `put_if_absent` creates at 1; `HGET ver` read directly from Redis agrees with the `CacheEntry` the plugin returned |
+| `RD-CACHE-003` | `compare_and_swap` atomicity under concurrent writers | 20 concurrent tasks CAS the same key from the same expected version; exactly one succeeds and 19 get `CasConflict`, each carrying a populated `current` (the same-round-trip conflict payload, DESIGN §4.1) |
+| `RD-CACHE-004` | Native TTL expiry | An entry with a 500 ms TTL is absent from `get`/`contains` after it lapses **with no reaper running anywhere** — Redis is the only expiry mechanism (DESIGN §4.2). `PTTL` confirms the TTL was set from the request, not inherited |
+| `RD-CACHE-005` | `compare_and_delete` survives a version reset | Delete-and-recreate resets the version to 1; `compare_and_delete` with the *old* value is a no-op and the new holder's claim is intact (`[cluster-cache-version-reset-caveat]`, DESIGN §2.3) |
+| `RD-CACHE-006` | `scan_prefix` correctness and isolation | Keys under the prefix returned with the plugin's own `<prefix>:c:` stripped; expired keys excluded; keys under a *different* `key_prefix` in the same database excluded (the isolation half — see §3 on why prefix isolation is the fallback); `KEYS` never issued (asserted via `MONITOR` or `INFO commandstats`) |
+| `RD-CACHE-007` | `Ttl::Indefinite` clears an existing TTL | `put` with a TTL, then `put` with `Indefinite`: `PTTL` reports −1 (persistent), not the old deadline. The SDK's two-valued `Ttl` says a write always states the TTL rather than preserving it |
+| `RD-CACHE-008` | `put_if_absent` on a live entry does not overwrite | Returns `None`, and the stored value and version are untouched — the contract leader election's `claim` depends on |
+| `RD-CACHE-009` | Command timeout is bounded client-side | With `command_timeout_ms: 200` against a container paused mid-command, a `get` returns `Provider { Timeout }` within a second rather than hanging. The bound DESIGN §12 records as a property: `fred` enforces `command_timeout` on every command, so no operation is unbounded once issued |
+| `RD-CACHE-010` | Every script is single-key at runtime | Each of the **seven** cache and lock scripts is invoked and `INFO commandstats` / a `MONITOR` capture confirms it was dispatched with exactly one key. The build-time structural check (`scripts.rs`, §2) plus this runtime one are what make `CROSSSLOT` unreachable (DESIGN §6) — and `RD-SPEC-008` exercises the routing that invariant exists for, on a real cluster |
+
+### 4.3 Lock Integration Scenarios
+
+| ID | Scenario | What it verifies |
+|---|---|---|
+| `RD-LOCK-001` | `try_lock` acquires and `release` frees | The lease key exists with the holder token as its value and a `PTTL` in range; a second `try_lock` — **from the same instance**, refused by the same `SET NX` a foreign one would be — returns `LockContended`; after `release` the key is gone and the name is acquirable |
+| `RD-LOCK-002` | `lock` with timeout | A blocked `lock` returns `LockTimeout` (not `Provider`) after the budget elapses, and leaves nothing behind: the name is acquirable the moment the holder releases |
+| `RD-LOCK-003` | `lock` wakes on an explicit release | A blocked `lock` acquires well under the 250 ms heartbeat after the holder calls `release`, confirming the publish-driven wake. A wake measured at ~one heartbeat means the notification was *missed*, not merely slow, which is what makes this assertion sharp rather than a latency check — and it is why DESIGN §3.2 step 4 awaits the initial subscribe before `build_and_start` returns: a release landing in that startup window would otherwise have no subscriber |
+| `RD-LOCK-004` | An expired lease is reclaimed with no reaper and no cooperation | A holds a 500 ms lock and never renews or releases; B acquires it purely on Redis expiry. The sharpest statement of what native TTL buys: there is no sweep in this plugin to be stalled (DESIGN §5.1). A's subsequent `renew` reports `LockExpired` |
+| `RD-LOCK-005` | `renew` extends the lease | `PTTL` after `renew(new_ttl)` reflects the new deadline; the lock is still held past the original one |
+| `RD-LOCK-006` | `renew` and `release` are token-fenced | A's lease lapses and B acquires the same name. A's `renew` → `LockExpired`; A's `release` → a no-op that leaves **B's** key intact (the release-if-still-holder contract, DESIGN §5.2). The one test that would fail on the classic bare-`DEL`-on-release bug |
+| `RD-LOCK-007` | 20 concurrent local acquirers, at most one holder | Exactly one succeeds, 19 get `LockContended`. Kept distinct from `RD-LOCK-011` even though both exercise `SET NX`: that local and cross-instance contention are arbitrated *identically* is the claim worth holding both halves to, and a regression adding a local short-circuit shows up here first |
+| `RD-LOCK-008` | End-to-end YAML routing: lock on Redis, cache elsewhere | Via `ClusterWiring::from_config` with `cache: { provider: standalone }` and `lock: { provider: redis, url: … }`: the resolved profile's lock writes a real lease key in the container while its cache is the in-process standalone one. Confirms `ClusterLockProvider` registration makes `provider: redis` resolvable for `lock` independently of `cache` (DESIGN §3.5) |
+| `RD-LOCK-009` | Standalone `RedisLockPlugin` needs no keyspace notifications | Against a container started **without** `notify-keyspace-events`, `RedisLockPlugin::build_and_start` returns `Ok` and `try_lock`/`renew`/`release`/blocking `lock` all behave identically to the combined plugin's lock (DESIGN §3.5). It does subscribe a keyspace pattern, for the eviction signal alone (`RD-LOCK-015`), and this is what pins that nothing it needs to *operate* rides on that subscription: with the notifications absent the plugin loses the eviction report and nothing else |
+| `RD-LOCK-010` | Held locks consume no connections | With `pool_size: 2`, hold 12 locks at once: all 12 succeed, all 12 keys exist, and a `renew` still gets a connection while they are held |
+| `RD-LOCK-011` | Two instances cannot hold the same lock | Two independent plugin instances on one server: A acquires, B's `try_lock` returns `LockContended`, exactly one key exists and its value is A's token, and B acquires as soon as A releases. The cross-replica guarantee the primitive rests on |
+| `RD-LOCK-012` | `lock()` after `stop()` answers `Shutdown` immediately | After a clean `stop()`, `lock(name, ttl, 30s)` returns `ClusterError::Shutdown` in well under a second rather than retrying a torn-down backend for its whole budget and reporting `LockTimeout` — which would leave a caller unable to tell "someone else holds it" from "this backend is gone". `try_lock` asserted alongside, since both take the same pre-work check |
+| `RD-LOCK-013` | `stop()` leaves held leases to expire, and says so | Hold three locks with a 10 s TTL, `stop()`, then assert the three keys are **still present** and then expire on their own deadlines. Deliberately asserts that leases are *left behind*: `cpt-cf-clst-fr-shutdown-ttl-cleanup` forbids best-effort remote cleanup on shutdown, and a lease needs no drain because it reaps itself (DESIGN §11). A future "tidy up on stop" change would fail here, which is the point |
+| `RD-LOCK-015` | The **standalone** plugin observes an evicted lease | The half of DESIGN §3.7 that a cache-scoped pattern cannot reach at all rather than merely narrowly: without its own keyspace subscription a lock-only deployment has every lease evicted out from under it and reports nothing — and it is the shape likeliest to be pointed at a *shared* Redis, having no cache working set to argue for its own instance. Memory pressure comes from a **raw client**, since there is no cache here to write filler through, which is why the fixture returns a URL. Asserts the WARN, its `primitive="lock"`, and the counter. Asserts no behaviour change: the lock keeps working through the eviction, and still asks for no `x` flag |
+| `RD-LOCK-014` | `WAIT` is applied when configured, and a short count surfaces | On the Sentinel fixture with `wait_replicas: 1`: an acquire succeeds while the replica acknowledges, then the replica is **stopped** and the next acquire surfaces `Provider { ResourceExhausted }` rather than reporting a success that is not yet replicated. Stopped rather than partitioned — partitioning is fault injection (§8), and the short count is the same observable either way, since the plugin cannot tell a gone replica from an unreachable one and is not meant to. Also asserts what `WAIT` does **not** do: `features().linearizable` is unchanged, because `WAIT` narrows the window a failover can lose a write in and does not close it (ADR-009, DESIGN §3.6) |
+
+### 4.4 Watch Integration Scenarios
+
+| ID | Scenario | What it verifies |
+|---|---|---|
+| `RD-WATCH-001` | `watch(key)` receives exactly one `Changed` per `put` | One event, not three. A `put` runs `HSET`+`HINCRBY`+`PEXPIRE`, so a raw-keyspace-notification implementation would deliver three — this is the assertion that holds the in-script publish design (DESIGN §4.3) to `cpt-cf-clst-nfr-watch-delivery`'s no-duplicates requirement |
+| `RD-WATCH-002` | `watch(key)` receives `Deleted` on `delete` and on `compare_and_delete` | Both paths publish `D`; a `compare_and_delete` that *mismatches* publishes nothing |
+| `RD-WATCH-003` | `watch(key)` receives `Expired` on TTL lapse | With keyspace notifications enabled, a 500 ms entry produces `Expired` (not `Deleted`) within ~1 s — sourced from Redis's own notification, the one event the plugin cannot publish itself |
+| `RD-WATCH-004` | `watch_prefix` is native and delivers per-key events | `PSUBSCRIBE`-backed: writes to three keys under the prefix produce three events on one prefix watch; a write outside the prefix produces none; `features().prefix_watch == true` on this fixture |
+| `RD-WATCH-005` | N watchers on one prefix cost one Redis pattern | Five prefix watches on the same prefix; `PUBSUB NUMPAT` reports 1 and all five receive every event (the in-process fan-out claim, DESIGN §4.3) |
+| `RD-WATCH-006` | Per-key ordering is preserved | 100 sequential `put`s on one key: the watcher observes 100 `Changed` in order with no gaps (`cpt-cf-clst-nfr-watch-delivery`) |
+| `RD-WATCH-007` | No cross-key delivery; independent watchers | A watcher on `"a"` sees nothing when `"b"` is written; two watchers on the same key both receive events and one dropping does not affect the other |
+| `RD-WATCH-008` | Buffer overflow produces `Lagged`, once, with a count | A watcher that stops draining while thousands of writes land receives `Lagged { count }` on resumption — coalesced into one event, not one per dropped message — and `cluster_redis_watch_events_dropped_total` agrees with the count. **The first test in the platform that produces `Lagged` at all**, and the reason ADR-003's variant is not dead weight |
+| `RD-WATCH-009` | `Closed(Shutdown)` before `stop()` returns | Every active watch (exact and prefix) observes the terminal `Closed(ClusterError::Shutdown)` before `stop().await` resolves (`cpt-cf-clst-fr-shutdown-revoke`) |
+| `RD-WATCH-010` | `watch_mode: disabled` degrades honestly | `watch`/`watch_prefix` return `Unsupported`; `features().prefix_watch == false`; no `PUBLISH` is issued on the write path (asserted via `INFO commandstats`) |
+
+### 4.5 Lifecycle Integration Scenarios
+
+| ID | Scenario | What it verifies |
+|---|---|---|
+| `RD-LIFE-001` | `build_and_start` connects, preflights, and loads scripts | Returns `Ok` against a fresh container; `SCRIPT EXISTS` reports every catalogued SHA present; the subscriber is subscribed before the call resolves (DESIGN §3.2 step 4) |
+| `RD-LIFE-002` | `build_and_start` is idempotent and creates nothing | Called twice against the same server; the second succeeds, and the keyspace is unchanged — there is no schema to create and no migration to re-run |
+| `RD-LIFE-003` | `stop` closes every connection | Counted with `INFO clients`, as a delta against a baseline taken before the plugin starts — not with `CLIENT LIST`, which sits on a `fred` interface the feature list leaves out, so `connected_clients` is what a build of this plugin can read. A delta rather than an absolute because the test's own control connection is one of them. The count returns to baseline after `stop`, command pool and subscriber alike |
+| `RD-LIFE-004` | Invalid URL is rejected as config, not as a fault | `build_and_start` with a malformed URL returns `InvalidConfig` immediately, not a `Provider` error and not a timeout — an operator reading it should be looking at their YAML, not their server (DESIGN §10) |
+| `RD-LIFE-005` | Unreachable server fails at startup, bounded | A valid URL pointing at a closed port returns `Provider { ConnectionLost }` within the connect budget rather than hanging or returning `Ok` with a background reconnect |
+| `RD-LIFE-006` | `Drop` without `stop()` surfaces loudly (ADR-006) | A `RedisClusterHandle` — and, separately, a `RedisLockHandle` — dropped without `stop()`: debug build panics with the "dropped without stop()" message, release build logs the WARN; `stop()`-then-drop does neither |
+| `RD-LIFE-007` | `Drop` during panic unwind degrades to a warning | A panic inside a closure owning an un-stopped handle does not abort the process (which a debug-build double panic would) and logs the skip message instead |
+| `RD-LIFE-008` | `NOSCRIPT` recovery | `SCRIPT FLUSH` behind the plugin's back, then a `put`: it succeeds via one reload-and-retry, `cluster_redis_script_reloads_total` increments by 1, and no error reaches the caller (DESIGN §6) |
+| `RD-LIFE-010` | A startup that fails after the connect leaks no subscriber | The failure half of `RD-LIFE-003`. A contradicted `durability` hint fails the preflight, which is past the connect, so both the pool and the already-connected subscriber have to be torn down (DESIGN §3.2 step 6). `connected_clients` returns to its baseline, polled through `wait_until` because `QUIT` is asynchronous server-side. Dropping the subscriber closes nothing — `fred` 10.1.0 gates `Drop for ClientInner` behind `credential-provider`, which nothing here enables — so without the explicit teardown the connection and its router task survive every failed boot, one per supervisor retry |
+| `RD-LIFE-009` | `stop()` terminates against an unresponsive server | Hold four locks and an active watch, `pause` the container so the socket stays open but nothing answers, then `stop()`: it returns inside a 30 s budget. Bounded by `command_timeout_ms` and `POOL_CLOSE_TIMEOUT` (DESIGN §11), and a general claim rather than an accident of timing: every command this plugin issues is bounded client-side, so no in-flight operation can hold a background task's join open indefinitely (DESIGN §12) |
+
+### 4.6 Redis-specific Scenarios
+
+The declaration-and-environment tests. Several are the only coverage of DESIGN's
+honesty claims, which no conformance scenario can reach.
+
+| ID | Scenario | What it verifies |
+|---|---|---|
+| `RD-SPEC-001` | Stock container declares `EventuallyConsistent` | Default fixture (no AOF): `consistency()` is `EventuallyConsistent`, `features().linearizable` on the lock is `false`, and `cluster.provider.weak_consistency` (WARN) is logged exactly once at startup naming the detected topology (DESIGN §3.6) |
+| `RD-SPEC-002` | Replicated topology declares `EventuallyConsistent` even with AOF | Sentinel fixture with `appendfsync always` on the primary: still `EventuallyConsistent`, because async replication is the binding weakness (ADR-009). The only fixture that puts durability and topology in *conflict* — every other one is weak on both or safe on both — so it is what catches reading `appendfsync` without reading topology. The premise is asserted too, reading `appendfsync` and `state=online` back off the primary: a fixture that quietly failed to enable AOF, or to attach the replica, would let this pass for the wrong reason |
+| `RD-SPEC-003` | Verified single-node durable topology declares `Linearizable` | `start_redis_durable`: `consistency()` is `Linearizable`, the lock declares `linearizable: true`, and **no** `weak_consistency` WARN is logged. The positive branch the leader conformance suite depends on (§3) |
+| `RD-SPEC-004` | The strict leader constructor refuses a weak cache | `CasBasedLeaderElectionBackend::new` over the default fixture's cache returns `Err`, and `ClusterWiring::from_config` on a profile binding `cache: { provider: redis }` with `leader_election` omitted **fails startup** with an actionable error. Asserts the blocker rather than working around it (DESIGN §7, §13 D1) and stays green after D1 lands, since the flag defaults to `false` — the default-off behaviour is exactly what this pins |
+| `RD-SPEC-004b` | The opt-in flag reaches the weak constructor | With `leader_election: { provider: default, allow_weak_consistency: true }` **and an explicit `lock: { provider: redis, url: … }`** (the `cf-gears-cluster` addition delivered in this change, DESIGN §13 D1). Both halves of that profile are load-bearing: `provider: default` is the reserved sentinel the flag rides, since a bare `allow_weak_consistency` cannot deserialize against a required `provider` field; and the explicit lock binding is what keeps the omit-default lock's own consistency guard out of the way of a scenario about leader election, which a leader-only opt-in would otherwise have died on. The same profile that fails in `RD-SPEC-004` starts successfully, the resolved leader-election backend elects a leader over the weak Redis cache, and the SDK's own construction-time warning is logged. Also asserts the flag does **not** launder capability validation — a consumer declaring `CacheCapability::Linearizable` against the same profile still fails with `CapabilityNotMet`. The end-to-end half of the pair whose wiring-level half lives in `cluster/src/wiring_tests.rs` (DESIGN §13 D1 "Delivery") |
+| `RD-SPEC-005` | Missing keyspace notifications degrade, loudly and safely | Container without `notify-keyspace-events`: `build_and_start` returns `Ok`, `cluster.provider.expiry_events_unavailable` (WARN, once) is logged, `Changed`/`Deleted` still arrive, no `Expired` ever does, and an expired entry still reads as absent. Promptness lost, correctness intact (DESIGN §4.3) |
+| `RD-SPEC-005b` | `manage_keyspace_notifications: true` sets the flags and says so | Same container with the flag: the plugin issues one `CONFIG SET`, `CONFIG GET` confirms the required flags, `cluster.provider.keyspace_notifications_set` (INFO) is logged, and `Expired` events then arrive. With the flag `false` (default) no `CONFIG SET` is issued at all |
+| `RD-SPEC-006` | Unsafe `maxmemory-policy` is warned at startup | Container with `--maxmemory-policy allkeys-lru`: `cluster.provider.maxmemory_policy_unsafe` (WARN, once) names the policy; startup still succeeds (a server-wide setting must not block a gear, DESIGN §3.7) |
+| `RD-SPEC-007` | A real eviction is observed, reported, and mapped | With a tiny `maxmemory` and `allkeys-lru`, write enough to force eviction of a watched cluster key: the watcher receives `Deleted` (**not** `Expired`), `cluster.provider.eviction_observed` (WARN) is logged, and `cluster_redis_evictions_observed_total{provider}` increments — **and `cluster_provider_errors_total` does not move**, which is asserted alongside because the tempting shortcut (`kind = "other"` on the catalog counter) would make an eviction indistinguishable from every other backend failure while inflating a rate that is supposed to mean "operations are failing". The plugin's top operational risk, driven end to end rather than asserted in prose. Covers the evicted *cache entry*; `RD-SPEC-007b` covers the lease |
+| `RD-SPEC-007b` | An evicted **lock lease** is observed and attributed | The case DESIGN §3.7 opens with and rates worst: an evicted lease hands the lock to a second holder with no TTL having lapsed. Acquire a lease with a 600 s TTL, never renew it — so it is the oldest untouched key when `allkeys-lru` starts choosing, and cannot be lost to expiry instead — then write filler through the cache until the eviction line appears. Asserts the line carries `primitive="lock"`, that the **cache's** line survives the same storm (a rate limiter shared between primitives would let the flood of evicted entries suppress the one lock line, which is emitted precisely under that much pressure), that both are counted, and that `cluster_provider_errors_total` still does not move |
+| `RD-SPEC-008` | Cluster mode routes every operation correctly | 3-primary cluster fixture: 300 keys, asserted to have landed on more than one shard (per-node `DBSIZE`), then every cache and lock operation once — `get`, `compare_and_swap`, `put_if_absent`, `contains`, `delete`, `try_lock`, `release`. Each is a Lua script, and a script whose keys hash to different slots is rejected outright, so "all of these succeeded" *is* the zero-`CROSSSLOT` assertion (DESIGN §6). The spread assertion is what makes it a routing test: keys landing on one shard would exercise no routing and pass anyway. The invariant itself remains held statically by `scripts.rs`'s source-derived single-key assertion; this is the runtime half |
+| `RD-SPEC-009` | `scan_prefix` in cluster mode covers every shard | 300 keys planted under one prefix, asserted to span shards, are **all** returned by one `scan_prefix` call — so `scan_cluster_buffered` really iterates every primary rather than only the one the client reached (DESIGN §4.4). A short count here — a key on an unvisited shard silently dropped — would pass every other scenario in this suite |
+| `RD-SPEC-010` | Cluster mode declares `prefix_watch: false` — **the gate on lifting it** | On the cluster fixture, `features().prefix_watch` is `false` and `watch_prefix` returns `Unsupported`, while `watch(key)` still works — its event is a plugin `PUBLISH`, which is broadcast cluster-wide, unlike the node-local keyspace notifications a prefix watcher would need. Deliberately an assertion of the *current, honest* limitation (DESIGN §4.3, §13 D2): the follow-up that implements per-shard expiry subscriptions replaces this test with its positive counterpart, and until then nothing may declare `true` — which this now holds mechanically rather than by review |
+| `RD-SPEC-014` | Sharded pub/sub is detected but not used | Against a Redis 7 container, `cluster.provider.sharded_pubsub_available` (DEBUG) is logged once, and `INFO commandstats` confirms **no** `SPUBLISH`/`SSUBSCRIBE` was issued — v1 records the capability without acting on it (DESIGN §13 D3). Against a Redis 6 container, neither the log nor the commands appear. Guards against a half-landed follow-up silently switching the publish path |
+| `RD-SPEC-011` | An operator hint contradicted by the server fails startup | `durability: fsync_always` against a container running `appendfsync everysec`: `build_and_start` returns `InvalidConfig` naming both the claimed and the actual value. With `CONFIG GET` denied by ACL, the same hint is trusted and `cluster.provider.consistency_asserted` (WARN) is logged instead (DESIGN §3.6) |
+| `RD-SPEC-012` | `database` selects a logical DB, and channels follow it | With `database: 3`, keys land in DB 3 (`SELECT 3` + `DBSIZE`), DB 0 is untouched, and `expired` notifications are received on `__keyspace@3__:…` rather than `@0` — the off-by-one-database bug that would silently deliver no expiry events |
+| `RD-SPEC-015` | A `topology` hint skips the `INFO replication` round trip | Two startups against one container, unhinted then with `topology: standalone`, each measured as an `INFO` call-count delta from a baseline taken immediately before it: the difference between the two deltas is exactly 1. Both `RedisClusterConfig::topology` and `PreflightRequest::topology_hint` promise the skip and DESIGN §3.4 says the hint "replaces detection", so a preflight that detects anyway wastes a round trip on every hinted deployment — and on the locked-down managed instance the hint exists for, logs `cluster.provider.topology_unknown` announcing a conservative declaration `resolve_topology` never makes. Asserted as a call count rather than as an absent WARN because no fixture refuses `INFO`, and because the count is the stronger claim: the WARN is unreachable once the command is not issued |
+| `RD-SPEC-013` | Throughput smoke against the OAGW envelope | 10 000 `compare_and_swap` operations on a small key set, measured and printed as an artefact rather than asserted against a threshold (a CI container's absolute numbers are not a production predictor). Recorded because `cpt-cf-clst-actor-oagw`'s 10k+ counter updates/sec is the reason this plugin exists; a regression of an order of magnitude is what the artefact makes visible. Read with `-- --nocapture` |
+
+## 5. Layer 4 — Fault Injection (Toxiproxy) and Failover
+
+> **None of this layer exists, and neither does the infrastructure it assumes.**
+> Toxiproxy appears nowhere in this repository — not in any `Cargo.toml`, not in
+> any test, not in any workflow — and there is no nightly integration workflow to
+> hang it off: the only `schedule:`d workflows are `clippy-nightly.yml`,
+> `e2e.yml`, `shear-nightly.yml`, `codeql.yml`, `scorecard.yml`, and
+> `cache_cleanup.yml`, none of which runs cluster integration tests. So this
+> section describes infrastructure the platform does not have rather than a
+> harness this plugin declined to plug into, and the postgres plugin's own
+> TESTING.md §5 (`PG-FAULT-001..007`) is the same document written a change
+> earlier and never built either.
+>
+> It is kept rather than deleted because the scenarios below are a *worked design*
+> — `RD-FAULT-006` and `RD-FAULT-007` in particular are the only place this
+> plugin's consistency story is stated as a pair of executable claims rather than
+> as prose — and because the `RD-FAULT-*` IDs are referenced from §7, §8, and the
+> implementation plan. §8 records the whole layer as one gap, with what stands in
+> for each scenario today. Read every row below as a specification, not as
+> coverage.
+
+Toxiproxy sits between the plugin and Redis; the Sentinel fixture supplies
+the failover cases, which are the ones that actually probe ADR-009's claims.
+
+| ID | Scenario | Fault | Expected behaviour |
+|---|---|---|---|
+| `RD-FAULT-001` | Subscriber connection loss → `Reset` | Kill the subscriber's TCP connection | Every watcher receives `Reset` (never a silent gap); `fred` reconnects and replays subscriptions; subsequent events are delivered; `cluster_watch_resets_total` and `cluster_redis_subscriber_resubscribes_total` both increment |
+| `RD-FAULT-002` | Command connection loss → `ConnectionLost` | Kill a pool connection mid-command | `get`/`put` return `Provider { ConnectionLost }`; the next call succeeds on a reconnected connection |
+| `RD-FAULT-003` | Latency spike → `Timeout` | 10 s latency, `command_timeout_ms: 500` | `get` returns `Provider { Timeout }` at ~500 ms, not 10 s |
+| `RD-FAULT-004` | Reconnect fails past the retry budget | Permanent blackhole | Watchers receive `Closed(Provider { ConnectionLost })` once `fred`'s reconnect policy is exhausted; `cluster_redis_connection_state` reads 0 |
+| `RD-FAULT-005` | A blocking `lock()` survives a Sentinel failover | Partition the primary; Sentinel promotes the replica mid-`lock()` | `lock()` retries through the topology change inside the caller's budget and acquires against the new primary, rather than returning `LockTimeout` (DESIGN §5.3's `Provider`-vs-`LockTimeout` distinction) |
+| `RD-FAULT-006` | Failover **can** grant a lock twice — the documented unsafety, demonstrated | Acquire against the primary, partition it before replication, promote the replica, then acquire the same name from a second instance | Both instances hold the lock. **This test asserts the failure**, because DESIGN §3.6/§5.1 promise only `EventuallyConsistent`/`linearizable: false` in this topology, and a plugin whose declaration says one thing while its behaviour says another is the exact dishonesty ADR-009 §"Honest backend declaration" forbids. It is also the evidence for §7's recommendation to route leader election elsewhere |
+| `RD-FAULT-007` | No split-brain under partition on the durable single-node fixture | 5 `CasBasedLeaderElectionBackend` instances, each with its own pool, electing the same name against `start_redis_durable`; Toxiproxy partitions a random subset for several TTL intervals, then restores | Sampling every candidate's `status()` throughout (`tokio::time`-driven, not wall-clock sleeps): at no sampled instant do two report `Leader`. The real-backend counterpart to the non-runnable `SC-LEAD-010`, and the *positive* pair to `RD-FAULT-006` — the same test on the fixture whose declaration says it should hold |
+| `RD-FAULT-008` | `OOM` under `maxmemory` with `noeviction` | Fill to `maxmemory` with `noeviction` | Writes return `Provider { ResourceExhausted }` (retryable), reads keep working, and no key is silently lost — the safe failure mode `noeviction` buys versus `RD-SPEC-007`'s eviction |
+
+`RD-FAULT-006` and `RD-FAULT-007` are the pair that make this plugin's consistency
+story testable rather than merely documented: the same code, the same scenario, one
+topology where the guarantee is claimed and one where it is explicitly not.
+
+## 6. Static Analysis
+
+- **`cargo check`** — no errors.
+- **`cargo clippy`** — no warnings beyond the workspace allow-list.
+- **`dylint`** — `cargo gears lint --dylint` is clean. Note what this does **not**
+  include: there is no `no-remote-in-lock-critical-section` rule anywhere in this
+  workspace. `tools/dylint_lints/` contains only `de12_documentation`, and there is
+  no `lint_utils` crate for such a rule to be built on. ADR-002's
+  no-remote-I/O-in-the-critical-section rule therefore stands as a design constraint
+  **reviewers** enforce, and it is worth being explicit about: a rule believed to be
+  lint-enforced gets less review attention than one known not to be.
+- **No serde in SDK contract types** — the workspace layer rule. This plugin's
+  `config.rs` uses serde; the plugin adds no serde derive to any `cluster-sdk` type.
+- **`cargo test --doc`** — all doc examples compile and pass; `cargo doc --no-deps`
+  is warning-free.
+- **No `KEYS`, no `FLUSHALL`, no `FLUSHDB`** — a crate-local test
+  (`src/static_analysis_tests.rs`) walking every non-test `.rs` file under `src/`,
+  plus a Lua half in `scripts_tests.rs` for the `redis.call` form. `KEYS` on a shared
+  production Redis is an outage rather than a slow query — O(N) over the whole
+  keyspace, blocking the single-threaded server for the duration (DESIGN §4.4) — and
+  `FLUSHALL`/`FLUSHDB` would delete other tenants' data, so all three are worth a
+  mechanical check rather than review vigilance.
+
+  **The scan is on the fred call form (`.keys(`, `.flushall(`, `.flushdb(`), not on
+  the command name**, and that is not a shortcut. Matching the bare word `KEYS` is
+  unusable here: it appears in `REQUIRED_KEYSPACE_FLAGS`, in the
+  `keyspace_notifications_set` event name, and in **every script's `KEYS[1]`** —
+  where it is Lua's argument global rather than a command, and the correct use. The
+  trailing `(` is what distinguishes a call site from a mention in a doc comment.
+  Two meta-tests pin the matcher: one that it recognizes a planted call, so a check
+  that has quietly stopped matching anything cannot pass vacuously, and one that it
+  tolerates all three legitimate uses, so a future tightening back to a bare word
+  match fails here rather than in whichever module it breaks first. The walk is
+  recursive rather than a file list, so a module added later is covered without
+  anyone remembering to add it — a check that silently stops covering new code is
+  worse than no check, because it still reads as a green guarantee.
+
+  **The `B*` blocking family is deliberately not scanned.** DESIGN §3.1 names
+  `fred`'s interface features individually and leaves `i-lists` out, so `BLPOP`,
+  `BRPOP`, `BLMOVE` and the rest are not in the trait surface this crate can see:
+  reaching for one is a **compile error**, which is a stronger guarantee than any
+  text scan.
+  Scanning for them would in fact be counterproductive — `lock/mod.rs` and
+  `lock/waiters.rs` both name `BLPOP` in prose, explaining why the release-waiter
+  registry exists instead of it, and a text scan would turn that explanation into a
+  failure.
+
+- **Every `warn!`/`error!` carries a `name:`** — the same crate-local test file,
+  over the same source walk. DESIGN §9's rule is that a catalogued event carries
+  its name twice, and the structural half is what a collector filters on: an event
+  without it is unalertable however severe the condition it reports. That is not
+  hypothetical — the WARN announcing that the subscriber is permanently gone
+  shipped without one, which is precisely the line an operator most needs to match.
+
+  A site that is genuinely not an operator's business is marked
+  `not-a-catalogued-event:` with a reason, in the comment-and-attribute run
+  immediately above it. The four ADR-006 `Drop` guards are the whole of the current
+  set: they fire on a programming error, in the release build of the same arm that
+  panics in debug, so cataloguing them would put a developer diagnostic in the
+  table an operator alerts on. The matcher has its own capable-of-failing test,
+  for the reason the forbidden-call one does.
+
+## 7. CI Cadence
+
+**Everything this plugin runs, runs on every PR.** There is no nightly row, because
+nothing has earned one: the fixtures that would ordinarily justify a slower cadence
+are the Sentinel and Cluster ones, and `nextest` overlaps their container startup
+with the rest of the suite, so they cost no wall clock against the run as a whole
+(the L3 row below).
+
+| Layer | Trigger | Approx. duration |
+|---|---|---|
+| L1 unit tests | Every PR — `cargo test -p cf-redis-cluster-plugin --lib`, no Docker | 211 tests, sub-second |
+| L2 conformance + L3 integration, over eight single-node shapes plus two multi-node topologies | Every PR touching Rust — `make test-cluster-redis`, in `ci.yml`'s `integration` job | 280 tests total in ~10 s of test time, ~35 s including the build |
+| L3 Sentinel and Cluster topologies (`RD-SPEC-002`, `008..010`, `RD-LOCK-014`) | Every PR, in the same `make test-cluster-redis` run | 5 tests, and **no wall-clock cost** — `nextest` overlaps their containers with the single-node ones, so the suite still finishes in about ten seconds |
+| ~~L4 fault injection and failover~~ (`RD-FAULT-001..008`) | **Never — not built**; §5 and §8 | — |
+
+The 280 are 211 unit tests, 66 Layer 3 test functions, and the three conformance
+suites. Note that the 66 functions cover the **63** scenarios of §4.2–§4.6 (10
+`RD-CACHE-*`, 15 `RD-LOCK-*`, 10 `RD-WATCH-*`, 10 `RD-LIFE-*`, 18 `RD-SPEC-*`) and
+not 66 of them: a scenario whose halves must fail distinguishably is split across
+two functions — `RD-LIFE-006`'s silent-drop and panicking-drop halves are the
+worked example — so scenario count and test count are deliberately different
+numbers, and this is the only place either is written down.
+
+`make test-cluster-redis` passes `--retries 1`, for the reason
+`make test-cluster-pg` does: container setup is load-sensitive on a busy CI host,
+and a genuine logic regression fails both attempts, so the retry absorbs Docker
+churn without masking one.
+
+L3 tests are gated behind an `integration` feature so a default `cargo test` needs
+no Docker. Cargo forces the mechanics: `testcontainers`/`testcontainers-modules` are
+declared **optional under `[dependencies]`** rather than `[dev-dependencies]`, because
+Cargo does not allow optional dev-dependencies and the feature array must name them
+via `dep:`. That placement trips `cargo-shear`'s misplaced-optional-dependency
+heuristic, so it needs a `[package.metadata.cargo-shear] ignored` entry; every
+reference to them lives in `tests/`, so the feature has no effect on the compiled
+plugin. Each test binary carries `required-features = ["integration"]` so the binaries
+are not even built without the flag:
+
+```toml
+[features]
+integration = ["dep:testcontainers", "dep:testcontainers-modules"]
+```
+
+**There is no `integration-topology` feature.** The natural place for one would be
+gating the Sentinel and Cluster fixtures so a per-PR run does not pay their startup
+— but there is no startup to avoid paying. `nextest` runs the suite's containers
+concurrently, so both multi-node fixtures come up alongside the single-node ones and
+the run finishes in about the same ten seconds it would without them (the L3 row
+above). A gate would therefore buy nothing and cost a configuration in which the
+strongest topology coverage in the suite is off by default, which is the wrong
+default for the scenarios DESIGN §13 D2 designates as its gates.
+
+Workspace entries this plugin relies on:
+
+- `fred` in `[workspace.dependencies]`, with the feature set DESIGN §3.1 records.
+- `testcontainers-modules` with its `redis` feature enabled.
+
+## 8. Coverage Gaps and Follow-ups
+
+This section is the register of what the suite does **not** hold. It is written to
+be read against §1's four-layer pyramid, because the honest summary is that this
+plugin ships three of those four layers and no L4 at all: L1 and L3 in full —
+every topology, single-node and multi-node alike — and L2 with one scenario
+short, `SC-LEAD-006`, which the shared runner skips under
+`TimeControl::Real` and which therefore has no Redis coverage at all. "Three
+layers delivered" is a statement about the layers, not a claim that every
+scenario in them runs; the row below is where the one that does not is recorded.
+
+That is a narrower delivery than the platform-wide
+[TESTING-STRATEGY.md](../../../docs/TESTING-STRATEGY.md) promises — its §6 and its
+cadence table (§"Every PR" / §"Nightly") describe Toxiproxy fault injection and
+`turmoil` deterministic simulation as standing layers, and neither exists for any
+cluster backend: the postgres plugin documents the identical L4 and does not have it
+either. **The discrepancy is recorded here rather than resolved by editing the
+platform document**, because whether the platform's four-layer promise should be
+narrowed or the two missing layers should be built is a decision about every
+cluster backend, not about this one.
+
+### 8.1 Deferred scope — specified but not covered
+
+Every row here is a scenario or fixture §4 and §5 describe and the suite does not
+run. The `RD-*` IDs are retained deliberately: a deferred scenario still needs an
+ID to be referenceable, from source comments and from the follow-up that eventually
+builds it.
+
+| Gap | Severity | Tracking |
+|---|---|---|
+| `RD-FAULT-001..008` and **the whole of §5's Toxiproxy layer** | Warning — Toxiproxy appears nowhere in this repository and there is no nightly integration workflow to run it from, so §5 specifies infrastructure the platform does not have. What is lost is every deliberate-failure path: subscriber loss → `Reset`, an exhausted reconnect policy → `Closed(Provider { ConnectionLost })`, a latency spike → `Timeout`, `OOM` under `noeviction`, and both halves of the failover pair. Several of those paths have been exercised by hand against containers — killing the subscriber's connection to observe `Reset`, a closed port for `RD-LIFE-005` — but by-hand is not a regression test | Follow-up, gated on the platform acquiring a fault-injection harness |
+| `RD-FAULT-006`/`RD-FAULT-007` specifically — the pair that makes the consistency story *executable* | Warning — these are the only two scenarios anywhere that assert the declaration against behaviour in both directions: that a Sentinel failover really can grant one lock twice (which DESIGN §3.6 promises it may, and which is the evidence for §7's "route leader election elsewhere"), and that the same test does *not* split-brain on the durable single-node fixture. Without them, "honest declaration" is a claim this suite documents rather than one it demonstrates. `RD-SPEC-002` now asserts the *declaration* against a live replicated topology, which is the static half; these two are the behavioural half | Follow-up; needs fault injection **and** a Sentinel fixture whose nodes are separately killable — this one co-locates them (§4.1), so it can observe a replica leaving but not a failover |
+| `RD-LIFE-011` — a startup whose **subscriber** connect times out leaks no connection and no router task | Warning — the failure arm is `connect.rs`'s subscriber `wait_for_connect()` timeout (as opposed to the pool's, `RD-LIFE-005`, or the post-connect steps, `RD-LIFE-010`). Forcing it end-to-end needs the subscriber's connection to accept-then-hang past `CONNECT_TIMEOUT` *while the pool connects*, and pool and subscriber share one URL against one real server — so the pool-succeeds/subscriber-hangs split cannot be arranged without per-connection latency injection (Toxiproxy, the §5 layer this crate does not build). What **is** covered: the teardown primitive both arms call, `abandon_subscriber`, is unit-tested to abort the router task rather than leak it (`shutdown_tests.rs::abandon_subscriber_stops_the_router_task`), and reading `connect.rs` confirms both the timeout and the connect-error arm call it before returning | Follow-up, gated on the platform acquiring a fault-injection harness |
+
+### 8.2 Known limits of what *is* covered
+
+| Gap | Severity | Tracking |
+|---|---|---|
+| The conformance runner skips `SC-LEAD-006` under `TimeControl::Real` | Warning — it forces a *missed* renewal to assert re-enrolment, which a healthy real backend never exhibits by waiting, so the shared runner skips it on a real clock. It maps to fault injection, which §8.1 defers. One conformance scenario therefore has no Redis coverage at all, which the suite's green result does not say | Accepted — would need L4 |
+| `Lagged` count exactness under extreme backpressure | Warning — `RD-WATCH-008` asserts a `Lagged` arrives with a plausible count and that `cluster_redis_watch_events_dropped_total` agrees with it, not that the count is exact. Exactness would require pausing the fan-out task at a known point, which needs a `#[cfg(test)]` seam. Worth keeping in view precisely because this is the **first test in the platform that produces `Lagged` at all** — ADR-003's variant had no producer before it, so this row is the limit of the only coverage that variant has anywhere | Accepted — would need a pause hook |
+| Sharded pub/sub (`SPUBLISH`) is detected and not used, so the Cluster publish ceiling stands | Warning — ADR-001 puts clustered `PUBLISH` around 12 500/sec, below this plugin's write ceiling, making pub/sub the binding constraint on a clustered heavily-watched deployment (DESIGN §12). `RD-SPEC-014` asserts the detect-and-do-not-use behaviour in both directions; no test measures where the ceiling actually lands. The Cluster fixture could now carry one — what is missing is a reason to spend the wall clock on a number that a CI container cannot make a production predictor anyway (see the performance row in §8.3) | Follow-up, gated on a deployment hitting it (DESIGN §13 D3) |
+| Managed-Redis ACL restrictions are approximated by a `CONFIG`-denied ACL user, not by a real managed instance | Warning — `RD-SPEC-011`'s denied-`CONFIG` branch runs against a container started with `--user limited on '>pw' '~*' '&*' +@all -config`, so the approximation is real and executed rather than deferred. It is still an approximation: the plugin only cares that the command errors, which is the part ElastiCache/MemoryDB reproduce, but no CI job runs against one of those. (`&*` in that flag is load-bearing — without it the user cannot subscribe, and the plugin opens its subscriber before it reaches the durability check) | Accepted |
+| The consistency declaration is never re-evaluated after startup | Warning — a single node that gains a replica keeps a now-false `Linearizable` declaration (DESIGN §12). Untestable without a fixture that changes topology under a running plugin, and unfixable without a capability model that allows post-resolution changes | Accepted |
+| Multi-node Cluster **failover** (as opposed to Sentinel failover, `RD-FAULT-005..006`) | Future — needs a cluster fixture with replicas plus a real slot handover, to probe whether slot migration adds failure modes beyond async replication (ADR-009 hints it does). The 3-primary fixture of §4.1 has no replicas, so it cannot exercise it | Out of initial scope |
+| No test drives two *different* plugin instances against one Redis with different `key_prefix`es for a full cross-primitive isolation sweep | Warning — `RD-CACHE-006` covers `scan_prefix` isolation and the conformance suites isolate by database *and* prefix, but lock names, event channels, and keyspace notifications are only covered per-primitive. A shared Redis with two independent cluster deployments is a plausible arrangement | Follow-up |
+| `${VAR}` expansion is covered by the `${VAR:-default}` branch only | Warning, and permanently so — edition 2024 makes `std::env::set_var` `unsafe` and this crate is `#![forbid(unsafe_code)]`, so no unit test can set a variable for the plain `${VAR}` branch to resolve. The `:-default` test drives the identical `expand_vars()` call down the other branch, and `provider.rs`'s unresolvable-var test covers the failure path. Not a gap to close — a constraint to record | Accepted — structural |
+
+### 8.3 Non-gaps, recorded so they are not re-investigated
+
+| Apparent gap | Why it is not one |
+|---|---|
+| The `allow_weak_consistency` opt-in spans two crates, so the Redis suite alone does not prove the wiring half | **Both halves run.** `cf-gears-cluster` carries the reserved-`default`-provider tests over a stub weak cache in `config_tests.rs` and `wiring_tests.rs` — default-off fails, flag-on constructs, the leader flag alone still fails on the lock, and capability validation is unaffected — and `RD-SPEC-004`/`004b` cover the same paths end to end through real operator YAML against a real container, `cluster/src/gear.rs` having registered both Redis providers. The duplication is deliberate: the wiring tests prove the dispatch against *any* weak cache, the scenarios prove an operator's YAML reaches it with Redis bound |
+| The no-`KEYS` check does not scan for the `B*` blocking family, and matches a call form rather than a command name | **Both are deliberate, and §6 gives the reasoning in full.** `KEYS` appears legitimately in `REQUIRED_KEYSPACE_FLAGS`, in `KEYSPACE_NOTIFICATIONS_SET`, and in every script's `KEYS[1]` — where it is Lua's argument global and the *correct* use — so a bare word match is unusable and the scan is on `.keys(`. The blocking family is a compile error rather than a convention, since `i-lists` is absent from `fred`'s feature list, and two source files name `BLPOP` in prose explaining exactly that, which a text scan would turn into a failure. **Genuinely open:** the check is crate-local, so a future Redis consumer elsewhere in the workspace inherits no protection. Promoting it to a dylint rule is worth doing once a second Redis consumer exists (DESIGN §13 D6) |
+| Performance numbers are artefacts, not thresholds | **Intended, not a shortfall.** `RD-SPEC-013` prints one — 10 000 `compare_and_swap` operations over a small key set, measured and reported rather than asserted against a threshold, read with `-- --nocapture`. Per `docs/PRD.md` §6.2 quantitative per-backend SLOs are excluded from the cluster-wide NFR set and owned by each plugin's own tests, and a CI container's absolute timings are not a production predictor; the artefact makes an order-of-magnitude regression visible, which is the actionable part |
+| `watch_mode: keyspace` (the middle mode) is untested | **There is nothing to test.** The mode was considered and rejected (DESIGN §13 D4); `WatchMode` is a two-variant enum with no `todo!()` arm, so no unimplemented path exists. Retained here only so the question is not reopened as an oversight |

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/cache/mod.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/cache/mod.rs
@@ -1,0 +1,613 @@
+//! [`RedisCache`] — the native `ClusterCacheBackend` (DESIGN.md §4).
+//!
+//! ## The entry is a two-field hash, and every mutation is a script
+//!
+//! An entry is `HSET <prefix>:c:<key> v <bytes> ver <decimal>`, and DESIGN.md
+//! §2.2 records why it is not the obvious framed string: Redis's embedded Lua is
+//! 5.1, whose numbers are IEEE doubles, so a version past 2^53 compared or
+//! incremented *in Lua* silently loses precision and starts producing
+//! duplicates. With a hash, comparison is a string compare (`HGET` returns a
+//! string, `ARGV[1]` is a string, `==` is exact for every `u64`) and increment
+//! is `HINCRBY`, 64-bit integer arithmetic in C. No number ever enters Lua, and
+//! [`decode_entry`] below is the Rust-side half of the same rule — it parses the
+//! version out of the decimal string rather than through any float.
+//!
+//! `get`, `contains`, and `scan_prefix` are the only operations that avoid Lua,
+//! and that is not an oversight to fix later: every mutation needs an atomic
+//! read-modify-write over two hash fields plus a conditional TTL plus a publish,
+//! which no single Redis command expresses (DESIGN.md §4.1).
+//!
+//! ## Atomicity is not the same as the consistency declaration
+//!
+//! Each operation here is atomic — Redis runs a script to completion without
+//! interleaving, so a `compare_and_swap` cannot lose to a concurrent CAS and
+//! `put_if_absent` cannot admit two winners. The weakness ADR-009 names, and
+//! that [`consistency`](RedisCache::consistency) reports, is entirely about
+//! *losing an acknowledged write* to an fsync gap or a failover. Conflating the
+//! two would either overstate the backend or understate it (DESIGN.md §4.5).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cluster_sdk::cache::{PutRequest, Ttl};
+use cluster_sdk::{
+    CacheConsistency, CacheEntry, CacheFeatures, CacheWatch, ClusterCacheBackend, ClusterError,
+    ProviderErrorKind,
+};
+use fred::clients::Pool;
+use fred::interfaces::{HashesInterface, KeysInterface};
+use fred::types::Value;
+
+use crate::cache::watch::{ChannelNames, WatchRegistry};
+use crate::config::WatchMode;
+use crate::observability::RedisSignals;
+use crate::redis_error::map_redis_error;
+use crate::scripts::{
+    CACHE_CAS, CACHE_COMPARE_AND_DELETE, CACHE_DELETE, CACHE_PUT, CACHE_PUT_IF_ABSENT,
+    PoolScriptExecutor, ScriptCache, eval,
+};
+use crate::wait::{self, WaitPolicy};
+
+pub mod scan;
+pub mod watch;
+
+/// The `ARGV` sentinel meaning "no TTL" — the scripts branch on it to `PERSIST`
+/// rather than `PEXPIRE` (DESIGN.md §6).
+///
+/// A sentinel rather than an omitted argument because a script's `ARGV` is
+/// positional: leaving the slot out would shift every argument after it, and the
+/// scripts that carry a channel name after the TTL would publish to whatever the
+/// TTL used to be.
+const NO_TTL: &str = "-1";
+
+/// The native Redis cache backend.
+pub struct RedisCache {
+    pool: Pool,
+    executor: PoolScriptExecutor,
+    scripts: Arc<ScriptCache>,
+    /// The operator's `key_prefix`, already combined with this cache's `:c:`
+    /// primitive segment so the hot path concatenates once instead of twice.
+    entry_prefix: String,
+    /// The channel prefix, `<key_prefix>:e:c:`.
+    channel_prefix: String,
+    consistency: CacheConsistency,
+    watch_mode: WatchMode,
+    /// Whether the client is in Redis Cluster mode, which changes how
+    /// [`scan::scan_prefix`] enumerates keys and whether prefix watch is
+    /// offered at all.
+    clustered: bool,
+    wait: WaitPolicy,
+    /// The channel and pattern names, shared with the subscriber fan-out so the
+    /// publisher and the subscriber cannot disagree on them.
+    names: ChannelNames,
+    /// The watcher registry, or `None` under `watch_mode: disabled`.
+    watchers: Option<Arc<WatchRegistry>>,
+    /// The plugin's signal sink.
+    ///
+    /// The cache's *own* ADR-004 signals do not come from here: the handle wraps
+    /// this backend in the SDK's `InstrumentedCache`, which emits every
+    /// `cluster.cache.*` span, the ops counter, the duration histogram, and
+    /// `cluster.provider.error` around each call (DESIGN.md §9). What this field
+    /// carries is the one thing a decorator cannot see — a `NOSCRIPT` recovery,
+    /// which happens *inside* an otherwise successful operation.
+    signals: Arc<RedisSignals>,
+}
+
+/// Everything [`RedisCache::new`] needs, bundled so the call site names each
+/// field — five of these are `String`s and `bool`s that would otherwise be
+/// positional and interchangeable.
+pub struct CacheInit {
+    /// The connected command pool.
+    pub pool: Pool,
+    /// The SHAs `SCRIPT LOAD` returned at startup.
+    pub scripts: Arc<ScriptCache>,
+    /// The operator's `key_prefix` (DESIGN.md §2.1).
+    pub key_prefix: String,
+    /// The declaration the preflight computed (DESIGN.md §3.6).
+    pub consistency: CacheConsistency,
+    /// The operator's `watch_mode`.
+    pub watch_mode: WatchMode,
+    /// Whether the client is clustered.
+    pub clustered: bool,
+    /// The operator's `WAIT` policy, if any.
+    pub wait: WaitPolicy,
+    /// The logical database, which scopes the keyspace-notification pattern.
+    pub database: u8,
+    /// The watcher registry, or `None` under `watch_mode: disabled`.
+    pub watchers: Option<Arc<WatchRegistry>>,
+    /// The plugin's signal sink, shared with the lock and the fan-out.
+    pub signals: Arc<RedisSignals>,
+}
+
+impl RedisCache {
+    /// Builds the cache over an already-connected pool and an already-loaded
+    /// script catalog.
+    #[must_use]
+    pub fn new(init: CacheInit) -> Self {
+        let executor = PoolScriptExecutor::new(init.pool.clone());
+        let names = ChannelNames::new(&init.key_prefix, init.database);
+        Self {
+            pool: init.pool,
+            executor,
+            scripts: init.scripts,
+            entry_prefix: format!("{}:c:", init.key_prefix),
+            channel_prefix: format!("{}:e:c:", init.key_prefix),
+            consistency: init.consistency,
+            watch_mode: init.watch_mode,
+            clustered: init.clustered,
+            wait: init.wait,
+            names,
+            watchers: init.watchers,
+            signals: init.signals,
+        }
+    }
+
+    /// The watcher registry, so the handle can close every watch at shutdown
+    /// and the fan-out task can dispatch into it.
+    #[must_use]
+    pub fn watch_registry(&self) -> Option<Arc<WatchRegistry>> {
+        self.watchers.clone()
+    }
+
+    /// The channel naming scheme, shared with the subscriber fan-out.
+    #[must_use]
+    pub fn channel_names(&self) -> ChannelNames {
+        self.names.clone()
+    }
+
+    /// Whether this cache offers a native prefix watch (DESIGN.md §4.3).
+    ///
+    /// `false` under `watch_mode: disabled`, and `false` in Redis Cluster: plain
+    /// `PUBLISH` is broadcast cluster-wide so the plugin's own events do reach a
+    /// subscriber on any node, but `expired`/`evicted` keyspace notifications
+    /// are emitted only by the node owning the key, so a clustered prefix watch
+    /// would silently never report an expiry outside its own shard. Declaring
+    /// `true` on the strength of that untested, half-working path is precisely
+    /// the dishonest declaration ADR-009 forbids; DESIGN.md §13 D2 records the
+    /// decision and designates `RD-SPEC-010` as the gate on lifting it.
+    fn offers_prefix_watch(&self) -> bool {
+        self.watchers.is_some() && !self.clustered && self.watch_mode == WatchMode::Publish
+    }
+
+    /// The Redis key holding `key`'s entry: `<prefix>:c:<key>`.
+    ///
+    /// `key` arrives already scope-prefixed by the SDK's `ScopedCacheBackend`,
+    /// and this never inspects the consumer's portion of it (DESIGN.md §2.1).
+    #[must_use]
+    pub fn entry_key(&self, key: &str) -> String {
+        format!("{}{key}", self.entry_prefix)
+    }
+
+    /// The pub/sub channel `key`'s events are published on:
+    /// `<prefix>:e:c:<key>` — or the **empty string** under
+    /// `watch_mode: disabled`, which every mutation script reads as "do not
+    /// publish".
+    ///
+    /// No key exists at this name — it is a channel. It is passed to each
+    /// mutation script as an `ARGV` rather than a second `KEYS` entry, because
+    /// `PUBLISH` is not slot-routed and a second key would make the script
+    /// multi-key for nothing (DESIGN.md §6).
+    ///
+    /// # Why the mode is enforced here rather than at each call site
+    ///
+    /// The write path is where the saving is. Gating only the watcher registry
+    /// and the subscriptions would leave every write still issuing its `PUBLISH`,
+    /// to a channel with — by construction — no subscriber: watches off, and none
+    /// of the write-path cost saved that the mode exists to save. That is
+    /// precisely backwards, since DESIGN.md §4.3 offers the mode for "a managed
+    /// Redis where neither `CONFIG` nor the publish overhead is acceptable", and
+    /// this type's own config documentation promises "no publish and no
+    /// cache-event subscriber". `RD-WATCH-010` is the regression test.
+    ///
+    /// Routing it through this one accessor means the five mutation paths cannot
+    /// disagree about it — each already calls this to build its channel argument,
+    /// so none of them needs to know the mode exists.
+    #[must_use]
+    pub fn event_channel(&self, key: &str) -> String {
+        if self.watch_mode == WatchMode::Disabled {
+            return String::new();
+        }
+        format!("{}{key}", self.channel_prefix)
+    }
+
+    /// The prefix every entry key of this cache starts with, `<prefix>:c:` —
+    /// the `MATCH` stem and the strip target for the `scan` module's
+    /// `scan_prefix`.
+    #[must_use]
+    pub fn entry_prefix(&self) -> &str {
+        &self.entry_prefix
+    }
+
+    /// Issues the operator's `WAIT` after a conditional write, if there is one.
+    ///
+    /// The policy itself lives in [`crate::wait`], shared with the lock: this is
+    /// only the choice of *which* writes carry it. `put_if_absent`,
+    /// `compare_and_swap`, and `compare_and_delete` do, following DESIGN.md
+    /// §3.6's "each lock and CAS write" literally; an unconditional `put` or
+    /// `delete` carries no decision made on a value that a failover could
+    /// invalidate, which is what `WAIT` exists to narrow.
+    async fn wait_for_replicas(&self) -> Result<(), ClusterError> {
+        wait::wait_for_replicas(&self.pool, self.wait).await
+    }
+}
+
+/// Renders a [`Ttl`] as the script's TTL argument: milliseconds, or the
+/// [`NO_TTL`] sentinel.
+///
+/// A write always sets the entry's TTL explicitly and never preserves a previous
+/// one implicitly, which is why `Indefinite` becomes an active `PERSIST` inside
+/// the script rather than "leave it alone" — that is what the SDK's two-valued
+/// `Ttl` says should happen (DESIGN.md §4.2).
+///
+/// A sub-millisecond `Ttl::Of` rounds up to 1 ms rather than down to 0:
+/// `PEXPIRE k 0` deletes the key outright, so rounding down would turn "expires
+/// almost immediately" into "was never stored", and the caller's subsequent read
+/// would see an absence it could not distinguish from a failed write.
+///
+/// A `Duration` whose millisecond count exceeds `u64` **saturates**, and that is
+/// deliberate rather than overlooked — `an_absurd_ttl_saturates_rather_than_wrapping`
+/// pins it, as its sibling does for [`px_millis`](crate::px_millis). Unlike
+/// `wait_timeout_ms`, which is operator YAML and so is rejected up front by
+/// [`WaitPolicy::from_config`](crate::WaitPolicy::from_config), a [`Ttl`] is
+/// built by a Rust caller out of a `Duration` three orders of magnitude past
+/// anything a cache entry means, and the saturated value is one Redis itself
+/// rejects: `PEXPIRE`'s deadline is `now + ttl`, which overflows. So the caller
+/// gets an error either way, and this function stays infallible for the
+/// unreachable case rather than putting a `Result` on every ordinary write.
+/// What must not happen is a *wrap* into a short TTL, which would silently
+/// expire an entry the caller asked to keep.
+#[must_use]
+pub fn ttl_argument(ttl: Ttl) -> String {
+    match ttl {
+        Ttl::Of(duration) => {
+            let millis = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
+            millis.max(1).to_string()
+        }
+        Ttl::Indefinite => NO_TTL.to_owned(),
+    }
+}
+
+/// Decodes an `HMGET K v ver` reply into an entry (DESIGN.md §4.1).
+///
+/// Both fields `nil` is an absent key — which also covers a key that exists but
+/// carries neither field, a state this plugin never writes and cannot
+/// meaningfully read. Exactly one field present is a different matter: every
+/// mutation writes both inside one script, so a half-populated hash means
+/// something *other than this plugin* owns the key, and reporting that as an
+/// absence would let the next write silently merge into a stranger's hash.
+///
+/// # Errors
+/// [`ClusterError::Provider`] with [`ProviderErrorKind::Other`] for a reply that
+/// is not a two-element array, for a half-populated entry, or for a version that
+/// is not a decimal integer.
+pub fn decode_entry(key: &str, reply: &Value) -> Result<Option<CacheEntry>, ClusterError> {
+    let malformed = |detail: String| ClusterError::Provider {
+        kind: ProviderErrorKind::Other,
+        message: format!("cache entry at `{key}` is not one this plugin wrote: {detail}"),
+    };
+
+    let Value::Array(fields) = reply else {
+        return Err(malformed(format!(
+            "expected an HMGET array reply, got {:?}",
+            reply.kind()
+        )));
+    };
+    let [value, version] = fields.as_slice() else {
+        return Err(malformed(format!(
+            "expected exactly the two fields `v` and `ver`, got {} element(s)",
+            fields.len()
+        )));
+    };
+
+    match (value.is_null(), version.is_null()) {
+        (true, true) => Ok(None),
+        (false, false) => {
+            let bytes = value
+                .clone()
+                .into_owned_bytes()
+                .ok_or_else(|| malformed(format!("field `v` is {:?}, not bytes", value.kind())))?;
+            Ok(Some(CacheEntry {
+                value: bytes,
+                version: decode_version(version).ok_or_else(|| {
+                    malformed(format!("field `ver` is not a decimal integer: {version:?}"))
+                })?,
+            }))
+        }
+        // Named for what it holds — `value.is_null()` — rather than inverted:
+        // `true` here means `v` is *absent*, so the field that *is* set is
+        // `ver`. A binding called `present_v` would read as the opposite and
+        // invite a later reader to swap the two strings.
+        (value_is_null, _) => Err(malformed(format!(
+            "only the `{}` field is set; every write in this plugin sets both atomically",
+            if value_is_null { "ver" } else { "v" }
+        ))),
+    }
+}
+
+/// Parses a version out of a script or `HGET` reply, without ever going through
+/// a float.
+///
+/// `HINCRBY` is `i64` server-side and `HGET` returns the counter as a decimal
+/// string, so both shapes appear depending on which command produced the reply.
+/// Both are parsed as integers: routing either through `f64` would silently
+/// round any version past 2^53, which is the exact failure DESIGN.md §2.2 chose
+/// the hash encoding to avoid.
+#[must_use]
+pub fn decode_version(value: &Value) -> Option<u64> {
+    match value {
+        Value::Integer(raw) => u64::try_from(*raw).ok(),
+        Value::String(raw) => raw.parse::<u64>().ok(),
+        Value::Bytes(raw) => std::str::from_utf8(raw).ok()?.parse::<u64>().ok(),
+        _ => None,
+    }
+}
+
+#[async_trait]
+impl ClusterCacheBackend for RedisCache {
+    fn consistency(&self) -> CacheConsistency {
+        // Whatever the startup preflight computed (DESIGN.md §3.6), never
+        // re-evaluated. A topology that changes under a running plugin does not
+        // downgrade a live declaration — a real gap, recorded in DESIGN.md §12
+        // rather than solved, because the resolution model cannot express a
+        // backend whose capabilities change after consumers resolved on them.
+        self.consistency
+    }
+
+    fn features(&self) -> CacheFeatures {
+        CacheFeatures::new(self.offers_prefix_watch())
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<CacheEntry>, ClusterError> {
+        let entry_key = self.entry_key(key);
+        let reply: Value = self
+            .pool
+            .hmget(entry_key, vec!["v", "ver"])
+            .await
+            .map_err(map_redis_error)?;
+        decode_entry(key, &reply)
+    }
+
+    async fn put(&self, req: PutRequest<'_>) -> Result<(), ClusterError> {
+        let args = vec![
+            Value::Bytes(req.value.to_vec().into()),
+            Value::String(ttl_argument(req.ttl).into()),
+            Value::String(self.event_channel(req.key).into()),
+        ];
+        eval(
+            &self.executor,
+            &self.scripts,
+            &CACHE_PUT,
+            &self.entry_key(req.key),
+            &args,
+            &self.signals,
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn put_if_absent(&self, req: PutRequest<'_>) -> Result<Option<CacheEntry>, ClusterError> {
+        let args = vec![
+            Value::Bytes(req.value.to_vec().into()),
+            Value::String(ttl_argument(req.ttl).into()),
+            Value::String(self.event_channel(req.key).into()),
+        ];
+        let reply = eval(
+            &self.executor,
+            &self.scripts,
+            &CACHE_PUT_IF_ABSENT,
+            &self.entry_key(req.key),
+            &args,
+            &self.signals,
+        )
+        .await?;
+        // The script returns `false` (a RESP nil) when the key already existed
+        // and `1` when it created it at version 1.
+        if reply.is_null() || reply == Value::Boolean(false) {
+            return Ok(None);
+        }
+        self.wait_for_replicas().await?;
+        Ok(Some(CacheEntry {
+            value: req.value.to_vec(),
+            version: 1,
+        }))
+    }
+
+    async fn compare_and_swap(
+        &self,
+        key: &str,
+        expected_version: u64,
+        new_value: &[u8],
+        ttl: Ttl,
+    ) -> Result<CacheEntry, ClusterError> {
+        let args = vec![
+            Value::String(expected_version.to_string().into()),
+            Value::Bytes(new_value.to_vec().into()),
+            Value::String(ttl_argument(ttl).into()),
+            Value::String(self.event_channel(key).into()),
+        ];
+        let reply = eval(
+            &self.executor,
+            &self.scripts,
+            &CACHE_CAS,
+            &self.entry_key(key),
+            &args,
+            &self.signals,
+        )
+        .await?;
+        match decode_cas_reply(key, &reply)? {
+            CasOutcome::Swapped { version } => {
+                self.wait_for_replicas().await?;
+                Ok(CacheEntry {
+                    value: new_value.to_vec(),
+                    version,
+                })
+            }
+            CasOutcome::Conflict { current } => Err(ClusterError::CasConflict {
+                key: key.to_owned(),
+                current,
+            }),
+        }
+    }
+
+    async fn compare_and_delete(
+        &self,
+        key: &str,
+        expected_value: &[u8],
+    ) -> Result<bool, ClusterError> {
+        let args = vec![
+            Value::Bytes(expected_value.to_vec().into()),
+            Value::String(self.event_channel(key).into()),
+        ];
+        let reply = eval(
+            &self.executor,
+            &self.scripts,
+            &CACHE_COMPARE_AND_DELETE,
+            &self.entry_key(key),
+            &args,
+            &self.signals,
+        )
+        .await?;
+        let deleted = reply.as_i64().unwrap_or(0) == 1;
+        if deleted {
+            self.wait_for_replicas().await?;
+        }
+        Ok(deleted)
+    }
+
+    async fn delete(&self, key: &str) -> Result<bool, ClusterError> {
+        let args = vec![Value::String(self.event_channel(key).into())];
+        let reply = eval(
+            &self.executor,
+            &self.scripts,
+            &CACHE_DELETE,
+            &self.entry_key(key),
+            &args,
+            &self.signals,
+        )
+        .await?;
+        Ok(reply.as_i64().unwrap_or(0) == 1)
+    }
+
+    async fn contains(&self, key: &str) -> Result<bool, ClusterError> {
+        let present: i64 = self
+            .pool
+            .exists(self.entry_key(key))
+            .await
+            .map_err(map_redis_error)?;
+        Ok(present > 0)
+    }
+
+    async fn watch(&self, key: &str) -> Result<CacheWatch, ClusterError> {
+        // `Unsupported` rather than a channel nothing ever sends on: a watch
+        // that silently never fires is indistinguishable from a quiet key, and
+        // every consumer of it would be reasoning about a guarantee it does not
+        // have. Under `watch_mode: disabled` there is no subscriber at all, so
+        // this is the honest answer (DESIGN.md §4.3).
+        let Some(registry) = self.watchers.as_ref() else {
+            return Err(ClusterError::Unsupported { feature: "watch" });
+        };
+        registry
+            .register_key(key, &self.names.channel_for_key(key))
+            .await
+    }
+
+    async fn watch_prefix(&self, prefix: &str) -> Result<CacheWatch, ClusterError> {
+        // One guard, not two: `offers_prefix_watch` already requires
+        // `self.watchers.is_some()`, so a separate `as_ref()` check below it can
+        // never fire and would only state the invariant a second time.
+        let Some(registry) = self
+            .watchers
+            .as_ref()
+            .filter(|_| self.offers_prefix_watch())
+        else {
+            return Err(ClusterError::Unsupported {
+                feature: "prefix_watch",
+            });
+        };
+        registry
+            .register_prefix(prefix, &self.names.pattern_for_prefix(prefix))
+            .await
+    }
+
+    async fn scan_prefix(&self, prefix: &str) -> Result<Vec<String>, ClusterError> {
+        scan::scan_prefix(&self.pool, self.clustered, &self.entry_prefix, prefix).await
+    }
+}
+
+/// The three shapes `cache_cas` can reply with, collapsed to the two the caller
+/// acts on.
+#[derive(Debug, PartialEq, Eq)]
+pub enum CasOutcome {
+    /// The expected version matched and the write went through.
+    Swapped {
+        /// The version the entry now carries.
+        version: u64,
+    },
+    /// The expected version did not match, or the key was absent.
+    Conflict {
+        /// The entry as it stands, when the script could supply it. `None` for
+        /// an absent key, which is what `CasConflict { current: None }` means.
+        current: Option<CacheEntry>,
+    },
+}
+
+/// Decodes the `cache_cas` reply (DESIGN.md §6).
+///
+/// The script answers `{1, new_version}` on success, `{0, current_version,
+/// current_value}` on a version mismatch, and `{0}` when the key is absent. The
+/// mismatch arm carrying the current entry is what lets `CasConflict.current` be
+/// populated without a second round trip — and a `None` there is a real answer
+/// (the key is gone), not a missing one.
+///
+/// # Errors
+/// [`ClusterError::Provider`] with [`ProviderErrorKind::Other`] for a reply
+/// shape the script cannot have produced, which would mean the loaded script is
+/// not the one this code was written against.
+pub fn decode_cas_reply(key: &str, reply: &Value) -> Result<CasOutcome, ClusterError> {
+    let malformed = |detail: String| ClusterError::Provider {
+        kind: ProviderErrorKind::Other,
+        message: format!(
+            "cache_cas returned a reply this plugin cannot read for `{key}`: {detail}"
+        ),
+    };
+
+    let Value::Array(parts) = reply else {
+        return Err(malformed(format!(
+            "expected an array, got {:?}",
+            reply.kind()
+        )));
+    };
+    match parts.as_slice() {
+        [status, version] if status.as_i64() == Some(1) => Ok(CasOutcome::Swapped {
+            version: decode_version(version)
+                .ok_or_else(|| malformed(format!("new version is not an integer: {version:?}")))?,
+        }),
+        [_absent] => Ok(CasOutcome::Conflict { current: None }),
+        [_status, current_version, current_value] => Ok(CasOutcome::Conflict {
+            current: Some(CacheEntry {
+                value: current_value.clone().into_owned_bytes().ok_or_else(|| {
+                    malformed(format!(
+                        "current value is {:?}, not bytes",
+                        current_value.kind()
+                    ))
+                })?,
+                version: decode_version(current_version).ok_or_else(|| {
+                    malformed(format!(
+                        "current version is not an integer: {current_version:?}"
+                    ))
+                })?,
+            }),
+        }),
+        other => Err(malformed(format!(
+            "expected 1, 2, or 3 elements, got {}",
+            other.len()
+        ))),
+    }
+}
+
+// Layer-1 unit tests (TESTING.md §2, `cache/mod.rs` row): key and channel
+// construction, TTL rendering, and reply decoding. Every command this file
+// issues is covered at Layer 3. Out-of-line per DE1101.
+#[cfg(test)]
+#[path = "mod_tests.rs"]
+mod tests;

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/cache/mod_tests.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/cache/mod_tests.rs
@@ -1,0 +1,342 @@
+use std::time::Duration;
+
+use super::*;
+
+/// A cache with no pool behind it, for the pure key/channel construction.
+///
+/// `RedisCache::new` needs a `Pool`, and building one dials nothing — `fred`
+/// only connects on `init()` — so this is a real cache object that simply never
+/// issues a command.
+fn cache(key_prefix: &str) -> RedisCache {
+    cache_in_mode(key_prefix, WatchMode::Publish)
+}
+
+/// [`cache`], in an explicit [`WatchMode`] — the mode changes what
+/// `event_channel` answers, which is the whole of the publish-suppression rule.
+fn cache_in_mode(key_prefix: &str, watch_mode: WatchMode) -> RedisCache {
+    let pool = fred::types::Builder::default_centralized()
+        .build_pool(1)
+        .expect("a one-connection pool builds without connecting");
+    RedisCache::new(CacheInit {
+        pool,
+        scripts: Arc::new(ScriptCache::default()),
+        key_prefix: key_prefix.to_owned(),
+        consistency: CacheConsistency::EventuallyConsistent,
+        watch_mode,
+        clustered: false,
+        wait: WaitPolicy::Disabled,
+        database: 0,
+        watchers: None,
+        signals: crate::test_support::recording_signals().0,
+    })
+}
+
+#[test]
+fn disabled_watch_mode_yields_the_no_publish_sentinel() {
+    // The write path is where `watch_mode: disabled` saves anything (DESIGN.md
+    // §4.3). Gating only the registry and the subscriptions would leave every
+    // write publishing to a channel that by construction has no subscriber —
+    // watches off, and none of the cost saved that the mode exists to save.
+    //
+    // The empty channel is the sentinel every mutation script reads as "do not
+    // publish", so this is the assertion that the write path goes quiet.
+    let disabled = cache_in_mode("cluster", WatchMode::Disabled);
+    assert_eq!(
+        disabled.event_channel("k"),
+        "",
+        "under watch_mode: disabled the channel argument must be the empty no-publish sentinel"
+    );
+    // The entry key is unaffected: the mode is about events, not about where
+    // values live, and a mode that moved keys would make it unswitchable.
+    assert_eq!(disabled.entry_key("k"), "cluster:c:k");
+
+    let publishing = cache_in_mode("cluster", WatchMode::Publish);
+    assert_eq!(
+        publishing.event_channel("k"),
+        "cluster:e:c:k",
+        "and the default mode must still name a real channel"
+    );
+}
+
+#[test]
+fn every_mutation_script_guards_its_publish_on_a_non_empty_channel() {
+    // The other half of the sentinel: it only suppresses anything if each script
+    // actually checks it. Asserted over the catalog rather than per script so a
+    // sixth mutation script cannot be added with an unguarded PUBLISH.
+    for script in crate::scripts::CACHE_SCRIPTS {
+        // Whitespace-normalized before matching, so the assertion is about the
+        // guard being there and not about how the Lua happens to be laid out —
+        // a author who wraps the guard across two lines has not broken it.
+        let source = script
+            .source
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        let publishes = source.matches("redis.call('PUBLISH'").count();
+        let guards = source.matches("~= '' then redis.call('PUBLISH'").count();
+        assert_eq!(
+            publishes, guards,
+            "`{}` has {publishes} PUBLISH call(s) but {guards} empty-channel guard(s); every one \
+             must be gated so watch_mode: disabled genuinely stops publishing",
+            script.name
+        );
+    }
+}
+
+#[test]
+fn the_key_and_its_channel_are_built_from_the_same_input() {
+    let cache = cache("cluster");
+    assert_eq!(
+        cache.entry_key("tenant-42/limit"),
+        "cluster:c:tenant-42/limit"
+    );
+    assert_eq!(
+        cache.event_channel("tenant-42/limit"),
+        "cluster:e:c:tenant-42/limit"
+    );
+    assert_eq!(cache.entry_prefix(), "cluster:c:");
+}
+
+#[test]
+fn the_operator_key_prefix_is_honoured() {
+    let cache = cache("gears-prod");
+    assert_eq!(cache.entry_key("k"), "gears-prod:c:k");
+    assert_eq!(cache.event_channel("k"), "gears-prod:e:c:k");
+}
+
+#[test]
+fn a_scope_prefixed_key_is_passed_through_untouched() {
+    // The SDK's `ScopedCacheBackend` has already composed the consumer's scope
+    // into the key; this plugin adds its own prefix on top and never inspects
+    // the rest (DESIGN.md §2.1).
+    let cache = cache("cluster");
+    assert_eq!(
+        cache.entry_key("gear/orders/tenant-7/counter"),
+        "cluster:c:gear/orders/tenant-7/counter"
+    );
+}
+
+#[test]
+fn a_finite_ttl_becomes_milliseconds() {
+    assert_eq!(ttl_argument(Ttl::Of(Duration::from_secs(30))), "30000");
+    assert_eq!(ttl_argument(Ttl::Of(Duration::from_millis(1))), "1");
+}
+
+#[test]
+fn an_indefinite_ttl_becomes_the_persist_sentinel() {
+    assert_eq!(ttl_argument(Ttl::Indefinite), "-1");
+}
+
+#[test]
+fn a_sub_millisecond_ttl_rounds_up_rather_than_deleting_the_key() {
+    // `PEXPIRE k 0` deletes outright, so rounding down would turn "expires
+    // almost immediately" into "was never stored" — and the caller's next read
+    // could not tell that apart from a failed write.
+    assert_eq!(ttl_argument(Ttl::Of(Duration::from_nanos(1))), "1");
+    assert_eq!(ttl_argument(Ttl::Of(Duration::ZERO)), "1");
+}
+
+#[test]
+fn an_absurd_ttl_saturates_rather_than_wrapping() {
+    // The counterpart of `px_millis`'s test of the same name, and the same
+    // reasoning: `Duration::MAX` in milliseconds overflows `u64` by three orders
+    // of magnitude, and Redis rejects the saturated value because `PEXPIRE`'s
+    // `now + ttl` deadline overflows — which is the honest outcome. What must
+    // not happen is a wrap into a short TTL, silently expiring an entry the
+    // caller asked to keep.
+    assert_eq!(ttl_argument(Ttl::Of(Duration::MAX)), u64::MAX.to_string());
+}
+
+/// The `HMGET K v ver` reply shape: a two-element array, either element `nil`.
+fn hmget(value: Option<&[u8]>, version: Option<&str>) -> Value {
+    Value::Array(vec![
+        value.map_or(Value::Null, |bytes| Value::Bytes(bytes.to_vec().into())),
+        version.map_or(Value::Null, |raw| Value::String(raw.into())),
+    ])
+}
+
+#[test]
+fn both_fields_nil_decodes_as_absent() {
+    assert_eq!(
+        decode_entry("k", &hmget(None, None)).expect("decodes"),
+        None
+    );
+}
+
+#[test]
+fn a_populated_entry_decodes_to_its_value_and_version() {
+    let entry = decode_entry("k", &hmget(Some(b"\x00\x01payload"), Some("7")))
+        .expect("decodes")
+        .expect("present");
+    assert_eq!(entry.value, b"\x00\x01payload");
+    assert_eq!(entry.version, 7);
+}
+
+#[test]
+fn a_version_at_the_hincrby_ceiling_decodes_losslessly() {
+    // The claim DESIGN.md §2.2's whole hash encoding rests on: the version is a
+    // decimal string on the wire and an integer here, never a float. Routed
+    // through an `f64`, `i64::MAX` comes back as 9223372036854775808 — one too
+    // many, and every subsequent CAS on the key fails.
+    let ceiling = i64::MAX.to_string();
+    let entry = decode_entry("k", &hmget(Some(b"v"), Some(&ceiling)))
+        .expect("decodes")
+        .expect("present");
+    assert_eq!(entry.version, 9_223_372_036_854_775_807);
+    assert_eq!(entry.version.to_string(), ceiling);
+}
+
+#[test]
+fn a_version_returned_as_an_integer_decodes_too() {
+    // `HINCRBY` replies with an integer and `HGET` with a string, so both shapes
+    // reach `decode_version` depending on which command produced them.
+    assert_eq!(decode_version(&Value::Integer(42)), Some(42));
+    assert_eq!(decode_version(&Value::String("42".into())), Some(42));
+    assert_eq!(
+        decode_version(&Value::Bytes(b"42".to_vec().into())),
+        Some(42)
+    );
+    assert_eq!(decode_version(&Value::Integer(-1)), None);
+    assert_eq!(decode_version(&Value::String("not a number".into())), None);
+}
+
+#[test]
+fn a_half_populated_hash_is_an_error_rather_than_an_absence() {
+    // Every mutation writes both fields inside one script, so this means some
+    // other writer owns the key. Reporting it as absent would let the next write
+    // merge into a stranger's hash.
+    for reply in [hmget(Some(b"v"), None), hmget(None, Some("3"))] {
+        let err = decode_entry("k", &reply).expect_err("a torn entry must not read as absent");
+        assert!(matches!(err, ClusterError::Provider { .. }), "got {err:?}");
+    }
+}
+
+#[test]
+fn a_reply_that_is_not_a_two_element_array_is_an_error() {
+    for reply in [
+        Value::Null,
+        Value::Integer(1),
+        Value::Array(vec![Value::Null]),
+        Value::Array(vec![Value::Null, Value::Null, Value::Null]),
+    ] {
+        assert!(
+            decode_entry("k", &reply).is_err(),
+            "{reply:?} is not an HMGET reply this plugin can have produced"
+        );
+    }
+}
+
+#[test]
+fn the_decode_error_names_the_key() {
+    let err = decode_entry("tenant-42/limit", &Value::Integer(1)).expect_err("errors");
+    assert!(
+        err.to_string().contains("tenant-42/limit"),
+        "an operator needs to know which key, got {err}"
+    );
+}
+
+#[test]
+fn a_successful_cas_reply_carries_the_new_version() {
+    let reply = Value::Array(vec![Value::Integer(1), Value::Integer(8)]);
+    assert_eq!(
+        decode_cas_reply("k", &reply).expect("decodes"),
+        CasOutcome::Swapped { version: 8 }
+    );
+}
+
+#[test]
+fn a_version_mismatch_carries_the_current_entry_for_the_conflict() {
+    // The reason the script returns three elements rather than a bare 0: the
+    // caller populates `CasConflict { current }` from it without a second round
+    // trip.
+    let reply = Value::Array(vec![
+        Value::Integer(0),
+        Value::String("5".into()),
+        Value::Bytes(b"current".to_vec().into()),
+    ]);
+    assert_eq!(
+        decode_cas_reply("k", &reply).expect("decodes"),
+        CasOutcome::Conflict {
+            current: Some(CacheEntry {
+                value: b"current".to_vec(),
+                version: 5,
+            })
+        }
+    );
+}
+
+#[test]
+fn an_absent_key_is_a_conflict_with_no_current_entry() {
+    // `{0}` — a real answer (the key is gone), not a missing one.
+    let reply = Value::Array(vec![Value::Integer(0)]);
+    assert_eq!(
+        decode_cas_reply("k", &reply).expect("decodes"),
+        CasOutcome::Conflict { current: None }
+    );
+}
+
+#[test]
+fn a_cas_reply_shape_the_script_cannot_produce_is_an_error() {
+    for reply in [
+        Value::Integer(1),
+        Value::Array(vec![]),
+        Value::Array(vec![
+            Value::Integer(0),
+            Value::Integer(1),
+            Value::Integer(2),
+            Value::Integer(3),
+        ]),
+    ] {
+        assert!(
+            decode_cas_reply("k", &reply).is_err(),
+            "{reply:?} would mean the loaded script is not the catalogued one"
+        );
+    }
+}
+
+#[tokio::test]
+async fn watch_is_unsupported_until_the_subscriber_lands() {
+    // A cache built with no watcher registry answers `Unsupported` rather than
+    // handing back a channel nothing ever sends on — a silent never-firing watch
+    // is indistinguishable from a quiet key.
+    let cache = cache("cluster");
+    assert!(matches!(
+        cache.watch("k").await,
+        Err(ClusterError::Unsupported { feature: "watch" })
+    ));
+    assert!(matches!(
+        cache.watch_prefix("k").await,
+        Err(ClusterError::Unsupported {
+            feature: "prefix_watch"
+        })
+    ));
+    assert!(!cache.features().prefix_watch);
+}
+
+#[test]
+fn the_consistency_declaration_is_whatever_the_preflight_computed() {
+    let pool = fred::types::Builder::default_centralized()
+        .build_pool(1)
+        .expect("a pool builds");
+    let linearizable = RedisCache::new(CacheInit {
+        pool,
+        scripts: Arc::new(ScriptCache::default()),
+        key_prefix: "cluster".to_owned(),
+        consistency: CacheConsistency::Linearizable,
+        watch_mode: WatchMode::Publish,
+        clustered: false,
+        wait: WaitPolicy::Disabled,
+        database: 0,
+        watchers: None,
+        signals: crate::test_support::recording_signals().0,
+    });
+    assert_eq!(
+        linearizable.consistency(),
+        CacheConsistency::Linearizable,
+        "the cache reports the startup decision, it does not re-derive one"
+    );
+    assert_eq!(
+        cache("cluster").consistency(),
+        CacheConsistency::EventuallyConsistent
+    );
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/cache/scan.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/cache/scan.rs
@@ -1,0 +1,205 @@
+//! `scan_prefix` over `SCAN` (DESIGN.md §4.4).
+//!
+//! **`KEYS` is never used.** It is O(N) *blocking the whole server*, which on a
+//! shared production Redis is an outage rather than a slow query. `SCAN` pages
+//! the keyspace instead, and its weak guarantees — keys present for the whole
+//! scan are returned at least once, keys added or removed mid-scan may or may
+//! not appear — are exactly the contract `PollingPrefixWatch` needs and no
+//! stronger, since it diffs sets rather than trusting order or completeness.
+//!
+//! Two costs worth naming rather than discovering. `MATCH` filters *after* the
+//! server has already looked at each key, so the cost scales with the whole
+//! keyspace and not the matched subset — which is one of the reasons
+//! `watch_mode: publish` (making the native prefix watch available and the
+//! polling polyfill unnecessary) is the default. And in cluster mode the scan
+//! runs on every primary and concatenates, so a slot migration mid-scan can
+//! duplicate or miss a key.
+
+use cluster_sdk::ClusterError;
+use fred::clients::Pool;
+use fred::types::Key;
+use futures_util::TryStreamExt;
+
+use crate::redis_error::map_redis_error;
+
+/// Keys requested per `SCAN` page (DESIGN.md §4.4).
+///
+/// A hint, not a limit: `COUNT` bounds the work the server does per call, not
+/// the number of matches returned. 500 keeps each page's server-side work short
+/// enough not to stall other clients on a shared instance, while making the
+/// round-trip count for a large keyspace a fraction of the default `COUNT 10`.
+const SCAN_COUNT: u32 = 500;
+
+/// Lists the consumer-visible keys under `prefix`.
+///
+/// `entry_prefix` is the cache's own `<key_prefix>:c:` stem: it is prepended to
+/// build the `MATCH` pattern and stripped from every key on the way out, so the
+/// caller never sees the plugin's own namespacing.
+///
+/// Both halves of the pattern are glob-escaped, and the stem for the same reason
+/// as the consumer's prefix: it embeds the operator's `key_prefix`, which no
+/// validation constrains to a glob-free charset. Escaping only the caller's half
+/// would leave `key_prefix: "tenant[a]"` scanning a character class — matching
+/// `tenanta:c:…` and missing every key this cache actually wrote. Stripping on
+/// the way out uses the *unescaped* stem, because that is what the stored keys
+/// carry; only the pattern is escaped.
+///
+/// # Errors
+/// Whatever [`map_redis_error`] makes of a failing `SCAN`.
+pub async fn scan_prefix(
+    pool: &Pool,
+    clustered: bool,
+    entry_prefix: &str,
+    prefix: &str,
+) -> Result<Vec<String>, ClusterError> {
+    let pattern = match_pattern(entry_prefix, prefix);
+    // `scan` lives on the concrete client rather than on `Pool`, so this picks
+    // one connection and runs the whole cursor loop on it. That is what `SCAN`
+    // requires anyway: a cursor is meaningful only to the node that issued it,
+    // so spreading pages across a pool would restart the scan on each page.
+    let client = pool.next();
+
+    // The buffered variants run the cursor loop internally, which is precisely
+    // the "until the cursor returns to 0" loop DESIGN.md §4.4 describes —
+    // driving `Scanner::next()` by hand here would reimplement `fred`'s pager
+    // for no gain, since this function collects every page before returning and
+    // so has no use for the backpressure the manual form buys.
+    let keys: Vec<Key> = if clustered {
+        client
+            .scan_cluster_buffered(pattern, Some(SCAN_COUNT), None)
+            .try_collect()
+            .await
+            .map_err(map_redis_error)?
+    } else {
+        client
+            .scan_buffered(pattern, Some(SCAN_COUNT), None)
+            .try_collect()
+            .await
+            .map_err(map_redis_error)?
+    };
+
+    Ok(keys
+        .iter()
+        .filter_map(|key| strip_entry_prefix(entry_prefix, key))
+        .collect())
+}
+
+/// Strips the plugin's `<key_prefix>:c:` stem from a scanned key, or drops the
+/// key when it does not carry one.
+///
+/// A key that does not match the stem cannot have been returned by this
+/// function's own `MATCH` pattern, so reaching this is either a non-UTF-8 key or
+/// something outside the plugin's namespace. Dropping it is the conservative
+/// answer: the alternative is handing a consumer a key it did not write and
+/// cannot address.
+fn strip_entry_prefix(entry_prefix: &str, key: &Key) -> Option<String> {
+    key.as_str()?.strip_prefix(entry_prefix).map(str::to_owned)
+}
+
+/// The `MATCH` pattern covering every entry under `prefix`.
+///
+/// Split out from [`scan_prefix`] so the escaping rule is reachable from a
+/// Layer-1 test without a pool: the cursor loop needs a server, the pattern does
+/// not, and the pattern is the part that has been wrong.
+fn match_pattern(entry_prefix: &str, prefix: &str) -> String {
+    format!("{}{}*", escape_glob(entry_prefix), escape_glob(prefix))
+}
+
+/// Escapes the glob metacharacters Redis's `MATCH` recognizes, so a consumer key
+/// containing one is matched literally.
+///
+/// Without this, `scan_prefix("report[2024]")` would be handed to Redis as a
+/// character class and match `report2`, `report0`, `report4`, and nothing the
+/// caller meant — and `scan_prefix("*")` would return the entire cache. The
+/// consumer's key space is opaque to this plugin (DESIGN.md §2.1), so nothing
+/// upstream rules these characters out.
+///
+/// Redis's glob syntax treats `\` as the escape character and gives `*`, `?`,
+/// `[`, and `]` their special meanings; escaping the backslash itself first is
+/// what keeps a key that legitimately contains one from consuming the next
+/// character.
+#[must_use]
+pub fn escape_glob(pattern: &str) -> String {
+    let mut escaped = String::with_capacity(pattern.len());
+    for ch in pattern.chars() {
+        if matches!(ch, '\\' | '*' | '?' | '[' | ']') {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped
+}
+
+// Layer-1 unit tests: glob escaping and prefix stripping, the two pure pieces of
+// this file. The cursor loop itself is Layer 3.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_plain_prefix_is_unchanged() {
+        assert_eq!(escape_glob("tenant-42/rate-limit"), "tenant-42/rate-limit");
+    }
+
+    #[test]
+    fn glob_metacharacters_are_escaped() {
+        // Without the escape this pattern is a character class, and the scan
+        // returns keys the caller never asked about.
+        assert_eq!(escape_glob("report[2024]"), r"report\[2024\]");
+        assert_eq!(escape_glob("a*b?c"), r"a\*b\?c");
+    }
+
+    #[test]
+    fn a_lone_star_stops_matching_the_whole_cache() {
+        assert_eq!(escape_glob("*"), r"\*");
+    }
+
+    #[test]
+    fn a_backslash_is_escaped_before_it_can_escape_something_else() {
+        // `a\*` unescaped would tell Redis to match a literal `*`; escaped, it
+        // matches a backslash followed by anything, which is what the key says.
+        assert_eq!(escape_glob(r"a\*"), r"a\\\*");
+    }
+
+    #[test]
+    fn the_match_pattern_escapes_both_halves() {
+        // The operator's `key_prefix` reaches this stem, and nothing validates
+        // it against a glob-free charset. Escaping only the consumer's half
+        // would leave `key_prefix: "tenant[a]"` scanning a character class:
+        // Redis would match `tenanta:c:...` and miss every key this cache
+        // actually wrote, so `scan_prefix` would answer "empty" for a populated
+        // cache. `LockNames::release_pattern` and `KeyspaceNames::new` escape
+        // the same operator prefix for the same reason.
+        assert_eq!(
+            match_pattern("tenant[a]:c:", "report[2024]"),
+            r"tenant\[a\]:c:report\[2024\]*"
+        );
+    }
+
+    #[test]
+    fn a_plain_match_pattern_carries_no_escapes() {
+        // The escaping must be invisible to the overwhelmingly common case, or
+        // it changes what a default deployment scans.
+        assert_eq!(
+            match_pattern("cluster:c:", "tenant-42/"),
+            "cluster:c:tenant-42/*"
+        );
+    }
+
+    #[test]
+    fn the_plugin_prefix_is_stripped_from_scanned_keys() {
+        let key = Key::from("cluster:c:tenant-42/limit");
+        assert_eq!(
+            strip_entry_prefix("cluster:c:", &key).as_deref(),
+            Some("tenant-42/limit")
+        );
+    }
+
+    #[test]
+    fn a_key_outside_the_plugin_namespace_is_dropped() {
+        // Unreachable through this module's own MATCH pattern; dropping beats
+        // handing a consumer a key it did not write.
+        let key = Key::from("someone-elses:key");
+        assert_eq!(strip_entry_prefix("cluster:c:", &key), None);
+    }
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/cache/watch.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/cache/watch.rs
@@ -1,0 +1,856 @@
+//! The watcher registry and the subscriber fan-out (DESIGN.md §4.3).
+//!
+//! Ported from `postgres-cluster-plugin/src/cache/watch.rs` — the slot/`Lagged`
+//! bookkeeping, the `closed` latch, and the mutex serializing terminal broadcasts
+//! are that registry's, and the reasoning recorded on each is its reasoning.
+//! Copied rather than hoisted into `cluster-sdk`: sharing it would mean new
+//! public SDK surface, a refactor of a shipped crate, and postgres regression
+//! risk, and the real overlap across three implementations is worth seeing before
+//! it is factored. What is new here is
+//! everything to do with *subscriptions*: Postgres has one static `LISTEN`
+//! channel, and Redis has one channel per watched key, one pattern per watched
+//! prefix, and a keyspace pattern besides.
+//!
+//! ## Three channel families, and why each message reaches each watcher once
+//!
+//! ```text
+//! plugin PUBLISH (in-script)  ──►  <prefix>:e:c:<key>       ──►  message_rx        ──┐
+//! Redis `expired`  keyspace   ──►  __keyspace@<db>__:<key>  ──►  keyspace_event_rx ──┼─► fan-out ─► watchers
+//! Redis `evicted`  keyspace   ──►  __keyspace@<db>__:<key>  ──►  keyspace_event_rx ──┘
+//! ```
+//!
+//! Three families but **two streams**, and that is a `fred` behaviour rather
+//! than a design choice: its router recognizes the `__keyspace@`/`__keyevent@`
+//! channel prefixes and diverts those messages to `keyspace_event_rx()`,
+//! pre-parsed into a `KeyspaceEvent`, so they never appear on `message_rx()` at
+//! all (`fred/src/router/responses.rs`). A fan-out reading only the pub/sub
+//! stream — the obvious reading of DESIGN.md §4.3's diagram — subscribes to the
+//! keyspace pattern successfully, sees the server deliver on it, and still
+//! never emits a single `Expired`.
+//!
+//! A key with both an exact watcher and a covering prefix watcher is subscribed
+//! **twice** on the server — once by `SUBSCRIBE <prefix>:e:c:<key>` and once by
+//! the prefix's `PSUBSCRIBE` — so one `PUBLISH` produces two deliveries to this
+//! client. Redis distinguishes them (`message` versus `pmessage`) and so does
+//! this fan-out: an exact-subscription message is routed only to exact watchers,
+//! and a pattern message only to prefix watchers. Each watcher therefore sees
+//! exactly one event per write, which is what `RD-WATCH-001` pins and what
+//! `cpt-cf-clst-nfr-watch-delivery`'s "zero duplicate events per subscriber per
+//! key" requires. Routing both message kinds to both sets — the obvious
+//! implementation — would deliver two `Changed`s for one `put` to any watcher
+//! whose key is covered both ways.
+//!
+//! The keyspace family has no such twin: it is one blanket pattern, so its
+//! messages go to both sets.
+//!
+//! ## Subscriptions are reference-counted, and the counting is serialized
+//!
+//! `SUBSCRIBE` on the first watcher of a key and `UNSUBSCRIBE` when the last one
+//! goes away, so N consumers watching one prefix cost one Redis pattern
+//! (`RD-WATCH-005`) and a key nobody watches any more stops costing a message
+//! per write. Both decisions run under [`WatchRegistry::subscriptions`], and
+//! that mutex is load-bearing rather than defensive: pruning notices emptiness
+//! on the delivery path while registration inserts on the caller's, so without
+//! serialization an `UNSUBSCRIBE` decided just before a new `watch()` can land
+//! just after its `SUBSCRIBE`, leaving a registered watcher with no server-side
+//! subscription and no event ever again. Under the mutex, "still empty" is
+//! authoritative.
+//!
+//! It is not on the hot path: delivery never takes it. Only `watch`,
+//! `watch_prefix`, and the rare prune-to-empty do.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use cluster_sdk::observability::ResourceId;
+use cluster_sdk::{
+    CacheEvent, CacheWatch, CacheWatchEvent, CacheWatchSender, CacheWatchTrySendError, ClusterError,
+};
+use dashmap::DashMap;
+use fred::clients::SubscriberClient;
+use fred::interfaces::PubsubInterface;
+use fred::types::Value;
+
+use crate::observability::RedisSignals;
+use crate::redis_error::map_redis_error;
+use crate::subscriber::confirm_subscriptions;
+
+/// The per-watcher buffer, in events (DESIGN.md §4.3).
+///
+/// Bounded on purpose: the fan-out never awaits a slow watcher, so a full buffer
+/// has to drop and report rather than apply backpressure to the write path. 64
+/// is deep enough that an ordinarily-scheduled consumer never sees `Lagged`, and
+/// shallow enough that a stalled one is reported promptly instead of
+/// accumulating unbounded memory per watcher.
+const WATCH_BUFFER: usize = 64;
+
+/// Upper bound on how long one terminal delivery waits for a full consumer to
+/// free a buffer slot before giving up.
+///
+/// The terminal `Reset`/`Closed` is delivered with a blocking `send` rather than
+/// the fan-out's `try_send`, so a watcher whose buffer is momentarily full still
+/// gets the *typed* event instead of a bare channel close it cannot tell apart
+/// from a dropped sender. A consumer that has stopped draining altogether must
+/// not stall `stop()` on that, hence the bound.
+const TERMINAL_GRACE: Duration = Duration::from_secs(5);
+
+/// The payload a mutation script publishes (DESIGN.md §2.5).
+///
+/// One character, because the channel already carries the key and the SDK's
+/// cache events are key-only by contract. There is no `Expired` payload:
+/// nothing runs plugin code when a TTL lapses, so that one event can only come
+/// from Redis's own keyspace notification.
+const PAYLOAD_CHANGED: &str = "C";
+/// See [`PAYLOAD_CHANGED`].
+const PAYLOAD_DELETED: &str = "D";
+
+/// The Redis keyspace-notification event name for a lapsed TTL.
+const KEYSPACE_EXPIRED: &str = "expired";
+/// The Redis keyspace-notification event name for a key `maxmemory` pressure
+/// removed.
+const KEYSPACE_EVICTED: &str = "evicted";
+
+/// What the fan-out decided a raw message means (DESIGN.md §2.5, §4.3).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParsedNotification {
+    /// The key was created or updated.
+    Changed {
+        /// The affected key, with the plugin's prefix already stripped.
+        key: String,
+    },
+    /// The key was deleted — by an explicit delete, or by an eviction.
+    Deleted {
+        /// The affected key.
+        key: String,
+    },
+    /// The key's TTL lapsed.
+    Expired {
+        /// The affected key.
+        key: String,
+    },
+    /// Something arrived on this key's channel that the plugin cannot
+    /// interpret.
+    ///
+    /// Delivered as a `Reset` to every watcher **on that key**, per ADR-003's
+    /// mapping for an unintelligible backend signal and DESIGN.md §2.5: it costs
+    /// a spurious re-read and cannot be mistaken for a real event. Distinct from
+    /// the registry-wide `Reset` of [`WatchRegistry::broadcast_reset`], which
+    /// says the whole subscription gapped.
+    Reset {
+        /// The key whose channel carried the unintelligible payload.
+        key: String,
+    },
+    /// A keyspace notification outside this plugin's vocabulary, dropped.
+    ///
+    /// Not a `Reset`: these arrive only when the server's `notify-keyspace-events`
+    /// is configured more widely than the plugin asked for, and there is one per
+    /// Redis *command* rather than per logical write — so turning them into
+    /// resets would make an over-configured server cost a re-read on every
+    /// mutation.
+    Ignored,
+}
+
+/// Maps a published payload to its event (DESIGN.md §2.5).
+///
+/// An unrecognized payload is [`ParsedNotification::Reset`] rather than a
+/// discarded message: it means either an unrelated publisher on this plugin's
+/// channel or a future payload format this version does not know, and in both
+/// cases a re-read is the safe answer.
+#[must_use]
+pub fn parse_publish_payload(key: &str, payload: &Value) -> ParsedNotification {
+    match payload.as_str().as_deref() {
+        Some(PAYLOAD_CHANGED) => ParsedNotification::Changed {
+            key: key.to_owned(),
+        },
+        Some(PAYLOAD_DELETED) => ParsedNotification::Deleted {
+            key: key.to_owned(),
+        },
+        _ => ParsedNotification::Reset {
+            key: key.to_owned(),
+        },
+    }
+}
+
+/// Whether `operation` is Redis's own eviction notification (DESIGN.md §3.7).
+///
+/// Separate from [`parse_keyspace_event`] because that function deliberately
+/// erases the distinction — an eviction is delivered to watchers as `Deleted` —
+/// while the operational signal needs precisely the distinction it erased: an
+/// `expired` is a TTL doing its job, and an `evicted` is memory pressure
+/// removing a key nobody asked it to.
+#[must_use]
+pub fn is_eviction(operation: &str) -> bool {
+    operation == KEYSPACE_EVICTED
+}
+
+/// Maps a Redis keyspace-notification operation to its cache event.
+///
+/// **`evicted` becomes `Deleted`, not `Expired`** (DESIGN.md §3.7). No TTL
+/// lapsed — `maxmemory` pressure removed a key nobody asked to remove — and a
+/// consumer distinguishing the two would be told the entry aged out when in
+/// fact its instance is misconfigured. `Deleted` is the truthful one of the two
+/// the SDK offers.
+#[must_use]
+pub fn parse_keyspace_event(key: &str, operation: &str) -> ParsedNotification {
+    match operation {
+        KEYSPACE_EXPIRED => ParsedNotification::Expired {
+            key: key.to_owned(),
+        },
+        KEYSPACE_EVICTED => ParsedNotification::Deleted {
+            key: key.to_owned(),
+        },
+        // `del`, `hset`, `rename_from` and the rest of the keyspace vocabulary
+        // reach here only if the server's flags are wider than this plugin asked
+        // for. Reporting them would double every mutation, since the in-script
+        // publish already carried it, so they are dropped outright rather than
+        // turned into a `Reset` that would make every write cost a re-read.
+        _ => ParsedNotification::Ignored,
+    }
+}
+
+/// One registered watcher: the sender plus a count of events dropped because
+/// its buffer was full, drained as a synthesized [`CacheWatchEvent::Lagged`] the
+/// next time a delivery to it succeeds.
+struct WatcherSlot {
+    /// Process-unique, so [`WatchRegistry::register`] can withdraw *its own*
+    /// slot when it loses the race against a terminal close.
+    id: u64,
+    sender: CacheWatchSender,
+    dropped: AtomicU64,
+}
+
+/// Delivers `event` to `slot` via `try_send` — a fan-out path must never block
+/// on one slow consumer — first flushing any pending `Lagged` count. Returns
+/// `false` when the slot should be pruned because its consumer dropped the
+/// watch.
+///
+/// The `Lagged` rides the next successful send rather than being emitted the
+/// moment the buffer drains, because nothing polls a drained buffer. A watcher
+/// that lags and then sees no further traffic on its key never learns it lagged
+/// — a real limitation, stated rather than papered over (DESIGN.md §4.3), and the
+/// reason `RD-WATCH-008` drives enough writes to make it fire.
+///
+/// `cluster_redis_watch_events_dropped_total` is incremented once per dropped
+/// event, including the drop of a `Lagged` that itself found no room. That is
+/// what keeps the counter equal to the `dropped` count the consumer eventually
+/// receives, which is the equality `RD-WATCH-008` asserts.
+fn deliver(slot: &WatcherSlot, event: CacheWatchEvent, signals: &RedisSignals) -> bool {
+    let dropped = slot.dropped.load(Ordering::Relaxed);
+    if dropped > 0 {
+        match slot.sender.try_send(CacheWatchEvent::Lagged { dropped }) {
+            Ok(()) => slot.dropped.store(0, Ordering::Relaxed),
+            Err(CacheWatchTrySendError::Full) => {
+                slot.dropped.fetch_add(1, Ordering::Relaxed);
+                signals.watch_event_dropped();
+                return true;
+            }
+            Err(CacheWatchTrySendError::Closed) => return false,
+        }
+    }
+    match slot.sender.try_send(event) {
+        Ok(()) => true,
+        Err(CacheWatchTrySendError::Full) => {
+            slot.dropped.fetch_add(1, Ordering::Relaxed);
+            signals.watch_event_dropped();
+            true
+        }
+        Err(CacheWatchTrySendError::Closed) => false,
+    }
+}
+
+/// Which family of watchers a message is for — see the module docs on why one
+/// message never reaches both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WatcherKind {
+    /// Watchers registered through `watch(key)`, served by an exact
+    /// `SUBSCRIBE`.
+    Exact,
+    /// Watchers registered through `watch_prefix(prefix)`, served by a
+    /// `PSUBSCRIBE`.
+    Prefix,
+    /// Both — the keyspace family, which has a single blanket pattern and so
+    /// cannot double-deliver.
+    Both,
+}
+
+/// Registry of active watchers, plus the subscription bookkeeping that keeps the
+/// server-side channel and pattern sets in step with it.
+pub struct WatchRegistry {
+    /// Exact-key watchers, keyed by the consumer's key.
+    keys: DashMap<String, Vec<WatcherSlot>>,
+    /// Prefix watchers, keyed by the consumer's prefix.
+    prefixes: DashMap<String, Vec<WatcherSlot>>,
+    /// Source of [`WatcherSlot::id`].
+    next_id: AtomicU64,
+    /// The subscriber this registry drives, and the serialization point for
+    /// every `SUBSCRIBE`/`UNSUBSCRIBE` it issues. See the module docs.
+    ///
+    /// `None` under `watch_mode: disabled`, where no subscriber exists — but
+    /// that path never reaches the registry, since `watch`/`watch_prefix` answer
+    /// `Unsupported` before registering.
+    subscriptions: tokio::sync::Mutex<Option<SubscriberClient>>,
+    /// Serializes every terminal broadcast — the `Reset` fan-out and
+    /// [`close_all`](Self::close_all) — against each other.
+    ///
+    /// Without it those two interleave and both interleavings are wrong. A
+    /// `Reset` broadcast that had already collected its senders when `close_all`
+    /// ran would send on the same channels *after* the terminal
+    /// `Closed(Shutdown)`, which the SDK's `CacheWatch` contract forbids. The
+    /// other order is no better: the `Reset` empties the maps first, so
+    /// `close_all` finds nothing and delivers no terminal event at all.
+    terminal: tokio::sync::Mutex<()>,
+    /// Set, under `terminal`, by the first terminal broadcast, to the very error
+    /// that broadcast delivered. A registry that has closed stays closed.
+    ///
+    /// It holds the error rather than a bare flag because *which* error closed
+    /// the registry is load-bearing: `close_all` closes with
+    /// [`ClusterError::Shutdown`], while an exhausted reconnect budget closes
+    /// with `Provider { ConnectionLost }`, and only the latter is
+    /// [`ClusterError::is_retryable`]. A late registration answered with a
+    /// hardcoded `Shutdown` would tell the SDK's `RestartingWatch` combinator
+    /// that the subsystem is going away when the truth is a lost connection, so
+    /// the consumer's own retry policy would never get to run.
+    closed: std::sync::OnceLock<ClusterError>,
+    /// The plugin's signal sink: the dropped-event counter on the delivery path,
+    /// and `cluster.provider.error` for an `UNSUBSCRIBE` the server refused.
+    signals: Arc<RedisSignals>,
+}
+
+impl WatchRegistry {
+    /// Builds a registry over `subscriber`, or over nothing under
+    /// `watch_mode: disabled`.
+    #[must_use]
+    pub fn new(subscriber: Option<SubscriberClient>, signals: Arc<RedisSignals>) -> Arc<Self> {
+        Arc::new(Self {
+            keys: DashMap::new(),
+            prefixes: DashMap::new(),
+            next_id: AtomicU64::new(0),
+            subscriptions: tokio::sync::Mutex::new(subscriber),
+            terminal: tokio::sync::Mutex::new(()),
+            closed: std::sync::OnceLock::new(),
+            signals,
+        })
+    }
+
+    /// Registers an exact-key watch, subscribing to the key's channel if this is
+    /// its first watcher.
+    ///
+    /// # Errors
+    /// Whatever [`map_redis_error`] makes of a failing `SUBSCRIBE`. The slot is
+    /// withdrawn first, so a failed subscribe leaves no watcher behind that
+    /// would receive nothing forever.
+    pub async fn register_key(&self, key: &str, channel: &str) -> Result<CacheWatch, ClusterError> {
+        self.register(WatcherKind::Exact, key, channel).await
+    }
+
+    /// Registers a prefix watch, pattern-subscribing if this is the prefix's
+    /// first watcher.
+    ///
+    /// # Errors
+    /// Whatever [`map_redis_error`] makes of a failing `PSUBSCRIBE`.
+    pub async fn register_prefix(
+        &self,
+        prefix: &str,
+        pattern: &str,
+    ) -> Result<CacheWatch, ClusterError> {
+        self.register(WatcherKind::Prefix, prefix, pattern).await
+    }
+
+    /// The shared body of the two registrations above.
+    ///
+    /// A `watch()` landing during or after [`close_all`](Self::close_all) must
+    /// not produce a watcher that silently receives nothing forever, so this is
+    /// a check-insert-recheck against the [`closed`](Self::closed) latch. The
+    /// recheck is what makes it airtight: the latch can be set between the first
+    /// check and the insert, and losing that race is resolved by *whoever
+    /// actually holds the slot* — [`take_slot`](Self::take_slot) returns `true`
+    /// only if this call removed it, which means the terminal broadcast did not
+    /// collect it and this call owes the watcher its terminal event.
+    async fn register(
+        &self,
+        kind: WatcherKind,
+        target: &str,
+        subscription: &str,
+    ) -> Result<CacheWatch, ClusterError> {
+        let (sender, watch) = CacheWatch::channel(WATCH_BUFFER);
+
+        if !self.is_closed() {
+            // Held across the insert and the subscribe, so a concurrent
+            // prune-to-empty cannot decide to unsubscribe a channel this call
+            // has just claimed. See the module docs.
+            let held = self.subscriptions.lock().await;
+            let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+            let first = self.insert_slot(kind, target, id, sender.clone());
+            if first && let Some(client) = held.as_ref() {
+                let issued = match kind {
+                    WatcherKind::Exact => client.subscribe(subscription.to_owned()).await,
+                    // `Both` never registers: it is a routing target, not a
+                    // watcher kind a consumer can ask for.
+                    WatcherKind::Prefix | WatcherKind::Both => {
+                        client.psubscribe(subscription.to_owned()).await
+                    }
+                };
+                // Awaiting the subscribe is *not* enough — see
+                // [`confirm_subscriptions`]. Without the round trip that follows
+                // it, `watch()` can return before the server has processed the
+                // `SUBSCRIBE`, and a `put` issued immediately afterwards
+                // publishes to a channel nobody is listening on yet.
+                let confirmed = match issued {
+                    Ok(()) => confirm_subscriptions(client).await,
+                    Err(err) => Err(map_redis_error(err)),
+                };
+                if let Err(err) = confirmed {
+                    // Withdraw before returning: a registered slot with no
+                    // server-side subscription is a watch that never fires and
+                    // never says why.
+                    let _withdrawn = self.take_slot(kind, target, id);
+                    return Err(err);
+                }
+            }
+            drop(held);
+            if !self.is_closed() || !self.take_slot(kind, target, id) {
+                return Ok(watch);
+            }
+        }
+
+        // The registry is closed and this watcher's slot is ours to answer for.
+        // `try_send` on a channel with an empty buffer always has room.
+        let _delivered = sender.try_send(CacheWatchEvent::Closed(self.terminal_error()));
+        Ok(watch)
+    }
+
+    /// Inserts a slot, reporting whether it is the first for `target` — the
+    /// signal to subscribe.
+    fn insert_slot(
+        &self,
+        kind: WatcherKind,
+        target: &str,
+        id: u64,
+        sender: CacheWatchSender,
+    ) -> bool {
+        let map = self.map_for(kind);
+        let mut slots = map.entry(target.to_owned()).or_default();
+        let first = slots.is_empty();
+        slots.push(WatcherSlot {
+            id,
+            sender,
+            dropped: AtomicU64::new(0),
+        });
+        first
+    }
+
+    fn map_for(&self, kind: WatcherKind) -> &DashMap<String, Vec<WatcherSlot>> {
+        match kind {
+            WatcherKind::Exact => &self.keys,
+            WatcherKind::Prefix | WatcherKind::Both => &self.prefixes,
+        }
+    }
+
+    /// Whether a terminal broadcast has already run.
+    fn is_closed(&self) -> bool {
+        self.closed.get().is_some()
+    }
+
+    /// The error the terminal broadcast closed with, for replaying to a
+    /// registration that arrived too late to be collected by it.
+    fn terminal_error(&self) -> ClusterError {
+        self.closed.get().cloned().unwrap_or(ClusterError::Shutdown)
+    }
+
+    /// Removes the slot with `id` under `target`, reporting whether it was still
+    /// there. See [`register`](Self::register) for why the answer matters.
+    ///
+    /// The emptied entry goes through [`DashMap::remove_if`] rather than
+    /// `remove`, for the reason spelled out on [`deliver_to`](Self::deliver_to):
+    /// releasing the guard and re-acquiring the shard lock opens a window a
+    /// concurrent `register` can insert into, and an unconditional `remove`
+    /// would then discard that live watcher.
+    fn take_slot(&self, kind: WatcherKind, target: &str, id: u64) -> bool {
+        let map = self.map_for(kind);
+        let removed = {
+            let Some(mut slots) = map.get_mut(target) else {
+                return false;
+            };
+            let before = slots.len();
+            slots.retain(|slot| slot.id != id);
+            slots.len() != before
+        };
+        map.remove_if(target, |_, slots| slots.is_empty());
+        removed
+    }
+
+    /// Fans one parsed notification out to the watchers `kind` selects,
+    /// returning the subscriptions that lost their last watcher and should be
+    /// torn down.
+    ///
+    /// Synchronous, and every send on it is a non-blocking `try_send`, which is
+    /// what makes it safe to run inline in the subscriber's read loop: a loop
+    /// that stopped reading would let `fred`'s broadcast buffer overflow, and
+    /// every watcher would then be told `Reset` because one was slow.
+    ///
+    /// A prefix watcher receives an event for any key it covers, matched here
+    /// rather than by the server, because a message arrives stamped with the
+    /// channel it was published on and not with the pattern that matched it —
+    /// so with several overlapping patterns registered there is nothing in the
+    /// message to route on. The scan is over distinct watched prefixes, which is
+    /// the count `RD-WATCH-005` keeps at one per prefix rather than one per
+    /// watcher.
+    #[must_use]
+    pub fn dispatch(&self, notification: &ParsedNotification, kind: WatcherKind) -> Vec<Orphaned> {
+        let (key, event) = match notification {
+            ParsedNotification::Changed { key } => (
+                key,
+                CacheWatchEvent::Event(CacheEvent::Changed { key: key.clone() }),
+            ),
+            ParsedNotification::Deleted { key } => (
+                key,
+                CacheWatchEvent::Event(CacheEvent::Deleted { key: key.clone() }),
+            ),
+            ParsedNotification::Expired { key } => (
+                key,
+                CacheWatchEvent::Event(CacheEvent::Expired { key: key.clone() }),
+            ),
+            // Per-key, not registry-wide: one message was unintelligible, which
+            // is not evidence the subscription gapped.
+            ParsedNotification::Reset { key } => (key, CacheWatchEvent::Reset),
+            ParsedNotification::Ignored => return Vec::new(),
+        };
+
+        let mut orphaned = Vec::new();
+        if matches!(kind, WatcherKind::Exact | WatcherKind::Both)
+            && Self::deliver_to(&self.keys, key, &event, &self.signals)
+        {
+            orphaned.push(Orphaned {
+                kind: WatcherKind::Exact,
+                target: key.clone(),
+            });
+        }
+        if matches!(kind, WatcherKind::Prefix | WatcherKind::Both) {
+            // Collected before delivering, not iterated in place: `deliver_to`
+            // takes a `get_mut` on the same map, and holding a `DashMap`
+            // iterator across that deadlocks on the shard.
+            let covering: Vec<String> = self
+                .prefixes
+                .iter()
+                .filter(|entry| key.starts_with(entry.key().as_str()))
+                .map(|entry| entry.key().clone())
+                .collect();
+            for prefix in covering {
+                if Self::deliver_to(&self.prefixes, &prefix, &event, &self.signals) {
+                    orphaned.push(Orphaned {
+                        kind: WatcherKind::Prefix,
+                        target: prefix,
+                    });
+                }
+            }
+        }
+        orphaned
+    }
+
+    /// Delivers to every slot under `target`, pruning the dead ones. Returns
+    /// whether the entry was left empty and its subscription is now orphaned.
+    ///
+    /// The removal is [`DashMap::remove_if`] rather than a `drop` followed by
+    /// `remove`, and the difference is not stylistic. Those are two separate
+    /// acquisitions of the shard lock, so a `register` racing in between would
+    /// push a live slot into the vector this path has already decided is empty,
+    /// and the `remove` would then throw that watcher away — its consumer would
+    /// see `recv() -> None` with no terminal event, which this registry
+    /// promises never happens. The `subscriptions` mutex does not close the gap,
+    /// because delivery never takes it. `remove_if` re-tests emptiness under the
+    /// same lock, so the racing watcher survives and — the entry still being
+    /// present — is correctly reported as *not* orphaned.
+    fn deliver_to(
+        map: &DashMap<String, Vec<WatcherSlot>>,
+        target: &str,
+        event: &CacheWatchEvent,
+        signals: &RedisSignals,
+    ) -> bool {
+        {
+            let Some(mut slots) = map.get_mut(target) else {
+                return false;
+            };
+            slots.retain(|slot| deliver(slot, event.clone(), signals));
+        }
+        map.remove_if(target, |_, slots| slots.is_empty()).is_some()
+    }
+
+    /// Tears down a subscription whose last watcher went away, unless one
+    /// arrived again in the meantime.
+    ///
+    /// The re-check under the lock is the whole point — see the module docs on
+    /// why an unsubscribe decided on the delivery path cannot be issued
+    /// unconditionally.
+    pub async fn release_subscription(&self, orphaned: &Orphaned, subscription: &str) {
+        let held = self.subscriptions.lock().await;
+        if self.map_for(orphaned.kind).contains_key(&orphaned.target) {
+            // A new watcher claimed it while this was in flight. Its own
+            // `register` already ensured the subscription, so leaving it alone
+            // is both correct and the only safe move.
+            return;
+        }
+        let Some(client) = held.as_ref() else {
+            return;
+        };
+        let released = match orphaned.kind {
+            WatcherKind::Exact => client.unsubscribe(subscription.to_owned()).await,
+            WatcherKind::Prefix | WatcherKind::Both => {
+                client.punsubscribe(subscription.to_owned()).await
+            }
+        };
+        if let Err(err) = released {
+            // Not fatal: the cost of a stale subscription is messages this
+            // registry drops on arrival, not incorrect delivery. So the DEBUG
+            // stays, for explaining an unexpectedly busy subscriber. It is still
+            // a command the server refused, though, and every backend failure
+            // reaches `cluster_provider_errors_total` and the
+            // `cluster.provider.error` ERROR through the one shared emitter
+            // (DESIGN.md §9) - and unlike a cache or lock operation, no
+            // catalogued op wraps this one, so nothing else would count it.
+            let err = map_redis_error(err);
+            tracing::debug!(
+                subscription,
+                error = %err,
+                "failed to release a redis subscription with no watchers left"
+            );
+            self.signals
+                .provider_error("unsubscribe", ResourceId::Key(&orphaned.target), &err);
+        }
+    }
+
+    /// Broadcasts a non-terminal `Reset` to every watcher, so consumers re-read
+    /// (DESIGN.md §4.3).
+    ///
+    /// The registrations survive it. `Reset` means *re-read*, not *this watch is
+    /// over*, so every watcher keeps receiving on the same [`CacheWatch`] and a
+    /// consumer that responds by calling `watch()` again merely gets a second,
+    /// redundant one.
+    ///
+    /// Returns whether the broadcast ran; `false` means the registry was already
+    /// closed and the `Reset` was deliberately dropped, since nothing may follow
+    /// a terminal `Closed`.
+    pub async fn broadcast_reset(&self) -> bool {
+        self.broadcast_and_clear(None).await
+    }
+
+    /// Closes every active watch terminally with [`ClusterError::Shutdown`]
+    /// (DESIGN.md §11 step 2) and latches the registry closed so nothing can
+    /// follow it.
+    pub async fn close_all(&self) {
+        let _broadcast = self.broadcast_and_clear(Some(ClusterError::Shutdown)).await;
+    }
+
+    /// Closes every active watch terminally with `err` — the path an exhausted
+    /// reconnect budget takes, where the error must survive to the consumer so
+    /// its own retry policy can read it as retryable.
+    pub async fn close_all_with(&self, err: ClusterError) {
+        let _broadcast = self.broadcast_and_clear(Some(err)).await;
+    }
+
+    /// Sends the terminal or reset event to every active watcher, clearing the
+    /// registrations only when the event is a terminal one.
+    ///
+    /// Unlike the per-key fan-out — which drops on a full buffer and coalesces a
+    /// later `Lagged` — this delivers the event with a blocking `send`, so a
+    /// watcher whose buffer is momentarily full still receives the typed event
+    /// rather than a bare channel close it cannot distinguish from a dropped
+    /// sender. Each delivery is bounded by [`TERMINAL_GRACE`] and they run
+    /// concurrently, so a consumer that is alive but has stopped draining cannot
+    /// stall shutdown.
+    async fn broadcast_and_clear(&self, terminal: Option<ClusterError>) -> bool {
+        // Held across collection *and* delivery. See [`terminal`](Self::terminal)
+        // for the two interleavings this excludes.
+        let _serialized = self.terminal.lock().await;
+        if self.is_closed() {
+            return false;
+        }
+        if let Some(err) = terminal.clone() {
+            let _latched = self.closed.set(err);
+        }
+
+        // A terminal close ends every watch, so the registrations go with it. A
+        // `Reset` is non-terminal (DESIGN.md §4.3) and the consumer keeps
+        // polling the same `CacheWatch`, so its sender has to survive the
+        // broadcast — dropping it would end the stream on a signal that means
+        // *re-read*. The registrations survive with it: `fred`'s
+        // `manage_subscriptions()` replay task restores the server-side
+        // subscriptions on reconnect, so there is nothing here to re-establish.
+        let senders = match &terminal {
+            Some(_) => self.drain_senders(),
+            None => self.clone_senders(),
+        };
+        let mut deliveries = tokio::task::JoinSet::new();
+        for sender in senders {
+            let event = match &terminal {
+                Some(err) => CacheWatchEvent::Closed(err.clone()),
+                None => CacheWatchEvent::Reset,
+            };
+            deliveries.spawn(async move {
+                let _delivered = tokio::time::timeout(TERMINAL_GRACE, sender.send(event)).await;
+            });
+        }
+        while deliveries.join_next().await.is_some() {}
+        true
+    }
+
+    /// Removes every registered watcher and returns their senders.
+    ///
+    /// Key by key via [`DashMap::remove`], **not** `iter()` then `clear()`.
+    /// Those are separate operations with no atomicity between them, and a
+    /// watcher registering in the gap would be collected by neither the
+    /// iteration nor — having been inserted after it — spared by the clear: it
+    /// would simply be removed with no event ever delivered, and its consumer
+    /// would see an end-of-stream `None` instead of `Reset`. `remove` is atomic
+    /// per key against `entry().or_default().push()`, which holds the same shard
+    /// lock, so every registration falls cleanly on one side.
+    fn drain_senders(&self) -> Vec<CacheWatchSender> {
+        let mut senders = Vec::new();
+        for map in [&self.keys, &self.prefixes] {
+            let targets: Vec<String> = map.iter().map(|entry| entry.key().clone()).collect();
+            for target in targets {
+                if let Some((_, slots)) = map.remove(&target) {
+                    senders.extend(slots.into_iter().map(|slot| slot.sender));
+                }
+            }
+        }
+        senders
+    }
+
+    /// Clones every registered watcher's sender, leaving the registrations in
+    /// place.
+    ///
+    /// The counterpart to [`drain_senders`](Self::drain_senders) for a
+    /// non-terminal broadcast. [`CacheWatchSender`] is `Clone` and every clone
+    /// feeds the same consumer channel, so the delivery below reaches the
+    /// watcher while the slot it was cloned from keeps the stream open.
+    fn clone_senders(&self) -> Vec<CacheWatchSender> {
+        let mut senders = Vec::new();
+        for map in [&self.keys, &self.prefixes] {
+            for entry in map {
+                senders.extend(entry.value().iter().map(|slot| slot.sender.clone()));
+            }
+        }
+        senders
+    }
+
+    /// The number of distinct prefixes with at least one live watcher — the
+    /// Redis pattern count this registry is responsible for, which
+    /// `RD-WATCH-005` asserts stays at one per prefix however many consumers
+    /// watch it.
+    #[must_use]
+    pub fn prefix_pattern_count(&self) -> usize {
+        self.prefixes.len()
+    }
+
+    /// The number of distinct keys with at least one live watcher.
+    #[must_use]
+    pub fn key_subscription_count(&self) -> usize {
+        self.keys.len()
+    }
+}
+
+/// A subscription whose last watcher went away, handed back by
+/// [`WatchRegistry::dispatch`] so the caller — which is async and can await a
+/// round trip — tears it down.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Orphaned {
+    /// Which family the subscription belongs to.
+    pub kind: WatcherKind,
+    /// The consumer-facing key or prefix, from which the caller rebuilds the
+    /// channel or pattern.
+    pub target: String,
+}
+
+/// The channel and pattern names this plugin subscribes to, all derived from the
+/// operator's `key_prefix` (DESIGN.md §2.1).
+///
+/// One place, because the publisher and the subscriber have to agree exactly:
+/// the scripts build `<prefix>:e:c:<key>` from `KEYS[1]` server-side, and a
+/// mismatch here would be a watch that silently never fires.
+#[derive(Debug, Clone)]
+pub struct ChannelNames {
+    /// `<key_prefix>:e:c:`.
+    event_prefix: String,
+    /// `<key_prefix>:c:`.
+    entry_prefix: String,
+    /// The logical database, which scopes the keyspace-notification channel.
+    database: u8,
+}
+
+impl ChannelNames {
+    /// Builds the naming scheme for one cache.
+    #[must_use]
+    pub fn new(key_prefix: &str, database: u8) -> Self {
+        Self {
+            event_prefix: format!("{key_prefix}:e:c:"),
+            entry_prefix: format!("{key_prefix}:c:"),
+            database,
+        }
+    }
+
+    /// The channel one key's events are published on.
+    #[must_use]
+    pub fn channel_for_key(&self, key: &str) -> String {
+        format!("{}{key}", self.event_prefix)
+    }
+
+    /// The pattern covering every key under `prefix`.
+    ///
+    /// The consumer's prefix is glob-escaped for the same reason `scan_prefix`
+    /// escapes it: the key space is opaque to this plugin, so a prefix
+    /// containing `[` or `*` would otherwise subscribe to something other than
+    /// what was asked for — and here the consequence is worse than a wrong scan
+    /// result, because the watcher would receive events for keys it does not
+    /// watch and miss the ones it does.
+    ///
+    /// The `<key_prefix>:e:c:` stem is escaped too, matching what
+    /// `LockNames::release_pattern` and `KeyspaceNames::new` already do with the
+    /// same operator prefix: nothing validates `key_prefix` against a glob-free
+    /// charset, and unescaped a `[` in it silently redirects every prefix watch
+    /// this cache registers.
+    #[must_use]
+    pub fn pattern_for_prefix(&self, prefix: &str) -> String {
+        format!(
+            "{}{}*",
+            super::scan::escape_glob(&self.event_prefix),
+            super::scan::escape_glob(prefix)
+        )
+    }
+
+    /// Recovers the consumer's key from a published event channel, or `None`
+    /// when the channel is not one of this cache's.
+    #[must_use]
+    pub fn key_from_event_channel(&self, channel: &str) -> Option<String> {
+        channel.strip_prefix(&self.event_prefix).map(str::to_owned)
+    }
+
+    /// Recovers the consumer's key from a *Redis key* — what a keyspace
+    /// notification reports, `fred` having already split the channel apart for
+    /// us — or `None` when the key is not one of this cache's entries.
+    ///
+    /// `None` is a routing answer rather than an error: the keyspace pattern is
+    /// plugin-wide (`KeyspaceNames`), so a **lock lease** legitimately arrives
+    /// here and must be declined so the lock's own parser can claim it. Both
+    /// share the operator's prefix and differ by one segment.
+    #[must_use]
+    pub fn key_from_entry_key(&self, entry_key: &str) -> Option<String> {
+        entry_key
+            .strip_prefix(&self.entry_prefix)
+            .map(str::to_owned)
+    }
+
+    /// The logical database this cache lives in, so a keyspace notification
+    /// from another database on the same server is not mistaken for one of
+    /// this cache's own keys.
+    #[must_use]
+    pub fn database(&self) -> u8 {
+        self.database
+    }
+}
+
+// Layer-1 unit tests (TESTING.md §2, `cache/watch.rs` row). Out-of-line per
+// DE1101.
+#[cfg(test)]
+#[path = "watch_tests.rs"]
+mod tests;

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/cache/watch_tests.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/cache/watch_tests.rs
@@ -1,0 +1,615 @@
+use futures_util::FutureExt;
+
+use super::*;
+
+/// A registry with no subscriber behind it.
+///
+/// Every subscription decision short-circuits on `None`, so registration and
+/// fan-out run exactly as they do in production while nothing reaches a server.
+/// That is the whole registry apart from the two `SUBSCRIBE`/`UNSUBSCRIBE`
+/// round trips, which Layer 3 covers.
+fn registry() -> Arc<WatchRegistry> {
+    // A recording sink rather than the production one: the registry's own
+    // `cluster_redis_watch_events_dropped_total` and its `cluster.provider.error`
+    // on a refused `UNSUBSCRIBE` are then observable without a meter provider.
+    WatchRegistry::new(None, crate::test_support::recording_signals().0)
+}
+
+fn names() -> ChannelNames {
+    ChannelNames::new("cluster", 0)
+}
+
+async fn watch_key(registry: &WatchRegistry, key: &str) -> CacheWatch {
+    registry
+        .register_key(key, &names().channel_for_key(key))
+        .await
+        .expect("registration without a subscriber cannot fail")
+}
+
+async fn watch_prefix(registry: &WatchRegistry, prefix: &str) -> CacheWatch {
+    registry
+        .register_prefix(prefix, &names().pattern_for_prefix(prefix))
+        .await
+        .expect("registration without a subscriber cannot fail")
+}
+
+fn changed(key: &str) -> ParsedNotification {
+    ParsedNotification::Changed {
+        key: key.to_owned(),
+    }
+}
+
+/// Drains what is buffered without awaiting, so a test can assert "nothing
+/// further arrived" without risking a hang.
+///
+/// `CacheWatch` exposes only an async `recv`, so `now_or_never` is what turns it
+/// into a poll — the same thing the Postgres plugin's watch tests do, and for
+/// the same reason.
+fn drain(watch: &mut CacheWatch) -> Vec<CacheWatchEvent> {
+    let mut events = Vec::new();
+    while let Some(Some(event)) = watch.recv().now_or_never() {
+        events.push(event);
+    }
+    events
+}
+
+fn changed_keys(events: &[CacheWatchEvent]) -> Vec<String> {
+    events
+        .iter()
+        .filter_map(|event| match event {
+            CacheWatchEvent::Event(CacheEvent::Changed { key }) => Some(key.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Per-key fan-out.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn every_watcher_on_a_key_receives_its_event() {
+    let registry = registry();
+    let mut first = watch_key(&registry, "k").await;
+    let mut second = watch_key(&registry, "k").await;
+    let mut other = watch_key(&registry, "other").await;
+
+    let orphaned = registry.dispatch(&changed("k"), WatcherKind::Exact);
+
+    assert!(orphaned.is_empty());
+    assert_eq!(changed_keys(&drain(&mut first)), vec!["k".to_owned()]);
+    assert_eq!(changed_keys(&drain(&mut second)), vec!["k".to_owned()]);
+    assert!(
+        drain(&mut other).is_empty(),
+        "a watcher on a different key must see nothing"
+    );
+}
+
+#[tokio::test]
+async fn two_watchers_on_one_key_cost_one_subscription() {
+    let registry = registry();
+    let _first = watch_key(&registry, "k").await;
+    let _second = watch_key(&registry, "k").await;
+    assert_eq!(registry.key_subscription_count(), 1);
+}
+
+#[tokio::test]
+async fn five_prefix_watches_on_one_prefix_cost_one_pattern() {
+    // `RD-WATCH-005`. `PSUBSCRIBE` matching runs per published message against
+    // every registered pattern, so N consumers watching one prefix must not
+    // register N patterns.
+    let registry = registry();
+    let _watches: Vec<CacheWatch> = {
+        let mut held = Vec::new();
+        for _ in 0..5 {
+            held.push(watch_prefix(&registry, "tenant-1/").await);
+        }
+        held
+    };
+    assert_eq!(registry.prefix_pattern_count(), 1);
+
+    let _other = watch_prefix(&registry, "tenant-2/").await;
+    assert_eq!(registry.prefix_pattern_count(), 2);
+}
+
+#[tokio::test]
+async fn a_prefix_watcher_receives_every_key_it_covers() {
+    let registry = registry();
+    let mut watch = watch_prefix(&registry, "tenant-1/").await;
+
+    let _orphaned = registry.dispatch(&changed("tenant-1/a"), WatcherKind::Prefix);
+    let _orphaned = registry.dispatch(&changed("tenant-1/b"), WatcherKind::Prefix);
+    let _orphaned = registry.dispatch(&changed("tenant-2/a"), WatcherKind::Prefix);
+
+    assert_eq!(
+        changed_keys(&drain(&mut watch)),
+        vec!["tenant-1/a".to_owned(), "tenant-1/b".to_owned()],
+        "a key outside the prefix must not reach this watcher"
+    );
+}
+
+#[tokio::test]
+async fn overlapping_prefixes_each_receive_the_key() {
+    let registry = registry();
+    let mut broad = watch_prefix(&registry, "tenant-1/").await;
+    let mut narrow = watch_prefix(&registry, "tenant-1/orders/").await;
+
+    let _orphaned = registry.dispatch(&changed("tenant-1/orders/7"), WatcherKind::Prefix);
+
+    assert_eq!(drain(&mut broad).len(), 1);
+    assert_eq!(drain(&mut narrow).len(), 1);
+}
+
+#[tokio::test]
+async fn a_key_covered_both_ways_still_sees_exactly_one_event_per_write() {
+    // The routing rule the module docs set out, and the reason `RD-WATCH-001`
+    // asserts one `Changed` per `put`: the server delivers a `message` for the
+    // exact subscription *and* a `pmessage` for the covering pattern, so a
+    // fan-out that routed both to both sets would double every write for any
+    // watcher covered twice.
+    let registry = registry();
+    let mut exact = watch_key(&registry, "tenant-1/a").await;
+    let mut prefixed = watch_prefix(&registry, "tenant-1/").await;
+
+    // One write, two deliveries from Redis.
+    let _orphaned = registry.dispatch(&changed("tenant-1/a"), WatcherKind::Exact);
+    let _orphaned = registry.dispatch(&changed("tenant-1/a"), WatcherKind::Prefix);
+
+    assert_eq!(
+        drain(&mut exact).len(),
+        1,
+        "the exact watcher must not also receive the pattern delivery"
+    );
+    assert_eq!(
+        drain(&mut prefixed).len(),
+        1,
+        "the prefix watcher must not also receive the exact delivery"
+    );
+}
+
+#[tokio::test]
+async fn a_keyspace_event_reaches_both_families_from_its_single_pattern() {
+    // The keyspace family has one blanket pattern, so there is no twin delivery
+    // to split — routing it to only one family would silently drop the other's
+    // `Expired`.
+    let registry = registry();
+    let mut exact = watch_key(&registry, "tenant-1/a").await;
+    let mut prefixed = watch_prefix(&registry, "tenant-1/").await;
+
+    let expired = ParsedNotification::Expired {
+        key: "tenant-1/a".to_owned(),
+    };
+    let _orphaned = registry.dispatch(&expired, WatcherKind::Both);
+
+    for events in [drain(&mut exact), drain(&mut prefixed)] {
+        assert!(matches!(
+            events.as_slice(),
+            [CacheWatchEvent::Event(CacheEvent::Expired { .. })]
+        ));
+    }
+}
+
+#[tokio::test]
+async fn a_dropped_watcher_is_pruned_and_orphans_its_subscription() {
+    let registry = registry();
+    let watch = watch_key(&registry, "k").await;
+    assert_eq!(registry.key_subscription_count(), 1);
+    drop(watch);
+
+    let orphaned = registry.dispatch(&changed("k"), WatcherKind::Exact);
+
+    assert_eq!(
+        orphaned,
+        vec![Orphaned {
+            kind: WatcherKind::Exact,
+            target: "k".to_owned(),
+        }],
+        "the last watcher going away must hand its subscription back for teardown"
+    );
+    assert_eq!(registry.key_subscription_count(), 0);
+}
+
+#[tokio::test]
+async fn a_surviving_watcher_keeps_the_subscription() {
+    let registry = registry();
+    let dropped = watch_key(&registry, "k").await;
+    let mut kept = watch_key(&registry, "k").await;
+    drop(dropped);
+
+    let orphaned = registry.dispatch(&changed("k"), WatcherKind::Exact);
+
+    assert!(
+        orphaned.is_empty(),
+        "one watcher remains, so nothing orphans"
+    );
+    assert_eq!(drain(&mut kept).len(), 1);
+    assert_eq!(registry.key_subscription_count(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Backpressure.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_full_buffer_drops_coalesces_and_reports_one_lagged() {
+    let registry = registry();
+    let mut watch = watch_key(&registry, "k").await;
+
+    // Fill the 64-slot buffer, then overrun it by three.
+    for _ in 0..(WATCH_BUFFER + 3) {
+        let _orphaned = registry.dispatch(&changed("k"), WatcherKind::Exact);
+    }
+    // Drain everything buffered, freeing the whole buffer.
+    let first_batch = drain(&mut watch);
+    assert_eq!(first_batch.len(), WATCH_BUFFER);
+    assert!(
+        first_batch
+            .iter()
+            .all(|event| matches!(event, CacheWatchEvent::Event(_))),
+        "the buffered events themselves are ordinary events"
+    );
+
+    // The `Lagged` rides the next successful delivery rather than appearing the
+    // moment the buffer drains — nothing polls a drained buffer.
+    let _orphaned = registry.dispatch(&changed("k"), WatcherKind::Exact);
+    let second_batch = drain(&mut watch);
+    assert!(
+        matches!(
+            second_batch.as_slice(),
+            [
+                CacheWatchEvent::Lagged { dropped: 3 },
+                CacheWatchEvent::Event(_)
+            ]
+        ),
+        "exactly one coalesced Lagged, carrying the total dropped, then the event: got \
+         {second_batch:?}"
+    );
+}
+
+#[tokio::test]
+async fn the_dropped_counter_agrees_with_the_lagged_the_consumer_receives() {
+    // `RD-WATCH-008`'s Layer 1 half. The two numbers are produced by different
+    // mechanisms — the counter is incremented per failed `try_send`, the
+    // `Lagged` is a coalesced total drained on the next success — so their
+    // agreeing is a property rather than a tautology, and it is the property a
+    // dashboard reading the counter is relying on.
+    let (signals, readback) = crate::test_support::metered_signals();
+    let registry = WatchRegistry::new(None, signals);
+    let mut watch = watch_key(&registry, "k").await;
+
+    for _ in 0..(WATCH_BUFFER + 7) {
+        let _orphaned = registry.dispatch(&changed("k"), WatcherKind::Exact);
+    }
+    let _first_batch = drain(&mut watch);
+    let _orphaned = registry.dispatch(&changed("k"), WatcherKind::Exact);
+    let second_batch = drain(&mut watch);
+
+    let Some(CacheWatchEvent::Lagged { dropped }) = second_batch.first() else {
+        panic!("expected a coalesced Lagged first, got {second_batch:?}");
+    };
+    assert_eq!(*dropped, 7);
+    assert_eq!(
+        readback.counter("cluster_redis_watch_events_dropped_total"),
+        *dropped
+    );
+}
+
+#[tokio::test]
+async fn a_slow_watcher_does_not_stall_a_fast_one() {
+    // The fan-out never awaits a slow consumer: `try_send`, so one stalled
+    // watcher costs itself events and costs everyone else nothing.
+    let registry = registry();
+    let _slow = watch_key(&registry, "k").await;
+    let mut fast = watch_key(&registry, "k").await;
+
+    for _ in 0..(WATCH_BUFFER + 10) {
+        let _orphaned = registry.dispatch(&changed("k"), WatcherKind::Exact);
+        // Keep the fast watcher's buffer clear.
+        let _drained = drain(&mut fast);
+    }
+    // Reaching here at all is the assertion: a blocking fan-out would have
+    // deadlocked on the slow watcher's full buffer.
+    assert_eq!(registry.key_subscription_count(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Reset and the terminal close.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn an_unintelligible_payload_resets_only_that_key() {
+    // DESIGN.md §2.5: broadcast to every watcher *on that key*, not the whole
+    // registry — one bad message is not evidence the subscription gapped.
+    let registry = registry();
+    let mut watched = watch_key(&registry, "k").await;
+    let mut elsewhere = watch_key(&registry, "other").await;
+
+    let unknown = parse_publish_payload("k", &Value::String("Z".into()));
+    assert_eq!(
+        unknown,
+        ParsedNotification::Reset {
+            key: "k".to_owned()
+        }
+    );
+    let _orphaned = registry.dispatch(&unknown, WatcherKind::Exact);
+
+    assert!(matches!(
+        drain(&mut watched).as_slice(),
+        [CacheWatchEvent::Reset]
+    ));
+    assert!(drain(&mut elsewhere).is_empty());
+}
+
+#[tokio::test]
+async fn a_registry_wide_reset_reaches_every_watcher() {
+    // The registrations survive it. `Reset` is non-terminal (DESIGN.md §4.3),
+    // so the watcher lists stay as they are and the subscription counts do not
+    // move.
+    let registry = registry();
+    let mut key_watch = watch_key(&registry, "k").await;
+    let mut prefix_watch = watch_prefix(&registry, "p/").await;
+
+    assert!(registry.broadcast_reset().await);
+
+    assert!(matches!(
+        drain(&mut key_watch).as_slice(),
+        [CacheWatchEvent::Reset]
+    ));
+    assert!(matches!(
+        drain(&mut prefix_watch).as_slice(),
+        [CacheWatchEvent::Reset]
+    ));
+    assert_eq!(registry.key_subscription_count(), 1);
+    assert_eq!(registry.prefix_pattern_count(), 1);
+}
+
+#[tokio::test]
+async fn a_watch_survives_a_reset_and_keeps_receiving() {
+    // The consumer contract, asserted positively: a `Reset` means *re-read*, so
+    // the stream stays open and the next event still arrives on it. The SDK
+    // documents `recv() -> None` as the backend having dropped the sender
+    // *without* a terminal `Closed` (`cluster-sdk/src/cache/watch.rs`), which is
+    // exactly what a consumer must never see here.
+    let registry = registry();
+    let mut watch = watch_key(&registry, "k").await;
+
+    assert!(registry.broadcast_reset().await);
+    assert!(matches!(
+        drain(&mut watch).as_slice(),
+        [CacheWatchEvent::Reset]
+    ));
+
+    let orphaned = registry.dispatch(&changed("k"), WatcherKind::Exact);
+    assert!(orphaned.is_empty());
+    assert_eq!(
+        changed_keys(&drain(&mut watch)),
+        vec!["k".to_owned()],
+        "a reset watcher must still receive the events that follow"
+    );
+
+    // And the terminal path still clears what the reset left in place.
+    registry.close_all().await;
+    assert!(matches!(
+        drain(&mut watch).as_slice(),
+        [CacheWatchEvent::Closed(ClusterError::Shutdown)]
+    ));
+    assert_eq!(registry.key_subscription_count(), 0);
+}
+
+#[tokio::test]
+async fn close_all_delivers_the_terminal_event_to_every_watcher() {
+    let registry = registry();
+    let mut key_watch = watch_key(&registry, "k").await;
+    let mut prefix_watch = watch_prefix(&registry, "p/").await;
+
+    registry.close_all().await;
+
+    for events in [drain(&mut key_watch), drain(&mut prefix_watch)] {
+        assert!(
+            matches!(
+                events.as_slice(),
+                [CacheWatchEvent::Closed(ClusterError::Shutdown)]
+            ),
+            "got {events:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn no_reset_is_ever_delivered_after_a_terminal_close() {
+    // The SDK's `CacheWatch` contract forbids anything following a `Closed`.
+    let registry = registry();
+    let mut watch = watch_key(&registry, "k").await;
+
+    registry.close_all().await;
+    assert!(
+        !registry.broadcast_reset().await,
+        "a Reset after the registry closed must be suppressed, not delivered"
+    );
+
+    assert!(matches!(
+        drain(&mut watch).as_slice(),
+        [CacheWatchEvent::Closed(ClusterError::Shutdown)]
+    ));
+}
+
+#[tokio::test]
+async fn a_watch_registered_after_close_gets_its_terminal_event_immediately() {
+    // Otherwise it registers into a map nothing will ever dispatch to again and
+    // silently receives nothing forever.
+    let registry = registry();
+    registry.close_all().await;
+
+    let mut late = watch_key(&registry, "k").await;
+
+    assert!(matches!(
+        drain(&mut late).as_slice(),
+        [CacheWatchEvent::Closed(ClusterError::Shutdown)]
+    ));
+}
+
+#[tokio::test]
+async fn a_late_registration_is_told_the_error_that_actually_closed_the_registry() {
+    // Not a hardcoded `Shutdown`: only a `ConnectionLost` is
+    // `ClusterError::is_retryable`, and the SDK's `RestartingWatch` branches on
+    // exactly that. Told `Shutdown`, a consumer's retry policy would never run
+    // against what is in fact a recoverable outage.
+    let registry = registry();
+    registry
+        .close_all_with(crate::subscriber::subscriber_lost())
+        .await;
+
+    let mut late = watch_key(&registry, "k").await;
+    let events = drain(&mut late);
+    let [CacheWatchEvent::Closed(err)] = events.as_slice() else {
+        panic!("expected one terminal event, got {events:?}");
+    };
+    assert!(
+        err.is_retryable(),
+        "a lost subscriber must close retryably, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn the_terminal_event_reaches_a_watcher_whose_buffer_is_full() {
+    // Delivered with a blocking `send` rather than the fan-out's `try_send`, so
+    // a momentarily-full consumer still gets the typed `Closed` instead of a
+    // bare channel close it cannot tell apart from a dropped sender.
+    let registry = registry();
+    let mut watch = watch_key(&registry, "k").await;
+    for _ in 0..WATCH_BUFFER {
+        let _orphaned = registry.dispatch(&changed("k"), WatcherKind::Exact);
+    }
+
+    let close = tokio::spawn({
+        let registry = Arc::clone(&registry);
+        async move { registry.close_all().await }
+    });
+    // Free a slot so the blocking terminal send can land.
+    let _drained = drain(&mut watch);
+    close.await.expect("close_all completes");
+
+    let remaining = drain(&mut watch);
+    assert!(
+        remaining
+            .iter()
+            .any(|event| matches!(event, CacheWatchEvent::Closed(_))),
+        "the typed terminal event must reach a consumer that was briefly full: got {remaining:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Payload and channel mapping.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn published_payloads_map_to_their_events() {
+    assert_eq!(
+        parse_publish_payload("k", &Value::String("C".into())),
+        changed("k")
+    );
+    assert_eq!(
+        parse_publish_payload("k", &Value::String("D".into())),
+        ParsedNotification::Deleted {
+            key: "k".to_owned()
+        }
+    );
+}
+
+#[test]
+fn an_eviction_maps_to_deleted_and_not_to_expired() {
+    // DESIGN.md §3.7: no TTL lapsed. Telling a consumer the entry aged out when
+    // in fact the instance is misconfigured would mislead it about which of the
+    // two problems it has.
+    assert_eq!(
+        parse_keyspace_event("k", "evicted"),
+        ParsedNotification::Deleted {
+            key: "k".to_owned()
+        }
+    );
+    assert_eq!(
+        parse_keyspace_event("k", "expired"),
+        ParsedNotification::Expired {
+            key: "k".to_owned()
+        }
+    );
+}
+
+#[test]
+fn an_unasked_for_keyspace_event_is_dropped_rather_than_reset() {
+    // These arrive only when the server's flags are wider than `Kxe`, and there
+    // is one per Redis *command* — turning them into resets would make an
+    // over-configured server cost a re-read on every mutation.
+    for event in ["hset", "del", "expire", "rename_from"] {
+        assert_eq!(
+            parse_keyspace_event("k", event),
+            ParsedNotification::Ignored,
+            "`{event}` is already covered by the in-script publish"
+        );
+    }
+}
+
+#[test]
+fn channel_names_round_trip_to_the_key() {
+    let names = names();
+    let channel = names.channel_for_key("tenant-1/a");
+    assert_eq!(channel, "cluster:e:c:tenant-1/a");
+    assert_eq!(
+        names.key_from_event_channel(&channel).as_deref(),
+        Some("tenant-1/a")
+    );
+}
+
+#[test]
+fn an_entry_key_round_trips_back_to_the_consumers_key() {
+    // `fred` splits a keyspace notification into `(db, key, operation)` before
+    // it reaches this plugin, so the recovery here is from the Redis *key*
+    // rather than from the channel. The pattern that delivers it is plugin-wide
+    // and lives on `KeyspaceNames`, not here — see `subscriber.rs`.
+    let names = ChannelNames::new("cluster", 3);
+    assert_eq!(names.database(), 3);
+    assert_eq!(
+        names.key_from_entry_key("cluster:c:tenant-1/a").as_deref(),
+        Some("tenant-1/a")
+    );
+}
+
+#[test]
+fn a_foreign_channel_or_key_is_not_this_caches() {
+    let names = names();
+    assert_eq!(names.key_from_event_channel("someone-else:e:c:k"), None);
+    assert_eq!(names.key_from_event_channel("cluster:e:l:some-lock"), None);
+    // The lock primitive's own keys share the operator prefix but not the
+    // cache's `:c:` segment, so an expiry on a lease must not be reported as a
+    // cache deletion.
+    assert_eq!(names.key_from_entry_key("cluster:l:some-lock"), None);
+    assert_eq!(names.key_from_entry_key("someone-elses:key"), None);
+}
+
+#[test]
+fn a_prefix_pattern_escapes_glob_metacharacters() {
+    // Worse here than in `scan_prefix`: an unescaped `[` would subscribe the
+    // watcher to keys it does not watch *and* miss the ones it does.
+    let names = names();
+    assert_eq!(
+        names.pattern_for_prefix("lit[0]/"),
+        r"cluster:e:c:lit\[0\]/*"
+    );
+    assert_eq!(names.pattern_for_prefix("t/"), "cluster:e:c:t/*");
+}
+
+#[test]
+fn a_prefix_pattern_escapes_the_operators_prefix_too() {
+    // The consumer's half was escaped from the start; the `<key_prefix>:e:c:`
+    // stem was not, and the operator's `key_prefix` is embedded in it with no
+    // validation constraining its charset. Unescaped, `key_prefix: "tenant[a]"`
+    // makes the stem a character class: every prefix watch this cache registers
+    // would subscribe to `tenanta:e:c:...` and receive nothing that was ever
+    // published. `LockNames::release_pattern` and `KeyspaceNames::new` already
+    // escape the same value, so this closes the last site that did not.
+    let names = ChannelNames::new("tenant[a]", 0);
+    assert_eq!(
+        names.pattern_for_prefix("lit[0]/"),
+        r"tenant\[a\]:e:c:lit\[0\]/*"
+    );
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/config.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/config.rs
@@ -1,0 +1,408 @@
+//! Configuration for the Redis cluster plugin (DESIGN.md §8).
+//!
+//! Two config types exist because the combined cache+lock plugin and the
+//! standalone lock-only provider (DESIGN.md §3.5) need different field sets:
+//! [`RedisClusterConfig`] carries `watch_mode` and
+//! `manage_keyspace_notifications`, neither of which
+//! mean anything without the cache half, and [`RedisLockConfig`] omits them.
+//!
+//! ## Why the shared fields are duplicated rather than flattened
+//!
+//! DESIGN.md §8 proposes factoring the shared subset into one inner struct so
+//! the two types cannot drift. That is not implementable: it needs
+//! `#[serde(flatten)]`, and serde refuses to derive `flatten` together with the
+//! `#[serde(deny_unknown_fields)]` that DESIGN.md §8 and TESTING.md §2 both
+//! require. Flattening is implemented by buffering every unmatched key and
+//! replaying it into the inner type, so the outer type can no longer tell an
+//! inner field from an operator's typo — serde rejects the combination at
+//! compile time rather than silently picking one.
+//!
+//! `deny_unknown_fields` is the more valuable half: it is what turns
+//! `pool_sise: 8` into a startup error instead of a silently-ignored key, and
+//! it is also what makes a misplaced `allow_weak_consistency` on a *native*
+//! binding fail loudly (DESIGN.md §7). So the fields are duplicated, exactly as
+//! `postgres-cluster-plugin/src/config.rs` does and for the same reason, and two
+//! things hold the copies together: every default
+//! lives in one `default_*` function shared by both types, and
+//! `config_tests.rs`'s drift guard compares the two types' accepted field sets
+//! mechanically, so adding a field to one and not the other fails a test.
+
+use std::fmt;
+use std::time::Duration;
+
+use cluster_sdk::ClusterError;
+use serde::Deserialize;
+
+/// The masked stand-in rendered for `url` in `Debug` output, so a `{:?}` of a
+/// config (in a log line or a panic message) never leaks the password the
+/// expanded connection URL embeds. Both config types hand-write `Debug` rather
+/// than `#[derive]`ing it for this reason (DESIGN.md §8).
+const REDACTED_URL: &str = "<redacted>";
+
+/// Default command-pool size. DESIGN.md §8 / §3.3.
+///
+/// About pipelining headroom rather than resource thrift: a Redis connection
+/// costs ~20 KB (ADR-001) and a held lock consumes none, so the pool never has
+/// to be sized against the workload's concurrency.
+#[must_use]
+pub fn default_pool_size() -> u32 {
+    4
+}
+
+/// Default per-command timeout, in milliseconds. DESIGN.md §8.
+#[must_use]
+pub fn default_command_timeout() -> u64 {
+    5_000
+}
+
+/// Default prefix for every key and channel the plugin owns. DESIGN.md §2.1.
+#[must_use]
+pub fn default_key_prefix() -> String {
+    "cluster".to_owned()
+}
+
+/// Default `WAIT` timeout, in milliseconds, used when `wait_replicas` is set.
+///
+/// DESIGN.md §8 declares the field with a default but does not name a value.
+/// 1 s is chosen because `WAIT` sits on the tail of a lock or CAS write that
+/// already carries a 5 s command timeout: a replica that has not acknowledged
+/// within a second is not about to, and blocking the write for the whole
+/// command budget would turn a narrowed failover window into a latency
+/// regression. A `WAIT` that times out is surfaced rather than swallowed
+/// (DESIGN.md §3.6), so the shorter bound loses no information.
+#[must_use]
+pub fn default_wait_timeout() -> u64 {
+    1_000
+}
+
+/// Operator hint for the server topology (DESIGN.md §8).
+///
+/// If omitted, the plugin detects the topology from `INFO replication` at
+/// startup (DESIGN.md §3.4). If present, the plugin **trusts it and skips the
+/// corresponding detection** — the escape hatch for a locked-down managed
+/// instance whose operator knows an answer the plugin cannot read. A hint is
+/// therefore never *verified*, which is why a `Linearizable` declaration
+/// resting on one is flagged as asserted-not-verified (DESIGN.md §3.6,
+/// [`crate::ConsistencyDecision`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Topology {
+    /// A single Redis server with no replicas. The only topology that can
+    /// reach `Linearizable`, and only when paired with durable writes.
+    Standalone,
+    /// A Sentinel-managed primary with asynchronous replicas.
+    Sentinel,
+    /// Redis Cluster.
+    Cluster,
+}
+
+/// Operator hint for write durability at acknowledgement time (DESIGN.md §8).
+///
+/// If omitted, the plugin detects durability from
+/// `CONFIG GET appendonly|appendfsync`. Unlike [`Topology`], a
+/// [`Durability::FsyncAlways`] hint is *cross-checked* whenever `CONFIG GET` is
+/// readable, and a hint the server contradicts fails startup naming both values
+/// (DESIGN.md §3.6) — claiming the one setting that unlocks `Linearizable` is
+/// the claim worth checking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Durability {
+    /// `appendonly yes` with `appendfsync always`: nothing is acknowledged
+    /// before it is fsynced.
+    FsyncAlways,
+    /// `appendonly yes` with `appendfsync everysec` — the Redis default. Up to
+    /// one second of accepted writes is lost on a crash.
+    FsyncEverysec,
+    /// No append-only file. Acknowledged writes survive only in memory.
+    None,
+}
+
+/// How cache watches are sourced (DESIGN.md §4.3).
+///
+/// Two variants, not three: DESIGN.md §13 D4 considered and rejected a raw
+/// keyspace-notification mode, so there is no `todo!()` arm here waiting to be
+/// filled in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WatchMode {
+    /// The default: each mutation publishes its own event from inside the Lua
+    /// script, and Redis `expired`/`evicted` keyspace notifications supply the
+    /// two events no plugin code can observe.
+    #[default]
+    Publish,
+    /// No publish and no cache-event subscriber. `watch`/`watch_prefix` return
+    /// `Unsupported`. The honest answer for a managed
+    /// Redis where neither `CONFIG` nor the publish overhead is acceptable.
+    Disabled,
+}
+
+/// Configuration for the combined `RedisClusterPlugin` (cache + lock,
+/// DESIGN.md §3.2).
+#[derive(Clone, Deserialize, toolkit_macros::ExpandVars)]
+#[serde(deny_unknown_fields)]
+pub struct RedisClusterConfig {
+    /// Connection URL. `redis://`, `rediss://`, `redis-sentinel://`, or
+    /// `redis-cluster://`.
+    ///
+    /// Supports `${VAR}` / `${VAR:-default}` expansion via
+    /// `toolkit_utils::var_expand`, resolved through `ctx.config_expanded()` —
+    /// the same mechanism `libs/toolkit-db` uses for DB DSNs. A credstore-backed
+    /// (`secret_ref`) path is deferred (DESIGN.md §13 D5).
+    ///
+    /// The expanded value embeds a password, which is why `Debug` is
+    /// hand-written below and masks this field.
+    #[expand_vars]
+    pub url: String,
+
+    /// Command-pool size. Default: 4. See [`default_pool_size`].
+    #[serde(default = "default_pool_size")]
+    pub pool_size: u32,
+
+    /// Per-command timeout, in milliseconds. Default: 5000.
+    ///
+    /// Enforced client-side by `fred`, so no command can block indefinitely
+    /// once issued — the bound that `stop()` and `RD-LIFE-009` rely on
+    /// (DESIGN.md §11, §12). Zero is rejected by [`Self::validate`]: `fred`
+    /// reads a zero `default_command_timeout` as "no timeout at all", so it
+    /// would silently remove that bound rather than shorten it.
+    #[serde(default = "default_command_timeout")]
+    pub command_timeout_ms: u64,
+
+    /// Prefix for every key and channel this plugin owns. Default: `"cluster"`.
+    /// DESIGN.md §2.1.
+    #[serde(default = "default_key_prefix")]
+    pub key_prefix: String,
+
+    /// Logical database index. Ignored in Cluster mode, which has only db 0.
+    /// Default: 0.
+    #[serde(default)]
+    pub database: u8,
+
+    /// Operator hint for topology. Omitted → detected via `INFO replication`
+    /// (DESIGN.md §3.4). Drives the consistency declaration (DESIGN.md §3.6).
+    #[serde(default)]
+    pub topology: Option<Topology>,
+
+    /// Operator hint for write durability. Omitted → detected via
+    /// `CONFIG GET appendonly|appendfsync`. A hint contradicted by a readable
+    /// server config fails startup with `InvalidConfig` (DESIGN.md §3.6).
+    #[serde(default)]
+    pub durability: Option<Durability>,
+
+    /// Append `WAIT <n> <wait_timeout_ms>` to lock and CAS writes. Narrows the
+    /// Sentinel failover window; per ADR-009 it does **not** upgrade the
+    /// declared consistency (DESIGN.md §3.6). Default: none.
+    ///
+    /// `Some(0)` is accepted and means what Redis means by it — `WAIT 0`
+    /// returns immediately — so it is a no-op rather than an error.
+    #[serde(default)]
+    pub wait_replicas: Option<u32>,
+
+    /// Timeout for the `WAIT` above, in milliseconds. Default: 1000.
+    /// See [`default_wait_timeout`].
+    ///
+    /// Bounded above as well as below: `WAIT`'s timeout argument is signed, so a
+    /// value past `i64::MAX` fails startup with `InvalidConfig`
+    /// ([`WaitPolicy::from_config`](crate::WaitPolicy::from_config)) rather than
+    /// being clamped into a deadline no operator asked for.
+    #[serde(default = "default_wait_timeout")]
+    pub wait_timeout_ms: u64,
+
+    /// How cache watches are sourced (DESIGN.md §4.3). Default: `publish`.
+    #[serde(default)]
+    pub watch_mode: WatchMode,
+
+    /// When `true`, and the server's `notify-keyspace-events` lacks the flags
+    /// `Expired` events need, issue one `CONFIG SET` adding them and re-read to
+    /// confirm (DESIGN.md §3.4).
+    ///
+    /// Default `false`: this writes a **server-wide** setting that unrelated
+    /// tenants of the same Redis share, so it is exactly the kind of surprise
+    /// an operator should have to opt into.
+    #[serde(default)]
+    pub manage_keyspace_notifications: bool,
+}
+
+impl fmt::Debug for RedisClusterConfig {
+    /// Hand-written so `url` (which embeds the Redis password after
+    /// `expand_vars`) is masked — see the `REDACTED_URL` const.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RedisClusterConfig")
+            .field("url", &REDACTED_URL)
+            .field("pool_size", &self.pool_size)
+            .field("command_timeout_ms", &self.command_timeout_ms)
+            .field("key_prefix", &self.key_prefix)
+            .field("database", &self.database)
+            .field("topology", &self.topology)
+            .field("durability", &self.durability)
+            .field("wait_replicas", &self.wait_replicas)
+            .field("wait_timeout_ms", &self.wait_timeout_ms)
+            .field("watch_mode", &self.watch_mode)
+            .field(
+                "manage_keyspace_notifications",
+                &self.manage_keyspace_notifications,
+            )
+            .finish()
+    }
+}
+
+/// Rejects a zero `pool_size`.
+///
+/// `fred::clients::Pool::new` already refuses an empty pool, but with
+/// `"Pool cannot be empty."` — a message that names neither the config key nor
+/// the file it came from. Failing here instead means the operator reads the
+/// name of the field they have to change.
+fn reject_zero_pool_size(value: u32) -> Result<(), ClusterError> {
+    if value == 0 {
+        return Err(ClusterError::InvalidConfig {
+            reason: "pool_size must be greater than zero".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+/// Rejects a zero duration for a config key whose zero value means something
+/// materially different from "very small", naming the offending key.
+///
+/// Both callers are that shape rather than merely defensive:
+/// `command_timeout_ms: 0` disables `fred`'s command timeout outright, and
+/// `wait_timeout_ms: 0` makes `WAIT` block until the replicas answer with no
+/// deadline at all. Each silently removes a bound the design relies on, so
+/// neither can be left to the backend to discover.
+fn reject_zero_duration(value: u64, field: &str) -> Result<(), ClusterError> {
+    if value == 0 {
+        return Err(ClusterError::InvalidConfig {
+            reason: format!("{field} must be greater than zero"),
+        });
+    }
+    Ok(())
+}
+
+impl RedisClusterConfig {
+    /// Validates the config values that can only fail at startup, before any
+    /// pool, subscriber, or background task is constructed. Called at the top
+    /// of `build_and_start`.
+    ///
+    /// # Errors
+    /// [`ClusterError::InvalidConfig`] for a zero `pool_size`,
+    /// `command_timeout_ms`, or `wait_timeout_ms`.
+    pub fn validate(&self) -> Result<(), ClusterError> {
+        reject_zero_pool_size(self.pool_size)?;
+        reject_zero_duration(self.command_timeout_ms, "command_timeout_ms")?;
+        reject_zero_duration(self.wait_timeout_ms, "wait_timeout_ms")?;
+        Ok(())
+    }
+
+    /// The per-command timeout as a [`Duration`].
+    #[must_use]
+    pub fn command_timeout(&self) -> Duration {
+        Duration::from_millis(self.command_timeout_ms)
+    }
+
+    /// The `WAIT` timeout as a [`Duration`].
+    #[must_use]
+    pub fn wait_timeout(&self) -> Duration {
+        Duration::from_millis(self.wait_timeout_ms)
+    }
+}
+
+/// Configuration for the standalone `RedisLockPlugin` (DESIGN.md §3.5).
+///
+/// A separate, smaller type carrying only the fields the lock primitive uses.
+/// The two it omits — `watch_mode` and `manage_keyspace_notifications` — are
+/// cache concerns, and `deny_unknown_fields` turns
+/// each of them into a startup error here rather than an ignored key: a
+/// lock-only binding that sets `watch_mode` has misunderstood something, and
+/// says so at startup.
+#[derive(Clone, Deserialize, toolkit_macros::ExpandVars)]
+#[serde(deny_unknown_fields)]
+pub struct RedisLockConfig {
+    /// See [`RedisClusterConfig::url`].
+    #[expand_vars]
+    pub url: String,
+
+    /// See [`RedisClusterConfig::pool_size`].
+    #[serde(default = "default_pool_size")]
+    pub pool_size: u32,
+
+    /// See [`RedisClusterConfig::command_timeout_ms`].
+    #[serde(default = "default_command_timeout")]
+    pub command_timeout_ms: u64,
+
+    /// See [`RedisClusterConfig::key_prefix`].
+    #[serde(default = "default_key_prefix")]
+    pub key_prefix: String,
+
+    /// See [`RedisClusterConfig::database`].
+    #[serde(default)]
+    pub database: u8,
+
+    /// See [`RedisClusterConfig::topology`].
+    #[serde(default)]
+    pub topology: Option<Topology>,
+
+    /// See [`RedisClusterConfig::durability`].
+    #[serde(default)]
+    pub durability: Option<Durability>,
+
+    /// See [`RedisClusterConfig::wait_replicas`].
+    #[serde(default)]
+    pub wait_replicas: Option<u32>,
+
+    /// See [`RedisClusterConfig::wait_timeout_ms`].
+    #[serde(default = "default_wait_timeout")]
+    pub wait_timeout_ms: u64,
+}
+
+impl fmt::Debug for RedisLockConfig {
+    /// Hand-written so `url` is masked — see the `REDACTED_URL` const.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RedisLockConfig")
+            .field("url", &REDACTED_URL)
+            .field("pool_size", &self.pool_size)
+            .field("command_timeout_ms", &self.command_timeout_ms)
+            .field("key_prefix", &self.key_prefix)
+            .field("database", &self.database)
+            .field("topology", &self.topology)
+            .field("durability", &self.durability)
+            .field("wait_replicas", &self.wait_replicas)
+            .field("wait_timeout_ms", &self.wait_timeout_ms)
+            .finish()
+    }
+}
+
+impl RedisLockConfig {
+    /// Validates the config values that can only fail at startup, before any
+    /// pool or subscriber is constructed. Called at the top of
+    /// `build_and_start`.
+    ///
+    /// # Errors
+    /// [`ClusterError::InvalidConfig`] for a zero `pool_size`,
+    /// `command_timeout_ms`, or `wait_timeout_ms`.
+    pub fn validate(&self) -> Result<(), ClusterError> {
+        reject_zero_pool_size(self.pool_size)?;
+        reject_zero_duration(self.command_timeout_ms, "command_timeout_ms")?;
+        reject_zero_duration(self.wait_timeout_ms, "wait_timeout_ms")?;
+        Ok(())
+    }
+
+    /// The per-command timeout as a [`Duration`].
+    #[must_use]
+    pub fn command_timeout(&self) -> Duration {
+        Duration::from_millis(self.command_timeout_ms)
+    }
+
+    /// The `WAIT` timeout as a [`Duration`].
+    #[must_use]
+    pub fn wait_timeout(&self) -> Duration {
+        Duration::from_millis(self.wait_timeout_ms)
+    }
+}
+
+// Layer-1 unit tests (TESTING.md §2, `config.rs` row). Pure serde, expansion,
+// and validation — no container. Out-of-line because DE1101 caps an inline test
+// block at 100 lines (`dylint.toml`), the same reason the Postgres plugin's
+// config tests live in their own file.
+#[cfg(test)]
+#[path = "config_tests.rs"]
+mod tests;

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/config_tests.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/config_tests.rs
@@ -1,0 +1,417 @@
+use std::collections::BTreeSet;
+
+use serde::de::DeserializeOwned;
+use serde_json::{Value, json};
+use toolkit::var_expand::ExpandVars;
+
+use super::*;
+
+/// The two fields [`RedisClusterConfig`] carries and [`RedisLockConfig`] does
+/// not, per DESIGN.md §8: each is meaningless without the cache half.
+const CACHE_ONLY_FIELDS: [&str; 2] = ["watch_mode", "manage_keyspace_notifications"];
+
+fn minimal(extra: Value) -> Value {
+    let mut config = json!({ "url": "redis://redis:6379/0" });
+    let (Value::Object(target), Value::Object(source)) = (&mut config, extra) else {
+        panic!("both halves must be JSON objects");
+    };
+    target.extend(source);
+    config
+}
+
+#[test]
+fn cluster_config_applies_documented_defaults() {
+    let config: RedisClusterConfig =
+        serde_json::from_value(minimal(json!({}))).expect("minimal config deserializes");
+    assert_eq!(config.pool_size, 4);
+    assert_eq!(config.command_timeout_ms, 5_000);
+    assert_eq!(config.key_prefix, "cluster");
+    assert_eq!(config.database, 0);
+    assert_eq!(config.topology, None);
+    assert_eq!(config.durability, None);
+    assert_eq!(config.wait_replicas, None);
+    assert_eq!(config.wait_timeout_ms, 1_000);
+    assert_eq!(config.watch_mode, WatchMode::Publish);
+    assert!(!config.manage_keyspace_notifications);
+}
+
+#[test]
+fn lock_config_applies_the_same_defaults_for_the_fields_it_shares() {
+    let config: RedisLockConfig =
+        serde_json::from_value(minimal(json!({}))).expect("minimal lock config deserializes");
+    assert_eq!(config.pool_size, 4);
+    assert_eq!(config.command_timeout_ms, 5_000);
+    assert_eq!(config.key_prefix, "cluster");
+    assert_eq!(config.database, 0);
+    assert_eq!(config.topology, None);
+    assert_eq!(config.durability, None);
+    assert_eq!(config.wait_replicas, None);
+    assert_eq!(config.wait_timeout_ms, 1_000);
+}
+
+#[test]
+fn cluster_config_round_trips_every_field() {
+    let config: RedisClusterConfig = serde_json::from_value(json!({
+        "url": "rediss://:pw@redis-primary:6379/3",
+        "pool_size": 8,
+        "command_timeout_ms": 1_234,
+        "key_prefix": "gears",
+        "database": 3,
+        "topology": "sentinel",
+        "durability": "fsync_everysec",
+        "wait_replicas": 1,
+        "wait_timeout_ms": 2_500,
+        "watch_mode": "disabled",
+        "manage_keyspace_notifications": true,
+    }))
+    .expect("full config deserializes");
+    assert_eq!(config.url, "rediss://:pw@redis-primary:6379/3");
+    assert_eq!(config.pool_size, 8);
+    assert_eq!(config.command_timeout_ms, 1_234);
+    assert_eq!(config.key_prefix, "gears");
+    assert_eq!(config.database, 3);
+    assert_eq!(config.topology, Some(Topology::Sentinel));
+    assert_eq!(config.durability, Some(Durability::FsyncEverysec));
+    assert_eq!(config.wait_replicas, Some(1));
+    assert_eq!(config.wait_timeout_ms, 2_500);
+    assert_eq!(config.watch_mode, WatchMode::Disabled);
+    assert!(config.manage_keyspace_notifications);
+}
+
+#[test]
+fn every_enum_variant_round_trips() {
+    for (raw, expected) in [
+        ("standalone", Topology::Standalone),
+        ("sentinel", Topology::Sentinel),
+        ("cluster", Topology::Cluster),
+    ] {
+        let config: RedisClusterConfig =
+            serde_json::from_value(minimal(json!({ "topology": raw })))
+                .expect("a topology hint deserializes");
+        assert_eq!(config.topology, Some(expected));
+    }
+
+    for (raw, expected) in [
+        ("fsync_always", Durability::FsyncAlways),
+        ("fsync_everysec", Durability::FsyncEverysec),
+        ("none", Durability::None),
+    ] {
+        let config: RedisClusterConfig =
+            serde_json::from_value(minimal(json!({ "durability": raw })))
+                .expect("a durability hint deserializes");
+        assert_eq!(config.durability, Some(expected));
+    }
+
+    for (raw, expected) in [
+        ("publish", WatchMode::Publish),
+        ("disabled", WatchMode::Disabled),
+    ] {
+        let config: RedisClusterConfig =
+            serde_json::from_value(minimal(json!({ "watch_mode": raw })))
+                .expect("a watch_mode deserializes");
+        assert_eq!(config.watch_mode, expected);
+    }
+}
+
+#[test]
+fn unknown_enum_variants_are_rejected() {
+    // `watch_mode: keyspace` is the specific one worth pinning: DESIGN.md §13
+    // D4 considered a third mode and decided against it, so an operator who
+    // read the design and tried it must get an error rather than a silent
+    // fall back to `publish`.
+    for (field, raw) in [
+        ("topology", "redis-cluster"),
+        ("durability", "fsync"),
+        ("watch_mode", "keyspace"),
+    ] {
+        let result: Result<RedisClusterConfig, _> =
+            serde_json::from_value(minimal(json!({ field: raw })));
+        assert!(
+            result.is_err(),
+            "an unknown `{field}` variant `{raw}` must be rejected"
+        );
+    }
+}
+
+#[test]
+fn an_operator_typo_is_rejected_rather_than_ignored() {
+    // `deny_unknown_fields` is what makes this a startup error instead of a
+    // pool that quietly stays at its default size.
+    let result: Result<RedisClusterConfig, _> =
+        serde_json::from_value(minimal(json!({ "pool_sise": 8 })));
+    let err = result.expect_err("a misspelled field must be rejected");
+    assert!(
+        err.to_string().contains("pool_sise"),
+        "the error must name the key the operator wrote, got {err}"
+    );
+}
+
+#[test]
+fn the_lock_config_rejects_the_cache_only_fields() {
+    // Not merely "unknown": binding a lock-only provider and setting
+    // `watch_mode` means the operator expects a watch they will not get.
+    for field in CACHE_ONLY_FIELDS {
+        let value = if field == "manage_keyspace_notifications" {
+            json!(true)
+        } else if field == "watch_mode" {
+            json!("publish")
+        } else {
+            json!(1_000)
+        };
+        let result: Result<RedisLockConfig, _> =
+            serde_json::from_value(minimal(json!({ field: value })));
+        assert!(
+            result.is_err(),
+            "RedisLockConfig must reject the cache-only field `{field}`"
+        );
+    }
+}
+
+/// Reads a type's accepted field names back out of the `unknown field …,
+/// expected one of …` error `deny_unknown_fields` produces.
+///
+/// The mechanical half of the drift guard below. Deriving the field set from
+/// the type itself is what makes the guard real: a list written by hand here
+/// would have to be updated by the same person who forgot to update the second
+/// config type, so it would pass exactly when it should fail.
+///
+/// If serde ever changes that message, this panics rather than silently
+/// returning an empty set and reporting two types as identical.
+fn accepted_fields<T: DeserializeOwned>() -> BTreeSet<String> {
+    let result: Result<T, _> =
+        serde_json::from_value(json!({ "a_field_no_config_type_declares": true }));
+    let message = result
+        .err()
+        .expect("deny_unknown_fields must reject an unknown key")
+        .to_string();
+    let (_, expected) = message
+        .split_once("expected one of ")
+        .expect("serde's unknown-field error must list the accepted fields");
+    expected
+        .split(',')
+        .filter_map(|field| field.trim().split('`').nth(1))
+        .map(str::to_owned)
+        .collect()
+}
+
+#[test]
+fn the_two_config_types_have_not_drifted() {
+    // DESIGN.md §8's "the two config types cannot drift" requirement, enforced
+    // the only way it can be once the shared subset is duplicated rather than
+    // flattened (see the module docs for why it has to be): the lock config's
+    // fields must be exactly the cluster config's, minus the three cache-only
+    // ones. Adding a field to one type and not the other fails here.
+    let cluster = accepted_fields::<RedisClusterConfig>();
+    let lock = accepted_fields::<RedisLockConfig>();
+
+    let cache_only: BTreeSet<String> = CACHE_ONLY_FIELDS.iter().map(|f| (*f).to_owned()).collect();
+    let expected_lock_fields: BTreeSet<String> = cluster.difference(&cache_only).cloned().collect();
+
+    assert_eq!(
+        lock, expected_lock_fields,
+        "RedisLockConfig must carry exactly RedisClusterConfig's fields minus {CACHE_ONLY_FIELDS:?}"
+    );
+    assert!(
+        cache_only.is_subset(&cluster),
+        "every field named cache-only must actually exist on RedisClusterConfig"
+    );
+}
+
+#[test]
+fn the_shared_fields_deserialize_identically_in_both_types() {
+    // The value half of the drift guard: matching field *names* would still
+    // allow the two types to disagree on a default or a type.
+    let shared = json!({
+        "url": "redis://:pw@h:6379/1",
+        "pool_size": 9,
+        "command_timeout_ms": 111,
+        "key_prefix": "shared",
+        "database": 1,
+        "topology": "cluster",
+        "durability": "fsync_always",
+        "wait_replicas": 2,
+        "wait_timeout_ms": 222,
+    });
+    let cluster: RedisClusterConfig =
+        serde_json::from_value(shared.clone()).expect("cluster config deserializes");
+    let lock: RedisLockConfig =
+        serde_json::from_value(shared).expect("lock config deserializes from the same object");
+
+    assert_eq!(cluster.url, lock.url);
+    assert_eq!(cluster.pool_size, lock.pool_size);
+    assert_eq!(cluster.command_timeout_ms, lock.command_timeout_ms);
+    assert_eq!(cluster.key_prefix, lock.key_prefix);
+    assert_eq!(cluster.database, lock.database);
+    assert_eq!(cluster.topology, lock.topology);
+    assert_eq!(cluster.durability, lock.durability);
+    assert_eq!(cluster.wait_replicas, lock.wait_replicas);
+    assert_eq!(cluster.wait_timeout_ms, lock.wait_timeout_ms);
+}
+
+#[test]
+fn url_expands_a_default_when_the_var_is_unset() {
+    let mut config: RedisClusterConfig = serde_json::from_value(json!({
+        "url": "redis://:${REDIS_CLUSTER_PW_UNSET:-fallbackpw}@redis:6379/0",
+    }))
+    .expect("config deserializes");
+    config
+        .expand_vars()
+        .expect("expansion with a default succeeds");
+    assert_eq!(config.url, "redis://:fallbackpw@redis:6379/0");
+}
+
+#[test]
+fn a_missing_env_var_without_a_default_is_an_error() {
+    // The failure mode this prevents: a literal `${REDIS_PASSWORD}` reaching
+    // `fred` as the password, which fails at connect time with an auth error
+    // that says nothing about the unset variable.
+    let mut config: RedisClusterConfig = serde_json::from_value(json!({
+        "url": "redis://:${REDIS_CLUSTER_PW_UNSET_NODEFAULT}@redis:6379/0",
+    }))
+    .expect("config deserializes");
+    assert!(
+        config.expand_vars().is_err(),
+        "a referenced env var with no default and no value must surface as an error"
+    );
+
+    let mut lock: RedisLockConfig = serde_json::from_value(json!({
+        "url": "redis://:${REDIS_CLUSTER_PW_UNSET_NODEFAULT}@redis:6379/0",
+    }))
+    .expect("lock config deserializes");
+    assert!(
+        lock.expand_vars().is_err(),
+        "the lock config must expand its url the same way"
+    );
+}
+
+#[test]
+fn debug_masks_the_url() {
+    // The url embeds a password after expansion, and DESIGN.md §8 requires it
+    // to be masked. A `{:?}` in a log line or a panic message would otherwise
+    // leak it.
+    let cluster: RedisClusterConfig =
+        serde_json::from_value(json!({ "url": "redis://:supersecret@redis:6379/0" }))
+            .expect("config deserializes");
+    let rendered = format!("{cluster:?}");
+    assert!(
+        !rendered.contains("supersecret"),
+        "Debug must not leak the password"
+    );
+    assert!(
+        !rendered.contains("redis://"),
+        "Debug must not leak the url"
+    );
+    assert!(
+        rendered.contains(REDACTED_URL),
+        "Debug must show the redaction marker"
+    );
+
+    let lock: RedisLockConfig =
+        serde_json::from_value(json!({ "url": "redis://:supersecret@redis:6379/0" }))
+            .expect("lock config deserializes");
+    let rendered = format!("{lock:?}");
+    assert!(
+        !rendered.contains("supersecret"),
+        "lock Debug must not leak the password"
+    );
+    assert!(
+        rendered.contains(REDACTED_URL),
+        "lock Debug must show the redaction marker"
+    );
+}
+
+#[test]
+fn debug_still_renders_every_other_field() {
+    // A hand-written `Debug` is a place a field can be silently dropped, and a
+    // config key missing from a diagnostic dump is exactly the kind of gap
+    // nobody notices until they need it.
+    let config: RedisClusterConfig = serde_json::from_value(json!({
+        "url": "redis://redis:6379/0",
+        "watch_mode": "disabled",
+        "topology": "cluster",
+    }))
+    .expect("config deserializes");
+    let rendered = format!("{config:?}");
+    for field in [
+        "pool_size",
+        "command_timeout_ms",
+        "key_prefix",
+        "database",
+        "topology",
+        "durability",
+        "wait_replicas",
+        "wait_timeout_ms",
+        "watch_mode",
+        "manage_keyspace_notifications",
+    ] {
+        assert!(
+            rendered.contains(field),
+            "Debug must render `{field}`, got {rendered}"
+        );
+    }
+}
+
+#[test]
+fn validate_accepts_the_defaults() {
+    let config: RedisClusterConfig =
+        serde_json::from_value(minimal(json!({}))).expect("minimal config deserializes");
+    config
+        .validate()
+        .expect("the documented defaults are valid");
+
+    let lock: RedisLockConfig =
+        serde_json::from_value(minimal(json!({}))).expect("minimal lock config deserializes");
+    lock.validate().expect("the documented defaults are valid");
+}
+
+#[test]
+fn validate_rejects_every_zero_that_removes_a_bound() {
+    for field in ["pool_size", "command_timeout_ms", "wait_timeout_ms"] {
+        let config: RedisClusterConfig = serde_json::from_value(minimal(json!({ field: 0 })))
+            .expect("a zero value still deserializes; validate is what rejects it");
+        let err = config
+            .validate()
+            .expect_err("a zero {field} must be rejected");
+        let ClusterError::InvalidConfig { reason } = err else {
+            panic!("a zero `{field}` must be an InvalidConfig, not a provider error");
+        };
+        assert!(
+            reason.contains(field),
+            "the error must name the offending key, got {reason}"
+        );
+    }
+}
+
+#[test]
+fn the_lock_config_validates_its_own_three_zeros() {
+    for field in ["pool_size", "command_timeout_ms", "wait_timeout_ms"] {
+        let config: RedisLockConfig = serde_json::from_value(minimal(json!({ field: 0 })))
+            .expect("a zero value still deserializes");
+        let err = config
+            .validate()
+            .expect_err("a zero value must be rejected");
+        assert!(
+            matches!(err, ClusterError::InvalidConfig { ref reason } if reason.contains(field)),
+            "the lock config must reject a zero `{field}`, got {err}"
+        );
+    }
+}
+
+#[test]
+fn the_duration_accessors_agree_with_their_millisecond_fields() {
+    let config: RedisClusterConfig = serde_json::from_value(minimal(json!({
+        "command_timeout_ms": 250,
+        "wait_timeout_ms": 750,
+    })))
+    .expect("config deserializes");
+    assert_eq!(config.command_timeout(), Duration::from_millis(250));
+    assert_eq!(config.wait_timeout(), Duration::from_millis(750));
+
+    let lock: RedisLockConfig = serde_json::from_value(minimal(json!({
+        "command_timeout_ms": 250,
+        "wait_timeout_ms": 750,
+    })))
+    .expect("lock config deserializes");
+    assert_eq!(lock.command_timeout(), Duration::from_millis(250));
+    assert_eq!(lock.wait_timeout(), Duration::from_millis(750));
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/connect.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/connect.rs
@@ -1,0 +1,287 @@
+//! Opening the `fred` command pool and the subscriber client — step 1 of both
+//! plugins' `build_and_start` (DESIGN.md §3.2, §3.3).
+//!
+//! Shared between `RedisClusterHandle` and `RedisLockHandle` for the same
+//! reason `shutdown.rs` is (DESIGN.md §3.1): the two plugins open
+//! exactly this pair of connections, and everything decided here is a policy
+//! neither of them may differ on. The client-side command timeout is what makes
+//! `stop()` finite (DESIGN.md §11, §12); awaiting the initial connect is what
+//! turns an unreachable server into a startup error rather than a pool that
+//! reconnects in the background while every command fails. A second copy of
+//! this file would be free to drift on either, which is what happened to the
+//! Postgres plugin's two shutdown paths.
+
+use std::time::Duration;
+
+use cluster_sdk::ClusterError;
+use fred::clients::{Pool, SubscriberClient};
+use fred::interfaces::ClientLike;
+use fred::types::config::{Config, ReconnectPolicy, ServerConfig};
+use fred::types::{Builder, ConnectHandle};
+
+use crate::config::Topology;
+use crate::redis_error::map_redis_error;
+use crate::shutdown::{abandon_subscriber, close_pool};
+
+/// Upper bound on the initial connect, so an unreachable server fails startup
+/// promptly instead of spending [`RECONNECT_ATTEMPTS`]' whole schedule on it.
+///
+/// Needed the moment a reconnect policy exists: `init()` retries the *initial*
+/// connect under the same policy, so without this bound a plugin pointed at a
+/// closed port would sit in `build_and_start` for minutes rather than reporting
+/// `Provider { ConnectionLost }` (`RD-LIFE-005`). Ten seconds is long enough to
+/// ride out a container that is still binding its port and short enough to stay
+/// inside any supervisor's start budget.
+pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How many times a connection is re-established before the client gives up.
+///
+/// `fred` defaults to **no policy at all** (`Builder::from_config` leaves
+/// `policy: None`), which is not a viable default for this plugin: a single
+/// dropped TCP connection would end the client permanently, so every subsequent
+/// command would fail forever and every watcher would be closed on the first
+/// blip. Everything DESIGN.md §4.3 and §10 say about recovery — `fred` replaying
+/// the subscription set, the `Reset` a watcher then receives, the terminal close
+/// "once the reconnect policy is exhausted" — presumes a policy that this file
+/// has to supply.
+///
+/// **Bounded, not unlimited**, and that is the load-bearing half. Unlimited
+/// retries would make `spawn_connection_watchdog` dead code — its signal is the
+/// `ConnectHandle` resolving, which only ever happens when the policy gives up —
+/// so a watcher waiting on a server that is never coming back would wait
+/// forever, told nothing. With the schedule below the client rides out roughly
+/// six minutes of outage, which covers a rolling restart or a Sentinel failover,
+/// and then tells its consumers.
+pub const RECONNECT_ATTEMPTS: u32 = 20;
+/// The first reconnect delay, in milliseconds.
+const RECONNECT_MIN_DELAY_MS: u32 = 100;
+/// The ceiling on the exponential backoff, in milliseconds.
+const RECONNECT_MAX_DELAY_MS: u32 = 30_000;
+/// The backoff base: each attempt waits twice as long as the last, to the
+/// ceiling above.
+const RECONNECT_BASE: u32 = 2;
+
+/// The policy both clients reconnect under. See [`RECONNECT_ATTEMPTS`].
+#[must_use]
+pub fn reconnect_policy() -> ReconnectPolicy {
+    ReconnectPolicy::new_exponential(
+        RECONNECT_ATTEMPTS,
+        RECONNECT_MIN_DELAY_MS,
+        RECONNECT_MAX_DELAY_MS,
+        RECONNECT_BASE,
+    )
+}
+
+/// What a plugin wants opened. A struct rather than five positional parameters
+/// because three of the five are integers whose order nothing would catch.
+pub struct ConnectSpec<'a> {
+    /// The operator's connection URL, already `${VAR}`-expanded.
+    pub url: &'a str,
+    /// The logical database. Applied only when non-zero — the URL may carry one
+    /// in its path, and 0 is both the default and the only legal value in
+    /// cluster mode, where `fred` ignores it.
+    pub database: u8,
+    /// Command-pool size (DESIGN.md §3.3).
+    pub pool_size: u32,
+    /// The per-command client-side bound.
+    pub command_timeout: Duration,
+}
+
+/// What [`connect`] established.
+pub struct Connected {
+    /// The connected command pool.
+    pub pool: Pool,
+    /// The subscriber client and the `ConnectHandle` that resolves when its
+    /// reconnect policy is exhausted.
+    ///
+    /// Not optional, and deliberately not skipped under `watch_mode: disabled`.
+    /// The subscriber is a plugin-level connection carrying three families
+    /// (DESIGN.md §3.3), and the third is the lock-release wake a blocked
+    /// `lock()` rides — so a *cache* setting must not close it, or every blocked
+    /// acquisition is silently pushed onto the heartbeat fallback. What
+    /// `watch_mode: disabled` does save is every subscription and the whole
+    /// watcher registry.
+    pub subscriber: (SubscriberClient, ConnectHandle),
+    /// Whether the client is in Redis Cluster mode.
+    pub clustered: bool,
+    /// What the URL scheme itself said about the topology.
+    pub url_topology: Option<Topology>,
+}
+
+/// Builds the pool from the operator's URL and awaits the initial connect, so a
+/// bad DSN or an unreachable server fails here rather than at first use.
+///
+/// Also reports what the URL itself said about the topology, which both the
+/// preflight and `scan_prefix` need: a `redis-cluster://` URL puts `fred` in
+/// cluster mode, and that is a fact about the client rather than an inference
+/// from any one server's `INFO`.
+///
+/// # Errors
+/// [`ClusterError::InvalidConfig`] for a URL `fred` cannot parse, and
+/// [`ClusterError::Provider`] for a failing connect. A subscriber that fails to
+/// connect abandons its own router task *and* closes the pool on the way out, so
+/// a half-open startup leaves nothing behind.
+pub async fn connect(spec: ConnectSpec<'_>) -> Result<Connected, ClusterError> {
+    let mut client_config = Config::from_url(spec.url).map_err(map_redis_error)?;
+    if spec.database != 0 {
+        client_config.database = Some(spec.database);
+    }
+    let clustered = client_config.server.is_clustered();
+    let url_topology = topology_from_server_config(&client_config.server);
+    let subscriber_config = client_config.clone();
+
+    let mut builder = Builder::from_config(client_config);
+    builder.set_policy(reconnect_policy());
+    let pool = builder
+        .with_performance_config(|perf| {
+            // The client-side bound every other timing guarantee rests on: with
+            // it, no command can block indefinitely once issued, which is what
+            // makes `stop()`'s pool drain finite (DESIGN.md §11, §12). Each
+            // config's `validate` has already rejected the zero that would
+            // disable it rather than shorten it.
+            perf.default_command_timeout = spec.command_timeout;
+        })
+        .build_pool(usize::try_from(spec.pool_size).unwrap_or(usize::MAX))
+        .map_err(map_redis_error)?;
+
+    // `init` awaits the first successful connect and surfaces the failure to the
+    // caller, rather than returning a pool that reconnects in the background
+    // while every command fails.
+    //
+    // Bounded by [`CONNECT_TIMEOUT`], because the reconnect policy applies to
+    // the initial connect too: without the bound, a URL pointing at a closed
+    // port would retry for the policy's whole schedule before `build_and_start`
+    // returned (`RD-LIFE-005`).
+    match tokio::time::timeout(CONNECT_TIMEOUT, pool.init()).await {
+        Ok(Ok(_connection)) => {}
+        Ok(Err(err)) => {
+            close_pool(&pool).await;
+            return Err(map_redis_error(err));
+        }
+        Err(_elapsed) => {
+            close_pool(&pool).await;
+            return Err(unreachable_within_budget());
+        }
+    }
+
+    // Built from the same config but outside the pool, because a connection in
+    // subscribe mode accepts only subscribe-family commands (DESIGN.md §3.3).
+    let mut subscriber_builder = Builder::from_config(subscriber_config);
+    subscriber_builder.set_policy(reconnect_policy());
+    let client = match subscriber_builder
+        .with_performance_config(|perf| {
+            // The same bound the pool gets, and for the same reason: the
+            // subscribe-family commands this client carries — the `SUBSCRIBE`
+            // behind every `watch()`, the `PSUBSCRIBE` of the keyspace pattern,
+            // the `PING` that confirms them — are commands like any other, and
+            // without this they are the one path in either plugin that can
+            // block indefinitely. That would leave `watch()` unbounded against
+            // a server that accepted the connection and then stopped answering,
+            // which is exactly the state DESIGN.md §11 and §12 rest on not
+            // being reachable.
+            perf.default_command_timeout = spec.command_timeout;
+        })
+        .build_subscriber_client()
+    {
+        Ok(client) => client,
+        Err(err) => {
+            close_pool(&pool).await;
+            return Err(map_redis_error(err));
+        }
+    };
+    // `connect()` + `wait_for_connect()` rather than the `init()` shorthand,
+    // because the shorthand only hands back the [`ConnectHandle`] on success and
+    // this function needs it on the failure paths: `connect()` has already
+    // spawned the router task by then, and [`abandon_subscriber`] documents why
+    // dropping the client does not end it in this build of `fred`. `init()`
+    // resets the task itself when the *connect* fails, but a timeout drops the
+    // `init()` future before it can, which leaks one connection and one task per
+    // `build_and_start` attempt — the same leak `RD-LIFE-010` covers for the
+    // startup steps after this one.
+    let connection = client.connect();
+    let subscriber = match tokio::time::timeout(CONNECT_TIMEOUT, client.wait_for_connect()).await {
+        // The handle stays pending while the client is connected or retrying,
+        // and resolves when the reconnect policy gives up — the signal each
+        // plugin's watchdog acts on.
+        Ok(Ok(())) => (client, connection),
+        Ok(Err(err)) => {
+            abandon_subscriber(&client, &connection).await;
+            close_pool(&pool).await;
+            return Err(map_redis_error(err));
+        }
+        Err(_elapsed) => {
+            abandon_subscriber(&client, &connection).await;
+            close_pool(&pool).await;
+            return Err(unreachable_within_budget());
+        }
+    };
+
+    Ok(Connected {
+        pool,
+        subscriber,
+        clustered,
+        url_topology,
+    })
+}
+
+/// The error a connect that outlived [`CONNECT_TIMEOUT`] reports.
+///
+/// `ConnectionLost` rather than `Timeout`, because it describes the server
+/// rather than one command: the operator's URL is fine and their Redis is not
+/// answering, which is the same state a mid-life outage produces and the same
+/// one their retry policy should treat as retryable.
+fn unreachable_within_budget() -> ClusterError {
+    ClusterError::Provider {
+        kind: cluster_sdk::ProviderErrorKind::ConnectionLost,
+        message: format!(
+            "redis did not answer within the {} ms connect budget; the server is unreachable or \
+             is refusing connections",
+            CONNECT_TIMEOUT.as_millis()
+        ),
+    }
+}
+
+/// What the connection URL's scheme says about the topology, or `None` for a
+/// plain `redis://`/`rediss://` URL that says nothing.
+///
+/// A centralized URL is deliberately not reported as `Standalone`: it means "one
+/// address", not "no replicas", and the single-node row of DESIGN.md §3.6 is the
+/// one place a wrong answer weakens a guarantee. Detection via
+/// `INFO replication` decides that case.
+#[must_use]
+pub fn topology_from_server_config(server: &ServerConfig) -> Option<Topology> {
+    match server {
+        ServerConfig::Clustered { .. } => Some(Topology::Cluster),
+        ServerConfig::Sentinel { .. } => Some(Topology::Sentinel),
+        ServerConfig::Centralized { .. } => None,
+    }
+}
+
+// Layer-1 unit tests: the URL-scheme topology mapping, the one decision in this
+// file that needs no server. Everything else here is a connect against a
+// container (Layer 3).
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_clustered_url_is_reported_as_cluster() {
+        let config = Config::from_url("redis-cluster://node-a:6379?node=node-b:6379")
+            .expect("a clustered url parses");
+        assert!(config.server.is_clustered());
+        assert_eq!(
+            topology_from_server_config(&config.server),
+            Some(Topology::Cluster)
+        );
+    }
+
+    #[test]
+    fn a_plain_url_says_nothing_about_replicas() {
+        // The trap this guards: reading `redis://one-host` as "standalone, so no
+        // replicas" would let a Sentinel-managed primary reach the one row of
+        // DESIGN.md §3.6 that declares Linearizable.
+        let config = Config::from_url("redis://:pw@redis:6379/0").expect("a plain url parses");
+        assert!(!config.server.is_clustered());
+        assert_eq!(topology_from_server_config(&config.server), None);
+    }
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/lib.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/lib.rs
@@ -1,0 +1,141 @@
+//! # Redis cluster plugin
+//!
+//! `redis_cluster_plugin` is the Redis backend plugin for the cluster gear
+//! (DESIGN.md §1). It provides a native `ClusterCacheBackend` over a `fred`
+//! connection pool and a native `DistributedLockBackend` over a `SET NX PX`
+//! lease key with Lua-fenced renew and release (DESIGN.md §5). Leader election
+//! is derived from the SDK default backend over the
+//! Redis cache — no additional keys or connections are required for that
+//! primitive (DESIGN.md §7).
+//!
+//! This is the recommended cache and lock backend for the **K8s +
+//! high-throughput cache** deployment shape (`../../../docs/DESIGN.md` §4.2),
+//! where Redis serves cache and lock and K8s Lease serves leader election.
+//! ADR-001 puts Redis 10–100× above every other backend on
+//! cache and lock throughput, which is what makes the OAGW requirement of
+//! 10 000+ counter updates per second reachable at all.
+//!
+//! ## Consistency: read this before binding a profile to Redis
+//!
+//! This is the **first `EventuallyConsistent` cache backend in the workspace** —
+//! the Postgres and standalone caches both declare `Linearizable`. ADR-009 rates
+//! Redis unsafe for CAS-based leader election in *every* replicated
+//! configuration, and this plugin declares that rather than papering over it
+//! (DESIGN.md §3.6): `consistency()` is `EventuallyConsistent` unless the
+//! preflight *verifies* a single node with `appendonly yes` and
+//! `appendfsync always` and no replicas.
+//!
+//! The practical consequence is that a profile binding `cache: { provider: redis }`
+//! and omitting `leader_election` or `lock` **fails startup**, because both SDK
+//! default backends reject a weak cache. That is correct behaviour, not a bug.
+//! The three ways out are documented in DESIGN.md §7; the intended one is to
+//! route leader election to a linearizable backend, and to bind
+//! `lock: { provider: redis }` explicitly so the native lease-based lock is used
+//! instead of the CAS default.
+//!
+//! ## Status
+//!
+//! **Feature-complete and reachable.** Both primitives are here and both provider
+//! impls are implemented: the cache with its native TTL, watch, and `scan_prefix`
+//! ([`RedisCache`]), the lock with its `SET NX PX` lease, Lua-fenced renew and
+//! release, and publish-driven blocking acquisition ([`RedisLock`]), the two
+//! lifecycle shapes ([`RedisClusterPlugin`], [`RedisLockPlugin`]), and the two
+//! providers the wiring matches on ([`RedisCacheProvider`],
+//! [`RedisLockProvider`]), with the ADR-004 observability catalog wired through
+//! [`RedisSignals`] — the cache via the SDK's `InstrumentedCache` decorator, the
+//! lock natively at each site, and the four plugin-local metrics of DESIGN.md §9
+//! through a meter this plugin owns.
+//!
+//! **`cluster/src/gear.rs` registers both providers**, so `provider: redis` under
+//! either `cache` or `lock` resolves in any build of the cluster gear — there is
+//! no cargo feature an operator has to know about. The accepted cost is that every
+//! cluster-gear build links `fred` and its rustls stack whether or not a profile
+//! binds Redis.
+//!
+//! Tests: Layer 1 unit tests (no Docker, sub-second), the four wireable
+//! conformance suites, and the Layer 3 scenarios of `docs/TESTING.md` §4.2–§4.6,
+//! run by `make test-cluster-redis` in CI's `integration` job. Both multi-node
+//! fixtures are built and run on every PR: `RD-SPEC-002` on Sentinel,
+//! `RD-SPEC-008`/`009`/`010` and `RD-LOCK-014` on a 3-node Cluster.
+//! `docs/TESTING.md` is the register — counts live there and nowhere else,
+//! because a number repeated across four files goes stale in three of them.
+//!
+//! **What is not verified**: the `RD-FAULT-*` fault-injection scenarios, which
+//! need a Toxiproxy layer that does not exist. `docs/TESTING.md` §8 is the full
+//! register.
+//!
+//! ## What this crate exports, and why some of it is wider than a consumer needs
+//!
+//! Some of the re-exports below — the preflight parsers, the script catalog —
+//! are not things a consumer of the plugin ever calls. They are public because
+//! the modules themselves are private (the Postgres plugin's shape) and each is
+//! a testable unit in its own right. The consumer-facing surface is much
+//! narrower: the two config types, the two plugins and their handles, and the
+//! two providers.
+//!
+//! [`docs/DESIGN.md`]: https://github.com/constructorfabric/gears-rust/blob/main/gears/system/cluster/plugins/redis-cluster-plugin/docs/DESIGN.md
+//! [`docs/TESTING.md`]: https://github.com/constructorfabric/gears-rust/blob/main/gears/system/cluster/plugins/redis-cluster-plugin/docs/TESTING.md
+
+#![forbid(unsafe_code)]
+#![deny(rust_2018_idioms)]
+
+mod cache;
+mod config;
+mod connect;
+mod lock;
+mod observability;
+mod plugin;
+mod preflight;
+mod provider;
+mod redis_error;
+mod scripts;
+mod shutdown;
+mod subscriber;
+mod wait;
+
+/// The recording [`ClusterMetrics`](cluster_sdk::ClusterMetrics) double every
+/// module's Layer-1 signal tests share.
+#[cfg(test)]
+mod test_support;
+
+/// TESTING.md §6's mechanical source checks — the commands this plugin must
+/// never issue. Crate-level rather than per-module because the rule is about the
+/// whole of `src/`, and a check scoped to one module would go stale the moment a
+/// new one was added.
+#[cfg(test)]
+#[path = "static_analysis_tests.rs"]
+mod static_analysis_tests;
+
+pub use cache::{CacheInit, RedisCache};
+pub use config::{
+    Durability, RedisClusterConfig, RedisLockConfig, Topology, WatchMode, default_command_timeout,
+    default_key_prefix, default_pool_size, default_wait_timeout,
+};
+pub use lock::waiters::{HEARTBEAT, ReleaseWait, ReleaseWaiters, wake_cap, wake_delay};
+pub use lock::{
+    LockInit, LockNames, RedisLock, RedisLockBuilder, RedisLockHandle, RedisLockPlugin,
+    lease_remaining, px_millis,
+};
+pub use observability::{
+    EvictionReporter, PLUGIN_SCOPE, RedisSignals, logs, plugin_meter,
+    spawn_connection_state_observer,
+};
+pub use plugin::{RedisClusterBuilder, RedisClusterHandle, RedisClusterPlugin};
+pub use preflight::{
+    Appendfsync, ConsistencyDecision, DurabilityReading, EVICTION_KEYSPACE_FLAGS, PreflightOutcome,
+    PreflightRequest, REQUIRED_KEYSPACE_FLAGS, ReplicationInfo, ReplicationRole,
+    SAFE_MAXMEMORY_POLICY, SHARDED_PUBSUB_MAJOR, TopologyFinding, decide_consistency,
+    maxmemory_policy_is_safe, merge_keyspace_flags, missing_keyspace_flags, parse_config_get,
+    parse_info, parse_info_replication, resolve_topology, run_preflight, supports_sharded_pubsub,
+    topology_from_replication,
+};
+pub use provider::{PROVIDER_NAME, RedisCacheProvider, RedisLockProvider};
+pub use redis_error::{is_noscript, map_redis_error};
+pub use scripts::{
+    ALL_SCRIPTS, CACHE_SCRIPTS, LOCK_SCRIPTS, PoolScriptExecutor, ScriptCache, ScriptExecutor,
+    ScriptSpec, eval, load_catalog,
+};
+pub use shutdown::{
+    DropDiagnosis, GUARD_DRAIN_TIMEOUT, POOL_CLOSE_TIMEOUT, cancel_and_diagnose_drop,
+};
+pub use wait::{WaitPolicy, WaitTarget};

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/lock/mod.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/lock/mod.rs
@@ -1,0 +1,1271 @@
+//! [`RedisLock`] — the native `DistributedLockBackend` (DESIGN.md §5) — and the
+//! standalone lock-only plugin of DESIGN.md §3.5.
+//!
+//! ## The whole mutual-exclusion mechanism is one command
+//!
+//! `SET <prefix>:l:<name> <holder_token> NX PX <ttl_ms>`. `OK` is the lock,
+//! `nil` is contention. `NX` is atomic on a single primary and `PX` makes the
+//! entry its own reaper, so there is no liveness proxy, no reclamation sweep,
+//! and no in-process registry of what this instance holds. Nothing has to
+//! distinguish "the holder crashed" from "the lease lapsed", because a crashed
+//! holder stops renewing and the key evaporates on its own deadline with
+//! nothing having to notice.
+//!
+//! The token is a fresh v4 UUID per acquisition, and it is what makes `renew`
+//! and `release` safe against a successor: both are Lua scripts that compare
+//! `GET KEYS[1]` against the token before acting (DESIGN.md §5.2). A bare `DEL`
+//! on release is the classic bug in this pattern — a holder whose lease already
+//! lapsed deletes its successor's lock — and `RD-LOCK-006` is the regression
+//! test for it.
+//!
+//! ## A held lock consumes no connection
+//!
+//! DESIGN.md §3.3, and `RD-LOCK-010` holds twelve locks on a pool of two to say
+//! so. What a held lock *does* consume is one task: the SDK hands the consumer a
+//! [`LockGuard`] built by `LockGuard::channel` and the backend owns the paired
+//! `LockCommandReceiver`, so something has to be selecting on it to service
+//! `Renew` and `Release` (DESIGN.md §5). A task is not a checked-out connection: it
+//! borrows one from the pool only for the round trip a command actually needs.
+//!
+//! Those tasks are the detached-task class `shutdown.rs` exists to warn about,
+//! so they are spawned onto a [`TaskTracker`] the handle drains under a bound —
+//! not with `tokio::spawn`, which would leave `stop()` unable to say whether
+//! anything it started is still running.
+//!
+//! ## Blocking `lock()` waits in process, and the reason is a missing feature
+//!
+//! Redis has no "wait for this key" command this plugin can reach: `i-lists` is
+//! absent from `fred`'s feature list (DESIGN.md §3.1) so `BLPOP` and
+//! the rest of the blocking family do not compile, and a companion-list wait
+//! would leak a list per lock name anyway. The loop instead re-attempts the
+//! `SET NX` — always the source of truth — woken by whichever comes first of the
+//! holder's release publish, the blocking lease's own `PTTL`, and a jittered
+//! heartbeat. See [`waiters`] for the registry and the delay policy.
+
+pub mod waiters;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use cluster_sdk::observability::{ResourceId, spans};
+use cluster_sdk::{
+    ClusterError, DistributedLockBackend, LockCommandReceiver, LockFeatures, LockGuard,
+    LockRequest, ProviderErrorKind,
+};
+use fred::clients::{Pool, SubscriberClient};
+use fred::interfaces::{KeysInterface, PubsubInterface};
+use fred::types::{ConnectHandle, Expiration, SetOptions, Value};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+use tracing::{Instrument, warn};
+use uuid::Uuid;
+
+use crate::cache::scan::escape_glob;
+use crate::config::RedisLockConfig;
+use crate::connect::{ConnectSpec, Connected, connect};
+use crate::lock::waiters::{ReleaseWait, ReleaseWaiters, wake_delay};
+use crate::observability::{RedisSignals, logs, spawn_connection_state_observer};
+use crate::preflight::{EVICTION_KEYSPACE_FLAGS, PreflightRequest, run_preflight};
+use crate::provider::PROVIDER_NAME;
+use crate::redis_error::map_redis_error;
+use crate::scripts::{
+    LOCK_RELEASE, LOCK_RENEW, LOCK_SCRIPTS, PoolScriptExecutor, ScriptCache, eval,
+};
+use crate::shutdown::{
+    DropDiagnosis, abandon_subscriber, cancel_and_diagnose_drop, close_pool, drain_tracked_tasks,
+};
+use crate::subscriber::{
+    FanOutRoutes, KeyspaceNames, LockRoute, confirm_subscriptions, quit_subscriber,
+    spawn_connection_watchdog, spawn_fan_out,
+};
+use crate::wait::{WaitPolicy, wait_for_replicas};
+
+/// The in-flight command buffer of each guard's channel.
+///
+/// The SDK notes that 1 suffices when the consumer awaits each `renew` before
+/// issuing the next, and to size it larger only if a guard is shared across
+/// tasks that may renew concurrently. 4 takes the second option: a guard behind
+/// an `Arc` is an ordinary thing for a consumer to build, and a buffer of 1
+/// would serialize those renewals on the channel rather than on the server,
+/// which is the wrong place to discover the contention.
+const GUARD_COMMAND_BUFFER: usize = 4;
+
+// ---------------------------------------------------------------------------
+// Naming
+// ---------------------------------------------------------------------------
+
+/// The key and channel names the lock owns, all derived from the operator's
+/// `key_prefix` (DESIGN.md §2.1).
+///
+/// One place, because the publisher and the subscriber have to agree exactly:
+/// `lock_release` builds `<prefix>:e:l:<name>` from an argument this type
+/// produced, and the fan-out parses the name back out of the channel it arrives
+/// on. A mismatch would be a blocked `lock()` that silently never gets its wake.
+#[derive(Debug, Clone)]
+pub struct LockNames {
+    /// `<key_prefix>:l:`.
+    lease_prefix: String,
+    /// `<key_prefix>:e:l:`.
+    release_prefix: String,
+}
+
+impl LockNames {
+    /// Builds the naming scheme for one lock backend.
+    #[must_use]
+    pub fn new(key_prefix: &str) -> Self {
+        Self {
+            lease_prefix: format!("{key_prefix}:l:"),
+            release_prefix: format!("{key_prefix}:e:l:"),
+        }
+    }
+
+    /// The Redis key holding `name`'s lease: `<prefix>:l:<name>`.
+    ///
+    /// `name` arrives already scope-prefixed by the SDK's
+    /// `ScopedDistributedLockBackend`, and this never inspects the consumer's
+    /// portion of it.
+    #[must_use]
+    pub fn lease_key(&self, name: &str) -> String {
+        format!("{}{name}", self.lease_prefix)
+    }
+
+    /// The channel `name`'s release is published on: `<prefix>:e:l:<name>`.
+    ///
+    /// No key exists at this name — it is a channel. It is passed to
+    /// `lock_release` as an `ARGV` rather than a second `KEYS` entry, because
+    /// `PUBLISH` is not slot-routed and a second key would make the script
+    /// multi-key for nothing (DESIGN.md §6).
+    #[must_use]
+    pub fn release_channel(&self, name: &str) -> String {
+        format!("{}{name}", self.release_prefix)
+    }
+
+    /// The one blanket pattern carrying every release under this prefix.
+    ///
+    /// One always-on pattern rather than a `SUBSCRIBE` per contended name, and
+    /// the reason is the shape of the acquisition loop: a waiter's interest
+    /// lasts one iteration, so per-name subscriptions would put a
+    /// `SUBSCRIBE`/`UNSUBSCRIBE` round trip either side of every retry and
+    /// re-introduce exactly the ordering race the cache's registry needs a mutex
+    /// to exclude. Releases are bounded by critical sections rather than by
+    /// write rate, so the traffic a blanket pattern delivers to an uninterested
+    /// instance is a `DashMap` miss (see [`ReleaseWaiters::notify`]).
+    ///
+    /// The operator's prefix is glob-escaped for the same reason `scan_prefix`
+    /// escapes the consumer's: nothing rules out a `[` in it, and unescaped it
+    /// would be a character class subscribing to something else entirely.
+    #[must_use]
+    pub fn release_pattern(&self) -> String {
+        format!("{}*", escape_glob(&self.release_prefix))
+    }
+
+    /// Recovers the lock name from a release channel, or `None` when the channel
+    /// is not one of this backend's.
+    ///
+    /// The counterpart to `ChannelNames::key_from_event_channel`, and
+    /// deliberately a separate function rather than a widened one: the two
+    /// families differ by one segment (`:e:l:` against `:e:c:`), and a parser
+    /// that accepted both would route a cache event into the waiter registry the
+    /// first time a prefix was mistyped.
+    #[must_use]
+    pub fn name_from_release_channel(&self, channel: &str) -> Option<String> {
+        channel
+            .strip_prefix(&self.release_prefix)
+            .map(str::to_owned)
+    }
+
+    /// Recovers the lock name from a *Redis key* — what a keyspace notification
+    /// reports — or `None` when the key is not one of this backend's leases.
+    ///
+    /// The counterpart to `ChannelNames::key_from_entry_key`, and what lets the
+    /// eviction signal of DESIGN.md §3.7 name an evicted lease. It matches
+    /// `<prefix>:l:` and not `<prefix>:e:l:`, which is a channel no key ever
+    /// exists at, so the two cannot be confused however a notification arrives.
+    #[must_use]
+    pub fn name_from_lease_key(&self, entry_key: &str) -> Option<String> {
+        entry_key
+            .strip_prefix(&self.lease_prefix)
+            .map(str::to_owned)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure decisions
+// ---------------------------------------------------------------------------
+
+/// Renders a TTL as the `PX` / `PEXPIRE` argument: whole milliseconds, floored
+/// at 1.
+///
+/// The floor is not defensive. `PX 0` is an error reply (`invalid expire time`)
+/// and `PEXPIRE k 0` deletes the key outright, so rounding a sub-millisecond TTL
+/// down to zero would turn "expires almost immediately" into either a failed
+/// acquisition or a lock that was released the instant it was taken — and the
+/// caller's next `renew` would report `LockExpired` for a lease it was never
+/// given.
+#[must_use]
+pub fn px_millis(ttl: Duration) -> i64 {
+    i64::try_from(ttl.as_millis()).unwrap_or(i64::MAX).max(1)
+}
+
+/// Reads a `PTTL` reply as the blocking lease's remaining life (DESIGN.md §5.3).
+///
+/// Redis overloads the reply with two negative sentinels and they mean opposite
+/// things here:
+///
+/// - **`-2`, the key does not exist** — the lease lapsed or was released between
+///   the `SET NX` that just failed and this read, so the name is free *now* and
+///   the waiter should re-attempt immediately rather than sleep.
+/// - **`-1`, the key exists with no TTL** — not a lease this plugin wrote (every
+///   acquisition carries `PX`), so there is no deadline to schedule against and
+///   the heartbeat is the honest answer.
+#[must_use]
+pub fn lease_remaining(pttl: i64) -> Option<Duration> {
+    match pttl {
+        -2 => Some(Duration::ZERO),
+        negative if negative < 0 => None,
+        millis => Some(Duration::from_millis(
+            u64::try_from(millis).unwrap_or(u64::MAX),
+        )),
+    }
+}
+
+/// What one acquisition attempt left the blocking loop with.
+enum Attempt {
+    /// The `SET NX` took the lock.
+    Acquired(LockGuard),
+    /// Redis answered, and the answer was that someone else holds the name.
+    Contended,
+    /// The attempt never reached a Redis that could answer. Retried inside the
+    /// caller's budget, and reported instead of `LockTimeout` if the budget runs
+    /// out while it is still the last thing that happened.
+    Unreachable(ClusterError),
+    /// End the loop now and report this.
+    Fatal(ClusterError),
+    /// The caller's `timeout` is spent.
+    BudgetSpent,
+}
+
+/// Decides whether an attempt's error is worth waiting out (DESIGN.md §5.3).
+///
+/// Only the two kinds that describe an *unreachable server* are retried:
+/// `fred`'s reconnect is what carries a `lock()` through a Sentinel failover, and
+/// a caller that asked for thirty seconds of patience should get it rather than
+/// a failure ten milliseconds in. Everything else — a config fault, a script the
+/// server rejected, an `OOM`, a shutdown — either will not clear by waiting or
+/// is already the caller's answer, and retrying it would spend the whole budget
+/// to report the same thing later.
+fn classify_attempt(err: ClusterError) -> Attempt {
+    match err {
+        ClusterError::Provider {
+            kind: ProviderErrorKind::ConnectionLost | ProviderErrorKind::Timeout,
+            ..
+        } => Attempt::Unreachable(err),
+        other => Attempt::Fatal(other),
+    }
+}
+
+/// The error a `lock()` reports when its budget runs out, as a function of how
+/// long the caller waited and what the last attempt saw (DESIGN.md §5.3).
+///
+/// The distinction is the point. `LockTimeout` tells a caller "someone else
+/// holds this name", which is a fact about the fleet and usually means back off
+/// and try later. A retained `Provider` tells it "Redis was unreachable for your
+/// whole budget", which is a fact about the deployment and usually means alert.
+/// Collapsing the second into the first — which is what a loop that discarded
+/// `last` would do — leaves a caller unable to tell contention from an outage.
+///
+/// `last` is cleared by every attempt that gets a *real* answer, so a blip early
+/// in a long wait cannot masquerade as the cause of a timeout that was in fact
+/// ordinary contention.
+fn lock_failure(name: &str, waited: Duration, last: Option<ClusterError>) -> ClusterError {
+    match last {
+        Some(unreachable) => unreachable,
+        None => ClusterError::LockTimeout {
+            name: name.to_owned(),
+            waited,
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The backend
+// ---------------------------------------------------------------------------
+
+/// Everything [`RedisLock::new`] needs, bundled so the call site names each
+/// field rather than relying on the order of two `Arc`s and a `bool`.
+pub struct LockInit {
+    /// The connected command pool.
+    pub pool: Pool,
+    /// The SHAs `SCRIPT LOAD` returned for [`LOCK_SCRIPTS`] at startup.
+    pub scripts: Arc<ScriptCache>,
+    /// The key and channel naming scheme, shared with the subscriber fan-out.
+    pub names: LockNames,
+    /// The declaration, derived from the preflight exactly as the cache's is.
+    pub linearizable: bool,
+    /// The operator's `WAIT` policy, if any.
+    pub wait: WaitPolicy,
+    /// The release-waiter registry the fan-out feeds.
+    pub waiters: Arc<ReleaseWaiters>,
+    /// The handle's shutdown token.
+    pub shutdown: CancellationToken,
+    /// The plugin's signal sink.
+    ///
+    /// The lock emits its ADR-004 signals *natively* rather than through a
+    /// decorator, because there is no `InstrumentedLock` in the SDK to wrap it
+    /// in — the lock's surface includes a guard whose `renew`/`release` arrive
+    /// on a channel long after the call that produced it, which a decorator
+    /// around the backend trait cannot see (DESIGN.md §9).
+    pub signals: Arc<RedisSignals>,
+}
+
+/// The native Redis distributed-lock backend.
+pub struct RedisLock {
+    pool: Pool,
+    executor: PoolScriptExecutor,
+    scripts: Arc<ScriptCache>,
+    names: LockNames,
+    /// Mirrors the cache's declared consistency (DESIGN.md §5.1): `true` only
+    /// under the verified single-node durable topology, so a consumer requiring
+    /// `LockCapability::Linearizable` against a Sentinel or Cluster deployment
+    /// fails startup rather than receiving a lock a failover can hand to two
+    /// holders.
+    linearizable: bool,
+    wait: WaitPolicy,
+    waiters: Arc<ReleaseWaiters>,
+    shutdown: CancellationToken,
+    /// The per-guard tasks, tracked rather than detached so `stop()` can say
+    /// whether they have finished. See the module docs.
+    guards: TaskTracker,
+    /// The sink every `cluster.lock.*` span, counter, and histogram goes
+    /// through, mirroring `CasBasedDistributedLockBackend::record_lock` so a
+    /// dashboard cannot tell which of the two locks a profile is bound to.
+    signals: Arc<RedisSignals>,
+}
+
+impl RedisLock {
+    /// Builds the lock over an already-connected pool and an already-loaded
+    /// script catalog.
+    #[must_use]
+    pub fn new(init: LockInit) -> Self {
+        let executor = PoolScriptExecutor::new(init.pool.clone());
+        Self {
+            pool: init.pool,
+            executor,
+            scripts: init.scripts,
+            names: init.names,
+            linearizable: init.linearizable,
+            wait: init.wait,
+            waiters: init.waiters,
+            shutdown: init.shutdown,
+            guards: TaskTracker::new(),
+            signals: init.signals,
+        }
+    }
+
+    /// Closes the guard-task tracker and waits for the tasks under a bound —
+    /// step 1 of either handle's `stop()`.
+    ///
+    /// The caller must have cancelled the shared token first: that is what makes
+    /// this finite, since each guard task selects on it and every command it
+    /// could be mid-flight on is bounded client-side.
+    pub async fn drain_guards(&self) {
+        drain_tracked_tasks(&self.guards, "held redis lock guards").await;
+    }
+
+    /// The context each guard task carries: everything a held lock needs to
+    /// answer `Renew` and `Release`, and nothing else. Cheap to clone — a pool
+    /// handle, two `Arc`s, two `String`s, and a token clone.
+    fn guard_context(&self) -> GuardContext {
+        GuardContext {
+            executor: self.executor.clone(),
+            scripts: Arc::clone(&self.scripts),
+            names: self.names.clone(),
+            shutdown: self.shutdown.clone(),
+            signals: Arc::clone(&self.signals),
+        }
+    }
+
+    /// One `SET NX PX`, plus everything that has to be true before a guard is
+    /// handed out. `Ok(None)` is contention.
+    ///
+    /// # Errors
+    /// [`ClusterError::Shutdown`] when `stop()` has run or races this, and
+    /// whatever [`map_redis_error`] makes of a failing `SET` or `WAIT`.
+    async fn try_acquire(
+        &self,
+        name: &str,
+        ttl: Duration,
+    ) -> Result<Option<LockGuard>, ClusterError> {
+        // Checked before any lock work, so an acquisition arriving after
+        // `stop()` answers immediately instead of writing a lease nothing will
+        // ever hold (DESIGN.md §5.3). `lock()` reaches this through the same
+        // path, which is what keeps the two in agreement.
+        if self.shutdown.is_cancelled() {
+            return Err(ClusterError::Shutdown);
+        }
+
+        let token = Uuid::new_v4().to_string();
+        let acquired: Value = self
+            .pool
+            .set(
+                self.names.lease_key(name),
+                token.clone(),
+                Some(Expiration::PX(px_millis(ttl))),
+                Some(SetOptions::NX),
+                false,
+            )
+            .await
+            .map_err(map_redis_error)?;
+        if acquired.is_null() {
+            return Ok(None);
+        }
+
+        // `WAIT` on acquisition and on nothing else in this file, which is
+        // narrower than the cache's rule and deliberately so. Losing an
+        // *acquisition* to a promotion is the failure `WAIT` exists for: the new
+        // primary has no lease key, so a second instance takes the name while
+        // this one believes it holds it. Losing a *renewal* fails the other way
+        // — the lease reverts to its earlier, shorter deadline — and losing a
+        // *release* only leaves a name unacquirable until its TTL. Neither can
+        // produce two holders, so neither is worth a round trip on every call.
+        if let Err(short) = wait_for_replicas(&self.pool, self.wait).await {
+            self.abandon(name, &token).await;
+            return Err(short);
+        }
+
+        // `stop()` may have run while that `SET` was in flight. Nobody holds
+        // this lease — no guard has been handed out — so releasing it is not the
+        // remote cleanup `cpt-cf-clst-fr-shutdown-ttl-cleanup` forbids: that
+        // rule is about leases a consumer *is* holding, which `stop()` leaves to
+        // expire (`RD-LOCK-013`). Wedging a name nobody took, for a full TTL,
+        // would be the worse answer.
+        if self.shutdown.is_cancelled() {
+            self.abandon(name, &token).await;
+            return Err(ClusterError::Shutdown);
+        }
+
+        // DEBUG and a *log line*, never a metric: a holder token is unbounded
+        // and would explode the label cardinality of anything it touched
+        // (ADR-004's cardinality rule). As a line it is what makes a token read
+        // out of Redis by an operator traceable back to the instance holding it
+        // (DESIGN.md §5.5).
+        tracing::debug!(
+            name: logs::LOCK_ACQUIRED,
+            provider = self.signals.provider(),
+            lock = %name,
+            holder = %token,
+            "cluster.lock.acquired: this instance now holds the lease under this token"
+        );
+
+        let (commands, guard) = LockGuard::channel(name.to_owned(), GUARD_COMMAND_BUFFER);
+        self.guards.spawn(run_guard_task(
+            name.to_owned(),
+            token,
+            self.guard_context(),
+            commands,
+        ));
+        Ok(Some(guard))
+    }
+
+    /// Gives back a lease this instance took but never handed to a consumer.
+    ///
+    /// Token-fenced like every other release, which is what makes it safe to
+    /// call unconditionally: if the lease has already lapsed and been re-taken,
+    /// this matches nothing rather than deleting the successor's key. Failures
+    /// are swallowed because the caller is already returning an error and the
+    /// TTL is the backstop either way.
+    async fn abandon(&self, name: &str, token: &str) {
+        if let Err(err) = release_lease(&self.guard_context(), name, token).await {
+            tracing::debug!(
+                error = %err,
+                "could not give back a redis lease that was taken but never handed out; it will \
+                 lapse at its TTL"
+            );
+            // Swallowed for the *caller*, who is already being handed an error
+            // and for whom the TTL is the backstop either way - but not for the
+            // deployment: this is a command the backend refused, and it is
+            // wrapped by no catalogued op, so without this the only trace of a
+            // Redis that is failing every release would be a DEBUG line.
+            self.signals
+                .provider_error("abandon", ResourceId::Lock(name), &err);
+        }
+    }
+
+    /// Runs one acquisition attempt inside whatever is left of the caller's
+    /// budget.
+    ///
+    /// The bound matters because `try_acquire`'s own bound is `fred`'s
+    /// `command_timeout_ms` (5 s by default), which can be far longer than a
+    /// caller's `timeout`: without it a `lock(name, ttl, 1s)` against an
+    /// unresponsive server returns after five seconds. An attempt cancelled
+    /// after its `SET` committed leaves a lease nobody holds, which is exactly
+    /// the case DESIGN.md §5.1 already accounts for — it expires at its TTL like
+    /// any other, with nothing local claiming to own it.
+    ///
+    /// The *first* attempt always runs, even with a spent or zero budget, so
+    /// `lock(free_name, ttl, Duration::ZERO)` acquires instead of reporting a
+    /// timeout without ever having tried — matching the SDK default backend's
+    /// attempt-before-budget-check ordering.
+    async fn attempt(
+        &self,
+        name: &str,
+        ttl: Duration,
+        deadline: tokio::time::Instant,
+        first: bool,
+    ) -> Attempt {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() && !first {
+            return Attempt::BudgetSpent;
+        }
+        let acquire = self.try_acquire(name, ttl);
+        let outcome = if remaining.is_zero() {
+            acquire.await
+        } else {
+            match tokio::time::timeout(remaining, acquire).await {
+                Ok(outcome) => outcome,
+                Err(_elapsed) => return Attempt::BudgetSpent,
+            }
+        };
+        match outcome {
+            Ok(Some(guard)) => Attempt::Acquired(guard),
+            Ok(None) => Attempt::Contended,
+            Err(err) => classify_attempt(err),
+        }
+    }
+
+    /// Waits for whichever comes first of the holder's release, the blocking
+    /// lease's own deadline, and a jittered heartbeat (DESIGN.md §5.3).
+    ///
+    /// `released` is registered by the caller *before* its attempt rather than
+    /// here, and that ordering is the one deviation from §5.3's pseudo-code. A
+    /// release landing between a failed `SET NX` and the registration would
+    /// otherwise be missed, and the waiter would sit out a full delay for a lock
+    /// that is already free — which is precisely the "the notification was
+    /// missed, not slow" outcome `RD-LOCK-003` is built to catch.
+    ///
+    /// # Errors
+    /// [`ClusterError::Shutdown`] if `stop()` fires while parked, so a blocked
+    /// caller is told the backend is gone rather than waiting out its whole
+    /// budget for a `LockTimeout` that would read as contention (DESIGN.md §11
+    /// step 1).
+    async fn park(
+        &self,
+        name: &str,
+        released: ReleaseWait,
+        deadline: tokio::time::Instant,
+    ) -> Result<(), ClusterError> {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        // Read on the attempt that just failed, so the sleep is sized against
+        // the lease actually blocking us. An unreadable reply is not worth
+        // failing over: the heartbeat covers it, and the attempt that follows
+        // the sleep reports the outage properly if it is still there - so this
+        // is a DEBUG rather than another provider error, which would otherwise
+        // count once per loop iteration for a single unreachable server.
+        //
+        // Bounded by the same `remaining` that bounds the sleep it sizes, and by
+        // the same rule DESIGN.md §5.3's third bound states: the caller's
+        // `timeout` is the budget for the whole `lock()` call, not for each
+        // command inside it. Unbounded, this round trip is capped only by
+        // `fred`'s 5 s default command timeout, so a Redis that stalls here — a
+        // `BGSAVE` fork pause, a slow `SCAN` from another tenant — overruns a
+        // 50 ms budget by seconds. The acquisition attempt on the same loop is
+        // already wrapped this way (see `attempt`); this is the read between
+        // them.
+        let read = self.pool.pttl(self.names.lease_key(name));
+        let pttl: Option<i64> = match tokio::time::timeout(remaining, read).await {
+            Ok(Ok(pttl)) => Some(pttl),
+            // The budget ran out while reading. Sizing the sleep is moot at that
+            // point: the loop's next `attempt` finds no budget left and reports
+            // the timeout.
+            Err(_elapsed) => None,
+            Ok(Err(err)) => {
+                tracing::debug!(
+                    lock = name,
+                    error = %err,
+                    "could not read the blocking lease's PTTL; falling back to the heartbeat"
+                );
+                None
+            }
+        };
+        // Re-read rather than reusing the `remaining` above, because the read
+        // just spent some of it. Bounding the read and then sizing the sleep
+        // against the pre-read budget would leave the two bounds serialized —
+        // worst case a stalled read consumes the whole budget and the sleep
+        // spends it a second time, which is the same overrun one layer down.
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let delay = wake_delay(pttl.and_then(lease_remaining), remaining);
+        tokio::select! {
+            () = self.shutdown.cancelled() => return Err(ClusterError::Shutdown),
+            _woken = released => {}
+            () = tokio::time::sleep(delay) => {}
+        }
+        Ok(())
+    }
+}
+
+/// The per-guard context: everything a held lock needs beyond its own name and
+/// token. Grouped into one value rather than threaded as separate parameters,
+/// which keeps `run_guard_task` and the two operations below within a sane
+/// argument count.
+#[derive(Clone)]
+struct GuardContext {
+    executor: PoolScriptExecutor,
+    scripts: Arc<ScriptCache>,
+    names: LockNames,
+    shutdown: CancellationToken,
+    /// Carried into the per-guard task so `renew` and `release` emit the same
+    /// signals `try_lock` and `lock` do. Without it the two halves of the lock's
+    /// surface would be observable and unobservable respectively, and the
+    /// unobservable half is the one that runs for the whole critical section.
+    signals: Arc<RedisSignals>,
+}
+
+/// Drives one held lock's [`LockCommandReceiver`] until `Release`, until the
+/// consumer drops its guard without releasing, or until `stop()`.
+///
+/// All three endings leave the lease alone, and that is the TTL safety net
+/// rather than an omission: a dropped guard is documented by the SDK as "no I/O
+/// in `Drop`, the entry lapses via TTL", and a `stop()` is
+/// `cpt-cf-clst-fr-shutdown-ttl-cleanup`, which `RD-LOCK-013` pins by asserting
+/// the keys are **still there** afterwards. Once this task returns, the
+/// consumer's `renew` sees a closed channel and reports `LockExpired` while its
+/// `release` reports the best-effort `Ok` the SDK specifies for a backend that
+/// has gone away.
+async fn run_guard_task(
+    name: String,
+    token: String,
+    ctx: GuardContext,
+    mut commands: LockCommandReceiver,
+) {
+    loop {
+        tokio::select! {
+            // Exit promptly rather than waiting on a consumer that may never
+            // act. This is what keeps `drain_guards` bounded by the in-flight
+            // command rather than by the critical section.
+            () = ctx.shutdown.cancelled() => return,
+            request = commands.recv() => {
+                let Some(request) = request else {
+                    // The consumer dropped the guard without releasing.
+                    return;
+                };
+                match request {
+                    LockRequest::Renew { new_ttl, responder } => {
+                        let span = tracing::info_span!(
+                            spans::LOCK_RENEW,
+                            provider = %ctx.signals.provider(),
+                            lock = %name
+                        );
+                        let started = std::time::Instant::now();
+                        let out = renew_lease(&ctx, &name, &token, new_ttl)
+                            .instrument(span)
+                            .await;
+                        ctx.signals.record_lock("renew", &name, started, &out);
+                        responder.respond(out);
+                    }
+                    LockRequest::Release { responder } => {
+                        let span = tracing::info_span!(
+                            spans::LOCK_RELEASE,
+                            provider = %ctx.signals.provider(),
+                            lock = %name
+                        );
+                        let started = std::time::Instant::now();
+                        let out = release_lease(&ctx, &name, &token).instrument(span).await;
+                        ctx.signals.record_lock("release", &name, started, &out);
+                        responder.respond(out);
+                        // Release consumes the guard, so there is nothing left
+                        // to service.
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// `lock_renew`: `PEXPIRE` the lease, but only while the token still matches
+/// (DESIGN.md §5.2).
+///
+/// `PEXPIRE` is absolute-from-now on Redis's own clock, so a lease deadline
+/// never depends on the client's wall clock and a skewed instance cannot hold a
+/// lock longer than it was granted.
+///
+/// # Errors
+/// [`ClusterError::LockExpired`] when the script reports zero — the lease
+/// lapsed, or a successor took it. The consumer's response is the same in both
+/// cases (abort the critical section), which is why the SDK models it as one
+/// error.
+async fn renew_lease(
+    ctx: &GuardContext,
+    name: &str,
+    token: &str,
+    new_ttl: Duration,
+) -> Result<(), ClusterError> {
+    let args = [
+        Value::String(token.into()),
+        Value::String(px_millis(new_ttl).to_string().into()),
+    ];
+    let renewed = eval(
+        &ctx.executor,
+        &ctx.scripts,
+        &LOCK_RENEW,
+        &ctx.names.lease_key(name),
+        &args,
+        &ctx.signals,
+    )
+    .await?;
+    if renewed.as_i64() == Some(1) {
+        return Ok(());
+    }
+    Err(ClusterError::LockExpired {
+        name: name.to_owned(),
+    })
+}
+
+/// `lock_release`: delete the lease and publish the wake, but only while the
+/// token still matches (DESIGN.md §5.2).
+///
+/// **A zero reply is not an error.** It is the SDK's release-if-still-holder
+/// contract (`cpt-cf-clst-algo-distributed-lock-release-if-holder`): this
+/// holder's lease had already lapsed and someone else's entry is under the key,
+/// so the script left it alone. From this holder's view the lease is gone, which
+/// is what it asked for. `RD-LOCK-006` is the test that fails if the script is
+/// ever reduced to a bare `DEL`.
+///
+/// # Errors
+/// Whatever [`eval`] makes of a failing `EVALSHA`.
+async fn release_lease(ctx: &GuardContext, name: &str, token: &str) -> Result<(), ClusterError> {
+    let args = [
+        Value::String(token.into()),
+        Value::String(ctx.names.release_channel(name).into()),
+    ];
+    let released = eval(
+        &ctx.executor,
+        &ctx.scripts,
+        &LOCK_RELEASE,
+        &ctx.names.lease_key(name),
+        &args,
+        &ctx.signals,
+    )
+    .await?;
+    if released.as_i64() != Some(1) {
+        tracing::debug!(
+            lock = name,
+            "released a redis lock this instance no longer holds; the lease had already lapsed \
+             and another holder's entry was left intact"
+        );
+    }
+    Ok(())
+}
+
+#[async_trait]
+impl DistributedLockBackend for RedisLock {
+    fn features(&self) -> LockFeatures {
+        LockFeatures::new(self.linearizable)
+    }
+
+    fn provider_name(&self) -> &'static str {
+        // Overridden rather than left to the default `type_name`, because this
+        // string reaches operators through `CapabilityNotMet { provider }` and
+        // `redis` is the name they wrote in their YAML.
+        PROVIDER_NAME
+    }
+
+    async fn try_lock(&self, name: &str, ttl: Duration) -> Result<LockGuard, ClusterError> {
+        let span = tracing::info_span!(
+            spans::LOCK_TRY_LOCK,
+            provider = %self.signals.provider(),
+            lock = %name
+        );
+        let started = std::time::Instant::now();
+        let out = async {
+            match self.try_acquire(name, ttl).await? {
+                Some(guard) => Ok(guard),
+                None => Err(ClusterError::LockContended {
+                    name: name.to_owned(),
+                }),
+            }
+        }
+        .instrument(span)
+        .await;
+        // `LockContended` lands on the bounded `result` label as `contended` and
+        // *not* on the provider-error counter: someone else holding the name is
+        // this call's answer, not a fault (`result::label`).
+        self.signals.record_lock("try_lock", name, started, &out);
+        out
+    }
+
+    async fn lock(
+        &self,
+        name: &str,
+        ttl: Duration,
+        timeout: Duration,
+    ) -> Result<LockGuard, ClusterError> {
+        // Instrumented once *around* the loop rather than inside it, following
+        // the postgres plugin's shape: a blocking acquisition is one operation
+        // however many `SET NX`s it takes, so one span covering the whole wait
+        // and one duration measuring it is what a consumer asked for. Recording
+        // per attempt would report a 30 s wait as a hundred fast operations.
+        let span = tracing::info_span!(
+            spans::LOCK_LOCK,
+            provider = %self.signals.provider(),
+            lock = %name
+        );
+        let op_started = std::time::Instant::now();
+        let out = async {
+            let started = tokio::time::Instant::now();
+            let deadline = started + timeout;
+            // The last attempt that never reached Redis, cleared by every
+            // attempt that got a real answer. See [`lock_failure`] for why it
+            // survives at all.
+            let mut last: Option<ClusterError> = None;
+            let mut first = true;
+            loop {
+                // Registered before the attempt, not after — see [`park`].
+                let released = self.waiters.wait_for(name);
+                match self.attempt(name, ttl, deadline, first).await {
+                    Attempt::Acquired(guard) => return Ok(guard),
+                    Attempt::Contended => last = None,
+                    Attempt::Unreachable(err) => last = Some(err),
+                    Attempt::Fatal(err) => return Err(err),
+                    Attempt::BudgetSpent => {
+                        return Err(lock_failure(name, started.elapsed(), last));
+                    }
+                }
+                first = false;
+                if tokio::time::Instant::now() >= deadline {
+                    return Err(lock_failure(name, started.elapsed(), last));
+                }
+                self.park(name, released, deadline).await?;
+            }
+        }
+        .instrument(span)
+        .await;
+        self.signals.record_lock("lock", name, op_started, &out);
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The standalone lock-only plugin (DESIGN.md §3.5)
+// ---------------------------------------------------------------------------
+
+/// Entry point for the standalone lock-only plugin, which lets an operator bind
+/// `lock: { provider: redis }` alongside a cache of any other kind.
+///
+/// It opens its own pool and its own subscriber rather than borrowing the
+/// combined plugin's — the SDK's provider contract is that non-cache providers
+/// do not receive the cache backend, and sharing would need a
+/// lifecycle-ownership story (whose `stop()` closes the pool?) for two providers
+/// the SDK deliberately made independent. At ~20 KB per connection that is
+/// cheaper than the coupling it avoids.
+///
+/// ```no_run
+/// # async fn doc(config: redis_cluster_plugin::RedisLockConfig) -> Result<(), cluster_sdk::ClusterError> {
+/// use redis_cluster_plugin::RedisLockPlugin;
+/// let handle = RedisLockPlugin::builder(config).build_and_start().await?;
+/// let _lock = handle.lock();
+/// handle.stop().await;
+/// # Ok(())
+/// # }
+/// ```
+pub struct RedisLockPlugin;
+
+impl RedisLockPlugin {
+    // No `#[must_use]` here: `RedisLockBuilder` already carries a
+    // `#[must_use = "..."]` message, so a bare attribute on this function would
+    // be a `clippy::double_must_use` no-op.
+    /// Starts building the plugin from operator config.
+    pub fn builder(config: RedisLockConfig) -> RedisLockBuilder {
+        RedisLockBuilder {
+            config,
+            meter: None,
+        }
+    }
+}
+
+/// Fluent builder for [`RedisLockPlugin`].
+#[must_use = "a builder starts nothing until `.build_and_start()` is called"]
+pub struct RedisLockBuilder {
+    config: RedisLockConfig,
+    /// Optional override for the meter every signal is emitted through. `None`
+    /// in production (the process-global provider). See
+    /// [`__with_meter`](Self::__with_meter).
+    meter: Option<opentelemetry::metrics::Meter>,
+}
+
+impl RedisLockBuilder {
+    /// Test-only: routes both the ADR-004 catalog signals and this plugin's four
+    /// local metrics through `meter` instead of the process-global provider, so
+    /// a test can attach an in-memory reader and read every signal back by name
+    /// rather than by eye.
+    ///
+    /// Gated behind `--features integration` so the seam is compiled out of
+    /// release builds entirely, mirroring
+    /// `PostgresLockBuilder::__with_reaper_meter`.
+    #[cfg(feature = "integration")]
+    #[doc(hidden)]
+    pub fn __with_meter(mut self, meter: opentelemetry::metrics::Meter) -> Self {
+        self.meter = Some(meter);
+        self
+    }
+
+    /// Builds and starts the lock-only plugin.
+    ///
+    /// The same six steps as the combined plugin's `build_and_start`, minus
+    /// everything the cache owns: only [`LOCK_SCRIPTS`] is loaded, only the
+    /// release pattern is subscribed, and the preflight is told **not** to check
+    /// `notify-keyspace-events`. That last one is DESIGN.md §3.5's third row and
+    /// the reason it is worth stating: a lease lapse is discovered by the next
+    /// acquire attempt, so a lock-only deployment works with keyspace
+    /// notifications entirely unavailable, with no degradation at all
+    /// (`RD-LOCK-009`).
+    ///
+    /// As in the combined plugin, the initial `PSUBSCRIBE` is awaited before
+    /// this returns: Redis pub/sub does not replay for a client that subscribes
+    /// late, so a release landing in the startup window would otherwise be lost
+    /// with nothing to show for it.
+    ///
+    /// # Errors
+    /// - [`ClusterError::InvalidConfig`] for a zero-valued config bound, a URL
+    ///   `fred` cannot parse, or an `INFO server` the server refuses.
+    /// - [`ClusterError::Provider`] if the initial connect, the `SCRIPT LOAD`,
+    ///   or the initial `PSUBSCRIBE` fails.
+    pub async fn build_and_start(self) -> Result<RedisLockHandle, ClusterError> {
+        let config = self.config;
+        config.validate()?;
+        // Before the connect, so an unrepresentable `wait_timeout_ms` is a plain
+        // `?` rather than an error path with a pool and a subscriber to tear
+        // down. See [`WaitPolicy::from_config`].
+        let wait = WaitPolicy::from_config(config.wait_replicas, config.wait_timeout_ms)?;
+
+        // One sink for this plugin, built before anything that could emit
+        // through it: the lock's own signals, the fan-out's, and the
+        // connection-state gauge all share it, so `provider` is fixed once and
+        // `cluster_lock_ops_total` is one instrument rather than three.
+        let signals = Arc::new(match self.meter {
+            Some(meter) => RedisSignals::over_meter(&meter, PROVIDER_NAME),
+            None => RedisSignals::from_global_meters(PROVIDER_NAME),
+        });
+
+        let Connected {
+            pool,
+            subscriber: (client, connection),
+            url_topology,
+            ..
+        } = connect(ConnectSpec {
+            url: &config.url,
+            database: config.database,
+            pool_size: config.pool_size,
+            command_timeout: config.command_timeout(),
+        })
+        .await?;
+
+        // Everything past the connect has to tear the pool *and the subscriber*
+        // down on the way out — both are connected, so returning the error alone
+        // would leak the connections until the process exited. See
+        // [`abandon_subscriber`] for why dropping the subscriber is not enough.
+        let outcome = match run_preflight(
+            &pool,
+            PreflightRequest {
+                topology_hint: config.topology,
+                url_topology,
+                durability_hint: config.durability,
+                // The narrow set: `Ke` for the eviction signal, never `x`. A
+                // lapsed lease is found by the next acquire attempt, so this
+                // plugin has no use for `expired` and asking a shared server to
+                // turn on a server-wide flag it never reads would be a cost
+                // charged to unrelated tenants (DESIGN.md §3.5, §3.7).
+                keyspace_flags: Some(EVICTION_KEYSPACE_FLAGS),
+                // Never: the flags this plugin wants are an observability
+                // improvement rather than something it needs to function, and a
+                // server-wide `CONFIG SET` is too blunt an instrument to reach
+                // for on that basis. The combined plugin exposes the opt-in
+                // because its cache genuinely degrades without them.
+                manage_keyspace_notifications: false,
+            },
+        )
+        .await
+        {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                abandon_subscriber(&client, &connection).await;
+                close_pool(&pool).await;
+                return Err(err);
+            }
+        };
+
+        let executor = PoolScriptExecutor::new(pool.clone());
+        let scripts = match crate::scripts::load_catalog(&executor, LOCK_SCRIPTS).await {
+            Ok(scripts) => Arc::new(scripts),
+            Err(err) => {
+                abandon_subscriber(&client, &connection).await;
+                close_pool(&pool).await;
+                return Err(err);
+            }
+        };
+
+        let shutdown = CancellationToken::new();
+        let waiters = ReleaseWaiters::new();
+        let names = LockNames::new(&config.key_prefix);
+        let lock = Arc::new(RedisLock::new(LockInit {
+            pool: pool.clone(),
+            scripts,
+            names: names.clone(),
+            linearizable: outcome.consistency == cluster_sdk::CacheConsistency::Linearizable,
+            wait,
+            waiters: Arc::clone(&waiters),
+            shutdown: shutdown.clone(),
+            signals: Arc::clone(&signals),
+        }));
+
+        let subscription = match start_release_subscriber(ReleaseSubscriberSetup {
+            client,
+            connection,
+            names: &names,
+            // No cache half: this plugin owns leases and nothing else, so a
+            // notification for a `<prefix>:c:` key belongs to a *different*
+            // deployment sharing the prefix and is classified as neither.
+            keyspace: KeyspaceNames::new(&config.key_prefix, config.database, None, names.clone()),
+            waiters,
+            signals: Arc::clone(&signals),
+            shutdown: &shutdown,
+        })
+        .await
+        {
+            Ok(subscription) => subscription,
+            Err(err) => {
+                close_pool(&pool).await;
+                return Err(err);
+            }
+        };
+
+        let connection_state =
+            spawn_connection_state_observer(pool.clone(), signals, shutdown.clone());
+
+        Ok(RedisLockHandle {
+            lock,
+            pool,
+            subscription: Some(subscription),
+            connection_state: Some(connection_state),
+            shutdown,
+            stopped: false,
+        })
+    }
+}
+
+/// What [`start_release_subscriber`] needs. A struct because six parameters,
+/// three of them references, is where a positional call stops being readable.
+struct ReleaseSubscriberSetup<'a> {
+    client: SubscriberClient,
+    connection: ConnectHandle,
+    names: &'a LockNames,
+    keyspace: KeyspaceNames,
+    waiters: Arc<ReleaseWaiters>,
+    signals: Arc<RedisSignals>,
+    shutdown: &'a CancellationToken,
+}
+
+/// The subscriber client and the tasks that ride it, owned by the handle so
+/// `stop()` can end them in order.
+struct LockSubscription {
+    client: SubscriberClient,
+    fan_out: JoinHandle<()>,
+    /// `fred`'s own subscription-replay task, which is what makes a reconnect
+    /// recoverable at all.
+    manager: JoinHandle<()>,
+    /// Logs once if the reconnect policy is ever exhausted.
+    watchdog: JoinHandle<()>,
+}
+
+/// Subscribes the release and keyspace patterns, awaits them, and spawns the
+/// fan-out.
+///
+/// There is no reconnect observer here, unlike the combined plugin's. That task
+/// exists to broadcast a cache `Reset` after a subscription gap, and a lock has
+/// no equivalent to reset: a release missed during a gap costs its waiter one
+/// jittered delay, after which the `SET NX` — the source of truth throughout —
+/// answers correctly. Telling anyone about the gap would give them nothing to
+/// do with it.
+///
+/// The **keyspace** pattern is here for one reason and it is not expiry: a
+/// lapsed lease needs no event, but an *evicted* one hands the lock to a second
+/// holder with no TTL having elapsed and nothing else in the system that could
+/// notice (DESIGN.md §3.7). A lock-only deployment on a shared Redis under
+/// `allkeys-lru` is exactly where that happens, so it subscribes the pattern and
+/// reports what arrives. Nothing depends on the notifications arriving: a server
+/// without the `Ke` flags degrades this to silence, which the preflight has
+/// already warned about, and the lock keeps working unchanged.
+///
+/// # Errors
+/// Whatever [`map_redis_error`] makes of a failing `PSUBSCRIBE`. The subscriber
+/// is quit on that path, so a half-open second connection does not outlive the
+/// failed startup.
+async fn start_release_subscriber(
+    setup: ReleaseSubscriberSetup<'_>,
+) -> Result<LockSubscription, ClusterError> {
+    let ReleaseSubscriberSetup {
+        client,
+        connection,
+        names,
+        keyspace,
+        waiters,
+        signals,
+        shutdown,
+    } = setup;
+    // The replay task first: a reconnect between the subscribes below and this
+    // spawn would otherwise lose the subscription set permanently.
+    let manager = client.manage_subscriptions();
+    let mut subscribed = Ok(());
+    for pattern in [names.release_pattern(), keyspace.pattern().to_owned()] {
+        if let Err(err) = client.psubscribe(pattern).await {
+            subscribed = Err(map_redis_error(err));
+            break;
+        }
+    }
+    // `psubscribe` resolving is not the server having processed it, so the round
+    // trip is what actually makes the patterns live before this returns — see
+    // [`confirm_subscriptions`]. `RD-LOCK-003` is the assertion that notices
+    // when it is not: a release landing in the startup window would otherwise
+    // reach no subscriber, and the waiter would fall back to the heartbeat with
+    // nothing to show for it.
+    let subscribed = match subscribed {
+        Ok(()) => confirm_subscriptions(&client).await,
+        Err(err) => Err(err),
+    };
+    if let Err(err) = subscribed {
+        manager.abort();
+        connection.abort();
+        quit_subscriber(&client).await;
+        return Err(err);
+    }
+
+    // The same watchdog the combined plugin spawns, with nothing to close: a
+    // blocked `lock()` loses only its wake path when the subscriber is
+    // permanently gone, and keeps acquiring on the heartbeat. Reusing it is what
+    // keeps the two plugins from growing two descriptions of one event.
+    let watchdog = spawn_connection_watchdog(connection, None, shutdown.clone());
+    let fan_out = spawn_fan_out(
+        &client,
+        FanOutRoutes {
+            cache: None,
+            locks: LockRoute {
+                waiters,
+                names: names.clone(),
+            },
+            // Present although `cache` is not: this plugin owns no cache
+            // entries, and the keyspace route exists here purely to observe
+            // evictions of its own leases.
+            keyspace: Some(keyspace),
+            signals,
+        },
+        shutdown.clone(),
+    );
+    Ok(LockSubscription {
+        client,
+        fan_out,
+        manager,
+        watchdog,
+    })
+}
+
+/// The running standalone lock plugin.
+///
+/// Call [`stop`](Self::stop) on graceful shutdown. Dropping the handle without
+/// it is a programming error and says so — the same ADR-006 guard the combined
+/// handle carries, independently, because this handle owns its own pool and
+/// subscriber.
+pub struct RedisLockHandle {
+    lock: Arc<RedisLock>,
+    pool: Pool,
+    /// `Option`, not a bare field, for the same reason the combined handle's is:
+    /// this type has a `Drop` impl, so `stop` cannot move out of it and uses
+    /// `.take()` to drain in place.
+    subscription: Option<LockSubscription>,
+    /// The task keeping `cluster_redis_connection_state` current (DESIGN.md §9).
+    connection_state: Option<JoinHandle<()>>,
+    shutdown: CancellationToken,
+    /// Set by `stop` so the `Drop` guard can tell a graceful shutdown apart from
+    /// a forgotten one (ADR-006 §Confirmation).
+    stopped: bool,
+}
+
+impl RedisLockHandle {
+    /// The lock backend.
+    ///
+    /// Handed out bare, and it stays bare: the ADR-004 lock signal set is
+    /// emitted by [`RedisLock`] itself at each of its four sites rather than by
+    /// a decorator around it (DESIGN.md §9), because a guard's `renew` and
+    /// `release` arrive on a channel that nothing wrapping this trait can see.
+    #[must_use]
+    pub fn lock(&self) -> Arc<dyn DistributedLockBackend> {
+        Arc::clone(&self.lock) as Arc<dyn DistributedLockBackend>
+    }
+
+    /// Shuts the plugin down (DESIGN.md §11).
+    ///
+    /// 1. Cancels the shared token, which unparks every blocked `lock()` waiter
+    ///    — they return `ClusterError::Shutdown` rather than sitting out their
+    ///    whole budget for a `LockTimeout` that would read as contention — and
+    ///    ends every per-guard task.
+    /// 2. Drains the guard tasks under a bound, **before** the pool closes,
+    ///    since a task mid-`renew` still needs a connection.
+    /// 3. Quits the subscriber, then the command pool, both bounded.
+    ///
+    /// **Held leases are left to expire** (`cpt-cf-clst-fr-shutdown-ttl-cleanup`,
+    /// `RD-LOCK-013`): there is no best-effort remote cleanup here, and adding
+    /// one would fail that test on purpose.
+    pub async fn stop(mut self) {
+        self.shutdown.cancel();
+        self.lock.drain_guards().await;
+        if let Some(observer) = self.connection_state.take() {
+            let _observer_exited = observer.await;
+        }
+        if let Some(subscription) = self.subscription.take() {
+            let _fan_out_exited = subscription.fan_out.await;
+            let _watchdog_exited = subscription.watchdog.await;
+            // `fred`'s replay task ends with the client rather than with the
+            // token, so it is aborted rather than joined.
+            subscription.manager.abort();
+            quit_subscriber(&subscription.client).await;
+        }
+        close_pool(&self.pool).await;
+        self.stopped = true;
+    }
+}
+
+/// Diagnostic guard (ADR-006 §Confirmation): dropping a `RedisLockHandle`
+/// without calling `stop()` leaves its pool, its subscriber, and its guard tasks
+/// running, surfaced loudly rather than silently.
+impl Drop for RedisLockHandle {
+    fn drop(&mut self) {
+        match cancel_and_diagnose_drop(self.stopped, &self.shutdown) {
+            DropDiagnosis::StoppedCleanly => {}
+            // not-a-catalogued-event: an ADR-006 developer diagnostic, not an
+            // operator's business — this is the release-build arm of the same
+            // programming error that panics in debug.
+            DropDiagnosis::DuringPanic => warn!(
+                "RedisLockHandle dropped during panic unwind without stop(); skipping debug panic \
+                 to avoid double-panic abort"
+            ),
+            DropDiagnosis::Unstopped => {
+                #[cfg(debug_assertions)]
+                panic!("RedisLockHandle dropped without stop() - programming error");
+                // not-a-catalogued-event: as above.
+                #[cfg(not(debug_assertions))]
+                warn!(
+                    "RedisLockHandle dropped without stop() - programming error; the command pool \
+                     and any background tasks may leak"
+                );
+            }
+        }
+    }
+}
+
+// Layer-1 unit tests (TESTING.md §2, `lock/mod.rs` row): key and channel
+// construction, the holder token, the `SET NX PX` argument assembly, and the
+// three-outcome classification of a failed `lock()`. Out-of-line per DE1101.
+#[cfg(test)]
+#[path = "mod_tests.rs"]
+mod tests;

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/lock/mod_tests.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/lock/mod_tests.rs
@@ -1,0 +1,359 @@
+//! Layer-1 tests for the lock (TESTING.md §2, `lock/mod.rs` row): key and
+//! channel construction, the holder token, the `SET NX PX` argument assembly,
+//! and the three-outcome classification of a failed `lock()`.
+//!
+//! Everything the acquisition loop *does* with those decisions needs a server
+//! and is `RD-LOCK-001..013` at Layer 3. What is here is the part that can be
+//! wrong without a server noticing: a channel the fan-out cannot parse back, a
+//! TTL rounded to a value Redis reads as "delete this", or a timeout reported as
+//! contention when Redis was in fact unreachable.
+
+use super::*;
+use std::collections::HashSet;
+
+fn names() -> LockNames {
+    LockNames::new("cluster")
+}
+
+// ---------------------------------------------------------------------------
+// Naming
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_lease_key_carries_the_primitive_segment() {
+    assert_eq!(
+        names().lease_key("tenant-42/rate-limit"),
+        "cluster:l:tenant-42/rate-limit"
+    );
+}
+
+#[test]
+fn the_release_channel_carries_its_own_segment() {
+    assert_eq!(
+        names().release_channel("tenant-42/rate-limit"),
+        "cluster:e:l:tenant-42/rate-limit"
+    );
+}
+
+#[test]
+fn a_release_channel_round_trips_back_to_its_name() {
+    // The property the wake path rests on: `lock_release` publishes to a channel
+    // this type built, and the fan-out recovers the name with this function. A
+    // mismatch would be a blocked `lock()` that silently never wakes.
+    let names = names();
+    for name in ["ledger", "tenant-42/rate-limit", "a:b:c", ""] {
+        assert_eq!(
+            names.name_from_release_channel(&names.release_channel(name)),
+            Some(name.to_owned()),
+            "the release channel for {name:?} must parse back to it"
+        );
+    }
+}
+
+#[test]
+fn a_cache_event_channel_is_not_a_release_channel() {
+    // The two families differ by one segment, and each is parsed only by the
+    // type that builds it. `cache/watch_tests.rs` asserts the mirror image —
+    // that `key_from_event_channel` returns `None` for a `:e:l:` channel — so
+    // between them no message can be routed to the wrong registry.
+    assert_eq!(
+        names().name_from_release_channel("cluster:e:c:some-key"),
+        None
+    );
+    assert_eq!(
+        names().name_from_release_channel("cluster:l:some-lock"),
+        None
+    );
+    assert_eq!(names().name_from_release_channel("other:e:l:ledger"), None);
+}
+
+#[test]
+fn the_release_pattern_covers_this_prefix_and_escapes_it() {
+    assert_eq!(names().release_pattern(), "cluster:e:l:*");
+    // A `[` in an operator's `key_prefix` is a glob character class unescaped,
+    // so the subscription would cover something other than what was asked for.
+    assert_eq!(
+        LockNames::new("cluster[a]").release_pattern(),
+        r"cluster\[a\]:e:l:*"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The holder token
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_acquisition_mints_a_fresh_token() {
+    // The token is the entire fence behind `renew` and `release` (DESIGN.md
+    // §5.2). Two acquisitions sharing one would let a lapsed holder renew or
+    // release its successor's lease, which is the bug `RD-LOCK-006` exists for.
+    let tokens: HashSet<String> = (0..1_000).map(|_| Uuid::new_v4().to_string()).collect();
+    assert_eq!(tokens.len(), 1_000, "holder tokens must not repeat");
+}
+
+// ---------------------------------------------------------------------------
+// SET NX PX / PEXPIRE argument assembly
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_ttl_renders_as_whole_milliseconds() {
+    assert_eq!(px_millis(Duration::from_secs(30)), 30_000);
+    assert_eq!(px_millis(Duration::from_millis(1)), 1);
+}
+
+#[test]
+fn a_sub_millisecond_ttl_rounds_up_rather_than_to_zero() {
+    // `PX 0` is an error reply and `PEXPIRE k 0` deletes the key outright, so
+    // rounding down would turn "expires almost immediately" into either a failed
+    // acquisition or a lock released the instant it was taken.
+    assert_eq!(px_millis(Duration::from_nanos(1)), 1);
+    assert_eq!(px_millis(Duration::ZERO), 1);
+}
+
+#[test]
+fn an_absurd_ttl_saturates_rather_than_wrapping() {
+    // Redis rejects it, which is the honest outcome — what must not happen is a
+    // wrap into a small or negative expiry, which would silently hand out a
+    // lease far shorter than the caller asked for.
+    assert_eq!(px_millis(Duration::MAX), i64::MAX);
+}
+
+// ---------------------------------------------------------------------------
+// PTTL, and the two negative sentinels
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_positive_pttl_is_the_lease_deadline() {
+    assert_eq!(lease_remaining(40), Some(Duration::from_millis(40)));
+}
+
+#[test]
+fn a_vanished_key_asks_for_an_immediate_retry() {
+    // `-2` means the lease lapsed or was released between the `SET NX` that just
+    // failed and this read, so the name is free now.
+    assert_eq!(lease_remaining(-2), Some(Duration::ZERO));
+}
+
+#[test]
+fn a_key_with_no_ttl_falls_back_to_the_heartbeat() {
+    // `-1` is a key with no expiry, which is not a lease this plugin wrote —
+    // every acquisition carries `PX`. There is no deadline to schedule against.
+    assert_eq!(lease_remaining(-1), None);
+}
+
+// ---------------------------------------------------------------------------
+// The three-outcome classification of a failed lock()
+// ---------------------------------------------------------------------------
+
+fn provider(kind: ProviderErrorKind) -> ClusterError {
+    ClusterError::Provider {
+        kind,
+        message: "test".to_owned(),
+    }
+}
+
+#[test]
+fn an_unreachable_server_is_retried_inside_the_budget() {
+    // `fred`'s reconnect is what carries a `lock()` through a Sentinel failover,
+    // so a caller that asked for thirty seconds of patience gets it.
+    for kind in [
+        ProviderErrorKind::ConnectionLost,
+        ProviderErrorKind::Timeout,
+    ] {
+        assert!(
+            matches!(classify_attempt(provider(kind)), Attempt::Unreachable(_)),
+            "{kind:?} must be waited out rather than ending the loop"
+        );
+    }
+}
+
+#[test]
+fn a_shutdown_ends_the_loop_at_once() {
+    // The distinction `RD-LOCK-012` measures: retrying a torn-down backend for a
+    // 30 s budget and then reporting `LockTimeout` would leave a caller unable to
+    // tell "someone else holds it" from "this backend is gone".
+    assert!(matches!(
+        classify_attempt(ClusterError::Shutdown),
+        Attempt::Fatal(ClusterError::Shutdown)
+    ));
+}
+
+#[test]
+fn errors_that_waiting_cannot_fix_end_the_loop_at_once() {
+    // Each of these is either the caller's answer already or a condition no
+    // amount of patience clears; retrying would spend the whole budget to report
+    // the same thing later.
+    let fatal = [
+        provider(ProviderErrorKind::AuthFailure),
+        provider(ProviderErrorKind::ResourceExhausted),
+        provider(ProviderErrorKind::Other),
+        ClusterError::InvalidConfig {
+            reason: "test".to_owned(),
+        },
+        ClusterError::Unsupported { feature: "test" },
+    ];
+    for err in fatal {
+        assert!(
+            matches!(classify_attempt(err), Attempt::Fatal(_)),
+            "an error waiting cannot fix must end the loop"
+        );
+    }
+}
+
+#[test]
+fn a_budget_spent_against_a_contended_lock_is_a_lock_timeout() {
+    let waited = Duration::from_millis(750);
+    let failure = lock_failure("ledger", waited, None);
+    assert!(
+        matches!(
+            failure,
+            ClusterError::LockTimeout { ref name, waited: reported }
+                if name == "ledger" && reported == waited
+        ),
+        "genuine contention must report LockTimeout carrying what was waited, got {failure:?}"
+    );
+}
+
+#[test]
+fn a_budget_spent_against_an_unreachable_server_reports_the_outage() {
+    // The half that matters operationally: `LockTimeout` says "back off and try
+    // later", a retained `Provider` says "your Redis is down". Collapsing the
+    // second into the first is what a loop that discarded its last error would
+    // do.
+    let failure = lock_failure(
+        "ledger",
+        Duration::from_secs(30),
+        Some(provider(ProviderErrorKind::ConnectionLost)),
+    );
+    assert!(
+        matches!(
+            failure,
+            ClusterError::Provider {
+                kind: ProviderErrorKind::ConnectionLost,
+                ..
+            }
+        ),
+        "an outage that lasted the whole budget must not be reported as contention"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The ADR-004 lock signal set (DESIGN.md §9).
+//
+// The lock emits natively rather than through a decorator, so "which signal
+// fires for which outcome" is this file's question rather than the SDK's. A
+// recording `ClusterMetrics` answers it with no server: the two outcomes below
+// are both reached before a single command is issued, which is exactly why they
+// are the ones a Layer 1 test can hold.
+// ---------------------------------------------------------------------------
+
+/// A lock over a pool that is built but never connected.
+///
+/// `fred` only dials on `init()`, so this is a real backend that simply has no
+/// server behind it. Both tests below return before reaching the pool at all.
+fn lock_backend(
+    shutdown: &CancellationToken,
+    signals: Arc<crate::observability::RedisSignals>,
+) -> RedisLock {
+    let pool = fred::types::Builder::default_centralized()
+        .build_pool(1)
+        .expect("a one-connection pool builds without connecting");
+    RedisLock::new(LockInit {
+        pool,
+        scripts: Arc::new(crate::scripts::ScriptCache::default()),
+        names: names(),
+        linearizable: false,
+        wait: WaitPolicy::Disabled,
+        waiters: ReleaseWaiters::new(),
+        shutdown: shutdown.clone(),
+        signals,
+    })
+}
+
+#[tokio::test]
+async fn a_shutdown_try_lock_is_recorded_as_shutdown_and_not_as_an_error() {
+    // The trap `result::label` exists to close: `Shutdown` is a bounded outcome
+    // of its own, so a graceful cluster shutdown must not spike
+    // `cluster_provider_errors_total` once per in-flight acquisition.
+    let (signals, recorder) = crate::test_support::recording_signals();
+    let shutdown = CancellationToken::new();
+    let lock = lock_backend(&shutdown, signals);
+    shutdown.cancel();
+
+    let outcome = lock.try_lock("ledger", Duration::from_secs(10)).await;
+    assert!(matches!(outcome, Err(ClusterError::Shutdown)));
+    assert_eq!(
+        recorder.lock_ops(),
+        vec![("try_lock".to_owned(), "shutdown".to_owned())]
+    );
+    assert!(
+        recorder.provider_error_kinds().is_empty(),
+        "a shutdown is an outcome, not a backend fault"
+    );
+}
+
+#[tokio::test]
+async fn a_shutdown_blocking_lock_is_recorded_under_the_lock_op() {
+    // `lock` and `try_lock` are separate `op` label values because they are
+    // separate operations with wildly different latency distributions: folding
+    // a 30 s blocked acquisition into `try_lock`'s histogram would make the
+    // non-blocking op look pathological.
+    let (signals, recorder) = crate::test_support::recording_signals();
+    let shutdown = CancellationToken::new();
+    let lock = lock_backend(&shutdown, signals);
+    shutdown.cancel();
+
+    let outcome = lock
+        .lock("ledger", Duration::from_secs(10), Duration::from_secs(30))
+        .await;
+    assert!(matches!(outcome, Err(ClusterError::Shutdown)));
+    assert_eq!(
+        recorder.lock_ops(),
+        vec![("lock".to_owned(), "shutdown".to_owned())]
+    );
+    assert!(recorder.provider_error_kinds().is_empty());
+}
+// ---------------------------------------------------------------------------
+// The third bound (DESIGN.md §5.3): the caller's `timeout` bounds the whole
+// `lock()` call, including the reads inside it.
+// ---------------------------------------------------------------------------
+
+/// `park` returns on the caller's budget even when the `PTTL` that sizes its
+/// sleep never answers.
+///
+/// The overrun this closes: `park` reads `PTTL` to size the sleep against the
+/// lease actually blocking the caller, and that round trip used to carry no
+/// bound but `fred`'s 5 s default command timeout. A Redis that stalls at that
+/// moment — a `BGSAVE` fork pause, a slow `SCAN` from another tenant — turns a
+/// 50 ms budget into a 5 s one, and `lock()` reports `LockTimeout` seconds late
+/// to a caller measuring its own budget. The acquisition attempt on the same
+/// loop was already wrapped; this is the read between the two.
+///
+/// A pool that is built but never `init()`ed is what makes this a Layer-1 test:
+/// `fred` only dials on `init()`, so the command is queued against a router that
+/// does not exist and the future is simply pending forever — the stalled server,
+/// without a server. `tokio::time::pause()` then supplies the clock, so the
+/// assertion is on virtual time and the test costs no wall clock.
+#[tokio::test(start_paused = true)]
+async fn park_returns_on_the_callers_budget_when_the_pttl_read_stalls() {
+    const BUDGET: Duration = Duration::from_millis(50);
+
+    let shutdown = CancellationToken::new();
+    let (signals, _recorder) = crate::test_support::recording_signals();
+    let lock = lock_backend(&shutdown, signals);
+    let waiters = ReleaseWaiters::new();
+    let released = waiters.wait_for("ledger");
+
+    let started = tokio::time::Instant::now();
+    lock.park("ledger", released, started + BUDGET)
+        .await
+        .expect("park returns Ok when it is the budget rather than shutdown that ends the wait");
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed <= BUDGET,
+        "park must not outlive the budget it was given. Unbounded, the PTTL read is capped only \
+         by fred's 5 s default command timeout, so this returns two orders of magnitude late \
+         (budget {BUDGET:?}, elapsed {elapsed:?})"
+    );
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/lock/waiters.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/lock/waiters.rs
@@ -1,0 +1,243 @@
+//! The in-process release-waiter registry and the wake delay a blocked
+//! `lock()` sleeps for between attempts (DESIGN.md §5.3).
+//!
+//! ## Why an in-process registry rather than a server-side wait
+//!
+//! Redis has no "wait for this key" command short of `BLPOP` on a companion
+//! list — and this plugin cannot reach one: `i-lists` is deliberately absent
+//! from `fred`'s feature list (DESIGN.md §3.1), which makes the
+//! whole blocking family unreachable at compile time. That absence is the
+//! reason this file exists rather than an obstacle it works around. A
+//! companion-list wait would leak one list per lock name and need its own
+//! cleanup story, to produce a wake the `lock_release` script already publishes
+//! for free on `<prefix>:e:l:<name>` (DESIGN.md §2.5).
+//!
+//! So the wake path is: holder releases → the release script `PUBLISH`es →
+//! every instance's subscriber fan-out sees the message → that instance's
+//! registry wakes its own blocked waiters for that name. The registry is
+//! per-process; the publish is what crosses instances.
+//!
+//! **A missed wake costs latency, never correctness.** The acquisition loop
+//! re-attempts `SET NX PX` itself as the source of truth, so a waiter that
+//! registered a microsecond after the publish landed, or one whose subscriber
+//! is mid-reconnect, simply waits out [`wake_delay`] and tries again.
+//!
+//! ## What is ported and what is new
+//!
+//! The registry's shape is `postgres-cluster-plugin/src/lock/notify.rs`'s: a
+//! per-name map of per-waiter ids, and deregistration on drop. Both halves are
+//! load-bearing there for a reason that applies identically here — an earlier
+//! `Vec<Sender>` was only ever drained by a notification, so a name that is
+//! renewed but never released grew one dead sender per heartbeat tick for the
+//! whole life of the waiter (PGR-M7).
+//!
+//! [`wake_delay`] is new: Postgres has no remaining-TTL to read, so its loop
+//! sleeps a flat heartbeat. Redis answers `PTTL` on the lease that is blocking
+//! us, and a lease due in 40 ms should not be waited out for 250 ms.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Weak};
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use dashmap::DashMap;
+use rand::RngExt as _;
+use tokio::sync::oneshot;
+
+/// The safety-net wake interval for a blocked `lock()` (DESIGN.md §5.3).
+///
+/// This is what a waiter falls back to when no release notification arrives —
+/// because the holder crashed rather than releasing, because the subscriber is
+/// reconnecting, or because the publish landed in the instant between a
+/// waiter's failed attempt and its registration. `RD-LOCK-003` asserts a
+/// publish-driven wake lands *well under* this, which is what makes that test a
+/// statement about the notification path rather than a latency measurement: a
+/// wake at roughly one heartbeat means the notification was missed, not slow.
+pub const HEARTBEAT: Duration = Duration::from_millis(250);
+
+/// The upper bound on the next wake, before jitter: `min(PTTL, HEARTBEAT)`,
+/// further clamped to the caller's own remaining budget.
+///
+/// Three bounds, each for its own reason:
+///
+/// - **`HEARTBEAT`** is the safety net against a wake that never comes.
+/// - **`pttl`** is the lease that is actually blocking us, read on the attempt
+///   that just failed. A lock due to expire in 40 ms should be retried in 40 ms;
+///   sleeping a full heartbeat past its deadline would hand the name to whoever
+///   happens to poll next instead of to the waiter that has been waiting for it.
+///   `None` means the `PTTL` was unreadable or the key had already gone (in
+///   which case the next attempt will find it free anyway).
+/// - **`remaining`** is what is left of the caller's `timeout`. Without it a
+///   waiter with 5 ms of budget left sleeps 250 ms and reports `LockTimeout`
+///   245 ms late, which is visible to any caller that measures its own budget.
+#[must_use]
+pub fn wake_cap(pttl: Option<Duration>, remaining: Duration) -> Duration {
+    HEARTBEAT.min(pttl.unwrap_or(HEARTBEAT)).min(remaining)
+}
+
+/// The actual sleep: **full jitter** over `[0, wake_cap]` (DESIGN.md §5.3).
+///
+/// Full jitter — uniform from zero rather than a fixed delay, or a fixed delay
+/// plus a small perturbation — is what `rand` is a direct dependency for.
+/// Without it every instance contending for one name retries on the same
+/// deterministic schedule, and a hot lock turns the fleet's retries into
+/// synchronized `SET NX` bursts against the single key already under contention.
+/// Decorrelation is the whole product here; the mean delay it happens to
+/// produce is not the point.
+///
+/// Drawing from zero means an occasional near-immediate retry, which is one
+/// extra round trip and no correctness cost. The mean is `wake_cap / 2`, so a
+/// waiter blocked on a healthy lock costs about eight `SET NX`s a second rather
+/// than four — cheap enough that a floor, which would reintroduce exactly the
+/// correlation this exists to break, is not worth adding.
+#[must_use]
+pub fn wake_delay(pttl: Option<Duration>, remaining: Duration) -> Duration {
+    let cap = wake_cap(pttl, remaining);
+    // Nanoseconds, saturating: `wake_cap` is bounded above by `HEARTBEAT`, so
+    // the fallback is unreachable in practice and exists only so the conversion
+    // needs no `unwrap`.
+    let nanos = u64::try_from(cap.as_nanos()).unwrap_or(u64::MAX);
+    // Inclusive, because an exclusive `0..0` is an empty range and panics.
+    Duration::from_nanos(rand::rng().random_range(0..=nanos))
+}
+
+/// Registry of in-process waiters blocked in
+/// [`lock()`](cluster_sdk::DistributedLockBackend::lock), keyed by the lock name
+/// they are waiting to retry.
+///
+/// Fed by the subscriber fan-out, which is the only caller of
+/// [`notify`](Self::notify): a release anywhere in the fleet reaches this
+/// process as a `PUBLISH` on the lock's release channel, and reaches this map
+/// from there.
+pub struct ReleaseWaiters {
+    /// Per-name set of live waiters, each keyed by a process-unique id so a
+    /// waiter can withdraw *its own* registration on drop without disturbing
+    /// its siblings. See the module docs for why the id is not optional.
+    waiters: DashMap<String, HashMap<u64, oneshot::Sender<()>>>,
+    /// Monotonic source of the per-waiter ids above.
+    next_id: AtomicU64,
+}
+
+impl ReleaseWaiters {
+    /// Builds an empty registry.
+    #[must_use]
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            waiters: DashMap::new(),
+            next_id: AtomicU64::new(0),
+        })
+    }
+
+    /// Registers interest in `name`'s next release, returning a future that
+    /// resolves once [`notify`](Self::notify) fires for that name — or
+    /// immediately if this registry is dropped first, which only the plugin's
+    /// own teardown can cause and which the caller's timeout covers anyway.
+    ///
+    /// Dropping the returned future without it resolving deregisters the
+    /// waiter, so a caller that gives up (its budget elapsed, or its heartbeat
+    /// re-attempt succeeded) leaves nothing behind.
+    pub fn wait_for(self: &Arc<Self>, name: &str) -> ReleaseWait {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = oneshot::channel();
+        self.waiters
+            .entry(name.to_owned())
+            .or_default()
+            .insert(id, tx);
+        ReleaseWait {
+            // A `Weak`, not an `Arc`: a parked waiter must not keep the registry
+            // — and through it the plugin's state — alive past the handle's own
+            // lifetime. Dropping the registry closes this waiter's sender, which
+            // resolves the wait and sends the caller back to its `SET NX`.
+            registry: Arc::downgrade(self),
+            name: name.to_owned(),
+            id,
+            rx,
+        }
+    }
+
+    /// Wakes every waiter registered under `name`.
+    ///
+    /// Synchronous and allocation-light on purpose: it runs inline on the
+    /// subscriber fan-out's read loop, which must never block. A waiter that has
+    /// already given up and dropped its receiver is silently skipped.
+    pub fn notify(&self, name: &str) {
+        if let Some((_name, senders)) = self.waiters.remove(name) {
+            for (_id, sender) in senders {
+                // `Err` only means the waiter gave up first, which is not an
+                // event: it re-attempts the acquire on its own schedule either
+                // way. Bound rather than `_` to satisfy `let_underscore_must_use`.
+                let _delivered = sender.send(());
+            }
+        }
+    }
+
+    /// The number of live waiters registered under `name`, for the unit tests
+    /// that assert registration and deregistration.
+    #[cfg(test)]
+    fn registered(&self, name: &str) -> usize {
+        self.waiters.get(name).map_or(0, |entry| entry.len())
+    }
+
+    /// Withdraws waiter `id` under `name` — called from [`ReleaseWait::drop`].
+    fn deregister(&self, name: &str, id: u64) {
+        let now_empty = {
+            let Some(mut entry) = self.waiters.get_mut(name) else {
+                return;
+            };
+            entry.remove(&id);
+            entry.is_empty()
+        };
+        // Prune the now-empty per-name entry, but only if a concurrent
+        // `wait_for` has not repopulated it in the gap after the `get_mut` guard
+        // was dropped — dropping it first is what avoids a same-shard re-entrant
+        // lock.
+        if now_empty {
+            self.waiters
+                .remove_if(name, |_name, waiters| waiters.is_empty());
+        }
+    }
+}
+
+/// A registered blocked-`lock()` waiter, resolving when its name is released.
+///
+/// Deregisters itself from [`ReleaseWaiters`] on drop, so the acquisition
+/// loop's per-attempt `wait_for` cannot accumulate stale senders for a name
+/// that is renewed but never released.
+pub struct ReleaseWait {
+    registry: Weak<ReleaseWaiters>,
+    name: String,
+    id: u64,
+    rx: oneshot::Receiver<()>,
+}
+
+impl Future for ReleaseWait {
+    /// `Ok(())` — woken by a release for this name. `Err(())` — the sender was
+    /// dropped, meaning the registry itself went away. Both mean "stop waiting
+    /// and re-attempt the acquire", since the `SET NX` is the source of truth
+    /// regardless; the distinction exists only for the unit tests.
+    type Output = Result<(), ()>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), ()>> {
+        Pin::new(&mut self.rx)
+            .poll(cx)
+            .map(|received| received.map_err(|_dropped| ()))
+    }
+}
+
+impl Drop for ReleaseWait {
+    fn drop(&mut self) {
+        // Nothing to withdraw from if the registry is already gone.
+        if let Some(registry) = self.registry.upgrade() {
+            registry.deregister(&self.name, self.id);
+        }
+    }
+}
+
+// Layer-1 unit tests (TESTING.md §2, `lock/waiters.rs` row). Out-of-line per
+// DE1101.
+#[cfg(test)]
+#[path = "waiters_tests.rs"]
+mod tests;

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/lock/waiters_tests.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/lock/waiters_tests.rs
@@ -1,0 +1,196 @@
+//! Layer-1 tests for the release-waiter registry and the wake-delay policy
+//! (TESTING.md §2, `lock/waiters.rs` row). No server and no clock control: the
+//! registry is pure in-process state, and the delay is a pure function of two
+//! `Duration`s plus a draw.
+
+use super::*;
+
+// ---------------------------------------------------------------------------
+// register / notify / deregister-on-drop
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_notified_waiter_is_woken() {
+    let waiters = ReleaseWaiters::new();
+    let wait = waiters.wait_for("ledger");
+    assert_eq!(waiters.registered("ledger"), 1);
+
+    waiters.notify("ledger");
+
+    assert!(wait.await.is_ok(), "a notified waiter must be woken");
+    assert_eq!(
+        waiters.registered("ledger"),
+        0,
+        "notifying must consume the registration rather than leave it behind"
+    );
+}
+
+#[tokio::test]
+async fn notifying_a_name_with_no_waiter_is_a_no_op() {
+    // The common case on the fan-out path: every instance sees every release
+    // published under this plugin's prefix, and almost none of them has a
+    // blocked `lock()` for that name.
+    let waiters = ReleaseWaiters::new();
+    waiters.notify("nobody-is-waiting");
+    assert_eq!(waiters.registered("nobody-is-waiting"), 0);
+}
+
+#[tokio::test]
+async fn an_abandoned_wait_deregisters_itself_on_drop() {
+    let waiters = ReleaseWaiters::new();
+    {
+        let _wait = waiters.wait_for("ledger");
+        assert_eq!(waiters.registered("ledger"), 1);
+    }
+    assert_eq!(
+        waiters.registered("ledger"),
+        0,
+        "a waiter that gave up must withdraw its own registration"
+    );
+}
+
+#[tokio::test]
+async fn repeated_waits_for_a_never_released_name_do_not_accumulate() {
+    // The regression the per-waiter id exists for (PGR-M7, ported): the
+    // acquisition loop calls `wait_for` once per attempt, so a name that is
+    // renewed but never released would otherwise grow one dead sender per
+    // heartbeat for the whole life of the waiter.
+    let waiters = ReleaseWaiters::new();
+    for _attempt in 0..100 {
+        let _wait = waiters.wait_for("renewed-forever");
+    }
+    assert_eq!(waiters.registered("renewed-forever"), 0);
+}
+
+#[tokio::test]
+async fn dropping_one_waiter_leaves_its_siblings_registered() {
+    let waiters = ReleaseWaiters::new();
+    let live = waiters.wait_for("ledger");
+    {
+        let _abandoned = waiters.wait_for("ledger");
+        assert_eq!(waiters.registered("ledger"), 2);
+    }
+    assert_eq!(
+        waiters.registered("ledger"),
+        1,
+        "withdrawing one waiter must not withdraw another"
+    );
+
+    waiters.notify("ledger");
+    assert!(live.await.is_ok(), "the surviving waiter must still wake");
+}
+
+#[tokio::test]
+async fn a_waiter_outliving_its_registry_resolves_rather_than_hanging() {
+    // The registry is held by the lock backend, so this is what a waiter parked
+    // across a handle teardown sees. It must not park forever: the caller's
+    // next move is a `SET NX` against a pool that is closing, which answers.
+    let waiters = ReleaseWaiters::new();
+    let wait = waiters.wait_for("ledger");
+    drop(waiters);
+    assert!(
+        wait.await.is_err(),
+        "a dropped registry must resolve its waiters, not strand them"
+    );
+}
+
+#[tokio::test]
+async fn waiters_on_different_names_are_independent() {
+    let waiters = ReleaseWaiters::new();
+    let ledger = waiters.wait_for("ledger");
+    let invoices = waiters.wait_for("invoices");
+
+    waiters.notify("ledger");
+
+    assert!(ledger.await.is_ok());
+    assert_eq!(
+        waiters.registered("invoices"),
+        1,
+        "a release of one name must not wake waiters on another"
+    );
+    drop(invoices);
+}
+
+// ---------------------------------------------------------------------------
+// the wake delay: min(PTTL, heartbeat), full jitter
+// ---------------------------------------------------------------------------
+
+/// A budget large enough never to be the binding constraint in the cases below.
+const AMPLE: Duration = Duration::from_secs(30);
+
+#[test]
+fn the_cap_is_the_heartbeat_when_the_lease_outlives_it() {
+    assert_eq!(
+        wake_cap(Some(Duration::from_secs(10)), AMPLE),
+        HEARTBEAT,
+        "a long lease must not stretch the wake past the safety-net heartbeat"
+    );
+}
+
+#[test]
+fn the_cap_is_the_lease_when_it_expires_first() {
+    // The reason `PTTL` is read at all: a lock due in 40 ms should be retried
+    // in 40 ms, not waited out for the heartbeat.
+    let pttl = Duration::from_millis(40);
+    assert_eq!(wake_cap(Some(pttl), AMPLE), pttl);
+}
+
+#[test]
+fn an_unreadable_lease_falls_back_to_the_heartbeat() {
+    assert_eq!(wake_cap(None, AMPLE), HEARTBEAT);
+}
+
+#[test]
+fn the_cap_never_exceeds_the_callers_remaining_budget() {
+    let remaining = Duration::from_millis(5);
+    assert_eq!(
+        wake_cap(Some(Duration::from_secs(10)), remaining),
+        remaining,
+        "a waiter with 5ms left must not sleep 250ms and report LockTimeout late"
+    );
+}
+
+#[test]
+fn the_delay_stays_inside_its_cap() {
+    let pttl = Duration::from_millis(40);
+    for _draw in 0..1_000 {
+        let delay = wake_delay(Some(pttl), AMPLE);
+        assert!(
+            delay <= pttl,
+            "full jitter must stay within min(PTTL, heartbeat), got {delay:?}"
+        );
+    }
+}
+
+#[test]
+fn the_delay_is_bounded_by_the_heartbeat_however_long_the_lease() {
+    for _draw in 0..1_000 {
+        assert!(wake_delay(Some(Duration::from_hours(1)), AMPLE) <= HEARTBEAT);
+    }
+}
+
+#[test]
+fn the_delay_varies_across_draws() {
+    // Asserted as non-identity rather than as a distribution: the property that
+    // matters is that two instances contending for one name do not retry on the
+    // same schedule (DESIGN.md §5.3). With a 250 ms cap at nanosecond
+    // resolution, 64 identical draws is not a run this can see by chance.
+    let draws: Vec<Duration> = (0..64).map(|_| wake_delay(None, AMPLE)).collect();
+    let first = draws[0];
+    assert!(
+        draws.iter().any(|delay| *delay != first),
+        "an unjittered retry schedule turns a hot lock into a synchronized \
+         fleet-wide SET NX burst"
+    );
+}
+
+#[test]
+fn a_spent_budget_yields_no_sleep_rather_than_a_panic() {
+    // The degenerate input the acquisition loop can genuinely produce: the
+    // deadline check and the sleep are not one atomic step, so `remaining` can
+    // reach zero in between. An exclusive `0..0` range would panic here.
+    assert_eq!(
+        wake_delay(Some(Duration::ZERO), Duration::ZERO),
+        Duration::ZERO
+    );
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/observability.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/observability.rs
@@ -1,0 +1,597 @@
+//! The plugin's observability surface (DESIGN.md §9, ADR-004): the one metrics
+//! sink both plugins share, the four plugin-local instruments the contract sink
+//! cannot carry, and the log-event names §9 catalogues.
+//!
+//! ## Two sinks, because the contract has a shape the plugin exceeds
+//!
+//! [`RedisSignals`] holds both halves and hands them out through one value, so
+//! no call site has to know which half a given signal belongs to:
+//!
+//! - the **ADR-004 catalog** goes through `cluster_sdk`'s [`ClusterMetrics`]
+//!   port — in production the SDK's own `OtelClusterMetrics`, so instrument
+//!   names, units, and the label allowlist are defined once for every provider
+//!   rather than re-derived here;
+//! - the **four plugin-local metrics** of DESIGN.md §9 go through an
+//!   OpenTelemetry [`Meter`] this plugin owns directly. They have to:
+//!   `cluster_redis_connection_state` is a gauge and [`ClusterMetrics`] has no
+//!   gauge method, and the other three cover Redis-specific subjects that no
+//!   catalog instrument names.
+//!
+//! ## The cardinality rule is structural here
+//!
+//! Keys, lock names, and holder tokens reach [`ClusterMetrics`] nowhere — the
+//! port takes no such parameter — and the plugin-local instruments below attach
+//! only `provider`. They appear as span attributes and log fields instead:
+//! `cluster.lock.acquired` carries a holder token because it is a DEBUG *log
+//! line* (DESIGN.md §5.5), and [`ResourceId`] is what puts a key or a lock name
+//! on `cluster.provider.error` without it ever becoming a label.
+//!
+//! ## Log events carry their name twice, on purpose
+//!
+//! Every event in [`logs`] is emitted with `name:` set — the structural form,
+//! which is what a filtering collector matches on — *and* with the same name
+//! opening the human message. The default `tracing` `fmt` layer prints the
+//! message and not the event name, so an operator tailing logs would otherwise
+//! see prose with no way to tell which catalogued event it is. The two halves
+//! cost one duplicated string constant per site and make the same event
+//! findable both ways.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use cluster_sdk::observability::otel::OtelClusterMetrics;
+use cluster_sdk::observability::{
+    ClusterMetrics, ResourceId, emit_provider_error, primitive, result,
+};
+use cluster_sdk::{ClusterCacheBackend, ClusterError, InstrumentedCache};
+use fred::clients::Pool;
+use fred::interfaces::ClientLike;
+use opentelemetry::metrics::{Counter, Gauge, Meter};
+use opentelemetry::{InstrumentationScope, KeyValue, global};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+/// The log-event names DESIGN.md §9 catalogues for this plugin, plus the two
+/// catalog events it also emits.
+///
+/// Constants rather than literals at each site because several are emitted from
+/// more than one place — `expiry_events_unavailable` from three preflight
+/// branches, `cluster.watch.reset` from the fan-out's lagged path and the
+/// reconnect observer — and a catalogued name that drifted between two of its
+/// own emission sites is exactly the failure ADR-004's naming contract exists to
+/// prevent.
+pub mod logs {
+    /// Re-exported so a caller emitting the catalog's watch-reset event does not
+    /// have to reach into two modules for two names in the same table.
+    pub use cluster_sdk::observability::logs::{PROVIDER_ERROR, WATCH_RESET};
+
+    /// `maxmemory-policy` is not `noeviction` (WARN, once at startup).
+    pub const MAXMEMORY_POLICY_UNSAFE: &str = "cluster.provider.maxmemory_policy_unsafe";
+    /// `CONFIG GET maxmemory-policy` was refused, so the risk above cannot be
+    /// assessed at all (WARN, once at startup).
+    ///
+    /// Plugin-local rather than an ADR-004 catalog event (DESIGN.md §9).
+    pub const MAXMEMORY_POLICY_UNKNOWN: &str = "cluster.provider.maxmemory_policy_unknown";
+    /// An `evicted` notification arrived for one of this plugin's keys (WARN,
+    /// rate-limited). See [`EvictionReporter`](super::EvictionReporter).
+    pub const EVICTION_OBSERVED: &str = "cluster.provider.eviction_observed";
+    /// The declared consistency is `EventuallyConsistent` (WARN, once at
+    /// startup).
+    pub const WEAK_CONSISTENCY: &str = "cluster.provider.weak_consistency";
+    /// A `Linearizable` declaration rests on an operator hint the server would
+    /// not let the plugin verify (WARN, once at startup).
+    pub const CONSISTENCY_ASSERTED: &str = "cluster.provider.consistency_asserted";
+    /// `Expired` watch events will not be delivered (WARN, once at startup).
+    pub const EXPIRY_EVENTS_UNAVAILABLE: &str = "cluster.provider.expiry_events_unavailable";
+    /// `manage_keyspace_notifications: true` changed the server's global flags
+    /// (INFO, once).
+    pub const KEYSPACE_NOTIFICATIONS_SET: &str = "cluster.provider.keyspace_notifications_set";
+    /// The server supports `SPUBLISH`/`SSUBSCRIBE`, which v1 records but does
+    /// not use (DEBUG, once at startup).
+    pub const SHARDED_PUBSUB_AVAILABLE: &str = "cluster.provider.sharded_pubsub_available";
+    /// `INFO replication` was refused, so the topology could not be detected
+    /// (WARN, once at startup).
+    ///
+    /// Plugin-local rather than an ADR-004 catalog event (DESIGN.md §9).
+    pub const TOPOLOGY_UNKNOWN: &str = "cluster.provider.topology_unknown";
+    /// `appendfsync` reported a value this plugin does not recognize (WARN, once
+    /// at startup).
+    ///
+    /// Plugin-local rather than an ADR-004 catalog event (DESIGN.md §9).
+    pub const DURABILITY_UNKNOWN: &str = "cluster.provider.durability_unknown";
+    /// The command pool did not close inside its bound (WARN, at shutdown).
+    ///
+    /// Plugin-local rather than an ADR-004 catalog event (DESIGN.md §9).
+    pub const POOL_CLOSE_TIMEOUT: &str = "cluster.provider.pool_close_timeout";
+    /// Tracked background tasks did not drain inside their bound (WARN, at
+    /// shutdown).
+    ///
+    /// Plugin-local rather than an ADR-004 catalog event (DESIGN.md §9).
+    pub const TASK_DRAIN_TIMEOUT: &str = "cluster.provider.task_drain_timeout";
+    /// The subscriber's reconnect policy is exhausted, so every cache watch is
+    /// closed terminally and blocked `lock()` callers fall back to the heartbeat
+    /// (WARN, once, DESIGN.md §10).
+    ///
+    /// In the `cluster.provider.*` family rather than `cluster.watch.*` because
+    /// the condition is a connection outcome that also costs the lock its
+    /// release wake: `spawn_connection_watchdog` runs with `registry: None`
+    /// under `watch_mode: disabled` and in the standalone lock plugin, where
+    /// there are no watches at all.
+    ///
+    /// Plugin-local rather than an ADR-004 catalog event (DESIGN.md §9).
+    pub const SUBSCRIBER_LOST: &str = "cluster.provider.subscriber_lost";
+    /// A lock was acquired: its name and the holder token now under its key
+    /// (DEBUG, DESIGN.md §5.5).
+    pub const LOCK_ACQUIRED: &str = "cluster.lock.acquired";
+}
+
+/// The instrumentation scope the four plugin-local metrics are registered under.
+///
+/// Distinct from the `cf-gears-cluster` scope `OtelClusterMetrics` uses for the
+/// ADR-004 contract signals: these are this plugin's own additions, and a
+/// dashboard that wants to know which build emitted them should see this
+/// plugin's name rather than the SDK's.
+pub const PLUGIN_SCOPE: &str = "cf-redis-cluster-plugin";
+
+/// How often the connection-state observer samples the command pool.
+///
+/// A gauge that only moved at startup and shutdown would answer "was Redis
+/// reachable when this process booted", which is not the question DESIGN.md §9
+/// asks it. Ten seconds is under every ordinary Prometheus scrape interval, so
+/// a transient outage is visible in at least one sample, while costing one timer
+/// wakeup per plugin.
+const CONNECTION_STATE_INTERVAL: Duration = Duration::from_secs(10);
+
+/// The minimum gap between two `cluster.provider.eviction_observed` WARNs.
+///
+/// Evictions arrive in bursts by their nature — `maxmemory` pressure does not
+/// remove one key — so an unthrottled WARN would turn one incident into
+/// thousands of lines and bury the rest of the log. The suppressed count rides
+/// the next line that is emitted, so the burst is still *reported*, just not
+/// line by line.
+const EVICTION_WARN_WINDOW: Duration = Duration::from_secs(30);
+
+/// Strips the ADR-004 `_total` suffix from a counter name.
+///
+/// The same rule `cluster_sdk::observability::otel` applies to the catalog
+/// counters and for the same reason: the `opentelemetry-prometheus` exporter
+/// appends `_total` when it renders a counter, so an instrument created with the
+/// suffix already on it scrapes as `..._total_total`. The constant below keeps
+/// the *contract* name — what a dashboard queries — as the single source of
+/// truth for the name.
+fn counter_name(contract: &'static str) -> &'static str {
+    contract.strip_suffix("_total").unwrap_or(contract)
+}
+
+/// `cluster_redis_watch_events_dropped_total{provider}` — events dropped to a
+/// full watcher buffer, i.e. the `Lagged` count (DESIGN.md §9).
+const WATCH_EVENTS_DROPPED: &str = "cluster_redis_watch_events_dropped_total";
+/// `cluster_redis_subscriber_resubscribes_total{provider}` — subscriber
+/// reconnect-and-replay cycles (DESIGN.md §9).
+/// `pub` rather than private only so `subscriber_tests` can assert on it by the
+/// same name the emitter uses; the module itself is private and this is not
+/// re-exported, so it stays crate-internal.
+pub const SUBSCRIBER_RESUBSCRIBES: &str = "cluster_redis_subscriber_resubscribes_total";
+/// `cluster_redis_script_reloads_total{provider}` — `NOSCRIPT` recoveries
+/// (DESIGN.md §9, §6).
+const SCRIPT_RELOADS: &str = "cluster_redis_script_reloads_total";
+/// `cluster_redis_connection_state{provider}` — 1 when every connection in the
+/// command pool believes it is connected, else 0 (DESIGN.md §9).
+const CONNECTION_STATE: &str = "cluster_redis_connection_state";
+/// `cluster_redis_evictions_observed_total{provider, primitive}` — evictions of
+/// this plugin's own keys.
+///
+/// `primitive` is `cache` or `lock`, and it is the label that makes the counter
+/// actionable rather than merely present: an evicted cache entry costs a re-read,
+/// while an evicted lock lease means two holders believe they hold one lock
+/// (DESIGN.md §3.7). An alert that cannot tell them apart has to treat every
+/// eviction as the worse one or the milder one, and both are wrong.
+///
+/// **Not in DESIGN.md §9.** §3.7 and TESTING.md `RD-SPEC-007` both specify
+/// `cluster_provider_errors_total{op="eviction"}`, which cannot be emitted as
+/// written: that counter carries `{provider, kind}` and no `op`
+/// (`cluster-sdk/src/observability/otel.rs`), and an eviction is not a
+/// [`ClusterError`] at all, so it cannot travel through [`emit_provider_error`]
+/// either. Folding it onto the catalog counter as `kind = "other"` would make an
+/// eviction indistinguishable from every other unclassified backend failure and
+/// would inflate a provider-error rate with something that is not an operation
+/// failure. A counter that says what it counts is the honest form
+/// (DESIGN.md §3.7).
+const EVICTIONS_OBSERVED: &str = "cluster_redis_evictions_observed_total";
+
+/// The process-global meter under [`PLUGIN_SCOPE`], used when no meter is
+/// injected (production).
+///
+/// Tests and the `RD-SPEC-*` smoke runs inject their own meter over an in-memory
+/// reader instead, through [`RedisSignals::over_meter`] and the builders'
+/// `__with_meter` seam.
+#[must_use]
+pub fn plugin_meter() -> Meter {
+    global::meter_with_scope(InstrumentationScope::builder(PLUGIN_SCOPE).build())
+}
+
+/// Which primitive owned a key the plugin has something to say about
+/// (DESIGN.md §3.7, §9).
+///
+/// A type rather than a bare `&'static str` because it selects behaviour as
+/// well as labelling it — [`RedisSignals::eviction_observed`] picks a rate
+/// limiter from it — and a typo in a string would silently give one primitive
+/// the other's window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Primitive {
+    /// A cache entry. An eviction costs a re-read.
+    Cache,
+    /// A lock lease. An eviction hands the lock to a second holder.
+    Lock,
+}
+
+impl Primitive {
+    /// The bounded `primitive` label value this reports as.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Cache => "cache",
+            Self::Lock => "lock",
+        }
+    }
+}
+
+/// Rate limiter for `cluster.provider.eviction_observed`.
+///
+/// Deliberately allocation-free and lock-free: it is consulted on the subscriber
+/// fan-out's read loop, which must never block or stop draining — a stalled loop
+/// overflows `fred`'s broadcast buffer and resets every watcher, so an eviction
+/// storm would cost every consumer a re-read on top of the eviction itself.
+/// [`claim`](Self::claim) is a pure function of the elapsed-millisecond reading
+/// it is handed, which is what makes the whole policy unit-testable with no
+/// clock.
+pub struct EvictionReporter {
+    /// The zero point [`elapsed_millis`](Self::elapsed_millis) measures from.
+    started: Instant,
+    /// Milliseconds (since `started`) at which the last WARN was emitted, or
+    /// [`Self::NEVER`].
+    last_report: AtomicU64,
+    /// Evictions observed since the last WARN, drained onto the next one.
+    suppressed: AtomicU64,
+    window_millis: u64,
+}
+
+impl EvictionReporter {
+    /// The `last_report` value meaning "nothing has been reported yet", so the
+    /// very first eviction always emits.
+    const NEVER: u64 = u64::MAX;
+
+    /// Builds a reporter that emits at most one WARN per `window`.
+    #[must_use]
+    pub fn new(window: Duration) -> Self {
+        Self {
+            started: Instant::now(),
+            last_report: AtomicU64::new(Self::NEVER),
+            suppressed: AtomicU64::new(0),
+            window_millis: u64::try_from(window.as_millis()).unwrap_or(u64::MAX),
+        }
+    }
+
+    /// Milliseconds since this reporter was built — one monotonic clock read, no
+    /// allocation.
+    #[must_use]
+    pub fn elapsed_millis(&self) -> u64 {
+        u64::try_from(self.started.elapsed().as_millis()).unwrap_or(u64::MAX)
+    }
+
+    /// Records one observed eviction and reports whether it should be logged,
+    /// carrying the number of evictions suppressed since the last line.
+    ///
+    /// `Some(0)` is an ordinary answer — a lone eviction with nothing suppressed
+    /// behind it — and distinct from `None`, which means the window is not open.
+    /// The compare-exchange is what keeps two fan-out tasks (the two plugins can
+    /// both be running) from emitting for the same window: the loser suppresses
+    /// rather than retrying, because a WARN a few microseconds later carries no
+    /// information the winner's did not.
+    #[must_use]
+    pub fn claim(&self, now_millis: u64) -> Option<u64> {
+        let last = self.last_report.load(Ordering::Relaxed);
+        let open = last == Self::NEVER || now_millis.saturating_sub(last) >= self.window_millis;
+        if !open
+            || self
+                .last_report
+                .compare_exchange(last, now_millis, Ordering::Relaxed, Ordering::Relaxed)
+                .is_err()
+        {
+            self.suppressed.fetch_add(1, Ordering::Relaxed);
+            return None;
+        }
+        Some(self.suppressed.swap(0, Ordering::Relaxed))
+    }
+}
+
+/// Everything this plugin emits through, built once per plugin and shared by the
+/// cache decorator, the lock, the watcher registry, and the subscriber fan-out.
+///
+/// One per plugin rather than one per component, because the `provider` label is
+/// fixed at construction (the [`ClusterMetrics`] port has no per-call provider
+/// argument) and because two sinks would mean two `cluster_cache_ops_total`
+/// instruments disagreeing about the same deployment.
+pub struct RedisSignals {
+    /// The bounded `provider` label, on every signal this plugin emits.
+    provider: &'static str,
+    /// The ADR-004 catalog sink.
+    metrics: Arc<dyn ClusterMetrics>,
+    watch_events_dropped: Counter<u64>,
+    subscriber_resubscribes: Counter<u64>,
+    script_reloads: Counter<u64>,
+    evictions_observed: Counter<u64>,
+    connection_state: Gauge<u64>,
+    /// The rate limiter for the cache's eviction WARN. Its counter above is
+    /// *not* rate limited: a suppressed line is still a counted eviction.
+    cache_evictions: EvictionReporter,
+    /// The lock's, kept **separate** rather than sharing the cache's window.
+    ///
+    /// A shared limiter would let an eviction storm in the cache — thousands of
+    /// entries, each costing a re-read — spend the budget that the one line
+    /// saying a *lock lease* was evicted needs. That line reports two holders
+    /// believing they hold one lock (DESIGN.md §3.7), and it is precisely under
+    /// memory pressure heavy enough to storm the cache that it gets emitted, so
+    /// one window for both would suppress it exactly when it matters.
+    lock_evictions: EvictionReporter,
+}
+
+impl RedisSignals {
+    /// Builds the sink over an explicit [`ClusterMetrics`] and an explicit
+    /// meter.
+    ///
+    /// The seam the Layer-1 tests use: a recording `ClusterMetrics` double turns
+    /// "which signal fires for which outcome" into a question answerable with no
+    /// server at all.
+    #[must_use]
+    pub fn new(metrics: Arc<dyn ClusterMetrics>, meter: &Meter, provider: &'static str) -> Self {
+        Self {
+            provider,
+            metrics,
+            watch_events_dropped: meter
+                .u64_counter(counter_name(WATCH_EVENTS_DROPPED))
+                .with_description("Cache watch events dropped to a full watcher buffer")
+                .build(),
+            subscriber_resubscribes: meter
+                .u64_counter(counter_name(SUBSCRIBER_RESUBSCRIBES))
+                .with_description("Redis subscriber reconnect-and-replay cycles")
+                .build(),
+            script_reloads: meter
+                .u64_counter(counter_name(SCRIPT_RELOADS))
+                .with_description("Lua script cache misses recovered with EVAL")
+                .build(),
+            evictions_observed: meter
+                .u64_counter(counter_name(EVICTIONS_OBSERVED))
+                .with_description("Evictions observed on keys owned by this plugin")
+                .build(),
+            connection_state: meter
+                .u64_gauge(CONNECTION_STATE)
+                .with_description("Whether the Redis command pool believes it is connected")
+                .build(),
+            cache_evictions: EvictionReporter::new(EVICTION_WARN_WINDOW),
+            lock_evictions: EvictionReporter::new(EVICTION_WARN_WINDOW),
+        }
+    }
+
+    /// Production: the SDK's OpenTelemetry sink over the process-global meter
+    /// for the catalog, and this plugin's own scope for its four additions.
+    #[must_use]
+    pub fn from_global_meters(provider: &'static str) -> Self {
+        Self::new(
+            Arc::new(OtelClusterMetrics::from_global_meter(provider)),
+            &plugin_meter(),
+            provider,
+        )
+    }
+
+    /// Routes **both** halves through `meter`, so one in-memory reader observes
+    /// the catalog signals and the plugin-local ones together.
+    ///
+    /// The two scopes collapse into one here, which is the deliberate cost of
+    /// reading everything back through a single reader; nothing in either name
+    /// set collides, so no signal is lost to the merge.
+    #[must_use]
+    pub fn over_meter(meter: &Meter, provider: &'static str) -> Self {
+        Self::new(
+            Arc::new(OtelClusterMetrics::new(meter, provider)),
+            meter,
+            provider,
+        )
+    }
+
+    /// The ADR-004 sink, for the SDK decorators that take one directly.
+    #[must_use]
+    pub fn metrics(&self) -> Arc<dyn ClusterMetrics> {
+        Arc::clone(&self.metrics)
+    }
+
+    /// The bounded `provider` label.
+    #[must_use]
+    pub fn provider(&self) -> &'static str {
+        self.provider
+    }
+
+    /// Wraps `cache` in the SDK's [`InstrumentedCache`] decorator — the
+    /// supported path for the ADR-004 cache signal set (DESIGN.md §9).
+    ///
+    /// Every `cluster.cache.*` span, `cluster_cache_ops_total` increment, and
+    /// `cluster.provider.error` on a cache operation comes from there rather
+    /// than from this plugin, which is what keeps the naming contract identical
+    /// across providers instead of re-implemented per backend.
+    #[must_use]
+    pub fn instrument_cache(
+        &self,
+        cache: Arc<dyn ClusterCacheBackend>,
+    ) -> Arc<dyn ClusterCacheBackend> {
+        Arc::new(InstrumentedCache::new(
+            cache,
+            self.provider,
+            Arc::clone(&self.metrics),
+        ))
+    }
+
+    /// Records the metric side of a finished lock op — duration, the
+    /// bounded-`result` counter, and the shared provider-error signals.
+    ///
+    /// Mirrors `cluster::defaults::lock::record_lock` deliberately: the SDK's
+    /// CAS-based default lock and this native one must be indistinguishable on a
+    /// dashboard, or an operator moving a profile from the default lock to the
+    /// Redis one would see their panels go blank.
+    pub fn record_lock<T>(
+        &self,
+        op: &'static str,
+        lock: &str,
+        started: Instant,
+        outcome: &Result<T, ClusterError>,
+    ) {
+        self.metrics
+            .lock_op_duration(op, started.elapsed().as_secs_f64());
+        self.metrics.lock_op(op, result::label(outcome));
+        if let Err(err) = outcome {
+            self.provider_error(op, ResourceId::Lock(lock), err);
+        }
+    }
+
+    /// Emits the shared provider-error signals for a failure that is not
+    /// wrapped by a catalogued operation.
+    ///
+    /// A no-op unless `err` is a genuine [`ClusterError::Provider`]: a CAS
+    /// conflict, lock contention, a lock timeout, an expired lease, and a
+    /// shutdown are normal outcomes rather than backend errors, and the SDK's
+    /// [`emit_provider_error`] is where that rule lives so no plugin has to
+    /// re-derive it.
+    pub fn provider_error(&self, op: &str, resource: ResourceId<'_>, err: &ClusterError) {
+        emit_provider_error(&*self.metrics, self.provider, op, resource, err);
+    }
+
+    /// `cluster_watch_resets_total{provider,primitive="cache"}` — the catalog
+    /// counter behind the `cluster.watch.reset` event.
+    pub fn watch_reset(&self) {
+        self.metrics.watch_reset(primitive::CACHE);
+    }
+
+    /// Counts events a full watcher buffer forced the fan-out to drop.
+    ///
+    /// One per dropped event rather than one per `Lagged`, so the counter agrees
+    /// with the `dropped` count the consumer eventually receives
+    /// (`RD-WATCH-008`).
+    pub fn watch_event_dropped(&self) {
+        self.watch_events_dropped.add(1, &self.labels());
+    }
+
+    /// Counts one subscriber reconnect-and-replay cycle.
+    pub fn subscriber_resubscribed(&self) {
+        self.subscriber_resubscribes.add(1, &self.labels());
+    }
+
+    /// Counts one `NOSCRIPT` recovery (DESIGN.md §6).
+    pub fn script_reloaded(&self) {
+        self.script_reloads.add(1, &self.labels());
+    }
+
+    /// Records the command pool's current connectedness.
+    pub fn connection_state(&self, connected: bool) {
+        self.connection_state
+            .record(u64::from(connected), &self.labels());
+    }
+
+    /// Counts an observed eviction and emits the rate-limited WARN
+    /// (DESIGN.md §3.7).
+    ///
+    /// `primitive` is whichever owned the evicted key, as the subscriber's
+    /// `OwnedKey::primitive` reports it. It labels the counter, appears on the
+    /// line, and selects the rate
+    /// limiter — the two are throttled independently, so a cache storm cannot
+    /// spend the budget the lock's line needs.
+    ///
+    /// The counter is unconditional and only the log line is throttled: an
+    /// alert has to see every eviction, while an operator reading the log needs
+    /// one line naming a key plus how many others it stands for.
+    pub fn eviction_observed(&self, primitive: Primitive, key: &str) {
+        self.evictions_observed.add(
+            1,
+            &[
+                KeyValue::new(
+                    cluster_sdk::observability::fields::label::PROVIDER,
+                    self.provider,
+                ),
+                KeyValue::new(
+                    cluster_sdk::observability::fields::label::PRIMITIVE,
+                    primitive.label(),
+                ),
+            ],
+        );
+        let reporter = match primitive {
+            Primitive::Cache => &self.cache_evictions,
+            Primitive::Lock => &self.lock_evictions,
+        };
+        let Some(suppressed) = reporter.claim(reporter.elapsed_millis()) else {
+            return;
+        };
+        tracing::warn!(
+            name: logs::EVICTION_OBSERVED,
+            provider = self.provider,
+            primitive = primitive.label(),
+            key = %key,
+            suppressed,
+            "cluster.provider.eviction_observed: redis evicted a key owned by this plugin. No TTL \
+             lapsed and no consumer asked for it: under memory pressure an evicted lock key hands \
+             the lock to a second holder, and an evicted leader key elects a second leader. Run \
+             cluster keys on a dedicated instance, or set maxmemory-policy noeviction \
+             (DESIGN.md sec 3.7)"
+        );
+    }
+
+    /// The one label every plugin-local instrument carries. Rebuilt per call
+    /// rather than cached because [`KeyValue`] is not `Copy` and the array is a
+    /// stack value either way.
+    fn labels(&self) -> [KeyValue; 1] {
+        [KeyValue::new(
+            cluster_sdk::observability::fields::label::PROVIDER,
+            self.provider,
+        )]
+    }
+}
+
+/// Spawns the task that keeps `cluster_redis_connection_state` current
+/// (DESIGN.md §9).
+///
+/// A sampling task rather than an OpenTelemetry *observable* gauge, which is the
+/// obvious fit and the wrong one here: an observable gauge's callback is
+/// registered on the meter provider for the life of the process and is not
+/// unregistered when the instrument handle drops, so it would outlive `stop()`
+/// holding a `Pool` clone — and a second plugin instance would register a second
+/// callback reporting the same `{provider}` series, which is a conflict rather
+/// than a sum. A task is cancellable, which is exactly the property that
+/// mismatch needs.
+///
+/// The pool is read through every one of its clients rather than through
+/// `ClientLike` on the pool itself: `Pool::inner()` rotates, so the trait
+/// methods answer for whichever client came next rather than for the pool.
+#[must_use]
+pub fn spawn_connection_state_observer(
+    pool: Pool,
+    signals: Arc<RedisSignals>,
+    shutdown: CancellationToken,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            signals.connection_state(pool.clients().iter().all(ClientLike::is_connected));
+            tokio::select! {
+                () = shutdown.cancelled() => break,
+                () = tokio::time::sleep(CONNECTION_STATE_INTERVAL) => {}
+            }
+        }
+        // The pool is about to close, so the last sample a scrape can see should
+        // say so rather than leave the series stuck at its final live reading.
+        signals.connection_state(false);
+    })
+}
+
+// Layer-1 unit tests (the eviction rate limiter's pure policy, and the
+// contract-name/`_total` rule). The signal-per-outcome tests live beside the
+// primitives that emit them. Out-of-line per DE1101.
+#[cfg(test)]
+#[path = "observability_tests.rs"]
+mod tests;

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/observability_tests.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/observability_tests.rs
@@ -1,0 +1,192 @@
+//! Layer-1 unit tests for the observability surface (TESTING.md §2): the
+//! eviction rate limiter's pure policy, the `_total` naming rule, and the
+//! provider-error routing rule the whole plugin depends on.
+
+use std::time::Duration;
+
+use cluster_sdk::observability::{ResourceId, kind, metrics as catalog};
+use cluster_sdk::{ClusterError, ProviderErrorKind};
+
+use super::*;
+use crate::test_support::{metered_signals, recording_signals};
+
+#[test]
+fn the_first_eviction_always_reports() {
+    // A rate limiter that started "closed" would swallow the single most
+    // valuable line this plugin emits on a deployment that evicts once.
+    let reporter = EvictionReporter::new(Duration::from_secs(30));
+    assert_eq!(reporter.claim(0), Some(0));
+}
+
+#[test]
+fn evictions_inside_the_window_are_suppressed_and_counted_onto_the_next_line() {
+    let reporter = EvictionReporter::new(Duration::from_secs(30));
+    assert_eq!(reporter.claim(0), Some(0));
+    assert_eq!(reporter.claim(1), None);
+    assert_eq!(reporter.claim(29_999), None);
+    // The burst is reported rather than lost: the two suppressed evictions ride
+    // the first line the window allows through.
+    assert_eq!(reporter.claim(30_000), Some(2));
+    // And the count resets, so the next line does not re-report them.
+    assert_eq!(reporter.claim(60_000), Some(0));
+}
+
+#[test]
+fn a_clock_that_does_not_advance_still_terminates() {
+    // `saturating_sub` rather than a subtraction: a reading that goes backwards
+    // (or stays put) must suppress, never panic and never divide by a window.
+    let reporter = EvictionReporter::new(Duration::from_secs(30));
+    assert_eq!(reporter.claim(1_000), Some(0));
+    assert_eq!(reporter.claim(0), None);
+}
+
+#[test]
+fn counter_instruments_drop_the_contract_total_suffix() {
+    // The exporter re-appends it, so an instrument created with the suffix
+    // already on it scrapes as `..._total_total`. The catalog constant stays the
+    // name a dashboard queries.
+    assert_eq!(
+        counter_name(WATCH_EVENTS_DROPPED),
+        "cluster_redis_watch_events_dropped"
+    );
+    assert_eq!(
+        counter_name(catalog::PROVIDER_ERRORS_TOTAL),
+        "cluster_provider_errors"
+    );
+    // A gauge carries no `_total` to strip and is used verbatim.
+    assert_eq!(counter_name(CONNECTION_STATE), CONNECTION_STATE);
+}
+
+#[test]
+fn the_plugin_local_metric_names_are_the_ones_design_9_lists() {
+    // Pinned as literals rather than derived, because these four names are the
+    // contract: a rename is a dashboard break, and it should look like one in
+    // the diff.
+    assert_eq!(
+        WATCH_EVENTS_DROPPED,
+        "cluster_redis_watch_events_dropped_total"
+    );
+    assert_eq!(
+        SUBSCRIBER_RESUBSCRIBES,
+        "cluster_redis_subscriber_resubscribes_total"
+    );
+    assert_eq!(SCRIPT_RELOADS, "cluster_redis_script_reloads_total");
+    assert_eq!(CONNECTION_STATE, "cluster_redis_connection_state");
+    // The plugin-local counter DESIGN.md §9 names, and the replacement
+    // for the unemittable `cluster_provider_errors_total{op="eviction"}`.
+    assert_eq!(EVICTIONS_OBSERVED, "cluster_redis_evictions_observed_total");
+}
+
+#[test]
+fn the_subscriber_lost_event_name_is_the_one_design_9_lists() {
+    // Pinned for the same reason as the metric names above: this is the line
+    // announcing that the subscriber is permanently gone, so it is the one an
+    // alert filters structurally on, and a rename should look like a broken
+    // alert in the diff.
+    //
+    // In the `cluster.provider.*` family deliberately — the condition also costs
+    // a blocked `lock()` its release wake, and the watchdog that emits it runs
+    // with no registry at all under `watch_mode: disabled` and in the standalone
+    // lock plugin.
+    assert_eq!(
+        crate::observability::logs::SUBSCRIBER_LOST,
+        "cluster.provider.subscriber_lost"
+    );
+}
+
+#[test]
+fn a_normal_outcome_is_never_counted_as_a_provider_error() {
+    // The rule the whole plugin rests on: contention, a CAS conflict, a lock
+    // timeout, an expired lease, and a shutdown are answers, not faults. Every
+    // one of them reaching `cluster_provider_errors_total` would make the error
+    // rate track lock contention.
+    let (signals, recorder) = recording_signals();
+    for err in [
+        ClusterError::LockContended {
+            name: "n".to_owned(),
+        },
+        ClusterError::LockTimeout {
+            name: "n".to_owned(),
+            waited: Duration::from_secs(1),
+        },
+        ClusterError::LockExpired {
+            name: "n".to_owned(),
+        },
+        ClusterError::CasConflict {
+            key: "k".to_owned(),
+            current: None,
+        },
+        ClusterError::Shutdown,
+        ClusterError::Unsupported { feature: "watch" },
+    ] {
+        signals.provider_error("try_lock", ResourceId::Lock("n"), &err);
+    }
+    assert!(
+        recorder.provider_error_kinds().is_empty(),
+        "normal outcomes must not reach the provider-error counter, got {:?}",
+        recorder.provider_error_kinds()
+    );
+}
+
+#[test]
+fn a_backend_failure_is_counted_under_its_bounded_kind() {
+    let (signals, recorder) = recording_signals();
+    signals.provider_error(
+        "renew",
+        ResourceId::Lock("n"),
+        &ClusterError::Provider {
+            kind: ProviderErrorKind::ConnectionLost,
+            message: "gone".to_owned(),
+        },
+    );
+    assert_eq!(recorder.provider_error_kinds(), vec![kind::CONNECTION_LOST]);
+}
+
+#[test]
+fn every_eviction_is_counted_even_though_only_some_are_logged() {
+    // The half of the rate limiter that is easy to get wrong: throttling the
+    // WARN must not throttle the counter, or an alert on an eviction storm would
+    // see one eviction per window and fire on none of them.
+    let (signals, readback) = metered_signals();
+    for index in 0..25 {
+        signals.eviction_observed(Primitive::Cache, &format!("tenant-{index}/key"));
+    }
+    assert_eq!(readback.counter(EVICTIONS_OBSERVED), 25);
+}
+
+#[test]
+fn an_evicted_lease_and_an_evicted_entry_are_both_counted() {
+    // Both primitives land on the same counter under their own `primitive`
+    // label, because an alert has to be able to tell a re-read from a
+    // double-held lock. A counter fed only by the cache would miss the case
+    // DESIGN.md §3.7 opens with and rates worst.
+    let (signals, readback) = metered_signals();
+    signals.eviction_observed(Primitive::Cache, "tenant-1/entry");
+    signals.eviction_observed(Primitive::Lock, "tenant-1/leader");
+    assert_eq!(readback.counter(EVICTIONS_OBSERVED), 2);
+}
+
+#[test]
+fn an_eviction_is_not_counted_as_a_provider_error() {
+    // DESIGN.md §3.7 and `RD-SPEC-007` both
+    // ask for `cluster_provider_errors_total{op="eviction"}`, which has no `op`
+    // label to carry it and no `ClusterError` to travel through. The counter
+    // above is the replacement, and this pins that the catalog counter was not
+    // quietly conscripted for it instead.
+    let (signals, recorder) = recording_signals();
+    signals.eviction_observed(Primitive::Cache, "tenant-1/key");
+    assert!(
+        recorder.provider_error_kinds().is_empty(),
+        "an eviction is not an operation failure and must not reach the error counter"
+    );
+}
+
+#[test]
+fn a_watch_reset_is_attributed_to_the_cache_primitive() {
+    // `primitive` is a bounded label and the cache is the only primitive with a
+    // watch here: the lock's release wake is not a watch and must not inflate
+    // this series.
+    let (signals, recorder) = recording_signals();
+    signals.watch_reset();
+    assert_eq!(recorder.watch_resets(), vec!["cache"]);
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/plugin.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/plugin.rs
@@ -1,0 +1,545 @@
+//! The combined [`RedisClusterPlugin`] (cache + lock) builder and lifecycle
+//! handle (DESIGN.md §3.2), following the outbox-style builder/handle pattern
+//! (ADR-006). Not a `RunnableCapability` — the cluster gear (`cf-gears-cluster`)
+//! owns its lifecycle via `build_and_start`/`stop`.
+
+use std::sync::Arc;
+
+use cluster_sdk::{CacheConsistency, ClusterCacheBackend, ClusterError, DistributedLockBackend};
+use fred::clients::{Pool, SubscriberClient};
+use fred::interfaces::PubsubInterface;
+use fred::types::ConnectHandle;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::cache::watch::WatchRegistry;
+use crate::cache::{CacheInit, RedisCache};
+use crate::config::{RedisClusterConfig, WatchMode};
+use crate::connect::{ConnectSpec, Connected, connect};
+use crate::lock::waiters::ReleaseWaiters;
+use crate::lock::{LockInit, LockNames, RedisLock};
+use crate::observability::{RedisSignals, spawn_connection_state_observer};
+use crate::preflight::{PreflightRequest, REQUIRED_KEYSPACE_FLAGS, run_preflight};
+use crate::provider::PROVIDER_NAME;
+use crate::redis_error::map_redis_error;
+use crate::scripts::{ALL_SCRIPTS, PoolScriptExecutor, load_catalog};
+use crate::shutdown::{DropDiagnosis, abandon_subscriber, cancel_and_diagnose_drop, close_pool};
+use crate::subscriber::{
+    CacheRoute, FanOutRoutes, KeyspaceNames, LockRoute, confirm_subscriptions, quit_subscriber,
+    spawn_connection_watchdog, spawn_fan_out, spawn_reconnect_observer,
+};
+use crate::wait::WaitPolicy;
+
+/// Entry point for constructing the combined Redis cluster plugin.
+///
+/// ```no_run
+/// # async fn doc(config: redis_cluster_plugin::RedisClusterConfig) -> Result<(), cluster_sdk::ClusterError> {
+/// use redis_cluster_plugin::RedisClusterPlugin;
+/// let handle = RedisClusterPlugin::builder(config).build_and_start().await?;
+/// let _cache = handle.cache();
+/// handle.stop().await;
+/// # Ok(())
+/// # }
+/// ```
+pub struct RedisClusterPlugin;
+
+impl RedisClusterPlugin {
+    // No `#[must_use]` here: `RedisClusterBuilder` already carries a
+    // `#[must_use = "..."]` message, so a bare attribute on this function would
+    // be a `clippy::double_must_use` no-op.
+    /// Starts building the plugin from operator config.
+    pub fn builder(config: RedisClusterConfig) -> RedisClusterBuilder {
+        RedisClusterBuilder {
+            config,
+            meter: None,
+        }
+    }
+}
+
+/// Fluent builder for [`RedisClusterPlugin`].
+#[must_use = "a builder starts nothing until `.build_and_start()` is called"]
+pub struct RedisClusterBuilder {
+    config: RedisClusterConfig,
+    /// Optional override for the meter every signal is emitted through. `None`
+    /// in production (the process-global provider). See
+    /// [`__with_meter`](Self::__with_meter).
+    meter: Option<opentelemetry::metrics::Meter>,
+}
+
+impl RedisClusterBuilder {
+    /// Test-only: routes both the ADR-004 catalog signals and this plugin's four
+    /// local metrics through `meter` instead of the process-global provider, so
+    /// a test can attach an in-memory reader and read every signal back by name
+    /// rather than by eye.
+    ///
+    /// Gated behind `--features integration` so the seam is compiled out of
+    /// release builds entirely, mirroring
+    /// `PostgresClusterBuilder::__with_reaper_meter`.
+    #[cfg(feature = "integration")]
+    #[doc(hidden)]
+    pub fn __with_meter(mut self, meter: opentelemetry::metrics::Meter) -> Self {
+        self.meter = Some(meter);
+        self
+    }
+
+    /// Builds and starts the plugin, following DESIGN.md §3.2's six steps.
+    ///
+    /// Step 4's ordering is load-bearing rather than tidy: the initial
+    /// `PSUBSCRIBE`s are **live on the server before this returns**, so a write
+    /// in the startup window cannot publish to a channel nobody is listening on
+    /// yet. Redis pub/sub does not queue or replay for a client that subscribes
+    /// late, so that event would be lost with nothing to show for it.
+    ///
+    /// Two things are needed for that, not one. `tokio::spawn` only schedules a
+    /// task, so subscribing inside the fan-out task would let `build_and_start`
+    /// resolve — and a caller's first publish land — before the subscription
+    /// existed. And *awaiting* the subscribe is not by itself the guarantee it
+    /// reads as: `fred` resolves it when the command reaches the connection, not
+    /// when the server has answered, so the round trip in
+    /// `subscriber::confirm_subscriptions` is what actually closes the
+    /// window (DESIGN.md §3.2 step 4).
+    ///
+    /// By the time this resolves, the pool is connected, the preflight has run,
+    /// the scripts are loaded, and the subscriber is live — there is no
+    /// readiness gate for callers to reason about, and a failure at any step
+    /// tears down whatever the earlier steps started.
+    ///
+    /// # Errors
+    /// - [`ClusterError::InvalidConfig`] for a zero-valued config bound, a URL
+    ///   `fred` cannot parse, or an `INFO server` the server refuses.
+    /// - [`ClusterError::Provider`] if the initial connect or the `SCRIPT LOAD`
+    ///   fails.
+    pub async fn build_and_start(self) -> Result<RedisClusterHandle, ClusterError> {
+        let config = self.config;
+        // Before anything is opened: a zero `command_timeout_ms` disables
+        // `fred`'s command timeout outright rather than shortening it, and the
+        // bounded `stop()` below depends on that timeout existing.
+        config.validate()?;
+        // Here rather than at its use below, for the same reason: this is the
+        // one conversion of `wait_timeout_ms` into the signed count `WAIT`
+        // takes, and doing it before the pool exists means an unrepresentable
+        // one is a plain `?` rather than an error path that has to tear down a
+        // connected pool and subscriber.
+        let wait = WaitPolicy::from_config(config.wait_replicas, config.wait_timeout_ms)?;
+
+        // One sink for this whole plugin (DESIGN.md §9): the `InstrumentedCache`
+        // decorator, the native lock, the watcher registry, the subscriber
+        // fan-out, and the connection-state gauge all share it. One rather than
+        // one per component, because the `provider` label is fixed at
+        // construction and two sinks would mean two `cluster_cache_ops_total`
+        // instruments disagreeing about the same deployment.
+        let signals = Arc::new(match self.meter {
+            Some(meter) => RedisSignals::over_meter(&meter, PROVIDER_NAME),
+            None => RedisSignals::from_global_meters(PROVIDER_NAME),
+        });
+
+        let Connected {
+            pool,
+            subscriber,
+            clustered,
+            url_topology,
+        } = connect(ConnectSpec {
+            url: &config.url,
+            database: config.database,
+            pool_size: config.pool_size,
+            command_timeout: config.command_timeout(),
+        })
+        .await?;
+        // The registry owns the subscriber for subscription purposes; the handle
+        // owns it for lifecycle purposes. One clone each — `SubscriberClient` is
+        // a handle to one connection, not the connection itself.
+        //
+        // `None` under `watch_mode: disabled`, which is now what that mode
+        // means: no watcher registry and no cache subscriptions, rather than no
+        // second connection (see `ConnectSpec`).
+        let registry = (config.watch_mode == WatchMode::Publish)
+            .then(|| WatchRegistry::new(Some(subscriber.0.clone()), Arc::clone(&signals)));
+
+        // Everything after the connect has to tear the pool *and the subscriber*
+        // down on the way out — both are connected, so returning the error alone
+        // would leak the connections until the process exited. See
+        // [`abandon_subscriber`] for why dropping the subscriber is not enough.
+        let outcome = match run_preflight(
+            &pool,
+            PreflightRequest {
+                topology_hint: config.topology,
+                url_topology,
+                durability_hint: config.durability,
+                // The combined plugin owns a cache, so it needs `expired` as
+                // well as `evicted` — the standalone lock asks for the narrower
+                // set (DESIGN.md §3.5's third row).
+                keyspace_flags: Some(REQUIRED_KEYSPACE_FLAGS),
+                manage_keyspace_notifications: config.manage_keyspace_notifications,
+            },
+        )
+        .await
+        {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                abandon_subscriber(&subscriber.0, &subscriber.1).await;
+                close_pool(&pool).await;
+                return Err(err);
+            }
+        };
+
+        let executor = PoolScriptExecutor::new(pool.clone());
+        let scripts = match load_catalog(&executor, ALL_SCRIPTS).await {
+            Ok(scripts) => Arc::new(scripts),
+            Err(err) => {
+                abandon_subscriber(&subscriber.0, &subscriber.1).await;
+                close_pool(&pool).await;
+                return Err(err);
+            }
+        };
+
+        // Created before the subscriber so every task it spawns observes the
+        // same signal, and so the teardown paths below have something to cancel.
+        let shutdown = CancellationToken::new();
+
+        let cache = Arc::new(RedisCache::new(CacheInit {
+            pool: pool.clone(),
+            scripts: Arc::clone(&scripts),
+            key_prefix: config.key_prefix.clone(),
+            consistency: outcome.consistency,
+            watch_mode: config.watch_mode,
+            clustered,
+            wait,
+            database: config.database,
+            watchers: registry,
+            signals: Arc::clone(&signals),
+        }));
+
+        // Wrapped once, here, rather than per `cache()` call: the decorator is
+        // what emits the whole ADR-004 cache signal set (DESIGN.md §9), and the
+        // handle keeps the concrete `Arc<RedisCache>` beside it because `stop()`
+        // and `start_subscriber` need `watch_registry()` and `channel_names()`,
+        // which the trait object does not carry.
+        let instrumented =
+            signals.instrument_cache(Arc::clone(&cache) as Arc<dyn ClusterCacheBackend>);
+
+        // The lock shares the pool, the catalog, and the shutdown token with the
+        // cache — one plugin, one connection budget (DESIGN.md §3.3). It is the
+        // *standalone* plugin that gets its own of each, and only because the
+        // SDK keeps non-cache providers independent of the cache one.
+        let waiters = ReleaseWaiters::new();
+        let lock_names = LockNames::new(&config.key_prefix);
+        let lock = Arc::new(RedisLock::new(LockInit {
+            pool: pool.clone(),
+            scripts,
+            names: lock_names.clone(),
+            // The same declaration the cache makes, from the same preflight: the
+            // lock is exactly as safe as the server it runs on (DESIGN.md §5.1).
+            linearizable: outcome.consistency == CacheConsistency::Linearizable,
+            wait,
+            waiters: Arc::clone(&waiters),
+            shutdown: shutdown.clone(),
+            signals: Arc::clone(&signals),
+        }));
+
+        // Built here rather than inside `start_subscriber` because it needs the
+        // operator's prefix and database, which the cache and the lock each
+        // carry only their own half of.
+        let keyspace = KeyspaceNames::new(
+            &config.key_prefix,
+            config.database,
+            Some(cache.channel_names()),
+            lock_names.clone(),
+        );
+
+        let subscription = match start_subscriber(SubscriberSetup {
+            cache: &cache,
+            lock_names,
+            keyspace,
+            waiters,
+            subscriber,
+            signals: Arc::clone(&signals),
+            shutdown: &shutdown,
+        })
+        .await
+        {
+            Ok(subscription) => subscription,
+            Err(err) => {
+                close_pool(&pool).await;
+                return Err(err);
+            }
+        };
+
+        let connection_state =
+            spawn_connection_state_observer(pool.clone(), signals, shutdown.clone());
+
+        Ok(RedisClusterHandle {
+            cache,
+            instrumented,
+            lock,
+            pool,
+            subscription: Some(subscription),
+            connection_state: Some(connection_state),
+            shutdown,
+            stopped: false,
+        })
+    }
+}
+
+/// The subscriber client and the two tasks that ride it, owned by the handle so
+/// `stop()` can end them in order.
+struct Subscription {
+    client: SubscriberClient,
+    fan_out: JoinHandle<()>,
+    /// `None` under `watch_mode: disabled` — there are no watchers to reset.
+    reconnects: Option<JoinHandle<()>>,
+    /// `fred`'s own subscription-replay task, which is what makes a reconnect
+    /// recoverable at all (DESIGN.md §4.3).
+    manager: JoinHandle<()>,
+    /// Reports an exhausted reconnect policy, closing every watch if there are
+    /// any.
+    watchdog: JoinHandle<()>,
+}
+
+/// What [`start_subscriber`] needs. A struct because six parameters, three of
+/// them references, is where a positional call stops being readable.
+struct SubscriberSetup<'a> {
+    cache: &'a RedisCache,
+    lock_names: LockNames,
+    keyspace: KeyspaceNames,
+    waiters: Arc<ReleaseWaiters>,
+    subscriber: (SubscriberClient, ConnectHandle),
+    signals: Arc<RedisSignals>,
+    shutdown: &'a CancellationToken,
+}
+
+/// Awaits the initial `PSUBSCRIBE`s and spawns the tasks that ride the
+/// subscriber — DESIGN.md §3.2 steps 4 and 5.
+///
+/// Two always-on patterns, and each is always-on for its own reason:
+///
+/// - the **keyspace** pattern carries `expired` and `evicted` for every key this
+///   plugin owns — cache entries *and* lock leases — and cannot be subscribed
+///   lazily because §3.7's eviction signal has to observe keys nobody is
+///   watching. Subscribed under `watch_mode: disabled` too, where it delivers no
+///   watcher events because there is no registry, and still counts every
+///   eviction;
+/// - the **lock-release** pattern carries every release under this prefix,
+///   because a waiter's interest lasts one loop iteration and per-name
+///   subscriptions would put a round trip either side of every retry (see
+///   [`LockNames::release_pattern`]).
+///
+/// Both are awaited before this returns, for the reason DESIGN.md §3.2 step 4
+/// gives: Redis pub/sub does not queue or replay for a client that subscribes
+/// late, so an event landing in the startup window would be lost with nothing to
+/// show for it. `RD-LOCK-003` is the test that would fail first.
+///
+/// # Errors
+/// Whatever [`map_redis_error`] makes of a failing `PSUBSCRIBE`. The subscriber
+/// is quit on that path, so a half-open second connection does not outlive the
+/// failed startup.
+async fn start_subscriber(setup: SubscriberSetup<'_>) -> Result<Subscription, ClusterError> {
+    let SubscriberSetup {
+        cache,
+        lock_names,
+        keyspace,
+        waiters,
+        subscriber: (client, connection),
+        signals,
+        shutdown,
+    } = setup;
+    let registry = cache.watch_registry();
+    let names = cache.channel_names();
+
+    // The replay task first: a reconnect between the subscribes below and this
+    // spawn would otherwise lose the subscription set permanently.
+    let manager = client.manage_subscriptions();
+
+    let patterns = [lock_names.release_pattern(), keyspace.pattern().to_owned()];
+    for pattern in patterns {
+        if let Err(err) = client.psubscribe(pattern).await {
+            manager.abort();
+            connection.abort();
+            quit_subscriber(&client).await;
+            return Err(map_redis_error(err));
+        }
+    }
+
+    // Awaited, and awaited *here*: `psubscribe` resolving is not the server
+    // having processed it (see [`confirm_subscriptions`]), and DESIGN.md §3.2
+    // step 4's whole point is that no write in the startup window can publish
+    // to a channel nobody is listening on yet.
+    if let Err(err) = confirm_subscriptions(&client).await {
+        manager.abort();
+        connection.abort();
+        quit_subscriber(&client).await;
+        return Err(err);
+    }
+
+    // The reconnect observer is cache-only — its whole job is broadcasting a
+    // `Reset` after a subscription gap, and a lock has no equivalent to reset —
+    // so under `watch_mode: disabled` it is not spawned at all. The watchdog is
+    // spawned either way: it also has something to say about the lock.
+    let reconnects = registry.as_ref().map(|registry| {
+        spawn_reconnect_observer(
+            &client,
+            Arc::clone(registry),
+            Arc::clone(&signals),
+            shutdown.clone(),
+        )
+    });
+    let watchdog = spawn_connection_watchdog(connection, registry.clone(), shutdown.clone());
+    let fan_out = spawn_fan_out(
+        &client,
+        FanOutRoutes {
+            cache: registry.map(|registry| CacheRoute { registry, names }),
+            locks: LockRoute {
+                waiters,
+                names: lock_names,
+            },
+            keyspace: Some(keyspace),
+            signals,
+        },
+        shutdown.clone(),
+    );
+    Ok(Subscription {
+        client,
+        fan_out,
+        reconnects,
+        manager,
+        watchdog,
+    })
+}
+
+/// The running combined plugin. Hands its cache backend to the wiring crate for
+/// `ClientHub` registration.
+///
+/// Call [`stop`](Self::stop) on graceful shutdown (DESIGN.md §11). Dropping the
+/// handle without it is a programming error and says so.
+pub struct RedisClusterHandle {
+    /// The concrete backend, kept beside the instrumented one because `stop()`
+    /// and `start_subscriber` need `watch_registry()` and `channel_names()` —
+    /// neither of which survives the widening to `dyn ClusterCacheBackend`.
+    cache: Arc<RedisCache>,
+    /// What [`cache`](Self::cache) hands out: the same backend behind the SDK's
+    /// telemetry decorator.
+    instrumented: Arc<dyn ClusterCacheBackend>,
+    lock: Arc<RedisLock>,
+    pool: Pool,
+    /// `Option`, not a bare field, for the same reason the join handles are:
+    /// this type has a `Drop` impl, so `stop` cannot move out of it and uses
+    /// `.take()` to drain in place.
+    subscription: Option<Subscription>,
+    /// The task keeping `cluster_redis_connection_state` current (DESIGN.md §9).
+    connection_state: Option<JoinHandle<()>>,
+    shutdown: CancellationToken,
+    /// Set by `stop` so the `Drop` guard can tell a graceful shutdown apart from
+    /// a forgotten one (ADR-006 §Confirmation).
+    stopped: bool,
+}
+
+impl RedisClusterHandle {
+    /// The cache backend, wrapped in the SDK's `InstrumentedCache` decorator.
+    ///
+    /// The decorator is the supported path for the ADR-004 cache signal set
+    /// (DESIGN.md §9), and using it rather than emitting here is what keeps the
+    /// span names, the bounded `result` vocabulary, and the cardinality rule
+    /// identical to every other provider instead of re-derived per backend. It
+    /// also stamps each returned `CacheWatch` with the provider and the sink, so
+    /// an `auto_restart`ed consumer's own resets reach
+    /// `cluster_watch_resets_total` alongside this plugin's.
+    ///
+    /// Wrapped once at startup rather than per call: the decorator holds two
+    /// `Arc`s, and a fresh one per `cache()` would be two allocations for a
+    /// value the wiring asks for once.
+    #[must_use]
+    pub fn cache(&self) -> Arc<dyn ClusterCacheBackend> {
+        Arc::clone(&self.instrumented)
+    }
+
+    /// The lock backend, for a profile that binds `lock: { provider: redis }`
+    /// alongside this plugin's cache.
+    ///
+    /// The same backend the standalone `RedisLockPlugin` hands out, over this
+    /// plugin's pool rather than a second one — which is the whole difference
+    /// between the two shapes (DESIGN.md §3.5).
+    #[must_use]
+    pub fn lock(&self) -> Arc<dyn DistributedLockBackend> {
+        Arc::clone(&self.lock) as Arc<dyn DistributedLockBackend>
+    }
+
+    /// Shuts the plugin down (DESIGN.md §11).
+    ///
+    /// 1. Cancels the shared `CancellationToken`, which the subscriber fan-out
+    ///    and reconnect-observer tasks join on, which ends every per-guard lock
+    ///    task, and which unparks every blocked `lock()` waiter so it returns
+    ///    `Shutdown` rather than `LockTimeout`.
+    /// 2. Broadcasts `Closed(Shutdown)` to every active watcher, dispatched
+    ///    directly against the registry **before** the fan-out task is awaited,
+    ///    so every watcher observes it before `stop()` returns
+    ///    (`cpt-cf-clst-fr-shutdown-revoke`). Going through the registry rather
+    ///    than the task is what makes that independent of whether the task has
+    ///    noticed the cancel yet.
+    /// 3. Drains the guard tasks under a bound, **before** the pool closes: a
+    ///    task caught mid-`renew` still needs a connection to finish on.
+    /// 4. Quits the subscriber, then the command pool, both bounded — so an
+    ///    unresponsive server cannot spend a supervisor's whole shutdown budget.
+    ///
+    /// **No remote cleanup** (`cpt-cf-clst-fr-shutdown-ttl-cleanup`): held
+    /// locks, leader claims, and service registrations are left to lapse via
+    /// their TTL rather than deleted on the way out. That is nearly free to
+    /// honour here — a Redis lease expires by itself, so there is no drain step,
+    /// no statement that can half-succeed, and no partial-cleanup failure mode
+    /// to alert on. `RD-LOCK-013` asserts the lease keys are still present after
+    /// this returns, so a future "tidy up on stop" would fail there on purpose.
+    ///
+    /// [`POOL_CLOSE_TIMEOUT`]: crate::shutdown::POOL_CLOSE_TIMEOUT
+    pub async fn stop(mut self) {
+        self.shutdown.cancel();
+        // Before the tasks are joined, so a watcher cannot be left waiting on a
+        // fan-out that has already exited.
+        if let Some(registry) = self.cache.watch_registry() {
+            registry.close_all().await;
+        }
+        self.lock.drain_guards().await;
+        if let Some(observer) = self.connection_state.take() {
+            let _observer_exited = observer.await;
+        }
+        if let Some(subscription) = self.subscription.take() {
+            let _fan_out_exited = subscription.fan_out.await;
+            if let Some(reconnects) = subscription.reconnects {
+                let _observer_exited = reconnects.await;
+            }
+            // `fred`'s replay task ends with the client rather than with the
+            // token, so it is aborted rather than joined.
+            subscription.manager.abort();
+            let _watchdog_exited = subscription.watchdog.await;
+            quit_subscriber(&subscription.client).await;
+        }
+        close_pool(&self.pool).await;
+        self.stopped = true;
+    }
+}
+
+/// Diagnostic guard (ADR-006 §Confirmation), mirroring the wiring's own
+/// `ClusterHandle` guard: dropping a `RedisClusterHandle` without calling
+/// `stop()` leaves its pool, its subscriber, and its background tasks running,
+/// surfaced loudly rather than silently.
+impl Drop for RedisClusterHandle {
+    fn drop(&mut self) {
+        match cancel_and_diagnose_drop(self.stopped, &self.shutdown) {
+            DropDiagnosis::StoppedCleanly => {}
+            // not-a-catalogued-event: an ADR-006 developer diagnostic, not an
+            // operator's business — this is the release-build arm of the same
+            // programming error that panics in debug.
+            DropDiagnosis::DuringPanic => tracing::warn!(
+                "RedisClusterHandle dropped during panic unwind without stop(); skipping debug \
+                 panic to avoid double-panic abort"
+            ),
+            DropDiagnosis::Unstopped => {
+                #[cfg(debug_assertions)]
+                panic!("RedisClusterHandle dropped without stop() - programming error");
+                // not-a-catalogued-event: as above.
+                #[cfg(not(debug_assertions))]
+                tracing::warn!(
+                    "RedisClusterHandle dropped without stop() - programming error; the command \
+                     pool and any background tasks may leak"
+                );
+            }
+        }
+    }
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/preflight.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/preflight.rs
@@ -1,0 +1,931 @@
+//! Startup preflight (DESIGN.md §3.4) and the consistency declaration
+//! (DESIGN.md §3.6): the reply parsers, and the decision table as a pure
+//! function.
+//!
+//! ## The decision is pure, the detection is not
+//!
+//! [`decide_consistency`] takes only what the preflight learned — a topology
+//! finding, the operator's durability hint, and what `CONFIG GET` said about
+//! durability — and returns the declaration. It issues no command, holds no
+//! client, and logs nothing. That split is deliberate: the consistency
+//! declaration is the single most consequential thing this plugin decides
+//! (it is what makes a Redis-backed profile fail or start, ADR-009), and every
+//! row of DESIGN.md §3.6's table plus the hint-contradiction case is therefore
+//! exercisable as a unit test with no server, rather than only against whatever
+//! topologies a container fixture happens to reproduce.
+//!
+//! The `fred`-dependent half is [`run_preflight`]: it issues `INFO` and
+//! `CONFIG GET`, degrades when a managed Redis refuses either, and logs the
+//! reason for every conservative fallback. It feeds this module's parsers and
+//! then this module's decision, and holds no policy of its own — every branch
+//! it takes on a *value* is one of the pure functions above.
+//!
+//! ## Nothing here upgrades a guarantee it did not verify
+//!
+//! Every unreadable answer resolves to the *weaker* declaration, and the one
+//! case where an unverifiable operator hint is trusted — a `fsync_always` claim
+//! the plugin cannot check because `CONFIG` is refused — is reported back
+//! through [`ConsistencyDecision::asserted_not_verified`] so the caller can log
+//! `cluster.provider.consistency_asserted`. An operator's claim is then visible
+//! in the logs of the deployment that made it.
+
+use std::collections::BTreeMap;
+
+use cluster_sdk::{CacheConsistency, ClusterError, ProviderErrorKind};
+use fred::interfaces::{ClientLike, ConfigInterface};
+use fred::types::InfoKind;
+use tracing::{debug, warn};
+
+use crate::config::{Durability, Topology};
+use crate::observability::logs;
+use crate::redis_error::map_redis_error;
+
+/// The `notify-keyspace-events` flags the cache's watch needs (DESIGN.md §4.3).
+///
+/// `K` turns on keyspace notifications, `x` adds `expired`, and `e` adds
+/// `evicted` — the two events no plugin code can publish for itself
+/// (DESIGN.md §4.3).
+///
+/// Minimal matters here rather than being tidiness. Every flag is
+/// **server-wide**, and `manage_keyspace_notifications: true` writes the setting
+/// globally, so anything beyond these three is traffic unrelated tenants of the
+/// same Redis pay for and this plugin never reads. The tempting additions are the
+/// worst offenders: `g` adds a notification for every generic command and `$` for
+/// every string command.
+pub const REQUIRED_KEYSPACE_FLAGS: &str = "Kxe";
+
+/// The subset [`EVICTION_KEYSPACE_FLAGS`] needs: `K` to route the notification
+/// to a `__keyspace@…__` channel, `e` for `evicted` itself.
+///
+/// Separate from [`REQUIRED_KEYSPACE_FLAGS`] because the two deployments want
+/// different things and asking for the union would overstate one of them. The
+/// cache's watch needs `x` as well, since an entry whose TTL lapses has no other
+/// way to reach a watcher. The eviction signal of DESIGN.md §3.7 needs no `x` at
+/// all: a lapsed **lock lease** is not an incident, and the standalone lock
+/// plugin (DESIGN.md §3.5) would be asking a shared server for a server-wide
+/// flag it never reads.
+pub const EVICTION_KEYSPACE_FLAGS: &str = "Ke";
+
+/// The first Redis major version with sharded pub/sub (`SPUBLISH`/`SSUBSCRIBE`).
+///
+/// Detected and recorded but never used: v1 publishes with plain `PUBLISH`,
+/// which is broadcast cluster-wide and therefore correct on every topology,
+/// and DESIGN.md §13 D3 keeps the sharded variant as a follow-up. Knowing
+/// whether a deployment *could* take it is an input to that decision, which is
+/// why the finding is a DEBUG line rather than an INFO one.
+pub const SHARDED_PUBSUB_MAJOR: u32 = 7;
+
+/// The `maxmemory-policy` value under which cluster keys cannot be evicted.
+///
+/// Any other policy is a documented misconfiguration (DESIGN.md §3.7): an
+/// evicted lock key hands the lock to a second holder while the first still
+/// believes it holds it, and no TTL has lapsed and no consumer is told.
+pub const SAFE_MAXMEMORY_POLICY: &str = "noeviction";
+
+/// The role a server reports in `INFO replication`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplicationRole {
+    /// `role:master` — accepts writes.
+    Primary,
+    /// `role:slave` — a replica, and therefore by definition part of a
+    /// replicated topology.
+    Replica,
+}
+
+/// The two `INFO replication` fields the topology decision reads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReplicationInfo {
+    /// The reported `role`.
+    pub role: ReplicationRole,
+    /// The reported `connected_slaves`, or `None` when the field was absent.
+    ///
+    /// Absent is not the same as zero, and the difference is load-bearing:
+    /// only a primary that *reports* zero replicas can reach the single-node
+    /// row of DESIGN.md §3.6, so a reply that omits the field is treated as
+    /// replicated rather than assumed quiet.
+    pub connected_replicas: Option<u32>,
+}
+
+/// The topology input to DESIGN.md §3.6's table.
+///
+/// The single-node case is split by provenance and the others are not, because
+/// only the single-node row can produce `Linearizable`: for every other row the
+/// answer is `EventuallyConsistent` whether the plugin read it off the server
+/// or took the operator's word for it, so carrying the distinction there would
+/// be a variant nothing branches on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TopologyFinding {
+    /// `INFO replication` reported `role:master` with `connected_slaves:0`.
+    VerifiedSingleNode,
+    /// The operator's `topology: standalone` hint, with detection skipped
+    /// (DESIGN.md §3.4). Trusted, but never verified — which is what makes a
+    /// `Linearizable` declaration built on it asserted rather than confirmed.
+    AssertedSingleNode,
+    /// Sentinel, a primary with replicas, or a replica. Asynchronous
+    /// replication means every failover may promote a node that never saw an
+    /// accepted write.
+    Replicated,
+    /// Redis Cluster: the same asynchronous replication, plus slot-migration
+    /// edge cases.
+    Cluster,
+    /// `INFO replication` was refused or unintelligible and no operator hint
+    /// was given.
+    ///
+    /// Distinct from [`Self::Replicated`] even though both decide the same way.
+    /// DESIGN.md §3.4 says an unreadable `INFO replication` is treated *as*
+    /// replicated, and it is — but the caller logs a different reason for each,
+    /// and an operator debugging a surprise `EventuallyConsistent` needs to
+    /// know whether the plugin saw a replica or saw nothing.
+    Unknown,
+}
+
+/// The `appendfsync` policy, as the server reports it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Appendfsync {
+    /// Every write is fsynced before it is acknowledged.
+    Always,
+    /// The Redis default: fsync once a second, so a crash can lose up to a
+    /// second of already-acknowledged writes.
+    Everysec,
+    /// Leave fsync to the operating system.
+    No,
+}
+
+impl Appendfsync {
+    /// Parses the `appendfsync` value Redis reports, or `None` for a value this
+    /// plugin does not recognize.
+    #[must_use]
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim() {
+            "always" => Some(Self::Always),
+            "everysec" => Some(Self::Everysec),
+            "no" => Some(Self::No),
+            _ => None,
+        }
+    }
+}
+
+/// What `CONFIG GET appendonly|appendfsync` reported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DurabilityReading {
+    /// Both settings were read back.
+    Readable {
+        /// `appendonly yes`.
+        appendonly: bool,
+        /// The `appendfsync` policy.
+        appendfsync: Appendfsync,
+    },
+    /// `CONFIG GET` was refused, unavailable, or answered with something this
+    /// plugin could not parse.
+    ///
+    /// Managed Redis (`ElastiCache`, `MemoryDB`, Azure Cache) commonly restricts
+    /// `CONFIG`, so this is an ordinary state rather than a failure — the
+    /// plugin treats it as non-durable and carries on (DESIGN.md §3.4).
+    Unreadable,
+}
+
+impl DurabilityReading {
+    /// Whether the server's own answer is the one configuration ADR-009 rates
+    /// safe: an append-only file fsynced before every acknowledgement.
+    #[must_use]
+    fn is_fsync_always(self) -> bool {
+        matches!(
+            self,
+            Self::Readable {
+                appendonly: true,
+                appendfsync: Appendfsync::Always,
+            }
+        )
+    }
+
+    /// Renders the reading the way the contradiction error reports it, so the
+    /// operator sees the two `CONFIG` values rather than a verdict.
+    fn describe(self) -> String {
+        match self {
+            Self::Readable {
+                appendonly,
+                appendfsync,
+            } => {
+                let appendonly = if appendonly { "yes" } else { "no" };
+                let appendfsync = match appendfsync {
+                    Appendfsync::Always => "always",
+                    Appendfsync::Everysec => "everysec",
+                    Appendfsync::No => "no",
+                };
+                format!("appendonly {appendonly}, appendfsync {appendfsync}")
+            }
+            Self::Unreadable => "unreadable".to_owned(),
+        }
+    }
+}
+
+/// The outcome of DESIGN.md §3.6's decision table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ConsistencyDecision {
+    /// What `ClusterCacheBackend::consistency()` will return for the life of
+    /// the plugin. Computed once at startup and never re-evaluated — a
+    /// topology that changes underneath a running plugin does not downgrade a
+    /// live declaration, which is a real gap recorded in DESIGN.md §12 rather
+    /// than solved, because the resolution model has no way to express a
+    /// backend whose capabilities change after consumers resolved against them.
+    pub consistency: CacheConsistency,
+
+    /// `true` when a [`CacheConsistency::Linearizable`] declaration rests on an
+    /// operator hint the preflight could not check, so the caller should log
+    /// `cluster.provider.consistency_asserted` (WARN, once, DESIGN.md §3.6).
+    ///
+    /// Always `false` for an `EventuallyConsistent` declaration: the flag warns
+    /// about an unverified *upgrade*, and there is no such thing as an
+    /// unverified downgrade — the conservative answer needs no evidence.
+    pub asserted_not_verified: bool,
+}
+
+/// Resolves the topology the consistency decision branches on, preferring the
+/// operator's hint over detection.
+///
+/// The hint wins outright rather than being cross-checked, unlike the
+/// durability hint below. That asymmetry is DESIGN.md §3.4's: the hint exists
+/// for a locked-down managed instance whose `INFO` the plugin cannot read at
+/// all, so there is usually nothing to cross-check against, and unlike
+/// `fsync_always` a topology claim is not the lever that unlocks
+/// `Linearizable` on its own.
+#[must_use]
+pub fn resolve_topology(hint: Option<Topology>, detected: TopologyFinding) -> TopologyFinding {
+    match hint {
+        Some(Topology::Standalone) => TopologyFinding::AssertedSingleNode,
+        Some(Topology::Sentinel) => TopologyFinding::Replicated,
+        Some(Topology::Cluster) => TopologyFinding::Cluster,
+        None => detected,
+    }
+}
+
+/// Derives the topology finding from a parsed `INFO replication`, or
+/// [`TopologyFinding::Unknown`] when the reply could not be parsed.
+///
+/// Only `role:master` with an explicit `connected_slaves:0` yields
+/// [`TopologyFinding::VerifiedSingleNode`]. A replica is replicated by
+/// definition, a primary with replicas obviously so, and a primary whose reply
+/// omitted the replica count is treated as replicated because the single-node
+/// row is the only one that can weaken a guarantee by being wrong.
+///
+/// Cluster mode is not derivable from `INFO replication` — every node in a
+/// cluster reports a plain `role` — so it comes from the operator hint or from
+/// the connection URL scheme, both handled by [`resolve_topology`] and its
+/// caller.
+#[must_use]
+pub fn topology_from_replication(info: Option<ReplicationInfo>) -> TopologyFinding {
+    match info {
+        Some(ReplicationInfo {
+            role: ReplicationRole::Primary,
+            connected_replicas: Some(0),
+        }) => TopologyFinding::VerifiedSingleNode,
+        Some(_) => TopologyFinding::Replicated,
+        None => TopologyFinding::Unknown,
+    }
+}
+
+/// DESIGN.md §3.6's decision table, as a pure function of the topology finding,
+/// the operator's `durability` hint, and what `CONFIG GET` reported.
+///
+/// | Topology | Durable writes | Declaration |
+/// |---|---|---|
+/// | Single node, verified or asserted | `appendonly yes` + `appendfsync always` | `Linearizable` |
+/// | Single node | anything weaker | `EventuallyConsistent` |
+/// | Sentinel / any replicated primary | — | `EventuallyConsistent` |
+/// | Redis Cluster | — | `EventuallyConsistent` |
+/// | Unknown | — | `EventuallyConsistent` |
+///
+/// `WAIT` does not appear because it changes nothing here: per ADR-009's "no
+/// linearizable-ish middle ground", `WAIT 1` narrows the Sentinel failover
+/// window but does not close it, and `CacheConsistency` is deliberately
+/// two-valued.
+///
+/// # Errors
+/// [`ClusterError::InvalidConfig`] when the operator declared
+/// `durability: fsync_always` and a readable `CONFIG GET` contradicts it. The
+/// error names both the claim and the two values the server reported, because
+/// the operator has to change one of them and cannot tell which from a verdict
+/// alone. Only this direction fails: a hint *weaker* than the server's actual
+/// setting can only under-declare, which is safe, and is a legitimate choice
+/// for an operator who does not want a durable-today server to silently become
+/// the basis of a `Linearizable` declaration tomorrow.
+pub fn decide_consistency(
+    topology: TopologyFinding,
+    durability: Option<Durability>,
+    readability: DurabilityReading,
+) -> Result<ConsistencyDecision, ClusterError> {
+    let claims_fsync_always = durability == Some(Durability::FsyncAlways);
+
+    if claims_fsync_always
+        && matches!(readability, DurabilityReading::Readable { .. })
+        && !readability.is_fsync_always()
+    {
+        return Err(ClusterError::InvalidConfig {
+            reason: format!(
+                "durability: fsync_always was declared for this Redis binding, but the server \
+                 reports {}. Either set appendonly yes with appendfsync always on the server, or \
+                 remove the durability hint so the plugin declares the consistency it can verify \
+                 (DESIGN.md sec 3.6)",
+                readability.describe()
+            ),
+        });
+    }
+
+    // The hint, when present, decides; only `fsync_always` can mean durable, so
+    // an `everysec` or `none` hint settles the question without consulting the
+    // server at all. With no hint, the server's answer decides, and an
+    // unreadable answer is non-durable — the conservative direction.
+    let durable_writes = match durability {
+        Some(Durability::FsyncAlways) => true,
+        Some(Durability::FsyncEverysec | Durability::None) => false,
+        None => readability.is_fsync_always(),
+    };
+
+    let single_node = matches!(
+        topology,
+        TopologyFinding::VerifiedSingleNode | TopologyFinding::AssertedSingleNode
+    );
+
+    if single_node && durable_writes {
+        // Asserted whenever either leg rests on something unchecked: a
+        // `topology: standalone` hint (no `INFO replication` was read, so the
+        // "no replicas" half is the operator's word) or a `fsync_always` hint
+        // that `CONFIG GET` could not corroborate.
+        let topology_verified = topology == TopologyFinding::VerifiedSingleNode;
+        let durability_verified = readability.is_fsync_always();
+        return Ok(ConsistencyDecision {
+            consistency: CacheConsistency::Linearizable,
+            asserted_not_verified: !(topology_verified && durability_verified),
+        });
+    }
+
+    Ok(ConsistencyDecision {
+        consistency: CacheConsistency::EventuallyConsistent,
+        asserted_not_verified: false,
+    })
+}
+
+/// Parses an `INFO` reply into its `key:value` pairs.
+///
+/// Shared by the `INFO server` and `INFO replication` checks of DESIGN.md §3.4
+/// rather than written once per section, since the reply format is the same for
+/// both: `# Section` header lines, blank lines, and `key:value` lines with
+/// `\r\n` endings. The split is on the **first** colon only, because values
+/// legitimately contain them (`slave0:ip=10.0.0.1,port=6379,…`).
+#[must_use]
+pub fn parse_info(reply: &str) -> BTreeMap<&str, &str> {
+    reply
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .filter_map(|line| line.split_once(':'))
+        .collect()
+}
+
+/// Extracts the topology-relevant fields from an `INFO replication` reply, or
+/// `None` when the reply carries no recognizable `role`.
+///
+/// A missing or unrecognized `role` is the "unreadable" case rather than an
+/// error: DESIGN.md §3.4 degrades on it instead of failing startup, because a
+/// managed Redis may restrict `INFO` sections and refusing to run there would
+/// make the plugin unusable on the platforms it is most often deployed to.
+#[must_use]
+pub fn parse_info_replication(reply: &str) -> Option<ReplicationInfo> {
+    let fields = parse_info(reply);
+    let role = match fields.get("role")?.trim() {
+        "master" => ReplicationRole::Primary,
+        "slave" => ReplicationRole::Replica,
+        _ => return None,
+    };
+    let connected_replicas = fields
+        .get("connected_slaves")
+        .and_then(|raw| raw.trim().parse::<u32>().ok());
+    Some(ReplicationInfo {
+        role,
+        connected_replicas,
+    })
+}
+
+/// Parses a `CONFIG GET` reply — a flat array of alternating parameter names
+/// and values — into a map.
+///
+/// The empty-value case is ordinary rather than exceptional and must survive
+/// the round trip: an unconfigured `notify-keyspace-events` reads back as
+/// `["notify-keyspace-events", ""]`, and collapsing that to "absent" would make
+/// the plugin unable to distinguish "the server has no flags set" from "the
+/// server would not tell me", which are opposite conclusions
+/// ([`missing_keyspace_flags`] versus a WARN and best-effort `Expired`).
+///
+/// # Errors
+/// [`ClusterError::Provider`] with [`ProviderErrorKind::Other`] when the reply
+/// has an odd number of elements. That is the server or the client library
+/// violating the command's own reply shape, and silently dropping the unpaired
+/// trailing element would turn it into a missing setting.
+pub fn parse_config_get(reply: &[String]) -> Result<BTreeMap<String, String>, ClusterError> {
+    if !reply.len().is_multiple_of(2) {
+        return Err(ClusterError::Provider {
+            kind: ProviderErrorKind::Other,
+            message: format!(
+                "CONFIG GET returned {} elements; a parameter/value reply must have an even count",
+                reply.len()
+            ),
+        });
+    }
+    Ok(reply
+        .chunks_exact(2)
+        .map(|pair| (pair[0].clone(), pair[1].clone()))
+        .collect())
+}
+
+/// Returns the flags of `required` that `current` — the server's
+/// `notify-keyspace-events` value — does not already provide, in the order they
+/// are listed.
+///
+/// `required` is [`REQUIRED_KEYSPACE_FLAGS`] or [`EVICTION_KEYSPACE_FLAGS`]
+/// depending on which plugin is asking, rather than a constant read from here:
+/// a lock-only deployment must not be told it is missing `x`.
+///
+/// `A` is handled rather than compared literally: Redis defines it as an alias
+/// for every event class except `K`, `E`, `m`, and `n`, so a server configured
+/// `KA` already delivers `expired` and `evicted` and needs nothing added. It
+/// does *not* imply `K`, which is what actually routes those events to a
+/// `__keyspace@…__` channel, so `K` is still required alongside it.
+#[must_use]
+pub fn missing_keyspace_flags(current: &str, required: &str) -> Vec<char> {
+    let has_all_classes = current.contains('A');
+    required
+        .chars()
+        .filter(|flag| {
+            let covered_by_alias = has_all_classes && *flag != 'K';
+            !current.contains(*flag) && !covered_by_alias
+        })
+        .collect()
+}
+
+/// The value to pass to `CONFIG SET notify-keyspace-events` so the server keeps
+/// everything it already emits and gains what this plugin needs — the one
+/// mutation `manage_keyspace_notifications: true` permits (DESIGN.md §3.4).
+///
+/// Additive by construction. The setting is server-wide, so replacing it with
+/// `required` alone would silently switch off notifications an unrelated tenant
+/// of the same Redis is subscribed to.
+#[must_use]
+pub fn merge_keyspace_flags(current: &str, required: &str) -> String {
+    let mut merged = current.to_owned();
+    merged.extend(missing_keyspace_flags(current, required));
+    merged
+}
+
+/// Whether `version` — the `redis_version` field of `INFO server` — is new
+/// enough for sharded pub/sub (DESIGN.md §13 D3).
+///
+/// Only the major component is read, and an unparseable one answers `false`.
+/// The conservative direction is the right one here for an unusual reason: the
+/// answer feeds a DEBUG line and nothing else, so a false negative costs a log
+/// line while a false positive would put a wrong capability claim in the record
+/// a future decision is made from.
+#[must_use]
+pub fn supports_sharded_pubsub(version: &str) -> bool {
+    version
+        .trim()
+        .split('.')
+        .next()
+        .and_then(|major| major.parse::<u32>().ok())
+        .is_some_and(|major| major >= SHARDED_PUBSUB_MAJOR)
+}
+
+/// Whether `policy` — the server's `maxmemory-policy` — leaves cluster keys
+/// safe from eviction (DESIGN.md §3.7).
+///
+/// A `false` here is a WARN and not a startup failure, because the policy is a
+/// server-wide setting the cluster keys may be sharing with unrelated tenants:
+/// refusing to start would make this plugin unusable on any shared Redis, which
+/// is a worse outcome than an alertable warning on a real risk.
+#[must_use]
+pub fn maxmemory_policy_is_safe(policy: &str) -> bool {
+    policy.trim().eq_ignore_ascii_case(SAFE_MAXMEMORY_POLICY)
+}
+
+/// What the caller wants the preflight to check, and the operator hints it must
+/// honour (DESIGN.md §3.4).
+#[derive(Debug, Clone, Copy)]
+pub struct PreflightRequest {
+    /// The operator's `topology` hint. When set, `INFO replication` detection is
+    /// skipped entirely.
+    pub topology_hint: Option<Topology>,
+    /// What the connection URL itself says about the topology — `Cluster` for a
+    /// `redis-cluster://` URL, `Sentinel` for `redis-sentinel://`, `None`
+    /// otherwise.
+    ///
+    /// A fact about the client rather than a claim about the server, so it
+    /// outranks detection: a clustered client is talking to a cluster whatever a
+    /// single node's `INFO replication` reports about its own replicas. It still
+    /// loses to an explicit operator hint, which is the documented override for
+    /// everything the plugin infers.
+    pub url_topology: Option<Topology>,
+    /// The operator's `durability` hint, cross-checked against `CONFIG GET`
+    /// whenever that is readable.
+    pub durability_hint: Option<Durability>,
+    /// Which `notify-keyspace-events` flags this deployment needs, or `None` to
+    /// skip the check entirely.
+    ///
+    /// [`REQUIRED_KEYSPACE_FLAGS`] for the combined plugin, whose cache watch
+    /// needs `expired` as well; [`EVICTION_KEYSPACE_FLAGS`] for the standalone
+    /// lock plugin, which needs only the eviction signal of DESIGN.md §3.7.
+    ///
+    /// What the two deployments lose without their flags differs in kind, which
+    /// is why the set is a request field rather than a constant. The cache loses
+    /// prompt `Expired` delivery. The lock loses **nothing it needs to operate**
+    /// — a lease lapse is still discovered by the next acquire attempt — and
+    /// only forfeits the report that an eviction handed one of its locks to a
+    /// second holder. Neither is fatal; both are worth a WARN.
+    pub keyspace_flags: Option<&'static str>,
+    /// Whether the plugin may issue one `CONFIG SET notify-keyspace-events` to
+    /// add the flags it needs (DESIGN.md §3.4).
+    pub manage_keyspace_notifications: bool,
+}
+
+/// What the preflight concluded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PreflightOutcome {
+    /// The declaration `consistency()` returns for the life of the handle.
+    pub consistency: CacheConsistency,
+}
+
+/// Runs the DESIGN.md §3.4 preflight against a connected client and computes the
+/// §3.6 consistency declaration — step 2 of `build_and_start` (DESIGN.md §3.2).
+///
+/// Generic over the client rather than taking a `Pool` so the standalone lock
+/// plugin can run the same checks against its own pool, and so nothing here
+/// depends on which of `fred`'s client types is in play.
+///
+/// **Every check except the first degrades rather than fails.** Managed Redis
+/// commonly restricts `CONFIG`, and a plugin that treated an ACL denial as a
+/// hard failure would be unusable on the platforms this backend is most often
+/// deployed to. `INFO server` is the exception: a server that will not answer it
+/// at all is locked down past the point of usefulness, and failing at startup is
+/// better than discovering that one command at a time.
+///
+/// # Errors
+/// - [`ClusterError::InvalidConfig`] when `INFO server` is refused, or when a
+///   `durability: fsync_always` hint is contradicted by a readable server config
+///   (via [`decide_consistency`]).
+/// - [`ClusterError::Provider`] for a `CONFIG SET` that fails while
+///   `manage_keyspace_notifications` is enabled — the operator asked for the
+///   write, so it is not silently degraded.
+pub async fn run_preflight<C>(
+    client: &C,
+    request: PreflightRequest,
+) -> Result<PreflightOutcome, ClusterError>
+where
+    C: ClientLike + ConfigInterface,
+{
+    require_reachable_server(client).await?;
+    let consistency = declare_consistency(client, request).await?;
+    warn_on_eviction_policy(client).await;
+
+    // Run for its `?` and its WARN, not for its answer. Nothing branches on
+    // keyspace availability: the degradation is fully reported by the WARN
+    // `ensure_keyspace_notifications` emits where it discovers it, and a field
+    // holding the answer would be state the plugin maintains and never consults
+    // — the shape DESIGN.md §13 D3 rejects by name, where it also says the
+    // change that first *uses* it should decide where it lives.
+    if let Some(required) = request.keyspace_flags {
+        let _available =
+            ensure_keyspace_notifications(client, required, request.manage_keyspace_notifications)
+                .await?;
+    }
+
+    Ok(PreflightOutcome { consistency })
+}
+
+/// The one preflight check that fails rather than degrades (DESIGN.md §3.4).
+///
+/// # Errors
+/// [`ClusterError::InvalidConfig`] when `INFO server` is refused.
+async fn require_reachable_server<C: ClientLike>(client: &C) -> Result<(), ClusterError> {
+    let info: String =
+        client
+            .info(Some(InfoKind::Server))
+            .await
+            .map_err(|err| ClusterError::InvalidConfig {
+                reason: format!(
+                    "redis: `INFO server` was refused ({err}); a server this locked down cannot be \
+                 preflighted, so the plugin will not start against it (DESIGN.md sec 3.4)"
+                ),
+            })?;
+    let Some(version) = parse_info(&info).get("redis_version").copied() else {
+        return Ok(());
+    };
+    debug!(redis_version = version, "redis preflight: server reached");
+    if supports_sharded_pubsub(version) {
+        debug!(
+            name: logs::SHARDED_PUBSUB_AVAILABLE,
+            redis_version = version,
+            "cluster.provider.sharded_pubsub_available: this server supports SPUBLISH/SSUBSCRIBE, \
+             which v1 records and does not use. Plain PUBLISH is broadcast cluster-wide and is \
+             therefore correct on every topology; the sharded variant is a follow-up \
+             (DESIGN.md sec 13 D3)"
+        );
+    }
+    Ok(())
+}
+
+/// Resolves the topology, reads the durability, and runs the §3.6 table over
+/// both — warning when the answer rests on an operator hint the plugin could not
+/// check, and warning again whenever the answer is the weak one.
+///
+/// The two warnings are not alternatives. `consistency_asserted` says *the
+/// evidence was missing*; `weak_consistency` says *the declaration is
+/// `EventuallyConsistent`*, which is the expected state for Sentinel and Cluster
+/// and still has to appear in the log of every deployment it applies to
+/// (DESIGN.md §9). Exactly one of them can fire per startup, because an asserted
+/// declaration is by construction a `Linearizable` one.
+///
+/// # Errors
+/// [`ClusterError::InvalidConfig`] when a `durability: fsync_always` hint is
+/// contradicted by a readable server config.
+async fn declare_consistency<C>(
+    client: &C,
+    request: PreflightRequest,
+) -> Result<CacheConsistency, ClusterError>
+where
+    C: ClientLike + ConfigInterface,
+{
+    // The operator's hint outranks the URL, which outranks detection — each
+    // layer is more specific about intent than the one below it.
+    //
+    // Detection runs only when nothing above it has already settled the answer.
+    // `resolve_topology` returns a constant from every `Some(_)` arm, so with an
+    // assertion in hand the `INFO replication` round trip decides nothing — and
+    // issuing it anyway costs more than a wasted command. The reason to set
+    // `topology: standalone` on a locked-down managed instance is precisely that
+    // `INFO replication` is refused there, so the refusal would log
+    // `cluster.provider.topology_unknown` announcing a conservative
+    // `EventuallyConsistent` declaration that `resolve_topology` is not going to
+    // make. Skipping the call is what both `PreflightRequest::topology_hint` and
+    // `config::Topology` already promise, and it is what makes that WARN
+    // truthful wherever it does fire.
+    //
+    // The URL-derived topology settles it just as an explicit hint does: a
+    // `redis-cluster://` URL is a fact about the client rather than a claim
+    // about the server (see [`PreflightRequest::url_topology`]).
+    let asserted = request.topology_hint.or(request.url_topology);
+    let topology = match asserted {
+        Some(hint) => resolve_topology(Some(hint), TopologyFinding::Unknown),
+        None => resolve_topology(None, detect_topology(client).await),
+    };
+    let durability = read_durability(client).await;
+    let decision = decide_consistency(topology, request.durability_hint, durability)?;
+    if decision.asserted_not_verified {
+        warn!(
+            name: logs::CONSISTENCY_ASSERTED,
+            topology = ?topology,
+            "cluster.provider.consistency_asserted: declaring Linearizable on the strength of an \
+             operator hint this server would not let the plugin verify. If the hint is wrong, \
+             leader election over this cache can elect two leaders (DESIGN.md sec 3.6)"
+        );
+    }
+    if decision.consistency == CacheConsistency::EventuallyConsistent {
+        warn!(
+            name: logs::WEAK_CONSISTENCY,
+            topology = ?topology,
+            durability = ?durability,
+            "cluster.provider.weak_consistency: this Redis is declared EventuallyConsistent, so \
+             ADR-009 rates it unsafe for CAS-based leader election and for the SDK's default \
+             lock: an accepted write can be lost to an fsync gap or a failover, which is two \
+             leaders. Not an error and the expected state for Sentinel and Cluster, but a profile \
+             binding this cache must route leader election elsewhere or opt in explicitly \
+             (DESIGN.md sec 3.6, sec 7)"
+        );
+    }
+    Ok(decision.consistency)
+}
+
+/// `INFO replication`, degrading to [`TopologyFinding::Unknown`] when the server
+/// will not answer.
+///
+/// DESIGN.md §3.4 says an unreadable `INFO replication` is treated as
+/// replicated; `Unknown` is that, plus the ability to say *why* in the log.
+async fn detect_topology<C: ClientLike>(client: &C) -> TopologyFinding {
+    match client.info::<String>(Some(InfoKind::Replication)).await {
+        Ok(reply) => topology_from_replication(parse_info_replication(&reply)),
+        Err(err) => {
+            warn!(
+                name: logs::TOPOLOGY_UNKNOWN,
+                error = %err,
+                "cluster.provider.topology_unknown: `INFO replication` was refused, so the \
+                 topology could not be detected; declaring the conservative \
+                 EventuallyConsistent (DESIGN.md sec 3.4)"
+            );
+            TopologyFinding::Unknown
+        }
+    }
+}
+
+/// `CONFIG GET appendonly` and `CONFIG GET appendfsync`, degrading to
+/// [`DurabilityReading::Unreadable`] if either is refused or unrecognized.
+///
+/// Both are read, not just `appendfsync`, because `appendfsync always` means
+/// nothing with `appendonly no` — there is no append-only file to fsync, and a
+/// check that read only the policy would declare `Linearizable` for a server
+/// keeping no durable log at all.
+async fn read_durability<C: ConfigInterface>(client: &C) -> DurabilityReading {
+    let Some(appendonly) = read_config_value(client, "appendonly").await else {
+        return DurabilityReading::Unreadable;
+    };
+    let Some(appendfsync) = read_config_value(client, "appendfsync").await else {
+        return DurabilityReading::Unreadable;
+    };
+    let Some(appendfsync) = Appendfsync::parse(&appendfsync) else {
+        warn!(
+            name: logs::DURABILITY_UNKNOWN,
+            value = appendfsync,
+            "cluster.provider.durability_unknown: `appendfsync` reported a value this plugin does \
+             not recognize; treating durability as unverifiable (DESIGN.md sec 3.4)"
+        );
+        return DurabilityReading::Unreadable;
+    };
+    DurabilityReading::Readable {
+        appendonly: appendonly.trim().eq_ignore_ascii_case("yes"),
+        appendfsync,
+    }
+}
+
+/// One `CONFIG GET`, returning `None` when the command is refused or the
+/// parameter is absent from the reply.
+///
+/// The reply is taken as the flat parameter/value array RESP2 defines and run
+/// through [`parse_config_get`] rather than decoded straight into a map, so the
+/// empty-value case stays distinguishable from an absent one — see that
+/// function for why the difference matters.
+async fn read_config_value<C: ConfigInterface>(client: &C, parameter: &str) -> Option<String> {
+    let reply: Vec<String> = match client.config_get(parameter.to_owned()).await {
+        Ok(reply) => reply,
+        Err(err) => {
+            debug!(
+                parameter,
+                error = %err,
+                "redis preflight: CONFIG GET was refused; degrading for this check"
+            );
+            return None;
+        }
+    };
+    // Not `.ok()?`: an odd-length reply is the server or `fred` violating the
+    // reply shape, which `parse_config_get` documents must not be dropped
+    // silently. Degrading to `None` is still the conservative answer, but
+    // without this line it is indistinguishable from the refusal above and the
+    // protocol violation leaves no trace anywhere.
+    match parse_config_get(&reply) {
+        Ok(parsed) => parsed.get(parameter).cloned(),
+        Err(err) => {
+            // not-a-catalogued-event: the server or `fred` breaking the RESP
+            // reply shape is a defect in one of them, not a condition an
+            // operator can act on — the check has already degraded safely. WARN
+            // rather than the DEBUG the refusal arm uses, because a refusal is
+            // expected on an ACL-restricted deployment and this is expected
+            // nowhere.
+            warn!(
+                parameter,
+                error = %err,
+                "redis preflight: CONFIG GET returned a malformed parameter/value reply; \
+                 degrading for this check"
+            );
+            None
+        }
+    }
+}
+
+/// Reads `maxmemory-policy` and warns if cluster keys can be evicted
+/// (DESIGN.md §3.7).
+///
+/// WARN and never an error: the policy is server-wide and the cluster keys may
+/// be sharing the instance with unrelated tenants, so refusing to start would
+/// make this plugin unusable on any shared Redis — a worse outcome than an
+/// alertable warning on a real risk.
+async fn warn_on_eviction_policy<C: ConfigInterface>(client: &C) {
+    let Some(policy) = read_config_value(client, "maxmemory-policy").await else {
+        warn!(
+            name: logs::MAXMEMORY_POLICY_UNKNOWN,
+            "cluster.provider.maxmemory_policy_unknown: `CONFIG GET maxmemory-policy` was \
+             refused, so the plugin cannot tell whether its keys can be evicted. An evicted lock \
+             or leader key hands the name to a second holder with no TTL having lapsed \
+             (DESIGN.md sec 3.7)"
+        );
+        return;
+    };
+    if !maxmemory_policy_is_safe(&policy) {
+        warn!(
+            name: logs::MAXMEMORY_POLICY_UNSAFE,
+            policy,
+            "cluster.provider.maxmemory_policy_unsafe: this Redis can evict the plugin's own \
+             keys, which silently breaks every primitive at once: an evicted lock key hands the \
+             lock to a second holder while the first still believes it holds it. Run cluster keys \
+             on a dedicated instance, or set maxmemory-policy noeviction (DESIGN.md sec 3.7)"
+        );
+    }
+}
+
+/// Checks `notify-keyspace-events`, optionally adding the missing flags, and
+/// reports whether `expired`/`evicted` notifications will arrive.
+///
+/// # Errors
+/// [`ClusterError::Provider`] when `manage_keyspace_notifications` is on and the
+/// `CONFIG SET` fails. An operator who opted into the write gets told it did not
+/// happen rather than a silent downgrade to best-effort `Expired` events.
+async fn ensure_keyspace_notifications<C: ConfigInterface>(
+    client: &C,
+    required: &str,
+    manage: bool,
+) -> Result<bool, ClusterError> {
+    let Some(current) = read_config_value(client, "notify-keyspace-events").await else {
+        warn!(
+            name: logs::EXPIRY_EVENTS_UNAVAILABLE,
+            required,
+            "cluster.provider.expiry_events_unavailable: `notify-keyspace-events` could not be \
+             read, so observed evictions cannot be reported, and where this deployment has a \
+             cache its Expired events are best-effort. This degrades promptness and \
+             observability, not correctness: an expired entry still reads as absent and a lapsed \
+             lease is still found by the next acquire (DESIGN.md sec 4.3, sec 3.7)"
+        );
+        return Ok(false);
+    };
+
+    let missing = missing_keyspace_flags(&current, required);
+    if missing.is_empty() {
+        return Ok(true);
+    }
+
+    if !manage {
+        warn!(
+            name: logs::EXPIRY_EVENTS_UNAVAILABLE,
+            current,
+            required,
+            missing = missing.iter().collect::<String>(),
+            "cluster.provider.expiry_events_unavailable: this server's notify-keyspace-events \
+             lacks flags this deployment needs. Add them on the server, or set \
+             manage_keyspace_notifications: true to let the plugin add them (DESIGN.md sec 3.4)"
+        );
+        return Ok(false);
+    }
+
+    add_keyspace_flags(client, &current, required).await
+}
+
+/// Issues the one `CONFIG SET notify-keyspace-events` that
+/// `manage_keyspace_notifications: true` permits, and confirms it took.
+///
+/// # Errors
+/// [`ClusterError::Provider`] when the `CONFIG SET` itself fails.
+async fn add_keyspace_flags<C: ConfigInterface>(
+    client: &C,
+    current: &str,
+    required: &str,
+) -> Result<bool, ClusterError> {
+    // Additive, never a replacement: the setting is server-wide, so overwriting
+    // it with just this plugin's flags would switch off notifications an
+    // unrelated tenant of the same Redis is subscribed to.
+    let merged = merge_keyspace_flags(current, required);
+    client
+        .config_set("notify-keyspace-events", merged.clone())
+        .await
+        .map_err(map_redis_error)?;
+
+    // Re-read rather than trusting the write (DESIGN.md §3.4). A `CONFIG SET`
+    // can succeed against a proxy that accepts and drops it, and the plugin
+    // would then spend the deployment's life believing in events that never
+    // arrive.
+    let confirmed = read_config_value(client, "notify-keyspace-events")
+        .await
+        .is_some_and(|value| missing_keyspace_flags(&value, required).is_empty());
+    if confirmed {
+        // INFO rather than DEBUG, and this is the only config *mutation* the
+        // plugin ever performs: `notify-keyspace-events` is server-wide, so an
+        // operator reading this deployment's log has to be able to see that
+        // their Redis was changed on a gear's behalf without turning DEBUG on
+        // (DESIGN.md §9).
+        tracing::info!(
+            name: logs::KEYSPACE_NOTIFICATIONS_SET,
+            previous = current,
+            flags = merged,
+            "cluster.provider.keyspace_notifications_set: manage_keyspace_notifications was \
+             enabled and this server's global notify-keyspace-events has been extended, \
+             additively, with the flags Expired and eviction events need (DESIGN.md sec 3.4)"
+        );
+    } else {
+        warn!(
+            name: logs::EXPIRY_EVENTS_UNAVAILABLE,
+            requested = merged,
+            "cluster.provider.expiry_events_unavailable: the CONFIG SET was accepted but the \
+             flags did not stick on re-read; Expired events remain best-effort (DESIGN.md sec 3.4)"
+        );
+    }
+    Ok(confirmed)
+}
+
+// Layer-1 unit tests (TESTING.md §2, `preflight.rs` row): all five rows of the
+// §3.6 table, the hint-contradiction case, and the reply parsers. Out-of-line
+// per DE1101.
+#[cfg(test)]
+#[path = "preflight_tests.rs"]
+mod tests;

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/preflight_tests.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/preflight_tests.rs
@@ -1,0 +1,533 @@
+use super::*;
+
+/// The durability reading for a server that fsyncs before acknowledging — the
+/// one configuration ADR-009 rates safe.
+const DURABLE: DurabilityReading = DurabilityReading::Readable {
+    appendonly: true,
+    appendfsync: Appendfsync::Always,
+};
+
+/// The Redis default: an append-only file fsynced once a second, so a crash can
+/// lose up to a second of already-acknowledged writes.
+const EVERYSEC: DurabilityReading = DurabilityReading::Readable {
+    appendonly: true,
+    appendfsync: Appendfsync::Everysec,
+};
+
+fn decide(
+    topology: TopologyFinding,
+    durability: Option<Durability>,
+    readability: DurabilityReading,
+) -> ConsistencyDecision {
+    decide_consistency(topology, durability, readability).expect("this row does not contradict")
+}
+
+// ---------------------------------------------------------------------------
+// DESIGN.md §3.6, row by row.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn row_1_a_verified_durable_single_node_is_linearizable() {
+    let decision = decide(TopologyFinding::VerifiedSingleNode, None, DURABLE);
+    assert_eq!(decision.consistency, CacheConsistency::Linearizable);
+    assert!(
+        !decision.asserted_not_verified,
+        "both halves were read off the server, so nothing is being taken on trust"
+    );
+}
+
+#[test]
+fn row_2_a_single_node_with_weaker_durability_is_eventually_consistent() {
+    // A crash between the ack and the fsync loses accepted writes, which for
+    // CAS-based leader election means two leaders.
+    for reading in [
+        EVERYSEC,
+        DurabilityReading::Readable {
+            appendonly: false,
+            appendfsync: Appendfsync::Always,
+        },
+        DurabilityReading::Readable {
+            appendonly: true,
+            appendfsync: Appendfsync::No,
+        },
+        DurabilityReading::Unreadable,
+    ] {
+        let decision = decide(TopologyFinding::VerifiedSingleNode, None, reading);
+        assert_eq!(
+            decision.consistency,
+            CacheConsistency::EventuallyConsistent,
+            "{reading:?} is not fsync-always and must not reach Linearizable"
+        );
+    }
+}
+
+#[test]
+fn row_3_a_replicated_primary_is_eventually_consistent_however_durable() {
+    // Durability cannot rescue this row: replication is asynchronous, so every
+    // failover may promote a node that never saw an accepted write, no matter
+    // how carefully the old primary fsynced it.
+    let decision = decide(
+        TopologyFinding::Replicated,
+        Some(Durability::FsyncAlways),
+        DURABLE,
+    );
+    assert_eq!(decision.consistency, CacheConsistency::EventuallyConsistent);
+    assert!(!decision.asserted_not_verified);
+}
+
+#[test]
+fn row_4_redis_cluster_is_eventually_consistent() {
+    let decision = decide(
+        TopologyFinding::Cluster,
+        Some(Durability::FsyncAlways),
+        DURABLE,
+    );
+    assert_eq!(decision.consistency, CacheConsistency::EventuallyConsistent);
+}
+
+#[test]
+fn row_5_an_unknown_topology_is_eventually_consistent() {
+    let decision = decide(
+        TopologyFinding::Unknown,
+        Some(Durability::FsyncAlways),
+        DURABLE,
+    );
+    assert_eq!(decision.consistency, CacheConsistency::EventuallyConsistent);
+}
+
+// ---------------------------------------------------------------------------
+// Hints: trusted, cross-checked, and contradicted.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_uncheckable_fsync_always_hint_is_trusted_and_flagged() {
+    // The managed-Redis case: `CONFIG` is refused, so the plugin cannot verify
+    // the claim. It declares what the operator said and reports back that the
+    // caller should log `cluster.provider.consistency_asserted` — an operator's
+    // claim is then visible in the logs of the deployment that made it.
+    let decision = decide(
+        TopologyFinding::VerifiedSingleNode,
+        Some(Durability::FsyncAlways),
+        DurabilityReading::Unreadable,
+    );
+    assert_eq!(decision.consistency, CacheConsistency::Linearizable);
+    assert!(decision.asserted_not_verified);
+}
+
+#[test]
+fn a_standalone_topology_hint_is_also_only_asserted() {
+    // `topology: standalone` skips `INFO replication` entirely, so the "no
+    // replicas" half of row 1 is the operator's word even when `CONFIG GET`
+    // corroborates the durability half.
+    let decision = decide(TopologyFinding::AssertedSingleNode, None, DURABLE);
+    assert_eq!(decision.consistency, CacheConsistency::Linearizable);
+    assert!(decision.asserted_not_verified);
+}
+
+#[test]
+fn a_contradicted_fsync_always_hint_fails_startup_naming_both_values() {
+    let err = decide_consistency(
+        TopologyFinding::VerifiedSingleNode,
+        Some(Durability::FsyncAlways),
+        EVERYSEC,
+    )
+    .expect_err("a hint the server contradicts must fail startup");
+    let ClusterError::InvalidConfig { reason } = err else {
+        panic!("a contradicted hint is a config fault, not a provider one");
+    };
+    assert!(
+        reason.contains("fsync_always"),
+        "the error must name the claim, got {reason}"
+    );
+    assert!(
+        reason.contains("everysec"),
+        "the error must name what the server actually reports, got {reason}"
+    );
+}
+
+#[test]
+fn the_contradiction_check_does_not_depend_on_the_topology() {
+    // A claim is contradicted whether or not it would have changed the
+    // declaration. Only checking it on the row that can reach `Linearizable`
+    // would let the same untrue config sit unreported on a Sentinel deployment
+    // until the day it was moved to a single node.
+    for topology in [
+        TopologyFinding::Replicated,
+        TopologyFinding::Cluster,
+        TopologyFinding::Unknown,
+        TopologyFinding::AssertedSingleNode,
+    ] {
+        assert!(
+            decide_consistency(topology, Some(Durability::FsyncAlways), EVERYSEC).is_err(),
+            "{topology:?} must still report the contradicted hint"
+        );
+    }
+}
+
+#[test]
+fn a_hint_weaker_than_the_server_is_accepted() {
+    // Only the direction that could *upgrade* the declaration fails. Declaring
+    // yourself weaker than you are can only under-declare, which is safe — and
+    // is a legitimate way to keep a durable-today server from silently becoming
+    // the basis of a Linearizable declaration tomorrow.
+    let decision = decide(
+        TopologyFinding::VerifiedSingleNode,
+        Some(Durability::FsyncEverysec),
+        DURABLE,
+    );
+    assert_eq!(decision.consistency, CacheConsistency::EventuallyConsistent);
+    assert!(!decision.asserted_not_verified);
+}
+
+#[test]
+fn an_eventually_consistent_declaration_is_never_flagged_as_asserted() {
+    // The flag warns about an unverified upgrade; there is no such thing as an
+    // unverified downgrade, and emitting the WARN on one would train operators
+    // to ignore it.
+    for topology in [
+        TopologyFinding::Replicated,
+        TopologyFinding::Cluster,
+        TopologyFinding::Unknown,
+        TopologyFinding::VerifiedSingleNode,
+        TopologyFinding::AssertedSingleNode,
+    ] {
+        let decision = decide(topology, None, DurabilityReading::Unreadable);
+        if decision.consistency == CacheConsistency::EventuallyConsistent {
+            assert!(!decision.asserted_not_verified, "{topology:?}");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resolving the topology input.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_operator_topology_hint_replaces_detection() {
+    for (hint, expected) in [
+        (Topology::Standalone, TopologyFinding::AssertedSingleNode),
+        (Topology::Sentinel, TopologyFinding::Replicated),
+        (Topology::Cluster, TopologyFinding::Cluster),
+    ] {
+        assert_eq!(
+            resolve_topology(Some(hint), TopologyFinding::VerifiedSingleNode),
+            expected,
+            "the {hint:?} hint must win over detection"
+        );
+    }
+    assert_eq!(
+        resolve_topology(None, TopologyFinding::Replicated),
+        TopologyFinding::Replicated
+    );
+}
+
+#[test]
+fn only_a_primary_reporting_zero_replicas_is_a_verified_single_node() {
+    assert_eq!(
+        topology_from_replication(Some(ReplicationInfo {
+            role: ReplicationRole::Primary,
+            connected_replicas: Some(0),
+        })),
+        TopologyFinding::VerifiedSingleNode
+    );
+    assert_eq!(
+        topology_from_replication(Some(ReplicationInfo {
+            role: ReplicationRole::Primary,
+            connected_replicas: Some(2),
+        })),
+        TopologyFinding::Replicated
+    );
+    assert_eq!(
+        topology_from_replication(Some(ReplicationInfo {
+            role: ReplicationRole::Replica,
+            connected_replicas: Some(0),
+        })),
+        TopologyFinding::Replicated,
+        "a replica is replicated by definition, whatever it reports downstream"
+    );
+    // Absent is not zero: the only row that can weaken a guarantee by being
+    // wrong is the one that needs an explicit answer.
+    assert_eq!(
+        topology_from_replication(Some(ReplicationInfo {
+            role: ReplicationRole::Primary,
+            connected_replicas: None,
+        })),
+        TopologyFinding::Replicated
+    );
+    assert_eq!(
+        topology_from_replication(None),
+        TopologyFinding::Unknown,
+        "an unreadable INFO is Unknown, so the caller can log why rather than what"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Reply parsers.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn info_replication_parses_a_lone_primary() {
+    let reply = "# Replication\r\nrole:master\r\nconnected_slaves:0\r\n\
+                 master_failover_state:no-failover\r\n";
+    assert_eq!(
+        parse_info_replication(reply),
+        Some(ReplicationInfo {
+            role: ReplicationRole::Primary,
+            connected_replicas: Some(0),
+        })
+    );
+}
+
+#[test]
+fn info_replication_parses_a_primary_with_replicas() {
+    // The `slave0:` line is the reason the parser splits on the *first* colon
+    // only: its value is full of them.
+    let reply = "# Replication\r\nrole:master\r\nconnected_slaves:2\r\n\
+                 slave0:ip=10.0.0.2,port=6379,state=online,offset=99,lag=0\r\n\
+                 slave1:ip=10.0.0.3,port=6379,state=online,offset=99,lag=1\r\n";
+    let info = parse_info_replication(reply).expect("a primary with replicas parses");
+    assert_eq!(info.role, ReplicationRole::Primary);
+    assert_eq!(info.connected_replicas, Some(2));
+}
+
+#[test]
+fn info_replication_parses_a_primary_with_no_connected_slaves_field() {
+    let reply = "# Replication\r\nrole:master\r\n";
+    assert_eq!(
+        parse_info_replication(reply),
+        Some(ReplicationInfo {
+            role: ReplicationRole::Primary,
+            connected_replicas: None,
+        })
+    );
+}
+
+#[test]
+fn info_replication_parses_a_replica() {
+    let reply = "# Replication\r\nrole:slave\r\nmaster_host:10.0.0.1\r\nmaster_link_status:up\r\n";
+    let info = parse_info_replication(reply).expect("a replica parses");
+    assert_eq!(info.role, ReplicationRole::Replica);
+}
+
+#[test]
+fn an_info_reply_with_no_usable_role_is_none() {
+    for reply in [
+        "",
+        "# Replication\r\n",
+        "# Replication\r\nrole:sentinel\r\n",
+        "this is not an INFO reply at all",
+    ] {
+        assert!(
+            parse_info_replication(reply).is_none(),
+            "`{reply}` carries no recognizable role"
+        );
+    }
+}
+
+#[test]
+fn parse_info_skips_headers_and_blank_lines() {
+    let fields =
+        parse_info("# Server\r\nredis_version:7.2.4\r\n\r\n# Clients\r\nconnected_clients:3\r\n");
+    assert_eq!(fields.get("redis_version").copied(), Some("7.2.4"));
+    assert_eq!(fields.get("connected_clients").copied(), Some("3"));
+    assert_eq!(
+        fields.len(),
+        2,
+        "`#` headers and blank lines are not fields"
+    );
+}
+
+#[test]
+fn config_get_parses_pairs_including_an_empty_value() {
+    // The empty value is the ordinary case, not an edge one: an unconfigured
+    // `notify-keyspace-events` reads back exactly like this, and collapsing it
+    // to "absent" would confuse "no flags are set" with "the server would not
+    // tell me" — opposite conclusions.
+    let reply = vec![
+        "notify-keyspace-events".to_owned(),
+        String::new(),
+        "maxmemory-policy".to_owned(),
+        "noeviction".to_owned(),
+    ];
+    let parsed = parse_config_get(&reply).expect("an even-length reply parses");
+    assert_eq!(
+        parsed.get("notify-keyspace-events").map(String::as_str),
+        Some("")
+    );
+    assert_eq!(
+        parsed.get("maxmemory-policy").map(String::as_str),
+        Some("noeviction")
+    );
+}
+
+#[test]
+fn config_get_parses_an_empty_reply() {
+    // What a server answers for a parameter it does not have.
+    assert!(
+        parse_config_get(&[])
+            .expect("an empty reply parses")
+            .is_empty()
+    );
+}
+
+#[test]
+fn an_odd_length_config_get_reply_is_an_error() {
+    let reply = vec!["appendfsync".to_owned()];
+    let err = parse_config_get(&reply).expect_err("an unpaired element must not be dropped");
+    assert!(matches!(err, ClusterError::Provider { .. }));
+}
+
+// ---------------------------------------------------------------------------
+// Keyspace notification flags and the eviction policy.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_required_flag_set_is_the_minimal_one() {
+    // DESIGN.md §4.3: the minimal correct set is `Kxe`, and
+    // `g` and `$` add a notification for every generic and every string command
+    // *server-wide* — on a shared Redis that is unrelated tenants' traffic.
+    assert_eq!(REQUIRED_KEYSPACE_FLAGS, "Kxe");
+    assert!(!REQUIRED_KEYSPACE_FLAGS.contains('g'));
+    assert!(!REQUIRED_KEYSPACE_FLAGS.contains('$'));
+}
+
+#[test]
+fn the_eviction_flag_set_asks_for_no_expiry() {
+    // The standalone lock plugin's set (DESIGN.md §3.5, §3.7). `x` is absent on
+    // purpose rather than by omission: a lapsed lease is found by the next
+    // acquire attempt, so asking a shared server to turn on a server-wide flag
+    // this deployment never reads would charge unrelated tenants for nothing.
+    assert_eq!(EVICTION_KEYSPACE_FLAGS, "Ke");
+    assert!(
+        !EVICTION_KEYSPACE_FLAGS.contains('x'),
+        "a lock-only deployment has no use for `expired`"
+    );
+    // And the eviction half is common to both, or the combined plugin would be
+    // observing evictions the standalone one could not.
+    for flag in EVICTION_KEYSPACE_FLAGS.chars() {
+        assert!(
+            REQUIRED_KEYSPACE_FLAGS.contains(flag),
+            "`{flag}` is needed for eviction observation, which both plugins do"
+        );
+    }
+}
+
+#[test]
+fn an_unconfigured_server_is_missing_every_flag() {
+    assert_eq!(
+        missing_keyspace_flags("", REQUIRED_KEYSPACE_FLAGS),
+        vec!['K', 'x', 'e']
+    );
+    assert_eq!(merge_keyspace_flags("", REQUIRED_KEYSPACE_FLAGS), "Kxe");
+    // The lock-only deployment is told about its own two and never about `x`.
+    assert_eq!(
+        missing_keyspace_flags("", EVICTION_KEYSPACE_FLAGS),
+        vec!['K', 'e']
+    );
+}
+
+#[test]
+fn a_server_configured_for_evictions_only_still_owes_the_cache_its_expiry_flag() {
+    // The case the split exists for: `Ke` satisfies a lock-only deployment
+    // completely and leaves a cache one without `Expired`. One constant for both
+    // would have to pick a side, and either choice is a wrong answer for the
+    // other deployment.
+    assert!(missing_keyspace_flags("Ke", EVICTION_KEYSPACE_FLAGS).is_empty());
+    assert_eq!(
+        missing_keyspace_flags("Ke", REQUIRED_KEYSPACE_FLAGS),
+        vec!['x']
+    );
+}
+
+#[test]
+fn a_correctly_configured_server_needs_nothing_added() {
+    assert!(missing_keyspace_flags("Kxe", REQUIRED_KEYSPACE_FLAGS).is_empty());
+    assert_eq!(merge_keyspace_flags("Kxe", REQUIRED_KEYSPACE_FLAGS), "Kxe");
+}
+
+#[test]
+fn the_all_classes_alias_covers_the_event_flags_but_not_the_keyspace_one() {
+    // Redis defines `A` as every class except `K`, `E`, `m`, and `n`, so `KA`
+    // already delivers `expired` and `evicted`. Treating `A` as an opaque
+    // character would make the plugin rewrite a perfectly good config.
+    assert!(missing_keyspace_flags("KA", REQUIRED_KEYSPACE_FLAGS).is_empty());
+    assert_eq!(merge_keyspace_flags("KA", REQUIRED_KEYSPACE_FLAGS), "KA");
+    assert!(missing_keyspace_flags("KA", EVICTION_KEYSPACE_FLAGS).is_empty());
+    // `A` on its own still lacks `K`, which is what actually routes the events
+    // to a `__keyspace@…__` channel.
+    assert_eq!(
+        missing_keyspace_flags("A", REQUIRED_KEYSPACE_FLAGS),
+        vec!['K']
+    );
+    assert_eq!(merge_keyspace_flags("A", REQUIRED_KEYSPACE_FLAGS), "AK");
+}
+
+#[test]
+fn merging_preserves_flags_the_server_already_had() {
+    // `notify-keyspace-events` is server-wide, so replacing it would switch off
+    // notifications an unrelated tenant is subscribed to.
+    assert_eq!(
+        missing_keyspace_flags("Elg", REQUIRED_KEYSPACE_FLAGS),
+        vec!['K', 'x', 'e']
+    );
+    let merged = merge_keyspace_flags("Elg", REQUIRED_KEYSPACE_FLAGS);
+    assert!(merged.starts_with("Elg"), "existing flags must survive");
+    for flag in REQUIRED_KEYSPACE_FLAGS.chars() {
+        assert!(
+            merged.contains(flag),
+            "`{flag}` must be present in {merged}"
+        );
+    }
+}
+
+#[test]
+fn only_noeviction_is_a_safe_maxmemory_policy() {
+    assert!(maxmemory_policy_is_safe("noeviction"));
+    assert!(maxmemory_policy_is_safe(" noeviction\n"));
+    for policy in [
+        "allkeys-lru",
+        "allkeys-lfu",
+        "allkeys-random",
+        "volatile-lru",
+        "volatile-ttl",
+        "",
+    ] {
+        assert!(
+            !maxmemory_policy_is_safe(policy),
+            "`{policy}` can evict a lock or leader key with no TTL having lapsed"
+        );
+    }
+}
+
+#[test]
+fn appendfsync_parses_the_three_values_redis_reports() {
+    assert_eq!(Appendfsync::parse("always"), Some(Appendfsync::Always));
+    assert_eq!(Appendfsync::parse("everysec"), Some(Appendfsync::Everysec));
+    assert_eq!(Appendfsync::parse("no"), Some(Appendfsync::No));
+    assert_eq!(Appendfsync::parse("sometimes"), None);
+}
+
+// ---------------------------------------------------------------------------
+// Sharded pub/sub detection (DESIGN.md §13 D3).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sharded_pubsub_is_detected_from_the_major_version_only() {
+    // The finding feeds a DEBUG line and nothing else, so a false negative costs
+    // a log line while a false positive would put a wrong capability claim into
+    // the record a follow-up decision is made from. Everything unparseable
+    // therefore answers `false`.
+    for version in ["7.0.0", "7.2.4", "8.0.1", " 7.4.1 "] {
+        assert!(
+            supports_sharded_pubsub(version),
+            "{version} should support SPUBLISH/SSUBSCRIBE"
+        );
+    }
+    for version in ["6.2.14", "5.0.7", "", "unknown", "v7.0.0"] {
+        assert!(
+            !supports_sharded_pubsub(version),
+            "{version} must not be reported as supporting sharded pub/sub"
+        );
+    }
+    assert_eq!(SHARDED_PUBSUB_MAJOR, 7);
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/provider.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/provider.rs
@@ -1,0 +1,249 @@
+//! The two provider implementations the wiring crate registers for the Redis
+//! backend (DESIGN.md §1.1, §3.5).
+//!
+//! Both answer `provider() -> "redis"`, and they are independent by the SDK's
+//! design: `ClusterCacheProvider` and `ClusterLockProvider` are separate traits
+//! and a non-cache provider never receives the cache backend, so
+//! `lock: { provider: redis }` resolves whether or not `cache` also points at
+//! Redis. The cost is a second pool when both do, which DESIGN.md §3.5 accepts
+//! rather than invent a lifecycle-ownership story for a shared one.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cluster_sdk::{
+    ClusterCacheBackend, ClusterCacheProvider, ClusterError, ClusterLockProvider,
+    DistributedLockBackend, StopHook,
+};
+use toolkit::var_expand::ExpandVars;
+
+use crate::config::{RedisClusterConfig, RedisLockConfig};
+use crate::lock::RedisLockPlugin;
+use crate::plugin::RedisClusterPlugin;
+
+/// The operator config `provider` name that selects the Redis backend, for both
+/// the `cache` and the `lock` primitive bindings.
+pub const PROVIDER_NAME: &str = "redis";
+
+/// Deserializes `options` into `T` and applies `#[derive(ExpandVars)]`
+/// expansion, mapping both failure modes to [`ClusterError::InvalidConfig`].
+///
+/// Both are operator errors rather than backend faults, and neither may become
+/// a silent fallback: a misspelled key must not leave a default in place
+/// (`deny_unknown_fields` is what turns it into the error this reports), and an
+/// unresolved `${REDIS_PASSWORD}` must not be sent to the server as a literal
+/// password, which would surface as an auth failure pointing at the wrong thing
+/// entirely.
+fn deserialize_and_expand<T>(
+    options: &serde_json::Map<String, serde_json::Value>,
+) -> Result<T, ClusterError>
+where
+    T: serde::de::DeserializeOwned + ExpandVars,
+{
+    let mut config: T = serde_json::from_value(serde_json::Value::Object(options.clone()))
+        .map_err(|err| ClusterError::InvalidConfig {
+            reason: format!("redis: invalid options: {err}"),
+        })?;
+    config
+        .expand_vars()
+        .map_err(|err| ClusterError::InvalidConfig {
+            reason: format!("redis: `url` env-var expansion failed: {err}"),
+        })?;
+    Ok(config)
+}
+
+/// Builds the Redis cache backend from operator config.
+pub struct RedisCacheProvider;
+
+#[async_trait]
+impl ClusterCacheProvider for RedisCacheProvider {
+    fn provider(&self) -> &'static str {
+        PROVIDER_NAME
+    }
+
+    async fn build_cache(
+        &self,
+        options: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<(Arc<dyn ClusterCacheBackend>, StopHook), ClusterError> {
+        let config: RedisClusterConfig = deserialize_and_expand(options)?;
+        let handle = RedisClusterPlugin::builder(config)
+            .build_and_start()
+            .await?;
+        let cache = handle.cache();
+        // The hook owns the handle, so the wiring's shutdown is the only thing
+        // that can drop it — which is what keeps the ADR-006 `Drop` guard from
+        // firing on a perfectly ordinary shutdown.
+        let stop: StopHook = Box::new(move || Box::pin(async move { handle.stop().await }));
+        Ok((cache, stop))
+    }
+}
+
+/// Builds the standalone Redis lock backend from operator config
+/// (DESIGN.md §3.5).
+///
+pub struct RedisLockProvider;
+
+#[async_trait]
+impl ClusterLockProvider for RedisLockProvider {
+    fn provider(&self) -> &'static str {
+        PROVIDER_NAME
+    }
+
+    async fn build_lock(
+        &self,
+        options: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<(Arc<dyn DistributedLockBackend>, StopHook), ClusterError> {
+        // `RedisLockConfig`, not `RedisClusterConfig`: the three cache-only keys
+        // are absent from it, so a lock binding that sets `watch_mode` fails at
+        // startup with the key named rather than having it silently ignored
+        // (DESIGN.md §8).
+        let config: RedisLockConfig = deserialize_and_expand(options)?;
+        let handle = RedisLockPlugin::builder(config).build_and_start().await?;
+        let lock = handle.lock();
+        // The hook owns the handle, so the wiring's shutdown is the only thing
+        // that can drop it — which is what keeps the ADR-006 `Drop` guard from
+        // firing on a perfectly ordinary shutdown.
+        let stop: StopHook = Box::new(move || Box::pin(async move { handle.stop().await }));
+        Ok((lock, stop))
+    }
+}
+
+// Layer-1 unit tests (TESTING.md §2, `provider.rs` row). Every case below fails
+// at deserialization or env-var expansion — before any connection is attempted —
+// so none of them needs a container.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn options(value: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+        match value {
+            serde_json::Value::Object(map) => map,
+            _ => panic!("options must be a JSON object"),
+        }
+    }
+
+    #[test]
+    fn both_provider_names_are_redis() {
+        // One name, two primitives: an operator writes `provider: redis` under
+        // `cache` and under `lock` and gets this plugin for both.
+        assert_eq!(RedisCacheProvider.provider(), "redis");
+        assert_eq!(RedisLockProvider.provider(), "redis");
+    }
+
+    #[tokio::test]
+    async fn the_lock_provider_rejects_a_cache_only_option() {
+        // `RedisLockConfig` omits `watch_mode` and `deny_unknown_fields` turns
+        // that omission into an error rather than an ignored key: a lock-only
+        // binding that sets it has misunderstood something and hears so at
+        // startup (DESIGN.md §8).
+        let result = RedisLockProvider
+            .build_lock(&options(json!({
+                "url": "redis://redis:6379/0",
+                "watch_mode": "disabled",
+            })))
+            .await;
+        let Err(ClusterError::InvalidConfig { reason }) = result else {
+            panic!("a cache-only option on a lock binding must be rejected");
+        };
+        assert!(
+            reason.contains("watch_mode"),
+            "the error must name the offending key, got {reason}"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_lock_provider_rejects_a_missing_url_before_connecting() {
+        let result = RedisLockProvider
+            .build_lock(&options(json!({ "pool_size": 4 })))
+            .await;
+        assert!(
+            matches!(result, Err(ClusterError::InvalidConfig { .. })),
+            "a lock options map with no url must surface as InvalidConfig"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_lock_provider_needs_no_cache_backend_to_be_asked_for_one() {
+        // The SDK's "non-cache providers do not receive the cache backend"
+        // contract, asserted the only way a signature can be: `build_lock` takes
+        // options and nothing else, so there is no cache for it to consult even
+        // when one exists. This fails at config validation, before any
+        // connection, which is what keeps it a Layer 1 test.
+        let result = RedisLockProvider
+            .build_lock(&options(json!({
+                "url": "redis://127.0.0.1:1/0",
+                "pool_size": 0,
+            })))
+            .await;
+        let Err(ClusterError::InvalidConfig { reason }) = result else {
+            panic!("a zero pool_size must be rejected as InvalidConfig");
+        };
+        assert!(
+            reason.contains("pool_size"),
+            "the error must name the offending key, got {reason}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_missing_url_is_invalid_config() {
+        let result = RedisCacheProvider
+            .build_cache(&options(json!({ "pool_size": 4 })))
+            .await;
+        assert!(
+            matches!(result, Err(ClusterError::InvalidConfig { .. })),
+            "a malformed options map must surface as InvalidConfig"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unknown_option_key_is_invalid_config() {
+        // The `deny_unknown_fields` payoff at the provider boundary: an
+        // `allow_weak_consistency` misplaced onto this native binding (see
+        // DESIGN.md §13 D1) fails loudly here instead of being
+        // ignored.
+        let result = RedisCacheProvider
+            .build_cache(&options(json!({
+                "url": "redis://redis:6379/0",
+                "allow_weak_consistency": true,
+            })))
+            .await;
+        assert!(
+            matches!(result, Err(ClusterError::InvalidConfig { .. })),
+            "an unknown option key must surface as InvalidConfig"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unresolvable_env_var_is_invalid_config() {
+        let result = RedisCacheProvider
+            .build_cache(&options(json!({
+                "url": "redis://:${REDIS_CLUSTER_PROVIDER_UNSET}@redis:6379/0",
+            })))
+            .await;
+        assert!(
+            matches!(result, Err(ClusterError::InvalidConfig { .. })),
+            "an unresolvable env var must surface as InvalidConfig"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_zero_pool_size_is_rejected_before_any_connection() {
+        // `config.validate()` runs at the top of `build_and_start`, so this
+        // returns without ever dialling — which is also what makes it a Layer 1
+        // test rather than a Layer 3 one.
+        let result = RedisCacheProvider
+            .build_cache(&options(json!({
+                "url": "redis://127.0.0.1:1/0",
+                "pool_size": 0,
+            })))
+            .await;
+        let Err(ClusterError::InvalidConfig { reason }) = result else {
+            panic!("a zero pool_size must be rejected as InvalidConfig");
+        };
+        assert!(
+            reason.contains("pool_size"),
+            "the error must name the offending key, got {reason}"
+        );
+    }
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/redis_error.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/redis_error.rs
@@ -1,0 +1,155 @@
+//! `fred::error::Error` → [`ClusterError`] mapping (DESIGN.md §10), shared by
+//! the cache, the lock, and the startup preflight.
+//!
+//! Two things about `fred`'s error model shape this module, and both are worth
+//! stating because neither is guessable from the mapping table alone.
+//!
+//! **A Redis error reply is not a distinct `ErrorKind`.** `fred` parses the
+//! wire reply in `protocol::utils::pretty_error`, which switches on only the
+//! first token and recognizes just `ERR`, `WRONGTYPE`, `NOAUTH`, `WRONGPASS`,
+//! `MOVED`, `ASK`, and `CLUSTERDOWN`; everything else — `OOM`, `READONLY`,
+//! `LOADING`, `MASTERDOWN`, `NOSCRIPT`, `CROSSSLOT` — arrives as
+//! [`ErrorKind::Unknown`] with the full reply text in `details()`. So the
+//! server-reply rows of DESIGN.md §10 can only be recognized by reading that
+//! first token back out, which is what [`server_error_code`] does, and that
+//! check has to run *before* the `ErrorKind` match or every one of those rows
+//! would collapse into `Other`.
+//!
+//! **A malformed URL is a config fault, not a backend fault.** `ErrorKind::Url`
+//! and `ErrorKind::Config` map to [`ClusterError::InvalidConfig`] rather than
+//! being wrapped as [`ClusterError::Provider`], so an operator reading the error
+//! is pointed at their YAML instead of at their server (`RD-LIFE-004`).
+
+use cluster_sdk::{ClusterError, ProviderErrorKind};
+use fred::error::{Error, ErrorKind};
+
+/// The `NOSCRIPT` error code, as Redis spells it on the wire.
+///
+/// Named because two places have to agree on it: this module, which classifies
+/// it, and `scripts.rs`, which acts on the classification by reloading the
+/// catalog exactly once (DESIGN.md §6).
+const NOSCRIPT: &str = "NOSCRIPT";
+
+/// Returns the leading error code of a Redis error reply — the `OOM` of
+/// `OOM command not allowed when used memory > 'maxmemory'`.
+///
+/// Redis's error-reply grammar puts an uppercase code first, so the first
+/// whitespace-delimited token is the code whenever the error came from the
+/// server at all. For a client-side `fred` error (an IO failure, a timeout)
+/// the first token is just the first word of a prose message and matches
+/// nothing in the table below, which is why this is safe to run over every
+/// error unconditionally.
+fn server_error_code(details: &str) -> &str {
+    details.split_whitespace().next().unwrap_or("")
+}
+
+/// Returns `true` when `err` is the server reporting that the script hash it
+/// was handed is not in its script cache.
+///
+/// The one `fred` error this plugin recovers from rather than surfaces: the
+/// server restarted or its cache was flushed, so the catalog is reloaded and
+/// the `EVALSHA` retried exactly once (DESIGN.md §6, `scripts::eval`). A
+/// second `NOSCRIPT` is not recovered from — it falls through this module's
+/// normal mapping and becomes `Provider { Other }`.
+#[must_use]
+pub fn is_noscript(err: &Error) -> bool {
+    server_error_code(err.details()) == NOSCRIPT
+}
+
+/// Maps a `fred` error to a [`ClusterError`] per DESIGN.md §10.
+///
+/// | `fred` error / server reply | Result |
+/// |---|---|
+/// | `ErrorKind::Config`, `ErrorKind::Url` | `InvalidConfig` |
+/// | `ErrorKind::IO` | `Provider { ConnectionLost }` |
+/// | `ErrorKind::Timeout` | `Provider { Timeout }` |
+/// | `ErrorKind::Auth` (which is where `fred` puts `NOAUTH`/`WRONGPASS`) | `Provider { AuthFailure }` |
+/// | `ErrorKind::Backpressure` | `Provider { ResourceExhausted }` |
+/// | `OOM …` | `Provider { ResourceExhausted }` |
+/// | `READONLY …` | `Provider { ConnectionLost }` |
+/// | `LOADING …`, `MASTERDOWN …`, `CLUSTERDOWN …` | `Provider { ResourceExhausted }` |
+/// | anything else, including `NOSCRIPT` and `CROSSSLOT` | `Provider { Other }` |
+///
+/// Takes `err` by value so call sites can write `.map_err(map_redis_error)`
+/// without a wrapping closure — the dominant call pattern once the cache and
+/// lock land — rather than for its own sake.
+#[allow(clippy::needless_pass_by_value)]
+#[must_use]
+pub fn map_redis_error(err: Error) -> ClusterError {
+    // A bad DSN, an unparseable URL, or a client configuration `fred` refuses
+    // outright is the operator's YAML, not the server. `InvalidConfig` rather
+    // than `Provider` so it does not read as a backend fault and, in
+    // particular, so it is never classified retryable (DESIGN.md §10).
+    if matches!(err.kind(), ErrorKind::Config | ErrorKind::Url) {
+        return ClusterError::InvalidConfig {
+            reason: err.to_string(),
+        };
+    }
+
+    let kind = server_reply_kind(err.details()).unwrap_or_else(|| client_error_kind(err.kind()));
+
+    ClusterError::Provider {
+        kind,
+        message: err.to_string(),
+    }
+}
+
+/// Classifies the Redis error replies DESIGN.md §10 enumerates but `fred` does
+/// not give a distinct `ErrorKind`, returning `None` when the error did not
+/// come from the server or carries a code this table does not name.
+///
+/// `CROSSSLOT` and `NOSCRIPT` are deliberately absent: both fall through to
+/// `Other`. `CROSSSLOT` is unreachable by construction — every script in the
+/// catalog declares exactly one key (DESIGN.md §6) — so if it ever appears it
+/// is a plugin bug, and `Other` is right because no amount of retrying fixes
+/// one. `NOSCRIPT` is handled a layer up by [`is_noscript`] and only reaches
+/// here on the second occurrence, which DESIGN.md §6 likewise makes `Other`
+/// rather than an unbounded retry.
+fn server_reply_kind(details: &str) -> Option<ProviderErrorKind> {
+    match server_error_code(details) {
+        // The routing landed on a node that is now a replica, mid-failover.
+        // `ConnectionLost` rather than `Other` because that is exactly its
+        // retry semantics: `fred` re-resolves the topology and the next attempt
+        // reaches the new primary.
+        "READONLY" => Some(ProviderErrorKind::ConnectionLost),
+
+        // Four transient refusals that clear on their own, so all four are
+        // retryable-with-backoff and share one arm. `OOM` is the instance being
+        // over `maxmemory` — DESIGN.md §3.7 is the operator's pointer for why
+        // it should not be in that state at all; `LOADING` is a server still
+        // reading its dataset after a restart; `MASTERDOWN` and `CLUSTERDOWN`
+        // are a Sentinel or cluster with no reachable primary for the slot
+        // right now, which a failover in progress is already resolving.
+        "OOM" | "LOADING" | "MASTERDOWN" | "CLUSTERDOWN" => {
+            Some(ProviderErrorKind::ResourceExhausted)
+        }
+
+        // `NOAUTH`/`WRONGPASS` are not listed here on purpose: `fred`'s own
+        // reply parser already classifies both as `ErrorKind::Auth`, so the
+        // client-side arm below covers them and a second copy of the rule here
+        // could only drift from it.
+        _ => None,
+    }
+}
+
+/// Classifies a client-side `fred` error by its [`ErrorKind`].
+///
+/// `ErrorKind::Cluster` (`MOVED`/`ASK`) is intentionally left to the `Other`
+/// catch-all: `fred` follows redirections and re-resolves the slot map itself,
+/// so one surfacing to a caller means the redirection could not be followed,
+/// which is not something a retry at this layer improves.
+fn client_error_kind(kind: &ErrorKind) -> ProviderErrorKind {
+    match kind {
+        ErrorKind::IO => ProviderErrorKind::ConnectionLost,
+        ErrorKind::Timeout => ProviderErrorKind::Timeout,
+        ErrorKind::Auth => ProviderErrorKind::AuthFailure,
+        ErrorKind::Backpressure => ProviderErrorKind::ResourceExhausted,
+        _ => ProviderErrorKind::Other,
+    }
+}
+
+// Layer-1 unit tests (TESTING.md §2, `redis_error.rs` row): the full DESIGN.md
+// §10 table row by row. Out-of-line per DE1101.
+#[cfg(test)]
+#[path = "redis_error_tests.rs"]
+mod tests;

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/redis_error_tests.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/redis_error_tests.rs
@@ -1,0 +1,181 @@
+use super::*;
+
+/// Builds the error `fred` produces for a Redis error *reply*.
+///
+/// `fred` parses a reply in `protocol::utils::pretty_error`, which recognizes
+/// only a handful of leading tokens and leaves everything else as
+/// [`ErrorKind::Unknown`] with the reply text intact. These tests reproduce
+/// that classification rather than guess at it, so each case says which arm of
+/// `pretty_error` it is standing in for.
+fn reply(kind: ErrorKind, text: &'static str) -> Error {
+    Error::new(kind, text)
+}
+
+fn provider_kind(err: &ClusterError) -> ProviderErrorKind {
+    match err {
+        ClusterError::Provider { kind, .. } => *kind,
+        other => panic!("expected a Provider error, got {other:?}"),
+    }
+}
+
+#[test]
+fn client_side_kinds_map_per_the_table() {
+    for (kind, expected) in [
+        (ErrorKind::IO, ProviderErrorKind::ConnectionLost),
+        (ErrorKind::Timeout, ProviderErrorKind::Timeout),
+        (ErrorKind::Auth, ProviderErrorKind::AuthFailure),
+        (
+            ErrorKind::Backpressure,
+            ProviderErrorKind::ResourceExhausted,
+        ),
+    ] {
+        let mapped = map_redis_error(Error::new(kind.clone(), "boom"));
+        assert_eq!(
+            provider_kind(&mapped),
+            expected,
+            "{kind:?} must map to {expected:?}"
+        );
+    }
+}
+
+#[test]
+fn noauth_and_wrongpass_are_auth_failures() {
+    // `pretty_error` classifies both of these as `ErrorKind::Auth` from the
+    // reply's leading token, which is why `redis_error.rs` has no separate
+    // string rule for them — asserted here so that reliance is checked rather
+    // than assumed.
+    for text in [
+        "NOAUTH Authentication required.",
+        "WRONGPASS invalid username-password pair or user is disabled.",
+    ] {
+        let mapped = map_redis_error(reply(ErrorKind::Auth, text));
+        assert_eq!(provider_kind(&mapped), ProviderErrorKind::AuthFailure);
+    }
+}
+
+#[test]
+fn oom_is_resource_exhausted_and_therefore_retryable() {
+    let mapped = map_redis_error(reply(
+        ErrorKind::Unknown,
+        "OOM command not allowed when used memory > 'maxmemory'.",
+    ));
+    assert_eq!(provider_kind(&mapped), ProviderErrorKind::ResourceExhausted);
+    assert!(
+        mapped.is_retryable(),
+        "an OOM clears once memory is reclaimed, so it must classify retryable"
+    );
+}
+
+#[test]
+fn readonly_is_connection_lost() {
+    // A demoted primary mid-failover. `ConnectionLost` and not `Other`, because
+    // `fred` re-resolves the topology and the next attempt reaches the new
+    // primary — the retry semantics are the point of the classification.
+    let mapped = map_redis_error(reply(
+        ErrorKind::Unknown,
+        "READONLY You can't write against a read only replica.",
+    ));
+    assert_eq!(provider_kind(&mapped), ProviderErrorKind::ConnectionLost);
+    assert!(mapped.is_retryable());
+}
+
+#[test]
+fn transient_server_states_are_resource_exhausted() {
+    for (kind, text) in [
+        (
+            ErrorKind::Unknown,
+            "LOADING Redis is loading the dataset in memory",
+        ),
+        (
+            ErrorKind::Unknown,
+            "MASTERDOWN Link with MASTER is down and replica-serve-stale-data is set to 'no'.",
+        ),
+        // `CLUSTERDOWN` is the one server reply `fred` does give a distinct
+        // kind (`ErrorKind::Cluster`), so it also pins that the reply-code
+        // check runs *before* the kind match — via the kind arm alone it would
+        // fall through to `Other`.
+        (ErrorKind::Cluster, "CLUSTERDOWN Hash slot not served"),
+    ] {
+        let mapped = map_redis_error(reply(kind, text));
+        assert_eq!(
+            provider_kind(&mapped),
+            ProviderErrorKind::ResourceExhausted,
+            "`{text}` must classify as retryable resource exhaustion"
+        );
+    }
+}
+
+#[test]
+fn a_malformed_url_is_a_config_error_and_never_a_provider_error() {
+    // `RD-LIFE-004`: an operator reading this should be looking at their YAML,
+    // not at their server. Wrapping it as `Provider` would also put it in front
+    // of `is_retryable`, and a bad DSN does not become good on retry.
+    for kind in [ErrorKind::Url, ErrorKind::Config] {
+        let mapped = map_redis_error(Error::new(kind.clone(), "relative URL without a base"));
+        assert!(
+            matches!(mapped, ClusterError::InvalidConfig { .. }),
+            "{kind:?} must map to InvalidConfig, got {mapped:?}"
+        );
+        assert!(!mapped.is_retryable());
+    }
+}
+
+#[test]
+fn crossslot_is_other_because_it_can_only_be_a_plugin_bug() {
+    // Unreachable by construction: every catalogued script declares exactly one
+    // key (DESIGN.md §6, asserted in `scripts_tests.rs`). If one ever appears,
+    // no retry helps — the script has to change.
+    let mapped = map_redis_error(reply(
+        ErrorKind::Unknown,
+        "CROSSSLOT Keys in request don't hash to the same slot",
+    ));
+    assert_eq!(provider_kind(&mapped), ProviderErrorKind::Other);
+    assert!(!mapped.is_retryable());
+}
+
+#[test]
+fn a_second_noscript_surfaces_as_other_rather_than_looping() {
+    // `scripts::eval` recovers from the first `NOSCRIPT` and does not re-enter
+    // the recovery path, so the second one arrives here. DESIGN.md §10 makes it
+    // `Other` precisely so it cannot be retried again.
+    let mapped = map_redis_error(reply(ErrorKind::Unknown, "NOSCRIPT No matching script."));
+    assert_eq!(provider_kind(&mapped), ProviderErrorKind::Other);
+}
+
+#[test]
+fn an_unrecognized_error_falls_through_to_other() {
+    let mapped = map_redis_error(reply(
+        ErrorKind::Unknown,
+        "ERR unknown command 'NOTACOMMAND'",
+    ));
+    assert_eq!(provider_kind(&mapped), ProviderErrorKind::Other);
+}
+
+#[test]
+fn the_underlying_message_is_preserved() {
+    // The classification is for machines; the message is the only thing an
+    // operator reading a log line has to go on.
+    let mapped = map_redis_error(reply(
+        ErrorKind::Unknown,
+        "OOM command not allowed when used memory > 'maxmemory'.",
+    ));
+    assert!(
+        mapped.to_string().contains("maxmemory"),
+        "the server's own text must survive the mapping, got {mapped}"
+    );
+}
+
+#[test]
+fn only_a_noscript_reply_is_classified_as_one() {
+    assert!(is_noscript(&reply(
+        ErrorKind::Unknown,
+        "NOSCRIPT No matching script."
+    )));
+    // The code has to be the leading token, not merely present: a message that
+    // happens to mention the word must not trigger a reload.
+    assert!(!is_noscript(&reply(
+        ErrorKind::Unknown,
+        "ERR the NOSCRIPT case is handled elsewhere"
+    )));
+    assert!(!is_noscript(&Error::new(ErrorKind::IO, "connection reset")));
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/scripts.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/scripts.rs
@@ -1,0 +1,488 @@
+//! The Lua script catalog (DESIGN.md §6): the sources, the SHA cache that
+//! `SCRIPT LOAD` fills, and the `EVALSHA` driver with its single `NOSCRIPT`
+//! reload-and-retry.
+//!
+//! ## Every script takes exactly one key
+//!
+//! That is what makes the catalog Redis-Cluster-correct: Redis routes an
+//! `EVALSHA` by its declared keys, so a single-key script always lands on the
+//! node owning that key and `CROSSSLOT` is unreachable. The published channel
+//! name is passed as an `ARGV` rather than as a second key — `ARGV[3]` for
+//! `cache_put`, `ARGV[4]` for `cache_cas`, `ARGV[2]` for `lock_release` —
+//! because `PUBLISH` is not slot-routed and passing the channel as a key would
+//! make the script multi-key for no gain.
+//!
+//! The channel is therefore built Rust-side, by
+//! [`RedisCache::event_channel`](crate::cache::RedisCache) and
+//! [`LockNames::release_channel`](crate::lock::LockNames), and that is
+//! load-bearing rather than incidental: `watch_mode: disabled` works by
+//! `event_channel` answering the empty string and every mutation script
+//! skipping its `PUBLISH` on `ARGV[n] ~= ''`. A reader who believes the channel
+//! is derived server-side from `KEYS[1]` cannot reconstruct how `disabled`
+//! reaches the write path at all.
+//!
+//! The invariant is asserted structurally rather than trusted:
+//! [`ScriptSpec::declared_key_indices`] reads the `KEYS[n]` references back out
+//! of the Lua source, and a unit test requires every catalogued script to
+//! declare exactly `{1}`. A future two-key script therefore fails the build's
+//! tests instead of production's `CROSSSLOT`. The single-key rule is also
+//! encoded in [`ScriptExecutor::evalsha`]'s signature, which takes one `key`
+//! and cannot express a second.
+//!
+//! ## Why the SHA cache needs no interior mutability
+//!
+//! A script's SHA is a pure function of its source, so it never changes for the
+//! life of the process. [`ScriptCache`] is built once by [`load_catalog`] and
+//! shared immutably, with no lock on the hot path — and the `NOSCRIPT` recovery
+//! below repopulates the *server's* script cache, not this one, so it has
+//! nothing to write back.
+//!
+//! ## `NOSCRIPT` recovers with `EVAL`, not with a second `SCRIPT LOAD`
+//!
+//! The startup load is one `SCRIPT LOAD` per script and is deliberately not
+//! broadcast to every primary, which is not reachable here anyway: `fred`'s
+//! `script_load_cluster` — its only broadcasting API — is gated behind the `sha-1`
+//! feature, because it hashes the script client-side to have something to return,
+//! and this workspace keeps a SHA-1 implementation out of its dependency graph.
+//!
+//! The recovery path answers the same need better than a broadcast would. On
+//! `NOSCRIPT`, [`eval`] retries with `EVAL <source>` rather than reloading and
+//! re-`EVALSHA`ing:
+//!
+//! - **It is routed by the key**, so in cluster mode it necessarily reaches the
+//!   node that just reported the miss. A `SCRIPT LOAD` carries no key and is
+//!   routed to whichever node the client picks, so the reload could easily warm
+//!   a node other than the one about to be retried.
+//! - **It is one round trip instead of two**, and it both executes the call and
+//!   populates that node's script cache, so subsequent `EVALSHA`s on the same
+//!   shard hit.
+//! - **It self-heals**, which a startup broadcast cannot: a primary added by a
+//!   reshard, or one restarted mid-life, has an empty script cache no
+//!   startup-time load ever reached.
+//!
+//! The cost is one extra round trip the first time each shard sees each script,
+//! amortized to nothing thereafter, and it is why `load_catalog` still issues
+//! `SCRIPT LOAD` at startup: that is where the SHA comes from, and it is also
+//! the check that the server accepts the script at all rather than discovering a
+//! syntax error on the first write.
+//!
+//! ## Why a `ScriptExecutor` seam
+//!
+//! The three round-trips sit behind [`ScriptExecutor`] so the recovery policy —
+//! the part with a real failure mode, an unbounded retry loop against a server
+//! that answers `NOSCRIPT` to everything — is testable with no Redis at all.
+
+use std::collections::{BTreeSet, HashMap};
+
+use cluster_sdk::{ClusterError, ProviderErrorKind};
+use fred::clients::Pool;
+use fred::error::Error;
+use fred::interfaces::LuaInterface;
+use fred::types::Value;
+
+use crate::observability::RedisSignals;
+use crate::redis_error::{is_noscript, map_redis_error};
+
+/// One entry in the catalog: a name to look its SHA up by, and the Lua source
+/// `SCRIPT LOAD` is given.
+///
+/// `source` is `&'static str` so a script can never be assembled at runtime
+/// from a key, a name, or anything else a caller supplies — the catalog is
+/// fixed at compile time, and Lua injection has nowhere to enter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScriptSpec {
+    /// The catalog name, used as the [`ScriptCache`] lookup key and in logs.
+    pub name: &'static str,
+    /// The Lua source, verbatim as sent to `SCRIPT LOAD`.
+    pub source: &'static str,
+}
+
+impl ScriptSpec {
+    /// Returns the distinct `KEYS[n]` indices this script's source references.
+    ///
+    /// The mechanical form of DESIGN.md §6's single-key rule: the answer for
+    /// every catalogued script must be exactly `{1}`. Reading it out of the
+    /// source rather than storing a hand-maintained count is the point — a
+    /// count can be copied along with the script it no longer describes.
+    ///
+    /// Deliberately naive: it looks for the literal `KEYS[` followed by
+    /// decimal digits and `]`, which is the only form the catalog uses. A
+    /// computed index (`KEYS[i]`) would not be counted, and that is the
+    /// conservative direction only because nothing in the catalog computes
+    /// one — a script that did would need this to grow with it.
+    #[must_use]
+    pub fn declared_key_indices(&self) -> BTreeSet<usize> {
+        let mut indices = BTreeSet::new();
+        let mut rest = self.source;
+        while let Some(start) = rest.find("KEYS[") {
+            rest = &rest[start + "KEYS[".len()..];
+            let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+            if let Some(stripped) = rest.strip_prefix(digits.as_str())
+                && stripped.starts_with(']')
+                && let Ok(index) = digits.parse::<usize>()
+            {
+                indices.insert(index);
+            }
+        }
+        indices
+    }
+}
+
+/// `cache_put` — unconditional write. DESIGN.md §6.
+///
+/// `HINCRBY` rather than a Lua `ver + 1` because Redis's embedded Lua is 5.1,
+/// whose numbers are IEEE doubles: a version past 2^53 would silently lose
+/// precision and start producing duplicates (DESIGN.md §2.2). `HINCRBY` is
+/// 64-bit integer arithmetic in C, and no number ever enters Lua.
+pub const CACHE_PUT: ScriptSpec = ScriptSpec {
+    name: "cache_put",
+    source: r"
+-- KEYS[1]=entry  ARGV[1]=value  ARGV[2]=px_or_-1  ARGV[3]=channel
+-- Returns: the new version, as an integer
+local ver = redis.call('HINCRBY', KEYS[1], 'ver', 1)
+redis.call('HSET', KEYS[1], 'v', ARGV[1])
+if ARGV[2] == '-1' then redis.call('PERSIST', KEYS[1])
+else redis.call('PEXPIRE', KEYS[1], ARGV[2]) end
+if ARGV[3] ~= '' then redis.call('PUBLISH', ARGV[3], 'C') end
+return ver
+",
+};
+
+/// `cache_put_if_absent` — create-only write. DESIGN.md §6.
+///
+/// Needs Lua rather than a bare `SET NX` because the entry is a two-field hash
+/// and the version has to be seeded to 1 atomically with the value
+/// (DESIGN.md §2.2, §2.3).
+pub const CACHE_PUT_IF_ABSENT: ScriptSpec = ScriptSpec {
+    name: "cache_put_if_absent",
+    source: r"
+-- KEYS[1]=entry  ARGV[1]=value  ARGV[2]=px_or_-1  ARGV[3]=channel
+-- Returns: 1 when created (version 1), or false when the key already existed
+if redis.call('EXISTS', KEYS[1]) == 1 then return false end
+redis.call('HSET', KEYS[1], 'v', ARGV[1], 'ver', 1)
+if ARGV[2] ~= '-1' then redis.call('PEXPIRE', KEYS[1], ARGV[2]) end
+if ARGV[3] ~= '' then redis.call('PUBLISH', ARGV[3], 'C') end
+return 1
+",
+};
+
+/// `cache_cas` — version-guarded write. DESIGN.md §6.
+///
+/// The version comparison is a *string* compare: `HGET` returns a string,
+/// `ARGV[1]` is a string, and `==` between them is exact for every `u64`
+/// (DESIGN.md §2.2). The mismatch reply carries the current version and value
+/// so the caller can populate `CasConflict { current }` without a second round
+/// trip.
+pub const CACHE_CAS: ScriptSpec = ScriptSpec {
+    name: "cache_cas",
+    source: r"
+-- KEYS[1]=entry  ARGV[1]=expected_version  ARGV[2]=new_value
+--                ARGV[3]=px_or_-1          ARGV[4]=channel
+-- Returns: {1, new_version} on success
+--          {0, current_version, current_value} on version mismatch
+--          {0} when the key is absent (caller reports CasConflict{current: None})
+local cur = redis.call('HGET', KEYS[1], 'ver')
+if not cur then return {0} end
+if cur ~= ARGV[1] then
+    return {0, cur, redis.call('HGET', KEYS[1], 'v')}
+end
+local ver = redis.call('HINCRBY', KEYS[1], 'ver', 1)
+redis.call('HSET', KEYS[1], 'v', ARGV[2])
+if ARGV[3] == '-1' then redis.call('PERSIST', KEYS[1])
+else redis.call('PEXPIRE', KEYS[1], ARGV[3]) end
+if ARGV[4] ~= '' then redis.call('PUBLISH', ARGV[4], 'C') end
+return {1, ver}
+",
+};
+
+/// `cache_compare_and_delete` — value-guarded delete. DESIGN.md §6.
+///
+/// Guarded on the **value**, not the version, and that is the whole point:
+/// a version resets to 1 when a key is deleted and recreated
+/// (`cluster-cache-version-reset-caveat`), so a version guard could match a
+/// successor's fresh entry and wipe its claim. A successor that re-claimed the
+/// key after a TTL lapse wrote a different value, so the value guard is a safe
+/// no-op against it.
+pub const CACHE_COMPARE_AND_DELETE: ScriptSpec = ScriptSpec {
+    name: "cache_compare_and_delete",
+    source: r"
+-- KEYS[1]=entry  ARGV[1]=expected_value  ARGV[2]=channel
+-- Returns: 1 when deleted, 0 on value mismatch or absent key (never an error)
+if redis.call('HGET', KEYS[1], 'v') ~= ARGV[1] then return 0 end
+redis.call('DEL', KEYS[1])
+if ARGV[2] ~= '' then redis.call('PUBLISH', ARGV[2], 'D') end
+return 1
+",
+};
+
+/// `cache_delete` — unconditional delete. DESIGN.md §6.
+///
+/// The `DEL` return value gates the `PUBLISH` so a delete of an absent key
+/// emits no event, keeping the "one event per logical mutation" property
+/// DESIGN.md §4.3 rests on.
+pub const CACHE_DELETE: ScriptSpec = ScriptSpec {
+    name: "cache_delete",
+    source: r"
+-- KEYS[1]=entry  ARGV[1]=channel
+-- Returns: 1 when the key existed, else 0
+if redis.call('DEL', KEYS[1]) == 0 then return 0 end
+if ARGV[1] ~= '' then redis.call('PUBLISH', ARGV[1], 'D') end
+return 1
+",
+};
+
+/// `lock_renew` — token-fenced lease extension. DESIGN.md §6, §5.2.
+///
+/// The `GET`-then-`PEXPIRE` pair has to be one script: between a client-side
+/// read and a bare `PEXPIRE`, the lease can lapse and a successor can claim it,
+/// and the renewal would then extend *their* lease.
+pub const LOCK_RENEW: ScriptSpec = ScriptSpec {
+    name: "lock_renew",
+    source: r"
+-- KEYS[1]=lock  ARGV[1]=holder_token  ARGV[2]=px
+-- Returns: 1 when renewed, 0 when the token does not match or the key is gone
+if redis.call('GET', KEYS[1]) ~= ARGV[1] then return 0 end
+return redis.call('PEXPIRE', KEYS[1], ARGV[2])
+",
+};
+
+/// `lock_release` — token-fenced release. DESIGN.md §6, §5.2.
+///
+/// The classic bug this exists to prevent: a bare `DEL` on release deletes
+/// whatever is under the key, so a holder whose lease already lapsed releases
+/// its *successor's* lock. `RD-LOCK-006` is the regression test.
+pub const LOCK_RELEASE: ScriptSpec = ScriptSpec {
+    name: "lock_release",
+    source: r"
+-- KEYS[1]=lock  ARGV[1]=holder_token  ARGV[2]=channel
+-- Returns: 1 when released, 0 when we are no longer the holder
+if redis.call('GET', KEYS[1]) ~= ARGV[1] then return 0 end
+redis.call('DEL', KEYS[1])
+redis.call('PUBLISH', ARGV[2], 'R')
+return 1
+",
+};
+
+/// The cache half of the catalog.
+///
+/// Acquisition and the read path are absent because neither needs a script:
+/// `SET K token NX PX ttl` is already atomic (DESIGN.md §5.1), and
+/// `get`/`contains`/`scan_prefix` are plain commands (DESIGN.md §4.1).
+pub const CACHE_SCRIPTS: &[ScriptSpec] = &[
+    CACHE_PUT,
+    CACHE_PUT_IF_ABSENT,
+    CACHE_CAS,
+    CACHE_COMPARE_AND_DELETE,
+    CACHE_DELETE,
+];
+
+/// The lock half of the catalog — the only two the standalone
+/// `RedisLockPlugin` loads (DESIGN.md §3.5).
+pub const LOCK_SCRIPTS: &[ScriptSpec] = &[LOCK_RENEW, LOCK_RELEASE];
+
+/// Every script, for the combined cache+lock plugin.
+pub const ALL_SCRIPTS: &[ScriptSpec] = &[
+    CACHE_PUT,
+    CACHE_PUT_IF_ABSENT,
+    CACHE_CAS,
+    CACHE_COMPARE_AND_DELETE,
+    CACHE_DELETE,
+    LOCK_RENEW,
+    LOCK_RELEASE,
+];
+
+/// The two server round-trips the script layer needs, behind a seam so the
+/// reload-and-retry policy is testable without a Redis.
+///
+/// Not dyn-compatible — the methods return `impl Future` — and deliberately so:
+/// there is exactly one production implementation (the `fred` pool) and one test
+/// double, both known statically, so the seam costs no allocation and no vtable.
+pub trait ScriptExecutor: Sync {
+    /// `SCRIPT LOAD <source>`, returning the SHA **the server computed**.
+    ///
+    /// The plugin never hashes a script itself: `fred`'s `Script::from_lua`
+    /// would, but it is gated behind the `sha-1` feature, and this workspace
+    /// keeps a SHA-1 implementation out of its dependency graph for what is only
+    /// script-cache addressing (`dylint.toml` DE0708 records the FIPS rule this
+    /// follows).
+    ///
+    /// Issued once per script at startup, and never again: it is where the SHA
+    /// comes from, not the recovery path (see the module docs).
+    fn script_load(
+        &self,
+        source: &'static str,
+    ) -> impl Future<Output = Result<String, Error>> + Send;
+
+    /// `EVALSHA <sha> 1 <key> <args…>` — the steady-state call.
+    ///
+    /// One key, not a slice: the single-key invariant of DESIGN.md §6 is a
+    /// property of the whole catalog, so encoding it in the signature means a
+    /// multi-key call cannot be written at all.
+    fn evalsha(
+        &self,
+        sha: &str,
+        key: &str,
+        args: &[Value],
+    ) -> impl Future<Output = Result<Value, Error>> + Send;
+
+    /// `EVAL <source> 1 <key> <args…>` — the `NOSCRIPT` recovery.
+    ///
+    /// Carries the same key as the [`evalsha`](Self::evalsha) it replaces, which
+    /// is the whole point: the retry is routed to the node that reported the
+    /// miss, and caches the script there on the way through.
+    fn eval_source(
+        &self,
+        source: &'static str,
+        key: &str,
+        args: &[Value],
+    ) -> impl Future<Output = Result<Value, Error>> + Send;
+}
+
+/// The production [`ScriptExecutor`]: a connected `fred` command pool.
+///
+/// Carries no cluster flag, and that is a consequence of the recovery design
+/// rather than an omission — every method here is either key-routed (`EVALSHA`,
+/// `EVAL`) or indifferent to which node serves it (`SCRIPT LOAD`, whose only
+/// job is to return the SHA). See the module docs.
+#[derive(Debug, Clone)]
+pub struct PoolScriptExecutor {
+    pool: Pool,
+}
+
+impl PoolScriptExecutor {
+    /// Wraps a connected pool.
+    #[must_use]
+    pub fn new(pool: Pool) -> Self {
+        Self { pool }
+    }
+}
+
+impl ScriptExecutor for PoolScriptExecutor {
+    async fn script_load(&self, source: &'static str) -> Result<String, Error> {
+        self.pool.script_load(source).await
+    }
+
+    async fn evalsha(&self, sha: &str, key: &str, args: &[Value]) -> Result<Value, Error> {
+        // One key, always — the catalog's single-key invariant (see the module
+        // docs) is what makes this routable in cluster mode at all.
+        self.pool.evalsha(sha, key, args.to_vec()).await
+    }
+
+    async fn eval_source(
+        &self,
+        source: &'static str,
+        key: &str,
+        args: &[Value],
+    ) -> Result<Value, Error> {
+        self.pool.eval(source, key, args.to_vec()).await
+    }
+}
+
+/// The catalog's SHAs, keyed by [`ScriptSpec::name`].
+///
+/// Immutable after [`load_catalog`] builds it — see the module docs for why a
+/// `NOSCRIPT` reload does not have to write back into it.
+#[derive(Debug, Clone, Default)]
+pub struct ScriptCache {
+    shas: HashMap<&'static str, String>,
+}
+
+impl ScriptCache {
+    /// The SHA `SCRIPT LOAD` returned for `name`.
+    ///
+    /// # Errors
+    /// [`ClusterError::Provider`] with [`ProviderErrorKind::Other`] when the
+    /// name is not in the cache. That is a plugin bug rather than an operator
+    /// or server condition — it means a script was evaluated that its plugin
+    /// never loaded — so it is reported as unretryable and says so.
+    pub fn sha(&self, name: &str) -> Result<&str, ClusterError> {
+        self.shas
+            .get(name)
+            .map(String::as_str)
+            .ok_or_else(|| ClusterError::Provider {
+                kind: ProviderErrorKind::Other,
+                message: format!(
+                    "script `{name}` was evaluated but is not in this plugin's loaded catalog \
+                     (a plugin bug: the catalog loaded at startup does not contain it)"
+                ),
+            })
+    }
+}
+
+/// `SCRIPT LOAD`s each script in `scripts` once and returns the resulting SHA
+/// cache. Step 3 of `build_and_start` (DESIGN.md §3.2).
+///
+/// # Errors
+/// Whatever [`map_redis_error`] makes of a failing `SCRIPT LOAD` — in practice
+/// a connection or auth failure, since the sources are compile-time constants
+/// and cannot be rejected for syntax at runtime without having been rejected in
+/// every prior deployment too.
+pub async fn load_catalog<E: ScriptExecutor>(
+    executor: &E,
+    scripts: &'static [ScriptSpec],
+) -> Result<ScriptCache, ClusterError> {
+    let mut shas = HashMap::with_capacity(scripts.len());
+    for script in scripts {
+        let sha = executor
+            .script_load(script.source)
+            .await
+            .map_err(map_redis_error)?;
+        shas.insert(script.name, sha);
+    }
+    Ok(ScriptCache { shas })
+}
+
+/// Evaluates `script` against `key`, recovering **exactly once** if the server
+/// reports `NOSCRIPT` (DESIGN.md §6).
+///
+/// The bound is the point. A server that restarts under load answers `NOSCRIPT`
+/// to every in-flight command, and a policy that recovered on each failure
+/// without a limit would turn one restart into an unbounded retry storm against
+/// a server that is already struggling. The recovery path is entered at most
+/// once per call and never re-entered, so anything that goes wrong inside it —
+/// including a second `NOSCRIPT`, which `EVAL` cannot actually produce — falls
+/// through [`map_redis_error`] to `Provider { Other }`.
+///
+/// # Errors
+/// [`ClusterError::Provider`] for a failing `EVALSHA` or a failing recovery, and
+/// whatever [`ScriptCache::sha`] returns if `script` was never loaded.
+pub async fn eval<E: ScriptExecutor>(
+    executor: &E,
+    cache: &ScriptCache,
+    script: &ScriptSpec,
+    key: &str,
+    args: &[Value],
+    signals: &RedisSignals,
+) -> Result<Value, ClusterError> {
+    let sha = cache.sha(script.name)?;
+    match executor.evalsha(sha, key, args).await {
+        Ok(value) => Ok(value),
+        Err(err) if is_noscript(&err) => {
+            // DEBUG, not WARN: an emptied server-side script cache is a normal
+            // consequence of a restart, a `SCRIPT FLUSH`, or (in cluster mode)
+            // the first call to reach a given shard — all fully recovered from
+            // here. What makes it alertable is the aggregate rather than the
+            // line: `cluster_redis_script_reloads_total` climbing steadily means
+            // something is flushing the script cache under the plugin
+            // (DESIGN.md §9).
+            signals.script_reloaded();
+            tracing::debug!(
+                script = script.name,
+                "redis script cache miss; retrying with EVAL, which reaches the same node and \
+                 caches the script there"
+            );
+            executor
+                .eval_source(script.source, key, args)
+                .await
+                .map_err(map_redis_error)
+        }
+        Err(err) => Err(map_redis_error(err)),
+    }
+}
+
+// Layer-1 unit tests (TESTING.md §2, `scripts.rs` row): the single-key
+// structural invariant, one `SCRIPT LOAD` per script, and the bounded
+// reload-and-retry. Out-of-line per DE1101.
+#[cfg(test)]
+#[path = "scripts_tests.rs"]
+mod tests;

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/scripts_tests.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/scripts_tests.rs
@@ -1,0 +1,392 @@
+use std::collections::BTreeSet;
+use std::sync::Mutex;
+
+use fred::error::ErrorKind;
+
+use super::*;
+
+/// What the double should answer.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EvalOutcome {
+    /// Succeed.
+    Ok,
+    /// Answer `NOSCRIPT` to everything, including the `EVAL` recovery — which a
+    /// real server cannot do, since `EVAL` carries the source. The double can,
+    /// and that is the point: it is the only way to observe that the recovery
+    /// path is entered at most once.
+    NoScript,
+    /// Answer `NOSCRIPT` to `EVALSHA` and succeed on the `EVAL` recovery — the
+    /// ordinary case this policy exists for.
+    NoScriptThenOk,
+}
+
+/// An in-memory [`ScriptExecutor`] that records what it was asked to do.
+///
+/// The point of the seam: the recovery bound has a real failure mode — a server
+/// that answers `NOSCRIPT` to everything turning one restart into an unbounded
+/// retry storm — and it is only observable by counting calls, which a live Redis
+/// makes far harder than a double does.
+struct FakeExecutor {
+    outcome: EvalOutcome,
+    state: Mutex<Calls>,
+}
+
+#[derive(Default)]
+struct Calls {
+    /// Sources passed to `SCRIPT LOAD`.
+    loads: Vec<&'static str>,
+    /// SHAs passed to `EVALSHA`.
+    evalshas: Vec<String>,
+    /// `(source, key)` pairs passed to the `EVAL` recovery.
+    eval_sources: Vec<(&'static str, String)>,
+}
+
+impl FakeExecutor {
+    fn new(outcome: EvalOutcome) -> Self {
+        Self {
+            outcome,
+            state: Mutex::new(Calls::default()),
+        }
+    }
+
+    fn load_count(&self) -> usize {
+        self.state.lock().expect("uncontended").loads.len()
+    }
+
+    fn evalsha_count(&self) -> usize {
+        self.state.lock().expect("uncontended").evalshas.len()
+    }
+
+    fn eval_source_calls(&self) -> Vec<(&'static str, String)> {
+        self.state.lock().expect("uncontended").eval_sources.clone()
+    }
+
+    fn noscript() -> Error {
+        Error::new(ErrorKind::Unknown, "NOSCRIPT No matching script.")
+    }
+}
+
+impl ScriptExecutor for FakeExecutor {
+    async fn script_load(&self, source: &'static str) -> Result<String, Error> {
+        self.state.lock().expect("uncontended").loads.push(source);
+        // A stand-in for the SHA the server computes: stable per source, as a
+        // real one is.
+        Ok(format!("sha-of-{:x}", source.len()))
+    }
+
+    async fn evalsha(&self, sha: &str, _key: &str, _args: &[Value]) -> Result<Value, Error> {
+        self.state
+            .lock()
+            .expect("uncontended")
+            .evalshas
+            .push(sha.to_owned());
+        if self.outcome == EvalOutcome::Ok {
+            Ok(Value::Integer(1))
+        } else {
+            Err(Self::noscript())
+        }
+    }
+
+    async fn eval_source(
+        &self,
+        source: &'static str,
+        key: &str,
+        _args: &[Value],
+    ) -> Result<Value, Error> {
+        self.state
+            .lock()
+            .expect("uncontended")
+            .eval_sources
+            .push((source, key.to_owned()));
+        if self.outcome == EvalOutcome::NoScript {
+            Err(Self::noscript())
+        } else {
+            Ok(Value::Integer(1))
+        }
+    }
+}
+
+#[tokio::test]
+async fn every_script_is_loaded_exactly_once_and_its_sha_cached() {
+    let executor = FakeExecutor::new(EvalOutcome::Ok);
+    let cache = load_catalog(&executor, ALL_SCRIPTS)
+        .await
+        .expect("the catalog loads");
+
+    assert_eq!(
+        executor.load_count(),
+        ALL_SCRIPTS.len(),
+        "SCRIPT LOAD must be issued once per catalogued script, not once per call site"
+    );
+    for script in ALL_SCRIPTS {
+        cache
+            .sha(script.name)
+            .unwrap_or_else(|err| panic!("`{}` must be in the cache: {err}", script.name));
+    }
+}
+
+/// The signal sink `eval` reports a `NOSCRIPT` recovery through.
+///
+/// `cluster_redis_script_reloads_total` is an `OpenTelemetry` counter rather
+/// than a `ClusterMetrics` call, so its *value* needs a reader and is asserted
+/// at Layer 3 (`RD-LIFE-008`). What this keeps testable here is the recovery
+/// policy itself, which is the part with a real failure mode.
+fn signals() -> std::sync::Arc<crate::observability::RedisSignals> {
+    crate::test_support::recording_signals().0
+}
+
+#[tokio::test]
+async fn a_successful_eval_costs_one_round_trip_and_no_recovery() {
+    let executor = FakeExecutor::new(EvalOutcome::Ok);
+    let cache = load_catalog(&executor, CACHE_SCRIPTS)
+        .await
+        .expect("the catalog loads");
+    let loads_after_startup = executor.load_count();
+
+    let script = &CACHE_SCRIPTS[0];
+    eval(&executor, &cache, script, "cluster:c:k", &[], &signals())
+        .await
+        .expect("the eval succeeds");
+
+    assert_eq!(executor.evalsha_count(), 1);
+    assert!(
+        executor.eval_source_calls().is_empty(),
+        "the happy path must not fall back to EVAL"
+    );
+    assert_eq!(
+        executor.load_count(),
+        loads_after_startup,
+        "the happy path must not touch SCRIPT LOAD"
+    );
+}
+
+#[tokio::test]
+async fn one_noscript_recovers_with_a_single_key_routed_eval() {
+    let executor = FakeExecutor::new(EvalOutcome::NoScriptThenOk);
+    let cache = load_catalog(&executor, CACHE_SCRIPTS)
+        .await
+        .expect("the catalog loads");
+    let loads_after_startup = executor.load_count();
+
+    let script = &CACHE_SCRIPTS[0];
+    eval(&executor, &cache, script, "cluster:c:k", &[], &signals())
+        .await
+        .expect("the recovery succeeds");
+
+    assert_eq!(
+        executor.evalsha_count(),
+        1,
+        "the EVALSHA is not repeated; EVAL replaces it"
+    );
+    assert_eq!(
+        executor.load_count(),
+        loads_after_startup,
+        "recovery is EVAL, not a second SCRIPT LOAD: a keyless SCRIPT LOAD could warm a node \
+         other than the one that reported the miss"
+    );
+    assert_eq!(
+        executor.eval_source_calls(),
+        vec![(script.source, "cluster:c:k".to_owned())],
+        "the recovery must carry the same key, so it routes to the node that missed"
+    );
+}
+
+#[tokio::test]
+async fn a_second_noscript_is_a_provider_error_rather_than_an_unbounded_loop() {
+    let executor = FakeExecutor::new(EvalOutcome::NoScript);
+    let cache = load_catalog(&executor, CACHE_SCRIPTS)
+        .await
+        .expect("the catalog loads");
+
+    let script = &CACHE_SCRIPTS[0];
+    let err = eval(&executor, &cache, script, "cluster:c:k", &[], &signals())
+        .await
+        .expect_err("a server that always answers NOSCRIPT must fail the call");
+
+    assert!(
+        matches!(
+            err,
+            ClusterError::Provider {
+                kind: ProviderErrorKind::Other,
+                ..
+            }
+        ),
+        "a NOSCRIPT from the recovery path must surface as Provider{{Other}}, got {err:?}"
+    );
+    assert_eq!(executor.evalsha_count(), 1);
+    assert_eq!(
+        executor.eval_source_calls().len(),
+        1,
+        "the recovery path must be entered at most once per call"
+    );
+}
+
+#[tokio::test]
+async fn a_non_noscript_failure_is_not_retried_at_all() {
+    struct AlwaysDown;
+    impl ScriptExecutor for AlwaysDown {
+        async fn script_load(&self, _source: &'static str) -> Result<String, Error> {
+            Ok("sha".to_owned())
+        }
+        async fn evalsha(&self, _sha: &str, _key: &str, _args: &[Value]) -> Result<Value, Error> {
+            Err(Error::new(ErrorKind::IO, "connection reset by peer"))
+        }
+        async fn eval_source(
+            &self,
+            _source: &'static str,
+            _key: &str,
+            _args: &[Value],
+        ) -> Result<Value, Error> {
+            panic!("an IO failure is not a script-cache miss and must not reach the recovery path")
+        }
+    }
+
+    let cache = load_catalog(&AlwaysDown, CACHE_SCRIPTS)
+        .await
+        .expect("the catalog loads");
+    let err = eval(&AlwaysDown, &cache, &CACHE_SCRIPTS[0], "k", &[], &signals())
+        .await
+        .expect_err("an IO failure must surface");
+    assert!(
+        matches!(
+            err,
+            ClusterError::Provider {
+                kind: ProviderErrorKind::ConnectionLost,
+                ..
+            }
+        ),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn evaluating_a_script_the_plugin_never_loaded_names_the_plugin_bug() {
+    // The standalone lock plugin loads only `LOCK_SCRIPTS` (DESIGN.md §3.5), so
+    // a cache script reaching it is a wiring mistake inside the plugin, not an
+    // operator or server condition.
+    let executor = FakeExecutor::new(EvalOutcome::Ok);
+    let cache = load_catalog(&executor, LOCK_SCRIPTS)
+        .await
+        .expect("the lock catalog loads");
+
+    let err = eval(&executor, &cache, &CACHE_SCRIPTS[0], "k", &[], &signals())
+        .await
+        .expect_err("an unloaded script must not be evaluated");
+    let ClusterError::Provider { kind, message } = err else {
+        panic!("expected a Provider error");
+    };
+    assert_eq!(kind, ProviderErrorKind::Other);
+    assert!(
+        message.contains(CACHE_SCRIPTS[0].name),
+        "the error must name the script, got {message}"
+    );
+    assert_eq!(
+        executor.evalsha_count(),
+        0,
+        "nothing must reach the server on a cache miss"
+    );
+}
+
+#[test]
+fn every_catalogued_script_declares_exactly_one_key() {
+    // DESIGN.md §6's Cluster-correctness invariant, read back out of the Lua
+    // source so a future two-key script fails here rather than in production
+    // with `CROSSSLOT`.
+    let expected: BTreeSet<usize> = [1].into_iter().collect();
+    for script in ALL_SCRIPTS {
+        assert_eq!(
+            script.declared_key_indices(),
+            expected,
+            "`{}` must reference KEYS[1] and nothing else",
+            script.name
+        );
+    }
+}
+
+#[test]
+fn the_key_index_scan_actually_sees_a_second_key() {
+    // Guards the guard: an invariant check that cannot fail is worse than none,
+    // because it reads as coverage.
+    let two_key = ScriptSpec {
+        name: "hypothetical",
+        source: "redis.call('SET', KEYS[1], redis.call('GET', KEYS[2]))",
+    };
+    assert_eq!(
+        two_key.declared_key_indices(),
+        [1, 2].into_iter().collect::<BTreeSet<usize>>()
+    );
+}
+
+#[test]
+fn the_catalog_halves_partition_the_whole() {
+    // The standalone lock plugin loads `LOCK_SCRIPTS` and the combined plugin
+    // loads `ALL_SCRIPTS`; a script present in neither half would be loaded by
+    // the combined plugin and silently missing from the standalone one.
+    let all: Vec<&str> = ALL_SCRIPTS.iter().map(|s| s.name).collect();
+    let halves: Vec<&str> = CACHE_SCRIPTS
+        .iter()
+        .chain(LOCK_SCRIPTS)
+        .map(|s| s.name)
+        .collect();
+    assert_eq!(all, halves);
+    assert_eq!(
+        all.iter().collect::<BTreeSet<_>>().len(),
+        all.len(),
+        "script names are cache keys and must be unique"
+    );
+}
+
+#[test]
+fn no_script_source_uses_a_blocking_or_nondeterministic_command() {
+    // TESTING.md §6's "no blocking commands" rule reaches Lua too, where the
+    // compile-time guard of leaving `i-lists` out of fred's feature list does
+    // not apply: a script body is a string. `TIME`/`RANDOMKEY` are here for a
+    // different reason — a script that read either would be non-deterministic,
+    // which is what makes a script unsafe to replicate.
+    for script in ALL_SCRIPTS {
+        for forbidden in [
+            "BLPOP",
+            "BRPOP",
+            "BLMOVE",
+            "BLMPOP",
+            "WAIT",
+            "TIME",
+            "RANDOMKEY",
+        ] {
+            assert!(
+                !script.source.contains(forbidden),
+                "`{}` must not call {forbidden}",
+                script.name
+            );
+        }
+    }
+}
+
+#[test]
+fn no_script_source_issues_a_keyspace_wide_command() {
+    // The Lua half of TESTING.md §6's `KEYS`/`FLUSHALL`/`FLUSHDB` rule, whose
+    // Rust half is `static_analysis_tests.rs`. Split because the two need
+    // different matchers, not because the rule differs: a bare `KEYS` cannot be
+    // searched for in a script body, since `KEYS[1]` is Lua's *argument global*
+    // and appears — correctly — in every script in the catalog. The `redis.call`
+    // form is what distinguishes issuing the command from indexing the global.
+    //
+    // Every script here is single-key by design (DESIGN.md §6, asserted
+    // structurally by `every_catalogued_script_declares_exactly_one_key`), so a
+    // keyspace-wide command inside one would additionally break the Cluster
+    // routing invariant that makes `CROSSSLOT` unreachable.
+    for script in ALL_SCRIPTS {
+        for command in ["KEYS", "FLUSHALL", "FLUSHDB", "SCAN", "RANDOMKEY"] {
+            for quote in ['\'', '"'] {
+                let call = format!("redis.call({quote}{command}{quote}");
+                assert!(
+                    !script.source.contains(&call),
+                    "`{}` must not issue {command}: it reaches past the single key the script \
+                     declares, which is both a keyspace-wide operation and a Cluster routing \
+                     violation",
+                    script.name
+                );
+            }
+        }
+    }
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/shutdown.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/shutdown.rs
@@ -1,0 +1,184 @@
+//! Shutdown machinery shared by both plugin handles — `RedisClusterHandle`
+//! (cache + lock) and `RedisLockHandle` (lock only) — DESIGN.md §11.
+//!
+//! One file rather than a copy per handle, and DESIGN.md §3.1 records why. The
+//! obvious alternative — the ADR-006 `Drop` guard in `plugin.rs`, the bounded
+//! pool close in `lock/mod.rs` — is what the Postgres plugin does, and its two
+//! copies drifted in both directions: one handle bounded its pool close and the
+//! other did not, one cancelled the shutdown token in `Drop` and the other did
+//! not, so a `stop()` future dropped by a supervisor timeout leaked every
+//! background task and the pool with it while the design document asserted the
+//! opposite. This plugin has the identical two-handle shape, so it holds one
+//! implementation of each rule and neither handle can drift from a rule it does
+//! not own.
+
+use std::time::Duration;
+
+use fred::clients::{Pool, SubscriberClient};
+use fred::interfaces::ClientLike;
+use fred::types::ConnectHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::warn;
+
+/// Upper bound on the final pool `quit()` in either handle's `stop()`
+/// (DESIGN.md §11 step 3).
+///
+/// `fred`'s `quit` drains in-flight commands before closing each connection,
+/// which is the behaviour worth having — a `stop()` that severed the socket
+/// mid-command would turn an orderly shutdown into a spurious `ConnectionLost`
+/// for whatever was in flight. The bound exists because that drain is only as
+/// fast as the server: against an unresponsive Redis the drain is exactly as
+/// long as the server is unresponsive, and a supervisor's shutdown budget must
+/// not be spent there.
+///
+/// Ten seconds: comfortably longer than the 5 s default `command_timeout_ms`,
+/// so every healthy in-flight command either completes or times out well inside
+/// it, and short enough to stay within a typical supervisor budget. Giving up
+/// on the wait still leaves the client shut down — what is lost is only the
+/// guarantee that the server has seen the `QUIT`, which an unresponsive peer was
+/// never going to give.
+pub const POOL_CLOSE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Upper bound on draining a handle's tracked background tasks in `stop()`,
+/// before the pool it shares with them is closed.
+///
+/// The per-guard lock tasks (DESIGN.md §5) are the reason this exists. Each selects on the shutdown token, so the only
+/// thing that can delay one is a `renew` or `release` already in flight — which
+/// `command_timeout_ms` bounds client-side. Five seconds is therefore generous
+/// rather than tight: it is the default command timeout, which is the longest
+/// any single in-flight command can take, and it keeps the drain well inside the
+/// pool close that follows it.
+pub const GUARD_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Closes `tracker` to new tasks and waits for the running ones under
+/// [`GUARD_DRAIN_TIMEOUT`].
+///
+/// Tracking rather than detaching is what makes this possible at all: a
+/// `tokio::spawn`ed guard task is invisible to `stop()`, which could then return
+/// while tasks it started were still holding pool clones — the exact leak the
+/// module docs above describe the Postgres plugin suffering. `what` names the
+/// task family in the timeout warning, so an operator reading it knows which
+/// one did not finish.
+pub async fn drain_tracked_tasks(tracker: &tokio_util::task::TaskTracker, what: &str) {
+    tracker.close();
+    if tokio::time::timeout(GUARD_DRAIN_TIMEOUT, tracker.wait())
+        .await
+        .is_err()
+    {
+        warn!(
+            name: crate::observability::logs::TASK_DRAIN_TIMEOUT,
+            what,
+            timeout_ms = u64::try_from(GUARD_DRAIN_TIMEOUT.as_millis()).unwrap_or(u64::MAX),
+            "cluster.provider.task_drain_timeout: background tasks did not finish within the \
+             shutdown budget; the pool is closed either way, but at least one task may outlive \
+             stop()"
+        );
+    }
+}
+
+/// Quits `pool` under [`POOL_CLOSE_TIMEOUT`], logging if the budget elapses
+/// rather than blocking `stop()` indefinitely.
+pub async fn close_pool(pool: &Pool) {
+    match tokio::time::timeout(POOL_CLOSE_TIMEOUT, pool.quit()).await {
+        Ok(Ok(())) => {}
+        // A `quit` that fails is ordinary rather than alarming — the commonest
+        // cause is the connection already being gone, which is the state `quit`
+        // was trying to reach. DEBUG so it is available when reconstructing a
+        // shutdown, without making every restart against a bounced server look
+        // like a problem.
+        Ok(Err(err)) => {
+            tracing::debug!(error = %err, "redis pool quit reported an error while shutting down");
+        }
+        Err(_elapsed) => warn!(
+            name: crate::observability::logs::POOL_CLOSE_TIMEOUT,
+            timeout_ms = u64::try_from(POOL_CLOSE_TIMEOUT.as_millis()).unwrap_or(u64::MAX),
+            "cluster.provider.pool_close_timeout: the redis command pool did not finish draining \
+             within the shutdown budget; the client is shut down either way, but at least one \
+             connection may outlive stop()"
+        ),
+    }
+}
+
+/// Tears down a subscriber that was connected but never subscribed — the
+/// startup steps between `connect()` and `start_subscriber` (DESIGN.md §3.2
+/// step 6).
+///
+/// **Dropping the client closes nothing.** `fred` 10.1.0's
+/// `impl Drop for ClientInner` (`src/modules/inner.rs:484`) sits behind
+/// `#[cfg(feature = "credential-provider")]`, which nothing in this tree
+/// enables, so in this build the client has no `Drop` impl at all — and even
+/// under that feature its body only aborts the credential-refresh task, with a
+/// `TODO` where the router quit would go. The router task spawned by `init()`
+/// holds its own reference and keeps the socket open under the reconnect
+/// policy for the life of the process; dropping the [`ConnectHandle`] detaches
+/// its task rather than ending it. An error path that returns without calling
+/// this leaks one connection and one task per attempt, which a supervisor
+/// retrying gear boot accumulates indefinitely.
+///
+/// The order mirrors `start_subscriber`'s own failure paths: abort the
+/// connection task, then `QUIT`. There is no `manager` to abort at these
+/// earlier points, because `manage_subscriptions()` has not been called yet.
+pub async fn abandon_subscriber(client: &SubscriberClient, connection: &ConnectHandle) {
+    connection.abort();
+    crate::subscriber::quit_subscriber(client).await;
+}
+
+/// What a handle's `Drop` should say about itself, once
+/// [`cancel_and_diagnose_drop`] has done the part that must happen regardless.
+#[derive(Debug, PartialEq, Eq)]
+pub enum DropDiagnosis {
+    /// `stop()` ran to completion. Nothing to cancel and nothing to report.
+    StoppedCleanly,
+    /// Dropped while a panic was already unwinding. The caller should warn and
+    /// **not** panic: a second panic during unwind aborts the process, which
+    /// would replace a legible test failure with a bare `SIGABRT`.
+    DuringPanic,
+    /// Dropped without `stop()` outside a panic — the case worth shouting about
+    /// (panic in debug, warn in release, per ADR-006 §Confirmation).
+    Unstopped,
+}
+
+/// Cancels `shutdown` unless the handle stopped cleanly, then reports what the
+/// caller should do about it.
+///
+/// **The cancel comes first and unconditionally, and that ordering is the whole
+/// point of this function.** Reaching a handle's `Drop` with `stopped == false`
+/// covers two cases, and the second is the one that matters operationally:
+///
+/// 1. a handle genuinely forgotten — the programming error the diagnosis exists
+///    to shout about; and
+/// 2. a `stop()` whose *future was dropped part-way*, which is exactly what
+///    `tokio::time::timeout(d, handle.stop())` does when its budget elapses —
+///    the supervisor-level pattern DESIGN.md §11 recommends.
+///
+/// In both, cancelling is what lets the subscriber fan-out task, the reconnect
+/// observer, and the per-guard lock tasks observe shutdown and exit, instead of
+/// running forever against a handle nobody owns while each
+/// still holds a pool clone that consequently never closes. In case 2 the handle
+/// is not misused at all, so a diagnosis that ran *instead of* cancelling would
+/// punish the caller for following the documented advice.
+///
+/// It must also precede the caller's `#[cfg(debug_assertions)] panic!`, or the
+/// cancel would be unreachable in debug builds — which is why this returns a
+/// [`DropDiagnosis`] rather than emitting the diagnosis itself. The panic is
+/// compiled in exactly the configuration tests run in, so "the token was
+/// cancelled on the path that would otherwise panic" is not observable from a
+/// test that lets the `Drop` impl run to completion. Returning the decision
+/// makes that ordering directly assertable.
+#[must_use]
+pub fn cancel_and_diagnose_drop(stopped: bool, shutdown: &CancellationToken) -> DropDiagnosis {
+    if stopped {
+        return DropDiagnosis::StoppedCleanly;
+    }
+    shutdown.cancel();
+    if std::thread::panicking() {
+        return DropDiagnosis::DuringPanic;
+    }
+    DropDiagnosis::Unstopped
+}
+
+// Layer-1 unit tests: the `Drop`-ordering rule this module exists to hold.
+// Out-of-line per DE1101.
+#[cfg(test)]
+#[path = "shutdown_tests.rs"]
+mod tests;

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/shutdown_tests.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/shutdown_tests.rs
@@ -1,0 +1,158 @@
+use super::*;
+
+/// The regression this function exists for: a handle dropped without `stop()`
+/// must have cancelled the shared token *before* the caller reaches its
+/// diagnosis, so the background tasks unwind. The Postgres plugin's combined
+/// handle shipped without this and leaked both reapers and both `LISTEN` tasks —
+/// each pinning a pool clone, so the pool never closed either — for the life of
+/// the process.
+#[test]
+fn dropping_without_stop_cancels_before_diagnosing() {
+    let shutdown = CancellationToken::new();
+
+    let diagnosis = cancel_and_diagnose_drop(false, &shutdown);
+
+    assert_eq!(
+        diagnosis,
+        DropDiagnosis::Unstopped,
+        "a handle dropped without stop() outside a panic must be reported"
+    );
+    assert!(
+        shutdown.is_cancelled(),
+        "the token must already be cancelled by the time the caller diagnoses, or the debug-build \
+         panic makes the cancel unreachable"
+    );
+}
+
+/// A clean `stop()` has already cancelled the token itself, and the handle
+/// carries nothing left to unwind — so `Drop` must stay silent rather than
+/// re-reporting a shutdown that worked.
+#[test]
+fn a_cleanly_stopped_handle_is_not_diagnosed() {
+    let shutdown = CancellationToken::new();
+
+    assert_eq!(
+        cancel_and_diagnose_drop(true, &shutdown),
+        DropDiagnosis::StoppedCleanly
+    );
+}
+
+/// `stopped == true` must not cancel on its own account. The flag means `stop()`
+/// completed, which already cancelled the token; cancelling here would be
+/// harmless but would make this function's contract ("cancels unless the handle
+/// stopped cleanly") false, and the next reader would have to re-derive which of
+/// the two actually holds.
+#[test]
+fn a_cleanly_stopped_handle_does_not_cancel_here() {
+    let shutdown = CancellationToken::new();
+
+    let _diagnosis = cancel_and_diagnose_drop(true, &shutdown);
+
+    assert!(
+        !shutdown.is_cancelled(),
+        "stop() owns the cancel on the clean path; Drop must not claim it too"
+    );
+}
+
+/// Cancelling is unconditional, but the *diagnosis* is not: during a panic
+/// unwind the caller must warn instead of panicking, since a second panic
+/// aborts. The token still has to be cancelled — a test failing mid-critical
+/// section is precisely when the background tasks most need to be told.
+#[test]
+fn dropping_during_a_panic_still_cancels_but_asks_for_a_warning() {
+    // `std::thread::panicking()` is only true inside an unwinding drop, so drive
+    // the real thing rather than faking the predicate.
+    struct Dropper {
+        shutdown: CancellationToken,
+        diagnosis: std::sync::Arc<std::sync::Mutex<Option<DropDiagnosis>>>,
+    }
+    impl Drop for Dropper {
+        fn drop(&mut self) {
+            let diagnosis = cancel_and_diagnose_drop(false, &self.shutdown);
+            *self.diagnosis.lock().expect("uncontended") = Some(diagnosis);
+        }
+    }
+
+    let shutdown = CancellationToken::new();
+    let diagnosis = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let panicked = std::panic::catch_unwind({
+        let shutdown = shutdown.clone();
+        let diagnosis = std::sync::Arc::clone(&diagnosis);
+        move || {
+            let _dropper = Dropper {
+                shutdown,
+                diagnosis,
+            };
+            panic!(
+                "simulated failure mid-shutdown (expected: this test drives a real unwinding \
+                 Drop, so this line on stderr is part of a passing run)"
+            );
+        }
+    });
+
+    assert!(panicked.is_err(), "setup: the closure must have panicked");
+    assert_eq!(
+        *diagnosis.lock().expect("uncontended"),
+        Some(DropDiagnosis::DuringPanic),
+        "a Drop running during unwind must ask for a warning, never a second panic"
+    );
+    assert!(
+        shutdown.is_cancelled(),
+        "cancelling is unconditional: a panicking shutdown still has to unwind its tasks"
+    );
+}
+
+/// [`abandon_subscriber`] must actually stop the router task `connect()` spawned,
+/// not merely drop a handle to it. Dropping the `SubscriberClient` closes nothing
+/// in this build of `fred` (the function's own doc explains why), so a startup
+/// that failed after the subscriber connected — `connect.rs`'s subscriber
+/// timeout/error arms — would leak one connection and one router task per attempt
+/// without this call. `RD-LIFE-010` proves the leak-free property for the startup
+/// steps *after* `connect()`; this covers the teardown primitive those arms rely
+/// on, at the unit layer, since forcing the end-to-end subscriber connect timeout
+/// itself needs the fault-injection harness this crate does not build
+/// (TESTING.md §5/§8).
+///
+/// Pointed at a closed port under the production reconnect policy on purpose: the
+/// router task then stays *pending*, retrying (`RECONNECT_ATTEMPTS` = 20 with
+/// exponential backoff runs for minutes), so its disappearance after teardown is
+/// attributable to the abort rather than to the task exhausting its schedule on
+/// its own. No server, so this stays a Layer 1 test.
+#[tokio::test]
+async fn abandon_subscriber_stops_the_router_task() {
+    use fred::types::Builder;
+    use fred::types::config::Config;
+
+    let config = Config::from_url("redis://127.0.0.1:1").expect("a well-formed url parses");
+    let mut builder = Builder::from_config(config);
+    builder.set_policy(crate::connect::reconnect_policy());
+    let client = builder
+        .build_subscriber_client()
+        .expect("the subscriber client builds");
+    let connection = client.connect();
+    assert!(
+        !connection.is_finished(),
+        "setup: the router task retries under the reconnect policy, so it is running before \
+         teardown - otherwise the assertion below would pass on a task that ended by itself"
+    );
+
+    // Bounded on purpose: a teardown that blocked on an unresponsive client would
+    // be the very hang `stop()` exists to avoid, so completing at all is part of
+    // what is under test.
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        abandon_subscriber(&client, &connection),
+    )
+    .await
+    .expect("abandon_subscriber must complete promptly, not block on an unresponsive client");
+
+    // `abort()` schedules cancellation; awaiting the handle observes it land, and
+    // `is_cancelled()` is what distinguishes "the abort stopped it" from "it would
+    // have stopped anyway".
+    let outcome = connection.await;
+    assert!(
+        outcome.map_or_else(|err| err.is_cancelled(), |_completed| false),
+        "the router task must be gone after teardown - aborted, not left retrying the \
+         reconnect schedule"
+    );
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/static_analysis_tests.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/static_analysis_tests.rs
@@ -1,0 +1,265 @@
+//! TESTING.md §6's mechanical source checks: the commands this plugin must
+//! never issue, asserted over its own source rather than left to review
+//! vigilance.
+//!
+//! Only one of §6's two rules needs a test at all, and knowing which is the
+//! point of this file:
+//!
+//! - **The `B*` blocking family is a compile-time impossibility**, not a
+//!   convention. DESIGN.md §3.1 names `fred`'s interface features individually and leaves
+//!   `i-lists` out, so `BLPOP`/`BRPOP`/`BLMOVE`/`BLMPOP` are not in the trait
+//!   surface this crate can see: reaching for one is a type error, which is a
+//!   stronger guarantee than any scan. Scanning for them here would be actively
+//!   counterproductive — `lock/mod.rs` and `lock/waiters.rs` both *name* `BLPOP`
+//!   in prose, explaining why the release-waiter registry exists instead of it,
+//!   and a text scan would turn that explanation into a failure.
+//! - **`KEYS`, `FLUSHALL`, and `FLUSHDB` are all reachable**, so they are what
+//!   this file checks. `KEYS` is in `i-keys` alongside the `GET`/`SET`/`PEXPIRE`
+//!   family the cache is built on, and `flushall`/`flushdb` sit on `ClientLike`
+//!   itself — ungated by any feature, so no feature list can put them out of
+//!   reach. `KEYS` on a shared production Redis is an outage rather than a slow
+//!   query (DESIGN.md §4.4): it is O(N) over the whole keyspace and blocks the
+//!   single-threaded server for the duration, which is why `cache/scan.rs`
+//!   iterates with a `SCAN` cursor. `FLUSHALL`/`FLUSHDB` would delete other
+//!   tenants' data, not merely this plugin's.
+//!
+//! ## Why the check is on the call form, not the command name
+//!
+//! Matching the bare word `KEYS` is unusable here: `preflight.rs`'s
+//! `REQUIRED_KEYSPACE_FLAGS`, `observability.rs`'s
+//! `KEYSPACE_NOTIFICATIONS_SET`, and every Lua script's `KEYS[1]` all contain
+//! it, and the last of those is the *correct* use — `KEYS` is Lua's argument
+//! global, not a command, inside a script body. So this scans for the Rust
+//! method call that would actually issue the command (`.keys(`), and
+//! `scripts_tests.rs` covers the Lua half separately by looking for the
+//! `redis.call` form.
+//!
+//! Test sources are excluded from the scan: the forbidden strings necessarily
+//! appear in this file, and §6's rule is about the shipped plugin.
+
+use std::path::{Path, PathBuf};
+
+/// Method-call fragments that would issue a command this plugin must never
+/// issue, paired with why each is disqualifying.
+///
+/// The trailing `(` is load-bearing: it is what distinguishes a call from a
+/// mention in a doc comment, and it is why `keys` — a common enough word — can
+/// be matched at all without false positives on prose or on identifiers like
+/// `MultipleKeys`.
+const FORBIDDEN_CALLS: &[(&str, &str)] = &[
+    (
+        ".keys(",
+        "KEYS is O(N) over the whole keyspace and blocks the single-threaded server for the \
+         duration, so on a shared production Redis it is an outage rather than a slow query. Use \
+         the SCAN cursor loop in cache/scan.rs (DESIGN.md sec 4.4)",
+    ),
+    (
+        ".flushall(",
+        "FLUSHALL deletes every key on the server, including those of unrelated tenants sharing \
+         it. This plugin owns only its own key prefix and must never reach past it",
+    ),
+    (
+        ".flushdb(",
+        "FLUSHDB deletes every key in the logical database, including those of unrelated tenants \
+         sharing it. This plugin owns only its own key prefix and must never reach past it",
+    ),
+];
+
+/// Every non-test `.rs` file under `src/`, as (path, contents).
+///
+/// Walked rather than listed so a module added later is covered without anyone
+/// remembering to add it here — a check that silently stops covering new code is
+/// worse than no check, because it still reads as a green guarantee.
+fn plugin_sources() -> Vec<(PathBuf, String)> {
+    fn walk(dir: &Path, found: &mut Vec<(PathBuf, String)>) {
+        let entries = std::fs::read_dir(dir).expect("the crate's src/ directory is readable");
+        for entry in entries {
+            let path = entry.expect("a src/ directory entry is readable").path();
+            if path.is_dir() {
+                walk(&path, found);
+                continue;
+            }
+            let is_rust = path.extension().is_some_and(|ext| ext == "rs");
+            let name = path
+                .file_name()
+                .and_then(std::ffi::OsStr::to_str)
+                .unwrap_or_default();
+            // `*_tests.rs` and `test_support.rs` are `#[cfg(test)]`-only and are
+            // not part of the shipped plugin; this file's own forbidden-string
+            // table would otherwise fail the check it defines.
+            let is_test = name.ends_with("_tests.rs") || name == "test_support.rs";
+            if is_rust && !is_test {
+                let contents =
+                    std::fs::read_to_string(&path).expect("a src/ Rust file is valid UTF-8");
+                found.push((path, contents));
+            }
+        }
+    }
+
+    let mut found = Vec::new();
+    walk(
+        &Path::new(env!("CARGO_MANIFEST_DIR")).join("src"),
+        &mut found,
+    );
+    assert!(
+        !found.is_empty(),
+        "the source walk found nothing, so this check is passing vacuously"
+    );
+    found
+}
+
+#[test]
+fn no_source_file_issues_a_keyspace_wide_command() {
+    for (path, contents) in plugin_sources() {
+        for (call, why) in FORBIDDEN_CALLS {
+            assert!(
+                !contents.contains(call),
+                "{} issues `{call}`, which TESTING.md sec 6 forbids anywhere in src/: {why}",
+                path.display()
+            );
+        }
+    }
+}
+
+/// Marks a `warn!`/`error!` that is deliberately not an ADR-004 catalog event,
+/// placed on the line above the macro with the reason after it.
+///
+/// The escape hatch exists because not every warning is an operator's business.
+/// The ADR-006 `Drop` guards are the whole of the current set: they fire on a
+/// *programming error*, in the release build of the same arm that panics in
+/// debug, and cataloguing them would put a developer diagnostic in the event
+/// table an operator alerts on.
+const CATALOG_EXEMPT: &str = "not-a-catalogued-event:";
+
+/// Whether `line` opens a `warn!`/`error!` macro call in code rather than prose.
+///
+/// The line is truncated at the first `//` so a doc comment naming the macro —
+/// this file's own module docs, for one — is not read as a call site. That
+/// truncation is why the check is on the macro-open line rather than on the
+/// whole invocation: a `//` inside a message string would cut the scan short,
+/// and the message never sits on the opening line.
+fn opens_a_warn_or_error(line: &str) -> bool {
+    let code = line.split("//").next().unwrap_or_default();
+    code.contains("warn!(") || code.contains("error!(")
+}
+
+/// Whether the comment-and-attribute run immediately above `index` carries
+/// [`CATALOG_EXEMPT`].
+///
+/// The whole run rather than the single line above it, because the reason for an
+/// exemption is worth a sentence and a sentence wraps — and because a
+/// `#[cfg(...)]` frequently sits between the comment and the macro.
+fn is_exempted(lines: &[&str], index: usize) -> bool {
+    let mut cursor = index;
+    while let Some(before) = cursor.checked_sub(1) {
+        let line = lines[before].trim_start();
+        if !line.starts_with("//") && !line.starts_with("#[") {
+            return false;
+        }
+        if line.contains(CATALOG_EXEMPT) {
+            return true;
+        }
+        cursor = before;
+    }
+    false
+}
+
+#[test]
+fn every_warn_and_error_carries_a_catalogued_event_name() {
+    // DESIGN.md §9's contract, held mechanically. A WARN without a `name:` field
+    // cannot be matched structurally by a collector, so the condition it reports
+    // is unalertable however severe it is — which is how
+    // `cluster.provider.subscriber_lost`, the line announcing that the
+    // subscriber is permanently gone, went uncatalogued.
+    //
+    // `name:` is the macro's first argument by convention
+    // (`observability.rs`'s "carry its name twice"), so it is on the opening
+    // line or the one after it.
+    for (path, contents) in plugin_sources() {
+        let lines: Vec<&str> = contents.lines().collect();
+        for (index, line) in lines.iter().enumerate() {
+            if !opens_a_warn_or_error(line) {
+                continue;
+            }
+            let next = lines.get(index + 1).copied().unwrap_or_default();
+            if line.contains("name:") || next.contains("name:") {
+                continue;
+            }
+            assert!(
+                is_exempted(&lines, index),
+                "{}:{} emits a WARN or ERROR with no `name:` field. A collector filters \
+                 structurally on `name`, so an event without one is unalertable (DESIGN.md sec 9). \
+                 Add a constant to `observability::logs` and a row to DESIGN.md sec 9's table, or \
+                 mark the site `{CATALOG_EXEMPT} <reason>` on the line above if it is a developer \
+                 diagnostic rather than an operator's business",
+                path.display(),
+                index + 1
+            );
+        }
+    }
+}
+
+#[test]
+fn the_event_name_scan_is_capable_of_failing() {
+    // The same guard `the_scan_is_capable_of_failing` puts on the forbidden-call
+    // matcher: a scan that cannot fire is indistinguishable from one whose
+    // pattern stopped matching anything.
+    assert!(
+        opens_a_warn_or_error("        tracing::warn!("),
+        "the matcher must recognize a real macro-call site"
+    );
+    assert!(
+        opens_a_warn_or_error("            DropDiagnosis::DuringPanic => warn!("),
+        "including one opened part-way through a match arm"
+    );
+    assert!(
+        !opens_a_warn_or_error("/// so a doc comment writing warn!( is not a call site"),
+        "prose naming the macro must not match"
+    );
+
+    // The exemption is found across a wrapped comment and an intervening
+    // attribute, which is the shape both ADR-006 `Drop` guards actually have,
+    // and is not found when the run above the site says nothing.
+    let exempted = [
+        "// not-a-catalogued-event: a developer diagnostic,",
+        "// not an operator's business.",
+        "#[cfg(not(debug_assertions))]",
+        "warn!(",
+    ];
+    assert!(is_exempted(&exempted, 3));
+    let unmarked = ["// just an ordinary comment", "warn!("];
+    assert!(!is_exempted(&unmarked, 1));
+}
+
+#[test]
+fn the_scan_is_capable_of_failing() {
+    // A source-scanning check that cannot fail is indistinguishable from one
+    // that passes because the pattern never matches anything — a `.keys(`
+    // renamed upstream, say, or a walk that quietly stopped finding files. This
+    // pins that the matcher itself works on text known to contain a violation.
+    let planted = "let all = pool.keys(\"*\").await?;";
+    let (call, _why) = FORBIDDEN_CALLS[0];
+    assert!(
+        planted.contains(call),
+        "the forbidden-call matcher must recognize a real call site"
+    );
+}
+
+#[test]
+fn the_scan_tolerates_the_lua_keys_global_and_keyspace_identifiers() {
+    // The three legitimate uses of the letters `KEYS` in this crate, pinned so a
+    // future tightening of the matcher back to a bare word match fails here
+    // rather than in whichever module it breaks first.
+    for legitimate in [
+        "redis.call('HSET', KEYS[1], 'v', ARGV[1])",
+        "pub const REQUIRED_KEYSPACE_FLAGS: &str = \"Kxe\";",
+        "cluster.provider.keyspace_notifications_set",
+    ] {
+        for (call, _why) in FORBIDDEN_CALLS {
+            assert!(
+                !legitimate.contains(call),
+                "`{legitimate}` is a legitimate use and must not match `{call}`"
+            );
+        }
+    }
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/subscriber.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/subscriber.rs
@@ -1,0 +1,738 @@
+//! The subscriber client's fan-out and reconnect-observer tasks
+//! (DESIGN.md §3.2 steps 4–5, §4.3).
+//!
+//! ## Why the subscriber is its own client
+//!
+//! A Redis connection in subscribe mode accepts only subscribe-family commands,
+//! so the cache's reads and writes cannot share it. `fred`'s `SubscriberClient`
+//! additionally tracks its own subscription set and replays it after a
+//! reconnect, which is what the `Reset` handling below is built on: without the
+//! replay, a reconnect would leave every watcher silently subscribed to nothing.
+//!
+//! ## One subscriber, two primitives
+//!
+//! The connection this drives is a *plugin*-level one (DESIGN.md §3.3), which is
+//! why the module sits beside `connect.rs` and `shutdown.rs` rather than under
+//! either primitive: the subscriber carries plugin-published cache events, Redis
+//! `expired`/`evicted` keyspace notifications, **and** the lock-release events a
+//! blocked `lock()` wakes on (DESIGN.md §5.3), so it draws its names from
+//! `cache::watch` and `lock` alike and belongs to neither. The fan-out therefore
+//! takes [`FanOutRoutes`], with the cache half optional: the standalone lock
+//! plugin (DESIGN.md §3.5) runs this same task with only [`LockRoute`]
+//! populated, which is what keeps its wake path identical to the combined
+//! plugin's (`RD-LOCK-009`) instead of a second near-copy of this loop. A module
+//! owned by `cache/` could not serve a deployment that has no cache.
+//!
+//! ## Two tasks, because they wait on different things
+//!
+//! The fan-out task drains the message stream and must never block; the
+//! reconnect observer parks on a separate notification stream and, when it
+//! fires, runs a registry-wide broadcast that *does* block. Folding them into
+//! one `select!` would mean a `Reset` broadcast — bounded by `TERMINAL_GRACE`
+//! per non-draining watcher — stalls message delivery for everyone, which is
+//! exactly the "one slow consumer must not stall delivery" rule the registry
+//! exists to keep.
+
+use std::sync::Arc;
+
+use cluster_sdk::{ClusterError, ProviderErrorKind};
+use fred::clients::SubscriberClient;
+use fred::interfaces::{ClientLike, EventInterface};
+use fred::types::config::Server;
+use fred::types::{ConnectHandle, KeyspaceEvent, Message, MessageKind};
+use tokio::sync::broadcast::error::RecvError;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::cache::watch::{
+    ChannelNames, Orphaned, ParsedNotification, WatchRegistry, WatcherKind, is_eviction,
+    parse_keyspace_event, parse_publish_payload,
+};
+use crate::lock::LockNames;
+use crate::lock::waiters::ReleaseWaiters;
+use crate::observability::{Primitive, RedisSignals, logs};
+
+/// The cache half of the fan-out's routing table.
+pub struct CacheRoute {
+    /// The watcher registry every cache notification is dispatched into.
+    pub registry: Arc<WatchRegistry>,
+    /// The cache's channel and pattern names.
+    pub names: ChannelNames,
+}
+
+/// The lock half of the fan-out's routing table.
+pub struct LockRoute {
+    /// The release-waiter registry a release wakes.
+    pub waiters: Arc<ReleaseWaiters>,
+    /// The lock's key and channel names.
+    pub names: LockNames,
+}
+
+/// Which primitive a notified Redis key belongs to, with the operator's prefix
+/// already stripped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OwnedKey {
+    /// A cache entry, from `<prefix>:c:<key>`.
+    Cache(String),
+    /// A lock lease, from `<prefix>:l:<name>`.
+    Lock(String),
+}
+
+impl OwnedKey {
+    /// Which primitive owns this key, for the `primitive` label and the rate
+    /// limiter it selects (DESIGN.md §9).
+    #[must_use]
+    pub fn primitive(&self) -> Primitive {
+        match self {
+            Self::Cache(_) => Primitive::Cache,
+            Self::Lock(_) => Primitive::Lock,
+        }
+    }
+
+    /// The name itself, whichever primitive owns it.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Cache(key) | Self::Lock(key) => key,
+        }
+    }
+}
+
+/// The keyspace-notification pattern, and the classifier that says which
+/// primitive a notified key belongs to (DESIGN.md §3.7).
+///
+/// ## Why the pattern spans the whole prefix
+///
+/// The eviction signal exists because an evicted **lock lease** hands the lock
+/// to a second holder while the first still believes it holds it — that is the
+/// case DESIGN.md §3.7 opens with and the worst one it names. A pattern scoped
+/// to `<prefix>:c:` would observe every case except that one. So there is a
+/// single `<prefix>:*` pattern and this type sorts what arrives, rather than one
+/// pattern per primitive: the notification stream is one connection's, the
+/// classification is a prefix compare, and two patterns would double the
+/// server-side matching for nothing.
+///
+/// ## Why it delegates rather than re-deriving
+///
+/// Nothing here spells `:c:` or `:l:`. Classification asks [`ChannelNames`] and
+/// then [`LockNames`], each of which owns its own segment and is the same type
+/// the publisher builds names with. A copy of those rules here would be a second
+/// place for them to drift, and a drift would show up as evictions silently
+/// attributed to the wrong primitive — or to neither.
+#[derive(Debug, Clone)]
+pub struct KeyspaceNames {
+    /// `__keyspace@<db>__:<key_prefix>:*`.
+    pattern: String,
+    /// The logical database the pattern is scoped to.
+    database: u8,
+    /// `None` in the standalone lock plugin, which owns no cache entries.
+    ///
+    /// Present under `watch_mode: disabled` even though no watcher registry is:
+    /// the mode turns off the cache's *watch*, and an evicted entry is still an
+    /// incident worth counting.
+    cache: Option<ChannelNames>,
+    /// The lock's namer, present in both plugins — both own a lock backend.
+    locks: LockNames,
+}
+
+impl KeyspaceNames {
+    /// Builds the keyspace naming for one plugin.
+    #[must_use]
+    pub fn new(
+        key_prefix: &str,
+        database: u8,
+        cache: Option<ChannelNames>,
+        locks: LockNames,
+    ) -> Self {
+        Self {
+            // Scoped to the operator's prefix, so a shared Redis does not
+            // deliver unrelated tenants' keyspace traffic to this subscriber,
+            // and glob-escaped for the reason `pattern_for_prefix` escapes:
+            // a `[` in the prefix would otherwise be a character class.
+            pattern: format!(
+                "__keyspace@{database}__:{}:*",
+                crate::cache::scan::escape_glob(key_prefix)
+            ),
+            database,
+            cache,
+            locks,
+        }
+    }
+
+    /// The one blanket pattern carrying `expired` and `evicted` for every key
+    /// this plugin owns.
+    ///
+    /// Always-on rather than registered per watcher, because §3.7's signal has
+    /// to observe evictions of keys nobody is watching — including every lock
+    /// lease, which nothing ever watches.
+    #[must_use]
+    pub fn pattern(&self) -> &str {
+        &self.pattern
+    }
+
+    /// The logical database this plugin's keys live in.
+    #[must_use]
+    pub fn database(&self) -> u8 {
+        self.database
+    }
+
+    /// Sorts a notified Redis key into the primitive that owns it, or `None`
+    /// when it belongs to neither.
+    ///
+    /// `None` is reachable in ordinary operation rather than only on a mistyped
+    /// prefix: the pattern covers `<prefix>:*`, and this plugin's own event
+    /// *channels* (`<prefix>:e:c:`, `<prefix>:e:l:`) share that prefix. No key
+    /// exists at a channel name, so nothing real is dropped — but a future key
+    /// family under this prefix would land here silently, which is why the
+    /// caller logs it.
+    #[must_use]
+    pub fn classify(&self, entry_key: &str) -> Option<OwnedKey> {
+        if let Some(key) = self
+            .cache
+            .as_ref()
+            .and_then(|names| names.key_from_entry_key(entry_key))
+        {
+            return Some(OwnedKey::Cache(key));
+        }
+        self.locks
+            .name_from_lease_key(entry_key)
+            .map(OwnedKey::Lock)
+    }
+}
+
+/// Where the fan-out delivers each family of message.
+///
+/// The lock route is not optional: both plugins own a lock backend, and the
+/// combined one subscribes the release pattern even under `watch_mode:
+/// disabled`, where the cache route is `None`. That mode disables the *cache's*
+/// watch, not the connection — see [`spawn_fan_out`].
+pub struct FanOutRoutes {
+    /// `None` under `watch_mode: disabled`, where no watcher registry exists.
+    pub cache: Option<CacheRoute>,
+    /// The lock's release-wake route.
+    pub locks: LockRoute,
+    /// The keyspace route, or `None` when no keyspace pattern was subscribed.
+    ///
+    /// Independent of [`cache`](Self::cache): under `watch_mode: disabled` the
+    /// keyspace route is live and the cache route is not, because an eviction is
+    /// worth counting whether or not anyone is watching the key it removed.
+    pub keyspace: Option<KeyspaceNames>,
+    /// The plugin's signal sink: the eviction WARN and counter of DESIGN.md
+    /// §3.7, and the watch-reset counter behind a lagged stream.
+    pub signals: Arc<RedisSignals>,
+}
+
+/// Spawns the task that routes every subscriber message to the registry that
+/// asked for it.
+///
+/// Cancellation-aware so `stop()` can join it; the watch registry's own
+/// `close_all` is what tells the watchers, and it runs independently of this
+/// task so a watcher observes `Closed(Shutdown)` whether or not the task has
+/// noticed the cancel yet.
+#[must_use]
+pub fn spawn_fan_out(
+    subscriber: &SubscriberClient,
+    routes: FanOutRoutes,
+    shutdown: CancellationToken,
+) -> JoinHandle<()> {
+    // Two receivers, because `fred` splits the streams: anything on a
+    // `__keyspace@`/`__keyevent@` channel is diverted to the keyspace broadcast
+    // and never appears on the pub/sub one. Reading only the latter subscribes
+    // to the keyspace pattern, watches the server deliver on it, and still
+    // emits no `Expired` — see the `watch.rs` module docs.
+    let mut messages = subscriber.message_rx();
+    let mut keyspace = subscriber.keyspace_event_rx();
+    tokio::spawn(async move {
+        loop {
+            let dispatched = tokio::select! {
+                () = shutdown.cancelled() => return,
+                received = messages.recv() => match received {
+                    Ok(message) => published(&routes, &message),
+                    Err(err) => match on_lag(&routes, err, "pub/sub").await {
+                        Continue::Yes => continue,
+                        Continue::No => return,
+                    },
+                },
+                received = keyspace.recv() => match received {
+                    Ok(event) => keyspace_notification(&routes, &event),
+                    Err(err) => match on_lag(&routes, err, "keyspace").await {
+                        Continue::Yes => continue,
+                        Continue::No => return,
+                    },
+                },
+            };
+            // Only the cache produces something to dispatch: a lock release is
+            // delivered to its waiters inside `published`, because the waiter
+            // registry is woken synchronously and has no orphaned subscriptions
+            // to tear down afterwards.
+            let (Some((notification, kind)), Some(cache)) = (dispatched, routes.cache.as_ref())
+            else {
+                continue;
+            };
+            let orphaned = cache.registry.dispatch(&notification, kind);
+            release_all(&cache.registry, &cache.names, orphaned).await;
+        }
+    })
+}
+
+/// Whether the fan-out loop should keep going after a stream error.
+enum Continue {
+    Yes,
+    No,
+}
+
+/// Turns a broadcast-stream error into the loop's next move.
+///
+/// A lagged buffer means messages were lost before this task could read them,
+/// with no way to know which — so a registry-wide `Reset` is the honest answer,
+/// the same signal a reconnect gap produces. A closed stream means the client
+/// is gone and the loop is done.
+///
+/// Lock releases lost in the same gap need no equivalent, and get none: their
+/// waiters re-attempt the `SET NX` on the jittered heartbeat regardless, so the
+/// cost is latency rather than a stale view somebody has to be told about.
+async fn on_lag(routes: &FanOutRoutes, err: RecvError, stream: &str) -> Continue {
+    match err {
+        RecvError::Lagged(missed) => {
+            let Some(cache) = routes.cache.as_ref() else {
+                // The standalone lock plugin: nothing to reset, and nothing that
+                // would make `cluster_watch_resets_total` true if incremented.
+                tracing::debug!(
+                    missed,
+                    stream,
+                    "the redis subscriber fell behind on a lock-only client; blocked lock() \
+                     callers fall back to the jittered heartbeat"
+                );
+                return Continue::Yes;
+            };
+            // Named, not merely written into the message: this is the catalog's
+            // `cluster.watch.reset` and it is emitted from two places (here and
+            // the reconnect observer), so both have to answer to the same name
+            // and the same counter (ADR-004).
+            tracing::warn!(
+                name: logs::WATCH_RESET,
+                provider = routes.signals.provider(),
+                primitive = "cache",
+                missed,
+                stream,
+                "cluster.watch.reset: the redis subscriber fell behind and dropped messages; \
+                 every watcher is being reset (DESIGN.md sec 4.3)"
+            );
+            routes.signals.watch_reset();
+            let _broadcast = cache.registry.broadcast_reset().await;
+            Continue::Yes
+        }
+        RecvError::Closed => Continue::No,
+    }
+}
+
+/// Interprets a message from the pub/sub stream — an in-script `PUBLISH`, from
+/// either a cache mutation or a lock release.
+///
+/// The lock family is answered here and reports `None`, because waking a waiter
+/// is a synchronous registry hit with nothing for the caller to dispatch
+/// afterwards. The two families are told apart by their own channel prefixes
+/// (`:e:c:` against `:e:l:`), each parsed by the type that builds it, so neither
+/// can claim the other's message.
+fn published(
+    routes: &FanOutRoutes,
+    message: &Message,
+) -> Option<(ParsedNotification, WatcherKind)> {
+    if let Some(name) = routes
+        .locks
+        .names
+        .name_from_release_channel(&message.channel)
+    {
+        // Woken on *any* payload rather than only on the `R` of DESIGN.md §2.5.
+        // A wake is a hint: the acquisition loop re-attempts the `SET NX` as the
+        // source of truth, so a spurious one costs a single round trip while a
+        // wake withheld on an unrecognized payload would cost a real waiter its
+        // whole delay.
+        routes.locks.waiters.notify(&name);
+        return None;
+    }
+    let Some(cache) = routes.cache.as_ref() else {
+        // The standalone lock plugin subscribes only the release pattern, so
+        // anything else here is a message it never asked for.
+        tracing::debug!(
+            channel = %message.channel,
+            "redis subscriber saw a message outside this plugin's lock channels"
+        );
+        return None;
+    };
+    let names = &cache.names;
+    let Some(key) = names.key_from_event_channel(&message.channel) else {
+        // Not one of this cache's channels. The subscriber is this plugin's own
+        // client, so the only way here is a pattern it registered matching
+        // something it did not expect — worth a DEBUG, not an event.
+        tracing::debug!(
+            channel = %message.channel,
+            "redis subscriber saw a message outside this cache's channels"
+        );
+        return None;
+    };
+    // The routing rule the `watch.rs` module docs explain: an exact
+    // subscription and a covering pattern both deliver the same `PUBLISH`, so
+    // each message serves only its own family, or every doubly-covered watcher
+    // sees the write twice.
+    let kind = match message.kind {
+        MessageKind::PMessage => WatcherKind::Prefix,
+        MessageKind::Message | MessageKind::SMessage => WatcherKind::Exact,
+    };
+    let notification = parse_publish_payload(&key, &message.value);
+    report_unintelligible_payload(&routes.signals, &notification, &key);
+    Some((notification, kind))
+}
+
+/// Emits `cluster.watch.reset` for a payload this plugin cannot interpret —
+/// DESIGN.md §9's second source for that event, alongside the reconnect
+/// observer.
+///
+/// It means either an unrelated publisher on this prefix or a future payload
+/// format, and the watchers on that key are being told to re-read, which is a
+/// watch reset in every sense the catalog means even though only one key's
+/// watchers are affected.
+fn report_unintelligible_payload(
+    signals: &RedisSignals,
+    notification: &ParsedNotification,
+    key: &str,
+) {
+    if !matches!(notification, ParsedNotification::Reset { .. }) {
+        return;
+    }
+    tracing::warn!(
+        name: logs::WATCH_RESET,
+        provider = signals.provider(),
+        primitive = "cache",
+        key = %key,
+        "cluster.watch.reset: an unintelligible payload arrived on this cache's own event \
+         channel; the key's watchers are being told to re-read (DESIGN.md sec 2.5, sec 4.3)"
+    );
+    signals.watch_reset();
+}
+
+/// Interprets an event from the keyspace stream — Redis's own `expired` or
+/// `evicted` notification, already split into `(db, key, operation)` by `fred`.
+///
+/// **Both primitives arrive here**, because the pattern spans `<prefix>:*`
+/// (see [`KeyspaceNames`]), and they are answered differently:
+///
+/// - an **eviction** is reported for either, labelled with the primitive that
+///   owned the key. This is the whole reason the pattern is not scoped to the
+///   cache: an evicted lease is the worst case DESIGN.md §3.7 names;
+/// - only a **cache entry** goes on to the watchers. A lock lease has none — the
+///   acquisition loop treats the `SET NX` as the source of truth (DESIGN.md
+///   §5), so there is nothing a delivery would tell anyone.
+///
+/// A cache `expired`/`evicted` is served to **both** watcher families: one
+/// blanket pattern means no twin delivery to split, unlike the published family,
+/// and routing it to one family would silently drop the other's `Expired`.
+fn keyspace_notification(
+    routes: &FanOutRoutes,
+    event: &KeyspaceEvent,
+) -> Option<(ParsedNotification, WatcherKind)> {
+    let names = routes.keyspace.as_ref()?;
+    // The pattern is already scoped to this database, but the check is cheap
+    // and a notification attributed to the wrong database would be reported as
+    // a deletion of a key this plugin never had.
+    if event.db != names.database() {
+        return None;
+    }
+    let entry_key = event.key.as_str()?;
+    let Some(owned) = names.classify(entry_key.as_ref()) else {
+        // Under this plugin's prefix but owned by neither primitive. Today the
+        // only keys matching that are none — the event *channels* share the
+        // prefix but no key exists at a channel name — so this is a DEBUG
+        // against a future key family rather than an expected path.
+        tracing::debug!(
+            key = %entry_key,
+            operation = %event.operation,
+            "redis keyspace notification under this plugin's prefix belongs to neither the cache \
+             nor the lock"
+        );
+        return None;
+    };
+    if is_eviction(&event.operation) {
+        // The one place the plugin's top operational risk stops being a
+        // prediction (DESIGN.md §3.7). Reported for *every* key under this
+        // plugin's prefix, watched or not and whichever primitive owns it,
+        // which is why the keyspace pattern is always on rather than registered
+        // per watcher.
+        //
+        // Rate-limited, allocation-free, and synchronous, because this runs on
+        // the fan-out's read loop: a loop that stopped draining would overflow
+        // `fred`'s broadcast buffer and reset every watcher, so an eviction
+        // storm would cost every consumer a re-read on top of the eviction.
+        routes
+            .signals
+            .eviction_observed(owned.primitive(), owned.name());
+    }
+    // An `expired` lease is the ordinary end of a lock's life rather than an
+    // incident, and nothing waits on the event, so the lock's half of the
+    // stream ends here.
+    let OwnedKey::Cache(key) = &owned else {
+        return None;
+    };
+    match parse_keyspace_event(key, &event.operation) {
+        ParsedNotification::Ignored => None,
+        notification => Some((notification, WatcherKind::Both)),
+    }
+}
+
+/// Tears down the subscriptions that lost their last watcher during a dispatch.
+///
+/// Awaited on the fan-out path rather than spawned, so a teardown and a fresh
+/// `watch()` for the same target cannot be reordered against each other. It is
+/// rare — only a dropped watch reaches it — and the alternative costs the
+/// serialization the registry's subscription mutex exists to provide.
+async fn release_all(registry: &WatchRegistry, names: &ChannelNames, orphaned: Vec<Orphaned>) {
+    for entry in orphaned {
+        let subscription = match entry.kind {
+            WatcherKind::Exact => names.channel_for_key(&entry.target),
+            WatcherKind::Prefix | WatcherKind::Both => names.pattern_for_prefix(&entry.target),
+        };
+        registry.release_subscription(&entry, &subscription).await;
+    }
+}
+
+/// Spawns the task that turns a subscriber reconnect into a registry-wide
+/// `Reset` (DESIGN.md §4.3).
+///
+/// **Every notification is acted on, including the first, and this task skips
+/// none.** The tempting reasoning for a skip is that `fred` fires a reconnect
+/// event on the *initial* connect, which it does — but the receiver is created
+/// here, *after* `connect()` has already awaited `init()`, and a `tokio`
+/// broadcast receiver only ever sees sends that follow its own subscription. The
+/// initial notification is therefore already gone by the time this subscribes, so
+/// a skip consumes the first **genuine** reconnect instead: the first
+/// subscription gap of a process's life delivers no `Reset` at all, leaving every
+/// watcher believing a stale view is current until a second reconnect comes
+/// along. Confirmed against a container by killing the subscriber's connection
+/// twice — with a skip in place, only the second kill produces a `Reset`.
+///
+/// Acting on every notification is safe even if that ordering ever changes. The
+/// only cost of acting on an initial-connect one would be a single registry-wide
+/// `Reset` broadcast at startup — and `build_and_start` has not returned yet at
+/// that point, so no consumer has had the chance to register a watch for it to
+/// reach.
+///
+/// The `Reset` is emitted as soon as the reconnect is observed, which may be
+/// marginally before `fred` finishes replaying the subscription set. That
+/// ordering is deliberate rather than sloppy: `Reset` means "re-read", the
+/// re-read goes through the command pool rather than this client, and every
+/// event in the gap is lost whether the consumer is told early or late. Telling
+/// it late would leave a window in which a consumer believes stale data is
+/// current.
+#[must_use]
+pub fn spawn_reconnect_observer(
+    subscriber: &SubscriberClient,
+    registry: Arc<WatchRegistry>,
+    signals: Arc<RedisSignals>,
+    shutdown: CancellationToken,
+) -> JoinHandle<()> {
+    let mut reconnects = subscriber.reconnect_rx();
+    tokio::spawn(async move {
+        loop {
+            let event = tokio::select! {
+                () = shutdown.cancelled() => return,
+                received = reconnects.recv() => received,
+            };
+            if observe_reconnect(event, &registry, &signals)
+                .await
+                .is_break()
+            {
+                return;
+            }
+        }
+    })
+}
+
+/// Handles one reconnect notification, returning whether the observer carries on.
+///
+/// Split out of [`spawn_reconnect_observer`]'s loop so both non-terminal arms are
+/// reachable from a unit test: driving a real `RecvError::Lagged` means
+/// overflowing `fred`'s internal notification channel, which needs a connection
+/// that flaps faster than the observer reads. The arms are what is worth testing
+/// — that each moves the same two signals *and* says so — and they need no
+/// client at all.
+async fn observe_reconnect(
+    event: Result<Server, RecvError>,
+    registry: &WatchRegistry,
+    signals: &RedisSignals,
+) -> std::ops::ControlFlow<()> {
+    match event {
+        Ok(server) => {
+            tracing::warn!(
+                name: logs::WATCH_RESET,
+                provider = signals.provider(),
+                server = %server,
+                primitive = "cache",
+                "cluster.watch.reset: the redis subscriber reconnected; resetting every \
+                 watcher, since pub/sub is fire-and-forget and every gap is a total gap \
+                 (DESIGN.md sec 4.3)"
+            );
+            // Two counters, because they answer different questions.
+            // `cluster_watch_resets_total` says every watcher was reset;
+            // `cluster_redis_subscriber_resubscribes_total` says the
+            // subscriber flapped. Together they separate "one flap" from
+            // "a flap per minute" (DESIGN.md §9).
+            signals.subscriber_resubscribed();
+            signals.watch_reset();
+            let _broadcast = registry.broadcast_reset().await;
+        }
+        // A missed reconnect notification is still a reconnect: reset
+        // rather than ignore.
+        //
+        // Logged under the same catalogued name as the `Ok` arm above,
+        // and for the same reason it is logged at all: this arm moves
+        // `cluster_watch_resets_total`, so a silent one leaves the
+        // counter and the log stream disagreeing, with no line to
+        // explain a reset an operator can see in the metric. Not a
+        // fourth `Reset` source — it is DESIGN.md §4.3's first source,
+        // "the subscriber reconnected", reached by a lagged receiver.
+        //
+        // `missed` is the one thing this path can say that the `Ok` path
+        // cannot: how many reconnects went unobserved. A `u64` count
+        // rather than a key or a token, so it is safe as a field — and
+        // it stays off every metric label.
+        Err(RecvError::Lagged(missed)) => {
+            tracing::warn!(
+                name: logs::WATCH_RESET,
+                provider = signals.provider(),
+                missed,
+                primitive = "cache",
+                "cluster.watch.reset: reconnect notifications were missed, which is still \
+                 a reconnect; resetting every watcher (DESIGN.md sec 4.3)"
+            );
+            signals.subscriber_resubscribed();
+            signals.watch_reset();
+            let _broadcast = registry.broadcast_reset().await;
+        }
+        // The sender is gone, so no further notification can arrive and the
+        // observer has nothing left to do.
+        Err(RecvError::Closed) => return std::ops::ControlFlow::Break(()),
+    }
+    std::ops::ControlFlow::Continue(())
+}
+
+/// Spawns the task that reacts to `fred` giving up on reconnecting the
+/// subscriber (DESIGN.md §10).
+///
+/// The signal is the `ConnectHandle` `init()` returned: it stays pending for as
+/// long as the client is connected *or* retrying, and resolves only when the
+/// reconnect policy is exhausted. Watching that rather than the error stream is
+/// what distinguishes "a connection dropped and is coming back" — which is a
+/// `Reset`, handled above — from "this subscriber is never coming back".
+///
+/// The two primitives lose different things and are told differently. A
+/// **watcher** would otherwise wait forever, receiving nothing and told nothing,
+/// so every watch is closed terminally with a *retryable* error (see
+/// [`subscriber_lost`]). A blocked **`lock()`** loses only its release wake and
+/// keeps acquiring on the jittered heartbeat, so there is nothing to close and
+/// the WARN is the whole of the response — which is also why `registry` is
+/// optional: the standalone lock plugin and `watch_mode: disabled` run this same
+/// task with nothing to close.
+#[must_use]
+pub fn spawn_connection_watchdog(
+    connection: ConnectHandle,
+    registry: Option<Arc<WatchRegistry>>,
+    shutdown: CancellationToken,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let outcome = tokio::select! {
+            // An ordinary `stop()`: `close_all` has already run (or is about to)
+            // with `Shutdown`, which is the right error for that path.
+            () = shutdown.cancelled() => return,
+            resolved = connection => resolved,
+        };
+        tracing::warn!(
+            name: logs::SUBSCRIBER_LOST,
+            outcome = ?outcome,
+            "cluster.provider.subscriber_lost: the redis subscriber's reconnect policy is \
+             exhausted; every cache watch is being \
+             closed so consumers see a retryable terminal error rather than silence, and blocked \
+             lock() callers fall back to the jittered heartbeat, which costs latency rather than \
+             correctness (DESIGN.md sec 10, sec 5.3)"
+        );
+        if let Some(registry) = registry {
+            registry.close_all_with(subscriber_lost()).await;
+        }
+    })
+}
+
+/// The terminal error a watcher is closed with when the subscriber's reconnect
+/// policy gives up (DESIGN.md §10).
+///
+/// `ConnectionLost` rather than `Shutdown` because only the former is
+/// [`ClusterError::is_retryable`], and the SDK's `RestartingWatch` combinator
+/// branches on exactly that: told `Shutdown`, a consumer's retry policy would
+/// never run against what is in fact a recoverable outage.
+#[must_use]
+pub fn subscriber_lost() -> ClusterError {
+    ClusterError::Provider {
+        kind: ProviderErrorKind::ConnectionLost,
+        message: "the redis subscriber's reconnect policy was exhausted; cache watches are closed \
+                  and must be re-established"
+            .to_owned(),
+    }
+}
+
+/// Blocks until every subscribe-family command already issued on `client` has
+/// been **processed by the server**, by awaiting one `PING` behind them.
+///
+/// ## Why awaiting the `SUBSCRIBE` itself is not enough
+///
+/// `fred`'s `subscribe`/`psubscribe` futures resolve when the command has been
+/// handed to the connection, not when Redis has answered it. The confirmation
+/// frame never completes the command: `fred`'s reader classifies
+/// `["subscribe", <channel>, <count>]` as a subscription response and **drops
+/// it** (`router/responses.rs::is_subscription_response`, "Dropping unused
+/// subscription response") before the frame can be matched to anything.
+///
+/// So the ordering DESIGN.md §3.2 step 4 asks for — the subscription live before
+/// `build_and_start` returns, and before `watch()` returns — is not obtainable
+/// from `fred`'s subscribe API alone. Without this barrier a `watch(k)` followed
+/// immediately by a `put(k)` from the same process can miss its own event: the
+/// `PUBLISH` travels the command pool's connection and reaches the server first,
+/// while the `SUBSCRIBE` is still in flight on the subscriber's. Verified
+/// against a container with `MONITOR`, which showed `SUBSCRIBE` executing
+/// *after* the `PUBLISH` it was supposed to precede. It is a race rather than a
+/// certainty, and an easy one to miss: it widens sharply with a second subscriber
+/// command outstanding, which the lock-release pattern supplies, so a plugin
+/// carrying only the startup subscription can pass its own checks and still lose
+/// the race in production.
+///
+/// `PING` is the barrier because it is one of the few commands a connection in
+/// subscribe mode accepts, and — unlike the subscribe family — its reply is an
+/// ordinary frame that completes an ordinary command. Redis processes one
+/// connection's commands in order, so a `PING` that has answered proves
+/// everything written before it on that connection has run.
+///
+/// The cost is one round trip per `watch()` and per startup, on paths that are
+/// already doing a round trip. Delivery is untouched: nothing on the fan-out
+/// path calls this.
+///
+/// # Errors
+/// Whatever [`map_redis_error`] makes of a failing `PING` — which the caller
+/// should treat exactly like a failing `SUBSCRIBE`, since an unconfirmed
+/// subscription is one that may not exist.
+pub async fn confirm_subscriptions(client: &SubscriberClient) -> Result<(), ClusterError> {
+    client
+        .ping::<()>(None)
+        .await
+        .map_err(crate::redis_error::map_redis_error)
+}
+
+/// Quits the subscriber client, logging rather than propagating a failure —
+/// `stop()` has nothing useful to do with one.
+pub async fn quit_subscriber(subscriber: &SubscriberClient) {
+    if let Err(err) = subscriber.quit().await {
+        tracing::debug!(error = %err, "redis subscriber quit reported an error during shutdown");
+    }
+}
+
+// Layer-1 unit tests (TESTING.md §2, `subscriber.rs` row). Out-of-line per
+// DE1101.
+#[cfg(test)]
+#[path = "subscriber_tests.rs"]
+mod tests;

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/subscriber_tests.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/subscriber_tests.rs
@@ -1,0 +1,207 @@
+use super::*;
+
+/// The combined plugin's keyspace naming: both primitives under one prefix.
+fn combined() -> KeyspaceNames {
+    KeyspaceNames::new(
+        "cluster",
+        3,
+        Some(ChannelNames::new("cluster", 3)),
+        LockNames::new("cluster"),
+    )
+}
+
+/// The standalone lock plugin's: the same prefix, no cache half.
+fn lock_only() -> KeyspaceNames {
+    KeyspaceNames::new("cluster", 0, None, LockNames::new("cluster"))
+}
+
+#[test]
+fn the_keyspace_pattern_spans_the_whole_prefix_rather_than_the_caches_share_of_it() {
+    // The regression this file exists for. A pattern of
+    // `__keyspace@3__:cluster:c:*` observes every eviction except a lock
+    // lease's — which is the case DESIGN.md §3.7 opens with and the worst one it
+    // names, because an evicted lease hands the lock to a second holder with no
+    // TTL having lapsed and nothing else in the system able to notice.
+    assert_eq!(combined().pattern(), "__keyspace@3__:cluster:*");
+    assert_eq!(combined().database(), 3);
+    assert!(
+        !combined().pattern().contains(":c:"),
+        "a pattern narrowed to the cache's segment cannot see an evicted lease"
+    );
+}
+
+#[test]
+fn the_pattern_stays_scoped_to_this_plugins_prefix_and_database() {
+    // Both halves of the scoping matter on a shared Redis: the prefix keeps
+    // unrelated tenants' keyspace traffic off this subscriber, and the database
+    // keeps a notification from another logical db from being read as one of
+    // this plugin's own keys.
+    let names = KeyspaceNames::new(
+        "other-deployment",
+        7,
+        None,
+        LockNames::new("other-deployment"),
+    );
+    assert_eq!(names.pattern(), "__keyspace@7__:other-deployment:*");
+    assert_eq!(names.database(), 7);
+}
+
+#[test]
+fn the_pattern_escapes_glob_metacharacters_in_the_operators_prefix() {
+    // Nothing rules out a `[` in `key_prefix`, and unescaped it is a character
+    // class: the subscription would silently cover a different key space than
+    // the one this plugin writes to, so evictions of its own keys would arrive
+    // for some prefixes and not others.
+    let names = KeyspaceNames::new("we[i]rd", 0, None, LockNames::new("we[i]rd"));
+    assert_eq!(names.pattern(), "__keyspace@0__:we\\[i\\]rd:*");
+}
+
+#[test]
+fn a_cache_entry_and_a_lock_lease_are_each_attributed_to_their_own_primitive() {
+    let names = combined();
+    assert_eq!(
+        names.classify("cluster:c:tenant-1/a"),
+        Some(OwnedKey::Cache("tenant-1/a".to_owned()))
+    );
+    assert_eq!(
+        names.classify("cluster:l:tenant-1/leader"),
+        Some(OwnedKey::Lock("tenant-1/leader".to_owned()))
+    );
+}
+
+#[test]
+fn the_primitive_label_matches_the_family_the_key_came_from() {
+    // The label is what makes the eviction counter actionable: an evicted entry
+    // costs a re-read, an evicted lease means two holders believe they hold one
+    // lock. An alert that cannot separate them has to treat every eviction as
+    // one or the other, and both readings are wrong.
+    assert_eq!(
+        OwnedKey::Cache("a".to_owned()).primitive(),
+        Primitive::Cache
+    );
+    assert_eq!(OwnedKey::Lock("a".to_owned()).primitive(), Primitive::Lock);
+    assert_eq!(Primitive::Cache.label(), "cache");
+    assert_eq!(Primitive::Lock.label(), "lock");
+    assert_eq!(OwnedKey::Cache("a".to_owned()).name(), "a");
+    assert_eq!(OwnedKey::Lock("b".to_owned()).name(), "b");
+}
+
+#[test]
+fn a_key_under_this_prefix_owned_by_neither_primitive_is_declined() {
+    let names = combined();
+    // The plugin's own *event channels* share the operator prefix and match the
+    // pattern. No key exists at a channel name, so nothing real is dropped —
+    // but classifying one as an entry would report an eviction of a key that
+    // never existed.
+    assert_eq!(names.classify("cluster:e:c:tenant-1/a"), None);
+    assert_eq!(names.classify("cluster:e:l:tenant-1/leader"), None);
+    // And a future key family under this prefix is declined rather than
+    // guessed at.
+    assert_eq!(names.classify("cluster:q:job-1"), None);
+}
+
+#[test]
+fn another_deployments_key_is_never_this_plugins() {
+    let names = combined();
+    assert_eq!(names.classify("someone-else:c:a"), None);
+    assert_eq!(names.classify("someone-else:l:a"), None);
+    assert_eq!(names.classify("no-prefix-at-all"), None);
+}
+
+#[test]
+fn the_standalone_lock_plugin_claims_leases_and_disclaims_cache_entries() {
+    // Its `cache` half is `None`, so a `<prefix>:c:` key belongs to a *different*
+    // deployment sharing the prefix — a plausible arrangement, since the two
+    // plugins are independent (DESIGN.md §3.5) — and reporting an eviction of
+    // one would attribute another deployment's incident to this one.
+    let names = lock_only();
+    assert_eq!(
+        names.classify("cluster:l:tenant-1/leader"),
+        Some(OwnedKey::Lock("tenant-1/leader".to_owned()))
+    );
+    assert_eq!(names.classify("cluster:c:tenant-1/a"), None);
+}
+
+#[test]
+fn the_standalone_plugin_still_watches_the_whole_prefix() {
+    // It subscribes the same wide pattern rather than a lease-only one. The
+    // narrower `<prefix>:l:*` would work today and would silently stop covering
+    // a second lock-key family the moment one existed; the classifier is what
+    // decides ownership, and it is the same classifier in both plugins.
+    assert_eq!(lock_only().pattern(), "__keyspace@0__:cluster:*");
+}
+
+// ---------------------------------------------------------------------------
+// The reconnect observer's two non-terminal arms (DESIGN.md §4.3, §9).
+// ---------------------------------------------------------------------------
+
+/// A registry with no subscriber behind it — every subscription decision
+/// short-circuits on `None`, so the broadcast runs exactly as it does in
+/// production while nothing reaches a server.
+fn watch_registry(signals: &Arc<RedisSignals>) -> Arc<WatchRegistry> {
+    WatchRegistry::new(None, Arc::clone(signals))
+}
+
+#[tokio::test]
+async fn a_missed_reconnect_notification_resets_every_watcher_and_says_so() {
+    // Both halves together, deliberately. This arm moved
+    // `cluster_watch_resets_total` and
+    // `cluster_redis_subscriber_resubscribes_total` and logged nothing, so the
+    // counter and the log stream disagreed — an operator saw a reset in the
+    // metric with no line anywhere explaining it. DESIGN.md §4.3 states that
+    // each `Reset` logs `cluster.watch.reset` *and* increments the counter, so
+    // asserting either one alone would leave the defect reachable.
+    let (signals, recorder, readback) = crate::test_support::recording_metered_signals();
+    let registry = watch_registry(&signals);
+    let (_guard, log) = crate::test_support::scoped_capture();
+
+    let flow = observe_reconnect(Err(RecvError::Lagged(7)), &registry, &signals).await;
+
+    assert!(
+        flow.is_continue(),
+        "a missed notification is still a reconnect, so the observer carries on"
+    );
+    assert_eq!(
+        recorder.watch_resets(),
+        vec!["cache".to_owned()],
+        "the counter must move - this is the half that always worked"
+    );
+    assert_eq!(
+        readback.counter(crate::observability::SUBSCRIBER_RESUBSCRIBES),
+        1,
+        "and the Redis-specific counter with it. Asserted because the comment above names both: \
+         without this, `signals.subscriber_resubscribed()` could be deleted from the Lagged arm \
+         and nothing would fail, leaving one flap and a flap per minute indistinguishable in the \
+         metric"
+    );
+    assert_eq!(
+        crate::test_support::count_occurrences(&log, logs::WATCH_RESET),
+        1,
+        "and the catalogued line must accompany it. Captured: {}",
+        crate::test_support::captured(&log)
+    );
+    assert!(
+        crate::test_support::captured(&log).contains("missed=7"),
+        "carrying the count of unobserved reconnects, which is the one thing this path can say \
+         that the Ok path cannot. Captured: {}",
+        crate::test_support::captured(&log)
+    );
+}
+
+#[tokio::test]
+async fn a_closed_notification_stream_ends_the_observer() {
+    // The one terminal arm: the sender is gone, so no further notification can
+    // arrive. Distinguished from `Lagged` because getting it wrong in either
+    // direction is a live task spinning on a dead channel, or an observer that
+    // stops resetting after one missed notification.
+    let (signals, recorder) = crate::test_support::recording_signals();
+    let registry = watch_registry(&signals);
+
+    let flow = observe_reconnect(Err(RecvError::Closed), &registry, &signals).await;
+
+    assert!(flow.is_break());
+    assert!(
+        recorder.watch_resets().is_empty(),
+        "a closed stream is not a reconnect and must reset nothing"
+    );
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/test_support.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/test_support.rs
@@ -1,0 +1,313 @@
+//! A recording [`ClusterMetrics`] double, shared by the Layer-1 tests of every
+//! module that emits (TESTING.md §2).
+//!
+//! The ADR-004 contract is a *port*, so "which signal fires for which outcome"
+//! is decidable with no server: a recording sink turns the question into an
+//! assertion over a list. Only the OpenTelemetry adapter and the real log lines
+//! need a container, which is what the `RD-SPEC-*` runs cover.
+
+use std::sync::{Arc, Mutex};
+
+use cluster_sdk::observability::ClusterMetrics;
+use opentelemetry::metrics::Meter;
+
+use crate::observability::{RedisSignals, plugin_meter};
+
+/// One recorded call on the [`ClusterMetrics`] port.
+///
+/// Durations are recorded as the bare fact that a duration was recorded rather
+/// than its value: an elapsed time is not reproducible, and what the tests need
+/// to know is that the histogram was fed for the same op the counter was.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Signal {
+    /// `cluster_cache_ops_total{op,result}`.
+    CacheOp(String, String),
+    /// `cluster_cache_op_duration_seconds{op}`.
+    CacheDuration(String),
+    /// `cluster_lock_ops_total{op,result}`.
+    LockOp(String, String),
+    /// `cluster_lock_op_duration_seconds{op}`.
+    LockDuration(String),
+    /// `cluster_leader_transitions_total{transition}`.
+    LeaderTransition(String),
+    /// `cluster_watch_resets_total{primitive}`.
+    WatchReset(String),
+    /// `cluster_provider_errors_total{kind}`.
+    ProviderError(String),
+}
+
+/// A [`ClusterMetrics`] that remembers everything it was told, in order.
+#[derive(Debug, Default)]
+pub struct RecordingMetrics {
+    recorded: Mutex<Vec<Signal>>,
+}
+
+impl RecordingMetrics {
+    /// Everything recorded so far, in emission order.
+    pub fn signals(&self) -> Vec<Signal> {
+        self.recorded
+            .lock()
+            .expect("the recording metrics mutex is never poisoned in tests")
+            .clone()
+    }
+
+    /// The `(op, result)` pairs recorded on `cluster_lock_ops_total`.
+    pub fn lock_ops(&self) -> Vec<(String, String)> {
+        self.signals()
+            .into_iter()
+            .filter_map(|signal| match signal {
+                Signal::LockOp(op, result) => Some((op, result)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// The bounded `kind`s recorded on `cluster_provider_errors_total`.
+    pub fn provider_error_kinds(&self) -> Vec<String> {
+        self.signals()
+            .into_iter()
+            .filter_map(|signal| match signal {
+                Signal::ProviderError(kind) => Some(kind),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// The `primitive`s recorded on `cluster_watch_resets_total`.
+    pub fn watch_resets(&self) -> Vec<String> {
+        self.signals()
+            .into_iter()
+            .filter_map(|signal| match signal {
+                Signal::WatchReset(primitive) => Some(primitive),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn push(&self, signal: Signal) {
+        self.recorded
+            .lock()
+            .expect("the recording metrics mutex is never poisoned in tests")
+            .push(signal);
+    }
+}
+
+impl ClusterMetrics for RecordingMetrics {
+    fn cache_op(&self, op: &str, result: &str) {
+        self.push(Signal::CacheOp(op.to_owned(), result.to_owned()));
+    }
+
+    fn cache_op_duration(&self, op: &str, _seconds: f64) {
+        self.push(Signal::CacheDuration(op.to_owned()));
+    }
+
+    fn lock_op(&self, op: &str, result: &str) {
+        self.push(Signal::LockOp(op.to_owned(), result.to_owned()));
+    }
+
+    fn lock_op_duration(&self, op: &str, _seconds: f64) {
+        self.push(Signal::LockDuration(op.to_owned()));
+    }
+
+    fn leader_transition(&self, transition: &str) {
+        self.push(Signal::LeaderTransition(transition.to_owned()));
+    }
+
+    fn watch_reset(&self, primitive: &str) {
+        self.push(Signal::WatchReset(primitive.to_owned()));
+    }
+
+    fn provider_error(&self, kind: &str) {
+        self.push(Signal::ProviderError(kind.to_owned()));
+    }
+}
+
+/// A meter with no provider installed behind it, so the plugin-local
+/// instruments a test builds are inert.
+///
+/// The default for tests that only care about the [`ClusterMetrics`] port. Use
+/// [`metered_signals`] instead when the assertion is about one of the four
+/// plugin-local instruments, which are OpenTelemetry-side and need a reader.
+pub fn inert_meter() -> Meter {
+    plugin_meter()
+}
+
+/// A signals value over a recording sink, plus the sink itself.
+pub fn recording_signals() -> (Arc<RedisSignals>, Arc<RecordingMetrics>) {
+    let recorder = Arc::new(RecordingMetrics::default());
+    let signals = Arc::new(RedisSignals::new(
+        Arc::clone(&recorder) as Arc<dyn ClusterMetrics>,
+        &inert_meter(),
+        crate::provider::PROVIDER_NAME,
+    ));
+    (signals, recorder)
+}
+
+/// An in-process reader over the plugin-local instruments.
+///
+/// Holds the provider as well as the exporter because a counter is only visible
+/// after a collection: [`counter`](Self::counter) flushes first, which is what
+/// makes the readback deterministic rather than dependent on a periodic
+/// reader's timer.
+pub struct MetricReadback {
+    provider: opentelemetry_sdk::metrics::SdkMeterProvider,
+    exporter: opentelemetry_sdk::metrics::InMemoryMetricExporter,
+}
+
+impl MetricReadback {
+    /// The summed value of the `u64` counter whose *instrument* name is `name`.
+    ///
+    /// The instrument name, not the contract name: the `_total` suffix is
+    /// re-appended by the Prometheus exporter rather than carried on the
+    /// instrument, so a caller asserting on `cluster_redis_script_reloads_total`
+    /// passes it through the same strip the emitter used. `0` covers both "the
+    /// counter exists and is zero" and "nothing was ever recorded", which are
+    /// the same thing to a scrape.
+    pub fn counter(&self, name: &str) -> u64 {
+        use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+        let name = name.strip_suffix("_total").unwrap_or(name);
+        let _flushed = self.provider.force_flush();
+        let Ok(collected) = self.exporter.get_finished_metrics() else {
+            return 0;
+        };
+        let mut total = 0;
+        for resource in &collected {
+            for scope in resource.scope_metrics() {
+                for metric in scope.metrics() {
+                    if metric.name() == name
+                        && let AggregatedMetrics::U64(MetricData::Sum(sum)) = metric.data()
+                    {
+                        total += sum
+                            .data_points()
+                            .map(opentelemetry_sdk::metrics::data::SumDataPoint::value)
+                            .sum::<u64>();
+                    }
+                }
+            }
+        }
+        total
+    }
+}
+
+/// A `tracing` writer that appends into a shared buffer.
+#[derive(Clone)]
+struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for SharedWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0
+            .lock()
+            .expect("the log capture mutex is never poisoned in tests")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl tracing_subscriber::fmt::MakeWriter<'_> for SharedWriter {
+    type Writer = Self;
+
+    fn make_writer(&self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// Installs a thread-local WARN capture for the current test, returning its
+/// uninstall guard and buffer.
+///
+/// The Layer-1 counterpart of `tests/common`'s `scoped_capture`, and it exists
+/// for the assertions a recording [`ClusterMetrics`] cannot make: whether a path
+/// that moved a counter also *said* so. A counter and a log stream that disagree
+/// leave an operator with a reset they can see in the metric and no line
+/// explaining it.
+///
+/// Thread-local rather than global, so one test's capture cannot see another's
+/// events. That is sufficient here because the events under test are emitted
+/// inline by a directly-awaited function rather than from a spawned task — the
+/// reason `tests/common` needs a global sink as well.
+///
+/// A process-global sink is installed first all the same, and idempotently,
+/// because `tracing` caches each callsite's interest process-wide the first time
+/// it is evaluated: another test reaching the callsite first, on a thread with no
+/// subscriber, caches it as `Interest::never` and every later evaluation
+/// short-circuits before consulting the thread-local dispatcher. The capture then
+/// comes back empty and the test fails claiming the event was never emitted.
+pub fn scoped_capture() -> (tracing::subscriber::DefaultGuard, Arc<Mutex<Vec<u8>>>) {
+    use std::sync::OnceLock;
+    // Discarded. This exists only so the callsites are interesting process-wide.
+    static GLOBAL: OnceLock<()> = OnceLock::new();
+    GLOBAL.get_or_init(|| {
+        let sink = tracing_subscriber::fmt()
+            .with_writer(SharedWriter(Arc::new(Mutex::new(Vec::new()))))
+            .with_max_level(tracing::Level::TRACE)
+            .with_ansi(false)
+            .finish();
+        let _installed = tracing::subscriber::set_global_default(sink);
+    });
+
+    let buf = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(SharedWriter(Arc::clone(&buf)))
+        .with_max_level(tracing::Level::WARN)
+        // No ANSI: this buffer is searched as text, and the styling wraps field
+        // names in escape codes, so `primitive="cache"` would stop being a
+        // contiguous substring while still looking like one in a failure message.
+        .with_ansi(false)
+        .finish();
+    (tracing::subscriber::set_default(subscriber), buf)
+}
+
+/// How many times `needle` appears in a capture buffer.
+///
+/// Every DESIGN.md §9 event carries its catalogued name twice — as the `name:`
+/// field and opening the human message — so passing a `logs::*` constant matches
+/// the message half, which is what the `fmt` layer prints.
+pub fn count_occurrences(buf: &Arc<Mutex<Vec<u8>>>, needle: &str) -> usize {
+    let bytes = buf
+        .lock()
+        .expect("the log capture mutex is never poisoned in tests");
+    String::from_utf8_lossy(&bytes).matches(needle).count()
+}
+
+/// The whole capture buffer, for a failure message that should show what *was*
+/// logged when the expected line is missing.
+pub fn captured(buf: &Arc<Mutex<Vec<u8>>>) -> String {
+    let bytes = buf
+        .lock()
+        .expect("the log capture mutex is never poisoned in tests");
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+/// A signals value whose plugin-local instruments are readable in-process.
+pub fn metered_signals() -> (Arc<RedisSignals>, MetricReadback) {
+    let (signals, _recorder, readback) = recording_metered_signals();
+    (signals, readback)
+}
+
+/// Both sinks at once: the [`ClusterMetrics`] recorder *and* a reader over the
+/// plugin-local instruments.
+///
+/// For the assertions that span both halves of the signal surface — a path that
+/// is specified to move a catalog counter and a Redis-specific one together, so
+/// that asserting either alone would leave the other removable without a test
+/// failing. [`recording_signals`] and [`metered_signals`] stay as the narrower
+/// defaults; this is the same construction with nothing discarded.
+pub fn recording_metered_signals() -> (Arc<RedisSignals>, Arc<RecordingMetrics>, MetricReadback) {
+    use opentelemetry::metrics::MeterProvider;
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
+
+    let exporter = InMemoryMetricExporter::default();
+    let provider = SdkMeterProvider::builder()
+        .with_reader(PeriodicReader::builder(exporter.clone()).build())
+        .build();
+    let recorder = Arc::new(RecordingMetrics::default());
+    let signals = Arc::new(RedisSignals::new(
+        Arc::clone(&recorder) as Arc<dyn ClusterMetrics>,
+        &provider.meter("redis-cluster-plugin-tests"),
+        crate::provider::PROVIDER_NAME,
+    ));
+    (signals, recorder, MetricReadback { provider, exporter })
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/wait.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/wait.rs
@@ -1,0 +1,129 @@
+//! The optional `WAIT <replicas> <timeout>` an operator can append to writes
+//! whose outcome a failover must not silently undo (DESIGN.md §3.6).
+//!
+//! Its own module because both primitives use it and neither owns it: the cache
+//! applies it to its conditional writes and the lock applies it to acquisition,
+//! and a second copy would be free to disagree about what a short count means.
+//!
+//! **`WAIT` does not upgrade anything.** Per ADR-009 it narrows the Sentinel
+//! failover window and leaves the declaration alone — `WAIT 1` reduces but does
+//! not eliminate the window in which an acknowledged write is lost to a
+//! promotion, and `CacheConsistency` is deliberately two-valued. Nothing in this
+//! module touches `consistency()` or `features().linearizable`.
+
+use cluster_sdk::{ClusterError, ProviderErrorKind};
+use fred::clients::Pool;
+use fred::interfaces::ServerInterface;
+
+use crate::redis_error::map_redis_error;
+
+/// The `WAIT` policy an operator configured, or the absence of one.
+///
+/// An enum rather than an `Option<WaitPolicy>` threaded through a function
+/// argument and three struct fields: "wait, or don't" is a closed either/or, and
+/// [`Disabled`](Self::Disabled) already says "no policy", so an `Option` around
+/// it would encode the same absence twice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WaitPolicy {
+    /// No `WAIT` is issued after a write or a lock acquisition.
+    Disabled,
+    /// Issue `WAIT <replicas> <timeout_ms>` and treat a short count as an error.
+    Enabled(WaitTarget),
+}
+
+/// What an enabled [`WaitPolicy`] waits for: how many replicas, for how long.
+///
+/// A separate type with **private fields** rather than a struct variant, because
+/// an enum variant's fields are always as visible as the enum itself and so
+/// cannot be closed off. Closing them is the point: [`WaitPolicy::from_config`]
+/// is then the only way to obtain one, which is what makes an unrepresentable
+/// `timeout_ms` impossible rather than merely discouraged. The conversion from
+/// the operator's `u64` milliseconds happens there, once, where there is
+/// somewhere to report the failure — at the call site there is not, and the
+/// clamp that results turns an oversized `wait_timeout_ms` into
+/// `WAIT <n> 9223372036854775807`, a ~292-million-year deadline, silently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WaitTarget {
+    /// How many replicas must acknowledge.
+    replicas: u32,
+    /// How long to wait for them, in milliseconds — already narrowed to the
+    /// signed count `fred`'s `WAIT` takes.
+    timeout_ms: i64,
+}
+
+impl WaitPolicy {
+    /// Builds the policy from the operator's `wait_replicas` and
+    /// `wait_timeout_ms`.
+    ///
+    /// Called before any connection is opened, alongside the config's other
+    /// startup checks, so a `wait_timeout_ms` that cannot be expressed fails
+    /// startup the way a zero one already does rather than being clamped at the
+    /// first write.
+    ///
+    /// # Errors
+    /// [`ClusterError::InvalidConfig`] when `wait_timeout_ms` does not fit the
+    /// signed 64-bit millisecond count `WAIT`'s timeout argument takes.
+    pub fn from_config(
+        wait_replicas: Option<u32>,
+        wait_timeout_ms: u64,
+    ) -> Result<Self, ClusterError> {
+        let Some(replicas) = wait_replicas else {
+            return Ok(Self::Disabled);
+        };
+        let timeout_ms = i64::try_from(wait_timeout_ms).map_err(|_| ClusterError::InvalidConfig {
+            reason: format!(
+                "wait_timeout_ms {wait_timeout_ms} does not fit in the signed 64-bit millisecond \
+                 count `WAIT`'s timeout argument takes"
+            ),
+        })?;
+        Ok(Self::Enabled(WaitTarget {
+            replicas,
+            timeout_ms,
+        }))
+    }
+}
+
+/// Issues `WAIT <replicas> <timeout>` when a policy is configured, and reports a
+/// short count as an error.
+///
+/// The short-count arm is the whole reason this is not a fire-and-forget call.
+/// `WAIT` does not *error* when it times out — it returns however many replicas
+/// acknowledged — so a caller that ignored the count would have opted into a
+/// durability guarantee and then silently not received it, which is worse than
+/// never having offered the option.
+///
+/// # Errors
+/// [`ClusterError::Provider`] with [`ProviderErrorKind::ResourceExhausted`] when
+/// fewer than `replicas` acknowledged before the deadline, and whatever
+/// [`map_redis_error`] makes of a failing `WAIT`.
+pub async fn wait_for_replicas(pool: &Pool, policy: WaitPolicy) -> Result<(), ClusterError> {
+    let WaitPolicy::Enabled(WaitTarget {
+        replicas,
+        timeout_ms,
+    }) = policy
+    else {
+        return Ok(());
+    };
+    let acked: i64 = pool
+        .wait(i64::from(replicas), timeout_ms)
+        .await
+        .map_err(map_redis_error)?;
+    if acked < i64::from(replicas) {
+        return Err(ClusterError::Provider {
+            kind: ProviderErrorKind::ResourceExhausted,
+            message: format!(
+                "WAIT {replicas} {timeout_ms}ms: only {acked} replica(s) acknowledged the write \
+                 before the deadline. The write is on the primary but is not yet replicated, so \
+                 a failover now could lose it (DESIGN.md sec 3.6)"
+            ),
+        });
+    }
+    Ok(())
+}
+
+// Layer-1 unit tests (TESTING.md §2, `wait.rs` row): what the operator's two
+// config fields become, and the one value that cannot become a policy at all.
+// The `WAIT` round trip itself is covered at Layer 3. Out-of-line per DE1101.
+#[cfg(test)]
+#[path = "wait_tests.rs"]
+mod tests;

--- a/gears/system/cluster/plugins/redis-cluster-plugin/src/wait_tests.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/src/wait_tests.rs
@@ -1,0 +1,58 @@
+//! Layer-1 unit tests for [`crate::wait`] — TESTING.md §2, `wait.rs` row.
+
+use cluster_sdk::ClusterError;
+
+use super::WaitPolicy;
+
+#[test]
+fn no_wait_replicas_is_no_policy_at_all() {
+    // Whatever the timeout says: `wait_replicas` is the switch, and
+    // `wait_timeout_ms` carries a default even when nothing reads it.
+    assert_eq!(
+        WaitPolicy::from_config(None, 1_000).expect("an absent policy cannot fail"),
+        WaitPolicy::Disabled
+    );
+}
+
+#[test]
+fn a_configured_policy_carries_both_operator_values() {
+    let policy = WaitPolicy::from_config(Some(2), 2_500).expect("2500 ms fits in an i64");
+    let WaitPolicy::Enabled(target) = policy else {
+        panic!("a configured `wait_replicas` must enable the policy, got {policy:?}");
+    };
+    // Rendered rather than destructured: the fields are private precisely so
+    // nothing outside `wait.rs` reads them, and the `WAIT` line is what a short
+    // count reports back to the operator.
+    assert_eq!(
+        format!("{target:?}"),
+        "WaitTarget { replicas: 2, timeout_ms: 2500 }"
+    );
+}
+
+#[test]
+fn a_wait_timeout_too_large_for_wait_fails_startup_rather_than_clamping() {
+    // The failure this type exists to make impossible: `WAIT`'s timeout argument
+    // is signed, so a `u64` past `i64::MAX` has no honest rendering. Clamping it
+    // would turn an unreadable config into `WAIT 1 9223372036854775807` — a
+    // ~292-million-year deadline nobody asked for and no operator would see.
+    let rejected = WaitPolicy::from_config(Some(1), u64::MAX);
+    assert!(
+        matches!(
+            rejected,
+            Err(ClusterError::InvalidConfig { ref reason })
+                if reason.contains("wait_timeout_ms") && reason.contains("18446744073709551615")
+        ),
+        "an unrepresentable wait_timeout_ms must be rejected as config, got {rejected:?}"
+    );
+}
+
+#[test]
+fn the_largest_representable_timeout_is_still_accepted() {
+    // The boundary is `i64::MAX`, not something short of it: rejecting a value
+    // `WAIT` can express would be its own bug.
+    let policy = WaitPolicy::from_config(Some(1), i64::MAX.unsigned_abs());
+    assert!(
+        matches!(policy, Ok(WaitPolicy::Enabled(_))),
+        "i64::MAX ms is representable and must be accepted, got {policy:?}"
+    );
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/tests/cache_integration.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/tests/cache_integration.rs
@@ -1,0 +1,765 @@
+//! Layer 3 — cache integration scenarios (docs/TESTING.md §4.2), `RD-CACHE-001`
+//! through `RD-CACHE-010`.
+//!
+//! These mirror the Layer 2 conformance scenarios but assert on the **actual
+//! Redis keyspace** rather than only through the backend trait. That is the whole
+//! reason they exist alongside L2: conformance pins the contract, and these pin
+//! the encoding and the command choices the contract does not constrain. A future
+//! re-encoding of a cache entry, or a `scan_prefix` quietly reaching for `KEYS`,
+//! passes every conformance scenario and fails here.
+//!
+//! Each scenario starts its own container. That is more Docker than sharing one,
+//! and it buys the thing sharing cannot: no scenario can be affected by a key,
+//! a subscription, or a server setting another left behind — and several of these
+//! read server-wide counters (`INFO commandstats`) where another scenario's
+//! traffic would be indistinguishable from this one's.
+
+#![cfg(feature = "integration")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration tests: a setup failure IS the test failure"
+)]
+
+mod common;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use cluster_sdk::cache::{PutRequest, Ttl};
+use cluster_sdk::{ClusterCacheBackend, ClusterError};
+use fred::interfaces::{HashesInterface, KeysInterface};
+use redis_cluster_plugin::{RedisClusterHandle, RedisClusterPlugin};
+use serde_json::json;
+
+/// The value every scenario writes when the bytes themselves do not matter.
+const VALUE: &[u8] = b"v1";
+
+/// Starts a plugin over a stock container and hands back the pieces every
+/// scenario needs: the container (which must outlive the test), the plugin
+/// handle, the cache, and a raw client for keyspace assertions.
+///
+/// The handle is returned rather than the cache alone because **every scenario
+/// must `stop()` it**: `RedisClusterHandle` panics on drop without `stop()` in a
+/// debug build (ADR-006), which is what `cargo test` produces.
+async fn fixture(
+    overrides: serde_json::Value,
+) -> (
+    testcontainers::ContainerAsync<testcontainers_modules::redis::Redis>,
+    RedisClusterHandle,
+    Arc<dyn ClusterCacheBackend>,
+    fred::clients::Client,
+    String,
+) {
+    let (container, config) = common::start_redis_with(overrides).await;
+    let url = config.url.clone();
+    let key_prefix = config.key_prefix.clone();
+    let database = config.database;
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the plugin starts against the test container");
+    let cache = handle.cache();
+    let raw = common::raw_client_on(&url, database).await;
+    (container, handle, cache, raw, key_prefix)
+}
+
+/// The Redis key the plugin stores `key` under — `<prefix>:c:<key>` (DESIGN.md
+/// §2.1).
+///
+/// Spelled out here rather than taken from the plugin so the test states the wire
+/// format independently: reading it back through `RedisCache::entry_key` would
+/// make `RD-CACHE-001` agree with whatever the plugin currently does, which is
+/// the opposite of what a wire-format assertion is for.
+fn entry_key(prefix: &str, key: &str) -> String {
+    format!("{prefix}:c:{key}")
+}
+
+/// `RD-CACHE-001` — a `put`/`get` round-trip, and the stored key really is a hash
+/// with exactly the fields `v` and `ver`.
+///
+/// The keyspace half is the point. DESIGN.md §2.2 specifies a two-field hash, and
+/// every mutation script writes both fields together; asserting the shape *at the
+/// server* means a future re-encoding (a serialized struct in a string key, a
+/// third field) is a test failure rather than a silent wire change that only
+/// breaks a mixed-version fleet.
+#[tokio::test]
+async fn rd_cache_001_put_get_round_trip_stores_a_two_field_hash() {
+    let (_container, handle, cache, raw, prefix) = fixture(json!({})).await;
+
+    cache
+        .put(PutRequest {
+            key: "alpha",
+            value: VALUE,
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put succeeds");
+    let read = cache
+        .get("alpha")
+        .await
+        .expect("get succeeds")
+        .expect("the entry just written is present");
+    assert_eq!(read.value, VALUE, "the value must round-trip unchanged");
+    assert_eq!(
+        read.version, 1,
+        "the first write to a fresh key is version 1"
+    );
+
+    let stored: HashMap<String, String> = raw
+        .hgetall(entry_key(&prefix, "alpha"))
+        .await
+        .expect("HGETALL on the entry key succeeds");
+    let mut fields: Vec<&str> = stored.keys().map(String::as_str).collect();
+    fields.sort_unstable();
+    assert_eq!(
+        fields,
+        vec!["v", "ver"],
+        "DESIGN.md sec 2.2's encoding is a hash with exactly `v` and `ver`; found {fields:?}"
+    );
+    assert_eq!(stored.get("v").map(String::as_str), Some("v1"));
+
+    handle.stop().await;
+}
+
+/// `RD-CACHE-002` — versions increment by exactly 1 per write, `put_if_absent`
+/// creates at 1, and the server agrees with what the plugin reported.
+///
+/// Reading `ver` straight out of Redis is what makes this more than a restatement
+/// of the conformance scenario: a plugin that kept its own counter and never wrote
+/// it, or wrote it as a different type, would satisfy the trait and fail here.
+#[tokio::test]
+async fn rd_cache_002_versions_increment_by_one_and_the_server_agrees() {
+    let (_container, handle, cache, raw, prefix) = fixture(json!({})).await;
+
+    let created = cache
+        .put_if_absent(PutRequest {
+            key: "beta",
+            value: VALUE,
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put_if_absent succeeds")
+        .expect("an absent key is created");
+    assert_eq!(created.version, 1, "a created entry starts at version 1");
+
+    let mut previous = created.version;
+    for expected in 2..=5_u64 {
+        cache
+            .put(PutRequest {
+                key: "beta",
+                value: VALUE,
+                ttl: Ttl::Indefinite,
+            })
+            .await
+            .expect("put succeeds");
+        let entry = cache
+            .get("beta")
+            .await
+            .expect("get succeeds")
+            .expect("the entry just written is present");
+        assert_eq!(
+            entry.version,
+            previous + 1,
+            "each put must increment the version by exactly 1, not by an arbitrary amount"
+        );
+        assert_eq!(entry.version, expected);
+        previous = entry.version;
+    }
+
+    let server_version: String = raw
+        .hget(entry_key(&prefix, "beta"), "ver")
+        .await
+        .expect("HGET ver succeeds");
+    assert_eq!(
+        server_version,
+        previous.to_string(),
+        "the version the plugin reported must be the one stored in the hash"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-CACHE-003` — 20 concurrent writers CAS the same key from the same expected
+/// version: exactly one wins and 19 get `CasConflict`, each carrying a populated
+/// `current`.
+///
+/// The conflict payload is the half worth holding: DESIGN.md §4.1 has the CAS
+/// script return the current entry on mismatch, so a loser learns the value it
+/// lost to in the *same round trip* rather than needing a follow-up `get` that
+/// could itself be stale. A plugin that reported a bare conflict would pass the
+/// contract and cost every retrying caller an extra read.
+#[tokio::test]
+async fn rd_cache_003_concurrent_cas_has_exactly_one_winner() {
+    let (_container, handle, cache, _raw, _prefix) = fixture(json!({ "pool_size": 8 })).await;
+
+    cache
+        .put(PutRequest {
+            key: "gamma",
+            value: VALUE,
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("the seed put succeeds");
+    let base = cache
+        .get("gamma")
+        .await
+        .expect("get succeeds")
+        .expect("the seed entry is present");
+
+    let mut tasks = Vec::new();
+    for contender in 0..20_u32 {
+        let cache = Arc::clone(&cache);
+        let expected = base.version;
+        tasks.push(tokio::spawn(async move {
+            cache
+                .compare_and_swap(
+                    "gamma",
+                    expected,
+                    format!("writer-{contender}").as_bytes(),
+                    Ttl::Indefinite,
+                )
+                .await
+        }));
+    }
+
+    let mut winners = 0_u32;
+    let mut conflicts = 0_u32;
+    for task in tasks {
+        match task.await.expect("no CAS task panics") {
+            Ok(entry) => {
+                winners += 1;
+                assert_eq!(
+                    entry.version,
+                    base.version + 1,
+                    "the winning CAS advances the version by one"
+                );
+            }
+            Err(ClusterError::CasConflict { current, .. }) => {
+                conflicts += 1;
+                let current = current.expect(
+                    "DESIGN.md sec 4.1 has the CAS script return the current entry on mismatch, so \
+                     a loser must not have to issue a second read to learn what it lost to",
+                );
+                assert_eq!(
+                    current.version,
+                    base.version + 1,
+                    "the conflict payload must carry the version that beat this writer"
+                );
+            }
+            Err(other) => panic!("a losing CAS must be CasConflict, got {other:?}"),
+        }
+    }
+    assert_eq!(
+        winners, 1,
+        "exactly one of 20 concurrent CAS writers may win"
+    );
+    assert_eq!(conflicts, 19, "the other 19 must all report CasConflict");
+
+    handle.stop().await;
+}
+
+/// `RD-CACHE-004` — a TTL'd entry disappears on its own, with **no reaper running
+/// anywhere**, and `PTTL` shows the TTL came from the request.
+///
+/// The sharpest statement of what native expiry buys (DESIGN.md §4.2): the
+/// Postgres plugin needs a sweeper task per cache and a scenario like this has to
+/// wait for a sweep tick. Here there is nothing in the plugin to be stalled,
+/// because Redis is the only expiry mechanism. A regression that reintroduced a
+/// reaper would still pass — but one that stopped setting `PX`, and leaned on a
+/// reaper that does not exist, fails.
+#[tokio::test]
+async fn rd_cache_004_native_ttl_expires_with_no_reaper() {
+    let (_container, handle, cache, raw, prefix) = fixture(json!({})).await;
+
+    cache
+        .put(PutRequest {
+            key: "delta",
+            value: VALUE,
+            ttl: Ttl::Of(Duration::from_millis(500)),
+        })
+        .await
+        .expect("put with a ttl succeeds");
+
+    // The TTL is the request's, not something inherited from a previous write or
+    // a server default.
+    let pttl: i64 = raw
+        .pttl(entry_key(&prefix, "delta"))
+        .await
+        .expect("PTTL succeeds");
+    assert!(
+        (1..=500).contains(&pttl),
+        "PTTL must reflect the 500 ms the caller asked for, got {pttl}"
+    );
+
+    let gone = common::wait_until(
+        Duration::from_secs(3),
+        Duration::from_millis(50),
+        async || matches!(cache.get("delta").await, Ok(None)),
+    )
+    .await;
+    assert!(
+        gone,
+        "a lapsed entry must be absent from get with no reaper"
+    );
+    assert!(
+        !cache.contains("delta").await.expect("contains succeeds"),
+        "contains must agree with get about a lapsed entry"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-CACHE-005` — `compare_and_delete` survives a version reset.
+///
+/// The regression this guards is subtle and is recorded in memory as
+/// `cluster-cache-version-reset-caveat`: deleting and recreating a key resets
+/// `ver` to 1, so a version is **not** monotonic across re-creation the way a
+/// Kubernetes `resourceVersion` is. Any release-if-still-mine primitive built on
+/// versions would therefore let a stale holder delete a new holder's claim. The
+/// SDK's answer is that `compare_and_delete` is *value*-guarded (DESIGN.md §2.3),
+/// and this is the scenario that holds it.
+#[tokio::test]
+async fn rd_cache_005_compare_and_delete_survives_a_version_reset() {
+    let (_container, handle, cache, _raw, _prefix) = fixture(json!({})).await;
+
+    cache
+        .put(PutRequest {
+            key: "epsilon",
+            value: b"first-holder",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("the first holder writes its claim");
+    assert!(
+        cache.delete("epsilon").await.expect("delete succeeds"),
+        "the key existed, so delete reports true"
+    );
+    cache
+        .put(PutRequest {
+            key: "epsilon",
+            value: b"second-holder",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("the second holder writes its claim");
+    let recreated = cache
+        .get("epsilon")
+        .await
+        .expect("get succeeds")
+        .expect("the second holder's entry is present");
+    assert_eq!(
+        recreated.version, 1,
+        "delete-and-recreate resets the version to 1 - this is the caveat the value guard exists \
+         for, so if it ever stops being true this scenario should be revisited rather than fixed"
+    );
+
+    let deleted = cache
+        .compare_and_delete("epsilon", b"first-holder")
+        .await
+        .expect("compare_and_delete succeeds");
+    assert!(
+        !deleted,
+        "the first holder's stale value must not match, so nothing is deleted"
+    );
+    let survivor = cache
+        .get("epsilon")
+        .await
+        .expect("get succeeds")
+        .expect("the second holder's claim must still be present");
+    assert_eq!(
+        survivor.value, b"second-holder",
+        "the new holder's claim must be intact after a stale compare_and_delete"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-CACHE-006` — `scan_prefix` returns consumer-facing keys, excludes lapsed
+/// ones and foreign prefixes, and **never issues `KEYS`**.
+///
+/// Three properties in one scenario because they share a keyspace setup, and the
+/// third is the one that matters operationally: `KEYS` on a shared production
+/// Redis is O(N) over the whole keyspace and blocks the single-threaded server for
+/// the duration, so it is an outage rather than a slow query (DESIGN.md §4.4).
+/// `INFO commandstats` is the mechanical check — the same rule is enforced
+/// statically in `src/static_analysis_tests.rs`, and both are worth having: the
+/// static one covers code the tests never reach, this one covers a `KEYS` reaching
+/// the server from anywhere at all, including from inside a Lua script.
+///
+/// The foreign-prefix half is why TESTING §3 calls prefix isolation the *fallback*
+/// for conformance: a prefix bug is exactly what would let one deployment read
+/// another's keyspace, so the scenario that looks for it must not itself depend on
+/// prefixes being right.
+#[tokio::test]
+async fn rd_cache_006_scan_prefix_is_isolated_and_never_issues_keys() {
+    let (_container, handle, cache, raw, _prefix) = fixture(json!({})).await;
+    let baseline_keys = common::command_calls(&raw, "keys").await;
+
+    for key in ["reports:a", "reports:b", "reports:c"] {
+        cache
+            .put(PutRequest {
+                key,
+                value: VALUE,
+                ttl: Ttl::Indefinite,
+            })
+            .await
+            .expect("put succeeds");
+    }
+    cache
+        .put(PutRequest {
+            key: "reports:doomed",
+            value: VALUE,
+            ttl: Ttl::Of(Duration::from_millis(300)),
+        })
+        .await
+        .expect("put with a short ttl succeeds");
+    cache
+        .put(PutRequest {
+            key: "invoices:a",
+            value: VALUE,
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put outside the scanned prefix succeeds");
+
+    // A second plugin instance on the same database under a *different*
+    // `key_prefix` — the isolation half. Its keys share the scanned consumer
+    // prefix and must still be invisible, because the plugin prefix is what
+    // separates two deployments sharing one Redis.
+    let foreign_config =
+        common::cluster_config_json(&raw_url(&raw), json!({ "key_prefix": "otherdeployment" }));
+    let foreign = RedisClusterPlugin::builder(foreign_config)
+        .build_and_start()
+        .await
+        .expect("a second instance under a different key_prefix starts");
+    foreign
+        .cache()
+        .put(PutRequest {
+            key: "reports:foreign",
+            value: VALUE,
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("the foreign instance writes under its own prefix");
+
+    // Waited on through `scan_prefix` itself rather than through `get`, and with a
+    // generous budget. Two reasons, and the first is a correctness one: Redis
+    // reaps a lapsed key either lazily on access or on its background cycle, so a
+    // `get` that has returned `None` is not by itself proof that a `SCAN` no
+    // longer lists it — waiting on one observation while asserting on another
+    // leaves exactly that window open. The second is load: this is a precondition
+    // rather than the property under test, and starving it on a busy host should
+    // slow the scenario down, not fail it. (Observed once as a flake in a full
+    // parallel run at a 3 s budget, while passing 6/6 in isolation.)
+    let lapsed = common::wait_until(
+        Duration::from_secs(15),
+        Duration::from_millis(50),
+        async || {
+            cache
+                .scan_prefix("reports:")
+                .await
+                .is_ok_and(|keys| !keys.iter().any(|key| key == "reports:doomed"))
+        },
+    )
+    .await;
+    assert!(lapsed, "the short-ttl key must lapse before the scan");
+
+    let mut found = cache
+        .scan_prefix("reports:")
+        .await
+        .expect("scan_prefix succeeds");
+    found.sort();
+    assert_eq!(
+        found,
+        vec![
+            "reports:a".to_owned(),
+            "reports:b".to_owned(),
+            "reports:c".to_owned()
+        ],
+        "scan_prefix must return consumer keys with the plugin's own `<prefix>:c:` stripped, \
+         excluding the lapsed key, the key outside the scanned prefix, and the other deployment's \
+         key entirely"
+    );
+
+    assert_eq!(
+        common::command_calls(&raw, "keys").await,
+        baseline_keys,
+        "scan_prefix must iterate with a SCAN cursor and never issue KEYS, which on a shared \
+         production Redis is an outage rather than a slow query (DESIGN.md sec 4.4)"
+    );
+    let scans = common::command_calls(&raw, "scan").await;
+    assert!(
+        scans > 0,
+        "and it must actually have scanned - a scan_prefix that issued neither KEYS nor SCAN would \
+         satisfy the assertion above vacuously"
+    );
+
+    foreign.stop().await;
+    handle.stop().await;
+}
+
+/// `RD-CACHE-007` — `Ttl::Indefinite` **clears** an existing TTL rather than
+/// preserving it.
+///
+/// The SDK's `Ttl` is two-valued with no "leave it alone" variant, so a write
+/// always states the TTL. That makes this a contract property rather than a
+/// preference: a plugin whose `put` script omitted the `PERSIST` branch would keep
+/// the old deadline and silently expire an entry the caller asked to keep
+/// forever — and `get` would agree with the caller right up until it didn't.
+#[tokio::test]
+async fn rd_cache_007_indefinite_clears_an_existing_ttl() {
+    let (_container, handle, cache, raw, prefix) = fixture(json!({})).await;
+
+    cache
+        .put(PutRequest {
+            key: "zeta",
+            value: VALUE,
+            ttl: Ttl::Of(Duration::from_secs(30)),
+        })
+        .await
+        .expect("put with a ttl succeeds");
+    let with_ttl: i64 = raw
+        .pttl(entry_key(&prefix, "zeta"))
+        .await
+        .expect("PTTL succeeds");
+    assert!(
+        with_ttl > 0,
+        "the first write sets a deadline, got {with_ttl}"
+    );
+
+    cache
+        .put(PutRequest {
+            key: "zeta",
+            value: VALUE,
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put with Indefinite succeeds");
+    let persisted: i64 = raw
+        .pttl(entry_key(&prefix, "zeta"))
+        .await
+        .expect("PTTL succeeds");
+    assert_eq!(
+        persisted, -1,
+        "PTTL must report -1 (persistent), not the old deadline: `Ttl::Indefinite` states a TTL \
+         rather than declining to"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-CACHE-008` — `put_if_absent` on a live entry does not overwrite it.
+///
+/// The contract leader election's `claim` rests on: a candidate that lost the race
+/// must not clobber the winner's key. Asserting the stored value *and* version are
+/// untouched is what distinguishes "returned None" from "returned None and wrote
+/// anyway", which are indistinguishable from the return value alone.
+#[tokio::test]
+async fn rd_cache_008_put_if_absent_does_not_overwrite_a_live_entry() {
+    let (_container, handle, cache, _raw, _prefix) = fixture(json!({})).await;
+
+    let winner = cache
+        .put_if_absent(PutRequest {
+            key: "eta",
+            value: b"winner",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("the first put_if_absent succeeds")
+        .expect("an absent key is created");
+
+    let loser = cache
+        .put_if_absent(PutRequest {
+            key: "eta",
+            value: b"loser",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("the second put_if_absent succeeds as an operation");
+    assert!(
+        loser.is_none(),
+        "put_if_absent on a live entry reports None rather than creating"
+    );
+
+    let stored = cache
+        .get("eta")
+        .await
+        .expect("get succeeds")
+        .expect("the winner's entry is present");
+    assert_eq!(
+        stored.value, b"winner",
+        "the loser must not have overwritten the winner's value"
+    );
+    assert_eq!(
+        stored.version, winner.version,
+        "and must not have bumped the version either - a version change would tell every CAS \
+         holder their claim was stale when it was not"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-CACHE-009` — a command against an unresponsive server is bounded
+/// client-side.
+///
+/// The container is **paused**, not stopped: the socket stays open and nothing
+/// answers, which is the failure mode a client-side timeout exists for — a closed
+/// socket would fail fast on its own and prove nothing. DESIGN.md §12 records the
+/// bound as a property of every command rather than of any one, since `fred`
+/// enforces `default_command_timeout` on all of them, and it is what makes
+/// `stop()` finite (`RD-LIFE-009`).
+#[tokio::test]
+async fn rd_cache_009_a_command_is_bounded_client_side() {
+    let (container, handle, cache, _raw, _prefix) =
+        fixture(json!({ "command_timeout_ms": 200 })).await;
+
+    cache
+        .put(PutRequest {
+            key: "theta",
+            value: VALUE,
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("a put against a live server succeeds");
+
+    container.pause().await.expect("the container pauses");
+    let started = std::time::Instant::now();
+    let result = cache.get("theta").await;
+    let elapsed = started.elapsed();
+    // Unpause before asserting: a panic here would otherwise leave a paused
+    // container for `stop()` to fight, and `stop()` runs on the unwind path.
+    container.unpause().await.expect("the container unpauses");
+
+    assert!(
+        matches!(
+            result,
+            Err(ClusterError::Provider {
+                kind: cluster_sdk::ProviderErrorKind::Timeout,
+                ..
+            })
+        ),
+        "a command against a paused server must surface as Provider {{ Timeout }}, got {result:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "the 200 ms client-side bound must hold - a caller cannot be left waiting on a server that \
+         is not answering. Took {elapsed:?}"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-CACHE-010` — every script is dispatched with exactly one key at runtime.
+///
+/// The runtime half of DESIGN.md §6's Cluster-correctness invariant, whose
+/// build-time half is `scripts.rs`'s `every_catalogued_script_declares_exactly_one_key`.
+/// Both are needed and neither is redundant: the structural check reads the Lua
+/// source and would miss a call site passing two keys to a one-key script, and
+/// this one exercises the call sites but only over the scripts a scenario happens
+/// to reach.
+///
+/// `CROSSSLOT` is the failure being made unreachable. A multi-key script whose
+/// keys hash to different slots is rejected by Redis Cluster at runtime, so a
+/// violation would surface only on a clustered deployment — which has no fixture, and
+/// which is exactly why the invariant is worth holding on a single node where it
+/// *cannot* fail on its own.
+#[tokio::test]
+async fn rd_cache_010_every_script_is_dispatched_with_one_key() {
+    let (_container, handle, cache, raw, _prefix) = fixture(json!({})).await;
+    let baseline_errors = common::command_calls(&raw, "eval").await;
+
+    // Drive all five cache scripts: put, put_if_absent, cas, compare_and_delete,
+    // delete. A `CROSSSLOT` or a wrong-arity dispatch would fail the operation
+    // outright rather than merely mis-route it, so "every one of these succeeded"
+    // is the assertion.
+    cache
+        .put_if_absent(PutRequest {
+            key: "iota",
+            value: b"one",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put_if_absent dispatches with one key")
+        .expect("created");
+    cache
+        .put(PutRequest {
+            key: "iota",
+            value: b"two",
+            ttl: Ttl::Of(Duration::from_secs(30)),
+        })
+        .await
+        .expect("put dispatches with one key");
+    let written = cache
+        .get("iota")
+        .await
+        .expect("get succeeds")
+        .expect("the entry just written is present");
+    let swapped = cache
+        .compare_and_swap("iota", written.version, b"three", Ttl::Indefinite)
+        .await
+        .expect("compare_and_swap dispatches with one key");
+    assert!(
+        !cache
+            .compare_and_delete("iota", b"not-the-value")
+            .await
+            .expect("compare_and_delete dispatches with one key"),
+        "a mismatched compare_and_delete is a no-op rather than an error"
+    );
+    assert!(
+        cache
+            .compare_and_delete("iota", b"three")
+            .await
+            .expect("compare_and_delete dispatches with one key"),
+        "a matching compare_and_delete removes the entry"
+    );
+    assert_eq!(swapped.value, b"three");
+
+    cache
+        .put(PutRequest {
+            key: "iota",
+            value: VALUE,
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put succeeds");
+    assert!(
+        cache
+            .delete("iota")
+            .await
+            .expect("delete dispatches with one key"),
+        "delete removes the entry"
+    );
+
+    // No script needed the `EVAL` fallback: every dispatch found its SHA cached,
+    // which is also the evidence that `SCRIPT LOAD` ran at startup as DESIGN.md
+    // §3.2 step 3 specifies rather than each call re-sending its source.
+    assert_eq!(
+        common::command_calls(&raw, "eval").await,
+        baseline_errors,
+        "every script must dispatch via EVALSHA against the SHA loaded at startup; an EVAL here \
+         means a NOSCRIPT recovery fired when nothing had flushed the cache"
+    );
+    assert!(
+        common::command_calls(&raw, "evalsha").await > 0,
+        "and EVALSHA must actually have been used - otherwise the assertion above is vacuous"
+    );
+
+    handle.stop().await;
+}
+
+/// The URL a raw client was built against, recovered from its own config so
+/// `RD-CACHE-006` can start a second plugin instance against the same container
+/// without the fixture having to thread the URL through every return type.
+fn raw_url(client: &fred::clients::Client) -> String {
+    use fred::interfaces::ClientLike;
+    let server = client
+        .client_config()
+        .server
+        .hosts()
+        .first()
+        .cloned()
+        .expect("a centralized client has exactly one host");
+    format!("redis://{}:{}", server.host, server.port)
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/tests/common/mod.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/tests/common/mod.rs
@@ -1,0 +1,1437 @@
+//! Shared testcontainers fixtures for the Redis cluster plugin's Layer 2/3 test
+//! suites (docs/TESTING.md §4.1). Not a test binary itself — every `tests/*.rs`
+//! file that needs it declares `mod common;`.
+//!
+//! Gated behind `--features integration` end to end (docs/TESTING.md §7): this
+//! whole module is compiled out of a default `cargo test`, so it never requires a
+//! Docker daemon unless the feature is explicitly enabled.
+//!
+//! # Why a parameterized recipe rather than TESTING §4.1's two functions
+//!
+//! TESTING §4.1 names four fixtures. The *scenario* set needs more container
+//! shapes than that, because several scenarios are precisely about server
+//! configuration rather than about plugin logic:
+//!
+//! | Shape | Needed by |
+//! |---|---|
+//! | stock (`EventuallyConsistent`) | most of §4.2–§4.5, `RD-SPEC-001` |
+//! | durable single node (`Linearizable`) | the leader conformance suite (§3), `RD-SPEC-003` |
+//! | no keyspace notifications | `RD-SPEC-005`, `RD-SPEC-005b`, `RD-LOCK-009` |
+//! | unsafe `maxmemory-policy`, no `maxmemory` | `RD-SPEC-006` |
+//! | tiny `maxmemory` + `allkeys-lru` | `RD-SPEC-007`, `RD-SPEC-007b`, `RD-LOCK-015` |
+//! | `appendfsync everysec` | `RD-SPEC-011` |
+//! | Redis 6 | `RD-SPEC-014`'s negative half |
+//!
+//! Named wrappers over one [`RedisRecipe`] rather than one copy each of the
+//! start-and-retry sequence: the shapes differ only in server flags, and a
+//! duplicated retry loop is the kind of thing that gets fixed in one copy.
+//!
+//! # The two multi-node topologies are built differently, and have to be
+//!
+//! [`start_redis_sentinel`] and [`start_redis_cluster`] do not go through
+//! [`RedisRecipe`]. Each runs every node as a *process inside one container*
+//! with host ports mapped 1:1, because both topologies advertise an address to
+//! the client — Sentinel the primary's, a cluster node its `MOVED` target — and
+//! only 1:1 mapping makes one address correct for both the nodes' own gossip
+//! and a client outside Docker. [`free_port_base`] carries the full reasoning.
+//!
+//! # The keyspace flags are `Kxe`, and they are set by container flag
+//!
+//! TESTING §4.1 writes `Kgx$e`; the correct minimal set is **`Kxe`**
+//! (DESIGN.md §4.3). `K` plus `x` yields `expired` and `K`
+//! plus `e` yields `evicted` — the two events no plugin code can publish for
+//! itself — while `g` and `$` would add a notification for every generic and
+//! every string command **server-wide**, which on a shared Redis is a cost paid
+//! by unrelated tenants for nothing this plugin reads.
+//!
+//! Set by container flag rather than by `CONFIG SET` so the *default* test
+//! posture matches a well-configured production server: a plugin that only works
+//! after mutating a server-wide setting is not the thing TESTING §4 means to
+//! exercise. The fixtures that deliberately omit the flags
+//! ([`start_redis_no_notifications`]) are how the degradation path gets covered.
+
+#![cfg(feature = "integration")]
+#![allow(
+    dead_code,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test harness: a fixture setup failure IS the test failure, and not every helper \
+              below is used by every test binary that `mod common;`s this file"
+)]
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use fred::clients::Client;
+use fred::interfaces::ClientLike;
+use fred::types::Builder;
+use fred::types::config::Config;
+use redis_cluster_plugin::{RedisClusterConfig, RedisLockConfig};
+use serde_json::json;
+use testcontainers::core::ContainerPort;
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{ContainerAsync, ImageExt};
+use testcontainers_modules::redis::{REDIS_PORT, Redis};
+
+/// The Redis image tag every per-PR fixture runs, pinned rather than `latest` so
+/// a scenario asserting on server *behaviour* (keyspace notification wording,
+/// eviction accounting, `PTTL` sentinels) cannot start failing because Docker Hub
+/// moved a tag. `alpine` for start-up time: the fixtures are per-PR and TESTING
+/// §7 budgets the whole suite at 20–30 s.
+///
+/// The `testcontainers_modules::redis::Redis` image defaults to tag `5.0`, which
+/// predates sharded pub/sub and several `INFO` fields, so every fixture below
+/// overrides it explicitly.
+pub const REDIS_TAG: &str = "7-alpine";
+
+/// The Redis 6 tag, for `RD-SPEC-014`'s negative half — a server that supports
+/// neither `SPUBLISH` nor `SSUBSCRIBE`, so the plugin must log no
+/// `sharded_pubsub_available` and issue no sharded command.
+pub const REDIS_6_TAG: &str = "6-alpine";
+
+/// The minimal correct `notify-keyspace-events` set — see this module's header
+/// and DESIGN.md §4.3.
+///
+/// Deliberately not read from `redis_cluster_plugin::REQUIRED_KEYSPACE_FLAGS`:
+/// a fixture that configures the server from the same constant the plugin checks
+/// against would agree with the plugin by construction, and `RD-SPEC-005`'s whole
+/// subject is what happens when the two disagree.
+pub const KEYSPACE_FLAGS: &str = "Kxe";
+
+/// A container shape: the server flags that distinguish one fixture from
+/// another.
+///
+/// Every field maps to one `redis-server` command-line flag, and every fixture
+/// below is one of these plus a name. Constructed through the `stock`/`durable`
+/// constructors and the `with_*` builders rather than by literal, so a new field
+/// gets a default at every existing call site instead of a compile error at seven
+/// of them.
+#[derive(Debug, Clone)]
+pub struct RedisRecipe {
+    /// Image tag. [`REDIS_TAG`] for everything except `RD-SPEC-014`'s negative
+    /// half.
+    pub tag: &'static str,
+    /// `--notify-keyspace-events`. `None` leaves the server at its default of
+    /// *no* notifications, which is what `RD-SPEC-005`/`005b` and `RD-LOCK-009`
+    /// need.
+    pub keyspace_flags: Option<&'static str>,
+    /// `--appendonly yes --appendfsync <this>`. `None` means no AOF at all, the
+    /// stock posture. `Some("always")` is the only value that can reach a
+    /// `Linearizable` declaration (DESIGN.md §3.6).
+    pub appendfsync: Option<&'static str>,
+    /// `--maxmemory`. `None` means unlimited, so nothing is ever evicted.
+    pub maxmemory: Option<&'static str>,
+    /// `--maxmemory-policy`. `None` leaves the server default (`noeviction`),
+    /// which is the one policy this plugin rates safe.
+    pub maxmemory_policy: Option<&'static str>,
+    /// An extra ACL user, as `(username, password)`, granted everything **except**
+    /// `CONFIG` — see [`RedisRecipe::with_config_denied_user`].
+    ///
+    /// The password is owned rather than `&'static str` because it is generated
+    /// per container rather than written here as a literal.
+    pub config_denied_user: Option<(&'static str, String)>,
+}
+
+impl RedisRecipe {
+    /// Stock Redis: no AOF, no memory ceiling, keyspace notifications on.
+    ///
+    /// `--save ""` disables RDB snapshotting. Not thrift: a background save
+    /// forks the server and can add tens of milliseconds of latency at an
+    /// arbitrary moment, which would show up as flake in the scenarios that
+    /// assert a wake landed in single-digit milliseconds (`RD-LOCK-003`).
+    #[must_use]
+    pub fn stock() -> Self {
+        Self {
+            tag: REDIS_TAG,
+            keyspace_flags: Some(KEYSPACE_FLAGS),
+            appendfsync: None,
+            maxmemory: None,
+            maxmemory_policy: None,
+            config_denied_user: None,
+        }
+    }
+
+    /// The one configuration ADR-009 rates safe: a single node with
+    /// `appendonly yes` and `appendfsync always` and no replicas, so nothing is
+    /// acknowledged before it is fsynced and the cache declares `Linearizable`.
+    #[must_use]
+    pub fn durable() -> Self {
+        Self {
+            appendfsync: Some("always"),
+            ..Self::stock()
+        }
+    }
+
+    /// No keyspace notifications at all — the degradation path.
+    #[must_use]
+    pub fn without_keyspace_notifications(mut self) -> Self {
+        self.keyspace_flags = None;
+        self
+    }
+
+    /// A `maxmemory-policy` that can evict this plugin's keys.
+    #[must_use]
+    pub fn with_maxmemory_policy(mut self, policy: &'static str) -> Self {
+        self.maxmemory_policy = Some(policy);
+        self
+    }
+
+    /// A memory ceiling low enough that writing past it forces real eviction.
+    #[must_use]
+    pub fn with_maxmemory(mut self, maxmemory: &'static str) -> Self {
+        self.maxmemory = Some(maxmemory);
+        self
+    }
+
+    /// A different `appendfsync` — `RD-SPEC-011` needs `everysec` specifically,
+    /// to contradict a `durability: fsync_always` hint.
+    #[must_use]
+    pub fn with_appendfsync(mut self, appendfsync: &'static str) -> Self {
+        self.appendfsync = Some(appendfsync);
+        self
+    }
+
+    /// A different image tag.
+    #[must_use]
+    pub fn with_tag(mut self, tag: &'static str) -> Self {
+        self.tag = tag;
+        self
+    }
+
+    /// Adds an ACL user granted every command **except** `CONFIG`, so a plugin
+    /// connecting as it can read `INFO` but cannot read `CONFIG GET`.
+    ///
+    /// The local stand-in for a managed Redis (`ElastiCache`, `MemoryDB`) that hides
+    /// `CONFIG` from its tenants — the environment DESIGN.md §3.6's
+    /// asserted-not-verified branch exists for, and which `RD-SPEC-011`'s second
+    /// half needs. TESTING §8 already records that this is an approximation of a
+    /// managed instance rather than the thing itself; it is close because all the
+    /// plugin cares about is that the command errors.
+    ///
+    /// Declared as a **server flag** rather than set with `ACL SETUSER`, which
+    /// matters for more than tidiness: `ACL` sits on `fred`'s `i-acl` interface,
+    /// which DESIGN.md §3.1 deliberately leaves out of the feature list, so no build of this
+    /// plugin — or of its tests — can issue one.
+    ///
+    /// `password` is owned and expected to be generated per container — see
+    /// [`throwaway_password`], and [`start_redis_config_denied_with`] for the one
+    /// caller.
+    #[must_use]
+    pub fn with_config_denied_user(mut self, username: &'static str, password: String) -> Self {
+        self.config_denied_user = Some((username, password));
+        self
+    }
+
+    /// The `redis-server` argument vector this recipe describes.
+    fn command(&self) -> Vec<String> {
+        // The official image's entrypoint is `docker-entrypoint.sh`, so the
+        // command has to name `redis-server` itself rather than only its flags.
+        let mut command = vec![
+            "redis-server".to_owned(),
+            "--save".to_owned(),
+            String::new(),
+        ];
+        if let Some(flags) = self.keyspace_flags {
+            command.push("--notify-keyspace-events".to_owned());
+            command.push(flags.to_owned());
+        }
+        if let Some(appendfsync) = self.appendfsync {
+            command.push("--appendonly".to_owned());
+            command.push("yes".to_owned());
+            command.push("--appendfsync".to_owned());
+            command.push(appendfsync.to_owned());
+        }
+        if let Some(maxmemory) = self.maxmemory {
+            command.push("--maxmemory".to_owned());
+            command.push(maxmemory.to_owned());
+        }
+        if let Some(policy) = self.maxmemory_policy {
+            command.push("--maxmemory-policy".to_owned());
+            command.push(policy.to_owned());
+        }
+        if let Some((username, password)) = &self.config_denied_user {
+            // `~*` all keys, `&*` all pub/sub channels, `+@all` every command,
+            // then `-config` to take that one back. `&*` is not optional here:
+            // without it the user cannot subscribe, and this plugin opens a
+            // subscriber before it ever reaches the durability check.
+            command.extend([
+                "--user".to_owned(),
+                (*username).to_owned(),
+                "on".to_owned(),
+                format!(">{password}"),
+                "~*".to_owned(),
+                "&*".to_owned(),
+                "+@all".to_owned(),
+                "-config".to_owned(),
+            ]);
+        }
+        command
+    }
+}
+
+/// Starts a container from `recipe` and returns it with a `redis://` URL pointed
+/// at its mapped host port.
+///
+/// Retries the whole create → `.start()` → `get_host_port_ipv4` sequence up to 5
+/// times with backoff, for the reason the Postgres plugin's fixture records: under
+/// parallel test load the container's own wait strategy passes but the follow-up
+/// Docker port inspect transiently fails, and a fresh container per attempt
+/// side-steps that flake. Every fixture below goes through here, so all of them
+/// inherit the retry rather than one of them having it.
+///
+/// The container is returned rather than kept alive internally because the caller
+/// has to outlive it: dropping a `ContainerAsync` removes the container, so a
+/// fixture that dropped it would hand back a URL pointing at nothing.
+pub async fn start(recipe: &RedisRecipe) -> (ContainerAsync<Redis>, String) {
+    // 250ms, 500ms, 1s, 2s between the 5 attempts (the last has no sleep).
+    let backoffs = [
+        Duration::from_millis(250),
+        Duration::from_millis(500),
+        Duration::from_secs(1),
+        Duration::from_secs(2),
+    ];
+    let attempts = backoffs.len() + 1;
+    let mut last_error = String::new();
+    for attempt in 1..=attempts {
+        let request = Redis::default()
+            .with_tag(recipe.tag)
+            .with_cmd(recipe.command());
+        let container = match request.start().await {
+            Ok(container) => container,
+            Err(error) => {
+                last_error = format!("container start: {error}");
+                if let Some(backoff) = backoffs.get(attempt - 1) {
+                    tokio::time::sleep(*backoff).await;
+                }
+                continue;
+            }
+        };
+        match container.get_host_port_ipv4(REDIS_PORT).await {
+            Ok(port) => return (container, format!("redis://127.0.0.1:{port}")),
+            Err(error) => {
+                last_error = format!("mapped host port: {error}");
+                // Drop the failed container before backing off, so a retry does
+                // not leave one running behind it.
+                drop(container);
+                if let Some(backoff) = backoffs.get(attempt - 1) {
+                    tokio::time::sleep(*backoff).await;
+                }
+            }
+        }
+    }
+    panic!(
+        "Redis container acquisition failed after {attempts} attempts; last error: {last_error}"
+    );
+}
+
+/// Retries container acquisition for the two multi-node fixtures the way [`start`]
+/// does for the single-node ones — kept in one copy for the same reason, and
+/// carrying one hazard the single-node path does not: the ports come from
+/// [`free_port_base`], whose probe-then-release leaves a window a parallel process
+/// can claim a port in (documented there), and the 1:1 mapping turns a lost race
+/// into a failed `request.start()` rather than a slow reconnect. A fresh probe per
+/// attempt makes that recoverable, so neither multi-node fixture is a single roll
+/// of the port dice — which matters more here than for the single-node shapes,
+/// because these fixtures **bypassed** `start`'s retry entirely before.
+///
+/// `build(base)` returns the container's shell command and the host ports to map
+/// 1:1 for that base; the caller runs its own topology wait on the returned
+/// container and derives its ports from the returned base the same way `build`
+/// did. `port_count` is what to hand [`free_port_base`], not the length of the
+/// mapped-port list (the Cluster fixture maps two ports per node).
+async fn start_multinode(
+    port_count: u16,
+    build: impl Fn(u16) -> (String, Vec<u16>),
+) -> (ContainerAsync<Redis>, u16) {
+    let backoffs = [
+        Duration::from_millis(250),
+        Duration::from_millis(500),
+        Duration::from_secs(1),
+        Duration::from_secs(2),
+    ];
+    let attempts = backoffs.len() + 1;
+    let mut last_error = String::new();
+    for attempt in 1..=attempts {
+        // A fresh base per attempt: retrying the same ports would just lose the
+        // same race, so re-probing is the whole point.
+        let base = free_port_base(port_count);
+        let (script, ports) = build(base);
+        let mut request = Redis::default()
+            .with_tag(REDIS_TAG)
+            // The official image's `docker-entrypoint.sh` prepends `redis-server`
+            // only when the first argument is a flag or a `.conf`, and `exec "$@"`s
+            // anything else — so a shell command passes through untouched.
+            .with_cmd(["sh".to_owned(), "-c".to_owned(), script])
+            .with_startup_timeout(Duration::from_secs(90));
+        for port in ports {
+            request = request.with_mapped_port(port, ContainerPort::Tcp(port));
+        }
+        match request.start().await {
+            Ok(container) => return (container, base),
+            Err(error) => {
+                last_error = format!("multi-node container start: {error}");
+                if let Some(backoff) = backoffs.get(attempt - 1) {
+                    tokio::time::sleep(*backoff).await;
+                }
+            }
+        }
+    }
+    panic!(
+        "multi-node Redis container acquisition failed after {attempts} attempts; \
+         last error: {last_error}"
+    );
+}
+
+/// Builds a [`RedisClusterConfig`] from `url` plus `overrides` (a JSON object
+/// merged over the minimal required fields).
+///
+/// Goes through `serde_json` rather than a `Default` impl because
+/// `RedisClusterConfig` deliberately does not derive `Default` — `url` has no
+/// sensible default — so this is the test-only equivalent of the
+/// `..RedisClusterConfig::default()` spread TESTING §4.1 sketches. It also means
+/// every fixture config travels the same `serde` path an operator's YAML does,
+/// including `deny_unknown_fields`: a typo in an override below fails here rather
+/// than being silently ignored.
+///
+/// `pool_size` is left at the plugin's own default of 4. Nothing in this plugin
+/// holds a pool connection for the life of anything — a held lock is a key with a
+/// TTL, not a pinned connection (DESIGN.md §3.3) — so unlike the Postgres
+/// fixture there is no per-scenario connection arithmetic to do.
+pub fn cluster_config_json(url: &str, overrides: serde_json::Value) -> RedisClusterConfig {
+    let mut base = json!({ "url": url });
+    merge(&mut base, overrides);
+    serde_json::from_value(base).expect("valid RedisClusterConfig")
+}
+
+/// A [`RedisLockConfig`] against `url` with `overrides` merged over the shared
+/// defaults, for the standalone lock-only path (DESIGN.md §3.5).
+pub fn lock_config_json(url: &str, overrides: serde_json::Value) -> RedisLockConfig {
+    let mut base = json!({ "url": url });
+    merge(&mut base, overrides);
+    serde_json::from_value(base).expect("valid RedisLockConfig")
+}
+
+/// Shallow object merge — sufficient for the flat config shapes here.
+fn merge(base: &mut serde_json::Value, overrides: serde_json::Value) {
+    let (serde_json::Value::Object(base_map), serde_json::Value::Object(override_map)) =
+        (base, overrides)
+    else {
+        return;
+    };
+    for (key, value) in override_map {
+        base_map.insert(key, value);
+    }
+}
+
+/// The default fixture: stock Redis, no AOF. Declares `EventuallyConsistent`
+/// (DESIGN.md §3.6), which makes it the fixture most of §4.2–§4.5 runs on and the
+/// one `RD-SPEC-001` asserts the weak declaration against.
+pub async fn start_redis() -> (ContainerAsync<Redis>, RedisClusterConfig) {
+    start_redis_with(json!({})).await
+}
+
+/// [`start_redis`] with `RedisClusterConfig` field overrides, for scenarios that
+/// need a non-default value (`command_timeout_ms`, `watch_mode`, `database`, …).
+pub async fn start_redis_with(
+    overrides: serde_json::Value,
+) -> (ContainerAsync<Redis>, RedisClusterConfig) {
+    let (container, url) = start(&RedisRecipe::stock()).await;
+    let config = cluster_config_json(&url, overrides);
+    (container, config)
+}
+
+/// Single node, `--appendonly yes --appendfsync always`, no replicas — the one
+/// configuration ADR-009 rates safe, so the cache declares `Linearizable`.
+///
+/// Required by the leader conformance suite (TESTING §3) and by `RD-SPEC-003`:
+/// `CasBasedLeaderElectionBackend::new` is the strict constructor and refuses an
+/// `EventuallyConsistent` cache, so on the default fixture the leader suite would
+/// fail to *construct* rather than fail a scenario.
+pub async fn start_redis_durable() -> (ContainerAsync<Redis>, RedisClusterConfig) {
+    start_redis_durable_with(json!({})).await
+}
+
+/// [`start_redis_durable`] with field overrides.
+pub async fn start_redis_durable_with(
+    overrides: serde_json::Value,
+) -> (ContainerAsync<Redis>, RedisClusterConfig) {
+    let (container, url) = start(&RedisRecipe::durable()).await;
+    let config = cluster_config_json(&url, overrides);
+    (container, config)
+}
+
+/// Stock Redis with `notify-keyspace-events` left empty — the degradation path
+/// (`RD-SPEC-005`, `RD-SPEC-005b`, `RD-LOCK-009`).
+///
+/// **`RD-SPEC-005b` must not share this container with `RD-SPEC-005`.** It is the
+/// one scenario that issues `CONFIG SET notify-keyspace-events`, and that setting
+/// is server-wide and outlives the test — so a shared container would make the
+/// pair order-dependent, with `RD-SPEC-005`'s "the flags are absent" assertion
+/// passing or failing depending on which ran first. Each takes its own.
+pub async fn start_redis_no_notifications() -> (ContainerAsync<Redis>, RedisClusterConfig) {
+    start_redis_no_notifications_with(json!({})).await
+}
+
+/// [`start_redis_no_notifications`] with field overrides — `RD-SPEC-005b` needs
+/// `manage_keyspace_notifications: true`.
+pub async fn start_redis_no_notifications_with(
+    overrides: serde_json::Value,
+) -> (ContainerAsync<Redis>, RedisClusterConfig) {
+    let (container, url) = start(&RedisRecipe::stock().without_keyspace_notifications()).await;
+    let config = cluster_config_json(&url, overrides);
+    (container, config)
+}
+
+/// Stock Redis with `--maxmemory-policy allkeys-lru` and **no** `maxmemory`, so
+/// the policy is unsafe but nothing is ever actually evicted (`RD-SPEC-006`).
+///
+/// The two halves are deliberately separate fixtures: `RD-SPEC-006` is about the
+/// startup WARN firing on a policy that *could* evict, and keeping the ceiling
+/// off means it asserts that without also being at the mercy of a real eviction
+/// landing mid-test.
+pub async fn start_redis_unsafe_policy() -> (ContainerAsync<Redis>, RedisClusterConfig) {
+    let (container, url) = start(&RedisRecipe::stock().with_maxmemory_policy("allkeys-lru")).await;
+    let config = cluster_config_json(&url, json!({}));
+    (container, config)
+}
+
+/// Stock Redis with a 3 MiB ceiling and `allkeys-lru`, so writing past it forces
+/// a real eviction of this plugin's keys (`RD-SPEC-007`).
+///
+/// 3 MiB rather than something tighter because Redis needs headroom for its own
+/// overhead before it will accept any write at all; verified against a container
+/// that ~16 KiB of filler values reliably pushes a small watched key out.
+pub async fn start_redis_evicting() -> (ContainerAsync<Redis>, RedisClusterConfig) {
+    let (container, url) = start(
+        &RedisRecipe::stock()
+            .with_maxmemory("3mb")
+            .with_maxmemory_policy("allkeys-lru"),
+    )
+    .await;
+    let config = cluster_config_json(&url, json!({}));
+    (container, config)
+}
+
+/// A single node with `appendonly yes` but `appendfsync everysec` — durable
+/// enough to look it, weak enough that a `durability: fsync_always` hint is a
+/// falsehood the plugin must refuse (`RD-SPEC-011`).
+pub async fn start_redis_everysec_with(
+    overrides: serde_json::Value,
+) -> (ContainerAsync<Redis>, RedisClusterConfig) {
+    let (container, url) = start(&RedisRecipe::durable().with_appendfsync("everysec")).await;
+    let config = cluster_config_json(&url, overrides);
+    (container, config)
+}
+
+/// A fresh credential for one throwaway container's ACL user.
+///
+/// Generated rather than written as a literal, and the reason is tooling as much
+/// as hygiene. Nothing depends on the value — it is created for a container that
+/// is removed when the test's `ContainerAsync` drops, and it never leaves the
+/// Docker bridge — but a string literal assigned to something named `PASSWORD` is
+/// indistinguishable, to `CodeQL`'s hard-coded-credential rule and to every secret
+/// scanner, from a real credential committed to the repository. Generating it
+/// removes the finding truthfully instead of suppressing it, and costs one UUID
+/// per container.
+///
+/// Hex, via `Uuid::simple`, so the value needs no escaping in either place it is
+/// interpolated: a `redis://user:password@host` URL and a `>password` argument to
+/// the server's `--user` ACL flag.
+fn throwaway_password() -> String {
+    uuid::Uuid::new_v4().simple().to_string()
+}
+
+/// A single node with `appendfsync everysec` whose `CONFIG` is denied to the
+/// connecting user — `RD-SPEC-011`'s second half.
+///
+/// The URL carries the restricted user's credentials, so the plugin connects as
+/// it and finds `CONFIG GET` refused. With durability unreadable, a
+/// `durability: fsync_always` hint cannot be contradicted, so it is trusted and
+/// the declaration is flagged as asserted-not-verified rather than failing
+/// startup (DESIGN.md §3.6).
+pub async fn start_redis_config_denied_with(
+    overrides: serde_json::Value,
+) -> (ContainerAsync<Redis>, RedisClusterConfig) {
+    const USER: &str = "limited";
+    let password = throwaway_password();
+    let (container, url) = start(
+        &RedisRecipe::durable()
+            .with_appendfsync("everysec")
+            .with_config_denied_user(USER, password.clone()),
+    )
+    .await;
+    // `redis://user:password@host:port` — the plugin connects as the restricted
+    // user rather than as `default`, which is the whole point.
+    let authed = url.replace("redis://", &format!("redis://{USER}:{password}@"));
+    let config = cluster_config_json(&authed, overrides);
+    (container, config)
+}
+
+/// A Redis 6 container — `RD-SPEC-014`'s negative half, where neither the
+/// sharded-pub/sub DEBUG nor any `SPUBLISH`/`SSUBSCRIBE` may appear.
+pub async fn start_redis_6() -> (ContainerAsync<Redis>, RedisClusterConfig) {
+    let (container, url) = start(&RedisRecipe::stock().with_tag(REDIS_6_TAG)).await;
+    let config = cluster_config_json(&url, json!({}));
+    (container, config)
+}
+
+/// A stock container returning a [`RedisLockConfig`], for the standalone
+/// lock-only plugin (DESIGN.md §3.5).
+pub async fn start_redis_lock_only() -> (ContainerAsync<Redis>, RedisLockConfig) {
+    start_redis_lock_only_with(json!({})).await
+}
+
+/// [`start_redis_lock_only`] with field overrides.
+pub async fn start_redis_lock_only_with(
+    overrides: serde_json::Value,
+) -> (ContainerAsync<Redis>, RedisLockConfig) {
+    let (container, url) = start(&RedisRecipe::stock()).await;
+    let config = lock_config_json(&url, overrides);
+    (container, config)
+}
+
+/// A memory-capped, evicting container returning a [`RedisLockConfig`] **and its
+/// URL** — `RD-LOCK-015`'s fixture.
+///
+/// The URL comes back because this plugin owns no cache to write filler through:
+/// the memory pressure that forces a real eviction has to come from a raw client
+/// rather than from the thing under test.
+pub async fn start_redis_evicting_lock_only() -> (ContainerAsync<Redis>, RedisLockConfig, String) {
+    let (container, url) = start(
+        &RedisRecipe::stock()
+            .with_maxmemory("3mb")
+            .with_maxmemory_policy("allkeys-lru"),
+    )
+    .await;
+    let config = lock_config_json(&url, json!({}));
+    (container, config, url)
+}
+
+/// A stock container with **no** keyspace notifications, returning a
+/// [`RedisLockConfig`] — `RD-LOCK-009`'s subject: the standalone lock needs none
+/// of them, because a release is a `PUBLISH` the plugin issues itself rather than
+/// a notification the server emits.
+pub async fn start_redis_lock_only_no_notifications() -> (ContainerAsync<Redis>, RedisLockConfig) {
+    let (container, url) = start(&RedisRecipe::stock().without_keyspace_notifications()).await;
+    let config = lock_config_json(&url, json!({}));
+    (container, config)
+}
+
+/// A per-scenario [`RedisClusterConfig`] on a shared container, isolated **both**
+/// ways TESTING §3 describes: its own logical database and its own `key_prefix`.
+///
+/// §3 prefers database isolation and calls prefix isolation the fallback, on the
+/// grounds that a shared prefix space leaves a scenario able to see another's
+/// keys through `scan_prefix`. Doing both is strictly stronger than either and
+/// costs nothing, and it is what makes the two suites that need more than 15
+/// scenarios work on one container rather than one container per scenario.
+///
+/// The database cycles `1..=15` rather than starting at 0 so nothing lands in the
+/// database a stray client would connect to by default, and so a scenario's
+/// `expired` notifications arrive on `__keyspace@<n>__` with `n` non-zero — the
+/// off-by-one-database bug `RD-SPEC-012` exists to catch would otherwise be
+/// invisible here.
+pub fn cluster_config_for_scenario(
+    url: &str,
+    suite: &str,
+    index: usize,
+    overrides: serde_json::Value,
+) -> RedisClusterConfig {
+    let mut base = json!({
+        "database": database_for_scenario(index),
+        "key_prefix": format!("{suite}{index}"),
+    });
+    merge(&mut base, overrides);
+    cluster_config_json(url, base)
+}
+
+/// A per-scenario [`RedisLockConfig`] on a shared container, isolated the same
+/// two ways as [`cluster_config_for_scenario`].
+///
+/// Both halves matter for the lock suite specifically: the conformance scenarios
+/// reuse a handful of lock names (`"res"`, `"m"`), so a lease still held past one
+/// scenario's teardown would collide with the next — and `stop()` deliberately
+/// *leaves* held leases to expire (`cpt-cf-clst-fr-shutdown-ttl-cleanup`,
+/// `RD-LOCK-013`), so there is no handback to rely on the way the Postgres plugin
+/// now can.
+pub fn lock_config_for_scenario(
+    url: &str,
+    suite: &str,
+    index: usize,
+    overrides: serde_json::Value,
+) -> RedisLockConfig {
+    let mut base = json!({
+        "database": database_for_scenario(index),
+        "key_prefix": format!("{suite}{index}"),
+    });
+    merge(&mut base, overrides);
+    lock_config_json(url, base)
+}
+
+/// Cycles a scenario index over the 15 non-default logical databases a stock
+/// Redis provides (`databases 16`, indices 0–15).
+fn database_for_scenario(index: usize) -> u8 {
+    u8::try_from(index % 15 + 1).expect("a value in 1..=15 fits a u8")
+}
+
+/// A bare `fred` client against the same container, for assertions on
+/// Redis-level state (`HGETALL`, `PTTL`, `INFO commandstats`, `PUBSUB NUMPAT`,
+/// `CONFIG GET`) rather than only through the plugin's own API.
+///
+/// Carries the same short command timeout the plugin's own pool does, so a raw
+/// assertion against a paused container fails the test instead of hanging it.
+/// Callers that assert on *connection counts* (`RD-LIFE-003`) must
+/// [`quit`](ClientLike::quit) theirs first, since this one is a connection too.
+pub async fn raw_client(url: &str) -> Client {
+    raw_client_on(url, 0).await
+}
+
+/// [`raw_client`], on a specific logical database — needed by every scenario
+/// whose config is a [`cluster_config_for_scenario`], since those do not run on
+/// database 0.
+pub async fn raw_client_on(url: &str, database: u8) -> Client {
+    let mut config = Config::from_url(url).expect("the fixture url parses");
+    if database != 0 {
+        config.database = Some(database);
+    }
+    let client = Builder::from_config(config)
+        .with_performance_config(|perf| {
+            perf.default_command_timeout = Duration::from_secs(5);
+        })
+        .build()
+        .expect("a raw client builds from the fixture url");
+    client.init().await.expect("the raw client connects");
+    client
+}
+
+/// The server's current `notify-keyspace-events` value.
+///
+/// Read back through `CONFIG GET` rather than assumed from the recipe, because
+/// two scenarios turn on the difference: `RD-SPEC-005` asserts the flags are
+/// absent and `RD-SPEC-005b` asserts the plugin's one `CONFIG SET` put them
+/// there.
+pub async fn keyspace_flags(client: &Client) -> String {
+    use fred::interfaces::ConfigInterface;
+    let reply: Vec<String> = client
+        .config_get("notify-keyspace-events")
+        .await
+        .expect("CONFIG GET notify-keyspace-events succeeds");
+    reply.get(1).cloned().unwrap_or_default()
+}
+
+/// How many times `command` has been dispatched on this server, from
+/// `INFO commandstats`.
+///
+/// The mechanism behind every "this command was never issued" assertion
+/// (`RD-CACHE-006`'s no-`KEYS`, `RD-WATCH-010`'s no-`PUBLISH`, `RD-SPEC-014`'s
+/// no-`SPUBLISH`). `0` covers both "the counter exists and is zero" and "the
+/// command has never been called, so there is no line for it", which are the same
+/// statement.
+///
+/// `INFO commandstats` lines are `cmdstat_<command>:calls=N,usec=…`, and the
+/// command name is lower-cased with multi-word commands joined by `|`
+/// (`cmdstat_config|set`). Counting is server-wide and cumulative, so a caller
+/// asserting an *increase* must read a baseline first — asserting an absolute
+/// count would also be counting the plugin's own startup traffic.
+pub async fn command_calls(client: &Client, command: &str) -> u64 {
+    use fred::types::InfoKind;
+    let info: String = client
+        .info(Some(InfoKind::CommandStats))
+        .await
+        .expect("INFO commandstats succeeds");
+    let needle = format!("cmdstat_{}:", command.to_lowercase());
+    for line in info.lines() {
+        let Some(rest) = line.trim().strip_prefix(&needle) else {
+            continue;
+        };
+        for field in rest.split(',') {
+            if let Some(calls) = field.strip_prefix("calls=") {
+                return calls.parse().unwrap_or(0);
+            }
+        }
+    }
+    0
+}
+
+/// Polls `condition` until it returns `true` or `timeout` elapses, sleeping
+/// `interval` between attempts.
+///
+/// Used instead of a single fixed sleep wherever the assertion is about state
+/// that changes asynchronously — a pub/sub delivery, a TTL lapse, an eviction —
+/// so a scenario neither hard-codes a latency bound tighter than it is about nor
+/// pays a worst-case sleep on every run.
+///
+/// The whole wait, including each in-flight `condition().await`, is bounded by
+/// `timeout`: checking the deadline only between attempts would let one stalled
+/// command inside `condition` overrun it indefinitely.
+pub async fn wait_until<F>(timeout: Duration, interval: Duration, mut condition: F) -> bool
+where
+    F: AsyncFnMut() -> bool,
+{
+    tokio::time::timeout(timeout, async {
+        loop {
+            if condition().await {
+                return true;
+            }
+            tokio::time::sleep(interval).await;
+        }
+    })
+    .await
+    .unwrap_or(false)
+}
+
+/// An in-memory OpenTelemetry reader plus the [`Meter`] to inject into a plugin
+/// builder's `__with_meter` seam.
+///
+/// `__with_meter` routes **both** halves of the plugin's telemetry through one
+/// meter — the ADR-004 catalog signals via `OtelClusterMetrics::new` and the four
+/// plugin-local instruments directly — so a single reader observes everything the
+/// plugin emits. That is what lets `RD-WATCH-008`, `RD-SPEC-007` and `RD-LIFE-008`
+/// assert on counters by their contracted names instead of by eye.
+///
+/// [`Meter`]: opentelemetry::metrics::Meter
+pub fn in_memory_meter() -> (opentelemetry::metrics::Meter, MetricReadback) {
+    use opentelemetry::metrics::MeterProvider;
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
+
+    let exporter = InMemoryMetricExporter::default();
+    let provider = SdkMeterProvider::builder()
+        .with_reader(PeriodicReader::builder(exporter.clone()).build())
+        .build();
+    let meter = provider.meter("redis-cluster-plugin-integration");
+    (meter, MetricReadback { provider, exporter })
+}
+
+/// Reads the plugin's instruments back out of an in-process exporter.
+///
+/// The crate's own `src/test_support.rs` has a Layer-1 equivalent, but it is
+/// `#[cfg(test)]` on the library and an integration test binary links the library
+/// as a normal dependency — so it cannot see it, and the readback is re-expressed
+/// here.
+///
+/// # Read the last batch, never the sum of all of them
+///
+/// `InMemoryMetricExporter` **accumulates** one `ResourceMetrics` batch per flush
+/// and each batch carries the counter's full cumulative value. So summing data
+/// points across batches multiplies the answer by the number of times it has been
+/// read: a counter genuinely at 1, read three times, reports 6. Both readers below
+/// therefore take the *last* batch that mentions the instrument.
+pub struct MetricReadback {
+    provider: opentelemetry_sdk::metrics::SdkMeterProvider,
+    exporter: opentelemetry_sdk::metrics::InMemoryMetricExporter,
+}
+
+impl MetricReadback {
+    /// The current value of the `u64` counter whose *contract* name is `name`.
+    ///
+    /// The `_total` suffix is stripped before matching: the Prometheus exporter
+    /// appends it when it renders a counter, so the instrument is registered
+    /// without it and `cluster_cache_ops_total` is the instrument
+    /// `cluster_cache_ops`. Passing either form works, which keeps a call site
+    /// free to quote the name a dashboard would.
+    ///
+    /// Flushes first, so the readback is deterministic rather than dependent on
+    /// the periodic reader's timer.
+    pub fn counter(&self, name: &str) -> u64 {
+        use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+        let name = name.strip_suffix("_total").unwrap_or(name);
+        let _flushed = self.provider.force_flush();
+        let Ok(collected) = self.exporter.get_finished_metrics() else {
+            return 0;
+        };
+        let mut latest = 0;
+        for resource in &collected {
+            for scope in resource.scope_metrics() {
+                for metric in scope.metrics() {
+                    if metric.name() == name
+                        && let AggregatedMetrics::U64(MetricData::Sum(sum)) = metric.data()
+                    {
+                        // Within one batch, summing across data points is right:
+                        // they are distinct label sets, not repeated readings.
+                        latest = sum
+                            .data_points()
+                            .map(opentelemetry_sdk::metrics::data::SumDataPoint::value)
+                            .sum::<u64>();
+                    }
+                }
+            }
+        }
+        latest
+    }
+
+    /// The most recent value of the `u64` gauge named `name`, or `None` if it has
+    /// never been recorded.
+    ///
+    /// `None` and `Some(0)` are genuinely different here:
+    /// `cluster_redis_connection_state` records `0` on the way out of `stop()`, so
+    /// "never sampled" and "sampled as disconnected" are not the same fact.
+    pub fn gauge(&self, name: &str) -> Option<u64> {
+        use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+        let _flushed = self.provider.force_flush();
+        let collected = self.exporter.get_finished_metrics().ok()?;
+        let mut latest = None;
+        for resource in &collected {
+            for scope in resource.scope_metrics() {
+                for metric in scope.metrics() {
+                    if metric.name() == name
+                        && let AggregatedMetrics::U64(MetricData::Gauge(gauge)) = metric.data()
+                        && let Some(point) = gauge.data_points().last()
+                    {
+                        latest = Some(point.value());
+                    }
+                }
+            }
+        }
+        latest
+    }
+
+    /// Every instrument name the exporter has seen, for the "nothing is emitted
+    /// under an uncontracted name" half of ADR-004's naming rule.
+    pub fn instrument_names(&self) -> std::collections::BTreeSet<String> {
+        let _flushed = self.provider.force_flush();
+        let mut names = std::collections::BTreeSet::new();
+        if let Ok(collected) = self.exporter.get_finished_metrics() {
+            for resource in &collected {
+                for scope in resource.scope_metrics() {
+                    for metric in scope.metrics() {
+                        names.insert(metric.name().to_owned());
+                    }
+                }
+            }
+        }
+        names
+    }
+}
+
+/// A `tracing` writer that appends to a shared buffer, so a test can grep what
+/// was logged.
+#[derive(Clone)]
+pub struct SharedWriter(pub Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for SharedWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0
+            .lock()
+            .expect("the log capture mutex is never poisoned in tests")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SharedWriter {
+    type Writer = Self;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// Installs a **process-global** capture at `level` once per test binary and
+/// returns its buffer.
+///
+/// Global rather than thread-local, deliberately and for a reason
+/// `tracing-test` cannot serve: several of the events these suites assert on are
+/// emitted from **spawned tasks** — `cluster.provider.eviction_observed` and
+/// `cluster.watch.reset` come off the subscriber fan-out, `pool_close_timeout`
+/// off a shutdown path — and a thread-local subscriber never sees those. The
+/// Postgres plugin's `install_global_warn_capture` is the precedent.
+///
+/// The cost is that the buffer is shared by every test in the binary, so it can
+/// only support "this event appeared" assertions, never "this event did not".
+/// Use [`scoped_capture`] for the absence half, and give it its own container.
+pub fn install_global_capture(level: tracing::Level) -> Arc<Mutex<Vec<u8>>> {
+    use std::sync::OnceLock;
+    static BUF: OnceLock<Arc<Mutex<Vec<u8>>>> = OnceLock::new();
+    Arc::clone(BUF.get_or_init(|| {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(SharedWriter(Arc::clone(&buf)))
+            .with_max_level(level)
+            // No ANSI: this buffer is searched with `count_occurrences`, not
+            // read by a terminal, and the styling wraps *field names* in escape
+            // codes. `primitive="lock"` then stops being a contiguous substring
+            // while still looking like one in any failure message that prints
+            // the buffer, which is a false negative that reads as a real one.
+            .with_ansi(false)
+            .finish();
+        // Ignore an already-installed global: nothing else in these binaries
+        // sets one, and losing the race would only mean a second caller reuses
+        // the first's buffer, which is what `OnceLock` already arranges.
+        let _installed = tracing::subscriber::set_global_default(subscriber);
+        buf
+    }))
+}
+
+/// Installs a **thread-local** capture at `level` for the current test, returning
+/// its uninstall guard and buffer.
+///
+/// `set_default`, not `set_global_default`, so this test's capture is isolated
+/// from every other test's plugin — which is what makes asserting the *absence*
+/// of an event possible at all (`RD-SPEC-003`'s "no `weak_consistency` WARN",
+/// `RD-SPEC-005b`'s "no `expiry_events_unavailable`"). `#[tokio::test]` runs a
+/// current-thread runtime, so anything emitted inline by `build_and_start` lands
+/// on this thread and is captured; anything emitted from a spawned task will not
+/// be, which is the trade [`install_global_capture`] exists for.
+///
+/// # Why this installs a process-global sink first
+///
+/// A thread-local subscriber alone is **not** sufficient, and the way it fails is
+/// silent: `tracing` caches each callsite's interest *process-wide* the first time
+/// it is evaluated. In a test binary running several tests in parallel, another
+/// test's plugin can reach a `warn!` callsite first, on a thread with no
+/// subscriber installed — the callsite is then cached as `Interest::never` and
+/// every later evaluation short-circuits **before** consulting the thread-local
+/// dispatcher. The capture comes back empty and the test fails claiming the event
+/// was not emitted, when it was.
+///
+/// This is not hypothetical: it is what `rd_life_startup_events` did on its first
+/// run, passing in isolation and failing in the full binary, at every level.
+/// Installing a global sink first (idempotent, and its buffer is discarded) forces
+/// the callsite to be enabled process-wide — `set_global_default` rebuilds the
+/// interest cache — after which the thread-local default receives events normally
+/// on the thread that installed it.
+pub fn scoped_capture(
+    level: tracing::Level,
+) -> (tracing::subscriber::DefaultGuard, Arc<Mutex<Vec<u8>>>) {
+    // Discarded: this exists only so the callsites are interesting. TRACE rather
+    // than `level`, because the global is installed once per binary and a later
+    // caller asking for a more verbose level would otherwise inherit the first
+    // caller's ceiling.
+    let _global = install_global_capture(tracing::Level::TRACE);
+    let buf = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(SharedWriter(Arc::clone(&buf)))
+        .with_max_level(level)
+        // See `install_global_capture`: styled field names are not searchable.
+        .with_ansi(false)
+        .finish();
+    let guard = tracing::subscriber::set_default(subscriber);
+    (guard, buf)
+}
+
+/// How many times `needle` appears in a capture buffer.
+///
+/// Every §9 log event carries its catalogued name **twice** — as the structural
+/// `name:` field and opening the human message — so passing an event constant
+/// from `redis_cluster_plugin::logs` matches the message half, which is what the
+/// default `fmt` layer prints. That is why these assertions can be a substring
+/// count rather than needing a layer that reads `event.metadata().name()`.
+pub fn count_occurrences(buf: &Arc<Mutex<Vec<u8>>>, needle: &str) -> usize {
+    let bytes = buf
+        .lock()
+        .expect("the log capture mutex is never poisoned in tests");
+    String::from_utf8_lossy(&bytes).matches(needle).count()
+}
+
+/// The whole capture buffer as a string, for assertion messages that should show
+/// what *was* logged when the expected line is missing.
+pub fn captured(buf: &Arc<Mutex<Vec<u8>>>) -> String {
+    let bytes = buf
+        .lock()
+        .expect("the log capture mutex is never poisoned in tests");
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+// ---------------------------------------------------------------------------
+// Multi-node topologies (TESTING.md §4.1)
+// ---------------------------------------------------------------------------
+
+/// How many consecutive free ports [`free_port_base`] looks for, and the offset
+/// at which the Cluster bus ports live.
+///
+/// Redis defaults a node's bus port to `port + 10000`, and the fixtures keep
+/// that convention rather than setting `cluster-port`, so a reader comparing the
+/// fixture against `CLUSTER NODES` output sees the arithmetic they expect.
+const CLUSTER_BUS_OFFSET: u16 = 10_000;
+
+/// Finds `count` consecutive free TCP ports on the loopback interface, returning
+/// the base.
+///
+/// ## Why the fixtures need this at all
+///
+/// Both multi-node topologies **advertise an address to the client**: Sentinel
+/// answers `get-master-addr-by-name` with the primary's address, and a Cluster
+/// node answers a wrong-slot command with `MOVED <slot> <addr>`. The client then
+/// has to connect to that address. With testcontainers' usual random port
+/// mapping the address a node knows about (its container port) is not the address
+/// the host can reach (the mapped port), so every redirect points somewhere the
+/// test process cannot go.
+///
+/// Mapping each port **1:1** removes the distinction: `127.0.0.1:7000` means the
+/// same endpoint inside the container and outside it, so an advertised address is
+/// correct for both audiences at once. That is why these fixtures pick their own
+/// ports rather than letting Docker choose.
+///
+/// The ports are probed by binding and immediately dropping the listener, so
+/// there is a window between the probe and the container claiming them. It is
+/// small and the alternative — hard-coded ports — collides with whatever else the
+/// developer is running, which is a worse failure because it is not random. A
+/// lost race is no longer fatal either: [`start_multinode`] re-probes a fresh base
+/// and retries, so a parallel process grabbing a port inside the window costs an
+/// attempt rather than the whole fixture.
+fn free_port_base(count: u16) -> u16 {
+    use std::net::TcpListener;
+    // A fixed window rather than an OS-assigned ephemeral port. The ephemeral
+    // range starts around 49152, and every port here needs its bus port
+    // `CLUSTER_BUS_OFFSET` above it, so an ephemeral base overflows `u16` far
+    // more often than not.
+    const WINDOW: std::ops::Range<u16> = 7_000..40_000;
+    // Staggered by process id so two test binaries running side by side start
+    // their search in different places rather than racing for the same base.
+    let stride = count + 1;
+    let span = WINDOW.end - WINDOW.start;
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "deliberately reduced mod the window's span, which is a u16"
+    )]
+    let stagger = ((u64::from(std::process::id()) * u64::from(stride)) % u64::from(span)) as u16;
+    #[expect(
+        clippy::integer_division,
+        reason = "a count of whole strides that fit in the window is exactly what is wanted"
+    )]
+    let attempts = span / stride;
+    'candidate: for step in 0..attempts {
+        // Widened before the sum, not after: `stagger` reaches `span - 1` and
+        // `step * stride` reaches nearly the same, so the addition overflows
+        // `u16` and panics in a debug build. It takes several rejected
+        // candidates to get there, which is what would make it surface as an
+        // intermittent fixture failure under parallel load rather than a
+        // reproducible one.
+        let offset = (u32::from(stagger) + u32::from(step) * u32::from(stride))
+            % u32::from(span - CLUSTER_BUS_OFFSET);
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "reduced mod a span that is itself a u16"
+        )]
+        let base = WINDOW.start + offset as u16;
+        if base + CLUSTER_BUS_OFFSET + count >= WINDOW.end {
+            continue;
+        }
+        let mut held = Vec::new();
+        for offset in 0..count {
+            for port in [base + offset, base + CLUSTER_BUS_OFFSET + offset] {
+                match TcpListener::bind(("127.0.0.1", port)) {
+                    Ok(listener) => held.push(listener),
+                    Err(_) => continue 'candidate,
+                }
+            }
+        }
+        // Released here, so the container can claim them. The window between
+        // this and the container binding is the fixture's one race, and it is
+        // narrower than the hard-coded alternative's certainty of collision.
+        drop(held);
+        return base;
+    }
+    panic!("no run of {count} consecutive free ports was found in {WINDOW:?}");
+}
+
+/// Waits for a container's topology to finish forming, by running `probe` inside
+/// it until it answers `expected`.
+///
+/// Run **inside** the container with `docker exec` rather than over a client from
+/// the host, deliberately: this is asking whether the topology is ready, and a
+/// host-side client failing to connect cannot distinguish "not ready yet" from
+/// "the port mapping is wrong", which is the one failure mode worth telling
+/// apart when a fixture like this misbehaves.
+async fn await_topology<I: testcontainers::Image>(
+    container: &ContainerAsync<I>,
+    probe: &[String],
+    expected: &str,
+    what: &str,
+) {
+    let ready = wait_until(
+        Duration::from_mins(1),
+        Duration::from_millis(250),
+        async || {
+            let Ok(mut output) = container
+                .exec(testcontainers::core::ExecCommand::new(
+                    probe.iter().cloned(),
+                ))
+                .await
+            else {
+                return false;
+            };
+            let Ok(stdout) = output.stdout_to_vec().await else {
+                return false;
+            };
+            String::from_utf8_lossy(&stdout).contains(expected)
+        },
+    )
+    .await;
+    assert!(ready, "the {what} fixture never reported `{expected}`");
+}
+
+/// A **Sentinel-managed** topology: one primary, one replica, one Sentinel, all
+/// in a single container (TESTING.md §4.1).
+///
+/// Returns the container, a `redis-sentinel://` [`RedisClusterConfig`], and the
+/// primary and replica ports, so a scenario can reach past the client to the
+/// servers themselves — to read the primary's config back (`RD-SPEC-002`) or to
+/// take the replica away under a running plugin (`RD-LOCK-014`).
+///
+/// ## Why one container and not three
+///
+/// Three containers on a Docker network is the shape this topology has in
+/// production, and it is the wrong shape for a test on this side of the network
+/// boundary: Sentinel would answer `get-master-addr-by-name` with the primary's
+/// *network* address, which the test process cannot reach. Putting all three
+/// processes in one container with 1:1 port mapping (see [`free_port_base`])
+/// makes `127.0.0.1:<port>` mean the same thing to Sentinel, to the replica, and
+/// to the test — so the address Sentinel advertises is one the client can use.
+///
+/// What this costs is the thing a Sentinel topology is otherwise *for*: the
+/// processes share a failure domain, so killing the container kills the quorum
+/// along with the primary and no failover can be observed. That is the boundary
+/// between this fixture and the `RD-FAULT-005..007` failover scenarios, which
+/// stay deferred (§8) — they need fault injection between separately-killable
+/// nodes, and this fixture deliberately does not pretend to provide it.
+///
+/// `appendfsync always` on the primary is not incidental. It is what makes
+/// `RD-SPEC-002` a real test: the durability reading says "safe" and the topology
+/// reading says "replicated", and the declaration has to come out
+/// `EventuallyConsistent` on the strength of the second alone.
+pub async fn start_redis_sentinel() -> (ContainerAsync<Redis>, RedisClusterConfig, u16, u16) {
+    let (container, base) = start_multinode(2, |base| {
+        let (primary, replica) = (base, base + 1);
+        let sentinel = base + CLUSTER_BUS_OFFSET;
+        // `&` rather than `--daemonize yes`: a daemonized server detaches and
+        // stops writing to the container's stdout, which is where a failed
+        // fixture's diagnosis has to come from.
+        //
+        // The `until … PONG` wait replaces a bare `sleep 1`: Sentinel's
+        // `monitor` needs the primary reachable, and a fixed second is a guess
+        // that a cold image or a loaded host can exceed, which then surfaces as
+        // `await_topology` burning its whole budget rather than as this readiness
+        // step waiting a few hundred ms more. Sentinel retries `monitor` on its
+        // own, so this only tightens an already-recoverable path — but it removes
+        // the guess.
+        let script = format!(
+            "redis-server --port {primary} --appendonly yes --appendfsync always --save '' \
+               --notify-keyspace-events {KEYSPACE_FLAGS} & \
+             redis-server --port {replica} --replicaof 127.0.0.1 {primary} --save '' \
+               --appendonly no & \
+             until redis-cli -p {primary} ping 2>/dev/null | grep -q PONG; do sleep 0.1; done && \
+             printf 'port {sentinel}\\n\
+sentinel monitor {SENTINEL_SERVICE} 127.0.0.1 {primary} 1\\n\
+sentinel down-after-milliseconds {SENTINEL_SERVICE} 2000\\n\
+sentinel failover-timeout {SENTINEL_SERVICE} 5000\\n' > /data/sentinel.conf && \
+             redis-sentinel /data/sentinel.conf"
+        );
+        (script, vec![primary, replica, sentinel])
+    })
+    .await;
+    let (primary, replica) = (base, base + 1);
+    let sentinel = base + CLUSTER_BUS_OFFSET;
+    // The replica being *online* is the precondition every scenario here rests
+    // on: `RD-SPEC-002` needs the primary to report a replica for the topology to
+    // read as replicated, and `RD-LOCK-014` needs one for `WAIT` to be satisfiable
+    // before it is made unsatisfiable.
+    await_topology(
+        &container,
+        &[
+            "redis-cli".to_owned(),
+            "-p".to_owned(),
+            primary.to_string(),
+            "info".to_owned(),
+            "replication".to_owned(),
+        ],
+        "state=online",
+        "sentinel",
+    )
+    .await;
+    await_topology(
+        &container,
+        &[
+            "redis-cli".to_owned(),
+            "-p".to_owned(),
+            sentinel.to_string(),
+            "sentinel".to_owned(),
+            "get-master-addr-by-name".to_owned(),
+            SENTINEL_SERVICE.to_owned(),
+        ],
+        &primary.to_string(),
+        "sentinel",
+    )
+    .await;
+    let url =
+        format!("redis-sentinel://127.0.0.1:{sentinel}?sentinelServiceName={SENTINEL_SERVICE}");
+    let config = cluster_config_json(&url, json!({}));
+    (container, config, primary, replica)
+}
+
+/// The Sentinel service name the fixture monitors under, and that the URL's
+/// `service_name` names.
+pub const SENTINEL_SERVICE: &str = "mymaster";
+
+/// How many primaries the Cluster fixture runs. Three is the minimum a Redis
+/// Cluster accepts, and enough for the property under test: that a prefix's keys
+/// land on more than one shard.
+pub const CLUSTER_NODES: u16 = 3;
+
+/// A **3-primary Redis Cluster**, all nodes in a single container
+/// (TESTING.md §4.1).
+///
+/// Returns the container, a `redis-cluster://` [`RedisClusterConfig`], and the
+/// three node ports.
+///
+/// ## Why one container, again
+///
+/// The same reason as [`start_redis_sentinel`] and more sharply: a cluster node
+/// answers a wrong-slot command with `MOVED <slot> <ip:port>`, and the client is
+/// required to follow it. Each node therefore advertises an address through
+/// `cluster-announce-ip`/`cluster-announce-port`, and that one address has to
+/// work for two audiences — the other nodes' gossip and the host's client.
+/// Co-locating the nodes and mapping ports 1:1 is what lets `127.0.0.1:<port>`
+/// satisfy both. Separate containers cannot: an address that reaches a peer
+/// across the Docker network is not one the test process can dial.
+///
+/// No replicas. Every scenario on this fixture (`RD-SPEC-008`, `009`, `010`) is
+/// about **slot routing** rather than about failover, and replicas would add
+/// startup time to a per-PR fixture for a property nothing here asserts — the
+/// failover scenarios are deferred to fault injection either way (§8).
+pub async fn start_redis_cluster() -> (ContainerAsync<Redis>, RedisClusterConfig, Vec<u16>) {
+    let (container, base) = start_multinode(CLUSTER_NODES, |base| {
+        let ports: Vec<u16> = (0..CLUSTER_NODES).map(|offset| base + offset).collect();
+        let servers = ports
+            .iter()
+            .map(|port| {
+                format!(
+                    "redis-server --port {port} --cluster-enabled yes \
+                     --cluster-config-file node-{port}.conf --cluster-node-timeout 5000 \
+                     --cluster-announce-ip 127.0.0.1 --cluster-announce-port {port} \
+                     --cluster-announce-bus-port {bus} --save '' --appendonly no \
+                     --notify-keyspace-events {KEYSPACE_FLAGS} &",
+                    bus = port + CLUSTER_BUS_OFFSET
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+        let members = ports
+            .iter()
+            .map(|port| format!("127.0.0.1:{port}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        // Wait for every node to answer `PING` before the one-shot
+        // `cluster create`, then retry the create itself a bounded number of
+        // times. The old `sleep 1` was a guess that a cold image or a loaded host
+        // can exceed, and the create ran exactly once: a create issued a beat too
+        // early errored with no retry, the cluster never formed, and the failure
+        // showed up a minute later as `await_topology` timing out on a `MOVED`-less
+        // cluster rather than here where it happened. Readiness is awaited rather
+        // than slept, and a create that loses the first race gets a few more.
+        let waits = ports
+            .iter()
+            .map(|port| {
+                format!(
+                    "until redis-cli -p {port} ping 2>/dev/null | grep -q PONG; do sleep 0.1; done"
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(" && ");
+        // `--cluster-yes` answers the interactive slot-allocation prompt. The
+        // `wait` at the end keeps the container alive on the backgrounded servers.
+        let script = format!(
+            "{servers} {waits} && \
+             tries=0; \
+             until redis-cli --cluster create {members} --cluster-yes; do \
+               tries=$((tries+1)); [ \"$tries\" -ge 10 ] && break; sleep 0.5; \
+             done && wait"
+        );
+        let mut mapped = Vec::with_capacity(usize::from(CLUSTER_NODES) * 2);
+        for port in &ports {
+            mapped.push(*port);
+            mapped.push(port + CLUSTER_BUS_OFFSET);
+        }
+        (script, mapped)
+    })
+    .await;
+    let ports: Vec<u16> = (0..CLUSTER_NODES).map(|offset| base + offset).collect();
+    // `cluster_state:ok` rather than merely "the process is up": until every one
+    // of the 16384 slots is served, a command for an unassigned slot answers
+    // `CLUSTERDOWN`, and a scenario starting into that would fail for a reason
+    // that has nothing to do with what it tests.
+    //
+    // Asked of **every** node rather than of the one the URL names. A client
+    // builds its slot map from whichever node answers first, so a node that has
+    // not yet finished gossiping reports a partial cluster and `fred` rejects the
+    // topology outright ("Invalid or missing cluster state"). Waiting on one node
+    // makes that a race the fixture loses intermittently.
+    for port in &ports {
+        for marker in [
+            "cluster_state:ok".to_owned(),
+            format!("cluster_known_nodes:{CLUSTER_NODES}"),
+        ] {
+            await_topology(
+                &container,
+                &[
+                    "redis-cli".to_owned(),
+                    "-p".to_owned(),
+                    port.to_string(),
+                    "cluster".to_owned(),
+                    "info".to_owned(),
+                ],
+                &marker,
+                "cluster",
+            )
+            .await;
+        }
+    }
+    // Every node in the URL, not only the first: `fred` seeds its slot map from
+    // whichever of them answers, so naming all three means a single slow node
+    // cannot stall startup.
+    let nodes = ports
+        .iter()
+        .skip(1)
+        .map(|port| format!("node=127.0.0.1:{port}"))
+        .collect::<Vec<_>>()
+        .join("&");
+    let url = format!("redis-cluster://127.0.0.1:{}?{nodes}", ports[0]);
+    let config = cluster_config_json(&url, json!({}));
+    (container, config, ports)
+}
+
+/// Runs `args` inside `container` and returns its stdout.
+///
+/// The escape hatch the multi-node fixtures need: their nodes are processes
+/// inside one container rather than addressable containers, so "ask this
+/// specific node something" and "stop this specific node" are both `docker exec`
+/// rather than anything the client can express. Used to read per-shard key counts
+/// (`RD-SPEC-008`, `RD-SPEC-009`) and to take the replica away under a running
+/// plugin (`RD-LOCK-014`).
+pub async fn exec_in<I: testcontainers::Image>(
+    container: &ContainerAsync<I>,
+    args: &[&str],
+) -> String {
+    let mut output = container
+        .exec(testcontainers::core::ExecCommand::new(
+            args.iter().map(|arg| (*arg).to_owned()),
+        ))
+        .await
+        .expect("the exec is accepted by the container");
+    let stdout = output
+        .stdout_to_vec()
+        .await
+        .expect("the exec's stdout is readable");
+    String::from_utf8_lossy(&stdout).trim().to_owned()
+}
+
+/// How many keys each node of the Cluster fixture currently holds.
+///
+/// The evidence that a "spread across shards" scenario really spread: a test
+/// that planted a thousand keys which all happened to land on one shard would
+/// pass a per-shard scan assertion while proving nothing about the other two.
+pub async fn keys_per_node<I: testcontainers::Image>(
+    container: &ContainerAsync<I>,
+    ports: &[u16],
+) -> Vec<u64> {
+    let mut counts = Vec::new();
+    for port in ports {
+        let raw = exec_in(container, &["redis-cli", "-p", &port.to_string(), "dbsize"]).await;
+        counts.push(raw.trim().parse().unwrap_or(0));
+    }
+    counts
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/tests/conformance.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/tests/conformance.rs
@@ -1,0 +1,235 @@
+//! Layer 2 — the conformance suite (docs/TESTING.md §3), wired against real
+//! Redis containers.
+//!
+//! Passing these is the primary signal that this plugin implements the
+//! `ClusterCacheBackend` and `DistributedLockBackend` contracts: the scenario
+//! bodies are the shared, backend-agnostic ones every cluster backend runs, so a
+//! divergence here is a divergence from the contract rather than from this
+//! plugin's own expectations.
+//!
+//! # Four suites, and four is the complete set
+//!
+//! `cluster-conformance` exports six `run_*_conformance` entry points and only
+//! four of them take a backend factory. `run_restart_conformance` and
+//! `run_watch_lifecycle_conformance` exercise SDK-level combinator logic against
+//! channels — there is no backend to hand them — so the four below are everything
+//! a plugin can wire, not a subset someone stopped at.
+//!
+//! # `TimeControl::Real`, never `Virtual`
+//!
+//! Every suite passes [`TimeControl::Real`]. A paused or auto-advancing clock is
+//! not merely unnecessary against a real backend, it is actively wrong: `fred`
+//! runs its own per-command timeouts and its reconnect backoff on this same
+//! runtime, and `tokio`'s paused clock auto-advances to the next pending timer
+//! deadline whenever the runtime has nothing to poll — which, while a real socket
+//! read is parked, is constantly. Those timers would fire spuriously and every
+//! command would report `Provider { Timeout }` against a perfectly healthy
+//! server. The Postgres plugin hit the same thing through `sqlx`'s acquire
+//! timeout, which is what put `TimeControl` in the shared crate in the first
+//! place.
+//!
+//! The cost is that the runners skip the two virtual-time fault simulations
+//! (`SC-LEAD-006`, `SC-DISC-006`) themselves. Both force a *missed* renewal to
+//! assert re-enrolment, which a healthy real backend never exhibits by waiting;
+//! they map to fault injection, which this plugin has no harness for
+//! (TESTING.md §8).
+//!
+//! # Which fixture each suite runs on, and why they differ
+//!
+//! | Suite | Fixture | Why |
+//! |---|---|---|
+//! | cache | `start_redis` | Stock Redis is the deployment this plugin is for; its `EventuallyConsistent` declaration is honest and no cache scenario depends on linearizability |
+//! | lock | `start_redis_lock_only` | The standalone `RedisLockPlugin` — the same path `ClusterLockProvider::build_lock` takes in production (DESIGN.md §3.5) |
+//! | leader | **`start_redis_durable`** | `CasBasedLeaderElectionBackend::new` is the strict constructor and *refuses* an `EventuallyConsistent` cache, so on the default fixture this suite would fail to construct rather than fail a scenario |
+//!
+//! The leader row is the one wrinkle no other backend has, and it is deliberately
+//! *not* worked around with the `allow_weak_consistency` opt-in. That flag
+//! makes weak-cache leader election **expressible by an operator who opts in**,
+//! not correct — and this suite asserts correctness properties like
+//! single-leader-among-contenders. Pointing it at a weak cache via the flag would
+//! produce a suite asserting guarantees the backend does not claim: a test that
+//! fails for the right reason at the wrong layer. The flag's own path is
+//! `RD-SPEC-004b`, and the negative half — that the strict constructor really does
+//! refuse the ordinary container's cache — is `RD-SPEC-004`, which is the more
+//! important of the two.
+//!
+//! # One container per suite, one backend per scenario
+//!
+//! Each suite starts a single container and builds a **fresh plugin instance per
+//! scenario** over it, isolated into its own logical database *and* its own
+//! `key_prefix` (`common::cluster_config_for_scenario`). A shared backend across
+//! scenarios is not viable: the scenarios reuse key and lock names, and this
+//! plugin's `stop()` deliberately *leaves* held leases to expire rather than
+//! handing them back (`cpt-cf-clst-fr-shutdown-ttl-cleanup`), so a lease held past
+//! one scenario's teardown would still be held when the next asked for the same
+//! name.
+//!
+//! # Each suite is `Box::pin`ned
+//!
+//! A `run_*_conformance` future holds every scenario body in the suite, so it is
+//! ~20 KB and trips clippy's `large_futures` (denied workspace-wide via
+//! `pedantic`). Boxing is the right answer rather than an `allow`: these run once
+//! per suite, so one heap allocation is free, and a 20 KB future living on the
+//! stack of a test thread is worth avoiding on its own merits.
+//!
+//! Every `ScenarioBackend` is built with
+//! [`ScenarioBackend::with_teardown`](cluster_conformance::ScenarioBackend::with_teardown)
+//! and its teardown owns the handle and `stop()`s it. That is mandatory rather
+//! than tidy: `RedisClusterHandle` and `RedisLockHandle` both **panic on drop**
+//! without `stop()` in a debug build (ADR-006), which is what a test build is — so
+//! a factory that dropped a handle would abort the process instead of failing a
+//! test. `run_scenario` awaits the teardown even when a scenario assertion panics,
+//! so this holds on the failure path too.
+
+#![cfg(feature = "integration")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration tests: a setup failure IS the test failure"
+)]
+
+mod common;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use cluster_conformance::{ScenarioBackend, TimeControl};
+use redis_cluster_plugin::{RedisClusterPlugin, RedisLockPlugin};
+
+/// Every `SC-CACHE-*` scenario against a fresh Redis-backed cache per scenario.
+///
+/// The cache is taken through `handle.cache()`, so what the suite exercises is
+/// the same `InstrumentedCache`-wrapped backend the wiring hands a consumer — not
+/// the bare `RedisCache` underneath. That is deliberate: the decorator sits on
+/// every call in production, and a contract violation it introduced (a swallowed
+/// error, a mangled `CacheWatch`) would otherwise be invisible to the suite that
+/// exists to catch contract violations.
+#[tokio::test]
+async fn cache_conformance() {
+    use cluster_conformance::run_cache_conformance;
+
+    let (_container, base_config) = common::start_redis().await;
+    let url = base_config.url;
+    let scenario_index = AtomicUsize::new(0);
+
+    Box::pin(run_cache_conformance(
+        || {
+            let url = url.clone();
+            let index = scenario_index.fetch_add(1, Ordering::Relaxed);
+            async move {
+                let config = common::cluster_config_for_scenario(
+                    &url,
+                    "confcache",
+                    index,
+                    serde_json::json!({}),
+                );
+                let handle = RedisClusterPlugin::builder(config)
+                    .build_and_start()
+                    .await
+                    .expect("a fresh per-scenario instance starts against the test container");
+                let cache = handle.cache();
+                ScenarioBackend::with_teardown(cache, async move { handle.stop().await })
+            }
+        },
+        TimeControl::Real,
+    ))
+    .await;
+}
+
+/// Every `SC-LOCK-*` scenario against the **standalone** `RedisLockPlugin`.
+///
+/// The standalone shape rather than the combined plugin's `handle.lock()`, and
+/// this is the shape the runner's signature already implies: it hands the factory
+/// no cache (`F: Fn() -> Fut`), which matches this plugin exactly. The native lock
+/// builds its own pool and never rides a cache, so there is no shared-pool
+/// shortcut being skipped here — `RedisLockProvider::build_lock` takes this same
+/// path in production (DESIGN.md §3.5).
+///
+/// The combined plugin's lock is the *same* `RedisLock` over a shared pool, and
+/// `RD-LOCK-008` is what covers that half end to end through real wiring.
+#[tokio::test]
+async fn lock_conformance() {
+    use cluster_conformance::run_lock_conformance;
+
+    let (_container, base_config) = common::start_redis_lock_only().await;
+    let url = base_config.url;
+    let scenario_index = AtomicUsize::new(0);
+
+    Box::pin(run_lock_conformance(
+        || {
+            let url = url.clone();
+            let index = scenario_index.fetch_add(1, Ordering::Relaxed);
+            async move {
+                let config = common::lock_config_for_scenario(
+                    &url,
+                    "conflock",
+                    index,
+                    serde_json::json!({}),
+                );
+                let handle = RedisLockPlugin::builder(config)
+                    .build_and_start()
+                    .await
+                    .expect("a fresh per-scenario standalone lock instance starts");
+                let lock = handle.lock();
+                ScenarioBackend::with_teardown(lock, async move { handle.stop().await })
+            }
+        },
+        TimeControl::Real,
+    ))
+    .await;
+}
+
+/// The `SC-LEAD-*` scenarios against `CasBasedLeaderElectionBackend` over this
+/// plugin's cache — the SDK default, which is the only way leader election is ever
+/// served on Redis (DESIGN.md §7: there is no native implementation and no
+/// `ClusterLeaderElectionProvider` registered for `redis`).
+///
+/// **On `start_redis_durable`, not the default fixture.** `::new` is the strict
+/// constructor: it rejects any cache declaring `EventuallyConsistent`, so this
+/// factory would return `Err` on every scenario against stock Redis. The durable
+/// single node (`appendonly yes`, `appendfsync always`, no replicas) is the one
+/// configuration ADR-009 rates safe, so its cache declares `Linearizable` and the
+/// constructor accepts it — which also means the `expect` below is a real
+/// assertion, not a formality: it is what would catch the consistency declaration
+/// silently weakening on this fixture.
+///
+/// `run_leader_conformance` skips `SC-LEAD-006` itself under `Real` — see this
+/// module's header on why a forced renewal *miss* is fault injection rather than a
+/// long sleep.
+#[tokio::test]
+async fn leader_conformance() {
+    use cluster::defaults::CasBasedLeaderElectionBackend;
+    use cluster_conformance::run_leader_conformance;
+    use cluster_sdk::LeaderElectionBackend;
+
+    let (_container, base_config) = common::start_redis_durable().await;
+    let url = base_config.url;
+    let scenario_index = AtomicUsize::new(0);
+
+    Box::pin(run_leader_conformance(
+        || {
+            let url = url.clone();
+            let index = scenario_index.fetch_add(1, Ordering::Relaxed);
+            async move {
+                let config = common::cluster_config_for_scenario(
+                    &url,
+                    "confleader",
+                    index,
+                    serde_json::json!({}),
+                );
+                let handle = RedisClusterPlugin::builder(config)
+                    .build_and_start()
+                    .await
+                    .expect("a fresh per-scenario instance starts against the durable container");
+                let leader = Arc::new(CasBasedLeaderElectionBackend::new(handle.cache()).expect(
+                    "the durable single-node fixture's cache must declare Linearizable, or the \
+                         strict leader constructor refuses it and this suite cannot run at all \
+                         (TESTING.md sec 3, RD-SPEC-003)",
+                )) as Arc<dyn LeaderElectionBackend>;
+                ScenarioBackend::with_teardown(leader, async move { handle.stop().await })
+            }
+        },
+        TimeControl::Real,
+    ))
+    .await;
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/tests/lifecycle_integration.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/tests/lifecycle_integration.rs
@@ -1,0 +1,620 @@
+//! Layer 3 — lifecycle integration scenarios (docs/TESTING.md §4.5),
+//! `RD-LIFE-001` through `RD-LIFE-010`.
+//!
+//! Startup, shutdown, and the two failure modes an operator most needs told
+//! apart: a config fault and a backend fault. Reading `InvalidConfig` should send
+//! someone to their YAML and `Provider { ConnectionLost }` should send them to
+//! their server, so `RD-LIFE-004` and `RD-LIFE-005` are as much about which error
+//! is returned as about failing at all.
+//!
+//! The `stop()` scenarios carry most of the weight here. Redis makes shutdown
+//! unusually cheap — there is no schema, no migration, and a lease reaps itself
+//! (`RD-LOCK-013`) — so what is left to get wrong is boundedness, and
+//! `RD-LIFE-009` drives it against a server that has stopped answering.
+//!
+//! Teardown is not only `stop()`'s job, which is what `RD-LIFE-010` covers: a
+//! startup that fails after the connect has to tear down what the earlier steps
+//! started, and the subscriber is the handle that does not close itself.
+
+#![cfg(feature = "integration")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration tests: a setup failure IS the test failure"
+)]
+
+mod common;
+
+use std::time::{Duration, Instant};
+
+use cluster_sdk::cache::{PutRequest, Ttl};
+use cluster_sdk::{ClusterError, ProviderErrorKind};
+use fred::interfaces::{ClientLike, LuaInterface, PubsubInterface, ServerInterface};
+use redis_cluster_plugin::{ALL_SCRIPTS, RedisClusterPlugin, RedisLockPlugin, logs};
+use serde_json::json;
+
+/// Downcasts a `catch_unwind` payload to its message.
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    payload
+        .downcast_ref::<&str>()
+        .map(|s| (*s).to_owned())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+        .unwrap_or_default()
+}
+
+/// `RD-LIFE-001` — `build_and_start` connects, preflights, loads the script
+/// catalog, and has the subscriber **live** before it returns.
+///
+/// The subscriber half is the load-bearing one (DESIGN.md §3.2 step 4). Redis
+/// pub/sub does not queue or replay for a client that subscribes late, so a
+/// release or a write landing between `build_and_start` returning and the
+/// subscription being established is simply lost. Two things are needed for that
+/// and only one is obvious: `tokio::spawn` merely schedules, and *awaiting*
+/// `psubscribe` is not the server having processed it — `fred` resolves it when
+/// the command reaches the connection (DESIGN.md §3.2 step 4). The
+/// patterns being visible in `PUBSUB NUMPAT` **from another connection** is the
+/// only assertion that distinguishes "we sent a subscribe" from "the server has
+/// one".
+#[tokio::test]
+async fn rd_life_001_start_connects_preflights_loads_scripts_and_subscribes() {
+    let (_container, config) = common::start_redis().await;
+    let url = config.url.clone();
+    let database = config.database;
+
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("build_and_start must succeed against a fresh container");
+
+    let raw = common::raw_client_on(&url, database).await;
+
+    // The whole catalog was loaded, once each, at startup — not lazily on first
+    // use, which is what makes `RD-CACHE-010`'s "no EVAL fallback fired" mean
+    // something.
+    let loads = common::command_calls(&raw, "script|load").await;
+    assert!(
+        loads >= ALL_SCRIPTS.len() as u64,
+        "every one of the {} catalogued scripts must be SCRIPT LOADed at startup, saw {loads} \
+         SCRIPT LOAD calls",
+        ALL_SCRIPTS.len()
+    );
+
+    // The two always-on patterns (keyspace events, lock releases) are live on the
+    // server before this point — asserted from a *different* connection, so it is
+    // the server's view rather than the plugin's belief.
+    let patterns: u64 = raw.pubsub_numpat().await.expect("PUBSUB NUMPAT succeeds");
+    assert!(
+        patterns >= 2,
+        "the keyspace and lock-release patterns must be live on the server before \
+         build_and_start returns, saw {patterns}"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-LIFE-002` — starting twice against the same server is idempotent and
+/// creates nothing.
+///
+/// There is no schema here and no migration to re-run, so "idempotent" is a
+/// stronger claim than it is for the Postgres plugin: the second start must leave
+/// the keyspace **byte for byte** as it found it. `DBSIZE` before and after is the
+/// check, and it would catch a plugin that started writing a registration key, an
+/// instance marker, or a lock-table stand-in — anything that turned a stateless
+/// startup into a stateful one.
+#[tokio::test]
+async fn rd_life_002_starting_twice_creates_nothing() {
+    let (_container, config) = common::start_redis().await;
+    let url = config.url.clone();
+    let key_prefix = config.key_prefix.clone();
+    let database = config.database;
+
+    let first = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the first start succeeds");
+    let raw = common::raw_client_on(&url, database).await;
+    let before: u64 = raw.dbsize().await.expect("DBSIZE succeeds");
+
+    let second_config = common::cluster_config_json(
+        &url,
+        json!({ "key_prefix": key_prefix, "database": database }),
+    );
+    let second = RedisClusterPlugin::builder(second_config)
+        .build_and_start()
+        .await
+        .expect("a second start against the same server also succeeds");
+    let after: u64 = raw.dbsize().await.expect("DBSIZE succeeds");
+
+    assert_eq!(
+        before, after,
+        "starting a second time must create no keys - there is no schema to migrate and no \
+         registration to write (before {before}, after {after})"
+    );
+
+    second.stop().await;
+    first.stop().await;
+}
+
+/// `RD-LIFE-003` — `stop()` closes every connection this plugin opened, the
+/// command pool and the subscriber alike.
+///
+/// Counted through `INFO clients` rather than `CLIENT LIST`: `client_list` sits on
+/// `fred`'s `i-client` interface, which DESIGN.md §3.1 deliberately leaves out of the feature
+/// list, so `connected_clients` is what a build of this plugin can actually read.
+/// It counts the whole server, so the assertion is on the *drop* — the control
+/// connection this test holds is one of them and stays.
+///
+/// A leaked subscriber is the specific failure worth catching: it is a single
+/// connection, so it never exhausts anything, and a gear that restarted its
+/// cluster profile a few hundred times would accumulate them silently.
+#[tokio::test]
+async fn rd_life_003_stop_closes_every_connection() {
+    let (_container, config) = common::start_redis_with(json!({ "pool_size": 4 })).await;
+    let url = config.url.clone();
+    let database = config.database;
+
+    let raw = common::raw_client_on(&url, database).await;
+    let baseline = connected_clients(&raw).await;
+
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the plugin starts");
+    let while_running = connected_clients(&raw).await;
+    assert!(
+        while_running >= baseline + 5,
+        "a running plugin holds its pool of 4 plus a subscriber, so at least 5 more connections \
+         than the baseline (baseline {baseline}, running {while_running})"
+    );
+
+    handle.stop().await;
+
+    let closed = common::wait_until(
+        Duration::from_secs(5),
+        Duration::from_millis(100),
+        async || connected_clients(&raw).await <= baseline,
+    )
+    .await;
+    assert!(
+        closed,
+        "stop() must close the command pool *and* the subscriber; still {} connections against a \
+         baseline of {baseline}",
+        connected_clients(&raw).await
+    );
+}
+
+/// `RD-LIFE-010` — a startup that fails *after* the connect leaks nothing.
+///
+/// The failure half of `RD-LIFE-003`, and the half that is easy to get wrong.
+/// DESIGN.md §3.2 step 6 opens "A failure at any step tears down whatever the
+/// earlier steps started", and between `connect()` and `start_subscriber` there
+/// are two steps — the preflight and the `SCRIPT LOAD` — that had only the pool
+/// to tear down. **Dropping the `SubscriberClient` does not close it**:
+/// `fred` 10.1.0 gates `impl Drop for ClientInner` behind
+/// `credential-provider`, which nothing in this tree enables, so the router task
+/// `init()` spawned keeps the socket open under the reconnect policy. A
+/// supervisor retrying gear boot every 30 s accumulates one connection and one
+/// task per attempt, indefinitely.
+///
+/// A contradicted `durability` hint is the cheapest post-connect failure: the
+/// server reports `everysec`, the operator claims `always`, and the preflight
+/// refuses it (`RD-SPEC-011`'s first half). It fails on the first of the two
+/// paths, which is enough — both call the same helper.
+///
+/// Asserted with `wait_until` rather than an immediate read, because `QUIT` is
+/// asynchronous server-side. The control connection this test holds is the
+/// baseline and stays.
+#[tokio::test]
+async fn rd_life_010_a_failed_startup_leaks_no_subscriber_connection() {
+    let (_container, config) =
+        common::start_redis_everysec_with(json!({ "durability": "fsync_always", "pool_size": 4 }))
+            .await;
+    let url = config.url.clone();
+    let database = config.database;
+
+    let raw = common::raw_client_on(&url, database).await;
+    let baseline = connected_clients(&raw).await;
+
+    match RedisClusterPlugin::builder(config).build_and_start().await {
+        Err(ClusterError::InvalidConfig { .. }) => {}
+        Err(other) => {
+            panic!("expected the contradicted hint to fail as InvalidConfig, got {other:?}")
+        }
+        // Stopped rather than dropped: an un-stopped handle panics on drop
+        // (ADR-006), which would replace this scenario's message with a teardown
+        // one.
+        Ok(started) => {
+            started.stop().await;
+            panic!("a durability hint the server contradicts must fail startup");
+        }
+    }
+
+    let closed = common::wait_until(
+        Duration::from_secs(5),
+        Duration::from_millis(100),
+        async || connected_clients(&raw).await <= baseline,
+    )
+    .await;
+    assert!(
+        closed,
+        "a startup that fails after the connect must close the subscriber as well as the pool. \
+         Dropping the client closes nothing in this build of fred, so the connection and its \
+         router task survive the returned error; still {} connections against a baseline of \
+         {baseline}",
+        connected_clients(&raw).await
+    );
+}
+
+/// `connected_clients` from `INFO clients`.
+async fn connected_clients(client: &fred::clients::Client) -> u64 {
+    use fred::types::InfoKind;
+    let info: String = client
+        .info(Some(InfoKind::Clients))
+        .await
+        .expect("INFO clients succeeds");
+    for line in info.lines() {
+        if let Some(value) = line.trim().strip_prefix("connected_clients:") {
+            return value
+                .trim()
+                .parse()
+                .expect("connected_clients is reported as a number");
+        }
+    }
+    // Not `0`: `rd_life_003` and `rd_life_010` both assert
+    // `connected_clients(..) <= baseline`, so a helper that answered `0` for
+    // output it could not parse would satisfy them without a single connection
+    // having been verified — a fixture fault reading as a passing test, which is
+    // the one failure mode a leak check must not have.
+    panic!("INFO clients must report connected_clients, got: {info}")
+}
+
+/// `RD-LIFE-004` — a malformed URL is rejected as **config**, not as a fault.
+///
+/// `InvalidConfig` rather than `Provider`, and immediately rather than after a
+/// connect budget. The distinction is the operator's next action: a `Provider`
+/// error sends someone to look at their Redis, and there is nothing wrong with
+/// their Redis. DESIGN.md §10 makes this a rule rather than a nicety — a config
+/// fault must never read as a backend fault.
+#[tokio::test]
+async fn rd_life_004_a_malformed_url_is_config_not_a_fault() {
+    let config = common::cluster_config_json("not-a-redis-url", json!({}));
+    let started = Instant::now();
+    let result = RedisClusterPlugin::builder(config).build_and_start().await;
+    let elapsed = started.elapsed();
+
+    let Err(err) = result else {
+        panic!("a malformed URL must not start a plugin");
+    };
+    assert!(
+        matches!(err, ClusterError::InvalidConfig { .. }),
+        "a URL fred cannot parse is an operator error, not a backend one - reading a Provider \
+         error here would send someone to inspect a perfectly healthy server. Got {err:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "and it must fail before dialling anything, took {elapsed:?}"
+    );
+}
+
+/// `RD-LIFE-005` — a valid URL pointing at a closed port fails startup, bounded.
+///
+/// Three ways this could go wrong and all three are covered by one assertion pair:
+/// hanging (the reconnect policy retrying its full ~6-minute schedule), returning
+/// `Ok` with a background reconnect (so every later command fails against a plugin
+/// that reported healthy), or reporting the wrong kind.
+///
+/// It is bounded only because `connect.rs` wraps `init()` in `CONNECT_TIMEOUT` —
+/// which became necessary the moment a reconnect policy existed, since the policy
+/// applies to the *initial* connect too (DESIGN.md §10). A
+/// regression removing that wrapper passes every unit test and fails here.
+#[tokio::test]
+async fn rd_life_005_an_unreachable_server_fails_startup_bounded() {
+    // Port 1 on loopback: valid to parse, nothing listening, and refused fast
+    // rather than filtered (which would time out instead).
+    let config = common::cluster_config_json("redis://127.0.0.1:1", json!({}));
+    let started = Instant::now();
+    let result = RedisClusterPlugin::builder(config).build_and_start().await;
+    let elapsed = started.elapsed();
+
+    let Err(err) = result else {
+        panic!(
+            "an unreachable server must not return a started plugin with a background reconnect"
+        );
+    };
+    assert!(
+        matches!(
+            err,
+            ClusterError::Provider {
+                kind: ProviderErrorKind::ConnectionLost,
+                ..
+            }
+        ),
+        "an unreachable server is a backend fault and retryable, got {err:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(15),
+        "startup must fail inside the connect budget rather than spending the reconnect policy's \
+         whole schedule, took {elapsed:?}"
+    );
+}
+
+/// `RD-LIFE-006` — dropping a handle without `stop()` panics in a debug build
+/// (ADR-006), for **both** handle shapes; `stop()`-then-drop does neither.
+///
+/// The guard exists because the failure it catches is otherwise silent: a dropped
+/// handle leaves its pool, its subscriber, and its background tasks running, and
+/// nothing observable goes wrong until the connections accumulate. A test build is
+/// a debug build, so this is also what makes the *other* scenarios' teardown
+/// discipline enforced rather than merely intended.
+///
+/// Both shapes are asserted separately because they are two `Drop` impls. The
+/// Postgres plugin's two copies of this rule drifted, which is why this crate
+/// shares one `cancel_and_diagnose_drop` between them — and why the test still
+/// checks each.
+#[cfg(debug_assertions)]
+#[tokio::test]
+async fn rd_life_006_drop_without_stop_panics_in_debug() {
+    let (_container, config) = common::start_redis().await;
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the combined plugin starts");
+    let payload = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || drop(handle)))
+        .expect_err("dropping an un-stopped RedisClusterHandle must panic in debug");
+    assert!(
+        panic_message(&*payload).contains("RedisClusterHandle dropped without stop()"),
+        "the panic must name the programming error, got {:?}",
+        panic_message(&*payload)
+    );
+
+    let (_lock_container, lock_config) = common::start_redis_lock_only().await;
+    let lock_handle = RedisLockPlugin::builder(lock_config)
+        .build_and_start()
+        .await
+        .expect("the standalone lock plugin starts");
+    let payload = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || drop(lock_handle)))
+        .expect_err("dropping an un-stopped RedisLockHandle must panic in debug");
+    assert!(
+        panic_message(&*payload).contains("RedisLockHandle dropped without stop()"),
+        "the standalone handle's guard must fire too, got {:?}",
+        panic_message(&*payload)
+    );
+}
+
+/// `RD-LIFE-006` (the clean half) — `stop()` then drop is silent.
+///
+/// Separated from the panic half so a regression that made the guard fire
+/// *always* is distinguishable from one that made it never fire. Without this, a
+/// guard that panicked unconditionally would pass the scenario above.
+#[tokio::test]
+async fn rd_life_006_stop_then_drop_is_silent() {
+    let (_container, config) = common::start_redis().await;
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the plugin starts");
+    handle.stop().await;
+
+    // `stop()` consumes the handle, so the drop under test already happened
+    // inside it. Reaching this line is the whole assertion: a guard that fired
+    // on a cleanly-stopped handle would have panicked out of `stop()` above.
+}
+
+/// `RD-LIFE-007` — a `Drop` during panic unwind degrades to a warning instead of
+/// aborting the process.
+///
+/// A debug-build panic inside `Drop` **while already unwinding** is a double panic,
+/// which Rust turns into an immediate `abort()` — no unwinding, no test harness
+/// report, no original failure message. So the guard that exists to make a
+/// forgotten `stop()` loud would, in exactly the situation where a test is already
+/// failing, destroy the report of what actually went wrong. `cancel_and_diagnose_drop`
+/// checks `std::thread::panicking()` and logs instead.
+///
+/// This test passing *at all* is most of the assertion: if the degradation were
+/// missing, the process would abort and the whole binary's results would be lost
+/// rather than this one test failing.
+#[tokio::test]
+async fn rd_life_007_drop_during_unwind_degrades_to_a_warning() {
+    let (_container, config) = common::start_redis().await;
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the plugin starts");
+
+    let payload = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+        // `handle` is owned by this closure, so it drops during the unwind the
+        // panic below starts.
+        let _owned = handle;
+        panic!("the original failure");
+    }))
+    .expect_err("the closure's own panic must propagate");
+
+    assert_eq!(
+        panic_message(&*payload),
+        "the original failure",
+        "the original panic must survive: a double panic from the Drop guard would have aborted \
+         the process instead, taking the failure report with it"
+    );
+}
+
+/// `RD-LIFE-008` — a `NOSCRIPT` is recovered transparently, once, and counted.
+///
+/// `SCRIPT FLUSH` behind the plugin's back is the realistic form of this: a Redis
+/// restart, a failover to a replica that never saw the `SCRIPT LOAD`, or an
+/// operator clearing the cache. The recovery is a key-routed `EVAL` rather than a
+/// second `SCRIPT LOAD` plus a re-`EVALSHA` (DESIGN.md §6):
+/// `EVAL` necessarily reaches the node that reported the miss, costs one round trip
+/// instead of two, and caches the script there on the way through.
+///
+/// No error may reach the caller — that is what "transparently" means, and it is
+/// the difference between a self-healing plugin and one that fails every write
+/// after a restart until someone notices.
+#[tokio::test]
+async fn rd_life_008_noscript_is_recovered_transparently_and_counted() {
+    let (meter, metrics) = common::in_memory_meter();
+    let (_container, config) = common::start_redis().await;
+    let url = config.url.clone();
+    let database = config.database;
+    let handle = RedisClusterPlugin::builder(config)
+        .__with_meter(meter)
+        .build_and_start()
+        .await
+        .expect("the plugin starts");
+    let cache = handle.cache();
+
+    cache
+        .put(PutRequest {
+            key: "flush:key",
+            value: b"before",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("a put before the flush succeeds");
+    assert_eq!(
+        metrics.counter("cluster_redis_script_reloads_total"),
+        0,
+        "nothing has been flushed yet, so no recovery may have fired"
+    );
+
+    let raw = common::raw_client_on(&url, database).await;
+    raw.script_flush(false)
+        .await
+        .expect("SCRIPT FLUSH succeeds");
+
+    cache
+        .put(PutRequest {
+            key: "flush:key",
+            value: b"after",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect(
+            "the put after the flush must still succeed - the recovery is transparent to the \
+                 caller, not an error it has to retry",
+        );
+    assert_eq!(
+        cache
+            .get("flush:key")
+            .await
+            .expect("get succeeds")
+            .expect("the entry is present")
+            .value,
+        b"after",
+        "and it must have actually written"
+    );
+
+    assert_eq!(
+        metrics.counter("cluster_redis_script_reloads_total"),
+        1,
+        "exactly one recovery: the EVAL caches the script on the node it reaches, so a second \
+         write must not need another"
+    );
+
+    cache
+        .put(PutRequest {
+            key: "flush:key",
+            value: b"third",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("a third put succeeds");
+    assert_eq!(
+        metrics.counter("cluster_redis_script_reloads_total"),
+        1,
+        "the recovery is not repeated once the script is cached again"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-LIFE-009` — `stop()` terminates against a server that has stopped
+/// answering.
+///
+/// The container is **paused**: sockets stay open and nothing replies, which is
+/// the case a shutdown path can hang on. The plugin holds locks and an active
+/// watch when it happens, so `stop()` has guard tasks to drain, a terminal
+/// broadcast to make, a subscriber to quit, and a pool to close — every step of
+/// DESIGN.md §11 with a server that will not cooperate.
+///
+/// It is bounded rather than lucky, and by a general property rather than by any
+/// one timeout: every command this plugin issues carries a client-side
+/// `command_timeout`, so no in-flight operation can hold a background task's join
+/// open indefinitely (DESIGN.md §12), and `POOL_CLOSE_TIMEOUT` and
+/// `GUARD_DRAIN_TIMEOUT` bound the two steps that wait on something other than a
+/// command.
+#[tokio::test]
+async fn rd_life_009_stop_terminates_against_an_unresponsive_server() {
+    let (container, config) = common::start_redis_with(json!({ "command_timeout_ms": 500 })).await;
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the plugin starts");
+    let cache = handle.cache();
+    let lock = handle.lock();
+
+    let mut guards = Vec::new();
+    for index in 0..4 {
+        guards.push(
+            lock.try_lock(&format!("res-{index}"), Duration::from_secs(30))
+                .await
+                .expect("acquire"),
+        );
+    }
+    let _watch = cache.watch("shut:key").await.expect("watch succeeds");
+
+    container.pause().await.expect("the container pauses");
+
+    let started = Instant::now();
+    handle.stop().await;
+    let elapsed = started.elapsed();
+
+    // Unpause so the container can be removed cleanly on drop.
+    container.unpause().await.expect("the container unpauses");
+
+    assert!(
+        elapsed < Duration::from_secs(30),
+        "stop() must return inside a supervisor's shutdown budget even against a server that \
+         answers nothing, took {elapsed:?}"
+    );
+    drop(guards);
+}
+
+/// The `RD-LIFE-*` log events, checked as a set.
+///
+/// A cheap guard on something none of the scenarios above would catch: an event
+/// emitted under a name that is not its catalogued one. ADR-004's naming contract
+/// is only useful if a collector can match on it, and a renamed event breaks every
+/// dashboard and alert silently — the plugin keeps working and the operator stops
+/// hearing from it.
+///
+/// Only the startup events are asserted here, since those are the ones a lifecycle
+/// scenario provokes; the eviction, consistency, and keyspace events belong to
+/// `redis_specific.rs`, which has the fixtures that produce them.
+#[tokio::test]
+async fn rd_life_startup_events_use_their_catalogued_names() {
+    let (_guard, log) = common::scoped_capture(tracing::Level::WARN);
+    let (_container, config) = common::start_redis().await;
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the plugin starts");
+
+    // A stock container is EventuallyConsistent, so exactly this one WARN fires.
+    assert_eq!(
+        common::count_occurrences(&log, logs::WEAK_CONSISTENCY),
+        1,
+        "the weak-consistency WARN must be logged once, under its catalogued name. Captured: {}",
+        common::captured(&log)
+    );
+    // And its counterpart must not: an asserted declaration is by construction a
+    // Linearizable one, so exactly one of the pair can fire per startup.
+    assert_eq!(
+        common::count_occurrences(&log, logs::CONSISTENCY_ASSERTED),
+        0,
+        "consistency_asserted fires only for a Linearizable declaration resting on an unverifiable \
+         hint, which this is not. Captured: {}",
+        common::captured(&log)
+    );
+
+    handle.stop().await;
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/tests/lock_integration.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/tests/lock_integration.rs
@@ -1,0 +1,1008 @@
+//! Layer 3 — lock integration scenarios (docs/TESTING.md §4.3), `RD-LOCK-001`
+//! through `RD-LOCK-015`. `RD-LOCK-014` runs on the Sentinel fixture.
+//!
+//! These run against the **standalone** `RedisLockPlugin` unless a scenario is
+//! specifically about the combined plugin or about wiring. That is the shape
+//! `ClusterLockProvider::build_lock` takes in production (DESIGN.md §3.5), and it
+//! is also the smaller thing to start: no cache, no watcher registry, one pool and
+//! one subscriber.
+//!
+//! # What these hold that conformance does not
+//!
+//! `SC-LOCK-*` pins the contract — acquire, contend, time out, renew, release.
+//! What it cannot see is *how* the lease is represented, and nearly every lock bug
+//! worth catching lives there:
+//!
+//! - the lease is a key whose **value is the holder's token**, which is what makes
+//!   `renew` and `release` fenceable (`RD-LOCK-006`, the bare-`DEL` regression);
+//! - reclamation is **Redis expiry and nothing else** — there is no sweep in this
+//!   plugin to stall (`RD-LOCK-004`);
+//! - a blocked acquire wakes on a **publish**, not on its heartbeat, and the
+//!   difference is two orders of magnitude (`RD-LOCK-003`);
+//! - a held lock consumes **no connection** (`RD-LOCK-010`);
+//! - `stop()` deliberately **leaves leases behind** to expire (`RD-LOCK-013`).
+
+#![cfg(feature = "integration")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration tests: a setup failure IS the test failure"
+)]
+
+mod common;
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use cluster_sdk::{ClusterError, DistributedLockBackend};
+use fred::interfaces::KeysInterface;
+use redis_cluster_plugin::{RedisLockHandle, RedisLockPlugin, logs};
+use serde_json::json;
+
+/// A generous TTL for scenarios that are not about expiry, long enough that a
+/// slow CI container cannot let a lease lapse mid-scenario and turn a contention
+/// assertion into a spurious acquisition.
+const LONG_TTL: Duration = Duration::from_secs(30);
+
+/// The Redis key a lease is stored under — `<prefix>:l:<name>` (DESIGN.md §2.1).
+///
+/// Written out rather than read from `LockNames` for the same reason
+/// `cache_integration.rs` spells out its entry key: a wire-format assertion that
+/// derives the format from the code under test asserts nothing.
+fn lease_key(prefix: &str, name: &str) -> String {
+    format!("{prefix}:l:{name}")
+}
+
+/// Spawns a blocked `lock` on `name`, returning its outcome **and the instant it
+/// acquired**.
+///
+/// Returning the acquisition instant rather than an elapsed duration is what makes
+/// the three publish-driven-wake scenarios measure the right interval. The waiter
+/// necessarily starts before the holder releases — it has to be blocked for a
+/// release to wake it — so the time from *its* start includes however long the
+/// test chose to wait first, which swamps the few milliseconds actually under
+/// test. The interval that means anything is release → acquire, and only the
+/// releasing side knows when the release happened.
+fn spawn_waiter(
+    lock: &Arc<dyn DistributedLockBackend>,
+    name: &'static str,
+) -> tokio::task::JoinHandle<(Result<cluster_sdk::lock::LockGuard, ClusterError>, Instant)> {
+    let lock = Arc::clone(lock);
+    tokio::spawn(async move {
+        let guard = lock.lock(name, LONG_TTL, Duration::from_secs(10)).await;
+        (guard, Instant::now())
+    })
+}
+
+/// How many release→wake samples [`assert_woken_by_publish_repeatedly`] takes.
+/// Odd, so the median is a single observed sample rather than an average of two,
+/// and small enough that five ~200 ms setups stay cheap against the suite's ten
+/// seconds.
+const WAKE_SAMPLES: usize = 5;
+
+/// Asserts a blocked acquire was woken by the release **publish** rather than by
+/// the fallback heartbeat, over the **median** of [`WAKE_SAMPLES`] release→wake
+/// cycles.
+///
+/// The margin is the assertion, not the bound. `HEARTBEAT` is 250 ms and the wake
+/// delay is uniform over `[0, min(PTTL, 250 ms, remaining budget)]`, so a
+/// heartbeat-driven wake averages ~125 ms and a publish-driven one lands in single
+/// digits. 60 ms sits far enough below the fallback's mean that a pass cannot have
+/// come from a lucky jitter draw, and far enough above a publish round trip that
+/// the happy path clears it comfortably.
+///
+/// Why the median rather than one sample: a single wall-clock reading also rode
+/// one scheduler stall, and a loaded CI box can delay the spawned waiter's wakeup
+/// past 60 ms on a genuinely publish-driven wake — which then fails as exactly the
+/// correctness bug this is meant to catch. The median needs a *majority* of the
+/// samples to stall before it misreports, which a transient spike cannot do, while
+/// a genuinely missed notification wakes near the ~125 ms heartbeat mean on
+/// *every* sample and so is still caught. Median specifically, because the other
+/// two order statistics move the wrong way here: min-of-N would let a missed
+/// wake's occasional fast jitter draw pass, and max-of-N would turn a single stall
+/// straight back into a failure.
+///
+/// A missed notification is the scenario the `PING` barrier of DESIGN.md §3.2
+/// step 4 exists for.
+///
+/// `holder_lock` acquires and holds the name each cycle; `waiter_lock` is the
+/// instance whose blocked `lock()` the release must wake — the same instance for
+/// the local scenarios, and the *other* replica for `RD-LOCK-011`'s cross-instance
+/// publish.
+async fn assert_woken_by_publish_repeatedly(
+    holder_lock: &Arc<dyn DistributedLockBackend>,
+    waiter_lock: &Arc<dyn DistributedLockBackend>,
+    name: &'static str,
+) {
+    let mut latencies = Vec::with_capacity(WAKE_SAMPLES);
+    for sample in 0..WAKE_SAMPLES {
+        let holder = holder_lock
+            .try_lock(name, LONG_TTL)
+            .await
+            .unwrap_or_else(|error| panic!("sample {sample}: the holder acquires: {error:?}"));
+        let waiter = spawn_waiter(waiter_lock, name);
+        // Let the waiter reach its first failed `SET NX` and register its interest
+        // before the release, so a wake can only be the publish (DESIGN.md §5.3).
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let released_at = Instant::now();
+        holder.release().await.expect("the holder releases");
+        let (acquired, acquired_at) = waiter.await.expect("the waiter task does not panic");
+        let guard = acquired.expect("the waiter acquires once the holder releases");
+        latencies.push(acquired_at.saturating_duration_since(released_at));
+        guard.release().await.expect("the waiter's guard releases");
+    }
+    latencies.sort_unstable();
+    #[expect(
+        clippy::integer_division,
+        reason = "the middle index of an odd-length sorted slice is exactly the median"
+    )]
+    let median = latencies[latencies.len() / 2];
+    assert!(
+        median < Duration::from_millis(60),
+        "the wake must be publish-driven: a median wake at or near the 250 ms heartbeat means the \
+         release notification was missed rather than merely slow. Samples (sorted): {latencies:?}"
+    );
+}
+
+/// Starts a standalone lock plugin over a stock container.
+///
+/// Returns the container (which must outlive the test), the handle (which
+/// **every** scenario must `stop()` — `RedisLockHandle` panics on drop without it
+/// in a debug build, ADR-006), the lock backend, a raw client, the key prefix, and
+/// the URL for scenarios that start a second instance.
+async fn fixture(
+    overrides: serde_json::Value,
+) -> (
+    testcontainers::ContainerAsync<testcontainers_modules::redis::Redis>,
+    RedisLockHandle,
+    Arc<dyn DistributedLockBackend>,
+    fred::clients::Client,
+    String,
+    String,
+) {
+    let (container, config) = common::start_redis_lock_only_with(overrides).await;
+    let url = config.url.clone();
+    let key_prefix = config.key_prefix.clone();
+    let database = config.database;
+    let handle = RedisLockPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the standalone lock plugin starts against the test container");
+    let lock = handle.lock();
+    let raw = common::raw_client_on(&url, database).await;
+    (container, handle, lock, raw, key_prefix, url)
+}
+
+/// `RD-LOCK-001` — `try_lock` writes a real lease, a second attempt contends, and
+/// `release` frees the name.
+///
+/// The second `try_lock` is issued **from the same instance**, deliberately.
+/// Nothing in this plugin tracks locally-held names, so it is refused by the same
+/// `SET NX` a foreign instance would hit — and a regression that added a local
+/// short-circuit "optimisation" would make this instance's own second attempt
+/// behave differently from everyone else's, which is the bug this pins.
+#[tokio::test]
+async fn rd_lock_001_try_lock_writes_a_lease_and_release_frees_it() {
+    let (_container, handle, lock, raw, prefix, _url) = fixture(json!({})).await;
+    let key = lease_key(&prefix, "res");
+
+    let guard = lock
+        .try_lock("res", LONG_TTL)
+        .await
+        .expect("try_lock on a free name succeeds");
+
+    let token: String = raw.get(&key).await.expect("GET on the lease key succeeds");
+    assert!(
+        uuid::Uuid::parse_str(&token).is_ok(),
+        "the lease value must be the holder token - a v4 UUID (DESIGN.md sec 5.1) - got {token:?}"
+    );
+    let pttl: i64 = raw.pttl(&key).await.expect("PTTL succeeds");
+    // Compared in `u128`, the type `as_millis` returns, rather than casting it
+    // down to the `i64` Redis reports: the cast is the only lossy step in the
+    // comparison and it is avoidable.
+    let remaining = u128::try_from(pttl).unwrap_or(0);
+    assert!(
+        pttl > 0 && remaining <= LONG_TTL.as_millis(),
+        "the lease must carry the requested deadline, got {pttl}"
+    );
+
+    let contended = lock.try_lock("res", LONG_TTL).await;
+    assert!(
+        matches!(contended, Err(ClusterError::LockContended { .. })),
+        "a second try_lock - even from this same instance - must contend, got {contended:?}"
+    );
+
+    guard.release().await.expect("release succeeds");
+    let exists: i64 = raw.exists(&key).await.expect("EXISTS succeeds");
+    assert_eq!(exists, 0, "release must remove the lease key");
+    let reacquired = lock
+        .try_lock("res", LONG_TTL)
+        .await
+        .expect("the name is acquirable again after release");
+    reacquired.release().await.expect("release succeeds");
+
+    handle.stop().await;
+}
+
+/// `RD-LOCK-002` — a blocked `lock` reports `LockTimeout`, not `Provider`, and
+/// leaves nothing behind.
+///
+/// The distinction is the whole scenario (DESIGN.md §5.3): `LockTimeout` means
+/// "someone else holds it" and `Provider` means "the backend is broken", and a
+/// caller's retry policy should differ. A blocking loop that reported its last
+/// transient error instead of classifying the outcome would look identical from
+/// the outside until an operator tried to alert on it.
+#[tokio::test]
+async fn rd_lock_002_a_blocked_lock_times_out_and_leaves_nothing_behind() {
+    let (_container, handle, lock, _raw, _prefix, _url) = fixture(json!({})).await;
+
+    let holder = lock
+        .try_lock("res", LONG_TTL)
+        .await
+        .expect("the holder acquires");
+
+    let started = Instant::now();
+    let blocked = lock.lock("res", LONG_TTL, Duration::from_millis(600)).await;
+    let waited = started.elapsed();
+    assert!(
+        matches!(blocked, Err(ClusterError::LockTimeout { .. })),
+        "a contended blocking acquire must report LockTimeout rather than a Provider error, got \
+         {blocked:?}"
+    );
+    assert!(
+        waited >= Duration::from_millis(500),
+        "it must actually have waited its budget rather than failing fast, took {waited:?}"
+    );
+    assert!(
+        waited < Duration::from_secs(3),
+        "and must not have overrun it, took {waited:?}"
+    );
+
+    holder.release().await.expect("release succeeds");
+    let after = lock
+        .try_lock("res", LONG_TTL)
+        .await
+        .expect("the timed-out attempt left no registration or lease behind");
+    after.release().await.expect("release succeeds");
+
+    handle.stop().await;
+}
+
+/// `RD-LOCK-003` — a blocked `lock` wakes on the release **publish**, far under
+/// the 250 ms heartbeat.
+///
+/// The sharpest assertion in this file, and it is sharp because of the margin
+/// rather than the bound: a wake measured at roughly one heartbeat means the
+/// notification was *missed* and the fallback poll picked it up, which is a
+/// correctness bug wearing a latency costume. A wake in single-digit milliseconds
+/// can only have come from the publish.
+///
+/// It is also why DESIGN.md §3.2 step 4 awaits the initial subscribe before
+/// `build_and_start` returns — and why that await is followed by a `PING`
+/// (DESIGN.md §3.2 step 4): `fred` resolves a `psubscribe` when the
+/// command reaches the connection, not when the server has processed it, so a
+/// release landing in that window would otherwise reach no subscriber.
+#[tokio::test]
+async fn rd_lock_003_a_blocked_lock_wakes_on_the_release_publish() {
+    let (_container, handle, lock, _raw, _prefix, _url) = fixture(json!({})).await;
+
+    // Each cycle registers the waiter's interest before the release (the helper's
+    // 200 ms settle), so a wake can only be the publish (DESIGN.md §5.3), and the
+    // median over the cycles is what one scheduler stall cannot flip.
+    assert_woken_by_publish_repeatedly(&lock, &lock, "res").await;
+
+    handle.stop().await;
+}
+
+/// `RD-LOCK-004` — an abandoned lease is reclaimed by Redis expiry alone, and the
+/// abandoning holder learns it lost the lock.
+///
+/// The clearest statement of what a native TTL buys (DESIGN.md §5.1): holder A
+/// never renews and never releases, and B acquires purely because the key
+/// expired. There is no reaper in this plugin to be stalled, no sweep interval to
+/// tune, and no lock table to grow — which is exactly the class of failure the
+/// Postgres plugin has to test around.
+///
+/// A's follow-up `renew` reporting `LockExpired` is the other half: a holder whose
+/// lease lapsed must find out, or it would keep running a critical section two
+/// processes are now inside.
+#[tokio::test]
+async fn rd_lock_004_an_expired_lease_is_reclaimed_with_no_reaper() {
+    let (_container, handle, lock, _raw, _prefix, _url) = fixture(json!({})).await;
+
+    let abandoned = lock
+        .try_lock("res", Duration::from_millis(500))
+        .await
+        .expect("A acquires a short lease");
+
+    let reclaimed = common::wait_until(
+        Duration::from_secs(5),
+        Duration::from_millis(50),
+        async || {
+            match lock.try_lock("res", LONG_TTL).await {
+                Ok(guard) => {
+                    // Leak deliberately: releasing here would free the name before the
+                    // assertions below, and the handle's `stop()` leaves leases to
+                    // expire anyway.
+                    std::mem::forget(guard);
+                    true
+                }
+                Err(_still_held) => false,
+            }
+        },
+    )
+    .await;
+    assert!(
+        reclaimed,
+        "B must acquire on Redis expiry alone - nothing in this plugin sweeps abandoned leases"
+    );
+
+    let renewed = abandoned.renew(LONG_TTL).await;
+    assert!(
+        matches!(renewed, Err(ClusterError::LockExpired { .. })),
+        "A's renew after its lease lapsed must report LockExpired rather than silently \
+         resurrecting a lock B now holds, got {renewed:?}"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-LOCK-005` — `renew` extends the lease past its original deadline.
+///
+/// Asserted through `PTTL` rather than only through the return value, because
+/// "renew returned Ok" and "the server's deadline moved" are different claims and
+/// only the second one keeps the lock held.
+#[tokio::test]
+async fn rd_lock_005_renew_extends_the_lease() {
+    let (_container, handle, lock, raw, prefix, _url) = fixture(json!({})).await;
+    let key = lease_key(&prefix, "res");
+
+    let guard = lock
+        .try_lock("res", Duration::from_secs(1))
+        .await
+        .expect("acquire with a short lease");
+    let before: i64 = raw.pttl(&key).await.expect("PTTL succeeds");
+    assert!(before <= 1_000, "the original deadline is one second");
+
+    guard
+        .renew(Duration::from_secs(30))
+        .await
+        .expect("renew succeeds");
+    let after: i64 = raw.pttl(&key).await.expect("PTTL succeeds");
+    assert!(
+        after > 1_000,
+        "PTTL must reflect the new deadline, got {after} (was {before})"
+    );
+
+    // Past the original deadline, the lock is still held.
+    tokio::time::sleep(Duration::from_millis(1_200)).await;
+    let contended = lock.try_lock("res", LONG_TTL).await;
+    assert!(
+        matches!(contended, Err(ClusterError::LockContended { .. })),
+        "the renewed lock must outlive its original deadline, got {contended:?}"
+    );
+
+    guard.release().await.expect("release succeeds");
+    handle.stop().await;
+}
+
+/// `RD-LOCK-006` — `renew` and `release` are token-fenced.
+///
+/// **The one test that fails on the classic bare-`DEL`-on-release bug.** A's lease
+/// lapses and B acquires the same name; A then calls `release`, which on a naive
+/// implementation deletes whatever is under the key — B's lease — handing the lock
+/// to a third party while B believes it holds it. Here `release` is a Lua script
+/// that deletes only if the value is still A's token (DESIGN.md §5.2), so A's call
+/// is a no-op and B's key survives.
+///
+/// The assertion is on **B's token still being under the key**, not merely on the
+/// key existing: a `release` that deleted and a `try_lock` that raced back in
+/// would leave a key there too.
+#[tokio::test]
+async fn rd_lock_006_renew_and_release_are_token_fenced() {
+    let (_container, handle, lock, raw, prefix, _url) = fixture(json!({})).await;
+    let key = lease_key(&prefix, "res");
+
+    let stale = lock
+        .try_lock("res", Duration::from_millis(400))
+        .await
+        .expect("A acquires a short lease");
+    let lapsed = common::wait_until(
+        Duration::from_secs(5),
+        Duration::from_millis(50),
+        async || {
+            let exists: i64 = raw.exists(&key).await.unwrap_or(1);
+            exists == 0
+        },
+    )
+    .await;
+    assert!(lapsed, "A's lease must lapse before B acquires");
+
+    let fresh = lock
+        .try_lock("res", LONG_TTL)
+        .await
+        .expect("B acquires the freed name");
+    let b_token: String = raw.get(&key).await.expect("GET succeeds");
+
+    let renewed = stale.renew(LONG_TTL).await;
+    assert!(
+        matches!(renewed, Err(ClusterError::LockExpired { .. })),
+        "A's renew must report LockExpired rather than extending B's lease, got {renewed:?}"
+    );
+
+    stale
+        .release()
+        .await
+        .expect("A's release is a no-op rather than an error - it held nothing to give back");
+    let after: String = raw
+        .get(&key)
+        .await
+        .expect("B's lease key must still be present after A's stale release");
+    assert_eq!(
+        after, b_token,
+        "A's stale release must leave B's key intact. A bare DEL-on-release would have removed it, \
+         handing the lock to whoever asked next while B was still inside its critical section"
+    );
+
+    fresh.release().await.expect("B's release succeeds");
+    handle.stop().await;
+}
+
+/// `RD-LOCK-007` — 20 concurrent local acquirers, at most one holder.
+///
+/// Kept distinct from `RD-LOCK-011` even though both exercise `SET NX`: the claim
+/// worth holding both halves to is that local and cross-instance contention are
+/// arbitrated *identically*. A regression that added a local fast path — an
+/// in-process held-names set consulted before the round trip — would pass
+/// `RD-LOCK-011` and show up here first.
+#[tokio::test]
+async fn rd_lock_007_twenty_local_acquirers_yield_one_holder() {
+    let (_container, handle, lock, _raw, _prefix, _url) = fixture(json!({ "pool_size": 8 })).await;
+
+    let mut tasks = Vec::new();
+    for _ in 0..20 {
+        let lock = Arc::clone(&lock);
+        tasks.push(tokio::spawn(
+            async move { lock.try_lock("res", LONG_TTL).await },
+        ));
+    }
+
+    let mut winners = Vec::new();
+    let mut contended = 0_u32;
+    for task in tasks {
+        match task.await.expect("no acquirer task panics") {
+            Ok(guard) => winners.push(guard),
+            Err(ClusterError::LockContended { .. }) => contended += 1,
+            Err(other) => panic!("a losing acquirer must report LockContended, got {other:?}"),
+        }
+    }
+    assert_eq!(
+        winners.len(),
+        1,
+        "exactly one of 20 acquirers may hold the lock"
+    );
+    assert_eq!(contended, 19, "the other 19 must all report LockContended");
+
+    for guard in winners {
+        guard.release().await.expect("release succeeds");
+    }
+    handle.stop().await;
+}
+
+/// `RD-LOCK-008` — end-to-end YAML routing: the lock on Redis, the cache on
+/// another provider entirely.
+///
+/// This is the scenario that needs the `cluster/src/gear.rs` registration, and it is the
+/// only thing that proves `provider: redis` under `lock` is reachable *through the
+/// wiring* rather than merely callable off this plugin's own builder. It exercises
+/// the SDK's "non-cache providers do not receive the cache backend" contract from
+/// the operator's side: the profile binds `cache: { provider: standalone }`, so if
+/// the lock provider consulted a cache at all it would be an in-process one, and
+/// the lease key asserted below would not exist on the server.
+#[tokio::test]
+async fn rd_lock_008_end_to_end_yaml_routing_lock_redis_cache_standalone() {
+    use cluster::{ClusterConfig, ClusterWiring, ProfileRegistry, ProviderRegistry};
+    use cluster_sdk::lock::DistributedLockV1;
+    use cluster_sdk::profile::ClusterProfile;
+    use redis_cluster_plugin::RedisLockProvider;
+    use standalone_cluster_plugin::StandaloneCacheProvider;
+    use toolkit::client_hub::ClientHub;
+
+    #[derive(Clone, Copy)]
+    struct RoutingProfile;
+    impl ClusterProfile for RoutingProfile {
+        const NAME: &'static str = "redislockrouting";
+    }
+
+    let (_container, config) = common::start_redis_lock_only().await;
+    let url = config.url.clone();
+    let key_prefix = config.key_prefix.clone();
+
+    // Operator config is normally YAML, but `ClusterConfig` is a plain
+    // `serde::Deserialize` type — an equivalent JSON value travels the identical
+    // `BackendBinding`/flattened-`options` path without a YAML dev-dependency.
+    let mut profiles = serde_json::Map::new();
+    profiles.insert(
+        RoutingProfile::NAME.to_owned(),
+        json!({
+            "cache": { "provider": "standalone" },
+            "lock": { "provider": "redis", "url": url, "pool_size": 4 },
+        }),
+    );
+    let cluster_config: ClusterConfig = serde_json::from_value(json!({ "profiles": profiles }))
+        .expect("the routing profile config parses");
+
+    let providers = ProviderRegistry::new()
+        .with_cache_provider(Arc::new(StandaloneCacheProvider))
+        .with_lock_provider(Arc::new(RedisLockProvider));
+    let hub = Arc::new(ClientHub::new());
+    let (mut handle, bound) =
+        ClusterWiring::from_config(Arc::clone(&hub), &cluster_config, &providers)
+            .await
+            .expect("the wiring must resolve lock: redis independently of cache: standalone");
+    handle.publish(&Arc::new(ProfileRegistry::new()), bound);
+
+    let lock = DistributedLockV1::resolver(&hub)
+        .profile(RoutingProfile)
+        .resolve()
+        .await
+        .expect("the lock facade resolves for the routing profile");
+    let guard = lock
+        .try_lock("res", LONG_TTL)
+        .await
+        .expect("try_lock succeeds through the resolved facade");
+
+    // A separate connection must see the lease: that is what makes this a real
+    // Redis lock rather than the in-process standalone one the cache is bound to.
+    let raw = common::raw_client(&url).await;
+    let token: String = raw
+        .get(lease_key(&key_prefix, "res"))
+        .await
+        .expect("the lease key must exist on the server");
+    assert!(
+        uuid::Uuid::parse_str(&token).is_ok(),
+        "the resolved facade must be backed by a real Redis lease, got {token:?}"
+    );
+
+    guard.release().await.expect("release succeeds");
+    handle.stop().await;
+}
+
+/// `RD-LOCK-009` — the standalone lock needs no keyspace notifications.
+///
+/// Against a container started with `notify-keyspace-events` empty. The
+/// distinction that makes this work (DESIGN.md §3.5, third row): a release is a
+/// `PUBLISH` **this plugin issues itself** on a channel it owns, not a keyspace
+/// notification the server emits — so the wake path is entirely independent of a
+/// server-wide setting the operator may have no ability to change. Only the
+/// *cache*'s `Expired` events need the flags, and a lock-only deployment has no
+/// cache.
+///
+/// Asserted alongside: the server really does have no flags set, so the scenario
+/// cannot pass because a previous test configured the container.
+#[tokio::test]
+async fn rd_lock_009_the_standalone_lock_needs_no_keyspace_notifications() {
+    let (_container, config) = common::start_redis_lock_only_no_notifications().await;
+    let url = config.url.clone();
+    let handle = RedisLockPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the standalone lock plugin starts against a server with no keyspace events");
+    let lock = handle.lock();
+    let raw = common::raw_client(&url).await;
+
+    assert_eq!(
+        common::keyspace_flags(&raw).await,
+        "",
+        "the fixture must genuinely have no keyspace notifications, or this scenario proves nothing"
+    );
+
+    // Every acquisition path behaves as it does on a fully-configured server.
+    let holder = lock.try_lock("res", LONG_TTL).await.expect("try_lock");
+    assert!(
+        matches!(
+            lock.try_lock("res", LONG_TTL).await,
+            Err(ClusterError::LockContended { .. })
+        ),
+        "contention is arbitrated by SET NX, which no server setting affects"
+    );
+    holder.renew(LONG_TTL).await.expect("renew");
+    holder
+        .release()
+        .await
+        .expect("release the setup holder before the timed cycles");
+
+    // Still publish-driven on a server with no keyspace notifications at all,
+    // because a release is this plugin's own PUBLISH rather than anything the
+    // server emits.
+    assert_woken_by_publish_repeatedly(&lock, &lock, "res").await;
+
+    handle.stop().await;
+}
+
+/// `RD-LOCK-010` — held locks consume no connections.
+///
+/// `pool_size: 2` with 12 locks held at once. On a lock implementation that pins a
+/// connection per held lock — which is what a Postgres session-level advisory lock
+/// does, and why that plugin had to move off it — the third acquisition would
+/// block forever. Here a lease is a key with a TTL (DESIGN.md §3.3), so the pool
+/// is sized for pipelining rather than for concurrency.
+///
+/// The `renew` at the end is the part that would catch a *leaked* connection
+/// rather than a pinned one: if each acquisition had quietly retained a pooled
+/// connection, the pool would be exhausted and this call would time out.
+#[tokio::test]
+async fn rd_lock_010_held_locks_consume_no_connections() {
+    let (_container, handle, lock, raw, prefix, _url) = fixture(json!({ "pool_size": 2 })).await;
+
+    let mut guards = Vec::new();
+    for index in 0..12 {
+        guards.push(
+            lock.try_lock(&format!("res-{index}"), LONG_TTL)
+                .await
+                .unwrap_or_else(|err| {
+                    panic!(
+                        "holding 12 locks on a pool of 2 must succeed; lock {index} failed: {err:?}"
+                    )
+                }),
+        );
+    }
+
+    for index in 0..12 {
+        let exists: i64 = raw
+            .exists(lease_key(&prefix, &format!("res-{index}")))
+            .await
+            .expect("EXISTS succeeds");
+        assert_eq!(exists, 1, "every held lease must exist on the server");
+    }
+
+    guards[0]
+        .renew(LONG_TTL)
+        .await
+        .expect("a renew must still get a pool connection while 12 locks are held");
+
+    for guard in guards {
+        guard.release().await.expect("release succeeds");
+    }
+    handle.stop().await;
+}
+
+/// `RD-LOCK-011` — two independent instances cannot hold the same lock.
+///
+/// The cross-replica guarantee the whole primitive rests on, and the one property
+/// no single-instance test can establish: two plugin instances with separate pools
+/// and separate subscribers, arbitrated only by the server's `SET NX`.
+///
+/// B waking on A's release is the second half, and it is a *cross-process* publish
+/// rather than the in-process waiter registry — B's fan-out receives a message A's
+/// pool sent, which is the only reason a blocked acquire in one replica is fast
+/// when the holder is in another.
+#[tokio::test]
+async fn rd_lock_011_two_instances_cannot_hold_the_same_lock() {
+    let (_container, handle_a, lock_a, raw, prefix, url) = fixture(json!({})).await;
+    let key = lease_key(&prefix, "res");
+
+    // The same `key_prefix` and database, a different instance — two replicas of
+    // one deployment, which is the arrangement under test.
+    let config_b = common::lock_config_json(&url, json!({ "key_prefix": prefix.clone() }));
+    let handle_b = RedisLockPlugin::builder(config_b)
+        .build_and_start()
+        .await
+        .expect("a second independent instance starts");
+    let lock_b = handle_b.lock();
+
+    let held_by_a = lock_a.try_lock("res", LONG_TTL).await.expect("A acquires");
+    let a_token: String = raw.get(&key).await.expect("GET succeeds");
+    assert!(
+        matches!(
+            lock_b.try_lock("res", LONG_TTL).await,
+            Err(ClusterError::LockContended { .. })
+        ),
+        "B must contend on a name A holds"
+    );
+    let keys_present: i64 = raw.exists(&key).await.expect("EXISTS succeeds");
+    assert_eq!(keys_present, 1, "exactly one lease key exists for the name");
+
+    // One real cross-instance cycle for the token assertion: B must acquire under
+    // its *own* token once A releases, not inherit A's.
+    let waiter = spawn_waiter(&lock_b, "res");
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    held_by_a.release().await.expect("A releases");
+
+    let (acquired, _acquired_at) = waiter.await.expect("B's waiter task does not panic");
+    let held_by_b = acquired.expect("B acquires as soon as A releases");
+    let b_token: String = raw.get(&key).await.expect("GET succeeds");
+    assert_ne!(
+        a_token, b_token,
+        "B must hold under its own token, not inherit A's"
+    );
+    held_by_b.release().await.expect("B releases");
+
+    // B's wake rides A's *cross-instance* publish: B's own subscriber received a
+    // message A's pool sent, which is the only reason a blocked acquire in one
+    // replica is fast when the holder is in another. Measured as a median over
+    // several cross-instance cycles so one scheduler stall cannot fail it.
+    assert_woken_by_publish_repeatedly(&lock_a, &lock_b, "res").await;
+
+    handle_b.stop().await;
+    handle_a.stop().await;
+}
+
+/// `RD-LOCK-012` — after `stop()`, an acquisition answers `Shutdown` immediately.
+///
+/// Immediately is the assertion. Without the pre-work check, a blocking `lock`
+/// against a torn-down backend would retry for its whole 30 s budget and then
+/// report `LockTimeout` — which tells a caller "someone else holds it" when the
+/// truth is "this backend is gone". Those need different handling, and the only
+/// way a caller can tell them apart is if the backend says so.
+///
+/// `try_lock` is asserted alongside because both take the same check, and a
+/// regression that guarded only the blocking path would leave the cheaper one
+/// reporting a connection error from a closed pool.
+#[tokio::test]
+async fn rd_lock_012_acquiring_after_stop_answers_shutdown_at_once() {
+    let (_container, handle, lock, _raw, _prefix, _url) = fixture(json!({})).await;
+    handle.stop().await;
+
+    let started = Instant::now();
+    let blocked = lock.lock("res", LONG_TTL, Duration::from_secs(30)).await;
+    let elapsed = started.elapsed();
+    assert!(
+        matches!(blocked, Err(ClusterError::Shutdown)),
+        "a blocking lock after stop() must report Shutdown, not LockTimeout, got {blocked:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "and must report it at once rather than spending the whole 30 s budget, took {elapsed:?}"
+    );
+
+    let immediate = lock.try_lock("res", LONG_TTL).await;
+    assert!(
+        matches!(immediate, Err(ClusterError::Shutdown)),
+        "try_lock takes the same pre-work check, got {immediate:?}"
+    );
+}
+
+/// `RD-LOCK-013` — `stop()` leaves held leases behind, and they expire on their
+/// own deadlines.
+///
+/// **Deliberately asserts that cleanup does *not* happen.**
+/// `cpt-cf-clst-fr-shutdown-ttl-cleanup` forbids best-effort remote cleanup on
+/// shutdown, and a lease needs none: it reaps itself. So there is no drain step to
+/// time out, no statement that can half-succeed, and no partial-cleanup failure
+/// mode for an operator to alert on.
+///
+/// A future "tidy up on stop" change would fail here, which is the point — it
+/// would look like an improvement and would introduce a shutdown path that can
+/// fail against an unresponsive server.
+#[tokio::test]
+async fn rd_lock_013_stop_leaves_held_leases_to_expire() {
+    let (_container, handle, lock, raw, prefix, _url) = fixture(json!({})).await;
+
+    let mut guards = Vec::new();
+    for index in 0..3 {
+        guards.push(
+            lock.try_lock(&format!("res-{index}"), Duration::from_secs(4))
+                .await
+                .expect("acquire"),
+        );
+    }
+    // Dropped rather than released: a supervisor shutting the gear down does not
+    // hand every guard back first, which is the situation this scenario is about.
+    drop(guards);
+    handle.stop().await;
+
+    for index in 0..3 {
+        let exists: i64 = raw
+            .exists(lease_key(&prefix, &format!("res-{index}")))
+            .await
+            .expect("EXISTS succeeds");
+        assert_eq!(
+            exists, 1,
+            "lease res-{index} must still be present after stop() - shutdown does no remote \
+             cleanup (cpt-cf-clst-fr-shutdown-ttl-cleanup)"
+        );
+    }
+
+    let all_expired = common::wait_until(
+        Duration::from_secs(10),
+        Duration::from_millis(200),
+        async || {
+            let mut remaining = 0_i64;
+            for index in 0..3 {
+                remaining += raw
+                    .exists::<i64, _>(lease_key(&prefix, &format!("res-{index}")))
+                    .await
+                    .unwrap_or(1);
+            }
+            remaining == 0
+        },
+    )
+    .await;
+    assert!(
+        all_expired,
+        "and each must then lapse on its own deadline - the reason no cleanup is needed"
+    );
+}
+
+/// `RD-LOCK-015` — the **standalone** lock plugin observes an evicted lease.
+///
+/// The half of DESIGN.md §3.7 that a cache-scoped pattern cannot reach at all
+/// rather than merely narrowly. Without its own keyspace subscription this
+/// plugin — the shape `ClusterLockProvider::build_lock` produces in production —
+/// has every lease it holds evicted out from under it and reports nothing.
+///
+/// It matters most precisely here. A lock-only deployment is the one likeliest to
+/// be pointed at a *shared* Redis, since it has no cache whose working set would
+/// argue for its own instance, and a shared cache instance under `allkeys-lru` is
+/// the documented misconfiguration §3.7 exists to report.
+///
+/// The pressure comes from a raw client rather than from the thing under test:
+/// this plugin owns no cache to write filler through, which is the same reason
+/// the fixture hands back a URL.
+///
+/// What is *not* asserted is any change in behaviour. The lock keeps working
+/// through the eviction — the acquisition loop treats the `SET NX` as the source
+/// of truth throughout — and the plugin still needs no `expired` flag. The whole
+/// of the response is the report.
+#[tokio::test]
+async fn rd_lock_015_the_standalone_plugin_observes_an_evicted_lease() {
+    let (_guard, log) = common::scoped_capture(tracing::Level::WARN);
+    let (meter, metrics) = common::in_memory_meter();
+    let (_container, config, url) = common::start_redis_evicting_lock_only().await;
+    let database = config.database;
+    let handle = RedisLockPlugin::builder(config)
+        .__with_meter(meter)
+        .build_and_start()
+        .await
+        .expect("the standalone lock plugin starts against a memory-capped container");
+
+    // Acquired first and never renewed, so it is the oldest untouched key when
+    // `allkeys-lru` starts choosing. The TTL is far longer than the scenario, so
+    // an expiry cannot be mistaken for the eviction under test.
+    let _lease = handle
+        .lock()
+        .try_lock("evictable", Duration::from_mins(10))
+        .await
+        .expect("the lease is acquired on an empty container");
+
+    let raw = common::raw_client_on(&url, database).await;
+    let filler = vec![b'f'; 16 * 1024];
+    let mut observed = false;
+    for index in 0..1_200 {
+        let _: () = raw
+            .set(
+                format!("filler:{index}"),
+                filler.as_slice(),
+                None,
+                None,
+                false,
+            )
+            .await
+            .expect("filler writes succeed under allkeys-lru");
+        if common::count_occurrences(&log, "primitive=\"lock\"") >= 1 {
+            observed = true;
+            break;
+        }
+    }
+
+    assert!(
+        observed,
+        "the standalone plugin must report an evicted lease. It subscribed no keyspace pattern \
+         at all before this landed, so a lock-only deployment on a shared evicting Redis was \
+         silent about the one failure it most needed to report. Captured: {}",
+        common::captured(&log)
+    );
+    assert!(
+        common::count_occurrences(&log, logs::EVICTION_OBSERVED) >= 1,
+        "under the same contracted event name the combined plugin uses"
+    );
+    assert!(
+        metrics.counter("cluster_redis_evictions_observed_total") >= 1,
+        "and counted, so an alert can fire on a lock-only deployment too"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-LOCK-014` — `WAIT` is applied when configured, a short count surfaces, and
+/// the declaration is unchanged by either.
+///
+/// `wait.rs`'s short-count arm is the whole reason `WAIT` is not fire-and-forget:
+/// an operator who opted into "this write is on a replica before I proceed" must
+/// not silently not receive it. Reaching that arm needs a real replica that can
+/// really stop acknowledging, which is why this waits on the Sentinel fixture.
+///
+/// The replica is **stopped** rather than partitioned. Partitioning is fault
+/// injection and stays deferred (§8); what this arm is about is the *short count*,
+/// and `WAIT` returning fewer acks than asked for is the same observable either
+/// way — the plugin cannot tell a gone replica from an unreachable one, and is not
+/// supposed to.
+///
+/// The third assertion is the one most easily lost: `WAIT` narrows a **window**,
+/// not a guarantee. It does not make the topology durable, so it must not move
+/// `consistency()` or `features().linearizable` (ADR-009, DESIGN.md §3.6). A
+/// plugin that upgraded its declaration because `WAIT` was configured would hand
+/// a consumer exactly the false assurance §3.6 exists to refuse.
+#[tokio::test]
+async fn rd_lock_014_wait_is_applied_and_a_short_count_surfaces() {
+    let (container, config, primary, replica) = common::start_redis_sentinel().await;
+    let lock_config = common::lock_config_json(
+        &config.url,
+        json!({ "wait_replicas": 1, "wait_timeout_ms": 500 }),
+    );
+    let handle = RedisLockPlugin::builder(lock_config)
+        .build_and_start()
+        .await
+        .expect("the standalone lock plugin starts against a sentinel-managed primary");
+    let lock = handle.lock();
+
+    assert!(
+        !lock.features().linearizable,
+        "WAIT narrows the window in which a failover can lose an acknowledged write; it does not \
+         close it. The declaration tracks the topology, and configuring WAIT must not upgrade it \
+         (ADR-009, DESIGN.md sec 3.6)"
+    );
+
+    // With the replica online, `WAIT 1 500` is satisfied and the acquire is
+    // ordinary. This half is what makes the failure half meaningful: without it,
+    // a plugin that failed every acquire would also "pass" below.
+    let guard = lock
+        .try_lock("waited", LONG_TTL)
+        .await
+        .expect("an acquire succeeds while the replica is acknowledging");
+    guard.release().await.expect("release succeeds");
+
+    // Take the replica away. `SHUTDOWN NOSAVE` stops the process; the primary and
+    // the sentinel are separate processes in the same container and keep running.
+    let _ = common::exec_in(
+        &container,
+        &[
+            "redis-cli",
+            "-p",
+            &replica.to_string(),
+            "shutdown",
+            "nosave",
+        ],
+    )
+    .await;
+    let detached = common::wait_until(
+        Duration::from_secs(15),
+        Duration::from_millis(200),
+        async || {
+            !common::exec_in(
+                &container,
+                &[
+                    "redis-cli",
+                    "-p",
+                    &primary.to_string(),
+                    "info",
+                    "replication",
+                ],
+            )
+            .await
+            .contains("state=online")
+        },
+    )
+    .await;
+    assert!(
+        detached,
+        "the fixture's replica must actually detach, or the short-count arm is never reached"
+    );
+
+    let short = lock.try_lock("waited-again", LONG_TTL).await;
+    assert!(
+        matches!(
+            short,
+            Err(ClusterError::Provider {
+                kind: cluster_sdk::ProviderErrorKind::ResourceExhausted,
+                ..
+            })
+        ),
+        "an acquire whose WAIT is not satisfied must surface ResourceExhausted rather than \
+         reporting success: the lease is on the primary but not replicated, so a failover now \
+         could hand the same lock to a second holder. Got {short:?}"
+    );
+
+    handle.stop().await;
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/tests/redis_specific.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/tests/redis_specific.rs
@@ -1,0 +1,1461 @@
+//! Layer 3 — Redis-specific scenarios (docs/TESTING.md §4.6).
+//!
+//! The declaration-and-environment tests. Several are the **only** coverage of
+//! DESIGN.md's honesty claims, which no conformance scenario can reach: a
+//! conformance suite exercises what a backend does, and these exercise whether
+//! what it *says about itself* is true.
+//!
+//! That is not a stylistic distinction. This plugin's declared consistency is
+//! **computed from the server it is talking to** (DESIGN.md §3.6), and every
+//! capability check downstream — the strict leader constructor, the SDK default
+//! lock's guard, `CacheCapability::Linearizable` — dispatches on that answer. A
+//! plugin that declared `Linearizable` against a replicated server would defeat
+//! all of them at once, and no scenario in §4.2–§4.5 would notice.
+//!
+//! # Four of these need a multi-node fixture
+//!
+//! `RD-SPEC-002` (replicated topology) runs on the Sentinel fixture, and
+//! `RD-SPEC-008`/`009`/`010` (cluster mode) on the 3-node Cluster one. Both
+//! fixtures are built and both run on every PR: `nextest` overlaps their
+//! container startup with the rest of the suite, so the quorum and slot-assignment
+//! waits cost no wall clock against the run as a whole.
+//!
+//! They are what closes the two claims that would otherwise rest on unit tests:
+//! `RD-SPEC-010` is the gate DESIGN.md §13 D2 designates for lifting cluster-mode
+//! `prefix_watch: false`, and `RD-SPEC-002` puts §3.6's replicated row against a
+//! live replica rather than against parsed `INFO replication` output.
+//!
+//! # Why so many scenarios take their own container
+//!
+//! Almost every fixture here differs in *server* configuration, and two of them
+//! mutate it. `RD-SPEC-005b` in particular issues the plugin's one
+//! `CONFIG SET notify-keyspace-events`, which is server-wide and outlives the
+//! test — sharing a container with `RD-SPEC-005`, which asserts those flags are
+//! absent, would make the pair order-dependent and intermittently red.
+
+#![cfg(feature = "integration")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration tests: a setup failure IS the test failure"
+)]
+
+mod common;
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use cluster_sdk::cache::{
+    CacheCapability, CacheConsistency, CacheEvent, CacheWatchEvent, PutRequest, Ttl,
+};
+use cluster_sdk::{ClusterCacheBackend, ClusterError};
+use fred::interfaces::ServerInterface;
+use redis_cluster_plugin::{RedisClusterPlugin, logs};
+use serde_json::json;
+
+const VALUE: &[u8] = b"v";
+
+/// `RD-SPEC-001` — a stock container declares `EventuallyConsistent`, the lock
+/// agrees, and the WARN fires exactly once.
+///
+/// The plugin's default posture, and the one an operator will actually meet.
+/// "Exactly once" matters because this WARN appears in the log of **every**
+/// ordinary Redis deployment: emitted per operation it would be noise an operator
+/// filters out, and the one time it mattered they would have filtered it already.
+///
+/// The lock's declaration is asserted alongside the cache's because they come from
+/// one preflight: the lock is exactly as safe as the server it runs on
+/// (DESIGN.md §5.1), and a lock that declared `linearizable: true` over a weak
+/// cache would let a consumer require the capability and be told it was met.
+#[tokio::test]
+async fn rd_spec_001_a_stock_container_declares_eventually_consistent() {
+    let (_guard, log) = common::scoped_capture(tracing::Level::WARN);
+    let (_container, config) = common::start_redis().await;
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("a stock container starts - a weak declaration is not a startup failure");
+
+    assert_eq!(
+        handle.cache().consistency(),
+        CacheConsistency::EventuallyConsistent,
+        "stock Redis has no AOF, so nothing is fsynced before it is acknowledged"
+    );
+    assert!(
+        !handle.lock().features().linearizable,
+        "the lock's declaration tracks the cache's - both come from one preflight"
+    );
+    assert_eq!(
+        common::count_occurrences(&log, logs::WEAK_CONSISTENCY),
+        1,
+        "the weak-consistency WARN must be logged exactly once at startup, not per operation. \
+         Captured: {}",
+        common::captured(&log)
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-SPEC-003` — a verified single-node durable topology declares
+/// `Linearizable`, and logs **no** weak-consistency WARN.
+///
+/// The positive branch the leader conformance suite depends on
+/// (`tests/conformance.rs::leader_conformance`): `CasBasedLeaderElectionBackend::new`
+/// is the strict constructor and accepts only this. If the declaration on this
+/// fixture ever weakened, that whole suite would stop being able to construct its
+/// backend — so this scenario is what localises such a regression to the
+/// declaration rather than to the leader suite.
+///
+/// The absent WARN is asserted with a **thread-local** capture, since it is a
+/// negative: a process-global buffer would be polluted by every other test's
+/// plugin, and `RD-SPEC-001`'s own WARN would satisfy the search.
+#[tokio::test]
+async fn rd_spec_003_a_durable_single_node_declares_linearizable() {
+    let (_guard, log) = common::scoped_capture(tracing::Level::WARN);
+    let (_container, config) = common::start_redis_durable().await;
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the durable single-node fixture starts");
+
+    assert_eq!(
+        handle.cache().consistency(),
+        CacheConsistency::Linearizable,
+        "a verified single node with appendonly yes and appendfsync always is the one \
+         configuration ADR-009 rates safe"
+    );
+    assert!(
+        handle.lock().features().linearizable,
+        "and the lock declares it too"
+    );
+    assert_eq!(
+        common::count_occurrences(&log, logs::WEAK_CONSISTENCY),
+        0,
+        "no weak-consistency WARN may be logged for a Linearizable declaration. Captured: {}",
+        common::captured(&log)
+    );
+    assert_eq!(
+        common::count_occurrences(&log, logs::CONSISTENCY_ASSERTED),
+        0,
+        "and this declaration is *verified*, not asserted - CONFIG GET was readable, so nothing \
+         rests on an operator hint. Captured: {}",
+        common::captured(&log)
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-SPEC-004` — the strict leader constructor **refuses** a weak cache, and a
+/// profile that omits `leader_election` over a Redis cache fails startup.
+///
+/// This asserts the blocker rather than working around it (DESIGN.md §7, §13 D1),
+/// and it is the more important half of the `004`/`004b` pair: it pins that the
+/// opt-in defaults to *off*, so a weak-consistency leader election can only ever
+/// be something an operator asked for in writing.
+///
+/// The wiring half is what makes it real. `ClusterWiring::from_config` auto-fills
+/// the omitted primitives with the SDK defaults over the profile's cache, so
+/// `cache: { provider: redis }` alone produces exactly the deployment shape
+/// `../../../docs/DESIGN.md` §4.2 lists as "Redis-only" — and it must fail loudly
+/// with an actionable error rather than start and elect two leaders later.
+#[tokio::test]
+async fn rd_spec_004_the_strict_leader_constructor_refuses_a_weak_cache() {
+    use cluster::defaults::CasBasedLeaderElectionBackend;
+    use cluster::{ClusterConfig, ClusterWiring, ProviderRegistry};
+    use redis_cluster_plugin::RedisCacheProvider;
+    use toolkit::client_hub::ClientHub;
+
+    let (_container, config) = common::start_redis().await;
+    let url = config.url.clone();
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the plugin itself starts fine - it is the CAS default over it that cannot");
+
+    // The direct half: the constructor itself refuses.
+    assert!(
+        CasBasedLeaderElectionBackend::new(handle.cache()).is_err(),
+        "the strict constructor must refuse an EventuallyConsistent cache rather than construct a \
+         backend that can elect two leaders"
+    );
+    handle.stop().await;
+
+    // The wiring half: the same refusal reached through operator config.
+    let mut profiles = serde_json::Map::new();
+    profiles.insert(
+        "redisweak".to_owned(),
+        json!({ "cache": { "provider": "redis", "url": url } }),
+    );
+    let cluster_config: ClusterConfig =
+        serde_json::from_value(json!({ "profiles": profiles })).expect("the profile config parses");
+    let providers = ProviderRegistry::new().with_cache_provider(Arc::new(RedisCacheProvider));
+    let outcome =
+        ClusterWiring::from_config(Arc::new(ClientHub::new()), &cluster_config, &providers).await;
+
+    let Err(err) = outcome else {
+        panic!(
+            "a profile binding cache: redis and omitting leader_election must fail startup - the \
+             omit-default is a CAS backend that rejects a weak cache, and starting anyway would \
+             mean silently electing two leaders"
+        );
+    };
+    let message = format!("{err:?}");
+    assert!(
+        message.to_lowercase().contains("consisten"),
+        "the error must be actionable about *why* - an operator needs to know their cache's \
+         consistency is the problem, not merely that startup failed. Got {message}"
+    );
+}
+
+/// `RD-SPEC-004b` — the opt-in flag reaches the weak constructor, and launders
+/// nothing.
+///
+/// The end-to-end half of the pair whose wiring-level half lives in
+/// `cluster/src/config_tests.rs`. Two things about the profile are load-bearing
+/// (DESIGN.md §13 D1):
+///
+/// - **`provider: default`**, not an omitted provider. `BackendBinding.provider` is
+///   a required field, so `leader_election: { allow_weak_consistency: true }`
+///   cannot deserialize at all; the reserved name `default` means "the SDK default
+///   backend over this profile's cache, with options". Making `provider` an
+///   `Option` instead was rejected because `BackendBinding` flattens unknown keys
+///   into `options`, so a misspelled `providr: redis` would silently become an SDK
+///   default rather than a startup error — a config typo must never change which
+///   backend runs.
+/// - **An explicit `lock: { provider: redis }`.** The omit-default *lock* is also a
+///   CAS backend sharing the same `reject_weak_consistency` guard, so a profile
+///   that opted in on leader election alone would clear that hurdle and then die on
+///   the lock. A single-flag implementation passes every leader test and fails only
+///   here.
+///
+/// The capability assertion at the end is what keeps the flag honest: waiving a
+/// constructor guard confers no guarantee, so a consumer that *requires*
+/// linearizability must still be refused.
+#[tokio::test]
+async fn rd_spec_004b_the_opt_in_reaches_the_weak_constructor_without_laundering() {
+    use cluster::{ClusterConfig, ClusterWiring, ProfileRegistry, ProviderRegistry};
+    use cluster_sdk::leader::LeaderStatus;
+    use cluster_sdk::profile::ClusterProfile;
+    use cluster_sdk::{ClusterCacheV1, LeaderElectionV1};
+    use redis_cluster_plugin::{RedisCacheProvider, RedisLockProvider};
+    use toolkit::client_hub::ClientHub;
+
+    #[derive(Clone, Copy)]
+    struct WeakProfile;
+    impl ClusterProfile for WeakProfile {
+        const NAME: &'static str = "redisweakoptin";
+    }
+
+    let (_container, config) = common::start_redis().await;
+    let url = config.url.clone();
+
+    let mut profiles = serde_json::Map::new();
+    profiles.insert(
+        WeakProfile::NAME.to_owned(),
+        json!({
+            "cache": { "provider": "redis", "url": url },
+            // The reserved sentinel plus the explicit acknowledgement.
+            "leader_election": { "provider": "default", "allow_weak_consistency": true },
+            // Defect 2: without this the omit-default CAS lock rejects the same
+            // weak cache and startup fails after leader election has been cleared.
+            "lock": { "provider": "redis", "url": url },
+        }),
+    );
+    let cluster_config: ClusterConfig = serde_json::from_value(json!({ "profiles": profiles }))
+        .expect("the opt-in profile config parses");
+
+    let providers = ProviderRegistry::new()
+        .with_cache_provider(Arc::new(RedisCacheProvider))
+        .with_lock_provider(Arc::new(RedisLockProvider));
+    let hub = Arc::new(ClientHub::new());
+    let (mut handle, bound) = ClusterWiring::from_config(
+        Arc::clone(&hub),
+        &cluster_config,
+        &providers,
+    )
+    .await
+    .expect(
+        "the same profile that fails in RD-SPEC-004 must start once the operator opts in on \
+             both CAS defaults",
+    );
+    // The gear's post-`from_config` step: publish the bound set so the process can
+    // resolve the profile through its local cluster client.
+    handle.publish(&Arc::new(ProfileRegistry::new()), bound);
+
+    // The resolved backend really elects, over the weak Redis cache.
+    let leader = LeaderElectionV1::resolver(&hub)
+        .profile(WeakProfile)
+        .resolve()
+        .await
+        .expect("the leader-election facade resolves for the opted-in profile");
+    let mut watch = leader.elect("svc").await.expect("elect succeeds");
+    let became_leader = tokio::time::timeout(Duration::from_secs(10), async {
+        while !watch.is_leader() {
+            let _event = watch.changed().await;
+        }
+    })
+    .await
+    .is_ok();
+    assert!(
+        became_leader,
+        "the sole candidate must become leader over the weak cache - the flag routes to the SDK's \
+         new_allow_weak_consistency constructor, which works, rather than to a stub. Last status: \
+         {:?}",
+        watch.status()
+    );
+    assert_eq!(watch.status(), LeaderStatus::Leader);
+
+    // And the flag launders nothing: a consumer requiring linearizability is still
+    // refused, naming the capability and the provider. `ClusterCacheV1` is not
+    // `Debug`, so the outcome is matched rather than formatted.
+    match ClusterCacheV1::resolver(&hub)
+        .profile(WeakProfile)
+        .require(CacheCapability::Linearizable)
+        .resolve()
+        .await
+    {
+        Err(ClusterError::CapabilityNotMet { capability, .. }) => {
+            assert_eq!(
+                capability, "Linearizable",
+                "the refusal must name the capability that was not met, so an operator reading the \
+                 startup error knows which requirement their backend cannot serve"
+            );
+        }
+        Err(other) => panic!("expected CapabilityNotMet, got {other:?}"),
+        Ok(_resolved) => panic!(
+            "opting in waives a *constructor guard*, not the capability model - a consumer that \
+             requires Linearizable must still be told it is not available"
+        ),
+    }
+
+    drop(watch);
+    handle.stop().await;
+}
+
+/// `RD-SPEC-005` — missing keyspace notifications degrade loudly and safely.
+///
+/// The trade in one scenario: **promptness is lost, correctness is intact.**
+/// `Changed` and `Deleted` still arrive because the plugin publishes those itself
+/// from inside its scripts; `Expired` never does, because that one can only come
+/// from the server. And an expired entry still reads as absent — the TTL is
+/// Redis's own `PEXPIRE`, so expiry is unaffected by whether anyone is *told*
+/// about it.
+///
+/// This is the environment a managed Redis often is, so startup must not fail. It
+/// must, however, say so once — an operator debugging "why don't I get expiry
+/// events" needs the answer in their log rather than in this document.
+#[tokio::test]
+async fn rd_spec_005_missing_keyspace_notifications_degrade_loudly_and_safely() {
+    let (_guard, log) = common::scoped_capture(tracing::Level::WARN);
+    let (_container, config) = common::start_redis_no_notifications().await;
+    let url = config.url.clone();
+    let database = config.database;
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect(
+            "a server without keyspace notifications must still start - this is what a managed \
+                 Redis often looks like",
+        );
+    let cache = handle.cache();
+    let raw = common::raw_client_on(&url, database).await;
+
+    assert_eq!(
+        common::keyspace_flags(&raw).await,
+        "",
+        "the fixture must genuinely have no flags, and the plugin must not have set them: \
+         manage_keyspace_notifications defaults to false because the setting is server-wide"
+    );
+    assert_eq!(
+        common::count_occurrences(&log, logs::EXPIRY_EVENTS_UNAVAILABLE),
+        1,
+        "the degradation must be reported once. Captured: {}",
+        common::captured(&log)
+    );
+
+    let mut watch = cache.watch("deg:key").await.expect("watch succeeds");
+    cache
+        .put(PutRequest {
+            key: "deg:key",
+            value: VALUE,
+            ttl: Ttl::Of(Duration::from_millis(400)),
+        })
+        .await
+        .expect("put succeeds");
+    let changed = tokio::time::timeout(Duration::from_secs(2), watch.recv())
+        .await
+        .expect("Changed still arrives")
+        .expect("the stream is open");
+    assert!(
+        matches!(changed, CacheWatchEvent::Event(CacheEvent::Changed { .. })),
+        "Changed is published by the plugin's own script and is unaffected, got {changed:?}"
+    );
+
+    // The entry still expires — that is Redis's PEXPIRE, not a notification.
+    let gone = common::wait_until(
+        Duration::from_secs(4),
+        Duration::from_millis(50),
+        async || matches!(cache.get("deg:key").await, Ok(None)),
+    )
+    .await;
+    assert!(
+        gone,
+        "correctness is intact: the TTL is the server's own and expires regardless of whether \
+         anybody is told"
+    );
+
+    // But no `Expired` ever arrives.
+    let stray = tokio::time::timeout(Duration::from_millis(700), watch.recv()).await;
+    assert!(
+        !matches!(
+            stray,
+            Ok(Some(CacheWatchEvent::Event(CacheEvent::Expired { .. })))
+        ),
+        "no Expired may arrive without keyspace notifications - this is exactly the promptness \
+         that was lost, got {stray:?}"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-SPEC-005b` — `manage_keyspace_notifications: true` sets the flags, says so,
+/// and `Expired` then arrives.
+///
+/// **This scenario has its own container, deliberately.** It is the one place the
+/// plugin mutates server state: `CONFIG SET notify-keyspace-events` is server-wide
+/// and outlives the test, so sharing a container with `RD-SPEC-005` — which asserts
+/// the flags are *absent* — would make the pair order-dependent and intermittently
+/// red depending on which ran first.
+///
+/// `keyspace_notifications_set` is INFO rather than DEBUG for the same reason this
+/// whole scenario needs its own container: it is the only
+/// configuration *mutation* this plugin performs, and it is global. An operator
+/// should be able to find it without turning DEBUG on.
+///
+/// The merge is additive, not a replacement — the plugin adds the flags it needs to
+/// whatever is already there, since clobbering the value would switch off
+/// notifications another tenant of the same server depends on.
+#[tokio::test]
+async fn rd_spec_005b_managed_keyspace_notifications_are_set_and_reported() {
+    let (_guard, log) = common::scoped_capture(tracing::Level::INFO);
+    let (_container, config) =
+        common::start_redis_no_notifications_with(json!({ "manage_keyspace_notifications": true }))
+            .await;
+    let url = config.url.clone();
+    let database = config.database;
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the plugin starts and manages the flags");
+    let cache = handle.cache();
+    let raw = common::raw_client_on(&url, database).await;
+
+    let flags = common::keyspace_flags(&raw).await;
+    for required in ['K', 'x', 'e'] {
+        assert!(
+            flags.contains(required),
+            "CONFIG GET must confirm the flag `{required}` was set; got {flags:?}. Kxe is the \
+             minimal correct set: K+x yields expired and K+e yields evicted, while g and $ would \
+             add a notification per generic and per string command server-wide"
+        );
+    }
+    assert_eq!(
+        common::count_occurrences(&log, logs::KEYSPACE_NOTIFICATIONS_SET),
+        1,
+        "the only server-wide mutation this plugin performs must be reported at INFO, once. \
+         Captured: {}",
+        common::captured(&log)
+    );
+    assert_eq!(
+        common::count_occurrences(&log, logs::EXPIRY_EVENTS_UNAVAILABLE),
+        0,
+        "and the degradation WARN must *not* fire, since the flags are now present. Captured: {}",
+        common::captured(&log)
+    );
+
+    // The payoff: Expired now arrives where RD-SPEC-005 saw none.
+    let mut watch = cache.watch("man:key").await.expect("watch succeeds");
+    cache
+        .put(PutRequest {
+            key: "man:key",
+            value: VALUE,
+            ttl: Ttl::Of(Duration::from_millis(400)),
+        })
+        .await
+        .expect("put succeeds");
+
+    let expired = tokio::time::timeout(Duration::from_secs(6), async {
+        loop {
+            match watch.recv().await {
+                Some(CacheWatchEvent::Event(CacheEvent::Expired { key })) => return Some(key),
+                Some(_other) => {}
+                None => return None,
+            }
+        }
+    })
+    .await
+    .ok()
+    .flatten();
+    assert_eq!(
+        expired.as_deref(),
+        Some("man:key"),
+        "with the flags set by the plugin, a TTL lapse must deliver Expired"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-SPEC-005b` (the default half) — with the flag `false`, no `CONFIG SET` is
+/// issued at all.
+///
+/// Separated so a regression that made the plugin *always* manage the flags is
+/// distinguishable from one that made it never. Without this, a plugin that
+/// ignored the setting and always wrote would pass the scenario above — and would
+/// be silently reconfiguring every server it ever connected to, which is precisely
+/// what the default-`false` exists to prevent.
+#[tokio::test]
+async fn rd_spec_005b_the_default_issues_no_config_set() {
+    let (_container, config) = common::start_redis_no_notifications().await;
+    let url = config.url.clone();
+    let database = config.database;
+    let raw = common::raw_client_on(&url, database).await;
+    let baseline = common::command_calls(&raw, "config|set").await;
+
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the plugin starts");
+
+    assert_eq!(
+        common::command_calls(&raw, "config|set").await,
+        baseline,
+        "with manage_keyspace_notifications at its default of false, no CONFIG SET may be issued: \
+         the setting is server-wide and shared with unrelated tenants, so it is exactly the kind \
+         of surprise an operator must opt into"
+    );
+    assert_eq!(
+        common::keyspace_flags(&raw).await,
+        "",
+        "and the server's flags must be exactly as they were found"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-SPEC-006` — an unsafe `maxmemory-policy` is warned about at startup, and
+/// startup still succeeds.
+///
+/// Both halves matter and they pull in opposite directions. `allkeys-lru` means
+/// Redis may delete this plugin's keys under memory pressure — an evicted lock
+/// lease hands the lock to a second holder, and an evicted leader key elects a
+/// second leader — so it has to be said. But `maxmemory-policy` is a *server-wide*
+/// setting the gear's operator may not control, so refusing to start would take a
+/// service down over a condition it cannot fix (DESIGN.md §3.7).
+///
+/// This fixture sets the policy with **no** `maxmemory`, so the risk exists and no
+/// eviction actually happens; driving a real eviction is `RD-SPEC-007`. Keeping
+/// them apart means this scenario cannot pass or fail on whether an eviction
+/// happened to land mid-test.
+#[tokio::test]
+async fn rd_spec_006_an_unsafe_maxmemory_policy_is_warned_at_startup() {
+    let (_guard, log) = common::scoped_capture(tracing::Level::WARN);
+    let (_container, config) = common::start_redis_unsafe_policy().await;
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("an unsafe server-wide policy must not block a gear from starting");
+
+    assert_eq!(
+        common::count_occurrences(&log, logs::MAXMEMORY_POLICY_UNSAFE),
+        1,
+        "the unsafe policy must be named once at startup. Captured: {}",
+        common::captured(&log)
+    );
+    assert!(
+        common::captured(&log).contains("allkeys-lru"),
+        "and the WARN must name the actual policy, so an operator knows what to change. \
+         Captured: {}",
+        common::captured(&log)
+    );
+
+    // The cache still works — the warning is about risk, not about capability.
+    let cache = handle.cache();
+    cache
+        .put(PutRequest {
+            key: "warned:key",
+            value: VALUE,
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("the cache works normally on a server with an unsafe policy");
+
+    handle.stop().await;
+}
+
+/// `RD-SPEC-007` — a real eviction is observed, reported, and mapped correctly.
+///
+/// The plugin's top operational risk, driven end to end under genuine memory
+/// pressure rather than asserted in prose. Four claims, and each fails differently:
+///
+/// - the watcher receives **`Deleted`, not `Expired`**. No TTL elapsed, so calling
+///   it `Expired` would tell a consumer its data aged out when in fact the server
+///   threw it away (DESIGN.md §3.7);
+/// - `cluster.provider.eviction_observed` (WARN) is logged;
+/// - `cluster_redis_evictions_observed_total` increments;
+/// - `cluster_provider_errors_total` does **not**.
+///
+/// The last two are the point of the pair. The catalog counter cannot carry an
+/// eviction in two independent ways: it takes `{provider, kind}` and no
+/// `op` at all, and an eviction is not a `ClusterError`, so it cannot travel
+/// through `emit_provider_error`. Folding it on as `kind = "other"` would make an
+/// eviction indistinguishable from every other unclassified backend failure *and*
+/// inflate a provider-error rate with something that is not an operation failure —
+/// which is why the negative assertion is here rather than merely implied.
+///
+/// The shape of the setup is what makes it reliable: write a small watched victim
+/// **first** and never touch it again, then push filler in until `allkeys-lru`
+/// picks the least-recently-used key — which is the victim, by construction.
+#[tokio::test]
+async fn rd_spec_007_a_real_eviction_is_observed_reported_and_mapped() {
+    let (_guard, log) = common::scoped_capture(tracing::Level::WARN);
+    let (meter, metrics) = common::in_memory_meter();
+    let (_container, config) = common::start_redis_evicting().await;
+    let handle = RedisClusterPlugin::builder(config)
+        .__with_meter(meter)
+        .build_and_start()
+        .await
+        .expect("the plugin starts against a memory-capped container");
+    let cache = handle.cache();
+
+    // The victim: small, watched, and never read again, so LRU picks it first.
+    cache
+        .put(PutRequest {
+            key: "victim",
+            value: b"small",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("the victim is written");
+    let mut watch = cache.watch("victim").await.expect("watch succeeds");
+
+    // Filler until the victim is gone. 16 KiB values against a 3 MiB ceiling, and
+    // a generous bound: the eviction happens when Redis decides it must, not on a
+    // schedule this test controls.
+    let filler = vec![b'f'; 16 * 1024];
+    let mut evicted = false;
+    for index in 0..600 {
+        cache
+            .put(PutRequest {
+                key: &format!("filler:{index}"),
+                value: &filler,
+                ttl: Ttl::Indefinite,
+            })
+            .await
+            .expect(
+                "filler writes succeed under allkeys-lru - eviction makes room rather than \
+                     refusing the write",
+            );
+        if matches!(cache.get("victim").await, Ok(None)) {
+            evicted = true;
+            break;
+        }
+    }
+    assert!(
+        evicted,
+        "the watched victim must be evicted under real memory pressure, or this scenario proves \
+         nothing about eviction"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match watch.recv().await {
+                Some(CacheWatchEvent::Event(event)) => return Some(event),
+                Some(_other) => {}
+                None => return None,
+            }
+        }
+    })
+    .await
+    .ok()
+    .flatten()
+    .expect("the eviction must reach the watcher");
+    assert!(
+        matches!(&event, CacheEvent::Deleted { key } if key == "victim"),
+        "an eviction maps to Deleted, never Expired: no TTL elapsed, the server simply threw the \
+         key away, and a consumer told 'Expired' would believe its data aged out. Got {event:?}"
+    );
+
+    assert!(
+        common::count_occurrences(&log, logs::EVICTION_OBSERVED) >= 1,
+        "the eviction WARN must be logged. Captured: {}",
+        common::captured(&log)
+    );
+    assert!(
+        metrics.counter("cluster_redis_evictions_observed_total") >= 1,
+        "and counted under a name that says what it counts (DESIGN.md sec 3.7)"
+    );
+    assert_eq!(
+        metrics.counter("cluster_provider_errors_total"),
+        0,
+        "an eviction is not an operation failure and must not inflate the provider-error rate - \
+         which is what folding it onto that counter as kind=other would have done, while also \
+         making it indistinguishable from every other unclassified backend failure"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-SPEC-007b` — an evicted **lock lease** is observed and attributed to the
+/// lock, alongside the cache's own evictions.
+///
+/// `RD-SPEC-007` covers the cache entry. This covers the case DESIGN.md §3.7
+/// *opens* with and rates worst: an evicted lease hands the lock to a second
+/// holder while the first still believes it holds it, with no TTL having lapsed
+/// and nothing else in the system able to notice. The keyspace pattern spans
+/// `<prefix>:*` so that notification arrives at all, and the fan-out sorts it by
+/// the primitive that owns the key.
+///
+/// Two things are asserted that a shared signal would fail:
+///
+/// - the line carries `primitive="lock"`, so an operator can tell a re-read from
+///   a double-held lock. A single unlabelled eviction event would leave the two
+///   indistinguishable at exactly the moment the difference matters;
+/// - the cache's own line survives the same storm. The WARN is rate-limited, and
+///   a limiter shared across primitives would let the flood of evicted *entries*
+///   — which is what memory pressure produces most of — spend the window the one
+///   lock line needs.
+///
+/// The lease is acquired **first** and never renewed, so it is the oldest
+/// untouched key in the database when `allkeys-lru` starts choosing victims. Its
+/// TTL is far longer than the scenario, so an expiry cannot be mistaken for the
+/// eviction under test.
+#[tokio::test]
+async fn rd_spec_007b_an_evicted_lock_lease_is_observed_and_attributed() {
+    let (_guard, log) = common::scoped_capture(tracing::Level::WARN);
+    let (meter, metrics) = common::in_memory_meter();
+    let (_container, config) = common::start_redis_evicting().await;
+    let handle = RedisClusterPlugin::builder(config)
+        .__with_meter(meter)
+        .build_and_start()
+        .await
+        .expect("the plugin starts against a memory-capped container");
+    let cache = handle.cache();
+
+    // Held for the whole scenario and never renewed: nothing touches this key
+    // again, which is what puts it at the front of the LRU queue.
+    let _guard_lease = handle
+        .lock()
+        .try_lock("evictable", Duration::from_mins(10))
+        .await
+        .expect("the lease is acquired on an empty container");
+
+    // Filler until the lock line appears. The bound is generous for the same
+    // reason `RD-SPEC-007`'s is: eviction happens when Redis decides it must,
+    // and which key it samples is approximate.
+    let filler = vec![b'f'; 16 * 1024];
+    let mut lock_evicted = false;
+    for index in 0..1_200 {
+        cache
+            .put(PutRequest {
+                key: &format!("filler:{index}"),
+                value: &filler,
+                ttl: Ttl::Indefinite,
+            })
+            .await
+            .expect("filler writes succeed under allkeys-lru");
+        if common::count_occurrences(&log, "primitive=\"lock\"") >= 1 {
+            lock_evicted = true;
+            break;
+        }
+    }
+
+    assert!(
+        lock_evicted,
+        "an evicted lock lease must be reported. A keyspace pattern scoped to `<prefix>:c:*` \
+         never receives the lease notification at all, which leaves the worst case DESIGN.md \
+         sec 3.7 names entirely unreported. Captured: {}",
+        common::captured(&log)
+    );
+    assert!(
+        common::count_occurrences(&log, logs::EVICTION_OBSERVED) >= 1,
+        "the eviction WARN keeps its contracted name whichever primitive owned the key"
+    );
+    assert!(
+        common::count_occurrences(&log, "primitive=\"cache\"") >= 1,
+        "the cache's own eviction line must survive the same storm - a rate limiter shared \
+         between the primitives would let the flood of evicted entries suppress it, or the lock \
+         line, depending on which arrived first. Captured: {}",
+        common::captured(&log)
+    );
+    assert!(
+        metrics.counter("cluster_redis_evictions_observed_total") >= 2,
+        "both primitives' evictions are counted on the one counter, separated by the label"
+    );
+    assert_eq!(
+        metrics.counter("cluster_provider_errors_total"),
+        0,
+        "an evicted lease is still not an operation failure"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-SPEC-011` — an operator hint the server contradicts fails startup, and the
+/// same hint is trusted when the server will not say.
+///
+/// The two branches of DESIGN.md §3.6's hint handling, and the asymmetry between
+/// them is the design:
+///
+/// - **Contradicted**: `durability: fsync_always` against a server running
+///   `appendfsync everysec` fails startup naming both values. `fsync_always` is
+///   the one setting that unlocks `Linearizable`, so it is the one claim worth
+///   checking — a wrong hint here does not degrade a guarantee, it fabricates one.
+/// - **Unverifiable**: the same hint against a server that refuses `CONFIG GET` is
+///   *trusted*, because that is the escape hatch a locked-down managed instance
+///   needs, and flagged `consistency_asserted` so the declaration's provenance is
+///   in the log rather than only in the operator's memory.
+#[tokio::test]
+async fn rd_spec_011_a_contradicted_hint_fails_and_an_unverifiable_one_is_flagged() {
+    // Contradicted: the server says everysec, the operator says always.
+    let (_container, config) =
+        common::start_redis_everysec_with(json!({ "durability": "fsync_always" })).await;
+    match RedisClusterPlugin::builder(config).build_and_start().await {
+        Err(ClusterError::InvalidConfig { reason }) => {
+            assert!(
+                reason.contains("always") && reason.contains("everysec"),
+                "the error must name both the claimed and the actual value, so an operator can see \
+                 which of the two to change. Got {reason}"
+            );
+        }
+        Err(other) => panic!("expected InvalidConfig naming both values, got {other:?}"),
+        // Stopped rather than dropped: an un-stopped handle panics on drop
+        // (ADR-006), which would replace this scenario's failure message with a
+        // teardown one.
+        Ok(started) => {
+            started.stop().await;
+            panic!(
+                "a durability hint the server contradicts must fail startup: fsync_always is what \
+                 unlocks Linearizable, so trusting a false one fabricates a guarantee rather than \
+                 degrading one"
+            );
+        }
+    }
+
+    // Unverifiable: CONFIG is denied to the connecting user, so the same hint is
+    // trusted — and flagged.
+    let (_denied_container, denied_config) =
+        common::start_redis_config_denied_with(json!({ "durability": "fsync_always" })).await;
+    let (_guard, log) = common::scoped_capture(tracing::Level::WARN);
+    let handle = RedisClusterPlugin::builder(denied_config)
+        .build_and_start()
+        .await
+        .expect(
+            "a server that will not let the plugin read CONFIG must not block startup - that is \
+             the managed-Redis escape hatch the hint exists for",
+        );
+
+    assert_eq!(
+        handle.cache().consistency(),
+        CacheConsistency::Linearizable,
+        "the hint is trusted when it cannot be checked"
+    );
+    assert_eq!(
+        common::count_occurrences(&log, logs::CONSISTENCY_ASSERTED),
+        1,
+        "but the declaration's provenance must be in the log: this Linearizable rests on an \
+         operator's word rather than on evidence. Captured: {}",
+        common::captured(&log)
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-SPEC-012` — `database` selects a logical DB, and the event channels follow
+/// it.
+///
+/// The second half is the whole scenario. Redis keyspace notifications are
+/// published on `__keyspace@<db>__:<key>`, so a plugin that subscribed on `@0`
+/// while writing to DB 3 would work perfectly for `Changed` and `Deleted` — which
+/// it publishes itself on channels of its own naming — and silently deliver **no
+/// `Expired` at all**. That is an off-by-one nobody would notice until an entry
+/// aged out and no consumer heard about it.
+///
+/// DB 0 being untouched is the cheap half, and still worth holding: it is what
+/// makes `database` usable for isolating two deployments on one server.
+#[tokio::test]
+async fn rd_spec_012_the_database_selects_a_logical_db_and_channels_follow() {
+    let (_container, config) = common::start_redis_with(json!({ "database": 3 })).await;
+    let url = config.url.clone();
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the plugin starts against database 3");
+    let cache = handle.cache();
+
+    let mut watch = cache.watch("db:key").await.expect("watch succeeds");
+    cache
+        .put(PutRequest {
+            key: "db:key",
+            value: VALUE,
+            ttl: Ttl::Of(Duration::from_millis(400)),
+        })
+        .await
+        .expect("put succeeds");
+
+    let in_db_3 = common::raw_client_on(&url, 3).await;
+    let in_db_0 = common::raw_client_on(&url, 0).await;
+    let size_3: u64 = in_db_3.dbsize().await.expect("DBSIZE succeeds");
+    let size_0: u64 = in_db_0.dbsize().await.expect("DBSIZE succeeds");
+    assert!(size_3 >= 1, "the key must land in database 3, saw {size_3}");
+    assert_eq!(
+        size_0, 0,
+        "database 0 must be untouched - this is what makes `database` usable for isolating two \
+         deployments on one server"
+    );
+
+    // And `Expired` arrives, which it only can if the keyspace subscription is on
+    // `__keyspace@3__` rather than `@0`.
+    let expired = tokio::time::timeout(Duration::from_secs(6), async {
+        loop {
+            match watch.recv().await {
+                Some(CacheWatchEvent::Event(CacheEvent::Expired { key })) => return Some(key),
+                Some(_other) => {}
+                None => return None,
+            }
+        }
+    })
+    .await
+    .ok()
+    .flatten();
+    assert_eq!(
+        expired.as_deref(),
+        Some("db:key"),
+        "Expired must arrive on database 3: a plugin subscribed on __keyspace@0__ while writing to \
+         DB 3 would deliver Changed and Deleted perfectly and no Expired ever"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-SPEC-014` — sharded pub/sub is **detected but not used**.
+///
+/// v1 records the capability without acting on it (DESIGN.md §13 D3): plain
+/// `PUBLISH` is broadcast cluster-wide and is therefore correct on every topology,
+/// while `SPUBLISH` would be a Cluster-only optimisation with its own
+/// slot-migration story. The DEBUG line means a follow-up can tell from a log
+/// whether a given deployment could support it.
+///
+/// The assertion that no `SPUBLISH`/`SSUBSCRIBE` is issued is the important one: it
+/// guards against a **half-landed follow-up** silently switching the publish path,
+/// which would work on a single node and quietly change delivery semantics on a
+/// cluster.
+///
+/// The Redis 6 half is why this scenario needs two containers. A detection that
+/// reported "available" everywhere would be indistinguishable from a working one
+/// here, and the version gate is the whole logic.
+#[tokio::test]
+async fn rd_spec_014_sharded_pubsub_is_detected_but_not_used() {
+    {
+        let (_guard, log) = common::scoped_capture(tracing::Level::DEBUG);
+        let (_container, config) = common::start_redis().await;
+        let url = config.url.clone();
+        let database = config.database;
+        let handle = RedisClusterPlugin::builder(config)
+            .build_and_start()
+            .await
+            .expect("the plugin starts against Redis 7");
+        let cache = handle.cache();
+        cache
+            .put(PutRequest {
+                key: "sharded:key",
+                value: VALUE,
+                ttl: Ttl::Indefinite,
+            })
+            .await
+            .expect("put succeeds");
+
+        assert_eq!(
+            common::count_occurrences(&log, logs::SHARDED_PUBSUB_AVAILABLE),
+            1,
+            "Redis 7 supports SPUBLISH/SSUBSCRIBE, and the capability must be recorded once. \
+             Captured: {}",
+            common::captured(&log)
+        );
+
+        let raw = common::raw_client_on(&url, database).await;
+        for command in ["spublish", "ssubscribe"] {
+            assert_eq!(
+                common::command_calls(&raw, command).await,
+                0,
+                "v1 records the capability and does not act on it: a {command} here would mean a \
+                 half-landed follow-up had switched the publish path, which works on a single node \
+                 and changes delivery semantics on a cluster"
+            );
+        }
+
+        handle.stop().await;
+    }
+
+    // Redis 6: neither the log line nor the commands.
+    let (_guard, log) = common::scoped_capture(tracing::Level::DEBUG);
+    let (_container, config) = common::start_redis_6().await;
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the plugin starts against Redis 6 - every command it issues predates 7");
+    assert_eq!(
+        common::count_occurrences(&log, logs::SHARDED_PUBSUB_AVAILABLE),
+        0,
+        "Redis 6 has no sharded pub/sub, so the detection must say nothing. A detection that \
+         reported it everywhere would be indistinguishable from a working one on Redis 7. \
+         Captured: {}",
+        common::captured(&log)
+    );
+    handle.stop().await;
+}
+
+/// `RD-SPEC-015` — a `topology` hint skips the `INFO replication` round trip.
+///
+/// Both `RedisClusterConfig::topology` and `PreflightRequest::topology_hint`
+/// document the skip, and DESIGN.md §3.4 says the hint "replaces detection". The
+/// operator-facing reason it has to be true is the locked-down managed instance:
+/// setting `topology: standalone` there is precisely a way of saying *do not ask
+/// this server, it will refuse* — and a preflight that asks anyway logs
+/// `cluster.provider.topology_unknown` announcing a conservative
+/// `EventuallyConsistent` declaration that `resolve_topology` never makes.
+///
+/// **Asserted as a call-count delta rather than as an absent WARN.** No fixture
+/// refuses `INFO` — `start_redis_config_denied_with` denies `CONFIG` — so the
+/// WARN has no trigger to withhold. The delta is the stronger assertion anyway:
+/// the WARN is unreachable once the command is not issued.
+///
+/// Both startups run against one container so the two counts are comparable, and
+/// each is measured as a delta from a baseline taken immediately before it.
+/// `command_calls` reports `cmdstat_info`, which counts `INFO server`,
+/// `INFO replication` **and the helper's own `INFO commandstats`** — so only the
+/// difference between the two deltas is meaningful, and it must be exactly one.
+#[tokio::test]
+async fn rd_spec_015_a_topology_hint_skips_the_info_replication_round_trip() {
+    let (_container, config) = common::start_redis().await;
+    let url = config.url.clone();
+    let raw = common::raw_client(&url).await;
+
+    // Unhinted: detection runs.
+    let before = common::command_calls(&raw, "info").await;
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the plugin starts against a stock container");
+    handle.stop().await;
+    let unhinted = common::command_calls(&raw, "info").await - before;
+
+    // Hinted: the same startup with the answer already supplied.
+    let hinted_config = common::cluster_config_json(&url, json!({ "topology": "standalone" }));
+    let before = common::command_calls(&raw, "info").await;
+    let handle = RedisClusterPlugin::builder(hinted_config)
+        .build_and_start()
+        .await
+        .expect("the plugin starts with a topology hint");
+    assert_eq!(
+        handle.cache().consistency(),
+        CacheConsistency::EventuallyConsistent,
+        "a standalone hint on a non-durable server still declares the weak consistency - this \
+         scenario is about the round trip, not about the declaration (DESIGN.md sec 3.6)"
+    );
+    handle.stop().await;
+    let hinted = common::command_calls(&raw, "info").await - before;
+
+    assert_eq!(
+        // Widened rather than subtracted in `u64`: a flipped delta must fail as
+        // this assertion, with both counts in the message, and not as an
+        // overflow panic that hides them.
+        i128::from(unhinted) - i128::from(hinted),
+        1,
+        "a topology hint must skip exactly the INFO replication round trip. Both field docs \
+         promise it and DESIGN.md sec 3.4 says the hint replaces detection, so issuing it anyway \
+         is a wasted command on every hinted deployment and a false \
+         cluster.provider.topology_unknown wherever the server refuses it \
+         (unhinted={unhinted}, hinted={hinted})"
+    );
+}
+
+/// `RD-SPEC-013` — throughput smoke against the OAGW envelope.
+///
+/// **Measured and printed as an artefact, never asserted against a threshold.** A
+/// CI container's absolute numbers are not a production predictor, and per
+/// `docs/PRD.md` §6.2 quantitative per-backend SLOs are explicitly excluded from
+/// the cluster-wide NFR set. What the artefact makes visible is an
+/// order-of-magnitude regression, which is the actionable part.
+///
+/// Recorded because `cpt-cf-clst-actor-oagw`'s 10 000+ counter updates per second
+/// is the reason this plugin exists at all: ADR-001 puts Redis 10–100× above every
+/// other backend on cache and lock throughput, and `compare_and_swap` on a small
+/// key set is the exact shape of an OAGW counter update.
+///
+/// Read it with `-- --nocapture`.
+#[tokio::test]
+async fn rd_spec_013_throughput_smoke_against_the_oagw_envelope() {
+    const OPERATIONS: u32 = 10_000;
+    const KEYS: u32 = 16;
+
+    let (_container, config) = common::start_redis_with(json!({ "pool_size": 8 })).await;
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the plugin starts");
+    let cache: Arc<dyn ClusterCacheBackend> = handle.cache();
+
+    for index in 0..KEYS {
+        cache
+            .put(PutRequest {
+                key: &format!("bench:{index}"),
+                value: b"0",
+                ttl: Ttl::Indefinite,
+            })
+            .await
+            .expect("seed put succeeds");
+    }
+
+    let started = Instant::now();
+    let mut done = 0_u32;
+    let mut conflicts = 0_u32;
+    for round in 0..OPERATIONS {
+        let key = format!("bench:{}", round % KEYS);
+        let Some(current) = cache.get(&key).await.expect("get succeeds") else {
+            panic!("a seeded key must be present");
+        };
+        match cache
+            .compare_and_swap(&key, current.version, b"1", Ttl::Indefinite)
+            .await
+        {
+            Ok(_entry) => done += 1,
+            Err(ClusterError::CasConflict { .. }) => conflicts += 1,
+            Err(other) => panic!("an unexpected failure during the smoke run: {other:?}"),
+        }
+    }
+    let elapsed = started.elapsed();
+
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "an operations-per-second figure printed for a human to eyeball; the precision \
+                  lost at these magnitudes is far below the run-to-run variance it is read against"
+    )]
+    let per_second = f64::from(done) / elapsed.as_secs_f64();
+    // A millisecond count rather than `{elapsed:?}`: clippy's `use_debug` is
+    // denied workspace-wide, and a plain integer reads better in an artefact line
+    // than `Duration`'s own representation anyway.
+    let elapsed_ms = elapsed.as_millis();
+    println!(
+        "RD-SPEC-013 artefact: {done} compare_and_swap ops ({conflicts} conflicts) over {KEYS} \
+         keys in {elapsed_ms} ms = {per_second:.0} ops/sec. Not a threshold - a CI container's \
+         absolute numbers are not a production predictor (TESTING.md sec 8). The reference point \
+         is cpt-cf-clst-actor-oagw's 10 000+ counter updates/sec, and what this makes visible is \
+         an order-of-magnitude regression."
+    );
+    assert_eq!(
+        done + conflicts,
+        OPERATIONS,
+        "every operation must have completed one way or the other - a smoke run that silently did \
+         less work would report a flattering number"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-SPEC-002` — a replicated topology declares `EventuallyConsistent` **even
+/// with `appendfsync always`**.
+///
+/// The most consequential thing this plugin computes, and the one row of
+/// DESIGN.md §3.6 that decides whether a Redis-backed profile starts at all. Every
+/// other fixture makes the declaration easy: a stock container is weak on
+/// durability *and* topology, and the durable single node is safe on both. This
+/// one puts them in conflict — the strongest possible durability setting on a
+/// server that also has a replica — so a plugin that read `appendfsync` and
+/// stopped would declare `Linearizable` here and be wrong.
+///
+/// Async replication is the binding weakness (ADR-009): an acknowledged write can
+/// be lost to a failover no matter how faithfully it was fsynced first. The test
+/// asserts the premise as well as the conclusion, reading `appendfsync` back off
+/// the primary — without that, a fixture that quietly failed to enable AOF would
+/// let this pass for the wrong reason.
+#[tokio::test]
+async fn rd_spec_002_a_replicated_topology_declares_eventually_consistent() {
+    let (_guard, log) = common::scoped_capture(tracing::Level::WARN);
+    let (container, config, primary, _replica) = common::start_redis_sentinel().await;
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the plugin starts against a sentinel-managed primary");
+
+    // The premise: durability really is at its strongest here.
+    let appendfsync = common::exec_in(
+        &container,
+        &[
+            "redis-cli",
+            "-p",
+            &primary.to_string(),
+            "config",
+            "get",
+            "appendfsync",
+        ],
+    )
+    .await;
+    assert!(
+        appendfsync.contains("always"),
+        "the fixture's primary must run appendfsync always, or this scenario is not the conflict \
+         it exists to resolve. Got {appendfsync:?}"
+    );
+    let replication = common::exec_in(
+        &container,
+        &[
+            "redis-cli",
+            "-p",
+            &primary.to_string(),
+            "info",
+            "replication",
+        ],
+    )
+    .await;
+    assert!(
+        replication.contains("state=online"),
+        "and it must really have a replica attached. Got {replication:?}"
+    );
+
+    assert_eq!(
+        handle.cache().consistency(),
+        CacheConsistency::EventuallyConsistent,
+        "a replicated topology is EventuallyConsistent whatever its durability: async replication \
+         can lose an acknowledged write to a failover, and no amount of fsync changes that \
+         (ADR-009, DESIGN.md sec 3.6)"
+    );
+    assert!(
+        !handle.lock().features().linearizable,
+        "and the lock declares the same, from the same preflight - a lock claiming linearizable \
+         here would let a consumer require the capability and be told a failover-losable write \
+         satisfies it"
+    );
+    assert!(
+        common::count_occurrences(&log, logs::WEAK_CONSISTENCY) >= 1,
+        "the weak-consistency WARN must fire on a replicated server. Captured: {}",
+        common::captured(&log)
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-SPEC-008` — cluster mode routes every operation, with zero `CROSSSLOT`.
+///
+/// The single-key-script invariant (DESIGN.md §6) is held *statically* by
+/// `scripts.rs`'s source-derived `KEYS[n]` assertion and by `evalsha`'s one-key
+/// signature. What no single-node test can show is that Redis routes what those
+/// produce: `CROSSSLOT` is an error only a clustered server raises, so on one node
+/// the invariant is unfalsifiable.
+///
+/// Every mutation here is a Lua script, and a script whose keys hash to different
+/// slots is rejected outright — so "all of these succeeded" is the assertion. The
+/// spread is asserted too: keys landing on one shard would exercise no routing at
+/// all and pass anyway.
+#[tokio::test]
+async fn rd_spec_008_cluster_mode_routes_every_operation() {
+    let (container, config, ports) = common::start_redis_cluster().await;
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the plugin starts against a 3-primary cluster");
+    let cache = handle.cache();
+
+    for index in 0..300 {
+        cache
+            .put(PutRequest {
+                key: &format!("routed/{index}"),
+                value: VALUE,
+                ttl: Ttl::Indefinite,
+            })
+            .await
+            .expect("every put routes to its own slot - a CROSSSLOT would surface here");
+    }
+
+    let counts = common::keys_per_node(&container, &ports).await;
+    let populated = counts.iter().filter(|count| **count > 0).count();
+    assert!(
+        populated >= 2,
+        "the keys must land on more than one shard, or nothing about routing is being tested. \
+         Per-node counts: {counts:?}"
+    );
+
+    // The rest of the surface, once each: every one is a script dispatched with
+    // exactly one key, and each would fail with CROSSSLOT if that ever stopped
+    // being true.
+    let entry = cache
+        .get("routed/1")
+        .await
+        .expect("get routes")
+        .expect("the entry is present");
+    cache
+        .compare_and_swap("routed/1", entry.version, VALUE, Ttl::Indefinite)
+        .await
+        .expect("compare_and_swap routes");
+    cache
+        .put_if_absent(PutRequest {
+            key: "routed/fresh",
+            value: VALUE,
+            ttl: Ttl::Of(Duration::from_secs(30)),
+        })
+        .await
+        .expect("put_if_absent routes");
+    assert!(
+        cache.contains("routed/1").await.expect("contains routes"),
+        "contains routes and finds the entry"
+    );
+    cache.delete("routed/2").await.expect("delete routes");
+
+    let guard = handle
+        .lock()
+        .try_lock("routed-lock", Duration::from_secs(30))
+        .await
+        .expect("the lock's SET NX routes to its own slot");
+    guard.release().await.expect("the release script routes");
+
+    handle.stop().await;
+}
+
+/// `RD-SPEC-009` — `scan_prefix` in cluster mode covers **every** shard.
+///
+/// `cache/scan.rs` branches on `clustered` and takes `scan_cluster_buffered`,
+/// which iterates each primary in turn rather than issuing one `SCAN`. On a single
+/// node that branch is dead code: a per-shard scan that silently returned only the
+/// keys of whichever primary the client happened to reach would pass every other
+/// scenario in this suite, and would break service discovery in production, which
+/// is built on `scan_prefix` (DESIGN.md §4.4).
+///
+/// The spread assertion is what makes this a cluster test rather than a repeat of
+/// `RD-CACHE-*`'s: if every key landed on one shard, a single-shard scan would
+/// return all of them and the bug would go unseen.
+#[tokio::test]
+async fn rd_spec_009_scan_prefix_covers_every_shard() {
+    /// Enough keys that the default hash-slot distribution reaches every shard
+    /// with overwhelming likelihood, while staying well inside a per-PR budget.
+    const PLANTED: usize = 300;
+
+    let (container, config, ports) = common::start_redis_cluster().await;
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the plugin starts against a 3-primary cluster");
+    let cache = handle.cache();
+
+    for index in 0..PLANTED {
+        cache
+            .put(PutRequest {
+                key: &format!("sd/instance-{index}"),
+                value: VALUE,
+                ttl: Ttl::Indefinite,
+            })
+            .await
+            .expect("put succeeds");
+    }
+
+    let counts = common::keys_per_node(&container, &ports).await;
+    let populated = counts.iter().filter(|count| **count > 0).count();
+    assert!(
+        populated >= 2,
+        "the planted keys must span shards, or a single-shard scan would pass this. Per-node \
+         counts: {counts:?}"
+    );
+
+    let mut found = cache
+        .scan_prefix("sd/")
+        .await
+        .expect("scan_prefix succeeds in cluster mode");
+    found.sort();
+    found.dedup();
+    assert_eq!(
+        found.len(),
+        PLANTED,
+        "one scan_prefix must return every key under the prefix, from every shard. Got \
+         {} of {PLANTED}, with per-node counts {counts:?} - a short count here is the per-shard \
+         iteration returning only the primary the client reached",
+        found.len()
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-SPEC-010` — cluster mode declares `prefix_watch: false`, **the gate
+/// DESIGN.md §13 D2 designates**.
+///
+/// Deliberately an assertion of a *current limitation* rather than of a feature.
+/// A prefix watch is served by one `PSUBSCRIBE` on the plugin's own event
+/// channels, which is broadcast cluster-wide and works — but `expired` and
+/// `evicted` arrive as **keyspace notifications, which are node-local**, so a
+/// prefix watcher in cluster mode would silently miss every expiry outside the
+/// shard its subscriber happens to be attached to. Declaring `false` sends the SDK
+/// to `PollingPrefixWatch`, which is slower and correct.
+///
+/// The per-key watch is asserted to still work in the same breath, because that is
+/// the half that does not depend on keyspace notifications for its ordinary event:
+/// a `put` publishes, and a cluster-wide `PUBLISH` reaches the subscriber whichever
+/// node it landed on.
+///
+/// **The follow-up that implements per-shard expiry subscriptions replaces this
+/// test with its positive counterpart.** Until then nothing may declare `true`,
+/// and this is what says so mechanically rather than in review.
+#[tokio::test]
+async fn rd_spec_010_cluster_mode_declares_no_prefix_watch() {
+    let (_container, config, _ports) = common::start_redis_cluster().await;
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the plugin starts against a 3-primary cluster");
+    let cache = handle.cache();
+
+    assert!(
+        !cache.features().prefix_watch,
+        "cluster mode must declare no native prefix watch: keyspace notifications are node-local, \
+         so a prefix watcher would miss every expiry outside its subscriber's shard. The SDK's \
+         PollingPrefixWatch is the honest fallback (DESIGN.md sec 4.3, sec 13 D2)"
+    );
+    assert!(
+        matches!(
+            cache.watch_prefix("sd/").await,
+            Err(ClusterError::Unsupported {
+                feature: "prefix_watch"
+            })
+        ),
+        "and watch_prefix must answer Unsupported rather than opening a stream that drops events"
+    );
+
+    // The per-key watch still works: its event is a plugin `PUBLISH`, which is
+    // broadcast cluster-wide rather than confined to one node.
+    let mut watch = cache
+        .watch("watched/key")
+        .await
+        .expect("a per-key watch is supported in cluster mode");
+    cache
+        .put(PutRequest {
+            key: "watched/key",
+            value: VALUE,
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put succeeds");
+    let event = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match watch.recv().await {
+                Some(CacheWatchEvent::Event(event)) => return Some(event),
+                Some(_other) => {}
+                None => return None,
+            }
+        }
+    })
+    .await
+    .ok()
+    .flatten()
+    .expect("the write must reach the watcher - PUBLISH is cluster-wide");
+    assert!(
+        matches!(&event, CacheEvent::Changed { key } if key == "watched/key"),
+        "got {event:?}"
+    );
+
+    handle.stop().await;
+}

--- a/gears/system/cluster/plugins/redis-cluster-plugin/tests/watch_integration.rs
+++ b/gears/system/cluster/plugins/redis-cluster-plugin/tests/watch_integration.rs
@@ -1,0 +1,744 @@
+//! Layer 3 — watch integration scenarios (docs/TESTING.md §4.4), `RD-WATCH-001`
+//! through `RD-WATCH-010`.
+//!
+//! Watch is where this plugin diverges most from the other two backends, and where
+//! the design decisions are least visible from the trait:
+//!
+//! - events are **published from inside the mutation script**, so one logical
+//!   write is one event even though it is three Redis commands (`RD-WATCH-001`);
+//! - `Expired` is the one event the plugin cannot publish for itself and comes
+//!   from a server keyspace notification instead (`RD-WATCH-003`);
+//! - prefix watch is **native** here — `PSUBSCRIBE`, not a polling polyfill — and
+//!   N watchers on one prefix cost one server-side pattern (`RD-WATCH-004`,
+//!   `RD-WATCH-005`). This is the first backend in the platform for which that is
+//!   true;
+//! - Redis pub/sub backpressure is ADR-003's canonical `Lagged` source, and
+//!   `RD-WATCH-008` is **the first test in the platform that produces `Lagged` at
+//!   all**.
+//!
+//! Every scenario drains its watch with a bounded `recv` rather than a bare
+//! `.await`: a watch that never delivers is exactly the bug several of these look
+//! for, and an unbounded await turns that into a hung test run rather than a
+//! failure.
+
+#![cfg(feature = "integration")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration tests: a setup failure IS the test failure"
+)]
+
+mod common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use cluster_sdk::cache::{CacheEvent, CacheWatch, CacheWatchEvent, PutRequest, Ttl};
+use cluster_sdk::{ClusterCacheBackend, ClusterError};
+use fred::interfaces::PubsubInterface;
+use redis_cluster_plugin::{RedisClusterHandle, RedisClusterPlugin};
+use serde_json::json;
+
+const VALUE: &[u8] = b"v";
+
+/// How long a scenario waits for an event that should already be in flight.
+///
+/// Generous relative to a local pub/sub round trip (single-digit milliseconds) so
+/// a loaded CI container does not fail a correctness assertion on timing, and
+/// still short enough that a genuinely undelivered event fails the test in about a
+/// second rather than hanging the run.
+const DELIVERY_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Starts a plugin over a stock container. Every scenario must `stop()` the
+/// handle (ADR-006's `Drop` guard panics in a debug build).
+async fn fixture(
+    overrides: serde_json::Value,
+) -> (
+    testcontainers::ContainerAsync<testcontainers_modules::redis::Redis>,
+    RedisClusterHandle,
+    Arc<dyn ClusterCacheBackend>,
+    fred::clients::Client,
+) {
+    let (container, config) = common::start_redis_with(overrides).await;
+    let url = config.url.clone();
+    let database = config.database;
+    let handle = RedisClusterPlugin::builder(config)
+        .build_and_start()
+        .await
+        .expect("the plugin starts against the test container");
+    let cache = handle.cache();
+    let raw = common::raw_client_on(&url, database).await;
+    (container, handle, cache, raw)
+}
+
+/// Receives one event, or `None` if nothing arrives within [`DELIVERY_TIMEOUT`].
+async fn next_event(watch: &mut CacheWatch) -> Option<CacheWatchEvent> {
+    tokio::time::timeout(DELIVERY_TIMEOUT, watch.recv())
+        .await
+        .ok()
+        .flatten()
+}
+
+/// Receives one event and asserts it is a `Changed`/`Deleted`/`Expired` for
+/// `key`, returning it. Panics with what actually arrived, which is what makes a
+/// failure diagnosable — "expected Changed, got Reset" says where to look.
+async fn expect_event(watch: &mut CacheWatch, context: &str) -> CacheEvent {
+    match next_event(watch).await {
+        Some(CacheWatchEvent::Event(event)) => event,
+        other => panic!("{context}: expected a cache event, got {other:?}"),
+    }
+}
+
+/// Asserts nothing arrives within a short grace period.
+///
+/// Deliberately shorter than [`DELIVERY_TIMEOUT`]: this is proving a negative, and
+/// every scenario that uses it pays the full wait on the happy path. A pub/sub
+/// message that was going to arrive would have arrived in single-digit
+/// milliseconds, so 300 ms is many times the margin needed.
+async fn expect_silence(watch: &mut CacheWatch, context: &str) {
+    let stray = tokio::time::timeout(Duration::from_millis(300), watch.recv()).await;
+    assert!(
+        stray.is_err(),
+        "{context}: expected no further event, got {stray:?}"
+    );
+}
+
+/// `RD-WATCH-001` — exactly **one** `Changed` per `put`, not three.
+///
+/// The assertion that holds the in-script publish design (DESIGN.md §4.3). A `put`
+/// runs `HSET` + `HINCRBY` + `PEXPIRE`, so an implementation sourcing events from
+/// raw keyspace notifications would deliver three events for one logical write —
+/// and every consumer would re-read three times, which
+/// `cpt-cf-clst-nfr-watch-delivery`'s no-duplicates requirement forbids.
+///
+/// The key is also covered by a prefix watch here, which is the sharper half: a
+/// key watched both exactly and by prefix is subscribed twice server-side, so one
+/// `PUBLISH` genuinely arrives twice on the connection. The registry routes
+/// `message` only to exact watchers and `pmessage` only to prefix watchers, and
+/// this is what pins that.
+#[tokio::test]
+async fn rd_watch_001_one_changed_per_put_even_when_doubly_covered() {
+    let (_container, handle, cache, _raw) = fixture(json!({})).await;
+
+    let mut exact = cache.watch("cov:key").await.expect("watch succeeds");
+    let mut prefix = cache
+        .watch_prefix("cov:")
+        .await
+        .expect("watch_prefix succeeds");
+
+    cache
+        .put(PutRequest {
+            key: "cov:key",
+            value: VALUE,
+            ttl: Ttl::Of(Duration::from_secs(30)),
+        })
+        .await
+        .expect("put succeeds");
+
+    let event = expect_event(&mut exact, "RD-WATCH-001 exact").await;
+    assert!(
+        matches!(&event, CacheEvent::Changed { key } if key == "cov:key"),
+        "one put must deliver exactly one Changed, got {event:?}"
+    );
+    expect_silence(
+        &mut exact,
+        "RD-WATCH-001: a put is HSET+HINCRBY+PEXPIRE, but one event",
+    )
+    .await;
+
+    let event = expect_event(&mut prefix, "RD-WATCH-001 prefix").await;
+    assert!(
+        matches!(&event, CacheEvent::Changed { key } if key == "cov:key"),
+        "the prefix watcher must also see exactly one Changed, got {event:?}"
+    );
+    expect_silence(
+        &mut prefix,
+        "RD-WATCH-001: a doubly-covered key arrives twice on the connection and must be routed \
+         once to each family, not twice to both",
+    )
+    .await;
+
+    handle.stop().await;
+}
+
+/// `RD-WATCH-002` — `Deleted` on both delete paths, and **nothing** on a
+/// mismatched `compare_and_delete`.
+///
+/// The negative half is the interesting one: a `compare_and_delete` whose value
+/// guard fails changed nothing, so publishing would tell every watcher to re-read
+/// a key that is exactly as they last saw it. Because the publish is inside the
+/// script, it sits on the same branch as the delete itself — which is what makes
+/// "no change, no event" structural rather than a check someone remembered.
+#[tokio::test]
+async fn rd_watch_002_deleted_on_both_paths_and_nothing_on_a_mismatch() {
+    let (_container, handle, cache, _raw) = fixture(json!({})).await;
+
+    cache
+        .put(PutRequest {
+            key: "del:a",
+            value: VALUE,
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put succeeds");
+    let mut watch = cache.watch("del:a").await.expect("watch succeeds");
+    assert!(cache.delete("del:a").await.expect("delete succeeds"));
+    let event = expect_event(&mut watch, "RD-WATCH-002 delete").await;
+    assert!(
+        matches!(&event, CacheEvent::Deleted { key } if key == "del:a"),
+        "delete must publish Deleted, got {event:?}"
+    );
+
+    cache
+        .put(PutRequest {
+            key: "del:b",
+            value: b"mine",
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put succeeds");
+    let mut watch = cache.watch("del:b").await.expect("watch succeeds");
+
+    assert!(
+        !cache
+            .compare_and_delete("del:b", b"not-mine")
+            .await
+            .expect("compare_and_delete succeeds"),
+        "the guard does not match, so nothing is deleted"
+    );
+    expect_silence(
+        &mut watch,
+        "RD-WATCH-002: a mismatched compare_and_delete changed nothing and must publish nothing",
+    )
+    .await;
+
+    assert!(
+        cache
+            .compare_and_delete("del:b", b"mine")
+            .await
+            .expect("compare_and_delete succeeds"),
+        "the matching guard deletes"
+    );
+    let event = expect_event(&mut watch, "RD-WATCH-002 compare_and_delete").await;
+    assert!(
+        matches!(&event, CacheEvent::Deleted { key } if key == "del:b"),
+        "a matching compare_and_delete must publish Deleted, got {event:?}"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-WATCH-003` — a TTL lapse delivers `Expired`, not `Deleted`.
+///
+/// The one event no plugin code can publish: nothing runs when a key expires, so
+/// this arrives as a Redis `expired` keyspace notification and is the whole reason
+/// the fixtures set `notify-keyspace-events Kxe` (DESIGN.md §4.3, TESTING.md §4.1,
+/// 8 — `Kxe`, not TESTING §4.1's `Kgx$e`).
+///
+/// `Expired` rather than `Deleted` matters to a consumer: a TTL lapse is expected
+/// and a delete is somebody's decision, and a cache-warming consumer would treat
+/// them differently. Eviction maps the other way — to `Deleted`, since no TTL
+/// elapsed — which is `RD-SPEC-007`.
+#[tokio::test]
+async fn rd_watch_003_a_ttl_lapse_delivers_expired() {
+    let (_container, handle, cache, _raw) = fixture(json!({})).await;
+
+    let mut watch = cache.watch("exp:key").await.expect("watch succeeds");
+    cache
+        .put(PutRequest {
+            key: "exp:key",
+            value: VALUE,
+            ttl: Ttl::Of(Duration::from_millis(500)),
+        })
+        .await
+        .expect("put succeeds");
+    let created = expect_event(&mut watch, "RD-WATCH-003 put").await;
+    assert!(matches!(created, CacheEvent::Changed { .. }));
+
+    // Redis delivers `expired` when the key is actively reaped, which for a key
+    // nobody touches is the background cycle rather than the deadline itself — so
+    // this waits well past the TTL rather than exactly for it.
+    let expired = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match watch.recv().await {
+                Some(CacheWatchEvent::Event(CacheEvent::Expired { key })) => return Some(key),
+                Some(CacheWatchEvent::Event(CacheEvent::Deleted { key })) => {
+                    panic!(
+                        "a TTL lapse must map to Expired, not Deleted - a consumer distinguishes \
+                         'its time was up' from 'somebody removed it' ({key})"
+                    )
+                }
+                Some(_other) => {}
+                None => return None,
+            }
+        }
+    })
+    .await
+    .ok()
+    .flatten();
+    assert_eq!(
+        expired.as_deref(),
+        Some("exp:key"),
+        "a lapsed key must deliver Expired, sourced from the server's own keyspace notification"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-WATCH-004` — `watch_prefix` is native and delivers per-key events.
+///
+/// Native meaning `PSUBSCRIBE` rather than the SDK's `PollingPrefixWatch` polyfill
+/// over `scan_prefix`. `features().prefix_watch` is asserted alongside the
+/// behaviour because the declaration is what the SDK dispatches on: a backend that
+/// delivered prefix events but declared `false` would silently get the polyfill,
+/// and one that declared `true` without delivering would leave every service
+/// discovery consumer watching a stream that never fires.
+#[tokio::test]
+async fn rd_watch_004_prefix_watch_is_native_and_per_key() {
+    let (_container, handle, cache, _raw) = fixture(json!({})).await;
+
+    assert!(
+        cache.features().prefix_watch,
+        "on a non-clustered server under watch_mode: publish, prefix watch is native"
+    );
+
+    let mut watch = cache
+        .watch_prefix("tree:")
+        .await
+        .expect("watch_prefix succeeds");
+
+    for key in ["tree:a", "tree:b", "tree:c"] {
+        cache
+            .put(PutRequest {
+                key,
+                value: VALUE,
+                ttl: Ttl::Indefinite,
+            })
+            .await
+            .expect("put succeeds");
+    }
+    cache
+        .put(PutRequest {
+            key: "other:a",
+            value: VALUE,
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("a put outside the prefix succeeds");
+
+    let mut seen = Vec::new();
+    for _ in 0..3 {
+        seen.push(
+            expect_event(&mut watch, "RD-WATCH-004")
+                .await
+                .key()
+                .to_owned(),
+        );
+    }
+    seen.sort();
+    assert_eq!(
+        seen,
+        vec![
+            "tree:a".to_owned(),
+            "tree:b".to_owned(),
+            "tree:c".to_owned()
+        ],
+        "each key under the prefix produces its own event, naming that key"
+    );
+    expect_silence(
+        &mut watch,
+        "RD-WATCH-004: a write outside the prefix must not reach a prefix watcher",
+    )
+    .await;
+
+    handle.stop().await;
+}
+
+/// `RD-WATCH-005` — five watchers on one prefix cost **one** Redis pattern.
+///
+/// `PUBSUB NUMPAT` is read from a separate connection, so it reports the server's
+/// view rather than the plugin's belief about it. The in-process fan-out claim
+/// (DESIGN.md §4.3) is not an optimisation detail: a pattern per watcher would put
+/// the server's delivery cost in proportion to how many consumers a deployment
+/// happens to have, on a broadcast every one of them then filters.
+///
+/// All five receiving every event is the other half — deduplicating subscriptions
+/// is only correct if the fan-out actually fans out.
+#[tokio::test]
+async fn rd_watch_005_five_prefix_watchers_cost_one_pattern() {
+    let (_container, handle, cache, raw) = fixture(json!({})).await;
+
+    // The plugin's own always-on patterns (the keyspace family and the lock-release
+    // family) are already subscribed, so the assertion is on the *increase*.
+    let before: u64 = raw.pubsub_numpat().await.expect("PUBSUB NUMPAT succeeds");
+
+    let mut watchers = Vec::new();
+    for _ in 0..5 {
+        watchers.push(
+            cache
+                .watch_prefix("fan:")
+                .await
+                .expect("watch_prefix succeeds"),
+        );
+    }
+
+    let after: u64 = raw.pubsub_numpat().await.expect("PUBSUB NUMPAT succeeds");
+    assert_eq!(
+        after - before,
+        1,
+        "five watchers on one prefix must cost exactly one server-side pattern, not five \
+         (before {before}, after {after})"
+    );
+
+    cache
+        .put(PutRequest {
+            key: "fan:key",
+            value: VALUE,
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put succeeds");
+
+    for (index, watch) in watchers.iter_mut().enumerate() {
+        let event = expect_event(watch, &format!("RD-WATCH-005 watcher {index}")).await;
+        assert_eq!(
+            event.key(),
+            "fan:key",
+            "watcher {index} must receive the event the shared pattern carried"
+        );
+    }
+
+    handle.stop().await;
+}
+
+/// `RD-WATCH-006` — per-key ordering is preserved across 100 sequential writes.
+///
+/// `cpt-cf-clst-nfr-watch-delivery` requires per-key ordering with no gaps. The
+/// count is what makes this more than a smoke test: a fan-out that dispatched each
+/// message onto its own task, or that used an unordered map iteration to route,
+/// would pass a three-event version of this and reorder here.
+///
+/// The buffer is 64 slots, so 100 writes *would* lag a watcher that stopped
+/// draining — this one drains as it goes, which is exactly the difference between
+/// this scenario and `RD-WATCH-008`.
+#[tokio::test]
+async fn rd_watch_006_per_key_ordering_is_preserved() {
+    let (_container, handle, cache, _raw) = fixture(json!({})).await;
+
+    let mut watch = cache.watch("seq:key").await.expect("watch succeeds");
+
+    // Drain concurrently with the writes: the channel holds 64 and 100 are coming.
+    let drainer = tokio::spawn(async move {
+        let mut received = 0_u32;
+        let mut lagged = false;
+        while received < 100 {
+            match tokio::time::timeout(DELIVERY_TIMEOUT, watch.recv()).await {
+                Ok(Some(CacheWatchEvent::Event(CacheEvent::Changed { .. }))) => received += 1,
+                Ok(Some(CacheWatchEvent::Lagged { .. })) => lagged = true,
+                Ok(Some(_other)) => {}
+                Ok(None) | Err(_) => break,
+            }
+        }
+        (received, lagged)
+    });
+
+    for index in 0..100_u32 {
+        cache
+            .put(PutRequest {
+                key: "seq:key",
+                value: index.to_string().as_bytes(),
+                ttl: Ttl::Indefinite,
+            })
+            .await
+            .expect("put succeeds");
+    }
+
+    let (received, lagged) = drainer.await.expect("the drainer task does not panic");
+    assert!(
+        !lagged,
+        "a watcher draining as fast as one sequential writer produces must not lag"
+    );
+    assert_eq!(
+        received, 100,
+        "all 100 sequential writes must be delivered with no gaps"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-WATCH-007` — no cross-key delivery, and watchers on one key are
+/// independent.
+///
+/// Two properties that a single shared broadcast channel would get wrong in
+/// opposite directions: routing everything to everyone (the cross-key half), or
+/// letting one consumer's disappearance take the others' subscription with it (the
+/// independence half). The second is the reference-counted-subscription behaviour
+/// registry does — `UNSUBSCRIBE` only when the *last* watcher on a key is pruned.
+#[tokio::test]
+async fn rd_watch_007_no_cross_key_delivery_and_independent_watchers() {
+    let (_container, handle, cache, _raw) = fixture(json!({})).await;
+
+    let mut on_a = cache.watch("iso:a").await.expect("watch succeeds");
+    let mut first_on_b = cache.watch("iso:b").await.expect("watch succeeds");
+    let mut second_on_b = cache.watch("iso:b").await.expect("watch succeeds");
+
+    cache
+        .put(PutRequest {
+            key: "iso:b",
+            value: VALUE,
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put succeeds");
+
+    assert_eq!(
+        expect_event(&mut first_on_b, "RD-WATCH-007 first")
+            .await
+            .key(),
+        "iso:b"
+    );
+    assert_eq!(
+        expect_event(&mut second_on_b, "RD-WATCH-007 second")
+            .await
+            .key(),
+        "iso:b",
+        "two watchers on one key must both receive the event"
+    );
+    expect_silence(
+        &mut on_a,
+        "RD-WATCH-007: a watcher on `iso:a` must see nothing when `iso:b` is written",
+    )
+    .await;
+
+    // Dropping one watcher must not disturb its sibling's subscription.
+    drop(first_on_b);
+    cache
+        .put(PutRequest {
+            key: "iso:b",
+            value: VALUE,
+            ttl: Ttl::Indefinite,
+        })
+        .await
+        .expect("put succeeds");
+    assert_eq!(
+        expect_event(&mut second_on_b, "RD-WATCH-007 survivor")
+            .await
+            .key(),
+        "iso:b",
+        "the surviving watcher keeps its subscription when a sibling is dropped - the \
+         UNSUBSCRIBE is reference-counted and fires only on the last one"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-WATCH-008` — buffer overflow produces `Lagged`, **once**, with a count that
+/// the drop counter agrees with.
+///
+/// **The first test in the platform that produces `Lagged` at all**, and the
+/// reason ADR-003's variant is not dead weight: Redis pub/sub backpressure is the
+/// canonical source, and neither the Postgres nor the standalone backend can drop
+/// events under load the way this one can.
+///
+/// Coalesced into *one* `Lagged` rather than one per dropped message is the
+/// assertion that matters. A consumer's response to `Lagged` is to re-read every
+/// watched key; one per drop would turn a burst into thousands of re-reads and
+/// make the backpressure worse than what caused it.
+///
+/// The known limitation (DESIGN.md §4.3): `Lagged` can only
+/// ride the *next successful send* to that watcher — nothing polls a drained
+/// buffer — so this scenario keeps writing after the watcher resumes.
+#[tokio::test]
+async fn rd_watch_008_overflow_produces_one_lagged_agreeing_with_the_counter() {
+    let (meter, metrics) = common::in_memory_meter();
+    let (_container, config) = common::start_redis().await;
+    let handle = RedisClusterPlugin::builder(config)
+        .__with_meter(meter)
+        .build_and_start()
+        .await
+        .expect("the plugin starts against the test container");
+    let cache = handle.cache();
+
+    let mut watch = cache.watch("lag:key").await.expect("watch succeeds");
+
+    // The watch buffer is 64 slots and nothing is draining it, so most of these
+    // are dropped.
+    for index in 0..600_u32 {
+        cache
+            .put(PutRequest {
+                key: "lag:key",
+                value: index.to_string().as_bytes(),
+                ttl: Ttl::Indefinite,
+            })
+            .await
+            .expect("put succeeds");
+    }
+
+    // Drain what buffered, counting the coalesced `Lagged`. More writes follow
+    // inside the loop because a `Lagged` rides the next successful send: a watcher
+    // that lagged and then saw no further traffic on its key would never learn it
+    // lagged at all.
+    let mut lagged_events = 0_u32;
+    let mut dropped_reported = 0_u64;
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while std::time::Instant::now() < deadline && lagged_events == 0 {
+        match tokio::time::timeout(Duration::from_millis(200), watch.recv()).await {
+            Ok(Some(CacheWatchEvent::Lagged { dropped })) => {
+                lagged_events += 1;
+                dropped_reported = dropped;
+            }
+            Ok(Some(_other)) => {}
+            Ok(None) => break,
+            Err(_timeout) => {
+                cache
+                    .put(PutRequest {
+                        key: "lag:key",
+                        value: VALUE,
+                        ttl: Ttl::Indefinite,
+                    })
+                    .await
+                    .expect("put succeeds");
+            }
+        }
+    }
+
+    assert_eq!(
+        lagged_events, 1,
+        "the drops must coalesce into exactly one Lagged, not one per dropped message"
+    );
+    assert!(
+        dropped_reported > 0,
+        "the Lagged must carry how many events were lost, so a consumer knows this is a re-read \
+         rather than a hiccup"
+    );
+
+    let counted = metrics.counter("cluster_redis_watch_events_dropped_total");
+    assert!(
+        counted >= dropped_reported,
+        "cluster_redis_watch_events_dropped_total ({counted}) must account for every event the \
+         consumer was told about ({dropped_reported}) - the counter is incremented per dropped \
+         event, so an operator's dashboard and the consumer's Lagged describe the same incident"
+    );
+
+    handle.stop().await;
+}
+
+/// `RD-WATCH-009` — every active watch observes `Closed(Shutdown)` **before**
+/// `stop()` returns.
+///
+/// `cpt-cf-clst-fr-shutdown-revoke`. The ordering is the contract: a consumer that
+/// learned its watch was dead only *after* shutdown completed would have a window
+/// in which it believed a stale view current, which is the whole failure mode the
+/// terminal event exists to close. `stop()` dispatches the terminal broadcast
+/// against the registry directly rather than through the fan-out task, so it does
+/// not depend on that task having noticed the cancellation yet.
+///
+/// Both watch kinds are asserted, since they are separate maps in the registry and
+/// a close that walked only one would leave the other's consumers hanging.
+#[tokio::test]
+async fn rd_watch_009_every_watch_is_closed_before_stop_returns() {
+    let (_container, handle, cache, _raw) = fixture(json!({})).await;
+
+    let mut exact = cache.watch("shut:key").await.expect("watch succeeds");
+    let mut prefix = cache
+        .watch_prefix("shut:")
+        .await
+        .expect("watch_prefix succeeds");
+
+    handle.stop().await;
+
+    // No timeout needed on the receives: `stop()` has already returned, so if the
+    // terminal event were not already queued it would never arrive — but a bound
+    // keeps a regression a failure rather than a hang.
+    for (label, watch) in [("exact", &mut exact), ("prefix", &mut prefix)] {
+        let event = tokio::time::timeout(Duration::from_millis(500), watch.recv())
+            .await
+            .unwrap_or_else(|_| panic!("the {label} watch must already hold its terminal event"));
+        assert!(
+            matches!(event, Some(CacheWatchEvent::Closed(ClusterError::Shutdown))),
+            "the {label} watch must observe Closed(Shutdown) before stop() returns, got {event:?}"
+        );
+    }
+}
+
+/// `RD-WATCH-010` — `watch_mode: disabled` degrades honestly.
+///
+/// "Honestly" is the operative word and it has four parts: both watch entry points
+/// answer `Unsupported` rather than returning a stream that never fires, the
+/// declaration matches so the SDK dispatches accordingly, **no `PUBLISH` is issued
+/// on the write path** so the mode actually saves what it claims to, and the cache
+/// itself keeps working.
+///
+/// The `PUBLISH` check is the one that would catch a half-implemented mode: a
+/// plugin that stopped delivering but kept publishing would look correct from every
+/// consumer's side while still paying the cost the operator turned the mode on to
+/// avoid.
+///
+/// The subscriber connection itself stays open in this mode, which is a
+/// amendment worth not "fixing": it carries the lock-release wake as well as cache
+/// events (DESIGN.md §3.3), so closing it would silently push every blocked
+/// acquisition onto the heartbeat fallback.
+#[tokio::test]
+async fn rd_watch_010_disabled_mode_degrades_honestly() {
+    let (_container, handle, cache, raw) = fixture(json!({ "watch_mode": "disabled" })).await;
+    let baseline_publishes = common::command_calls(&raw, "publish").await;
+
+    assert!(
+        !cache.features().prefix_watch,
+        "watch_mode: disabled must declare no native prefix watch, so the SDK falls back to \
+         PollingPrefixWatch rather than opening a stream that never fires"
+    );
+    assert!(
+        matches!(
+            cache.watch("off:key").await,
+            Err(ClusterError::Unsupported { feature: "watch" })
+        ),
+        "watch must answer Unsupported"
+    );
+    assert!(
+        matches!(
+            cache.watch_prefix("off:").await,
+            Err(ClusterError::Unsupported {
+                feature: "prefix_watch"
+            })
+        ),
+        "watch_prefix must answer Unsupported"
+    );
+
+    // The cache still works, and scan_prefix — which the SD polyfill drives — still
+    // enumerates, so a disabled-watch deployment keeps working service discovery.
+    for key in ["off:a", "off:b"] {
+        cache
+            .put(PutRequest {
+                key,
+                value: VALUE,
+                ttl: Ttl::Indefinite,
+            })
+            .await
+            .expect("put succeeds");
+    }
+    let mut found = cache
+        .scan_prefix("off:")
+        .await
+        .expect("scan_prefix still works with watches disabled");
+    found.sort();
+    assert_eq!(found, vec!["off:a".to_owned(), "off:b".to_owned()]);
+    assert_eq!(
+        cache
+            .get("off:a")
+            .await
+            .expect("get succeeds")
+            .expect("the entry is present")
+            .value,
+        VALUE
+    );
+
+    assert_eq!(
+        common::command_calls(&raw, "publish").await,
+        baseline_publishes,
+        "no PUBLISH may be issued on the write path in this mode - otherwise the deployment pays \
+         the cost it turned the mode on to avoid, while looking correct from every consumer's side"
+    );
+
+    handle.stop().await;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added Redis-backed cache and distributed-lock support.
- Supports standalone Redis, Sentinel, and Redis Cluster deployments.
- Added configurable durability, consistency, keyspace watches, replication waits, TTLs, and logical databases.
- Added reserved `default` bindings for SDK-provided locking and leader-election backends, including weak-consistency opt-ins.
- Added Redis operation metrics, diagnostics, and connection monitoring.

## Bug Fixes
- Improved startup failure cleanup and orderly shutdown.

## Documentation
- Added Redis plugin setup, design, and testing documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->