### PR TITLE
ci(release): move release-plz to its documented push-only shape

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
+  # PR CI only ever validates the ephemeral refs/pull/N/merge ref, so without
+  # this trigger the integrated tip of main is tested nowhere: a semantic
+  # conflict between two PRs merged minutes apart is caught by neither PR's run.
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   workflow_dispatch:
 
 # NOTE: workflow-level paths-ignore above still skips the entire workflow for

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [ closed ]
-    branches: [ main ]
   workflow_dispatch:
     inputs:
       mode:
@@ -22,193 +19,39 @@ on:
 permissions:
   contents: read
 
-# One constant group for the whole workflow. `release-pr` (push to main) and
-# `release` (release PR merged) mutate the same state — tags, the release
-# branch, crates.io — and both fire on the same merge.
-concurrency:
-  group: release-plz-${{ github.repository }}
-  cancel-in-progress: false
-
 jobs:
-  release-pr:
-    name: Create release PR
-    runs-on: ubuntu-latest
-    if: ${{ github.repository == 'constructorfabric/gears-rust' && (github.event_name == 'push' || github.event.inputs.mode == 'release-pr') }}
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Install Rust toolchain from rust-toolchain.toml
-        run: |
-          rustup show active-toolchain || rustup toolchain install
-          rustup show
-
-      - name: release-plz release-pr
-        uses: release-plz/action@52440b50d383aa252927de395c8b2c1e0a9cf8e9 # v0.3.155
-        with:
-          command: release-pr
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  cleanup-caches:
-    name: Cleanup PR caches before release
+  # `release-plz release` publishes only versions present in the manifests and absent
+  # from crates.io, so running it on every push is safe and makes an interrupted release
+  # self-healing: the next push to main finishes it. That is why this needs no
+  # pull_request trigger and no label matching to decide whether a release is happening.
+  release:
+    name: Publish crates
     runs-on: ubuntu-latest
     if: >-
       ${{
         github.repository == 'constructorfabric/gears-rust'
         && (
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'release')
-          || (
-            github.event_name == 'pull_request'
-            && github.event.pull_request.merged == true
-            && contains(join(github.event.pull_request.labels.*.name, ','), 'release-plz')
-          )
+          github.event_name == 'push'
+          || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'release')
         )
       }}
-    permissions:
-      actions: write
-    steps:
-      - name: Delete PR rust caches
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO_FULL: ${{ github.repository }}
-        run: |
-          set -euxo pipefail
-
-          OWNER="${REPO_FULL%%/*}"
-          REPO="${REPO_FULL##*/}"
-          MAX_DELETE=500
-          DELETED=0
-
-          RESP=$(gh api "/repos/$OWNER/$REPO/actions/caches?per_page=100&page=1")
-          COUNT=$(echo "$RESP" | jq '[.actions_caches[] | select(.key | startswith("v0-rust-pr-"))] | length')
-          SIZE=$(echo "$RESP" | jq '[.actions_caches[] | select(.key | startswith("v0-rust-pr-")) | .size_in_bytes] | add // 0')
-          echo "PR caches (page 1): count=$COUNT, size_bytes=$SIZE"
-
-          PAGE=1
-          while true; do
-            RESP=$(gh api \
-              "/repos/$OWNER/$REPO/actions/caches?per_page=100&page=$PAGE")
-
-            TOTAL=$(echo "$RESP" | jq '.actions_caches | length')
-            [ "$TOTAL" -eq 0 ] && break
-
-            IDS=$(echo "$RESP" | jq -r '
-              .actions_caches[]
-              | select(.key | startswith("v0-rust-pr-"))
-              | .id
-            ')
-
-            if [ -n "$IDS" ]; then
-              for id in $IDS; do
-                if [ "$DELETED" -ge "$MAX_DELETE" ]; then
-                  echo "Reached MAX_DELETE=$MAX_DELETE, stopping."
-                  exit 0
-                fi
-                echo "Deleting cache $id"
-                gh api -X DELETE \
-                  "/repos/$OWNER/$REPO/actions/caches/$id" || true
-                DELETED=$((DELETED+1))
-              done
-            fi
-
-            PAGE=$((PAGE+1))
-          done
-
-          echo "Deleted $DELETED PR cache(s)."
-
-  release:
-    name: Publish crates
-    needs: cleanup-caches
-    runs-on: ubuntu-latest
-    # IMPORTANT: don't publish on every push. Publish only:
-    # - manually via workflow_dispatch (mode=release), or
-    # - when a release PR (labeled `release-plz`) is merged into main.
-    # The `!cancelled()` below is what matters — it replaces the implicit
-    # `success()` on `needs`, so a failed or skipped cache cleanup no longer
-    # blocks the publish.
-    if: >-
-      ${{
-        !cancelled()
-        && github.repository == 'constructorfabric/gears-rust'
-        && (
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'release')
-          || (
-            github.event_name == 'pull_request'
-            && github.event.pull_request.merged == true
-            && contains(join(github.event.pull_request.labels.*.name, ','), 'release-plz')
-          )
-        )
-      }}
+    # No concurrency group, deliberately. Any group can cancel a *pending* run when a
+    # newer one joins it, and a skipped publish is silent — no crates, no tags, no
+    # failure. release-plz's docs mandate this: "the concurrency block cancels the
+    # pending job if a new commit is pushed — we can't risk to skip a release." Two
+    # concurrent publishes are harmless, since each publishes only what crates.io lacks.
     permissions:
       contents: write
