### PR TITLE
fix(cluster): make postgres plugin's conformance dev-dep path-only

### DIFF
--- a/gears/system/cluster/plugins/postgres-cluster-plugin/Cargo.toml
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/Cargo.toml
@@ -116,7 +116,9 @@ futures-util = { workspace = true }
 # Layer 2 conformance suite (TESTING.md §3): the same parametrized suites
 # every other backend runs, wired against this plugin's real Postgres-backed
 # cache/lock/leader/discovery in `tests/conformance.rs`.
-cf-gears-cluster-conformance = { workspace = true }
+# Path-only, no version on purpose: cargo drops a path-only dev-dependency from the published
+# manifest, so publishing this plugin never needs the conformance crate on crates.io.
+cf-gears-cluster-conformance = { path = "../../cluster-conformance" }
 # `cluster::defaults::{CasBasedLeaderElectionBackend, CacheBasedServiceDiscoveryBackend}`
 # (TESTING.md §3): leader election and service discovery are always the SDK
 # defaults over this plugin's cache (DESIGN.md §6), so the L2/L3 tests exercise


### PR DESCRIPTION
`cargo package` for cf-postgres-cluster-plugin failed with:

    failed to select a version for the requirement
    `cf-gears-cluster-conformance = "^0.2.0"`
    candidate versions found which didn't match: 0.1.3, 0.1.2, 0.1.1, ...

`{ workspace = true }` inherits `version = "0.2.0"` from the workspace table, so the dev-dependency survives into the published manifest and cargo requires it to resolve on crates.io. Conformance 0.2.0 has never been published, so the publish job failed.

release-plz does honor dev-dependency edges when ordering publishes, but that guarantee is lost inside a cycle: `cf-gears-cluster` normal-depends on this plugin while this plugin dev-depends on `cf-gears-cluster` — the only dependency cycle in the workspace. Breaking it drops the dev edges, so conformance was scheduled *after* the plugin that needs it.

Declaring the dev-dep path-only (the convention already used in `cluster/Cargo.toml:65`) removes it from the published manifest entirely, so publish order stops mattering rather than needing to be correct. Local tests are unaffected — the dep still resolves by path.

Verified: `cargo package` now succeeds and the packaged manifest retains only registry dev-deps; `cargo check --tests --features integration` passes; `cf-gears-cluster-conformance` 0.2.0 packages cleanly as the next crate in the publish queue.