### PR TITLE
fix(usage-collector): migrate the contract test off the deprecated .public()

### DIFF
--- a/gears/system/usage-collector/usage-collector/src/api/rest/routes/openapi_contract_tests.rs
+++ b/gears/system/usage-collector/usage-collector/src/api/rest/routes/openapi_contract_tests.rs
@@ -707,7 +707,8 @@ fn canonical_error_statuses() -> BTreeSet<u16> {
     let reg = OpenApiRegistryImpl::new();
     let _router: Router = OperationBuilder::get("/probe")
         .operation_id("probe")
-        .public()
+        .anonymous()
+        .exposed()
         .handler(probe)
         .json_response(StatusCode::OK, "probe")
         .standard_errors(&reg)


### PR DESCRIPTION
## What

One-line unbreak of main's Clippy: replace the deprecated `.public()` with `.anonymous().exposed()` in `openapi_contract_tests.rs` — exactly what the deprecation note prescribes, and what the `.public()` alias forwards to. No behavior change. This is the only remaining `.public()` call site in the workspace (everything else matching is docs and `.orig` leftovers).

## How main went red

Two individually green PRs crossed:

1. **#4397** (opened Aug 3) added this contract test calling `.public()` — legal on its base. Its Clippy last ran **Aug 11, 10:03 UTC** — green, honestly.
2. **#4403** merged **Aug 12, 02:51 UTC** and deprecated `.public()` in toolkit (its branch predates the test file, so its CI never saw the new call site — also honestly green).
3. **#4397** merged **Aug 12, 10:53 UTC** with its day-old green check, never re-run against the new base. No textual conflict, so nothing objected. With `-D warnings` the deprecation is an error → Clippy has been red on every main commit since 9ab9ecd0e, and every PR rebased onto current main inherits the failure (e.g. #4444).

## Verification

- `cargo clippy -p cf-gears-usage-collector --all-targets --all-features -- -D warnings -D clippy::perf` — clean (the exact CI invocation, scoped to the crate).
- `cargo test -p cf-gears-usage-collector openapi_contract` — 10/10 green.

## Systemic note

This class of failure (semantic conflict + stale check) is only prevented by requiring branches to be up to date before merge, or by a merge queue — main currently has neither (rulesets on `main` are empty). Worth a separate discussion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the canonical error-status probe to use an anonymously accessible, exposed operation, improving the accuracy of API error-status validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->