-      checks: read
+      # release-plz resolves PR numbers and contributors for changelogs and releases.
+      pull-requests: read
     steps:
-      # Pin the checkout to the merge commit this run was triggered by. Without
-      # `ref`, actions/checkout resolves the default branch and does
-      # `git checkout -B main refs/remotes/origin/main` — i.e. main's tip at the
-      # moment the job happens to start, minutes after the merge event. Any PR
-      # merged in that window would silently be published under the version
-      # numbers from the release PR. workflow_dispatch has no PR context, so it
-      # falls back to github.sha.
+      # No `ref:` needed. On push, checkout defaults to github.sha, which is exactly the
+      # commit that was pushed — for a release PR merge, its merge commit.
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
           fetch-depth: 0
           persist-credentials: false
-
-      # Pinning makes the published tree deterministic, but not automatically
-      # the tree CI validated: PR checks run against the ephemeral
-      # refs/pull/N/merge computed when the run started, and GitHub silently
-      # recomputes that ref as main advances without re-running CI. If the merge
-      # was trivial (release PR was up to date with main) the merge commit's
-      # tree is byte-identical to the PR head's tree and the green signal does
-      # cover it. This is the workflow-level equivalent of the branch-protection
-      # setting "require branches to be up to date before merging".
-      - name: Verify the published tree is the reviewed tree
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
-        run: |
-          set -euo pipefail
-
-          actual=$(git rev-parse HEAD)
-          if [ "$actual" != "$MERGE_SHA" ]; then
-            echo "::error::checkout landed on $actual, expected merge commit $MERGE_SHA"
-            exit 1
-          fi
-
-          if ! git cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null; then
-            git fetch --no-tags --quiet origin "$HEAD_SHA" || true
-          fi
-          if ! git cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null; then
-            echo "::error::release PR head $HEAD_SHA is unreachable (squash-merged with the branch deleted?);" \
-                 "cannot prove the tree about to be published is the one that was reviewed and tested"
-            exit 1
-          fi
-
-          merge_tree=$(git rev-parse "${MERGE_SHA}^{tree}")
-          head_tree=$(git rev-parse "${HEAD_SHA}^{tree}")
-          echo "merge commit $MERGE_SHA  tree=$merge_tree"
-          echo "PR head      $HEAD_SHA  tree=$head_tree"
-
-          if [ "$merge_tree" != "$head_tree" ]; then
-            echo "::error::main advanced after the release PR was last updated, so the merge is not trivial." \
-                 "The tree about to be published was never tested as a whole. Re-run release-plz to refresh" \
-                 "the release PR against current main, or publish via workflow_dispatch to override."
-            git --no-pager diff --stat "$HEAD_SHA" "$MERGE_SHA" | tail -20
-            exit 1
-          fi
-
-          echo "merge was trivial: published tree == reviewed tree"
 
       - name: Disk report (before cleanup)
         run: |
