### PR TITLE
fix(deps): bump lru to 0.18.2 to resolve RUSTSEC-2026-0253

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3104,7 +3104,7 @@ dependencies = [
  "cf-gears-types-registry-sdk",
  "gts",
  "inventory",
- "lru 0.17.0",
+ "lru 0.18.2",
  "parking_lot",
  "serde",
  "serde_json",
@@ -5070,7 +5070,7 @@ dependencies = [
  "html-escape",
  "html5ever",
  "image",
- "lru 0.18.0",
+ "lru 0.18.2",
  "memchr",
  "once_cell",
  "regex",
@@ -6167,18 +6167,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.17.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
-dependencies = [
- "hashbrown 0.17.0",
-]
-
-[[package]]
-name = "lru"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.0",
 ]

--- a/gears/system/types-registry/types-registry/Cargo.toml
+++ b/gears/system/types-registry/types-registry/Cargo.toml
@@ -38,7 +38,7 @@ axum = { workspace = true, features = ["macros"] }
 uuid = { workspace = true, features = ["v5"] }
 thiserror = { workspace = true }
 parking_lot = { workspace = true }
-lru = "0.17"
+lru = "0.18.2"
 
 # Local dependencies
 toolkit = { workspace = true }


### PR DESCRIPTION
Bump `lru` in `types-registry` for https://rustsec.org/advisories/RUSTSEC-2026-0253.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal caching dependency to a newer version, with no visible changes to the product experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->