### PR TITLE
fix(oagw): stop relay spin on closed shutdown rx

### DIFF
--- a/gears/system/oagw/oagw/Cargo.toml
+++ b/gears/system/oagw/oagw/Cargo.toml
@@ -100,7 +100,7 @@ credstore-sdk = { workspace = true, features = ["test-util"] }
 toolkit = { workspace = true, features = ["bootstrap"] }
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 types-registry-sdk = { workspace = true, features = ["test-util"] }
-tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time", "net"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time", "net", "test-util"] }
 tower = { workspace = true, features = ["util"] }
 hyper = { workspace = true }
 hyper-util = { workspace = true }

--- a/gears/system/oagw/oagw/src/infra/proxy/websocket.rs
+++ b/gears/system/oagw/oagw/src/infra/proxy/websocket.rs
@@ -308,6 +308,11 @@ async fn frame_relay(
     let deadline = tokio::time::sleep(idle_timeout);
     tokio::pin!(deadline);
 
+    // Once the shutdown sender is gone no signal can ever arrive, and
+    // `changed()` would resolve `Err` on every poll — spinning the loop at
+    // full CPU. Disable the branch instead.
+    let mut shutdown_closed = false;
+
     // Main relay loop (Open state).
     loop {
         tokio::select! {
@@ -410,13 +415,19 @@ async fn frame_relay(
                 let _ = write_frame(upstream_write, WsOpcode::Close, &close, true, true).await;
                 return RelayOutcome::IdleTimeout;
             }
-            result = shutdown_rx.changed() => {
-                // Graceful server shutdown — close both sides cleanly.
-                if result.is_ok() && *shutdown_rx.borrow() {
-                    let close = make_close_payload(1001, "Going Away");
-                    let _ = write_frame(client_write, WsOpcode::Close, &close, false, true).await;
-                    let _ = write_frame(upstream_write, WsOpcode::Close, &close, true, true).await;
-                    return RelayOutcome::Shutdown;
+            result = shutdown_rx.changed(), if !shutdown_closed => {
+                match result {
+                    // Graceful server shutdown — close both sides cleanly.
+                    Ok(()) if *shutdown_rx.borrow() => {
+                        let close = make_close_payload(1001, "Going Away");
+                        let _ = write_frame(client_write, WsOpcode::Close, &close, false, true).await;
+                        let _ = write_frame(upstream_write, WsOpcode::Close, &close, true, true).await;
+                        return RelayOutcome::Shutdown;
+                    }
+                    // Changed back to `false` — keep relaying.
+                    Ok(()) => {}
+                    // Sender dropped; no shutdown signal can arrive from here on.
+                    Err(_) => shutdown_closed = true,
                 }
             }
         }
@@ -1555,7 +1566,10 @@ mod tests {
 
     // -- Idle timer reset on activity --
 
-    #[tokio::test]
+    // Virtual clock: the 60ms/100ms margin is far too tight for wall-clock
+    // time under a loaded test runner — a single late wakeup lets the idle
+    // timeout fire and the relay answers with Close instead of the frame.
+    #[tokio::test(start_paused = true)]
     async fn relay_idle_timer_resets_on_data() {
         // With a 100ms idle timeout, send a frame every 60ms to keep the
         // connection alive — verify it survives past the original deadline.


### PR DESCRIPTION
Fixes the flaky test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket relay shutdown handling to prevent repeated failed shutdown checks.
  * Ensured active shutdown signals close both connection sides cleanly.
  * Improved reliability of idle-timer behavior during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->