### PR TITLE
security(deps)!: bump OpenTelemetry stack to 0.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
  "futures",
  "getrandom 0.3.4",
  "rand 0.9.4",
- "reqwest 0.13.3",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
@@ -1404,7 +1404,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "parking_lot",
- "reqwest 0.13.3",
+ "reqwest",
  "sea-orm",
  "sea-orm-migration",
  "serde",
@@ -1899,7 +1899,7 @@ dependencies = [
  "inventory",
  "opentelemetry",
  "quick-xml 0.41.0",
- "reqwest 0.13.3",
+ "reqwest",
  "ring",
  "rusty-s3",
  "s3s",
@@ -2272,7 +2272,7 @@ dependencies = [
  "parking_lot",
  "rcgen",
  "regex",
- "reqwest 0.13.3",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
@@ -6864,9 +6864,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -6878,22 +6878,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -6901,18 +6901,18 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.28",
+ "reqwest",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -6923,15 +6923,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
@@ -8391,40 +8392,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
@@ -8432,6 +8399,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -10669,6 +10637,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10794,9 +10773,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -364,12 +364,12 @@ tracing-subscriber = { version = "0.3", features = [
     "local-time",
 ] }
 tracing-log = "0.2"
-tracing-opentelemetry = "0.32"
+tracing-opentelemetry = "0.33"
 tracing-appender = "0.2"
 tracing-test = "0.2"
-opentelemetry = { version = "0.31", features = ["trace", "metrics"] }
-opentelemetry_sdk = { version = "0.31", features = ["trace", "rt-tokio", "metrics"] }
-opentelemetry-otlp = { version = "0.31", features = [
+opentelemetry = { version = "0.32", features = ["trace", "metrics"] }
+opentelemetry_sdk = { version = "0.32", features = ["trace", "rt-tokio", "metrics"] }
+opentelemetry-otlp = { version = "0.32", features = [
     "grpc-tonic",
     "http-proto",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -368,7 +368,7 @@ tracing-opentelemetry = "0.33"
 tracing-appender = "0.2"
 tracing-test = "0.2"
 opentelemetry = { version = "0.32", features = ["trace", "metrics"] }
-opentelemetry_sdk = { version = "0.32", features = ["trace", "rt-tokio", "metrics"] }
+opentelemetry_sdk = { version = "0.32.1", features = ["trace", "rt-tokio", "metrics"] }
 opentelemetry-otlp = { version = "0.32", features = [
     "grpc-tonic",
     "http-proto",


### PR DESCRIPTION
Supersedes #4152.

`opentelemetry_sdk` 0.31 is affected by [GHSA-w9wp-h8wv-79jx](https://github.com/open-telemetry/opentelemetry-rust/security/advisories/GHSA-w9wp-h8wv-79jx) / CVE-2026-48504 (medium, availability only): `BaggagePropagator::extract_with_context` parsed an inbound `baggage` header before applying the W3C Baggage limits, so an oversized attacker-controlled header bought per-entry parse, decode and allocation work for entries the SDK then discarded. Fixed in 0.32.1.

The SDK cannot move alone — 0.32 is built against the `opentelemetry` 0.32 API crate, so bumping it by itself leaves two incompatible `opentelemetry` versions in the graph, which is why every compile job on #4152 fails with `expected opentelemetry::common::KeyValue, found opentelemetry::KeyValue`. This moves the family together: `opentelemetry` 0.32.0, `opentelemetry_sdk` 0.32.1, `opentelemetry-otlp` 0.32.0, `tracing-opentelemetry` 0.33.0 (first release requiring `opentelemetry ^0.32`), plus `opentelemetry-http`/`-proto` transitively. The SDK requirement is `0.32.1`, not `0.32`, since `^0.32` still admits the vulnerable 0.32.0.

No source changes: the workspace uses none of the APIs 0.32 removed (`SpanBuilder` setters, the `SamplingResult` move into `opentelemetry_sdk::trace`, otlp's `ExportConfig`/`HasTonicConfig`/`HasHttpConfig` — `telemetry/init.rs` uses only the unchanged `With*Config` traits — and `SimpleConcurrentLogProcessor`), and every enabled feature keeps its 0.31 expansion. In the lock, `grpc-tonic` adds `tonic-types` and `reqwest` 0.12 drops out: `opentelemetry-http` moved to `^0.13.1` and now shares the workspace's 0.13, one duplicate major fewer.

**Version bump: MINOR, breaking under the 0.x policy.** OpenTelemetry types sit in the public API of published crates — `with_meter(&opentelemetry::metrics::Meter, …)` (`libs/toolkit-http/src/layers/metrics.rs:130`) and `OtelLayer` (`libs/toolkit/src/bootstrap/host/logging.rs:12`) — so consumers still on 0.31 stop compiling and must move in lockstep; hence the `BREAKING CHANGE:` footer for release-plz. Happy to drop it if you would rather sequence the release differently.

Verified on 1.97.0: `cargo check --workspace --all-targets`, `cargo clippy --all-targets --all-features -- -D warnings -D clippy::perf` over the 15 OpenTelemetry-touching crates, `cfs validate` (0 errors), and 3151 unit tests across the crates asserting on emitted instruments. The one red job is not from this diff — `Security` fails on RUSTSEC-2026-0253 (`LruCache::pop()` unsoundness in `lru` 0.16.4, untouched here), which also failed on `main` in run 31499432570.

One deployment note: otlp 0.32 now errors at build time for an `https://` endpoint with no TLS feature enabled, where 0.31 silently sent plaintext. Nothing in-repo points OTLP at `https://` — defaults are `http://127.0.0.1:4317/4318`.
