### PR TITLE
feat(toolkit-canonical-errors): add per-occurrence transport overrides

### DIFF
--- a/docs/arch/errors/DESIGN.md
+++ b/docs/arch/errors/DESIGN.md
@@ -94,6 +94,8 @@ GTS ID pattern: `gts.cf.core.errors.err.v1~cf.core.err.{category}.v1~`
 
 Note: this design keeps Google `unavailable` semantics, but uses the explicit platform name `service_unavailable` for the canonical category identifier.
 
+The HTTP column above is the fixed **default** per category. A specific occurrence MAY override it via `TransportOverride` without changing its category — see [§2.2 Transport Overrides](#transport-overrides).
+
 See [§ 4. Category Reference](#4-category-reference) for full definitions including context schemas, constructors, and JSON wire examples.
 
 ### 1.3 Architecture Drivers
@@ -237,6 +239,7 @@ Every error response consists of **contract parts** (fixed per category) and **v
 - `instance` path
 - `trace_id`
 - Context field values
+- Per-occurrence transport override (e.g. `Http::status_code(..)`) — see below
 
 **Breaking changes** (require major version bump of `cf-gears-toolkit-errors`):
 - Removing or renaming a canonical category
@@ -249,6 +252,37 @@ Every error response consists of **contract parts** (fixed per category) and **v
 **Non-breaking changes** (minor version):
 - Adding a new optional field to a context type
 - Adding a new canonical category
+
+#### Transport Overrides
+
+- [ ] `p2` - **ID**: `cpt-cf-errors-constraint-transport-overrides`
+
+A caller MAY attach a transport-specific override to a single `CanonicalError` occurrence, without changing that occurrence's canonical category, GTS type, title, or context schema — only the named transport's wire projection is affected. This is an escape hatch for cases where a specific call site needs to diverge from the category's default HTTP status (e.g. a `not_found` that must read as `410 Gone` for one legacy endpoint) while keeping the category correct for dispatch, classification, and any future gRPC/SSE mapping.
+
+```rust
+use toolkit_canonical_errors::{CanonicalError, Http};
+
+let err = UserResourceError::not_found("Resource permanently removed")
+    .with_resource(id)
+    .with_override(Http::status_code(410))
+    .create();
+
+assert_eq!(err.status_code(), 410);                 // wire status: overridden
+assert_eq!(err.gts_type(), /* not_found GTS id */);  // category: unaffected
+assert_eq!(err.title(), "Not Found");                // title: unaffected
+```
+
+`.with_override(TransportOverride)` is available on every error builder, at any point in the chain. `TransportOverride` is `#[non_exhaustive]`; the only variant today is `Http` (constructed via `Http::status_code(u16)`, a `const fn`), but the shape leaves room for future transports (gRPC, SSE) to add their own variant without a breaking change. Re-applying an override for the same transport replaces the prior value; overrides for different transports are independent of one another.
+
+**Caller contract**: `type` and `title` remain the authoritative signal for programmatic dispatch even when `status` is overridden. Consumers that key behavior off the numeric `status` instead of the canonical `type` should be aware overrides exist and can make `status` diverge from the category's documented default.
+
+**Round-trip**: no change to the `Problem` wire schema is needed to carry an override. `TryFrom<Problem> for CanonicalError` recovers it by comparing the wire `status` against the category's known default — if they differ, the reconstructed `CanonicalError` carries the override, so `status_code()` on the round-tripped value always matches the original wire `status`.
+
+**Known limitation**: an override whose value equals the category's default (e.g. `Http::status_code(404)` on a `not_found` error) is indistinguishable on the wire from "no override was set." `status_code()` is unaffected (`404` either way), but `http_status_override()` on the round-tripped value returns `None` instead of `Some(404)`. This is the direct consequence of recovering the override from the wire `status` alone rather than adding a dedicated `Problem` field (see above) — accepted rather than fixed, since a wire schema change would undo that property.
+
+**Wire validation**: `TryFrom<Problem>` rejects a `status` outside the RFC 9110 range (100-599) with `ProblemConversionError::InvalidStatus`, since that boundary accepts untrusted, out-of-process input. `Http::status_code` (local construction) does not range-validate — that path is trusted caller input, consistent with this crate's existing caller-contract-via-doc-comment style elsewhere (e.g. `ServiceUnavailableBuilder::with_detail`).
+
+**Status-class consistency**: an override MUST stay within the same HTTP status-code class (first digit) as its category's default — an `invalid_argument` (4xx) error cannot be overridden into 5xx, and vice versa. Flipping class would silently change client retry semantics (5xx implies transient/retry-safe, 4xx implies the caller's fault) despite the category staying reported as client-fault or server-fault via `type`. This is enforced at two tiers matching the trust boundaries above: `TryFrom<Problem>` returns `ProblemConversionError::CategoryStatusMismatch` for untrusted wire input; local construction (`.create()` on both builders) uses `debug_assert!` — it catches the mistake in development and tests without adding a panic path to production release builds or changing `.create()`'s (infallible) signature.
 
 #### Macro-Based GTS Construction
 
@@ -439,7 +473,7 @@ Every REST error response follows this structure:
 |-------|--------|------|-------------|
 | `type` | GTS URI from category | **Contract** | Error type URI (e.g., `gts.cf.core.errors.err.v1~cf.core.err.not_found.v1~`) |
 | `title` | Static per category | **Contract** | Human-readable summary (e.g., "Not Found") |
-| `status` | HTTP status from mapping | **Contract** | HTTP status code as integer |
+| `status` | HTTP status from mapping, or a per-occurrence `TransportOverride` | **Contract** (default) / Variable (override) | HTTP status code as integer — see [§2.2 Transport Overrides](#transport-overrides) |
 | `detail` | `CanonicalError.detail` | Variable | Human-readable explanation of this occurrence |
 | `instance` | Request URI path | Variable | URI identifying this specific occurrence |
 | `trace_id` | Request context | Variable | W3C trace ID for correlation |

--- a/libs/toolkit-canonical-errors/src/builder.rs
+++ b/libs/toolkit-canonical-errors/src/builder.rs
@@ -5,6 +5,7 @@ use crate::context::{
     Unimplemented, Unknown,
 };
 use crate::error::CanonicalError;
+use crate::transport::{TransportOverride, TransportOverrides};
 
 // ---------------------------------------------------------------------------
 // Resource markers
@@ -213,6 +214,7 @@ pub struct ResourceErrorBuilder<Resource, Context> {
     variant: ErrorVariant,
     resource: Resource,
     context: Context,
+    overrides: TransportOverrides,
 }
 
 // ---------------------------------------------------------------------------
@@ -228,6 +230,7 @@ impl ResourceErrorBuilder<ResourceMissing, NoContext> {
             variant: ErrorVariant::NotFound,
             resource: ResourceMissing,
             context: NoContext,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -239,6 +242,7 @@ impl ResourceErrorBuilder<ResourceMissing, NoContext> {
             variant: ErrorVariant::AlreadyExists,
             resource: ResourceMissing,
             context: NoContext,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -250,6 +254,7 @@ impl ResourceErrorBuilder<ResourceMissing, NoContext> {
             variant: ErrorVariant::DataLoss,
             resource: ResourceMissing,
             context: NoContext,
+            overrides: TransportOverrides::default(),
         }
     }
 }
@@ -263,6 +268,7 @@ impl ResourceErrorBuilder<ResourceOptional, NeedsReason> {
             variant: ErrorVariant::Aborted,
             resource: ResourceOptional,
             context: NeedsReason,
+            overrides: TransportOverrides::default(),
         }
     }
 }
