### PR TITLE
fix(oagw)!: relay WebSocket frames without parsing

### DIFF
--- a/gears/system/oagw/docs/features/0007-cpt-cf-oagw-feature-streaming.md
+++ b/gears/system/oagw/docs/features/0007-cpt-cf-oagw-feature-streaming.md
@@ -134,25 +134,20 @@ Design constraints enforced: `cpt-cf-oagw-constraint-https-only`.
 5. [x] - `p1` - **ELSE** (upstream rejects upgrade) - `inst-ws-5`
    1. [x] - `p1` - **RETURN** 502 ProtocolError with `X-OAGW-Error-Source: gateway` — upstream rejected WebSocket upgrade - `inst-ws-5a`
 6. [x] - `p1` - **FOR EACH** message from caller - `inst-ws-6`
-   1. [x] - `p1` - **IF** message exceeds configured max frame size (default: no limit; pass-through) - `inst-ws-6a`
-      1. [x] - `p1` - Send Close frame (1009 Message Too Big) to caller and abort upstream - `inst-ws-6a1`
-   2. [x] - `p1` - Forward message to upstream (text or binary frame, preserve opcode) - `inst-ws-6b`
+   1. [x] - `p1` - Relay bytes to upstream verbatim — frames are never parsed, so opcode, masking, RSV bits and fragmentation are preserved by construction, and no per-message size limit is applied - `inst-ws-6b`
 7. [x] - `p1` - **FOR EACH** message from upstream - `inst-ws-7`
-   1. [x] - `p1` - **IF** message exceeds configured max frame size (default: no limit; pass-through) - `inst-ws-7a`
-      1. [x] - `p1` - Send Close frame (1009 Message Too Big) to upstream and close caller - `inst-ws-7a1`
-   2. [x] - `p1` - Forward message to caller (text or binary frame, preserve opcode) - `inst-ws-7b`
+   1. [x] - `p1` - Relay bytes to caller verbatim, with the same guarantees as `inst-ws-6b` - `inst-ws-7b`
 8. [x] - `p1` - **IF** either side sends Close frame - `inst-ws-8`
    1. [x] - `p1` - Forward Close frame to the other side with status code and reason - `inst-ws-8a`
-   2. [x] - `p1` - Wait for Close frame response (up to close timeout) - `inst-ws-8b`
-   3. [x] - `p1` - Release connection resources - `inst-ws-8c`
+   2. [x] - `p1` - Release connection resources once the byte copy ends — the gateway does not interpret the Close frame or wait for the peer's echo - `inst-ws-8c`
 9. [x] - `p1` - **IF** upstream connection drops unexpectedly - `inst-ws-9`
-   1. [x] - `p1` - Send Close frame (1006 Abnormal Closure) to caller - `inst-ws-9a`
+   1. [x] - `p1` - Half-close the caller's leg so it observes EOF with no Close frame; the caller's own stack reports 1006 Abnormal Closure, which the gateway does not synthesise - `inst-ws-9a`
    2. [x] - `p1` - Release connection resources - `inst-ws-9b`
 10. [x] - `p1` - **IF** caller disconnects unexpectedly - `inst-ws-10`
-    1. [x] - `p1` - Send Close frame to upstream - `inst-ws-10a`
+    1. [x] - `p1` - Propagate the disconnect to upstream as a TCP half-close (EOF); no Close frame is synthesised - `inst-ws-10a`
     2. [x] - `p1` - Release connection resources - `inst-ws-10b`
-11. [x] - `p1` - **IF** idle timeout exceeded (no messages in either direction within configured timeout) - `inst-ws-11`
-    1. [x] - `p1` - Send Close frame (1001 Going Away) to both sides - `inst-ws-11a`
+11. [x] - `p1` - **IF** idle timeout exceeded (no bytes in either direction within configured timeout) - `inst-ws-11`
+    1. [x] - `p1` - Send Close frame (1001 Going Away) to both sides, each announcement bounded independently by `websocket_close_timeout_secs` - `inst-ws-11a`
     2. [x] - `p1` - Release connection resources - `inst-ws-11b`
 
 ### WebTransport Proxy Flow
@@ -274,7 +269,7 @@ The system **MUST** detect SSE responses (`Content-Type: text/event-stream`) fro
 
 - [x] `p1` - **ID**: `cpt-cf-oagw-dod-websocket-streaming`
 
-The system **MUST** handle HTTP Upgrade (`Upgrade: websocket`) by negotiating the WebSocket handshake with both the caller and upstream. Messages (text and binary frames) **MUST** be forwarded bidirectionally with opcode preservation. **IF** a configurable max frame size is set, messages exceeding the limit **MUST** trigger Close frame 1009 (Message Too Big); by default, no per-message size limit is enforced (pass-through). Close frames **MUST** be propagated with status code and reason; Close frame reason strings **MUST NOT** include internal gateway details (use standard WebSocket status codes only). The system **MUST** handle unexpected disconnects: upstream drop (send 1006 Abnormal Closure to caller), caller drop (send Close to upstream), idle timeout (send 1001 Going Away to both sides). Auth and guard plugins **MUST** execute before the upgrade handshake. Transform plugins are NOT executed on individual WebSocket frames. Upstream rejection of the upgrade **MUST** return 502 ProtocolError with `X-OAGW-Error-Source: gateway`.
+The system **MUST** handle HTTP Upgrade (`Upgrade: websocket`) by negotiating the WebSocket handshake with both the caller and upstream. After the 101 the connection **MUST** be relayed as an opaque byte stream: frames are not parsed, so opcodes, masking, RSV bits and fragmentation are preserved verbatim, and no per-message or per-frame size limit is enforced. Close frames originated by a peer **MUST** be propagated with status code and reason; Close frame reason strings the gateway itself originates **MUST NOT** include internal gateway details (use standard WebSocket status codes only). The system **MUST** handle unexpected disconnects by propagating them as a half-close rather than a synthesised frame: an upstream drop leaves the caller observing EOF (its stack reports 1006 Abnormal Closure), and a caller drop reaches upstream as EOF. The gateway **MUST** originate Close 1001 (Going Away) toward both sides on idle timeout and on graceful shutdown, announcing to each side independently under its own `websocket_close_timeout_secs` budget so an unresponsive peer cannot suppress the other side's close. Auth and guard plugins **MUST** execute before the upgrade handshake. Transform plugins are NOT executed on individual WebSocket frames. Upstream rejection of the upgrade **MUST** return 502 ProtocolError with `X-OAGW-Error-Source: gateway`.
 
 **Implements**:
 - `cpt-cf-oagw-flow-streaming-websocket`
@@ -320,8 +315,8 @@ The system **MUST** implement adaptive per-host HTTP version detection using ALP
 - [x] WebSocket upgrade requests (`Upgrade: websocket`) are negotiated with both caller and upstream
 - [x] WebSocket text and binary messages are forwarded bidirectionally with opcode preservation
 - [x] WebSocket Close frames are propagated with status code and reason to the other side
-- [x] Upstream WebSocket drop sends 1006 Abnormal Closure to caller
-- [x] Caller WebSocket disconnect sends Close frame to upstream
+- [x] Upstream WebSocket drop half-closes the caller's leg, so the caller sees EOF and reports 1006 Abnormal Closure itself
+- [x] Caller WebSocket disconnect propagates to upstream as a TCP half-close (EOF), without a synthesised Close frame
 - [x] Idle timeout on WebSocket session sends 1001 Going Away to both sides
 - [x] Upstream rejection of WebSocket upgrade returns 502 ProtocolError with `X-OAGW-Error-Source: gateway`
 - [x] Transform plugins are NOT executed on individual WebSocket frames
@@ -337,7 +332,8 @@ The system **MUST** implement adaptive per-host HTTP version detection using ALP
 - [x] `X-OAGW-Error-Source` header is set correctly for all streaming error scenarios (gateway vs upstream)
 - [x] No credentials appear in logs or error messages during streaming sessions
 - [x] WebSocket Close frame reason strings do not leak internal gateway details
-- [x] When a configurable max WebSocket frame size is set, oversized messages trigger Close frame 1009 (Message Too Big)
+- [x] WebSocket messages of any size are relayed without a per-frame or per-message cap; Close 1009 (Message Too Big) is never originated by the gateway
+- [x] A WebSocket peer that has stopped reading cannot suppress or delay the other side's Close 1001 announcement
 - [x] Backpressure is applied via TCP flow control when one side of a streaming connection is slower than the other
 - [x] Protocol version cache entries are evicted on protocol-level errors (re-negotiation on next request)
 
@@ -353,15 +349,14 @@ Streaming connections are forwarded at the TCP/TLS level with no per-event proce
 
 All streaming connections are subject to the same auth and guard plugin chain as regular proxy requests — authentication and authorization are enforced before any upgrade or session establishment. HTTPS-only constraint (`cpt-cf-oagw-constraint-https-only`) applies to all streaming upstream connections. Credential isolation per `cpt-cf-oagw-principle-cred-isolation` is maintained — secrets are resolved from `cred_store` at connection time and never logged or stored. WebSocket and WebTransport sessions do not re-authenticate after the initial handshake (session-scoped auth).
 
-**Input validation**: SSE events and WebSocket/WebTransport frames are forwarded as-is (pass-through proxy). Per-message size limits are not enforced by default — the upstream controls payload granularity. An optional max WebSocket frame size can be configured per upstream/route; oversized messages result in Close frame 1009 (Message Too Big). WebSocket Close frame reason strings **MUST NOT** include internal gateway details to prevent information leakage.
+**Input validation**: SSE events and WebSocket/WebTransport frames are forwarded as-is (pass-through proxy). Per-message size limits are not enforced — the upstream controls payload granularity, and the endpoint that deserialises a message is the one that can bound it. After the 101 the gateway relays bytes without parsing frames, so memory is bounded by the copy buffer rather than by frame size and there is no allocation for a size cap to protect. WebSocket Close frame reason strings **MUST NOT** include internal gateway details to prevent information leakage.
 
 ### Configuration Parameters
 
 | Parameter | Scope | Default | Description |
 |-----------|-------|---------|-------------|
 | `streaming_idle_timeout_seconds` | upstream / route | Inherited from `timeout` guard plugin or system default | Idle timeout for streaming connections (no data in either direction) |
-| `websocket_max_frame_size_bytes` | upstream / route | None (pass-through) | Optional max WebSocket message size; exceeding triggers Close 1009 |
-| `websocket_close_timeout_seconds` | system | 5 | Timeout for WebSocket Close frame handshake |
+| `websocket_close_timeout_secs` | system | 5 | Bound on delivering the gateway's Close 1001 and half-closing both legs at teardown |
 | `protocol_version_cache_ttl_seconds` | system | 3600 (1 hour) | TTL for cached ALPN negotiation results per host |
 
 All parameters are read from upstream/route configuration at connection time. System-level defaults are set via gear configuration (`OagwConfig`).

