### PR TITLE
docs(policy-engine,admission-control): PRD, DESIGN

### DIFF
--- a/gears/system/admission-control/docs/DESIGN.md
+++ b/gears/system/admission-control/docs/DESIGN.md
@@ -1,0 +1,814 @@
+# Technical Design — Admission Control
+
+
+<!-- toc -->
+
+- [1. Architecture Overview](#1-architecture-overview)
+  - [1.1 Architectural Vision](#11-architectural-vision)
+  - [1.2 Architecture Drivers](#12-architecture-drivers)
+  - [1.3 Architecture Layers](#13-architecture-layers)
+- [2. Principles & Constraints](#2-principles--constraints)
+  - [2.1 Design Principles](#21-design-principles)
+  - [2.2 Constraints](#22-constraints)
+- [3. Technical Architecture](#3-technical-architecture)
+  - [3.1 Domain Model](#31-domain-model)
+  - [3.2 Component Model](#32-component-model)
+  - [3.3 API Contracts](#33-api-contracts)
+  - [3.4 Internal Dependencies](#34-internal-dependencies)
+  - [3.5 External Dependencies](#35-external-dependencies)
+  - [3.6 Interactions & Sequences](#36-interactions--sequences)
+  - [3.7 Database schemas & tables](#37-database-schemas--tables)
+  - [3.8 Deployment Topology](#38-deployment-topology)
+- [4. Additional context](#4-additional-context)
+  - [4.1 Telemetry surface](#41-telemetry-surface)
+  - [4.2 Security boundaries and threat model](#42-security-boundaries-and-threat-model)
+  - [4.3 Testability and test strategy](#43-testability-and-test-strategy)
+  - [4.4 Known design risks](#44-known-design-risks)
+  - [4.5 Areas recorded as not applicable](#45-areas-recorded-as-not-applicable)
+- [5. Traceability](#5-traceability)
+
+<!-- /toc -->
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-design-admission-control`
+## 1. Architecture Overview
+
+### 1.1 Architectural Vision
+
+The gate is an evaluator and a router, not a service with state. Its decision path holds two stages: evaluation of the built-in policies compiled from configuration at startup, and one call to the selected policy engine. There is no store, no cache with an invalidation problem, and nothing on the path that can change between two requests except the engine's answer. That is what makes a 5 ms overhead budget an allocation rather than an aspiration: the only work the gate does for itself is bounded evaluation of a small set of already-compiled content, and the bound is what holds the figure rather than the set being cheap.
+
+Everything else in the design is failure handling. Because the gate fails closed, the interesting behaviour is not what happens when the engine answers but what happens when it does not, and the design converges every such path — unreachable, timed out, errored, unmappable, absent, backing off — on one refusal constructor that stamps the could-not-run cause. That constructor is the only way to build a refusal from a failure, which makes the property in `cpt-cf-admission-control-nfr-fail-closed` structural rather than a matter of remembering to handle each case.
+
+That thinness raises a fair question the documents should answer rather than imply: why a gear at all, when the caller-side helper pattern — `PolicyEnforcer` in `authz-resolver-sdk` — already exists for reaching a pluggable decision point from a domain gear. Three reasons. A library cannot be deployed out-of-process, and this component is one a deployment may want to run, scale, and secure separately. A library cannot serve the operational surface an operator needs to see which built-in policies loaded and which engine resolved. And the platform already has this exact shape as a gear: `authz-resolver` is a few hundred lines that select a plugin and route to it, with its caller-side helper in the SDK beside it — which is the arrangement here, and the precedent for it.
+
+The third shaping force is what the gate refuses to do. It never modifies a request, so the request value it receives is passed to the engine and dropped; nothing in the design writes to it, and the response type carries no field through which a modification could travel. It never stores policy content, so built-in policies arrive as configuration and are compiled once. Both are absences rather than mechanisms, and both are what keep this gear from becoming the second policy engine its own risk register warns about.
+
+### 1.2 Architecture Drivers
+
+Requirements that significantly influence architecture decisions.
+
+#### Functional Drivers
+
+| Requirement | Design Response |
+|-------------|------------------|
+| `cpt-cf-admission-control-fr-admission-interface` | `cpt-cf-admission-control-component-admission-service` exposes one method pair, single and batch; the response type has no field capable of carrying a modified request, and one collection that carries obligations through from the engine untouched. |
+| `cpt-cf-admission-control-fr-request-authenticity` | The security context is a required parameter of the admission trait rather than an ambient value. `cpt-cf-admission-control-component-admission-service` takes the subject and its tenant from it and refuses a mismatch through the verdict builder's own arm for that cause, before any built-in policy runs; `cpt-cf-admission-control-component-engine-client` forwards the same context and has no path that constructs one, so the identity the engine derives is the one the caller presented. |
+| `cpt-cf-admission-control-fr-decision-order` | The service runs `cpt-cf-admission-control-component-builtin-evaluator` before `cpt-cf-admission-control-component-engine-client`, and returns on the first built-in-policy prohibition without constructing an engine request. |
+| `cpt-cf-admission-control-fr-refusal-cause` | `cpt-cf-admission-control-component-verdict-builder` is the sole constructor of a refusal, and takes the cause as a required argument rather than defaulting it. |
+| `cpt-cf-admission-control-fr-deferral-relay` | The engine result type carries a deferral variant from the first version, and the verdict reserves a third value that no code path constructs yet; `cpt-cf-admission-control-component-engine-client` maps a deferral as a **result**, not through the failure funnel, so it never reaches the could-not-run constructor, and `cpt-cf-admission-control-component-verdict-builder` stamps the awaiting-approval cause instead. |
+| `cpt-cf-admission-control-fr-batch-admission` | `cpt-cf-admission-control-component-batch-combiner` folds member verdicts under an absorbing refusal, collecting every refused member rather than short-circuiting. |
+| `cpt-cf-admission-control-fr-deferral-verdict` | The reserved third value becomes constructible in `cpt-cf-admission-control-component-verdict-builder`, and `cpt-cf-admission-control-component-batch-combiner` gains one ordering rule — refusal absorbs, then deferral, then admission — leaving the fold order-independent. No component gains state, because nothing here holds a deferred operation open. |
+| `cpt-cf-admission-control-fr-remote-decision-surface` | The admission client is a trait over a service that holds no in-process assumption, so the remote projection is an added transport binding rather than a second implementation; `cpt-cf-admission-control-component-admission-service` is unchanged by it. |
+| `cpt-cf-admission-control-fr-builtin-policy-form` | `cpt-cf-admission-control-component-policy-set` compiles each configured policy through the evaluation facility at startup; `cpt-cf-admission-control-component-builtin-evaluator` evaluates the compiled set and maps anything that is not a prohibition to "fall through to the engine". |
+| `cpt-cf-admission-control-fr-builtin-policy-precedence` | Built-in policies are evaluated before the engine and a prohibition returns immediately; no code path lets an engine result overturn one. |
+| `cpt-cf-admission-control-fr-builtin-policy-independence` | The built-in policy set is built from configuration and the types registry only, with no reference to the engine; it is populated even when engine resolution fails. The named reserved-name-prefix fixture is what makes that observable: the conformance suite runs it against two stub engines and against an engine-less deployment, so the property fails a test rather than going unchallenged. |
+| `cpt-cf-admission-control-fr-builtin-evaluation-bounds` | `cpt-cf-admission-control-component-builtin-evaluator` wraps each policy evaluation in its configured bound and the set in a total bound; it constructs the evaluation context from the request and a gate-supplied timestamp, passing no handle of any kind. Where the backend's bound is cooperative it also sets the check interval rather than inheriting a default, since the overrun is one work unit wide and is spent from the gate's own overhead. Determinism is not enforced here but at startup, by `cpt-cf-admission-control-component-config-validator`. |
+| `cpt-cf-admission-control-fr-engine-selection` | `cpt-cf-admission-control-component-engine-client` resolves one GTS instance at startup and holds it; no per-request resolution and no second candidate is retained. |
+| `cpt-cf-admission-control-fr-absent-engine` | No engine configured starts the gear in a degraded state reported by `cpt-cf-admission-control-component-operational-api`, refusing with could-not-run on every request that no built-in policy already prohibits; a configured identifier that will not resolve fails startup in the config validator instead. Degraded rather than unready, because in-process the host is shared with the gears being gated. |
+| `cpt-cf-admission-control-fr-engine-result` | The engine's permission cause is copied into the record and never read by the verdict builder, so no branch on it exists to be added by accident. |
+| `cpt-cf-admission-control-fr-fail-closed` | Every engine-facing error converges on the refusal constructor; the configuration type has no field that could express an admit-on-failure setting. |
+| `cpt-cf-admission-control-fr-engine-bound` | The engine call is wrapped in a configured timeout; expiry is one of the conditions the refusal constructor accepts. |
+| `cpt-cf-admission-control-fr-engine-backoff` | A back-off signal opens a gate-side window during which calls are throttled and requests refuse without reaching the engine. |
+| `cpt-cf-admission-control-fr-admission-records` | `cpt-cf-admission-control-component-recorder` owns the field set and its single builder; every other component contributes fields through it. |
+| `cpt-cf-admission-control-fr-record-path-failure` | `cpt-cf-admission-control-component-recorder` owns the condition, because buffer age is its own signal: on sink unreachability, an aged oldest record, or a full buffer it reports and the admission service refuses from then on. Those refusals are counted rather than buffered — enqueueing them would need the capacity whose exhaustion caused them — and one gap record naming the interval and the count is published when the drain recovers. No component holds a path that drops, samples, or truncates a record to relieve pressure. |
+| `cpt-cf-admission-control-fr-record-confidentiality` | The record type carries property names as a collection of strings and has no field of a type that could hold a value, so exclusion is structural. |
+| `cpt-cf-admission-control-fr-subject-data-handling` | The record type carries the subject as the opaque reference the security context supplies and has no field able to hold a profile attribute. `cpt-cf-admission-control-component-recorder` exposes no delete, rewrite, or resolve path, and needs none: erasure belongs to the identity provider, and nothing in a published record changes when it happens. |
+| `cpt-cf-admission-control-fr-operational-surface` | `cpt-cf-admission-control-component-operational-api` reads the built-in policy set and the engine handle directly; it holds no state of its own and registers no route that mutates either. Refusal counts come from bounded in-memory counters over a recent window, kept by the same component that constructs a refusal, so no path writes them twice and none of them is durable state — the durable evidence is the admission record on the audit topic. |
+| `cpt-cf-admission-control-fr-metrics` | Telemetry surface in Section 4.1, emitted by the component owning each measurement. |
+| `cpt-cf-admission-control-fr-configuration-validation` | Configuration is a deny-unknown-fields structure validated during the init phase, including syntax validation of every built-in policy through the evaluation facility, resolution of every resource type those policies name, resolution of the engine identifier, and a screen of each policy's parsed form for builtins denylisted for the backend build in use. |
+
+#### NFR Allocation
+
+This table maps non-functional requirements from PRD to specific design/architecture responses.
+
+| NFR ID | NFR Summary | Allocated To | Design Response | Verification Approach |
+|--------|-------------|--------------|-----------------|----------------------|
+| `cpt-cf-admission-control-nfr-overhead` | p95 5 ms, p99 10 ms excluding engine time | `cpt-cf-admission-control-component-policy-set`, `-builtin-evaluator` | Content compiled once at startup, so no request parses anything; selection is a hash lookup plus a pattern check with no I/O. Evaluation of the selected policies is the dominant term in the figure, which is why the per-policy and total bounds of `cpt-cf-admission-control-fr-builtin-evaluation-bounds` are what keep it inside budget rather than the selection cost | Benchmark at the gate boundary with engine time subtracted; per-stage timing histograms separating selection from evaluation |
+| `cpt-cf-admission-control-nfr-fail-closed` | Zero admissions on any failure | `cpt-cf-admission-control-component-verdict-builder` | One refusal constructor; admission is reachable only from an engine permission, never from an error branch and never from a built-in policy | Fault injection across the enumerated conditions |
+| `cpt-cf-admission-control-nfr-non-modification` | Request unchanged after the call | `cpt-cf-admission-control-component-admission-service` | The request is taken by shared reference and never cloned into the response; the response type has no request-shaped field | Conformance test comparing the caller's request before and after, on both verdicts |
+| `cpt-cf-admission-control-nfr-availability` | No host impact in-process; 99.95 percent out-of-process | `cpt-cf-admission-control-topology-in-process` | Nothing on the decision path runs in the background, holds an unbounded queue, or holds a lock across an await. One background task exists off that path — the recorder's drain in `cpt-cf-admission-control-component-recorder` — and it is bounded by the buffer it drains, with its failures caught at the task boundary so a drain panic degrades the record path per `cpt-cf-admission-control-fr-record-path-failure` rather than reaching the host. The one resource that could otherwise grow without bound is that record buffer, which is bounded | Fault injection asserting zero host-fatal outcomes, including a panic injected into the drain task; availability measurement in the out-of-process shape |
+| `cpt-cf-admission-control-nfr-record-completeness` | One record per decision, ≤5 s awaiting durability, with one accounted exception | `cpt-cf-admission-control-component-recorder` | Records appended to a bounded in-memory buffer on the decision path and drained by a separate task; buffer age and occupancy exported. The exception is the serving condition of `cpt-cf-admission-control-fr-record-path-failure`: rather than sampling or dropping under sink failure, the gate refuses and accounts for the interval with one gap record, so every decision is either recorded or inside a stated gap | Throughput test asserting record count equals decision count; fault-injected sink outage and buffer saturation asserting refusal rather than admission, no dropped record, and exactly one gap record on recovery |
+
+#### Key ADRs
+
+No decision record exists for this gear yet. The decisions below are the ones this design takes that warrant one. Identifiers are omitted until the records exist, because allocating them before produces dangling references that the repository's deterministic validation rejects.
+
+| Planned decision | Decision Summary |
+|--------|-----------------|
+| Single engine selection | Select exactly one policy engine per deployment rather than combining verdicts from several, following the platform's existing plugin-selection idiom and declining the Kubernetes multi-webhook model. |
+| Built-in policies evaluated in the gate | Evaluate the platform's own policies here, through the shared evaluation facility, rather than delegating them to the selected engine — which is what makes them survive substitution of that engine. Management stays out: they arrive as deployment configuration, with no authoring surface. |
+| Fail closed without bypass | Refuse on every engine failure and expose no configuration that converts a failure into an admission. |
+| Judgement without modification | Return a verdict only, leaving request enrichment to the calling gear's own pipeline. |
+| Gear rather than caller-side library | Ship as a gear with an SDK beside it, rather than as a library each enforcing gear links, so that the component can be deployed out-of-process and can serve an operational surface — following `authz-resolver`, which is the same shape. |
+
+### 1.3 Architecture Layers
+
+```mermaid
+graph TD
+    EG[Enforcing gear]
+    OP[Platform operator]
+    CFG[Deployment configuration]
+    subgraph Presentation
+        REST[Operational REST surface]
+    end
+    subgraph Application
+        ACL[Admission client]
+        CV[Config validator]
+    end
+    subgraph Domain
+        SEQ[Decision sequence]
+    end
+    subgraph Infrastructure
+        PS[Built-in policy compilation and evaluation, via the evaluation facility]
+        ECL[Engine client]
+        REC[Recorder]
+    end
+    EG --> ACL
+    OP --> REST
+    CFG --> CV
+    TR[types-registry] --> CV
+    CV --> PS
+    CV --> ECL
+    ACL --> SEQ
+    SEQ --> PS
+    SEQ --> ECL
+    SEQ --> REC
+    REST --> PS
+    REST --> ECL
+    ECL --> PE[Selected policy engine]
+    REC -.->|async| BR[event-broker audit topic]
+```
+
+Nodes inside the layer boxes are this gear's own code and the libraries it links, the evaluation facility among them. Nodes outside are separate gears and external systems, reached rather than linked — and there is no store among them, which is the gear's defining property.
+
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-tech-stack`
+
+| Layer | Responsibility | Technology |
+|-------|---------------|------------|
+| Presentation | A read-only operational surface — readiness, selected engine, loaded built-in policies and match counts — present in both deployment shapes. The decision surface is projected here only in the out-of-process shape | `toolkit-http`, `toolkit-canonical-errors` |
+| Application | The admission client registered in ClientHub, the engine plugin contract, gear lifecycle, configuration | ToolKit gear capabilities, ClientHub |
+| Domain | Built-in policy selection, verdict and cause construction, batch combination, record construction | Rust, `#[domain_model]` types |
+| Infrastructure | Built-in policy compilation and evaluation, engine resolution and invocation, types-registry resolution, record emission | Evaluation facility, ClientHub scoped resolution, `toolkit-gts`, `toolkit-canonical-errors` |
+
+## 2. Principles & Constraints
+
+### 2.1 Design Principles
+
+#### Decide Nothing That Can Be Delegated
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-principle-thin`
+
+The gate answers one question and owns only what that question needs: the interface, the ordering, the failure semantics, and the built-in policies. Policy semantics belong to the engine, request enrichment belongs to the calling gear, and content lifecycle belongs to neither. Every capability this gear does not have is load-bearing — the split that created it exists because a gateway that manages policy is a policy engine with a different name.
+
+**Planned decision record**: Built-in policies evaluated in the gate
+
+#### Compiled at Startup, Evaluated at Request Time
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-principle-compile-at-startup`
+
+Built-in policies arrive as configuration, are validated and compiled at startup through the evaluation facility, and are evaluated at request time against the request context. Compiling once is what keeps parsing off the decision path; the cost that remains is evaluation itself, bounded per policy and in total. The gate holds the same isolation obligation the engine does — the backend receives the context, the content, and a supplied timestamp, and no capability.
+
+**Planned decision record**: Built-in policies evaluated in the gate
+
+#### One Way to Refuse From a Failure
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-principle-single-refusal`
+
+Every path that cannot obtain an answer — no engine, unreachable engine, timeout, error, unmappable result, active back-off — converges on a single constructor that stamps the could-not-run cause. Admission is reachable only from an engine permission. Making this structural rather than conventional is what stops a new failure path from silently defaulting to admit, which is the one defect in this gear that would be invisible in production.
+
+**Planned decision record**: Fail closed without bypass
+
+#### The Request Belongs to the Caller
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-principle-no-modification`
+
+The gate borrows the request, reads it, and returns a verdict. It does not clone it into the response, and the response type has no field shaped to carry one back. A caller's validation of its own request is therefore never conditional on what the gate did with it.
+
+**Planned decision record**: Judgement without modification
+
+#### Nothing on the Decision Path Changes Between Requests
+
+- [ ] `p2` - **ID**: `cpt-cf-admission-control-principle-stateless-path`
+
+After startup, the built-in policy set and the engine handle are immutable for the life of the process. The decision path performs no read that could return different data to two concurrent requests, which is what makes the gate's contribution to latency flat and its behaviour reproducible from configuration alone.
+
+### 2.2 Constraints
+
+#### No Management API for Built-in Policies
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-constraint-no-builtin-policy-api`
+
+Built-in policies are supplied by deployment configuration and change with the deployment. The gear exposes no endpoint and no client method that creates, modifies, or withdraws one. This is the boundary the gear exists to hold: a runtime-authorable built-in policy set here would duplicate the policy engine's lifecycle, versioning, and audit with a second model.
+
+#### Exactly One Engine
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-constraint-single-engine`
+
+One policy engine is resolved at startup and held. The design carries no verdict-combination model, no engine ordering, and no per-engine failure policy, because none is reachable with a single engine. Adding a second engine later is a change to this constraint and to the requirements that rest on it, not a configuration change.
+
+**Planned decision record**: Single engine selection
+
+#### The Evaluation Facility Is a Hard Dependency
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-constraint-evaluation-facility`
+
+The gate links the platform's evaluation facility, which does not yet exist. It shares that exposure with the policy engine rather than avoiding it: built-in policies are real policy content, and evaluating them is what makes them independent of the selected engine. What the gate does not take on is content **management** — no store, no lifecycle, no authoring surface — which is the boundary that matters, and it is unaffected by the dependency.
+
+The audit of the first candidate backend settled two things the gate must therefore build for. Its cost bound is cooperative, so a per-policy limit overruns by up to one unit of work, spent from the gate's own overhead rather than the engine's. And it declares no sandbox posture of its own while registering builtins that read a clock or generate random values, none of which can be removed or shadowed — so determinism is a startup-time content check here, not a runtime guarantee obtained from the facility.
+
+#### The Overhead Budget Is Borrowed
+
+- [ ] `p2` - **ID**: `cpt-cf-admission-control-constraint-borrowed-budget`
+
+The gate's 5 ms is a slice of the enforcing gear's own budget, taken alongside the engine's 25 ms. Any design change that adds a synchronous dependency to the decision path spends the caller's budget, which is why the path admits exactly two things: in-process evaluation of the compiled built-in set, under its own bounds, and one engine call.
+
+#### In-Process at First Release
+
+- [ ] `p2` - **ID**: `cpt-cf-admission-control-constraint-in-process`
+
+The gate, its enforcing gears, and the selected engine share one process. The contracts are transport-agnostic, so an out-of-process deployment needs no contract change — but it needs the overhead and availability figures revisited, since neither contains an allowance for a transport hop.
+
+## 3. Technical Architecture
+
+### 3.1 Domain Model
+
+**Technology**: Rust domain types under `#[domain_model]`; GTS identifiers for resource types, engine instances, and error families
+
+**Location**: `gears/system/admission-control/admission-control/src/domain/`
+
+**Core Entities**:
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-entity-admission-request`
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-entity-gated-operation`
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-entity-verdict`
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-entity-builtin-policy`
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-entity-policy-set`
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-entity-admission-record`
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-entity-engine-result`
+
+| Entity | Description | Schema |
+|--------|-------------|--------|
+| AdmissionRequest | What an enforcing gear submits: subject and subject tenant, action, resource type and optional identifier, tenant context, and caller-supplied operation properties, alongside the caller's propagated security context. The subject fields are checked against that context and taken from it per `cpt-cf-admission-control-fr-request-authenticity`, so they restate an authenticated fact rather than asserting one. Borrowed by the gate, never retained. Carries no correlation identifier — the gate mints that itself. | Value type |
+| GatedOperation | The gate's own view of one admission: the request plus the correlation identifier minted for it, and the batch identifier where it belongs to a batch. Created at entry, carried to the engine, and consumed by the record. | Value type |
+| Verdict | Admitted or refused, with a cause on a refusal, and on an admission the engine's permission cause plus any obligations it attached. Refusal causes include the identity mismatch of `cpt-cf-admission-control-fr-request-authenticity`, which is a caller defect rather than an outage and is therefore distinct from could-not-run. Carries a reserved third value for a deferral, which no code path constructs until `cpt-cf-admission-control-fr-deferral-verdict` ships. The gate's whole answer. | Value type |
+| BuiltinPolicy | One of the platform's own policies as configuration supplies it: a stable identity the refusal names, the resource types and operations it applies to, and policy content in a language a backend of the evaluation facility accepts. Yields a prohibition or nothing. | Configuration |
+| BuiltinPolicySet | The compiled, immutable set built at startup — each policy's compiled content, plus a selection index keyed for constant-time lookup on the common path. | In-memory |
+| EngineResult | What the engine returns: a permission with its cause and obligations, a prohibition with a reason, or a deferral. A back-off request is not a fourth variant — it is an optional signal carried **alongside** a result, and the result it accompanies is the engine's own transient failure, which the gate maps to could-not-run while `cpt-cf-admission-control-fr-engine-backoff` opens the window. Modelling it as a variant would make it a result the gate has to map, and the only mapping available would be the failure funnel, which is where it already lands by the shorter route. Mapped to a Verdict, never surfaced raw — but obligations are copied across untouched. The deferral variant exists from the first version even though no engine emits one, which is what keeps it out of the unmappable-result path. | Value type |
+| AdmissionRecord | The durable projection of a decision, carrying the field set of `cpt-cf-admission-control-fr-admission-records`. One further shape shares the topic and is not a decision: the gap record of `cpt-cf-admission-control-fr-record-path-failure`, which names an interval and a count of refusals the gate could not record individually. | Published to the `event-broker` audit topic |
+
+**Relationships**:
+- AdmissionRequest → GatedOperation: each request becomes exactly one gated operation at entry, which is where the correlation identifier is minted.
+- AdmissionRequest → Verdict: each request yields exactly one verdict, and a batch yields one verdict per member plus one combined.
+- BuiltinPolicy → BuiltinPolicySet: the set is compiled from configuration once; a built-in policy has no existence at request time outside it.
+- EngineResult → Verdict: mapped, never passed through, so no engine-specific shape reaches a caller.
+- Verdict → AdmissionRecord: each verdict yields exactly one record.
+
+### 3.2 Component Model
+
+The gear is two crates: `admission-control-sdk`, carrying the admission client, the engine plugin contract, the shared models, and the error family; and `admission-control`, carrying the gate itself. Components below are modules, not processes.
+
+```mermaid
+graph LR
+    AS[Admission service] --> BE[Built-in evaluator]
+    AS --> EC[Engine client]
+    AS --> VB[Verdict builder]
+    AS --> BC[Batch combiner]
+    AS --> REC[Recorder]
+    BE --> PS[Built-in policy set]
+    BE --> EF[Evaluation facility]
+    CV[Config validator] --> PS
+    CV --> EC
+```
+
+#### Admission Service
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-component-admission-service`
+
+##### Why this component exists
+
+Enforcing gears need one call. This is that call, and the only component they link.
+
+##### Responsibility scope
+
+Owns the decision sequence and its ordering: security-context check, then built-in evaluation, then engine call, then verdict, then record. The context check is first and cheap — the subject and its tenant come from the context, and a request asserting different ones refuses through the verdict builder's own arm for it, before a built-in policy is evaluated and without an engine request being constructed. Implements `cpt-cf-admission-control-interface-admission-client` for single and batch requests. Holds the request by shared reference for the duration of the call and returns without retaining it.
+
+##### Responsibility boundaries
+
+Evaluates no policy, stores no content, and constructs no refusal itself — it delegates that to the verdict builder so that every refusal has one origin. Does not enforce its own verdict and has no way to observe whether a caller did.
+
+##### Related components (by ID)
+
+- `cpt-cf-admission-control-component-builtin-evaluator` — calls
+- `cpt-cf-admission-control-component-engine-client` — calls
+- `cpt-cf-admission-control-component-verdict-builder` — calls
+- `cpt-cf-admission-control-component-batch-combiner` — calls
+- `cpt-cf-admission-control-component-recorder` — publishes to
+
+#### Built-in Policy Set
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-component-policy-set`
+
+##### Why this component exists
+
+Built-in policies must be applied on every gated operation without parsing content per request, without a selection cost that grows with the size of the set, and without touching anything outside the process.
+
+##### Responsibility scope
+
+Compiles each configured built-in policy through the evaluation facility at startup, holding the compiled forms in an immutable set alongside a selection index keyed by resource type, with namespace-wildcard entries held separately and checked only when the exact key misses. Resolves every concrete resource type through the types registry during compilation, so an unresolvable type fails startup rather than producing a policy that never fires.
+
+##### Responsibility boundaries
+
+Holds no request state and is never rebuilt after startup. Compilation and syntax failures surface at startup, so content that will not compile never reaches a request. It does not evaluate: a failure while evaluating compiled content at request time belongs to `cpt-cf-admission-control-component-builtin-evaluator` and refuses there.
+
+##### Related components (by ID)
+
+- `cpt-cf-admission-control-component-config-validator` — built by
+- `cpt-cf-admission-control-component-builtin-evaluator` — owns data for
+
+#### Built-in Evaluator
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-component-builtin-evaluator`
+
+##### Why this component exists
+
+It is the platform's own check, and the only part of the verdict the gate decides itself.
+
+##### Responsibility scope
+
+Selects the built-in policies applicable to a request from the index by resource type and operation, exact key first and wildcard second, then evaluates each selected policy through the evaluation facility under its configured per-policy bound and the whole selection under the total bound. Where the backend checks that bound cooperatively it sets the check interval explicitly, because the overrun is one work unit wide and is charged to the gate's overhead figure rather than the engine's. Constructs the evaluation context from the request and a gate-supplied timestamp, and passes no client, connection, handle, or clock. Returns the identity of the first policy that prohibits, or nothing. Deterministic in configuration order, so two policies prohibiting the same operation always name the same one.
+
+##### Responsibility boundaries
+
+Cannot admit. A selection that produces no prohibition yields no verdict at all, which the service reads as "proceed to the engine" rather than as a permission — the distinction that keeps built-in policies from becoming an admission path. Compiles nothing: it evaluates what `cpt-cf-admission-control-component-policy-set` compiled at startup. An exceeded bound or a backend failure is not a non-match — both converge on the refusal constructor with the could-not-run cause, because a policy that could not be evaluated is one whose prohibition cannot be ruled out.
+
+##### Related components (by ID)
+
+- `cpt-cf-admission-control-component-policy-set` — depends on
+- `cpt-cf-admission-control-component-admission-service` — called by
+- `cpt-cf-admission-control-component-verdict-builder` — refuses through, on a bound exceedance or a backend failure
+
+#### Engine Client
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-component-engine-client`
+
+##### Why this component exists
+
+The engine is a remote-shaped dependency even when it is in-process, and every call to it needs a bound, a failure mapping, and a back-off state.
+
+##### Responsibility scope
+
+Resolves the configured engine's GTS instance from ClientHub once at startup and holds the handle. Forwards the caller's security context unchanged on every call, and has no path that constructs one, so the identity the engine derives is the identity the caller presented. Wraps each call in the configured timeout, maps every failure mode onto the could-not-run condition, and owns the back-off window a back-off signal opens — during which it refuses without calling.
+
+##### Responsibility boundaries
+
+Interprets no result beyond mapping it to an `EngineResult`; an engine answer it cannot map is a failure, not a guess. A deferral is mappable and is mapped, which is the point of carrying the variant before any engine emits one — an outcome the type cannot name would land in the failure funnel and be reported as an outage. Obligations pass through the mapping unexamined — the gate holds no registry of obligation identifiers and needs none, because recognising them is the enforcing gear's duty. Never retries within a request: a retry inside the caller's budget spends the caller's budget.
+
+##### Related components (by ID)
+
+- `cpt-cf-admission-control-component-verdict-builder` — calls
+- `cpt-cf-admission-control-component-config-validator` — configured by
+
+#### Verdict Builder
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-component-verdict-builder`
+
+##### Why this component exists
+
+The fail-closed property is worth having as a structural guarantee rather than as a convention observed at each call site.
+
+##### Responsibility scope
+
+The sole constructor of a Verdict. Takes a cause as a required argument for every refusal, and constructs an admission only from an engine permission. An identity mismatch is its own arm, distinct from the failure arm, because a caller asserting an identity it does not hold is a defect to be fixed in the caller rather than an outage to be retried. An engine deferral is constructed as a refusal carrying the awaiting-approval cause, from its own arm rather than from the failure arm, so the two can never be confused by a later edit; the reserved third value has no constructor at all until `cpt-cf-admission-control-fr-deferral-verdict` ships. Carries the engine's permission cause and its obligations onto the verdict without reading either. Obligations are copied by the same move that copies the cause, so there is no branch that could inspect one and no path that could drop one.
+
+##### Responsibility boundaries
+
+Performs no I/O and makes no decision of its own — it records the decision another component reached, in a form the caller can branch on. Its exclusivity is the invariant: no other module may construct a Verdict.
+
+##### Related components (by ID)
+
+- `cpt-cf-admission-control-component-admission-service` — called by
+
+#### Batch Combiner
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-component-batch-combiner`
+
+##### Why this component exists
+
+A caller admitting a plan needs one answer plus enough detail to report every fault at once.
+
+##### Responsibility scope
+
+Folds member verdicts under an absorbing refusal and collects every refused member with its cause. Enforces the configured batch bound before any member is evaluated. The fold takes one further precedence once `cpt-cf-admission-control-fr-deferral-verdict` ships — refusal absorbs, then deferral, then admission — which keeps it order-independent and matches the engine's own combination.
+
+##### Responsibility boundaries
+
+A pure fold with no I/O, so batch semantics are testable without an engine. Does not short-circuit on the first refusal, because the caller needs the complete list — the cost of continuing is bounded by the batch limit.
+
+##### Related components (by ID)
+
+- `cpt-cf-admission-control-component-admission-service` — called by
+
+#### Recorder
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-component-recorder`
+
+##### Why this component exists
+
+Every decision must leave evidence, and writing it synchronously would spend the overhead budget it is measured against.
+
+##### Responsibility scope
+
+Owns the record field set and its single builder. Appends to a bounded in-memory buffer on the decision path and drains it from a separate task, publishing to the `event-broker` audit topic. Exports buffer age and occupancy so the loss window is observable. The buffer is the only place a record is unpublished, so its occupancy is the whole of what a crash would lose — the gate holds no store behind it to recover from.
+
+Owns the serving condition of `cpt-cf-admission-control-fr-record-path-failure` and the counters behind it. When the sink is unreachable, the oldest buffered record ages past the window, or the buffer fills, it reports the condition and the admission service refuses from then on; the refusals that condition produces are counted rather than buffered, because buffering them would need the capacity whose absence caused them. When the drain recovers, the recorder publishes one gap record naming the interval and the count. That record is the only thing it emits which is not a decision, and it exists so the hole is stated by the stream rather than inferred from a thinning of it.
+
+Mints the correlation identifier at entry, before any built-in policy is evaluated and before the engine is reached, so that the identifier exists on every path that can produce a record — including the two paths on which no engine record will ever exist: a refusal by built-in policy, and a could-not-run refusal. Minting on entry rather than at record construction is what makes the identifier available to forward, and forwarding it is the whole of the join.
+
+##### Responsibility boundaries
+
+Does not decide, does not filter which decisions are recorded, and never writes a credential or a caller-supplied property value — the record type carries property names only, so exclusion is a property of the type rather than of a filtering step. Offers no path that deletes or rewrites a published record, and needs none: per `cpt-cf-admission-control-fr-subject-data-handling` the subject is written as the opaque identity-provider reference the context carries, and erasure happens at that provider without any record changing. A gear with no store can hold that position precisely because it makes no claim to rewrite anything.
+
+##### Related components (by ID)
+
+- `cpt-cf-admission-control-component-admission-service` — called by
+
+#### Operational API
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-component-operational-api`
+
+##### Why this component exists
+
+Every other component here produces a decision whose inputs an operator cannot see. A built-in policy that never fires and an engine that resolved to something unexpected are both silent failures, and this is the only place they become visible.
+
+##### Responsibility scope
+
+Registers the gear's read-only routes and its readiness check — the latter matters structurally, because the platform hangs `healthcheck` off the same capability as route registration, so a gear with no routes has no way to report readiness at all. Reports the selected engine's identity, the loaded built-in policies with their identities and match counts, the degraded state when no engine is configured, and the record-path condition of `cpt-cf-admission-control-fr-record-path-failure` together with the refusals it has produced — which is the only place those are visible, since they are the refusals deliberately kept out of the record stream.
+
+##### Responsibility boundaries
+
+Reads the built-in policy set and the engine handle and holds no state of its own. Registers no route that mutates either, which is what keeps `cpt-cf-admission-control-constraint-no-builtin-policy-api` true in the presence of a REST surface. Reports content identities and counts, never content bodies, so the surface cannot become a way to read what the platform's own policies say. Exposes no admission decision: in the in-process shape the decision surface is a typed client, and in the out-of-process shape it is projected separately over the platform transport.
+
+##### Related components (by ID)
+
+- `cpt-cf-admission-control-component-policy-set` — reads
+- `cpt-cf-admission-control-component-engine-client` — reads
+
+#### Config Validator
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-component-config-validator`
+
+##### Why this component exists
+
+Every setting here changes what the platform refuses, and a setting that silently does nothing is the failure an operator cannot detect.
+
+##### Responsibility scope
+
+Runs during the gear's init phase. Rejects unknown keys, resolves the engine identifier and every resource type a built-in policy names through the types registry, validates each built-in policy's syntax through the evaluation facility independently of evaluating it, screens the parsed form for denylisted builtins, checks that bounds are present and positive, and fails startup on any of them. The denylist screen belongs here rather than at evaluation because a builtin can be neither removed from the backend nor shadowed by anything registered over its name, so startup is the last point at which the content can still be refused.
+
+##### Responsibility boundaries
+
+Does not construct the running components, only validates and hands over the validated values, so a partially valid configuration cannot produce a partially built gate.
+
+##### Related components (by ID)
+
+- `cpt-cf-admission-control-component-policy-set` — builds
+- `cpt-cf-admission-control-component-engine-client` — configures
+
+### 3.3 API Contracts
+
+#### Admission Client
+
+- **Realizes PRD interface**: `cpt-cf-admission-control-interface-admission-client`
+- **Contracts**: `cpt-cf-admission-control-contract-admission-record`
+- **Technology**: Rust async trait registered in ClientHub without scope
+- **Location**: `gears/system/admission-control/admission-control-sdk/src/api.rs`
+
+The surface enforcing gears link. Takes the caller's security context and the request by shared reference, returns a verdict by value. The context is a parameter rather than an ambient value precisely so that a call site cannot omit it and so that the subject cannot be read from anywhere else. There is no REST projection: the only caller is in-process, and a hop would spend the caller's budget.
+
+**Endpoints Overview**:
+
+| Method | Path | Description | Stability |
+|--------|------|-------------|-----------|
+| `n/a` | `admit` | One security context and one intended operation, one verdict, with obligations relayed on an admission | stable |
+| `n/a` | `admit_batch` | Several members, one combined verdict plus per-member verdicts | stable |
+
+#### Operational REST API
+
+- **Realizes PRD interface**: `cpt-cf-admission-control-interface-operational-api`
+- **Technology**: REST over the platform API prefix, RFC 9457 problem responses
+- **Location**: `gears/system/admission-control/admission-control/src/api/rest/`
+
+Read-only. Registering it is also what gives the gear a readiness carrier, since the platform hangs `healthcheck` off the same capability as route registration.
+
+**Endpoints Overview**:
+
+| Method | Path | Description | Stability |
+|--------|------|-------------|-----------|
+| `GET` | `/admission-control/v1/status` | Selected engine identity and degraded state | stable |
+| `GET` | `/admission-control/v1/builtin-policies` | Loaded built-in policies with identities and match counts | stable |
+| `GET` | `/admission-control/v1/refusals` | Recent-window refusal counts by built-in policy identity, by could-not-run failure condition, and by identity mismatch, reported separately from engine-decided refusals; includes the refusals produced while the record path was failing, which are counted here because they are deliberately not recorded individually | stable |
+
+#### Policy Engine Plugin Contract
+
+- **Realizes PRD interface**: `cpt-cf-admission-control-interface-engine-plugin`
+- **Contracts**: `cpt-cf-admission-control-contract-gts`
+- **Technology**: Rust async trait registered in ClientHub under a GTS instance scope
+- **Location**: `gears/system/admission-control/admission-control-sdk/src/plugin_api.rs`
+
+The contract an engine implements to be selectable. The gate owns it; the [Policy Engine](../../policy-engine/docs/PRD.md) is its first implementation.
+
+**Endpoints Overview**:
+
+| Method | Path | Description | Stability |
+|--------|------|-------------|-----------|
+| `n/a` | `evaluate` | One forwarded security context and one request, the latter carrying the correlation identifier minted here; a permission with cause and obligations, a prohibition with reason, or a deferral | unstable |
+| `n/a` | `evaluate_batch` | Several requests, per-member results | unstable |
+
+### 3.4 Internal Dependencies
+
+| Dependency Gear | Interface Used | Purpose |
+|-------------------|----------------|----------|
+| Selected policy engine | Plugin contract via scoped ClientHub | Evaluating tenant-authored policy; the only component that does |
+| `types-registry` | SDK client and GTS inventory | Resolving the engine identifier and every resource type a built-in policy names, at startup; registering the plugin specification and error family |
+| `toolkit-canonical-errors` | Library | The gear's error family and the five refusal causes of `cpt-cf-admission-control-fr-refusal-cause`: refused by a built-in policy, refused by policy, awaiting approval, identity mismatch, and could-not-run |
+| `toolkit-security` | Library | Security context propagation from the enforcing gear to the engine, and the source of the subject identity the gate derives rather than believes |
+| `event-broker` | Publish to the audit topic | Durability, retention, and export of admission records; the gate holds no store, so publication is where a record becomes durable |
+
+**Dependency Rules** (per project conventions):
+- No circular dependencies
+- Always use sdk modules for inter-gear communication
+- No cross-category sideways deps except through contracts
+- Only integration/adapter gears talk to external systems
+- `SecurityContext` must be propagated across all in-process calls
+
+**Shared type ownership.** Two of the schemas this gear reads are defined elsewhere and are worth naming, because the policy engine reads the same two and neither gear may define one. The declaration a backend *build* carries — the syntax-validation and imposed-cost-bound guarantees Section 2.2 depends on, plus the sandbox-and-determinism claim the gate refuses to run without — belongs to the evaluation facility's SDK, which is the only component that knows which features a build enables and which builtins it registers. The obligation base type, whose instances are the identifiers the gate relays and the enforcing gear honours, belongs in `libs/toolkit-gts` beside the authorization permission base type: the vocabulary crosses every gear on the path, so it cannot belong to a replaceable engine, and it should not belong to this gear's SDK either, since that would make an obligation-honouring gear depend on the gate in order to name what it is honouring. The policy engine's design states the same two positions and the reasoning behind them, and its PRD Section 13 carries the ownership question with platform architecture named as the owner — one question serving both gears, since a schema either of them owned would make the other depend on it. An answer that moves a schema changes only where both gears import it from.
+
+### 3.5 External Dependencies
+
+The gate owns no database, reads no file after startup, and links the evaluation facility as an in-process library rather than reaching a service for it. It has one external system: `event-broker`, which receives every admission record. That dependency is not incidental. Because the gate stores nothing itself, publication is the point at which a record becomes durable, so the broker's acceptance — not a local write — is what `cpt-cf-admission-control-nfr-record-completeness` measures. The gate publishes asynchronously and the broker acknowledges once the record is durable in its ingest outbox, which is what lets a gear with no store of its own still hold a bounded loss window.
+
+That absence is the design's main lever on `cpt-cf-admission-control-nfr-overhead` and `cpt-cf-admission-control-nfr-availability`: a component with no external dependency cannot be slowed or stopped by one, so its own contribution to latency and to failure is bounded by its code rather than by anything it waits on. The one thing it does wait on — the engine — is a gear, not an external system, and is bounded by `cpt-cf-admission-control-fr-engine-bound`.
+
+It also has a cost, and the cost is the serving condition. Because the topic is the durability point, a broker outage is not a logging problem here as it is for the policy engine, which still has its own table to fall back on. The gate has nothing behind the buffer, so the three properties of `cpt-cf-admission-control-fr-record-path-failure` — no sampling, a bounded window, and no blocking on the decision path — stop being jointly satisfiable the moment the sink is unreachable, and the design resolves that by refusing rather than by dropping. Two consequences follow for the components. The recorder owns the condition, because buffer age is the signal and it is the only component holding it; and the refusals the condition produces are counted rather than buffered, since enqueueing them would need the capacity whose exhaustion caused them. The gap record published on recovery is what keeps the resulting hole in the stream stated rather than silent, and it is the one payload here that does not describe a single decision.
+
+### 3.6 Interactions & Sequences
+
+#### Gate an operation
+
+**ID**: `cpt-cf-admission-control-seq-gate-operation`
+
+**Use cases**: `cpt-cf-admission-control-usecase-gate-operation`
+
+**Actors**: `cpt-cf-admission-control-actor-enforcing-gear`, `cpt-cf-admission-control-actor-policy-engine`
+
+```mermaid
+sequenceDiagram
+    participant G as Enforcing gear
+    participant A as Admission service
+    participant M as Built-in evaluator
+    participant E as Engine client
+    participant P as Policy engine
+    participant R as Recorder
+    G ->> A: admit(context, request)
+    A ->> A: subject from context, refuse on mismatch
+    A ->> M: evaluate built-ins(request)
+    M -->> A: no prohibition
+    A ->> E: evaluate(context, request)
+    E ->> P: evaluate
+    P -->> E: permission + cause
+    E -->> A: EngineResult
+    A ->> A: build verdict (admitted)
+    A ->> R: enqueue record
+    A -->> G: admitted
+```
+
+**Description**: The common path. The subject is taken from the propagated context before anything else runs, so a request asserting a different identity is refused without a built-in policy being evaluated or an engine request being built. Built-in evaluation is in-process over compiled content and bounded in time, the engine call is the only wait, and the record is enqueued rather than written so that durability does not extend the measured overhead.
+
+#### Refuse by built-in policy
+
+**ID**: `cpt-cf-admission-control-seq-builtin-refusal`
+
+**Use cases**: `cpt-cf-admission-control-usecase-gate-operation`
+
+**Actors**: `cpt-cf-admission-control-actor-enforcing-gear`, `cpt-cf-admission-control-actor-platform-operator`
+
+```mermaid
+sequenceDiagram
+    participant G as Enforcing gear
+    participant A as Admission service
+    participant M as Built-in evaluator
+    participant R as Recorder
+    G ->> A: admit(context, request)
+    A ->> M: evaluate built-ins(request)
+    M -->> A: policy B7 prohibits
+    A ->> A: build verdict (refused, built-in policy B7)
+    A ->> R: enqueue record naming B7
+    A -->> G: refused, built-in policy
+```
+
+**Description**: The engine is never called. The policy's identity travels to the caller and into the record, because a refusal an operator cannot attribute to a specific built-in policy is one they cannot change.
+
+#### Refuse because the engine could not answer
+
+**ID**: `cpt-cf-admission-control-seq-engine-failure`
+
+**Use cases**: `cpt-cf-admission-control-usecase-gate-operation`
+
+**Actors**: `cpt-cf-admission-control-actor-enforcing-gear`, `cpt-cf-admission-control-actor-policy-engine`
+
+```mermaid
+sequenceDiagram
+    participant G as Enforcing gear
+    participant A as Admission service
+    participant E as Engine client
+    participant P as Policy engine
+    participant R as Recorder
+    G ->> A: admit(context, request)
+    A ->> E: evaluate(context, request)
+    E ->> P: evaluate
+    P --x E: timeout at configured bound
+    E -->> A: could-not-run
+    A ->> A: build verdict (refused, could not run)
+    A ->> R: enqueue record with failure condition
+    A -->> G: refused, could not run
+```
+
+**Description**: The same shape covers an unreachable engine, an error, an unmappable result, an absent engine, and an active back-off window. The caller can distinguish this from a policy refusal and retry it as transient, which is what `cpt-cf-admission-control-fr-refusal-cause` exists to make possible. A deferral does **not** take this shape: it is a result the engine returned, so it is mapped rather than funnelled, and it refuses with the awaiting-approval cause — a refusal no retry resolves, and therefore the one it matters most not to label transient.
+
+#### Refuse because the decision could not be recorded
+
+**ID**: `cpt-cf-admission-control-seq-record-path-failure`
+
+**Use cases**: `cpt-cf-admission-control-usecase-gate-operation`
+
+**Actors**: `cpt-cf-admission-control-actor-platform-operator`, `cpt-cf-admission-control-actor-audit-sink`
+
+```mermaid
+sequenceDiagram
+    participant G as Enforcing gear
+    participant A as Admission service
+    participant R as Recorder
+    participant K as event-broker audit topic
+    R ->> K: publish buffered records
+    K --x R: sink unreachable
+    R ->> R: oldest buffered record ages past the window
+    R -->> A: record path failing
+    G ->> A: admit(context, request)
+    A ->> A: build verdict (refused, could not run)
+    A ->> R: count, do not enqueue
+    A -->> G: refused, could not run
+    R ->> K: drain recovers, publish one gap record
+```
+
+**Description**: The gate holds no store, so the topic is where a record becomes durable and an unreachable sink is a serving condition rather than a logging problem. Refusing is what keeps `cpt-cf-admission-control-nfr-record-completeness` true instead of quietly redefining it, and the refusals produced here are counted rather than buffered because the buffer is precisely what is exhausted. Built-in policies keep applying throughout — a refusal one of them reaches is unaffected by the state of the record path — but nothing is enqueued while the condition holds, so those refusals are counted too and are named separately in the gap record. That single record on recovery is the difference between a stated hole in the audit stream and a thin patch nobody can account for.
+
+#### Gate a multi-type change
+
+**ID**: `cpt-cf-admission-control-seq-gate-batch`
+
+**Use cases**: `cpt-cf-admission-control-usecase-gate-batch`
+
+**Actors**: `cpt-cf-admission-control-actor-enforcing-gear`
+
+```mermaid
+sequenceDiagram
+    participant G as Enforcing gear
+    participant A as Admission service
+    participant M as Built-in evaluator
+    participant E as Engine client
+    participant B as Batch combiner
+    G ->> A: admit_batch(context, members)
+    A ->> A: check batch bound
+    loop per member
+        A ->> M: evaluate built-ins
+        A ->> E: evaluate where no built-in prohibited
+    end
+    A ->> B: fold member verdicts
+    B -->> A: refused, members 2 and 5
+    A -->> G: batch refused, every refused member named
+```
+
+**Description**: Built-in evaluation runs per member, and only members it does not prohibit reach the engine. It is not free — a batch multiplies built-in evaluation cost by its member count, which is why the total bound of `cpt-cf-admission-control-fr-builtin-evaluation-bounds` is applied per member rather than per batch and why the batch bound caps the whole. The fold does not short-circuit, since the caller needs the complete fault list.
+
+#### Substitute the engine
+
+**ID**: `cpt-cf-admission-control-seq-substitute-engine`
+
+**Use cases**: `cpt-cf-admission-control-usecase-substitute-engine`
+
+**Actors**: `cpt-cf-admission-control-actor-platform-operator`, `cpt-cf-admission-control-actor-types-registry`
+
+```mermaid
+sequenceDiagram
+    participant O as Platform operator
+    participant C as Config validator
+    participant T as types-registry
+    participant E as Engine client
+    O ->> C: start with new engine identifier
+    C ->> T: resolve identifier
+    T -->> C: instance
+    C ->> E: hand over validated handle
+    E -->> O: ready
+```
+
+**Description**: Substitution is a restart with a different identifier. Built-in policies are compiled from configuration, through the evaluation facility and the registry, with no reference to the engine at all, so they are unaffected — which is the mechanism behind `cpt-cf-admission-control-fr-builtin-policy-independence`. An identifier that does not resolve fails startup rather than yielding a gate with no engine.
+
+### 3.7 Database schemas & tables
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-db-none`
+
+**The gear owns no database objects.** It declares no schema, contributes no migrations, and holds no persistent state. Built-in policies live in deployment configuration and are compiled at startup; admission records are published to the `event-broker` audit topic rather than stored here, and the storage backend bound to that topic owns their retention and deletion; the engine owns everything about policy content.
+
+This is stated rather than omitted because it is a design property with consequences, not an oversight. A gate with a table would need a namespace, migrations, a backup story, and a restore-consistency argument, and it would put a store on the path of every gated operation in the platform. The absence is what makes `cpt-cf-admission-control-nfr-overhead` reachable and `cpt-cf-admission-control-constraint-no-builtin-policy-api` enforceable — there is nowhere for a runtime-authored built-in policy to be written even if someone added the endpoint.
+
+### 3.8 Deployment Topology
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-topology-in-process`
+
+Two shapes are supported, and the gear's contracts are identical in both because they are transport-agnostic.
+
+**In-process**, the shape of first release: the gate is linked into a host binary alongside its enforcing gears and the selected engine, reached through ClientHub. Every instance holds its own built-in policy set and engine handle, built independently from the same configuration, so instances need no coordination and the gate adds no cross-instance traffic. Readiness is reported as degraded rather than unready when the engine is missing, because the host is shared with the gears being gated.
+
+**Out-of-process**, required at `p3` by `cpt-cf-admission-control-fr-remote-decision-surface`: the gate runs as its own service over the platform transport, becoming independently deployable, scalable, separately securable, and independently measurable — which is the shape the availability threshold's out-of-process clause is written for. The design admits it without change because the admission client is a trait over a service that holds no in-process assumption; what a remote deployment adds is a transport binding, not a second implementation.
+
+Two costs come with it, and both are why it is `p3` rather than `p1`. Every gated operation crosses the network twice over, once into the gate and once onward to the engine if that is also remote, and no budget here or in the consuming gear accounts for either. And the readiness semantics invert: unreadiness is unsafe in-process, where it would evict the gears being gated, and safe once the gate is separately deployed. A design that picked one would be wrong in the other shape, so this one states both and ties each to the tier that requires it.
+
+## 4. Additional context
+
+### 4.1 Telemetry surface
+
+| Signal | Type | Owner | Purpose |
+|---|---|---|---|
+| Admission latency excluding engine time | Histogram | Admission service | The measured surface of `cpt-cf-admission-control-nfr-overhead`, attributable to the gate rather than to the engine |
+| Engine call latency and failures by condition | Histogram, counter | Engine client | Separates a slow gate from a slow engine, and an engine outage from a tightened policy |
+| Verdicts by cause | Counter | Verdict builder | Distinguishes built-in-policy refusals, policy refusals, and could-not-run refusals in aggregate |
+| Ungoverned share of admissions | Counter | Recorder | How much of the estate policy is silent about; this gear sees every gated operation, so the figure is complete here and nowhere else |
+| Back-off windows entered and their duration | Counter, gauge | Engine client | Makes engine-requested throttling visible rather than appearing as unexplained refusals |
+| Record buffer age and occupancy | Gauge | Recorder | Makes the bounded loss window observable, and is the control input for the serving condition rather than telemetry alone |
+| Refusals produced while the record path was failing, and gap records published | Counter | Recorder | These refusals are deliberately not recorded individually, so the counter is the only per-decision account of them; the gap-record counter is what an auditor reconciles a thin interval against |
+| Identity-mismatch refusals | Counter | Verdict builder | A rising count is a defect in a calling gear or an attempt, and either way it is neither an outage nor a policy change |
+| Built-in policies loaded, and matches per policy | Gauge, counter | Built-in policy set, built-in evaluator | A built-in policy with zero matches over a long window is either dead configuration or a guardrail nobody is testing. Also readable per policy on the operational surface, since the operator asking the question usually wants it for one policy rather than as a time series |
+| Built-in evaluation duration and bound exceedances, per policy | Histogram, counter | Built-in evaluator | Built-in evaluation is the dominant term in `cpt-cf-admission-control-nfr-overhead`, so the gate's own overhead has to be attributable to the policy that spent it; exceedances are separated because they present as could-not-run refusals rather than as errors |
+
+### 4.2 Security boundaries and threat model
+
+**Trust boundaries.** Three. The enforcing gear and its `SecurityContext` are trusted — the gate forwards identity rather than establishing it. Built-in policy content is operator-supplied and therefore more trusted than a tenant's, but it is still content the gate executes rather than data it reads, so the evaluation backend that runs it is a boundary regardless of who wrote it. The caller-supplied operation context is untrusted input, judged by built-in policies, forwarded to the engine, and never interpreted by the gate itself.
+
+| Threat | Vector | Mitigation |
+|---|---|---|
+| Enforcement bypass through a failure path | A new error branch defaults to admit | Single refusal constructor; admission unreachable from any error path |
+| Subject spoofing by a calling gear | A caller submits a request naming a subject, or a subject tenant, that its own context does not carry — obtaining a verdict for an identity that never asked, leaving an admission record that preserves the fiction, and choosing a tenant that widens what the engine's reachability check allows | `cpt-cf-admission-control-fr-request-authenticity`: the context is a required parameter, the subject is taken from it, a mismatch refuses through its own arm before any policy runs, and the same context is forwarded to the engine unchanged so the gate cannot substitute an identity even by accident |
+| An audit gap that reads as a quiet period | The sink fails, records are dropped to keep serving, and the stream simply thins — so the interval with no evidence is indistinguishable from an interval with nothing to record | `cpt-cf-admission-control-fr-record-path-failure`: the gate refuses rather than admitting what it cannot record, counts those refusals, and publishes one gap record naming the interval and the count when the drain recovers |
+| Enforcement bypass through configuration | An operator disables the gate or sets admit-on-failure | No such setting exists in the configuration type; the absent-engine case refuses rather than passes through |
+| Built-in policy silently never fires | A built-in policy names a resource type that does not resolve, or content that will not compile | Resolution and syntax validation at startup, failing startup rather than loading a dead policy; per-policy match counters expose the rest |
+| Configuration as an execution surface | A built-in policy's content reaches the network or the filesystem, making deployment configuration a remote-execution vector on the path of every gated operation | `cpt-cf-admission-control-fr-builtin-evaluation-bounds`: no capability is passed into evaluation — the backend receives the request context, the content, and a gate-supplied timestamp only. Reaching outward additionally requires an I/O builtin, so the backend build's registered builtin set is part of this boundary and is audited with it |
+| A guardrail that does not decide the same way twice | A built-in policy reads a clock or a random generator, so the platform's own rule is not reproducible and a refusal cannot be defended | Denylisted at startup by `cpt-cf-admission-control-component-config-validator`, over the parsed form; the gate supplies the evaluation timestamp so that content has no reason to read a clock |
+| Denial of service through a built-in policy | Content whose evaluation cost is unbounded, spent on every gated operation across every calling gear | Operator-configurable per-policy and total bounds, with an exceedance refusing rather than continuing; per-policy duration exported so the cost is attributable |
+| Records as a leak channel | Caller-supplied property values reach a widely readable record | The record type carries names only and has no field able to hold a value |
+| A compromised engine admits everything | The selected engine is malicious or defective | Built-in policies are applied before the engine and cannot be overridden by it, which bounds what a bad engine can permit |
+
+Network segmentation, transport security, and CORS are not applicable: the gate opens no listener and exposes no external surface.
+
+### 4.3 Testability and test strategy
+
+The decision sequence is testable without an engine, because the engine is a trait resolved through ClientHub. The built-in evaluator is not a pure function — it calls the evaluation facility — so the facility is injected too, and selection is separable from evaluation and tested on its own.
+
+| Level | Coverage |
+|---|---|
+| Unit | Built-in policy selection including wildcard precedence, batch folding, cause construction, configuration validation |
+| Integration | Full sequence against a stub engine covering permission, prohibition, back-off, and each failure condition; built-in evaluation against a real backend covering prohibition, fall-through, per-policy bound exceedance, and total bound exceedance |
+| Fault injection | The failure set enumerated by `cpt-cf-admission-control-nfr-fail-closed`; this is that requirement's named verification method. Includes a per-policy bound exceedance, a total bound exceedance, and a backend failure during built-in evaluation as distinct conditions — the only three in the set that arise in this gear's own code, and the ones the stall clause of `cpt-cf-admission-control-nfr-availability` is measured against, since a cooperative bound is what makes a stall conceivable at all. Includes the audit sink unreachable and the record buffer saturated as distinct conditions, each asserting refusal rather than admission, no record dropped or sampled, and exactly one gap record once the drain recovers |
+| Security | An authenticity test asserting that a request whose asserted subject or subject tenant disagrees with the propagated context refuses with its own cause, that no built-in policy is evaluated and no engine request is constructed, and that the record names the context's identity — run against an authenticated deployment and against an auth-disabled one whose context carries the platform default subject, so the check cannot become a dev-mode outage; a determinism test admitting the same request twice and asserting identical verdicts; a test enumerating the backend build's registered builtins that fails when one is absent from the denylist, so an upgrade adding a non-deterministic builtin breaks the build rather than a guardrail |
+| Conformance | Request-unchanged assertion on both verdicts, which is the measurable form of `cpt-cf-admission-control-nfr-non-modification` |
+| Performance | Gate-boundary latency with engine time subtracted, separating selection from evaluation; built-in evaluation cost against set size and against content complexity; achieved versus configured per-policy bound, since a cooperative check overruns and `cpt-cf-admission-control-nfr-overhead` is measured on what happened |
+| Contract | The engine plugin trait exercised through a second stub implementation, which is also the test that `cpt-cf-admission-control-usecase-substitute-engine` describes; includes a stub returning a deferral, asserting the awaiting-approval cause rather than could-not-run, and an assertion that the context the stub receives is the one the caller presented |
+| Conformance, built-in independence | The reserved-name-prefix fixture of `cpt-cf-admission-control-fr-builtin-policy-independence` run against two stub engines and against a deployment with no engine, asserting the same refusal in all three; this is what keeps the property falsifiable while the shipped built-in set is still an open question |
+
+Compile-fail coverage applies to one invariant: the verdict builder's exclusivity. If another module can construct a Verdict, the fail-closed property is convention rather than structure, and a trybuild case asserting that it cannot is the only way to keep that true as the gear grows.
+
+### 4.4 Known design risks
+
+| Risk | Consequence | Response |
+|---|---|---|
+| A backend build registers a non-deterministic builtin the denylist does not name | A platform guardrail decides differently on two identical requests. Built-in refusals are the ones an operator trusts most, so the inconsistency is attributed anywhere but to the rule | Bind the denylist to the audited build; enumerate the backend's registered builtins in a test rather than maintaining the list by hand; re-audit on upgrade. One audit serves this gear and the policy engine |
+| The cooperative evaluation bound overruns the gate's overhead budget | `nfr-overhead` is measured at p95 5 ms with built-in evaluation as its dominant term, and a bound checked between work units can overshoot by a whole unit | Set the check interval explicitly rather than inheriting it, keep the per-policy bound well inside the total, and measure the achieved figure rather than asserting the configured one |
+| Built-in evaluation cost exceeds its share of the borrowed budget | The gate's own overhead breaches `cpt-cf-admission-control-nfr-overhead` even while the engine is fast, and the breach is attributed to the gear rather than to the configuration that caused it | Keep the built-in set small, hold the per-policy bound well inside the total, and export duration per policy so the cost names its own source |
+| The built-in set grows until it needs a lifecycle | Versioning, review, and tenant scoping are wanted for built-in policies, and the gate becomes a second policy engine with a second content model | The boundary is management, not expressiveness: content may say anything the facility can express, and arrives only as deployment configuration. Treat a request to author one at runtime as a request for content in the engine |
+| Fail-closed makes the engine a platform-wide single point of failure | Every engine incident stops all gated operations, and pressure builds for a bypass | Keep the engine bound tight so an outage is detected quickly; keep the could-not-run cause retryable so callers degrade rather than fail permanently |
+| The gate is specified before either component it sits between | Its interface is settled against assumptions rather than a consumer, and defects surface at integration | Exercise the interface against Infrastructure Resource Manager's stated admission requirements and against the policy engine's decision surface, both of which are specified even though neither is built |
+| A new engine outcome falls into the failure funnel | The design converges every unmapped result on the could-not-run constructor, which is what makes fail-closed structural — and also what would silently report a deferral, or any later outcome, as an outage | Name every outcome in the engine result type before an engine emits it, deferral included from the first version; assert in the contract test that a deferral produces the awaiting-approval cause and not the could-not-run one |
+| Obligations are dropped or reordered in the relay | A conditional permission becomes an unconditional one, silently, and the enforcing gear proceeds without the condition policy attached | Copy obligations by the same move that copies the permission cause, so no branch exists that could inspect or discard one; assert relay fidelity in the contract test against a stub engine that emits them |
+| Record volume equals total gated operation volume | The audit topic becomes the platform's highest-volume stream — carrying this gear's records and the engine's — and buffer pressure appears as refusals under the serving condition | Keep the record projection small — names not values, no request copy — and export buffer age as a first-class signal rather than as a debug metric |
+
+### 4.5 Areas recorded as not applicable
+
+Stated so that absence is distinguishable from oversight. **Data storage, migrations, and backup**: the gear owns none, per Section 3.7. **Caching**: nothing on the decision path is cached, because nothing on it is fetched. **Rate limiting**: the gate performs no work proportional to request size and is bounded by the engine behind it; the platform ingress owns inbound limiting. **Infrastructure-as-code and release strategy**: host concerns, and a mixed-version fleet is safe because each instance compiles its own built-in policy set from the same configuration. **An external decision API**: not offered in the in-process shape, where the decision surface is a typed client; the out-of-process shape projects it over the platform transport, and the latency consequence is recorded as an open question rather than absorbed silently. **Event architecture**: the gate publishes admission records to the `event-broker` audit topic and nothing else — no domain events announcing its own state changes, and no subscriptions. **Advisory output**: the gate relays obligations, which arise from the policy evaluation it mediates, and carries no warning channel — consumption diagnostics and threshold crossings come from the quota path, which an enforcing gear calls itself and which this gate does not sit on. **User-experience architecture**: no end-user interface. **Cost budgets**: not modelled per gear in this repository.
+
+## 5. Traceability
+
+- **PRD**: [PRD.md](./PRD.md)
+- **ADRs**: `ADR/` — not yet created; the decisions listed in Section 1.2 land here once written
+- **Features**: `features/` — not yet created
+- **Policy engine**: [Policy Engine](../../policy-engine/docs/PRD.md) and its [DESIGN](../../policy-engine/docs/DESIGN.md), the first implementation of the plugin contract
+- **First enforcing gear**: [Infrastructure Resource Manager](../../../infrastructure-resource-manager/docs/PRD.md)
+- **Platform architecture**: [ARCHITECTURE_MANIFEST.md](../../../../docs/ARCHITECTURE_MANIFEST.md)

--- a/gears/system/admission-control/docs/PRD.md
+++ b/gears/system/admission-control/docs/PRD.md
@@ -1,0 +1,751 @@
+# PRD — Admission Control
+
+<!-- toc -->
+
+- [1. Overview](#1-overview)
+  - [1.1 Purpose](#11-purpose)
+  - [1.2 Background / Problem Statement](#12-background--problem-statement)
+  - [1.3 Goals (Business Outcomes)](#13-goals-business-outcomes)
+  - [1.4 Glossary](#14-glossary)
+- [2. Actors](#2-actors)
+  - [2.1 Human Actors](#21-human-actors)
+  - [2.2 System Actors](#22-system-actors)
+- [3. Operational Concept & Environment](#3-operational-concept--environment)
+  - [3.1 Gear-Specific Environment Constraints](#31-gear-specific-environment-constraints)
+- [4. Scope](#4-scope)
+  - [4.1 In Scope](#41-in-scope)
+  - [4.2 Out of Scope](#42-out-of-scope)
+- [5. Functional Requirements](#5-functional-requirements)
+  - [5.1 The Admission Decision](#51-the-admission-decision)
+  - [5.2 Built-in Policies](#52-built-in-policies)
+  - [5.3 Engine Selection](#53-engine-selection)
+  - [5.4 Failure Semantics](#54-failure-semantics)
+  - [5.5 Observability](#55-observability)
+  - [5.6 Configuration](#56-configuration)
+- [6. Non-Functional Requirements](#6-non-functional-requirements)
+  - [6.1 Efficiency](#61-efficiency)
+  - [6.2 Reliability](#62-reliability)
+  - [6.3 Performance](#63-performance)
+  - [6.4 Security](#64-security)
+  - [6.5 Versatility](#65-versatility)
+  - [6.6 NFR Exclusions](#66-nfr-exclusions)
+- [7. Public Library Interfaces](#7-public-library-interfaces)
+  - [7.1 Public API Surface](#71-public-api-surface)
+  - [7.2 External Integration Contracts](#72-external-integration-contracts)
+- [8. Use Cases](#8-use-cases)
+- [9. Acceptance Criteria](#9-acceptance-criteria)
+- [10. Dependencies](#10-dependencies)
+- [11. Assumptions](#11-assumptions)
+- [12. Risks](#12-risks)
+- [13. Open Questions](#13-open-questions)
+- [14. Traceability](#14-traceability)
+
+<!-- /toc -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+Admission Control is the platform's gate on management operations. A gear about to perform an operation asks it one question — may this proceed — and receives one answer. The gate answers by applying the platform's own rules and by consulting the policy engine the deployment has selected, and it never modifies the operation it is asked about.
+
+The gear is deliberately small. It owns no policy content, offers no authoring surface, and holds no lifecycle: policy content and its management belong to the policy engine behind it, which is replaceable. What the gate owns is the question, the answer, the failure semantics, and the built-in policies that hold regardless of which engine is selected.
+
+### 1.2 Background / Problem Statement
+
+Management gears each decide for themselves whether an operation may proceed. [Infrastructure Resource Manager](../../../infrastructure-resource-manager/docs/PRD.md) states the consequence in its own requirements: enforcement across the estate was inconsistent and left audit gaps, which is why it now demands that every operation be policy-gated, and why it declares an abstract Policy Decision Service actor rather than a concrete one.
+
+Two things are missing between that demand and anything that could satisfy it. There is no single interception point a gear can call — so every gear that wants gating invents its own, and the platform cannot say what is gated or how. And there is nowhere to put rules the platform enforces for everyone: rules that must hold whichever policy engine a deployment selected, and that no tenant administrator can withdraw.
+
+The [Policy Engine](../../policy-engine/docs/PRD.md) supplies decisions but is not that interception point. It is one selectable engine, it evaluates tenant-authored content, and a deployment may replace it. A built-in policy stored inside it leaves with it. This gear is the seam that stays.
+
+**Boundary with `serverless-runtime`.** One gear already gates its own dispatch path, and the overlap is worth stating before two components answer the same question with different models. `serverless-runtime` consults a host-owned Tenant Policy Manager before dispatching to a runtime plugin, and that component holds five things: tenant enablement, quotas with their usage tracking, retention policies, a runtime allowlist naming which plugin types a tenant may invoke, and default limits for new functions. Three of the five are not this gate's to take. Quotas and usage tracking are allowance state, owned by `quota-enforcement` and called by the enforcing gear itself; Section 4.2 keeps this gate off that path entirely. Retention policies and default limits are that gear's own resource defaults, and a defaulting rule cannot move here at any tier, because the gate returns a judgement and never a modified request. The other two are genuinely admission: enablement and the runtime allowlist are judgements about whether an operation may proceed, which makes them the class that belongs in policy content in the engine where a tenant authors it, or in a built-in policy where the platform enforces it for everyone. Nothing moves on this document's say-so — that is `serverless-runtime`'s own integration decision, and Section 13 records it as a question owned by that gear.
+
+### 1.3 Goals (Business Outcomes)
+
+Milestones refer to this document's own priority tiers — "p1 complete" means every `p1` requirement in Sections 5 and 6 is met and verified.
+
+| Outcome | Baseline | Target | By |
+|---|---|---|---|
+| A gear reaches policy through one platform interface rather than its own check | Each gear invents its own policy check, or omits one | One interface, exercised for the policy question on every operation an enforcing gear declares as gated | p1 complete |
+| The platform can state rules that hold whichever engine is selected | Built-in policies can only live inside a replaceable engine | Built-in policies are applied on every gated operation and survive substitution of the engine | p1 complete |
+| An operation is never admitted because a check could not run | No defined behaviour; each gear improvises | Zero admissions across the complete set of injected failure conditions | p1 complete |
+| What the platform gates is knowable | No record of which operations were gated or how they were decided | Every admission decision is recorded with its cause and the identity of what decided it | p1 complete |
+| Replacing the policy engine does not disturb the gears that call the gate | Not applicable — no gate, no engine contract | The calling interface is unchanged by substitution of the engine behind it | p2 complete |
+
+### 1.4 Glossary
+
+| Term | Definition |
+|------|------------|
+| Admission | The act of permitting or refusing a management operation before it takes effect. |
+| Gate | This gear. The single point at which the platform decides whether a management operation may proceed. It issues the verdict; it does not carry it out. |
+| Enforcing Gear | A management gear that calls the gate before performing an operation and enforces the answer. The policy enforcement point: the only component that can actually stop the operation. Infrastructure Resource Manager first among them. |
+| Policy Engine | The pluggable component that evaluates tenant-authored policy and returns a decision. Exactly one is selected per deployment. |
+| Built-in Policy | A rule this gear applies itself, supplied by deployment configuration, enforced for every tenant, and independent of which policy engine is selected. |
+| Verdict | The gate's answer to an enforcing gear: admitted or refused, with a third value reserved for a deferral by `cpt-cf-admission-control-fr-deferral-relay` and served once `cpt-cf-admission-control-fr-deferral-verdict` ships. |
+| Deferral | An engine outcome that neither permits nor prohibits, but holds the operation for human approval. The gate relays it; it never routes it to an approver and never resolves one. |
+| Governed / Ungoverned | The cause the policy engine attaches to a permission, stating whether policy considered the operation or was silent about it. The gate records it and does not branch on it. |
+| PDP / PEP / PAP | Policy Decision Point, Policy Enforcement Point, Policy Administration Point. This gear is a decision point: it decides its built-in policies itself and delegates every tenant-authored question to the selected engine, which is the decision and administration point for that content. The **enforcing gear is the PEP** — it is the only component able to stop the operation, and Section 11 records that this gear cannot detect one that asks and then proceeds regardless. The gear's name follows the established term for this component in comparable systems and is not a claim to be the enforcement point. |
+| GTS | Global Type System. Provides the identifiers used for resource types, plugin instances, and error codes. |
+
+## 2. Actors
+
+> **Note**: Stakeholder needs are managed at project/task level by steering committee. Documented below are the actors that interact with this gear.
+
+### 2.1 Human Actors
+
+#### Platform Operator
+
+**ID**: `cpt-cf-admission-control-actor-platform-operator`
+
+- **Role**: Configures the gate: which policy engine is selected, what built-in policies apply, and what bounds the gate enforces on the engine. Responds to admission latency and availability incidents.
+- **Needs**: Configuration validated at startup rather than discovered at first traffic; visibility into what is being refused and by what; predictable behaviour when the engine is unavailable.
+
+#### Security Auditor
+
+**ID**: `cpt-cf-admission-control-actor-security-auditor`
+
+- **Role**: Reviews after the fact which operations were gated, which were refused, and whether the gate was ever bypassed or degraded.
+- **Needs**: A record for every gated operation, including those refused because a check could not run, distinguishable from those refused by a rule.
+
+### 2.2 System Actors
+
+#### Enforcing Gear
+
+**ID**: `cpt-cf-admission-control-actor-enforcing-gear`
+
+- **Role**: A management gear that calls the gate before an operation and enforces the verdict. Supplies the operation context; receives admitted or refused. Does not reach the policy engine directly.
+
+#### Policy Engine
+
+**ID**: `cpt-cf-admission-control-actor-policy-engine`
+
+- **Role**: The selected engine. Receives an evaluation request from the gate, returns a permission or a prohibition, and is the only component that evaluates tenant-authored policy. Exactly one is active per deployment, and it is replaceable.
+
+#### Types Registry
+
+**ID**: `cpt-cf-admission-control-actor-types-registry`
+
+- **Role**: Resolves the GTS identifier naming the selected policy engine, and the resource-type identifiers built-in policies and requests refer to.
+
+#### Admission Record Sink
+
+**ID**: `cpt-cf-admission-control-actor-audit-sink`
+
+- **Role**: Receives the admission records this gear emits, for retention, export, and analysis. The sink is `event-broker`: records are published to a platform-scoped audit topic whose bound storage backend owns retention, compaction, and deletion. `policy-engine` publishes its decision records to the same topic, so one stream carries both what was gated and how policy decided it. Because this gear owns no database, the topic is where its records become durable rather than a copy of state it already holds — a refusal by built-in policy and a could-not-run refusal exist nowhere else.
+
+## 3. Operational Concept & Environment
+
+> Project-wide runtime, operating system, architecture, lifecycle policy, and integration patterns are defined at the repository level in [ARCHITECTURE_MANIFEST.md](../../../../docs/ARCHITECTURE_MANIFEST.md) and the foundational [guidelines/](../../../../guidelines/). This gear has no parent gear PRD. Only gear-specific constraints appear below.
+
+### 3.1 Gear-Specific Environment Constraints
+
+- The gate is on the path of every operation an enforcing gear declares as gated. Its latency is added to that gear's, and because it fails closed, its unavailability presents as refusal of those operations rather than as a degraded feature.
+- The gate composes in-process, the platform's default execution mode: it, its enforcing gears, and the selected policy engine share one runtime and communicate through typed clients. Every `p1` requirement here is written for that shape.
+- Running the gate as its own service over the platform's remote transport is a separate capability, required at `p3` by `cpt-cf-admission-control-fr-remote-decision-surface`. The contracts do not change, because they are transport-agnostic; what changes is that the decision surface acquires a network projection, the latency figures in Section 6 stop applying, and unreadiness becomes a safe signal because removing the gate from rotation no longer removes the gears it gates.
+- The operational surface of `cpt-cf-admission-control-fr-operational-surface` is present regardless of which of the two the deployment composes.
+- The gate holds no persistent state of its own beyond its records. Built-in policies arrive as deployment configuration and are versioned with the deployment, not through an API.
+- The gate is one step inside an enforcing gear's own admission sequence, not a replacement for it. Infrastructure Resource Manager's pipeline may enrich a request with defaults before or after calling the gate; the gate itself never modifies anything.
+
+## 4. Scope
+
+### 4.1 In Scope
+
+- A single admission interface: one operation in, admitted or refused out.
+- Selection of exactly one policy engine per deployment, and the contract that engine implements.
+- Built-in policies: their form, their application, and their precedence over the engine's answer.
+- Failure semantics: what happens when the engine is unavailable, times out, or errors, and what happens when the audit sink is unavailable or the record buffer saturates.
+- Batch admission, where an enforcing gear needs one verdict over a change touching several resource types.
+- Admission records covering every gated operation, and the metrics over them.
+- Bounds the gate places on the engine, and back-off behaviour when the engine asks for it.
+- Configuration and its validation.
+
+### 4.2 Out of Scope
+
+- Policy content, its authoring, its lifecycle, its versioning, and its assignment to tenants. These belong to the policy engine, and this gear neither stores nor manages them.
+- Evaluation of tenant-authored policy. The gate evaluates its own built-in policies and delegates every tenant-authored question to the engine.
+- Modification of the operation being admitted. The gate is a judgement, never a rewrite: it produces no defaults, no injected fields, and no substitutions. Generating and mutating policy, in the sense Kyverno uses those terms, is excluded at every priority tier rather than deferred to one.
+- The enforcing gear's own admission sequence, including any enrichment it performs. The gate is one step within it.
+- Authorization: whether a subject may act on a resource at all. That is a different question, owned by `authz-resolver`, and reaching the gate does not answer it.
+- Quota and allowance state, owned by `quota-enforcement`, together with the advisory output that arises there. Consumption diagnostics come from that gear's own read surfaces, and threshold-crossing warnings are events it emits to sinks registered with it rather than values returned on a verdict. Neither travels with a policy decision, and this gate does not sit on the quota path at all: an enforcing gear calls quota itself, and Infrastructure Resource Manager orders that call before policy. Obligations differ: they arise from the policy evaluation this gate does mediate, and `cpt-cf-admission-control-fr-admission-interface` requires them relayed.
+- Combining verdicts from several policy engines. Exactly one engine is selected per deployment.
+- The tenant-level governance `serverless-runtime` keeps local. Its quotas and usage tracking belong to `quota-enforcement`, which this gate does not sit on; its retention policies and per-function default limits are that gear's own resource defaults and could not move here at any tier, because the gate produces no defaults and returns no modified request. Section 1.2 divides that component's five concerns and identifies the two that are admission questions; moving them is that gear's decision, not this document's.
+- Approval workflow for a deferred operation: requesting an approval, notifying an approver, storing a pending operation, resolving it, or expiring it. The gate relays a deferral per `cpt-cf-admission-control-fr-deferral-relay` and nothing more. Where a deferral terminates is an open question in Section 13 and in the engine's own requirements, and it belongs to `approval-service`, which has [upstream requirements](../../../approval-service/docs/UPSTREAM_REQS.md) but no design and no implementation.
+
+## 5. Functional Requirements
+
+> **Testing strategy**: All requirements are verified via automated tests targeting 90 percent or greater code coverage unless otherwise specified. Verification method is documented only where a non-test approach applies.
+
+### 5.1 The Admission Decision
+
+#### Single Admission Interface
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-admission-interface`
+
+The system **MUST** expose one operation by which an enforcing gear submits an intended operation and receives a verdict of admitted or refused. The verdict **MUST** be the whole of the answer: the system **MUST NOT** return a modified request or a partial result. An admitted verdict **MUST** carry, unaltered, any obligations the selected engine attached to its permission; the system **MUST NOT** interpret, validate, add to, or drop them.
+
+- **Rationale**: One interface is the point of the gear. A gate that answers in more than one shape becomes a component each caller integrates differently, which is the condition the platform is trying to leave. Refusing to return modifications is what keeps the caller's own sequence in the caller's hands. Obligations are the one thing that travels through rather than stopping here: they are the engine's instruction to the enforcing gear, not the gate's, and Infrastructure Resource Manager requires them delivered unaltered. A gate that dropped them would silently convert a conditional permission into an unconditional one.
+- **Actors**: `cpt-cf-admission-control-actor-enforcing-gear`
+
+#### Request Authenticity
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-request-authenticity`
+
+The system **MUST** require the calling gear's propagated security context on every admission and every batch, and **MUST** refuse a call that arrives without one. The subject and the subject's tenant **MUST** be taken from that context rather than believed from the request: where the request also carries them, the system **MUST** compare them against the context and **MUST** refuse a mismatch with the identity-mismatch cause of `cpt-cf-admission-control-fr-refusal-cause`, before any built-in policy is evaluated and without reaching the engine. The record of such a refusal **MUST** name the identity the context carries, and **MUST** record that a different one was asserted.
+
+The system **MUST** propagate that same context to the selected engine unchanged, and **MUST NOT** construct an evaluation request carrying an identity the caller did not present. The gate holds no delegated authority of its own and therefore offers no on-behalf-of mode — nor does the platform define one: the security context carries no actor field, and the two-plane authentication decision has tenant-scoped work initiated by a system actor carry an ordinary tenant context of its own, from a service-to-service token, rather than replaying the identity of whoever asked. An enforcing gear performing deferred work is consequently gated as the service it is, and the subject who requested the work is reachable through the correlation identifier on the earlier record rather than by asserting that subject here.
+
+Where a deployment runs with authentication disabled, the derived identity is the anonymous context's default subject and tenant, and a request **MUST NOT** assert a different one there either. The comparison is unconditional rather than configurable: disabling authentication changes which subject the context carries, never whether the request's own subject is believed instead.
+
+- **Rationale**: The gate decides whether an operation may proceed and its records are how the platform later says who asked, so both rest on identity — and `cpt-cf-admission-control-fr-admission-interface` accepts the subject as part of the request, which makes it a value the caller chooses. Left as data, a caller could obtain a verdict for a subject and a tenant that never asked, and the admission record would faithfully preserve the fiction; it would also let a caller name a subject tenant that widens what the engine's own reachability check permits. Taking identity from the context makes those fields a restatement of something already authenticated, and comparing rather than silently overwriting keeps a caller's defect visible instead of absorbed — a mismatch is either a bug in the calling gear or an attempt, and both are worth seeing. Propagating the same context onward is the other half: the engine derives the subject from it too, so a gate that substituted an identity would hand the engine a decision to make about someone who never asked and leave two records neither component could defend. Section 11 already assumed identity arrived established upstream; this makes it something the gate enforces rather than something it inherits.
+- **Actors**: `cpt-cf-admission-control-actor-enforcing-gear`, `cpt-cf-admission-control-actor-policy-engine`, `cpt-cf-admission-control-actor-security-auditor`
+
+#### Decision Order
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-decision-order`
+
+The system **MUST** apply built-in policies before consulting the policy engine, and **MUST** refuse without consulting the engine where a built-in policy refuses. Where no built-in policy refuses, the system **MUST** consult the engine and **MUST** admit only where the engine permits.
+
+- **Rationale**: Built-in policies are not overridable by tenant policy, so an engine that permits cannot rescue an operation a built-in policy refuses — and consulting it anyway spends the latency budget on an answer that cannot change the verdict. Ordering the cheap, local, non-overridable check first is both correct and the only ordering that saves work.
+- **Actors**: `cpt-cf-admission-control-actor-enforcing-gear`, `cpt-cf-admission-control-actor-policy-engine`
+
+#### Refusal Cause
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-refusal-cause`
+
+Every refusal **MUST** carry a machine-readable cause drawn from the platform's error type system, distinguishing at minimum: refused by a built-in policy, refused by policy, refused because the operation awaits approval per `cpt-cf-admission-control-fr-deferral-relay`, refused because the request asserted an identity the caller's own context does not carry per `cpt-cf-admission-control-fr-request-authenticity`, and refused because a check could not run. A refusal by a built-in policy **MUST** identify that policy; a refusal by policy **MUST** carry the reason the engine supplied.
+
+- **Rationale**: The causes demand different responses. A platform-rule refusal is permanent until configuration changes, a policy refusal is a tenant's own rule and may be corrected by editing content, an awaiting-approval refusal is neither wrong nor broken and clears when a person acts, and a could-not-run refusal is an incident and is retryable. An identity-mismatch refusal is none of those — it is a defect in the calling gear, or an attempt, and it is fixed by correcting the caller rather than by retrying, editing content, or waiting for a person. A caller that cannot tell them apart either retries what will never succeed or gives up on what would.
+- **Actors**: `cpt-cf-admission-control-actor-enforcing-gear`, `cpt-cf-admission-control-actor-platform-operator`
+
+#### Deferral Relay
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-deferral-relay`
+
+The policy engine plugin contract **MUST** carry a deferral alongside a permission and a prohibition from its first version, whether or not any selected engine emits one, and the verdict **MUST** reserve the corresponding third value unpopulated.
+
+Until `cpt-cf-admission-control-fr-deferral-verdict` ships, the system **MUST** map an engine deferral to a refusal carrying the awaiting-approval cause of `cpt-cf-admission-control-fr-refusal-cause`. It **MUST NOT** map a deferral to the could-not-run cause, to a refusal by policy, or to an admission. A deferral is a mapped engine result, so it is not the unmappable result enumerated in the threshold of `cpt-cf-admission-control-nfr-fail-closed`, and the fault-injection set **MUST NOT** treat it as one.
+
+- **Rationale**: The engine can already produce a third outcome — `cpt-cf-policy-engine-fr-deferral-outcome` makes the result three-valued — while this gear's verdict is two-valued, and the gate's own rule for a result it cannot map is to refuse with the could-not-run cause. Composed, those two turn "a person must approve this" into "the system is broken, retry", which is the precise conflation the engine's own requirement exists to prevent: a caller reading could-not-run retries a decision that no retry can change, and the approval it is waiting for is never requested because nothing told the caller one was needed. Carrying the deferral in the plugin contract from the first version is the same discipline the obligation collection already follows in `cpt-cf-admission-control-interface-engine-plugin` — a shape every engine implements is one that cannot be widened later without breaking all of them — and it is cheaper here than there, because the engine that will emit deferrals is specified today. Mapping it to a distinguishable refusal in the meantime is the honest interim: the operation genuinely does not proceed, so refusing is correct, and a caller that only understands refusals is still safe. What the distinct cause buys is that the refusal is not mistaken for an outage in the metrics of `cpt-cf-admission-control-fr-metrics`, and that a caller able to raise an approval knows to.
+- **Actors**: `cpt-cf-admission-control-actor-policy-engine`, `cpt-cf-admission-control-actor-enforcing-gear`, `cpt-cf-admission-control-actor-platform-operator`
+
+#### Batch Admission
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-batch-admission`
+
+The system **MUST** accept several intended operations as one batch and **MUST** return one verdict for the batch alongside the individual verdicts, such that a refusal of any member refuses the batch. The response **MUST** identify every refused member rather than only the first. Where a member defers, `cpt-cf-admission-control-fr-deferral-verdict` governs how it combines; until that requirement ships a deferral is a refusal and combines as one.
+
+- **Rationale**: An enforcing gear admitting a plan needs one answer for the plan, and needs it to match what a preview of the same plan returned. Per-member calls multiply the fixed cost of an admission across the plan and leave the caller to combine partial answers, which is where two callers begin combining them differently.
+- **Actors**: `cpt-cf-admission-control-actor-enforcing-gear`
+
+#### Three-Valued Verdict
+
+- [ ] `p3` - **ID**: `cpt-cf-admission-control-fr-deferral-verdict`
+
+The system **MUST** serve the third verdict value reserved by `cpt-cf-admission-control-fr-deferral-relay`, returning a deferral distinguishably from both an admission and a refusal, and **MUST NOT** admit an operation it defers. In a batch, a deferral **MUST** combine as follows: any refused member refuses the batch; otherwise any deferred member defers it; otherwise the batch is admitted. The system **MUST NOT** route the deferral to an approver, request an approval, or hold the operation open awaiting one.
+
+Serving this value changes what a caller can receive from a stable interface, so it **MUST** be a major version of `cpt-cf-admission-control-interface-admission-client`, and the tier of this requirement **MUST** track `cpt-cf-policy-engine-fr-deferral-outcome` — there is nothing to serve while no engine emits a deferral.
+
+- **Rationale**: A deferral is not a refusal: the operation proceeds once someone approves it, and a caller told "refused" has no reason to wait for that. Serving it as its own value is what lets an enforcing gear hold the request rather than abandon it. The combination rule mirrors the engine's, so a batch cannot be admitted whole while one member waits on a person, and prohibition still absorbs — a deferral cannot rescue an operation policy prohibits. Withholding the routing is the boundary: an approval flow needs a store, a lifetime, a notification path, and an actor who answers, none of which this gear has, and a gate that held operations open would acquire per-request state it is built without. This is `p3` for the same reason the engine's outcome is — nothing in the tree routes a deferral to an approver, so the value would be served to no one.
+- **Actors**: `cpt-cf-admission-control-actor-enforcing-gear`, `cpt-cf-admission-control-actor-policy-engine`
+
+#### Remote Decision Surface
+
+- [ ] `p3` - **ID**: `cpt-cf-admission-control-fr-remote-decision-surface`
+
+The system **MUST** be able to serve its admission decision over the platform's remote transport, so that a deployment can run the gate as a service separate from the gears it gates. The semantics **MUST NOT** differ from the in-process surface: the same verdicts, the same causes, the same failure behaviour, and the same refusal to modify a request.
+
+- **Rationale**: A deployment may want the gate isolated for scaling, for separate securing, or for reach from something that cannot link it. Nothing in the design prevents this — the contracts carry no in-process assumption — but a capability nothing requires is a capability nobody verifies, and the difference between "possible" and "supported" is a conformance test. It is `p3` because no consumer has asked for it and because the latency question it raises has no answer yet: two transport round trips, one into the gate and one onward to the engine, against a consumer budget that reserves nothing for either.
+- **Actors**: `cpt-cf-admission-control-actor-platform-operator`, `cpt-cf-admission-control-actor-enforcing-gear`
+
+### 5.2 Built-in Policies
+
+#### Built-in Policy Form
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-builtin-policy-form`
+
+The system **MUST** apply built-in policies supplied as deployment configuration, and **MUST** evaluate them itself through the platform's shared evaluation facility rather than delegating them to the selected policy engine. Their content is policy content in the language a backend of that facility accepts; this gear defines no language of its own.
+
+A built-in policy **MUST** yield either a prohibition or nothing. It **MUST NOT** yield a permission: an outcome that is not a prohibition leaves the decision to the selected engine, per `cpt-cf-admission-control-fr-decision-order`.
+
+The system **MUST NOT** offer an API by which built-in policies are created, modified, or withdrawn.
+
+- **Rationale**: Built-in policies are the platform's own, and they need the same expressive power as anything a tenant could write — a platform invariant that cannot state a condition is not much of an invariant. Evaluating them here rather than in the engine is what makes them survive substitution of that engine, which is the whole reason they are not simply content assigned at the root tenant. Confining them to prohibition keeps the precedence story sound: a built-in that could permit would let deployment configuration overrule a tenant's own rules in the permissive direction, which is the one direction a platform guardrail should never travel. Withholding a management API is not an omission but the boundary itself: the moment built-in policies become authorable at runtime, this gear is a second policy engine.
+- **Actors**: `cpt-cf-admission-control-actor-platform-operator`
+
+#### Built-in Policies Are Not Overridable
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-builtin-policy-precedence`
+
+A refusal by a built-in policy **MUST NOT** be overridable by policy content, by a tenant administrator, or by any request parameter. Built-in policies **MUST** apply to every tenant and to every enforcing gear identically.
+
+- **Rationale**: A rule a tenant can withdraw is a tenant's rule. The reason for keeping these outside the policy engine is that the engine is replaceable and its content is administrable; a built-in policy that inherited either property would not be a built-in policy. This is also the requirement that makes the gear's existence load-bearing rather than a convenience: without it, everything here could live in the engine.
+- **Actors**: `cpt-cf-admission-control-actor-platform-operator`, `cpt-cf-admission-control-actor-security-auditor`
+
+#### Built-in Policies Survive Engine Substitution
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-builtin-policy-independence`
+
+The system **MUST** apply built-in policies identically whichever policy engine is selected, and **MUST** continue to apply them when no engine is selected at all.
+
+Verification **MUST** use at least one concrete built-in policy as a fixture rather than an empty set, and **MUST** exercise that fixture against two different engines and against a deployment with no engine. The reserved-name-prefix candidate described below is that fixture until a shipped built-in supersedes it: nothing in this requirement depends on which policy the platform eventually chooses, and waiting for that choice would leave the property permanently unverified.
+
+- **Rationale**: This is what "built-in" means, and it is the one property that could not be obtained by assigning a bundle at the root tenant of the policy engine. A deployment that substitutes a vendor engine, or that runs before any engine is configured, still gets the platform's own rules. The fixture is part of the requirement rather than a note on it, because an empty built-in set makes the property unfalsifiable: there is nothing whose survival across a substitution can be observed, and a requirement nothing can contradict is not being met, only unchallenged.
+- **Verification Method**: Conformance test over the named fixture against two stub engines and against an engine-less deployment.
+- **Actors**: `cpt-cf-admission-control-actor-platform-operator`
+
+#### Built-in Evaluation Bounds
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-builtin-evaluation-bounds`
+
+The system **MUST NOT** pass any capability into the evaluation of a built-in policy: the backend receives the request context, the policy content, and an evaluation timestamp the gate supplies, and nothing else. The system **MUST** bound the wall-clock time spent evaluating a single built-in policy and the time spent on all of them for one admission, **MUST** make both bounds operator-configurable, and **MUST** treat an exceeded bound as a failure that refuses per `cpt-cf-admission-control-fr-fail-closed`. Where the backend's bound is checked cooperatively between units of work rather than preemptively, the configured figure is an upper bound plus one such unit, and `cpt-cf-admission-control-nfr-overhead` is measured against the achieved figure rather than the configured one.
+
+A built-in policy **MUST NOT** reference a non-deterministic builtin — a clock reader, a random number or identifier generator — and `cpt-cf-admission-control-fr-configuration-validation` **MUST** reject one that does. The gate supplies the evaluation timestamp precisely so that content need not read a clock, and a built-in policy whose verdict varies between two identical requests is a platform guardrail nobody can reproduce, review, or reason about.
+
+- **Rationale**: Once the gate evaluates rather than matches, it acquires the exposure the policy engine already carries: content that could reach the network would make configuration a remote-execution surface, and content whose cost is unbounded would make one badly written built-in a platform-wide latency problem on the path of every gated operation. The bounds are separate from the engine's because they are spent from a different budget — the gate's own overhead, before the engine is called at all.
+- **Actors**: `cpt-cf-admission-control-actor-platform-operator`
+
+**Candidate built-in policies (illustrative).** Section 13 asks which built-in policies the platform ships and the question is open, but naming a candidate costs nothing and buys the fixture `cpt-cf-admission-control-fr-builtin-policy-independence` needs: **reserved resource-name prefixes** — refusing any operation that would create or rename a resource whose name begins with a prefix the platform reserves for itself. It is a plausible first built-in and a good fixture for the same four reasons. It decides from the request alone, so it needs no state the gate does not have. It is a platform invariant no tenant should be able to withdraw, which is what makes it a built-in rather than content assigned at the engine's root tenant. It is expressible in any language the facility's backends accept. And it is deterministic, so it satisfies `cpt-cf-admission-control-fr-builtin-evaluation-bounds` without special handling. Naming it neither ships it nor closes the question — what it does is give the independence requirement something it can be false about.
+
+### 5.3 Engine Selection
+
+#### Single Engine Selection
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-engine-selection`
+
+The system **MUST** select exactly one policy engine, discovered through the types registry by its GTS identifier, and **MUST** select deterministically where more than one candidate is registered, following the platform's plugin priority convention. The system **MUST NOT** consult more than one engine for a decision.
+
+- **Rationale**: One engine at a time is how this platform composes plugins everywhere else, and it is what keeps the gate free of a verdict-combination model, an ordering model, and per-engine failure policy — none of which any consumer has asked for. Deterministic selection matters because a gate that resolves a different engine on two instances of the same deployment produces different verdicts for the same operation.
+- **Actors**: `cpt-cf-admission-control-actor-types-registry`, `cpt-cf-admission-control-actor-policy-engine`
+
+#### Absent Engine
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-absent-engine`
+
+Where no policy engine can be selected, the system **MUST** apply built-in policies and **MUST** refuse every operation those rules do not already refuse, carrying the could-not-run cause. The system **MUST** report the condition on its operational surface as degraded, and **MUST NOT** report it as an unreadiness that removes its host from rotation.
+
+Where a configured engine identifier cannot be resolved at startup, the system **MUST** fail to start. The two conditions are distinct: no engine configured is a deployment that has not finished being set up, and an engine configured but unresolvable is a deployment that is wrong.
+
+- **Rationale**: A deployment with no engine is misconfigured, not permissive, so refusing is correct. Reporting it as unreadiness is not: in the in-process shape the gate shares a host with the gears it gates, so failing readiness would evict their serving surfaces from rotation over a dependency only this gear needs. The platform's guidance on that method says the same — report a dependency outage as degraded and reserve unreadiness for what the gear itself cannot serve through, which this is not, because built-in policies still apply. Separating the unresolvable-identifier case is what keeps a typo from becoming a silently engine-less deployment: applying built-in policies regardless is what `cpt-cf-admission-control-fr-builtin-policy-independence` requires, and it is not licence to run without the engine someone asked for.
+- **Actors**: `cpt-cf-admission-control-actor-platform-operator`
+
+#### Engine Result Interpretation
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-engine-result`
+
+The system **MUST** admit where the engine returns a permission and **MUST** refuse where it returns a prohibition, without regard to the cause the engine attaches to a permission. A deferral is neither, and is governed by `cpt-cf-admission-control-fr-deferral-relay`. The system **MUST** record that cause verbatim and **MUST NOT** branch on it — not on ungoverned versus governed, and not on any further cause the engine's own closed set may come to carry, since the set belongs to the engine and this gear only relays it.
+
+- **Rationale**: The engine's answer is already the verdict; re-deciding it here would put policy semantics in a gear that owns no policy. The cause is worth recording because it is how an operator learns what share of the estate policy is silent about, but branching on it would mean the gate deciding that silence is refusal — a policy judgement, made in the wrong component, and one that would refuse every operation in a deployment that has authored nothing.
+- **Actors**: `cpt-cf-admission-control-actor-policy-engine`, `cpt-cf-admission-control-actor-enforcing-gear`
+
+### 5.4 Failure Semantics
+
+#### Fail Closed on Engine Failure
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-fail-closed`
+
+Where the selected engine is unreachable, exceeds its bound, or returns an error, the system **MUST** refuse the operation with the could-not-run cause. The system **MUST NOT** admit an operation it was unable to have evaluated, and **MUST NOT** expose configuration that converts an engine failure into an admission.
+
+- **Rationale**: An operation admitted because a check failed is an operation nobody checked, and the failure is invisible precisely when it matters. Refusing makes an engine outage a loud, bounded, retryable condition rather than a silent lapse in enforcement. Withholding a bypass switch is deliberate: a documented way to turn enforcement off is a way that gets left on.
+- **Actors**: `cpt-cf-admission-control-actor-enforcing-gear`, `cpt-cf-admission-control-actor-platform-operator`
+
+#### Engine Call Bound
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-engine-bound`
+
+The system **MUST** bound the time it waits on the engine, **MUST** make the bound operator-configurable with a documented default, and **MUST** treat an exceeded bound as an engine failure.
+
+- **Rationale**: The fail-closed requirement presupposes a bound to exceed. Without one a hung engine stalls the calling gear's request rather than refusing it, turning a bounded outage into an unbounded one and consuming the caller's own budget while it waits.
+- **Actors**: `cpt-cf-admission-control-actor-platform-operator`
+
+#### Honour Engine Back-Off
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-engine-backoff`
+
+Where the engine signals that it is refusing transiently and asks callers to back off, the system **MUST** reduce the rate at which it calls that engine for the stated interval, and **MUST** continue to refuse operations during it rather than admitting them.
+
+- **Rationale**: The engine refuses transiently when it cannot record what it decides, and a gate that retried at full rate would amplify load on the storage already failing. Continuing to refuse while backing off is what keeps the back-off from becoming an admission path.
+- **Actors**: `cpt-cf-admission-control-actor-policy-engine`
+
+### 5.5 Observability
+
+#### Admission Records
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-admission-records`
+
+The system **MUST** emit a record for every admission decision, with the one accounted exception `cpt-cf-admission-control-fr-record-path-failure` defines — an interval in which the gate refuses because it cannot publish, summarised by a single gap record instead. Within this gear, this requirement owns the normative field set and no other requirement here restates it; the engine's own decision record is governed by `policy-engine` and is neither restated nor constrained here. Every record **MUST** carry:
+
+- a correlation identifier the system **MUST** mint per gated operation, and the batch identifier where the decision was part of a batch. The system **MUST** supply both to the engine on the evaluation request, and **MUST NOT** derive either from a value the calling gear or its client controls
+- the calling enforcing gear
+- the subject and the subject's tenant, as the opaque identity-provider references of `cpt-cf-admission-control-fr-subject-data-handling`
+- the action, the resource type, and the resource identifier where the request named one
+- the verdict
+- the cause, and for a refusal by built-in policy the identity of that policy, for a refusal by policy the engine's reason, and for a could-not-run refusal the failure condition
+- for an admission, the permission cause the engine attached, and the identifiers of any obligations it carried
+- the identity of the selected engine
+- the elapsed time
+
+- **Rationale**: This is how the platform answers what was gated and how it was decided, which is the fourth goal of this document. Recording the engine's identity matters because a deployment can substitute it, and a record that does not say which engine decided cannot be compared across a substitution.
+
+  This gear mints the correlation identifier because it is the only component that sees a whole gated operation: the engine sees one evaluation within it, and the calling gear does not know an evaluation happened. Minting it here and forwarding it is what lets the two records reach the shared audit topic joinable, and a batch joins per member on the correlation identifier and as a group on the batch identifier. It is deliberately minted here rather than taken from a tracing identifier: an audit key has to be present on every record and outside the reach of whoever is being audited, and a value a caller can repeat, omit, or choose is not one an audit trail can be joined on.
+
+  Four fields here also appear on the engine's record — subject, action, resource, and the identifiers above. The duplication is deliberate, not drift: a refusal by built-in policy never reaches the engine, and a could-not-run refusal is by definition one the engine could not record, so this record has to be readable with no counterpart to join to. Every other field is one only this gear holds.
+- **Actors**: `cpt-cf-admission-control-actor-security-auditor`, `cpt-cf-admission-control-actor-audit-sink`
+
+#### Record Path Failure
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-record-path-failure`
+
+The system **MUST** hold unpublished records in a bounded buffer, **MUST NOT** sample, drop, truncate, or summarise a record to relieve pressure on it, and **MUST NOT** block a decision on publication — the caller's budget is not where durability is paid for.
+
+Those three cannot all hold while the audit sink is unavailable, so the system **MUST** resolve the conflict by refusing rather than by weakening any of them. Where the sink is unreachable, or the oldest unpublished record has been held longer than the window of `cpt-cf-admission-control-nfr-record-completeness`, or the buffer is full, the system **MUST** refuse every operation a built-in policy does not already refuse, carrying the could-not-run cause, and **MUST** report the condition on its operational surface as degraded. It **MUST NOT** admit an operation it cannot record, and **MUST NOT** expose configuration that converts this condition into an admission.
+
+While the condition holds, the system **MUST NOT** enqueue a record at all — neither for the could-not-run refusals the condition produces nor for the built-in-policy refusals that continue alongside them, since the capacity either would need is the capacity that is exhausted. It **MUST** instead count both in dedicated counters, report those counts on its operational surface, and, once the buffer drains, publish exactly one gap record naming the interval the condition covered, the number of refusals it produced, and how many of those were built-in-policy refusals. That is the only record this gear emits which does not describe a single decision, and its purpose is that a hole in the audit stream is stated by the stream rather than inferred from an absence in it.
+
+The fault-injection set of `cpt-cf-admission-control-nfr-fail-closed` **MUST** cover a sink outage and a saturated buffer as distinct conditions.
+
+- **Rationale**: The three properties in the first paragraph were each written for a good reason and are jointly unsatisfiable during an outage. Leaving that unresolved is how an implementation quietly picks the silent option, which is dropping records. Refusing is the only choice consistent with the rest of this document: the gate holds no store, so publication is where a record becomes durable, and an admission the platform cannot show it recorded is precisely the unaccountable decision `cpt-cf-admission-control-fr-admission-records` exists to prevent. The gap record is what keeps that resolution honest. Without it the stream merely thins during an incident and an auditor cannot tell a quiet period from a period whose evidence was never written — while trying to record each refusal individually would demand the buffer space whose absence caused the refusal in the first place. One record after the fact costs nothing and turns a silent hole into a stated one.
+- **Actors**: `cpt-cf-admission-control-actor-platform-operator`, `cpt-cf-admission-control-actor-security-auditor`, `cpt-cf-admission-control-actor-audit-sink`
+
+#### Operational Surface
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-operational-surface`
+
+The system **MUST** expose a read-only operational surface reporting its readiness and its effective configuration: which policy engine is selected, which built-in policies are loaded with their identities, and the match count for each. The surface **MUST** be read-only — it **MUST NOT** create, modify, or withdraw a built-in policy, or change the selected engine.
+
+The surface **MUST** additionally report the refusals this gear reached without an evaluation — those produced by a built-in policy, those produced because the engine could not be reached, and those produced because the request asserted an identity the caller's context does not carry — as counts over a bounded recent window, broken down by built-in policy identity, by failure condition, and as their own class respectively. These **MUST** be reported separately from refusals the engine decided. The surface **MUST** also report the record-path condition of `cpt-cf-admission-control-fr-record-path-failure` as a degraded state together with the refusals it has produced, because those are the refusals deliberately left out of the record stream and this is the only place they can be seen while the condition holds.
+
+- **Rationale**: Every other requirement here produces a decision an operator cannot see the inputs to. A rule that never fires, an engine that resolved to something unexpected, a deployment sitting in the degraded state of `cpt-cf-admission-control-fr-absent-engine` — none is discoverable from the outside without this, and the first two are the failure modes an operator is least able to detect because nothing happens. Keeping it read-only is what stops the surface becoming the rule-management API that `cpt-cf-admission-control-fr-builtin-policy-form` withholds.
+
+  The refusal counts exist because the engine's own refusal projection cannot carry these two classes and says so: a built-in refusal never reaches the engine, and a could-not-run refusal happens because the engine was unreachable. Without a surface here, the two refusal classes the platform most needs to see during an incident are the two that appear nowhere, and an operator reading an empty projection would take an outage for quiet. A match count alone does not answer this — it says a policy fired, not how often it refused or what it refused. Counts rather than a queryable history is the deliberate limit: the durable per-decision evidence is the admission record of `cpt-cf-admission-control-fr-admission-records` on the shared audit topic, and duplicating it into a queryable store here would give this gear the persistent state it is built without.
+- **Actors**: `cpt-cf-admission-control-actor-platform-operator`
+
+#### Record Confidentiality
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-record-confidentiality`
+
+Admission records **MUST NOT** contain bearer tokens or other subject credentials, and **MUST NOT** contain the values of caller-supplied operation context. Where a record refers to that context it **MUST** carry only the names of the properties supplied.
+
+- **Rationale**: Admission records are widely readable by design, and the gate has no schema for caller-supplied context — it forwards it rather than interpreting it. A component that cannot classify a value cannot decide whether keeping it is safe, so it keeps the names and not the values.
+- **Actors**: `cpt-cf-admission-control-actor-audit-sink`
+
+#### Subject Data Handling
+
+- [ ] `p2` - **ID**: `cpt-cf-admission-control-fr-subject-data-handling`
+
+The personal data this gear produces is confined to the admission record: the subject identifier, the subject's tenant, and the redacted context-property names of `cpt-cf-admission-control-fr-record-confidentiality`. The system **MUST NOT** collect subject attributes beyond the field set of `cpt-cf-admission-control-fr-admission-records`, and **MUST NOT** record any profile attribute of a subject.
+
+The subject identifier the system records is the opaque identity-provider reference its security context carries. The system **MUST NOT** resolve it to a person, **MUST NOT** enrich it, and **MUST NOT** offer an erasure operation over it. Erasure is performed by the identity provider, which [the platform's accepted position on user identity](../../account-management/docs/ADR/0005-cpt-cf-account-management-adr-idp-user-identity-source-of-truth.md) makes the sole source of truth for user identity and the sole handler of right-to-erasure requests; a record whose subject was erased there keeps its reference, which then resolves to nobody. That orphaned-reference outcome is one the platform already accepts wherever a gear holds such a reference.
+
+The system **MUST NOT** expect the audit topic or its storage backend to rewrite a published record, and needs no such rewrite: nothing in the record has to change when a subject is erased. How long the reference persists is set by the retention the shared topic's backend applies, which this gear does not configure.
+
+- **Rationale**: The gate produces a subject reference on every gated operation, so saying nothing here would leave a reader to assume it either handles no personal data or quietly deletes something. Neither is true, and the reason it needs no mechanism is worth stating rather than leaving to be inferred from an absence — particularly because the engine beside it publishes to the same topic, and two gears answering one erasure request by different mechanisms would be a defect in whichever was audited second.
+
+  The mechanism the obvious alternative would need does not exist and cannot: `event-broker` events are append-only and never modified once written, and its backend contract offers deletion of a sequence prefix and no update at all, so no rewrite of a published record is available to any producer. Recording an opaque reference sidesteps that entirely — there is nothing to rewrite — and it puts erasure where the platform already puts it rather than inventing a second answer inside two gears. The gate is also the wrong place for one on its own terms: it holds no store, and two of its record classes exist nowhere else, so dropping them is not an erasure strategy either.
+- **Actors**: `cpt-cf-admission-control-actor-platform-operator`, `cpt-cf-admission-control-actor-security-auditor`, `cpt-cf-admission-control-actor-audit-sink`
+
+#### Operational Metrics
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-metrics`
+
+The system **MUST** expose metrics covering admission latency, verdicts by cause, engine latency and failures, back-off periods entered, and the share of admissions whose permission cause was ungoverned.
+
+- **Rationale**: The gate fails closed, so its failures present as refusals rather than as errors, and without a could-not-run counter separated from policy refusals an engine outage is indistinguishable from a tightened rule. The ungoverned share is the platform's measure of how much of the estate policy is silent about, and this gear is where every operation passes, so it is the only place that number is complete.
+- **Actors**: `cpt-cf-admission-control-actor-platform-operator`
+
+### 5.6 Configuration
+
+#### Configuration Validation
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-fr-configuration-validation`
+
+The system **MUST** validate its configuration at startup — the engine identifier, every built-in policy, and every bound — **MUST** reject unknown configuration keys, and **MUST** fail to start rather than run with configuration it could not validate. Built-in policies naming a resource type that does not resolve **MUST** fail validation, as **MUST** those referencing a builtin denylisted by `cpt-cf-admission-control-fr-builtin-evaluation-bounds`. Both checks run against the parsed form of the content rather than its source text.
+
+- **Rationale**: Every setting here changes what the platform refuses. A misspelled engine identifier that resolves to nothing, or a built-in policy naming a type that does not exist, is a rule that silently never fires — and a guardrail that silently never fires is the failure an operator is least able to detect, because nothing happens.
+- **Actors**: `cpt-cf-admission-control-actor-platform-operator`
+
+## 6. Non-Functional Requirements
+
+> Project-wide baselines for performance, security, reliability, and scalability are defined at the repository level in [ARCHITECTURE_MANIFEST.md](../../../../docs/ARCHITECTURE_MANIFEST.md) and the foundational [guidelines/](../../../../guidelines/). This gear has no parent gear PRD. Only gear-specific NFRs appear below.
+
+Requirements below are grouped by the platform's five quality vectors — efficiency, reliability, performance, security, and versatility — so that a vector carrying no gear-specific requirement appears as a stated position rather than as an absence a reader has to notice.
+
+### 6.1 Efficiency
+
+No gear-specific efficiency threshold applies. The gate owns no store and performs no work proportional to request size, so its resource use is bounded functionally: the per-policy and total evaluation bounds of `cpt-cf-admission-control-fr-builtin-evaluation-bounds`, and the bounded record buffer of `cpt-cf-admission-control-fr-record-path-failure`. Cost itself is not modelled per gear in this repository, which Section 6.6 records as an exclusion.
+
+### 6.2 Reliability
+
+#### Fail-Closed Determinism
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-nfr-fail-closed`
+
+The system **MUST** refuse on every error path, and **MUST NOT** expose any configuration that converts a failure into an admission.
+
+- **Threshold**: Zero admissions across the complete set of injected failure conditions — a built-in policy exceeding its per-policy bound, a built-in policy set exceeding its total bound, the evaluation backend failing while evaluating a built-in policy, engine unreachable, engine timeout, engine error, engine returning an unmappable result, no engine selected, audit sink unreachable, record buffer saturated, and internal error. The three built-in-evaluation conditions are named first because they are the only ones arising in code the gate runs itself: everything else is a dependency failing, and a set that omitted them would leave the gate's own evaluation path — the one `cpt-cf-admission-control-fr-builtin-evaluation-bounds` requires to refuse, and the one whose bound is cooperative and can therefore overrun — outside the only requirement that tests it.
+
+A types-registry outage is deliberately **not** in this set. Every registry lookup the gate performs happens during startup validation, per `cpt-cf-admission-control-fr-configuration-validation`, and the decision path performs no I/O at all — so there is no served request during which the registry could be unavailable. An unreachable registry therefore fails startup rather than producing a decision, which that requirement already covers and which this threshold, measured over admissions the gate actually served, cannot.
+- **Rationale**: The gate is the platform's decision point on the admission path; the enforcing gear is what enforces, per Section 1.4. That division is exactly why a permissive failure mode here is so costly. Enforcing gears enforce the answer they are given, so a failure that produced an admission would be honoured across every gear that calls the gate, and the bypass would be silent — nothing downstream is positioned to notice that the answer was not really a decision. This requirement makes the property testable rather than incidental.
+- **Verification Method**: Fault injection across the enumerated failure conditions.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation.
+
+#### Availability
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-nfr-availability`
+
+The system **MUST NOT** reduce the availability of the process it runs in, and where it runs as a separate process **MUST** meet an availability target better than that of the gears whose operations it gates.
+
+- **Threshold**: Conditioned on deployment shape. **In-process**, the platform's default and the shape of first release: the gate's availability is the host's, and the measurable requirement is that no failure originating in the gate terminates, stalls, or exhausts its host — verified as zero host-fatal outcomes across the fault-injection set above. **Out-of-process**, which applies only where `cpt-cf-admission-control-fr-remote-decision-surface` is met: 99.95 percent measured monthly, with planned maintenance excluded only when announced in advance and capped at 30 minutes per month, since the gate fails closed and its maintenance is an outage of every gated operation.
+- **Rationale**: Because the gate fails closed, unavailability presents as refusal of every gated operation across every calling gear. An independent target is only meaningful where the gate can fail independently of its callers, which in-process composition does not provide.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation.
+
+#### Record Completeness
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-nfr-record-completeness`
+
+The system **MUST** produce a record for every admission decision, on both verdicts, carrying enough context to reconstruct the decision without access to the original request.
+
+- **Threshold**: One record per decision, on both verdicts, with no sampling. Record content is defined by `cpt-cf-admission-control-fr-admission-records` and is not restated here. Emission **MUST NOT** extend gate overhead, so records are durable asynchronously; at most 5 seconds of records may be awaiting durability at any moment, and that window **MUST** be observable. There is exactly one accounted exception, defined by `cpt-cf-admission-control-fr-record-path-failure`: while the gate is refusing because it cannot record, those refusals are counted and summarised by a single gap record rather than recorded individually, and the per-decision figure is measured over the decisions served outside that condition. Every decision is therefore either recorded or inside a stated gap, and there is no unaccounted third case.
+- **Rationale**: The record is how the platform answers what it gated. Sampling loses the rare decisions most likely to be investigated, and recording only refusals loses the admission that mattered. Durability cannot be synchronous without spending the overhead budget on it, so the honest requirement is a bounded, measured window. Naming the exception is what keeps the figure meaningful rather than tautological: a completeness target whose failure mode is undefined is met by definition, because the decisions it loses are the ones it stopped counting.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation.
+
+### 6.3 Performance
+
+#### Gate Overhead
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-nfr-overhead`
+
+The system **MUST** add a bounded overhead to the operation it gates, measured at the gate boundary and excluding the time the engine spends.
+
+- **Threshold**: In the in-process shape, p95 within 5 ms and p99 within 10 ms for a single admission, excluding engine time and excluding record emission, which is asynchronous. Evaluation of built-in policies is inside this figure and is the dominant term in it, which is why `cpt-cf-admission-control-fr-builtin-evaluation-bounds` requires a configurable cap: the figure holds only while the built-in set stays small and its per-policy bound stays well inside the total. This figure does not cover the remote shape of `cpt-cf-admission-control-fr-remote-decision-surface`, which adds a transport round trip in each direction that no budget here accounts for; Section 13 records the question that shape has to answer before it is deployed. Built-in policy matching is inside this figure. A batch of up to the configured batch bound adds no more than 10 ms at p95 beyond the sum of its members' engine time.
+- **Rationale**: The gate's cost is spent from the enforcing gear's budget, not its own. Infrastructure Resource Manager holds 500 ms at p95 for a mutation acknowledgment and the selected engine holds 25 ms; the gate's own share has to be small enough that inserting it does not change the consumer's arithmetic. Excluding engine time makes the figure attributable — a slow admission is then either the gate's fault or the engine's, and the metrics say which.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation.
+
+### 6.4 Security
+
+#### Non-Modification
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-nfr-non-modification`
+
+The request an enforcing gear submits **MUST** be unchanged by the gate.
+
+- **Threshold**: For every admitted operation across the conformance suite, the request the caller holds after the call is byte-identical to the one it submitted, and no field of it is readable back through the response.
+- **Rationale**: The gate's contract with its callers is that it judges and returns; a gate that could modify would make every caller's subsequent validation conditional on what the gate did. Stating it as a measurable property rather than as an omission is what stops a later mutating capability arriving without a decision.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation.
+
+### 6.5 Versatility
+
+No gear-specific versatility threshold applies, because what varies here is structural rather than measurable. Exactly one policy engine is selected and may be substituted without changing the interface callers use, per `cpt-cf-admission-control-fr-engine-selection` and `cpt-cf-admission-control-usecase-substitute-engine`; and both deployment shapes of Section 3.1 are supported, the remote one at `p3` by `cpt-cf-admission-control-fr-remote-decision-surface`.
+
+### 6.6 NFR Exclusions
+
+- Cost and resource-efficiency targets: not modelled per gear in this repository, so no efficiency threshold appears in Section 6.1. The gate owns no store and does no work proportional to request size, so what bounds its resource use is functional — the built-in evaluation bounds and the record buffer — rather than economic.
+- Data residency and geographic partitioning: the gate stores nothing in a location its deployment does not already determine.
+- Functional safety and hazard analysis: not applicable. The gear is an information system with no physical actuation.
+- Accessibility, internationalisation, and device support: not applicable. The gear exposes no end-user interface; its operational surface is consumed by operators and tooling.
+- Regulatory certification: not gear-specific. The gate holds no payment, health, or financial-reporting data. Personal data is confined to the subject reference in its records and governed by `cpt-cf-admission-control-fr-subject-data-handling`, which records an opaque identity-provider reference and places erasure with that provider rather than with any gear; retention on the topic follows the platform's model. Consent, data-subject access, and portability are platform-level obligations discharged where subject identity is owned, not here.
+- Support tiering and diagnostic service levels: inherited from the platform support model; the availability requirement above is the only gear-specific service level.
+- Scalability as a separate requirement: the gate holds no shared mutable state on the decision path, so its throughput is bounded by the engine behind it rather than by the gate. The overhead requirement governs the gate's own contribution at any load.
+
+## 7. Public Library Interfaces
+
+### 7.1 Public API Surface
+
+#### Admission Client
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-interface-admission-client`
+
+- **Type**: Rust trait, asynchronous, registered in ClientHub without scope
+- **Stability**: stable
+- **Description**: The interface enforcing gears call, and the gear's principal surface. Takes the caller's propagated security context together with an intended operation — subject, action, resource type and optional identifier, tenant context, and operation properties — singly or as a batch, and returns admitted or refused with a cause. The context is a required parameter rather than an ambient value: `cpt-cf-admission-control-fr-request-authenticity` derives the subject and its tenant from it and refuses a request that asserts different ones. An admitted verdict carries the obligations the engine attached, relayed unaltered; the collection is empty until the selected engine emits any. The verdict reserves a third value for a deferral, unpopulated: while `cpt-cf-admission-control-fr-deferral-verdict` is unimplemented a deferral arrives as a refusal carrying the awaiting-approval cause, so a caller that handles two values is conformant, and serving the third value later is the major version that requirement calls for.
+- **Conformance expectations on the caller**: two, neither observable by this gear. Any error result is a refusal. And an obligation the caller does not recognise makes the decision refused — the gate cannot apply that rule itself, because it recognises no obligation identifier and would therefore refuse every decision carrying one; it belongs to the gear that enforces.
+- **Breaking Change Policy**: Major version bump required.
+
+#### Operational REST API
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-interface-operational-api`
+
+- **Type**: REST API, versioned, served beneath the platform API prefix
+- **Stability**: stable
+- **Description**: The read-only surface of `cpt-cf-admission-control-fr-operational-surface`: readiness, the selected engine's identity, the loaded built-in policies and their match counts. Uses the canonical problem error envelope. This surface exists in both deployment shapes and is the carrier for the readiness the gear reports; it exposes no admission decision and accepts no mutation.
+- **Breaking Change Policy**: Backward compatible within a major version.
+
+#### Policy Engine Plugin Contract
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-interface-engine-plugin`
+
+- **Type**: Rust trait, asynchronous, registered in ClientHub under a GTS instance scope
+- **Stability**: unstable
+- **Description**: The contract a policy engine implements to be selectable by the gate. Receives the caller's security context, propagated unchanged, together with an evaluation request carrying the correlation identifier this gear minted for the operation, and returns a permission with its cause and any obligations, a prohibition with a reason, or a deferral. Those three are the whole of the result; a request that callers back off for a stated interval travels **alongside** a result rather than in place of one, and the result it accompanies is the engine's own transient failure — which is the shape `cpt-cf-admission-control-fr-engine-backoff` already assumes when it speaks of an engine that is refusing transiently and asking callers to back off. The context travels rather than being re-established because the engine derives the subject from it too, so the gate cannot substitute an identity even by accident. The obligation collection and the deferral both exist from the first version even though no engine populates either yet: adding them later would be a breaking change to a contract every engine implements, and the engine that will emit deferrals is already specified. This gear owns the contract; engines conform to it.
+- **Breaking Change Policy**: Minor version bump while unstable.
+
+### 7.2 External Integration Contracts
+
+#### GTS Registration
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-contract-gts`
+
+- **Direction**: provided to and required from the types registry
+- **Protocol/Format**: GTS link-time inventory in one direction, resolution in the other. The gate registers the policy engine plugin specification and its own error family; it resolves the selected engine's identifier and the resource types built-in policies and requests name.
+- **Compatibility**: Type identifiers are stable; new versions are new identifiers.
+
+#### Admission Record Contract
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-contract-admission-record`
+
+- **Direction**: provided to downstream consumers
+- **Protocol/Format**: Structured records with the stable field set of `cpt-cf-admission-control-fr-admission-records`, emitted per decision.
+- **Compatibility**: Additive field changes only within a major version; consumers must tolerate unknown fields.
+
+## 8. Use Cases
+
+#### Gate a Resource Operation
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-usecase-gate-operation`
+
+**Actor**: `cpt-cf-admission-control-actor-enforcing-gear`
+
+**Preconditions**:
+- A policy engine is selected and reachable.
+- The enforcing gear holds the operation it intends to perform and the security context of the initiating caller.
+
+**Main Flow**:
+1. The enforcing gear submits the intended operation to the gate.
+2. The gate evaluates the built-in policies the operation selects, through the shared evaluation facility and within its configured bounds, and none of them prohibits.
+3. The gate submits an evaluation request to the selected engine.
+4. The engine returns a permission with its cause.
+5. The gate returns admitted, and emits a record carrying the verdict, the cause, and the engine's identity.
+
+**Postconditions**:
+- The enforcing gear proceeds with an unmodified request, and the decision is recorded.
+
+**Alternative Flows**:
+- **A built-in policy refuses**: The gate refuses without consulting the engine, naming that policy.
+- **The engine prohibits**: The gate refuses, carrying the engine's reason.
+- **The engine is unreachable or exceeds its bound**: The gate refuses with the could-not-run cause, which the caller can retry as transient.
+
+#### Gate a Multi-Type Change
+
+- [ ] `p1` - **ID**: `cpt-cf-admission-control-usecase-gate-batch`
+
+**Actor**: `cpt-cf-admission-control-actor-enforcing-gear`
+
+**Preconditions**:
+- The enforcing gear has classified a change touching several resource types and needs one verdict before dispatching work.
+
+**Main Flow**:
+1. The enforcing gear submits one batch containing an intended operation per resource type the change touches.
+2. The gate applies built-in policies to every member.
+3. The gate submits the surviving members to the engine.
+4. The gate combines the member verdicts, refusing the batch if any member is refused.
+5. The gate returns the batch verdict with every refused member identified, and records each member.
+
+**Postconditions**:
+- The enforcing gear dispatches the whole change or refuses it whole, able to report every fault at once.
+
+**Alternative Flows**:
+- **Batch exceeds the configured bound**: The gate refuses the request against the limit rather than admitting a subset.
+
+#### Substitute the Policy Engine
+
+- [ ] `p2` - **ID**: `cpt-cf-admission-control-usecase-substitute-engine`
+
+**Actor**: `cpt-cf-admission-control-actor-platform-operator`
+
+**Preconditions**:
+- A second engine implementing the plugin contract is registered.
+
+**Main Flow**:
+1. The operator changes the configured engine identifier and restarts the deployment.
+2. The gate validates the new identifier at startup and resolves the engine.
+3. Built-in policies continue to apply unchanged.
+4. Subsequent records name the new engine.
+
+**Postconditions**:
+- Enforcing gears observe no change to the interface they call, and records distinguish decisions made before and after the substitution.
+
+**Alternative Flows**:
+- **The new identifier does not resolve**: The gate fails to start rather than running without an engine.
+
+## 9. Acceptance Criteria
+
+- [ ] An enforcing gear reaches the policy question through this interface on every operation it declares as gated, with no policy logic of its own beyond enforcing the verdict. Quota, licence, and authorization remain the enforcing gear's own calls, in the order its requirements set.
+- [ ] The request an enforcing gear submits is byte-identical after the call, on both verdicts.
+- [ ] A built-in policy refuses an operation with no policy engine configured at all.
+- [ ] A built-in policy refuses an operation that the selected engine would have permitted, and no configuration or policy content overturns it.
+- [ ] Substituting the policy engine changes no behaviour observable through the admission interface except the engine identity in records.
+- [ ] Every enumerated failure condition produces a refusal carrying the could-not-run cause, and no configuration produces an admission on failure.
+- [ ] A hung engine produces a refusal within the configured bound rather than stalling the calling gear.
+- [ ] The refusal causes are distinguishable by a caller without parsing prose, and a could-not-run refusal is distinguishable in the metrics from a policy refusal.
+- [ ] An engine deferral produces a refusal carrying the awaiting-approval cause, distinguishable from a could-not-run refusal in both the response and the metrics, and never an admission.
+- [ ] A batch refuses whole and names every refused member, and a preview of the same change returns the same verdict as its apply, given unchanged policy between the two. The gate holds no state, so nothing pins a verdict between a preview and an apply: a policy change, an assignment change, or a configuration change in the interval may legitimately produce a different answer, and no reservation, lease, or decision token is offered against that.
+- [ ] A batch answers for a set of operations and not for an ordered sequence: every member is judged against the state in force when the batch is submitted, so a member that only becomes admissible after an earlier member takes effect is refused. A caller sequencing dependent operations submits them as it performs them rather than as one batch.
+- [ ] Configuration naming an unresolvable engine or an unresolvable resource type fails startup.
+- [ ] Every decision is recorded on both verdicts, and no record contains a credential or a caller-supplied property value.
+- [ ] A request whose asserted subject or subject tenant disagrees with the caller's propagated security context is refused with its own cause, before any built-in policy runs and without reaching the engine, and the record names the context's identity while noting that another was asserted.
+- [ ] The engine receives the caller's context unchanged, and no path constructs an evaluation request carrying an identity the caller did not present.
+- [ ] With the audit sink unreachable or the record buffer full, the gate refuses rather than admitting, reports degraded, and publishes one gap record naming the interval and the number of refusals once the buffer drains — with no record dropped, sampled, or truncated to relieve the pressure.
+- [ ] The reserved-name-prefix fixture refuses the same operation under two different engines and with no engine configured, which is the observable form of built-in independence.
+
+## 10. Dependencies
+
+| Dependency | Description | Criticality |
+|------------|-------------|-------------|
+| Policy engine | The selected engine, reached through the plugin contract; without one the gate refuses every operation built-in policies do not already refuse | p1 |
+| Policy evaluation facility | Compiles and evaluates built-in policy content in the language its backends accept; without it the gate has no way to apply its own policies. Does not exist yet, in any form, anywhere in the repository | p1 |
+| `types-registry` | Resolution of the selected engine's identifier and of the resource types built-in policies and requests name; GTS registration of the plugin specification | p1 |
+| `toolkit-canonical-errors` | The gear's error family and its refusal causes | p1 |
+| `toolkit-security` | Security context propagation from the enforcing gear, and the source of the subject identity `cpt-cf-admission-control-fr-request-authenticity` derives rather than believes | p1 |
+| `event-broker` | Transport, retention, and export of admission records, published to the platform-scoped audit topic shared with `policy-engine`. On the durability path, unlike for that gear: this gate owns no database, so the topic is the only place an admission record becomes durable, and `cpt-cf-admission-control-nfr-record-completeness` is met against it. A refusal by built-in policy and a could-not-run refusal are recorded nowhere else, and a could-not-run refusal is by definition one the engine could not record either. Because the topic is the only durability point, its unavailability is a serving condition rather than a logging problem, which `cpt-cf-admission-control-fr-record-path-failure` defines | p1 |
+
+## 11. Assumptions
+
+- Subjects arrive already authenticated, with identity and tenant context established upstream, and the gate forwards that context rather than establishing it. What the gate does not assume is that the request agrees with the context: `cpt-cf-admission-control-fr-request-authenticity` derives the subject from the context and refuses a mismatch, so a calling gear that asserts an identity it does not hold is refused rather than trusted.
+- Enforcing gears enforce the verdicts they receive, including any obligations attached to an admission: they honour what they recognise and refuse rather than proceed on what they do not. The gate has no mechanism to detect a caller that asks and then proceeds regardless, and no requirement here depends on detecting one.
+- Enforcing gears supply complete operation context. A property the gate forwards is a property the caller chose to send; the gate has no schema for it and cannot tell an omission from an absence. This includes facts the caller relays rather than owns — a tenant's subscription plan or service tier, where policy is written to decide on one. The gate neither validates such a value nor knows which properties carry one, so a relayed entitlement is exactly as trustworthy as the gear that sent it; `cpt-cf-admission-control-fr-record-confidentiality` also keeps the value out of the admission record, which carries the property's name alone.
+- The selected engine returns a permission with a cause, a prohibition with a reason, or a deferral, per the contract in Section 7.1. An engine that cannot express that shape is not selectable. An engine that never emits a deferral is entirely conformant — the variant is carried so that the gate can map one, not because any engine must produce one.
+- Built-in policies are few and change with the deployment. Nothing here is designed for a built-in policy set that grows at tenant scale or changes at runtime; that is what the policy engine is for.
+- The evaluation facility's backends provide two properties this gear depends on and cannot supply itself: syntax validation independent of evaluation, so that `cpt-cf-admission-control-fr-configuration-validation` can reject a malformed built-in at startup, and acceptance of an externally imposed per-policy cost bound, so that `cpt-cf-admission-control-fr-builtin-evaluation-bounds` has an implementation. Both are confirmed present in the first candidate audited. What that audit also established is that a backend declares no sandbox posture of its own, that its determinism depends on which builtins its build registers, and that a builtin can be neither removed nor shadowed — so the denylist this gear enforces at startup is the only mechanism available, and it is a property of a specific backend build rather than of the backend.
+- Infrastructure Resource Manager, the first enforcing gear, exists as a specification and not yet as software, and its own requirements describe it calling a decision service directly. Routing it through this gate is a change to that gear's integration which nobody has yet agreed.
+
+## 12. Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| The gate becomes a second policy engine by increments — built-in policies gain an authoring API, then a lifecycle, then tenant scoping | The split this gear exists to create collapses, and the platform has two components managing policy content with different models | The boundary is management, not expressiveness: built-in policies may say anything the facility can express, and arrive only as deployment configuration. Treat any request to author one at runtime as a request for content in the engine |
+| The evaluation facility does not land | The gate cannot apply built-in policies at all, and two p1 requirements have no implementation path | Nothing this gear can mitigate; Section 10 records the dependency as a prerequisite |
+| A backend build registers a non-deterministic builtin the denylist does not name | A platform guardrail decides differently on two identical requests, and because built-in refusals are the ones an operator trusts most, the inconsistency is attributed to anything but the rule | Bind the denylist to the audited build and re-audit on upgrade; enumerate the backend's registered builtins in a test rather than trusting a hand-maintained list. The policy engine carries the same exposure, so it is one audit serving two gears |
+| No enforcing gear adopts the gate | A gate with no callers, and requirements shaped by speculation rather than integration | Validate the interface against Infrastructure Resource Manager's admission requirements before implementation; admit a second caller only with a concrete integration |
+| Gate overhead is measured but engine time is not attributed | A slow admission is blamed on the gate or the engine by argument rather than by measurement, and neither improves | Exclude engine time from the gate's own threshold and export both separately from first release |
+| Fail-closed behaviour makes every engine outage a platform-wide stoppage | An engine incident stops all gated operations, and pressure builds for a bypass switch | Hold the engine bound tight enough that an outage is detected quickly; keep the could-not-run cause retryable and distinguishable so callers degrade rather than fail permanently |
+| A deferral is reported as an outage | An operation waiting on a person looks like a broken dependency: the caller retries what no retry can resolve, the approval is never requested, and the metrics show an engine incident that is not happening | `cpt-cf-admission-control-fr-deferral-relay` carries the deferral in the plugin contract from the first version and gives it its own refusal cause, so the two are distinguishable before any engine emits one |
+| Built-in policies and policy content express overlapping intent | An operator cannot tell which component refused, or writes the same rule twice with different semantics | Name the responsible rule in every platform-rule refusal; keep the two vocabularies deliberately different, so a rule that can be expressed here obviously cannot be expressed there |
+
+## 13. Open Questions
+
+Each question carries an owner role and the point by which it must be answered.
+
+| Question | Owner | Needed by |
+|---|---|---|
+| Which built-in policies does the platform ship? The mechanism is specified and Section 5.2 names a candidate — reserved resource-name prefixes — which `cpt-cf-admission-control-fr-builtin-policy-independence` now uses as its conformance fixture, so the property is testable before this is answered. What is still open is which policies a deployment actually gets. | Platform architecture | Before first release |
+| Does `serverless-runtime` route its tenant enablement and runtime-allowlist checks through this gate, keeping quotas with `quota-enforcement` and its own defaults local, as Section 1.2 proposes? Until it does, one gear gates its dispatch path with its own component and the platform has two answers to the same question. | `serverless-runtime` owner | Before first release |
+| Does Infrastructure Resource Manager agree to reach policy through this gate rather than calling a decision service directly, and to keep its request enrichment inside its own pipeline? | Infrastructure Resource Manager owner | Before implementation |
+| What is the default engine call bound, and does it fit inside the enforcing gear's budget alongside the engine's own latency target? | Gear owner | Before implementation |
+| What is the bound on batch size, and is it the same bound the engine enforces or a separate one? | Gear owner | Before first release |
+| What latency budget applies where `cpt-cf-admission-control-fr-remote-decision-surface` is met, and does any consumer's own budget survive two transport round trips — one into the gate and one onward to the engine? Neither this document nor Infrastructure Resource Manager reserves an allowance for either. | Platform architecture | Before that requirement is implemented |
+| Should built-in policies be able to require that policy has governed an operation — refusing an admission whose permission cause is ungoverned — or is that a policy question that belongs in the engine? | Platform architecture | Before first release |
+| Does an audit trail full of orphaned subject references satisfy a right-to-erasure request, or does it need something further? `cpt-cf-admission-control-fr-subject-data-handling` follows the platform's position — the identity provider erases, gears keep an opaque reference that afterwards resolves to nobody — and that position already accepts orphaned references elsewhere. What nobody has confirmed is whether it is sufficient for records that persist on a shared audit topic for the topic's full retention, which is longer than any single gear's window. This is a data-protection judgement rather than an engineering one, and no mechanism in either gear changes depending on the answer; what could change is the retention the topic is configured with. | Platform architecture, with the data protection owner | Before first release |
+| Where does a deferral terminate, and who raises the approval — the enforcing gear that received the deferred verdict, or a service the gate does not know about? The engine's own requirements carry the same question, and `approval-service` has upstream requirements but no design and no implementation, so there is nothing to route a deferral to today. Answering it decides whether `cpt-cf-admission-control-fr-deferral-verdict` is enough or whether the gate needs a correlation the approval can be resolved against. | Platform architecture | Before the deferral verdict ships |
+
+## 14. Traceability
+
+- **Design**: [DESIGN.md](./DESIGN.md)
+- **ADRs**: `ADR/` — not yet created; the decisions listed in the design's Key ADRs table land here once written
+- **Features**: `features/` — not yet created
+- **Policy engine**: [Policy Engine](../../policy-engine/docs/PRD.md), the first implementation of the plugin contract in Section 7.1
+- **First enforcing gear**: [Infrastructure Resource Manager](../../../infrastructure-resource-manager/docs/PRD.md), whose admission pipeline, cascade admission, and policy gating requirements this gate serves
+- **Platform architecture**: [ARCHITECTURE_MANIFEST.md](../../../../docs/ARCHITECTURE_MANIFEST.md), [GEARS.md](../../../../docs/GEARS.md)
+- **Comparable plugin selection**: [quota-enforcement](../../quota-enforcement/docs/PRD.md) and `authz-resolver`, whose one-plugin-at-a-time selection model this gear follows
+- **Existing gate on a dispatch path**: [serverless-runtime](../../../serverless-runtime/docs/DESIGN.md), whose host-owned Tenant Policy Manager holds the checks Section 1.2 divides between this gate, `quota-enforcement`, and that gear itself
+- **Deferral destination**: [approval-service upstream requirements](../../../approval-service/docs/UPSTREAM_REQS.md), the nearest existing artifact for the approval flow a deferral would terminate in; that gear has no design and no implementation, which is why `cpt-cf-admission-control-fr-deferral-verdict` is `p3`
+- **Subject identity and erasure**: [account-management ADR-0005](../../account-management/docs/ADR/0005-cpt-cf-account-management-adr-idp-user-identity-source-of-truth.md), whose position that the identity provider is the sole source of truth for user identity and the sole handler of erasure requests is what `cpt-cf-admission-control-fr-subject-data-handling` follows
+- **Standards lineage**: the PDP, PEP, and PAP vocabulary in Section 1.4 derives from NIST SP 800-162, as it does in the policy engine beside this gear

--- a/gears/system/policy-engine/docs/DESIGN.md
+++ b/gears/system/policy-engine/docs/DESIGN.md
@@ -1,0 +1,1324 @@
+# Technical Design — Policy Engine
+
+
+<!-- toc -->
+
+- [1. Architecture Overview](#1-architecture-overview)
+  - [1.1 Architectural Vision](#11-architectural-vision)
+  - [1.2 Architecture Drivers](#12-architecture-drivers)
+  - [1.3 Architecture Layers](#13-architecture-layers)
+- [2. Principles & Constraints](#2-principles--constraints)
+  - [2.1 Design Principles](#21-design-principles)
+  - [2.2 Constraints](#22-constraints)
+- [3. Technical Architecture](#3-technical-architecture)
+  - [3.1 Domain Model](#31-domain-model)
+  - [3.2 Component Model](#32-component-model)
+  - [3.3 API Contracts](#33-api-contracts)
+  - [3.4 Internal Dependencies](#34-internal-dependencies)
+  - [3.5 External Dependencies](#35-external-dependencies)
+  - [3.6 Interactions & Sequences](#36-interactions--sequences)
+  - [3.7 Database schemas & tables](#37-database-schemas--tables)
+  - [3.8 Deployment Topology](#38-deployment-topology)
+- [4. Additional context](#4-additional-context)
+  - [4.1 Telemetry surface](#41-telemetry-surface)
+  - [4.2 Capacity envelope](#42-capacity-envelope)
+  - [4.3 Deferred items](#43-deferred-items)
+  - [4.4 Known design risks](#44-known-design-risks)
+  - [4.5 Reliability, error handling, and consistency](#45-reliability-error-handling-and-consistency)
+  - [4.6 Security boundaries and threat model](#46-security-boundaries-and-threat-model)
+  - [4.7 Testability and test strategy](#47-testability-and-test-strategy)
+  - [4.8 Compliance and privacy posture](#48-compliance-and-privacy-posture)
+  - [4.9 Deviations from platform baselines](#49-deviations-from-platform-baselines)
+  - [4.10 Migration, deprecation, and technical debt](#410-migration-deprecation-and-technical-debt)
+  - [4.11 Areas recorded as not applicable](#411-areas-recorded-as-not-applicable)
+- [5. Traceability](#5-traceability)
+
+<!-- /toc -->
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-design-policy-engine`
+## 1. Architecture Overview
+
+### 1.1 Architectural Vision
+
+The gear is built around one asymmetry: policy content changes rarely and is read on every gated operation. The design exploits that by moving all interpretation of content to activation time. When a bundle is activated, an activation compiler validates it, resolves its targets, compiles each document through the backend its declared language names, computes a content digest, and publishes an immutable snapshot. Evaluation then reads only that snapshot. No decision path issues a content query, parses an expression, or observes a partially applied write, which is what makes the latency budget in `cpt-cf-policy-engine-nfr-decision-latency` an allocation the gear can hold rather than a hope about database behaviour.
+
+The gear separates two surfaces that have nothing in common except the content they share. The management surface is a conventional CRUD-and-lifecycle service over a relational store, transactional, tenant-scoped, and reachable over REST. The decision surface is a synchronous in-process call that touches the snapshot, the tenant hierarchy cache, and nothing else. They are separate components with separate clients, so a consumer on the admission path never links the administration contract, and administration load cannot displace decision latency.
+
+Fail-closed behaviour is structural rather than defensive. Every path that cannot produce a well-founded outcome — an absent snapshot, a digest mismatch, an expression that exceeds its cost bound, an unreachable hierarchy provider, a tenant context that will not resolve — converges on a single refusal constructor that stamps a distinct cause. That constructor is the only way to build a negative decision from an error condition, and it marks the result so that `cpt-cf-policy-engine-fr-denial-versus-failure` can report the refusal as infrastructure rather than policy. Refusing and reporting honestly are separate obligations, and the design keeps them separately testable.
+
+### 1.2 Architecture Drivers
+
+Requirements that significantly influence architecture decisions.
+
+#### Functional Drivers
+
+| Requirement | Design Response |
+|-------------|------------------|
+| `cpt-cf-policy-engine-fr-bundle-composition` | `cpt-cf-policy-engine-entity-bundle`, `-document`, and `-target` model the content tree; the bundle version is the unit of digest, snapshot, and assignment. |
+| `cpt-cf-policy-engine-fr-document-kinds` | Kind is a closed enum on the document entity; the evaluator dispatches on it and rejects unknown kinds at validation rather than at evaluation. |
+| `cpt-cf-policy-engine-fr-target-binding` | `cpt-cf-policy-engine-component-matcher` indexes targets by trigger, phase, and resource type at compile time, so matching is a lookup rather than a scan. |
+| `cpt-cf-policy-engine-fr-content-validation` | `cpt-cf-policy-engine-component-validator` runs the same checks the activation compiler runs, against a draft, without publishing a snapshot. |
+| `cpt-cf-policy-engine-fr-lifecycle-states` | State lives on the version row, not the bundle; the four transitions are enforced in `cpt-cf-policy-engine-component-management` with conditional updates, and the at-most-one-active invariant is a partial unique index rather than an application check. |
+| `cpt-cf-policy-engine-fr-administration-audit` | `cpt-cf-policy-engine-component-management` writes an administration event in the same transaction as the change it describes, into `policy_engine__admin_event`; retention is independent of the decision-record sweep. |
+| `cpt-cf-policy-engine-fr-content-integrity` | Digest computed by the activation compiler, stored on the version row, verified at activation and whenever a generation is built or reloaded — never per evaluation, which the latency budget could not absorb. |
+| `cpt-cf-policy-engine-fr-optimistic-concurrency` | `etag` column on every mutable row, surfaced as an HTTP precondition and as an explicit parameter on the management client. |
+| `cpt-cf-policy-engine-fr-version-history` | Versions are immutable rows under a stable bundle identity; returning to earlier content seeds a new draft from a retained version and activates that draft, taking a new version identity and its own administration event, so a deprecated version is never reactivated in place. |
+| `cpt-cf-policy-engine-fr-deprecation` | Deprecation is a version-state transition that triggers snapshot republication, bounded by `cpt-cf-policy-engine-nfr-activation-propagation`. |
+| `cpt-cf-policy-engine-fr-version-comparison` | `cpt-cf-policy-engine-component-management` compares two retained versions structurally; the widening flag is computed from the compiled target index and outcome directives of each side, so it needs no evaluation and no sample traffic. |
+| `cpt-cf-policy-engine-fr-non-enforcing-assignment` | An enforcing flag on the assignment row travels into the snapshot, and `cpt-cf-policy-engine-component-combiner` folds outcomes from non-enforcing assignments into the trace and the record but not into the result. |
+| `cpt-cf-policy-engine-fr-effective-windows` | Window columns on the assignment row, evaluated by the assignment resolver against the evaluation timestamp. |
+| `cpt-cf-policy-engine-fr-tenant-assignment` | `cpt-cf-policy-engine-entity-assignment` binds a bundle to a tenant with a priority; the snapshot is keyed by assignment and resolves the bundle's active version when a generation is built, so activation, withdrawal, and amendment all republish a generation by the same path and none of them rewrites an assignment row. |
+| `cpt-cf-policy-engine-fr-nearest-tenant` | `cpt-cf-policy-engine-component-assignment-resolver` orders the ancestry chain nearest-first and applies priority within a tenant. |
+| `cpt-cf-policy-engine-fr-inheritance-barriers` | Barrier handling is read from the request and passed through to the hierarchy client; the resolver holds no default of its own. |
+| `cpt-cf-policy-engine-fr-assignment-authorization` | `cpt-cf-policy-engine-component-management` declares the barrier handling of its own surfaces rather than inheriting one: it resolves the target tenant through the hierarchy client with barriers respected and refuses an out-of-reach target with the boundary cause, so the management-plane rule is one check in one component instead of a convention repeated at each endpoint. The evaluation plane is untouched by it. |
+| `cpt-cf-policy-engine-fr-applicable-set` | Matcher intersects the compiled target index with the resolved assignment set, bounded by the applicable-set limit. |
+| `cpt-cf-policy-engine-fr-deterministic-ordering` | Ordering key is (proximity, priority descending, assignment identifier), applied as a total order before evaluation begins. |
+| `cpt-cf-policy-engine-fr-evaluation-phases` | Phase is part of the target index; the after-phase path discards the outcome's effect on the verdict while still recording it. |
+| `cpt-cf-policy-engine-fr-permit-provenance` | `cpt-cf-policy-engine-component-combiner` initialises the accumulator to an ungoverned permit, which a permitting outcome upgrades to governed and any prohibit overrides; no error path reaches the combiner at all, so no failure can produce a permission of any cause. The ungoverned share is exported as a metric. The emergency exception does not weaken this: it is constructed in `cpt-cf-policy-engine-component-decision` before the snapshot is consulted, so it never enters the combiner's fold and the combiner remains unable to produce it. |
+| `cpt-cf-policy-engine-fr-denial-precedence` | Combiner treats a prohibition as absorbing; no later permit can clear it, and no earlier one pre-empts it, which is what makes the fold order-independent. |
+| `cpt-cf-policy-engine-fr-outcome-combination` | Combination rules are a single pure function over the outcome sequence, unit-testable independently of evaluation. |
+| `cpt-cf-policy-engine-fr-short-circuit` | Combiner reports saturation to the evaluation loop; matched and evaluated counts are carried into the record. |
+| `cpt-cf-policy-engine-fr-denial-reason` | Refusal carries a canonical error identity plus the document identifier that produced it; detail is recorded and stripped from the response projection. |
+| `cpt-cf-policy-engine-fr-denial-versus-failure` | Single refusal constructor stamps an infrastructure cause distinct from every policy cause; the decision client surfaces the distinction to the caller. |
+| `cpt-cf-policy-engine-fr-deferral-outcome` | Deferral is a distinct variant in the outcome enum, in the decision projection, and in the decision client's result type, carried end to end even though no consumer routes it yet — reserved on the client specifically so the gateway can map it rather than funnel it as an unmappable result. |
+| `cpt-cf-policy-engine-fr-emergency-access` | Emergency entitlement is resolved from the security context alone, before the snapshot is consulted, so it survives a broken snapshot. The permission is built in `cpt-cf-policy-engine-component-decision` carrying the emergency cause — a third member of the permit-cause enum, not a flag beside it — which is why the record table has no separate emergency column and no path can report a governed permission that was in fact an override. |
+| `cpt-cf-policy-engine-fr-authorization-boundary` | `cpt-cf-policy-engine-entity-evaluation-input` has no field able to hold an entitlement, so content has nothing to decide access by and the exclusion is a property of the type rather than a check; no component resolves an entitlement during evaluation, and the emergency entitlement is resolved by `cpt-cf-policy-engine-component-decision` from the security context before the snapshot is consulted rather than passed into the evaluation context; `cpt-cf-policy-engine-component-combiner` yields a two-valued result carrying a cause and no grant. |
+| `cpt-cf-policy-engine-fr-evaluation-input` | Evaluation input is a value type carrying subject identity, action, resource, tenant context, and caller-supplied properties; no component fetches consumer state. |
+| `cpt-cf-policy-engine-fr-subject-authenticity` | The security context is a required parameter of the decision trait rather than an ambient value. `cpt-cf-policy-engine-component-decision` compares the asserted subject and tenant against it before the snapshot is consulted and refuses a mismatch from its own arm of the refusal constructor, and the record builder reads the subject from the context, so no path exists that could attribute a decision to an asserted identity. |
+| `cpt-cf-policy-engine-fr-batch-evaluation` | Batch is evaluated member-by-member over one snapshot read and one hierarchy resolution, then combined by the same absorbing rule. |
+| `cpt-cf-policy-engine-fr-obligations` | Obligations ride on the permitting decision as typed identifiers; the client documents the unrecognised-identifier obligation on the caller. |
+| `cpt-cf-policy-engine-fr-expression-evaluation` | `cpt-cf-policy-engine-component-evaluator` is the only component that links the evaluation facility, and routes each document to the backend its declared GTS identifier resolves to. |
+| `cpt-cf-policy-engine-fr-evaluation-isolation` | Evaluation receives a constructed context value and a gear-supplied timestamp and nothing else; no ambient capability is reachable from the call. `cpt-cf-policy-engine-component-evaluator` refuses to select a backend build whose GTS registration carries no sandbox-and-determinism declaration, and `cpt-cf-policy-engine-component-activation-compiler` refuses content referencing a denylisted builtin — the only enforcement point available, since builtins can be neither removed nor shadowed at call time. |
+| `cpt-cf-policy-engine-fr-evaluation-cost-bounds` | Per-document and per-evaluation bounds are enforced by the evaluator around each library call and across the loop, using the backend's own caller-set wall-clock limit where it offers one. That limit is cooperative — checked between work units rather than preemptively — so the configured figure is an upper bound plus one work unit, and the check interval is a tuning input the evaluator sets rather than a constant it inherits. The defaults sit inside the miss-path residue of `cpt-cf-policy-engine-nfr-decision-latency`, which is why the cooperative overrun has to be measured rather than assumed: a residue of roughly 5 ms leaves no slack for a work unit nobody sized. |
+| `cpt-cf-policy-engine-fr-dependency-timeouts` | Hierarchy client calls are wrapped in a configured timeout that converts expiry into an infrastructure refusal. |
+| `cpt-cf-policy-engine-fr-responsibility-boundary` | Evaluator validates every returned outcome against the closed outcome set before it reaches the combiner. |
+| `cpt-cf-policy-engine-fr-content-isolation` | All management repository access goes through the secure data layer with the caller's scope; absent and forbidden collapse to the same result. |
+| `cpt-cf-policy-engine-fr-cross-tenant` | Resolver checks resource tenant against the reachable subtree before matching, and stamps its own refusal cause. |
+| `cpt-cf-policy-engine-fr-record-visibility` | `cpt-cf-policy-engine-component-violations` and the decision-record reads scope on `resource_tenant_id` over the subtree reachable from the caller's context with barriers respected, never on content ownership; the cross-barrier read is a separate capability and writes an administration event, so a crossing is attributable rather than implicit. |
+| `cpt-cf-policy-engine-fr-admin-authorization` | Management operations are gated per capability through the platform enforcement helper; the six capabilities are distinct actions on the gear's own resource types, with the two record reads separate from content read and from each other. |
+| `cpt-cf-policy-engine-fr-bootstrap` | A configured bootstrap principal is authorised for management actions while no assignment exists, and the condition is observable. |
+| `cpt-cf-policy-engine-fr-decision-records` | `cpt-cf-policy-engine-component-recorder` owns the field set; every other component contributes fields through one builder. |
+| `cpt-cf-policy-engine-fr-violations` | `cpt-cf-policy-engine-component-violations` reads the record table with a prohibiting-outcome predicate; no violation table exists. |
+| `cpt-cf-policy-engine-fr-record-confidentiality` | The record row has no credential column and stores context property **names** only, never values, so exclusion is structural rather than a filtering step that can be misconfigured. |
+| `cpt-cf-policy-engine-fr-subject-data-handling` | `subject_id` and `subject_tenant_id` hold the opaque identity-provider references the security context carries, and no column holds a profile attribute. The gear offers no erasure path over them, because erasure belongs to the identity provider — so no component here ever rewrites a written record, which is what keeps the requirement satisfiable against an append-only export topic. Retention is the only lifetime bound the gear applies. |
+| `cpt-cf-policy-engine-fr-record-retention` | Retention sweep over the record table, with window and volume exported as metrics. |
+| `cpt-cf-policy-engine-fr-metrics` | Telemetry surface in Section 4.1, emitted from the components that own each measurement. |
+| `cpt-cf-policy-engine-fr-explanation` | Explanation is the evaluation trace the combiner already builds, returned instead of discarded. |
+| `cpt-cf-policy-engine-fr-dry-run` | Dry-run compiles a draft into a throwaway snapshot and evaluates against it without publication. |
+| `cpt-cf-policy-engine-fr-operational-limits` | Limits are validated at activation and re-checked at evaluation, so content that grew past a lowered bound fails closed. |
+| `cpt-cf-policy-engine-fr-configuration-validation` | Configuration is a deny-unknown-fields structure with documented defaults, rejected at startup. |
+
+#### NFR Allocation
+
+This table maps non-functional requirements from PRD to specific design/architecture responses, demonstrating how quality attributes are realized.
+
+| NFR ID | NFR Summary | Allocated To | Design Response | Verification Approach |
+|--------|-------------|--------------|-----------------|----------------------|
+| `cpt-cf-policy-engine-nfr-decision-latency` | p95 25 ms, p99 50 ms per evaluation, miss path included | `cpt-cf-policy-engine-component-snapshot`, `-matcher`, `-evaluator`, `-type-reference` | Activation-time compilation removes parsing and content I/O from the hot path entirely — content is served from the published generation, never read from storage during a decision, which is what leaves the ~5 ms remaining beside a 20 ms hierarchy miss. Matching is an index lookup against references the reference memo already holds, so the only registry call a decision can make is a memo miss on a resource type no policy has ever targeted | Benchmark at the gear boundary measured over all evaluations including forced cache misses, the reference memo's among them; per-stage timing histograms |
+| `cpt-cf-policy-engine-nfr-fail-closed` | No permit on any error path | `cpt-cf-policy-engine-component-combiner` | Single refusal constructor; no configuration path constructs a permit from an error; accumulator starts at refusal | Fault injection across the enumerated conditions |
+| `cpt-cf-policy-engine-nfr-availability` | Host-impact in-process; 99.95 percent per surface out-of-process, decision-surface maintenance capped at 30 min/month | `cpt-cf-policy-engine-topology-in-process` | In-process, the target is that no gear failure mode is host-fatal: every error path converges on a refusal rather than a panic, snapshot memory is bounded by the content limits, and evaluation is bounded in time. Out-of-process, the gear becomes independently addressable and the per-surface figure applies; the stateless decision path over process-resident content is what makes it reachable, since a store outage degrades management first and reaches decisions only once the record backlog ages past its window | Fault injection asserting zero host-fatal outcomes; per-surface availability measurement and store-outage drill in the out-of-process shape |
+| `cpt-cf-policy-engine-nfr-tenant-isolation` | Zero cross-tenant reads, writes, influences | `cpt-cf-policy-engine-component-repository`, `-violations` | Secure data layer scoping on every query. Content scopes on `owner_tenant_id`; records scope on `resource_tenant_id`, and the two differ whenever an ancestor's bundle refuses an operation in a descendant. The violations reader therefore scopes over the requesting context's reachable subtree of `resource_tenant_id`, not over content ownership, with barriers respected by declaration and a crossing available only under the separate platform capability | Isolation suite including barrier boundaries, plus an ancestor querying a descendant's refusals both with and without the cross-barrier capability |
+| `cpt-cf-policy-engine-nfr-decision-record` | One record per evaluation, no sampling | `cpt-cf-policy-engine-component-recorder` | Records enqueued to a transactional outbox and drained asynchronously; queue depth and loss window exported | Throughput test asserting record count equals evaluation count |
+| `cpt-cf-policy-engine-nfr-cache-safety` | Cached entries do not outlive their authority | `cpt-cf-policy-engine-component-snapshot` | Snapshot generation is part of every cache key; publication of a new generation invalidates the previous; error results are never cached | Cache-key property tests; revocation timing test |
+| `cpt-cf-policy-engine-nfr-activation-propagation` | Effective within 60 seconds | `cpt-cf-policy-engine-component-activation-compiler` | Generation counter polled by every instance at a configured interval bounded well inside the window | Measured propagation across a multi-instance deployment |
+| `cpt-cf-policy-engine-nfr-hierarchy-latency` | p95 2 ms on hit, 90 percent hit rate | `cpt-cf-policy-engine-component-assignment-resolver` | Ancestry cache keyed by tenant and barrier mode, with a bounded time to live | Hit-rate and latency metrics under steady load |
+| `cpt-cf-policy-engine-nfr-scalability` | Tenfold load, 1,000 concurrent | `cpt-cf-policy-engine-topology-in-process` | Read-only hot path over immutable state; no shared mutable structure on the decision path | Load and concurrency test asserting no contention failures |
+| `cpt-cf-policy-engine-nfr-instance-footprint` | Instance memory bounded by content limits, observable, not the binding scaling constraint | `cpt-cf-policy-engine-component-snapshot`, `-evaluator` | Snapshot memory is a function of the activated content one instance holds, so the content limits are the only lever; the registry holds one compiled artefact per active assignment and discards it when the version leaves the active set, and the evaluator allocates per call rather than retaining. Footprint is exported alongside generation age so growth is attributable to content rather than inferred from host metrics | Footprint measured across tenant count and content volume inside the scalability exercise, not as a separate benchmark |
+| `cpt-cf-policy-engine-nfr-durability` | Recovery point and time within 1 hour | `cpt-cf-policy-engine-db-policy-engine` | Content and versions in the platform store under its backup regime; records excluded and governed by retention | Restore exercise into a clean deployment |
+
+#### Key ADRs
+
+No decision record exists for this gear yet. The decisions below are the ones this design takes that warrant one, listed so that the ADRs can be written against a stated position rather than reconstructed from the design. The template's `ADR ID` column is replaced by a plain name here because allocating `cpt-cf-policy-engine-adr-*` identifiers before the records exist produces dangling references that the repository's deterministic validation rejects; the column returns, populated, as each record is written. PRD Section 13 gates the first four.
+
+| Planned decision | Decision Summary |
+|--------|-----------------|
+| Evaluation facility dependency | Link the platform's shared evaluation facility directly rather than building a gear-level engine registry, on the grounds that the facility already carries the backend contract; record why delegating pluggability downward is preferable to the local registries `quota-enforcement` and `event-broker` each built. |
+| Activation snapshot | Compile content into an immutable published snapshot at activation, rather than evaluating from the store, and accept a bounded propagation window as the cost. |
+| Violations as projection | Derive violations from decision records rather than maintaining standing violation state, and accept the retention window as the projection's horizon. |
+| Batch verdict | Evaluate a batch as members over one snapshot read with one absorbing combination, rather than as an independent request per member. |
+
+### 1.3 Architecture Layers
+
+```mermaid
+graph TD
+    GW[Admission gateway]
+    OP[Operator or administrator]
+    subgraph Presentation
+        REST[REST administration surface]
+    end
+    subgraph Application
+        DC[Decision client]
+        MC[Management client]
+    end
+    subgraph Domain
+        DEC[Decision pipeline]
+        LC[Content lifecycle and activation]
+        SNAP[Snapshot registry]
+        RB[Record buffer]
+    end
+    subgraph Infrastructure
+        REPO[Persistence and outbox]
+        HC[Hierarchy client]
+        EVAL[Evaluation facility]
+        REF[Type reference resolver]
+    end
+    GW --> DC
+    OP --> REST
+    REST --> MC
+    DC --> DEC
+    MC --> LC
+    LC --> SNAP
+    LC --> REPO
+    DEC --> SNAP
+    DEC --> HC
+    DEC --> EVAL
+    DEC --> RB
+    RB -.->|batched flush, off the decision path| REPO
+    HC --> TR[tenant-resolver]
+    DEC --> REF
+    LC --> REF
+    REF --> TY[types-registry]
+    REPO --> DB[(Platform store)]
+    REPO -.->|export| BR[event-broker audit topic]
+```
+
+Nodes inside the layer boxes are this gear's own code and the libraries it links, the evaluation facility among them. Nodes outside are separate gears and external systems, reached rather than linked.
+
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-tech-stack`
+
+| Layer | Responsibility | Technology |
+|-------|---------------|------------|
+| Presentation | Versioned REST administration surface, problem-shaped errors, precondition headers, OData listing and cursor pagination | `toolkit-http`, `toolkit-odata`, `toolkit-canonical-errors` |
+| Application | Decision and management clients registered in ClientHub, gear lifecycle, configuration | ToolKit gear capabilities, ClientHub |
+| Domain | Content model, activation compilation, assignment resolution, matching, outcome combination, record construction | Rust, `#[domain_model]` types |
+| Infrastructure | Content and record persistence, tenant hierarchy client, policy evaluation, GTS registration, registry-reference resolution in both directions | `toolkit-db` secure data layer, `tenant-resolver` SDK, evaluation facility, `toolkit-gts`, `types-registry` SDK |
+
+## 2. Principles & Constraints
+
+### 2.1 Design Principles
+
+#### Interpretation Happens at Activation
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-principle-compile-at-activation`
+
+Everything that can be decided from content alone is decided when the content is activated, not when a decision is requested: syntax, target vocabularies, limits, digest, target indexing, and expression compilation. The decision path consumes only compiled artefacts. This is what makes evaluation cost a function of the applicable set rather than of stored policy volume, and it moves authoring mistakes to the author instead of to the operation that trips over them.
+
+**Planned decision record**: Activation snapshot
+
+#### Content Is Immutable Once Active
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-principle-immutable-content`
+
+An activated bundle version is never modified. Changes create a new version, and withdrawal is a state transition that leaves the version intact. Immutability is what allows a decision record to name a version and mean something, allows a snapshot to be cached without invalidation logic beyond generation replacement, and allows returning to earlier content to be a fresh activation of a seeded draft rather than a reconstruction.
+
+**Planned decision record**: Activation snapshot
+
+#### The Caller Supplies the Facts
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-principle-caller-supplied-context`
+
+The gear judges what it is told. It holds no copy of the resources policy governs and retrieves none during evaluation. Policy commonly judges a resource that does not exist yet, so there is nothing to retrieve; and a gear that fetched consumer state would need the resource synchronisation the platform rejected, plus a fetch inside the latency budget. The cost of this principle is stated as an assumption in the PRD: a property the caller omits evaluates as absent.
+
+#### Semantics in the Gear, Language in the Library
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-principle-semantics-in-gear`
+
+The evaluation facility answers one question: what outcome does this document produce over this context. Everything else — which documents apply, in what order, how outcomes combine, what a refusal means, what gets recorded — belongs to the gear. The gear does not parse document content; it resolves the backend identifier the document declares, routes the content there, and reads only the outcome that comes back. Because a policy language can return an arbitrary shape rather than a boolean, the evaluator validates every result against the closed outcome set before it reaches the combiner, so a backend defect degrades to a refusal rather than becoming a policy bypass.
+
+**Planned decision record**: Evaluation facility dependency
+
+#### Records Are the Only Decision State
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-principle-records-only`
+
+The decision record is the single durable artefact an evaluation produces. Violations are a query over records, explanation is the trace the combiner already built, and metrics are aggregates. Nothing derived from a decision is separately stored, so nothing derived can disagree with the record it came from.
+
+**Planned decision record**: Violations as projection
+
+#### Management and Decision Do Not Share a Path
+
+- [ ] `p2` - **ID**: `cpt-cf-policy-engine-principle-surface-separation`
+
+The two surfaces share the content model and nothing else: separate clients, separate components, separate error surfaces, and no synchronous call from decision into management. A consumer on the admission path links only the decision contract. Administration traffic reaches the store; decision traffic reaches memory.
+
+### 2.2 Constraints
+
+#### The Expression Library Is a Hard Dependency
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-constraint-expression-library`
+
+There is no evaluation path without the shared evaluation facility, and no fallback interpreter in the gear. Two properties are required of every backend the facility carries, not of the facility in the abstract: syntax validation exposed separately from evaluation, and acceptance of an externally imposed per-document cost bound. Without both, `cpt-cf-policy-engine-fr-content-validation` and `cpt-cf-policy-engine-fr-evaluation-cost-bounds` have no implementation. Both are present in the first candidate audited, and the audit also settled what is **not** available and therefore has to be built here: a backend does not declare its own sandbox posture, its determinism depends on which builtins its build registers, and it offers no way to remove or shadow one. Isolation is consequently split — capabilities are withheld at the call, and determinism is enforced by refusing content at activation. The facility itself is still unwritten, which keeps its surface the gear's largest external risk.
+
+**Planned decision record**: Evaluation facility dependency
+
+#### Tenant Hierarchy Is Owned Elsewhere
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-constraint-hierarchy-external`
+
+Ancestry, descendants, barrier state, and tenant status come from `tenant-resolver`. The gear caches them and reinterprets none of them. Barrier handling arrives on the request and is passed through unchanged, because the platform's position is that the caller decides per resource type.
+
+#### Evaluation Is In-Process and Capability-Free
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-constraint-in-process-evaluation`
+
+Expression evaluation runs in the gear's process, inside the caller's task, with no handle to the network, the filesystem, the clock, or the database. The only ambient value is a gear-supplied evaluation timestamp. Co-location bounds the failure modes but does not remove them, so the cost bound applies regardless.
+
+#### Database Objects Carry the Gear Namespace
+
+- [ ] `p2` - **ID**: `cpt-cf-policy-engine-constraint-db-namespace`
+
+The gear declares `policy_engine` as its stable database namespace and names every object it creates accordingly. The platform's namespacing decision names `policies` specifically as the kind of generic table name that has already produced a collision, so this gear cannot use unprefixed names for its content tables.
+
+#### Type References Are Stored, Identifiers Are Not
+
+- [ ] `p2` - **ID**: `cpt-cf-policy-engine-constraint-type-references`
+
+Every reference this gear persists to a registry entity — the backend a document declares, the concrete type a target names, the resource type a record carries — is stored as the opaque registry reference the types-registry SDK returns, never as the GTS identifier string, and the gear neither derives a reference itself nor depends on its shape. The platform's storage-identity decision makes this the rule for every domain gear with typed objects, and this gear is the first design to demonstrate it, which the decision's own confirmation criteria ask for.
+
+Two consequences are load-bearing rather than incidental. Resolution becomes a dependency of the write path, so a draft naming a backend the registry does not know is refused at insert rather than at activation. And reverse resolution becomes a dependency of every path that speaks outward, which is why it sits in the export drain and the response projection and not in the flush transaction: the record table is where a decision becomes durable, and the serving condition of Section 4.5 must not be tripped by a registry outage.
+
+#### The Latency Budget Is Borrowed
+
+- [ ] `p2` - **ID**: `cpt-cf-policy-engine-constraint-latency-budget`
+
+The decision latency target is a fraction of a consumer's own budget, not an independent figure. Any design change that adds a synchronous dependency to the decision path spends the consumer's budget, so the hot path admits exactly three: the snapshot registry, in memory; the hierarchy cache, which is required to hit; and the reference memo of `cpt-cf-policy-engine-component-type-reference`, which is also required to hit and whose miss is a registry call charged against the same budget. The memo is admitted rather than avoided because the alternative is storing identifier strings, which `cpt-cf-policy-engine-constraint-type-references` forecloses; what keeps it cheap is that the mapping is immutable and activation has already populated it for every type policy targets.
+
+#### The Gateway Is the Only Path, and It Is Not Built Yet
+
+- [ ] `p2` - **ID**: `cpt-cf-policy-engine-constraint-no-gateway`
+
+Every evaluation reaches this gear through `admission-control`, which is specified but unbuilt: its engine plugin contract exists as `cpt-cf-admission-control-interface-engine-plugin` and is declared unstable, so the shape is known and may still move. Two things follow. The decision surface is specified independently of that contract, so conforming to it is an added implementation of a foreign trait over the same service rather than a change to how decisions are reached — and an unstable contract is a reason to keep that separation, not to collapse it. And until the gateway is built the gear can only be exercised through a harness standing in for it, so every integration property — context completeness, batch shape, refusal propagation — is verified against a specification rather than against a running consumer.
+
+## 3. Technical Architecture
+
+### 3.1 Domain Model
+
+**Technology**: Rust domain types under `#[domain_model]`, GTS identifiers for resource types and error families
+
+**Location**: `gears/system/policy-engine/policy-engine/src/domain/`
+
+**Core Entities**:
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-entity-bundle`
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-entity-bundle-version`
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-entity-document`
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-entity-target`
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-entity-assignment`
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-entity-evaluation-input`
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-entity-decision`
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-entity-decision-record`
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-entity-snapshot`
+- [ ] `p3` - **ID**: `cpt-cf-policy-engine-entity-obligation`
+
+| Entity | Description | Schema |
+|--------|-------------|--------|
+| PolicyBundle | Stable identity and ownership of a named body of policy within a tenant. Carries no content. | `policy_engine__bundle` |
+| PolicyBundleVersion | An immutable-once-activated revision of a bundle: lifecycle state, content digest, authorship, activation timestamp. The unit of versioning and integrity. | `policy_engine__bundle_version` |
+| PolicyDocument | One rule within a version: kind, the evaluation backend its content is written for — held as a registry reference in storage and as its GTS identifier everywhere the gear speaks to a person or another gear — the content itself as source that backend interprets, and the outcome directive the gear applies to what it returns. | `policy_engine__document` |
+| PolicyTarget | The binding that decides when a document is evaluated: trigger, phase, resource type or pattern, and conjunctive attribute filters. | `policy_engine__target` |
+| PolicyAssignment | Binds a bundle to a tenant with a policy priority, an optional effective window, and a barrier-reach declaration. Resolves to the bundle's active version at generation build, so it survives activation unchanged. | `policy_engine__assignment` |
+| EvaluationInput | Caller-supplied request value: subject identifier and subject tenant, action, resource type and optional identifier, tenant context, and operation properties. The subject fields are checked against the caller's propagated security context and taken from it, per `cpt-cf-policy-engine-fr-subject-authenticity`, so they are a restatement rather than an assertion. Carries no entitlement of the subject and has no field shaped to hold one, per `cpt-cf-policy-engine-fr-authorization-boundary`. Not persisted. | Value type |
+| Decision | The combined result: outcome, cause, responsible document, obligations, matched and evaluated counts, elapsed time. Not persisted directly. | Value type |
+| DecisionRecord | The durable projection of a Decision together with its request identity, written asynchronously and read by the violations projection. | `policy_engine__decision_record` |
+| PolicySnapshot | The compiled, digest-verified, immutable evaluation artefact for one activated version: compiled expressions plus the target index. Process-resident. | In-memory |
+| Obligation | A typed identifier attached to a permitting decision that the caller must honour or else refuse. | Embedded in Decision |
+
+**Relationships**:
+- PolicyBundle → PolicyBundleVersion: one bundle owns an ordered history of versions; exactly one is active at a time.
+- PolicyBundleVersion → PolicyDocument: a version owns its documents; documents do not exist outside a version.
+- PolicyDocument → PolicyTarget: a document declares one or more targets; a document with no target is never evaluated and fails validation.
+- PolicyBundle → PolicyAssignment: a bundle is assigned to zero or more tenants, and each assignment governs through whichever of that bundle's versions is active.
+- PolicyBundleVersion → PolicySnapshot: activation compiles exactly one snapshot per version; the snapshot is discarded when the version leaves the active set.
+- EvaluationInput → Decision → DecisionRecord: each input yields one decision, which yields exactly one record.
+
+### 3.2 Component Model
+
+The gear is two crates: `policy-engine-sdk`, carrying the client traits, models, error types, and GTS schemas that consumers link; and `policy-engine`, carrying the gear itself in the platform's domain, API, and infrastructure layering. Components below are modules within those crates, not separate processes.
+
+```mermaid
+graph TD
+    REST[REST API] --> MGMT[Management service]
+    MGMT --> VAL[Content validator]
+    MGMT --> REPO[Content repository]
+    MGMT --> VIO[Violations reader]
+    VAL --> COMP[Activation compiler]
+    MGMT --> COMP
+    COMP --> SNAP[Snapshot registry]
+    DEC[Decision service] --> SNAP
+    DEC --> AR[Assignment resolver]
+    DEC --> MATCH[Matcher]
+    DEC --> EVAL[Evaluator]
+    DEC --> COMB[Combiner]
+    DEC --> REC[Decision recorder]
+    DEC --> REF[Type reference resolver]
+    COMP --> REF
+    REC --> REF
+    VIO --> REF
+    AR --> HC[Hierarchy client]
+    REC --> REPO
+    VIO --> REPO
+```
+
+#### Decision Service
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-component-decision`
+
+##### Why this component exists
+
+Consumers need one call that turns an intended operation into a verdict they can enforce. This component is that call, and it is the only component a consumer on the admission path depends on.
+
+##### Responsibility scope
+
+Owns the decision pipeline and its ordering: security-context check, emergency-entitlement check, tenant reachability check, resource-type reference resolution, assignment resolution, matching, evaluation, combination, record construction. The context check is first and is not a formality: the subject and its tenant are taken from the propagated context, a request whose asserted values disagree is refused from its own arm of the refusal constructor before any content is reached, and the refusal is recorded under the context's subject rather than the asserted one. Owns the fail-closed constructor that every error path converges on, and the timeout wrappers around external calls. Implements `cpt-cf-policy-engine-interface-decision-client` for both single and batch requests.
+
+##### Responsibility boundaries
+
+Does not read or write policy content, does not interpret expressions, and does not resolve tenant hierarchy itself. Does not enforce its own decisions, and has no way to observe whether a caller honoured one.
+
+##### Related components (by ID)
+
+- `cpt-cf-policy-engine-component-snapshot` — depends on, for the compiled content of each applicable assignment
+- `cpt-cf-policy-engine-component-assignment-resolver` — calls
+- `cpt-cf-policy-engine-component-matcher` — calls
+- `cpt-cf-policy-engine-component-evaluator` — calls
+- `cpt-cf-policy-engine-component-combiner` — calls
+- `cpt-cf-policy-engine-component-type-reference` — calls
+- `cpt-cf-policy-engine-component-recorder` — publishes to
+
+#### Snapshot Registry
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-component-snapshot`
+
+##### Why this component exists
+
+The decision path must not query the store or parse content. The registry is the process-resident, immutable, generation-stamped view of every currently active assignment and the compiled content behind it.
+
+##### Responsibility scope
+
+Holds compiled snapshots keyed by assignment, together with a monotonic generation counter. Resolves each assignment's bundle to that bundle's active version while building a generation — the join that makes an activation take effect everywhere without an assignment row being touched, and the reason a snapshot is keyed by assignment rather than by version. Verifies the content digest when a snapshot is built and whenever it is reloaded. Publishes a new generation atomically, so a reader observes either the whole previous generation or the whole next one. Polls for generation changes at a configured interval bounded inside the activation propagation window, which is how a change made on one instance reaches the others.
+
+An assignment whose bundle has no active version — every version still a draft, or the last one deprecated without a successor — contributes nothing to the generation and is not an error. Its tenant is then governed by whatever other assignments reach it, and by nothing if there are none, which `cpt-cf-policy-engine-fr-permit-provenance` reports as an ungoverned permit rather than disguising as a refusal.
+
+##### Responsibility boundaries
+
+Does not compile content, does not decide what is active, and never serves a partially built generation. Holds nothing derived from a request, so it is not a decision cache and carries no request-scoped keys.
+
+##### Related components (by ID)
+
+- `cpt-cf-policy-engine-component-activation-compiler` — subscribes to
+- `cpt-cf-policy-engine-component-decision` — owns data for
+
+#### Activation Compiler
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-component-activation-compiler`
+
+##### Why this component exists
+
+Activation is the moment when content stops being text and becomes an evaluation artefact. Concentrating that transformation in one place is what keeps the decision path free of parsing and the validator honest about what activation will do.
+
+##### Responsibility scope
+
+Resolves each document's declared backend identifier and each concrete target type through `cpt-cf-policy-engine-component-type-reference`, storing the references the schema holds and keeping the identifiers only in the compiled artefact, compiles the document through the backend instance that resolves, builds the target index used by matching, computes and records the content digest, enforces the content limits, screens the compiled form for builtins denylisted for that backend build, and publishes the resulting snapshot as a new generation. A document whose backend identifier does not resolve, whose target names a resource type that does not, or which references a denylisted builtin, fails compilation here rather than at evaluation. The screen runs over the parsed form rather than over the source text, because a substring search for a builtin name is defeated by anything the language allows in its place. Runs the identical pipeline for dry-run against a draft, publishing nothing.
+
+##### Responsibility boundaries
+
+Does not decide lifecycle state transitions, does not write content, and does not evaluate. A compilation failure aborts activation and leaves the version in draft; it never produces a partial snapshot.
+
+##### Related components (by ID)
+
+- `cpt-cf-policy-engine-component-validator` — shares model with
+- `cpt-cf-policy-engine-component-snapshot` — publishes to
+- `cpt-cf-policy-engine-component-management` — subscribes to
+
+#### Content Validator
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-component-validator`
+
+##### Why this component exists
+
+An author needs the answer to "will this activate" before activating, and the answer has to be the same one activation would give.
+
+##### Responsibility scope
+
+Runs backend and resource-type identifier resolution through `cpt-cf-policy-engine-component-type-reference`, content syntax validation through the resolved backend, target vocabulary checks, the denylisted-builtin screen over the parsed form, and limit checks against a draft version, and reports every failure against the document that caused it rather than stopping at the first. The screen set is shared with `cpt-cf-policy-engine-component-activation-compiler` rather than reimplemented, because the promise that a draft which validates is a draft which activates is only true while the two run the same checks — and a denylist enforced at activation but not at validation would break it in the one direction that matters, by passing validation and then failing the activation an author has already been told will succeed.
+
+##### Responsibility boundaries
+
+Does not publish, does not mutate state, and does not answer whether a policy is correct — only whether it is well-formed and within bounds.
+
+##### Related components (by ID)
+
+- `cpt-cf-policy-engine-component-activation-compiler` — shares model with
+- `cpt-cf-policy-engine-component-management` — called by
+
+#### Assignment Resolver
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-component-assignment-resolver`
+
+##### Why this component exists
+
+Which policy applies is a question about the tenant tree, and answering it on every evaluation without a cache would put a remote call inside the latency budget.
+
+##### Responsibility scope
+
+Resolves the resource tenant's ancestry under the requested barrier mode and status filter, checks that the resource tenant lies within the reachable subtree, collects the assignments visible along the chain, applies effective windows, and orders the result by proximity, then priority, then assignment identifier. Caches ancestry keyed by tenant and barrier mode with a bounded lifetime.
+
+##### Responsibility boundaries
+
+Does not own hierarchy, does not apply a barrier default of its own, and does not evaluate. Converts a hierarchy timeout or outage into an infrastructure refusal rather than a narrowed or widened set.
+
+##### Related components (by ID)
+
+- `cpt-cf-policy-engine-component-hierarchy-client` — depends on
+- `cpt-cf-policy-engine-component-decision` — called by
+
+#### Matcher
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-component-matcher`
+
+##### Why this component exists
+
+Evaluating every document on every operation would make cost scale with stored policy rather than with relevant policy.
+
+##### Responsibility scope
+
+Intersects the compiled target index of each ordered assignment with the request's trigger, phase, resource type, and attribute filters, producing the applicable set in evaluation order and the matched count. The resource-type lookup has two lanes: an exact lane keyed by the registry reference the reference resolver returned for the request, and a pattern lane matched against the identifier and checked only when the exact lane misses — the same shape the gateway's built-in selection uses, and what keeps a wildcard target matching a type registered after the current generation was built. Enforces the applicable-set bound.
+
+##### Responsibility boundaries
+
+Performs no expression evaluation — attribute filters use the closed operator set and are structural, which is why they can run before the evaluator and cheaply exclude most content.
+
+##### Related components (by ID)
+
+- `cpt-cf-policy-engine-component-snapshot` — depends on
+- `cpt-cf-policy-engine-component-evaluator` — calls
+
+#### Evaluator
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-component-evaluator`
+
+##### Why this component exists
+
+It is the boundary with the evaluation facility, and the place where an untrusted result becomes a trusted one.
+
+##### Responsibility scope
+
+Builds the evaluation context from the request and a gear-supplied timestamp, invokes the compiled expression under the per-document cost bound, enforces the per-evaluation bound across the loop, and validates every returned outcome against the closed outcome set before passing it on. The per-document bound is set on the backend and is cooperative: it is checked between work units, so it overruns by at most one work unit, and the evaluator sets the check interval rather than accepting a default. The per-evaluation bound is the evaluator's own, measured across the loop, because no backend can see a budget that spans several of its invocations.
+
+##### Responsibility boundaries
+
+The only component that links the evaluation facility, and it evaluates through the backend instance the activation compiler already resolved rather than resolving one per request. It cannot enforce determinism at this point and does not try: builtins resolve inside the backend ahead of anything registered over the same name, so content that reached evaluation carrying a clock read or a random generator would be evaluated. That is why the denylist is the activation compiler's obligation and not this component's — by the time an expression is invoked here, the only remaining defence is the cost bound. Does not combine outcomes, does not record, and does not decide what to evaluate. Converts any backend failure, unavailable backend, or bound exceedance into an infrastructure refusal rather than a prohibition.
+
+##### Related components (by ID)
+
+- `cpt-cf-policy-engine-component-combiner` — calls
+- `cpt-cf-policy-engine-component-matcher` — called by
+
+#### Combiner
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-component-combiner`
+
+##### Why this component exists
+
+Consumers need one answer. The rules that produce it are a product decision and belong in one auditable place.
+
+##### Responsibility scope
+
+Folds the document-outcome sequence into a single two-valued result — permit or prohibit — under the absorbing-prohibition rule, starting from an ungoverned permit. A permitting outcome moves the cause to governed; a prohibit overrides both. The cause travels with the result rather than as a third variant, so a caller branching only on permit or prohibit is correct without knowing the cause exists. The emergency cause is not reachable from this fold and is not meant to be: it is constructed upstream in `cpt-cf-policy-engine-component-decision`, on a path that has already given up on producing an outcome sequence, which is what keeps this component's output a pure function of the outcomes it was given. Reports saturation so the caller can stop early, accumulates the evaluation trace used by explanation, and carries matched and evaluated counts. Combines batch members under the same rule and collects every refused member.
+
+##### Responsibility boundaries
+
+A pure, order-independent fold over outcomes, with no I/O and no knowledge of where they came from. Order-independence is a property worth testing directly: the same applicable set in any permutation must produce the same result, which is what keeps the ordering in `cpt-cf-policy-engine-fr-deterministic-ordering` a reporting concern rather than a semantic one.
+
+##### Related components (by ID)
+
+- `cpt-cf-policy-engine-component-decision` — called by
+
+#### Decision Recorder
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-component-recorder`
+
+##### Why this component exists
+
+Every evaluation must leave evidence, and writing that evidence synchronously would consume the latency budget it is measured against.
+
+##### Responsibility scope
+
+Owns the record field set and its single builder, and stages records in two stages so that durability never touches the decision path. On the decision path it appends the built record to a bounded in-memory buffer, which performs no I/O. Off it, a flusher periodically drains the buffer and, in one transaction, inserts the batch into `policy_engine__decision_record` and enqueues the same records for export on the `toolkit-db` outbox. Exports buffer age, buffer occupancy, and outbox depth, the first of which is the control input for the serving condition. Applies the retention sweep. Owns the export step too, and that is where a record's registry references become GTS identifiers again: the drain reverse-resolves each batch through `cpt-cf-policy-engine-component-type-reference` before publishing, so the topic carries identifiers while the table carries references, and a registry outage delays export without touching the durability the serving condition is defined against.
+
+##### Responsibility boundaries
+
+Does not decide, does not filter which evaluations are recorded, and does not project records into violations. Never writes a credential, and stores operation context only as a redacted projection.
+
+##### Related components (by ID)
+
+- `cpt-cf-policy-engine-component-repository` — depends on
+- `cpt-cf-policy-engine-component-violations` — owns data for
+
+#### Violations Reader
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-component-violations`
+
+##### Why this component exists
+
+An administrator needs to see what policy has refused within the retention window without reading gear logs, and that view must not be a second source of truth.
+
+##### Responsibility scope
+
+Queries the decision record table under a prohibiting-outcome predicate, filtered by tenant, document, resource type, and time range. Reports the retention window in force alongside the result, since the window is the projection's horizon.
+
+Scopes on `resource_tenant_id` over the subtree reachable from the caller's context with barriers respected, which is what `cpt-cf-policy-engine-fr-record-visibility` declares for this surface — never on the tenant that owns the content, because an ancestor's bundle refusing in a descendant is the ordinary case and the two answers differ there. Reading across a barrier requires the separate platform capability and leaves an administration event. Resolves a resource-type filter forward before the query and reverse-resolves the resource type of every row on the way out, so the caller sends and receives identifiers and never sees a reference.
+
+##### Responsibility boundaries
+
+Stores nothing, evaluates nothing, and never inspects resources. A refusal that has aged out of retention is simply absent. Nor does it reach beyond this gear's own records: a gateway's built-in refusal and a gateway's could-not-run refusal produced no evaluation here and therefore no row to project, and the surface states that boundary rather than letting an absence read as an all-clear.
+
+##### Related components (by ID)
+
+- `cpt-cf-policy-engine-component-repository` — depends on
+- `cpt-cf-policy-engine-component-management` — called by
+
+#### Management Service
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-component-management`
+
+##### Why this component exists
+
+Policy content needs an owner with a lifecycle, and the gear's own administration surface is a security boundary in its own right.
+
+##### Responsibility scope
+
+Owns bundle, version, document, target, and assignment lifecycle; enforces state transitions and preconditions; authorises each of the six management capabilities separately against the caller's context — content read, authoring, activation, assignment, decision-record read, and violations read; and exposes validation, dry-run, decision queries, and violation queries.
+
+Declares the barrier handling of its own surfaces rather than inheriting one, because the platform decides barrier enforcement per endpoint: assignment and record reads respect barriers, so an assignment at, or a record read of, a tenant behind a self-managed barrier is refused with the boundary cause rather than reported as absent, and the cross-barrier record read is a distinct platform-level capability whose every use is written as an administration event. Implements `cpt-cf-policy-engine-interface-management-client`.
+
+##### Responsibility boundaries
+
+Never evaluates policy for a consumer, and never grants an entitlement the caller does not itself hold. Bootstrap authorisation is confined here and is observable while it applies.
+
+##### Related components (by ID)
+
+- `cpt-cf-policy-engine-component-repository` — depends on
+- `cpt-cf-policy-engine-component-validator` — calls
+- `cpt-cf-policy-engine-component-activation-compiler` — calls
+- `cpt-cf-policy-engine-component-violations` — calls
+
+#### Content Repository
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-component-repository`
+
+##### Why this component exists
+
+All persistence is confined to one layer so that tenant scoping is applied in one place rather than at every call site.
+
+##### Responsibility scope
+
+Owns the gear's schema and migrations, and executes every query through the secure data layer with the caller's scope. Provides the transactional boundary that makes activation and its outbox enqueue atomic.
+
+##### Responsibility boundaries
+
+Holds no domain rules. Returns absent for content the caller is not entitled to, so forbidden and non-existent are indistinguishable above this layer.
+
+##### Related components (by ID)
+
+- `cpt-cf-policy-engine-component-management` — owns data for
+- `cpt-cf-policy-engine-component-recorder` — owns data for
+
+#### Type Reference Resolver
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-component-type-reference`
+
+##### Why this component exists
+
+The gear persists registry references rather than GTS identifier strings, so every write resolves forward and every read and export resolves back. Concentrating both directions here is what keeps a types-registry call out of each call site, and what keeps the decision path from paying for one per request.
+
+##### Responsibility scope
+
+Wraps the types-registry SDK's batch forward and reverse resolution under the configured timeout and memoises the mapping in both directions. The memo needs no invalidation: the registry guarantees that one identifier always resolves to one reference for the life of an installation, so the mapping is immutable, and the only volatile thing beside it — the per-tenant availability verdict — is not something a stored reference or a written record depends on. Activation and validation populate the memo for every backend and every concrete type the content mentions, so the steady-state miss on the decision path is a resource type no policy has ever targeted.
+
+##### Responsibility boundaries
+
+Derives no reference itself: the mapping is the registry's to compute and opaque here, which is what the platform's storage-identity decision requires of a domain gear. Holds no availability verdict and caches none, because availability is per-tenant and can change with nothing written in the registry. On a miss it cannot resolve — a timeout or an outage — it reports an infrastructure condition rather than a guess, and the decision path converts that into a refusal on the same terms as a hierarchy failure: a decision whose record could not name its resource type is a decision that cannot be recorded.
+
+##### Related components (by ID)
+
+- `cpt-cf-policy-engine-component-decision` — called by
+- `cpt-cf-policy-engine-component-activation-compiler` — called by
+- `cpt-cf-policy-engine-component-recorder` — called by
+- `cpt-cf-policy-engine-component-violations` — called by
+
+#### Hierarchy Client
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-component-hierarchy-client`
+
+##### Why this component exists
+
+Tenant ancestry comes from another gear, and every remote call on the decision path needs a bound and a cache.
+
+##### Responsibility scope
+
+Wraps the `tenant-resolver` client with the configured timeout and the ancestry cache, and passes barrier mode and status filter through unchanged.
+
+##### Responsibility boundaries
+
+Interprets nothing. On timeout or failure it reports an infrastructure condition and never substitutes a default subtree.
+
+##### Related components (by ID)
+
+- `cpt-cf-policy-engine-component-assignment-resolver` — called by
+
+#### REST API
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-component-rest`
+
+##### Why this component exists
+
+The gear must be operable by people and by tooling outside the process, and administration is the surface that needs to be reachable without a consuming gear.
+
+##### Responsibility scope
+
+Registers versioned operations through the platform's operation builder, maps management results into canonical problem responses, binds preconditions to the entity tag, and applies the platform's OData filtering and cursor pagination on list surfaces.
+
+##### Responsibility boundaries
+
+Contains no domain logic and exposes no decision endpoint: the decision surface is in-process only, because a network hop would spend a budget borrowed from the consumer.
+
+##### Related components (by ID)
+
+- `cpt-cf-policy-engine-component-management` — calls
+
+### 3.3 API Contracts
+
+#### Policy Decision Client
+
+- **Realizes PRD interface**: `cpt-cf-policy-engine-interface-decision-client`
+- **Contracts**: none at first release. `cpt-cf-policy-engine-contract-admission-engine` is a future conformance of this surface, not a dependency of it, and is not applicable until the gateway exists
+- **Technology**: Rust async trait registered in ClientHub without scope
+- **Location**: `gears/system/policy-engine/policy-engine-sdk/src/api.rs`
+
+Takes the caller's propagated security context and an evaluation input, or a batch of them, and returns a decision carrying outcome, cause, responsible document, obligations, and counts. The input carries the correlation identifier the gateway supplied; this gear records it and mints none of its own. The context is a required parameter, not an ambient value, because the subject and its tenant are derived from it and a request that asserts different ones is refused. The trait documents that any error result is a refusal for the caller. There is no REST projection of this surface.
+
+**Endpoints Overview**:
+
+| Method | Path | Description | Stability |
+|--------|------|-------------|-----------|
+| `n/a` | `evaluate` | Single evaluation over one operation | stable |
+| `n/a` | `evaluate_batch` | One verdict over several members, refusing whole | stable |
+
+#### Policy Management Client
+
+- **Realizes PRD interface**: `cpt-cf-policy-engine-interface-management-client`
+- **Contracts**: `cpt-cf-policy-engine-contract-decision-record` — the management client is where record and violation consumers read that contract
+- **Technology**: Rust async trait registered in ClientHub without scope
+- **Location**: `gears/system/policy-engine/policy-engine-sdk/src/api.rs`
+
+Content lifecycle, assignment, validation, dry-run, decision queries, and the violations projection. Each is authorised against one of the six capabilities of `cpt-cf-policy-engine-fr-admin-authorization`, so a consumer holding the record reads holds no content access by implication. Consumed in-process by tooling and by the REST layer.
+
+**Endpoints Overview**:
+
+| Method | Path | Description | Stability |
+|--------|------|-------------|-----------|
+| `n/a` | `bundle lifecycle` | Create, read, list, update draft, delete draft | stable |
+| `n/a` | `version lifecycle` | Draft (empty or seeded from a retained version), validate, activate, deprecate | stable |
+| `n/a` | `assignment lifecycle` | Assign, unassign, list by tenant | stable |
+| `n/a` | `queries` | Decisions and violations, filtered and paginated | stable |
+
+#### Policy Administration REST API
+
+- **Realizes PRD interface**: `cpt-cf-policy-engine-interface-rest-api`
+- **Contracts**: none. `cpt-cf-policy-engine-contract-gts` is a link-time registration to the types registry, realized by the gear's GTS inventory rather than by this REST surface
+- **Technology**: REST over the platform API prefix, OpenAPI-described, RFC 9457 problem responses
+- **Location**: `gears/system/policy-engine/policy-engine/src/api/rest/`
+
+Mutating operations require the entity tag as a precondition and reject a stale one as a conflict. List operations accept the platform's OData filter and order options with opaque cursor pagination. Error responses carry the gear's canonical error family; refusal detail from an evaluation is never exposed here.
+
+**Endpoints Overview**:
+
+| Method | Path | Description | Stability |
+|--------|------|-------------|-----------|
+| `POST` | `/policy-engine/v1/bundles` | Create a bundle | stable |
+| `GET` | `/policy-engine/v1/bundles` | List bundles for the scoped tenant | stable |
+| `GET` | `/policy-engine/v1/bundles/{id}` | Read a bundle | stable |
+| `POST` | `/policy-engine/v1/bundles/{id}/versions` | Create a draft version | stable |
+| `PUT` | `/policy-engine/v1/bundles/{id}/versions/{version}` | Replace draft content | stable |
+| `POST` | `/policy-engine/v1/bundles/{id}/versions/{version}/validate` | Validate without activating | stable |
+| `POST` | `/policy-engine/v1/bundles/{id}/versions/{version}/activate` | Activate a validated draft | stable |
+| `POST` | `/policy-engine/v1/bundles/{id}/versions/{version}/deprecate` | Withdraw an active version | stable |
+| `POST` | `/policy-engine/v1/assignments` | Assign a bundle to a tenant | stable |
+| `DELETE` | `/policy-engine/v1/assignments/{id}` | Remove an assignment | stable |
+| `GET` | `/policy-engine/v1/decisions` | Query decision records | stable |
+| `GET` | `/policy-engine/v1/violations` | Query the violations projection | stable |
+
+#### Consumed contracts
+
+The gear consumes one contract it does not define: `cpt-cf-policy-engine-contract-hierarchy-read`, the `tenant-resolver` read surface described in Section 3.4. It is consumed by `cpt-cf-policy-engine-component-hierarchy-client` and is the only external contract on the decision path.
+
+### 3.4 Internal Dependencies
+
+| Dependency Gear | Interface Used | Purpose |
+|-------------------|----------------|----------|
+| `tenant-resolver` | SDK client | Ancestry, descendants, barrier and status handling for assignment resolution |
+| `types-registry` | SDK client and GTS inventory | Registering the gear's resource types and error family. Both directions of registry-reference resolution through `cpt-cf-policy-engine-component-type-reference`: forward for the backend identifier each document declares, the concrete resource types its targets name, the obligation identifiers its decisions carry, and the resource type on every evaluation; reverse for every read and export that has to speak identifiers again |
+| `toolkit-db` | Library | Schema ownership, migrations, and tenant-scoped access through the secure data layer; also provides the transactional outbox used for record export, under this gear's own table prefix |
+| `toolkit-http` | Library | REST operation registration, precondition headers, problem responses |
+| `toolkit-odata` | Library | Filtering, ordering, and cursor pagination on list surfaces |
+| `toolkit-canonical-errors` | Library | The gear's error family and its RFC 9457 projection |
+| `authz-resolver` | SDK client, via the enforcement helper | Authorizing this gear's own management operations, one access request per management capability. Consumed by `cpt-cf-policy-engine-component-management` only; the decision path never calls it |
+| `toolkit-security` | Library | Security context propagation and management capability enforcement |
+| Evaluation facility | Library | Carries the evaluation backends; compilation, syntax validation, and bounded evaluation of document content in the language each document declares |
+
+**Dependency Rules** (per project conventions):
+- No circular dependencies
+- Always use sdk modules for inter-gear communication
+- No cross-category sideways deps except through contracts
+- Only integration/adapter gears talk to external systems
+- `SecurityContext` must be propagated across all in-process calls
+
+#### Shared type ownership
+
+Three schemas this gear reads are defined elsewhere, and naming the owner matters because two gears depend on each of them and neither is entitled to define one.
+
+**The backend guarantees and the sandbox declaration** belong to the **evaluation facility's SDK**, as the GTS type schema of a backend *build* instance. That covers the two properties Section 2.2 requires of every backend — syntax validation exposed separately from evaluation, and acceptance of an externally imposed cost bound — together with the sandbox-and-determinism declaration `cpt-cf-policy-engine-fr-evaluation-isolation` refuses to select a build without. The facility is the only component positioned to make the claim: it is a statement about which compile-time features a build enables and which builtins it registers, which the backend library says nothing about and this gear cannot inspect. Both this gear and `admission-control` read the same declaration and both refuse an undeclared build, so a schema owned by either would make the other depend on it.
+
+**The obligation base type** — the schema whose instances are the obligation identifiers of `cpt-cf-policy-engine-fr-obligations` — belongs in `libs/toolkit-gts`, beside the authorization permission base type that lives there for the same reason. An obligation travels from whichever decision point attached it, through the gateway, to the enforcing gear that must honour or refuse it, which makes the vocabulary platform-wide by construction. It cannot live here, because a replaceable engine must not own a type the platform depends on, and it should not live in the gateway's SDK either, because that would make every obligation-honouring gear depend on the gate in order to name what it is honouring. Individual obligation instances stay with the gears that define them, which is the pattern the permission base type already establishes.
+
+These are the positions this design assumes rather than decisions it may take alone: PRD Section 13 carries the ownership question — the row asking where these schemas belong — and names platform architecture as its owner, needed by before implementation. An answer that relocates a schema changes where this gear imports it from and nothing else — the refusal to select an undeclared build, and the resolution of an obligation identifier through the registry, are unaffected by where the schema sits.
+
+### 3.5 External Dependencies
+
+#### Platform relational store
+
+- **Contract**: `cpt-cf-policy-engine-contract-decision-record`
+
+The gear has two external systems, and only the first is on any critical path. The relational store reached through `toolkit-db` holds content, assignments, and decision records. It is not on the read path of a decision: a store outage stops activation, administration, and record durability, while evaluation itself continues from the published snapshot. The second is `event-broker`, which receives decision records from the outbox for retention and export; it is downstream of the evidence store, so a broker outage delays export without affecting durability, evaluation, or the violations projection, all three of which read the gear's own table.
+
+That asymmetry is bounded, and the bound is the record window rather than the outage itself. Evaluation continues from the published snapshot while the outbox still absorbs records inside the 5-second window of `cpt-cf-policy-engine-nfr-decision-record`. Once the oldest unflushed record ages past that window, the decision service stops returning permits and refuses with a distinct infrastructure cause until the drain recovers. The trigger is the age of the unflushed backlog, not store reachability: a brief outage the outbox absorbs changes nothing, and a slow drain under load trips the same condition a total outage would, which is correct — both mean a new decision cannot be shown to have been recorded.
+
+| Dependency Gear | Interface Used | Purpose |
+|-------------------|---------------|---------|
+| `toolkit-db` | Secure data layer | Content, assignment, and decision-record persistence with tenant scoping |
+| `event-broker` | Publish to the audit topic | Retention and export of decision records beyond this gear's own window, on the topic shared with `admission-control` |
+
+**Dependency Rules** (per project conventions):
+- No circular dependencies
+- Always use SDK modules for inter-gear communication
+- No cross-category sideways deps except through contracts
+- Only integration/adapter gears talk to external systems
+- `SecurityContext` must be propagated across all in-process calls
+
+### 3.6 Interactions & Sequences
+
+#### Admit a single operation
+
+**ID**: `cpt-cf-policy-engine-seq-admit-operation`
+
+**Use cases**: `cpt-cf-policy-engine-usecase-admit-operation`
+
+**Actors**: `cpt-cf-policy-engine-actor-admission-gateway`
+
+```mermaid
+sequenceDiagram
+    participant C as Admission gateway
+    participant D as Decision service
+    participant A as Assignment resolver
+    participant S as Snapshot registry
+    participant E as Evaluator
+    participant F as Type reference resolver
+    participant R as Decision recorder
+    C ->> D: evaluate(context, input)
+    D ->> D: subject from context, refuse on mismatch
+    D ->> F: reference for the named resource type
+    F -->> D: reference, memo hit in steady state
+    D ->> A: resolve(tenant, barrier, status)
+    A -->> D: ordered assignments
+    D ->> S: snapshots for assignments
+    S -->> D: compiled content
+    D ->> E: evaluate applicable documents
+    E -->> D: validated outcomes
+    D ->> D: combine, short-circuit on prohibition
+    D ->> R: enqueue record
+    D -->> C: decision, cause, responsible document
+```
+
+**Description**: The hot path. The subject is taken from the propagated context before anything else happens, so a request asserting a different identity is refused without reaching content. Hierarchy resolution and reference resolution are both cache hits in the common case, snapshot access is in-memory, and evaluation stops as soon as no remaining outcome can change the verdict. The record is enqueued, not written, so its durability does not extend the measured latency.
+
+#### Admit a multi-type change
+
+**ID**: `cpt-cf-policy-engine-seq-admit-batch`
+
+**Use cases**: `cpt-cf-policy-engine-usecase-admit-batch`
+
+**Actors**: `cpt-cf-policy-engine-actor-admission-gateway`
+
+```mermaid
+sequenceDiagram
+    participant C as Admission gateway
+    participant D as Decision service
+    participant A as Assignment resolver
+    participant E as Evaluator
+    participant R as Decision recorder
+    C ->> D: evaluate_batch(context, members)
+    D ->> D: check batch bound
+    D ->> A: resolve once per distinct tenant context
+    A -->> D: ordered assignments
+    loop per member
+        D ->> E: evaluate applicable documents
+        E -->> D: validated outcomes
+        D ->> R: enqueue member record
+    end
+    D ->> D: combine members, prohibition absorbing, order-independent
+    D -->> C: verdict plus every refused member
+```
+
+**Description**: One hierarchy resolution and one snapshot read serve every member, which is what keeps a plan-wide admission inside the consumer's preview and apply budgets. Members are recorded individually so that a batch refusal remains attributable per resource type.
+
+#### Author, validate, and activate
+
+**ID**: `cpt-cf-policy-engine-seq-activate-bundle`
+
+**Use cases**: `cpt-cf-policy-engine-usecase-activate-bundle`
+
+**Actors**: `cpt-cf-policy-engine-actor-policy-author`
+
+```mermaid
+sequenceDiagram
+    participant P as Policy author
+    participant T as REST API
+    participant M as Management service
+    participant V as Content validator
+    participant K as Activation compiler
+    participant S as Snapshot registry
+    P ->> T: create draft, add documents and targets
+    T ->> M: persist draft
+    P ->> T: validate
+    T ->> M: validate draft
+    M ->> V: syntax, vocabulary, limits
+    V -->> M: per-document findings
+    M -->> P: findings, nothing activated
+    P ->> T: activate with precondition
+    T ->> M: activate version
+    M ->> K: compile
+    K ->> K: compile expressions, index targets, digest
+    K ->> S: publish new generation
+    M -->> P: activated version
+```
+
+**Description**: Validation and activation run the same pipeline, so a draft that validates is a draft that activates. Publication of a generation is the only step that changes what decisions see, and it is atomic.
+
+#### Review current violations
+
+**ID**: `cpt-cf-policy-engine-seq-review-violations`
+
+**Use cases**: `cpt-cf-policy-engine-usecase-review-violations`
+
+**Actors**: `cpt-cf-policy-engine-actor-tenant-policy-admin`
+
+```mermaid
+sequenceDiagram
+    participant T as Tenant policy administrator
+    participant X as REST API
+    participant M as Management service
+    participant V as Violations reader
+    participant DB as Record store
+    T ->> X: GET violations with filters
+    X ->> M: query violations in caller scope
+    M ->> V: project prohibiting records
+    V ->> DB: scoped query over records
+    DB -->> V: rows within retention
+    V -->> M: entries plus retention window
+    M -->> T: violations, scoped
+```
+
+**Description**: The projection reads the same records an auditor reads, under the caller's scope. Nothing is computed against live resources, and the retention window is returned so an empty result is distinguishable from an aged-out one.
+
+#### Withdraw an active bundle
+
+**ID**: `cpt-cf-policy-engine-seq-withdraw-bundle`
+
+**Use cases**: `cpt-cf-policy-engine-usecase-withdraw-bundle`
+
+**Actors**: `cpt-cf-policy-engine-actor-platform-operator`
+
+```mermaid
+sequenceDiagram
+    participant O as Platform operator
+    participant M as Management service
+    participant K as Activation compiler
+    participant S as Snapshot registry
+    participant D as Decision service
+    O ->> M: deprecate version or remove assignment
+    M ->> M: record change against operator
+    M ->> K: recompute active set
+    K ->> S: publish new generation
+    S -->> D: generation observed within propagation window
+    M -->> O: withdrawn, effective within window
+```
+
+**Description**: Withdrawal is a generation change like activation. Every instance observes it by polling the generation counter, which is what bounds the propagation window rather than relying on a broadcast that can be missed.
+
+#### Fail closed on an unreachable dependency
+
+**ID**: `cpt-cf-policy-engine-seq-fail-closed`
+
+**Use cases**: `cpt-cf-policy-engine-usecase-admit-operation`
+
+**Actors**: `cpt-cf-policy-engine-actor-admission-gateway`, `cpt-cf-policy-engine-actor-hierarchy-provider`
+
+```mermaid
+sequenceDiagram
+    participant C as Admission gateway
+    participant D as Decision service
+    participant A as Assignment resolver
+    participant H as Hierarchy client
+    participant R as Decision recorder
+    C ->> D: evaluate(input)
+    D ->> A: resolve(tenant, barrier, status)
+    A ->> H: ancestry lookup
+    H --x A: timeout at configured bound
+    A -->> D: infrastructure condition
+    D ->> D: refuse, stamp infrastructure cause
+    D ->> R: enqueue record with cause
+    D -->> C: refusal marked as infrastructure
+```
+
+**Description**: The operation is refused, and the refusal is labelled so the consumer can retry it as transient rather than report a policy denial to its user. The same shape covers snapshot absence, digest mismatch, and cost-bound exceedance, each with its own cause.
+
+### 3.7 Database schemas & tables
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-db-policy-engine`
+
+The gear declares `policy_engine` as its stable database namespace. Every object below carries that prefix per the platform's object-namespacing convention. All access is through the secure data layer; the scope column that carries tenant identity is named on each table.
+
+#### Table: policy_engine__bundle
+
+**ID**: `cpt-cf-policy-engine-dbtable-bundle`
+
+**Schema**:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | uuid | Bundle identity, stable across versions |
+| owner_tenant_id | uuid | Owning tenant; the scope column |
+| name | text | Bundle name, unique within the owning tenant |
+| description | text | What this bundle governs |
+| etag | uuid | Precondition token for concurrency control |
+| created_at | timestamptz | Creation time |
+| created_by | uuid | Author identity |
+| updated_at | timestamptz | Last modification time |
+
+**PK**: id
+
+**Constraints**: `owner_tenant_id` and `name` unique together; `name` not null
+
+**Additional info**: Indexed on `owner_tenant_id` for scoped listing.
+
+#### Table: policy_engine__bundle_version
+
+**ID**: `cpt-cf-policy-engine-dbtable-bundle-version`
+
+**Schema**:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | uuid | Version identity, referenced by decision records |
+| bundle_id | uuid | Owning bundle |
+| owner_tenant_id | uuid | Owning tenant; the scope column |
+| ordinal | integer | Monotonic version number within the bundle |
+| state | smallint | Draft, active, or deprecated |
+| content_digest | bytea | Digest over the version's documents and targets |
+| etag | uuid | Precondition token |
+| activated_at | timestamptz | Activation time, null while draft |
+| activated_by | uuid | Activating identity, null while draft |
+
+**PK**: id
+
+**Constraints**: `bundle_id` and `ordinal` unique together; at most one active version per bundle; `content_digest` not null once active
+
+**Additional info**: Rows are immutable once state leaves draft, except for the transition to deprecated.
+
+#### Table: policy_engine__document
+
+**ID**: `cpt-cf-policy-engine-dbtable-document`
+
+**Schema**:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | uuid | Document identity, named in refusals and records |
+| version_id | uuid | Owning version |
+| owner_tenant_id | uuid | Owning tenant; the scope column |
+| name | text | Author-facing name |
+| kind | smallint | Document kind from the closed set of `cpt-cf-policy-engine-fr-document-kinds`, which has one member at first release: guardrail. Stored as an integer so that adding a member is a versioned widening rather than a schema change |
+| backend_ref | uuid | Registry reference of the evaluation backend this document's content is written for, obtained from the types-registry SDK and opaque here. The GTS identifier the author supplied is never persisted as text, per the platform's storage-identity decision |
+| content | text | Document source, opaque to the gear and interpreted by the declared backend |
+| outcome | smallint | Outcome directive the gear applies to what the backend returns |
+
+**PK**: id
+
+**Constraints**: `version_id` and `name` unique together; `content` and `backend_ref` not null for the guardrail kind; the author-supplied backend identifier resolved to its reference on write, so a draft naming a backend the registry does not know is rejected at insert rather than at activation. Storing a reference is what moves that check earlier: a reference can only be obtained by resolving, so the tolerance a text column allowed is given up deliberately. What activation still re-checks is availability, which is per-tenant and can change with no write to this row
+
+**Additional info**: Cascades with its version. Never updated after the version leaves draft.
+
+#### Table: policy_engine__target
+
+**ID**: `cpt-cf-policy-engine-dbtable-target`
+
+**Schema**:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | uuid | Target identity |
+| document_id | uuid | Owning document |
+| owner_tenant_id | uuid | Owning tenant; the scope column |
+| trigger_kind | smallint | Operation or event |
+| phase | smallint | Before or after |
+| resource_type_ref | uuid | Registry reference of the concrete resource type this target names; null where the target names a pattern |
+| resource_type_pattern | text | Validated GTS namespace wildcard pattern; null where the target names a concrete type |
+| filters | jsonb | Conjunctive attribute filters over the closed operator set, each carrying whether the attribute is required |
+
+**PK**: id
+
+**Constraints**: exactly one of `resource_type_ref` and `resource_type_pattern` present; a document must have at least one target before its version can activate
+
+**Additional info**: Indexed on `document_id`; the evaluation-time index is built in memory by the activation compiler, not by the database.
+
+A concrete type is stored as a reference and a pattern is not, because a pattern is not a registry entity and has no reference to hold — the platform's storage-identity decision expands one into a concrete reference set at query time instead. This gear does not need that expansion: it never queries the store by resource type on any path, and matching runs off the in-memory index, so the pattern is kept as validated text and matched with the platform's own identifier implementation. The index therefore has two lanes, an exact lane keyed by reference and a pattern lane checked only when the exact lane misses, which is also what keeps wildcard semantics live — a type registered after the current generation was built is matched by an existing pattern on its first request, rather than waiting for the next generation to expand a set.
+
+#### Table: policy_engine__assignment
+
+**ID**: `cpt-cf-policy-engine-dbtable-assignment`
+
+**Schema**:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | uuid | Assignment identity; the final ordering key |
+| bundle_id | uuid | Assigned bundle; the active version is resolved when a generation is built, never stored here |
+| tenant_id | uuid | Tenant the assignment attaches to |
+| owner_tenant_id | uuid | Owning tenant of the assigning administrator; the scope column |
+| priority | integer | Policy priority, higher wins within a tenant |
+| reaches_barriers | boolean | Whether the assignment may reach through barriers when the caller permits |
+| enforcing | boolean | Whether this assignment's outcomes contribute to the result, or are evaluated and recorded only |
+| effective_from | timestamptz | Window start, null for unbounded |
+| effective_to | timestamptz | Window end, null for unbounded |
+| etag | uuid | Precondition token |
+
+**PK**: id
+
+**Constraints**: `bundle_id` and `tenant_id` unique together; `effective_from` before `effective_to` when both present
+
+**Additional info**: Indexed on `tenant_id` for resolution and on `bundle_id` for withdrawal. There is no version column by design: `cpt-cf-policy-engine-fr-lifecycle-states` permits at most one active version per bundle, so an assigned version would be derived state that goes stale at the next activation, orphaning the assignment and silently ungoverning its tenant.
+
+#### Table: policy_engine__decision_record
+
+**ID**: `cpt-cf-policy-engine-dbtable-decision-record`
+
+**Schema**:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | uuid | Record identity |
+| evaluation_id | uuid | Identity of the evaluation this record describes; the idempotency key for outbox redelivery |
+| correlation_id | uuid | Correlation identifier as supplied by the caller; never generated here, and the key that joins this row to the gateway's admission record on the shared audit topic |
+| batch_id | uuid | Batch correlation as supplied by the caller, null for single evaluations |
+| subject_id | uuid | Evaluated subject, as the opaque identity-provider reference of `cpt-cf-policy-engine-fr-subject-data-handling`. Never rewritten: erasure is the identity provider's, and after it this reference resolves to nobody |
+| subject_tenant_id | uuid | Subject's tenant, and not the same as the resource's |
+| resource_tenant_id | uuid | Resource's tenant; the scope column, and not always the subject's. The projection filters on it, the retention sweep indexes it, and the export publishes under it |
+| action | text | Requested action |
+| resource_type_ref | uuid | Registry reference of the resource type the evaluation named |
+| resource_id | uuid | Resource identity where the evaluation named one |
+| outcome | smallint | Evaluation result: permit or prohibit, and deferral once that requirement ships |
+| permit_cause | smallint | For a permission, whether it was governed, ungoverned, or — once `cpt-cf-policy-engine-fr-emergency-access` ships — emergency; null for a prohibition. Stored as an integer so that the third member is a versioned widening rather than a schema change, and it is also the emergency marker `cpt-cf-policy-engine-fr-decision-records` requires, which is why no separate boolean column exists to disagree with it |
+| cause | text | Canonical cause identity, present on a negative outcome |
+| responsible_document_id | uuid | Document that produced a prohibition |
+| version_id | uuid | Version that determined the outcome |
+| participating_versions | jsonb | Identity and version of every bundle that took part, including the determining one |
+| backend_version | text | Identity and version of the evaluation backend that interpreted the content |
+| matched_count | integer | Documents that matched |
+| evaluated_count | integer | Documents actually evaluated |
+| elapsed_micros | integer | Measured evaluation time |
+| context_keys | jsonb | Names of the operation-context properties the evaluation read; never their values, which is also why a recorded decision cannot be replayed against a candidate version |
+| evaluated_at | timestamptz | Timestamp supplied to the backend; an input to the decision, required to reproduce one that turned on time |
+| created_at | timestamptz | Evaluation time; the retention key |
+
+**PK**: id
+
+**Constraints**: `uq_policy_engine__decision_record__evaluation` unique over `evaluation_id`, which is what makes at-least-once outbox delivery produce exactly one row and keeps `cpt-cf-policy-engine-nfr-decision-record`'s count-equality assertion true; no credential column exists by construction; `outcome` not null
+
+**Additional info**: Indexed on `resource_tenant_id` with `created_at` for the refusals projection and the retention sweep, and on `responsible_document_id` for per-policy queries. This is the only table whose row count grows with request rate rather than with policy volume, so it is range-partitioned by `created_at`: retention drops whole partitions instead of issuing bulk deletes against a table under continuous write, and the projection's tenant-and-time predicate prunes to a partition subset. Partition width is an operational setting; the retention window must be a whole multiple of it.
+
+Every surface that leaves the gear speaks GTS identifiers rather than references. The violations projection and the REST reads reverse-resolve `resource_type_ref` while the response is built, and the export path reverse-resolves it before publication, so no reader of a decision — an auditor, a downstream consumer, or an operator reading a dead-lettered payload — needs to know that a reference was ever stored. Reverse resolution is a batch call per response page and per export batch, not one call per row.
+
+#### Table: policy_engine__admin_event
+
+**ID**: `cpt-cf-policy-engine-dbtable-admin-event`
+
+**Schema**:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | uuid | Event identity |
+| owner_tenant_id | uuid | Owning tenant of the content changed; the scope column |
+| actor_id | uuid | Subject that made the change |
+| actor_tenant_id | uuid | That subject's tenant |
+| operation | smallint | Which transition or assignment change occurred |
+| bundle_id | uuid | Bundle affected |
+| version_id | uuid | Version affected, null for assignment-only changes |
+| assignment_id | uuid | Assignment affected, null for content changes |
+| etag_supplied | uuid | Precondition the caller presented, null where none was required |
+| occurred_at | timestamptz | Change time |
+
+**PK**: id
+
+**Constraints**: `actor_id` and `operation` not null; rows are insert-only, with no update or delete path in the schema
+
+**Additional info**: Written in the same transaction as the change it describes, so an applied change without its event is not reachable. Retained at least as long as the versions it references, and deliberately **not** covered by the decision-record retention sweep — the question it answers outlives every decision the content produced.
+
+#### Record staging: `toolkit-db` outbox
+
+The gear defines no staging or dead-letter tables of its own. Record export runs on the `toolkit-db` transactional outbox under the table prefix `policy_engine_outbox`, which creates its own independent family — body, partitions, incoming, outgoing, and dead letters — validated and migrated by the facility. Adopting it rather than hand-rolling a queue is what keeps retry, per-partition ordering, dead-lettering, batch enqueue, and vacuum out of this gear entirely.
+
+Two consequences shape how the gear uses it. The facility enqueues **inside the caller's transaction**, which suits activation and does not suit evaluation: an evaluation is a pure read with a latency budget that has no room for a database write, so records reach the outbox through the batched flush described in `cpt-cf-policy-engine-component-recorder` rather than one enqueue per decision. And the facility's dead-letter rows are generic — payload plus delivery metadata, with no tenant column — so the obligation falls on the gear to enqueue a payload that is already the redacted projection of `cpt-cf-policy-engine-fr-record-confidentiality`. A dead-lettered entry must be safe to hold in an untenanted table, because that is where it will sit.
+
+Export runs in leased mode, and its destination is the `event-broker` audit topic the gear shares with `admission-control`. At-least-once delivery there is acceptable because the topic is downstream of the evidence store: the record table, not the topic, is where a decision becomes durable, so a redelivery duplicates a published event rather than a decision. Exactly-once inside the gear comes from the record table's own unique constraint, not from the outbox, and the consumer is expected to be idempotent on the evaluation identifier — which is what `event-broker` asks of an audit-pipeline consumer in any case. Records are published under the resource tenant of `cpt-cf-policy-engine-fr-decision-records` rather than the subject's, so the topic partitions on the tenant the record is scoped and filtered by. The published payload carries the resource type as a GTS identifier, which is the same representation `admission-control` publishes on the shared topic, so the two records of one gated operation are comparable field by field without either consumer resolving anything.
+
+Resolution happens in the export step and not at enqueue, which is a deliberate ordering. Record durability is load-bearing — the serving condition in Section 4.5 is defined against it — and making the flush transaction wait on a types-registry call would put a second remote dependency in front of the write that clears the buffer, so a registry outage would trip a serving condition that has nothing to do with the registry. Staging references and resolving on the way out keeps that dependency off the durability path entirely. A dead-lettered payload therefore carries references rather than identifiers, which stays readable because the registry's mappings remain reverse-resolvable after deprecation and logical deletion for as long as domain references may exist.
+
+### 3.8 Deployment Topology
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-topology-in-process`
+
+First release composes the gear in-process, the platform's default mode: it is linked into a host binary alongside its consumers and reached through ClientHub, with the evaluation facility in the same process. The platform also supports out-of-process execution over gRPC, and the gear's contracts are transport-agnostic, so that shape needs no contract change. It does need two numbers revisited: the decision latency budget contains no allowance for a transport hop, and the availability target only becomes independently measurable once the gear can fail separately from its consumers. Every instance holds its own snapshot registry and hierarchy cache, and instances coordinate only through the store's generation counter, so the decision path scales horizontally with the host and adds no coordination traffic. The REST administration surface is exposed through the platform ingress like any other gear surface; the decision surface is not exposed over the network in any deployment shape.
+
+## 4. Additional context
+
+### 4.1 Telemetry surface
+
+Metrics are emitted by the component that owns each measurement, per `cpt-cf-policy-engine-fr-metrics`.
+
+| Signal | Type | Owner | Purpose |
+|---|---|---|---|
+| Decision latency by outcome | Histogram | Decision service | The measured surface of `cpt-cf-policy-engine-nfr-decision-latency` |
+| Decisions by outcome and cause | Counter | Combiner | Separates policy refusal from infrastructure refusal, and governed permits from ungoverned ones — the latter is how an operator sees what share of the estate policy is silent about |
+| Fail-closed refusals by cause | Counter | Decision service | Distinguishes an outage from a policy change, per the fail-closed requirement |
+| Expression evaluation duration and bound exceedances | Histogram, counter | Evaluator | Detects the authored expression that is degrading admission |
+| Applicable-set size, matched versus evaluated | Histogram | Matcher, combiner | Surfaces policy that never matches, and the effect of short-circuiting |
+| Hierarchy cache hit rate and lookup latency | Gauge, histogram | Hierarchy client | The measured surface of `cpt-cf-policy-engine-nfr-hierarchy-latency` |
+| Snapshot generation age and propagation delay | Gauge | Snapshot registry | The measured surface of `cpt-cf-policy-engine-nfr-activation-propagation` |
+| Record queue depth and unflushed window | Gauge | Decision recorder | Makes the bounded window observable, and is the control input for the serving condition in Section 4.5 rather than telemetry alone |
+| Reference resolution: memo hit rate, batch size, and failures | Gauge, histogram, counter | Type reference resolver | The memo is required to hit on the decision path, so a falling hit rate is early warning that the latency budget is about to be spent on the registry instead |
+| Cross-barrier record reads | Counter | Management service | A barrier crossing is meant to be rare and attributable; a rising count is either an incident or a capability granted to the wrong principal |
+| Bootstrap authorisation in effect | Gauge | Management service | Ensures the cold-start path is visible while it applies |
+
+### 4.2 Capacity envelope
+
+The limits in `cpt-cf-policy-engine-fr-operational-limits` are the inputs that keep the latency target reachable, and their numeric values are an open question in the PRD rather than a design decision. The design constrains them in shape: content size and document count per version bound snapshot memory and activation cost; applicable-set size bounds per-evaluation cost together with the per-document cost bound; batch size multiplies a request's cost by its member count and therefore needs its own bound rather than inheriting the single-evaluation one. Limits are checked both at activation and at evaluation, so lowering a limit takes effect against content that already exceeds it by refusing rather than by silently continuing.
+
+### 4.3 Deferred items
+
+Six of the PRD's seven p3 requirements are carried in the design as extension points rather than implemented shapes. The seventh, `cpt-cf-policy-engine-fr-effective-windows`, is not deferred at all: it has dedicated columns on the assignment table and is applied by the assignment resolver, because a window is a predicate on an existing lookup rather than a new mechanism. The deferred six are: the after-the-operation phase, which the target index already carries but the decision service discards; the deferral outcome, which is a variant in the outcome enum with no routing behind it; obligations, which the decision value carries with no consumer that honours them; emergency access, which needs a platform entitlement that does not yet exist; explanation and dry-run, which reuse the combiner trace and the activation compiler respectively and add no new mechanism. Keeping them as variants and unused paths rather than as absent concepts is deliberate: each one changes a shared value type, and adding a variant later is a breaking change to a stable contract.
+
+### 4.4 Known design risks
+
+| Risk | Consequence | Response |
+|---|---|---|
+| A backend build registers a non-deterministic builtin the denylist does not name | Two evaluations of one input disagree while policy, version and digest all match, which is the least attributable defect this gear can produce | Bind the denylist to the audited build, re-audit the builtin set on every upgrade, and refuse to select a build that carries no declaration. Assert the denylist in a test that enumerates the backend's registered builtins rather than one that checks a hand-written list. Detect the drift at startup rather than trusting the upgrade to have been audited: given a declaration carrying the backend version, the enabled feature set, and a digest over the builtin set it was audited against — the field set PRD Section 13 asks for — the gear digests the builtins the live build enumerates and refuses a mismatch on the same path as an absent declaration, which turns an un-re-audited bump into a failed startup instead of a silent divergence. The two digests have to be derived by different means, one from the audited claim and one from the running build, because a manifest compared against itself passes forever including after the bump it was meant to catch. Startup only: the set is fixed at link time and the decision budget could not absorb the check per evaluation. What this cannot reach is a builtin that keeps its name and changes behaviour, so the audit and not the check is what establishes the claim |
+| Evaluation memory is unbounded except by content size | A large intermediate value inside a small document exhausts the host, which the in-process availability clause is written to prevent | Bound content size, document count and applicable-set size, and measure snapshot and evaluation footprint under `cpt-cf-policy-engine-nfr-instance-footprint`, which is what turns that measurement into a requirement rather than a habit; treat an allocator-level cap as unavailable until a facility build offers one that does not conflict with the host allocator |
+| Snapshot memory grows with tenant count times content size | Instance memory becomes the scaling limit before latency does | Bound content per version and measure snapshot footprint against tenant count under `cpt-cf-policy-engine-nfr-instance-footprint`, not only against request rate |
+| Generation polling interval competes with the propagation window | Either propagation exceeds 60 seconds or polling load grows with instance count | Derive the interval from the window with margin; export propagation delay so drift is observed rather than assumed |
+| Outbox drain falls behind sustained evaluation rate | The bounded loss window is exceeded silently | Export queue depth and unflushed window as first-class signals; alert on the window rather than on the queue |
+
+### 4.5 Reliability, error handling, and consistency
+
+**Failure isolation.** The decision path has no shared single point of failure: every instance holds its own snapshot registry and hierarchy cache, and instances coordinate only through a generation counter. The store is a single point of failure for administration, activation, and record durability, but not for decisions already served by a published snapshot. Decision readiness is gated on the snapshot registry having completed its initial load, not on that load being non-empty: a deployment with no activated content is ready and refuses by default, which is correct behaviour rather than a fault. Management readiness is independent of it, because gating the management surface on compiled content would make the first bundle uncreatable and defeat `cpt-cf-policy-engine-fr-bootstrap`. An instance whose initial load has not completed reports unready rather than refusing every operation while appearing healthy.
+
+**Timeouts and retries.** The hierarchy read and every registry-reference resolution carry configured timeouts; expression evaluation carries per-document and per-evaluation cost bounds. The decision path performs no retries of its own. A retry would be spent from a latency budget borrowed from the consumer, and the consumer is the party that knows whether the operation is still worth attempting — which is exactly what Infrastructure Resource Manager's transient-retry requirement expects of it. Circuit breakers and bulkheads are deliberately absent: the gear has one bounded in-process dependency and one bounded remote read, and a breaker would convert a bounded refusal into a sustained one while `cpt-cf-policy-engine-nfr-cache-safety` forbids caching the error that opened it.
+
+**Error classification and propagation.** Errors fall into two disjoint classes carried by the gear's canonical error family: policy causes, which are correct outcomes, and infrastructure causes, which are incidents. Both converge on the single refusal constructor, and both reach the caller as a refusal — the class is what differs, and it is what the caller branches on. Graceful degradation is not available and not intended: a gear that degrades toward permitting is a gear that fails open.
+
+**Serving condition.** The gear stops returning permits when it cannot show that a new decision will be recorded — specifically when the oldest record still in the in-memory buffer exceeds the record window, or the buffer is full. The trigger is buffer age rather than outbox depth, because the buffer is the only stage where a record is not yet durable: once the flush transaction commits, the record survives process loss and a backlog further downstream delays export without risking evidence. This is a refusal, not a shutdown: evaluations return an infrastructure cause the caller can distinguish, carrying a retry-after signal so the gateway backs off rather than retrying immediately — otherwise consumer retries amplify load on the storage already failing. The management surface is unaffected, because it writes synchronously and fails on its own terms. In-process the condition is reported as a gear-level degraded signal and **does not** fail the host readiness probe, since doing so would take co-located consumers out of rotation over a dependency only this gear needs. Out-of-process the same condition may fail the gear's own readiness, because there the blast radius is the gear alone.
+
+**Queue handling.** Two queues exist and they answer different questions. The in-memory buffer is the gear's own and is what the loss window measures. Beyond it, delivery to the `event-broker` audit topic is the `toolkit-db` outbox's concern: retry budgets, dead-lettering, and per-partition ordering are the facility's, and a poison record lands in its dead-letter family rather than stalling the drain. Because a dead-lettered payload sits in a generic, untenanted table, the gear enqueues only the redacted projection — the confidentiality obligation is discharged before the record leaves the gear, not by the queue holding it.
+
+**Consistency.** Content is strongly consistent within the store and eventually consistent at the point of evaluation, bounded by `cpt-cf-policy-engine-nfr-activation-propagation`. Activation and its outbox enqueue share one transaction. Evaluation records do not: an evaluation is a pure read and joins no transaction, so its record reaches durability in the flusher's batch transaction instead, which is what makes the loss window buffer residency rather than zero. There are no distributed transactions and no sagas, because the gear writes to exactly one store. Activation is idempotent on version identity, evaluation is a pure read over immutable state, and record insertion is keyed by evaluation identity so an outbox redelivery cannot duplicate a record.
+
+**Recovery.** Content, versions, and assignments are restored under the platform backup regime to meet `cpt-cf-policy-engine-nfr-durability`; decision records are governed by retention and are not restore-critical. After a restore, each instance rebuilds its snapshot registry from restored content on the next generation poll, so recovery needs no separate cache-warming procedure.
+
+### 4.6 Security boundaries and threat model
+
+**Trust boundaries.** Three, in decreasing trust: the host process and its `SecurityContext`, which is trusted; policy content, which is tenant-authored and therefore semi-trusted — structurally valid but adversarially authored; and the caller-supplied operation context, which is untrusted input judged rather than believed. The evaluation backend that runs the content is the sandbox boundary between the second and the first.
+
+| Threat | Vector | Mitigation |
+|---|---|---|
+| Policy content as an execution vector | A tenant administrator authors an expression that reaches the network or filesystem | `cpt-cf-policy-engine-fr-evaluation-isolation`: no capability is passed into the library; the only ambient value is a gear-supplied timestamp. Reaching outward also requires a builtin that performs I/O, so the backend build's registered builtin set is part of this boundary and is audited with it |
+| Non-determinism as an audit-evasion vector | Content reads a clock or a random generator, so the same input yields different decisions and a recorded decision cannot be reproduced or disputed | The denylist of `cpt-cf-policy-engine-fr-evaluation-isolation`, enforced at activation over the parsed form. Determinism cannot be enforced at call time, because builtins resolve inside the backend ahead of any extension over the same name |
+| Denial of service through authored content | An expression whose cost is unbounded, evaluated on every gated operation | Per-document and per-evaluation cost bounds, applicable-set and batch bounds, all operator-configurable |
+| Cross-tenant policy influence | A decision for one tenant shaped by content the requester cannot reach | Reachability check before matching, scoped content reads, generation-and-tenant cache keys |
+| Privilege escalation through authoring | An administrator grants, via policy, an entitlement they do not hold | `cpt-cf-policy-engine-fr-admin-authorization`: six separated capabilities and an explicit no-self-grant rule |
+| Subject spoofing by a calling gear | A caller submits an evaluation naming a subject, or a subject tenant, that is not the one in its own context — obtaining a decision and leaving evidence for an identity that never asked, and choosing a subject tenant that widens the subtree the evaluation may reach | `cpt-cf-policy-engine-fr-subject-authenticity`: the security context is a required parameter, the subject is taken from it rather than from the request, and a mismatch is refused before any content is reached and recorded under the context's own subject |
+| Records as a cross-barrier read channel | An ancestor reads the decision history of a subtree that raised a barrier, obtaining the descendant's subjects, actions, and resource identities without reading any of its data directly | `cpt-cf-policy-engine-fr-record-visibility`: record surfaces respect barriers by declaration, the crossing needs a distinct platform-level capability, and every use of it is written as an administration event |
+| Policy administered inside a barriered subtree | An ancestor assigns a bundle at a self-managed descendant, taking over policy administration inside a boundary that descendant raised | `cpt-cf-policy-engine-fr-assignment-authorization`: assignment surfaces respect barriers and refuse an out-of-reach target with the boundary cause. The ancestor's existing guardrails still reach in on the evaluation plane, which is the separation that makes both halves defensible |
+| Admission policy used as an access-control path | An author writes rules over roles or permissions, putting a second answer to "who may do what" outside `authz-resolver`, with its own lifecycle and no obligation to agree | `cpt-cf-policy-engine-fr-authorization-boundary`: the evaluation input has no entitlement field, so content has nothing to decide access by, and a decision carries no grant and cannot widen access |
+| Audit trail as a leak channel | Records read widely, carrying credentials or full resource payloads | No credential column exists by construction; context stored only as a redacted projection |
+| Stale policy after withdrawal | A withdrawn bundle keeps refusing or keeps permitting | Generation-keyed snapshot and cache entries; propagation window measured, not assumed |
+
+**Data protection.** Confidentiality at rest and in transit is inherited, not implemented here, and the inheritance is worth stating because both data sets warrant it: policy content is a security control, and records carry subject identifiers. Content, records, outbox, and dead-letter rows sit in the platform relational store and take its at-rest encryption and its key management; the gear introduces no second store, no file spill, and no cache that outlives the process. In transit, the decision surface makes no network hop at all — it is an in-process call — and the management surface is exposed through the platform ingress, which terminates transport security. The gear holds no key material and performs no cryptography beyond the content digest of `cpt-cf-policy-engine-fr-content-integrity`, which is an integrity check and not a confidentiality one. Secure disposal follows the retention sweep and the partition drops described in Section 3.7.
+
+**Assumptions.** Subjects arrive authenticated, `SecurityContext` is propagated on every in-process call, and the host process is not itself hostile. **Supply chain**: the evaluation facility, and specifically the backend that runs tenant-authored content, is the one substantial dependency this gear adds, so it carries more review weight than any other dependency here.
+
+Network segmentation, DMZ placement, firewall rules, and CORS are not applicable: the gear opens no listener of its own, and its REST surface is exposed through the platform ingress, which owns those concerns.
+
+### 4.7 Testability and test strategy
+
+The component boundaries are drawn so that the decision pipeline is testable without a store, a tenant resolver, or an expression engine. The combiner is a pure function over an outcome sequence. The evaluator, hierarchy client, and repository are injected as traits, so each has a substitution point.
+
+| Level | Coverage |
+|---|---|
+| Unit | Outcome combination and precedence, deterministic ordering, target matching and filters, limit enforcement, refusal-cause construction |
+| Integration | Activation to snapshot to decision against a real store; inheritance and precedence across a constructed tenant hierarchy; optimistic-concurrency conflicts; the management-plane barrier rules, asserting that an assignment at and a record read of a barriered tenant are refused while an assignment above the barrier still governs inside it |
+| Fault injection | The failure set enumerated by `cpt-cf-policy-engine-nfr-fail-closed`; this is that requirement's named verification method |
+| Performance | Gear-boundary latency with warm caches, batch latency at the configured bound, snapshot memory against tenant and content count |
+| Security | A context-mismatch test asserting that an asserted subject or subject tenant disagreeing with the propagated context is refused, that no content is evaluated, and that the record names the context's subject, run in both an authenticated deployment and an auth-disabled one where the derived subject is the platform default — the second is what keeps the check from being a dev-mode outage; isolation tests asserting no capability is reachable from content; a determinism test evaluating identical input twice and asserting identical outcomes; a test that enumerates the backend build's registered builtins and fails when one is absent from the denylist, so an upgrade that adds a non-deterministic builtin breaks the build rather than the audit trail; the cross-tenant suite including barrier boundaries and the violations projection |
+| Contract | Decision and management client traits exercised through the SDK surface a consumer actually links; pinned identifier-to-reference fixtures asserting that a types-registry or identifier-library upgrade cannot silently change a persisted reference, which is what the platform's storage-identity decision asks of every gear that stores one; and a round-trip asserting that references never leave the gear — every response and every published record carries identifiers |
+
+Compile-fail coverage is narrow but not absent. The gear exposes no macro diagnostics and no generated-code contract, so those cases do not apply. One invariant does qualify: Section 1.1 states that the refusal constructor is the only way to build a negative decision from an error condition, and an exclusivity invariant enforced only by convention is one new code path away from a refusal that never receives its infrastructure cause. A compile-fail case asserting the constructor cannot be bypassed covers it, which is the class the repository's testing rule names when it asks for compile-fail suites over security invariants.
+
+### 4.8 Compliance and privacy posture
+
+The decision record is the audit-trail architecture: append-only by construction, with no update path at all — `cpt-cf-policy-engine-fr-subject-data-handling` needs none, because the subject is recorded as an opaque identity-provider reference and erasure happens at that provider rather than in this table. Evidence for any past decision is the record together with the retained version it names, which is why version history is durability-critical while records are not. Privacy is structural rather than procedural — the subject appears only as an opaque reference, the closed field set keeps every profile attribute out, and erasure at the identity provider leaves the audit chain whole while the reference it names resolves to nobody.
+
+Consent management, data-subject access, portability, and erasure are not implemented here: subject identity is owned upstream, and this gear holds opaque references rather than profiles. Cross-border transfer controls are determined by where the deployment places its store, not by this gear.
+
+### 4.9 Deviations from platform baselines
+
+| Deviation | Rationale | Review owner |
+|---|---|---|
+| No gear-level engine registry, unlike the gear-plus-plugin idiom `credstore`, `quota-enforcement`, `event-broker`, and `usage-collector` each built | The evaluation facility already carries a backend contract, so a second registry here would duplicate it and bind a deployment's language choice to a gear rather than to the platform. Pluggability is delegated one layer down, not removed; the gear routes on a declared, registry-resolved backend identifier and a new backend reaches every consumer at once | Steering committee, through the planned evaluation-facility decision record |
+| Gear placed under `gears/system/` while being a management-layer component | The infrastructure-management grouping does not exist yet, and inventing a directory tier inside this design would pre-empt a cross-team decision | Platform architecture, through the placement question in PRD Section 13 |
+| Decision surface is in-process only, with no REST projection, unlike gears that project their public client | The latency budget is borrowed from the consumer, and a network hop would spend it; the management surface carries the external contract instead | Gear owner |
+
+### 4.10 Migration, deprecation, and technical debt
+
+The gear is new: there is no data to migrate, no schema to evolve, and no existing consumer to move. The debt here is sequencing rather than code: the gear is specified ahead of both components above it, so its integration surface is settled against a gateway contract nobody has written. That is recorded as a risk rather than resolved, because the alternative — waiting for the gateway before specifying the engine — leaves the gateway with no engine to attach. The deferred items in Section 4.3 are the rest of the register, each held as an unused variant on a shared value type precisely so that adding it later is not a breaking change.
+
+Documentation for the gear is this design, the PRD beside it, the decision records listed in Section 1.2 once written, and the generated OpenAPI document for the administration surface. Operational runbooks belong to the deployment that composes the gear, not to the gear.
+
+### 4.11 Areas recorded as not applicable
+
+Stated explicitly so that absence is distinguishable from oversight.
+
+Five areas are the responsibility of something other than this gear, and are recorded rather than inferred. **Vendor and licensing constraints**: none for this gear, but not none for the platform. Every dependency here is in-tree or a platform library, and the evaluation facility is first-party — yet the facility carries a third-party policy-language implementation, so the licence, provenance and upgrade cadence of that crate are the facility's to own rather than absent. This gear inherits them, and the sandbox declaration of `cpt-cf-policy-engine-fr-evaluation-isolation` is where that inheritance becomes visible: it is a claim about a specific third-party build. **Secret management**: not applicable — the gear holds no credential, no key, and no connection string of its own; the store handle arrives from the runtime, which is also what `cpt-cf-policy-engine-fr-record-confidentiality` relies on when it says no credential column exists by construction. **Feature-flag strategy**: not used — the five deferred variants in Section 4.3 are inert by construction rather than gated at runtime, and introducing a flag to enable one would put an untested path one configuration change away from the admission path. **Alerting thresholds and error budgets**: deliberately not fixed here — the signals in Section 4.1 are specified, but their thresholds depend on the reference load that PRD Section 13 has not yet ratified, and a threshold set against a provisional load figure would be re-tuned before it ever fired. **Data catalog and master-data management**: not applicable — the gear is not a system of record for any entity another system would catalog; content belongs to its tenant and records are evidence, not master data.
+
+The remainder are host or repository concerns: infrastructure-as-code and deployment automation belong to the host binary and its chart, not to a linked gear; canary and blue-green deployment are host-level release strategies, and the gear's contribution is that a mixed-generation fleet remains correct because every instance fails closed on content it has not yet compiled; cost budgets are not modelled per gear in this repository; user-experience architecture is not applicable, as the gear exposes no end-user interface; and event architecture is narrow rather than absent: the gear publishes decision records to the `event-broker` audit topic described in Section 3.5, publishes no domain events announcing its own state changes, and subscribes to nothing.
+
+## 5. Traceability
+
+- **PRD**: [PRD.md](./PRD.md)
+- **ADRs**: `ADR/` — not yet created; the decisions listed in Section 1.2 land here once written
+- **Features**: `features/` — not yet created
+- **Consumer**: [admission-control](../../admission-control/docs/PRD.md) and its [DESIGN](../../admission-control/docs/DESIGN.md) — the gateway this gear's only evaluation path runs through, per `cpt-cf-policy-engine-constraint-no-gateway`
+- **First enforcing gear, reached through that gateway**: [Infrastructure Resource Manager](../../../infrastructure-resource-manager/docs/PRD.md)
+- **Platform architecture**: [ARCHITECTURE_MANIFEST.md](../../../../docs/ARCHITECTURE_MANIFEST.md)
+- **Database object naming**: [ADR-0001 object namespacing](../../../../docs/arch/database/ADR/0001-cpt-cf-database-adr-object-namespacing.md)
+- **Storage identity for GTS references**: [types-registry ADR-0001](../../types-registry/docs/ADR/0001-cpt-cf-types-registry-adr-storage-identity-query-model.md), whose reference-storage rule the tables in Section 3.7 apply, and whose confirmation criteria ask for exactly this — a domain gear design holding only references in its own schema

--- a/gears/system/policy-engine/docs/PRD.md
+++ b/gears/system/policy-engine/docs/PRD.md
@@ -1,0 +1,1212 @@
+# PRD — Policy Engine
+
+<!-- toc -->
+
+- [1. Overview](#1-overview)
+  - [1.1 Purpose](#11-purpose)
+  - [1.2 Background / Problem Statement](#12-background--problem-statement)
+  - [1.3 Goals (Business Outcomes)](#13-goals-business-outcomes)
+  - [1.4 Glossary](#14-glossary)
+- [2. Actors](#2-actors)
+  - [2.1 Human Actors](#21-human-actors)
+  - [2.2 System Actors](#22-system-actors)
+- [3. Operational Concept & Environment](#3-operational-concept--environment)
+  - [3.1 Gear-Specific Environment Constraints](#31-gear-specific-environment-constraints)
+- [4. Scope](#4-scope)
+  - [4.1 In Scope](#41-in-scope)
+  - [4.2 Out of Scope](#42-out-of-scope)
+- [5. Functional Requirements](#5-functional-requirements)
+  - [5.1 Policy Content Model](#51-policy-content-model)
+  - [5.2 Bundle Lifecycle](#52-bundle-lifecycle)
+  - [5.3 Assignment and Inheritance](#53-assignment-and-inheritance)
+  - [5.4 Policy Matching](#54-policy-matching)
+  - [5.5 Decision Semantics](#55-decision-semantics)
+  - [5.6 Evaluation Inputs and Outputs](#56-evaluation-inputs-and-outputs)
+  - [5.7 Expression Evaluation](#57-expression-evaluation)
+  - [5.8 Multi-Tenancy](#58-multi-tenancy)
+  - [5.9 Observability](#59-observability)
+  - [5.10 Configuration](#510-configuration)
+- [6. Non-Functional Requirements](#6-non-functional-requirements)
+  - [6.1 Efficiency](#61-efficiency)
+  - [6.2 Reliability](#62-reliability)
+  - [6.3 Performance](#63-performance)
+  - [6.4 Security](#64-security)
+  - [6.5 Versatility](#65-versatility)
+  - [6.6 NFR Exclusions](#66-nfr-exclusions)
+- [7. Public Library Interfaces](#7-public-library-interfaces)
+  - [7.1 Public API Surface](#71-public-api-surface)
+  - [7.2 External Integration Contracts](#72-external-integration-contracts)
+- [8. Use Cases](#8-use-cases)
+- [9. Acceptance Criteria](#9-acceptance-criteria)
+- [10. Dependencies](#10-dependencies)
+- [11. Assumptions](#11-assumptions)
+- [12. Risks](#12-risks)
+- [13. Open Questions](#13-open-questions)
+- [14. Traceability](#14-traceability)
+
+<!-- /toc -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+The Policy Engine is the Gears platform gear that owns admission control policy: it stores policy content, manages its lifecycle, evaluates it against the operations that management gears are about to perform, and returns a decision the caller enforces. It is the platform's home for policy that no single gear owns — content that is authored, versioned, assigned to tenants, and audited independently of the gears whose operations it governs.
+
+The gear is one of two components. The other is `admission-control`, a system gateway that admits or rejects an operation and delegates the check to a policy engine, of which this gear is one implementation — selected the way this platform selects every plugin, one at a time. This document specifies the engine only; the gateway, including how it is invoked and what it does with the answer, is specified separately. The gateway is this gear's only consumer: management gears reach policy through it, not around it.
+
+### 1.2 Background / Problem Statement
+
+Management gears need to refuse operations that violate a tenant's rules before those operations take effect, and today each one solves that alone. [Infrastructure Resource Manager](../../../infrastructure-resource-manager/docs/PRD.md) records the consequence directly: policy enforcement across the estate was inconsistent and left audit gaps, which is why its requirements now demand that every operation be policy-gated. It declares a Policy Decision Service actor for that purpose and states that the actor is a capability rather than a component.
+
+That actor is not unserved. Infrastructure Resource Manager maps it, informatively, onto the platform of today: admission and policy decisions to `authz-resolver`, quota to `quota-enforcement`, licence to the licence resolver — and it records the resulting dependency status as partial. What is missing is narrower and more specific than "no provider". No component owns tenant-authored policy content that spans gears: content with a lifecycle, a version history, an assignment to a tenant subtree, and an audit trail, judged against operations that gears are about to perform.
+
+[`quota-enforcement`](../../quota-enforcement/docs/PRD.md) and [`event-broker`](../../event-broker/docs/PRD.md) have each met a narrower version of this need, and neither generalises. Both evaluate policy over state they own themselves, and both keep their engine registry local to that domain. Policy that spans gears has no such owner, and Section 5.7 explains why this gear does not build a third local registry.
+
+Admission control policy has no owner today. The rules that say which operations a tenant may perform, under which conditions, are not the property of the gear that happens to execute them — they belong to whoever administers the tenant, they outlive any single gear, and they have to be reviewable as a body. Without a place to keep them, they end up compiled into the gears they constrain, where changing one requires a release and auditing one requires reading source.
+
+### 1.3 Goals (Business Outcomes)
+
+Milestones below refer to this document's own priority tiers — "p1 complete" means every `p1` requirement in Sections 5 and 6 is met and verified. The repository has no separate release-maturity vocabulary.
+
+| Outcome | Baseline | Target | By |
+|---|---|---|---|
+| A management gear can gate its operations on tenant policy without embedding rules in its own source | Zero shared decision paths; each gear hard-codes its checks | One supported decision path, exercised against the admission requirements Infrastructure Resource Manager specifies, through a harness standing in for the gateway until that gear exists | p1 complete |
+| Policy changes are versioned, attributable, and reviewable | Governance rules live in gear source; changing one requires a release | 100 percent of policy changes carry an author, a version, and a content digest, and take effect without a deployment | p1 complete |
+| An administrator can see what policy currently refuses | No record of refusals beyond gear-local logs | Every refusal is retrievable by tenant, by policy, and by resource type within the retention window | p1 complete |
+| Decisions are reconstructable after the fact | No decision records | Any decision in the retention window can be traced to the subject, the operation, and the policy version that determined it | p1 complete |
+| An operator can see how much of the estate policy is silent about | No record of what is ungoverned; absence is invisible | Every permission carries its cause, and the ungoverned share of decisions is observable as a metric | p1 complete |
+
+### 1.4 Glossary
+
+| Term | Definition |
+|------|------------|
+| Admission | The act of permitting or refusing an operation before it takes effect. |
+| Admission Control Policy | A rule that judges whether a management operation on a resource may proceed, evaluated against the operation's context. The content this gear owns and evaluates; the `admission-control` gear enforces the verdict but does not hold the content. |
+| Authorization Policy | A rule that judges whether a subject may act on a resource at all. A distinct kind, owned by `authz-resolver` and specified in [arch/authorization/](../../../../docs/arch/authorization/). This gear neither stores nor evaluates it, and the two kinds share no content, no lifecycle, and no decision path. |
+| Entitlement | What a subject is permitted to do, as recorded by the authorization subsystem: a role, a role binding, a permission or scope, a group membership, or the resolved statement that a subject may perform an action. Owned by `authz-resolver`. Distinct from the subject's **identity** — an identifier and a tenant — which is all this gear's evaluation input carries, per `cpt-cf-policy-engine-fr-authorization-boundary`. |
+| Admission Gateway | The `admission-control` system gear: a thin gateway that admits or rejects, delegating the check to the one policy engine selected in that deployment. Specified separately. |
+| Policy Bundle | A versioned, deployable collection of policy documents, assigned to a tenant. |
+| Policy Document | A single unit of policy content within a bundle, carrying a kind that determines how it is evaluated. |
+| Policy Target | The binding that determines when a policy document is evaluated, by trigger type, phase, resource type, and filters. |
+| Decision | The result of evaluating policy for a subject, an action, and a resource: permit or prohibit. Distinct from a document **outcome**, which is what one policy document yields. |
+| Ungoverned | The cause on a permission produced when no document permitted or prohibited. The operation proceeds, and the record says policy was silent about it rather than that policy approved it. |
+| Decision Record | The durable record of one evaluation, carrying the field set defined in Section 5.9. |
+| Refusal | A prohibiting decision. Exposed as a queryable projection over decision records within the retention window, not as separately stored state, and therefore a history of what policy refused rather than a list of conditions currently in breach. |
+| Obligation | An action a caller is required to perform when enforcing a permitting decision. |
+| Assignment | The binding of an active bundle to a tenant, determining which resources the bundle governs. |
+| Policy Priority | The ordering value on an assignment, used to break ties between assignments at the same tenant. |
+| Evaluation Facility | The platform's shared policy-evaluation toolkit library. It carries the contract that evaluation backends implement and selects among them, so a consumer links one facility rather than its own engine registry. Specified separately; this gear neither defines it nor chooses which backends it ships. |
+| Evaluation Backend | An implementation of a policy language behind the evaluation facility's contract. Policy content is written in the language of one backend, and declares which. |
+| PDP / PEP / PAP | Policy Decision Point, Policy Enforcement Point, Policy Administration Point. This gear administers and evaluates admission control policy, which makes it a PAP and a PDP for that content. The gateway that calls it is a decision point too, not an enforcement point: the PEP is the enforcing gear behind the gateway, because that is the only component able to stop the operation. The vocabulary is the same role pattern the authorization subsystem uses, applied to a different content kind — it does not imply a shared decision path. |
+| GTS | Global Type System. Provides the identifiers used for resource types, plugin instances, and error codes. |
+
+## 2. Actors
+
+> **Note**: Stakeholder needs are managed at project/task level by steering committee. Documented below are the actors that interact with this gear.
+
+### 2.1 Human Actors
+
+#### Policy Author
+
+**ID**: `cpt-cf-policy-engine-actor-policy-author`
+
+- **Role**: Authors and revises policy content, submits it for validation, and promotes it through the bundle lifecycle.
+- **Needs**: Authoring and validation feedback before activation; deterministic evaluation semantics; the ability to see what a policy will refuse before it takes effect.
+
+#### Platform Operator
+
+**ID**: `cpt-cf-policy-engine-actor-platform-operator`
+
+- **Role**: Configures and operates the gear, sets limits, and responds to availability and latency incidents.
+- **Needs**: Configuration with safe defaults; visibility into decision latency, cache behaviour, and refusal volume; predictable failure semantics.
+
+#### Tenant Policy Administrator
+
+**ID**: `cpt-cf-policy-engine-actor-tenant-policy-admin`
+
+- **Role**: Manages policy for a tenant subtree within the bounds set by ancestor tenants, and reviews what that policy currently refuses.
+- **Needs**: Policy management confined to their own subtree; visibility into which inherited policies constrain them; a list of current violations they can act on.
+
+#### Security Auditor
+
+**ID**: `cpt-cf-policy-engine-actor-security-auditor`
+
+- **Role**: Reviews admission decisions after the fact for compliance and incident investigation.
+- **Needs**: A complete decision record with enough context to reconstruct why a decision was reached, including the policy version in force at the time.
+
+### 2.2 System Actors
+
+#### Admission Gateway
+
+**ID**: `cpt-cf-policy-engine-actor-admission-gateway`
+
+- **Role**: The `admission-control` system gear, and this gear's only direct consumer. Selects this gear as its policy engine, supplies the operation context on behalf of the gear being gated, and relays the resulting decision back to it. Every evaluation this gear performs arrives through the gateway.
+
+#### Enforcing Gear
+
+**ID**: `cpt-cf-policy-engine-actor-enforcing-gear`
+
+- **Role**: A management gear whose operations are gated on policy — Infrastructure Resource Manager first among them, through the admission requirements in its own PRD. It originates the operation context and enforces the verdict, but it reaches this gear through the gateway and never calls it directly. Its requirements shape what policy must be able to express; its integration is with `admission-control`.
+
+#### Hierarchy Provider
+
+**ID**: `cpt-cf-policy-engine-actor-hierarchy-provider`
+
+- **Role**: `tenant-resolver` supplies tenant ancestry, descendants, and barrier state. Acts as a Policy Information Point during assignment resolution.
+
+#### Types Registry
+
+**ID**: `cpt-cf-policy-engine-actor-types-registry`
+
+- **Role**: Receives this gear's GTS registrations, and resolves the four kinds of identifier this gear stores or emits but does not own: the evaluation backend a document declares, the concrete resource types a target names, the obligation identifiers a decision carries, and the plugin instances behind them. Every one of those is content the gear validates rather than interprets, which is why the registry is on the authoring path as well as the evaluation path.
+
+#### Decision Record Sink
+
+**ID**: `cpt-cf-policy-engine-actor-audit-sink`
+
+- **Role**: Receives the decision records this gear emits, for retention, export, and analysis. The sink is `event-broker`, which carries an audit-pipeline use case for exactly this shape: records are published to a platform-scoped topic, and the storage backend bound to that topic owns their retention, compaction, and deletion. The `admission-control` gateway publishes its admission records to the same topic, so the record of what was gated and the record of how policy decided it are read from one stream rather than joined across two systems.
+
+## 3. Operational Concept & Environment
+
+> Project-wide runtime, operating system, architecture, lifecycle policy, and integration patterns are defined at the repository level in [ARCHITECTURE_MANIFEST.md](../../../../docs/ARCHITECTURE_MANIFEST.md) and the foundational [guidelines/](../../../../guidelines/). This gear has no parent gear PRD. Only gear-specific constraints appear below.
+
+### 3.1 Gear-Specific Environment Constraints
+
+- The gear sits inside the admission path of its consumers. Every gated operation results in an evaluation, so the gear's availability and latency bound the availability and latency of the management operations it governs, and it fails closed by design.
+- The gear is a decision authority, not a data owner for the resources policy governs. It never holds copies of those resources and never requires a consumer to synchronise resource state into it. Everything an evaluation needs arrives on the request.
+- The gear holds two data sets and owns neither outright. Policy content belongs to the tenant it is assigned to, which authors and withdraws it; the gear is its custodian and versioning authority. Decision records belong to the platform's audit function; the gear produces them and applies retention, and consumers of the record stream are entitled to them independently of this gear.
+- First release composes the gear in-process, the platform's default execution mode: the gear, its consumers, and the evaluation facility share one runtime and communicate through typed clients. The platform also supports out-of-process execution over gRPC, and the gear's contracts are unchanged by that choice, but two requirements are conditioned on it — `cpt-cf-policy-engine-nfr-availability` explicitly, and `cpt-cf-policy-engine-nfr-decision-latency` implicitly, since its budget contains no allowance for a transport hop.
+- The gear depends on a platform evaluation facility that does not yet exist: no such library, gear, or specification is present in the repository today. It is a prerequisite rather than a dependency the gear can degrade around — without it there is no evaluation path at all, and the backends it eventually carries bound which languages policy content can be written in. Every requirement below that refers to the facility is conditional on its arrival.
+- [GEARS.md](../../../../docs/GEARS.md) has no entry for this capability. Its nearest neighbour, Policy Manager, is defined as managing *authorization* policies for resources and actions, which Section 1.4 places outside this gear and which `authz-resolver` serves. The catalog needs a new entry rather than a reinterpretation of that one.
+- The gear's placement under `gears/system/` is provisional. A separation of core system gears from infrastructure-management gears has been proposed, and this gear would belong with the latter, but the repository defines three tiers today and no such grouping exists. Nothing in this document depends on where the gear finally sits.
+
+## 4. Scope
+
+### 4.1 In Scope
+
+- Policy content model: bundles, versions, documents, targets, and filters, with their relationships and constraints.
+- Bundle lifecycle: draft, activation, deprecation, immutability after activation, content integrity, and optimistic concurrency.
+- Policy assignment to tenants, with inheritance, precedence, and barrier handling across the platform's tenant tree.
+- Evaluation of a subject, an action, and a resource against the applicable policy set, returning a single decision with a reason.
+- Trigger-based matching of policy documents to operations by type, phase, resource type, and attribute filters.
+- Batch evaluation, returning one atomic verdict over the several resource types a single consumer change touches.
+- Obligations attached to permitting decisions.
+- Decision records covering every evaluation, and a violations projection over them.
+- Multi-tenant isolation of policy content and decisions.
+- A management API for policy content, decisions, and violations, offered as both an in-process client and a REST surface.
+- Configuration, observability, and operational limits.
+
+### 4.2 Out of Scope
+
+- The `admission-control` gateway gear: how it is invoked, how it selects an engine, what it does with a decision, and what its built-in platform policies are, are specified separately.
+- The shared evaluation facility: which backends it carries, the languages they accept, their evaluation semantics, and its own requirements belong to its own specification. This gear depends on it, declares which language its content is written in, and defines none of it.
+- Generating and mutating policies, in the sense that Kyverno uses those terms — policy that creates or rewrites resources rather than judging them. Explicitly excluded at every priority tier, not deferred to one.
+- Authorization policy, in the sense defined in Section 1.4: rules about whether a subject may act on a resource at all. That is a distinct content kind owned by `authz-resolver`, and this gear neither stores nor evaluates it. `cpt-cf-policy-engine-fr-authorization-boundary` makes the exclusion enforceable rather than declared, by withholding from the evaluation input the entitlements such a rule would need. Should the gear ever be asked to evaluate authorization policy, that is a new capability requiring its own requirements, and the positions recorded in [arch/authorization/](../../../../docs/arch/authorization/) would govern it.
+- Row-level constraint generation for collection queries, and the capability negotiation it requires. Constraints are an artifact of the authorization evaluation model, so they belong to that subsystem rather than to a later phase of this gear.
+- The identity of subjects and the validation of their credentials, which belong to `authn-resolver`.
+- Enforcement itself. Consumers enforce the decisions they receive; this gear has no mechanism to make them.
+- Tenant hierarchy ownership, which belongs to `tenant-resolver`. This gear reads hierarchy and does not maintain it.
+- Allowance state and its consumption, which belong to `quota-enforcement`. This gear does not hold counters, reserve allowance, or track consumption.
+- A policy authoring user interface.
+- Rolling a version out to a proportion of requests. Staged activation is expressed through assignment scope, effective window, and the enforcing flag — all of which are properties of *which* operations an assignment governs. Sampling by request fraction would make two evaluations of the same subject differ, which `cpt-cf-policy-engine-fr-deterministic-ordering` and the reproducibility of decision records both rule out.
+- Migration of policy content from external policy managers.
+
+## 5. Functional Requirements
+
+> **Testing strategy**: All requirements are verified via automated tests targeting 90 percent or greater code coverage unless otherwise specified. Verification method is documented only where a non-test approach applies.
+
+### 5.1 Policy Content Model
+
+#### Bundle Composition
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-bundle-composition`
+
+The system **MUST** represent policy content as bundles that contain policy documents, where each document carries a kind that determines how it is evaluated, a GTS identifier naming the evaluation backend its content is written for, and one or more targets that determine when it is evaluated. A bundle is the unit of versioning, assignment, and integrity.
+
+Document content is opaque to this gear: it is source text the declared backend interprets, not a structure the gear parses. The gear resolves the declared backend identifier through the types registry, routes the document to the instance that identifier names, and interprets only the outcome that comes back. Typing the backend rather than naming it by convention is what lets a deployment carry more than one and lets validation reject content no backend can run.
+
+- **Rationale**: Policy versioned per document cannot be reasoned about as a whole, and policy versioned per tenant cannot be shared. The bundle is the granularity at which authors think about a coherent set of rules and at which operators activate and withdraw them. The language declaration is what lets the evaluation facility carry more than one backend without the gear guessing: content that does not say what it is written in can only be routed by convention, and a convention is what breaks when a second backend arrives.
+- **Actors**: `cpt-cf-policy-engine-actor-policy-author`, `cpt-cf-policy-engine-actor-types-registry`
+
+#### Document Kinds
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-document-kinds`
+
+The system **MUST** distinguish policy documents by kind and **MUST** route each kind to the evaluation path appropriate to it. The kind set is closed and versioned, and at first release has one member: guardrail, which judges whether an operation is permitted. Adding a kind is a versioned change to the set, not a configuration option.
+
+- **Rationale**: A closed set lets consumers request only the policy relevant to them and lets the gear apply the right combination semantics, and declaring the discipline now is what makes a second kind a versioned change rather than a reinterpretation. One member is the honest count: every kind previously sketched here had no consumer asking for it, and a kind whose content the gear does not interpret cannot produce an outcome `cpt-cf-policy-engine-fr-responsibility-boundary` is able to map to the closed set.
+- **Actors**: `cpt-cf-policy-engine-actor-policy-author`, `cpt-cf-policy-engine-actor-enforcing-gear`
+
+#### Target Binding
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-target-binding`
+
+The system **MUST** allow each policy document to declare when it applies, by trigger type, evaluation phase, resource type, and attribute filters. Filters combine conjunctively. Resource type matching **MUST** support exact type identifiers and type patterns.
+
+Attribute filters compare a named attribute of the caller-supplied operation context against a literal value, using a closed operator set: equal, not equal, member of, not member of, present, and not present. Comparison is type-sensitive: an attribute whose supplied type differs from the literal's does not match, and **MUST NOT** be coerced. An attribute the caller did not supply is absent, and absent matches only the not-present operator — so a filter written over an attribute a caller omits stops selecting its document rather than selecting it by default. A target **MUST** be able to declare an attribute required, in which case an evaluation that omits it is an infrastructure failure rather than a silent non-match. Resource type patterns are the pattern forms the platform's type system already defines — a concrete identifier and a wildcard over a namespace — so this gear introduces no pattern syntax of its own. A concrete identifier **MUST** resolve through the types registry, and content naming one that does not **MUST** fail validation rather than activating as a target that can never match.
+
+The trigger and phase vocabularies are likewise closed and versioned. Trigger types are: an operation on a resource, and a system or domain event. Phases are: before the operation, where the outcome can refuse it; and after the operation, where it cannot. Adding to either set is a versioned change. First release implements the operation trigger in the before phase; the event trigger and the after phase are declared so that targets authored now remain valid when they land, and their implementation is tracked separately.
+
+- **Rationale**: Evaluating every document on every operation does not scale and makes policy behaviour opaque. Declared targets let the gear compute a small applicable set and let authors state intent precisely. The vocabularies are enumerated here because other requirements match on them, and a matching rule over an undefined set cannot be verified. Resolving concrete type identifiers against the registry is what keeps a typo from becoming a silently inert guardrail — the failure mode an author is least able to detect, because nothing happens.
+- **Actors**: `cpt-cf-policy-engine-actor-policy-author`, `cpt-cf-policy-engine-actor-types-registry`
+
+#### Content Validation
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-content-validation`
+
+The system **MUST** validate policy content before it can be activated, and **MUST** report validation failures against the specific documents that caused them without activating any part of the bundle. Validation **MUST** cover content syntax as the declared backend judges it, resolution of the declared backend identifier through the types registry to an instance the deployment carries, resolution of every concrete resource-type identifier the document targets, the declared target vocabularies, the absence of every builtin denylisted for that backend build by `cpt-cf-policy-engine-fr-evaluation-isolation`, and the operational limits in Section 5.10.
+
+- **Rationale**: Invalid content discovered at evaluation time fails closed and refuses real operations. Validation at authoring time moves that failure to a person who can fix it. Because the backend that will evaluate the content is already available to parse it, syntax validation costs an authoring-time call rather than new machinery, which is why this is p1 rather than deferred. Checking backend availability belongs here too: content naming a backend the deployment does not carry is undeployable, and discovering that at activation is far cheaper than discovering it on the first gated operation.
+- **Actors**: `cpt-cf-policy-engine-actor-policy-author`, `cpt-cf-policy-engine-actor-types-registry`
+
+### 5.2 Bundle Lifecycle
+
+#### Lifecycle States
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-lifecycle-states`
+
+Lifecycle state belongs to a bundle **version**, not to the bundle: a bundle is a stable identity and a name, and its versions move through draft, active, and deprecated. The system **MUST** permit modification only while a version is draft, and **MUST** reject modification of an active or deprecated version with a distinguishable conflict result.
+
+The system **MUST** support these transitions and no others: create a draft, either empty or seeded from any retained version of the same bundle; activate a draft, which deprecates the previously active version of that bundle; deprecate an active version; and delete a draft, which is the only deletion the lifecycle permits. A deprecated version **MUST NOT** be reactivated in place. Returning to earlier content means seeding a new draft from the retained version and activating that, and every activation — including one that restores earlier content — **MUST** produce a new version identity and **MUST** be recorded as its own administration event under `cpt-cf-policy-engine-fr-administration-audit`. At most one version of a bundle **MUST** be active at a time.
+
+- **Rationale**: An activated bundle is a decision authority. If it can change underneath, no decision record can be reproduced and no reviewer can be sure what was in force at a given moment. Requiring a new identity and an event for every activation is what keeps restoring earlier content from becoming a quieter path than authoring it: a design that instead rewound a pointer would let a principal who may roll back but may not author widen access by reverting to a more permissive version, with no authoring check and nothing in the audit trail that looks like a grant.
+- **Actors**: `cpt-cf-policy-engine-actor-policy-author`, `cpt-cf-policy-engine-actor-platform-operator`
+
+#### Administration Audit
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-administration-audit`
+
+The system **MUST** record every change to policy content, assignment, and lifecycle state as an administration event, and **MUST** retain those events for at least as long as the content versions they describe. Every event **MUST** carry the acting subject and their tenant, the time, the operation, the identity and version of the content affected, and the precondition token the caller supplied where the operation required one.
+
+- **Rationale**: Two commitments in this document depend on attribution that no other requirement delivers: the goal that every policy change carries an author, and the criterion that every state change is attributable to an actor. Decision records cannot serve — they describe evaluations, not authorship, and `cpt-cf-policy-engine-fr-decision-records` owns a field set with no administration fields in it. Retention has to outlast the content rather than follow the decision-record window, because the question an auditor asks is who put a rule in force, and that question outlives every decision the rule produced.
+- **Actors**: `cpt-cf-policy-engine-actor-security-auditor`, `cpt-cf-policy-engine-actor-tenant-policy-admin`, `cpt-cf-policy-engine-actor-platform-operator`
+
+#### Content Integrity
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-content-integrity`
+
+The system **MUST** record a content digest for each activated bundle version, and **MUST** verify it whenever content is loaded for evaluation and at each activation. Content whose digest does not match the recorded value **MUST NOT** be evaluated. Verification is not required per evaluation, which the decision latency budget could not absorb; the guarantee is therefore that no unverified content is ever loaded, not that every decision re-checks it.
+
+- **Rationale**: Policy is a security control. Undetected modification, whether from storage corruption or tampering, silently changes what the platform permits.
+- **Actors**: `cpt-cf-policy-engine-actor-security-auditor`, `cpt-cf-policy-engine-actor-platform-operator`
+
+#### Optimistic Concurrency
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-optimistic-concurrency`
+
+The system **MUST** require a precondition on every modifying operation against existing policy content and **MUST** reject the operation when the content has changed since it was read.
+
+- **Rationale**: Multiple administrators editing one tenant's policy is normal. Last-write-wins on a security control silently discards the other author's change.
+- **Actors**: `cpt-cf-policy-engine-actor-policy-author`, `cpt-cf-policy-engine-actor-tenant-policy-admin`
+
+#### Version History
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-version-history`
+
+The system **MUST** retain previous versions of a bundle after a new version is activated, **MUST** make each retained version identifiable by the decision records that reference it, and **MUST** support returning a bundle to a previously retained version by seeding a new draft from it, per the transitions in `cpt-cf-policy-engine-fr-lifecycle-states`, rather than by mutating a frozen version.
+
+- **Rationale**: Auditing a past decision requires the content that produced it, not the content in force today. The same retained versions make recovery from a bad activation a single operation rather than a reconstruction from memory.
+- **Actors**: `cpt-cf-policy-engine-actor-security-auditor`, `cpt-cf-policy-engine-actor-platform-operator`
+
+#### Deprecation
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-deprecation`
+
+The system **MUST** allow an active bundle to be deprecated, **MUST** stop including deprecated bundles in evaluation within the activation propagation window, and **MUST** retain the bundle and its history for audit.
+
+- **Rationale**: Withdrawing policy must be as controlled as activating it, and must not destroy the record of what was in force.
+- **Actors**: `cpt-cf-policy-engine-actor-platform-operator`
+
+#### Version Comparison
+
+- [ ] `p2` - **ID**: `cpt-cf-policy-engine-fr-version-comparison`
+
+The system **MUST** support comparing two retained versions of the same bundle, reporting the documents added, removed, and changed between them, and **MUST** flag a comparison in which the later version could permit something the earlier one prohibited.
+
+The flag is deliberately conservative: it **MUST** report every change that could widen — a prohibiting document removed, an outcome changed away from prohibit, or a target narrowed so a prohibiting document no longer matches — and reporting a change that turns out not to widen in practice is acceptable rather than a defect. The system **MUST NOT** claim that an unflagged comparison cannot widen.
+
+- **Rationale**: Reviewers and approval flows need one question answered above all others: does this change grant something the current version denies. Everything needed to answer it is already retained — immutable versions and their digests — and without a comparison surface every embedding platform invents its own diff semantics over the same store, which then disagree. Deciding widening exactly would mean comparing two decision functions over every possible input, which is not tractable for a general policy language; so the requirement is a sound over-approximation that never misses a widening and sometimes cries wolf, and it says so rather than implying a guarantee it cannot hold. Comparing against recorded decisions instead is not available: `cpt-cf-policy-engine-fr-record-confidentiality` keeps property values out of records, so a recorded decision cannot be replayed against a candidate version.
+- **Actors**: `cpt-cf-policy-engine-actor-policy-author`, `cpt-cf-policy-engine-actor-security-auditor`
+
+#### Effective Windows
+
+- [ ] `p3` - **ID**: `cpt-cf-policy-engine-fr-effective-windows`
+
+The system **MUST** allow an assignment to carry a start and an end time, and **MUST** include the assignment in evaluation only within that window. The window composes with the assignment's tenant scope and with `cpt-cf-policy-engine-fr-non-enforcing-assignment` rather than replacing either: the scope decides where an assignment applies, the window decides when, and the enforcing flag decides whether its outcome counts. All three are independent.
+
+- **Rationale**: Time-bounded policy — a maintenance window, a temporary relaxation, a contractual period — is otherwise implemented as a manual withdrawal that someone forgets.
+- **Actors**: `cpt-cf-policy-engine-actor-tenant-policy-admin`, `cpt-cf-policy-engine-actor-platform-operator`
+
+### 5.3 Assignment and Inheritance
+
+> Policy is assigned to tenants in the platform's single-root tenant tree and inherited down that tree. The gear introduces no hierarchy of its own.
+
+#### Tenant Assignment
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-tenant-assignment`
+
+The system **MUST** allow a bundle to be assigned to a tenant with an explicit policy priority, and **MUST** apply it to the tenant and to its descendants in the tenant tree. An assignment **MUST** remain in force across activations of that bundle: activating a new version **MUST** change what every existing assignment of it governs, and the system **MUST NOT** require any administrative action to re-establish an assignment after an activation. The system **MUST** equally allow an assignment to be withdrawn, and its priority, effective window, and barrier-reach declaration to be changed. Withdrawal and change **MUST** take effect within the activation propagation window and **MUST** be recorded as administration events, on the same terms as activation.
+
+- **Rationale**: Policy that must be attached to every tenant individually is unmaintainable at any real tenant count, and drifts the moment a tenant is created. Assigning to the platform's existing tree means policy inherits the structure everything else in the platform already uses. Assignments surviving activation is what makes the recovery claim in `cpt-cf-policy-engine-fr-version-history` true: if activation left existing assignments needing repair, returning to earlier content would take one activation plus one repair per affected tenant, and a partial failure would leave some tenants governed by nothing while still appearing to be governed — reported, correctly but silently, as the ungoverned permits of `cpt-cf-policy-engine-fr-permit-provenance`. An administrator would have to notice the absence of refusals to notice the fault.
+- **Actors**: `cpt-cf-policy-engine-actor-tenant-policy-admin`, `cpt-cf-policy-engine-actor-platform-operator`
+
+#### Nearest Tenant Precedence
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-nearest-tenant`
+
+Where assignments at more than one tenant in an ancestry chain apply to the same evaluation, the system **MUST** order them by proximity to the resource, nearest first, breaking ties among assignments on the same tenant by policy priority, highest first. This ordering **MUST NOT** affect the result, which `cpt-cf-policy-engine-fr-outcome-combination` determines independently of position. It determines which document a refusal names as responsible, and the order in which the applicable set is consumed before short-circuiting.
+
+- **Rationale**: Delegation works through denial precedence, not through position: a tenant refines what an ancestor permitted by prohibiting, and a prohibition anywhere in the chain refuses regardless of where it sits. That makes ancestor guardrails a consequence of the combination rule rather than a separate mechanism, which is why no separate guardrail requirement appears in this document — and it also means position cannot be allowed to decide anything, or a descendant could remove a constraint its ancestor is accountable for. What proximity is for is the refusal a tenant administrator actually reads: naming the nearest responsible policy first points them at the one they can change, rather than at an ancestor's guardrail they cannot.
+- **Actors**: `cpt-cf-policy-engine-actor-tenant-policy-admin`, `cpt-cf-policy-engine-actor-platform-operator`
+
+#### Non-Enforcing Assignment
+
+- [ ] `p2` - **ID**: `cpt-cf-policy-engine-fr-non-enforcing-assignment`
+
+The system **MUST** allow an assignment to be marked non-enforcing. A non-enforcing assignment **MUST** be evaluated and recorded exactly as an enforcing one, and its outcomes **MUST NOT** contribute to the result returned to the caller.
+
+- **Rationale**: Activating a new bundle is otherwise the only way to learn what it does to real traffic, which makes every rollout a production experiment. A non-enforcing assignment measures a candidate against live requests with no risk to them, and it is a property of the assignment rather than of the content, so the same version can enforce in one tenant subtree while observing in another. This is distinct from `cpt-cf-policy-engine-fr-dry-run`, which answers a supplied hypothetical, and from the observe document outcome, which is authored into content and cannot be turned off without editing it.
+- **Actors**: `cpt-cf-policy-engine-actor-policy-author`, `cpt-cf-policy-engine-actor-platform-operator`
+
+#### Barrier Handling in Inheritance
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-inheritance-barriers`
+
+The system **MUST** resolve the subtree an assignment reaches using the barrier handling supplied by the caller on the evaluation request, and **MUST NOT** apply a barrier default of its own. Where an assignment declares that it reaches through barriers, that declaration **MUST** widen the resolved subtree only for evaluations whose caller requested barrier handling that permits it, and **MUST NOT** override a caller that requested barriers be respected.
+
+- **Rationale**: The platform's position is that barriers are context-dependent and the caller decides per resource type. A stored barrier setting that overrode the caller would reverse that. The assignment-level declaration exists only so an operator guardrail can be marked as one that may reach through when the caller already permits it; composition is caller-first, and a gear-level default would make one of the two cases silently wrong.
+- **Actors**: `cpt-cf-policy-engine-actor-platform-operator`, `cpt-cf-policy-engine-actor-tenant-policy-admin`
+
+#### Assignment Authorization Across Barriers
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-assignment-authorization`
+
+The system **MUST** authorise the creation, amendment, and withdrawal of an assignment against the caller's own security context, and **MUST** declare the barrier handling its assignment surfaces apply rather than inheriting a platform-wide default. The platform's position is that barrier enforcement is decided per resource type and per endpoint, so a gear that declares nothing has no rule at all.
+
+The declared rule is that assignment surfaces **respect barriers**. A caller **MUST NOT** create, amend, or withdraw an assignment at a tenant that lies behind a self-managed barrier from its own context, and **MUST NOT** enumerate the assignments held at such a tenant. Both **MUST** be refused with the boundary cause of `cpt-cf-policy-engine-fr-cross-tenant` rather than reported as an absence: the platform already makes a descendant tenant's existence visible to its ancestor, so concealing the tenant here would conceal nothing and only make the refusal unexplainable.
+
+This governs the management plane alone. What an assignment made at or above a barrier *governs* is decided by `cpt-cf-policy-engine-fr-inheritance-barriers` on the evaluation plane, from the caller's requested barrier handling and the assignment's own reach declaration, so a self-managed tenant is not exempt from an ancestor's guardrail. What the barrier withholds is the ancestor's ability to administer policy *inside* the subtree, which is a different question from whether policy it already holds reaches in.
+
+- **Rationale**: Assignment is the one management operation whose target is a tenant rather than a piece of content, so `cpt-cf-policy-engine-fr-content-isolation` does not reach it and nothing else here did either. An undefined rule means the first implementation picks one by accident, and both accidents are bad: an ancestor silently able to attach policy inside a subtree that raised a barrier defeats the barrier as an autonomy boundary, while an ancestor unable to see the assignment it holds there cannot audit its own guardrails. Separating the two planes is what makes both halves defensible — the ancestor keeps the guardrail it is accountable for, and the self-managed tenant keeps administration of what happens inside it. Section 13's question about inheritance is a question about the evaluation plane; this requirement neither answers it nor depends on how it is answered.
+- **Actors**: `cpt-cf-policy-engine-actor-tenant-policy-admin`, `cpt-cf-policy-engine-actor-platform-operator`
+
+### 5.4 Policy Matching
+
+#### Applicable Set Determination
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-applicable-set`
+
+For each evaluation the system **MUST** determine the applicable set of policy documents by matching trigger type, resource type, evaluation phase, and attribute filters, restricted to active assignments visible from the requesting tenant context.
+
+- **Rationale**: The applicable set is what makes evaluation cost independent of total policy volume. It is also the explanation an author needs when a policy does not fire.
+- **Actors**: `cpt-cf-policy-engine-actor-enforcing-gear`
+
+#### Deterministic Ordering
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-deterministic-ordering`
+
+The system **MUST** evaluate the applicable set in a total order. Proximity to the resource orders first, policy priority second, and a stable property of the assignment itself resolves the remainder, so that two assignments on the same tenant sharing a policy priority still evaluate in a fixed order.
+
+- **Rationale**: The result does not depend on order, but three things a reader of a decision depends on do: which document a refusal names as responsible, how many documents were evaluated before short-circuiting stopped the loop, and therefore whether two runs of the same input produce identical records. Proximity and priority alone do not produce a total order, because nothing prevents two assignments on one tenant from carrying the same priority; without a third key those three become dependent on retrieval order, and an auditor comparing two records of the same decision sees a difference that means nothing.
+- **Actors**: `cpt-cf-policy-engine-actor-security-auditor`
+
+#### Evaluation Phases
+
+- [ ] `p3` - **ID**: `cpt-cf-policy-engine-fr-evaluation-phases`
+
+The system **MUST** evaluate documents in the after-the-operation phase without allowing their outcome to affect whether the operation proceeded, and **MUST** record those outcomes as it does any other.
+
+- **Rationale**: Governance frequently needs to observe before it enforces. Without a phase whose outcome cannot refuse, every new rule is a production risk. The phase vocabulary itself is defined by `cpt-cf-policy-engine-fr-target-binding`; this requirement covers only the non-blocking behaviour, which is why it is not needed for a first release that ships the blocking phase alone.
+- **Actors**: `cpt-cf-policy-engine-actor-enforcing-gear`, `cpt-cf-policy-engine-actor-policy-author`
+
+### 5.5 Decision Semantics
+
+#### Permit Provenance
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-permit-provenance`
+
+The system **MUST NOT** produce a permission from a failure. No error condition, unevaluable document, unreachable dependency, or unresolvable tenant context may yield a permit of any cause; every one of them refuses, per `cpt-cf-policy-engine-fr-denial-versus-failure`. There is one exception, and it is the same one `cpt-cf-policy-engine-fr-denial-precedence` carries: `cpt-cf-policy-engine-fr-emergency-access` permits on precisely these paths, under an entitlement resolved without consulting policy content, and stamps its own permission cause so that a permission obtained that way is never reported as governed or as ungoverned.
+
+An operation that policy does not govern **MUST** be permitted, and that permission **MUST** be marked ungoverned. The system **MUST** make the ungoverned count observable, so that an operator can see how much of the estate policy is silent about.
+
+- **Rationale**: Refusing what no policy governs is the wrong default for this gear: a deployment that has authored nothing would refuse every gated operation, and a resource type nobody wrote policy for would become unusable rather than unregulated. Permitting it is the honest answer — the gear was asked whether policy objects, and it does not. What must not happen is the two failure modes collapsing into that answer: a permit obtained because a dependency was down is not the same as one obtained because policy is silent, and only the first is a defect. Marking the ungoverned case is what keeps the silence visible instead of indistinguishable from approval, and counting it is what turns "we have no policy here" from an assumption into a number.
+- **Actors**: `cpt-cf-policy-engine-actor-enforcing-gear`, `cpt-cf-policy-engine-actor-platform-operator`
+
+#### Denial Precedence
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-denial-precedence`
+
+Where the applicable set yields both permitting and prohibiting outcomes, the system **MUST** refuse.
+
+- **Rationale**: A prohibition is a stated intent to prevent something. Allowing a permission elsewhere to override it would make prohibitions unreliable and therefore unusable as a control.
+- **Actors**: `cpt-cf-policy-engine-actor-policy-author`
+
+#### Outcome Combination
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-outcome-combination`
+
+A policy **document** yields exactly one outcome per evaluation, drawn from a closed, versioned set. At this priority the set is: permit, prohibit, and observe, which records without influencing the result. `cpt-cf-policy-engine-fr-deferral-outcome` adds a fourth member, and defines its own position in the rules below rather than leaving it to be inferred.
+
+An **evaluation** yields exactly one result: permit or prohibit. The system **MUST** combine document outcomes into that result by these rules:
+
+- any prohibit yields a prohibition;
+- otherwise the result is a permission.
+
+Every permission **MUST** carry a cause, drawn from a closed, versioned set, distinguishing the ways it arises. At this priority the set has two members: **governed**, where at least one document permitted, and **ungoverned**, where no document permitted or prohibited. An observe outcome never contributes, so an empty applicable set and one containing only observe outcomes are both ungoverned. `cpt-cf-policy-engine-fr-emergency-access` adds a third member, **emergency**, at its own priority tier, and defines when it is stamped rather than leaving it to be inferred; it is the one cause not derived from the outcome sequence at all, and while that requirement is unimplemented no path constructs it.
+
+These rules are order-independent by construction: the result is the same whatever sequence the applicable set is evaluated in. Ordering is required for other reasons, stated in `cpt-cf-policy-engine-fr-deterministic-ordering`, and **MUST NOT** be relied on to change a result.
+
+- **Rationale**: Consumers need one answer, not a list, and a two-valued answer is the one a caller can act on without a branch it might forget. The two facts a caller does need to keep apart — policy considered this and allowed it, versus no policy considered it — travel as a cause rather than as a third variant, on the same pattern the refusal side already uses. Stating order-independence in the requirement closes the gap that let two adjacent sections imply different algebras: prohibition wins over permission by precedence, not by position.
+- **Actors**: `cpt-cf-policy-engine-actor-enforcing-gear`
+
+#### Short-Circuit Evaluation
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-short-circuit`
+
+The system **MUST** stop evaluating the applicable set once no remaining outcome can change the result, and **MUST** record how many documents matched alongside how many were evaluated.
+
+- **Rationale**: Short-circuiting bounds evaluation cost, and a prohibition can be reached without examining the rest of the set. Recording both counts keeps that visible — otherwise an auditor cannot tell whether a policy was consulted and permitted, or never reached.
+- **Actors**: `cpt-cf-policy-engine-actor-enforcing-gear`, `cpt-cf-policy-engine-actor-security-auditor`
+
+#### Denial Reason
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-denial-reason`
+
+Every refusal **MUST** carry a machine-readable reason code drawn from the platform's error type system, and **MUST** permit an accompanying human-readable detail that identifies the policy responsible. The detail **MUST** be recorded, and **MUST NOT** be returned to end users.
+
+- **Rationale**: Callers must branch on the reason without parsing prose, and Infrastructure Resource Manager goes further: its cascade admission requires a refusal to identify which condition fired, so that the caller can report it against the offending resource. A caller cannot do that unless the decision carries the identity of what refused. Detail describes the tenant's policy posture, so returning it to an end user discloses how the control is configured.
+- **Actors**: `cpt-cf-policy-engine-actor-enforcing-gear`
+
+#### Denial and Failure Are Distinct
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-denial-versus-failure`
+
+The system **MUST** report an infrastructure failure distinctly from a policy refusal, and **MUST NOT** represent an evaluation failure, an unavailable evaluation backend, a hierarchy provider outage, or an internal error as a prohibiting decision. Nor **MUST** it represent any of them as a permission of any cause: an error means the gear could not evaluate, which is not the same as evaluating and finding nothing, and a caller that read the two alike would proceed with an operation because a dependency was down.
+
+- **Rationale**: Both outcomes block the operation, but they demand different responses: a refusal is correct behaviour, an outage is an incident. Conflating them hides outages from alerting and tells users their policy changed when it did not. Infrastructure Resource Manager depends on this distinction directly: it requires an unreachable decision service to be retried as transient rather than treated as a refusal.
+- **Actors**: `cpt-cf-policy-engine-actor-enforcing-gear`, `cpt-cf-policy-engine-actor-platform-operator`
+
+#### Deferral Outcome
+
+- [ ] `p3` - **ID**: `cpt-cf-policy-engine-fr-deferral-outcome`
+
+The system **MUST** support a document outcome that neither permits nor prohibits but defers the operation for human review, and **MUST** return the corresponding result distinguishably from both a permission and a prohibition. Its position in `cpt-cf-policy-engine-fr-outcome-combination` is between the two: any prohibit still yields a prohibition; otherwise any defer yields a deferral; otherwise the result is a permission with its cause as before. A deferral therefore overrides a permit and is overridden by a prohibit. Shipping it makes the result three-valued for the first time, but not for the first time *expressible*: `cpt-cf-policy-engine-interface-decision-client` reserves the variant unpopulated from its first version, so shipping widens a reserved shape rather than adding one, and the gateway reserves it likewise under `cpt-cf-admission-control-fr-deferral-relay`. What the reservation does not make cheap is the behavioural change — a caller that received a refusal will begin receiving a deferral — so serving it remains a versioned change on both surfaces.
+
+- **Rationale**: A deferral is not a refusal — the operation proceeds once someone approves it. Conflating them either blocks legitimate work or bypasses the review entirely, and the conflation is not hypothetical: the gateway's rule for an engine result it cannot map is to refuse with an infrastructure cause, so a deferral reaching a gateway with nowhere to put it would be reported as an outage. Reserving the variant on both contracts before either serves it is what stops that, and it costs nothing while no engine emits one. This is p3 because nothing in the tree currently routes a deferral to an approver.
+- **Actors**: `cpt-cf-policy-engine-actor-enforcing-gear`
+
+#### Emergency Access
+
+- [ ] `p3` - **ID**: `cpt-cf-policy-engine-fr-emergency-access`
+
+The system **MUST** permit an operation that policy would otherwise prohibit when all of the following hold: the request explicitly asserts emergency access, the subject holds the emergency entitlement, and the entitlement is resolvable without evaluating policy content.
+
+This is the sole exception to three requirements, and all three **MUST** be read as admitting it: `cpt-cf-policy-engine-fr-denial-precedence`, which a permission over a prohibiting outcome contradicts; the fail-closed threshold of `cpt-cf-policy-engine-nfr-fail-closed`, which already excludes and separately measures this path; and `cpt-cf-policy-engine-fr-permit-provenance`, whose prohibition on producing a permission from a failure this requirement overrides on exactly the paths that failed. The exception is available only on the paths those three would otherwise refuse — it **MUST NOT** apply where the refusal came from an unresolvable tenant context or a cross-tenant boundary, which no emergency entitlement may cross.
+
+A permission reached this way **MUST** carry the **emergency** cause that `cpt-cf-policy-engine-fr-outcome-combination` reserves for it, and **MUST NOT** carry governed or ungoverned. Neither fits and neither is a harmless approximation: documents prohibited, so the permission is not ungoverned, and none permitted, so it is not governed. That cause is the record marker required by `cpt-cf-policy-engine-fr-decision-records` — one field rather than a cause plus a flag beside it — and the decision **MUST** additionally increment a distinct metric.
+
+- **Rationale**: Incidents occur where correct policy blocks necessary recovery. The entitlement must resolve without evaluating content, because the incident being recovered from may be the content itself — an override that depends on the thing that is broken is not an override. An unmarked one is indistinguishable from an attack, so both the cause and the metric are part of the requirement rather than consequences of it. Naming all three exceptions matters more here than the tidiness of it: this is the only requirement in the document that permits where another requirement forbids, so a reader who finds only two of the three named has to guess whether the third is an oversight or a contradiction. Carrying the mark as a cause rather than as a separate flag is what stops the two disagreeing — a permission whose cause said governed while a flag said emergency would be a decision no auditor could classify, and the emergency permission is the single decision in this gear most likely to be disputed.
+- **Actors**: `cpt-cf-policy-engine-actor-platform-operator`, `cpt-cf-policy-engine-actor-security-auditor`
+
+### 5.6 Evaluation Inputs and Outputs
+
+#### Authorization Boundary
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-authorization-boundary`
+
+The system **MUST NOT** be usable as an authorization decision path, and **MUST** make that structural rather than declared. Two obligations follow.
+
+The evaluation input **MUST** carry the subject as an identifier together with the subject's tenant, and **MUST NOT** carry the subject's entitlements — no role, no role binding, no permission or scope, no group membership, and no resolved statement of what the subject may do. The system **MUST NOT** resolve an entitlement in the course of an evaluation, and where it resolves one outside evaluation it **MUST NOT** pass it in — which is the discipline `cpt-cf-policy-engine-fr-emergency-access` already follows, since the gear consults that entitlement itself and policy content never sees it.
+
+A decision **MUST NOT** widen access. The result of an evaluation states that policy does or does not object to an operation; it is never a statement that the subject is authorized to perform it, and no cause on a permission — governed, ungoverned, or the emergency cause of `cpt-cf-policy-engine-fr-emergency-access` — may be represented as one.
+
+**Conformance expectation on the caller**, not observable by this gear: authorization is decided before admission, and a permission from this gear is no substitute for it. A caller that gates an operation on this gear alone has performed no authorization check at all.
+
+- **Rationale**: The input of `cpt-cf-policy-engine-fr-evaluation-input` — subject, action, resource, and arbitrary caller-supplied context — is the shape every policy decision point takes, so the input alone cannot distinguish an admission question from an authorization one. Section 4.2 places authorization outside this gear in prose, and prose is not a boundary: nothing in the content model would stop an author writing rules over roles, which would put a second answer to "who may do what" in a component with its own lifecycle, its own audit trail, and no obligation to agree with `authz-resolver`. Withholding entitlements from the input is what makes such a rule unwritable rather than merely discouraged — content that cannot see a role cannot decide by role. The distinguishing test the two kinds actually admit is therefore about inputs and not about intent: a rule decidable from the subject's grants alone is authorization, and a rule needing the proposed values of the change is admission, which is the one this gear is given the facts for. Two holes remain, and are stated rather than implied: an author may still write a rule naming a subject identifier, and a caller may put anything into the operation context, which the gear has no schema for and cannot classify. Neither is closed here, and neither escalates — because a decision cannot widen access, the worst either produces is a refusal narrower than authorization already permitted, which is the only direction an admission control is allowed to travel. Adding an authorization content kind later would be the versioned change to the closed set that `cpt-cf-policy-engine-fr-document-kinds` describes, governed by the positions in [arch/authorization/](../../../../docs/arch/authorization/), and not a configuration option.
+- **Actors**: `cpt-cf-policy-engine-actor-policy-author`, `cpt-cf-policy-engine-actor-security-auditor`, `cpt-cf-policy-engine-actor-enforcing-gear`
+
+#### Evaluation Input Contract
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-evaluation-input`
+
+The system **MUST** accept, on each evaluation request, the subject and the subject's tenant, the action, the resource type and the resource identifier where one exists, the tenant context including barrier handling and status filtering, a caller-supplied operation context carrying the resource properties policy is to judge, and the caller's correlation identifier. The subject arrives as identity alone — an identifier and a tenant — because `cpt-cf-policy-engine-fr-authorization-boundary` forbids the input from carrying that subject's entitlements, and it arrives on the input without being trusted from it: `cpt-cf-policy-engine-fr-subject-authenticity` derives the subject and its tenant from the caller's propagated security context and refuses a request whose asserted values disagree. The system **MUST** additionally stamp each evaluation with the timestamp it will supply to the backend, and treat that timestamp as an input to the decision rather than as metadata about it. The system **MUST NOT** retrieve resource state from the consumer in order to evaluate. It **MUST NOT** generate a correlation identifier of its own under any circumstances, and **MUST** refuse an evaluation that arrives without one, reporting a caller defect distinctly from both a policy refusal and an infrastructure failure. Minting a substitute is not the lenient option it appears to be: the value's whole purpose is to match this gear's decision record to the gateway's admission record of the same gated operation, on the audit topic they share. A locally minted value matches no such record, so it produces a row that satisfies the field set of `cpt-cf-policy-engine-fr-decision-records` and still cannot be tied to the operation it describes — worse than an absent value, which at least reads as incomplete.
+
+- **Rationale**: Policy that judges a resource the consumer is about to create cannot read that resource — it does not exist yet, which is the whole point of judging before the operation. Making the input complete is also what keeps the gear free of the resource-synchronisation coupling that the platform rejected for authorization, and what makes an evaluation reproducible from its record. The correlation identifier is supplied rather than minted because this gear sees one evaluation and the gateway sees the whole gated operation. One gated operation leaves two records — the gateway's, saying what was gated and how it was answered, and this gear's, saying how policy reached that answer — and the correlation identifier is the only field they share, so it is the only thing that shows the two describe one event. An identifier minted here would be unique and present and would match no admission record at all. Accepting it is safe because of who the caller is and what that caller is required to do with it. The only caller is the gateway, per `cpt-cf-policy-engine-fr-subject-authenticity` and the single-path constraint of Section 4.2, and `cpt-cf-admission-control-fr-admission-records` requires the gateway to mint the value per gated operation and forbids it from deriving the value from anything the calling gear or its client controls. The identifier therefore arrives on the request while still being outside the reach of the subject being audited — which is the test an audit key has to pass, and which a value chosen by the party under audit would fail. It is deliberately not a tracing identifier for that same reason: a trace identifier is one the originating client may set, repeat, or omit, so it satisfies neither the presence requirement nor the reach requirement, however convenient the join would be.
+- **Actors**: `cpt-cf-policy-engine-actor-enforcing-gear`
+
+#### Subject Authenticity
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-subject-authenticity`
+
+The system **MUST** require the caller's propagated security context on every evaluation and on every batch, and **MUST** refuse an evaluation that arrives without one. The subject and the subject's tenant **MUST** be taken from that context rather than believed from the request: where the evaluation input also carries them, the system **MUST** compare them against the context and **MUST** refuse a mismatch with a cause distinct from both a policy refusal and an infrastructure failure. A refused mismatch **MUST** be recorded under the context's own subject, and the system **MUST NOT** evaluate content, return a decision, or write a record that attributes an evaluation to an identity the caller did not present.
+
+The system offers no on-behalf-of mode, and this follows the platform's own model rather than deferring a capability. The platform's two-plane authentication decision states that tenant-scoped work initiated by a system actor with no human behind it carries an ordinary tenant security context — obtained from a user token or from a service-to-service client-credentials token — and is authorized as itself. A caller performing work queued, scheduled, or retried earlier therefore presents either the requesting subject's context, where it still holds one, or its own service context; in the second case the decision and its record name that service, and the join back to the subject who asked is the correlation identifier of `cpt-cf-policy-engine-fr-evaluation-input`, which the earlier record carries too. What the platform has no representation for is the third thing — one subject acting for another — because the security context carries no actor field, so an on-behalf-of mode would need both that field and an authority able to sanction it.
+
+Where a deployment runs with authentication disabled, the context is the platform's anonymous context and its default subject and tenant are what the system derives; a caller **MUST NOT** assert a different subject there either. The comparison is therefore unconditional rather than configurable: what changes when authentication is disabled is which subject the context carries, never whether the request's own subject is believed instead.
+
+- **Rationale**: `cpt-cf-policy-engine-fr-evaluation-input` accepts the subject as part of the request, and a field the caller controls is a field the caller can choose. Everything downstream rests on the subject being real: the decision record is the audit trail, the violations projection is filtered by tenant, and `cpt-cf-policy-engine-fr-cross-tenant` decides reachability from the requesting context — so an input trusted as supplied would let a caller obtain a decision, and leave evidence, for an identity that never asked, and would let it choose a subject tenant that widens the subtree the evaluation may reach. Deriving both from the propagated context turns those fields into a restatement of something already authenticated; comparing rather than silently overwriting keeps a caller's mistake visible instead of absorbed, which matters because a mismatch is either a defect in the caller or an attempt, and both are worth seeing. None of this makes the gear an authorization decision point: `cpt-cf-policy-engine-fr-authorization-boundary` still withholds every entitlement of the subject, and what the context supplies here is identity, which that requirement already both permits and requires.
+- **Actors**: `cpt-cf-policy-engine-actor-enforcing-gear`, `cpt-cf-policy-engine-actor-security-auditor`
+
+#### Batch Evaluation
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-batch-evaluation`
+
+The system **MUST** accept several evaluation requests as one batch and **MUST** return one combined verdict alongside the individual outcomes, such that a prohibition on any member yields a prohibition for the batch. The combined verdict **MUST** identify every member that was refused, not only the first.
+
+- **Rationale**: A consumer admitting a plan needs one answer for the whole plan, and needs it to be the same answer preview gave. Issuing one request per member works against both: it multiplies the fixed cost of an evaluation — tenant resolution, applicable-set determination — across every member, and it leaves the caller to combine partial answers itself, which is where two callers start combining them differently. Returning every refused member rather than the first is what lets a caller report the whole problem at once instead of one round trip per fault.
+- **Actors**: `cpt-cf-policy-engine-actor-enforcing-gear`
+
+#### Obligations
+
+- [ ] `p3` - **ID**: `cpt-cf-policy-engine-fr-obligations`
+
+The system **MUST** allow a permitting decision to carry obligations the caller is required to honour, and each obligation **MUST** carry a stable identifier from the platform's type system. The obligation set is open rather than closed, so obligation identifiers are GTS identifiers resolved through the types registry rather than free-form strings. How a caller must behave on an identifier it does not recognise is a conformance expectation of the decision contract rather than gear behaviour, and is stated in `cpt-cf-policy-engine-interface-decision-client`; this gear cannot observe it.
+
+- **Rationale**: Some policy permits an action only under conditions the decision point cannot enforce itself. An obligation the caller does not understand must be rejected rather than ignored, so obligations must be identifiable rather than free-form, and a typed identifier is identifiable in a way a string is not.
+- **Actors**: `cpt-cf-policy-engine-actor-enforcing-gear`, `cpt-cf-policy-engine-actor-types-registry`
+
+### 5.7 Expression Evaluation
+
+#### Expression Evaluation Through the Shared Library
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-expression-evaluation`
+
+The system **MUST** evaluate policy content through the platform's shared evaluation facility, selecting the backend the content declares, and **MUST NOT** implement a policy language or an evaluator of its own.
+
+- **Rationale**: A gear that implements its own evaluator acquires a language surface to secure, bound, and version, and the platform already has two gears that each built one. Linking the shared facility instead keeps the backend contract in one place: the gear gains nothing by rebuilding a registry the facility already provides, and a deployment that needs a different language changes a backend rather than a gear. This is why the direct dependency is not a loss of optionality — the facility is where optionality lives, and it is the level at which a second language becomes available to every consumer at once rather than to one gear.
+- **Actors**: `cpt-cf-policy-engine-actor-policy-author`
+
+#### Evaluation Isolation
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-evaluation-isolation`
+
+The system **MUST NOT** pass any capability into evaluation: the backend receives the data supplied on the evaluation request, the policy content, and an evaluation timestamp the gear supplies, and nothing else — no client, no connection, no handle, and no clock. The system **MUST NOT** select a backend whose registration in `cpt-cf-policy-engine-contract-gts` does not declare a sandbox property covering both capability isolation and determinism. That declaration is made by the evaluation facility about a specific **build** of a backend, not by the backend library about itself: a policy-language implementation states no such guarantee, and its exposure is decided by which compile-time features the facility enables. Whether a backend honours the declaration is a property of the facility, which Section 4.2 places outside this gear; what this requirement governs is what the gear hands over, which backends it is willing to use, and what content it refuses to activate.
+
+Because determinism cannot be obtained by feature selection alone, the system **MUST** additionally reject content that references a non-deterministic builtin — a clock reader, a random number or identifier generator — and **MUST** reject it at validation and activation rather than at evaluation. A backend may register such builtins behind the same feature that makes it usable at all, in which case they cannot be excluded from the build; and a backend that offers no way to remove a builtin, and that resolves builtins ahead of any extension registered over the same name, cannot be constrained from the outside at call time either. A denylist checked where `cpt-cf-policy-engine-fr-content-validation` already resolves identifiers is then the only enforcement point that exists. The denylist is a property of the declared backend build and **MUST** be revised with it.
+
+- **Rationale**: Policy content is authored by tenant administrators and evaluated inside the platform's admission path. Content that could reach the network or the filesystem would make policy authoring a remote execution surface, and content whose result varied between two evaluations of the same input would make decision records unreproducible and short-circuiting unsafe. The two halves need different mechanisms, which is why they are stated separately. Capability isolation is obtained by handing over nothing, and it holds by construction. Determinism is not: it depends on which builtins the backend build registers, and an audit of the first candidate found a clock reader and two random generators present, one of them inseparable from the feature that makes the backend function. Requiring the facility to declare the property rather than the backend is the honest form of the rule — a declaration no implementation makes is a rule that silently never applies — and requiring the gear to refuse the content is what makes the guarantee real rather than declared.
+- **Actors**: `cpt-cf-policy-engine-actor-platform-operator`, `cpt-cf-policy-engine-actor-security-auditor`
+
+#### Bounded Evaluation Cost
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-evaluation-cost-bounds`
+
+The system **MUST** bound the wall-clock time spent evaluating a single policy document and the wall-clock time spent on a single evaluation as a whole, **MUST** make both bounds operator-configurable, **MUST** expose each bound and each exceedance as a metric, and **MUST** refuse the evaluation when a bound is exceeded rather than continuing.
+
+Defaults are 2 milliseconds per document and 4 milliseconds per evaluation. Both are derived from `cpt-cf-policy-engine-nfr-decision-latency` rather than chosen independently, and the derivation is the constraint: p95 must be met **by** the hierarchy-miss path, a miss consumes up to the 20 milliseconds `cpt-cf-policy-engine-fr-dependency-timeouts` allows, and roughly 5 milliseconds therefore remain for the whole of the rest of an evaluation. The per-evaluation bound takes 4 of those; matching, outcome combination, and record construction — all in memory — take the remainder. The per-document bound is set below the per-evaluation one because a bound equal to it would leave no room for a second document.
+
+- **Rationale**: An expression is authored content, so its cost is not under the gear's control. Without a bound, one tenant's expression makes every tenant's admission slow, and the latency requirement becomes unenforceable. `quota-enforcement` reached the same conclusion for its own engines and fixed an operator-tunable per-policy timeout. The figures have to close against the latency budget rather than being set to a comfortable round number: a per-evaluation default larger than the miss-path allowance would let an evaluation stay inside every documented default and still breach the p95 target, which makes the target unenforceable by exactly the configuration the gear ships with — and unenforceable in the direction hardest to notice, since every individual setting would look compliant.
+- **Actors**: `cpt-cf-policy-engine-actor-platform-operator`
+
+#### Dependency Timeouts
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-dependency-timeouts`
+
+The system **MUST** bound the time it will wait on each hierarchy provider and **MUST** refuse when a bound is exceeded rather than waiting indefinitely. The bound is operator-configurable with a default of 20 milliseconds, which is the figure `cpt-cf-policy-engine-nfr-decision-latency` allocates to a hierarchy miss.
+
+- **Rationale**: The fail-closed requirement names hierarchy timeouts as a condition that must refuse, which presupposes a timeout exists to be exceeded. A hung dependency otherwise stalls the request rather than refusing it, turning a bounded outage into an unbounded one.
+- **Actors**: `cpt-cf-policy-engine-actor-platform-operator`, `cpt-cf-policy-engine-actor-hierarchy-provider`
+
+#### Responsibility Boundary
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-responsibility-boundary`
+
+The system **MUST** own policy content, lifecycle, assignment resolution, hierarchy access, outcome combination, and decision recording, and **MUST** delegate to the evaluation facility only the interpretation of a document's content. The system **MUST** validate every outcome a backend returns against the closed outcome set before combining it, and **MUST** reject a result it cannot map to that set.
+
+- **Rationale**: Keeping semantics in the gear and language in the facility is what allows the facility to serve consumers with nothing to do with policy. Validating returned outcomes at the boundary matters more with a policy language than it would with a bare expression evaluator, because a policy document can return an arbitrary shape rather than a boolean: an evaluation result trusted without checking makes a backend defect into a policy bypass. This is the strict-boundary position `quota-enforcement` took for its engines, applied one layer out.
+- **Actors**: `cpt-cf-policy-engine-actor-platform-operator`
+
+### 5.8 Multi-Tenancy
+
+#### Policy Content Isolation
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-content-isolation`
+
+The system **MUST** confine policy content reads and writes to the requesting tenant and the tenants it is entitled to manage, and **MUST** make content belonging to other tenants indistinguishable from content that does not exist.
+
+- **Rationale**: Policy content describes a tenant's security posture. A response that distinguishes forbidden from absent confirms existence and leaks structure.
+- **Actors**: `cpt-cf-policy-engine-actor-tenant-policy-admin`
+
+#### Cross-Tenant Evaluation
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-cross-tenant`
+
+The system **MUST** refuse an evaluation whose resource tenant lies outside the subtree the subject's context is entitled to reach under the requested tenant mode, barrier handling, and status filtering, and **MUST** identify that refusal cause distinctly from an ordinary absence of permitting policy.
+
+- **Rationale**: A resource in a descendant tenant is the normal case in a hierarchy, so "different tenant" is not the test. The test is whether the resource lies within the reachable subtree once barriers and tenant status are applied. Access outside that boundary is the highest-consequence failure in a multi-tenant platform, so it needs its own refusal cause rather than being reported as no policy matched.
+- **Actors**: `cpt-cf-policy-engine-actor-enforcing-gear`, `cpt-cf-policy-engine-actor-security-auditor`
+
+#### Decision Record Visibility
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-record-visibility`
+
+The system **MUST** scope decision records and the violations projection by the resource tenant the record carries under `cpt-cf-policy-engine-fr-decision-records`, and **MUST NOT** scope them by the tenant that owns the content which produced them. The two diverge whenever an ancestor's bundle refuses an operation in a descendant, which inheritance makes the ordinary case rather than the exception.
+
+A caller **MUST** be able to read a record whose resource tenant lies within the subtree reachable from its own context, and **MUST NOT** be able to read one outside it. As with assignment, the system **MUST** declare the barrier handling these surfaces apply rather than inheriting a default: record surfaces **respect barriers**, so an ancestor **MUST NOT** read the records of a tenant behind a self-managed barrier even where the responsible document belongs to the ancestor's own bundle. The system **MUST** offer reading across a barrier only under a distinct platform-level capability, **MUST NOT** imply that capability from any tenant-level one, and **MUST** record every read performed under it as an administration event.
+
+Where a refusal in a tenant was produced by an ancestor's document, the system **MUST** return that document's identity to a reader entitled to the tenant's records, and **MUST NOT** thereby expose the document's content, the other documents of its bundle, or the assignment behind it. `cpt-cf-policy-engine-fr-content-isolation` continues to govern every content read: an identity is not content.
+
+- **Rationale**: A record describes an operation on a resource, so it belongs to the tenant of that resource and not to whoever wrote the rule. Scoping by content ownership would hand an ancestor the whole subtree's decision history and hand the tenant whose resources were judged nothing, which is backwards on both sides — and it is the divergence `cpt-cf-policy-engine-nfr-tenant-isolation` already assumes when it says content scopes on the owner and records scope on the resource tenant. Barriers have to be declared rather than assumed because the platform makes audit visibility across one a per-endpoint choice: a record carries a descendant's subject, action, and resource identity, which is exactly the business data a barrier exists to withhold, so the default respects it and the exception is separate, narrow, and attributable. Naming the responsible document to the tenant that was refused is the other half of the rule — a tenant told only that policy refused something cannot act on it, and the document identity is what makes a refusal explainable without disclosing an ancestor's rules.
+- **Actors**: `cpt-cf-policy-engine-actor-tenant-policy-admin`, `cpt-cf-policy-engine-actor-security-auditor`, `cpt-cf-policy-engine-actor-platform-operator`
+
+#### Administration Authorization
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-admin-authorization`
+
+The system **MUST** authorise every management operation against the caller's own security context, distinguishing at minimum the ability to read policy content, to author and modify drafts, to activate and withdraw bundles, to assign bundles to a tenant, to read decision records, and to read the violations projection. A caller **MUST NOT** be able to grant itself, or any subject, an entitlement it does not itself hold.
+
+The two read capabilities are separate from content read and from each other, and neither is implied by it. They are also scoped differently: `cpt-cf-policy-engine-fr-record-visibility` scopes both by the resource tenant a record carries rather than by the tenant that owns the content, and the cross-barrier read it defines is a further capability again, held at platform level and never with a tenant-level one.
+
+- **Rationale**: This gear decides what the platform refuses, which makes its own administration surface a high-value target. Undefined self-authorization means the first implementation invents it, and a privilege-escalation path through policy authoring defeats every policy the gear enforces. Separating content read from authoring, from activation, from assignment, and from the two record reads matters because they have different blast radii and are held by different people: a compliance reader needs decisions and refusals and no content at all, while a policy author needs content and has no business reading the estate's decision history.
+- **Actors**: `cpt-cf-policy-engine-actor-tenant-policy-admin`, `cpt-cf-policy-engine-actor-platform-operator`, `cpt-cf-policy-engine-actor-policy-author`
+
+#### Bootstrap
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-bootstrap`
+
+The system **MUST** provide a path by which the first policy content can be created in a deployment that has none, without that path depending on a decision the gear cannot yet make.
+
+- **Rationale**: A deployment starts with no content and no assignment, and the first bundle has to be creatable by someone. The management surface is authorised through the platform authorization path rather than by this gear's own content, so the cold start is not circular — but it is undefined, and an undefined cold start is where implementations invent an undocumented backdoor that then survives into production. Naming the path is what stops that.
+- **Actors**: `cpt-cf-policy-engine-actor-platform-operator`
+
+### 5.9 Observability
+
+#### Decision Records
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-decision-records`
+
+The system **MUST** emit a record for every evaluation. Within this gear, this requirement owns the normative field set and no other requirement here restates it; the gateway's admission record is governed by that gear and is neither restated nor constrained here. Every record **MUST** carry:
+
+- the correlation identifier the caller supplied under `cpt-cf-policy-engine-fr-evaluation-input`, which is what matches this record to the gateway's admission record of the same gated operation, and the batch identifier where the evaluation was part of a batch, which matches the batch as a group
+- an evaluation identifier, unique per evaluation, under which the record is written exactly once
+- the subject and the subject's tenant, as the opaque identity-provider references of `cpt-cf-policy-engine-fr-subject-data-handling`
+- the resource's tenant, which is the tenant the record is scoped and filtered by and is not always the subject's
+- the action
+- the resource type, and the resource identifier where the evaluation named one
+- the decision, and for a permission its cause: governed, ungoverned, or — once `cpt-cf-policy-engine-fr-emergency-access` ships — emergency. That third value is also the marker that requirement calls for, so the emergency path adds no field of its own to this set
+- the refusal cause, where the decision is negative, and the identity of the policy document that produced it
+- the identity and version of the policy content that determined the outcome
+- the identity and version of every bundle that took part in the evaluation, not only the one that determined it
+- the identity and version of the evaluation backend that interpreted the content
+- the count of documents that matched and the count actually evaluated, which differ when evaluation short-circuits
+- the names of the operation-context properties the evaluation read, in the form `cpt-cf-policy-engine-fr-record-confidentiality` permits
+- the evaluation timestamp supplied to the backend, without which a decision that turned on time cannot be reproduced
+- the elapsed time
+
+- **Rationale**: This is the evidence base for compliance and incident review, and it is also the substrate the refusals projection reads. Recording only refusals loses the permit that mattered; omitting the matched-versus-evaluated counts hides that short-circuiting left policy unexamined. Two fields exist because a decision is not a function of one input: recording every participating bundle is what keeps attribution from silently degrading where several assignments apply along a tenant chain, which is exactly the configuration a single determining-version field describes worst; and recording the backend version is what makes a decision reproducible at all, since the same content under a different interpreter is a different decision. Field sets that appear in more than one place drift, so every field any other requirement depends on is enumerated here and referenced from there — including the tenant the projection filters by, the emergency permission cause, and the context projection, each of which another requirement needs and none of which may be added independently of this list.
+- **Actors**: `cpt-cf-policy-engine-actor-security-auditor`, `cpt-cf-policy-engine-actor-audit-sink`
+
+#### Violations
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-violations`
+
+The system **MUST** expose refusals as a queryable projection over the prohibiting decision records within the retention window, filterable by the resource tenant, by policy document, by resource type, and by time range, and **MUST** return the retention window in force alongside every result. Which of those records a given caller may see is governed by `cpt-cf-policy-engine-fr-record-visibility`, and the capability required to ask at all by `cpt-cf-policy-engine-fr-admin-authorization`. A projected refusal **MUST NOT** be separately stored state, and the system **MUST NOT** evaluate policy against existing resources in order to produce one. The projection reports what policy has refused, not what currently violates policy: an entry does not clear when the underlying condition is corrected, and it disappears when it ages out of retention. The surface is named for what it returns — refusals within a window, not conditions currently in breach — and **MUST** distinguish an empty result from one truncated by that window.
+
+The projection covers refusals this gear produced, and no others. Refusals reached without an evaluation — a gateway's own built-in policy, or a gateway refusing because it could not reach this gear — leave no decision record here and **MUST NOT** appear. The system **MUST** state that boundary on the surface rather than leaving an absence to be read as an all-clear.
+
+- **Rationale**: An administrator whose policy refused something needs to find it without reading logs, and this is the third surface the gear's management API is required to offer. Deriving it from records rather than storing it keeps one source of truth and avoids a second lifecycle to keep consistent. Excluding evaluation against existing resources is the boundary that stops the projection from becoming a compliance scanner over an estate this gear does not own — but that boundary has a cost, and stating it in the requirement is what stops a reader from mistaking a refusal history for a standing compliance view. The second boundary is stated for the same reason: this gear cannot report a refusal it never made, and the two classes it misses are the ones an administrator is least likely to guess are missing — a gateway's built-in refusal is invisible here because the evaluation never happened, and a refusal caused by this gear being unreachable is invisible here precisely because this gear was unreachable. An administrator reading an empty projection during an outage would otherwise conclude that nothing was refused, when in fact everything was. Whether a standing view is wanted is a separate capability with its own requirement, and Section 12 carries the risk that this projection is not what administrators actually ask for.
+- **Actors**: `cpt-cf-policy-engine-actor-tenant-policy-admin`, `cpt-cf-policy-engine-actor-security-auditor`
+
+#### Record Confidentiality
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-record-confidentiality`
+
+Decision records **MUST NOT** contain bearer tokens or other subject credentials, and **MUST NOT** contain the values of caller-supplied operation context. Where a record refers to that context it **MUST** carry only the names of the properties the evaluation read.
+
+- **Rationale**: Audit records are widely readable by design. A record carrying a credential turns the audit trail into a credential store, and one carrying submitted property values turns it into a data leak — those values are supplied by the caller, the gear has no schema for them, and a gear that cannot classify a value cannot decide whether it is safe to keep. Recording the property names instead is what an auditor actually needs, since the question is which facts the policy judged, not what they were; and it makes the rule checkable by inspecting the record shape rather than by evaluating an entitlement the gear has no way to resolve.
+- **Actors**: `cpt-cf-policy-engine-actor-audit-sink`
+
+#### Subject Data Handling
+
+- [ ] `p2` - **ID**: `cpt-cf-policy-engine-fr-subject-data-handling`
+
+The personal data this gear holds is confined to the decision record: the subject identifier, the subject's tenant, and the redacted operation-context projection. The system **MUST NOT** collect subject attributes beyond the field set of `cpt-cf-policy-engine-fr-decision-records`, and **MUST NOT** store any profile attribute of a subject — no name, no address, no credential, no contact detail.
+
+The subject identifier the system records is the opaque identity-provider reference the platform's security context carries, and the system **MUST** treat it as such: it **MUST NOT** resolve it to a person, **MUST NOT** enrich it, and **MUST NOT** offer an erasure operation over it. Erasure of a subject is performed by the identity provider, which [the platform's accepted position on user identity](../../account-management/docs/ADR/0005-cpt-cf-account-management-adr-idp-user-identity-source-of-truth.md) places as the sole source of truth for user identity and the sole handler of right-to-erasure requests. A record whose subject has been erased there keeps its reference, which then resolves to nobody — the orphaned-reference outcome that position already accepts for every other gear holding one.
+
+The only bound this gear places on how long such a reference persists is `cpt-cf-policy-engine-fr-record-retention`.
+
+- **Rationale**: Policy content is about rules, not people, so the record is the gear's only personal-data surface and it is worth confining explicitly. What this requirement deliberately does **not** do is give the gear an erasure mechanism of its own, and the omission is load-bearing. The obvious alternative — rewriting a subject's identifiers in place on request — fails twice. It assigns to a gear an obligation the platform assigns to the identity provider, so two components would answer the same request by different mechanisms with no rule about which wins. And it would not work: the gear's own table can be rewritten, but the copy it exports to the shared audit topic cannot — `event-broker` events are append-only and never modified, and the topic retains records *beyond* this gear's own window — so a rewrite would clear the short-lived copy, leave the long-lived one, and report success. Recording an opaque reference and letting the identity provider erase behind it needs no rewrite anywhere, which is the only reason the position is compatible with an append-only audit stream.
+
+  Bounding the reference's lifetime by retention is what keeps the position honest. An orphaned reference is not nothing: it still records that *somebody* did something, and it remains joinable to other records carrying the same reference. Retention is therefore the gear's only real contribution to data minimisation here, and it is stated rather than implied.
+- **Actors**: `cpt-cf-policy-engine-actor-platform-operator`, `cpt-cf-policy-engine-actor-security-auditor`
+
+#### Decision Record Retention
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-record-retention`
+
+The system **MUST** apply a configurable retention period to decision records, **MUST** remove records beyond it, and **MUST** keep the retention period and the current record volume observable.
+
+- **Rationale**: Decision records accumulate at request rate and carry subject identifiers, so unbounded retention is both a storage problem and a data-protection one. The retention period also bounds the violations projection, which makes it a user-visible setting rather than an internal one. A retention period that is configurable but unobservable is indistinguishable from none.
+- **Actors**: `cpt-cf-policy-engine-actor-platform-operator`, `cpt-cf-policy-engine-actor-security-auditor`
+
+#### Operational Metrics
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-metrics`
+
+The system **MUST** expose metrics covering decision latency, decision outcomes by cause, hierarchy provider latency and failures, expression evaluation cost and bound exceedances, cache effectiveness, and every fail-closed refusal by cause.
+
+- **Rationale**: The gear fails closed, so its failures present as user-visible refusals rather than errors. Without a fail-closed counter separated by cause, an outage is indistinguishable from a policy change.
+- **Actors**: `cpt-cf-policy-engine-actor-platform-operator`
+
+#### Evaluation Explanation
+
+- [ ] `p3` - **ID**: `cpt-cf-policy-engine-fr-explanation`
+
+The system **MUST** support explaining a decision on request, reporting which documents were applicable, which were evaluated, and which determined the outcome, without changing the decision itself.
+
+- **Rationale**: The most common question about a policy engine is why it did what it did. Answering it by reading policy content does not scale past trivial configurations.
+- **Actors**: `cpt-cf-policy-engine-actor-policy-author`, `cpt-cf-policy-engine-actor-security-auditor`
+
+#### Evaluation Without Enforcement
+
+- [ ] `p3` - **ID**: `cpt-cf-policy-engine-fr-dry-run`
+
+The system **MUST** support evaluating a draft bundle against a supplied request without activating the bundle and without the result affecting any live decision.
+
+- **Rationale**: Activation is otherwise the only way to learn what a policy refuses, which makes every change a production experiment. Dry-run turns the blast radius of a new rule into something an author can measure beforehand.
+- **Actors**: `cpt-cf-policy-engine-actor-policy-author`
+
+### 5.10 Configuration
+
+#### Operational Limits
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-fr-operational-limits`
+
+The system **MUST** enforce configurable bounds on policy content size, on document count per bundle, on the applicable set per evaluation, and on batch size, and **MUST** fail an operation that exceeds a bound rather than degrading decision latency.
+
+- **Rationale**: Without bounds, one tenant's policy growth becomes every tenant's latency problem, and the latency target becomes unenforceable. Batch size needs its own bound because a batch multiplies a single request's cost by its member count.
+- **Actors**: `cpt-cf-policy-engine-actor-platform-operator`
+
+#### Configuration Validation
+
+- [ ] `p2` - **ID**: `cpt-cf-policy-engine-fr-configuration-validation`
+
+The system **MUST** reject unknown configuration keys at startup and **MUST** apply documented defaults to every optional setting.
+
+- **Rationale**: A misspelled key that is silently ignored leaves an operator believing a limit is in force when it is not.
+- **Actors**: `cpt-cf-policy-engine-actor-platform-operator`
+
+## 6. Non-Functional Requirements
+
+> Project-wide baselines for performance, security, reliability, and scalability are defined at the repository level in [ARCHITECTURE_MANIFEST.md](../../../../docs/ARCHITECTURE_MANIFEST.md) and the foundational [guidelines/](../../../../guidelines/). This gear has no parent gear PRD. Only gear-specific NFRs appear below.
+
+Requirements below are grouped by the platform's five quality vectors — efficiency, reliability, performance, security, and versatility — so that a vector carrying no gear-specific requirement appears as a stated position rather than as an absence a reader has to notice.
+
+### 6.1 Efficiency
+
+Cost itself is not modelled per gear in this repository, which Section 6.6 records as an exclusion. What is gear-specific is the memory one instance holds, because that is the only resource this gear consumes which no other requirement bounds.
+
+#### Instance Footprint
+
+- [ ] `p2` - **ID**: `cpt-cf-policy-engine-nfr-instance-footprint`
+
+The system **MUST** bound the memory one instance holds, **MUST** make that figure observable, and **MUST NOT** allow it to become the constraint that limits deployment size before the decision latency target does.
+
+- **Threshold**: Resident snapshot memory and transient per-evaluation memory are bounded by the content limits of `cpt-cf-policy-engine-fr-operational-limits` and by nothing else, so the requirement is stated against those limits rather than as an absolute ceiling. At the limits in force: snapshot memory grows no worse than linearly in the product of governed tenant count and content volume per tenant; one evaluation's transient allocation is bounded by the size of the content it evaluates; and both figures are exported. Both are measured against tenant count and content volume, not against request rate alone, in the exercise `cpt-cf-policy-engine-nfr-scalability` already requires. An absolute ceiling is deliberately absent until the limits themselves are ratified, which Section 13 tracks, because a figure chosen ahead of them would be re-derived rather than met.
+- **Rationale**: Two other requirements already rest on this being bounded and neither bounds it. The in-process clause of `cpt-cf-policy-engine-nfr-availability` is verified partly as "bounded memory under the content limits", and Section 11 assumes evaluation memory is bounded by those limits and by nothing else — an assumption that holds only if someone measures it. `cpt-cf-policy-engine-nfr-scalability` does not: it governs load and concurrency, and an instance can satisfy every latency and throughput target while approaching host exhaustion, because snapshot memory scales with governed tenants and stored content rather than with request rate. That is the failure this requirement exists to make visible, and its first symptom without measurement is the host dying rather than a threshold being missed. Stating it against the limits instead of as a byte figure is what keeps it honest while those limits are still open.
+- **Verification Method**: Footprint measurement across tenant count and content volume, run as part of the scalability exercise rather than as a separate benchmark.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation.
+
+### 6.2 Reliability
+
+#### Fail-Closed Determinism
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-nfr-fail-closed`
+
+The system **MUST** refuse on every error path, and **MUST NOT** expose any configuration that converts an evaluation failure into a permitting decision.
+
+- **Threshold**: Across the complete set of injected failure conditions — evaluation failure, evaluation cost bound exceeded, the declared backend unavailable, hierarchy provider unavailable, hierarchy provider timeout, malformed or digest-mismatched policy content, unresolvable tenant context, decision records not reaching durable storage within the window of `cpt-cf-policy-engine-nfr-decision-record`, and internal error — zero permitting decisions, of any cause. Every one **MUST** produce a refusal carrying an infrastructure cause. The emergency path of `cpt-cf-policy-engine-fr-emergency-access` is excluded from this threshold and measured separately, since permitting under a failed evaluation is precisely what it exists to do.
+- **Rationale**: The gear is the decision authority for operations that change infrastructure. A permissive failure mode converts any gear outage into an admission bypass. This requirement makes the property testable rather than incidental, and it is the reason `cpt-cf-policy-engine-fr-denial-versus-failure` must keep the two reportable apart: failing closed and reporting honestly are different obligations, and satisfying one must not be taken to satisfy the other.
+- **Verification Method**: Fault injection across the enumerated failure conditions.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation.
+
+#### Availability
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-nfr-availability`
+
+The system **MUST NOT** reduce the availability of the process it runs in, and where it runs as a separate process **MUST** meet an availability target strictly better than that of the consumers whose operations it gates.
+
+- **Threshold**: Conditioned on deployment shape, because the platform composes gears both ways and only one of them makes an independent target meaningful.
+  - **In-process**, the platform's default composition and the shape of first release: the gear's availability is the host's, so no separate figure applies. The measurable requirement is that no failure mode originating in the gear terminates, stalls, or exhausts its host — verified as zero host-fatal outcomes across the fault-injection set of `cpt-cf-policy-engine-nfr-fail-closed`, together with bounded memory under the content limits of `cpt-cf-policy-engine-fr-operational-limits` and bounded time under the evaluation bounds of `cpt-cf-policy-engine-fr-evaluation-cost-bounds`.
+  - **Out-of-process**, where the gear is deployed as its own service: 99.95 percent measured monthly over continuous operation, stated per surface, because the two fail independently there. Decision availability is measured at the decision client, counting any evaluation that returns neither a decision nor a distinguishable infrastructure refusal; management availability is measured at the REST surface. Planned maintenance is excluded only when announced in advance, and the cap differs by surface: 4 hours per month for the management surface, and 30 minutes per month for the decision surface. The decision figure is deliberately close to the error budget the target already allows, because excluding four hours from a 99.95 percent target would concede eleven times the budget the target claims to hold, and because the gear fails closed a decision-surface maintenance window is an outage of every gated operation in the consuming gear and **MUST** be scheduled as one.
+- **Rationale**: Because the gear fails closed, its unavailability presents to users as refusal of every gated operation in the consuming gear rather than as a degraded feature. That is what justifies a target better than the consumer's — Infrastructure Resource Manager holds 99.9 percent, and a dependency in its admission path that merely matched it could not leave the consumer room to reach its own figure, since independent outages compound. The argument depends on independence, and co-located code has none: in-process, the gear and its consumer fail together and a separate figure would be arithmetic about a single event. Splitting the requirement keeps the out-of-process target honest and gives the in-process case a property that can actually be failed.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation.
+
+#### Decision Record Completeness
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-nfr-decision-record`
+
+The system **MUST** produce a decision record for every evaluation, on both permitting and prohibiting paths, carrying enough context to reconstruct the decision without access to the original request.
+
+- **Threshold**: One record per evaluation, on both paths, with no sampling, at the sustained throughput in the scalability requirement. Record content is defined by `cpt-cf-policy-engine-fr-decision-records` and is not restated here. Emission **MUST NOT** extend decision latency, so records are durable asynchronously; at most 5 seconds of decisions may be awaiting durability at any moment, and that window **MUST** be observable. Where the system cannot bring a new decision inside that window — because records are not reaching durable storage — it **MUST** stop returning permitting decisions and refuse with an infrastructure cause until it can. Because that cause is transient and callers retry transients, the system **MUST** signal the condition to callers as one to back off from rather than retry immediately, and **MUST NOT** let retry traffic amplify load on the storage that is already failing. The bound is therefore a serving condition and not only a loss allowance: an unrecordable decision is not made.
+- **Rationale**: Auditors must be able to answer why a specific decision was reached months later, and sampling loses exactly the rare decisions most likely to be investigated. The violations projection also reads these records, so a sampled record set would produce a violations list that silently omits refusals. Durability cannot be synchronous without spending the latency budget on it, so the honest requirement is a bounded, measured window. Making that window a serving condition is what stops the bound being decorative: a gear that kept permitting through a long storage outage would produce exactly the unrecorded permits an auditor most needs, and would discover the breach only afterwards. Refusing is consistent with the gear's posture everywhere else — it already refuses when it cannot evaluate, and being unable to record is the same class of failure.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation.
+
+#### Decision Cache Safety
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-nfr-cache-safety`
+
+Where the system caches anything that contributes to a decision, the cached entry **MUST NOT** outlive the authority it was derived from.
+
+- **Threshold**: No cached entry contributes to a decision for a tenant other than the one it was derived from; no entry remains in use after the policy content version it was derived from stops being active, and in no case beyond the activation propagation window; no failed evaluation is served from cache.
+- **Rationale**: A cache that disregards tenant context lets one tenant's decision answer another's request, and one that outlives the content version it came from keeps withdrawn policy in force past the propagation window `cpt-cf-policy-engine-nfr-activation-propagation` promises. Serving a failed evaluation from cache would convert a transient dependency failure into a sustained refusal.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation.
+
+#### Activation Propagation
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-nfr-activation-propagation`
+
+The system **MUST** make an activated or deprecated bundle effective within a bounded and documented window across all evaluation paths.
+
+- **Threshold**: A bundle state change is reflected in decisions within 60 seconds; the window is documented and observable.
+- **Rationale**: Operators withdrawing policy during an incident need a known upper bound on when the change takes effect. An unbounded window makes withdrawal unverifiable. The window runs in the other direction too, and that direction is the one that surprises callers: it is equally the interval in which a newly *granted* permissiveness is not yet in force, so a caller that changes policy and immediately performs the operation the change was meant to allow is refused by the policy still in effect. Withdrawal tolerates the window because the old rule refusing for another minute is safe; a grant does not, because the new rule permitting a minute late is a broken workflow. A caller in that position either waits on the observable propagation delay or supplies the deciding fact on the request, per Section 11.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation.
+
+#### Content Durability
+
+- [ ] `p2` - **ID**: `cpt-cf-policy-engine-nfr-durability`
+
+The system **MUST** be recoverable to a recent consistent state after storage loss, for policy content and its version history.
+
+- **Threshold**: Recovery point within 1 hour and recovery time within 1 hour for policy content, versions, and assignments, verified by a restore exercise rather than by configuration review.
+- **Rationale**: Loss of policy content does not degrade the gear, it disarms it: with no content every decision becomes an ungoverned permit, so every guardrail a tenant relied on stops applying and operations that should be refused proceed. The ungoverned count makes that visible, but visible is not the same as prevented. The recovery time is deliberately tighter than the 4 hours Infrastructure Resource Manager allows itself, because the consumer's own recovery assumes its dependencies are already serving. The gear is also the only holder of the version history that audit depends on, and that history cannot be reconstructed from any other system. Decision records are covered by their own retention requirement and are not in scope here.
+- **Verification Method**: Restore exercise from backup into a clean deployment.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation.
+
+### 6.3 Performance
+
+#### Decision Latency
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-nfr-decision-latency`
+
+The system **MUST** return a decision within a bounded time at steady-state load, measured at the gear boundary and including policy matching, expression evaluation, and outcome combination.
+
+- **Threshold**: p95 within 25 ms and p99 within 50 ms for a single evaluation, measured at the gear boundary over **all** evaluations, including those whose hierarchy lookup misses cache. A batch of up to the configured batch bound completes within 100 ms at p95. Decision record emission is excluded, being asynchronous and off the response path. The miss path is not excluded, and it is the binding constraint rather than a tail case: at the hit rate `cpt-cf-policy-engine-nfr-hierarchy-latency` requires, up to one evaluation in ten misses, so the miss population falls inside p95 and the p95 figure must be met **by** the miss path. A miss is bounded at 20 milliseconds by `cpt-cf-policy-engine-fr-dependency-timeouts`, which leaves the rest of the evaluation roughly 5 milliseconds on that path — and that residue, not a figure of its own, is what the evaluation cost-bound defaults of `cpt-cf-policy-engine-fr-evaluation-cost-bounds` are set inside, so that a deployment running every documented default cannot breach this threshold. Retrieval of the applicable policy content is inside this budget with no separate allowance, so any content read that reaches storage on the decision path breaks the target rather than degrading it. The reference load is 50 evaluations per second sustained, over 1,000 tenants averaging 20 active policy documents each; that figure is provisional and its ratification against Infrastructure Resource Manager's load profile is tracked in Section 13.
+- **Rationale**: The budget is an allocation out of the enforcing gear's, not an independent target, and it is shared with the gateway that sits between them. Infrastructure Resource Manager holds 500 ms at p95 for a mutation acknowledgment, and admission is one step inside that path alongside validation, classification, and persistence — so a decision consuming more than a small fraction of the consumer's budget would show up as a regression in the consumer's own requirement. Stating the conditioning as unvalidated matches how the consumer states its own latency threshold, rather than inventing a load profile neither document has agreed.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation.
+
+#### Hierarchy Resolution Latency
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-nfr-hierarchy-latency`
+
+The system **MUST** resolve tenant hierarchy within a bounded time and **MUST** sustain a cache hit rate high enough to keep hierarchy resolution off the critical path for most evaluations.
+
+- **Threshold**: p95 within 2 ms on a cache hit; cache hit rate at or above 90 percent after warm-up under steady-state load.
+- **Rationale**: Assignment resolution requires hierarchy, and it sits inside the decision latency budget rather than beside it. A cache hit is an in-process lookup, so it must consume a fraction of that budget; without caching, each evaluation would add a Policy Information Point round trip and the decision target would depend on a dependency with its own budget.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation.
+
+#### Scalability
+
+- [ ] `p2` - **ID**: `cpt-cf-policy-engine-nfr-scalability`
+
+The system **MUST** absorb load growth and concurrency without violating the decision latency target or failing requests through internal contention.
+
+- **Threshold**: A tenfold increase over the reference load stated in `cpt-cf-policy-engine-nfr-decision-latency` stays within the decision latency target. Separately, and not implied by that rate, 1,000 concurrent in-flight evaluations complete with zero failures attributable to contention: this is a burst and isolation property, since the steady-state rate at the stated latency implies only a few tens in flight, and the number exists to bound what a synchronised arrival does to shared structures rather than to describe normal operation.
+- **Rationale**: Evaluation load scales with the total change rate across every gear that gates on policy, not with any single gear's usage.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation.
+
+### 6.4 Security
+
+#### Tenant Isolation
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-nfr-tenant-isolation`
+
+The system **MUST** enforce the content visibility and management boundary defined by `cpt-cf-policy-engine-fr-content-isolation` and `cpt-cf-policy-engine-fr-admin-authorization`, and **MUST NOT** allow a decision for one tenant to be influenced by policy content the requesting context is not entitled to.
+
+- **Threshold**: Zero cross-tenant reads, writes, or decision influences across the isolation test suite, including hierarchy traversal at barrier boundaries and the violations projection.
+- **Rationale**: Policy content reveals the security posture of its owner. Leakage across tenants is a confidentiality breach independent of whether any decision changes. The violations projection is named explicitly because it is a read path over records from many tenants and is therefore the easiest place to leak.
+- **Architecture Allocation**: See DESIGN.md § NFR Allocation.
+
+### 6.5 Versatility
+
+No gear-specific versatility threshold applies, because what varies here is structural rather than measurable. The gear runs in either deployment shape described in Section 3.1 with unchanged contracts, and a deployment changes the language policy is written in by changing an evaluation backend rather than by changing this gear, per `cpt-cf-policy-engine-fr-expression-evaluation`.
+
+### 6.6 NFR Exclusions
+
+- Cost and resource-efficiency targets: not modelled per gear in this repository, so no efficiency threshold appears in Section 6.1. What bounds resource use there is functional rather than economic — the operational limits and the evaluation cost bounds — and neither is expressed as a cost figure.
+- Data residency and geographic partitioning: policy content follows the deployment's existing residency posture; the gear introduces no separate residency surface.
+- Offline and air-gapped operation: not required at first release. The evaluation facility is expected to be in-process, so the gear's only remote dependency is the hierarchy provider, which shares the deployment's connectivity.
+- Functional safety and hazard analysis: not applicable. The gear is an information system with no physical actuation and no safety-critical control path.
+- Accessibility, internationalisation, and device support: not applicable at first release. The gear exposes no end-user interface; a policy authoring interface is out of scope, and the management API is consumed by operators and other gears.
+- Support tiering and diagnostic service levels: not specified here. The gear inherits the platform's support model; the availability requirement above is the only gear-specific service level.
+- Operator documentation: required, and inherited from the platform's documentation model rather than specified here — with one gear-specific exception. Because a misconfigured limit, an unpropagated withdrawal, or an unreachable bootstrap path refuses every gated operation across every consuming gear, the configuration surface, the operational limits, and the bootstrap path of `cpt-cf-policy-engine-fr-bootstrap` **MUST** be documented for operators before first release. End-user and training documentation are not applicable: the gear exposes no end-user interface.
+- Regulatory certification and data-subject rights beyond erasure: not gear-specific. The gear holds no payment, health, or financial-reporting data, so no scheme-specific regime attaches to it. Personal data is confined to the decision record and governed by `cpt-cf-policy-engine-fr-subject-data-handling` and `cpt-cf-policy-engine-fr-record-retention`; consent, data-subject access, and portability are platform-level obligations discharged where subject identity is owned, not here.
+
+## 7. Public Library Interfaces
+
+### 7.1 Public API Surface
+
+#### Policy Decision Client
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-interface-decision-client`
+
+- **Type**: Rust trait, asynchronous, registered in ClientHub without scope
+- **Stability**: stable
+- **Description**: The decision surface, consumed by the admission gateway on behalf of the gear being gated. Takes the caller's propagated security context together with the evaluation input defined in `cpt-cf-policy-engine-fr-evaluation-input` — which carries the caller-supplied correlation identifier this gear does not mint — singly or as a batch — the context is a required parameter rather than an ambient value, because `cpt-cf-policy-engine-fr-subject-authenticity` derives the subject and its tenant from it — and returns a result that is two-valued in practice — permit or prohibit — with the cause of a permission and the reason for a prohibition. The result type reserves a place for the obligations of `cpt-cf-policy-engine-fr-obligations` and for the deferral of `cpt-cf-policy-engine-fr-deferral-outcome`; until those requirements ship the collection is always empty and the deferral is never returned, so a caller that handles permit and prohibit alone is conformant. Both are reserved rather than added later for the same reason: this contract is stable, and widening a shape callers already match on is a major version. The permission cause is carried on the result rather than as a third variant, so a caller that only branches on permit or prohibit is correct by default and a caller that cares whether policy was silent can ask.
+- **Conformance expectations on the caller**: two, neither observable by this gear and both stated here rather than as requirements. Any error result is a refusal, and a caller that treats it otherwise defeats the fail-closed property. An obligation whose identifier the caller does not recognise makes the decision prohibiting; ignoring it silently enforces a permission the policy did not grant.
+- **Breaking Change Policy**: Major version bump required.
+
+#### Policy Management Client
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-interface-management-client`
+
+- **Type**: Rust trait, asynchronous, registered in ClientHub without scope
+- **Stability**: stable
+- **Description**: The administration surface for policy content. Covers bundle, version, document, and target lifecycle, tenant assignment, validation of content before activation, and the decision and violation queries of `cpt-cf-policy-engine-fr-violations`. Separated from the decision surface so that consumers in the admission path do not depend on the administration contract.
+- **Breaking Change Policy**: Major version bump required.
+
+#### Policy Administration REST API
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-interface-rest-api`
+
+- **Type**: REST API, versioned, served beneath the platform API prefix
+- **Stability**: stable
+- **Description**: External administration surface mirroring the management client: policy content, decisions, and violations. Uses the canonical problem error envelope, precondition headers for concurrency control, and the platform's OData query and cursor pagination conventions on list surfaces. Described by a generated OpenAPI document, and subject to the platform's ingress rate limiting rather than a limiter of its own. This is the surface that makes the gear operable without a consuming gear, which is why it is p1 rather than deferred.
+- **Breaking Change Policy**: Backward compatible within a major version.
+
+### 7.2 External Integration Contracts
+
+#### GTS Registration
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-contract-gts`
+
+- **Direction**: provided to the types registry
+- **Protocol/Format**: GTS link-time inventory in one direction, resolution in the other. The gear registers the policy resource types it exposes for management and its error type family; it resolves, against the registry, the evaluation backend each document declares, the concrete resource types its targets name, and the obligation identifiers its decisions carry.
+- **Compatibility**: Type identifiers are stable; new versions are new identifiers.
+
+#### Hierarchy Read Contract
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-contract-hierarchy-read`
+
+- **Direction**: required from `tenant-resolver`
+- **Protocol/Format**: In-process client trait via ClientHub. Requires tenant ancestry and descendants with barrier and status handling.
+- **Compatibility**: The gear depends on the read surface only and tolerates additive change.
+
+#### Decision Record Contract
+
+- [ ] `p2` - **ID**: `cpt-cf-policy-engine-contract-decision-record`
+
+- **Direction**: provided to downstream consumers
+- **Protocol/Format**: Structured records with the stable field set of `cpt-cf-policy-engine-fr-decision-records`, emitted per evaluation.
+- **Compatibility**: Additive field changes only within a major version; consumers must tolerate unknown fields.
+
+#### Admission Gateway Engine Contract
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-contract-admission-engine`
+
+- **Direction**: provided to `admission-control`
+- **Protocol/Format**: The engine-facing trait the gateway defines, implemented by this gear so the gateway can attach it as one of its engines. The gateway owns the contract; this gear conforms to it without changing its decision semantics. This is the only path by which an evaluation reaches this gear, which is why it is p1 rather than an eventual convenience.
+- **Compatibility**: Governed by the gateway's SDK version. The contract is specified — `cpt-cf-admission-control-interface-engine-plugin`, in the gateway's own [PRD](../../admission-control/docs/PRD.md) and [DESIGN](../../admission-control/docs/DESIGN.md) — and is declared unstable there, so its shape may still move under a minor version of that SDK. What does not exist is an implementation on either side. The decision surface it wraps is specified here and is not conditioned on it.
+
+## 8. Use Cases
+
+#### Author and Activate a Policy Bundle
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-usecase-activate-bundle`
+
+**Actor**: `cpt-cf-policy-engine-actor-policy-author`
+
+**Preconditions**:
+- The author is entitled to manage policy at the target tenant.
+
+**Main Flow**:
+1. The author creates a draft bundle and adds policy documents and targets to it.
+2. The author submits the draft for validation.
+3. The system validates expression syntax, target vocabularies, and limits, and reports any errors without activating.
+4. The author activates the bundle and assigns it to a tenant.
+5. The system records content integrity, freezes the bundle against further modification, and begins including it in evaluation.
+
+**Postconditions**:
+- The bundle is active, immutable, and effective at the assigned tenant and its descendants within the activation propagation window.
+
+**Alternative Flows**:
+- **Validation fails**: The bundle remains in draft; errors identify the offending documents; nothing changes for evaluation.
+- **Concurrent modification**: The activation is rejected on the precondition check and the author re-reads before retrying.
+
+#### Admit a Resource Operation
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-usecase-admit-operation`
+
+**Actor**: `cpt-cf-policy-engine-actor-admission-gateway`
+
+**Preconditions**:
+- An enforcing gear is about to perform an operation and has passed it to the gateway with the resource type, the resource properties, and the security context of the initiating caller.
+
+**Main Flow**:
+1. The gateway submits the evaluation input for the operation the enforcing gear is about to perform.
+2. The system resolves the applicable policy set for the resource's tenant, honouring inheritance and precedence.
+3. The system evaluates the matching documents and combines their outcomes into one result.
+4. The system returns the decision, with a refusal reason naming the responsible policy when negative.
+5. The system emits a decision record.
+
+**Postconditions**:
+- The gateway relays the decision, the enforcing gear proceeds or abandons the operation, and the evaluation is recorded.
+
+**Alternative Flows**:
+- **No applicable policy**: The system permits, marks the permission ungoverned, and records it as such — policy did not approve the operation, it was silent about it.
+- **Hierarchy provider unreachable**: The system reports an infrastructure failure distinct from a refusal, so it can be retried as transient rather than surfacing a false policy refusal.
+
+#### Admit a Multi-Type Change
+
+- [ ] `p1` - **ID**: `cpt-cf-policy-engine-usecase-admit-batch`
+
+**Actor**: `cpt-cf-policy-engine-actor-admission-gateway`
+
+**Preconditions**:
+- An enforcing gear has classified a change touching several resource types and needs one verdict, relayed through the gateway, before dispatching any work.
+
+**Main Flow**:
+1. The gateway submits one batch containing an evaluation input per resource type the change touches.
+2. The system evaluates each member and records each independently.
+3. The system combines the member outcomes into one verdict, refusing the batch if any member is refused.
+4. The system returns the verdict together with the per-member outcomes.
+
+**Postconditions**:
+- The enforcing gear either dispatches the whole change or refuses it whole, naming every member that was refused.
+
+**Alternative Flows**:
+- **Batch exceeds the configured bound**: The system fails the request against the limit rather than evaluating a subset.
+
+#### Review Recent Refusals
+
+- [ ] `p2` - **ID**: `cpt-cf-policy-engine-usecase-review-violations`
+
+**Actor**: `cpt-cf-policy-engine-actor-tenant-policy-admin`
+
+**Preconditions**:
+- Policy is active for the tenant and at least one operation has been refused within the retention window.
+
+**Main Flow**:
+1. The administrator queries violations for their tenant, filtered by policy document, resource type, or time range.
+2. The system returns the prohibiting decisions within the retention window that the administrator is entitled to see.
+3. The administrator inspects an entry to identify the policy that refused and the operation that was attempted.
+
+**Postconditions**:
+- The administrator can either correct the operation or revise the policy, without reading gear logs.
+
+**Alternative Flows**:
+- **Query spans tenants the administrator does not manage**: The system returns only the entitled subset, indistinguishably from those entries not existing.
+- **Retention window has elapsed**: Refusals older than the window are absent, and the window in force is reported alongside the result.
+
+#### Withdraw an Active Bundle
+
+- [ ] `p2` - **ID**: `cpt-cf-policy-engine-usecase-withdraw-bundle`
+
+**Actor**: `cpt-cf-policy-engine-actor-platform-operator`
+
+**Preconditions**:
+- A bundle is active and an operator has determined it must stop taking effect.
+
+**Main Flow**:
+1. The operator deprecates the bundle or removes its tenant assignment.
+2. The system stops including it in evaluation within the activation propagation window.
+3. The system records the change against the operator.
+
+**Postconditions**:
+- Decisions no longer reflect the withdrawn bundle; the bundle and its history remain available for audit.
+
+**Alternative Flows**:
+- **Withdrawal would leave no applicable policy**: Evaluation falls back to ungoverned permits, and the system makes that consequence visible before the change is applied, since an operator withdrawing a guardrail needs to know the operations it covered will start proceeding rather than start failing.
+
+## 9. Acceptance Criteria
+
+- [ ] A management gear can gate every operation it declares as policy-gated against this gear, with no policy rules remaining in its own source.
+- [ ] A deployment with no policy content admits operations rather than refusing them, and every such permission is marked ungoverned and counted.
+- [ ] The result of an evaluation is unchanged when the applicable set is presented in any order.
+- [ ] A change touching several resource types produces one verdict that names every refused type, in a single request.
+- [ ] Every enumerated failure condition produces a refusal carrying an infrastructure cause, and no configuration produces a permission of any cause on failure.
+- [ ] A refusal caused by an unreachable dependency is distinguishable, in both the response and the metrics, from a refusal caused by policy.
+- [ ] A hung hierarchy provider produces a refusal within the stated timeout rather than stalling the request.
+- [ ] An expression that exceeds the configured cost bound refuses its evaluation without affecting the latency observed by concurrent evaluations.
+- [ ] Policy content can be authored, validated, activated, and withdrawn without a deployment restart, and every state change is attributable to an actor.
+- [ ] An activated or withdrawn bundle takes effect within the activation propagation window, verified by measurement rather than by inspection.
+- [ ] An administrator can retrieve every refusal for their tenant within the retention window, without access to gear logs.
+- [ ] An auditor can reconstruct any past decision from its record, including which policy version determined it and how many documents were matched versus evaluated.
+- [ ] Policy content and its version history survive a restore exercise into a clean deployment within the stated recovery objectives.
+- [ ] Policy content, decisions, and violations are confined to their owning tenant across the isolation test suite, including at barrier boundaries.
+- [ ] An evaluation whose asserted subject or subject tenant disagrees with the caller's propagated security context is refused with its own cause, and no decision is returned and no record attributes the evaluation to the asserted identity.
+- [ ] An ancestor can neither assign policy at, nor read the records of, a tenant behind a self-managed barrier, while an assignment it holds above that barrier still governs inside it under the barrier handling the caller requests.
+- [ ] A tenant administrator reads a refusal produced by an ancestor's document, receives that document's identity, and cannot read its content.
+- [ ] Reading decision records and reading the violations projection are separately authorised, neither is implied by the ability to read policy content, and a read performed under the cross-barrier capability leaves an administration event.
+- [ ] No management operation allows a caller to grant an entitlement it does not itself hold.
+- [ ] The evaluation input carries the subject's identity and no entitlement of it, so no policy document can decide by role, permission, or group membership, and no decision the gear returns is expressible as an authorization grant.
+- [ ] A deployment with no policy content can create its first bundle without an undocumented path.
+- [ ] Policy content cannot reach the network or the filesystem, and two evaluations of identical input produce identical outcomes.
+
+## 10. Dependencies
+
+| Dependency | Description | Criticality |
+|------------|-------------|-------------|
+| Policy evaluation facility | Carries the evaluation backends and the contract they implement, and interprets document content in the language each declares. Does not exist yet, in any form, anywhere in the repository. No evaluation path exists without it, so this gear cannot ship before it does | p1 |
+| `tenant-resolver` | Tenant ancestry, descendants, barrier and status handling, used in assignment resolution | p1 |
+| `toolkit-db` | Persistence for policy content and decision records, with scoped access through the secure data layer | p1 |
+| `types-registry` | GTS registration, and both directions of registry-reference resolution: forward at write time for the identifiers this gear persists as references rather than as strings, and reverse at read and export time so every surface still speaks GTS identifiers. Covers the resource-type identifiers policy targets match, the backend each document declares, and the resource type each decision record carries | p1 |
+| `authz-resolver` | Authorizes this gear's own management operations. The gear is a Policy Enforcement Point for its administration surface only: it builds an access request per management capability and consumes the decision. It neither provides decisions to this path nor evaluates authorization policy | p1 |
+| Emergency entitlement source | Resolves whether a subject holds the emergency entitlement, without consulting policy content; no component provides this today | p3 |
+| `event-broker` | Transport, retention, and export of decision records, published to a platform-scoped audit topic shared with `admission-control`. Not on the durability path: the gear's own record table is where a decision becomes durable, and `cpt-cf-policy-engine-nfr-decision-record` is met against that table rather than against delivery. What the topic adds is retention beyond this gear's window and a single stream an auditor can read. The topic is scoped by the resource tenant of `cpt-cf-policy-engine-fr-decision-records`, which is not always the subject's tenant, so the tenant a record is published under is the tenant it is scoped and filtered by | p2 |
+
+## 11. Assumptions
+
+- Subjects arrive already authenticated, with identity and tenant context established upstream by `authn-resolver`.
+- The authorization path is present and has a decision point behind it. The gear authorizes its own management operations through it and cannot authorize them itself: policy content deciding who may write policy content would make the administration surface self-granting, which `cpt-cf-policy-engine-fr-admin-authorization` forbids.
+- Authorization is decided before admission on every gated operation, and the caller treats a permission from this gear as policy raising no objection rather than as an access grant. `cpt-cf-policy-engine-fr-authorization-boundary` places this on the caller because the gear cannot observe it: an evaluation request looks identical whether or not authorization ran first, so a consumer that skipped it would be refused nothing and warned of nothing.
+- Neither component above this gear is built yet. The `admission-control` gateway, this gear's only consumer, is specified — its PRD and design define the engine plugin contract this gear implements, and mark it unstable — but unbuilt; Infrastructure Resource Manager likewise exists as a specification and not yet as software. Infrastructure Resource Manager's own requirements describe it calling a decision service directly, so routing it through the gateway is a change to that gear's integration which nobody has yet agreed. Its admission requirements are stable enough to design against and are what this gear is measured by, but end-to-end integration validation, and ratification of the reference load in Section 6, wait on that gear being built. No requirement here depends on its implementation.
+- Consumers honour the obligations they receive, and refuse rather than proceed on an obligation identifier they do not recognise, as `cpt-cf-policy-engine-interface-decision-client` expects of them. The gear cannot observe whether they do, and no requirement here depends on detecting it. The assumption is safe to carry unverified while `cpt-cf-policy-engine-fr-obligations` remains p3, because nothing emits an obligation until it ships.
+- Tenant hierarchy is a single-root tree with barrier semantics as defined by the platform tenant model; the gear reads it and does not reinterpret it.
+- The evaluation facility, once it exists, runs in the same process as the gear. This bounds transport failure modes but does not remove them: an in-process evaluation can still exhaust its cost bound, so the isolation and cost requirements apply regardless of co-location, and the hierarchy provider is a separate gear in every deployment.
+- Every backend the evaluation facility carries provides two properties this gear depends on and cannot supply itself: syntax validation exposed independently of evaluation, and acceptance of an externally imposed per-document wall-clock bound. Both were confirmed against the first candidate audited, a Rego implementation, which parses a policy to an error or a package name without evaluating it and accepts a caller-set wall-clock limit checked cooperatively between work units. Two consequences of that audit are carried in the requirements rather than assumed away. The bound has a granularity, because it is checked between work units and not preemptively, so a per-document figure is an upper bound plus one work unit and not an instant. And no backend supplies the third property this gear once assumed of it — a declared sandbox guarantee — which is why `cpt-cf-policy-engine-fr-evaluation-isolation` now requires the facility to declare it for a specific backend build and requires this gear to enforce determinism by refusing content.
+- Evaluation memory is bounded by the content limits of `cpt-cf-policy-engine-fr-operational-limits` and by nothing else. An allocator-level bound on what one evaluation may allocate is not assumed to exist: the audited candidate offers one only through an allocator that may conflict with the host's, so the in-process clause of `cpt-cf-policy-engine-nfr-availability` rests on bounding the size of what is evaluated rather than on capping allocation during it.
+- Consumers enforce the decisions they receive. The gear has no mechanism to detect a caller that requests a decision and ignores it.
+- Consumers supply complete operation context. A property that policy needs and the caller omits evaluates as absent, so a policy author's filters and a consumer's context are coupled, and the platform has no mechanism to verify the coupling.
+- Tenant entitlements that change over the life of a tenant — a subscription plan, a service tier, a contract state — reach policy as operation-context properties supplied on the request, not as assignment structure the gear has to be reconfigured to reflect. This keeps an entitlement change out of `cpt-cf-policy-engine-nfr-activation-propagation` entirely: nothing about the policy changes, so nothing has to propagate, and the next request carries the new fact. Two costs come with it and neither is verifiable here. The gear cannot check a fact the caller relays but does not own — a subscription plan belongs to whatever system sells subscriptions, and the caller is repeating it — so the trust in that value is the trust in the caller and in the source the caller read it from, which Section 13 records as unresolved. And `cpt-cf-policy-engine-fr-record-confidentiality` keeps caller-supplied values out of the record, so a decision that turned on a relayed entitlement is attributable to the property name and not to the value it held; the record shows that the plan was read, never which plan it was. That is the same limit `cpt-cf-policy-engine-fr-version-comparison` already records for replaying a decision, and it bounds what the reconstruction promised by `cpt-cf-policy-engine-nfr-decision-record` can recover for this class of decision.
+- Policy content volume per tenant is small relative to resource volume, so policy retrieval is cacheable and does not dominate evaluation cost.
+
+## 12. Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| The evaluation facility does not land | No evaluation path exists at all, and the gear cannot ship | Nothing this gear can mitigate; the dependency is a prerequisite, and Section 10 records it as such |
+| A backend upgrade adds a non-deterministic builtin, and the denylist of `cpt-cf-policy-engine-fr-evaluation-isolation` goes stale | Determinism is lost silently. Nothing fails, no content is rejected, and the loss shows up only as two decision records that disagree about the same input — which is the hardest defect in this gear to attribute, because the policy, the version and the digest all match | Bind the denylist and the sandbox declaration to a specific backend build rather than to a backend, and make re-auditing the builtin set a required step of upgrading it. Treat an unaudited build as an undeclared one, which `cpt-cf-policy-engine-fr-evaluation-isolation` already refuses to select |
+| The facility carries only one backend for longer than expected, making the language a de facto platform commitment | Authors cannot express the rules they need, and pressure returns to add a gear-level engine registry after the contract has consumers | Validate the first backend's language against the guardrail set Infrastructure Resource Manager actually needs before DESIGN; keep the language declaration on every document from first release, so a second backend is an addition rather than a content migration |
+| Gear latency or unavailability propagates to every gated operation | The consuming gear cannot meet its own latency and availability requirements, since the two compound | Hold the latency and availability targets as release gates; measure at the gear boundary; keep hierarchy caching on the critical path |
+| Caller-supplied context and policy filters drift apart | Policy silently stops matching, and a guardrail that appears active refuses nothing | Make the applicable-set and matched-versus-evaluated counts observable per decision; treat a policy that never matches as an alertable condition rather than a silent one |
+| Policy inheritance behaves wrongly at self-managed tenant boundaries | An ancestor guardrail silently stops applying, or a delegated tenant's policy reaches beyond its boundary; both are invisible until a decision is questioned | Make barrier behaviour explicit per assignment rather than a global default; treat crossings as a test surface, not a configuration detail |
+| Policy content growth makes evaluation cost scale with tenant count | Latency target becomes unreachable at large deployments | Bound bundle size, document count, applicable-set size, and batch size; measure evaluation cost against tenant and document count, not only against request rate |
+| The gear accumulates policy responsibilities faster than consumers adopt it | Specified surface with no users, and requirements shaped by speculation rather than integration | Keep the document-kind set closed and narrow; admit a new kind or a new consumer only with a concrete integration behind it |
+| Neither component above this gear exists yet: the admission gateway is unbuilt and Infrastructure Resource Manager is a specification | This gear has no path to a real consumer and cannot be integration-validated until two other gears land, so defects in its contract surface late | Keep the decision surface specified independently of the gateway contract, so the gear can be exercised through a harness standing in for the gateway; treat the gateway's contract shape as a release gate rather than an implementation detail discovered during integration |
+| A tenant entitlement is modelled as assignment structure rather than as request input | The propagation window becomes an ordering hazard rather than a withdrawal bound: an upgrade that swaps assignments and immediately provisions is refused by the policy it has just replaced, and the refusal is correct, attributable to nothing the operator changed, and invisible until someone times it | Express a changing entitlement as an operation-context property so no propagation is involved; where the structure is genuinely the right model, order the entitlement change before the operations that depend on it and gate the sequence on the exported propagation delay rather than on a fixed sleep |
+| Violations derived from records prove insufficient for what administrators actually want | The projection is delivered, unused, and a standing-compliance capability is requested instead | Validate the projection against a real administrator query set before DESIGN; treat a request for standing state as a scope change requiring its own requirement, not an extension of this one |
+
+## 13. Open Questions
+
+Each question carries an owner role and the point by which it must be answered. A question unanswered past its point blocks the artefact named beside it.
+
+| Question | Owner | Needed by |
+|---|---|---|
+| What re-audits the sandbox-and-determinism declaration of `cpt-cf-policy-engine-fr-evaluation-isolation` when a build changes, and does the declaration carry enough for this gear to detect a stale one? DESIGN Section 3.4 places authorship with the evaluation facility's SDK, which settles where the claim is made and not what keeps it true. The claim is about a **build** — which compile-time features are enabled and which builtins the result registers — so it goes stale on a dependency bump or a feature change. The trigger that re-audits it is the facility's own to define and belongs in the facility's documentation, which Section 4.2 keeps outside this gear and which is not yet written. What this gear needs from that answer is the declaration's field set: it can presently refuse an absent declaration but not a stale one, and a schema two gears read cannot gain fields once implementation has begun, which is why the answer is needed before implementation rather than before first release. | Evaluation facility owner | Before implementation |
+| Where do the schemas that both this gear and `admission-control` read belong: the declaration a backend build carries — its two backend guarantees together with the sandbox-and-determinism claim `cpt-cf-policy-engine-fr-evaluation-isolation` refuses to select a build without — and the obligation base type whose instances travel from a decision point through the gateway to the enforcing gear? DESIGN Section 3.4 assumes the first belongs to the evaluation facility's SDK and the second to `libs/toolkit-gts`, and the gateway's design assumes the same; neither gear is entitled to decide it, because both read both, so a schema owned by either would make the other depend on it. An answer changes only where the two gears import from, which is why it is needed before implementation rather than before first release. | Platform architecture | Before implementation |
+| Is an allocator-level memory bound available in any facility build, or is evaluation memory bounded only by content size? The audited candidate offers one solely through an allocator that may conflict with the host's, which would leave `cpt-cf-policy-engine-nfr-availability` resting on content limits alone. | Gear owner | Before first release |
+| Should an assignment be inheritable across a self-managed tenant barrier, and under what caller conditions? The platform treats barriers as context-dependent, so a single default is wrong for either operator guardrails or delegated policy. This is the evaluation plane only: the management plane is settled by `cpt-cf-policy-engine-fr-assignment-authorization`, and the record plane by `cpt-cf-policy-engine-fr-record-visibility`, both of which respect barriers and neither of which depends on how this is answered. | Platform architecture | Before first release |
+| Does any enforcing gear need a decision for a subject other than the one in its own security context — work queued, scheduled, or retried after the requesting subject's context is gone — and is the service identity the platform's two-plane decision prescribes for that case sufficient? Today it has to be: the security context carries no actor field, so one subject acting for another is not expressible, and an on-behalf-of mode would need that field plus an authority able to sanction it. `cpt-cf-policy-engine-fr-subject-authenticity` refuses the case deliberately, which makes a real need for it a new platform capability rather than a relaxation of this gear's requirement. | Platform architecture | Before first release |
+| What are the bounds on bundle size, document count per bundle, applicable-set size, and batch size? These are user-visible limits that shape how policy can be organised. | Gear owner | Before first release |
+| Does the reference load in `cpt-cf-policy-engine-nfr-decision-latency` — 50 evaluations per second over 1,000 tenants at 20 documents each — match Infrastructure Resource Manager's real profile? The figure is provisional and every latency and scalability threshold is conditioned on it. | Gear owner | Before first release |
+| Who owns the emergency entitlement that `cpt-cf-policy-engine-fr-emergency-access` requires, and does it exist? The requirement needs an entitlement resolvable without consulting policy content, and no component provides one. | Platform architecture | Before the emergency path ships |
+| Where do deferred outcomes terminate? The approval service is the natural destination, but nothing connects them and that gear has no implementation. | Gear owner | Before the deferral outcome ships |
+| Does the event trigger and the after-the-operation phase have a consumer, or should the declared vocabulary narrow to what first release implements? | Gear owner | Before first release |
+| Which component owns the authoritative record of a tenant's subscription plan and entitlement state, and can an enforcing gear read it at request time? The Section 11 assumption that a changing entitlement arrives as request input depends on the caller having a trusted source to read; without one the caller is asserting its own entitlement, and the alternative — modelling the entitlement as assignment structure — pays the propagation window on every transition. | Platform architecture | Before first release |
+
+## 14. Traceability
+
+Downstream artifacts for this gear are partially written. ADRs and features belong alongside this document when they exist.
+
+- **Design**: [DESIGN.md](./DESIGN.md)
+- **ADRs**: `ADR/` — not yet created; the records land here once written
+- **Features**: `features/` — not yet created
+- **Enforcing gear**: [Infrastructure Resource Manager](../../../infrastructure-resource-manager/docs/PRD.md), reached through the gateway, whose admission requirements this gear's policy must be able to express: the pre-create admission pipeline, cascade admission, and policy gating. Its management-policy guardrails and its orphan-capacity rule are excluded — the first is that gear's own per-resource state and the second is a counter, and Section 4.2 places both outside this gear
+- **Consumer**: [admission-control](../../admission-control/docs/PRD.md) and its [DESIGN](../../admission-control/docs/DESIGN.md) — the gateway gear specified separately, this gear's only direct consumer, which attaches this gear as one of its engines and owns the plugin contract it conforms to
+- **Platform architecture**: [ARCHITECTURE_MANIFEST.md](../../../../docs/ARCHITECTURE_MANIFEST.md), [GEARS.md](../../../../docs/GEARS.md)
+- **Comparable gear**: [CredStore](../../../credstore/docs/PRD.md), for the local-implementation-plus-management pattern this gear follows
+- **Existing evaluation subsystems**: [quota-enforcement](../../quota-enforcement/docs/PRD.md) and [event-broker](../../event-broker/docs/PRD.md). This gear follows their engine-boundary discipline — the caller validates what the engine returns — and departs from their pluggable-engine shape, as Section 5.7 records
+- **Subject identity and erasure**: [account-management ADR-0005](../../account-management/docs/ADR/0005-cpt-cf-account-management-adr-idp-user-identity-source-of-truth.md), whose position that the identity provider is the sole source of truth for user identity and the sole handler of erasure requests is what `cpt-cf-policy-engine-fr-subject-data-handling` follows
+- **Standards lineage**: the PDP, PEP, PAP, and PIP vocabulary derives from NIST SP 800-162


### PR DESCRIPTION
Adds PRDs and design documents for two new system gears. policy-engine owns admission-control policy content, its version lifecycle, tenant assignment with inheritance and effective windows, evaluation, and decision recording; admission-control is the thin gateway enforcing gears call before an operation, routing to exactly one selected policy engine while evaluating a small set of platform-owned built-in policies itself. Both are specified against a deliberately two-valued decision contract - permit or prohibit, with a governed/ungoverned cause on permits so an unpoliced deployment is never silently mistaken for an approved one - and both fail closed, reporting an infrastructure failure distinctly from a policy refusal. Policy content is versioned immutably with rollback by reseeding rather than pointer rewind, and expression evaluation is delegated throughout to a shared toolkit facility referenced abstractly by GTS-typed backend identifier, specified separately and out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive product requirements and technical design documentation for Admission Control and Policy Engine capabilities.
  * Documented request validation, single and batch admission decisions, policy evaluation, precedence, deferrals, fail-closed behavior, audit records, reporting, metrics, and configuration.
  * Covered policy lifecycle and assignment, tenant isolation, operational interfaces, deployment options, security, telemetry, resilience, testing, integration contracts, use cases, acceptance criteria, assumptions, risks, and open questions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->