@@ -217,6 +60,10 @@ jobs:
           du -sh . || true
           du -xh . | sort -h | tail -n 40 || true
 
+      # Removing ~/.cargo/registry also clears its `index` subdirectory, which is the
+      # workaround for release-plz's gix slotmap overflow. Nothing between here and the
+      # publish repopulates it: free-disk-space, setup-go, setup-protoc and
+      # `rustup toolchain install` download no crates.
       - name: Runner-local cache cleanup
         run: |
           set -euxo pipefail
@@ -250,71 +97,10 @@ jobs:
           rustup show active-toolchain || rustup toolchain install
           rustup show
 
-      # No test run here on purpose. Merging a release PR is the maintainer's
-      # release decision, so re-testing could only override it, never inform it.
-      # The tree being published is the one CI validated on the release PR (see
-      # the tree check above); `cargo publish` still compiles every crate, so a
-      # crate that does not build cannot be published.
-
-      - name: Clear cargo registry index (workaround gix slotmap overflow)
-        run: rm -rf ~/.cargo/registry/index
-
-      # Advisory only: merging a release PR IS the maintainer's release decision,
-      # so this never blocks the publish and never waits on pending checks. It
-      # records what the state of the release PR was at publish time, so a
-      # release made over red or unfinished CI is visible afterwards in the run
-      # summary rather than having to be reconstructed from the PR.
-      - name: Report release PR check status
-        if: ${{ github.event_name == 'pull_request' }}
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO_FULL: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          # This workflow's own jobs are check runs on the same SHA; reporting
-          # our own in-progress state is just noise.
-          SELF_JOBS: '^(Publish crates|Create release PR|Cleanup PR caches before release)$'
-        run: |
-          set -uo pipefail
-
-          list=$(gh api "/repos/$REPO_FULL/commits/$HEAD_SHA/check-runs?per_page=100" \
-            --jq '.check_runs[]
-                  | select((.name | test(env.SELF_JOBS)) | not)
-                  | "\(.status)|\(.conclusion // "")|\(.name)"')
-
-          {
-            echo "### Release PR check status at publish time"
-            echo
-            echo "Head \`$HEAD_SHA\` of ${{ github.event.pull_request.html_url }}"
-            echo
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          if [ -z "$list" ]; then
-            echo "::warning::no check runs found on release PR head $HEAD_SHA"
-            echo "No check runs found." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          red=$(printf '%s\n' "$list" \
-            | awk -F'|' '$2 ~ /^(failure|timed_out|cancelled|action_required|stale)$/ {print $3" ("$2")"}')
-          pending=$(printf '%s\n' "$list" | awk -F'|' '$1 != "completed" {print $3" ("$1")"}')
-
-          if [ -n "$red" ]; then
-            echo "::warning::publishing over $(printf '%s\n' "$red" | wc -l | tr -d ' ') non-green check(s) — merged by maintainer decision"
-            { echo "**Not green:**"; printf '%s\n' "$red" | sed 's/^/- /'; echo; } >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-          if [ -n "$pending" ]; then
-            echo "::warning::publishing while $(printf '%s\n' "$pending" | wc -l | tr -d ' ') check(s) had not finished"
-            { echo "**Unfinished:**"; printf '%s\n' "$pending" | sed 's/^/- /'; echo; } >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-          if [ -z "$red" ] && [ -z "$pending" ]; then
-            echo "all $(printf '%s\n' "$list" | wc -l | tr -d ' ') check(s) green"
-            echo "All checks green." >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-          printf '%s\n' "$list" | awk -F'|' '{print "  "$3": "$1" "$2}'
+      # No test run here. ci.yml tests every push to main, and merging a release PR is
+      # the maintainer's release decision — re-testing could only override it, never
+      # inform it. `cargo publish` still compiles every crate, so a crate that does not
+      # build cannot be published.
 
       - name: release-plz release
         uses: release-plz/action@52440b50d383aa252927de395c8b2c1e0a9cf8e9 # v0.3.155
@@ -328,3 +114,46 @@ jobs:
       - name: Disk report (post-mortem)
         if: always()
         run: df -h
+
+  release-pr:
+    name: Create release PR
+    runs-on: ubuntu-latest
+    # Ordered after `release` so release-plz never derives the next versions from
+    # crates.io while a publish is mid-flight. `!cancelled()` keeps this running when
+    # `release` was skipped (manual release-pr dispatch) or failed.
+    needs: release
+    if: >-
+      ${{
+        !cancelled()
+        && github.repository == 'constructorfabric/gears-rust'
+        && (
+          github.event_name == 'push'
+          || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'release-pr')
+        )
+      }}
+    # Let a running instance finish — it is part-way through committing and force-pushing
+    # the release branch — and keep only the newest waiting one.
+    concurrency:
+      group: release-plz-pr-${{ github.ref }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust toolchain from rust-toolchain.toml
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
+
+      - name: release-plz release-pr
+        uses: release-plz/action@52440b50d383aa252927de395c8b2c1e0a9cf8e9 # v0.3.155
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -8,14 +8,28 @@ This repository uses **release-plz** to automate:
 
 ### How the flow works
 
-- **On every push to `main`** the workflow runs `release-plz release-pr`.
-- If there are releasable changes, release-plz opens a **Release PR** updating:
-  - crate versions (per-crate, based on each crate’s `Cargo.toml`)
-  - the root [`CHANGELOG.md`](../CHANGELOG.md)
-- The workflow automatically applies the label **`release-plz`** to that PR.
-- **After the Release PR (labeled `release-plz`) is merged**, the workflow runs `release-plz release` which:
-  - publishes crates to crates.io (only crates that are publishable and have a new version)
-  - creates GitHub Releases
+**Every push to `main`** runs both release-plz commands, in this order:
+
+1. `release-plz release` publishes crates to crates.io and creates GitHub Releases. It
+   only publishes versions that are in the manifests but **not yet on crates.io**, so on
+   an ordinary push it finds nothing to do and exits. This is also what makes the pipeline
+   self-healing: if a publish is interrupted, the next push to `main` finishes it — no
+   manual intervention.
+2. `release-plz release-pr` opens or updates a **Release PR** with:
+   - crate versions (per-crate, based on each crate's `Cargo.toml`)
+   - the root [`CHANGELOG.md`](../CHANGELOG.md)
+
+   It is ordered after `release` so it never derives the next versions from crates.io
+   while a publish is mid-flight.
+
+The Release PR is labelled **`release-plz`** automatically. Merging it is what puts the new
+versions on `main`; the workflow then attempts to publish on that merge's push, like any
+other. If that attempt fails, the versions stay on `main` unpublished until a later push
+retries them — see the self-healing note above.
+
+Nothing here keys off the label or off the Release PR being merged — `release` decides for
+itself by comparing manifests against crates.io. That is the shape release-plz documents,
+and it is why a release cannot be lost by a workflow being skipped or cancelled.
 
 Workflows:
 - Root workspace: [`.github/workflows/release-plz.yml`](../.github/workflows/release-plz.yml)
@@ -42,11 +56,34 @@ release-plz publishes crates in the correct order for intra-workspace dependenci
 
 ### Safety checks
 
-Before publishing, the root release workflow runs:
+The release workflow does **not** run tests and does **not** block on CI. Merging the
+Release PR is the maintainer's release decision; if you merge it, the workflow attempts
+to publish the crates.
 
-```bash
-cargo test --workspace --no-fail-fast --exclude cf-gears-toolkit-macros-tests --exclude cf-gears-toolkit-db-macros
-```
+What does verify a release:
+
+- [`ci.yml`](../.github/workflows/ci.yml) runs on every push to `main`, so the tip of
+  `main` gets tested — including the integrated result of merging, which PR CI never
+  sees. Pushes touching only markdown or `docs/**` are filtered out by the workflow's
+  `paths-ignore`, so no run is created for them: such a commit has no CI result of its
+  own and inherits none. That is acceptable only because its code is identical to the
+  previous commit, which does have one. If `CI` is ever made a required status check,
+  this case needs an always-succeeding placeholder job — a requirement whose workflow
+  never runs is never satisfied.
+- The publish job runs on the pushed commit itself, so each crate is built from the source
+  that landed on `main`. Not a byte-for-byte copy of it: cargo rewrites every manifest on
+  the way out, resolving workspace inheritance such as `version.workspace = true` into
+  concrete values.
+- `cargo publish` compiles every crate, so a crate that does not build cannot be
+  published. It builds lib and bin targets only — it runs no tests.
+
+What this does **not** give you: a green light at publish time. A CI run takes 34-57
+minutes while the publish starts within a few minutes of the push, so CI for the published
+commit is still running while the crates are going out. The CI result lands on the same
+commit afterwards and is visible on it in GitHub.
+
+If you want a blocking gate, that belongs in branch protection on `main` (required
+status checks) or a merge queue, not in the release workflow.
 
 ### Emergency / manual release
 
@@ -56,7 +93,9 @@ If you need a hotfix / manual release, prefer triggering the GitHub Actions work
 2. Go to GitHub → **Actions** → **Release (release-plz)** → **Run workflow**.
 3. Select `mode = release` (publishes crates + creates GitHub Releases).
 
-Note: the workflow already runs tests before publishing. Running tests locally is optional and just gives faster feedback.
+Note: `mode = release` publishes whatever is on the target branch and does not block on
+CI, so confirm the branch is green first. Running the workspace tests locally gives
+faster feedback than waiting for CI:
 
 ```bash
 cargo test --workspace --no-fail-fast --exclude cf-gears-toolkit-macros-tests --exclude cf-gears-toolkit-db-macros

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -7,7 +7,8 @@
 # Some repos can end up "dirty" due to generated/normalized files, so we allow it.
 allow_dirty = true
 
-# Add a stable label to the release PR so the publish workflow can filter on it.
+# Label the release PR so it is easy to spot in the PR list. No workflow filters on it:
+# the publish job decides what to release by comparing manifests against crates.io.
 pr_labels = ["release-plz"]
 changelog_update = true
 git_release_enable = true


### PR DESCRIPTION
- triggers: drop `pull_request`; keep `push: main` and `workflow_dispatch`.
- `release` runs on every push. No concurrency group, per upstream — "the concurrency block cancels the pending job if a new commit is pushed — we can't risk to skip a release" — and two concurrent publishes are harmless. Checkout needs no `ref:`: on push, `github.sha` is the commit that landed.
- `release-pr` gets `needs: release` so it never derives the next versions from crates.io mid-publish. That replaces the `gh run list` in-flight poll. Keeps the documented per-ref group with cancel-in-progress false, and `!cancelled()` so it still runs when `release` is skipped on a manual `release-pr` dispatch.
- `cleanup-caches` moves behind the publish, gated on the action's `releases_created` output (present in the pinned v0.3.155). It fired on the release path before; keying it to an actual release keeps that cadence instead of evicting caches open PRs are using on all 3-7 daily pushes, and takes it off the release's critical path.
- drop the advisory CI-report step. With ci.yml now running on push, the CI result lands on the published commit and is visible there; the step restated it in 75 lines of bash.
- ci.yml keeps the `push: branches: [main]` trigger added for this: PR CI only validates the ephemeral refs/pull/N/merge ref, so the integrated tip of main was tested nowhere, and CHANGELOG-only release PRs got no CI at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release Automation**
  - Releases now run automatically after changes reach the main branch.
  - Manual release and release-PR actions remain available when needed.
  - Retried releases can recover based on published package versions.
  - Release workflows include improved cleanup and completion reporting.

- **CI**
  - Continuous integration runs for pushes to the main branch, excluding documentation-only changes.

- **Documentation**
  - Updated release guidance explains the publishing flow, validation expectations, and manual release recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->