@@ -276,6 +282,7 @@ impl ResourceErrorBuilder<ResourceOptional, NoContext> {
             variant: ErrorVariant::Unknown,
             resource: ResourceOptional,
             context: NoContext,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -287,6 +294,7 @@ impl ResourceErrorBuilder<ResourceOptional, NoContext> {
             variant: ErrorVariant::DeadlineExceeded,
             resource: ResourceOptional,
             context: NoContext,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -298,6 +306,7 @@ impl ResourceErrorBuilder<ResourceOptional, NoContext> {
             variant: ErrorVariant::Unimplemented,
             resource: ResourceOptional,
             context: NoContext,
+            overrides: TransportOverrides::default(),
         }
     }
 }
@@ -311,6 +320,7 @@ impl ResourceErrorBuilder<ResourceAbsent, NeedsReason> {
             variant: ErrorVariant::PermissionDenied,
             resource: ResourceAbsent,
             context: NeedsReason,
+            overrides: TransportOverrides::default(),
         }
     }
 }
@@ -324,6 +334,7 @@ impl ResourceErrorBuilder<ResourceAbsent, NoContext> {
             variant: ErrorVariant::Cancelled,
             resource: ResourceAbsent,
             context: NoContext,
+            overrides: TransportOverrides::default(),
         }
     }
 }
@@ -337,6 +348,7 @@ impl ResourceErrorBuilder<ResourceOptional, NeedsFieldViolation> {
             variant: ErrorVariant::InvalidArgument,
             resource: ResourceOptional,
             context: NeedsFieldViolation,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -348,6 +360,7 @@ impl ResourceErrorBuilder<ResourceOptional, NeedsFieldViolation> {
             variant: ErrorVariant::OutOfRange,
             resource: ResourceOptional,
             context: NeedsFieldViolation,
+            overrides: TransportOverrides::default(),
         }
     }
 }
@@ -361,6 +374,7 @@ impl ResourceErrorBuilder<ResourceOptional, NeedsQuotaViolation> {
             variant: ErrorVariant::ResourceExhausted,
             resource: ResourceOptional,
             context: NeedsQuotaViolation,
+            overrides: TransportOverrides::default(),
         }
     }
 }
@@ -374,6 +388,7 @@ impl ResourceErrorBuilder<ResourceOptional, NeedsPreconditionViolation> {
             variant: ErrorVariant::FailedPrecondition,
             resource: ResourceOptional,
             context: NeedsPreconditionViolation,
+            overrides: TransportOverrides::default(),
         }
     }
 }
@@ -394,6 +409,7 @@ impl<Context> ResourceErrorBuilder<ResourceMissing, Context> {
             variant: self.variant,
             resource: ResourceSet(resource.into()),
             context: self.context,
+            overrides: self.overrides,
         }
     }
 }
@@ -410,7 +426,26 @@ impl<Context> ResourceErrorBuilder<ResourceOptional, Context> {
             variant: self.variant,
             resource: ResourceSet(resource.into()),
             context: self.context,
+            overrides: self.overrides,
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// with_override() — available at any point in the chain, any typestate
+// ---------------------------------------------------------------------------
+
+impl<Resource, Context> ResourceErrorBuilder<Resource, Context> {
+    /// Attach a transport-specific override (e.g. `Http::status_code(410)`)
+    /// to the error under construction. Does not change the error's
+    /// canonical category. Re-applying an override for the same transport
+    /// replaces the prior value; overrides for different transports are
+    /// independent.
+    #[must_use]
+    #[allow(clippy::needless_pass_by_value)] // owned value taken by design for fluent builder call sites (`.with_override(Http::status_code(410))`)
+    pub fn with_override(mut self, ov: TransportOverride) -> Self {
+        self.overrides.apply(&ov);
+        self
     }
 }
 
@@ -432,6 +467,7 @@ impl<Resource> ResourceErrorBuilder<Resource, NeedsFieldViolation> {
             variant: self.variant,
             resource: self.resource,
             context: HasFieldViolations(vec![FieldViolation::new(field, description, reason)]),
+            overrides: self.overrides,
         }
     }
 
@@ -447,6 +483,7 @@ impl<Resource> ResourceErrorBuilder<Resource, NeedsFieldViolation> {
             variant: self.variant,
             resource: self.resource,
             context: HasFormatMessage(msg),
+            overrides: self.overrides,
         }
     }
 
@@ -462,6 +499,7 @@ impl<Resource> ResourceErrorBuilder<Resource, NeedsFieldViolation> {
             variant: self.variant,
             resource: self.resource,
             context: HasConstraintMessage(msg),
+            overrides: self.overrides,
         }
     }
 }