--- a/gears/system/oagw/oagw/src/config.rs
+++ b/gears/system/oagw/oagw/src/config.rs
@@ -35,16 +35,11 @@ pub struct OagwConfig {
     /// will be torn down. Must be > 0. Default: 300 (5 minutes).
     #[serde(default = "default_websocket_idle_timeout_secs")]
     pub websocket_idle_timeout_secs: u64,
-    /// Timeout in seconds for the WebSocket Close frame handshake.
-    /// After sending or forwarding a Close frame, the gateway waits this long
-    /// for the Close response before force-closing. Must be > 0. Default: 5.
+    /// Timeout in seconds for announcing a gateway-originated WebSocket close.
+    /// On idle timeout or shutdown the gateway gives each leg this long to
+    /// accept Close 1001 and half-close. Must be > 0. Default: 5.
     #[serde(default = "default_websocket_close_timeout_secs")]
     pub websocket_close_timeout_secs: u64,
-    /// Optional maximum WebSocket frame payload size in bytes.
-    /// Frames exceeding this limit trigger Close frame 1009 (Message Too Big).
-    /// Default: None (pass-through, no limit enforced).
-    #[serde(default)]
-    pub websocket_max_frame_size_bytes: Option<usize>,
     /// Idle timeout in seconds for SSE streaming connections.
     /// A connection with no data received from upstream for this duration
     /// will be closed. Must be > 0. Default: 300 (5 minutes).
@@ -106,7 +101,6 @@ impl Default for OagwConfig {
             token_cache_capacity: default_token_cache_capacity(),
             websocket_idle_timeout_secs: default_websocket_idle_timeout_secs(),
             websocket_close_timeout_secs: default_websocket_close_timeout_secs(),
-            websocket_max_frame_size_bytes: None,
             streaming_idle_timeout_secs: default_streaming_idle_timeout_secs(),
             protocol_cache_ttl_secs: default_protocol_cache_ttl_secs(),
             management_api_enabled: true,
@@ -185,7 +179,6 @@ pub struct RuntimeConfig {
     pub max_body_size_bytes: usize,
     pub websocket_idle_timeout_secs: u64,
     pub websocket_close_timeout_secs: u64,
-    pub websocket_max_frame_size_bytes: Option<usize>,
     pub streaming_idle_timeout_secs: u64,
     pub management_api_enabled: bool,
 }
@@ -196,7 +189,6 @@ impl From<&OagwConfig> for RuntimeConfig {
             max_body_size_bytes: cfg.max_body_size_bytes,
             websocket_idle_timeout_secs: cfg.websocket_idle_timeout_secs,
             websocket_close_timeout_secs: cfg.websocket_close_timeout_secs,
-            websocket_max_frame_size_bytes: cfg.websocket_max_frame_size_bytes,
             streaming_idle_timeout_secs: cfg.streaming_idle_timeout_secs,
             management_api_enabled: cfg.management_api_enabled,
         }
@@ -243,10 +235,6 @@ impl fmt::Debug for OagwConfig {
             .field(
                 "websocket_close_timeout_secs",
                 &self.websocket_close_timeout_secs,
-            )
-            .field(
-                "websocket_max_frame_size_bytes",
-                &self.websocket_max_frame_size_bytes,
             )
             .field(
                 "streaming_idle_timeout_secs",

--- a/gears/system/oagw/oagw/src/domain/test_support.rs
+++ b/gears/system/oagw/oagw/src/domain/test_support.rs
@@ -513,7 +513,6 @@ pub struct TestDpBuilder {
     token_cache_config: TokenCacheConfig,
     websocket_idle_timeout: Option<Duration>,
     websocket_close_timeout: Option<Duration>,
-    websocket_max_frame_size: Option<usize>,
 }
 
 impl TestDpBuilder {
@@ -529,7 +528,6 @@ impl TestDpBuilder {
             token_cache_config: TokenCacheConfig::default(),
             websocket_idle_timeout: None,
             websocket_close_timeout: None,
-            websocket_max_frame_size: None,
         }
     }
 
@@ -598,13 +596,6 @@ impl TestDpBuilder {
         self
     }
 
-    /// Override the maximum WebSocket frame payload size.
-    #[must_use]
-    pub fn with_websocket_max_frame_size(mut self, size: Option<usize>) -> Self {
-        self.websocket_max_frame_size = size;
-        self
-    }
-
     /// Fetch `CredStoreClientV1` from the hub, create a DP service with
     /// the given CP, and return the trait object.
     pub(crate) fn build_and_register(
@@ -666,9 +657,6 @@ impl TestDpBuilder {
         if let Some(timeout) = self.websocket_close_timeout {
             svc = svc.with_websocket_close_timeout(timeout);
         }
-        if let Some(size) = self.websocket_max_frame_size {
-            svc = svc.with_websocket_max_frame_size(Some(size));
-        }
 
         Arc::new(svc)
     }
@@ -718,7 +706,6 @@ pub fn build_test_app_state(
                 max_body_size_bytes: 100 * 1024 * 1024, // 100 MB default for tests
                 websocket_idle_timeout_secs: 300,
                 websocket_close_timeout_secs: 5,
-                websocket_max_frame_size_bytes: None,
                 streaming_idle_timeout_secs: 300,
                 management_api_enabled: true,
             },

--- a/gears/system/oagw/oagw/src/gear.rs
+++ b/gears/system/oagw/oagw/src/gear.rs
@@ -153,7 +153,6 @@ impl Gear for OutboundApiGatewayGear {
             .with_allow_http_upstream(cfg.allow_http_upstream)
             .with_websocket_idle_timeout(Duration::from_secs(cfg.websocket_idle_timeout_secs))
             .with_websocket_close_timeout(Duration::from_secs(cfg.websocket_close_timeout_secs))
-            .with_websocket_max_frame_size(cfg.websocket_max_frame_size_bytes)
             .with_streaming_idle_timeout(Duration::from_secs(cfg.streaming_idle_timeout_secs)),
         );
 

--- a/gears/system/oagw/oagw/src/infra/proxy/service.rs
+++ b/gears/system/oagw/oagw/src/infra/proxy/service.rs
@@ -70,10 +70,8 @@ pub struct DataPlaneServiceImpl {
     max_body_size: usize,
     /// Idle timeout for WebSocket connections (no data in either direction).
     websocket_idle_timeout: Duration,
-    /// Timeout for the WebSocket Close frame handshake.
+    /// Bound on announcing Close 1001 and half-closing each leg at teardown.
     websocket_close_timeout: Duration,
-    /// Optional max WebSocket frame payload size (Close 1009 on exceed).
-    websocket_max_frame_size: Option<usize>,
     /// Idle timeout for SSE streaming connections (no data from upstream).
     streaming_idle_timeout: Duration,
     /// Operational metrics port (OTel-backed in production).
@@ -115,7 +113,6 @@ impl DataPlaneServiceImpl {
             max_body_size: MAX_BODY_SIZE,
             websocket_idle_timeout: Duration::from_secs(300),
             websocket_close_timeout: Duration::from_secs(5),
-            websocket_max_frame_size: None,
             streaming_idle_timeout: Duration::from_secs(300),
             metrics,
         }
@@ -149,17 +146,10 @@ impl DataPlaneServiceImpl {
         self
     }
 
-    /// Override the WebSocket Close frame handshake timeout.
+    /// Override the timeout for announcing a gateway-originated close.
     #[must_use]
     pub fn with_websocket_close_timeout(mut self, timeout: Duration) -> Self {
         self.websocket_close_timeout = timeout;
-        self
-    }
-
-    /// Override the maximum WebSocket frame payload size.
-    #[must_use]
-    pub fn with_websocket_max_frame_size(mut self, size: Option<usize>) -> Self {
-        self.websocket_max_frame_size = size;
         self
     }
 
@@ -997,7 +987,6 @@ impl DataPlaneServiceImpl {
                     leftover,
                     idle_timeout: self.websocket_idle_timeout,
                     close_timeout: self.websocket_close_timeout,
-                    max_frame_size: self.websocket_max_frame_size,
                     shutdown_rx: self.shutdown_rx.clone(),
                     metrics: Some(self.metrics.clone()),
                     host: pipeline.host.to_string(),

--- a/gears/system/oagw/oagw/src/infra/proxy/websocket.rs
+++ b/gears/system/oagw/oagw/src/infra/proxy/websocket.rs
@@ -1,24 +1,105 @@
 use std::pin::Pin;
 use std::sync::Arc;
-
-use parking_lot::Mutex;
+use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
 use bytes::{Buf, Bytes};
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
+use parking_lot::Mutex;
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf};
 use tokio::sync::watch;
 use tracing::{debug, warn};
 
 use crate::domain::ports::OagwMetricsPort;
 
 // ---------------------------------------------------------------------------
-// PrefixedReader — prepends buffered bytes before an inner AsyncRead
+// Close frames
 // ---------------------------------------------------------------------------
 
-/// An `AsyncRead` wrapper that first yields bytes from a `Bytes` prefix,
-/// then delegates to the inner reader. Used to feed leftover bytes from
-/// HTTP header parsing back into the WebSocket frame relay loop.
+/// RFC 6455 §7.4.1 status code for "Going Away".
+const CLOSE_GOING_AWAY: u16 = 1001;
+
+/// Reason text paired with [`CLOSE_GOING_AWAY`].
+const CLOSE_GOING_AWAY_REASON: &str = "Going Away";
+
+/// Payload length of the Close frame: 2 status bytes plus the reason.
+///
+/// Const-evaluated, so the 125-byte control-frame ceiling (RFC 6455 §5.5) is a
+/// compile-time guarantee rather than a runtime check.
+const CLOSE_PAYLOAD_LEN: u8 = {
+    let len = 2 + CLOSE_GOING_AWAY_REASON.len();
+    assert!(len <= 125, "close payload exceeds the control-frame limit");
+    len as u8
+};
+
+/// Serialise the Close frame the gateway sends when it tears a tunnel down.
+///
+/// This is frame *construction* of one fixed shape, not parsing. Nothing about
+/// the frame is parameterised except masking, because the gateway only ever
+/// originates one close code: 1001 on idle timeout or shutdown. A peer's own
+/// Close is relayed verbatim by the byte copy and never passes through here.
+///
+/// `mask` must be `Some` for frames sent toward the upstream — the gateway is
+/// the client on that leg, and RFC 6455 §5.3 requires client-to-server frames
+/// be masked — and `None` for frames sent toward the caller.
+fn going_away_frame(mask: Option<[u8; 4]>) -> Vec<u8> {
+    let capacity = 2 + mask.map_or(0, |_| 4) + usize::from(CLOSE_PAYLOAD_LEN);
+    let mut frame = Vec::with_capacity(capacity);
+    frame.push(0x88); // FIN | Close
+
+    // Streamed straight into `frame`, so the payload is never materialised
+    // separately.
+    let payload_bytes = CLOSE_GOING_AWAY
+        .to_be_bytes()
+        .into_iter()
+        .chain(CLOSE_GOING_AWAY_REASON.bytes());
+
+    match mask {
+        Some(key) => {
+            frame.push(0x80 | CLOSE_PAYLOAD_LEN);
+            frame.extend_from_slice(&key);
+            frame.extend(payload_bytes.enumerate().map(|(i, b)| b ^ key[i % 4]));
+        }
+        None => {
+            frame.push(CLOSE_PAYLOAD_LEN);
+            frame.extend(payload_bytes);
+        }
+    }
+    frame
+}
+
+/// Generate a 4-byte mask key using OS-seeded randomness.
+///
+/// Uses `RandomState` (SipHash with OS-random seeds) per thread, hashing
+/// an atomic counter through it. Satisfies RFC 6455 §5.3 requirement that
+/// mask keys be chosen unpredictably.
+fn rand_mask_key() -> [u8; 4] {
+    use std::hash::{BuildHasher, Hasher};
+
+    thread_local! {
+        static HASHER_STATE: std::collections::hash_map::RandomState =
+            std::collections::hash_map::RandomState::new();
+    }
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    HASHER_STATE.with(|state| {
+        let mut hasher = state.build_hasher();
+        hasher.write_u64(COUNTER.fetch_add(1, Ordering::Relaxed));
+        (hasher.finish() as u32).to_ne_bytes()
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Leftover prefix
+// ---------------------------------------------------------------------------
+
+/// Wraps the upstream leg so bytes already pulled off it are read back first.
+///
+/// Parsing the 101 response can consume past the header boundary. Those bytes
+/// are upstream's, so prefixing them onto upstream's *read* side puts them
+/// ahead of everything upstream sends next by construction, and delivers them
+/// through the relay — inside its idle timeout, shutdown arm and teardown —
+/// instead of via a separate unbounded write before the relay starts.
 struct PrefixedReader<R> {
     prefix: Bytes,
     inner: R,
@@ -47,441 +128,344 @@ impl<R: AsyncRead + Unpin> AsyncRead for PrefixedReader<R> {
     }
 }
 
-impl<R: Unpin> Unpin for PrefixedReader<R> {}
+impl<W: AsyncWrite + Unpin> AsyncWrite for PrefixedReader<W> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.inner).poll_shutdown(cx)
+    }
+}
 
 // ---------------------------------------------------------------------------
-// RFC 6455 frame parser/writer
+// Activity tracking
 // ---------------------------------------------------------------------------
 
-/// Absolute maximum frame payload size (64 MiB). Defense-in-depth cap
-/// applied before allocation, regardless of the configured `max_frame_size`.
-const HARD_MAX_FRAME_SIZE: usize = 64 * 1024 * 1024;
+/// `first_eof` sentinel: nobody has reached end-of-stream yet.
+const EOF_NONE: u8 = 0;
+/// `first_eof` sentinel: the caller's half ended first.
+const EOF_CLIENT: u8 = 1;
+/// `first_eof` sentinel: the upstream half ended first.
+const EOF_UPSTREAM: u8 = 2;
 
-/// WebSocket opcodes (RFC 6455 §5.2).
+/// Wraps one side of the tunnel and records when bytes last arrived.
+///
+/// Both sides share one cell, so "idle" means nothing moved in *either*
+/// direction. This is the byte-level equivalent of the frame-level idle timer
+/// the relay used to keep, and it needs no knowledge of framing.
+struct ActivityIo<T> {
+    inner: T,
+    since: tokio::time::Instant,
+    last_ms: Arc<AtomicU64>,
+    /// Which side this wrapper is, one of the `EOF_*` sentinels.
+    side: u8,
+    /// Records the *first* side to reach end-of-stream. `copy_bidirectional`
+    /// half-closes, so it only returns once both halves are done — the order
+    /// is what says whether the caller left or the upstream died under it.
+    first_eof: Arc<AtomicU8>,
+}
+
+impl<T> ActivityIo<T> {
+    fn new(
+        inner: T,
+        since: tokio::time::Instant,
+        last_ms: Arc<AtomicU64>,
+        side: u8,
+        first_eof: Arc<AtomicU8>,
+    ) -> Self {
+        Self {
+            inner,
+            since,
+            last_ms,
+            side,
+            first_eof,
+        }
+    }
+
+    fn touch(&self) {
+        let elapsed = u64::try_from(self.since.elapsed().as_millis()).unwrap_or(u64::MAX);
+        self.last_ms.store(elapsed, Ordering::Relaxed);
+    }
+}
+
+impl<T: AsyncRead + Unpin> AsyncRead for ActivityIo<T> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let before = buf.filled().len();
+        let this = self.get_mut();
+        let poll = Pin::new(&mut this.inner).poll_read(cx, buf);
+        if matches!(poll, Poll::Ready(Ok(()))) {
+            // A ready read that filled nothing is end-of-stream. (Callers here
+            // always supply a non-empty buffer, so this cannot misfire.)
+            if buf.filled().len() > before {
+                this.touch();
+            } else {
+                let _first = this.first_eof.compare_exchange(
+                    EOF_NONE,
+                    this.side,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                );
+            }
+        }
+        poll
+    }
+}
+
+impl<T: AsyncWrite + Unpin> AsyncWrite for ActivityIo<T> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.inner).poll_shutdown(cx)
+    }
+}
+
+/// Resolves once no bytes have moved in either direction for `idle`.
+///
+/// Re-derives the deadline from the shared cell after each sleep, so traffic
+/// simply pushes the deadline out rather than resetting a timer.
+async fn idle_elapsed(since: tokio::time::Instant, last_ms: &AtomicU64, idle: Duration) {
+    loop {
+        let deadline = since + Duration::from_millis(last_ms.load(Ordering::Relaxed)) + idle;
+        if tokio::time::Instant::now() >= deadline {
+            return;
+        }
+        tokio::time::sleep_until(deadline).await;
+    }
+}
+
+/// Resolves when the server signals shutdown.
+///
+/// Pends forever once the sender is gone: no signal can arrive after that, and
+/// returning would spin the relay's `select!` at full CPU.
+async fn shutdown_signalled(rx: &mut watch::Receiver<bool>) {
+    loop {
+        if *rx.borrow() {
+            return;
+        }
+        if rx.changed().await.is_err() {
+            std::future::pending::<()>().await;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Opaque relay
+// ---------------------------------------------------------------------------
+
+/// Which peer reached end-of-stream first.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum WsOpcode {
-    Continuation,
-    Text,
-    Binary,
-    Close,
-    Ping,
-    Pong,
-    Unknown(u8),
+pub(crate) enum TunnelEnd {
+    /// The caller disconnected first — the ordinary ending.
+    Client,
+    /// The upstream went away under a live caller — abnormal, worth a warning.
+    Upstream,
+    /// Neither half reported end-of-stream (the copy ended some other way).
+    Unknown,
 }
 
-impl WsOpcode {
-    fn from_u8(v: u8) -> Self {
-        match v {
-            0x0 => Self::Continuation,
-            0x1 => Self::Text,
-            0x2 => Self::Binary,
-            0x8 => Self::Close,
-            0x9 => Self::Ping,
-            0xA => Self::Pong,
-            other => Self::Unknown(other),
-        }
-    }
-
-    fn as_u8(self) -> u8 {
-        match self {
-            Self::Continuation => 0x0,
-            Self::Text => 0x1,
-            Self::Binary => 0x2,
-            Self::Close => 0x8,
-            Self::Ping => 0x9,
-            Self::Pong => 0xA,
-            Self::Unknown(v) => v,
-        }
-    }
-}
-
-/// Read a single WebSocket frame from `reader`.
-///
-/// Returns `None` on clean EOF (zero-byte read on the first header byte).
-/// Returns `(fin, opcode, payload)` — the FIN bit is preserved for
-/// fragmented message forwarding (RFC 6455 §5.4).
-///
-/// `max_payload` caps the allocation size before reading. If the declared
-/// payload length exceeds `min(max_payload, HARD_MAX_FRAME_SIZE)`, an
-/// `InvalidData` error is returned without allocating. Unmasked payload is
-/// always returned regardless of wire masking.
-async fn read_frame(
-    reader: &mut (impl AsyncRead + Unpin),
-    max_payload: Option<usize>,
-) -> std::io::Result<Option<(bool, WsOpcode, Vec<u8>)>> {
-    // Read the 2-byte header.
-    let mut hdr = [0u8; 2];
-    match reader.read(&mut hdr[..1]).await? {
-        0 => return Ok(None), // clean EOF
-        1 => {}
-        _ => unreachable!(),
-    }
-    reader.read_exact(&mut hdr[1..2]).await?;
-
-    let fin = hdr[0] & 0x80 != 0;
-    let opcode = WsOpcode::from_u8(hdr[0] & 0x0F);
-    let masked = hdr[1] & 0x80 != 0;
-    let len_byte = (hdr[1] & 0x7F) as u64;
-
-    let payload_len: usize = if len_byte < 126 {
-        len_byte as usize
-    } else if len_byte == 126 {
-        let mut buf = [0u8; 2];
-        reader.read_exact(&mut buf).await?;
-        u16::from_be_bytes(buf) as usize
-    } else {
-        // len_byte == 127
-        let mut buf = [0u8; 8];
-        reader.read_exact(&mut buf).await?;
-        u64::from_be_bytes(buf) as usize
-    };
-
-    // Enforce size limit before allocation to prevent OOM.
-    let effective_max = max_payload
-        .map(|m| m.min(HARD_MAX_FRAME_SIZE))
-        .unwrap_or(HARD_MAX_FRAME_SIZE);
-    if payload_len > effective_max {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!("frame payload {payload_len} bytes exceeds maximum {effective_max} bytes"),
-        ));
-    }
-
-    let mask_key = if masked {
-        let mut key = [0u8; 4];
-        reader.read_exact(&mut key).await?;
-        Some(key)
-    } else {
-        None
-    };
-
-    let mut payload = vec![0u8; payload_len];
-    if payload_len > 0 {
-        reader.read_exact(&mut payload).await?;
-    }
-
-    // Unmask if needed.
-    if let Some(key) = mask_key {
-        for (i, byte) in payload.iter_mut().enumerate() {
-            *byte ^= key[i % 4];
-        }
-    }
-
-    Ok(Some((fin, opcode, payload)))
-}
-
-/// Write a single WebSocket frame to `writer`.
-///
-/// The `fin` parameter controls the FIN bit — pass `true` for final/only
-/// frames, `false` for non-final fragments (RFC 6455 §5.4).
-/// If `masked` is true, applies a random 4-byte XOR mask (required for
-/// client-to-server direction per RFC 6455 §5.3).
-async fn write_frame(
-    writer: &mut (impl AsyncWrite + Unpin),
-    opcode: WsOpcode,
-    payload: &[u8],
-    masked: bool,
-    fin: bool,
-) -> std::io::Result<()> {
-    let len = payload.len();
-    // Pre-allocate: 2 header + 8 extended length + 4 mask + payload
-    let mut buf = Vec::with_capacity(14 + len);
-
-    let fin_bit = if fin { 0x80 } else { 0x00 };
-    buf.push(fin_bit | opcode.as_u8());
-
-    let mask_bit = if masked { 0x80 } else { 0x00 };
-    if len < 126 {
-        buf.push(mask_bit | len as u8);
-    } else if len < 65536 {
-        buf.push(mask_bit | 126);
-        buf.extend_from_slice(&(len as u16).to_be_bytes());
-    } else {
-        buf.push(mask_bit | 127);
-        buf.extend_from_slice(&(len as u64).to_be_bytes());
-    }
-
-    if masked {
-        let key: [u8; 4] = rand_mask_key();
-        buf.extend_from_slice(&key);
-        for (i, &byte) in payload.iter().enumerate() {
-            buf.push(byte ^ key[i % 4]);
-        }
-    } else {
-        buf.extend_from_slice(payload);
-    }
-
-    writer.write_all(&buf).await
-}
-
-/// Build a Close frame payload: 2-byte BE status code + UTF-8 reason.
-fn make_close_payload(code: u16, reason: &str) -> Vec<u8> {
-    let mut payload = Vec::with_capacity(2 + reason.len());
-    payload.extend_from_slice(&code.to_be_bytes());
-    payload.extend_from_slice(reason.as_bytes());
-    payload
-}
-
-/// Extract status code and reason bytes from a Close frame payload.
-#[cfg(test)]
-fn parse_close_payload(payload: &[u8]) -> (u16, &[u8]) {
-    if payload.len() >= 2 {
-        let code = u16::from_be_bytes([payload[0], payload[1]]);
-        (code, &payload[2..])
-    } else {
-        (1005, b"") // No status code provided (RFC 6455 §7.1.5)
-    }
-}
-
-/// Generate a 4-byte mask key using OS-seeded randomness.
-///
-/// Uses `RandomState` (SipHash with OS-random seeds) per thread, hashing
-/// an atomic counter through it. Satisfies RFC 6455 §5.3 requirement that
-/// mask keys be chosen unpredictably.
-fn rand_mask_key() -> [u8; 4] {
-    use std::hash::{BuildHasher, Hasher};
-    use std::sync::atomic::{AtomicU64, Ordering};
-
-    thread_local! {
-        static HASHER_STATE: std::collections::hash_map::RandomState =
-            std::collections::hash_map::RandomState::new();
-    }
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-
-    HASHER_STATE.with(|state| {
-        let mut hasher = state.build_hasher();
-        hasher.write_u64(COUNTER.fetch_add(1, Ordering::Relaxed));
-        (hasher.finish() as u32).to_ne_bytes()
-    })
-}
-
-// ---------------------------------------------------------------------------
-// Frame-aware relay
-// ---------------------------------------------------------------------------
-
-/// Outcome of the frame relay loop.
+/// Outcome of the relay loop.
 #[derive(Debug)]
 pub(crate) enum RelayOutcome {
-    /// Both sides completed the Close handshake.
-    CleanClose,
-    /// No data in either direction within the idle timeout.
+    /// Either side ended the tunnel; carries the byte tallies.
+    Closed {
+        to_upstream: u64,
+        to_client: u64,
+        ended_by: TunnelEnd,
+    },
+    /// No bytes moved in either direction within the idle timeout.
     IdleTimeout,
-    /// Upstream connection dropped unexpectedly.
-    UpstreamDrop,
-    /// Caller disconnected unexpectedly.
-    CallerDrop,
-    /// A frame exceeded the configured max size.
-    FrameTooLarge,
     /// Server is shutting down gracefully.
     Shutdown,
-    /// IO or protocol error.
+    /// IO error on either half.
     Error(std::io::Error),
 }
 
-/// Configuration for the frame relay loop.
+/// Configuration for the relay loop.
 struct RelayConfig {
+    /// Bytes already read off the upstream leg while parsing the 101 response.
+    /// Delivered to the caller ahead of anything upstream sends next.
+    leftover: Bytes,
     idle_timeout: Duration,
     close_timeout: Duration,
-    max_frame_size: Option<usize>,
     shutdown_rx: watch::Receiver<bool>,
 }
 
-/// Frame-aware WebSocket relay with idle timeout, close handshake,
-/// and optional max frame size enforcement.
+/// Opaque bidirectional relay between the caller and the upstream tunnel.
 ///
-/// Forwards frames bidirectionally between client and upstream, preserving
-/// FIN bits and continuation frames for fragmented messages (RFC 6455 §5.4).
-/// Client→upstream frames are re-masked; upstream→client frames are unmasked.
-async fn frame_relay(
-    client_read: &mut (impl AsyncRead + Unpin),
-    client_write: &mut (impl AsyncWrite + Unpin),
-    upstream_read: &mut (impl AsyncRead + Unpin),
-    upstream_write: &mut (impl AsyncWrite + Unpin),
-    cfg: RelayConfig,
-) -> RelayOutcome {
+/// After the 101 a WebSocket connection is just bytes, so frames are forwarded
+/// verbatim and the gateway never parses one. That keeps masking, RSV bits
+/// (`permessage-deflate`), fragmentation and unknown/reserved opcodes intact by
+/// construction rather than by matching on each case: a client-to-server frame
+/// arrives masked and leaves masked, exactly as RFC 6455 §5.3 requires.
+///
+/// Memory is bounded by the copy buffer, not by frame size — a huge frame
+/// streams through instead of being materialised — which is why there is no
+/// frame-size ceiling to enforce here.
+///
+/// `cfg.leftover` is prefixed onto upstream's read side, so bytes already taken
+/// off that leg reach the caller first and every write toward a peer happens
+/// under the timeouts and teardown below — including when the caller has
+/// stopped reading and cannot accept those bytes at all.
+///
+/// # Cancellation
+///
+/// `copy_bidirectional` is not cancellation safe: dropping it can discard bytes
+/// held in its transfer buffers, so the last frame toward a peer may arrive
+/// truncated when the idle or shutdown arm wins. That is accepted rather than
+/// prevented — both arms end the session, and neither restarts the copy, so a
+/// truncated frame is immediately followed by Close 1001 and the teardown the
+/// peer was going to get anyway.
+async fn relay<C, U>(client: C, upstream: U, cfg: RelayConfig) -> RelayOutcome
+where
+    C: AsyncRead + AsyncWrite + Unpin,
+    U: AsyncRead + AsyncWrite + Unpin,
+{
     let RelayConfig {
+        leftover,
         idle_timeout,
         close_timeout,
-        max_frame_size,
         mut shutdown_rx,
     } = cfg;
-    let deadline = tokio::time::sleep(idle_timeout);
-    tokio::pin!(deadline);
 
-    // Once the shutdown sender is gone no signal can ever arrive, and
-    // `changed()` would resolve `Err` on every poll — spinning the loop at
-    // full CPU. Disable the branch instead.
-    let mut shutdown_closed = false;
+    let upstream = PrefixedReader::new(leftover, upstream);
 
-    // Main relay loop (Open state).
-    loop {
-        tokio::select! {
-            result = read_frame(client_read, max_frame_size) => {
-                match result {
-                    Ok(Some((fin, opcode, payload))) => {
-                        deadline.as_mut().reset(tokio::time::Instant::now() + idle_timeout);
-                        match opcode {
-                            WsOpcode::Close => {
-                                // Forward close to upstream, then enter closing state.
-                                let _ = write_frame(upstream_write, WsOpcode::Close, &payload, true, true).await;
-                                return await_close_response(upstream_read, close_timeout).await;
-                            }
-                            WsOpcode::Text | WsOpcode::Binary | WsOpcode::Continuation => {
-                                if let Err(e) = write_frame(upstream_write, opcode, &payload, true, fin).await {
-                                    debug!(error = %e, "failed to forward frame to upstream");
-                                    return RelayOutcome::Error(e);
-                                }
-                            }
-                            WsOpcode::Ping | WsOpcode::Pong => {
-                                let _ = write_frame(upstream_write, opcode, &payload, true, true).await;
-                            }
-                            WsOpcode::Unknown(_) => {
-                                // Forward unknown opcodes transparently.
-                                let _ = write_frame(upstream_write, opcode, &payload, true, fin).await;
-                            }
-                        }
-                    }
-                    Ok(None) => {
-                        // Client EOF — send Close to upstream.
-                        let close = make_close_payload(1001, "Going Away");
-                        let _ = write_frame(upstream_write, WsOpcode::Close, &close, true, true).await;
-                        return RelayOutcome::CallerDrop;
-                    }
-                    Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
-                        // Frame exceeded max size — send Close 1009 to both sides.
-                        let close = make_close_payload(1009, "Message Too Big");
-                        let _ = write_frame(client_write, WsOpcode::Close, &close, false, true).await;
-                        let _ = write_frame(upstream_write, WsOpcode::Close, &close, true, true).await;
-                        return RelayOutcome::FrameTooLarge;
-                    }
-                    Err(_) => {
-                        let close = make_close_payload(1001, "Going Away");
-                        let _ = write_frame(upstream_write, WsOpcode::Close, &close, true, true).await;
-                        return RelayOutcome::CallerDrop;
-                    }
-                }
-            }
-            result = read_frame(upstream_read, max_frame_size) => {
-                match result {
-                    Ok(Some((fin, opcode, payload))) => {
-                        deadline.as_mut().reset(tokio::time::Instant::now() + idle_timeout);
-                        match opcode {
-                            WsOpcode::Close => {
-                                // Forward close to client, then enter closing state.
-                                let _ = write_frame(client_write, WsOpcode::Close, &payload, false, true).await;
-                                return await_close_response(client_read, close_timeout).await;
-                            }
-                            WsOpcode::Text | WsOpcode::Binary | WsOpcode::Continuation => {
-                                if let Err(e) = write_frame(client_write, opcode, &payload, false, fin).await {
-                                    debug!(error = %e, "failed to forward frame to client");
-                                    return RelayOutcome::Error(e);
-                                }
-                            }
-                            WsOpcode::Ping | WsOpcode::Pong => {
-                                let _ = write_frame(client_write, opcode, &payload, false, true).await;
-                            }
-                            WsOpcode::Unknown(_) => {
-                                let _ = write_frame(client_write, opcode, &payload, false, fin).await;
-                            }
-                        }
-                    }
-                    Ok(None) => {
-                        // Upstream EOF — send Close 1001 to client.
-                        // RFC 6455 §7.4.1: status 1006 MUST NOT be sent on the wire;
-                        // use 1001 (Going Away) instead.
-                        let close = make_close_payload(1001, "Going Away");
-                        let _ = write_frame(client_write, WsOpcode::Close, &close, false, true).await;
-                        return RelayOutcome::UpstreamDrop;
-                    }
-                    Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
-                        // Upstream frame exceeded max size — send Close 1009 to upstream
-                        // and close the client side.
-                        let close = make_close_payload(1009, "Message Too Big");
-                        let _ = write_frame(upstream_write, WsOpcode::Close, &close, true, true).await;
-                        let _ = write_frame(client_write, WsOpcode::Close, &close, false, true).await;
-                        return RelayOutcome::FrameTooLarge;
-                    }
-                    Err(_) => {
-                        let close = make_close_payload(1001, "Going Away");
-                        let _ = write_frame(client_write, WsOpcode::Close, &close, false, true).await;
-                        return RelayOutcome::UpstreamDrop;
-                    }
-                }
-            }
-            _ = &mut deadline => {
-                // Idle timeout — send Close 1001 to both sides.
-                let close = make_close_payload(1001, "Going Away");
-                let _ = write_frame(client_write, WsOpcode::Close, &close, false, true).await;
-                let _ = write_frame(upstream_write, WsOpcode::Close, &close, true, true).await;
-                return RelayOutcome::IdleTimeout;
-            }
-            result = shutdown_rx.changed(), if !shutdown_closed => {
-                match result {
-                    // Graceful server shutdown — close both sides cleanly.
-                    Ok(()) if *shutdown_rx.borrow() => {
-                        let close = make_close_payload(1001, "Going Away");
-                        let _ = write_frame(client_write, WsOpcode::Close, &close, false, true).await;
-                        let _ = write_frame(upstream_write, WsOpcode::Close, &close, true, true).await;
-                        return RelayOutcome::Shutdown;
-                    }
-                    // Changed back to `false` — keep relaying.
-                    Ok(()) => {}
-                    // Sender dropped; no shutdown signal can arrive from here on.
-                    Err(_) => shutdown_closed = true,
-                }
-            }
-        }
+    let since = tokio::time::Instant::now();
+    let last_ms = Arc::new(AtomicU64::new(0));
+    let first_eof = Arc::new(AtomicU8::new(EOF_NONE));
+    let mut client = ActivityIo::new(
+        client,
+        since,
+        Arc::clone(&last_ms),
+        EOF_CLIENT,
+        Arc::clone(&first_eof),
+    );
+    let mut upstream = ActivityIo::new(
+        upstream,
+        since,
+        Arc::clone(&last_ms),
+        EOF_UPSTREAM,
+        Arc::clone(&first_eof),
+    );
+
+    let outcome = tokio::select! {
+        result = tokio::io::copy_bidirectional(&mut client, &mut upstream) => match result {
+            Ok((to_upstream, to_client)) => RelayOutcome::Closed {
+                to_upstream,
+                to_client,
+                ended_by: match first_eof.load(Ordering::Relaxed) {
+                    EOF_CLIENT => TunnelEnd::Client,
+                    EOF_UPSTREAM => TunnelEnd::Upstream,
+                    _ => TunnelEnd::Unknown,
+                },
+            },
+            Err(e) => RelayOutcome::Error(e),
+        },
+        () = idle_elapsed(since, &last_ms, idle_timeout) => RelayOutcome::IdleTimeout,
+        () = shutdown_signalled(&mut shutdown_rx) => RelayOutcome::Shutdown,
+    };
+
+    if matches!(outcome, RelayOutcome::IdleTimeout | RelayOutcome::Shutdown) {
+        close_tunnel(&mut client, &mut upstream, close_timeout).await;
     }
+    outcome
 }
 
-/// Wait for a Close frame response from `reader`, up to `timeout`.
+/// Announce Close 1001 to both peers and half-close both write halves.
 ///
-/// Loops past non-Close frames (Ping, Pong, data) that the peer may send
-/// before responding with Close (permitted by RFC 6455 §5.5.1). Returns
-/// `CleanClose` regardless of whether the Close response arrives in time.
-async fn await_close_response(
-    reader: &mut (impl AsyncRead + Unpin),
-    timeout: Duration,
-) -> RelayOutcome {
-    let deadline = tokio::time::Instant::now() + timeout;
-    loop {
-        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-        if remaining.is_zero() {
-            debug!("close handshake timed out");
-            break;
-        }
-        // Close frame payload is at most 125 bytes per RFC 6455 §5.5.
-        match tokio::time::timeout(remaining, read_frame(reader, Some(125))).await {
-            Ok(Ok(Some((_, WsOpcode::Close, _)))) => {
-                debug!("received Close response, completing handshake");
-                break;
-            }
-            Ok(Ok(Some(_))) => {
-                debug!("received non-Close frame during close handshake, skipping");
-                continue;
-            }
-            Ok(Ok(None)) => {
-                debug!("connection closed during close handshake");
-                break;
-            }
-            Ok(Err(e)) => {
-                debug!(error = %e, "error during close handshake");
-                break;
-            }
-            Err(_) => {
-                debug!("close handshake timed out");
-                break;
-            }
-        }
+/// The two announcements are independent: each runs concurrently with its own
+/// `grace` budget, because the peer that triggered the teardown is exactly the
+/// peer that may have stopped reading. Announcing sequentially under one shared
+/// budget lets a stalled peer swallow the whole grace period, leaving the other
+/// side with no Close frame and no half-close at all.
+///
+/// The relay is *not* resumed afterwards: the gateway has told both peers to go
+/// away, so there is nothing left worth forwarding, and restarting the copy
+/// would append bytes after the Close frame it just wrote.
+async fn close_tunnel<C, U>(client: &mut C, upstream: &mut U, grace: Duration)
+where
+    C: AsyncWrite + Unpin,
+    U: AsyncWrite + Unpin,
+{
+    let toward_client = going_away_frame(None);
+    let toward_upstream = going_away_frame(Some(rand_mask_key()));
+
+    tokio::join!(
+        announce_close(client, &toward_client, "client", grace),
+        announce_close(upstream, &toward_upstream, "upstream", grace),
+    );
+}
+
+/// Deliver one Close frame to one peer, then half-close that write half, all
+/// bounded by `grace`.
+///
+/// The bound covers every step deliberately: a peer that has stopped reading
+/// would block `write_all` forever, and since the bridge task is detached
+/// (`api::rest::handlers::proxy`), that would strand the task, the upstream
+/// stream and the active-session gauge for the process's lifetime.
+///
+/// Failures are logged rather than returned — the session is over either way,
+/// and a peer that cannot receive its Close frame gets the half-close, or
+/// failing that the tunnel drop, as the fallback signal.
+async fn announce_close(
+    io: &mut (impl AsyncWrite + Unpin),
+    frame: &[u8],
+    side: &'static str,
+    grace: Duration,
+) {
+    let announced = tokio::time::timeout(grace, async {
+        io.write_all(frame).await?;
+        io.flush().await?;
+        // Half-close so the peer observes EOF promptly rather than waiting for
+        // the tunnel to be dropped.
+        io.shutdown().await
+    })
+    .await;
+
+    match announced {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => debug!(error = %e, side, "failed to announce Close 1001"),
+        Err(_elapsed) => debug!(
+            side,
+            grace_ms = u64::try_from(grace.as_millis()).unwrap_or(u64::MAX),
+            "close announcement did not complete within the grace period"
+        ),
     }
-    RelayOutcome::CleanClose
 }
 
 // ---------------------------------------------------------------------------
-// Bridge types and entry point
+// Bridge plumbing
 // ---------------------------------------------------------------------------
 
-/// Carries the DuplexStream and leftover bytes from a successful 101 response
+/// Carries the `DuplexStream` and leftover bytes from a successful 101 response
 /// through the response extensions, so the Axum handler can bridge the
 /// client's upgraded connection to the Pingora-managed upstream tunnel.
 pub(crate) struct WebSocketBridgeIo {
@@ -489,7 +473,6 @@ pub(crate) struct WebSocketBridgeIo {
     pub leftover: Bytes,
     pub idle_timeout: Duration,
     pub close_timeout: Duration,
-    pub max_frame_size: Option<usize>,
     pub shutdown_rx: watch::Receiver<bool>,
     /// Metrics port used to track session lifetime. May be `None` in tests
     /// that don't exercise metrics — the bridge still runs, just without
@@ -549,25 +532,26 @@ impl WebSocketBridgeHandle {
 }
 
 /// Bridge a client's upgraded connection to the Pingora-managed upstream
-/// tunnel via frame-aware WebSocket relay.
+/// tunnel.
 ///
-/// Any leftover bytes read past the header boundary during 101 response
-/// parsing are prepended to the upstream read stream via [`PrefixedReader`],
-/// so they enter the frame relay loop and are parsed as WebSocket frames
-/// rather than being written raw to the client.
+/// Any bytes read past the header boundary while parsing the 101 response
+/// already belong to the caller. They go in as the relay's leftover prefix
+/// rather than being written here: that keeps their ordering ahead of
+/// everything the upstream sends next, and leaves the relay owning every
+/// bounded write, the shutdown arm and the Close 1001 teardown — so a caller
+/// that never reads them cannot wedge this task, and with it the session guard,
+/// for the process's lifetime.
 pub(crate) async fn websocket_bridge(
     upgraded: hyper::upgrade::Upgraded,
     bridge: WebSocketBridgeIo,
 ) {
     use hyper_util::rt::TokioIo;
-    use tokio::io::split;
 
     let WebSocketBridgeIo {
         io,
         leftover,
         idle_timeout,
         close_timeout,
-        max_frame_size,
         shutdown_rx,
         metrics,
         host,
@@ -575,1043 +559,42 @@ pub(crate) async fn websocket_bridge(
     // RAII guard: increments the active-sessions gauge now, records duration
     // and decrements on drop — even on panic / future cancellation.
     let _session_guard = metrics.map(|m| WsSessionGuard::new(m, host));
-    let (upstream_read, mut upstream_write) = split(io);
-    // Prepend any leftover bytes from 101 header parsing to the upstream
-    // read stream so they are parsed as WebSocket frames by the relay.
-    let mut upstream_read = PrefixedReader::new(leftover, upstream_read);
-    // Wrap hyper's Upgraded in TokioIo so it implements tokio::io::AsyncRead/Write.
-    let tokio_upgraded = TokioIo::new(upgraded);
-    let (mut client_read, mut client_write) = split(tokio_upgraded);
 
-    match frame_relay(
-        &mut client_read,
-        &mut client_write,
-        &mut upstream_read,
-        &mut upstream_write,
+    // Wrap hyper's Upgraded in TokioIo so it implements tokio::io::AsyncRead/Write.
+    let mut client = TokioIo::new(upgraded);
+    let mut upstream = io;
+
+    match relay(
+        &mut client,
+        &mut upstream,
         RelayConfig {
+            leftover,
             idle_timeout,
             close_timeout,
-            max_frame_size,
             shutdown_rx,
         },
     )
     .await
     {
-        RelayOutcome::CleanClose => debug!("WebSocket closed normally"),
+        RelayOutcome::Closed {
+            to_upstream,
+            to_client,
+            ended_by: TunnelEnd::Upstream,
+        } => warn!(
+            to_upstream,
+            to_client, "upstream WebSocket connection dropped unexpectedly"
+        ),
+        RelayOutcome::Closed {
+            to_upstream,
+            to_client,
+            ended_by,
+        } => debug!(to_upstream, to_client, ?ended_by, "WebSocket tunnel closed"),
         RelayOutcome::IdleTimeout => debug!("WebSocket idle timeout, closing"),
-        RelayOutcome::UpstreamDrop => warn!("upstream WebSocket connection dropped unexpectedly"),
-        RelayOutcome::CallerDrop => debug!("caller disconnected"),
-        RelayOutcome::FrameTooLarge => warn!("WebSocket frame exceeded max size"),
         RelayOutcome::Shutdown => debug!("WebSocket closed due to server shutdown"),
-        RelayOutcome::Error(e) => debug!(error = %e, "WebSocket bridge error"),
+        RelayOutcome::Error(e) => warn!(error = %e, "WebSocket bridge error"),
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Create a no-op shutdown receiver for tests that don't exercise shutdown.
-    fn test_shutdown_rx() -> watch::Receiver<bool> {
-        let (_tx, rx) = watch::channel(false);
-        rx
-    }
-
-    // -- Frame parser/writer tests --
-
-    #[tokio::test]
-    async fn write_and_read_text_frame() {
-        let (mut writer_end, mut reader_end) = tokio::io::duplex(4096);
-        write_frame(&mut writer_end, WsOpcode::Text, b"hello", false, true)
-            .await
-            .unwrap();
-        drop(writer_end);
-
-        let (fin, op, payload) = read_frame(&mut reader_end, None).await.unwrap().unwrap();
-        assert!(fin);
-        assert_eq!(op, WsOpcode::Text);
-        assert_eq!(payload, b"hello");
-    }
-
-    #[tokio::test]
-    async fn write_and_read_close_frame() {
-        let (mut writer_end, mut reader_end) = tokio::io::duplex(4096);
-        let payload = make_close_payload(1000, "Normal Closure");
-        write_frame(&mut writer_end, WsOpcode::Close, &payload, false, true)
-            .await
-            .unwrap();
-        drop(writer_end);
-
-        let (fin, op, data) = read_frame(&mut reader_end, None).await.unwrap().unwrap();
-        assert!(fin);
-        assert_eq!(op, WsOpcode::Close);
-        let (code, reason) = parse_close_payload(&data);
-        assert_eq!(code, 1000);
-        assert_eq!(reason, b"Normal Closure");
-    }
-
-    #[tokio::test]
-    async fn read_masked_frame() {
-        let (mut writer_end, mut reader_end) = tokio::io::duplex(4096);
-        // Write a masked frame.
-        write_frame(
-            &mut writer_end,
-            WsOpcode::Binary,
-            b"masked data",
-            true,
-            true,
-        )
-        .await
-        .unwrap();
-        drop(writer_end);
-
-        // read_frame should unmask automatically.
-        let (fin, op, payload) = read_frame(&mut reader_end, None).await.unwrap().unwrap();
-        assert!(fin);
-        assert_eq!(op, WsOpcode::Binary);
-        assert_eq!(payload, b"masked data");
-    }
-
-    #[tokio::test]
-    async fn extended_length_payloads() {
-        // 126-byte extended length (2-byte encoding).
-        let payload_126 = vec![0xAB; 200];
-        let (mut w, mut r) = tokio::io::duplex(4096);
-        write_frame(&mut w, WsOpcode::Binary, &payload_126, false, true)
-            .await
-            .unwrap();
-        drop(w);
-        let (_, _, data) = read_frame(&mut r, None).await.unwrap().unwrap();
-        assert_eq!(data.len(), 200);
-        assert_eq!(data, payload_126);
-
-        // 127-byte extended length (8-byte encoding) — use 70000 bytes.
-        let payload_127 = vec![0xCD; 70_000];
-        let (mut w, mut r) = tokio::io::duplex(256 * 1024);
-        write_frame(&mut w, WsOpcode::Binary, &payload_127, false, true)
-            .await
-            .unwrap();
-        drop(w);
-        let (_, _, data) = read_frame(&mut r, None).await.unwrap().unwrap();
-        assert_eq!(data.len(), 70_000);
-        assert_eq!(data, payload_127);
-    }
-
-    #[tokio::test]
-    async fn parse_close_payload_no_code() {
-        let (code, reason) = parse_close_payload(b"");
-        assert_eq!(code, 1005);
-        assert!(reason.is_empty());
-    }
-
-    #[tokio::test]
-    async fn eof_returns_none() {
-        let (writer_end, mut reader_end) = tokio::io::duplex(4096);
-        drop(writer_end);
-        let result = read_frame(&mut reader_end, None).await.unwrap();
-        assert!(result.is_none());
-    }
-
-    #[tokio::test]
-    async fn read_frame_rejects_oversized_payload() {
-        let (mut writer_end, mut reader_end) = tokio::io::duplex(4096);
-        // Write a frame with 200-byte payload.
-        write_frame(&mut writer_end, WsOpcode::Text, &[0xAA; 200], false, true)
-            .await
-            .unwrap();
-        drop(writer_end);
-
-        // Reading with max_payload=50 should fail before allocation.
-        let err = read_frame(&mut reader_end, Some(50)).await.unwrap_err();
-        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
-    }
-
-    #[tokio::test]
-    async fn fin_bit_preserved_for_fragments() {
-        let (mut writer_end, mut reader_end) = tokio::io::duplex(4096);
-
-        // Write a non-final text frame (FIN=0).
-        write_frame(&mut writer_end, WsOpcode::Text, b"part1", false, false)
-            .await
-            .unwrap();
-        // Write a continuation frame (FIN=0).
-        write_frame(
-            &mut writer_end,
-            WsOpcode::Continuation,
-            b"part2",
-            false,
-            false,
-        )
-        .await
-        .unwrap();
-        // Write a final continuation frame (FIN=1).
-        write_frame(
-            &mut writer_end,
-            WsOpcode::Continuation,
-            b"part3",
-            false,
-            true,
-        )
-        .await
-        .unwrap();
-        drop(writer_end);
-
-        let (fin, op, payload) = read_frame(&mut reader_end, None).await.unwrap().unwrap();
-        assert!(!fin);
-        assert_eq!(op, WsOpcode::Text);
-        assert_eq!(payload, b"part1");
-
-        let (fin, op, payload) = read_frame(&mut reader_end, None).await.unwrap().unwrap();
-        assert!(!fin);
-        assert_eq!(op, WsOpcode::Continuation);
-        assert_eq!(payload, b"part2");
-
-        let (fin, op, payload) = read_frame(&mut reader_end, None).await.unwrap().unwrap();
-        assert!(fin);
-        assert_eq!(op, WsOpcode::Continuation);
-        assert_eq!(payload, b"part3");
-    }
-
-    // -- Frame relay tests --
-
-    #[tokio::test]
-    async fn relay_close_propagation() {
-        let (mut client_a, client_b) = tokio::io::duplex(4096);
-        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
-
-        let (mut cr, mut cw) = tokio::io::split(client_b);
-        let (mut ur, mut uw) = tokio::io::split(upstream_b);
-
-        let handle = tokio::spawn(async move {
-            frame_relay(
-                &mut cr,
-                &mut cw,
-                &mut ur,
-                &mut uw,
-                RelayConfig {
-                    idle_timeout: Duration::from_secs(5),
-                    close_timeout: Duration::from_secs(2),
-                    max_frame_size: None,
-                    shutdown_rx: test_shutdown_rx(),
-                },
-            )
-            .await
-        });
-
-        // Client sends Close 1000.
-        let close = make_close_payload(1000, "Normal");
-        write_frame(&mut client_a, WsOpcode::Close, &close, true, true)
-            .await
-            .unwrap();
-
-        // Upstream should receive the forwarded Close.
-        let (fin, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
-        assert!(fin);
-        assert_eq!(op, WsOpcode::Close);
-        let (code, _) = parse_close_payload(&data);
-        assert_eq!(code, 1000);
-
-        // Upstream sends Close response.
-        let resp_close = make_close_payload(1000, "Normal");
-        write_frame(&mut upstream_a, WsOpcode::Close, &resp_close, false, true)
-            .await
-            .unwrap();
-
-        let outcome = handle.await.unwrap();
-        assert!(matches!(outcome, RelayOutcome::CleanClose));
-    }
-
-    #[tokio::test]
-    async fn relay_upstream_drop_sends_1001() {
-        let (mut client_a, client_b) = tokio::io::duplex(4096);
-        let (upstream_a, upstream_b) = tokio::io::duplex(4096);
-
-        let (mut cr, mut cw) = tokio::io::split(client_b);
-        let (mut ur, mut uw) = tokio::io::split(upstream_b);
-
-        let handle = tokio::spawn(async move {
-            frame_relay(
-                &mut cr,
-                &mut cw,
-                &mut ur,
-                &mut uw,
-                RelayConfig {
-                    idle_timeout: Duration::from_secs(5),
-                    close_timeout: Duration::from_secs(2),
-                    max_frame_size: None,
-                    shutdown_rx: test_shutdown_rx(),
-                },
-            )
-            .await
-        });
-
-        // Drop upstream — triggers EOF.
-        drop(upstream_a);
-
-        // Client should receive Close 1001 (not 1006, which MUST NOT be sent
-        // on the wire per RFC 6455 §7.4.1).
-        let (fin, op, data) = read_frame(&mut client_a, None).await.unwrap().unwrap();
-        assert!(fin);
-        assert_eq!(op, WsOpcode::Close);
-        let (code, _) = parse_close_payload(&data);
-        assert_eq!(code, 1001);
-
-        let outcome = handle.await.unwrap();
-        assert!(matches!(outcome, RelayOutcome::UpstreamDrop));
-    }
-
-    #[tokio::test]
-    async fn relay_idle_timeout_sends_1001() {
-        let (mut client_a, client_b) = tokio::io::duplex(4096);
-        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
-
-        let (mut cr, mut cw) = tokio::io::split(client_b);
-        let (mut ur, mut uw) = tokio::io::split(upstream_b);
-
-        let handle = tokio::spawn(async move {
-            frame_relay(
-                &mut cr,
-                &mut cw,
-                &mut ur,
-                &mut uw,
-                RelayConfig {
-                    idle_timeout: Duration::from_millis(50),
-                    close_timeout: Duration::from_secs(2),
-                    max_frame_size: None,
-                    shutdown_rx: test_shutdown_rx(),
-                },
-            )
-            .await
-        });
-
-        let outcome = handle.await.unwrap();
-        assert!(matches!(outcome, RelayOutcome::IdleTimeout));
-
-        // Both sides should have received Close 1001.
-        let (_, op, data) = read_frame(&mut client_a, None).await.unwrap().unwrap();
-        assert_eq!(op, WsOpcode::Close);
-        let (code, _) = parse_close_payload(&data);
-        assert_eq!(code, 1001);
-
-        let (_, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
-        assert_eq!(op, WsOpcode::Close);
-        let (code, _) = parse_close_payload(&data);
-        assert_eq!(code, 1001);
-    }
-
-    #[tokio::test]
-    async fn relay_shutdown_sends_1001_to_both_sides() {
-        let (mut client_a, client_b) = tokio::io::duplex(4096);
-        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
-
-        let (mut cr, mut cw) = tokio::io::split(client_b);
-        let (mut ur, mut uw) = tokio::io::split(upstream_b);
-
-        let (shutdown_tx, shutdown_rx) = watch::channel(false);
-
-        let handle = tokio::spawn(async move {
-            frame_relay(
-                &mut cr,
-                &mut cw,
-                &mut ur,
-                &mut uw,
-                RelayConfig {
-                    idle_timeout: Duration::from_secs(5),
-                    close_timeout: Duration::from_secs(2),
-                    max_frame_size: None,
-                    shutdown_rx,
-                },
-            )
-            .await
-        });
-
-        // Signal shutdown.
-        shutdown_tx.send(true).unwrap();
-
-        let outcome = handle.await.unwrap();
-        assert!(matches!(outcome, RelayOutcome::Shutdown));
-
-        // Both sides should have received Close 1001 (Going Away).
-        let (_, op, data) = read_frame(&mut client_a, None).await.unwrap().unwrap();
-        assert_eq!(op, WsOpcode::Close);
-        let (code, _) = parse_close_payload(&data);
-        assert_eq!(code, 1001);
-
-        let (_, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
-        assert_eq!(op, WsOpcode::Close);
-        let (code, _) = parse_close_payload(&data);
-        assert_eq!(code, 1001);
-    }
-
-    #[tokio::test]
-    async fn relay_max_frame_size_sends_1009() {
-        let (mut client_a, client_b) = tokio::io::duplex(4096);
-        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
-
-        let (mut cr, mut cw) = tokio::io::split(client_b);
-        let (mut ur, mut uw) = tokio::io::split(upstream_b);
-
-        let handle = tokio::spawn(async move {
-            frame_relay(
-                &mut cr,
-                &mut cw,
-                &mut ur,
-                &mut uw,
-                RelayConfig {
-                    idle_timeout: Duration::from_secs(5),
-                    close_timeout: Duration::from_secs(2),
-                    max_frame_size: Some(10), // max 10 bytes
-                    shutdown_rx: test_shutdown_rx(),
-                },
-            )
-            .await
-        });
-
-        // Client sends a frame exceeding the limit.
-        write_frame(
-            &mut client_a,
-            WsOpcode::Text,
-            b"this is way too long",
-            true,
-            true,
-        )
-        .await
-        .unwrap();
-
-        // Client should receive Close 1009.
-        let (_, op, data) = read_frame(&mut client_a, None).await.unwrap().unwrap();
-        assert_eq!(op, WsOpcode::Close);
-        let (code, _) = parse_close_payload(&data);
-        assert_eq!(code, 1009);
-
-        // Upstream should also receive Close 1009.
-        let (_, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
-        assert_eq!(op, WsOpcode::Close);
-        let (code, _) = parse_close_payload(&data);
-        assert_eq!(code, 1009);
-
-        let outcome = handle.await.unwrap();
-        assert!(matches!(outcome, RelayOutcome::FrameTooLarge));
-    }
-
-    #[tokio::test]
-    async fn relay_close_timeout_enforced() {
-        let (mut client_a, client_b) = tokio::io::duplex(4096);
-        let (_upstream_a, upstream_b) = tokio::io::duplex(4096);
-
-        let (mut cr, mut cw) = tokio::io::split(client_b);
-        let (mut ur, mut uw) = tokio::io::split(upstream_b);
-
-        let handle = tokio::spawn(async move {
-            frame_relay(
-                &mut cr,
-                &mut cw,
-                &mut ur,
-                &mut uw,
-                RelayConfig {
-                    idle_timeout: Duration::from_secs(5),
-                    close_timeout: Duration::from_millis(50), // very short close timeout
-                    max_frame_size: None,
-                    shutdown_rx: test_shutdown_rx(),
-                },
-            )
-            .await
-        });
-
-        // Client sends Close. The upstream side (_upstream_a) never responds.
-        let close = make_close_payload(1000, "bye");
-        write_frame(&mut client_a, WsOpcode::Close, &close, true, true)
-            .await
-            .unwrap();
-
-        // Should still complete with CleanClose after close timeout.
-        let outcome = handle.await.unwrap();
-        assert!(matches!(outcome, RelayOutcome::CleanClose));
-    }
-
-    // -- PrefixedReader tests --
-
-    #[tokio::test]
-    async fn prefixed_reader_yields_prefix_then_inner() {
-        let prefix = Bytes::from_static(b"prefix-");
-        let inner = &b"inner"[..];
-        let mut reader = PrefixedReader::new(prefix, inner);
-
-        let mut buf = vec![0u8; 32];
-        let n = reader.read(&mut buf).await.unwrap();
-        assert_eq!(&buf[..n], b"prefix-");
-
-        let n = reader.read(&mut buf).await.unwrap();
-        assert_eq!(&buf[..n], b"inner");
-    }
-
-    #[tokio::test]
-    async fn prefixed_reader_empty_prefix_reads_inner_directly() {
-        let prefix = Bytes::new();
-        let inner = &b"data"[..];
-        let mut reader = PrefixedReader::new(prefix, inner);
-
-        let mut buf = vec![0u8; 32];
-        let n = reader.read(&mut buf).await.unwrap();
-        assert_eq!(&buf[..n], b"data");
-    }
-
-    #[tokio::test]
-    async fn relay_leftover_bytes_forwarded_as_frames() {
-        // Simulate leftover bytes from 101 header parsing: a complete
-        // upstream WebSocket text frame sitting in the leftover buffer.
-        let mut leftover_buf = Vec::new();
-        // Build an unmasked text frame with payload "from-upstream".
-        let payload = b"from-upstream";
-        leftover_buf.push(0x81); // FIN + text opcode
-        leftover_buf.push(payload.len() as u8); // no mask, len < 126
-        leftover_buf.extend_from_slice(payload);
-        let leftover = Bytes::from(leftover_buf);
-
-        let (mut client_a, client_b) = tokio::io::duplex(4096);
-        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
-
-        let (mut cr, mut cw) = tokio::io::split(client_b);
-        let (ur, mut uw) = tokio::io::split(upstream_b);
-        // Wrap upstream_read with leftover bytes, same as websocket_bridge does.
-        let mut ur = PrefixedReader::new(leftover, ur);
-
-        let handle = tokio::spawn(async move {
-            frame_relay(
-                &mut cr,
-                &mut cw,
-                &mut ur,
-                &mut uw,
-                RelayConfig {
-                    idle_timeout: Duration::from_secs(5),
-                    close_timeout: Duration::from_secs(2),
-                    max_frame_size: None,
-                    shutdown_rx: test_shutdown_rx(),
-                },
-            )
-            .await
-        });
-
-        // Client should receive the leftover frame parsed as a proper text frame.
-        let (fin, op, data) = read_frame(&mut client_a, None).await.unwrap().unwrap();
-        assert!(fin);
-        assert_eq!(op, WsOpcode::Text);
-        assert_eq!(data, b"from-upstream");
-
-        // Clean up: send Close from client to terminate the relay.
-        let close = make_close_payload(1000, "done");
-        write_frame(&mut client_a, WsOpcode::Close, &close, true, true)
-            .await
-            .unwrap();
-
-        // Upstream receives the forwarded Close.
-        let (_, op, _) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
-        assert_eq!(op, WsOpcode::Close);
-
-        // Respond with Close to complete handshake.
-        let resp = make_close_payload(1000, "done");
-        write_frame(&mut upstream_a, WsOpcode::Close, &resp, false, true)
-            .await
-            .unwrap();
-
-        let outcome = handle.await.unwrap();
-        assert!(matches!(outcome, RelayOutcome::CleanClose));
-    }
-
-    // -- await_close_response loop tests --
-
-    #[tokio::test]
-    async fn await_close_response_skips_non_close_frames() {
-        let (mut writer, reader) = tokio::io::duplex(4096);
-        let (mut reader, _) = tokio::io::split(reader);
-
-        // Write a Pong frame, a Text frame, then a Close frame.
-        write_frame(&mut writer, WsOpcode::Pong, b"", false, true)
-            .await
-            .unwrap();
-        write_frame(&mut writer, WsOpcode::Text, b"queued", false, true)
-            .await
-            .unwrap();
-        let close = make_close_payload(1000, "bye");
-        write_frame(&mut writer, WsOpcode::Close, &close, false, true)
-            .await
-            .unwrap();
-
-        let outcome = await_close_response(&mut reader, Duration::from_secs(2)).await;
-        assert!(matches!(outcome, RelayOutcome::CleanClose));
-    }
-
-    #[tokio::test]
-    async fn await_close_response_timeout_with_only_data_frames() {
-        let (mut writer, reader) = tokio::io::duplex(4096);
-        let (mut reader, _) = tokio::io::split(reader);
-
-        // Write a few Pong frames but never a Close.
-        for _ in 0..3 {
-            write_frame(&mut writer, WsOpcode::Pong, b"", false, true)
-                .await
-                .unwrap();
-        }
-        // Keep writer alive so reads block (no EOF).
-        let _writer = writer;
-
-        let outcome = await_close_response(&mut reader, Duration::from_millis(50)).await;
-        assert!(matches!(outcome, RelayOutcome::CleanClose));
-    }
-
-    // -- Caller disconnect tests --
-
-    #[tokio::test]
-    async fn relay_caller_drop_sends_close_to_upstream() {
-        let (client_a, client_b) = tokio::io::duplex(4096);
-        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
-
-        let (mut cr, mut cw) = tokio::io::split(client_b);
-        let (mut ur, mut uw) = tokio::io::split(upstream_b);
-
-        let handle = tokio::spawn(async move {
-            frame_relay(
-                &mut cr,
-                &mut cw,
-                &mut ur,
-                &mut uw,
-                RelayConfig {
-                    idle_timeout: Duration::from_secs(5),
-                    close_timeout: Duration::from_secs(2),
-                    max_frame_size: None,
-                    shutdown_rx: test_shutdown_rx(),
-                },
-            )
-            .await
-        });
-
-        // Drop client mid-session — triggers EOF on the client read side.
-        drop(client_a);
-
-        // Upstream should receive a Close 1001 (Going Away).
-        let (_, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
-        assert_eq!(op, WsOpcode::Close);
-        let (code, _) = parse_close_payload(&data);
-        assert_eq!(code, 1001);
-
-        let outcome = handle.await.unwrap();
-        assert!(matches!(outcome, RelayOutcome::CallerDrop));
-    }
-
-    #[tokio::test]
-    async fn relay_caller_drop_during_upstream_activity() {
-        // Upstream is actively sending data when the caller disconnects.
-        let (client_a, client_b) = tokio::io::duplex(4096);
-        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
-
-        let (mut cr, mut cw) = tokio::io::split(client_b);
-        let (mut ur, mut uw) = tokio::io::split(upstream_b);
-
-        let handle = tokio::spawn(async move {
-            frame_relay(
-                &mut cr,
-                &mut cw,
-                &mut ur,
-                &mut uw,
-                RelayConfig {
-                    idle_timeout: Duration::from_secs(5),
-                    close_timeout: Duration::from_secs(2),
-                    max_frame_size: None,
-                    shutdown_rx: test_shutdown_rx(),
-                },
-            )
-            .await
-        });
-
-        // Upstream sends a message first.
-        write_frame(&mut upstream_a, WsOpcode::Text, b"data", false, true)
-            .await
-            .unwrap();
-
-        // Small delay to let the relay forward it, then drop client.
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        drop(client_a);
-
-        // Upstream should receive Close 1001.
-        // May need to read past the frame that was in flight.
-        loop {
-            match read_frame(&mut upstream_a, None).await {
-                Ok(Some((_, WsOpcode::Close, data))) => {
-                    let (code, _) = parse_close_payload(&data);
-                    assert_eq!(code, 1001);
-                    break;
-                }
-                Ok(Some(_)) => continue,    // skip in-flight frames
-                Ok(None) | Err(_) => break, // EOF is also acceptable
-            }
-        }
-
-        let outcome = handle.await.unwrap();
-        assert!(matches!(
-            outcome,
-            RelayOutcome::CallerDrop | RelayOutcome::Error(_)
-        ));
-    }
-
-    // -- Upstream Close during active client transmission --
-
-    #[tokio::test]
-    async fn relay_upstream_sends_close_while_client_is_sending() {
-        let (mut client_a, client_b) = tokio::io::duplex(4096);
-        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
-
-        let (mut cr, mut cw) = tokio::io::split(client_b);
-        let (mut ur, mut uw) = tokio::io::split(upstream_b);
-
-        let handle = tokio::spawn(async move {
-            frame_relay(
-                &mut cr,
-                &mut cw,
-                &mut ur,
-                &mut uw,
-                RelayConfig {
-                    idle_timeout: Duration::from_secs(5),
-                    close_timeout: Duration::from_secs(2),
-                    max_frame_size: None,
-                    shutdown_rx: test_shutdown_rx(),
-                },
-            )
-            .await
-        });
-
-        // Client sends a text frame.
-        write_frame(&mut client_a, WsOpcode::Text, b"hello", true, true)
-            .await
-            .unwrap();
-
-        // Upstream receives the frame...
-        let (_, op, _) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
-        assert_eq!(op, WsOpcode::Text);
-
-        // ...then upstream initiates Close while client might still be sending.
-        let close = make_close_payload(1000, "Server done");
-        write_frame(&mut upstream_a, WsOpcode::Close, &close, false, true)
-            .await
-            .unwrap();
-
-        // Client should receive the Close frame forwarded by the relay.
-        let (_, op, data) = read_frame(&mut client_a, None).await.unwrap().unwrap();
-        assert_eq!(op, WsOpcode::Close);
-        let (code, _) = parse_close_payload(&data);
-        assert_eq!(code, 1000);
-
-        // Client sends Close response to complete the handshake.
-        let resp = make_close_payload(1000, "OK");
-        write_frame(&mut client_a, WsOpcode::Close, &resp, true, true)
-            .await
-            .unwrap();
-
-        let outcome = handle.await.unwrap();
-        assert!(matches!(outcome, RelayOutcome::CleanClose));
-    }
-
-    // -- Ping/Pong forwarding --
-
-    #[tokio::test]
-    async fn relay_ping_forwarded_to_upstream() {
-        let (mut client_a, client_b) = tokio::io::duplex(4096);
-        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
-
-        let (mut cr, mut cw) = tokio::io::split(client_b);
-        let (mut ur, mut uw) = tokio::io::split(upstream_b);
-
-        let handle = tokio::spawn(async move {
-            frame_relay(
-                &mut cr,
-                &mut cw,
-                &mut ur,
-                &mut uw,
-                RelayConfig {
-                    idle_timeout: Duration::from_secs(5),
-                    close_timeout: Duration::from_secs(2),
-                    max_frame_size: None,
-                    shutdown_rx: test_shutdown_rx(),
-                },
-            )
-            .await
-        });
-
-        // Client sends Ping.
-        write_frame(&mut client_a, WsOpcode::Ping, b"ping-data", true, true)
-            .await
-            .unwrap();
-
-        // Upstream should receive the Ping.
-        let (_, op, payload) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
-        assert_eq!(op, WsOpcode::Ping);
-        assert_eq!(payload, b"ping-data");
-
-        // Upstream sends Pong back.
-        write_frame(&mut upstream_a, WsOpcode::Pong, b"pong-data", false, true)
-            .await
-            .unwrap();
-
-        // Client should receive the Pong.
-        let (_, op, payload) = read_frame(&mut client_a, None).await.unwrap().unwrap();
-        assert_eq!(op, WsOpcode::Pong);
-        assert_eq!(payload, b"pong-data");
-
-        // Verify Ping resets the idle timer by sending after a short pause.
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        write_frame(&mut client_a, WsOpcode::Ping, b"", true, true)
-            .await
-            .unwrap();
-        let (_, op, _) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
-        assert_eq!(op, WsOpcode::Ping);
-
-        // Clean up.
-        let close = make_close_payload(1000, "done");
-        write_frame(&mut client_a, WsOpcode::Close, &close, true, true)
-            .await
-            .unwrap();
-        let _ = read_frame(&mut upstream_a, None).await; // consume forwarded Close
-        write_frame(&mut upstream_a, WsOpcode::Close, &close, false, true)
-            .await
-            .unwrap();
-
-        let outcome = handle.await.unwrap();
-        assert!(matches!(outcome, RelayOutcome::CleanClose));
-    }
-
-    // -- Upstream oversized frame sends 1009 --
-
-    #[tokio::test]
-    async fn relay_upstream_oversized_frame_sends_1009() {
-        let (mut client_a, client_b) = tokio::io::duplex(4096);
-        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
-
-        let (mut cr, mut cw) = tokio::io::split(client_b);
-        let (mut ur, mut uw) = tokio::io::split(upstream_b);
-
-        let handle = tokio::spawn(async move {
-            frame_relay(
-                &mut cr,
-                &mut cw,
-                &mut ur,
-                &mut uw,
-                RelayConfig {
-                    idle_timeout: Duration::from_secs(5),
-                    close_timeout: Duration::from_secs(2),
-                    max_frame_size: Some(10), // max 10 bytes
-                    shutdown_rx: test_shutdown_rx(),
-                },
-            )
-            .await
-        });
-
-        // Upstream sends an oversized frame.
-        write_frame(&mut upstream_a, WsOpcode::Text, &[0xBB; 50], false, true)
-            .await
-            .unwrap();
-
-        // Upstream should receive Close 1009.
-        let (_, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
-        assert_eq!(op, WsOpcode::Close);
-        let (code, _) = parse_close_payload(&data);
-        assert_eq!(code, 1009);
-
-        // Client should also receive Close 1009.
-        let (_, op, data) = read_frame(&mut client_a, None).await.unwrap().unwrap();
-        assert_eq!(op, WsOpcode::Close);
-        let (code, _) = parse_close_payload(&data);
-        assert_eq!(code, 1009);
-
-        let outcome = handle.await.unwrap();
-        assert!(matches!(outcome, RelayOutcome::FrameTooLarge));
-    }
-
-    // -- Fragmented message relay --
-
-    #[tokio::test]
-    async fn relay_fragmented_message_preserved() {
-        // Verify that fragmented messages (FIN=0 + continuation frames)
-        // are forwarded through the relay with FIN bits intact.
-        let (mut client_a, client_b) = tokio::io::duplex(4096);
-        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
-
-        let (mut cr, mut cw) = tokio::io::split(client_b);
-        let (mut ur, mut uw) = tokio::io::split(upstream_b);
-
-        let handle = tokio::spawn(async move {
-            frame_relay(
-                &mut cr,
-                &mut cw,
-                &mut ur,
-                &mut uw,
-                RelayConfig {
-                    idle_timeout: Duration::from_secs(5),
-                    close_timeout: Duration::from_secs(2),
-                    max_frame_size: None,
-                    shutdown_rx: test_shutdown_rx(),
-                },
-            )
-            .await
-        });
-
-        // Client sends a fragmented text message: non-final + continuation + final.
-        write_frame(&mut client_a, WsOpcode::Text, b"frag1", true, false)
-            .await
-            .unwrap();
-        write_frame(&mut client_a, WsOpcode::Continuation, b"frag2", true, false)
-            .await
-            .unwrap();
-        write_frame(&mut client_a, WsOpcode::Continuation, b"frag3", true, true)
-            .await
-            .unwrap();
-
-        // Upstream should receive all three fragments with FIN bits preserved.
-        let (fin, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
-        assert!(!fin);
-        assert_eq!(op, WsOpcode::Text);
-        assert_eq!(data, b"frag1");
-
-        let (fin, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
-        assert!(!fin);
-        assert_eq!(op, WsOpcode::Continuation);
-        assert_eq!(data, b"frag2");
-
-        let (fin, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
-        assert!(fin);
-        assert_eq!(op, WsOpcode::Continuation);
-        assert_eq!(data, b"frag3");
-
-        // Clean up.
-        let close = make_close_payload(1000, "done");
-        write_frame(&mut client_a, WsOpcode::Close, &close, true, true)
-            .await
-            .unwrap();
-        let _ = read_frame(&mut upstream_a, None).await;
-        write_frame(&mut upstream_a, WsOpcode::Close, &close, false, true)
-            .await
-            .unwrap();
-
-        let outcome = handle.await.unwrap();
-        assert!(matches!(outcome, RelayOutcome::CleanClose));
-    }
-
-    // -- Binary frame opcode preservation --
-
-    #[tokio::test]
-    async fn relay_binary_opcode_preserved() {
-        let (mut client_a, client_b) = tokio::io::duplex(4096);
-        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
-
-        let (mut cr, mut cw) = tokio::io::split(client_b);
-        let (mut ur, mut uw) = tokio::io::split(upstream_b);
-
-        let handle = tokio::spawn(async move {
-            frame_relay(
-                &mut cr,
-                &mut cw,
-                &mut ur,
-                &mut uw,
-                RelayConfig {
-                    idle_timeout: Duration::from_secs(5),
-                    close_timeout: Duration::from_secs(2),
-                    max_frame_size: None,
-                    shutdown_rx: test_shutdown_rx(),
-                },
-            )
-            .await
-        });
-
-        // Client sends a binary frame.
-        let binary_data = vec![0x00, 0xFF, 0x42, 0x13, 0x37];
-        write_frame(&mut client_a, WsOpcode::Binary, &binary_data, true, true)
-            .await
-            .unwrap();
-
-        // Upstream receives it as Binary (not Text).
-        let (fin, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
-        assert!(fin);
-        assert_eq!(op, WsOpcode::Binary);
-        assert_eq!(data, binary_data);
-
-        // Upstream responds with Binary.
-        let response_data = vec![0xDE, 0xAD, 0xBE, 0xEF];
-        write_frame(
-            &mut upstream_a,
-            WsOpcode::Binary,
-            &response_data,
-            false,
-            true,
-        )
-        .await
-        .unwrap();
-
-        // Client receives it as Binary.
-        let (fin, op, data) = read_frame(&mut client_a, None).await.unwrap().unwrap();
-        assert!(fin);
-        assert_eq!(op, WsOpcode::Binary);
-        assert_eq!(data, response_data);
-
-        // Clean up.
-        let close = make_close_payload(1000, "done");
-        write_frame(&mut client_a, WsOpcode::Close, &close, true, true)
-            .await
-            .unwrap();
-        let _ = read_frame(&mut upstream_a, None).await;
-        write_frame(&mut upstream_a, WsOpcode::Close, &close, false, true)
-            .await
-            .unwrap();
-
-        let outcome = handle.await.unwrap();
-        assert!(matches!(outcome, RelayOutcome::CleanClose));
-    }
-
-    // -- Idle timer reset on activity --
-
-    // Virtual clock: the 60ms/100ms margin is far too tight for wall-clock
-    // time under a loaded test runner — a single late wakeup lets the idle
-    // timeout fire and the relay answers with Close instead of the frame.
-    #[tokio::test(start_paused = true)]
-    async fn relay_idle_timer_resets_on_data() {
-        // With a 100ms idle timeout, send a frame every 60ms to keep the
-        // connection alive — verify it survives past the original deadline.
-        let (mut client_a, client_b) = tokio::io::duplex(4096);
-        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
-
-        let (mut cr, mut cw) = tokio::io::split(client_b);
-        let (mut ur, mut uw) = tokio::io::split(upstream_b);
-
-        let handle = tokio::spawn(async move {
-            frame_relay(
-                &mut cr,
-                &mut cw,
-                &mut ur,
-                &mut uw,
-                RelayConfig {
-                    idle_timeout: Duration::from_millis(100),
-                    close_timeout: Duration::from_secs(2),
-                    max_frame_size: None,
-                    shutdown_rx: test_shutdown_rx(),
-                },
-            )
-            .await
-        });
-
-        // Send 5 messages spaced 60ms apart. Total time ~300ms, well past
-        // the 100ms idle timeout — but each message resets the timer.
-        for i in 0..5 {
-            tokio::time::sleep(Duration::from_millis(60)).await;
-            let msg = format!("msg-{i}");
-            write_frame(&mut client_a, WsOpcode::Text, msg.as_bytes(), true, true)
-                .await
-                .unwrap();
-            let (_, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
-            assert_eq!(op, WsOpcode::Text);
-            assert_eq!(data, msg.as_bytes());
-        }
-
-        // Now stop sending and let the idle timeout fire.
-        tokio::time::sleep(Duration::from_millis(200)).await;
-
-        let outcome = handle.await.unwrap();
-        assert!(matches!(outcome, RelayOutcome::IdleTimeout));
-    }
-}
+#[path = "websocket_tests.rs"]
+mod websocket_tests;

--- a/gears/system/oagw/oagw/src/infra/proxy/websocket_tests.rs
+++ b/gears/system/oagw/oagw/src/infra/proxy/websocket_tests.rs
@@ -1,0 +1,656 @@
+use super::*;
+use tokio::io::AsyncReadExt;
+
+/// Create a no-op shutdown receiver for tests that don't exercise shutdown.
+fn test_shutdown_rx() -> watch::Receiver<bool> {
+    let (_tx, rx) = watch::channel(false);
+    rx
+}
+
+fn cfg(idle: Duration, shutdown_rx: watch::Receiver<bool>) -> RelayConfig {
+    cfg_with_leftover(idle, shutdown_rx, Bytes::new())
+}
+
+fn cfg_with_leftover(
+    idle: Duration,
+    shutdown_rx: watch::Receiver<bool>,
+    leftover: Bytes,
+) -> RelayConfig {
+    RelayConfig {
+        leftover,
+        idle_timeout: idle,
+        close_timeout: Duration::from_millis(100),
+        shutdown_rx,
+    }
+}
+
+/// Read exactly `n` bytes, failing the test with the underlying IO error
+/// rather than returning a short buffer that panics on indexing later.
+async fn read_n(io: &mut (impl AsyncRead + Unpin), n: usize) -> Vec<u8> {
+    let mut out = vec![0u8; n];
+    io.read_exact(&mut out)
+        .await
+        .unwrap_or_else(|e| panic!("expected {n} bytes, read failed: {e}"));
+    out
+}
+
+/// IO that never completes a read or a write. Models the peer that has
+/// stopped servicing its socket — the case that used to hang teardown.
+struct StalledIo;
+
+impl AsyncRead for StalledIo {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        _buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Poll::Pending
+    }
+}
+
+impl AsyncWrite for StalledIo {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        _buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Poll::Pending
+    }
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Poll::Pending
+    }
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Poll::Pending
+    }
+}
+
+/// IO whose first read fails, to drive the `RelayOutcome::Error` arm.
+struct BrokenIo;
+
+impl AsyncRead for BrokenIo {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        _buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Poll::Ready(Err(std::io::Error::new(
+            std::io::ErrorKind::BrokenPipe,
+            "peer reset",
+        )))
+    }
+}
+
+impl AsyncWrite for BrokenIo {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Poll::Ready(Ok(buf.len()))
+    }
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+// -- going_away_frame ----------------------------------------------------
+
+#[test]
+fn going_away_frame_unmasked_layout() {
+    let frame = going_away_frame(None);
+    assert_eq!(frame[0], 0x88, "FIN | Close");
+    assert_eq!(frame[1], 12, "no mask bit, 2 + 10 payload bytes");
+    assert_eq!(&frame[2..4], &1001u16.to_be_bytes());
+    assert_eq!(&frame[4..], b"Going Away");
+}
+
+#[test]
+fn going_away_frame_masked_sets_bit_and_xors_payload() {
+    let key = [0x11u8, 0x22, 0x33, 0x44];
+    let frame = going_away_frame(Some(key));
+    assert_eq!(frame[0], 0x88);
+    assert_eq!(frame[1], 0x80 | 12, "mask bit set");
+    assert_eq!(&frame[2..6], &key);
+
+    let unmasked: Vec<u8> = frame[6..]
+        .iter()
+        .enumerate()
+        .map(|(i, b)| b ^ key[i % 4])
+        .collect();
+    assert_eq!(&unmasked[..2], &1001u16.to_be_bytes());
+    assert_eq!(&unmasked[2..], b"Going Away");
+}
+
+// -- relay ---------------------------------------------------------------
+
+#[tokio::test]
+async fn relay_forwards_bytes_in_both_directions() {
+    let (mut client_a, client_b) = tokio::io::duplex(4096);
+    let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+    let handle = tokio::spawn(async move {
+        relay(
+            client_b,
+            upstream_b,
+            cfg(Duration::from_secs(5), test_shutdown_rx()),
+        )
+        .await
+    });
+
+    client_a.write_all(b"to-upstream").await.unwrap();
+    assert_eq!(read_n(&mut upstream_a, 11).await, b"to-upstream");
+
+    upstream_a.write_all(b"to-client").await.unwrap();
+    assert_eq!(read_n(&mut client_a, 9).await, b"to-client");
+
+    // Sequence the two closures rather than dropping both peers back to back,
+    // which would leave the attribution to `copy_bidirectional`'s poll order.
+    // The caller leaves first, and reading upstream to EOF waits for the relay
+    // to act on it: the upstream write half is shut down only once the
+    // client→upstream direction has seen the caller's EOF.
+    drop(client_a);
+    let mut upstream_tail = Vec::new();
+    upstream_a.read_to_end(&mut upstream_tail).await.unwrap();
+    assert!(
+        upstream_tail.is_empty(),
+        "nothing more was sent after the caller hung up"
+    );
+
+    // Only now does the upstream leg end, so `TunnelEnd::Client` is the only
+    // attribution the relay can reach.
+    drop(upstream_a);
+    let outcome = handle.await.unwrap();
+    assert!(
+        matches!(
+            outcome,
+            RelayOutcome::Closed {
+                ended_by: TunnelEnd::Client,
+                ..
+            }
+        ),
+        "caller hung up first, got {outcome:?}"
+    );
+}
+
+/// The point of the opaque relay: bytes the old frame layer would have
+/// rewritten — and that tungstenite / fastwebsockets reject outright — pass
+/// through untouched.
+#[tokio::test]
+async fn relay_forwards_masked_rsv_and_unknown_opcode_frames_verbatim() {
+    let (mut client_a, client_b) = tokio::io::duplex(4096);
+    let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+    let handle = tokio::spawn(async move {
+        relay(
+            client_b,
+            upstream_b,
+            cfg(Duration::from_secs(5), test_shutdown_rx()),
+        )
+        .await
+    });
+
+    // RSV1 set (permessage-deflate) + reserved opcode 3 + client masking.
+    // The old relay stripped RSV and re-masked with a fresh key.
+    let mask = [0x11u8, 0x22, 0x33, 0x44];
+    let mut frame = vec![0xC3, 0x83];
+    frame.extend_from_slice(&mask);
+    for (i, b) in b"abc".iter().enumerate() {
+        frame.push(b ^ mask[i % 4]);
+    }
+
+    client_a.write_all(&frame).await.unwrap();
+    assert_eq!(
+        read_n(&mut upstream_a, frame.len()).await,
+        frame,
+        "frame must reach upstream byte-for-byte"
+    );
+
+    drop(client_a);
+    drop(upstream_a);
+    let _outcome = handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn relay_peer_disconnect_ends_the_session() {
+    let (client_a, client_b) = tokio::io::duplex(4096);
+    let (upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+    let handle = tokio::spawn(async move {
+        relay(
+            client_b,
+            upstream_b,
+            cfg(Duration::from_secs(5), test_shutdown_rx()),
+        )
+        .await
+    });
+
+    drop(client_a);
+    drop(upstream_a);
+
+    let outcome = tokio::time::timeout(Duration::from_secs(2), handle)
+        .await
+        .expect("relay must end when both peers disconnect")
+        .unwrap();
+    assert!(matches!(outcome, RelayOutcome::Closed { .. }));
+}
+
+#[tokio::test]
+async fn relay_idle_timeout_sends_close_1001_to_both_sides() {
+    let (mut client_a, client_b) = tokio::io::duplex(4096);
+    let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+    let handle = tokio::spawn(async move {
+        relay(
+            client_b,
+            upstream_b,
+            cfg(Duration::from_millis(100), test_shutdown_rx()),
+        )
+        .await
+    });
+
+    // Caller side: unmasked Close 1001 — 2 header + 12 payload bytes.
+    let to_client = read_n(&mut client_a, 14).await;
+    assert_eq!(to_client[0], 0x88);
+    assert_eq!(to_client[1], 12, "server-to-client frames are not masked");
+    assert_eq!(&to_client[2..4], &1001u16.to_be_bytes());
+    assert_eq!(&to_client[4..14], b"Going Away");
+
+    // Upstream side: masked Close 1001 (the gateway is the client there) —
+    // 2 header + 4 mask + 12 payload bytes.
+    let to_upstream = read_n(&mut upstream_a, 18).await;
+    assert_eq!(to_upstream[0], 0x88);
+    assert_eq!(
+        to_upstream[1],
+        0x80 | 12,
+        "client-to-server frames are masked"
+    );
+    let key = [
+        to_upstream[2],
+        to_upstream[3],
+        to_upstream[4],
+        to_upstream[5],
+    ];
+    let unmasked: Vec<u8> = to_upstream[6..18]
+        .iter()
+        .enumerate()
+        .map(|(i, b)| b ^ key[i % 4])
+        .collect();
+    assert_eq!(&unmasked[..2], &1001u16.to_be_bytes());
+    assert_eq!(&unmasked[2..], b"Going Away");
+
+    let outcome = handle.await.unwrap();
+    assert!(matches!(outcome, RelayOutcome::IdleTimeout));
+}
+
+#[tokio::test]
+async fn relay_idle_timer_is_pushed_out_by_traffic() {
+    let (mut client_a, client_b) = tokio::io::duplex(4096);
+    let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+    let handle = tokio::spawn(async move {
+        relay(
+            client_b,
+            upstream_b,
+            cfg(Duration::from_millis(300), test_shutdown_rx()),
+        )
+        .await
+    });
+
+    // Keep the tunnel busy well past one idle window.
+    for _ in 0..4 {
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        client_a.write_all(b"ping").await.unwrap();
+        assert_eq!(read_n(&mut upstream_a, 4).await, b"ping");
+    }
+
+    assert!(!handle.is_finished(), "traffic must keep the session alive");
+
+    drop(client_a);
+    drop(upstream_a);
+    let _outcome = handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn relay_shutdown_sends_close_1001() {
+    let (mut client_a, client_b) = tokio::io::duplex(4096);
+    let (upstream_a, upstream_b) = tokio::io::duplex(4096);
+    let (tx, rx) = watch::channel(false);
+
+    let handle =
+        tokio::spawn(
+            async move { relay(client_b, upstream_b, cfg(Duration::from_secs(5), rx)).await },
+        );
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    tx.send(true).unwrap();
+
+    let to_client = read_n(&mut client_a, 14).await;
+    assert_eq!(to_client[0], 0x88);
+    assert_eq!(to_client[1], 12, "server-to-client frames are not masked");
+    assert_eq!(&to_client[2..4], &1001u16.to_be_bytes());
+    assert_eq!(&to_client[4..14], b"Going Away");
+
+    drop(upstream_a);
+    let outcome = handle.await.unwrap();
+    assert!(matches!(outcome, RelayOutcome::Shutdown));
+}
+
+/// A peer that has stopped reading must not be able to wedge teardown.
+/// Before the grace period covered the Close writes, `write_all` here
+/// blocked forever and stranded the detached bridge task, its upstream
+/// stream and the active-session gauge.
+#[tokio::test]
+async fn relay_teardown_is_bounded_when_a_peer_stops_reading() {
+    let (upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+    let started = tokio::time::Instant::now();
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(5),
+        relay(
+            StalledIo,
+            upstream_b,
+            cfg(Duration::from_millis(100), test_shutdown_rx()),
+        ),
+    )
+    .await
+    .expect("teardown must not hang on an unresponsive peer");
+
+    assert!(matches!(outcome, RelayOutcome::IdleTimeout));
+    // idle (100ms) + close grace (100ms), with slack for scheduling.
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "teardown took {:?}; the close grace period is not bounding it",
+        started.elapsed()
+    );
+    drop(upstream_a);
+}
+
+/// Each side's close announcement gets its own grace budget. When the two ran
+/// sequentially under one shared timeout, a stalled caller consumed the whole
+/// period and the upstream was never told anything at all.
+#[tokio::test]
+async fn relay_announces_close_to_upstream_even_when_the_caller_has_stalled() {
+    let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+    let handle = tokio::spawn(async move {
+        relay(
+            StalledIo,
+            upstream_b,
+            cfg(Duration::from_millis(100), test_shutdown_rx()),
+        )
+        .await
+    });
+
+    // Masked Close 1001: 2 header + 4 mask + 12 payload bytes.
+    let to_upstream = tokio::time::timeout(Duration::from_secs(2), read_n(&mut upstream_a, 18))
+        .await
+        .expect("upstream must be told to go away regardless of the caller");
+    assert_eq!(to_upstream[0], 0x88);
+    assert_eq!(to_upstream[1], 0x80 | 12);
+
+    // ...and the upstream leg is half-closed, not left waiting on the caller.
+    let mut rest = Vec::new();
+    tokio::time::timeout(Duration::from_secs(2), upstream_a.read_to_end(&mut rest))
+        .await
+        .expect("upstream write half must be shut down within the grace period")
+        .unwrap();
+    assert!(rest.is_empty(), "nothing follows the Close frame");
+
+    let outcome = tokio::time::timeout(Duration::from_secs(2), handle)
+        .await
+        .expect("teardown must not hang on an unresponsive caller")
+        .unwrap();
+    assert!(matches!(outcome, RelayOutcome::IdleTimeout));
+}
+
+/// The claim that justifies dropping `websocket_max_frame_size_bytes`: a
+/// payload far larger than the relay's copy buffer streams through instead
+/// of being materialised.
+#[tokio::test]
+async fn relay_streams_a_payload_far_larger_than_the_copy_buffer() {
+    let (mut client_a, client_b) = tokio::io::duplex(4096);
+    let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+    let handle = tokio::spawn(async move {
+        relay(
+            client_b,
+            upstream_b,
+            cfg(Duration::from_secs(10), test_shutdown_rx()),
+        )
+        .await
+    });
+
+    // 512 KiB — two orders of magnitude past the 4 KiB duplex buffer.
+    const LEN: usize = 512 * 1024;
+    let payload: Vec<u8> = (0..LEN).map(|i| (i % 251) as u8).collect();
+    let expected = payload.clone();
+
+    let writer = tokio::spawn(async move {
+        client_a.write_all(&payload).await.unwrap();
+        client_a
+    });
+
+    let mut got = vec![0u8; LEN];
+    upstream_a.read_exact(&mut got).await.unwrap();
+    assert_eq!(got, expected, "payload must arrive intact and in order");
+
+    let client_a = writer.await.unwrap();
+    drop(client_a);
+    drop(upstream_a);
+    let _outcome = handle.await.unwrap();
+}
+
+/// An upstream that dies under a live caller is abnormal and must be
+/// attributed as such, so the bridge can log it above debug. Note the
+/// half-close dance: `copy_bidirectional` shuts the caller's write half
+/// once the upstream ends, and only returns after the caller ends too — so
+/// the *order* of the EOFs is what carries the signal.
+#[tokio::test]
+async fn relay_reports_an_upstream_drop_distinctly() {
+    let (mut client_a, client_b) = tokio::io::duplex(4096);
+    let (upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+    let handle = tokio::spawn(async move {
+        relay(
+            client_b,
+            upstream_b,
+            cfg(Duration::from_secs(5), test_shutdown_rx()),
+        )
+        .await
+    });
+
+    // Only the upstream goes away; the caller is still connected.
+    drop(upstream_a);
+
+    // The relay half-closes toward the caller, which surfaces as EOF here.
+    let mut drained = Vec::new();
+    tokio::time::timeout(Duration::from_secs(2), client_a.read_to_end(&mut drained))
+        .await
+        .expect("relay must half-close the caller when the upstream dies")
+        .unwrap();
+
+    // Caller then hangs up, completing the other direction.
+    drop(client_a);
+
+    let outcome = tokio::time::timeout(Duration::from_secs(2), handle)
+        .await
+        .expect("relay ends once both halves are done")
+        .unwrap();
+    assert!(
+        matches!(
+            outcome,
+            RelayOutcome::Closed {
+                ended_by: TunnelEnd::Upstream,
+                ..
+            }
+        ),
+        "expected an upstream-attributed close, got {outcome:?}"
+    );
+}
+
+#[tokio::test]
+async fn relay_surfaces_io_errors() {
+    let (upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(2),
+        relay(
+            BrokenIo,
+            upstream_b,
+            cfg(Duration::from_secs(5), test_shutdown_rx()),
+        ),
+    )
+    .await
+    .expect("a broken peer must end the relay promptly");
+
+    assert!(matches!(outcome, RelayOutcome::Error(_)), "got {outcome:?}");
+    drop(upstream_a);
+}
+
+/// A session opened after shutdown was already announced must close at
+/// once, without waiting for a `changed()` edge that will never come.
+#[tokio::test]
+async fn relay_closes_when_shutdown_was_already_signalled() {
+    let (mut client_a, client_b) = tokio::io::duplex(4096);
+    let (upstream_a, upstream_b) = tokio::io::duplex(4096);
+    let (_tx, rx) = watch::channel(true);
+
+    let handle =
+        tokio::spawn(
+            async move { relay(client_b, upstream_b, cfg(Duration::from_secs(30), rx)).await },
+        );
+
+    let to_client = read_n(&mut client_a, 14).await;
+    assert_eq!(to_client[0], 0x88);
+    assert_eq!(to_client[1], 12, "server-to-client frames are not masked");
+    assert_eq!(&to_client[2..4], &1001u16.to_be_bytes());
+    assert_eq!(&to_client[4..14], b"Going Away");
+
+    drop(upstream_a);
+    let outcome = handle.await.unwrap();
+    assert!(matches!(outcome, RelayOutcome::Shutdown));
+}
+
+// -- leftover hand-off ---------------------------------------------------
+
+#[tokio::test]
+async fn leftover_bytes_reach_the_caller_ahead_of_later_upstream_data() {
+    let (mut client_a, client_b) = tokio::io::duplex(4096);
+    let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+    let handle = tokio::spawn(async move {
+        relay(
+            client_b,
+            upstream_b,
+            cfg_with_leftover(
+                Duration::from_secs(5),
+                test_shutdown_rx(),
+                Bytes::from_static(b"post-101-bytes"),
+            ),
+        )
+        .await
+    });
+
+    upstream_a.write_all(b"-then-live-data").await.unwrap();
+    assert_eq!(
+        read_n(&mut client_a, 29).await,
+        b"post-101-bytes-then-live-data",
+        "leftover must land before anything upstream sends next"
+    );
+
+    drop(client_a);
+    drop(upstream_a);
+    let _outcome = handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn empty_leftover_forwards_nothing_of_its_own() {
+    let (mut client_a, client_b) = tokio::io::duplex(4096);
+    let (upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+    let handle = tokio::spawn(async move {
+        relay(
+            client_b,
+            upstream_b,
+            cfg(Duration::from_secs(5), test_shutdown_rx()),
+        )
+        .await
+    });
+
+    drop(upstream_a);
+    let mut sink = Vec::new();
+    client_a.read_to_end(&mut sink).await.unwrap();
+    assert!(sink.is_empty(), "an empty leftover must be a no-op");
+
+    drop(client_a);
+    let _outcome = handle.await.unwrap();
+}
+
+/// The leftover prefix must not reintroduce an unbounded write outside the
+/// relay. It used to be handed to the caller *before* the relay started, so a
+/// caller that never read wedged the detached bridge task — and its session
+/// guard — for the process's lifetime.
+#[tokio::test]
+async fn relay_tears_down_when_leftover_bytes_meet_a_stalled_caller() {
+    let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+    let started = tokio::time::Instant::now();
+    let handle = tokio::spawn(async move {
+        relay(
+            StalledIo,
+            upstream_b,
+            cfg_with_leftover(
+                Duration::from_millis(100),
+                test_shutdown_rx(),
+                Bytes::from_static(b"never-accepted"),
+            ),
+        )
+        .await
+    });
+
+    // Upstream is still told to go away, even though the caller never accepted
+    // the leftover bytes: masked Close 1001, 2 header + 4 mask + 12 payload.
+    let to_upstream = tokio::time::timeout(Duration::from_secs(2), read_n(&mut upstream_a, 18))
+        .await
+        .expect("leftover delivery must not outlive the idle timeout");
+    assert_eq!(to_upstream[0], 0x88);
+    assert_eq!(to_upstream[1], 0x80 | 12);
+
+    let outcome = tokio::time::timeout(Duration::from_secs(2), handle)
+        .await
+        .expect("relay must return so the session guard drops")
+        .unwrap();
+    assert!(matches!(outcome, RelayOutcome::IdleTimeout));
+    // idle (100ms) + close grace (100ms), with slack for scheduling.
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "teardown took {:?}; leftover delivery is not bounded",
+        started.elapsed()
+    );
+}
+
+/// A dropped shutdown sender can never deliver a signal; the branch must go
+/// inert rather than resolving `Err` on every poll and spinning the loop.
+#[tokio::test]
+async fn relay_survives_a_dropped_shutdown_sender() {
+    let (mut client_a, client_b) = tokio::io::duplex(4096);
+    let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+    let (tx, rx) = watch::channel(false);
+    drop(tx);
+
+    let handle =
+        tokio::spawn(
+            async move { relay(client_b, upstream_b, cfg(Duration::from_secs(5), rx)).await },
+        );
+
+    client_a.write_all(b"still-works").await.unwrap();
+    assert_eq!(read_n(&mut upstream_a, 11).await, b"still-works");
+
+    drop(client_a);
+    drop(upstream_a);
+    let outcome = handle.await.unwrap();
+    assert!(matches!(outcome, RelayOutcome::Closed { .. }));
+}

--- a/gears/system/oagw/oagw/src/test_support/harness.rs
+++ b/gears/system/oagw/oagw/src/test_support/harness.rs
@@ -59,7 +59,6 @@ pub struct AppHarnessBuilder {
     skip_upstream_tls_verify: bool,
     websocket_idle_timeout: Option<Duration>,
     websocket_close_timeout: Option<Duration>,
-    websocket_max_frame_size: Option<usize>,
 }
 
 impl AppHarnessBuilder {
@@ -103,12 +102,6 @@ impl AppHarnessBuilder {
         self
     }
 
-    /// Override the maximum WebSocket frame payload size.
-    pub fn with_websocket_max_frame_size(mut self, size: usize) -> Self {
-        self.websocket_max_frame_size = Some(size);
-        self
-    }
-
     pub async fn build(self) -> AppHarness {
         let hub = ClientHub::new();
 
@@ -133,9 +126,6 @@ impl AppHarnessBuilder {
         }
         if let Some(timeout) = self.websocket_close_timeout {
             dp_builder = dp_builder.with_websocket_close_timeout(timeout);
-        }
-        if let Some(size) = self.websocket_max_frame_size {
-            dp_builder = dp_builder.with_websocket_max_frame_size(Some(size));
         }
         dp_builder =
             dp_builder.with_token_http_config(toolkit_http::HttpClientConfig::for_testing());

--- a/gears/system/oagw/oagw/tests/proxy_integration.rs
+++ b/gears/system/oagw/oagw/tests/proxy_integration.rs
@@ -4455,58 +4455,6 @@ async fn proxy_websocket_idle_timeout_sends_1001() {
     server_handle.abort();
 }
 
-// 14.7: Max frame size enforcement sends Close 1009 (Message Too Big).
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn proxy_websocket_max_frame_size_sends_1009() {
-    let h = AppHarness::builder()
-        .with_websocket_max_frame_size(50) // 50 bytes max
-        .build()
-        .await;
-    setup_ws_upstream(&h, "ws-maxframe").await;
-    let (addr, server_handle) = start_oagw_server(&h).await;
-
-    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-    ws_handshake(&mut stream, "/oagw/v1/proxy/ws-maxframe/ws/echo").await;
-
-    // Small frame should work fine.
-    let small_frame = build_masked_frame(0x1, b"ok");
-    tokio::io::AsyncWriteExt::write_all(&mut stream, &small_frame)
-        .await
-        .unwrap();
-    let echo = read_ws_frame(&mut stream).await.unwrap();
-    assert_eq!(echo.0, 0x1);
-    assert_eq!(echo.1, b"ok");
-
-    // Send a frame exceeding the 50-byte limit.
-    let oversized_payload = vec![0x41; 100]; // 100 bytes > 50
-    let oversized_frame = build_masked_frame(0x1, &oversized_payload);
-    tokio::io::AsyncWriteExt::write_all(&mut stream, &oversized_frame)
-        .await
-        .unwrap();
-
-    // Should receive Close 1009 (Message Too Big).
-    // On some platforms (notably Windows) the gateway may tear down the TCP
-    // connection before the Close frame is delivered, so EOF is also acceptable.
-    let frame = read_ws_frame(&mut stream).await;
-    match frame {
-        Some((opcode, payload)) => {
-            assert_eq!(opcode, 0x8, "expected Close frame for oversized message");
-            assert!(
-                payload.len() >= 2,
-                "close payload should contain status code"
-            );
-            let code = u16::from_be_bytes([payload[0], payload[1]]);
-            assert_eq!(code, 1009, "oversized frame should trigger Close 1009");
-        }
-        None => {
-            // EOF / connection reset — the gateway closed the connection after
-            // detecting the oversized frame, which is acceptable behaviour.
-        }
-    }
-
-    server_handle.abort();
-}
-
 // 14.8: Caller disconnect mid-session triggers upstream Close.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn proxy_websocket_caller_disconnect_mid_session() {

--- a/gears/system/oagw/scenarios/INDEX.md
+++ b/gears/system/oagw/scenarios/INDEX.md
@@ -328,6 +328,14 @@ Call your external service through OAGW's proxy endpoint: `{METHOD} /api/oagw/v1
 - **Scenario**: [positive-14.2-auth-injected-during-handshake.md](protocols/websocket/positive-14.2-auth-injected-during-handshake.md)
 - **Mechanism**: Upstream sees auth header on upgrade request. Subsequent WS frames forwarded unchanged.
 
+#### Frame relayed intact when split across multiple reads
+- **Scenario**: [positive-14.6-frame-relayed-intact-across-split-reads.md](protocols/websocket/positive-14.6-frame-relayed-intact-across-split-reads.md)
+- **Mechanism**: Header and payload sent as separate writes. Upstream receives byte-identical frame — relay never needs a whole frame at once.
+
+#### Fragmented message of any size relayed without a cap
+- **Scenario**: [positive-14.7-fragmented-message-relayed-without-size-limit.md](protocols/websocket/positive-14.7-fragmented-message-relayed-without-size-limit.md)
+- **Mechanism**: Large multi-fragment message relayed in full. No Close 1009 — there is no per-frame or per-message size limit to configure.
+
 ---
 
 ### gRPC
@@ -725,6 +733,10 @@ Full integration walkthroughs — each demonstrates the complete journey (upstre
 #### WS connection idle timeout enforced
 - **Scenario**: [negative-14.4-ws-connection-idle-timeout-enforced.md](protocols/websocket/negative-14.4-ws-connection-idle-timeout-enforced.md)
 - **What happens**: Idle connection closed after configured timeout.
+
+#### Stalled caller does not block upstream's graceful close
+- **Scenario**: [negative-14.5-stalled-caller-does-not-block-upstream-close.md](protocols/websocket/negative-14.5-stalled-caller-does-not-block-upstream-close.md)
+- **What happens**: Caller stops reading; upstream still gets Close 1001 and a half-close within the close timeout. Each side's announcement has its own grace budget.
 
 ---
 

--- a/gears/system/oagw/scenarios/protocols/websocket/negative-14.5-stalled-caller-does-not-block-upstream-close.md
+++ b/gears/system/oagw/scenarios/protocols/websocket/negative-14.5-stalled-caller-does-not-block-upstream-close.md
@@ -1,0 +1,28 @@
+# Stalled caller does not block upstream's graceful close
+
+## Setup
+
+- WebSocket idle timeout (or graceful server shutdown) is configured as usual.
+- Caller stops reading from its socket entirely after the handshake (its TCP
+  receive buffer fills and stays full - it never acknowledges anything the
+  gateway sends), while the connection itself stays open.
+
+## Steps
+
+1. Establish WebSocket connection, upstream accepts.
+2. Caller stops draining its socket (simulates a hung/unresponsive client).
+3. Trigger teardown: either let the idle timeout elapse, or initiate graceful
+   server shutdown.
+
+## Expected behavior
+
+- Upstream still receives Close 1001 ("Going Away") and has its connection
+  half-closed, within `websocket_close_timeout_secs` of teardown starting -
+  regardless of whether the caller ever acknowledges its own Close frame.
+- The caller being unresponsive costs only the caller's own close attempt the
+  grace period; it does not consume the upstream's share of it.
+
+## What to check
+
+- Announcing close to each side is independent - one side stalling must not
+  starve the other side's close notification.

--- a/gears/system/oagw/scenarios/protocols/websocket/positive-14.6-frame-relayed-intact-across-split-reads.md
+++ b/gears/system/oagw/scenarios/protocols/websocket/positive-14.6-frame-relayed-intact-across-split-reads.md
@@ -1,0 +1,22 @@
+# WebSocket frame relayed intact when delivered across multiple reads
+
+## Setup
+
+- Standard WebSocket proxy connection, established and upgraded.
+
+## Steps
+
+1. Client sends one WebSocket frame's header bytes and payload bytes as two
+   separate writes, with a short delay between them (simulating ordinary TCP
+   segmentation - nothing here should require frame-aligned reads).
+2. Upstream reads from its side of the tunnel.
+
+## Expected behavior
+
+- The frame arrives at upstream byte-identical to what was sent, uncorrupted
+  and unsplit at any boundary other than the one the sender chose.
+
+## What to check
+
+- The gateway relays raw bytes without needing to see a whole frame at once -
+  this must hold no matter how the underlying reads happen to chunk the bytes.

--- a/gears/system/oagw/scenarios/protocols/websocket/positive-14.7-fragmented-message-relayed-without-size-limit.md
+++ b/gears/system/oagw/scenarios/protocols/websocket/positive-14.7-fragmented-message-relayed-without-size-limit.md
@@ -1,0 +1,26 @@
+# Fragmented message of arbitrary size is relayed without a per-message cap
+
+## Setup
+
+- Standard WebSocket proxy connection. No per-message or per-frame size limit
+  exists to configure (removed - see
+  `../../../docs/features/0007-cpt-cf-oagw-feature-streaming.md`).
+
+## Steps
+
+1. Client sends one logical message as many small continuation frames whose
+   combined size is large (e.g., well beyond any size that used to be
+   configurable via the old `websocket_max_frame_size_bytes` setting).
+2. Upstream receives the reassembled stream.
+
+## Expected behavior
+
+- The full message is relayed successfully; no Close 1009 is ever sent, at any
+  point, regardless of total size.
+
+## What to check
+
+- This is intentional, current behavior, not a gap: size limiting was already
+  bypassable by fragmentation before this setting was removed (a single-frame
+  limit was never a real message-size limit), so this scenario documents the
+  behavior change rather than testing a regression.


### PR DESCRIPTION
The OAGW gateway no longer reads WebSocket frames. Once the handshake is done, it simply copies bytes back and forth between the caller and the upstream server.

The old code took each frame apart and rebuilt it. That was fragile: the reading step could be interrupted partway through, losing the bytes it had already taken, after which everything that followed was misread and the connection eventually froze. Copying bytes has nothing to interrupt partway.

It is also more faithful. Frames now arrive exactly as they were sent, so compressed frames, unusual frame types and the client's own scrambling all survive the trip. The old code quietly altered some of that. Memory use no longer depends on how big a frame is.

Idle timeouts and graceful shutdown still behave the same way. Both tell each side politely that the connection is going away, with a time limit so a peer that has stopped responding cannot hold shutdown open.

One setting was dropped, the maximum frame size. Limiting a frame requires reading frames, and the setting never did what its documentation claimed anyway. Anyone who set it must remove it, or the service will refuse to start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * WebSocket streaming now relays data transparently as raw bytes, preserving frames, fragmentation, masking, and protocol details.
  * Large streaming payloads are supported without per-frame or per-message size limits.
  * Activity tracking improves idle-timeout handling in both directions.
  * Shutdown uses bounded, independent teardown with graceful Close 1001 announcements and TCP half-closes.
  * Unexpected disconnects now propagate directly without synthesized close frames.
* **Configuration**
  * Removed the WebSocket maximum frame-size setting and oversized-frame closure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->