@@ -503,6 +541,7 @@ impl<Resource> ResourceErrorBuilder<Resource, NeedsPreconditionViolation> {
                 subject,
                 description,
             )]),
+            overrides: self.overrides,
         }
     }
 }
@@ -539,6 +578,7 @@ impl<Resource> ResourceErrorBuilder<Resource, NeedsQuotaViolation> {
             variant: self.variant,
             resource: self.resource,
             context: HasQuotaViolations(vec![QuotaViolation::new(subject, description)]),
+            overrides: self.overrides,
         }
     }
 }
@@ -589,6 +629,7 @@ impl<Resource> ResourceErrorBuilder<Resource, NeedsReason> {
             variant: self.variant,
             resource: self.resource,
             context: HasReason(reason.into()),
+            overrides: self.overrides,
         }
     }
 }
@@ -606,6 +647,7 @@ impl CanonicalError {
             variant: ErrorVariant::Internal,
             resource: ResourceAbsent,
             context: NoContext,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -614,6 +656,7 @@ impl CanonicalError {
         ServiceUnavailableBuilder {
             retry_after_seconds: None,
             detail: None,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -625,6 +668,7 @@ impl CanonicalError {
             variant: ErrorVariant::Unauthenticated,
             resource: ResourceAbsent,
             context: NeedsReason,
+            overrides: TransportOverrides::default(),
         }
     }
 }
@@ -642,6 +686,7 @@ where
     pub fn create(self) -> CanonicalError {
         let resource_name = self.resource.resolve();
         let ctx_data = self.context.into_context_data();
+        let overrides = self.overrides;
 
         let err = match self.variant {
             ErrorVariant::NotFound => CanonicalError::__not_found(NotFound::new()),
@@ -699,11 +744,23 @@ where
             err = err.with_resource_type(rt);
         }
 
-        if let Some(rn) = resource_name {
+        let mut err = if let Some(rn) = resource_name {
             err.with_resource(rn)
         } else {
             err
+        };
+
+        *err.transport_overrides_mut() = overrides;
+
+        if let Some(status) = err.http_status_override() {
+            debug_assert!(
+                err.is_same_status_class(status),
+                "transport override status {status} is a different HTTP status class than category default {}",
+                err.default_http_status()
+            );
         }
+
+        err
     }
 }
 
@@ -714,6 +771,7 @@ where
 pub struct ServiceUnavailableBuilder {
     retry_after_seconds: Option<u64>,
     detail: Option<String>,
+    overrides: TransportOverrides,
 }
 
 impl ServiceUnavailableBuilder {
@@ -743,12 +801,34 @@ impl ServiceUnavailableBuilder {
         self
     }
 
+    /// Attach a transport-specific override (e.g. `Http::status_code(503)`).
+    /// Does not change the error's canonical category.
+    #[must_use]
+    #[allow(clippy::needless_pass_by_value)] // owned value taken by design for fluent builder call sites (`.with_override(Http::status_code(503))`)
+    pub fn with_override(mut self, ov: TransportOverride) -> Self {
+        self.overrides.apply(&ov);
+        self
+    }
+
     #[must_use]
     pub fn create(self) -> CanonicalError {
         let detail = self
             .detail
             .unwrap_or_else(|| "Service temporarily unavailable".to_owned());
-        CanonicalError::__service_unavailable(ServiceUnavailable::new(self.retry_after_seconds))
-            .with_detail(detail)
+        let mut err = CanonicalError::__service_unavailable(ServiceUnavailable::new(
+            self.retry_after_seconds,
+        ))
+        .with_detail(detail);
+        *err.transport_overrides_mut() = self.overrides;
+
+        if let Some(status) = err.http_status_override() {
+            debug_assert!(
+                err.is_same_status_class(status),
+                "transport override status {status} is a different HTTP status class than category default {}",
+                err.default_http_status()
+            );
+        }
+
+        err
     }
 }

--- a/libs/toolkit-canonical-errors/src/error.rs
+++ b/libs/toolkit-canonical-errors/src/error.rs
@@ -12,11 +12,19 @@ use crate::context::{
     InvalidArgument, NotFound, OutOfRange, PermissionDenied, ResourceExhausted, ServiceUnavailable,
     Unauthenticated, Unimplemented, Unknown,
 };
+use crate::transport::TransportOverrides;
 
 // ---------------------------------------------------------------------------
 // CanonicalError Enum
 // ---------------------------------------------------------------------------
 
+// `overrides: TransportOverrides` below is intentionally `pub(crate)`-typed
+// inside a `pub` enum: it carries no public methods, so external crates that
+// bind it via `{ overrides, .. }` (permitted despite `#[non_exhaustive]`)
+// get an inert value they cannot do anything with. Keeping `TransportOverrides`
+// unexported is deliberate (see `transport.rs`) — only `TransportOverride`/
+// `Http` are part of the public override API.
+#[allow(private_interfaces)]
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum CanonicalError {
@@ -26,6 +34,7 @@ pub enum CanonicalError {
         detail: String,
         resource_type: Option<String>,
         resource_name: Option<String>,
+        overrides: TransportOverrides,
     },
     #[non_exhaustive]
     Unknown {
@@ -33,6 +42,7 @@ pub enum CanonicalError {
         detail: String,
         resource_type: Option<String>,
         resource_name: Option<String>,
+        overrides: TransportOverrides,
     },
     #[non_exhaustive]
     InvalidArgument {
@@ -40,6 +50,7 @@ pub enum CanonicalError {
         detail: String,
         resource_type: Option<String>,
         resource_name: Option<String>,
+        overrides: TransportOverrides,
     },
     #[non_exhaustive]
     DeadlineExceeded {
@@ -47,6 +58,7 @@ pub enum CanonicalError {
         detail: String,
         resource_type: Option<String>,
         resource_name: Option<String>,
+        overrides: TransportOverrides,
     },
     #[non_exhaustive]
     NotFound {
@@ -54,6 +66,7 @@ pub enum CanonicalError {
         detail: String,
         resource_type: Option<String>,
         resource_name: Option<String>,
+        overrides: TransportOverrides,
     },
     #[non_exhaustive]
     AlreadyExists {
@@ -61,6 +74,7 @@ pub enum CanonicalError {
         detail: String,
         resource_type: Option<String>,
         resource_name: Option<String>,
+        overrides: TransportOverrides,
     },
     #[non_exhaustive]
     PermissionDenied {
@@ -68,6 +82,7 @@ pub enum CanonicalError {
         detail: String,
         resource_type: Option<String>,
         resource_name: Option<String>,
+        overrides: TransportOverrides,
     },
     #[non_exhaustive]
     ResourceExhausted {
@@ -75,6 +90,7 @@ pub enum CanonicalError {
         detail: String,
         resource_type: Option<String>,
         resource_name: Option<String>,
+        overrides: TransportOverrides,
     },
     #[non_exhaustive]
     FailedPrecondition {
@@ -82,6 +98,7 @@ pub enum CanonicalError {
         detail: String,
         resource_type: Option<String>,
         resource_name: Option<String>,
+        overrides: TransportOverrides,
     },
     #[non_exhaustive]
     Aborted {
@@ -89,6 +106,7 @@ pub enum CanonicalError {
         detail: String,
         resource_type: Option<String>,
         resource_name: Option<String>,
+        overrides: TransportOverrides,
     },
     #[non_exhaustive]
     OutOfRange {
@@ -96,6 +114,7 @@ pub enum CanonicalError {
         detail: String,
         resource_type: Option<String>,
         resource_name: Option<String>,
+        overrides: TransportOverrides,
     },
     #[non_exhaustive]
     Unimplemented {
@@ -103,15 +122,21 @@ pub enum CanonicalError {
         detail: String,
         resource_type: Option<String>,
         resource_name: Option<String>,
+        overrides: TransportOverrides,
     },
     #[non_exhaustive]
-    Internal { ctx: Internal, detail: String },
+    Internal {
+        ctx: Internal,
+        detail: String,
+        overrides: TransportOverrides,
+    },
     #[non_exhaustive]
     ServiceUnavailable {
         ctx: ServiceUnavailable,
         detail: String,
         resource_type: Option<String>,
         resource_name: Option<String>,
+        overrides: TransportOverrides,
     },
     #[non_exhaustive]
     DataLoss {
@@ -119,6 +144,7 @@ pub enum CanonicalError {
         detail: String,
         resource_type: Option<String>,
         resource_name: Option<String>,
+        overrides: TransportOverrides,
     },
     #[non_exhaustive]
     Unauthenticated {
@@ -126,6 +152,7 @@ pub enum CanonicalError {
         detail: String,
         resource_type: Option<String>,
         resource_name: Option<String>,
+        overrides: TransportOverrides,
     },
 }
 
@@ -140,6 +167,7 @@ impl CanonicalError {
             detail: String::from("Operation cancelled by the client"),
             resource_type: None,
             resource_name: None,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -151,6 +179,7 @@ impl CanonicalError {
             detail: String::from("An unknown error occurred"),
             resource_type: None,
             resource_name: None,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -167,6 +196,7 @@ impl CanonicalError {
             detail,
             resource_type: None,
             resource_name: None,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -178,6 +208,7 @@ impl CanonicalError {
             detail: String::from("Operation did not complete within the allowed time"),
             resource_type: None,
             resource_name: None,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -189,6 +220,7 @@ impl CanonicalError {
             detail: String::from("Resource not found"),
             resource_type: None,
             resource_name: None,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -200,6 +232,7 @@ impl CanonicalError {
             detail: String::from("Resource already exists"),
             resource_type: None,
             resource_name: None,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -211,6 +244,7 @@ impl CanonicalError {
             detail: String::from("You do not have permission to perform this operation"),
             resource_type: None,
             resource_name: None,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -222,6 +256,7 @@ impl CanonicalError {
             detail: String::from("Quota exceeded"),
             resource_type: None,
             resource_name: None,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -233,6 +268,7 @@ impl CanonicalError {
             detail: String::from("Operation precondition not met"),
             resource_type: None,
             resource_name: None,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -244,6 +280,7 @@ impl CanonicalError {
             detail: String::from("Operation aborted due to concurrency conflict"),
             resource_type: None,
             resource_name: None,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -255,6 +292,7 @@ impl CanonicalError {
             detail: String::from("Value out of range"),
             resource_type: None,
             resource_name: None,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -266,6 +304,7 @@ impl CanonicalError {
             detail: String::from("This operation is not implemented"),
             resource_type: None,
             resource_name: None,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -275,6 +314,7 @@ impl CanonicalError {
         Self::Internal {
             ctx,
             detail: String::from("An internal error occurred. Please retry later."),
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -286,6 +326,7 @@ impl CanonicalError {
             detail: String::from("Service temporarily unavailable"),
             resource_type: None,
             resource_name: None,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -297,6 +338,7 @@ impl CanonicalError {
             detail: String::from("Data loss detected"),
             resource_type: None,
             resource_name: None,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -308,6 +350,7 @@ impl CanonicalError {
             detail: String::from("Authentication required"),
             resource_type: None,
             resource_name: None,
+            overrides: TransportOverrides::default(),
         }
     }
 
@@ -468,6 +511,57 @@ impl CanonicalError {
         }
     }
 
+    // --- Transport overrides ---
+
+    pub(crate) const fn transport_overrides(&self) -> &TransportOverrides {
+        match self {
+            Self::Cancelled { overrides, .. }
+            | Self::Unknown { overrides, .. }
+            | Self::InvalidArgument { overrides, .. }
+            | Self::DeadlineExceeded { overrides, .. }
+            | Self::NotFound { overrides, .. }
+            | Self::AlreadyExists { overrides, .. }
+            | Self::PermissionDenied { overrides, .. }
+            | Self::ResourceExhausted { overrides, .. }
+            | Self::FailedPrecondition { overrides, .. }
+            | Self::Aborted { overrides, .. }
+            | Self::OutOfRange { overrides, .. }
+            | Self::Unimplemented { overrides, .. }
+            | Self::ServiceUnavailable { overrides, .. }
+            | Self::DataLoss { overrides, .. }
+            | Self::Unauthenticated { overrides, .. }
+            | Self::Internal { overrides, .. } => overrides,
+        }
+    }
+
+    pub(crate) fn transport_overrides_mut(&mut self) -> &mut TransportOverrides {
+        match self {
+            Self::Cancelled { overrides, .. }
+            | Self::Unknown { overrides, .. }
+            | Self::InvalidArgument { overrides, .. }
+            | Self::DeadlineExceeded { overrides, .. }
+            | Self::NotFound { overrides, .. }
+            | Self::AlreadyExists { overrides, .. }
+            | Self::PermissionDenied { overrides, .. }
+            | Self::ResourceExhausted { overrides, .. }
+            | Self::FailedPrecondition { overrides, .. }
+            | Self::Aborted { overrides, .. }
+            | Self::OutOfRange { overrides, .. }
+            | Self::Unimplemented { overrides, .. }
+            | Self::ServiceUnavailable { overrides, .. }
+            | Self::DataLoss { overrides, .. }
+            | Self::Unauthenticated { overrides, .. }
+            | Self::Internal { overrides, .. } => overrides,
+        }
+    }
+
+    /// The HTTP status this occurrence was explicitly overridden to, if any.
+    /// `None` means `status_code()` returns the category's fixed default.
+    #[must_use]
+    pub fn http_status_override(&self) -> Option<u16> {
+        self.transport_overrides().http_status
+    }
+
     // --- Metadata accessors (direct match) ---
 
     #[must_use]
@@ -512,8 +606,12 @@ impl CanonicalError {
         }
     }
 
+    /// The fixed HTTP status for this error's canonical category, ignoring
+    /// any transport override. Used internally by [`Self::status_code`] and
+    /// by `TryFrom<Problem>` to detect when a wire `status` diverges from
+    /// the category default.
     #[must_use]
-    pub fn status_code(&self) -> u16 {
+    pub(crate) const fn default_http_status(&self) -> u16 {
         match self {
             Self::InvalidArgument { .. }
             | Self::FailedPrecondition { .. }
@@ -529,6 +627,28 @@ impl CanonicalError {
             Self::ServiceUnavailable { .. } => 503,
             Self::DeadlineExceeded { .. } => 504,
         }
+    }
+
+    /// The effective HTTP status for this occurrence: the transport override
+    /// if one was set via `.with_override(Http::status_code(..))`, otherwise
+    /// the category's fixed default.
+    #[must_use]
+    pub const fn status_code(&self) -> u16 {
+        match self.transport_overrides().http_status {
+            Some(v) => v,
+            None => self.default_http_status(),
+        }
+    }
+
+    /// `true` if `status` shares the same HTTP status-code class (first
+    /// digit) as this error's category default — e.g. both 4xx or both 5xx.
+    /// Used to catch overrides that would flip an error between
+    /// client-fault and server-fault semantics (different retry behavior
+    /// for HTTP clients, different bucketing for monitoring).
+    #[must_use]
+    #[allow(clippy::integer_division)] // intentional: bucketing into a status-code class, not a lossy calculation
+    pub(crate) const fn is_same_status_class(&self, status: u16) -> bool {
+        status / 100 == self.default_http_status() / 100
     }
 
     #[must_use]
@@ -553,7 +673,7 @@ impl CanonicalError {
         }
     }
 
-    fn category_name(&self) -> &'static str {
+    pub(crate) fn category_name(&self) -> &'static str {
         match self {
             Self::Cancelled { .. } => "cancelled",
             Self::Unknown { .. } => "unknown",

--- a/libs/toolkit-canonical-errors/src/lib.rs
+++ b/libs/toolkit-canonical-errors/src/lib.rs
@@ -4,6 +4,7 @@ pub mod builder;
 pub mod context;
 pub mod error;
 pub mod problem;
+pub mod transport;
 
 pub use builder::{ResourceErrorBuilder, ServiceUnavailableBuilder};
 pub use context::{
@@ -18,6 +19,7 @@ pub use context::{
 pub use error::CanonicalError;
 pub use problem::{Problem, ProblemConversionError};
 pub use toolkit_canonical_errors_macro::resource_error;
+pub use transport::{Http, TransportOverride};
 // Re-export the `gts_id!` helper so consumers using `#[resource_error(...)]`
 // can write `#[resource_error(gts_id!("cf.core.users.user.v1~"))]` without
 // adding a separate `gts-macros` dependency. The macro expands at compile

--- a/libs/toolkit-canonical-errors/src/problem.rs
+++ b/libs/toolkit-canonical-errors/src/problem.rs
@@ -12,6 +12,7 @@ use crate::context::{
     Unauthenticated, Unimplemented, Unknown,
 };
 use crate::error::CanonicalError;
+use crate::transport::TransportOverrides;
 
 /// Media type for RFC 9457 `application/problem+json` responses.
 pub const APPLICATION_PROBLEM_JSON: &str = "application/problem+json";
@@ -190,6 +191,21 @@ pub enum ProblemConversionError {
         #[source]
         source: serde_json::Error,
     },
+
+    /// The wire `status` is not a valid HTTP status code (RFC 9110: a
+    /// three-digit integer in the 100-599 range). Rejected here rather than
+    /// silently stored as an override, since `TryFrom<Problem>` is the
+    /// crate's one boundary for untrusted/out-of-process input.
+    #[error("invalid HTTP status in Problem: {0}")]
+    InvalidStatus(u16),
+
+    /// The wire `status` is syntactically valid but is in a different HTTP
+    /// status-code class than the matched category's default, e.g. an
+    /// `invalid_argument` (4xx) `Problem` carrying `status: 500`. Flipping
+    /// between client-fault and server-fault semantics changes client retry
+    /// behavior, so this is rejected rather than accepted as an override.
+    #[error("status {status} is a different HTTP status class than category {category}'s default")]
+    CategoryStatusMismatch { category: &'static str, status: u16 },
 }
 
 /// Prefix of every canonical GTS identifier. Stripped to expose the category
@@ -262,102 +278,118 @@ impl TryFrom<Problem> for CanonicalError {
         let (resource_type, resource_name) = extract_resource_fields(&problem.context);
         let ctx_value = problem.context;
 
-        let canonical = match category {
+        let mut canonical = match category {
             "cancelled" => Self::Cancelled {
                 ctx: deserialize_ctx::<Cancelled>("cancelled", ctx_value)?,
                 detail,
                 resource_type,
                 resource_name,
+                overrides: TransportOverrides::default(),
             },
             "unknown" => Self::Unknown {
                 ctx: deserialize_ctx::<Unknown>("unknown", ctx_value)?,
                 detail,
                 resource_type,
                 resource_name,
+                overrides: TransportOverrides::default(),
             },
             "invalid_argument" => Self::InvalidArgument {
                 ctx: deserialize_ctx::<InvalidArgument>("invalid_argument", ctx_value)?,
                 detail,
                 resource_type,
                 resource_name,
+                overrides: TransportOverrides::default(),
             },
             "deadline_exceeded" => Self::DeadlineExceeded {
                 ctx: deserialize_ctx::<DeadlineExceeded>("deadline_exceeded", ctx_value)?,
                 detail,
                 resource_type,
                 resource_name,
+                overrides: TransportOverrides::default(),
             },
             "not_found" => Self::NotFound {
                 ctx: deserialize_ctx::<NotFound>("not_found", ctx_value)?,
                 detail,
                 resource_type,
                 resource_name,
+                overrides: TransportOverrides::default(),
             },
             "already_exists" => Self::AlreadyExists {
                 ctx: deserialize_ctx::<AlreadyExists>("already_exists", ctx_value)?,
                 detail,
                 resource_type,
                 resource_name,
+                overrides: TransportOverrides::default(),
             },
             "permission_denied" => Self::PermissionDenied {
                 ctx: deserialize_ctx::<PermissionDenied>("permission_denied", ctx_value)?,
                 detail,
                 resource_type,
                 resource_name,
+                overrides: TransportOverrides::default(),
             },
             "resource_exhausted" => Self::ResourceExhausted {
                 ctx: deserialize_ctx::<ResourceExhausted>("resource_exhausted", ctx_value)?,
                 detail,
                 resource_type,
                 resource_name,
+                overrides: TransportOverrides::default(),
             },
             "failed_precondition" => Self::FailedPrecondition {
                 ctx: deserialize_ctx::<FailedPrecondition>("failed_precondition", ctx_value)?,
                 detail,
                 resource_type,
                 resource_name,
+                overrides: TransportOverrides::default(),
             },
             "aborted" => Self::Aborted {
                 ctx: deserialize_ctx::<Aborted>("aborted", ctx_value)?,
                 detail,
                 resource_type,
                 resource_name,
+                overrides: TransportOverrides::default(),
             },
             "out_of_range" => Self::OutOfRange {
                 ctx: deserialize_ctx::<OutOfRange>("out_of_range", ctx_value)?,
                 detail,
                 resource_type,
                 resource_name,
+                overrides: TransportOverrides::default(),
             },
             "unimplemented" => Self::Unimplemented {
                 ctx: deserialize_ctx::<Unimplemented>("unimplemented", ctx_value)?,
                 detail,
                 resource_type,
                 resource_name,
+                overrides: TransportOverrides::default(),
             },
             "internal" => Self::Internal {
                 // `Internal.description` is `#[serde(skip)]`; the wire
                 // never carries it, so it reconstructs as an empty string.
                 ctx: deserialize_ctx::<Internal>("internal", ctx_value)?,
                 detail,
+                overrides: TransportOverrides::default(),
             },
             "service_unavailable" => Self::ServiceUnavailable {
                 ctx: deserialize_ctx::<ServiceUnavailable>("service_unavailable", ctx_value)?,
                 detail,
                 resource_type,
                 resource_name,
+                overrides: TransportOverrides::default(),
             },
             "data_loss" => Self::DataLoss {
                 ctx: deserialize_ctx::<DataLoss>("data_loss", ctx_value)?,
                 detail,
                 resource_type,
                 resource_name,
+                overrides: TransportOverrides::default(),
             },
             "unauthenticated" => Self::Unauthenticated {
                 ctx: deserialize_ctx::<Unauthenticated>("unauthenticated", ctx_value)?,
                 detail,
                 resource_type,
                 resource_name,
+                overrides: TransportOverrides::default(),
             },
             _ => {
                 return Err(ProblemConversionError::UnknownProblemType(
@@ -365,6 +397,24 @@ impl TryFrom<Problem> for CanonicalError {
                 ));
             }
         };
+
+        if !(100..=599).contains(&problem.status) {
+            return Err(ProblemConversionError::InvalidStatus(problem.status));
+        }
+
+        if !canonical.is_same_status_class(problem.status) {
+            return Err(ProblemConversionError::CategoryStatusMismatch {
+                category: canonical.category_name(),
+                status: problem.status,
+            });
+        }
+
+        // Recover any transport override purely from the wire `status` — no
+        // additional field on `Problem` is needed since the category's
+        // default status is already known (`default_http_status`).
+        if problem.status != canonical.default_http_status() {
+            canonical.transport_overrides_mut().http_status = Some(problem.status);
+        }
 
         Ok(canonical)
     }

--- a/libs/toolkit-canonical-errors/src/transport.rs
+++ b/libs/toolkit-canonical-errors/src/transport.rs
@@ -1,0 +1,68 @@
+//! Transport-specific overrides for the wire projection of a `CanonicalError`
+//! occurrence. Overrides never change the error's canonical category (GTS
+//! type, title, context schema) — only the named transport's wire mapping
+//! reads them. See `docs/arch/errors/DESIGN.md` for the caller contract.
+
+// ---------------------------------------------------------------------------
+// TransportOverride (public)
+// ---------------------------------------------------------------------------
+
+/// A transport-specific override applied to the default canonical → wire
+/// mapping for a single error occurrence.
+///
+/// Construct via a transport namespace type (e.g. [`Http::status_code`]) and
+/// attach with `.with_override(...)` on any error builder. `#[non_exhaustive]`
+/// so future transports (gRPC, SSE) can add their own variant without a
+/// breaking change.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum TransportOverride {
+    /// Override the HTTP status code used by the `Problem` (RFC 9457)
+    /// projection. See [`Http::status_code`].
+    Http(HttpOverride),
+}
+
+/// Payload for [`TransportOverride::Http`]. Constructed via
+/// [`Http::status_code`], never directly.
+#[derive(Debug, Clone)]
+pub struct HttpOverride {
+    pub(crate) status_code: u16,
+}
+
+/// Namespace for constructing HTTP transport overrides.
+pub struct Http;
+
+impl Http {
+    /// Override the HTTP status code for a single `CanonicalError`
+    /// occurrence, without changing its canonical category.
+    ///
+    /// A `const fn` — it only constructs plain data, so callers can bind a
+    /// reusable named constant instead of repeating a literal at each call
+    /// site, e.g. `pub const GONE: TransportOverride = Http::status_code(410);`.
+    #[must_use]
+    pub const fn status_code(code: u16) -> TransportOverride {
+        TransportOverride::Http(HttpOverride { status_code: code })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TransportOverrides (private accumulator)
+// ---------------------------------------------------------------------------
+
+/// Per-error accumulator of transport overrides. One field per transport —
+/// setting one transport's override never touches another's. Never exported;
+/// the only public surface is [`TransportOverride`] and [`Http`].
+#[derive(Debug, Clone, Default)]
+pub(crate) struct TransportOverrides {
+    pub(crate) http_status: Option<u16>,
+}
+
+impl TransportOverrides {
+    pub(crate) fn apply(&mut self, ov: &TransportOverride) {
+        match ov {
+            TransportOverride::Http(HttpOverride { status_code }) => {
+                self.http_status = Some(*status_code);
+            }
+        }
+    }
+}

--- a/libs/toolkit-canonical-errors/tests/error.rs
+++ b/libs/toolkit-canonical-errors/tests/error.rs
@@ -1,7 +1,7 @@
 extern crate toolkit_canonical_errors;
 
 use toolkit_canonical_errors::resource_error;
-use toolkit_canonical_errors::{CanonicalError, Problem};
+use toolkit_canonical_errors::{CanonicalError, Http, Problem};
 use toolkit_gts::{GtsId, gts_id};
 
 #[resource_error(gts_id!("cf.core.users.user.v1~"))]
@@ -97,6 +97,87 @@ fn all_16_categories_convert_to_problem() {
         assert!(!problem.title.is_empty());
         assert!(problem.status > 0);
     }
+}
+
+// =========================================================================
+// Transport overrides
+// =========================================================================
+
+#[test]
+fn no_override_returns_category_default_status() {
+    let err = R::not_found("Resource not found")
+        .with_resource("user-123")
+        .create();
+    assert_eq!(err.status_code(), 404);
+    assert_eq!(err.http_status_override(), None);
+}
+
+#[test]
+fn override_changes_status_but_not_category() {
+    let err = R::not_found("Resource permanently removed")
+        .with_resource("user-123")
+        .with_override(Http::status_code(410))
+        .create();
+    assert_eq!(err.status_code(), 410);
+    assert_eq!(err.http_status_override(), Some(410));
+    assert_eq!(
+        err.gts_type(),
+        gts_id!("cf.core.errors.err.v1~cf.core.err.not_found.v1~")
+    );
+    assert_eq!(err.title(), "Not Found");
+}
+
+#[test]
+fn override_on_service_unavailable_builder() {
+    let err = CanonicalError::service_unavailable()
+        .with_retry_after_seconds(30)
+        .with_override(Http::status_code(503))
+        .create();
+    assert_eq!(err.status_code(), 503);
+    assert_eq!(err.http_status_override(), Some(503));
+}
+
+#[test]
+fn override_before_or_after_with_resource_is_equivalent() {
+    let before = R::not_found("Resource permanently removed")
+        .with_override(Http::status_code(410))
+        .with_resource("user-123")
+        .create();
+    let after = R::not_found("Resource permanently removed")
+        .with_resource("user-123")
+        .with_override(Http::status_code(410))
+        .create();
+    assert_eq!(before.status_code(), after.status_code());
+    assert_eq!(before.resource_name(), after.resource_name());
+    assert_eq!(before.detail(), after.detail());
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "different HTTP status class")]
+fn create_panics_in_debug_on_cross_class_override() {
+    // debug_assert! only fires with debug assertions enabled (the default
+    // for `cargo test`); skipped entirely in release builds via the cfg.
+    drop(
+        R::invalid_argument()
+            .with_field_violation("field", "bad format", "INVALID_FORMAT")
+            .with_override(Http::status_code(500))
+            .create(),
+    );
+}
+
+#[test]
+fn reapplying_override_for_same_transport_replaces_prior_value() {
+    // Both overrides stay in the 4xx class (same as `not_found`'s 404
+    // default) so this only exercises "replaces prior value", not the
+    // separate cross-class-override assertion covered by
+    // `create_panics_in_debug_on_cross_class_override`.
+    let err = R::not_found("Resource not found")
+        .with_resource("user-123")
+        .with_override(Http::status_code(410))
+        .with_override(Http::status_code(422))
+        .create();
+    assert_eq!(err.status_code(), 422);
 }
 
 // =========================================================================

--- a/libs/toolkit-canonical-errors/tests/problem.rs
+++ b/libs/toolkit-canonical-errors/tests/problem.rs
@@ -1,7 +1,7 @@
 extern crate toolkit_canonical_errors;
 
 use toolkit_canonical_errors::resource_error;
-use toolkit_canonical_errors::{CanonicalError, Problem};
+use toolkit_canonical_errors::{CanonicalError, Http, Problem};
 use toolkit_gts::{gts_id, gts_uri};
 
 const USER_RESOURCE: &str = gts_id!("cf.core.users.user.v1~");
@@ -28,6 +28,23 @@ fn problem_from_not_found_has_correct_fields() {
     assert_eq!(problem.detail, "Resource not found");
     assert_eq!(problem.context["resource_type"], USER_RESOURCE);
     assert_eq!(problem.context["resource_name"], "user-123");
+}
+
+#[test]
+fn problem_from_error_reflects_http_status_override() {
+    // Direct check of the CanonicalError -> Problem direction (as opposed to
+    // the round-trip tests below, which only verify it indirectly).
+    let err = R::not_found("Resource permanently removed")
+        .with_resource("user-123")
+        .with_override(Http::status_code(410))
+        .create();
+    let problem = Problem::from(err);
+    assert_eq!(problem.status, 410);
+    assert_eq!(
+        problem.problem_type,
+        gts_uri!("cf.core.errors.err.v1~cf.core.err.not_found.v1~")
+    );
+    assert_eq!(problem.title, "Not Found");
 }
 
 #[test]
@@ -465,6 +482,51 @@ fn round_trip_data_loss() {
 }
 
 #[test]
+fn round_trip_preserves_http_status_override() {
+    let original = R::not_found("Resource permanently removed")
+        .with_resource("user-123")
+        .with_override(Http::status_code(410))
+        .create();
+    let restored = round_trip(original);
+    assert_eq!(restored.status_code(), 410);
+    assert_eq!(restored.http_status_override(), Some(410));
+    assert_eq!(
+        restored.gts_type(),
+        gts_id!("cf.core.errors.err.v1~cf.core.err.not_found.v1~")
+    );
+    assert_eq!(restored.title(), "Not Found");
+}
+
+#[test]
+fn round_trip_without_override_has_no_spurious_override() {
+    let original = R::not_found("Resource not found")
+        .with_resource("user-123")
+        .create();
+    let restored = round_trip(original);
+    assert_eq!(restored.status_code(), 404);
+    assert_eq!(restored.http_status_override(), None);
+}
+
+#[test]
+fn round_trip_normalizes_override_equal_to_category_default() {
+    // Known limitation (see DESIGN.md §2.2 "Transport Overrides"): an
+    // override whose value matches the category default is indistinguishable
+    // on the wire from "no override was set" — `status_code()` is correct
+    // either way, but `http_status_override()` loses its `Some(..)` state.
+    // Pinned here rather than fixed, since fixing it would require adding a
+    // dedicated `Problem` field, which the design deliberately avoids.
+    let original = R::not_found("Resource not found")
+        .with_resource("user-123")
+        .with_override(Http::status_code(404))
+        .create();
+    assert_eq!(original.http_status_override(), Some(404));
+
+    let restored = round_trip(original);
+    assert_eq!(restored.status_code(), 404);
+    assert_eq!(restored.http_status_override(), None);
+}
+
+#[test]
 fn try_from_unknown_problem_type_returns_error() {
     let problem = Problem {
         problem_type: FUTURE_PROBLEM_TYPE.to_owned(),
@@ -481,6 +543,64 @@ fn try_from_unknown_problem_type_returns_error() {
             assert_eq!(t, FUTURE_PROBLEM_TYPE);
         }
         other => panic!("expected UnknownProblemType, got {other:?}"),
+    }
+}
+
+#[test]
+fn try_from_category_status_mismatch_returns_error() {
+    // invalid_argument's default is 400 (class 4xx); 500 is class 5xx.
+    let problem = Problem {
+        problem_type: gts_uri!("cf.core.errors.err.v1~cf.core.err.invalid_argument.v1~").to_owned(),
+        title: "Invalid Argument".to_owned(),
+        status: 500,
+        detail: "bad request".to_owned(),
+        instance: None,
+        trace_id: None,
+        context: serde_json::json!({"field_violations": []}),
+    };
+    let result = CanonicalError::try_from(problem);
+    match result {
+        Err(ProblemConversionError::CategoryStatusMismatch { category, status }) => {
+            assert_eq!(category, "invalid_argument");
+            assert_eq!(status, 500);
+        }
+        other => panic!("expected CategoryStatusMismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn try_from_zero_status_returns_error() {
+    let problem = Problem {
+        problem_type: gts_uri!("cf.core.errors.err.v1~cf.core.err.not_found.v1~").to_owned(),
+        title: "Not Found".to_owned(),
+        status: 0,
+        detail: "Resource not found".to_owned(),
+        instance: None,
+        trace_id: None,
+        context: serde_json::json!({}),
+    };
+    let result = CanonicalError::try_from(problem);
+    match result {
+        Err(ProblemConversionError::InvalidStatus(0)) => {}
+        other => panic!("expected InvalidStatus(0), got {other:?}"),
+    }
+}
+
+#[test]
+fn try_from_out_of_range_status_returns_error() {
+    let problem = Problem {
+        problem_type: gts_uri!("cf.core.errors.err.v1~cf.core.err.not_found.v1~").to_owned(),
+        title: "Not Found".to_owned(),
+        status: 6000,
+        detail: "Resource not found".to_owned(),
+        instance: None,
+        trace_id: None,
+        context: serde_json::json!({}),
+    };
+    let result = CanonicalError::try_from(problem);
+    match result {
+        Err(ProblemConversionError::InvalidStatus(6000)) => {}
+        other => panic!("expected InvalidStatus(6000), got {other:?}"),
     }
 }
 


### PR DESCRIPTION
Closes: #4465

Let a gear override the HTTP status of a single CanonicalError occurrence without changing its canonical category, so dispatch/GTS classification stays correct while the wire response can still diverge from the category's fixed default (e.g. surfacing `not_found` as 410 for a legacy endpoint). Adds `TransportOverride`/`Http::status_code` and `.with_override(...)` on both error builders; `TryFrom<Problem>` recovers the override from the wire `status` alone, so no schema change is needed for the round trip to stay lossless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-error HTTP status overrides without changing the error’s category, type, title, or context.
  * Added builder support for configuring and replacing HTTP status overrides.
  * Added public transport override types and constructors.
* **Bug Fixes**
  * Preserved HTTP status overrides when errors are converted to and restored from `Problem` representations.
* **Documentation**
  * Documented per-occurrence transport override behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->